### PR TITLE
refactor: parse .sch files instead of Schedule.htm

### DIFF
--- a/ibl5/classes/Utilities/SchFileParser.php
+++ b/ibl5/classes/Utilities/SchFileParser.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utilities;
+
+/**
+ * SchFileParser - Parse JSB .sch schedule files
+ *
+ * The .sch format is a compact fixed-width ASCII format (80,000 bytes):
+ * - 8,000 game slots of 10 bytes each
+ * - 500 date slots of 16 game slots each (up to 14 games + 2 padding per date)
+ * - Date mapping: 31 slots per month (Oct=0-30, Nov=31-61, Dec=62-92, Jan=93-123, etc.)
+ * - 10-byte game record: [teams:4][scores:6]
+ * - Empty slot: "0   0     "
+ */
+class SchFileParser
+{
+    public const FILE_SIZE = 80000;
+    public const RECORD_SIZE = 10;
+    public const TEAMS_FIELD_SIZE = 4;
+    public const SCORES_FIELD_SIZE = 6;
+    public const SLOTS_PER_DATE = 16;
+    public const MAX_GAMES_PER_DATE = 14;
+    public const DAYS_PER_MONTH = 31;
+    public const MAX_MONTH_OFFSET = 12;
+    public const BOX_ID_MONTH_MULTIPLIER = 500;
+    public const BOX_ID_DAY_MULTIPLIER = 15;
+
+    private const EMPTY_RECORD = '0   0     ';
+
+    /**
+     * Parse a .sch file and return all games as structured arrays.
+     *
+     * @return list<array{
+     *     date_slot: int,
+     *     game_index: int,
+     *     visitor: int,
+     *     home: int,
+     *     visitor_score: int,
+     *     home_score: int,
+     *     played: bool
+     * }>
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("Schedule file not found: {$filePath}");
+        }
+
+        $fileSize = filesize($filePath);
+        if ($fileSize !== self::FILE_SIZE) {
+            throw new \RuntimeException(
+                "Invalid .sch file size: expected " . self::FILE_SIZE . " bytes, got {$fileSize}"
+            );
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            throw new \RuntimeException("Failed to read schedule file: {$filePath}");
+        }
+
+        $games = [];
+        $bytesPerDate = self::SLOTS_PER_DATE * self::RECORD_SIZE;
+
+        for ($dateSlot = 0; $dateSlot < intdiv(self::FILE_SIZE, $bytesPerDate); $dateSlot++) {
+            $monthOffset = intdiv($dateSlot, self::DAYS_PER_MONTH);
+            if ($monthOffset >= self::MAX_MONTH_OFFSET) {
+                continue;
+            }
+
+            $monthDay = self::dateSlotToMonthDay($dateSlot);
+            if ($monthDay === null) {
+                continue;
+            }
+
+            for ($gameIndex = 0; $gameIndex < self::SLOTS_PER_DATE; $gameIndex++) {
+                $offset = ($dateSlot * self::SLOTS_PER_DATE + $gameIndex) * self::RECORD_SIZE;
+                $record = substr($data, $offset, self::RECORD_SIZE);
+
+                if ($record === self::EMPTY_RECORD) {
+                    continue;
+                }
+
+                $parsed = self::parseGameRecord($record);
+                if ($parsed === null) {
+                    continue;
+                }
+
+                $played = $parsed['visitor_score'] > 0 || $parsed['home_score'] > 0;
+
+                $games[] = [
+                    'date_slot' => $dateSlot,
+                    'game_index' => $gameIndex,
+                    'visitor' => $parsed['visitor'],
+                    'home' => $parsed['home'],
+                    'visitor_score' => $parsed['visitor_score'],
+                    'home_score' => $parsed['home_score'],
+                    'played' => $played,
+                ];
+            }
+        }
+
+        return $games;
+    }
+
+    /**
+     * Parse a single 10-byte game record.
+     *
+     * Teams field (4 bytes): visitor ID (unpadded) + home ID (zero-padded to 2 digits), right-padded with spaces.
+     * Scores field (6 bytes): visitor score (unpadded) + home score (zero-padded to 3 digits), right-padded with spaces.
+     *
+     * @return array{visitor: int, home: int, visitor_score: int, home_score: int}|null
+     */
+    public static function parseGameRecord(string $record): ?array
+    {
+        if (strlen($record) !== self::RECORD_SIZE) {
+            return null;
+        }
+
+        if ($record === self::EMPTY_RECORD) {
+            return null;
+        }
+
+        $teamsField = rtrim(substr($record, 0, self::TEAMS_FIELD_SIZE));
+        $scoresField = rtrim(substr($record, self::TEAMS_FIELD_SIZE, self::SCORES_FIELD_SIZE));
+
+        if (strlen($teamsField) < 2) {
+            return null;
+        }
+
+        // Home team is always the last 2 characters (zero-padded)
+        $home = (int) substr($teamsField, -2);
+        // Visitor is everything before the last 2 characters
+        $visitor = (int) substr($teamsField, 0, -2);
+
+        if ($visitor <= 0 || $home <= 0) {
+            return null;
+        }
+
+        // For unplayed games, scores field is just "0"
+        if ($scoresField === '0') {
+            return [
+                'visitor' => $visitor,
+                'home' => $home,
+                'visitor_score' => 0,
+                'home_score' => 0,
+            ];
+        }
+
+        if (strlen($scoresField) < 4) {
+            return null;
+        }
+
+        // Home score is always the last 3 characters (zero-padded)
+        $homeScore = (int) substr($scoresField, -3);
+        // Visitor score is everything before the last 3 characters
+        $visitorScore = (int) substr($scoresField, 0, -3);
+
+        return [
+            'visitor' => $visitor,
+            'home' => $home,
+            'visitor_score' => $visitorScore,
+            'home_score' => $homeScore,
+        ];
+    }
+
+    /**
+     * Convert a date_slot to a calendar date (month and day).
+     *
+     * @return array{month: int, day: int}|null Null for invalid dates (e.g., Nov 31, Feb 30)
+     */
+    public static function dateSlotToMonthDay(int $dateSlot): ?array
+    {
+        $monthOffset = intdiv($dateSlot, self::DAYS_PER_MONTH);
+        $dayZeroBased = $dateSlot % self::DAYS_PER_MONTH;
+
+        if ($monthOffset >= self::MAX_MONTH_OFFSET) {
+            return null;
+        }
+
+        // Convert month offset from October to calendar month (1-12)
+        // Offset 0 = October (10), 1 = November (11), 2 = December (12), 3 = January (1), etc.
+        $month = (($monthOffset + 9) % 12) + 1;
+        $day = $dayZeroBased + 1;
+
+        // Validate with checkdate (uses a leap year to allow Feb 29)
+        if (!checkdate($month, $day, 2000)) {
+            return null;
+        }
+
+        return [
+            'month' => $month,
+            'day' => $day,
+        ];
+    }
+
+    /**
+     * Compute the JSB BoxID from date slot and game index.
+     *
+     * Formula: month_from_october * 500 + (day - 1) * 15 + game_index
+     */
+    public static function computeBoxId(int $dateSlot, int $gameIndex): int
+    {
+        $monthOffset = intdiv($dateSlot, self::DAYS_PER_MONTH);
+        $dayZeroBased = $dateSlot % self::DAYS_PER_MONTH;
+
+        return $monthOffset * self::BOX_ID_MONTH_MULTIPLIER
+            + $dayZeroBased * self::BOX_ID_DAY_MULTIPLIER
+            + $gameIndex;
+    }
+}

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -78,7 +78,7 @@ try {
     flush();
 
     // Initialize components
-    $scheduleUpdater = new Updater\ScheduleUpdater($mysqli_db, $commonRepository, $season);
+    $scheduleUpdater = new Updater\ScheduleUpdater($mysqli_db, $season);
     echo "<p>✓ ScheduleUpdater initialized</p>";
     flush();
 

--- a/ibl5/tests/Utilities/SchFileParserTest.php
+++ b/ibl5/tests/Utilities/SchFileParserTest.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Utilities;
+
+use PHPUnit\Framework\TestCase;
+use Utilities\SchFileParser;
+
+/**
+ * SchFileParserTest - Tests for the JSB .sch file parser
+ *
+ * Covers:
+ * - Game record parsing (1-digit and 2-digit team IDs, various score widths)
+ * - Empty slot detection
+ * - Date slot to month/day conversion
+ * - Invalid date filtering (Nov 31, Feb 30, etc.)
+ * - BoxID computation
+ * - Full file parsing with real .sch data
+ */
+class SchFileParserTest extends TestCase
+{
+    // parseGameRecord tests
+
+    public function testParseGameRecordWithTwoDigitTeams(): void
+    {
+        // "2409146130" → V=24, H=09, VS=146, HS=130
+        $result = SchFileParser::parseGameRecord('2409146130');
+
+        $this->assertNotNull($result);
+        $this->assertSame(24, $result['visitor']);
+        $this->assertSame(9, $result['home']);
+        $this->assertSame(146, $result['visitor_score']);
+        $this->assertSame(130, $result['home_score']);
+    }
+
+    public function testParseGameRecordWithSingleDigitVisitor(): void
+    {
+        // "510 92131 " → V=5, H=10, VS=92, HS=131
+        $result = SchFileParser::parseGameRecord('510 92131 ');
+
+        $this->assertNotNull($result);
+        $this->assertSame(5, $result['visitor']);
+        $this->assertSame(10, $result['home']);
+        $this->assertSame(92, $result['visitor_score']);
+        $this->assertSame(131, $result['home_score']);
+    }
+
+    public function testParseGameRecordWithSingleDigitHome(): void
+    {
+        // "2206118136" → V=22, H=06, VS=118, HS=136
+        $result = SchFileParser::parseGameRecord('2206118136');
+
+        $this->assertNotNull($result);
+        $this->assertSame(22, $result['visitor']);
+        $this->assertSame(6, $result['home']);
+        $this->assertSame(118, $result['visitor_score']);
+        $this->assertSame(136, $result['home_score']);
+    }
+
+    public function testParseGameRecordWithPaddedScores(): void
+    {
+        // "1401111146" → V=14, H=01, VS=111, HS=146
+        $result = SchFileParser::parseGameRecord('1401111146');
+
+        $this->assertNotNull($result);
+        $this->assertSame(14, $result['visitor']);
+        $this->assertSame(1, $result['home']);
+        $this->assertSame(111, $result['visitor_score']);
+        $this->assertSame(146, $result['home_score']);
+    }
+
+    public function testParseGameRecordReturnsNullForEmptySlot(): void
+    {
+        $result = SchFileParser::parseGameRecord('0   0     ');
+
+        $this->assertNull($result);
+    }
+
+    public function testParseGameRecordReturnsNullForWrongLength(): void
+    {
+        $result = SchFileParser::parseGameRecord('short');
+
+        $this->assertNull($result);
+    }
+
+    public function testParseGameRecordHandlesUnplayedGame(): void
+    {
+        // "308 0     " → V=3, H=08, VS=0, HS=0
+        $result = SchFileParser::parseGameRecord('308 0     ');
+
+        $this->assertNotNull($result);
+        $this->assertSame(3, $result['visitor']);
+        $this->assertSame(8, $result['home']);
+        $this->assertSame(0, $result['visitor_score']);
+        $this->assertSame(0, $result['home_score']);
+    }
+
+    public function testParseGameRecordHandlesUnplayedGameWithTwoDigitTeams(): void
+    {
+        // "18200     " → V=18, H=20, VS=0, HS=0
+        $result = SchFileParser::parseGameRecord('18200     ');
+
+        $this->assertNotNull($result);
+        $this->assertSame(18, $result['visitor']);
+        $this->assertSame(20, $result['home']);
+        $this->assertSame(0, $result['visitor_score']);
+        $this->assertSame(0, $result['home_score']);
+    }
+
+    // dateSlotToMonthDay tests
+
+    public function testDateSlotToMonthDayNovember(): void
+    {
+        // Slot 32 → month_offset=1, day_offset=1 → November 2
+        $result = SchFileParser::dateSlotToMonthDay(32);
+
+        $this->assertNotNull($result);
+        $this->assertSame(11, $result['month']);
+        $this->assertSame(2, $result['day']);
+    }
+
+    public function testDateSlotToMonthDayDecember(): void
+    {
+        // Slot 62 → month_offset=2, day_offset=0 → December 1
+        $result = SchFileParser::dateSlotToMonthDay(62);
+
+        $this->assertNotNull($result);
+        $this->assertSame(12, $result['month']);
+        $this->assertSame(1, $result['day']);
+    }
+
+    public function testDateSlotToMonthDayJanuary(): void
+    {
+        // Slot 93 → month_offset=3, day_offset=0 → January 1
+        $result = SchFileParser::dateSlotToMonthDay(93);
+
+        $this->assertNotNull($result);
+        $this->assertSame(1, $result['month']);
+        $this->assertSame(1, $result['day']);
+    }
+
+    public function testDateSlotToMonthDayOctober(): void
+    {
+        // Slot 0 → month_offset=0, day_offset=0 → October 1
+        $result = SchFileParser::dateSlotToMonthDay(0);
+
+        $this->assertNotNull($result);
+        $this->assertSame(10, $result['month']);
+        $this->assertSame(1, $result['day']);
+    }
+
+    public function testDateSlotToMonthDayFebruary(): void
+    {
+        // Slot 124 → month_offset=4, day_offset=0 → February 1
+        $result = SchFileParser::dateSlotToMonthDay(124);
+
+        $this->assertNotNull($result);
+        $this->assertSame(2, $result['month']);
+        $this->assertSame(1, $result['day']);
+    }
+
+    public function testDateSlotToMonthDayReturnsNullForInvalidDate(): void
+    {
+        // Slot 61 → month_offset=1, day_offset=30 → November 31 (invalid)
+        $result = SchFileParser::dateSlotToMonthDay(61);
+
+        $this->assertNull($result);
+    }
+
+    public function testDateSlotToMonthDayReturnsNullForFeb30(): void
+    {
+        // Slot 153 → month_offset=4, day_offset=29 → February 30 (invalid)
+        $result = SchFileParser::dateSlotToMonthDay(153);
+
+        $this->assertNull($result);
+    }
+
+    public function testDateSlotToMonthDayReturnsNullForExcessiveOffset(): void
+    {
+        // Slot 372 → month_offset=12 → beyond MAX_MONTH_OFFSET
+        $result = SchFileParser::dateSlotToMonthDay(372);
+
+        $this->assertNull($result);
+    }
+
+    // computeBoxId tests
+
+    public function testComputeBoxIdNovember2FirstGame(): void
+    {
+        // Slot 32 → month_offset=1, day_offset=1, game_index=0
+        // BoxID = 1 * 500 + 1 * 15 + 0 = 515
+        $result = SchFileParser::computeBoxId(32, 0);
+
+        $this->assertSame(515, $result);
+    }
+
+    public function testComputeBoxIdDecember1FirstGame(): void
+    {
+        // Slot 62 → month_offset=2, day_offset=0, game_index=0
+        // BoxID = 2 * 500 + 0 * 15 + 0 = 1000
+        $result = SchFileParser::computeBoxId(62, 0);
+
+        $this->assertSame(1000, $result);
+    }
+
+    public function testComputeBoxIdWithGameIndex(): void
+    {
+        // Slot 32 → month_offset=1, day_offset=1, game_index=3
+        // BoxID = 1 * 500 + 1 * 15 + 3 = 518
+        $result = SchFileParser::computeBoxId(32, 3);
+
+        $this->assertSame(518, $result);
+    }
+
+    public function testComputeBoxIdJanuary1(): void
+    {
+        // Slot 93 → month_offset=3, day_offset=0, game_index=0
+        // BoxID = 3 * 500 + 0 * 15 + 0 = 1500
+        $result = SchFileParser::computeBoxId(93, 0);
+
+        $this->assertSame(1500, $result);
+    }
+
+    // parseFile tests
+
+    public function testParseFileThrowsForMissingFile(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Schedule file not found');
+
+        SchFileParser::parseFile('/nonexistent/path/IBL5.sch');
+    }
+
+    public function testParseFileThrowsForInvalidSize(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'sch_test_');
+        $this->assertIsString($tmpFile);
+        file_put_contents($tmpFile, str_repeat("\0", 100));
+
+        try {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('Invalid .sch file size');
+
+            SchFileParser::parseFile($tmpFile);
+        } finally {
+            unlink($tmpFile);
+        }
+    }
+
+    public function testParseFileWithRealData(): void
+    {
+        $schFile = dirname(__DIR__, 2) . '/IBL5.sch';
+        if (!file_exists($schFile)) {
+            $this->fail("Test .sch file not found at: {$schFile}");
+        }
+
+        $games = SchFileParser::parseFile($schFile);
+
+        $this->assertNotEmpty($games);
+
+        // Count played vs unplayed
+        $played = 0;
+        $unplayed = 0;
+        foreach ($games as $game) {
+            if ($game['played']) {
+                $played++;
+            } else {
+                $unplayed++;
+            }
+        }
+
+        $this->assertSame(1148, count($games), 'Total game count should be 1148');
+        $this->assertSame(627, $played, 'Played game count should be 627');
+        $this->assertSame(521, $unplayed, 'Unplayed game count should be 521');
+    }
+
+    public function testParseFileFirstGameMatchesExpected(): void
+    {
+        $schFile = dirname(__DIR__, 2) . '/IBL5.sch';
+        if (!file_exists($schFile)) {
+            $this->fail("Test .sch file not found at: {$schFile}");
+        }
+
+        $games = SchFileParser::parseFile($schFile);
+        $firstGame = $games[0];
+
+        // First game should be at date_slot 32 (November 2), game_index 0
+        $this->assertSame(32, $firstGame['date_slot']);
+        $this->assertSame(0, $firstGame['game_index']);
+        $this->assertSame(24, $firstGame['visitor']);
+        $this->assertSame(9, $firstGame['home']);
+        $this->assertSame(146, $firstGame['visitor_score']);
+        $this->assertSame(130, $firstGame['home_score']);
+        $this->assertTrue($firstGame['played']);
+    }
+
+    public function testParseFileGamesHaveValidTeamIds(): void
+    {
+        $schFile = dirname(__DIR__, 2) . '/IBL5.sch';
+        if (!file_exists($schFile)) {
+            $this->fail("Test .sch file not found at: {$schFile}");
+        }
+
+        $games = SchFileParser::parseFile($schFile);
+
+        foreach ($games as $game) {
+            $this->assertGreaterThan(0, $game['visitor'], 'Visitor team ID should be positive');
+            $this->assertGreaterThan(0, $game['home'], 'Home team ID should be positive');
+            $this->assertLessThanOrEqual(\League::MAX_REAL_TEAMID, $game['visitor']);
+            $this->assertLessThanOrEqual(\League::MAX_REAL_TEAMID, $game['home']);
+        }
+    }
+
+    public function testParseFileBoxIdsMatchExpected(): void
+    {
+        $schFile = dirname(__DIR__, 2) . '/IBL5.sch';
+        if (!file_exists($schFile)) {
+            $this->fail("Test .sch file not found at: {$schFile}");
+        }
+
+        $games = SchFileParser::parseFile($schFile);
+
+        // Verify the first few BoxIDs match known values
+        // Game 0: date_slot=32, game_index=0 → BoxID=515
+        $this->assertSame(515, SchFileParser::computeBoxId($games[0]['date_slot'], $games[0]['game_index']));
+
+        // Game 1: date_slot=32, game_index=1 → BoxID=516
+        $this->assertSame(516, SchFileParser::computeBoxId($games[1]['date_slot'], $games[1]['game_index']));
+    }
+}


### PR DESCRIPTION
## Summary

- **Add `SchFileParser` utility** — parses JSB's compact 80KB fixed-width `.sch` format, replacing fragile DOMDocument HTML parsing of `Schedule.htm`
- **Refactor `ScheduleUpdater`** — uses `SchFileParser` for schedule data extraction, removing HTML dependency, `extractBoxID()`, `resolveTeamId()`, and unused `$commonRepository`
- **22 new unit tests** for `SchFileParser` covering record parsing, date slot mapping, BoxID computation, and full-file validation against real `.sch` data (1148 games: 627 played, 521 unplayed)

## .sch Format

| Property | Value |
|----------|-------|
| Size | 80,000 bytes ASCII, no line terminators |
| Structure | 500 date slots × 16 game slots × 10 bytes |
| Game record | `[teams:4][scores:6]` — team IDs and scores in fixed-width fields |
| BoxID formula | `month_offset × 500 + day_offset × 15 + game_index` |

## Test plan

- [x] SchFileParser unit tests pass (22 tests)
- [x] ScheduleUpdater tests updated and passing
- [x] Full test suite passing (2863 tests, 14139 assertions)
- [x] PHPStan clean (level max + strict-rules + bleedingEdge)
- [x] Parser output validated against database: all 1148 games match exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)