### PR TITLE
refactor: introduce CSS @layer architecture for deterministic cascade

### DIFF
--- a/.claude/rules/css-architecture.md
+++ b/.claude/rules/css-architecture.md
@@ -1,0 +1,120 @@
+# CSS Architecture Reference
+
+Auto-loads when editing `**/design/**/*.css` or `**/*View.php`.
+
+## Layer Hierarchy
+
+```
+@layer theme, base, reset, legacy, components, overrides, utilities;
+```
+
+| Layer | Priority | Contents | File(s) |
+|-------|----------|----------|---------|
+| `theme` | Lowest | Tailwind theme variables | Tailwind internal |
+| `base` | Low | Tailwind preflight/reset | Tailwind internal |
+| `reset` | ↑ | `box-sizing`, `html`/`body` base | `base.css` |
+| `legacy` | ↑ | PHP-Nuke element normalization, legacy classes, legacy layout | `base.css` |
+| `components` | Normal | All IBL component CSS + Tailwind component classes | `components/*.css`, `tokens/tokens.css` |
+| `overrides` | High | Mobile forced layouts, sticky wrapper fixes, card overrides | Bottom of `player-cards.css`, `tables.css`, `base.css` |
+| `utilities` | Highest | Tailwind utility classes (`text-center`, `bg-navy-800`, etc.) | Tailwind internal |
+
+**Key rules:**
+- A selector in `components` *always* beats `legacy` regardless of specificity.
+- Use `@layer overrides` only when a component must override another component.
+- Tailwind utility classes (`@layer utilities`) always win over everything — this is correct.
+
+## Table Pattern Decision Tree
+
+```
+Need a data table?
+├── Simple table, no scroll → <table class="ibl-data-table">
+├── Team-colored table → <table class="ibl-data-table team-table">
+├── Need horizontal scroll on mobile?
+│   └── YES: Wrap in .table-scroll-wrapper > .table-scroll-container
+│       └── Need sticky left column(s)?
+│           ├── NO  → <table class="ibl-data-table">
+│           └── YES → <table class="ibl-data-table responsive-table">
+│               ├── 1 sticky col → td.sticky-col
+│               ├── 2 sticky cols → td.sticky-col-1, td.sticky-col-2
+│               └── 3 sticky cols → td.sticky-col-1, td.sticky-col-2, td.sticky-col-3
+└── Need sticky header AND sticky column (grid/matrix)?
+    └── .sticky-scroll-wrapper > .sticky-scroll-container
+        └── <table class="ibl-data-table sticky-table">
+            └── th.sticky-corner + td.sticky-col
+```
+
+### Three Sticky Table Patterns
+
+| Pattern | Wrapper | Table Class | Use Case |
+|---------|---------|-------------|----------|
+| 1. Simple scroll | `.table-scroll-wrapper` > `.table-scroll-container` | `.ibl-data-table` | Wide tables that scroll horizontally |
+| 2. Sticky columns | `.table-scroll-wrapper` > `.table-scroll-container` | `.ibl-data-table.responsive-table` | Mobile: left column(s) freeze while rest scrolls |
+| 3. Sticky header+column | `.sticky-scroll-wrapper` > `.sticky-scroll-container` | `.ibl-data-table.sticky-table` | Both-axis scroll: header AND first column freeze |
+
+## Overflow Rules
+
+| Context | `overflow` Value | Why |
+|---------|-----------------|-----|
+| `.ibl-data-table` | `hidden` | Clip content for `border-radius` |
+| `.ibl-data-table.responsive-table` (mobile) | `visible` | Required for `position: sticky` to work |
+| `.sticky-table` | `visible` | Sticky positioning needs visible overflow |
+| `.sticky-scroll-wrapper` | `auto` | This element provides the actual scroll viewport |
+| `.table-scroll-container` | `auto` (desktop) / `scroll` (mobile) | Horizontal scroll container |
+| `table, center` (legacy base.css) | `auto` | Prevent legacy layout overflow |
+
+**Rule:** Never set `overflow: hidden` on any element containing `position: sticky` cells.
+
+## Inline Style Policy
+
+### Allowed inline styles
+- **CSS custom properties** on containers: `style="--team-color-primary: #1a2e5a;"` (dynamic values from PHP)
+- **Row-level dynamic styles**: `style="--team-row-hover-bg: ..."` (computed per-team)
+- **Truly one-off layout**: `colspan`, unique padding on empty-state messages
+
+### Redundant — use CSS classes instead
+- `text-align: center` on `<td>` in `.ibl-data-table` (already set by `tables.css`)
+- `font-family` on any element (set by `base.css` and component CSS)
+- `font-size` on elements already styled by component classes
+- `color` on links inside `.ibl-data-table` (set by `tables.css`)
+
+## `white-space: nowrap` Locations
+
+These CSS selectors set `white-space: nowrap` — check them before debugging text-wrapping issues:
+
+| File | Selector | Purpose |
+|------|----------|---------|
+| `tables.css` | `.ibl-data-table th` | Header cells never wrap |
+| `tables.css` | `.ibl-data-table td.player-cell` | Player names on one line |
+| `tables.css` | `.responsive-table td` | All cells in scrollable tables |
+| `navigation.css` | `.ibl-tab` | Tab labels |
+| `navigation.css` | `.plr-nav__group-label` | Nav group labels |
+| `navigation.css` | `.plr-nav__pill` | Nav pills |
+| `cards.css` | `.ibl-card__meta` | Card metadata |
+| `player-cards.css` | `.stats-grid a`, `th`, `td` | Stats card cells |
+| `existing-components.css` | Various (7 selectors) | Legacy components |
+| `sco-parser.css` | `.sco-play-text` | Play-by-play text |
+| `saved-depth-charts.css` | `.saved-dc-table td` | Depth chart cells |
+
+## Common Cell/Row Modifier Classes
+
+| Class | Purpose | Applied to |
+|-------|---------|------------|
+| `.sep-team` | Team-colored vertical separator | `<td>`, `<th>` |
+| `.sep-weak` | Gray vertical separator | `<td>`, `<th>` |
+| `.salary` | Left-aligned salary column | `<td>`, `<th>` |
+| `.sticky-col` | Sticky first column (single) | `<td>`, `<th>` |
+| `.sticky-col-1/2/3` | Multi-column sticky | `<td>`, `<th>` |
+| `.sticky-corner` | Top-left corner cell (sticky header+col) | `<th>` |
+| `.ratings-highlight` | Team-colored highlight row | `<tr>` |
+| `.ratings-separator` | Zero-padding divider row | `<tr>` |
+| `.user-team-row` | Yellow highlight for user's team | `<tr>` |
+| `.drafted` | Grayed-out drafted player row | `<tr>` |
+| `.career-row` | Bold career totals row | `<tr>` |
+
+## `!important` Policy
+
+After `@layer` introduction, `!important` should only be used for:
+1. **User-agent override necessity** — e.g., iOS Safari auto-detection of phone numbers
+2. **JavaScript-set inline styles** that CSS must override
+
+All other specificity battles are resolved by layer ordering. If you need a component to beat another component, place the override in `@layer overrides`.

--- a/ibl5/classes/NextSim/NextSimView.php
+++ b/ibl5/classes/NextSim/NextSimView.php
@@ -297,40 +297,40 @@ window.IBL_initNextSimHighlight();
         <tr class="<?= $rowClass ?>" style="<?= $rowStyle ?>">
             <?= $gameInfoCell ?>
             <?= PlayerImageHelper::renderPlayerCell($player->playerID ?? 0, $player->decoratedName ?? '') ?>
-            <td style="text-align: center;"><?= htmlspecialchars($player->position ?? '') ?></td>
-            <td style="text-align: center;"><?= (int)$player->age ?></td>
+            <td><?= htmlspecialchars($player->position ?? '') ?></td>
+            <td><?= (int)$player->age ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFieldGoalAttempts ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFieldGoalPercentage ?></td>
+            <td><?= (int)$player->ratingFieldGoalAttempts ?></td>
+            <td><?= (int)$player->ratingFieldGoalPercentage ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFreeThrowAttempts ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFreeThrowPercentage ?></td>
+            <td><?= (int)$player->ratingFreeThrowAttempts ?></td>
+            <td><?= (int)$player->ratingFreeThrowPercentage ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingThreePointAttempts ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingThreePointPercentage ?></td>
+            <td><?= (int)$player->ratingThreePointAttempts ?></td>
+            <td><?= (int)$player->ratingThreePointPercentage ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingOffensiveRebounds ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingDefensiveRebounds ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingAssists ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingSteals ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingTurnovers ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingBlocks ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFouls ?></td>
+            <td><?= (int)$player->ratingOffensiveRebounds ?></td>
+            <td><?= (int)$player->ratingDefensiveRebounds ?></td>
+            <td><?= (int)$player->ratingAssists ?></td>
+            <td><?= (int)$player->ratingSteals ?></td>
+            <td><?= (int)$player->ratingTurnovers ?></td>
+            <td><?= (int)$player->ratingBlocks ?></td>
+            <td><?= (int)$player->ratingFouls ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingOutsideOffense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingDriveOffense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingPostOffense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingTransitionOffense ?></td>
+            <td><?= (int)$player->ratingOutsideOffense ?></td>
+            <td><?= (int)$player->ratingDriveOffense ?></td>
+            <td><?= (int)$player->ratingPostOffense ?></td>
+            <td><?= (int)$player->ratingTransitionOffense ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingOutsideDefense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingDriveDefense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingPostDefense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingTransitionDefense ?></td>
+            <td><?= (int)$player->ratingOutsideDefense ?></td>
+            <td><?= (int)$player->ratingDriveDefense ?></td>
+            <td><?= (int)$player->ratingPostDefense ?></td>
+            <td><?= (int)$player->ratingTransitionDefense ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingClutch ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingConsistency ?></td>
+            <td><?= (int)$player->ratingClutch ?></td>
+            <td><?= (int)$player->ratingConsistency ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= ($injuryDays > 0 && $injuryReturnDate !== '')
+            <td><?= ($injuryDays > 0 && $injuryReturnDate !== '')
                 ? TooltipLabel::render((string) $injuryDays, 'Returns: ' . $injuryReturnDate)
                 : (string) $injuryDays ?></td>
         </tr>

--- a/ibl5/classes/UI/Tables/Contracts.php
+++ b/ibl5/classes/UI/Tables/Contracts.php
@@ -122,11 +122,11 @@ class Contracts
     $player = $row['player'];
 ?>
         <tr>
-            <td style="text-align: center;"><?= htmlspecialchars($player->position ?? '') ?></td>
+            <td><?= htmlspecialchars($player->position ?? '') ?></td>
             <?= PlayerImageHelper::renderPlayerCell((int)$player->playerID, $player->decoratedName ?? '', $starterPids) ?>
-            <td style="text-align: center;"><?= (int)$player->age ?></td>
-            <td style="text-align: center;"><?= (int)$player->yearsOfExperience ?></td>
-            <td style="text-align: center;"><?= (int)$player->birdYears ?></td>
+            <td><?= (int)$player->age ?></td>
+            <td><?= (int)$player->yearsOfExperience ?></td>
+            <td><?= (int)$player->birdYears ?></td>
             <td class="sep-team"></td>
             <td class="salary"><?= $row['con1'] ?></td>
             <td class="salary"><?= $row['con2'] ?></td>
@@ -135,15 +135,15 @@ class Contracts
             <td class="salary"><?= $row['con5'] ?></td>
             <td class="salary"><?= $row['con6'] ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingTalent ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingSkill ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingIntangibles ?></td>
+            <td><?= (int)$player->ratingTalent ?></td>
+            <td><?= (int)$player->ratingSkill ?></td>
+            <td><?= (int)$player->ratingIntangibles ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->freeAgencyLoyalty ?></td>
-            <td style="text-align: center;"><?= (int)$player->freeAgencyPlayForWinner ?></td>
-            <td style="text-align: center;"><?= (int)$player->freeAgencyPlayingTime ?></td>
-            <td style="text-align: center;"><?= (int)$player->freeAgencySecurity ?></td>
-            <td style="text-align: center;"><?= (int)$player->freeAgencyTradition ?></td>
+            <td><?= (int)$player->freeAgencyLoyalty ?></td>
+            <td><?= (int)$player->freeAgencyPlayForWinner ?></td>
+            <td><?= (int)$player->freeAgencyPlayingTime ?></td>
+            <td><?= (int)$player->freeAgencySecurity ?></td>
+            <td><?= (int)$player->freeAgencyTradition ?></td>
         </tr>
 <?php endforeach; ?>
     </tbody>

--- a/ibl5/classes/UI/Tables/Per36Minutes.php
+++ b/ibl5/classes/UI/Tables/Per36Minutes.php
@@ -135,31 +135,31 @@ class Per36Minutes
 endif; ?>
             <td><?= htmlspecialchars($player->position ?? '') ?></td>
             <?= PlayerImageHelper::renderPlayerCell($player->playerID ?? 0, $player->decoratedName ?? '', $starterPids) ?>
-            <td style="text-align: center;"><?= $playerStats->seasonGamesPlayed ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonGamesStarted ?></td>
-            <td style="text-align: center;"><?= $row['stats_mpg'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_per36Min'] ?></td>
+            <td><?= $playerStats->seasonGamesPlayed ?></td>
+            <td><?= $playerStats->seasonGamesStarted ?></td>
+            <td><?= $row['stats_mpg'] ?></td>
+            <td><?= $row['stats_per36Min'] ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $row['stats_fgm'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_fga'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_fgp'] ?></td>
+            <td><?= $row['stats_fgm'] ?></td>
+            <td><?= $row['stats_fga'] ?></td>
+            <td><?= $row['stats_fgp'] ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $row['stats_ftm'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_fta'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_ftp'] ?></td>
+            <td><?= $row['stats_ftm'] ?></td>
+            <td><?= $row['stats_fta'] ?></td>
+            <td><?= $row['stats_ftp'] ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $row['stats_tgm'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_tga'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_tgp'] ?></td>
+            <td><?= $row['stats_tgm'] ?></td>
+            <td><?= $row['stats_tga'] ?></td>
+            <td><?= $row['stats_tgp'] ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $row['stats_opg'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_rpg'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_apg'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_spg'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_tpg'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_bpg'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_fpg'] ?></td>
-            <td style="text-align: center;"><?= $row['stats_ppg'] ?></td>
+            <td><?= $row['stats_opg'] ?></td>
+            <td><?= $row['stats_rpg'] ?></td>
+            <td><?= $row['stats_apg'] ?></td>
+            <td><?= $row['stats_spg'] ?></td>
+            <td><?= $row['stats_tpg'] ?></td>
+            <td><?= $row['stats_bpg'] ?></td>
+            <td><?= $row['stats_fpg'] ?></td>
+            <td><?= $row['stats_ppg'] ?></td>
         </tr>
 <?php endforeach; ?>
     </tbody>

--- a/ibl5/classes/UI/Tables/PeriodAverages.php
+++ b/ibl5/classes/UI/Tables/PeriodAverages.php
@@ -166,29 +166,29 @@ class PeriodAverages
         <tr>
             <td><?= htmlspecialchars($row['pos']) ?></td>
             <?= PlayerImageHelper::renderPlayerCell($row['pid'], $row['name'], $starterPids) ?>
-            <td style="text-align: center;"><?= (int)$row['games'] ?></td>
-            <td style="text-align: center;"><?= $row['min'] ?></td>
+            <td><?= (int)$row['games'] ?></td>
+            <td><?= $row['min'] ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $row['fgm'] ?></td>
-            <td style="text-align: center;"><?= $row['fga'] ?></td>
-            <td style="text-align: center;"><?= $row['fgp'] ?></td>
+            <td><?= $row['fgm'] ?></td>
+            <td><?= $row['fga'] ?></td>
+            <td><?= $row['fgp'] ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $row['ftm'] ?></td>
-            <td style="text-align: center;"><?= $row['fta'] ?></td>
-            <td style="text-align: center;"><?= $row['ftp'] ?></td>
+            <td><?= $row['ftm'] ?></td>
+            <td><?= $row['fta'] ?></td>
+            <td><?= $row['ftp'] ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $row['tgm'] ?></td>
-            <td style="text-align: center;"><?= $row['tga'] ?></td>
-            <td style="text-align: center;"><?= $row['tgp'] ?></td>
+            <td><?= $row['tgm'] ?></td>
+            <td><?= $row['tga'] ?></td>
+            <td><?= $row['tgp'] ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $row['orb'] ?></td>
-            <td style="text-align: center;"><?= $row['reb'] ?></td>
-            <td style="text-align: center;"><?= $row['ast'] ?></td>
-            <td style="text-align: center;"><?= $row['stl'] ?></td>
-            <td style="text-align: center;"><?= $row['tov'] ?></td>
-            <td style="text-align: center;"><?= $row['blk'] ?></td>
-            <td style="text-align: center;"><?= $row['pf'] ?></td>
-            <td style="text-align: center;"><?= $row['pts'] ?></td>
+            <td><?= $row['orb'] ?></td>
+            <td><?= $row['reb'] ?></td>
+            <td><?= $row['ast'] ?></td>
+            <td><?= $row['stl'] ?></td>
+            <td><?= $row['tov'] ?></td>
+            <td><?= $row['blk'] ?></td>
+            <td><?= $row['pf'] ?></td>
+            <td><?= $row['pts'] ?></td>
         </tr>
 <?php endforeach; ?>
     </tbody>

--- a/ibl5/classes/UI/Tables/Ratings.php
+++ b/ibl5/classes/UI/Tables/Ratings.php
@@ -120,44 +120,44 @@ class Ratings
     echo TeamCellHelper::renderTeamCellOrFreeAgent($player->teamID ?? 0, $player->teamName ?? '', $player->teamColor1 ?? 'FFFFFF', $player->teamColor2 ?? '000000');
 endif; ?>
             <?= PlayerImageHelper::renderPlayerCell((int)$player->playerID, $player->decoratedName ?? '', $starterPids) ?>
-            <td style="text-align: center;"><?= htmlspecialchars($player->position ?? '') ?></td>
-            <td style="text-align: center;"><?= (int)$player->age ?></td>
+            <td><?= htmlspecialchars($player->position ?? '') ?></td>
+            <td><?= (int)$player->age ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFieldGoalAttempts ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFieldGoalPercentage ?></td>
+            <td><?= (int)$player->ratingFieldGoalAttempts ?></td>
+            <td><?= (int)$player->ratingFieldGoalPercentage ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFreeThrowAttempts ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFreeThrowPercentage ?></td>
+            <td><?= (int)$player->ratingFreeThrowAttempts ?></td>
+            <td><?= (int)$player->ratingFreeThrowPercentage ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingThreePointAttempts ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingThreePointPercentage ?></td>
+            <td><?= (int)$player->ratingThreePointAttempts ?></td>
+            <td><?= (int)$player->ratingThreePointPercentage ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingOffensiveRebounds ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingDefensiveRebounds ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingAssists ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingSteals ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingTurnovers ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingBlocks ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingFouls ?></td>
+            <td><?= (int)$player->ratingOffensiveRebounds ?></td>
+            <td><?= (int)$player->ratingDefensiveRebounds ?></td>
+            <td><?= (int)$player->ratingAssists ?></td>
+            <td><?= (int)$player->ratingSteals ?></td>
+            <td><?= (int)$player->ratingTurnovers ?></td>
+            <td><?= (int)$player->ratingBlocks ?></td>
+            <td><?= (int)$player->ratingFouls ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingOutsideOffense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingDriveOffense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingPostOffense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingTransitionOffense ?></td>
+            <td><?= (int)$player->ratingOutsideOffense ?></td>
+            <td><?= (int)$player->ratingDriveOffense ?></td>
+            <td><?= (int)$player->ratingPostOffense ?></td>
+            <td><?= (int)$player->ratingTransitionOffense ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingOutsideDefense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingDriveDefense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingPostDefense ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingTransitionDefense ?></td>
+            <td><?= (int)$player->ratingOutsideDefense ?></td>
+            <td><?= (int)$player->ratingDriveDefense ?></td>
+            <td><?= (int)$player->ratingPostDefense ?></td>
+            <td><?= (int)$player->ratingTransitionDefense ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= (int)$player->ratingClutch ?></td>
-            <td style="text-align: center;"><?= (int)$player->ratingConsistency ?></td>
+            <td><?= (int)$player->ratingClutch ?></td>
+            <td><?= (int)$player->ratingConsistency ?></td>
             <td class="sep-team"></td>
             <?php
                 $injDays = (int) $row['injuryDays'];
                 $injReturn = $row['injuryReturnDate'];
             ?>
-            <td style="text-align: center;"><?= ($injDays > 0 && $injReturn !== '')
+            <td><?= ($injDays > 0 && $injReturn !== '')
                 ? TooltipLabel::render((string) $injDays, 'Returns: ' . $injReturn)
                 : (string) $injDays ?></td>
         </tr>

--- a/ibl5/classes/UI/Tables/SeasonAverages.php
+++ b/ibl5/classes/UI/Tables/SeasonAverages.php
@@ -115,30 +115,30 @@ class SeasonAverages
 endif; ?>
             <td><?= htmlspecialchars($player->position ?? '') ?></td>
             <?= PlayerImageHelper::renderPlayerCell($player->playerID ?? 0, $player->decoratedName ?? '', $starterPids) ?>
-            <td style="text-align: center;"><?= $playerStats->seasonGamesPlayed ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonGamesStarted ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonMinutesPerGame ?></td>
+            <td><?= $playerStats->seasonGamesPlayed ?></td>
+            <td><?= $playerStats->seasonGamesStarted ?></td>
+            <td><?= $playerStats->seasonMinutesPerGame ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFieldGoalsMadePerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFieldGoalsAttemptedPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFieldGoalPercentage ?></td>
+            <td><?= $playerStats->seasonFieldGoalsMadePerGame ?></td>
+            <td><?= $playerStats->seasonFieldGoalsAttemptedPerGame ?></td>
+            <td><?= $playerStats->seasonFieldGoalPercentage ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFreeThrowsMadePerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFreeThrowsAttemptedPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFreeThrowPercentage ?></td>
+            <td><?= $playerStats->seasonFreeThrowsMadePerGame ?></td>
+            <td><?= $playerStats->seasonFreeThrowsAttemptedPerGame ?></td>
+            <td><?= $playerStats->seasonFreeThrowPercentage ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $playerStats->seasonThreePointersMadePerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonThreePointersAttemptedPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonThreePointPercentage ?></td>
+            <td><?= $playerStats->seasonThreePointersMadePerGame ?></td>
+            <td><?= $playerStats->seasonThreePointersAttemptedPerGame ?></td>
+            <td><?= $playerStats->seasonThreePointPercentage ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $playerStats->seasonOffensiveReboundsPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonTotalReboundsPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonAssistsPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonStealsPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonTurnoversPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonBlocksPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonPersonalFoulsPerGame ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonPointsPerGame ?></td>
+            <td><?= $playerStats->seasonOffensiveReboundsPerGame ?></td>
+            <td><?= $playerStats->seasonTotalReboundsPerGame ?></td>
+            <td><?= $playerStats->seasonAssistsPerGame ?></td>
+            <td><?= $playerStats->seasonStealsPerGame ?></td>
+            <td><?= $playerStats->seasonTurnoversPerGame ?></td>
+            <td><?= $playerStats->seasonBlocksPerGame ?></td>
+            <td><?= $playerStats->seasonPersonalFoulsPerGame ?></td>
+            <td><?= $playerStats->seasonPointsPerGame ?></td>
         </tr>
 <?php endforeach; ?>
     </tbody>

--- a/ibl5/classes/UI/Tables/SeasonTotals.php
+++ b/ibl5/classes/UI/Tables/SeasonTotals.php
@@ -112,27 +112,27 @@ class SeasonTotals
 endif; ?>
             <td><?= htmlspecialchars($player->position ?? '') ?></td>
             <?= PlayerImageHelper::renderPlayerCell($player->playerID ?? 0, $player->decoratedName ?? '', $starterPids) ?>
-            <td style="text-align: center;"><?= $playerStats->seasonGamesPlayed ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonGamesStarted ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonMinutes ?></td>
+            <td><?= $playerStats->seasonGamesPlayed ?></td>
+            <td><?= $playerStats->seasonGamesStarted ?></td>
+            <td><?= $playerStats->seasonMinutes ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFieldGoalsMade ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFieldGoalsAttempted ?></td>
+            <td><?= $playerStats->seasonFieldGoalsMade ?></td>
+            <td><?= $playerStats->seasonFieldGoalsAttempted ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFreeThrowsMade ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonFreeThrowsAttempted ?></td>
+            <td><?= $playerStats->seasonFreeThrowsMade ?></td>
+            <td><?= $playerStats->seasonFreeThrowsAttempted ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $playerStats->seasonThreePointersMade ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonThreePointersAttempted ?></td>
+            <td><?= $playerStats->seasonThreePointersMade ?></td>
+            <td><?= $playerStats->seasonThreePointersAttempted ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $playerStats->seasonOffensiveRebounds ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonTotalRebounds ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonAssists ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonSteals ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonTurnovers ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonBlocks ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonPersonalFouls ?></td>
-            <td style="text-align: center;"><?= $playerStats->seasonPoints ?></td>
+            <td><?= $playerStats->seasonOffensiveRebounds ?></td>
+            <td><?= $playerStats->seasonTotalRebounds ?></td>
+            <td><?= $playerStats->seasonAssists ?></td>
+            <td><?= $playerStats->seasonSteals ?></td>
+            <td><?= $playerStats->seasonTurnovers ?></td>
+            <td><?= $playerStats->seasonBlocks ?></td>
+            <td><?= $playerStats->seasonPersonalFouls ?></td>
+            <td><?= $playerStats->seasonPoints ?></td>
         </tr>
 <?php endforeach; ?>
     </tbody>

--- a/ibl5/classes/UI/Tables/SplitStats.php
+++ b/ibl5/classes/UI/Tables/SplitStats.php
@@ -92,35 +92,35 @@ class SplitStats
     </thead>
     <tbody>
 <?php if ($playerRows === []): ?>
-        <tr><td colspan="25" style="text-align: center; padding: 2rem; color: var(--gray-500);">No games found for <strong><?= $safeSplitLabel ?></strong> split.</td></tr>
+        <tr><td colspan="25" style="padding: 2rem; color: var(--gray-500);">No games found for <strong><?= $safeSplitLabel ?></strong> split.</td></tr>
 <?php endif; ?>
 <?php foreach ($playerRows as $row): ?>
         <tr>
             <td><?= htmlspecialchars($row['pos']) ?></td>
             <?= PlayerImageHelper::renderPlayerCell($row['pid'], $row['name'], $starterPids) ?>
-            <td style="text-align: center;"><?= $row['games'] ?></td>
-            <td style="text-align: center;"><?= $row['min'] ?></td>
+            <td><?= $row['games'] ?></td>
+            <td><?= $row['min'] ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $row['fgm'] ?></td>
-            <td style="text-align: center;"><?= $row['fga'] ?></td>
-            <td style="text-align: center;"><?= $row['fgp'] ?></td>
+            <td><?= $row['fgm'] ?></td>
+            <td><?= $row['fga'] ?></td>
+            <td><?= $row['fgp'] ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $row['ftm'] ?></td>
-            <td style="text-align: center;"><?= $row['fta'] ?></td>
-            <td style="text-align: center;"><?= $row['ftp'] ?></td>
+            <td><?= $row['ftm'] ?></td>
+            <td><?= $row['fta'] ?></td>
+            <td><?= $row['ftp'] ?></td>
             <td class="sep-weak"></td>
-            <td style="text-align: center;"><?= $row['tgm'] ?></td>
-            <td style="text-align: center;"><?= $row['tga'] ?></td>
-            <td style="text-align: center;"><?= $row['tgp'] ?></td>
+            <td><?= $row['tgm'] ?></td>
+            <td><?= $row['tga'] ?></td>
+            <td><?= $row['tgp'] ?></td>
             <td class="sep-team"></td>
-            <td style="text-align: center;"><?= $row['orb'] ?></td>
-            <td style="text-align: center;"><?= $row['reb'] ?></td>
-            <td style="text-align: center;"><?= $row['ast'] ?></td>
-            <td style="text-align: center;"><?= $row['stl'] ?></td>
-            <td style="text-align: center;"><?= $row['tov'] ?></td>
-            <td style="text-align: center;"><?= $row['blk'] ?></td>
-            <td style="text-align: center;"><?= $row['pf'] ?></td>
-            <td style="text-align: center;"><?= $row['pts'] ?></td>
+            <td><?= $row['orb'] ?></td>
+            <td><?= $row['reb'] ?></td>
+            <td><?= $row['ast'] ?></td>
+            <td><?= $row['stl'] ?></td>
+            <td><?= $row['tov'] ?></td>
+            <td><?= $row['blk'] ?></td>
+            <td><?= $row['pf'] ?></td>
+            <td><?= $row['pts'] ?></td>
         </tr>
 <?php endforeach; ?>
     </tbody>

--- a/ibl5/design/base.css
+++ b/ibl5/design/base.css
@@ -2,26 +2,25 @@
  * IBL5 Base Styles
  *
  * Essential global styles that cannot be achieved with Tailwind utilities:
- * - CSS reset and box-sizing
- * - Body/HTML overflow management
- * - Legacy PHP-Nuke element normalization
- * - Legacy PHP-Nuke class compatibility
+ * - CSS reset and box-sizing (@layer reset)
+ * - Body/HTML overflow management (@layer reset)
+ * - Legacy PHP-Nuke element normalization (@layer legacy)
+ * - Legacy PHP-Nuke class compatibility (@layer legacy)
+ * - Mobile forced layouts for legacy tables (@layer overrides)
  *
  * Note: Utility classes like .text-center, .font-bold, .bg-white, etc.
  * are provided by Tailwind CSS and should NOT be duplicated here.
  */
 
 /* ==========================================================================
-   CSS Reset & Box Sizing
+   CSS Reset & Box Sizing — @layer reset (lowest priority)
    ========================================================================== */
+
+@layer reset {
 
 *, *::before, *::after {
     box-sizing: border-box;
 }
-
-/* ==========================================================================
-   HTML & Body Base Styles
-   ========================================================================== */
 
 html {
     overflow-x: clip;
@@ -39,13 +38,18 @@ body {
     margin: 0;
 }
 
-/* ==========================================================================
-   Legacy PHP-Nuke Element Normalization
+} /* end @layer reset */
 
+/* ==========================================================================
+   Legacy PHP-Nuke Styles — @layer legacy
+   ========================================================================== */
+
+@layer legacy {
+
+/* --- Element Normalization ---
    These styles normalize deprecated HTML elements that still exist in
    legacy PHP-Nuke code. They ensure consistent font rendering across
-   the old codebase while we transition to modern HTML/CSS.
-   ========================================================================== */
+   the old codebase while we transition to modern HTML/CSS. */
 
 FONT,
 TD,
@@ -63,12 +67,9 @@ SELECT {
     font-family: var(--font-sans);
 }
 
-/* ==========================================================================
-   Legacy Link Styles
-
+/* --- Link Styles ---
    PHP-Nuke uses explicit link states. These provide baseline styling
-   that individual components can override.
-   ========================================================================== */
+   that individual components can override. */
 
 A:link,
 A:active,
@@ -84,12 +85,9 @@ A:hover {
     text-decoration: underline;
 }
 
-/* ==========================================================================
-   Legacy PHP-Nuke Classes
-
+/* --- PHP-Nuke Classes ---
    These classes are used by core PHP-Nuke modules and cannot be removed
-   without refactoring the entire CMS. They provide backward compatibility.
-   ========================================================================== */
+   without refactoring the entire CMS. They provide backward compatibility. */
 
 .title {
     background: none;
@@ -143,11 +141,8 @@ A:hover {
     text-decoration: none;
 }
 
-/* ==========================================================================
-   Legacy Layout Constraints
-
-   Prevent legacy table-based layouts from causing horizontal overflow.
-   ========================================================================== */
+/* --- Layout Constraints ---
+   Prevent legacy table-based layouts from causing horizontal overflow. */
 
 table,
 center {
@@ -167,34 +162,41 @@ img {
     overflow: hidden;
 }
 
+} /* end @layer legacy */
+
 /* ==========================================================================
-   Mobile Layout Fixes for Legacy Tables
+   Mobile Layout Fixes for Legacy Tables — @layer overrides
 
    PHP-Nuke uses nested tables for layout. These rules force them to
-   stack vertically on mobile devices.
+   stack vertically on mobile devices. Uses @layer overrides so they
+   beat both legacy and component styles without needing !important.
    ========================================================================== */
+
+@layer overrides {
 
 @media (max-width: 768px) {
     body > table,
     body > table > tbody,
     body > table > tbody > tr,
     body > table > tbody > tr > td {
-        display: block !important;
-        width: 100% !important;
-        max-width: 100% !important;
-        padding-left: 0 !important;
-        padding-right: 0 !important;
+        display: block;
+        width: 100%;
+        max-width: 100%;
+        padding-left: 0;
+        padding-right: 0;
     }
 
     body > table > tbody > tr > td > table,
     body > table > tbody > tr > td > table > tbody,
     body > table > tbody > tr > td > table > tbody > tr,
     body > table > tbody > tr > td > table > tbody > tr > td {
-        display: block !important;
-        width: 100% !important;
-        max-width: 100% !important;
-        overflow-x: hidden !important;
-        padding-left: 0 !important;
-        padding-right: 0 !important;
+        display: block;
+        width: 100%;
+        max-width: 100%;
+        overflow-x: hidden;
+        padding-left: 0;
+        padding-right: 0;
     }
 }
+
+} /* end @layer overrides */

--- a/ibl5/design/components/auth.css
+++ b/ibl5/design/components/auth.css
@@ -9,6 +9,9 @@
  * - Logout
  */
 
+@layer components {
+
+
 /* ==========================================================================
    Auth Page Container
    Full-viewport centered layout
@@ -219,3 +222,5 @@
         display: none;
     }
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/cards.css
+++ b/ibl5/design/components/cards.css
@@ -7,6 +7,9 @@
  * - News articles
  */
 
+@layer components {
+
+
 /* ==========================================================================
    Shared Card Base — common properties for all card containers
    ========================================================================== */
@@ -427,3 +430,4 @@
     font-weight: 600;
 }
 
+} /* end @layer components */

--- a/ibl5/design/components/depth-chart-changes.css
+++ b/ibl5/design/components/depth-chart-changes.css
@@ -15,6 +15,9 @@
  * protanopia, deuteranopia, or tritanopia via luminance contrast alone.
  */
 
+@layer components {
+
+
 /* Glow intensity scale (lightest → strongest) */
 :root {
     --dc-glow-bg-1: #fff1e0;
@@ -73,3 +76,5 @@
     border-color: var(--dc-glow-border-5);
     box-shadow: 0 0 14px 4px rgba(249, 115, 22, 0.85);
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/existing-components.css
+++ b/ibl5/design/components/existing-components.css
@@ -6,6 +6,9 @@
  * preserving all the existing functionality.
  */
 
+@layer components {
+
+
 /* ==========================================================================
    Leaders Grid Layout (Side-by-Side on Desktop)
    ========================================================================== */
@@ -1958,3 +1961,5 @@ table.sortable thead th {
         margin-left: 0;
     }
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/forms.css
+++ b/ibl5/design/components/forms.css
@@ -8,6 +8,9 @@
  * - Settings pages
  */
 
+@layer components {
+
+
 /* ==========================================================================
    Base Form Elements
    ========================================================================== */
@@ -340,3 +343,5 @@
     transform: translateY(-1px);
     box-shadow: var(--shadow-md, 0 4px 6px -1px rgb(0 0 0 / 0.1));
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/navigation.css
+++ b/ibl5/design/components/navigation.css
@@ -7,6 +7,9 @@
  * - Tab navigation
  */
 
+@layer components {
+
+
 /* ==========================================================================
    Tab Navigation
    ========================================================================== */
@@ -93,7 +96,7 @@
     padding: var(--space-1) var(--space-3);
     border-radius: var(--radius-md);
     border: 2px solid color-mix(in srgb, var(--team-tab-bg-color) 50%, black);
-    background: color-mix(in srgb, var(--team-tab-bg-color) 15%, white) !important;
+    background: color-mix(in srgb, var(--team-tab-bg-color) 15%, white);
     color: color-mix(in srgb, var(--team-tab-bg-color) 75%, black);
     transition: all var(--transition-fast);
 }
@@ -334,13 +337,13 @@
 /* Main nav links (Home link and direct links) */
 nav .group > a:link,
 nav .group > a:visited {
-    color: var(--gray-200) !important;
-    font-size: 1rem !important;
-    font-weight: 500 !important;
+    color: var(--gray-200);
+    font-size: 1rem;
+    font-weight: 500;
 }
 
 nav .group > a:hover {
-    color: white !important;
+    color: white;
 }
 
 /* Desktop dropdown links */
@@ -354,8 +357,8 @@ nav .group > a:hover {
 }
 
 .nav-dropdown-item:hover {
-    color: white !important;
-    background-color: rgba(255, 255, 255, 0.05) !important;
+    color: white;
+    background-color: rgba(255, 255, 255, 0.05);
 }
 
 /* Inline links within rawHtml nav items (e.g. "Waivers: Add | Drop") */
@@ -382,7 +385,7 @@ span.nav-dropdown-item a:hover {
 }
 
 #nav-mobile-menu a:hover {
-    color: white !important;
+    color: white;
 }
 
 /* Mobile section buttons (not links) */
@@ -553,3 +556,5 @@ span.nav-dropdown-item a:hover {
     pointer-events: none;
     mix-blend-mode: overlay;
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/player-cards.css
+++ b/ibl5/design/components/player-cards.css
@@ -14,6 +14,9 @@
  *   CardFlipStyles (all CSS methods)
  */
 
+@layer components {
+
+
 /* ==========================================================================
    Trading Card Base Styles
    Shared between front (.trading-card) and back (.trading-card-back)
@@ -423,22 +426,27 @@
     }
 }
 
+} /* end @layer components */
+
 /* ==========================================================================
    Player Stats Card - Horizontal Layout
-   Uses !important to override legacy .player-table styles
+   @layer overrides — beats .ibl-data-table styles in @layer components
+   without needing !important.
    ========================================================================== */
 
+@layer overrides {
+
 .player-stats-card {
-    background: linear-gradient(145deg, var(--card-grad-start) 0%, var(--card-grad-mid) 20%, var(--card-grad-mid) 80%, var(--card-grad-end) 100%) !important;
-    border: 3px solid var(--card-border) !important;
-    border-radius: 12px !important;
+    background: linear-gradient(145deg, var(--card-grad-start) 0%, var(--card-grad-mid) 20%, var(--card-grad-mid) 80%, var(--card-grad-end) 100%);
+    border: 3px solid var(--card-border);
+    border-radius: 12px;
     box-shadow:
         0 0 0 1px var(--card-grad-mid),
         0 0 0 3px var(--card-border),
-        0 8px 32px rgba(0,0,0,0.3) !important;
-    margin: 16px auto !important;
-    padding: 16px !important;
-    color: var(--card-text) !important;
+        0 8px 32px rgba(0,0,0,0.3);
+    margin: 16px auto;
+    padding: 16px;
+    color: var(--card-text);
     overflow-x: auto;
     position: relative;
 }
@@ -447,18 +455,18 @@
     box-sizing: border-box;
 }
 
-/* Stats Table Styling - Override legacy .player-table and .sortable styles */
+/* Stats Table Styling - Override .ibl-data-table and legacy .player-table styles */
 .player-stats-card table,
 .player-stats-card .stats-table,
 .player-stats-card table.sortable,
 .player-stats-card table.player-table {
-    width: 100% !important;
-    border-collapse: collapse !important;
-    table-layout: auto !important;
-    font-size: 13px !important;
-    border: none !important;
-    background: transparent !important;
-    margin: 0 !important;
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: auto;
+    font-size: 13px;
+    border: none;
+    background: transparent;
+    margin: 0;
 }
 
 /* Table header - gold gradient */
@@ -466,63 +474,63 @@
 .player-stats-card .player-table-header,
 .player-stats-card td.player-table-header,
 .player-stats-card td.stats-table-header {
-    background: linear-gradient(135deg, var(--card-border) 0%, var(--card-accent) 100%) !important;
-    color: var(--card-grad-mid) !important;
-    font-weight: 700 !important;
-    font-size: 14px !important;
-    text-transform: uppercase !important;
-    letter-spacing: 0.5px !important;
-    padding: 10px 16px !important;
-    text-align: center !important;
-    border: none !important;
+    background: linear-gradient(135deg, var(--card-border) 0%, var(--card-accent) 100%);
+    color: var(--card-grad-mid);
+    font-weight: 700;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 10px 16px;
+    text-align: center;
+    border: none;
     border-radius: 8px 8px 0 0;
 }
 
 /* Column headers */
 .player-stats-card table th,
 .player-stats-card .stats-table th {
-    color: var(--card-accent) !important;
-    font-weight: 600 !important;
-    font-size: 11px !important;
-    text-transform: uppercase !important;
-    letter-spacing: 0.3px !important;
-    padding: 8px 6px !important;
-    text-align: center !important;
-    border: none !important;
+    color: var(--card-accent);
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    padding: 8px 6px;
+    text-align: center;
+    border: none;
     white-space: nowrap;
-    background: color-mix(in srgb, var(--card-border) 15%, transparent) !important;
-    border-bottom: 1px solid color-mix(in srgb, var(--card-border) 30%, transparent) !important;
+    background: color-mix(in srgb, var(--card-border) 15%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--card-border) 30%, transparent);
 }
 
 /* Table cells */
 .player-stats-card table td,
 .player-stats-card .stats-table td {
-    padding: 6px 6px !important;
-    text-align: center !important;
-    border: none !important;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08) !important;
-    color: var(--card-text-muted) !important;
-    font-family: 'Monaco', 'Menlo', 'Consolas', monospace !important;
-    font-size: 12px !important;
+    padding: 6px 6px;
+    text-align: center;
+    border: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    color: var(--card-text-muted);
+    font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+    font-size: 12px;
     white-space: nowrap;
-    background: transparent !important;
+    background: transparent;
 }
 
 /* Row hover effect */
 .player-stats-card table tbody tr:hover td,
 .player-stats-card .stats-table tbody tr:hover td {
-    background: color-mix(in srgb, var(--card-border) 8%, transparent) !important;
+    background: color-mix(in srgb, var(--card-border) 8%, transparent);
 }
 
 /* Alternating row colors */
 .player-stats-card table tbody tr:nth-child(even) td,
 .player-stats-card .stats-table tbody tr:nth-child(even) td {
-    background: rgba(0, 0, 0, 0.15) !important;
+    background: rgba(0, 0, 0, 0.15);
 }
 
 .player-stats-card table tbody tr:nth-child(even):hover td,
 .player-stats-card .stats-table tbody tr:nth-child(even):hover td {
-    background: color-mix(in srgb, var(--card-border) 12%, transparent) !important;
+    background: color-mix(in srgb, var(--card-border) 12%, transparent);
 }
 
 /* Career/Total Row Styling */
@@ -530,34 +538,35 @@
 .player-stats-card tr.player-table-row-bold td,
 .player-stats-card .stats-table .career-row td,
 .player-stats-card .stats-table tr.player-table-row-bold td {
-    font-weight: 700 !important;
-    color: var(--card-text) !important;
-    border-top: 2px solid var(--card-border) !important;
-    background: linear-gradient(90deg, color-mix(in srgb, var(--card-border) 20%, transparent) 0%, color-mix(in srgb, var(--card-border) 10%, transparent) 100%) !important;
+    font-weight: 700;
+    color: var(--card-text);
+    border-top: 2px solid var(--card-border);
+    background: linear-gradient(90deg, color-mix(in srgb, var(--card-border) 20%, transparent) 0%, color-mix(in srgb, var(--card-border) 10%, transparent) 100%);
 }
 
 /* Footer Row (e.g., Total Salary) */
 .player-stats-card .footer-row td,
 .player-stats-card .stats-table .footer-row td {
-    background: rgba(0, 0, 0, 0.3) !important;
-    color: var(--card-accent) !important;
-    font-weight: 600 !important;
+    background: rgba(0, 0, 0, 0.3);
+    color: var(--card-accent);
+    font-weight: 600;
     font-style: italic;
-    padding: 12px !important;
-    text-align: center !important;
-    border-top: 2px solid color-mix(in srgb, var(--card-border) 30%, transparent) !important;
+    padding: 12px;
+    text-align: center;
+    border-top: 2px solid color-mix(in srgb, var(--card-border) 30%, transparent);
 }
 
 /* Team Links */
 .player-stats-card table a,
 .player-stats-card .stats-table a {
-    color: var(--card-accent) !important;
-    text-decoration: none !important;
+    color: var(--card-accent);
+    text-decoration: none;
     transition: color 0.2s ease;
 }
 
 /* Neutralize Mobile Safari auto-detected telephone links (e.g. "773-1531")
-   so they inherit their parent td's color instead of getting --card-accent */
+   so they inherit their parent td's color instead of getting --card-accent.
+   Retains !important: necessary to override UA stylesheet auto-linking. */
 .player-stats-card a[href^="tel"] {
     color: inherit !important;
     text-decoration: inherit !important;
@@ -566,32 +575,40 @@
 
 .player-stats-card table a:hover,
 .player-stats-card .stats-table a:hover {
-    color: var(--card-text) !important;
-    text-decoration: underline !important;
+    color: var(--card-text);
+    text-decoration: underline;
 }
 
 /* Responsive: Horizontal scroll on small screens */
 @media (max-width: 768px) {
     .player-stats-card {
-        margin: 12px 8px !important;
-        padding: 12px !important;
-        border-radius: 8px !important;
+        margin: 12px 8px;
+        padding: 12px;
+        border-radius: 8px;
     }
 
     .player-stats-card table th,
     .player-stats-card table td,
     .player-stats-card .stats-table th,
     .player-stats-card .stats-table td {
-        padding: 4px 4px !important;
-        font-size: 10px !important;
+        padding: 4px 4px;
+        font-size: 10px;
     }
 
     .player-stats-card .stats-table-header,
     .player-stats-card .player-table-header {
-        font-size: 12px !important;
-        padding: 8px 12px !important;
+        font-size: 12px;
+        padding: 8px 12px;
     }
 }
+
+} /* end @layer overrides */
+
+/* ==========================================================================
+   Remaining Card Components — @layer components (continued)
+   ========================================================================== */
+
+@layer components {
 
 /* Card Title Badge */
 .player-stats-card .card-title-badge {
@@ -848,3 +865,5 @@
         height: 12px;
     }
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/player-views.css
+++ b/ibl5/design/components/player-views.css
@@ -5,6 +5,9 @@
  * Migrated from PlayerViewStyles::getStyles()
  */
 
+@layer components {
+
+
 /* Legacy player page colors (intentionally retro) */
 :root {
     --player-legacy-header: #0000cc;
@@ -163,3 +166,5 @@
     text-decoration: none;
     font-weight: bold;
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/saved-depth-charts.css
+++ b/ibl5/design/components/saved-depth-charts.css
@@ -1,5 +1,8 @@
 /* Saved Depth Charts - Dropdown, loading state, traded-player indicators */
 
+@layer components {
+
+
 .saved-dc-dropdown-container {
     text-align: center;
     margin: 0.75rem 0;
@@ -77,3 +80,5 @@ tr.depth-chart-traded-player select {
     vertical-align: middle;
     letter-spacing: 0.03em;
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/sco-parser.css
+++ b/ibl5/design/components/sco-parser.css
@@ -5,6 +5,9 @@
  * and All-Star team rename interface.
  */
 
+@layer components {
+
+
 /* ==========================================================================
    Parse Result Card
    ========================================================================== */
@@ -149,3 +152,5 @@
     color: var(--gray-500, #6b7280);
     font-style: italic;
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/season-archive.css
+++ b/ibl5/design/components/season-archive.css
@@ -7,6 +7,9 @@
  * Migrated from SeasonArchiveView::renderStyles()
  */
 
+@layer components {
+
+
 /* Navigation bar */
 .season-archive-nav {
     display: flex;
@@ -102,3 +105,5 @@
 .bracket-round-start td {
     border-top: 2px solid var(--gray-300, #d1d5db);
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/strength-of-schedule.css
+++ b/ibl5/design/components/strength-of-schedule.css
@@ -2,6 +2,9 @@
    Strength of Schedule - Tier Indicators & SOS Display
    ============================================================ */
 
+@layer components {
+
+
 /* SOS tier scale: 5-color gradient from hardest to easiest */
 :root {
     --sos-tier-elite: var(--error-500);     /* #ef4444 - hardest */
@@ -112,3 +115,5 @@
   align-items: center;
   justify-content: center;
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -11,6 +11,33 @@
  * - .ibl-data-table: Primary data table (navy header, alternating rows)
  */
 
+@layer components {
+
+/* ==========================================================================
+   STICKY TABLE DECISION TREE
+
+   Pattern 1: .table-scroll-wrapper > .table-scroll-container
+              → Simple horizontal scroll (no sticky columns)
+              → Table: .ibl-data-table
+
+   Pattern 2: .table-scroll-wrapper > .table-scroll-container
+              → Mobile sticky left column(s) that freeze while rest scrolls
+              → Table: .ibl-data-table.responsive-table
+              → Columns: .sticky-col (1 col) / .sticky-col-1 + .sticky-col-2 (2 cols)
+
+   Pattern 3: .sticky-scroll-wrapper > .sticky-scroll-container
+              → Both-axis scroll: sticky header AND sticky first column
+              → Table: .ibl-data-table.sticky-table
+              → Columns: .sticky-col + .sticky-corner (header intersection)
+
+   OVERFLOW RULES:
+   - .ibl-data-table: overflow: hidden (for border-radius clipping)
+   - .responsive-table (mobile): overflow: visible (required for position: sticky)
+   - .sticky-table: overflow: visible (same reason)
+   - .sticky-scroll-wrapper: overflow: auto (provides the scroll viewport)
+   - NEVER set overflow: hidden on elements containing position: sticky cells
+   ========================================================================== */
+
 /* ==========================================================================
    Primary Data Table (.ibl-data-table)
 
@@ -215,7 +242,7 @@
 
 /* Team-colored hover */
 .team-table tbody tr:hover {
-    background-color: var(--team-row-hover-bg) !important;
+    background-color: var(--team-row-hover-bg);
 }
 
 /* Team-colored link hover */
@@ -228,7 +255,7 @@
 .team-table td.sep-team {
     border-left: 0.5px solid var(--team-sep-color);
     border-right: 0.5px solid var(--team-sep-color);
-    padding: 0 !important;
+    padding: 0;
 }
 
 /* Weak separators (gray, same as before) */
@@ -236,13 +263,13 @@
 .team-table td.sep-weak {
     border-left: 0.5px solid var(--gray-200, #e5e7eb);
     border-right: 0.5px solid var(--gray-200, #e5e7eb);
-    padding: 0 !important;
+    padding: 0;
 }
 
 /* Salary column left alignment */
 .team-table th.salary,
 .team-table td.salary {
-    text-align: left !important;
+    text-align: left;
 }
 
 /* Team-colored tfoot */
@@ -260,16 +287,16 @@
 
 /* Ratings highlight rows (team-colored) */
 .team-table tr.ratings-highlight {
-    background-color: var(--team-row-highlight-bg) !important;
+    background-color: var(--team-row-highlight-bg);
 }
 
 .team-table tr.ratings-highlight:hover {
-    background-color: var(--team-row-highlight-hover-bg) !important;
+    background-color: var(--team-row-highlight-hover-bg);
 }
 
 /* Ratings separator row (zero-padding divider) */
 .team-table tr.ratings-separator td {
-    padding: 0 !important;
+    padding: 0;
 }
 
 /* ==========================================================================
@@ -529,30 +556,30 @@
 
     .table-scroll-container {
         display: block;
-        overflow-x: scroll !important;
+        overflow-x: scroll;
         overflow-y: visible;
         -webkit-overflow-scrolling: touch;
         touch-action: pan-x pan-y;
-        padding: 0 !important;
+        padding: 0;
         /* Width set by JavaScript for iOS compatibility */
     }
 
     /* Remove border-radius and padding on mobile for edge-to-edge tables */
     .standings-table-container {
-        border-radius: 0 !important;
-        padding: 0 !important;
-        margin: 0 !important;
+        border-radius: 0;
+        padding: 0;
+        margin: 0;
     }
 
     .table-scroll-wrapper {
-        padding: 0 !important;
-        margin-left: 0 !important;
-        margin-right: 0 !important;
+        padding: 0;
+        margin-left: 0;
+        margin-right: 0;
     }
 
     .standings-table {
-        margin-left: 0 !important;
-        margin-right: 0 !important;
+        margin-left: 0;
+        margin-right: 0;
     }
 }
 
@@ -630,15 +657,15 @@
 /* Disable any injected .table-scroll-wrapper / .table-scroll-container
    that would add extra overflow:hidden and break sticky positioning */
 .sticky-scroll-wrapper .table-scroll-wrapper {
-    overflow: visible !important;
+    overflow: visible;
 }
 
 .sticky-scroll-wrapper .table-scroll-wrapper::after {
-    display: none !important;
+    display: none;
 }
 
 .sticky-scroll-wrapper .table-scroll-container {
-    overflow: visible !important;
+    overflow: visible;
 }
 
 /* Table — remove the border-radius/shadow/overflow that .ibl-data-table sets,
@@ -803,10 +830,9 @@ tbody tr.user-team-row:nth-child(even):hover {
 }
 
 /* Team Cell with Colors - combines logo + team-specific background/text.
-   padding-inline !important is needed: .ibl-data-table th/td (0,1,1) outspecifies
-   this class (0,1,0), so the shorthand `padding` would win without it. */
-.ibl-team-cell--colored {
-    padding-inline: 0.5rem !important;
+   Specificity (0,2,0) beats .ibl-data-table th/td (0,1,1) for padding override */
+.ibl-data-table .ibl-team-cell--colored {
+    padding-inline: 0.5rem;
 }
 
 /* Left-align td cells only; th cells keep the default center from .ibl-data-table th.
@@ -845,10 +871,10 @@ td.ibl-team-cell--colored {
     }
 
     /* Center the logo when text is hidden */
-    .ibl-team-cell--colored {
-        text-align: center !important;
-        padding-left: 0rem !important;
-        padding-right: 0rem !important;
+    .ibl-data-table .ibl-team-cell--colored {
+        text-align: center;
+        padding-left: 0rem;
+        padding-right: 0rem;
     }
 
     .ibl-team-cell--colored .ibl-team-cell__name {
@@ -875,9 +901,9 @@ td.ibl-team-cell--colored {
     }
 
     .trading-team-select .ibl-team-cell--colored {
-        text-align: left !important;
-        padding-left: 0.75rem !important;
-        padding-right: 0.75rem !important;
+        text-align: left;
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
     }
 
     .trading-team-select .ibl-team-cell--colored .ibl-team-cell__name {
@@ -896,8 +922,9 @@ td.ibl-team-cell--colored {
    Player Name Cell
    ========================================================================== */
 
-.ibl-player-cell {
-    text-align: left !important;
+/* Specificity (0,2,0) beats .ibl-data-table td (0,1,1) for text-align override */
+.ibl-data-table .ibl-player-cell {
+    text-align: left;
     white-space: nowrap;
     vertical-align: middle;
 }
@@ -1415,8 +1442,9 @@ td.ibl-team-cell--colored {
 
 /* .league-stats-user-row replaced by .user-team-row (user-team-highlighter.js) */
 
-.league-stats-team-cell {
-    text-align: left !important;
+/* Specificity (0,2,0) beats .ibl-data-table td (0,1,1) for text-align override */
+.ibl-data-table .league-stats-team-cell {
+    text-align: left;
     padding: var(--space-2) var(--space-3);
     border-radius: var(--radius-sm);
 }
@@ -1678,3 +1706,4 @@ td.ibl-team-cell--colored {
     border-bottom: 1px solid var(--gray-200);
 }
 
+} /* end @layer components */

--- a/ibl5/design/components/team-splits.css
+++ b/ibl5/design/components/team-splits.css
@@ -5,6 +5,9 @@
  * Uses team colors via CSS custom properties.
  */
 
+@layer components {
+
+
 /* ==========================================================================
    View Dropdown Container
    ========================================================================== */
@@ -83,3 +86,5 @@
         font-size: 0.8rem;
     }
 }
+
+} /* end @layer components */

--- a/ibl5/design/components/updater.css
+++ b/ibl5/design/components/updater.css
@@ -5,6 +5,9 @@
  * Renders progressive output as a readable step-by-step log.
  */
 
+@layer components {
+
+
 /* ==========================================================================
    Page Override & Container
    ========================================================================== */
@@ -235,3 +238,5 @@ body:has(> .updater) {
     text-align: center;
     margin-top: var(--space-4, 1rem);
 }
+
+} /* end @layer components */

--- a/ibl5/design/input.css
+++ b/ibl5/design/input.css
@@ -9,14 +9,29 @@
  *
  * Architecture:
  * 1. Google Fonts - external font loading
- * 2. Tailwind CSS - utility-first framework (provides .text-*, .bg-*, .font-*, etc.)
- * 3. Design Tokens - CSS custom properties (colors, spacing, fonts)
- * 4. Base Styles - CSS reset, legacy PHP-Nuke compatibility
- * 5. Components - reusable UI components (tables, cards, navigation, etc.)
+ * 2. CSS Layer Order - deterministic cascade (theme < base < reset < legacy < components < overrides < utilities)
+ * 3. Tailwind CSS - utility-first framework (provides .text-*, .bg-*, .font-*, etc.)
+ * 4. Design Tokens - CSS custom properties (colors, spacing, fonts)
+ * 5. Base Styles - CSS reset (@layer reset) + legacy PHP-Nuke compatibility (@layer legacy)
+ * 6. Components - reusable UI components (@layer components)
+ * 7. Overrides - mobile forced layouts, sticky fixes, card table overrides (@layer overrides)
+ *
+ * Layer priority (lowest → highest): theme, base, reset, legacy, components, overrides, utilities
+ * A rule in "components" always beats "legacy" regardless of selector specificity.
+ * See .claude/rules/css-architecture.md for full reference.
  */
 
 /* Google Fonts - must be at very top */
 @import url('https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700;800&family=Barlow:wght@400;500;600;700&display=swap');
+
+/* CSS Layer Order - deterministic cascade priority, interleaved with Tailwind's layers.
+   Priority (lowest → highest): theme < base < reset < legacy < components < overrides < utilities
+   - Tailwind theme/base: foundational (lowest)
+   - reset/legacy: our CSS reset and PHP-Nuke compatibility
+   - components: all IBL component CSS + Tailwind component classes
+   - overrides: mobile forced layouts, sticky fixes, card overrides
+   - Tailwind utilities: highest (always wins, which is correct) */
+@layer theme, base, reset, legacy, components, overrides, utilities;
 
 /* Tailwind CSS 4 - provides all utility classes */
 @import 'tailwindcss';
@@ -96,9 +111,11 @@
 @import './components/team-splits.css';
 
 /* Site-wide layout wrapper (replaces legacy themeheader table) */
-.site-content {
-  max-width: 100%;
-  padding: 0rem 1rem;
-  vertical-align: top;
-  text-align: center;
+@layer components {
+  .site-content {
+    max-width: 100%;
+    padding: 0rem 1rem;
+    vertical-align: top;
+    text-align: center;
+  }
 }

--- a/ibl5/design/tokens/tokens.css
+++ b/ibl5/design/tokens/tokens.css
@@ -13,6 +13,8 @@
  * Note: Google Fonts import is in input.css (must be at top of stylesheet)
  */
 
+@layer components {
+
 :root {
     /* ========================================================================
        Color Aliases (source of truth: @theme in input.css)
@@ -125,3 +127,5 @@
     --gradient-navy-header: linear-gradient(135deg, var(--navy-800), var(--navy-900));
     --gradient-accent: linear-gradient(135deg, var(--accent-500), var(--accent-600));
 }
+
+} /* end @layer components */

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -205,5 +205,8 @@
         <testsuite name="JsbParser Module Tests">
             <directory>tests/JsbParser</directory>
         </testsuite>
+        <testsuite name="CSS Architecture Tests">
+            <directory>tests/CSS</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/ibl5/tests/CSS/InlineStyleRemovalTest.php
+++ b/ibl5/tests/CSS/InlineStyleRemovalTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CSS;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that redundant inline text-align: center styles have been
+ * removed from <td> elements in .ibl-data-table contexts.
+ *
+ * .ibl-data-table td already sets text-align: center via tables.css,
+ * so inline styles are redundant and block CSS-only overrides.
+ */
+class InlineStyleRemovalTest extends TestCase
+{
+    #[DataProvider('viewFileProvider')]
+    public function testViewFileHasNoRedundantInlineTextAlignCenter(string $filePath): void
+    {
+        $this->assertFileExists($filePath);
+        $content = file_get_contents($filePath);
+        $this->assertIsString($content);
+
+        // Match <td with style="text-align: center;" (the exact redundant pattern)
+        $matches = [];
+        preg_match_all('/<td[^>]*style="text-align: center;"/', $content, $matches);
+
+        $this->assertCount(
+            0,
+            $matches[0],
+            sprintf(
+                'File %s still contains %d <td> elements with redundant style="text-align: center;" — '
+                . '.ibl-data-table td already sets this via CSS.',
+                basename($filePath),
+                count($matches[0])
+            )
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function viewFileProvider(): array
+    {
+        $base = __DIR__ . '/../../classes';
+
+        return [
+            'NextSimView' => [$base . '/NextSim/NextSimView.php'],
+            'Ratings' => [$base . '/UI/Tables/Ratings.php'],
+            'Per36Minutes' => [$base . '/UI/Tables/Per36Minutes.php'],
+            'SeasonAverages' => [$base . '/UI/Tables/SeasonAverages.php'],
+            'PeriodAverages' => [$base . '/UI/Tables/PeriodAverages.php'],
+            'SplitStats' => [$base . '/UI/Tables/SplitStats.php'],
+            'SeasonTotals' => [$base . '/UI/Tables/SeasonTotals.php'],
+            'Contracts' => [$base . '/UI/Tables/Contracts.php'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces CSS `@layer` ordering (`theme, base, reset, legacy, components, overrides, utilities`) interleaved with Tailwind v4's internal layers, making the cascade deterministic by definition
- Reduces `!important` declarations from 131 to 13 (118 removed) — specificity battles are now resolved by layer ordering instead of `!important` hacks
- Removes 161 redundant inline `style="text-align: center;"` from `<td>` elements across 8 View files (`.ibl-data-table td` already sets this via CSS)
- Adds `.claude/rules/css-architecture.md` reference document with layer hierarchy, table pattern decision tree, overflow rules, and `!important` policy
- Adds PHPUnit `InlineStyleRemovalTest` (8 data-provider cases) to prevent regression

## !important Reduction Breakdown

| File | Before | After | Notes |
|------|--------|-------|-------|
| `player-cards.css` | 68 | 2 | Kept for Safari tel: link UA override |
| `tables.css` | 33 | 0 | Specificity increased via `.ibl-data-table` prefix |
| `navigation.css` | 11 | 3 | Kept for Tailwind utility layer overrides |
| `base.css` | 11 | 0 | Mobile block moved to `@layer overrides` |
| Other files | 8 | 8 | Unchanged (justified uses) |
| **Total** | **131** | **13** | **118 removed** |

## Test plan

- [x] Full PHPUnit suite passes (3087 tests, 16383 assertions)
- [x] PHPStan passes (0 errors, level max)
- [x] CSS builds successfully with Tailwind v4.2.1
- [x] Visual comparison against iblhoops.net at 375px, 768px, 1440px
- [x] Verify sticky columns on Standings page
- [x] Verify player card overrides on Player pages
- [x] Verify responsive tables on Trading page

🤖 Generated with [Claude Code](https://claude.com/claude-code)