### PR TITLE
feat: add Rookie, Sophomore, and All-Star career leaderboards

### DIFF
--- a/ibl5/classes/CareerLeaderboards/CachedCareerLeaderboardsRepository.php
+++ b/ibl5/classes/CareerLeaderboards/CachedCareerLeaderboardsRepository.php
@@ -10,7 +10,7 @@ use CareerLeaderboards\Contracts\CareerLeaderboardsRepositoryInterface;
 /**
  * CachedCareerLeaderboardsRepository - Caching decorator for CareerLeaderboardsRepositoryInterface.
  *
- * Caches full unsorted result sets per table key (8 entries total).
+ * Caches full unsorted result sets per table key (12 entries total).
  * On cache hit, filters by active-only, sorts by the requested column,
  * and slices for limit — all in PHP. This avoids running slow database
  * view queries on every sort/filter change.
@@ -32,6 +32,10 @@ class CachedCareerLeaderboardsRepository implements CareerLeaderboardsRepository
         'ibl_heat_career_avgs',
         'ibl_olympics_career_totals',
         'ibl_olympics_career_avgs',
+        'ibl_rookie_career_totals',
+        'ibl_sophomore_career_totals',
+        'ibl_allstar_career_totals',
+        'ibl_allstar_career_avgs',
     ];
 
     private CareerLeaderboardsRepositoryInterface $inner;
@@ -101,7 +105,7 @@ class CachedCareerLeaderboardsRepository implements CareerLeaderboardsRepository
     }
 
     /**
-     * Rebuild cache for all 8 table keys.
+     * Rebuild cache for all 12 table keys.
      *
      * Fetches full result sets from the inner repository and stores them.
      * Called by the warm-cache CLI script and optionally after game simulations.
@@ -119,7 +123,7 @@ class CachedCareerLeaderboardsRepository implements CareerLeaderboardsRepository
     }
 
     /**
-     * Invalidate cache for all 8 table keys.
+     * Invalidate cache for all 12 table keys.
      */
     public function invalidateCache(): void
     {

--- a/ibl5/classes/CareerLeaderboards/CareerLeaderboardsRepository.php
+++ b/ibl5/classes/CareerLeaderboards/CareerLeaderboardsRepository.php
@@ -30,6 +30,10 @@ class CareerLeaderboardsRepository extends \BaseMysqliRepository implements Care
         'ibl_heat_career_avgs',
         'ibl_olympics_career_totals',
         'ibl_olympics_career_avgs',
+        'ibl_rookie_career_totals',
+        'ibl_sophomore_career_totals',
+        'ibl_allstar_career_totals',
+        'ibl_allstar_career_avgs',
     ];
 
     // Whitelist of valid sort columns
@@ -133,6 +137,7 @@ class CareerLeaderboardsRepository extends \BaseMysqliRepository implements Care
             'ibl_playoff_career_avgs',
             'ibl_heat_career_avgs',
             'ibl_olympics_career_avgs',
+            'ibl_allstar_career_avgs',
         ];
 
         return in_array($tableKey, $avgTables, true) ? 'averages' : 'totals';

--- a/ibl5/classes/CareerLeaderboards/CareerLeaderboardsService.php
+++ b/ibl5/classes/CareerLeaderboards/CareerLeaderboardsService.php
@@ -113,6 +113,10 @@ class CareerLeaderboardsService implements CareerLeaderboardsServiceInterface
             'ibl_heat_career_avgs' => 'H.E.A.T. Averages',
             'ibl_olympics_career_totals' => 'Olympic Totals',
             'ibl_olympics_career_avgs' => 'Olympic Averages',
+            'ibl_rookie_career_totals' => 'Rookie Game Totals',
+            'ibl_sophomore_career_totals' => 'Sophomore Game Totals',
+            'ibl_allstar_career_totals' => 'All-Star Game Totals',
+            'ibl_allstar_career_avgs' => 'All-Star Game Averages',
         ];
     }
 

--- a/ibl5/classes/CareerLeaderboards/Contracts/CareerLeaderboardsRepositoryInterface.php
+++ b/ibl5/classes/CareerLeaderboards/Contracts/CareerLeaderboardsRepositoryInterface.php
@@ -8,7 +8,7 @@ namespace CareerLeaderboards\Contracts;
  * CareerLeaderboardsRepositoryInterface - Career Leaderboards database operations
  *
  * Handles all database operations for career statistics across
- * multiple table types (regular season, playoffs, H.E.A.T., Olympics).
+ * multiple table types (regular season, playoffs, H.E.A.T., Olympics, Rookie, Sophomore, All-Star).
  *
  * @phpstan-type CareerStatsRow array{pid: int, name: string, games: int|float|string, minutes: int|float|string, fgm: int|float|string, fga: int|float|string, fgpct?: float|string|null, ftm: int|float|string, fta: int|float|string, ftpct?: float|string|null, tgm: int|float|string, tga: int|float|string, tpct?: float|string|null, orb: int|float|string, reb: int|float|string, ast: int|float|string, stl: int|float|string, tvr: int|float|string, blk: int|float|string, pf: int|float|string, pts: int|float|string, retired: int|string}
  * @phpstan-type LeaderboardResult array{result: list<CareerStatsRow>, count: int}
@@ -36,6 +36,10 @@ interface CareerLeaderboardsRepositoryInterface
      * - ibl_heat_career_avgs
      * - ibl_olympics_career_totals
      * - ibl_olympics_career_avgs
+     * - ibl_rookie_career_totals
+     * - ibl_sophomore_career_totals
+     * - ibl_allstar_career_totals
+     * - ibl_allstar_career_avgs
      *
      * **Valid Sort Columns:**
      * pts, games, minutes, fgm, fga, fgpct, ftm, fta, ftpct,
@@ -71,6 +75,7 @@ interface CareerLeaderboardsRepositoryInterface
      * - ibl_playoff_career_avgs
      * - ibl_heat_career_avgs
      * - ibl_olympics_career_avgs
+     * - ibl_allstar_career_avgs
      *
      * **Total Tables:**
      * All other tables including ibl_hist

--- a/ibl5/migrations/create_allstar_rookie_sophomore_career_views.sql
+++ b/ibl5/migrations/create_allstar_rookie_sophomore_career_views.sql
@@ -1,0 +1,123 @@
+-- Migration: Create career leaderboard views for Rookie, Sophomore, and All-Star games
+-- These views filter ibl_box_scores by teamID to surface historical exhibition game data.
+-- Rookie (teamID=40), Sophomore (teamID=41), All-Star (teamID IN 50,51)
+
+-- Rookie Game Career Totals (teamID = 40)
+CREATE OR REPLACE VIEW ibl_rookie_career_totals AS
+SELECT
+    bs.pid AS pid,
+    p.name AS name,
+    CAST(COUNT(*) AS SIGNED) AS games,
+    CAST(SUM(bs.gameMIN) AS SIGNED) AS minutes,
+    CAST(SUM(bs.calc_fg_made) AS SIGNED) AS fgm,
+    CAST(SUM(bs.game2GA + bs.game3GA) AS SIGNED) AS fga,
+    CAST(SUM(bs.gameFTM) AS SIGNED) AS ftm,
+    CAST(SUM(bs.gameFTA) AS SIGNED) AS fta,
+    CAST(SUM(bs.game3GM) AS SIGNED) AS tgm,
+    CAST(SUM(bs.game3GA) AS SIGNED) AS tga,
+    CAST(SUM(bs.gameORB) AS SIGNED) AS orb,
+    CAST(SUM(bs.calc_rebounds) AS SIGNED) AS reb,
+    CAST(SUM(bs.gameAST) AS SIGNED) AS ast,
+    CAST(SUM(bs.gameSTL) AS SIGNED) AS stl,
+    CAST(SUM(bs.gameTOV) AS SIGNED) AS tvr,
+    CAST(SUM(bs.gameBLK) AS SIGNED) AS blk,
+    CAST(SUM(bs.gamePF) AS SIGNED) AS pf,
+    CAST(SUM(bs.calc_points) AS SIGNED) AS pts,
+    p.retired AS retired
+FROM ibl_box_scores bs
+JOIN ibl_plr p ON bs.pid = p.pid
+WHERE bs.teamID = 40
+GROUP BY bs.pid, p.name, p.retired;
+
+-- Sophomore Game Career Totals (teamID = 41)
+CREATE OR REPLACE VIEW ibl_sophomore_career_totals AS
+SELECT
+    bs.pid AS pid,
+    p.name AS name,
+    CAST(COUNT(*) AS SIGNED) AS games,
+    CAST(SUM(bs.gameMIN) AS SIGNED) AS minutes,
+    CAST(SUM(bs.calc_fg_made) AS SIGNED) AS fgm,
+    CAST(SUM(bs.game2GA + bs.game3GA) AS SIGNED) AS fga,
+    CAST(SUM(bs.gameFTM) AS SIGNED) AS ftm,
+    CAST(SUM(bs.gameFTA) AS SIGNED) AS fta,
+    CAST(SUM(bs.game3GM) AS SIGNED) AS tgm,
+    CAST(SUM(bs.game3GA) AS SIGNED) AS tga,
+    CAST(SUM(bs.gameORB) AS SIGNED) AS orb,
+    CAST(SUM(bs.calc_rebounds) AS SIGNED) AS reb,
+    CAST(SUM(bs.gameAST) AS SIGNED) AS ast,
+    CAST(SUM(bs.gameSTL) AS SIGNED) AS stl,
+    CAST(SUM(bs.gameTOV) AS SIGNED) AS tvr,
+    CAST(SUM(bs.gameBLK) AS SIGNED) AS blk,
+    CAST(SUM(bs.gamePF) AS SIGNED) AS pf,
+    CAST(SUM(bs.calc_points) AS SIGNED) AS pts,
+    p.retired AS retired
+FROM ibl_box_scores bs
+JOIN ibl_plr p ON bs.pid = p.pid
+WHERE bs.teamID = 41
+GROUP BY bs.pid, p.name, p.retired;
+
+-- All-Star Game Career Totals (teamID IN 50, 51)
+CREATE OR REPLACE VIEW ibl_allstar_career_totals AS
+SELECT
+    bs.pid AS pid,
+    p.name AS name,
+    CAST(COUNT(*) AS SIGNED) AS games,
+    CAST(SUM(bs.gameMIN) AS SIGNED) AS minutes,
+    CAST(SUM(bs.calc_fg_made) AS SIGNED) AS fgm,
+    CAST(SUM(bs.game2GA + bs.game3GA) AS SIGNED) AS fga,
+    CAST(SUM(bs.gameFTM) AS SIGNED) AS ftm,
+    CAST(SUM(bs.gameFTA) AS SIGNED) AS fta,
+    CAST(SUM(bs.game3GM) AS SIGNED) AS tgm,
+    CAST(SUM(bs.game3GA) AS SIGNED) AS tga,
+    CAST(SUM(bs.gameORB) AS SIGNED) AS orb,
+    CAST(SUM(bs.calc_rebounds) AS SIGNED) AS reb,
+    CAST(SUM(bs.gameAST) AS SIGNED) AS ast,
+    CAST(SUM(bs.gameSTL) AS SIGNED) AS stl,
+    CAST(SUM(bs.gameTOV) AS SIGNED) AS tvr,
+    CAST(SUM(bs.gameBLK) AS SIGNED) AS blk,
+    CAST(SUM(bs.gamePF) AS SIGNED) AS pf,
+    CAST(SUM(bs.calc_points) AS SIGNED) AS pts,
+    p.retired AS retired
+FROM ibl_box_scores bs
+JOIN ibl_plr p ON bs.pid = p.pid
+WHERE bs.teamID IN (50, 51)
+GROUP BY bs.pid, p.name, p.retired;
+
+-- All-Star Game Career Averages (teamID IN 50, 51)
+CREATE OR REPLACE VIEW ibl_allstar_career_avgs AS
+SELECT
+    bs.pid AS pid,
+    p.name AS name,
+    CAST(COUNT(*) AS SIGNED) AS games,
+    ROUND(AVG(bs.gameMIN), 2) AS minutes,
+    ROUND(AVG(bs.calc_fg_made), 2) AS fgm,
+    ROUND(AVG(bs.game2GA + bs.game3GA), 2) AS fga,
+    CASE WHEN SUM(bs.game2GA + bs.game3GA) > 0
+        THEN ROUND(SUM(bs.calc_fg_made) / SUM(bs.game2GA + bs.game3GA), 3)
+        ELSE 0.000
+    END AS fgpct,
+    ROUND(AVG(bs.gameFTM), 2) AS ftm,
+    ROUND(AVG(bs.gameFTA), 2) AS fta,
+    CASE WHEN SUM(bs.gameFTA) > 0
+        THEN ROUND(SUM(bs.gameFTM) / SUM(bs.gameFTA), 3)
+        ELSE 0.000
+    END AS ftpct,
+    ROUND(AVG(bs.game3GM), 2) AS tgm,
+    ROUND(AVG(bs.game3GA), 2) AS tga,
+    CASE WHEN SUM(bs.game3GA) > 0
+        THEN ROUND(SUM(bs.game3GM) / SUM(bs.game3GA), 3)
+        ELSE 0.000
+    END AS tpct,
+    ROUND(AVG(bs.gameORB), 2) AS orb,
+    ROUND(AVG(bs.calc_rebounds), 2) AS reb,
+    ROUND(AVG(bs.gameAST), 2) AS ast,
+    ROUND(AVG(bs.gameSTL), 2) AS stl,
+    ROUND(AVG(bs.gameTOV), 2) AS tvr,
+    ROUND(AVG(bs.gameBLK), 2) AS blk,
+    ROUND(AVG(bs.gamePF), 2) AS pf,
+    ROUND(AVG(bs.calc_points), 2) AS pts,
+    p.retired AS retired
+FROM ibl_box_scores bs
+JOIN ibl_plr p ON bs.pid = p.pid
+WHERE bs.teamID IN (50, 51)
+GROUP BY bs.pid, p.name, p.retired;

--- a/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
@@ -137,32 +137,34 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
         $this->assertSame('averages', $result);
     }
 
-    public function testRebuildCacheWarmsAllEightTables(): void
+    public function testRebuildCacheWarmsAllTwelveTables(): void
     {
         $mockInner = $this->createMock(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($mockInner, $this->cache);
 
         $sampleResult = ['result' => [['pid' => 1, 'name' => 'Test', 'pts' => 100, 'retired' => 0]], 'count' => 1];
 
-        $mockInner->expects($this->exactly(8))
+        $mockInner->expects($this->exactly(12))
             ->method('getLeaderboards')
             ->willReturn($sampleResult);
 
         $repository->rebuildCache();
 
-        // Verify all 8 keys are cached
+        // Verify all 12 keys are cached
         $tables = [
             'ibl_hist', 'ibl_season_career_avgs',
             'ibl_playoff_career_totals', 'ibl_playoff_career_avgs',
             'ibl_heat_career_totals', 'ibl_heat_career_avgs',
             'ibl_olympics_career_totals', 'ibl_olympics_career_avgs',
+            'ibl_rookie_career_totals', 'ibl_sophomore_career_totals',
+            'ibl_allstar_career_totals', 'ibl_allstar_career_avgs',
         ];
         foreach ($tables as $table) {
             $this->assertNotNull($this->cache->get('career_leaderboards:' . $table));
         }
     }
 
-    public function testInvalidateCacheDeletesAllEightKeys(): void
+    public function testInvalidateCacheDeletesAllTwelveKeys(): void
     {
         $stubInner = $this->createStub(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($stubInner, $this->cache);
@@ -173,6 +175,8 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
             'ibl_playoff_career_totals', 'ibl_playoff_career_avgs',
             'ibl_heat_career_totals', 'ibl_heat_career_avgs',
             'ibl_olympics_career_totals', 'ibl_olympics_career_avgs',
+            'ibl_rookie_career_totals', 'ibl_sophomore_career_totals',
+            'ibl_allstar_career_totals', 'ibl_allstar_career_avgs',
         ];
         foreach ($tables as $table) {
             $this->cache->set('career_leaderboards:' . $table, [['pid' => 1]], 86400);

--- a/ibl5/tests/CareerLeaderboards/CareerLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/CareerLeaderboards/CareerLeaderboardsRepositoryTest.php
@@ -16,6 +16,9 @@ final class CareerLeaderboardsRepositoryTest extends TestCase
         $this->assertEquals('totals', $repository->getTableType('ibl_playoff_career_totals'));
         $this->assertEquals('totals', $repository->getTableType('ibl_heat_career_totals'));
         $this->assertEquals('totals', $repository->getTableType('ibl_olympics_career_totals'));
+        $this->assertEquals('totals', $repository->getTableType('ibl_rookie_career_totals'));
+        $this->assertEquals('totals', $repository->getTableType('ibl_sophomore_career_totals'));
+        $this->assertEquals('totals', $repository->getTableType('ibl_allstar_career_totals'));
     }
 
     public function testGetTableTypeIdentifiesAverages(): void
@@ -27,6 +30,7 @@ final class CareerLeaderboardsRepositoryTest extends TestCase
         $this->assertEquals('averages', $repository->getTableType('ibl_playoff_career_avgs'));
         $this->assertEquals('averages', $repository->getTableType('ibl_heat_career_avgs'));
         $this->assertEquals('averages', $repository->getTableType('ibl_olympics_career_avgs'));
+        $this->assertEquals('averages', $repository->getTableType('ibl_allstar_career_avgs'));
     }
 
     public function testGetLeaderboardsRejectsInvalidTableName(): void

--- a/ibl5/tests/CareerLeaderboards/CareerLeaderboardsServiceTest.php
+++ b/ibl5/tests/CareerLeaderboards/CareerLeaderboardsServiceTest.php
@@ -168,11 +168,19 @@ final class CareerLeaderboardsServiceTest extends TestCase
         $boardTypes = $this->service->getBoardTypes();
 
         $this->assertIsArray($boardTypes);
-        $this->assertCount(8, $boardTypes);
+        $this->assertCount(12, $boardTypes);
         $this->assertArrayHasKey('ibl_hist', $boardTypes);
         $this->assertEquals('Regular Season Totals', $boardTypes['ibl_hist']);
         $this->assertArrayHasKey('ibl_season_career_avgs', $boardTypes);
         $this->assertEquals('Regular Season Averages', $boardTypes['ibl_season_career_avgs']);
+        $this->assertArrayHasKey('ibl_rookie_career_totals', $boardTypes);
+        $this->assertEquals('Rookie Game Totals', $boardTypes['ibl_rookie_career_totals']);
+        $this->assertArrayHasKey('ibl_sophomore_career_totals', $boardTypes);
+        $this->assertEquals('Sophomore Game Totals', $boardTypes['ibl_sophomore_career_totals']);
+        $this->assertArrayHasKey('ibl_allstar_career_totals', $boardTypes);
+        $this->assertEquals('All-Star Game Totals', $boardTypes['ibl_allstar_career_totals']);
+        $this->assertArrayHasKey('ibl_allstar_career_avgs', $boardTypes);
+        $this->assertEquals('All-Star Game Averages', $boardTypes['ibl_allstar_career_avgs']);
     }
 
     public function testGetSortCategories(): void


### PR DESCRIPTION
## Summary

- Add 4 new database views (`ibl_rookie_career_totals`, `ibl_sophomore_career_totals`, `ibl_allstar_career_totals`, `ibl_allstar_career_avgs`) that surface historical Rookie Game (teamID=40), Sophomore Game (teamID=41), and All-Star Game (teamID=50/51) box score data spanning 1989–2006
- Register the 4 new views across Repository, Service, Cache decorator, and Interface (8 → 12 board types)
- Update all CareerLeaderboards tests for the expanded table set (count assertions, table type assertions, cache rebuild/invalidate tests)

## Data Validated

| View | Row Count |
|------|-----------|
| `ibl_rookie_career_totals` | 180 players |
| `ibl_sophomore_career_totals` | 180 players |
| `ibl_allstar_career_totals` | 135 players |
| `ibl_allstar_career_avgs` | 135 players |

## Test plan

- [x] Full PHPUnit suite passes (3,132 tests, 16,319 assertions)
- [x] PHPStan level max passes with no errors
- [x] All 4 views return expected row counts
- [x] Load CareerLeaderboards in browser and select each new display type

🤖 Generated with [Claude Code](https://claude.com/claude-code)