### PR TITLE
Remove redundant Cap Totals cards from trading page

### DIFF
--- a/ibl5/classes/Trading/TradingView.php
+++ b/ibl5/classes/Trading/TradingView.php
@@ -124,7 +124,6 @@ class TradingView implements TradingViewInterface
             </div>
         </div>
 <?= $this->renderCashExchange($seasonEndingYear, $seasonPhase, $cashStartYear, $cashEndYear, $userTeam, $partnerTeam, $previousFormData) ?>
-<?= $this->renderCapTotals($pageData, $seasonEndingYear, $userTeam, $partnerTeam) ?>
         <div style="text-align: center; padding: 1rem;">
             <input type="hidden" name="fieldsCounter" value="<?= (int) $k ?>">
             <button type="submit" class="ibl-btn ibl-btn--primary">Make Trade Offer</button>
@@ -376,45 +375,6 @@ class TradingView implements TradingViewInterface
         $html = (string) ob_get_clean();
 
         return ['html' => $html, 'nextK' => $k];
-    }
-
-    /**
-     * Render the cap totals section of the trade form
-     *
-     * @param array{userFutureSalary: array{player: array<int, int>, hold: array<int, int>}, partnerFutureSalary: array{player: array<int, int>, hold: array<int, int>}, seasonPhase: string} $pageData
-     */
-    private function renderCapTotals(array $pageData, int $seasonEndingYear, string $userTeam, string $partnerTeam): string
-    {
-        $userFutureSalary = $pageData['userFutureSalary'];
-        $partnerFutureSalary = $pageData['partnerFutureSalary'];
-        $seasonPhase = $pageData['seasonPhase'];
-
-        $displayEndingYear = $seasonEndingYear;
-        $seasonsToDisplay = 6;
-        $isOffseason = ($seasonPhase === 'Playoffs' || $seasonPhase === 'Draft' || $seasonPhase === 'Free Agency');
-        if ($isOffseason) {
-            $displayEndingYear++;
-            $seasonsToDisplay--;
-        }
-
-        ob_start();
-        ?>
-<table class="ibl-data-table trading-cap-totals" data-no-responsive style="width: 100%; margin-top: 1rem;">
-    <thead><tr><th colspan="2">Cap Totals</th></tr></thead>
-    <tbody>
-<?php for ($z = 0; $z < $seasonsToDisplay; $z++):
-    $yearLabel = ($displayEndingYear + $z - 1) . '-' . ($displayEndingYear + $z);
-    $yearLabelEscaped = HtmlSanitizer::safeHtmlOutput($yearLabel);
-?>
-    <tr>
-        <td style="text-align: left;"><strong><?= $userTeam ?></strong> in <?= $yearLabelEscaped ?>: <?= $userFutureSalary['player'][$z] ?></td>
-        <td style="text-align: right;"><strong><?= $partnerTeam ?></strong> in <?= $yearLabelEscaped ?>: <?= $partnerFutureSalary['player'][$z] ?></td>
-    </tr>
-<?php endfor; ?>
-    </tbody>
-</table>
-        <?php
-        return (string) ob_get_clean();
     }
 
     /**

--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -1314,18 +1314,6 @@ td.ibl-team-cell--colored {
     word-break: break-word;
 }
 
-/* Cap totals table */
-.trading-cap-totals th {
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-    padding: 0.5rem 0.75rem;
-    text-align: center;
-}
-
-.trading-cap-totals td {
-    padding: 0.5rem 0.75rem;
-}
-
 /* Cash exchange table */
 .trading-cash-exchange td {
     padding: 0.5rem 0.75rem;

--- a/ibl5/tests/Trading/TradingViewTest.php
+++ b/ibl5/tests/Trading/TradingViewTest.php
@@ -80,15 +80,6 @@ class TradingViewTest extends TestCase
         $this->assertStringContainsString('R1', $html);
     }
 
-    public function testRenderTradeOfferFormContainsCapTotals(): void
-    {
-        $pageData = $this->createTradeOfferPageData();
-
-        $html = $this->view->renderTradeOfferForm($pageData);
-
-        $this->assertStringContainsString('Cap Totals', $html);
-    }
-
     public function testRenderTradeOfferFormContainsCashExchange(): void
     {
         $pageData = $this->createTradeOfferPageData();


### PR DESCRIPTION
## Summary

- Removed the standalone Cap Totals card tables from the trade offer form — this data is now shown in the Contracts tab of the Roster Preview panel
- Removed `renderCapTotals()` method from `TradingView.php` and its CSS rules from `tables.css`
- Removed the corresponding unit test `testRenderTradeOfferFormContainsCapTotals`

## Test plan

- [ ] Verify trading page renders without errors
- [ ] Confirm Cap Totals cards no longer appear below Cash Exchange
- [ ] Confirm Contracts tab in Roster Preview still shows cap totals per-year
- [ ] Run full PHPUnit suite — passes with 3323 tests, 16924 assertions
- [ ] Run PHPStan — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)