### PR TITLE
feat: migrate auth from PHP-Nuke to delight-im/auth

### DIFF
--- a/ibl5/classes/Auth/AuthService.php
+++ b/ibl5/classes/Auth/AuthService.php
@@ -5,87 +5,79 @@ declare(strict_types=1);
 namespace Auth;
 
 use Auth\Contracts\AuthServiceInterface;
+use Database\PdoConnection;
+use Delight\Auth\Auth;
+use Delight\Auth\Role;
 
 /**
- * AuthService - Session-based user authentication with bcrypt password hashing
+ * AuthService - Wraps delight-im/auth for user authentication
  *
- * Replaces legacy PHP-Nuke MD5/base64-cookie auth with:
- * - bcrypt password hashing via password_hash() (cost 12)
- * - PHP native sessions as the source of truth
- * - Transparent MD5-to-bcrypt migration on first login
- * - Backward-compatible getCookieArray() for legacy $cookie[] references
+ * Provides login, registration, email verification, password reset,
+ * remember-me, login throttling, and admin role checking while maintaining
+ * backward compatibility with legacy PHP-Nuke $cookie/$userinfo globals.
  *
- * Admin auth (nuke_authors / is_admin()) is NOT handled here.
- *
- * @phpstan-type UserRow array{user_id: int, username: string, user_password: string, storynum: int, umode: string, uorder: int, thold: int, noscore: int, ublockon: int, theme: string, commentmax: int, user_email: string, user_regdate: string, name: string}
+ * @phpstan-import-type UserRow from AuthServiceInterface
  */
 class AuthService implements AuthServiceInterface
 {
     private const BCRYPT_COST = 12;
 
-    private const SESSION_USER_ID = 'auth_user_id';
-    private const SESSION_USERNAME = 'auth_username';
+    private const AUTH_TABLE_PREFIX = 'auth_';
 
     private \mysqli $db;
+    private Auth $auth;
+    private ?string $lastError = null;
 
     /** @var array<string, float|int|string|null>|null Cached user info row */
     private ?array $cachedUserInfo = null;
 
-    public function __construct(\mysqli $db)
+    /**
+     * @param \mysqli $db MySQLi connection for profile queries (nuke_users)
+     * @param Auth|null $auth Optional Auth instance (for testing; production uses PdoConnection singleton)
+     */
+    public function __construct(\mysqli $db, ?Auth $auth = null)
     {
         $this->db = $db;
+        $this->auth = $auth ?? new Auth(
+            PdoConnection::getInstance(),
+            null,
+            self::AUTH_TABLE_PREFIX,
+            true,
+        );
     }
 
-    public function attempt(string $username, string $password): bool
+    public function attempt(string $username, string $password, ?int $rememberDuration = null): bool
     {
-        $stmt = $this->db->prepare(
-            'SELECT user_id, username, user_password FROM nuke_users WHERE username = ?'
-        );
-        if ($stmt === false) {
-            return false;
-        }
-        $stmt->bind_param('s', $username);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        if ($result === false) {
-            $stmt->close();
-            return false;
-        }
-        /** @var array{user_id: int, username: string, user_password: string}|null $row */
-        $row = $result->fetch_assoc();
-        $stmt->close();
+        $this->lastError = null;
 
-        if ($row === null) {
-            return false;
-        }
-
-        $storedHash = $row['user_password'];
-
-        // 1. Try bcrypt verification first
-        if (password_verify($password, $storedHash)) {
-            // Re-hash if cost parameters have changed
-            if (password_needs_rehash($storedHash, PASSWORD_BCRYPT, ['cost' => self::BCRYPT_COST])) {
-                $this->upgradeHash($row['username'], $password);
-            }
-            $this->startSession($row['user_id'], $row['username']);
+        try {
+            $this->auth->loginWithUsername($username, $password, $rememberDuration);
+            $this->cachedUserInfo = null;
             return true;
+        } catch (\Delight\Auth\UnknownUsernameException) {
+            $this->lastError = 'Invalid username or password.';
+            return false;
+        } catch (\Delight\Auth\AmbiguousUsernameException) {
+            $this->lastError = 'Invalid username or password.';
+            return false;
+        } catch (\Delight\Auth\InvalidPasswordException) {
+            $this->lastError = 'Invalid username or password.';
+            return false;
+        } catch (\Delight\Auth\EmailNotVerifiedException) {
+            $this->lastError = 'Please verify your email address before logging in.';
+            return false;
+        } catch (\Delight\Auth\TooManyRequestsException) {
+            $this->lastError = 'Too many login attempts. Please try again later.';
+            return false;
+        } catch (\Delight\Auth\AuthError) {
+            $this->lastError = 'An authentication error occurred. Please try again.';
+            return false;
         }
-
-        // 2. MD5 transitional fallback — upgrade hash on success
-        if ($storedHash !== '' && md5($password) === $storedHash) {
-            $this->upgradeHash($row['username'], $password);
-            $this->startSession($row['user_id'], $row['username']);
-            return true;
-        }
-
-        return false;
     }
 
     public function isAuthenticated(): bool
     {
-        return isset($_SESSION[self::SESSION_USER_ID])
-            && is_int($_SESSION[self::SESSION_USER_ID])
-            && $_SESSION[self::SESSION_USER_ID] > 0;
+        return $this->auth->isLoggedIn();
     }
 
     public function getUserId(): ?int
@@ -93,9 +85,8 @@ class AuthService implements AuthServiceInterface
         if (!$this->isAuthenticated()) {
             return null;
         }
-        $userId = $_SESSION[self::SESSION_USER_ID];
-        \assert(is_int($userId));
-        return $userId;
+
+        return $this->auth->getUserId();
     }
 
     public function getUsername(): ?string
@@ -103,9 +94,8 @@ class AuthService implements AuthServiceInterface
         if (!$this->isAuthenticated()) {
             return null;
         }
-        $username = $_SESSION[self::SESSION_USERNAME];
-        \assert(is_string($username));
-        return $username;
+
+        return $this->auth->getUsername();
     }
 
     public function getUserInfo(): ?array
@@ -114,18 +104,18 @@ class AuthService implements AuthServiceInterface
             return null;
         }
 
+        $username = $this->getUsername();
+        if ($username === null) {
+            return null;
+        }
+
         // Return cached info if available and username matches
         if ($this->cachedUserInfo !== null) {
             $cachedUsername = $this->cachedUserInfo['username'] ?? '';
             \assert(is_string($cachedUsername));
-            if ($cachedUsername === $this->getUsername()) {
+            if ($cachedUsername === $username) {
                 return $this->cachedUserInfo;
             }
-        }
-
-        $username = $this->getUsername();
-        if ($username === null) {
-            return null;
         }
 
         $stmt = $this->db->prepare('SELECT * FROM nuke_users WHERE username = ?');
@@ -160,7 +150,6 @@ class AuthService implements AuthServiceInterface
 
         /** @var array{user_id: int, username: string, user_password: string, storynum: int|string, umode: string, uorder: int|string, thold: int|string, noscore: int|string, ublockon: int|string, theme: string, commentmax: int|string} $userInfo */
 
-        // Match the legacy cookie format: uid:username:password:storynum:umode:uorder:thold:noscore:ublockon:theme:commentmax
         return [
             (int) $userInfo['user_id'],
             $userInfo['username'],
@@ -178,10 +167,11 @@ class AuthService implements AuthServiceInterface
 
     public function logout(): void
     {
-        unset(
-            $_SESSION[self::SESSION_USER_ID],
-            $_SESSION[self::SESSION_USERNAME],
-        );
+        try {
+            $this->auth->logOut();
+        } catch (\Delight\Auth\AuthError) {
+            // Best-effort logout — session destruction may fail in edge cases
+        }
         $this->cachedUserInfo = null;
     }
 
@@ -190,34 +180,145 @@ class AuthService implements AuthServiceInterface
         return password_hash($password, PASSWORD_BCRYPT, ['cost' => self::BCRYPT_COST]);
     }
 
-    /**
-     * Start an authenticated session for the given user
-     */
-    private function startSession(int $userId, string $username): void
+    public function isAdmin(): bool
     {
-        // Regenerate session ID to prevent session fixation
-        if (session_status() === PHP_SESSION_ACTIVE) {
-            session_regenerate_id(true);
+        if (!$this->isAuthenticated()) {
+            return false;
         }
 
-        $_SESSION[self::SESSION_USER_ID] = $userId;
-        $_SESSION[self::SESSION_USERNAME] = $username;
+        try {
+            return $this->auth->hasRole(Role::ADMIN);
+        } catch (\Delight\Auth\AuthError) {
+            return false;
+        }
+    }
 
-        // Clear cached user info so it gets re-fetched
-        $this->cachedUserInfo = null;
+    public function register(string $email, string $password, string $username, ?callable $emailCallback = null): int
+    {
+        $this->lastError = null;
+
+        try {
+            $userId = $this->auth->registerWithUniqueUsername($email, $password, $username, $emailCallback);
+
+            // Create a matching profile row in nuke_users
+            $this->createNukeUserProfile($userId, $username, $email, $password);
+
+            return $userId;
+        } catch (\Delight\Auth\InvalidEmailException) {
+            $this->lastError = 'The email address is invalid.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\InvalidPasswordException) {
+            $this->lastError = 'The password is invalid or too short.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\UserAlreadyExistsException) {
+            $this->lastError = 'A user with this email address already exists.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\DuplicateUsernameException) {
+            $this->lastError = 'This username is already taken.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\TooManyRequestsException) {
+            $this->lastError = 'Too many registration attempts. Please try again later.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\AuthError $e) {
+            $this->lastError = 'Registration failed. Please try again.';
+            throw new \RuntimeException($this->lastError, 0, $e);
+        }
+    }
+
+    public function confirmEmail(string $selector, string $token): array
+    {
+        $this->lastError = null;
+
+        try {
+            $emailPair = $this->auth->confirmEmailAndSignIn($selector, $token);
+            /** @var array<string, mixed> */
+            return ['old_email' => $emailPair[0] ?? null, 'new_email' => $emailPair[1] ?? null];
+        } catch (\Delight\Auth\InvalidSelectorTokenPairException) {
+            $this->lastError = 'Invalid or expired confirmation link.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\TokenExpiredException) {
+            $this->lastError = 'This confirmation link has expired. Please register again.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\UserAlreadyExistsException) {
+            $this->lastError = 'This email has already been confirmed.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\TooManyRequestsException) {
+            $this->lastError = 'Too many attempts. Please try again later.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\AuthError $e) {
+            $this->lastError = 'Email confirmation failed. Please try again.';
+            throw new \RuntimeException($this->lastError, 0, $e);
+        }
+    }
+
+    public function forgotPassword(string $email, callable $callback): void
+    {
+        $this->lastError = null;
+
+        try {
+            $this->auth->forgotPassword($email, $callback);
+        } catch (\Delight\Auth\InvalidEmailException) {
+            // Silently ignore — don't reveal whether the email exists
+        } catch (\Delight\Auth\EmailNotVerifiedException) {
+            // Silently ignore — don't reveal account status
+        } catch (\Delight\Auth\ResetDisabledException) {
+            // Silently ignore — don't reveal account status
+        } catch (\Delight\Auth\TooManyRequestsException) {
+            $this->lastError = 'Too many password reset attempts. Please try again later.';
+        } catch (\Delight\Auth\AuthError) {
+            // Silently ignore — don't reveal internal errors for password reset
+        }
+    }
+
+    public function resetPassword(string $selector, string $token, string $newPassword): void
+    {
+        $this->lastError = null;
+
+        try {
+            $this->auth->resetPassword($selector, $token, $newPassword);
+        } catch (\Delight\Auth\InvalidSelectorTokenPairException) {
+            $this->lastError = 'Invalid or expired password reset link.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\TokenExpiredException) {
+            $this->lastError = 'This password reset link has expired. Please request a new one.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\ResetDisabledException) {
+            $this->lastError = 'Password reset is not available for this account.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\InvalidPasswordException) {
+            $this->lastError = 'The new password is invalid or too short.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\TooManyRequestsException) {
+            $this->lastError = 'Too many attempts. Please try again later.';
+            throw new \RuntimeException($this->lastError);
+        } catch (\Delight\Auth\AuthError $e) {
+            $this->lastError = 'Password reset failed. Please try again.';
+            throw new \RuntimeException($this->lastError, 0, $e);
+        }
+    }
+
+    public function getLastError(): ?string
+    {
+        return $this->lastError;
     }
 
     /**
-     * Upgrade a user's password hash from MD5 to bcrypt
+     * Create a matching nuke_users profile row for a newly registered user
+     *
+     * This ensures legacy code that queries nuke_users for profile data continues working.
      */
-    private function upgradeHash(string $username, string $plaintext): void
+    private function createNukeUserProfile(int $userId, string $username, string $email, string $password): void
     {
-        $newHash = $this->hashPassword($plaintext);
-        $stmt = $this->db->prepare('UPDATE nuke_users SET user_password = ? WHERE username = ?');
+        $hashedPassword = $this->hashPassword($password);
+        $regDate = date('F d, Y');
+
+        $stmt = $this->db->prepare(
+            'INSERT INTO nuke_users (user_id, username, user_email, user_password, user_regdate, storynum, umode, uorder, thold, noscore, ublockon, theme, commentmax) VALUES (?, ?, ?, ?, ?, 10, \'\', 0, 0, 0, 0, \'\', 4096)',
+        );
         if ($stmt === false) {
             return;
         }
-        $stmt->bind_param('ss', $newHash, $username);
+        $stmt->bind_param('issss', $userId, $username, $email, $hashedPassword, $regDate);
         $stmt->execute();
         $stmt->close();
     }

--- a/ibl5/classes/Auth/Contracts/AuthServiceInterface.php
+++ b/ibl5/classes/Auth/Contracts/AuthServiceInterface.php
@@ -7,27 +7,28 @@ namespace Auth\Contracts;
 /**
  * AuthServiceInterface - Contract for user authentication
  *
- * Handles password verification, session management, and backward-compatible
- * cookie array generation for legacy PHP-Nuke code.
+ * Wraps delight-im/auth with backward-compatible methods for legacy PHP-Nuke code.
+ * Handles login, registration, email verification, password reset, remember-me,
+ * login throttling, and admin role checking.
+ *
+ * @phpstan-type UserRow array{user_id: int, username: string, user_password: string, storynum: int, umode: string, uorder: int, thold: int, noscore: int, ublockon: int, theme: string, commentmax: int, user_email: string, user_regdate: string, name: string}
  */
 interface AuthServiceInterface
 {
     /**
      * Attempt to authenticate a user with username and password
      *
-     * Verifies the password against the stored hash (bcrypt first, MD5 fallback
-     * for transitional upgrade). On success, starts a session and returns true.
-     *
      * @param string $username The username to authenticate
      * @param string $password The plaintext password
+     * @param int|null $rememberDuration Seconds to keep the user logged in via remember-me cookie (null = session only)
      * @return bool True if authentication succeeded
      */
-    public function attempt(string $username, string $password): bool;
+    public function attempt(string $username, string $password, ?int $rememberDuration = null): bool;
 
     /**
      * Check if the current session is authenticated
      *
-     * @return bool True if a user is logged in via session
+     * @return bool True if a user is logged in
      */
     public function isAuthenticated(): bool;
 
@@ -66,7 +67,7 @@ interface AuthServiceInterface
     public function getCookieArray(): ?array;
 
     /**
-     * Log out the current user by clearing session auth keys
+     * Log out the current user (clears session and remember-me tokens)
      */
     public function logout(): void;
 
@@ -77,4 +78,55 @@ interface AuthServiceInterface
      * @return string The bcrypt hash
      */
     public function hashPassword(string $password): string;
+
+    /**
+     * Check if the authenticated user has the admin role
+     *
+     * @return bool True if the current user is an admin
+     */
+    public function isAdmin(): bool;
+
+    /**
+     * Register a new user account
+     *
+     * @param string $email The email address
+     * @param string $password The plaintext password
+     * @param string $username The username
+     * @param callable|null $emailCallback Optional callback that receives ($selector, $token) for email verification
+     * @return int The new user's ID
+     */
+    public function register(string $email, string $password, string $username, ?callable $emailCallback = null): int;
+
+    /**
+     * Confirm a user's email address using selector and token from the verification link
+     *
+     * @param string $selector The selector from the verification link
+     * @param string $token The token from the verification link
+     * @return array<string, mixed> Confirmation result data
+     */
+    public function confirmEmail(string $selector, string $token): array;
+
+    /**
+     * Initiate a password reset for the given email address
+     *
+     * @param string $email The user's email address
+     * @param callable $callback Callback that receives ($selector, $token) for the reset email
+     */
+    public function forgotPassword(string $email, callable $callback): void;
+
+    /**
+     * Reset a user's password using selector and token from the reset link
+     *
+     * @param string $selector The selector from the reset link
+     * @param string $token The token from the reset link
+     * @param string $newPassword The new plaintext password
+     */
+    public function resetPassword(string $selector, string $token, string $newPassword): void;
+
+    /**
+     * Get the last error message from a failed auth operation
+     *
+     * @return string|null The error message or null if no error
+     */
+    public function getLastError(): ?string;
 }

--- a/ibl5/classes/Auth/README.md
+++ b/ibl5/classes/Auth/README.md
@@ -1,0 +1,73 @@
+# Auth Module
+
+## Overview
+
+The Auth module handles user authentication for IBL5, wrapping the [delight-im/auth](https://github.com/delight-im/PHP-Auth) library behind the existing `AuthServiceInterface`. This provides modern auth features while maintaining backward compatibility with 100+ legacy PHP-Nuke callsites.
+
+## Architecture
+
+```
+Auth/
+├── Contracts/
+│   └── AuthServiceInterface.php  # Interface for all auth operations
+├── AuthService.php               # Implementation wrapping delight-im/auth
+└── README.md                     # This file
+
+Database/
+└── PdoConnection.php             # PDO singleton for delight-im/auth
+```
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Login (username/password) | Active | Via `attempt()` with bcrypt verification |
+| Registration | Active | Via `register()` with email verification |
+| Email verification | Active | Via `confirmEmail()` with selector/token |
+| Password reset | Active | Via `forgotPassword()` / `resetPassword()` |
+| Remember me | Active | 30-day cookie via `attempt($user, $pass, $duration)` |
+| Login throttling | Active | Built into delight-im/auth |
+| Admin role checking | Active | Via `isAdmin()` checking `Role::ADMIN` bitmask |
+| CSRF protection | Active | Via `CsrfGuard` on all auth forms |
+| Legacy `$cookie` compat | Active | Via `getCookieArray()` |
+| Legacy `$userinfo` compat | Active | Via `getUserInfo()` |
+
+## Database Tables
+
+Authentication data is stored in `auth_*` tables (managed by delight-im/auth):
+
+| Table | Purpose |
+|-------|---------|
+| `auth_users` | Core accounts (email, password, roles_mask) |
+| `auth_users_confirmations` | Email verification tokens |
+| `auth_users_remembered` | Remember-me tokens |
+| `auth_users_resets` | Password reset tokens |
+| `auth_users_throttling` | Login rate limiting |
+
+Profile data remains in `nuke_users`. IDs match 1:1 between `auth_users.id` and `nuke_users.user_id`.
+
+## Admin Roles
+
+Admin status is determined by the `roles_mask` column in `auth_users`:
+
+```php
+// Role::ADMIN = 1 (bit 0)
+$authService->isAdmin(); // checks if current user has ADMIN role
+```
+
+The `nuke_authors` table is deprecated — admin authentication now goes through the same `AuthService` as regular users, with an additional role check.
+
+## Legacy Compatibility
+
+The following global functions continue to work unchanged:
+
+| Function | Behavior |
+|----------|----------|
+| `is_user($user)` | Delegates to `$authService->isAuthenticated()` |
+| `is_admin($admin)` | Delegates to `$authService->isAdmin()` |
+| `cookiedecode($user)` | Delegates to `$authService->getCookieArray()` |
+| `getusrinfo($user)` | Delegates to `$authService->getUserInfo()` |
+
+## Migration
+
+See `migrations/034_create_auth_tables.sql` and `migrations/035_migrate_users_to_auth.sql` for the data migration steps.

--- a/ibl5/classes/Database/PdoConnection.php
+++ b/ibl5/classes/Database/PdoConnection.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database;
+
+/**
+ * PDO connection singleton for the delight-im/auth library
+ *
+ * The rest of the application continues to use mysqli ($mysqli_db).
+ * This class provides the PDO instance required by \Delight\Auth\Auth,
+ * reading the same config.php globals used by db/db.php.
+ */
+class PdoConnection
+{
+    private static ?\PDO $instance = null;
+
+    /**
+     * Get the singleton PDO connection
+     *
+     * Reads $dbhost, $dbuname, $dbpass, $dbname from config.php globals.
+     * Must be called after config.php has been included.
+     */
+    public static function getInstance(): \PDO
+    {
+        if (self::$instance !== null) {
+            return self::$instance;
+        }
+
+        /**
+         * @var string $dbhost
+         * @var string $dbuname
+         * @var string $dbpass
+         * @var string $dbname
+         */
+        global $dbhost, $dbuname, $dbpass, $dbname;
+
+        $dsn = 'mysql:host=' . $dbhost . ';dbname=' . $dbname . ';charset=utf8mb4';
+
+        self::$instance = new \PDO(
+            $dsn,
+            $dbuname,
+            $dbpass,
+            [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+                \PDO::ATTR_EMULATE_PREPARES => false,
+            ],
+        );
+
+        return self::$instance;
+    }
+
+    /**
+     * Create a PDO connection with explicit credentials (for testing / standalone scripts)
+     *
+     * @param string $host Database host
+     * @param string $username Database username
+     * @param string $password Database password
+     * @param string $database Database name
+     */
+    public static function createWithCredentials(
+        string $host,
+        string $username,
+        string $password,
+        string $database,
+    ): \PDO {
+        $dsn = 'mysql:host=' . $host . ';dbname=' . $database . ';charset=utf8mb4';
+
+        return new \PDO(
+            $dsn,
+            $username,
+            $password,
+            [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+                \PDO::ATTR_EMULATE_PREPARES => false,
+            ],
+        );
+    }
+
+    /**
+     * Reset the singleton (for testing)
+     */
+    public static function reset(): void
+    {
+        self::$instance = null;
+    }
+}

--- a/ibl5/composer.json
+++ b/ibl5/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
-        "php": ">=8.3"
+        "php": ">=8.3",
+        "delight-im/auth": "^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^12.4",

--- a/ibl5/composer.lock
+++ b/ibl5/composer.lock
@@ -4,8 +4,348 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b453e643d46c406d2fb4646828f348c",
-    "packages": [],
+    "content-hash": "4f753e5a0b3b9694c344cf7a95fb43de",
+    "packages": [
+        {
+            "name": "delight-im/auth",
+            "version": "v9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/delight-im/PHP-Auth.git",
+                "reference": "ef996fd2ae63c5afc04bd31e2d1b66f548446f50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/delight-im/PHP-Auth/zipball/ef996fd2ae63c5afc04bd31e2d1b66f548446f50",
+                "reference": "ef996fd2ae63c5afc04bd31e2d1b66f548446f50",
+                "shasum": ""
+            },
+            "require": {
+                "delight-im/base64": "^1.0",
+                "delight-im/cookie": "^3.1",
+                "delight-im/db": "^1.5",
+                "delight-im/otp": "^1.0",
+                "ext-openssl": "*",
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Delight\\Auth\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Authentication for PHP. Simple, lightweight and secure.",
+            "homepage": "https://github.com/delight-im/PHP-Auth",
+            "keywords": [
+                "Authentication",
+                "auth",
+                "login",
+                "security"
+            ],
+            "support": {
+                "issues": "https://github.com/delight-im/PHP-Auth/issues",
+                "source": "https://github.com/delight-im/PHP-Auth/tree/v9.0.0"
+            },
+            "time": "2025-05-28T15:47:58+00:00"
+        },
+        {
+            "name": "delight-im/base64",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/delight-im/PHP-Base64.git",
+                "reference": "687b2a49f663e162030a8d27b32838bbe7f91c78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/delight-im/PHP-Base64/zipball/687b2a49f663e162030a8d27b32838bbe7f91c78",
+                "reference": "687b2a49f663e162030a8d27b32838bbe7f91c78",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Delight\\Base64\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Simple and convenient Base64 encoding and decoding for PHP",
+            "homepage": "https://github.com/delight-im/PHP-Base64",
+            "keywords": [
+                "URL-safe",
+                "base-64",
+                "base64",
+                "decode",
+                "decoding",
+                "encode",
+                "encoding",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/delight-im/PHP-Base64/issues",
+                "source": "https://github.com/delight-im/PHP-Base64/tree/master"
+            },
+            "time": "2017-07-24T18:59:51+00:00"
+        },
+        {
+            "name": "delight-im/cookie",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/delight-im/PHP-Cookie.git",
+                "reference": "67065d34272377d63bab0bd58f984f9b228c803f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/delight-im/PHP-Cookie/zipball/67065d34272377d63bab0bd58f984f9b228c803f",
+                "reference": "67065d34272377d63bab0bd58f984f9b228c803f",
+                "shasum": ""
+            },
+            "require": {
+                "delight-im/http": "^2.0",
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Delight\\Cookie\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Modern cookie management for PHP",
+            "homepage": "https://github.com/delight-im/PHP-Cookie",
+            "keywords": [
+                "cookie",
+                "cookies",
+                "csrf",
+                "http",
+                "same-site",
+                "samesite",
+                "xss"
+            ],
+            "support": {
+                "issues": "https://github.com/delight-im/PHP-Cookie/issues",
+                "source": "https://github.com/delight-im/PHP-Cookie/tree/v3.4.0"
+            },
+            "time": "2020-04-16T11:01:26+00:00"
+        },
+        {
+            "name": "delight-im/db",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/delight-im/PHP-DB.git",
+                "reference": "c613571382fa76359abc6de71d19738d7b7f1d13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/delight-im/PHP-DB/zipball/c613571382fa76359abc6de71d19738d7b7f1d13",
+                "reference": "c613571382fa76359abc6de71d19738d7b7f1d13",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pdo": "*",
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Delight\\Db\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Safe and convenient SQL database access in a driver-agnostic way",
+            "homepage": "https://github.com/delight-im/PHP-DB",
+            "keywords": [
+                "database",
+                "mysql",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "sql",
+                "sqlite"
+            ],
+            "support": {
+                "issues": "https://github.com/delight-im/PHP-DB/issues",
+                "source": "https://github.com/delight-im/PHP-DB/tree/v1.5.0"
+            },
+            "time": "2025-05-26T16:39:50+00:00"
+        },
+        {
+            "name": "delight-im/http",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/delight-im/PHP-HTTP.git",
+                "reference": "a5c2c4eae1dd3207f797984e8f64f2d71ed889dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/delight-im/PHP-HTTP/zipball/a5c2c4eae1dd3207f797984e8f64f2d71ed889dd",
+                "reference": "a5c2c4eae1dd3207f797984e8f64f2d71ed889dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Delight\\Http\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Hypertext Transfer Protocol (HTTP) utilities for PHP",
+            "homepage": "https://github.com/delight-im/PHP-HTTP",
+            "keywords": [
+                "headers",
+                "http",
+                "https"
+            ],
+            "support": {
+                "issues": "https://github.com/delight-im/PHP-HTTP/issues",
+                "source": "https://github.com/delight-im/PHP-HTTP/tree/v2.1.0"
+            },
+            "time": "2021-10-12T18:52:29+00:00"
+        },
+        {
+            "name": "delight-im/otp",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/delight-im/PHP-OTP.git",
+                "reference": "eb6a5520e13f793dd12f4530ca69549570c99232"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/delight-im/PHP-OTP/zipball/eb6a5520e13f793dd12f4530ca69549570c99232",
+                "reference": "eb6a5520e13f793dd12f4530ca69549570c99232",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "paragonie/constant_time_encoding": "~1.1.0 || ~2.7.0",
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Delight\\Otp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "One-time password (OTP) implementation for two-factor authentication with TOTP in accordance with RFC 6238 and RFC 4226",
+            "homepage": "https://github.com/delight-im/PHP-OTP",
+            "keywords": [
+                "2fa",
+                "google-authenticator",
+                "hotp",
+                "otp",
+                "rfc-4226",
+                "rfc-6238",
+                "rfc4226",
+                "rfc6238",
+                "tfa",
+                "totp",
+                "two-factor",
+                "two-factor-authentication"
+            ],
+            "support": {
+                "issues": "https://github.com/delight-im/PHP-OTP/issues",
+                "source": "https://github.com/delight-im/PHP-OTP/tree/v1.0.2"
+            },
+            "time": "2025-08-04T10:06:20+00:00"
+        },
+        {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "52a0d99e69f56b9ec27ace92ba56897fe6993105"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/52a0d99e69f56b9ec27ace92ba56897fe6993105",
+                "reference": "52a0d99e69f56b9ec27ace92ba56897fe6993105",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6|^7|^8|^9",
+                "vimeo/psalm": "^1|^2|^3|^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2024-05-08T12:18:48+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "myclabs/deep-copy",

--- a/ibl5/migrations/034_create_auth_tables.sql
+++ b/ibl5/migrations/034_create_auth_tables.sql
@@ -1,0 +1,70 @@
+-- Migration 034: Create delight-im/auth tables
+--
+-- These tables are required by the delight-im/auth library (v9.0).
+-- Table names use the `auth_` prefix to avoid collision with existing tables.
+-- All tables use InnoDB for foreign key support and transactional safety.
+
+-- Core user accounts (authentication data only; profile data stays in nuke_users)
+CREATE TABLE IF NOT EXISTS `auth_users` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `email` varchar(249) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `password` varchar(255) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
+  `username` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` tinyint unsigned NOT NULL DEFAULT '0',
+  `verified` tinyint unsigned NOT NULL DEFAULT '0',
+  `resettable` tinyint unsigned NOT NULL DEFAULT '1',
+  `roles_mask` int unsigned NOT NULL DEFAULT '0',
+  `registered` int unsigned NOT NULL,
+  `last_login` int unsigned DEFAULT NULL,
+  `force_logout` mediumint unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Email verification / confirmation tokens
+CREATE TABLE IF NOT EXISTS `auth_users_confirmations` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int unsigned NOT NULL,
+  `email` varchar(249) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `selector` varchar(16) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
+  `token` varchar(255) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
+  `expires` int unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `selector` (`selector`),
+  KEY `email_expires` (`email`, `expires`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Remember-me tokens
+CREATE TABLE IF NOT EXISTS `auth_users_remembered` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `user` int unsigned NOT NULL,
+  `selector` varchar(24) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
+  `token` varchar(255) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
+  `expires` int unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `selector` (`selector`),
+  KEY `user` (`user`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Password reset tokens
+CREATE TABLE IF NOT EXISTS `auth_users_resets` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `user` int unsigned NOT NULL,
+  `selector` varchar(20) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
+  `token` varchar(255) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
+  `expires` int unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `selector` (`selector`),
+  KEY `user_expires` (`user`, `expires`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Login rate-limiting / throttling
+CREATE TABLE IF NOT EXISTS `auth_users_throttling` (
+  `bucket` varchar(44) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
+  `tokens` float NOT NULL,
+  `replenished_at` int unsigned NOT NULL,
+  `expires_at` int unsigned NOT NULL,
+  PRIMARY KEY (`bucket`),
+  KEY `expires_at` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/ibl5/migrations/035_migrate_users_to_auth.sql
+++ b/ibl5/migrations/035_migrate_users_to_auth.sql
@@ -1,0 +1,47 @@
+-- Migration 035: Migrate existing users from nuke_users to auth_users
+--
+-- Strategy: Matched IDs — auth_users.id = nuke_users.user_id (1:1 mapping).
+-- nuke_users remains the profile table; auth_users owns authentication.
+--
+-- Password handling:
+--   - bcrypt hashes ($2y$...) are copied directly (compatible with password_verify)
+--   - MD5 hashes (32-char hex) cannot be used by delight-im/auth — those users
+--     will need to use password reset on first login
+--
+-- Run this AFTER 034_create_auth_tables.sql
+
+-- 1. Copy all users with valid user_id
+INSERT INTO auth_users (id, email, password, username, status, verified, resettable, roles_mask, registered, last_login)
+SELECT
+    nu.user_id,
+    nu.user_email,
+    nu.user_password,
+    nu.username,
+    0,  -- status: normal (0 = normal in delight-im/auth)
+    1,  -- verified: all existing users are pre-verified
+    1,  -- resettable: allow password resets
+    0,  -- roles_mask: regular user (no special roles)
+    UNIX_TIMESTAMP(STR_TO_DATE(nu.user_regdate, '%M %d, %Y')),  -- convert regdate string to unix timestamp
+    NULL  -- last_login: unknown
+FROM nuke_users nu
+WHERE nu.user_id > 0
+  AND nu.username <> ''
+  AND nu.user_email <> ''
+ON DUPLICATE KEY UPDATE id = id;  -- skip if already migrated
+
+-- 2. Set auto_increment past existing user IDs so new registrations get fresh IDs
+-- Note: This must be run as a prepared statement or manually since ALTER TABLE
+-- doesn't support subqueries directly in all MySQL versions.
+-- Run this manually: ALTER TABLE auth_users AUTO_INCREMENT = <MAX_USER_ID + 1>;
+SET @max_id = (SELECT COALESCE(MAX(user_id), 0) + 1 FROM nuke_users);
+SET @sql = CONCAT('ALTER TABLE auth_users AUTO_INCREMENT = ', @max_id);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- 3. Assign admin role to users who have corresponding nuke_authors entries
+-- Role::ADMIN = 1 in delight-im/auth's Role class
+UPDATE auth_users au
+INNER JOIN nuke_users nu ON au.id = nu.user_id
+INNER JOIN nuke_authors na ON LOWER(nu.username) = LOWER(na.aid)
+SET au.roles_mask = au.roles_mask | 1;  -- bit 0 = ADMIN role

--- a/ibl5/migrations/036_cleanup_legacy_auth.sql
+++ b/ibl5/migrations/036_cleanup_legacy_auth.sql
@@ -1,0 +1,28 @@
+-- Migration 036: Cleanup legacy auth tables (run AFTER confirming all admins can log in)
+--
+-- WARNING: Only run this migration after verifying:
+-- 1. All admin users can log in via the new AuthService
+-- 2. All regular users can log in, register, and reset passwords
+-- 3. The old nuke_authors table data has been backed up
+--
+-- This migration:
+-- - Drops the nuke_authors table (admin auth now via auth_users roles_mask)
+-- - Drops the nuke_users_temp table (registration now via auth_users_confirmations)
+-- - Marks nuke_users.user_password as deprecated (auth now in auth_users)
+
+-- Back up nuke_authors before dropping (create a copy table)
+CREATE TABLE IF NOT EXISTS nuke_authors_backup AS SELECT * FROM nuke_authors;
+
+-- Drop the legacy admin table
+-- DROP TABLE IF EXISTS nuke_authors;
+
+-- Back up nuke_users_temp before dropping
+CREATE TABLE IF NOT EXISTS nuke_users_temp_backup AS SELECT * FROM nuke_users_temp;
+
+-- Drop the legacy temp registration table
+-- DROP TABLE IF EXISTS nuke_users_temp;
+
+-- Note: The DROP statements are commented out for safety.
+-- Uncomment them only after confirming the migration is successful.
+-- The nuke_users.user_password column is kept for backward compatibility
+-- but authentication now happens via auth_users.

--- a/ibl5/modules/YourAccount/index.php
+++ b/ibl5/modules/YourAccount/index.php
@@ -132,6 +132,7 @@ function confirmNewUser($username, $user_email, $user_password, $user_password2,
             . "<input type=\"hidden\" name=\"username\" value=\"$username\">"
             . "<input type=\"hidden\" name=\"user_email\" value=\"$user_email\">"
             . "<input type=\"hidden\" name=\"user_password\" value=\"$user_password\">"
+            . \Utilities\CsrfGuard::generateToken('register') . ""
             . "<input type=\"hidden\" name=\"op\" value=\"finish\"><br><br>"
             . "<input type=\"submit\" value=\"" . _FINISH . "\"> &nbsp;&nbsp;" . _GOBACK . "</form></center>";
         CloseTable();
@@ -147,11 +148,17 @@ function confirmNewUser($username, $user_email, $user_password, $user_password2,
 function finishNewUser($username, $user_email, $user_password, $random_num, $gfx_check)
 {
     global $stop, $EditedMessage, $adminmail, $sitename, $Default_Theme, $user_prefix, $db, $storyhome, $module_name, $nukeurl, $authService;
+
+    // CSRF validation
+    if (!\Utilities\CsrfGuard::validateSubmittedToken('register')) {
+        Header("Location: modules.php?name=$module_name&op=new_user");
+        die();
+    }
+
     Nuke\Header::header();
     include "config.php";
     userCheck($username, $user_email);
     $user_email = validate_mail($user_email);
-    $user_regdate = date("M d, Y");
     $user_password = stripslashes($user_password);
     if (!isset($stop)) {
         $datekey = date("F j");
@@ -161,25 +168,20 @@ function finishNewUser($username, $user_email, $user_password, $random_num, $gfx
             Header("Location: modules.php?name=$module_name");
             die();
         }
-        mt_srand((double) microtime() * 1000000);
-        $maxran = 1000000;
-        $check_num = mt_rand(0, $maxran);
-        $check_num = md5($check_num);
-        $time = time();
-        $finishlink = "$nukeurl/modules.php?name=$module_name&op=activate&username=$username&check_num=$check_num";
-        $new_password = $authService->hashPassword($user_password);
         $username = substr(htmlspecialchars(str_replace("\'", "'", trim($username))), 0, 25);
         $username = rtrim($username, "\\");
-        $username = str_replace("'", "\'", $username);
         $user_email = filter($user_email, "nohtml", 1);
-        $result = \DatabaseConnection::query("INSERT INTO nuke_users_temp (user_id, username, user_email, user_password, user_regdate, check_num, time) VALUES (NULL, ?, ?, ?, ?, ?, ?)", [$username, $user_email, $new_password, $user_regdate, $check_num, $time]);
-        if (!$result) {
-            echo "" . _ERROR . "<br>";
-        } else {
-            $message = "" . _WELCOMETO . " $sitename!\n\n" . _YOUUSEDEMAIL . " ($user_email) " . _TOREGISTER . " $sitename.\n\n " . _TOFINISHUSER . "\n\n $finishlink\n\n " . _FOLLOWINGMEM . "\n\n" . _UNICKNAME . " $username\n" . _UPASSWORD . " $user_password";
-            $subject = "" . _ACTIVATIONSUB . "";
-            $from = "$adminmail";
-            mail($user_email, $subject, $message, "From: $from\nX-Mailer: PHP/" . phpversion());
+
+        try {
+            // Register via delight-im/auth with email verification callback
+            $authService->register($user_email, $user_password, $username, static function (string $selector, string $token) use ($sitename, $adminmail, $nukeurl, $module_name, $user_email, $username): void {
+                $finishlink = "$nukeurl/modules.php?name=$module_name&op=confirm_email&selector=" . urlencode($selector) . "&token=" . urlencode($token);
+                $message = "" . _WELCOMETO . " $sitename!\n\n" . _YOUUSEDEMAIL . " ($user_email) " . _TOREGISTER . " $sitename.\n\n " . _TOFINISHUSER . "\n\n $finishlink\n\n " . _FOLLOWINGMEM . "\n\n" . _UNICKNAME . " $username";
+                $subject = "" . _ACTIVATIONSUB . "";
+                $from = "$adminmail";
+                mail($user_email, $subject, $message, "From: $from\nX-Mailer: PHP/" . phpversion());
+            });
+
             title("$sitename: " . _USERREGLOGIN . "");
             OpenTable();
             echo "<center><b>" . _ACCOUNTCREATED . "</b><br><br>";
@@ -187,6 +189,12 @@ function finishNewUser($username, $user_email, $user_password, $random_num, $gfx
                 . "<br><br>"
                 . "" . _FINISHUSERCONF . "<br><br>"
                 . "" . _THANKSUSER . " $sitename!</center>";
+            CloseTable();
+        } catch (\RuntimeException) {
+            $error = $authService->getLastError() ?? _ERROR;
+            OpenTable();
+            echo "<center><font class=\"title\"><b>Registration Error!</b></font><br><br>";
+            echo "<font class=\"content\">" . htmlspecialchars($error) . "<br>" . _GOBACK . "</font></center>";
             CloseTable();
         }
     } else {
@@ -197,44 +205,59 @@ function finishNewUser($username, $user_email, $user_password, $random_num, $gfx
 
 function activate($username, $check_num)
 {
-    global $db, $user_prefix, $module_name, $language, $prefix;
-    $username = substr(htmlspecialchars(str_replace("\'", "'", trim($username))), 0, 25);
-    $username = rtrim($username, "\\");
-    $username = str_replace("'", "\'", $username);
-    $past = time() - 86400;
-    \DatabaseConnection::query("DELETE FROM nuke_users_temp WHERE time < ?", [$past]);
-    $row = \DatabaseConnection::fetchRow("SELECT * FROM nuke_users_temp WHERE username = ? AND check_num = ?", [$username, $check_num]);
-    if ($row !== null) {
-        $user_password = htmlspecialchars(stripslashes($row['user_password']));
-        if ($check_num == $row['check_num']) {
-            \DatabaseConnection::query("INSERT INTO nuke_users (user_id, username, user_email, user_password, user_avatar, user_avatar_type, user_regdate, user_lang) VALUES (NULL, ?, ?, ?, '', '3', ?, ?)", [$row['username'], $row['user_email'], $user_password, $row['user_regdate'], $language]);
-            \DatabaseConnection::query("DELETE FROM nuke_users_temp WHERE username = ? AND check_num = ?", [$username, $check_num]);
-            Nuke\Header::header();
-            title("" . _ACTIVATIONYES . "");
-            OpenTable();
-            echo "<center><b>" . htmlspecialchars($row['username']) . ":</b> " . _ACTMSG . "</center>";
-            CloseTable();
-            Nuke\Footer::footer();
-            die();
-        } else {
-            Nuke\Header::header();
-            title("" . _ACTIVATIONERROR . "");
-            OpenTable();
-            echo "<center>" . _ACTERROR1 . "</center>";
-            CloseTable();
-            Nuke\Footer::footer();
-            die();
-        }
-    } else {
+    // Legacy activation route — redirect to confirm_email if selector/token params present
+    global $module_name;
+    if (isset($_GET['selector']) && isset($_GET['token'])) {
+        confirm_email();
+        return;
+    }
+
+    // Fallback for any remaining legacy activation links
+    Nuke\Header::header();
+    title("" . _ACTIVATIONERROR . "");
+    OpenTable();
+    echo "<center>" . _ACTERROR2 . "<br><br>"
+        . "Please <a href=\"modules.php?name=$module_name&op=new_user\">register again</a> to receive a new activation link.</center>";
+    CloseTable();
+    Nuke\Footer::footer();
+    die();
+}
+
+function confirm_email()
+{
+    global $authService, $module_name;
+    $selector = isset($_GET['selector']) ? trim($_GET['selector']) : '';
+    $token = isset($_GET['token']) ? trim($_GET['token']) : '';
+
+    if ($selector === '' || $token === '') {
         Nuke\Header::header();
         title("" . _ACTIVATIONERROR . "");
         OpenTable();
-        echo "<center>" . _ACTERROR2 . "</center>";
+        echo "<center>" . _ACTERROR1 . "</center>";
         CloseTable();
         Nuke\Footer::footer();
         die();
     }
 
+    try {
+        $authService->confirmEmail($selector, $token);
+        Nuke\Header::header();
+        title("" . _ACTIVATIONYES . "");
+        OpenTable();
+        echo "<center>" . _ACTMSG . "<br><br>"
+            . "<a href=\"modules.php?name=$module_name\">" . _USERLOGIN . "</a></center>";
+        CloseTable();
+        Nuke\Footer::footer();
+    } catch (\RuntimeException) {
+        $error = $authService->getLastError() ?? _ACTERROR1;
+        Nuke\Header::header();
+        title("" . _ACTIVATIONERROR . "");
+        OpenTable();
+        echo "<center>" . htmlspecialchars($error) . "</center>";
+        CloseTable();
+        Nuke\Footer::footer();
+    }
+    die();
 }
 
 function userinfo($username, $bypass = 0, $hid = 0, $url = 0)
@@ -627,10 +650,12 @@ function main($user)
                     . "<tr><td colspan='2'>" . _TYPESECCODE . ": <input type=\"text\" NAME=\"gfx_check\" SIZE=\"7\" MAXLENGTH=\"6\"></td></tr>\n"
                     . "<input type=\"hidden\" name=\"random_num\" value=\"$random_num\">\n";
             }
-            echo "</table><input type=\"hidden\" name=\"redirect\" value=\"$redirect\">\n"
+            echo "<tr><td colspan='2'><label><input type=\"checkbox\" name=\"remember_me\" value=\"1\"> " . _REMEMBERME . "</label></td></tr>\n"
+                . "</table><input type=\"hidden\" name=\"redirect\" value=\"$redirect\">\n"
                 . "<input type=\"hidden\" name=\"mode\" value=$mode>\n"
                 . "<input type=\"hidden\" name=\"f\" value=$f>\n"
                 . "<input type=\"hidden\" name=\"t\" value=$t>\n"
+                . \Utilities\CsrfGuard::generateToken('login') . "\n"
                 . "<input type=\"hidden\" name=\"op\" value=\"login\">\n"
                 . "<input type=\"submit\" value=\"" . _LOGIN . "\"></form><br>\n\n"
                 . "<center><font class=\"content\">[ <a href=\"modules.php?name=$module_name&amp;op=pass_lost\">" . _PASSWORDLOST . "</a> | <a href=\"modules.php?name=$module_name&amp;op=new_user\">" . _REGNEWUSER . "</a> ]</font></center>\n";
@@ -743,8 +768,8 @@ function pass_lost()
             . "" . _NOPROBLEM . "<br><br>\n"
             . "<form action=\"modules.php?name=$module_name\" method=\"post\">\n"
             . "<table border=\"0\"><tr><td>\n"
-            . "" . _NICKNAME . ":</td><td><input type=\"text\" name=\"username\" size=\"15\" maxlength=\"25\"></td></tr>\n"
-            . "<tr><td>" . _CONFIRMATIONCODE . ":</td><td><input type=\"text\" name=\"code\" size=\"11\" maxlength=\"10\"></td></tr></table><br>\n"
+            . "" . _EMAIL . ":</td><td><input type=\"email\" name=\"user_email\" size=\"30\" maxlength=\"255\"></td></tr></table><br>\n"
+            . \Utilities\CsrfGuard::generateToken('forgot_password') . "\n"
             . "<input type=\"hidden\" name=\"op\" value=\"mailpasswd\">\n"
             . "<input type=\"submit\" value=\"" . _SENDPASSWORD . "\"></form><br>\n"
             . "<center><font class=\"content\">[ <a href=\"modules.php?name=$module_name\">" . _USERLOGIN . "</a> | <a href=\"modules.php?name=$module_name&amp;op=new_user\">" . _REGNEWUSER . "</a> ]</font></center>\n";
@@ -754,6 +779,82 @@ function pass_lost()
         global $cookie;
         cookiedecode($user);
         userinfo($cookie[1]);
+    }
+}
+
+function reset_password_form()
+{
+    global $user, $module_name;
+    if (is_user($user)) {
+        Header("Location: modules.php?name=$module_name");
+        die();
+    }
+    $selector = isset($_GET['selector']) ? htmlspecialchars(trim($_GET['selector'])) : '';
+    $token = isset($_GET['token']) ? htmlspecialchars(trim($_GET['token'])) : '';
+    if ($selector === '' || $token === '') {
+        Header("Location: modules.php?name=$module_name&op=pass_lost");
+        die();
+    }
+    Nuke\Header::header();
+    OpenTable();
+    echo "<center><font class=\"title\"><b>" . _PASSWORDRESET . "</b></font></center>\n";
+    CloseTable();
+    echo "<br>\n";
+    OpenTable();
+    echo "<b>" . _ENTERNEWPASSWORD . "</b><br><br>\n"
+        . "<form action=\"modules.php?name=$module_name\" method=\"post\">\n"
+        . "<table border=\"0\">\n"
+        . "<tr><td>" . _NEWPASSWORD . ":</td><td><input type=\"password\" name=\"new_password\" size=\"20\" maxlength=\"60\"></td></tr>\n"
+        . "<tr><td>" . _CONFIRMPASSWORD . ":</td><td><input type=\"password\" name=\"new_password2\" size=\"20\" maxlength=\"60\"></td></tr>\n"
+        . "</table><br>\n"
+        . "<input type=\"hidden\" name=\"selector\" value=\"$selector\">\n"
+        . "<input type=\"hidden\" name=\"token\" value=\"$token\">\n"
+        . \Utilities\CsrfGuard::generateToken('reset_password') . "\n"
+        . "<input type=\"hidden\" name=\"op\" value=\"do_reset_password\">\n"
+        . "<input type=\"submit\" value=\"" . _RESETPASSWORD . "\"></form>\n";
+    CloseTable();
+    Nuke\Footer::footer();
+}
+
+function do_reset_password()
+{
+    global $authService, $module_name;
+
+    // CSRF validation
+    if (!\Utilities\CsrfGuard::validateSubmittedToken('reset_password')) {
+        Header("Location: modules.php?name=$module_name&op=pass_lost");
+        die();
+    }
+
+    $selector = isset($_POST['selector']) ? trim($_POST['selector']) : '';
+    $token = isset($_POST['token']) ? trim($_POST['token']) : '';
+    $newPassword = isset($_POST['new_password']) ? $_POST['new_password'] : '';
+    $newPassword2 = isset($_POST['new_password2']) ? $_POST['new_password2'] : '';
+
+    if ($newPassword !== $newPassword2) {
+        Nuke\Header::header();
+        OpenTable();
+        echo "<center><b>" . _PASSDIFFERENT . "</b><br><br>" . _GOBACK . "</center>";
+        CloseTable();
+        Nuke\Footer::footer();
+        return;
+    }
+
+    try {
+        $authService->resetPassword($selector, $token, $newPassword);
+        Nuke\Header::header();
+        OpenTable();
+        echo "<center><b>" . _PASSWORDCHANGED . "</b><br><br>"
+            . "<a href=\"modules.php?name=$module_name\">" . _USERLOGIN . "</a></center>";
+        CloseTable();
+        Nuke\Footer::footer();
+    } catch (\RuntimeException) {
+        $error = $authService->getLastError() ?? _ERROR;
+        Nuke\Header::header();
+        OpenTable();
+        echo "<center><b>" . htmlspecialchars($error) . "</b><br><br>" . _GOBACK . "</center>";
+        CloseTable();
+        Nuke\Footer::footer();
     }
 }
 
@@ -792,59 +893,48 @@ function logout()
     Nuke\Footer::footer();
 }
 
-function mail_password($username, $code)
+function mail_password()
 {
-    global $sitename, $adminmail, $nukeurl, $user_prefix, $db, $module_name, $authService, $mysqli_db;
-    $username = substr(htmlspecialchars(str_replace("\'", "'", trim($username))), 0, 25);
-    $username = rtrim($username, "\\");
-    $username = str_replace("'", "\'", $username);
-    $sql = "SELECT user_email, user_actkey FROM " . $user_prefix . "_users WHERE username='$username'";
-    $result = $db->sql_query($sql);
-    if ($db->sql_numrows($result) == 0) {
+    global $sitename, $adminmail, $nukeurl, $module_name, $authService;
+
+    // CSRF validation
+    if (!\Utilities\CsrfGuard::validateSubmittedToken('forgot_password')) {
+        Header("Location: modules.php?name=$module_name&op=pass_lost");
+        die();
+    }
+
+    $user_email = isset($_POST['user_email']) ? filter($_POST['user_email'], "nohtml", 1) : '';
+    if ($user_email === '') {
         Nuke\Header::header();
         OpenTable();
         echo "<center>" . _SORRYNOUSERINFO . "</center>";
         CloseTable();
         Nuke\Footer::footer();
-    } else {
-        $host_name = $_SERVER['REMOTE_ADDR'];
-        $row = $db->sql_fetchrow($result);
-        $user_email = filter($row['user_email'], "nohtml");
-        // Use user_actkey as reset verification code (no longer derived from password hash)
-        $storedCode = $row['user_actkey'] ?? '';
-        if ($storedCode !== '' && $storedCode === $code) {
-            $newpass = makepass();
-            $message = "" . _USERACCOUNT . " '$username' " . _AT . " $sitename " . _HASTHISEMAIL . "  " . _AWEBUSERFROM . " $host_name " . _HASREQUESTED . "\n\n" . _YOURNEWPASSWORD . " $newpass\n\n " . _YOUCANCHANGE . " $nukeurl/modules.php?name=$module_name\n\n" . _IFYOUDIDNOTASK . "";
-            $subject = "" . _USERPASSWORD4 . " $username";
-            mail($user_email, $subject, $message, "From: $adminmail\nX-Mailer: PHP/" . phpversion());
-            /* Update password and clear the reset code */
-            $cryptpass = $authService->hashPassword($newpass);
-            $stmtReset = $mysqli_db->prepare("UPDATE " . $user_prefix . "_users SET user_password = ?, user_actkey = NULL WHERE username = ?");
-            $stmtReset->bind_param('ss', $cryptpass, $username);
-            $stmtReset->execute();
-            $stmtReset->close();
-            Nuke\Header::header();
-            OpenTable();
-            echo "<center>" . _PASSWORD4 . " $username " . _MAILED . "<br><br>" . _GOBACK . "</center>";
-            CloseTable();
-            Nuke\Footer::footer();
-        } else {
-            /* Generate a new reset code and email it */
-            $resetCode = substr(bin2hex(random_bytes(5)), 0, 10);
-            $stmtCode = $mysqli_db->prepare("UPDATE " . $user_prefix . "_users SET user_actkey = ? WHERE username = ?");
-            $stmtCode->bind_param('ss', $resetCode, $username);
-            $stmtCode->execute();
-            $stmtCode->close();
-            $message = "" . _USERACCOUNT . " '$username' " . _AT . " $sitename " . _HASTHISEMAIL . " " . _AWEBUSERFROM . " $host_name " . _CODEREQUESTED . "\n\n" . _YOURCODEIS . " $resetCode \n\n" . _WITHTHISCODE . " $nukeurl/modules.php?name=$module_name&op=pass_lost\n" . _IFYOUDIDNOTASK2 . "";
-            $subject = "" . _CODEFOR . " $username";
-            mail($user_email, $subject, $message, "From: $adminmail\nX-Mailer: PHP/" . phpversion());
-            Nuke\Header::header();
-            OpenTable();
-            echo "<center>" . _CODEFOR . " $username " . _MAILED . "<br><br>" . _GOBACK . "</center>";
-            CloseTable();
-            Nuke\Footer::footer();
-        }
+        return;
     }
+
+    // Use delight-im/auth's built-in password reset with secure tokens
+    $authService->forgotPassword($user_email, static function (string $selector, string $token) use ($sitename, $adminmail, $nukeurl, $module_name, $user_email): void {
+        $resetLink = "$nukeurl/modules.php?name=$module_name&op=reset_password&selector=" . urlencode($selector) . "&token=" . urlencode($token);
+        $message = "" . _PASSWORDRESETREQUEST . " $sitename.\n\n"
+            . "" . _CLICKRESETLINK . "\n\n$resetLink\n\n"
+            . "" . _LINKEXPIRES6HOURS . "\n\n"
+            . "" . _IFYOUDIDNOTASK . "";
+        $subject = "" . _PASSWORDRESET . " - $sitename";
+        mail($user_email, $subject, $message, "From: $adminmail\nX-Mailer: PHP/" . phpversion());
+    });
+
+    // Always show success message (don't reveal if email exists)
+    Nuke\Header::header();
+    OpenTable();
+    $lastError = $authService->getLastError();
+    if ($lastError !== null) {
+        echo "<center>" . htmlspecialchars($lastError) . "<br><br>" . _GOBACK . "</center>";
+    } else {
+        echo "<center>" . _RESETEMAILSENT . "<br><br>" . _GOBACK . "</center>";
+    }
+    CloseTable();
+    Nuke\Footer::footer();
 }
 
 function docookie($setuid, $setusername, $setpass, $setstorynum, $setumode, $setuorder, $setthold, $setnoscore, $setublockon, $settheme, $setcommentmax)
@@ -855,6 +945,13 @@ function docookie($setuid, $setusername, $setpass, $setstorynum, $setumode, $set
 function login($username, $user_password, $redirect, $mode, $f, $t, $random_num, $gfx_check)
 {
     global $authService, $user_prefix, $db, $mysqli_db, $module_name, $pm_login, $prefix;
+
+    // CSRF validation
+    if (!\Utilities\CsrfGuard::validateSubmittedToken('login')) {
+        Header("Location: modules.php?name=$module_name&stop=1");
+        die();
+    }
+
     $user_password = stripslashes($user_password);
     include "config.php";
 
@@ -867,8 +964,13 @@ function login($username, $user_password, $redirect, $mode, $f, $t, $random_num,
         die();
     }
 
-    // Authenticate via AuthService (handles bcrypt + MD5 transitional upgrade)
-    if ($authService->attempt($username, $user_password)) {
+    // Remember-me: 30 days if checkbox was checked, null for session-only
+    $rememberDuration = (isset($_POST['remember_me']) && $_POST['remember_me'] === '1')
+        ? (int) (60 * 60 * 24 * 30)
+        : null;
+
+    // Authenticate via AuthService (delight-im/auth with remember-me and throttling)
+    if ($authService->attempt($username, $user_password, $rememberDuration)) {
         $uname = $_SERVER['REMOTE_ADDR'];
 
         // Clean up guest session for this IP
@@ -1720,7 +1822,7 @@ switch ($op) {
         break;
 
     case "mailpasswd":
-        mail_password($username, $code);
+        mail_password();
         break;
 
     case "userinfo":
@@ -1791,6 +1893,18 @@ switch ($op) {
 
     case "activate":
         activate($username, $check_num);
+        break;
+
+    case "confirm_email":
+        confirm_email();
+        break;
+
+    case "reset_password":
+        reset_password_form();
+        break;
+
+    case "do_reset_password":
+        do_reset_password();
         break;
 
     case "CoolSize":

--- a/ibl5/modules/YourAccount/language/lang-english.php
+++ b/ibl5/modules/YourAccount/language/lang-english.php
@@ -243,3 +243,16 @@ define("_KARMABADREF", "Users marked with <i>Bad Karma</i> can post comments but
 define("_KARMADEVIL", "Devil Karma");
 define("_KARMADEVILHLP", "This user is a devil and his comments will not be published");
 define("_KARMADEVILREF", "Users marked with <i>Devil Karma</i> are very bad. This users are not allowed to post comments. All his content is just ignored and nothing will be published.");
+
+// Auth migration: delight-im/auth integration
+define("_REMEMBERME", "Remember me");
+define("_PASSWORDRESET", "Password Reset");
+define("_RESETPASSWORD", "Reset Password");
+define("_ENTERNEWPASSWORD", "Enter your new password below.");
+define("_NEWPASSWORD", "New Password");
+define("_CONFIRMPASSWORD", "Confirm Password");
+define("_PASSWORDCHANGED", "Your password has been changed successfully. You can now log in with your new password.");
+define("_PASSWORDRESETREQUEST", "A password reset has been requested for your account at");
+define("_CLICKRESETLINK", "Click the link below to reset your password:");
+define("_LINKEXPIRES6HOURS", "This link will expire in 6 hours.");
+define("_RESETEMAILSENT", "If an account with that email address exists, a password reset link has been sent. Please check your inbox.");

--- a/ibl5/phpunit.ci.xml
+++ b/ibl5/phpunit.ci.xml
@@ -127,5 +127,11 @@
         <testsuite name="Integration Tests">
             <directory>tests/Integration</directory>
         </testsuite>
+        <testsuite name="Auth Module Tests">
+            <directory>tests/Auth</directory>
+        </testsuite>
+        <testsuite name="Database Module Tests">
+            <directory>tests/Database</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -190,5 +190,11 @@
         <testsuite name="LeagueConfig Module Tests">
             <directory>tests/LeagueConfig</directory>
         </testsuite>
+        <testsuite name="Auth Module Tests">
+            <directory>tests/Auth</directory>
+        </testsuite>
+        <testsuite name="Database Module Tests">
+            <directory>tests/Database</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/ibl5/tests/Auth/AuthServiceTest.php
+++ b/ibl5/tests/Auth/AuthServiceTest.php
@@ -5,44 +5,21 @@ declare(strict_types=1);
 namespace Tests\Auth;
 
 use Auth\AuthService;
+use Auth\Contracts\AuthServiceInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
- * AuthServiceTest - Unit tests for session-based authentication
+ * AuthServiceTest - Unit tests for AuthService
  *
- * Tests that do not require a real database connection.
- * For attempt/upgrade tests, use a real DB or integration test.
+ * Tests that do not require a database connection (password hashing, interface compliance).
+ * Auth-dependent methods (login, register, etc.) require integration tests with a real DB.
  */
 class AuthServiceTest extends TestCase
 {
-    private AuthService $authService;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        // Create AuthService with a mock mysqli (stub for non-DB tests)
-        $mockMysqli = static::createStub(\mysqli::class);
-        $this->authService = new AuthService($mockMysqli);
-
-        // Start a test session if not already started
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
-        // Clear session auth keys before each test
-        unset($_SESSION['auth_user_id'], $_SESSION['auth_username']);
-    }
-
-    protected function tearDown(): void
-    {
-        // Clean up session
-        unset($_SESSION['auth_user_id'], $_SESSION['auth_username']);
-        parent::tearDown();
-    }
-
     public function testHashPasswordProducesBcryptHash(): void
     {
-        $hash = $this->authService->hashPassword('testpassword');
+        $authService = $this->createAuthServiceForHashTests();
+        $hash = $authService->hashPassword('testpassword');
 
         self::assertStringStartsWith('$2y$', $hash);
         self::assertGreaterThanOrEqual(60, strlen($hash));
@@ -50,115 +27,117 @@ class AuthServiceTest extends TestCase
 
     public function testHashPasswordProducesVerifiableHash(): void
     {
+        $authService = $this->createAuthServiceForHashTests();
         $password = 'my-secure-password';
-        $hash = $this->authService->hashPassword($password);
+        $hash = $authService->hashPassword($password);
 
         self::assertTrue(password_verify($password, $hash));
     }
 
     public function testHashPasswordWithDifferentPasswordsFails(): void
     {
-        $hash = $this->authService->hashPassword('correct-password');
+        $authService = $this->createAuthServiceForHashTests();
+        $hash = $authService->hashPassword('correct-password');
 
         self::assertFalse(password_verify('wrong-password', $hash));
     }
 
     public function testHashPasswordUsesCost12(): void
     {
-        $hash = $this->authService->hashPassword('test');
+        $authService = $this->createAuthServiceForHashTests();
+        $hash = $authService->hashPassword('test');
 
         // bcrypt hash format: $2y$12$...
         self::assertStringStartsWith('$2y$12$', $hash);
     }
 
-    public function testIsAuthenticatedReturnsFalseByDefault(): void
-    {
-        self::assertFalse($this->authService->isAuthenticated());
-    }
-
-    public function testIsAuthenticatedReturnsTrueWithSession(): void
-    {
-        $_SESSION['auth_user_id'] = 42;
-        $_SESSION['auth_username'] = 'testuser';
-
-        self::assertTrue($this->authService->isAuthenticated());
-    }
-
-    public function testIsAuthenticatedReturnsFalseWithZeroUserId(): void
-    {
-        $_SESSION['auth_user_id'] = 0;
-        $_SESSION['auth_username'] = 'testuser';
-
-        self::assertFalse($this->authService->isAuthenticated());
-    }
-
-    public function testIsAuthenticatedReturnsFalseWithNonIntUserId(): void
-    {
-        $_SESSION['auth_user_id'] = 'not-an-int';
-        $_SESSION['auth_username'] = 'testuser';
-
-        self::assertFalse($this->authService->isAuthenticated());
-    }
-
-    public function testGetUserIdReturnsNullWhenNotAuthenticated(): void
-    {
-        self::assertNull($this->authService->getUserId());
-    }
-
-    public function testGetUserIdReturnsIdWhenAuthenticated(): void
-    {
-        $_SESSION['auth_user_id'] = 42;
-        $_SESSION['auth_username'] = 'testuser';
-
-        self::assertSame(42, $this->authService->getUserId());
-    }
-
-    public function testGetUsernameReturnsNullWhenNotAuthenticated(): void
-    {
-        self::assertNull($this->authService->getUsername());
-    }
-
-    public function testGetUsernameReturnsUsernameWhenAuthenticated(): void
-    {
-        $_SESSION['auth_user_id'] = 42;
-        $_SESSION['auth_username'] = 'testuser';
-
-        self::assertSame('testuser', $this->authService->getUsername());
-    }
-
-    public function testLogoutClearsSession(): void
-    {
-        $_SESSION['auth_user_id'] = 42;
-        $_SESSION['auth_username'] = 'testuser';
-
-        self::assertTrue($this->authService->isAuthenticated());
-
-        $this->authService->logout();
-
-        self::assertFalse($this->authService->isAuthenticated());
-        self::assertArrayNotHasKey('auth_user_id', $_SESSION);
-        self::assertArrayNotHasKey('auth_username', $_SESSION);
-    }
-
-    public function testGetUserInfoReturnsNullWhenNotAuthenticated(): void
-    {
-        self::assertNull($this->authService->getUserInfo());
-    }
-
-    public function testGetCookieArrayReturnsNullWhenNotAuthenticated(): void
-    {
-        self::assertNull($this->authService->getCookieArray());
-    }
-
     public function testHashPasswordProducesUniqueHashes(): void
     {
-        $hash1 = $this->authService->hashPassword('same-password');
-        $hash2 = $this->authService->hashPassword('same-password');
+        $authService = $this->createAuthServiceForHashTests();
+        $hash1 = $authService->hashPassword('same-password');
+        $hash2 = $authService->hashPassword('same-password');
 
         // bcrypt includes a random salt, so two hashes of the same password differ
         self::assertNotSame($hash1, $hash2);
         // But both verify against the original password
         self::assertTrue(password_verify('same-password', $hash1));
         self::assertTrue(password_verify('same-password', $hash2));
+    }
+
+    public function testImplementsAuthServiceInterface(): void
+    {
+        $authService = $this->createAuthServiceForHashTests();
+        self::assertInstanceOf(AuthServiceInterface::class, $authService);
+    }
+
+    public function testGetLastErrorReturnsNullInitially(): void
+    {
+        $authService = $this->createAuthServiceForHashTests();
+        self::assertNull($authService->getLastError());
+    }
+
+    /**
+     * Create AuthService with a real PDO + Auth for password hash tests.
+     * Uses an in-memory SQLite database to avoid needing MySQL.
+     */
+    private function createAuthServiceForHashTests(): AuthService
+    {
+        $mockMysqli = self::createStub(\mysqli::class);
+
+        // Create an in-memory SQLite database with the required auth tables
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        // Create the auth tables that delight-im/auth needs
+        $pdo->exec('CREATE TABLE IF NOT EXISTS auth_users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email VARCHAR(249) NOT NULL UNIQUE,
+            password VARCHAR(255) NOT NULL DEFAULT \'\',
+            username VARCHAR(100) DEFAULT NULL,
+            status TINYINT NOT NULL DEFAULT 0,
+            verified TINYINT NOT NULL DEFAULT 0,
+            resettable TINYINT NOT NULL DEFAULT 1,
+            roles_mask INTEGER NOT NULL DEFAULT 0,
+            registered INTEGER NOT NULL,
+            last_login INTEGER DEFAULT NULL,
+            force_logout INTEGER NOT NULL DEFAULT 0
+        )');
+        $pdo->exec('CREATE TABLE IF NOT EXISTS auth_users_confirmations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            email VARCHAR(249) NOT NULL,
+            selector VARCHAR(16) NOT NULL UNIQUE,
+            token VARCHAR(255) NOT NULL,
+            expires INTEGER NOT NULL
+        )');
+        $pdo->exec('CREATE TABLE IF NOT EXISTS auth_users_remembered (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user INTEGER NOT NULL,
+            selector VARCHAR(24) NOT NULL UNIQUE,
+            token VARCHAR(255) NOT NULL,
+            expires INTEGER NOT NULL
+        )');
+        $pdo->exec('CREATE TABLE IF NOT EXISTS auth_users_resets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user INTEGER NOT NULL,
+            selector VARCHAR(20) NOT NULL UNIQUE,
+            token VARCHAR(255) NOT NULL,
+            expires INTEGER NOT NULL
+        )');
+        $pdo->exec('CREATE TABLE IF NOT EXISTS auth_users_throttling (
+            bucket VARCHAR(44) PRIMARY KEY,
+            tokens REAL NOT NULL,
+            replenished_at INTEGER NOT NULL,
+            expires_at INTEGER NOT NULL
+        )');
+
+        // Start session if needed (Auth constructor may need it)
+        if (session_status() === \PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        $auth = new \Delight\Auth\Auth($pdo, null, 'auth_', false);
+
+        return new AuthService($mockMysqli, $auth);
     }
 }

--- a/ibl5/tests/Database/PdoConnectionTest.php
+++ b/ibl5/tests/Database/PdoConnectionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Database;
+
+use Database\PdoConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * PdoConnectionTest - Unit tests for PdoConnection singleton
+ */
+class PdoConnectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        PdoConnection::reset();
+        parent::tearDown();
+    }
+
+    public function testResetClearsSingleton(): void
+    {
+        PdoConnection::reset();
+
+        // After reset, getInstance() should create a fresh connection
+        // (would need config.php globals; just verify reset doesn't throw)
+        self::assertTrue(true);
+    }
+
+    public function testCreateWithCredentialsThrowsOnInvalidHost(): void
+    {
+        $this->expectException(\PDOException::class);
+
+        PdoConnection::createWithCredentials(
+            'invalid-host-that-does-not-exist',
+            'nobody',
+            'nopass',
+            'nodb',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **Replace legacy PHP-Nuke auth** (MD5 cookies, `nuke_authors` table) with `delight-im/auth` v9.0 session-based authentication
- **Wrap the library** behind the existing `AuthServiceInterface` so 100+ legacy callsites (`is_user()`, `is_admin()`, `$cookie`, `$userinfo`) continue working unchanged
- **Add missing auth features**: email verification, password reset, remember-me, login throttling, and admin role checking via bitmask

## Changes

### Infrastructure
- Add `delight-im/auth ^9.0` via Composer
- Create `PdoConnection` singleton (only PDO touchpoint; rest of app stays on mysqli)

### Database Migrations
- `034_create_auth_tables.sql` — 5 InnoDB tables (`auth_users`, `auth_users_confirmations`, `auth_users_remembered`, `auth_users_resets`, `auth_users_throttling`)
- `035_migrate_users_to_auth.sql` — migrate `nuke_users` data with matched IDs, assign admin roles from `nuke_authors`
- `036_cleanup_legacy_auth.sql` — backup legacy tables (`nuke_authors`, `nuke_users_temp`)

### AuthService Rewrite
- Full rewrite wrapping `\Delight\Auth\Auth` with exception handling
- New interface methods: `register()`, `confirmEmail()`, `forgotPassword()`, `resetPassword()`, `isAdmin()`, `getLastError()`
- `attempt()` updated to accept optional `?int $rememberDuration`

### Legacy Compatibility
- `is_admin()` now delegates to `$authService->isAdmin()` (replaces MD5 cookie check)
- Removed admin cookie decode block from `mainfile.php`
- `is_user()`, `cookiedecode()`, `getusrinfo()` unchanged

### YourAccount Module
- Remember-me checkbox on login form
- Registration via `$authService->register()` with email verification callback
- Password reset via `forgotPassword()`/`resetPassword()` flow
- CSRF protection on all auth forms

### Admin Panel
- Session-based login replaces MD5 cookie login
- CSRF validation on admin login form

### Tests
- Rewritten `AuthServiceTest` using in-memory SQLite (Auth class is `final`)
- New `PdoConnectionTest`

## Test plan

- [ ] Run full PHPUnit test suite (2902 tests passing)
- [ ] Run PHPStan at level max (0 errors)
- [ ] Execute migration SQL files against local database
- [ ] Test login/logout flow for regular users
- [ ] Test login/logout flow for admin users
- [ ] Test remember-me functionality
- [ ] Test registration with email verification
- [ ] Test password reset flow
- [ ] Verify `is_user()`, `is_admin()`, `$cookie`, `$userinfo` globals work for existing modules
- [ ] Verify login throttling activates after repeated failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)