### PR TITLE
feat: add 15-player roster limit validation to Trading module

### DIFF
--- a/ibl5/classes/Trading/Contracts/TradeOfferInterface.php
+++ b/ibl5/classes/Trading/Contracts/TradeOfferInterface.php
@@ -44,6 +44,7 @@ interface TradeOfferInterface
      * IMPORTANT BEHAVIORS:
      *  - Validates minimum cash amounts (100 per year minimum)
      *  - Validates both teams stay under hard cap post-trade
+     *  - Validates neither team exceeds the 15-player roster limit post-trade
      *  - Creates ibl_trade_info records for each item
      *  - Creates ibl_trade_cash records for cash considerations
      *  - Sends Discord DM notification to receiving team

--- a/ibl5/classes/Trading/Contracts/TradeValidatorInterface.php
+++ b/ibl5/classes/Trading/Contracts/TradeValidatorInterface.php
@@ -75,6 +75,22 @@ interface TradeValidatorInterface
     public function canPlayerBeTraded(int $playerId): bool;
 
     /**
+     * Validate that neither team exceeds the maximum roster size after the trade
+     *
+     * @param string $userTeamName User's team name
+     * @param string $partnerTeamName Partner's team name
+     * @param int $userPlayersSent Number of players user is sending
+     * @param int $partnerPlayersSent Number of players partner is sending
+     * @return array{valid: bool, errors: array<string>}
+     */
+    public function validateRosterLimits(
+        string $userTeamName,
+        string $partnerTeamName,
+        int $userPlayersSent,
+        int $partnerPlayersSent
+    ): array;
+
+    /**
      * Get cash considerations for current season based on phase
      *
      * Determines which year's cash values to use for cap calculations

--- a/ibl5/classes/Trading/Contracts/TradingRepositoryInterface.php
+++ b/ibl5/classes/Trading/Contracts/TradingRepositoryInterface.php
@@ -322,6 +322,14 @@ interface TradingRepositoryInterface
     public function deleteTradeOffer(int $offerId): void;
 
     /**
+     * Count active roster players for a team (excludes retired and cash placeholders)
+     *
+     * @param string $teamName Team name
+     * @return int Number of active players on the team's roster
+     */
+    public function getTeamPlayerCount(string $teamName): int;
+
+    /**
      * Get all teams with city, name, colors and ID for trading UI
      *
      * @return list<TeamWithCityRow> Team rows ordered by city

--- a/ibl5/classes/Trading/TradeOffer.php
+++ b/ibl5/classes/Trading/TradeOffer.php
@@ -86,6 +86,39 @@ class TradeOffer implements TradeOfferInterface
             ];
         }
 
+        // Count players being sent by each side
+        $userPlayersSent = 0;
+        $partnerPlayersSent = 0;
+        $switchCounter = $tradeData['switchCounter'];
+        $fieldsCounter = $tradeData['fieldsCounter'];
+
+        for ($i = 0; $i < $switchCounter; $i++) {
+            if (($tradeData['check'][$i] ?? null) === 'on' && ($tradeData['type'][$i] ?? '') === '1') {
+                $userPlayersSent++;
+            }
+        }
+
+        for ($i = $switchCounter; $i < $fieldsCounter; $i++) {
+            if (($tradeData['check'][$i] ?? null) === 'on' && ($tradeData['type'][$i] ?? '') === '1') {
+                $partnerPlayersSent++;
+            }
+        }
+
+        // Validate roster limits
+        $rosterValidation = $this->validator->validateRosterLimits(
+            $tradeData['offeringTeam'],
+            $tradeData['listeningTeam'],
+            $userPlayersSent,
+            $partnerPlayersSent
+        );
+
+        if ($rosterValidation['valid'] !== true) {
+            return [
+                'success' => false,
+                'errors' => $rosterValidation['errors'],
+            ];
+        }
+
         // Process the trade offer creation
         $result = $this->insertTradeOfferData($tradeOfferId, $tradeData);
         

--- a/ibl5/classes/Trading/TradeValidator.php
+++ b/ibl5/classes/Trading/TradeValidator.php
@@ -88,6 +88,37 @@ class TradeValidator implements TradeValidatorInterface
     }
 
     /**
+     * @see TradeValidatorInterface::validateRosterLimits()
+     */
+    public function validateRosterLimits(
+        string $userTeamName,
+        string $partnerTeamName,
+        int $userPlayersSent,
+        int $partnerPlayersSent
+    ): array {
+        $userCurrentRoster = $this->repository->getTeamPlayerCount($userTeamName);
+        $partnerCurrentRoster = $this->repository->getTeamPlayerCount($partnerTeamName);
+
+        $userPostTradeRoster = $userCurrentRoster - $userPlayersSent + $partnerPlayersSent;
+        $partnerPostTradeRoster = $partnerCurrentRoster - $partnerPlayersSent + $userPlayersSent;
+
+        $errors = [];
+
+        if ($userPostTradeRoster > \Team::ROSTER_SPOTS_MAX) {
+            $errors[] = 'This trade is illegal since it puts your team over the ' . \Team::ROSTER_SPOTS_MAX . '-player roster limit.';
+        }
+
+        if ($partnerPostTradeRoster > \Team::ROSTER_SPOTS_MAX) {
+            $errors[] = 'This trade is illegal since it puts the other team over the ' . \Team::ROSTER_SPOTS_MAX . '-player roster limit.';
+        }
+
+        return [
+            'valid' => $errors === [],
+            'errors' => $errors,
+        ];
+    }
+
+    /**
      * @see TradeValidatorInterface::canPlayerBeTraded()
      */
     public function canPlayerBeTraded(int $playerId): bool

--- a/ibl5/classes/Trading/TradingRepository.php
+++ b/ibl5/classes/Trading/TradingRepository.php
@@ -536,6 +536,23 @@ class TradingRepository extends BaseMysqliRepository implements TradingRepositor
     }
 
     /**
+     * @see TradingRepositoryInterface::getTeamPlayerCount()
+     */
+    public function getTeamPlayerCount(string $teamName): int
+    {
+        /** @var array{cnt: int}|null $result */
+        $result = $this->fetchOne(
+            "SELECT COUNT(*) AS cnt FROM ibl_plr WHERE teamname = ? AND retired = '0' AND ordinal < 100000",
+            "s",
+            $teamName
+        );
+        if ($result === null) {
+            return 0;
+        }
+        return $result['cnt'];
+    }
+
+    /**
      * Get all teams with city, name, colors and ID for trading UI
      *
      * @return list<TeamWithCityRow> Team rows ordered by city

--- a/ibl5/tests/Trading/TradeApprovalTest.php
+++ b/ibl5/tests/Trading/TradeApprovalTest.php
@@ -10,10 +10,10 @@ class TradeApprovalTest extends TestCase
     {
         $this->db = new MockDatabase();
         
-        // Set up mock data for team ID lookups and player data
+        // Set up mock data for team ID lookups, player data, and roster counts
         $this->db->setMockData([
-            ['counter' => 1000],
-            ['name' => 'Test Player', 'pos' => 'PG']
+            ['counter' => 1000, 'cnt' => 10],
+            ['name' => 'Test Player', 'pos' => 'PG', 'cnt' => 10]
         ]);
         
         // Prevent Discord notifications and set SERVER_NAME for TradingRepository
@@ -292,6 +292,10 @@ class QueryAwareMockDatabase extends MockDatabase
         }
         
         if (stripos($query, 'ibl_plr') !== false) {
+            // Return roster count for COUNT queries
+            if (stripos($query, 'COUNT(*)') !== false) {
+                return new MockDatabaseResult([['cnt' => 10]]);
+            }
             // Return player data
             return new MockDatabaseResult([
                 ['name' => 'Test Player', 'pos' => 'PG']


### PR DESCRIPTION
## Summary

- Block trade offers where either team's post-trade roster would exceed `Team::ROSTER_SPOTS_MAX` (15 players)
- Validation runs at trade offer creation time, after salary cap checks pass
- Calculates post-trade roster: `currentRoster - playersSent + playersReceived` for each team

## Changes

- Add `getTeamPlayerCount()` to `TradingRepositoryInterface` and `TradingRepository` to count active roster players (excludes retired and cash placeholders)
- Add `validateRosterLimits()` to `TradeValidatorInterface` and `TradeValidator` with per-team error messages matching the `validateSalaryCaps` pattern
- Integrate roster validation in `TradeOffer::createTradeOffer()` by counting players (`type === '1'`) being sent by each side from form data
- Add 6 roster limit test cases to `TradeValidatorTest` covering within-limit, single-team exceed, both-exceed, equal swap, and exact-boundary scenarios
- Fix `TradeApprovalTest` mock data to include `cnt` key for roster count queries

## Test plan

- [x] PHPStan passes with zero errors
- [x] Full test suite passes: 2228 tests, 5633 assertions
- [x] New roster limit tests cover: valid trades, user exceeds, partner exceeds, both exceed, equal swap at limit, exactly at 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)