### PR TITLE
feat: switch home/away highs to box score data with RCB cross-validation

### DIFF
--- a/ibl5/classes/SeasonHighs/Contracts/SeasonHighsRepositoryInterface.php
+++ b/ibl5/classes/SeasonHighs/Contracts/SeasonHighsRepositoryInterface.php
@@ -30,7 +30,8 @@ interface SeasonHighsRepositoryInterface
         string $tableSuffix,
         string $startDate,
         string $endDate,
-        int $limit = 15
+        int $limit = 15,
+        ?string $locationFilter = null
     ): array;
 
     /**

--- a/ibl5/classes/SeasonHighs/Contracts/SeasonHighsServiceInterface.php
+++ b/ibl5/classes/SeasonHighs/Contracts/SeasonHighsServiceInterface.php
@@ -26,6 +26,8 @@ namespace SeasonHighs\Contracts;
  *
  * @phpstan-type RcbSeasonHighEntry array{stat_category: string, ranking: int, player_name: string, player_position: string|null, stat_value: int, record_season_year: int}
  *
+ * @phpstan-type RcbDiscrepancy array{context: string, stat: string, boxValue: int, boxPlayer: string, rcbValue: int, rcbPlayer: string}
+ *
  * @phpstan-type SeasonHighsData array{
  *     playerHighs: array<string, list<SeasonHighEntry>>,
  *     teamHighs: array<string, list<SeasonHighEntry>>
@@ -42,9 +44,19 @@ interface SeasonHighsServiceInterface
     public function getSeasonHighsData(string $seasonPhase): array;
 
     /**
-     * Get RCB-sourced home/away single-game records.
+     * Get home/away single-game records from box scores.
      *
-     * @return array{home: array<string, list<RcbSeasonHighEntry>>, away: array<string, list<RcbSeasonHighEntry>>}
+     * @param string $seasonPhase Season phase for date range calculation
+     * @return array{home: array<string, list<SeasonHighEntry>>, away: array<string, list<SeasonHighEntry>>}
      */
-    public function getHomeAwayHighs(): array;
+    public function getHomeAwayHighs(string $seasonPhase): array;
+
+    /**
+     * Validate box score home/away data against RCB records.
+     *
+     * @param array{home: array<string, list<SeasonHighEntry>>, away: array<string, list<SeasonHighEntry>>} $homeAwayData
+     * @param int $seasonYear Beginning year of the season
+     * @return list<RcbDiscrepancy>
+     */
+    public function validateAgainstRcb(array $homeAwayData, int $seasonYear): array;
 }

--- a/ibl5/classes/SeasonHighs/Contracts/SeasonHighsViewInterface.php
+++ b/ibl5/classes/SeasonHighs/Contracts/SeasonHighsViewInterface.php
@@ -10,7 +10,8 @@ namespace SeasonHighs\Contracts;
  * Provides method to render the season highs page.
  *
  * @phpstan-import-type SeasonHighsData from SeasonHighsServiceInterface
- * @phpstan-import-type RcbSeasonHighEntry from SeasonHighsServiceInterface
+ * @phpstan-import-type SeasonHighEntry from SeasonHighsServiceInterface
+ * @phpstan-import-type RcbDiscrepancy from SeasonHighsServiceInterface
  */
 interface SeasonHighsViewInterface
 {
@@ -24,10 +25,12 @@ interface SeasonHighsViewInterface
     public function render(string $seasonPhase, array $data): string;
 
     /**
-     * Render home/away season highs from RCB data.
+     * Render home/away season highs from box score data.
      *
-     * @param array{home: array<string, list<RcbSeasonHighEntry>>, away: array<string, list<RcbSeasonHighEntry>>} $data
+     * @param string $seasonPhase Current season phase
+     * @param array{home: array<string, list<SeasonHighEntry>>, away: array<string, list<SeasonHighEntry>>} $data
+     * @param list<RcbDiscrepancy> $discrepancies
      * @return string HTML output
      */
-    public function renderHomeAwayHighs(array $data): string;
+    public function renderHomeAwayHighs(string $seasonPhase, array $data, array $discrepancies): string;
 }

--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -1851,4 +1851,39 @@ td.record-book-retired-cell {
     padding-left: calc(0.5rem + 24px + 0.5rem) !important;
 }
 
+/* ==========================================================================
+   Season Highs Discrepancy Panel
+
+   Shows mismatches between box score data and RCB (Record Book) data
+   for admin cross-validation purposes.
+   ========================================================================== */
+
+.season-highs-discrepancy-panel {
+    margin-top: var(--space-6, 1.5rem);
+    padding: var(--space-4, 1rem);
+    border: 1px solid var(--amber-300, #fcd34d);
+    border-radius: var(--radius-lg, 0.5rem);
+    background: var(--amber-50, #fffbeb);
+}
+
+.discrepancy-panel-title {
+    font-family: var(--font-display, 'Barlow Condensed', -apple-system, BlinkMacSystemFont, sans-serif);
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--amber-800, #92400e);
+    margin-bottom: var(--space-3, 0.75rem);
+}
+
+.season-highs-discrepancy-panel .ibl-data-table {
+    font-size: 0.875rem;
+}
+
+.season-highs-discrepancy-panel .ibl-data-table thead {
+    background: var(--amber-600, #d97706);
+}
+
+.season-highs-discrepancy-panel .ibl-data-table td {
+    padding: var(--space-2, 0.5rem) var(--space-3, 0.75rem);
+}
+
 } /* end @layer components */

--- a/ibl5/modules/SeasonHighs/index.php
+++ b/ibl5/modules/SeasonHighs/index.php
@@ -45,12 +45,13 @@ $view = new SeasonHighsView();
 
 // Get season highs data
 $data = $service->getSeasonHighsData($seasonPhase);
-$homeAwayData = $service->getHomeAwayHighs();
+$homeAwayData = $service->getHomeAwayHighs($seasonPhase);
+$discrepancies = $service->validateAgainstRcb($homeAwayData, $season->beginningYear);
 
 // Render page
 PageLayout\PageLayout::header();
 
 echo $view->render($seasonPhase, $data);
-echo $view->renderHomeAwayHighs($homeAwayData);
+echo $view->renderHomeAwayHighs($seasonPhase, $homeAwayData, $discrepancies);
 
 PageLayout\PageLayout::footer();

--- a/ibl5/tests/SeasonHighs/SeasonHighsServiceTest.php
+++ b/ibl5/tests/SeasonHighs/SeasonHighsServiceTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\SeasonHighs;
 
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use SeasonHighs\Contracts\SeasonHighsRepositoryInterface;
 use SeasonHighs\Contracts\SeasonHighsServiceInterface;
@@ -13,30 +12,23 @@ use SeasonHighs\SeasonHighsService;
 /**
  * @covers \SeasonHighs\SeasonHighsService
  */
-#[AllowMockObjectsWithoutExpectations]
 class SeasonHighsServiceTest extends TestCase
 {
-    /** @var SeasonHighsRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private SeasonHighsRepositoryInterface $mockRepository;
-
-    protected function setUp(): void
-    {
-        $this->mockRepository = $this->createMock(SeasonHighsRepositoryInterface::class);
-    }
-
     public function testImplementsServiceInterface(): void
     {
-        $season = $this->createMockSeason(2024, 2025);
-        $service = new SeasonHighsService($this->mockRepository, $season);
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
 
         $this->assertInstanceOf(SeasonHighsServiceInterface::class, $service);
     }
 
     public function testGetSeasonHighsDataReturnsExpectedStructure(): void
     {
-        $this->mockRepository->method('getSeasonHighs')->willReturn([]);
-        $season = $this->createMockSeason(2024, 2025);
-        $service = new SeasonHighsService($this->mockRepository, $season);
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getSeasonHighs')->willReturn([]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
 
         $result = $service->getSeasonHighsData('Regular Season');
 
@@ -46,9 +38,10 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testGetSeasonHighsDataReturnsNineStatCategories(): void
     {
-        $this->mockRepository->method('getSeasonHighs')->willReturn([]);
-        $season = $this->createMockSeason(2024, 2025);
-        $service = new SeasonHighsService($this->mockRepository, $season);
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getSeasonHighs')->willReturn([]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
 
         $result = $service->getSeasonHighsData('Regular Season');
 
@@ -58,9 +51,10 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testGetSeasonHighsDataIncludesPointsStat(): void
     {
-        $this->mockRepository->method('getSeasonHighs')->willReturn([]);
-        $season = $this->createMockSeason(2024, 2025);
-        $service = new SeasonHighsService($this->mockRepository, $season);
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getSeasonHighs')->willReturn([]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
 
         $result = $service->getSeasonHighsData('Regular Season');
 
@@ -72,54 +66,282 @@ class SeasonHighsServiceTest extends TestCase
     public function testCallsRepositoryForPlayerAndTeamHighs(): void
     {
         // Each of 9 stats calls getSeasonHighs twice (player + team) = 18 calls
-        $this->mockRepository->expects($this->exactly(18))
+        $repo = $this->createMock(SeasonHighsRepositoryInterface::class);
+        $repo->expects($this->exactly(18))
             ->method('getSeasonHighs')
             ->willReturn([]);
-        $season = $this->createMockSeason(2024, 2025);
-        $service = new SeasonHighsService($this->mockRepository, $season);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
 
         $service->getSeasonHighsData('Regular Season');
     }
 
     public function testRegularSeasonUsesCorrectDateRange(): void
     {
-        $this->mockRepository->method('getSeasonHighs')
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getSeasonHighs')
             ->willReturnCallback(function (string $expr, string $name, string $suffix, string $start, string $end): array {
                 // Regular season: Nov 2024 to May 2025
                 $this->assertStringStartsWith('2024-11', $start);
                 $this->assertStringStartsWith('2025-05', $end);
                 return [];
             });
-        $season = $this->createMockSeason(2024, 2025);
-        $service = new SeasonHighsService($this->mockRepository, $season);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
 
         $service->getSeasonHighsData('Regular Season');
     }
 
     public function testPlayoffsUsesCorrectDateRange(): void
     {
-        $this->mockRepository->method('getSeasonHighs')
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getSeasonHighs')
             ->willReturnCallback(function (string $expr, string $name, string $suffix, string $start, string $end): array {
                 // Playoffs: June 2025
                 $this->assertStringStartsWith('2025-06', $start);
                 $this->assertStringStartsWith('2025-06', $end);
                 return [];
             });
-        $season = $this->createMockSeason(2024, 2025);
-        $service = new SeasonHighsService($this->mockRepository, $season);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
 
         $service->getSeasonHighsData('Playoffs');
     }
 
-    /**
-     * @return \Season&\PHPUnit\Framework\MockObject\MockObject
-     */
-    private function createMockSeason(int $beginningYear, int $endingYear): \Season
+    // --- Home/Away Highs Tests ---
+
+    public function testGetHomeAwayHighsReturnsHomeAndAwayKeys(): void
     {
-        $season = $this->createMock(\Season::class);
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getSeasonHighs')->willReturn([]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+
+        $result = $service->getHomeAwayHighs('Regular Season');
+
+        $this->assertArrayHasKey('home', $result);
+        $this->assertArrayHasKey('away', $result);
+    }
+
+    public function testGetHomeAwayHighsHasEightStatCategories(): void
+    {
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getSeasonHighs')->willReturn([]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+
+        $result = $service->getHomeAwayHighs('Regular Season');
+
+        $this->assertCount(8, $result['home']);
+        $this->assertCount(8, $result['away']);
+        $this->assertArrayNotHasKey('TURNOVERS', $result['home']);
+        $this->assertArrayNotHasKey('TURNOVERS', $result['away']);
+    }
+
+    public function testGetHomeAwayHighsPassesLocationFilter(): void
+    {
+        /** @var list<string|null> $locationFilters */
+        $locationFilters = [];
+
+        $repo = $this->createMock(SeasonHighsRepositoryInterface::class);
+        $repo->expects($this->exactly(16))
+            ->method('getSeasonHighs')
+            ->willReturnCallback(function (
+                string $expr,
+                string $name,
+                string $suffix,
+                string $start,
+                string $end,
+                int $limit = 15,
+                ?string $locationFilter = null
+            ) use (&$locationFilters): array {
+                $locationFilters[] = $locationFilter;
+                return [];
+            });
+
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+        $service->getHomeAwayHighs('Regular Season');
+
+        // 8 stats, each called twice (home then away) = 16 calls
+        $this->assertCount(16, $locationFilters);
+        $homeCount = 0;
+        $awayCount = 0;
+        foreach ($locationFilters as $i => $filter) {
+            if ($i % 2 === 0) {
+                $this->assertSame('home', $filter, "Call {$i} should be 'home'");
+                $homeCount++;
+            } else {
+                $this->assertSame('away', $filter, "Call {$i} should be 'away'");
+                $awayCount++;
+            }
+        }
+        $this->assertSame(8, $homeCount);
+        $this->assertSame(8, $awayCount);
+    }
+
+    public function testGetHomeAwayHighsUsesLimitOfTen(): void
+    {
+        $repo = $this->createMock(SeasonHighsRepositoryInterface::class);
+        $repo->expects($this->exactly(16))
+            ->method('getSeasonHighs')
+            ->willReturnCallback(function (
+                string $expr,
+                string $name,
+                string $suffix,
+                string $start,
+                string $end,
+                int $limit = 15,
+                ?string $locationFilter = null
+            ): array {
+                $this->assertSame(10, $limit);
+                return [];
+            });
+
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+        $service->getHomeAwayHighs('Regular Season');
+    }
+
+    // --- RCB Validation Tests ---
+
+    public function testValidateAgainstRcbReturnsEmptyWhenRcbEmpty(): void
+    {
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getRcbSeasonHighs')->willReturn([]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+
+        $homeAwayData = ['home' => ['POINTS' => [self::createBoxEntry()]], 'away' => []];
+        $result = $service->validateAgainstRcb($homeAwayData, 2024);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testValidateAgainstRcbReturnsEmptyWhenBoxScoreEmpty(): void
+    {
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getRcbSeasonHighs')->willReturn([
+            ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Test Player', 'player_position' => 'SF', 'stat_value' => 40, 'record_season_year' => 2024],
+        ]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+
+        $homeAwayData = ['home' => ['POINTS' => []], 'away' => ['POINTS' => []]];
+        $result = $service->validateAgainstRcb($homeAwayData, 2024);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testValidateAgainstRcbDetectsValueDiscrepancy(): void
+    {
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getRcbSeasonHighs')->willReturn([
+            ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Test Player', 'player_position' => 'SF', 'stat_value' => 50, 'record_season_year' => 2024],
+        ]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+
+        $homeAwayData = [
+            'home' => ['POINTS' => [self::createBoxEntry(['name' => 'Test Player', 'value' => 40])]],
+            'away' => [],
+        ];
+        $result = $service->validateAgainstRcb($homeAwayData, 2024);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('home', $result[0]['context']);
+        $this->assertSame('POINTS', $result[0]['stat']);
+        $this->assertSame(40, $result[0]['boxValue']);
+        $this->assertSame(50, $result[0]['rcbValue']);
+    }
+
+    public function testValidateAgainstRcbDetectsPlayerDiscrepancy(): void
+    {
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getRcbSeasonHighs')->willReturn([
+            ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Other Player', 'player_position' => 'PG', 'stat_value' => 40, 'record_season_year' => 2024],
+        ]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+
+        $homeAwayData = [
+            'home' => ['POINTS' => [self::createBoxEntry(['name' => 'Test Player', 'value' => 40])]],
+            'away' => [],
+        ];
+        $result = $service->validateAgainstRcb($homeAwayData, 2024);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Test Player', $result[0]['boxPlayer']);
+        $this->assertSame('Other Player', $result[0]['rcbPlayer']);
+    }
+
+    public function testValidateAgainstRcbAcceptsMatchingData(): void
+    {
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getRcbSeasonHighs')->willReturn([
+            ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Test Player', 'player_position' => 'SF', 'stat_value' => 40, 'record_season_year' => 2024],
+        ]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+
+        $homeAwayData = [
+            'home' => ['POINTS' => [self::createBoxEntry(['name' => 'Test Player', 'value' => 40])]],
+            'away' => [],
+        ];
+        $result = $service->validateAgainstRcb($homeAwayData, 2024);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testValidateAgainstRcbHandlesTruncatedNames(): void
+    {
+        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo->method('getRcbSeasonHighs')->willReturn([
+            ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Test Play', 'player_position' => 'SF', 'stat_value' => 40, 'record_season_year' => 2024],
+        ]);
+        $season = $this->createStubSeason(2024, 2025);
+        $service = new SeasonHighsService($repo, $season);
+
+        $homeAwayData = [
+            'home' => ['POINTS' => [self::createBoxEntry(['name' => 'Test Player', 'value' => 40])]],
+            'away' => [],
+        ];
+        $result = $service->validateAgainstRcb($homeAwayData, 2024);
+
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * @return \Season&\PHPUnit\Framework\MockObject\Stub
+     */
+    private function createStubSeason(int $beginningYear, int $endingYear): \Season
+    {
+        $season = $this->createStub(\Season::class);
         $season->beginningYear = $beginningYear;
         $season->endingYear = $endingYear;
 
         return $season;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array{name: string, date: string, value: int, pid: int, tid: int, teamname: string, color1: string, color2: string, boxId: int}
+     */
+    private static function createBoxEntry(array $overrides = []): array
+    {
+        $defaults = [
+            'name' => 'Test Player',
+            'date' => '2024-12-15',
+            'value' => 30,
+            'pid' => 1,
+            'tid' => 1,
+            'teamname' => 'Hawks',
+            'color1' => 'FF0000',
+            'color2' => '000000',
+            'boxId' => 100,
+        ];
+
+        /** @var array{name: string, date: string, value: int, pid: int, tid: int, teamname: string, color1: string, color2: string, boxId: int} */
+        return array_merge($defaults, $overrides);
     }
 }


### PR DESCRIPTION
## Summary

- **Switch home/away game highs from sparse RCB data to rich box score data** — gaining player thumbnails, team cells with colors, and dates linked to box scores
- **Add RCB cross-validation** that compares #1 box score entries against #1 RCB entries per stat/context, rendering an amber discrepancy panel when mismatches are detected
- **Clean up view layer** by removing 5 RCB-specific rendering methods and reusing `renderStatTable()` for home/away highs

## Changes

### Repository
- Add `?string $locationFilter` param to `getSeasonHighs()` — appends `AND bs.teamID = bs.homeTID` or `bs.visitorTID` (column-to-column, no extra bind params)
- Add `getRcbSeasonHighs()` for validation lookups

### Service
- Rewrite `getHomeAwayHighs()` to use box scores with 8 stats (no TURNOVERS), limit 10
- Add `validateAgainstRcb()` with `namesMatch()` prefix-matching helper
- Remove `RCB_STAT_LABELS`, `RCB_STAT_ORDER`, `groupRcbByCategory()`, `getRcbStatLabel()`

### View
- `renderHomeAwayHighs()` reuses `renderStatTable()` — shows player thumbnails, team cells, box score date links
- Add `renderDiscrepancies()` amber warning panel
- Remove `renderRcbStatTables()`, `renderRcbStatTable()`, `hasRcbData()`

### Tests
- 13 new tests (33 total): home/away structure, location filter, RCB validation scenarios, view rendering
- Refactored to use `createStub()` where no `expects()` configured

## Test plan

- [x] Full PHPUnit suite passes (3095 tests, 0 failures, 0 issues)
- [x] PHPStan clean (0 errors)
- [x] Load Season Highs page — verify home/away sections show thumbnails, team cells, box score links
- [x] Import RCB data and verify discrepancy panel appears/hides correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)