### PR TITLE
[IBL-19] Include current season info in Cap Info module

### DIFF
--- a/ibl5/classes/Team.php
+++ b/ibl5/classes/Team.php
@@ -27,6 +27,8 @@ class Team
     public $numberOfOpenRosterSpots;
     public $numberOfHealthyOpenRosterSpots;
 
+    public $currentSeasonTotalSalary;
+
     const SOFT_CAP_MAX = 5000;
     const HARD_CAP_MAX = 7000;
     const BUYOUT_PERCENTAGE_MAX = 0.40;
@@ -106,6 +108,8 @@ class Team
         $this->numberOfHealthyPlayers = $this->db->sql_numrows($this->getHealthyPlayersOrderedByNameResult());
         $this->numberOfOpenRosterSpots = 15 - $this->numberOfPlayers;
         $this->numberOfHealthyOpenRosterSpots = 15 - $this->numberOfHealthyPlayers;
+
+        $this->currentSeasonTotalSalary = $this->getTotalCurrentSeasonSalariesFromPlrResult($this->getRosterUnderContractOrderedByNameResult());
     }
 
     public function getBuyoutsResult()
@@ -118,7 +122,7 @@ class Team
         $result = $this->db->sql_query($query);
         return $result;
     }
-
+    
     public function getDraftHistoryResult()
     {
         $query = "SELECT *

--- a/ibl5/modules/Cap_Info/index.php
+++ b/ibl5/modules/Cap_Info/index.php
@@ -57,8 +57,13 @@ while ($i < $numberOfTeams) {
 			<a href=\"modules.php?name=Team&op=team&tid=$team->teamID&display=contracts\">
 				<font color=#$team->color2>$team->city $team->name
 			</a>
-		</td>
-		<td align=center>" . (Team::HARD_CAP_MAX - $team->currentSeasonTotalSalary) . "</td>
+		</td>";
+
+    if (!$sharedFunctions->isFreeAgencyModuleActive()) {
+         $table_echo .= "<td align=center>" . (Team::HARD_CAP_MAX - $team->currentSeasonTotalSalary) . "</td>";
+    }
+
+    $table_echo .= "
 		<td align=center>$teamTotalSalaryYear1[$i]</td>
 		<td align=center>$teamTotalSalaryYear2[$i]</td>
 		<td align=center>$teamTotalSalaryYear3[$i]</td>
@@ -82,8 +87,14 @@ while ($i < $numberOfTeams) {
 
 $text .= "<table class=\"sortable\" border=1>
 	<tr>
-		<th>Team</th>
-		<th>" . ($season->beginningYear) . "-<br>" . ($season->endingYear) . "<br>Total</th>
+		<th>Team</th>";
+
+
+if (!$sharedFunctions->isFreeAgencyModuleActive()) {
+    $text .= "<th>" . ($season->beginningYear) . "-<br>" . ($season->endingYear) . "<br>Total</th>";
+}
+		
+$text .= "
 		<th>" . ($season->endingYear + 0) . "-<br>" . ($season->endingYear + 1) . "<br>Total</th>
 		<th>" . ($season->endingYear + 1) . "-<br>" . ($season->endingYear + 2) . "<br>Total</th>
 		<th>" . ($season->endingYear + 2) . "-<br>" . ($season->endingYear + 3) . "<br>Total</th>

--- a/ibl5/modules/Cap_Info/index.php
+++ b/ibl5/modules/Cap_Info/index.php
@@ -68,8 +68,13 @@ while ($i < $numberOfTeams) {
 		<td align=center>$teamTotalSalaryYear2[$i]</td>
 		<td align=center>$teamTotalSalaryYear3[$i]</td>
 		<td align=center>$teamTotalSalaryYear4[$i]</td>
-		<td align=center>$teamTotalSalaryYear5[$i]</td>
-		<td align=center>$teamTotalSalaryYear6[$i]</td>
+		<td align=center>$teamTotalSalaryYear5[$i]</td>";
+
+    if ($sharedFunctions->isFreeAgencyModuleActive()) {
+        $table_echo .= "<td align=center>$teamTotalSalaryYear6[$i]</td>";
+    }
+
+	$table_echo .= "	
         <td bgcolor=#AAA></td>
         <td align=center>$teamTotalPGNextSeasonSalary</td>
         <td align=center>$teamTotalSGNextSeasonSalary</td>
@@ -99,8 +104,14 @@ $text .= "
 		<th>" . ($season->endingYear + 1) . "-<br>" . ($season->endingYear + 2) . "<br>Total</th>
 		<th>" . ($season->endingYear + 2) . "-<br>" . ($season->endingYear + 3) . "<br>Total</th>
 		<th>" . ($season->endingYear + 3) . "-<br>" . ($season->endingYear + 4) . "<br>Total</th>
-		<th>" . ($season->endingYear + 4) . "-<br>" . ($season->endingYear + 5) . "<br>Total</th>
-		<th>" . ($season->endingYear + 5) . "-<br>" . ($season->endingYear + 6) . "<br>Total</th>
+		<th>" . ($season->endingYear + 4) . "-<br>" . ($season->endingYear + 5) . "<br>Total</th>";
+
+
+if ($sharedFunctions->isFreeAgencyModuleActive()) {
+    $text .= "<th>" . ($season->endingYear + 5) . "-<br>" . ($season->endingYear + 6) . "<br>Total</th>";
+}
+
+$text .= "
         <td bgcolor=#AAA></td>
 		<th>" . ($season->endingYear + 0) . "-<br>" . ($season->endingYear + 1) . "<br>PG</th>
 		<th>" . ($season->endingYear + 0) . "-<br>" . ($season->endingYear + 1) . "<br>SG</th>

--- a/ibl5/modules/Cap_Info/index.php
+++ b/ibl5/modules/Cap_Info/index.php
@@ -58,6 +58,7 @@ while ($i < $numberOfTeams) {
 				<font color=#$team->color2>$team->city $team->name
 			</a>
 		</td>
+		<td align=center>" . (Team::HARD_CAP_MAX - $team->currentSeasonTotalSalary) . "</td>
 		<td align=center>$teamTotalSalaryYear1[$i]</td>
 		<td align=center>$teamTotalSalaryYear2[$i]</td>
 		<td align=center>$teamTotalSalaryYear3[$i]</td>
@@ -82,6 +83,7 @@ while ($i < $numberOfTeams) {
 $text .= "<table class=\"sortable\" border=1>
 	<tr>
 		<th>Team</th>
+		<th>" . ($season->beginningYear) . "-<br>" . ($season->endingYear) . "<br>Total</th>
 		<th>" . ($season->endingYear + 0) . "-<br>" . ($season->endingYear + 1) . "<br>Total</th>
 		<th>" . ($season->endingYear + 1) . "-<br>" . ($season->endingYear + 2) . "<br>Total</th>
 		<th>" . ($season->endingYear + 2) . "-<br>" . ($season->endingYear + 3) . "<br>Total</th>

--- a/ibl5/modules/Cap_Info/index.php
+++ b/ibl5/modules/Cap_Info/index.php
@@ -6,6 +6,7 @@ if (!mb_eregi("modules.php", $_SERVER['PHP_SELF'])) {
 
 $sharedFunctions = new Shared($db);
 $season = new Season($db);
+$isFreeAgencyModuleActive = $sharedFunctions->isFreeAgencyModuleActive();
 
 $module_name = basename(dirname(__FILE__));
 get_lang($module_name);
@@ -59,7 +60,7 @@ while ($i < $numberOfTeams) {
 			</a>
 		</td>";
 
-    if (!$sharedFunctions->isFreeAgencyModuleActive()) {
+    if (!$isFreeAgencyModuleActive) {
          $table_echo .= "<td align=center>" . (Team::HARD_CAP_MAX - $team->currentSeasonTotalSalary) . "</td>";
     }
 
@@ -70,7 +71,7 @@ while ($i < $numberOfTeams) {
 		<td align=center>$teamTotalSalaryYear4[$i]</td>
 		<td align=center>$teamTotalSalaryYear5[$i]</td>";
 
-    if ($sharedFunctions->isFreeAgencyModuleActive()) {
+    if ($isFreeAgencyModuleActive) {
         $table_echo .= "<td align=center>$teamTotalSalaryYear6[$i]</td>";
     }
 
@@ -95,7 +96,7 @@ $text .= "<table class=\"sortable\" border=1>
 		<th>Team</th>";
 
 
-if (!$sharedFunctions->isFreeAgencyModuleActive()) {
+if (!$isFreeAgencyModuleActive) {
     $text .= "<th>" . ($season->beginningYear) . "-<br>" . ($season->endingYear) . "<br>Total</th>";
 }
 		
@@ -107,7 +108,7 @@ $text .= "
 		<th>" . ($season->endingYear + 4) . "-<br>" . ($season->endingYear + 5) . "<br>Total</th>";
 
 
-if ($sharedFunctions->isFreeAgencyModuleActive()) {
+if ($isFreeAgencyModuleActive) {
     $text .= "<th>" . ($season->endingYear + 5) . "-<br>" . ($season->endingYear + 6) . "<br>Total</th>";
 }
 


### PR DESCRIPTION
Add current season salary cap space to the Cap Info module. This will also hide the current season column once the Free Agency module is active, and conversely hide the year 6 cap space column when the module is not active.