### PR TITLE
fix: correct All-Star Break handling in sim date projections

### DIFF
--- a/ibl5/classes/Boxscore/BoxscoreProcessor.php
+++ b/ibl5/classes/Boxscore/BoxscoreProcessor.php
@@ -136,7 +136,7 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
 
         // Check if regular season has progressed past All-Star Weekend
         $lastBoxScoreDate = $this->season->getLastBoxScoreDate();
-        $allStarCutoff = $operatingSeasonEndingYear . '-02-04';
+        $allStarCutoff = sprintf('%d-%02d-%02d', $operatingSeasonEndingYear, \Season::IBL_ALL_STAR_MONTH, \Season::IBL_ALL_STAR_BREAK_END_DAY);
 
         if ($lastBoxScoreDate === '' || $lastBoxScoreDate <= $allStarCutoff) {
             return [
@@ -315,7 +315,7 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
         $gameInfoLine = substr($line, 0, 58);
         $boxscoreGameInfo = \Boxscore::withGameInfoLine($gameInfoLine, $seasonEndingYear, 'Regular Season/Playoffs');
         $boxscoreGameInfo->overrideGameContext(
-            $seasonEndingYear . '-02-02',
+            sprintf('%d-%02d-%02d', $seasonEndingYear, \Season::IBL_ALL_STAR_MONTH, \Season::IBL_RISING_STARS_GAME_DAY),
             self::RISING_STARS_VISITOR_TID,
             self::RISING_STARS_HOME_TID,
             1,
@@ -352,7 +352,7 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
         int $seasonEndingYear,
         array &$messages,
     ): void {
-        $gameDate = $seasonEndingYear . '-02-03';
+        $gameDate = sprintf('%d-%02d-%02d', $seasonEndingYear, \Season::IBL_ALL_STAR_MONTH, \Season::IBL_ALL_STAR_GAME_DAY);
 
         $gameInfoLine = substr($line, 0, 58);
         $boxscoreGameInfo = \Boxscore::withGameInfoLine($gameInfoLine, $seasonEndingYear, 'Regular Season/Playoffs');

--- a/ibl5/classes/NextSim/NextSimService.php
+++ b/ibl5/classes/NextSim/NextSimService.php
@@ -46,7 +46,8 @@ class NextSimService implements NextSimServiceInterface
     {
         $projectedGames = $this->teamScheduleRepository->getProjectedGamesNextSimResult(
             $teamId,
-            $season->lastSimEndDate
+            $season->lastSimEndDate,
+            $season->projectedNextSimEndDate->format('Y-m-d')
         );
 
         $lastSimEndDateObject = new \DateTime($season->lastSimEndDate);

--- a/ibl5/classes/TeamSchedule/Contracts/TeamScheduleRepositoryInterface.php
+++ b/ibl5/classes/TeamSchedule/Contracts/TeamScheduleRepositoryInterface.php
@@ -32,7 +32,8 @@ interface TeamScheduleRepositoryInterface
      *
      * @param int $teamID Team ID to get schedule for
      * @param string $lastSimEndDate Date string (YYYY-MM-DD) of last sim end
+     * @param string $projectedNextSimEndDate Date string (YYYY-MM-DD) of projected next sim end (break-aware)
      * @return array<int, array<string, mixed>> Upcoming game rows ordered by date ascending
      */
-    public function getProjectedGamesNextSimResult(int $teamID, string $lastSimEndDate): array;
+    public function getProjectedGamesNextSimResult(int $teamID, string $lastSimEndDate, string $projectedNextSimEndDate): array;
 }

--- a/ibl5/classes/TeamSchedule/TeamScheduleRepository.php
+++ b/ibl5/classes/TeamSchedule/TeamScheduleRepository.php
@@ -41,24 +41,18 @@ class TeamScheduleRepository extends \BaseMysqliRepository implements TeamSchedu
      *
      * @return array<int, array<string, mixed>>
      */
-    public function getProjectedGamesNextSimResult(int $teamID, string $lastSimEndDate): array
+    public function getProjectedGamesNextSimResult(int $teamID, string $lastSimEndDate, string $projectedNextSimEndDate): array
     {
-        /** @var \mysqli $db */
-        $db = $this->db;
-        $league = new \League($db);
-        $simLengthInDays = $league->getSimLengthInDays();
-
         return $this->fetchAll(
             "SELECT * FROM `ibl_schedule`
              WHERE (Visitor = ? OR Home = ?)
-               AND Date BETWEEN ADDDATE(?, 1) AND ADDDATE(?, ?)
+               AND Date BETWEEN ADDDATE(?, 1) AND ?
              ORDER BY Date ASC",
-            'iissi',
+            'iiss',
             $teamID,
             $teamID,
             $lastSimEndDate,
-            $lastSimEndDate,
-            $simLengthInDays
+            $projectedNextSimEndDate
         );
     }
 }

--- a/ibl5/tests/Integration/Mocks/Season.php
+++ b/ibl5/tests/Integration/Mocks/Season.php
@@ -29,6 +29,12 @@ class Season
     const IBL_ALL_STAR_MONTH = 2;
     const IBL_REGULAR_SEASON_ENDING_MONTH = 5;
     const IBL_PLAYOFF_MONTH = 6;
+
+    const IBL_ALL_STAR_BREAK_START_DAY = 1;
+    const IBL_RISING_STARS_GAME_DAY = 2;
+    const IBL_ALL_STAR_GAME_DAY = 3;
+    const IBL_ALL_STAR_BREAK_END_DAY = 4;
+    const IBL_POST_ALL_STAR_FIRST_DAY = 5;
     
     protected object $db;
     
@@ -45,7 +51,7 @@ class Season
         $this->endingYear = 2024;
         $this->beginningYear = 2023;
         $this->regularSeasonStartDate = date_create("2023-11-01");
-        $this->postAllStarStartDate = date_create("2024-02-04");
+        $this->postAllStarStartDate = date_create("2024-02-05");
         $this->playoffsStartDate = date_create("2024-06-01");
         $this->playoffsEndDate = date_create("2024-06-30");
         $this->projectedNextSimEndDate = date_create("2024-01-10");

--- a/ibl5/tests/Integration/Schedule/ScheduleIntegrationTest.php
+++ b/ibl5/tests/Integration/Schedule/ScheduleIntegrationTest.php
@@ -183,28 +183,14 @@ class ScheduleIntegrationTest extends IntegrationTestCase
         // Arrange
         $teamId = 5;
         $lastSimEndDate = '2025-01-14';
-        $this->mockDb->setMockData([
-            ['value' => '7'] // Mock League data (matches ibl_settings.value column)
-        ]);
+        $projectedNextSimEndDate = '2025-01-21';
+        $this->mockDb->setMockData([]);
 
-        // Act - This will throw because League requires more data, but we can verify the query structure
-        try {
-            $this->repository->getProjectedGamesNextSimResult($teamId, $lastSimEndDate);
-        } catch (\Exception $e) {
-            // Expected - League initialization may fail in test environment
-        }
+        // Act
+        $this->repository->getProjectedGamesNextSimResult($teamId, $lastSimEndDate, $projectedNextSimEndDate);
 
-        // Assert - Verify query was attempted with ADDDATE
-        $queries = $this->getExecutedQueries();
-        $foundScheduleQuery = false;
-        foreach ($queries as $query) {
-            if (stripos($query, 'ibl_schedule') !== false && stripos($query, 'ADDDATE') !== false) {
-                $foundScheduleQuery = true;
-                break;
-            }
-        }
-        // Even if League init fails, we should have tried the schedule query or league query
-        $this->assertTrue(count($queries) > 0);
+        // Assert - Verify query was executed against ibl_schedule
+        $this->assertQueryExecuted('ibl_schedule');
     }
 
     // ========== SERVICE WIN/LOSS TRACKING TESTS ==========

--- a/ibl5/tests/SeasonTest.php
+++ b/ibl5/tests/SeasonTest.php
@@ -162,6 +162,31 @@ class SeasonTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(6, \Season::IBL_PLAYOFF_MONTH);
     }
 
+    public function testIblAllStarBreakStartDayConstant(): void
+    {
+        $this->assertSame(1, \Season::IBL_ALL_STAR_BREAK_START_DAY);
+    }
+
+    public function testIblRisingStarsGameDayConstant(): void
+    {
+        $this->assertSame(2, \Season::IBL_RISING_STARS_GAME_DAY);
+    }
+
+    public function testIblAllStarGameDayConstant(): void
+    {
+        $this->assertSame(3, \Season::IBL_ALL_STAR_GAME_DAY);
+    }
+
+    public function testIblAllStarBreakEndDayConstant(): void
+    {
+        $this->assertSame(4, \Season::IBL_ALL_STAR_BREAK_END_DAY);
+    }
+
+    public function testIblPostAllStarFirstDayConstant(): void
+    {
+        $this->assertSame(5, \Season::IBL_POST_ALL_STAR_FIRST_DAY);
+    }
+
     // ============================================
     // INSTANTIATION TESTS
     // ============================================


### PR DESCRIPTION
## Summary

- **Fixed sim date projection bug:** `getProjectedNextSimEndDate()` now correctly extends the projected end date when a sim period spans through the All-Star Break (Feb 1-4). Previously it only adjusted when the end date landed *inside* the break, missing cases where the sim started before and ended after the break.
- **Fixed off-by-one:** Feb 5 is a valid game day, not part of the break. Updated `postAllStarStartDate` from Feb 4 to Feb 5.
- **Centralized All-Star Break dates:** Added 5 day constants to `Season` and replaced 3 hardcoded date literals in `BoxscoreProcessor`.
- **Made NextSim break-aware:** `TeamScheduleRepository::getProjectedGamesNextSimResult()` now accepts the break-aware projected end date from `Season` instead of computing its own via raw SQL `ADDDATE` (which ignored the break entirely). Removed internal `League` dependency.

## Test plan

- [x] Full PHPUnit suite passes (2824 tests, 7132 assertions)
- [x] PHPStan passes with no errors
- [x] New constant tests added to SeasonTest
- [x] ScheduleIntegrationTest updated for new method signature
- [ ] Verify Schedule page on staging shows correct next-sim highlighting around All-Star Break
- [ ] Verify NextSim page correctly projects games when sim period crosses Feb 1-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)