### PR TITLE
fix: correct column name mismatch in historical team stats

### DIFF
--- a/ibl5/classes/Player/PlayerStats.php
+++ b/ibl5/classes/Player/PlayerStats.php
@@ -322,16 +322,16 @@ class PlayerStats implements PlayerStatsInterface
      */
     protected function fillHistorical(array $plrRow): void
     {
-        /** @var array{gm: ?int, min: ?int, fgm: ?int, fga: ?int, ftm: ?int, fta: ?int, '3gm': ?int, '3ga': ?int, orb: ?int, reb: ?int, ast: ?int, stl: ?int, blk: ?int, tvr: ?int, pf: ?int, ...} $plrRow */
+        /** @var array{games: ?int, minutes: ?int, fgm: ?int, fga: ?int, ftm: ?int, fta: ?int, tgm: ?int, tga: ?int, orb: ?int, reb: ?int, ast: ?int, stl: ?int, blk: ?int, tvr: ?int, pf: ?int, ...} $plrRow */
         $this->seasonGamesStarted = 0;
-        $this->seasonGamesPlayed = $plrRow['gm'] ?? 0;
-        $this->seasonMinutes = $plrRow['min'] ?? 0;
+        $this->seasonGamesPlayed = $plrRow['games'] ?? 0;
+        $this->seasonMinutes = $plrRow['minutes'] ?? 0;
         $this->seasonFieldGoalsMade = $plrRow['fgm'] ?? 0;
         $this->seasonFieldGoalsAttempted = $plrRow['fga'] ?? 0;
         $this->seasonFreeThrowsMade = $plrRow['ftm'] ?? 0;
         $this->seasonFreeThrowsAttempted = $plrRow['fta'] ?? 0;
-        $this->seasonThreePointersMade = $plrRow['3gm'] ?? 0;
-        $this->seasonThreePointersAttempted = $plrRow['3ga'] ?? 0;
+        $this->seasonThreePointersMade = $plrRow['tgm'] ?? 0;
+        $this->seasonThreePointersAttempted = $plrRow['tga'] ?? 0;
         $this->seasonOffensiveRebounds = $plrRow['orb'] ?? 0;
         $this->seasonTotalRebounds = $plrRow['reb'] ?? 0;
         $this->seasonDefensiveRebounds = $this->seasonTotalRebounds - $this->seasonOffensiveRebounds;


### PR DESCRIPTION
## Summary

- Fixed 4 column name mismatches in `PlayerStats::fillHistorical()` that caused historical team stats pages to display zeroes
- `gm`→`games`, `min`→`minutes`, `3gm`→`tgm`, `3ga`→`tga` to match actual `ibl_hist` table columns
- Updated PHPDoc array shape annotation to match corrected column names

## Affected Pages

- Season Totals (`display=total_s`): 3GM and 3GA columns now show real values
- Season Averages (`display=avg_s`): All per-game averages now populate (previously only FG%/FT% worked)
- Per 36 Minutes (`display=per36mins`): All per-36 stats now populate

## Test plan

- [x] Full PHPUnit test suite passes (2991 tests, 15852 assertions)
- [x] PHPStan clean (level max, strict-rules, bleedingEdge)
- [ ] Verify historical team page in browser: `modules.php?name=Team&op=team&teamID=13&yr=2005&display=total_s`
- [ ] Verify Season Averages: `display=avg_s` — all per-game averages populate
- [ ] Verify Per 36 Minutes: `display=per36mins` — all per-36 stats populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)