### PR TITLE
Refactor updater pipeline into Controller/Service/Step architecture

### DIFF
--- a/ibl5/classes/Updater/Contracts/PipelineStepInterface.php
+++ b/ibl5/classes/Updater/Contracts/PipelineStepInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Contracts;
+
+use Updater\StepResult;
+
+/**
+ * Contract for a single step in the update pipeline.
+ *
+ * Each step encapsulates one discrete operation (e.g., importing a file,
+ * updating standings). Steps are executed sequentially by the UpdaterService.
+ */
+interface PipelineStepInterface
+{
+    /**
+     * Human-readable label for this step (used in progress output).
+     */
+    public function getLabel(): string;
+
+    /**
+     * Execute this pipeline step.
+     *
+     * @return StepResult The outcome of the step execution
+     */
+    public function execute(): StepResult;
+}

--- a/ibl5/classes/Updater/Contracts/UpdaterControllerInterface.php
+++ b/ibl5/classes/Updater/Contracts/UpdaterControllerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Contracts;
+
+/**
+ * Contract for the updater pipeline controller.
+ *
+ * Responsible for wiring dependencies, registering steps,
+ * and managing progressive output via callbacks.
+ */
+interface UpdaterControllerInterface
+{
+    /**
+     * Execute the full update pipeline with progressive output.
+     */
+    public function run(): void;
+}

--- a/ibl5/classes/Updater/Contracts/UpdaterServiceInterface.php
+++ b/ibl5/classes/Updater/Contracts/UpdaterServiceInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Contracts;
+
+use Updater\StepResult;
+
+/**
+ * Contract for the pipeline orchestration service.
+ *
+ * Manages step registration, sequential execution with per-step error isolation,
+ * and progress callbacks for streaming output.
+ */
+interface UpdaterServiceInterface
+{
+    /**
+     * Register a step to be executed in the pipeline.
+     */
+    public function addStep(PipelineStepInterface $step): void;
+
+    /**
+     * Run all registered steps sequentially.
+     *
+     * Each step is wrapped in a try/catch so that one failure does not abort
+     * the remaining steps. Callbacks are invoked before and after each step
+     * for progressive output.
+     *
+     * @param callable(PipelineStepInterface): void $onStepStart Called before each step executes
+     * @param callable(StepResult): void $onStepComplete Called after each step completes (success or failure)
+     * @return list<StepResult> Results from all executed steps
+     */
+    public function run(callable $onStepStart, callable $onStepComplete): array;
+
+    /**
+     * Get the count of successful steps from the last run.
+     */
+    public function getSuccessCount(): int;
+
+    /**
+     * Get the count of failed steps from the last run.
+     */
+    public function getErrorCount(): int;
+}

--- a/ibl5/classes/Updater/Contracts/UpdaterViewInterface.php
+++ b/ibl5/classes/Updater/Contracts/UpdaterViewInterface.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Contracts;
+
+/**
+ * Contract for the updater page HTML rendering.
+ */
+interface UpdaterViewInterface
+{
+    /**
+     * Render the page opening: doctype, head, body open, title.
+     */
+    public function renderPageOpen(string $stylesheetPath): string;
+
+    /**
+     * Open a labelled section group.
+     */
+    public function renderSectionOpen(string $label): string;
+
+    /**
+     * Close a section group.
+     */
+    public function renderSectionClose(): string;
+
+    /**
+     * Render an initialization confirmation line.
+     */
+    public function renderInitStatus(string $label): string;
+
+    /**
+     * Render a step-in-progress indicator with spinner.
+     */
+    public function renderStepStart(string $label): string;
+
+    /**
+     * Render a completed step with green checkmark.
+     */
+    public function renderStepComplete(string $label, string $detail = ''): string;
+
+    /**
+     * Render a failed step with red X and error message.
+     */
+    public function renderStepError(string $label, string $error): string;
+
+    /**
+     * Render captured output as muted inline log content.
+     */
+    public function renderLog(string $capturedOutput): string;
+
+    /**
+     * Render trusted HTML inline within the pipeline's visual framework.
+     */
+    public function renderInlineHtml(string $trustedHtml): string;
+
+    /**
+     * Render summary status line showing success/error counts.
+     */
+    public function renderSummary(int $successCount, int $errorCount): string;
+
+    /**
+     * Render a list of messages as an expandable log.
+     *
+     * @param list<string> $messages
+     */
+    public function renderMessageLog(array $messages, int $errorCount): string;
+
+    /**
+     * Render the page closing: return link and close tags.
+     */
+    public function renderPageClose(): string;
+}

--- a/ibl5/classes/Updater/StepResult.php
+++ b/ibl5/classes/Updater/StepResult.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater;
+
+/**
+ * Immutable value object representing the outcome of a single pipeline step.
+ *
+ * Use the named static factories to create instances:
+ * - StepResult::success() — step completed normally
+ * - StepResult::failure() — step encountered an error
+ * - StepResult::skipped() — step was skipped (treated as a success)
+ */
+final class StepResult
+{
+    /**
+     * @param list<string> $messages
+     */
+    private function __construct(
+        public readonly string $label,
+        public readonly bool $success,
+        public readonly string $detail,
+        public readonly string $capturedLog,
+        public readonly string $inlineHtml,
+        public readonly string $errorMessage,
+        public readonly array $messages,
+        public readonly int $messageErrorCount,
+    ) {
+    }
+
+    /**
+     * Create a successful step result.
+     *
+     * @param list<string> $messages
+     */
+    public static function success(
+        string $label,
+        string $detail = '',
+        string $capturedLog = '',
+        string $inlineHtml = '',
+        array $messages = [],
+        int $messageErrorCount = 0,
+    ): self {
+        return new self(
+            label: $label,
+            success: true,
+            detail: $detail,
+            capturedLog: $capturedLog,
+            inlineHtml: $inlineHtml,
+            errorMessage: '',
+            messages: $messages,
+            messageErrorCount: $messageErrorCount,
+        );
+    }
+
+    /**
+     * Create a failed step result.
+     */
+    public static function failure(string $label, string $errorMessage): self
+    {
+        return new self(
+            label: $label,
+            success: false,
+            detail: '',
+            capturedLog: '',
+            inlineHtml: '',
+            errorMessage: $errorMessage,
+            messages: [],
+            messageErrorCount: 0,
+        );
+    }
+
+    /**
+     * Create a skipped step result (treated as success with a reason).
+     */
+    public static function skipped(string $label, string $reason): self
+    {
+        return new self(
+            label: $label,
+            success: true,
+            detail: $reason,
+            capturedLog: '',
+            inlineHtml: '',
+            errorMessage: '',
+            messages: [],
+            messageErrorCount: 0,
+        );
+    }
+}

--- a/ibl5/classes/Updater/Steps/ExtendDepthChartsStep.php
+++ b/ibl5/classes/Updater/Steps/ExtendDepthChartsStep.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use SavedDepthChart\SavedDepthChartRepository;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StepResult;
+
+/**
+ * Step 7: Extend active saved depth charts.
+ *
+ * Wraps SavedDepthChartRepository::extendActiveDepthCharts() and captures output.
+ */
+class ExtendDepthChartsStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly SavedDepthChartRepository $repository,
+        private readonly string $lastSimEndDate,
+        private readonly int $lastSimNumber,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Saved depth charts updated';
+    }
+
+    public function execute(): StepResult
+    {
+        ob_start();
+        $count = $this->repository->extendActiveDepthCharts($this->lastSimEndDate, $this->lastSimNumber);
+        $log = (string) ob_get_clean();
+
+        return StepResult::success($this->getLabel(), $count . ' active DCs extended', capturedLog: $log);
+    }
+}

--- a/ibl5/classes/Updater/Steps/ImportLeagueConfigStep.php
+++ b/ibl5/classes/Updater/Steps/ImportLeagueConfigStep.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use LeagueConfig\LeagueConfigRepository;
+use LeagueConfig\LeagueConfigService;
+use LeagueConfig\LeagueConfigView;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StepResult;
+
+/**
+ * Step 1: Import league config from .lge file.
+ *
+ * Skips if already imported for the current season or if the file is missing.
+ */
+class ImportLeagueConfigStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly LeagueConfigRepository $repository,
+        private readonly LeagueConfigService $service,
+        private readonly LeagueConfigView $view,
+        private readonly int $seasonEndingYear,
+        private readonly string $lgePath,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'League config';
+    }
+
+    public function execute(): StepResult
+    {
+        if ($this->repository->hasConfigForSeason($this->seasonEndingYear)) {
+            return StepResult::skipped($this->getLabel(), 'Already imported for ' . $this->seasonEndingYear);
+        }
+
+        if (!is_file($this->lgePath)) {
+            return StepResult::skipped($this->getLabel(), 'No IBL5.lge file found (skipped)');
+        }
+
+        $lgeResult = $this->service->processLgeFile($this->lgePath);
+        $inlineHtml = $this->view->renderParseResult($lgeResult);
+
+        if (!$lgeResult['success']) {
+            $error = is_string($lgeResult['error'] ?? null) ? $lgeResult['error'] : 'Unknown error';
+            return StepResult::failure($this->getLabel() . ' import failed', $error);
+        }
+
+        $discrepancies = $this->service->crossCheckWithFranchiseSeasons(
+            $lgeResult['season_ending_year'],
+        );
+        if ($discrepancies !== []) {
+            $inlineHtml .= $this->view->renderCrossCheckResults($discrepancies);
+        }
+
+        return StepResult::success($this->getLabel() . ' imported', inlineHtml: $inlineHtml);
+    }
+}

--- a/ibl5/classes/Updater/Steps/ParseJsbFilesStep.php
+++ b/ibl5/classes/Updater/Steps/ParseJsbFilesStep.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use JsbParser\JsbImportService;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StepResult;
+
+/**
+ * Step 10: Parse JSB engine files (.car, .trn, .his, .asw, .rcb).
+ *
+ * Wraps JsbImportService::processCurrentSeason() and captures output.
+ */
+class ParseJsbFilesStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly JsbImportService $service,
+        private readonly string $basePath,
+        private readonly \Season $season,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'JSB files parsed';
+    }
+
+    public function execute(): StepResult
+    {
+        ob_start();
+        $jsbResult = $this->service->processCurrentSeason($this->basePath, $this->season);
+        $log = (string) ob_get_clean();
+
+        return StepResult::success(
+            $this->getLabel(),
+            $jsbResult->summary(),
+            capturedLog: $log,
+            messages: $jsbResult->messages,
+            messageErrorCount: $jsbResult->errors,
+        );
+    }
+}

--- a/ibl5/classes/Updater/Steps/ParsePlayerFileStep.php
+++ b/ibl5/classes/Updater/Steps/ParsePlayerFileStep.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use PlrParser\PlrParserService;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StepResult;
+
+/**
+ * Step 2: Parse player file (.plr).
+ *
+ * Skips if the .plr file is missing.
+ */
+class ParsePlayerFileStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly PlrParserService $service,
+        private readonly string $plrPath,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Player file';
+    }
+
+    public function execute(): StepResult
+    {
+        if (!is_file($this->plrPath)) {
+            return StepResult::skipped($this->getLabel(), 'No IBL5.plr file found (skipped)');
+        }
+
+        $plrResult = $this->service->processPlrFile($this->plrPath);
+
+        return StepResult::success($this->getLabel() . ' parsed', $plrResult->summary());
+    }
+}

--- a/ibl5/classes/Updater/Steps/ProcessAllStarGamesStep.php
+++ b/ibl5/classes/Updater/Steps/ProcessAllStarGamesStep.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use Boxscore\BoxscoreProcessor;
+use Boxscore\BoxscoreRepository;
+use Boxscore\BoxscoreView;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StepResult;
+
+/**
+ * Step 9: Process All-Star games from .sco file.
+ *
+ * Skips if the .sco file is missing. Also checks for All-Star team renaming needs.
+ */
+class ProcessAllStarGamesStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly BoxscoreProcessor $processor,
+        private readonly BoxscoreRepository $boxscoreRepo,
+        private readonly BoxscoreView $view,
+        private readonly string $scoPath,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'All-Star games processed';
+    }
+
+    public function execute(): StepResult
+    {
+        if (!is_file($this->scoPath)) {
+            return StepResult::skipped('All-Star games', 'No IBL5.sco file found (skipped)');
+        }
+
+        $allStarResult = $this->processor->processAllStarGames($this->scoPath, 0);
+        $inlineHtml = $this->view->renderAllStarLog($allStarResult);
+
+        $pendingDefaults = $this->boxscoreRepo->findAllStarGamesWithDefaultNames();
+        if ($pendingDefaults !== []) {
+            $pendingRenames = [];
+            foreach ($pendingDefaults as $row) {
+                /** @var string $date */
+                $date = $row['Date'];
+                $teamID = $row['name'] === BoxscoreProcessor::DEFAULT_AWAY_NAME
+                    ? 50
+                    : 51;
+                $teamLabel = $teamID === 50 ? 'Away (Visitor)' : 'Home';
+                $seasonYear = (int) substr($date, 0, 4);
+                $players = $this->boxscoreRepo->getPlayersForAllStarTeam($date, $teamID);
+
+                $pendingRenames[] = [
+                    'id' => $row['id'],
+                    'date' => $date,
+                    'name' => $row['name'],
+                    'seasonYear' => $seasonYear,
+                    'teamLabel' => $teamLabel,
+                    'players' => $players,
+                ];
+            }
+            $inlineHtml .= $this->view->renderAllStarRenameUI($pendingRenames);
+        }
+
+        return StepResult::success($this->getLabel(), inlineHtml: $inlineHtml);
+    }
+}

--- a/ibl5/classes/Updater/Steps/ProcessBoxscoresStep.php
+++ b/ibl5/classes/Updater/Steps/ProcessBoxscoresStep.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use Boxscore\BoxscoreProcessor;
+use Boxscore\BoxscoreView;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StepResult;
+
+/**
+ * Step 8: Process boxscores from .sco file.
+ *
+ * Skips if the .sco file is missing.
+ */
+class ProcessBoxscoresStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly BoxscoreProcessor $processor,
+        private readonly BoxscoreView $view,
+        private readonly string $scoPath,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Boxscores processed';
+    }
+
+    public function execute(): StepResult
+    {
+        if (!is_file($this->scoPath)) {
+            return StepResult::skipped('Boxscores', 'No IBL5.sco file found (skipped)');
+        }
+
+        $scoResult = $this->processor->processScoFile($this->scoPath, 0, '');
+        $inlineHtml = $this->view->renderParseLog($scoResult);
+
+        return StepResult::success($this->getLabel(), inlineHtml: $inlineHtml);
+    }
+}

--- a/ibl5/classes/Updater/Steps/ResetExtensionAttemptsStep.php
+++ b/ibl5/classes/Updater/Steps/ResetExtensionAttemptsStep.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use Shared\SharedRepository;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StepResult;
+
+/**
+ * Step 6: Reset contract extension attempts.
+ *
+ * Wraps SharedRepository::resetSimContractExtensionAttempts().
+ */
+class ResetExtensionAttemptsStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly SharedRepository $repository,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Extension attempts reset';
+    }
+
+    public function execute(): StepResult
+    {
+        $this->repository->resetSimContractExtensionAttempts();
+
+        return StepResult::success($this->getLabel());
+    }
+}

--- a/ibl5/classes/Updater/Steps/UpdatePowerRankingsStep.php
+++ b/ibl5/classes/Updater/Steps/UpdatePowerRankingsStep.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use Updater\Contracts\PipelineStepInterface;
+use Updater\PowerRankingsUpdater;
+use Updater\StepResult;
+
+/**
+ * Step 5: Update power rankings.
+ *
+ * Wraps PowerRankingsUpdater::update() and captures any echoed output.
+ */
+class UpdatePowerRankingsStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly PowerRankingsUpdater $updater,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Power rankings updated';
+    }
+
+    public function execute(): StepResult
+    {
+        ob_start();
+        $this->updater->update();
+        $log = (string) ob_get_clean();
+
+        return StepResult::success($this->getLabel(), capturedLog: $log);
+    }
+}

--- a/ibl5/classes/Updater/Steps/UpdateScheduleStep.php
+++ b/ibl5/classes/Updater/Steps/UpdateScheduleStep.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use Updater\Contracts\PipelineStepInterface;
+use Updater\ScheduleUpdater;
+use Updater\StepResult;
+
+/**
+ * Step 3: Update schedule.
+ *
+ * Wraps ScheduleUpdater::update() and captures any echoed output.
+ */
+class UpdateScheduleStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly ScheduleUpdater $updater,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Schedule updated';
+    }
+
+    public function execute(): StepResult
+    {
+        ob_start();
+        $this->updater->update();
+        $log = (string) ob_get_clean();
+
+        return StepResult::success($this->getLabel(), capturedLog: $log);
+    }
+}

--- a/ibl5/classes/Updater/Steps/UpdateStandingsStep.php
+++ b/ibl5/classes/Updater/Steps/UpdateStandingsStep.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StandingsUpdater;
+use Updater\StepResult;
+
+/**
+ * Step 4: Update standings.
+ *
+ * Wraps StandingsUpdater::update() and captures any echoed output.
+ */
+class UpdateStandingsStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly StandingsUpdater $updater,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Standings updated';
+    }
+
+    public function execute(): StepResult
+    {
+        ob_start();
+        $this->updater->update();
+        $log = (string) ob_get_clean();
+
+        return StepResult::success($this->getLabel(), capturedLog: $log);
+    }
+}

--- a/ibl5/classes/Updater/UpdaterController.php
+++ b/ibl5/classes/Updater/UpdaterController.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater;
+
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Contracts\UpdaterControllerInterface;
+use Updater\Contracts\UpdaterViewInterface;
+
+/**
+ * Orchestrates the full update pipeline.
+ *
+ * Wires all dependencies, registers pipeline steps, and manages
+ * progressive output via callbacks that echo+flush each step's result.
+ */
+class UpdaterController implements UpdaterControllerInterface
+{
+    public function __construct(
+        private readonly UpdaterService $service,
+        private readonly UpdaterViewInterface $view,
+    ) {
+    }
+
+    /**
+     * @see UpdaterControllerInterface::run()
+     */
+    public function run(): void
+    {
+        echo $this->view->renderSectionOpen('Pipeline');
+        flush();
+
+        $this->service->run(
+            function (PipelineStepInterface $step): void {
+                echo $this->view->renderStepStart($this->getStepProgressLabel($step));
+                flush();
+            },
+            function (StepResult $result): void {
+                $this->renderStepResult($result);
+                flush();
+            },
+        );
+
+        echo $this->view->renderSectionClose();
+        flush();
+
+        echo $this->view->renderSummary(
+            $this->service->getSuccessCount(),
+            $this->service->getErrorCount(),
+        );
+        flush();
+    }
+
+    /**
+     * Map step labels to in-progress descriptions.
+     */
+    private function getStepProgressLabel(PipelineStepInterface $step): string
+    {
+        return match ($step->getLabel()) {
+            'League config' => 'Importing league config (.lge)...',
+            'Player file' => 'Parsing player file (.plr)...',
+            'Schedule updated' => 'Updating schedule...',
+            'Standings updated' => 'Updating standings...',
+            'Power rankings updated' => 'Updating power rankings...',
+            'Extension attempts reset' => 'Resetting extension attempts...',
+            'Saved depth charts updated' => 'Updating saved depth charts...',
+            'Boxscores processed' => 'Processing boxscores (.sco)...',
+            'All-Star games processed' => 'Processing All-Star games...',
+            'JSB files parsed' => 'Parsing JSB engine files...',
+            default => $step->getLabel() . '...',
+        };
+    }
+
+    /**
+     * Render a completed step result with all its optional components.
+     */
+    private function renderStepResult(StepResult $result): void
+    {
+        if ($result->success) {
+            echo $this->view->renderStepComplete($result->label, $result->detail);
+
+            if ($result->inlineHtml !== '') {
+                echo $this->view->renderInlineHtml($result->inlineHtml);
+            }
+
+            if ($result->capturedLog !== '') {
+                echo $this->view->renderLog($result->capturedLog);
+            }
+
+            if ($result->messages !== [] || $result->messageErrorCount > 0) {
+                echo $this->view->renderMessageLog($result->messages, $result->messageErrorCount);
+            }
+        } else {
+            echo $this->view->renderStepError($result->label, $result->errorMessage);
+        }
+    }
+}

--- a/ibl5/classes/Updater/UpdaterService.php
+++ b/ibl5/classes/Updater/UpdaterService.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater;
+
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Contracts\UpdaterServiceInterface;
+
+/**
+ * Pipeline orchestration service.
+ *
+ * Iterates registered steps sequentially, wrapping each in a try/catch
+ * for per-step error isolation. Invokes callbacks before and after each
+ * step to enable progressive output.
+ */
+class UpdaterService implements UpdaterServiceInterface
+{
+    /** @var list<PipelineStepInterface> */
+    private array $steps = [];
+
+    private int $successCount = 0;
+
+    private int $errorCount = 0;
+
+    /**
+     * @see UpdaterServiceInterface::addStep()
+     */
+    public function addStep(PipelineStepInterface $step): void
+    {
+        $this->steps[] = $step;
+    }
+
+    /**
+     * @see UpdaterServiceInterface::run()
+     *
+     * @param callable(PipelineStepInterface): void $onStepStart
+     * @param callable(StepResult): void $onStepComplete
+     * @return list<StepResult>
+     */
+    public function run(callable $onStepStart, callable $onStepComplete): array
+    {
+        $this->successCount = 0;
+        $this->errorCount = 0;
+
+        /** @var list<StepResult> $results */
+        $results = [];
+
+        foreach ($this->steps as $step) {
+            $onStepStart($step);
+
+            try {
+                $result = $step->execute();
+            } catch (\Throwable $e) {
+                $result = StepResult::failure($step->getLabel(), $e->getMessage());
+            }
+
+            if ($result->success) {
+                $this->successCount++;
+            } else {
+                $this->errorCount++;
+            }
+
+            $results[] = $result;
+            $onStepComplete($result);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @see UpdaterServiceInterface::getSuccessCount()
+     */
+    public function getSuccessCount(): int
+    {
+        return $this->successCount;
+    }
+
+    /**
+     * @see UpdaterServiceInterface::getErrorCount()
+     */
+    public function getErrorCount(): int
+    {
+        return $this->errorCount;
+    }
+}

--- a/ibl5/classes/Updater/UpdaterView.php
+++ b/ibl5/classes/Updater/UpdaterView.php
@@ -12,7 +12,7 @@ use Utilities\HtmlSanitizer;
  * Provides structured HTML rendering for the updateAllTheThings script,
  * with grouped sections and minimal visual accents.
  */
-class UpdaterView
+class UpdaterView implements Contracts\UpdaterViewInterface
 {
     /**
      * Render the page opening: doctype, head with fonts/stylesheet, body open, title

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -6,7 +6,7 @@ error_reporting(E_ALL);
 libxml_use_internal_errors(true);
 
 // Load mainfile first for authentication
-require __DIR__ . '/../mainfile.php';
+require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
 
 // SECURITY: Admin-only script - check authentication before proceeding
 if (!function_exists('is_admin') || !is_admin()) {
@@ -45,10 +45,9 @@ global $mysqli_db;
 
 $view = new Updater\UpdaterView();
 
-$stylesheetRelative = 'themes/IBL/style/style.css';
+$stylesheetPath = '/ibl5/themes/IBL/style/style.css';
 /** @var int|false $stylesheetMtime */
-$stylesheetMtime = filemtime(__DIR__ . '/../' . $stylesheetRelative);
-$stylesheetPath = '../' . $stylesheetRelative;
+$stylesheetMtime = filemtime($_SERVER['DOCUMENT_ROOT'] . $stylesheetPath);
 $cacheBuster = $stylesheetMtime !== false ? '?v=' . $stylesheetMtime : '';
 
 echo $view->renderPageOpen($stylesheetPath . $cacheBuster);
@@ -78,10 +77,7 @@ set_exception_handler(function (\Throwable $exception) use ($view): void {
     flush();
 });
 
-$successCount = 0;
-$errorCount = 0;
-
-$basePath = __DIR__ . '/..';
+$basePath = $_SERVER['DOCUMENT_ROOT'] . '/ibl5';
 
 try {
     // --- Initialization ---
@@ -118,221 +114,59 @@ try {
     echo $view->renderSectionClose();
     flush();
 
-    // --- Pipeline ---
-    echo $view->renderSectionOpen('Pipeline');
-    flush();
+    // --- Pipeline: register all steps and delegate to controller ---
+    $updaterService = new Updater\UpdaterService();
 
-    // --- Step 1: Import league config (.lge) ---
-    echo $view->renderStepStart('Importing league config (.lge)...');
-    flush();
+    $defaultLgePath = $basePath . '/IBL5.lge';
+    $defaultPlrPath = $basePath . '/IBL5.plr';
+    $defaultScoPath = $basePath . '/IBL5.sco';
 
     $lgeRepo = new LeagueConfig\LeagueConfigRepository($mysqli_db);
     $lgeService = new LeagueConfig\LeagueConfigService($lgeRepo);
     $lgeView = new LeagueConfig\LeagueConfigView();
-    $defaultLgePath = $basePath . '/IBL5.lge';
 
-    if ($lgeRepo->hasConfigForSeason($season->endingYear)) {
-        echo $view->renderStepComplete('League config', 'Already imported for ' . $season->endingYear);
-        $successCount++;
-    } elseif (!is_file($defaultLgePath)) {
-        echo $view->renderStepComplete('League config', 'No IBL5.lge file found (skipped)');
-        $successCount++;
-    } else {
-        $lgeResult = $lgeService->processLgeFile($defaultLgePath);
-        echo $view->renderInlineHtml($lgeView->renderParseResult($lgeResult));
+    $plrRepo = new PlrParser\PlrParserRepository($mysqli_db);
+    $plrService = new PlrParser\PlrParserService($plrRepo, $commonRepository, $season);
 
-        if ($lgeResult['success']) {
-            echo $view->renderStepComplete('League config imported');
-            $discrepancies = $lgeService->crossCheckWithFranchiseSeasons(
-                $lgeResult['season_ending_year'],
-            );
-            if ($discrepancies !== []) {
-                echo $view->renderInlineHtml($lgeView->renderCrossCheckResults($discrepancies));
-            }
-            $successCount++;
-        } else {
-            /** @var string $lgeError */
-            $lgeError = $lgeResult['error'] ?? 'Unknown error';
-            echo $view->renderStepError('League config import failed', $lgeError);
-            $errorCount++;
-        }
-    }
-    flush();
-
-    // --- Step 2: Parse player file (.plr) ---
-    echo $view->renderStepStart('Parsing player file (.plr)...');
-    flush();
-
-    $defaultPlrPath = $basePath . '/IBL5.plr';
-
-    if (!is_file($defaultPlrPath)) {
-        echo $view->renderStepComplete('Player file', 'No IBL5.plr file found (skipped)');
-    } else {
-        $plrRepo = new PlrParser\PlrParserRepository($mysqli_db);
-        $plrService = new PlrParser\PlrParserService($plrRepo, $commonRepository, $season);
-        $plrResult = $plrService->processPlrFile($defaultPlrPath);
-        echo $view->renderStepComplete('Player file parsed', $plrResult->summary());
-    }
-    flush();
-    $successCount++;
-
-    // --- Step 3: Update schedule ---
-    echo $view->renderStepStart('Updating schedule...');
-    flush();
-    ob_start();
-    $scheduleUpdater->update();
-    $log = (string) ob_get_clean();
-    echo $view->renderStepComplete('Schedule updated');
-    if ($log !== '') {
-        echo $view->renderLog($log);
-    }
-    flush();
-    $successCount++;
-
-    // --- Step 4: Update standings ---
-    echo $view->renderStepStart('Updating standings...');
-    flush();
-    ob_start();
-    $standingsUpdater->update();
-    $log = (string) ob_get_clean();
-    echo $view->renderStepComplete('Standings updated');
-    if ($log !== '') {
-        echo $view->renderLog($log);
-    }
-    flush();
-    $successCount++;
-
-    // --- Step 5: Update power rankings ---
-    echo $view->renderStepStart('Updating power rankings...');
-    flush();
-    ob_start();
-    $powerRankingsUpdater->update();
-    $log = (string) ob_get_clean();
-    echo $view->renderStepComplete('Power rankings updated');
-    if ($log !== '') {
-        echo $view->renderLog($log);
-    }
-    flush();
-    $successCount++;
-
-    // --- Step 6: Reset extension attempts ---
-    echo $view->renderStepStart('Resetting extension attempts...');
-    flush();
-    $sharedRepository->resetSimContractExtensionAttempts();
-    echo $view->renderStepComplete('Extension attempts reset');
-    flush();
-    $successCount++;
-
-    // --- Step 7: Extend active saved depth charts ---
-    echo $view->renderStepStart('Updating saved depth charts...');
-    flush();
-    $savedDcRepo = new SavedDepthChart\SavedDepthChartRepository($mysqli_db);
-    ob_start();
-    $savedDcCount = $savedDcRepo->extendActiveDepthCharts($season->lastSimEndDate, $season->lastSimNumber);
-    $log = (string) ob_get_clean();
-    echo $view->renderStepComplete('Saved depth charts updated', $savedDcCount . ' active DCs extended');
-    if ($log !== '') {
-        echo $view->renderLog($log);
-    }
-    flush();
-    $successCount++;
-
-    // --- Step 8: Process boxscores (.sco) ---
-    echo $view->renderStepStart('Processing boxscores (.sco)...');
-    flush();
-
-    $defaultScoPath = $basePath . '/IBL5.sco';
+    $boxscoreProcessor = new Boxscore\BoxscoreProcessor($mysqli_db);
+    $boxscoreRepo = new Boxscore\BoxscoreRepository($mysqli_db);
     $boxscoreView = new Boxscore\BoxscoreView();
 
-    if (!is_file($defaultScoPath)) {
-        echo $view->renderStepComplete('Boxscores', 'No IBL5.sco file found (skipped)');
-    } else {
-        $processor = new Boxscore\BoxscoreProcessor($mysqli_db);
-        $scoResult = $processor->processScoFile($defaultScoPath, 0, '');
-        echo $view->renderStepComplete('Boxscores processed');
-        echo $view->renderInlineHtml($boxscoreView->renderParseLog($scoResult));
-    }
-    flush();
-    $successCount++;
-
-    // --- Step 9: Process All-Star games (.sco) ---
-    echo $view->renderStepStart('Processing All-Star games...');
-    flush();
-
-    if (!is_file($defaultScoPath)) {
-        echo $view->renderStepComplete('All-Star games', 'No IBL5.sco file found (skipped)');
-    } else {
-        if (!isset($processor)) {
-            $processor = new Boxscore\BoxscoreProcessor($mysqli_db);
-        }
-        $allStarResult = $processor->processAllStarGames($defaultScoPath, 0);
-        echo $view->renderStepComplete('All-Star games processed');
-        echo $view->renderInlineHtml($boxscoreView->renderAllStarLog($allStarResult));
-
-        // Check for All-Star teams needing rename
-        $boxscoreRepo = new Boxscore\BoxscoreRepository($mysqli_db);
-        $pendingDefaults = $boxscoreRepo->findAllStarGamesWithDefaultNames();
-        if ($pendingDefaults !== []) {
-            $pendingRenames = [];
-            foreach ($pendingDefaults as $row) {
-                $date = $row['Date'];
-                $teamID = $row['name'] === Boxscore\BoxscoreProcessor::DEFAULT_AWAY_NAME
-                    ? 50
-                    : 51;
-                $teamLabel = $teamID === 50 ? 'Away (Visitor)' : 'Home';
-                $seasonYear = (int) substr($date, 0, 4);
-                $players = $boxscoreRepo->getPlayersForAllStarTeam($date, $teamID);
-
-                $pendingRenames[] = [
-                    'id' => $row['id'],
-                    'date' => $date,
-                    'name' => $row['name'],
-                    'seasonYear' => $seasonYear,
-                    'teamLabel' => $teamLabel,
-                    'players' => $players,
-                ];
-            }
-            echo $view->renderInlineHtml($boxscoreView->renderAllStarRenameUI($pendingRenames));
-        }
-    }
-    flush();
-    $successCount++;
-
-    // --- Step 10: Parse JSB engine files ---
-    echo $view->renderStepStart('Parsing JSB engine files...');
-    flush();
+    $savedDcRepo = new SavedDepthChart\SavedDepthChartRepository($mysqli_db);
 
     $jsbRepo = new JsbParser\JsbImportRepository($mysqli_db);
     $jsbResolver = new JsbParser\PlayerIdResolver($mysqli_db);
     $jsbService = new JsbParser\JsbImportService($jsbRepo, $jsbResolver);
 
-    ob_start();
-    $jsbResult = $jsbService->processCurrentSeason($basePath, $season);
-    $log = (string) ob_get_clean();
-    echo $view->renderStepComplete('JSB files parsed', $jsbResult->summary());
-    if ($log !== '') {
-        echo $view->renderLog($log);
-    }
-    if ($jsbResult->messages !== [] || $jsbResult->errors > 0) {
-        echo $view->renderMessageLog($jsbResult->messages, $jsbResult->errors);
-    }
-    flush();
-    $successCount++;
+    $updaterService->addStep(new Updater\Steps\ImportLeagueConfigStep(
+        $lgeRepo, $lgeService, $lgeView, $season->endingYear, $defaultLgePath,
+    ));
+    $updaterService->addStep(new Updater\Steps\ParsePlayerFileStep($plrService, $defaultPlrPath));
+    $updaterService->addStep(new Updater\Steps\UpdateScheduleStep($scheduleUpdater));
+    $updaterService->addStep(new Updater\Steps\UpdateStandingsStep($standingsUpdater));
+    $updaterService->addStep(new Updater\Steps\UpdatePowerRankingsStep($powerRankingsUpdater));
+    $updaterService->addStep(new Updater\Steps\ResetExtensionAttemptsStep($sharedRepository));
+    $updaterService->addStep(new Updater\Steps\ExtendDepthChartsStep(
+        $savedDcRepo, $season->lastSimEndDate, $season->lastSimNumber,
+    ));
+    $updaterService->addStep(new Updater\Steps\ProcessBoxscoresStep(
+        $boxscoreProcessor, $boxscoreView, $defaultScoPath,
+    ));
+    $updaterService->addStep(new Updater\Steps\ProcessAllStarGamesStep(
+        $boxscoreProcessor, $boxscoreRepo, $boxscoreView, $defaultScoPath,
+    ));
+    $updaterService->addStep(new Updater\Steps\ParseJsbFilesStep($jsbService, $basePath, $season));
 
-    echo $view->renderSectionClose();
-    flush();
-
-    echo $view->renderSummary($successCount, $errorCount);
-    flush();
+    $controller = new Updater\UpdaterController($updaterService, $view);
+    $controller->run();
 
 } catch (\Exception $e) {
-    $errorCount++;
     $safeMessage = \Utilities\HtmlSanitizer::safeHtmlOutput($e->getMessage());
     $safeTrace = \Utilities\HtmlSanitizer::safeHtmlOutput($e->getTraceAsString());
 
     echo $view->renderStepError('Exception', (string) $safeMessage);
     echo $view->renderLog('<pre>' . (string) $safeTrace . '</pre>');
-    echo $view->renderSummary($successCount, $errorCount);
+    echo $view->renderSummary(0, 1);
     flush();
 }
 

--- a/ibl5/tests/UpdateAllTheThings/StepResultTest.php
+++ b/ibl5/tests/UpdateAllTheThings/StepResultTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings;
+
+use PHPUnit\Framework\TestCase;
+use Updater\StepResult;
+
+class StepResultTest extends TestCase
+{
+    public function testSuccessFactoryCreatesSuccessfulResult(): void
+    {
+        $result = StepResult::success('Schedule updated');
+
+        $this->assertSame('Schedule updated', $result->label);
+        $this->assertTrue($result->success);
+        $this->assertSame('', $result->detail);
+        $this->assertSame('', $result->capturedLog);
+        $this->assertSame('', $result->inlineHtml);
+        $this->assertSame('', $result->errorMessage);
+        $this->assertSame([], $result->messages);
+        $this->assertSame(0, $result->messageErrorCount);
+    }
+
+    public function testSuccessFactoryWithAllOptionalParameters(): void
+    {
+        $result = StepResult::success(
+            label: 'JSB files parsed',
+            detail: '5 files processed',
+            capturedLog: '<p>Processing...</p>',
+            inlineHtml: '<div>Results</div>',
+            messages: ['File 1 OK', 'ERROR: File 2 failed'],
+            messageErrorCount: 1,
+        );
+
+        $this->assertSame('JSB files parsed', $result->label);
+        $this->assertTrue($result->success);
+        $this->assertSame('5 files processed', $result->detail);
+        $this->assertSame('<p>Processing...</p>', $result->capturedLog);
+        $this->assertSame('<div>Results</div>', $result->inlineHtml);
+        $this->assertSame('', $result->errorMessage);
+        $this->assertSame(['File 1 OK', 'ERROR: File 2 failed'], $result->messages);
+        $this->assertSame(1, $result->messageErrorCount);
+    }
+
+    public function testFailureFactoryCreatesFailedResult(): void
+    {
+        $result = StepResult::failure('League config', 'Connection refused');
+
+        $this->assertSame('League config', $result->label);
+        $this->assertFalse($result->success);
+        $this->assertSame('Connection refused', $result->errorMessage);
+        $this->assertSame('', $result->detail);
+        $this->assertSame('', $result->capturedLog);
+        $this->assertSame('', $result->inlineHtml);
+        $this->assertSame([], $result->messages);
+        $this->assertSame(0, $result->messageErrorCount);
+    }
+
+    public function testSkippedFactoryCreatesSuccessWithReason(): void
+    {
+        $result = StepResult::skipped('Player file', 'No IBL5.plr file found');
+
+        $this->assertSame('Player file', $result->label);
+        $this->assertTrue($result->success);
+        $this->assertSame('No IBL5.plr file found', $result->detail);
+        $this->assertSame('', $result->errorMessage);
+        $this->assertSame('', $result->capturedLog);
+        $this->assertSame('', $result->inlineHtml);
+        $this->assertSame([], $result->messages);
+        $this->assertSame(0, $result->messageErrorCount);
+    }
+
+    public function testSuccessWithDetailOnly(): void
+    {
+        $result = StepResult::success('Depth charts updated', '3 active DCs extended');
+
+        $this->assertTrue($result->success);
+        $this->assertSame('3 active DCs extended', $result->detail);
+    }
+
+    public function testSuccessWithCapturedLogOnly(): void
+    {
+        $result = StepResult::success('Schedule updated', capturedLog: '<p>Log output</p>');
+
+        $this->assertTrue($result->success);
+        $this->assertSame('<p>Log output</p>', $result->capturedLog);
+        $this->assertSame('', $result->detail);
+    }
+
+    public function testFailureErrorMessagePreservedExactly(): void
+    {
+        $errorMessage = "SQLSTATE[HY000]: General error: can't open file";
+        $result = StepResult::failure('Standings', $errorMessage);
+
+        $this->assertSame($errorMessage, $result->errorMessage);
+    }
+
+    public function testSuccessWithEmptyMessages(): void
+    {
+        $result = StepResult::success('Test', messages: [], messageErrorCount: 0);
+
+        $this->assertSame([], $result->messages);
+        $this->assertSame(0, $result->messageErrorCount);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/ExtendDepthChartsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ExtendDepthChartsStepTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use PHPUnit\Framework\TestCase;
+use SavedDepthChart\SavedDepthChartRepository;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Steps\ExtendDepthChartsStep;
+
+class ExtendDepthChartsStepTest extends TestCase
+{
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $stubRepo = $this->createStub(SavedDepthChartRepository::class);
+        $step = new ExtendDepthChartsStep($stubRepo, '2026-02-27', 15);
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $stubRepo = $this->createStub(SavedDepthChartRepository::class);
+        $step = new ExtendDepthChartsStep($stubRepo, '2026-02-27', 15);
+
+        $this->assertSame('Saved depth charts updated', $step->getLabel());
+    }
+
+    public function testExecuteReturnsSuccessWithCount(): void
+    {
+        $mockRepo = $this->createMock(SavedDepthChartRepository::class);
+        $mockRepo->expects($this->once())
+            ->method('extendActiveDepthCharts')
+            ->with('2026-02-27', 15)
+            ->willReturn(5);
+
+        $step = new ExtendDepthChartsStep($mockRepo, '2026-02-27', 15);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('5 active DCs extended', $result->detail);
+    }
+
+    public function testExecuteCapturesOutputBufferLog(): void
+    {
+        $stubRepo = $this->createStub(SavedDepthChartRepository::class);
+        $stubRepo->method('extendActiveDepthCharts')->willReturnCallback(static function (): int {
+            echo '<p>Extending DCs...</p>';
+            return 3;
+        });
+
+        $step = new ExtendDepthChartsStep($stubRepo, '2026-02-27', 15);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('<p>Extending DCs...</p>', $result->capturedLog);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/ImportLeagueConfigStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ImportLeagueConfigStepTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use LeagueConfig\LeagueConfigRepository;
+use LeagueConfig\LeagueConfigService;
+use LeagueConfig\LeagueConfigView;
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Steps\ImportLeagueConfigStep;
+
+class ImportLeagueConfigStepTest extends TestCase
+{
+    private LeagueConfigRepository $stubRepo;
+    private LeagueConfigService $stubService;
+    private LeagueConfigView $stubView;
+
+    protected function setUp(): void
+    {
+        $this->stubRepo = $this->createStub(LeagueConfigRepository::class);
+        $this->stubService = $this->createStub(LeagueConfigService::class);
+        $this->stubView = $this->createStub(LeagueConfigView::class);
+    }
+
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $step = $this->createStep('/tmp/IBL5.lge');
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $step = $this->createStep('/tmp/IBL5.lge');
+
+        $this->assertSame('League config', $step->getLabel());
+    }
+
+    public function testSkipsWhenAlreadyImported(): void
+    {
+        $this->stubRepo->method('hasConfigForSeason')->willReturn(true);
+
+        $step = $this->createStep('/tmp/IBL5.lge');
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('Already imported', $result->detail);
+    }
+
+    public function testSkipsWhenFileNotFound(): void
+    {
+        $this->stubRepo->method('hasConfigForSeason')->willReturn(false);
+
+        $step = $this->createStep('/nonexistent/IBL5.lge');
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('No IBL5.lge file found', $result->detail);
+    }
+
+    public function testSuccessfulImport(): void
+    {
+        $this->stubRepo->method('hasConfigForSeason')->willReturn(false);
+
+        $this->stubService->method('processLgeFile')->willReturn([
+            'success' => true,
+            'season_ending_year' => 2026,
+            'teams_stored' => 28,
+            'messages' => [],
+        ]);
+        $this->stubService->method('crossCheckWithFranchiseSeasons')->willReturn([]);
+
+        $this->stubView->method('renderParseResult')->willReturn('<div>Parsed</div>');
+
+        $step = $this->createStep($this->createTempFile());
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('League config imported', $result->label);
+        $this->assertStringContainsString('<div>Parsed</div>', $result->inlineHtml);
+    }
+
+    public function testSuccessfulImportWithDiscrepancies(): void
+    {
+        $this->stubRepo->method('hasConfigForSeason')->willReturn(false);
+
+        $this->stubService->method('processLgeFile')->willReturn([
+            'success' => true,
+            'season_ending_year' => 2026,
+            'teams_stored' => 28,
+            'messages' => [],
+        ]);
+        $this->stubService->method('crossCheckWithFranchiseSeasons')->willReturn(['Mismatch']);
+
+        $this->stubView->method('renderParseResult')->willReturn('<div>Parsed</div>');
+        $this->stubView->method('renderCrossCheckResults')->willReturn('<div>Discrepancy</div>');
+
+        $step = $this->createStep($this->createTempFile());
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('<div>Discrepancy</div>', $result->inlineHtml);
+    }
+
+    public function testFailedImportReturnsFailure(): void
+    {
+        $this->stubRepo->method('hasConfigForSeason')->willReturn(false);
+
+        $this->stubService->method('processLgeFile')->willReturn([
+            'success' => false,
+            'season_ending_year' => 0,
+            'teams_stored' => 0,
+            'messages' => [],
+            'error' => 'Invalid file format',
+        ]);
+
+        $this->stubView->method('renderParseResult')->willReturn('');
+
+        $step = $this->createStep($this->createTempFile());
+        $result = $step->execute();
+
+        $this->assertFalse($result->success);
+        $this->assertSame('Invalid file format', $result->errorMessage);
+    }
+
+    private function createStep(string $lgePath): ImportLeagueConfigStep
+    {
+        return new ImportLeagueConfigStep(
+            $this->stubRepo,
+            $this->stubService,
+            $this->stubView,
+            2026,
+            $lgePath,
+        );
+    }
+
+    private function createTempFile(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'lge_test_');
+        if ($path === false) {
+            $this->fail('Failed to create temp file');
+        }
+        $this->addToAssertionCount(1);
+
+        return $path;
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/ParseJsbFilesStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ParseJsbFilesStepTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use JsbParser\JsbImportResult;
+use JsbParser\JsbImportService;
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Steps\ParseJsbFilesStep;
+
+class ParseJsbFilesStepTest extends TestCase
+{
+    private JsbImportService $stubService;
+    private \Season $stubSeason;
+
+    protected function setUp(): void
+    {
+        $this->stubService = $this->createStub(JsbImportService::class);
+        $this->stubSeason = $this->createStub(\Season::class);
+    }
+
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
+
+        $this->assertSame('JSB files parsed', $step->getLabel());
+    }
+
+    public function testExecuteReturnsSuccessWithSummary(): void
+    {
+        $jsbResult = new JsbImportResult();
+        $jsbResult->addMessage('CAR: 150 records');
+        $jsbResult->addMessage('TRN: 10 trades');
+
+        $this->stubService->method('processCurrentSeason')->willReturn($jsbResult);
+
+        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('JSB files parsed', $result->label);
+        $this->assertNotSame('', $result->detail);
+        $this->assertSame(['CAR: 150 records', 'TRN: 10 trades'], $result->messages);
+        $this->assertSame(0, $result->messageErrorCount);
+    }
+
+    public function testExecutePassesErrorCountFromResult(): void
+    {
+        $jsbResult = new JsbImportResult();
+        $jsbResult->addError('Failed to parse player');
+        $jsbResult->addError('Unknown team');
+
+        $this->stubService->method('processCurrentSeason')->willReturn($jsbResult);
+
+        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame(2, $result->messageErrorCount);
+    }
+
+    public function testExecuteCapturesOutputBufferLog(): void
+    {
+        $jsbResult = new JsbImportResult();
+
+        $this->stubService->method('processCurrentSeason')->willReturnCallback(
+            static function () use ($jsbResult): JsbImportResult {
+                echo '<p>Processing JSB...</p>';
+                return $jsbResult;
+            }
+        );
+
+        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('<p>Processing JSB...</p>', $result->capturedLog);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/ParsePlayerFileStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ParsePlayerFileStepTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use PHPUnit\Framework\TestCase;
+use PlrParser\PlrParseResult;
+use PlrParser\PlrParserService;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Steps\ParsePlayerFileStep;
+
+class ParsePlayerFileStepTest extends TestCase
+{
+    private PlrParserService $stubService;
+
+    protected function setUp(): void
+    {
+        $this->stubService = $this->createStub(PlrParserService::class);
+    }
+
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $step = new ParsePlayerFileStep($this->stubService, '/tmp/IBL5.plr');
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $step = new ParsePlayerFileStep($this->stubService, '/tmp/IBL5.plr');
+
+        $this->assertSame('Player file', $step->getLabel());
+    }
+
+    public function testSkipsWhenFileNotFound(): void
+    {
+        $step = new ParsePlayerFileStep($this->stubService, '/nonexistent/IBL5.plr');
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('No IBL5.plr file found', $result->detail);
+    }
+
+    public function testSuccessfulParse(): void
+    {
+        $plrResult = new PlrParseResult();
+        $plrResult->playersUpserted = 150;
+        $plrResult->historyRowsUpserted = 300;
+        $plrResult->teamsAssigned = 28;
+
+        $this->stubService->method('processPlrFile')->willReturn($plrResult);
+
+        $path = tempnam(sys_get_temp_dir(), 'plr_test_');
+        if ($path === false) {
+            $this->fail('Failed to create temp file');
+        }
+
+        $step = new ParsePlayerFileStep($this->stubService, $path);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('Player file parsed', $result->label);
+        $this->assertNotSame('', $result->detail);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/ProcessAllStarGamesStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ProcessAllStarGamesStepTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use Boxscore\BoxscoreProcessor;
+use Boxscore\BoxscoreRepository;
+use Boxscore\BoxscoreView;
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Steps\ProcessAllStarGamesStep;
+
+class ProcessAllStarGamesStepTest extends TestCase
+{
+    private BoxscoreProcessor $stubProcessor;
+    private BoxscoreRepository $stubRepo;
+    private BoxscoreView $stubView;
+
+    protected function setUp(): void
+    {
+        $this->stubProcessor = $this->createStub(BoxscoreProcessor::class);
+        $this->stubRepo = $this->createStub(BoxscoreRepository::class);
+        $this->stubView = $this->createStub(BoxscoreView::class);
+    }
+
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $step = new ProcessAllStarGamesStep(
+            $this->stubProcessor,
+            $this->stubRepo,
+            $this->stubView,
+            '/tmp/IBL5.sco',
+        );
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $step = new ProcessAllStarGamesStep(
+            $this->stubProcessor,
+            $this->stubRepo,
+            $this->stubView,
+            '/tmp/IBL5.sco',
+        );
+
+        $this->assertSame('All-Star games processed', $step->getLabel());
+    }
+
+    public function testSkipsWhenFileNotFound(): void
+    {
+        $step = new ProcessAllStarGamesStep(
+            $this->stubProcessor,
+            $this->stubRepo,
+            $this->stubView,
+            '/nonexistent/IBL5.sco',
+        );
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('No IBL5.sco file found', $result->detail);
+    }
+
+    public function testSuccessfulProcessingWithoutPendingRenames(): void
+    {
+        $this->stubProcessor->method('processAllStarGames')->willReturn([
+            'success' => true,
+            'messages' => [],
+        ]);
+        $this->stubRepo->method('findAllStarGamesWithDefaultNames')->willReturn([]);
+        $this->stubView->method('renderAllStarLog')->willReturn('<div>All-Star OK</div>');
+
+        $path = tempnam(sys_get_temp_dir(), 'sco_test_');
+        if ($path === false) {
+            $this->fail('Failed to create temp file');
+        }
+
+        $step = new ProcessAllStarGamesStep(
+            $this->stubProcessor,
+            $this->stubRepo,
+            $this->stubView,
+            $path,
+        );
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('All-Star games processed', $result->label);
+        $this->assertStringContainsString('All-Star OK', $result->inlineHtml);
+    }
+
+    public function testSuccessfulProcessingWithPendingRenames(): void
+    {
+        $this->stubProcessor->method('processAllStarGames')->willReturn([
+            'success' => true,
+            'messages' => [],
+        ]);
+        $this->stubRepo->method('findAllStarGamesWithDefaultNames')->willReturn([
+            ['id' => 1, 'Date' => '2026-02-03', 'name' => BoxscoreProcessor::DEFAULT_AWAY_NAME, 'visitorTeamID' => 50, 'homeTeamID' => 51],
+        ]);
+        $this->stubRepo->method('getPlayersForAllStarTeam')->willReturn(['Player A', 'Player B']);
+        $this->stubView->method('renderAllStarLog')->willReturn('<div>Log</div>');
+        $this->stubView->method('renderAllStarRenameUI')->willReturn('<div>Rename UI</div>');
+
+        $path = tempnam(sys_get_temp_dir(), 'sco_test_');
+        if ($path === false) {
+            $this->fail('Failed to create temp file');
+        }
+
+        $step = new ProcessAllStarGamesStep(
+            $this->stubProcessor,
+            $this->stubRepo,
+            $this->stubView,
+            $path,
+        );
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('<div>Rename UI</div>', $result->inlineHtml);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/ProcessBoxscoresStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ProcessBoxscoresStepTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use Boxscore\BoxscoreProcessor;
+use Boxscore\BoxscoreView;
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Steps\ProcessBoxscoresStep;
+
+class ProcessBoxscoresStepTest extends TestCase
+{
+    private BoxscoreProcessor $stubProcessor;
+    private BoxscoreView $stubView;
+
+    protected function setUp(): void
+    {
+        $this->stubProcessor = $this->createStub(BoxscoreProcessor::class);
+        $this->stubView = $this->createStub(BoxscoreView::class);
+    }
+
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, '/tmp/IBL5.sco');
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, '/tmp/IBL5.sco');
+
+        $this->assertSame('Boxscores processed', $step->getLabel());
+    }
+
+    public function testSkipsWhenFileNotFound(): void
+    {
+        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, '/nonexistent/IBL5.sco');
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('No IBL5.sco file found', $result->detail);
+    }
+
+    public function testSuccessfulProcessing(): void
+    {
+        $scoResult = [
+            'success' => true,
+            'gamesInserted' => 10,
+            'gamesUpdated' => 2,
+            'gamesSkipped' => 0,
+            'linesProcessed' => 120,
+            'messages' => [],
+        ];
+
+        $this->stubProcessor->method('processScoFile')->willReturn($scoResult);
+        $this->stubView->method('renderParseLog')->willReturn('<div>10 games inserted</div>');
+
+        $path = tempnam(sys_get_temp_dir(), 'sco_test_');
+        if ($path === false) {
+            $this->fail('Failed to create temp file');
+        }
+
+        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, $path);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('Boxscores processed', $result->label);
+        $this->assertStringContainsString('10 games inserted', $result->inlineHtml);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/ResetExtensionAttemptsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ResetExtensionAttemptsStepTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use PHPUnit\Framework\TestCase;
+use Shared\SharedRepository;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Steps\ResetExtensionAttemptsStep;
+
+class ResetExtensionAttemptsStepTest extends TestCase
+{
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $stubRepo = $this->createStub(SharedRepository::class);
+        $step = new ResetExtensionAttemptsStep($stubRepo);
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $stubRepo = $this->createStub(SharedRepository::class);
+        $step = new ResetExtensionAttemptsStep($stubRepo);
+
+        $this->assertSame('Extension attempts reset', $step->getLabel());
+    }
+
+    public function testExecuteCallsResetAndReturnsSuccess(): void
+    {
+        $mockRepo = $this->createMock(SharedRepository::class);
+        $mockRepo->expects($this->once())->method('resetSimContractExtensionAttempts');
+
+        $step = new ResetExtensionAttemptsStep($mockRepo);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('Extension attempts reset', $result->label);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/UpdatePowerRankingsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/UpdatePowerRankingsStepTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\PowerRankingsUpdater;
+use Updater\Steps\UpdatePowerRankingsStep;
+
+class UpdatePowerRankingsStepTest extends TestCase
+{
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $stubUpdater = $this->createStub(PowerRankingsUpdater::class);
+        $step = new UpdatePowerRankingsStep($stubUpdater);
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $stubUpdater = $this->createStub(PowerRankingsUpdater::class);
+        $step = new UpdatePowerRankingsStep($stubUpdater);
+
+        $this->assertSame('Power rankings updated', $step->getLabel());
+    }
+
+    public function testExecuteCallsUpdateAndReturnsSuccess(): void
+    {
+        $mockUpdater = $this->createMock(PowerRankingsUpdater::class);
+        $mockUpdater->expects($this->once())->method('update');
+
+        $step = new UpdatePowerRankingsStep($mockUpdater);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('Power rankings updated', $result->label);
+    }
+
+    public function testExecuteCapturesOutputBufferLog(): void
+    {
+        $stubUpdater = $this->createStub(PowerRankingsUpdater::class);
+        $stubUpdater->method('update')->willReturnCallback(static function (): void {
+            echo '<p>Calculating power rankings...</p>';
+        });
+
+        $step = new UpdatePowerRankingsStep($stubUpdater);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('<p>Calculating power rankings...</p>', $result->capturedLog);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/UpdateScheduleStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/UpdateScheduleStepTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\ScheduleUpdater;
+use Updater\Steps\UpdateScheduleStep;
+
+class UpdateScheduleStepTest extends TestCase
+{
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $stubUpdater = $this->createStub(ScheduleUpdater::class);
+        $step = new UpdateScheduleStep($stubUpdater);
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $stubUpdater = $this->createStub(ScheduleUpdater::class);
+        $step = new UpdateScheduleStep($stubUpdater);
+
+        $this->assertSame('Schedule updated', $step->getLabel());
+    }
+
+    public function testExecuteCallsUpdateAndReturnsSuccess(): void
+    {
+        $mockUpdater = $this->createMock(ScheduleUpdater::class);
+        $mockUpdater->expects($this->once())->method('update');
+
+        $step = new UpdateScheduleStep($mockUpdater);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('Schedule updated', $result->label);
+    }
+
+    public function testExecuteCapturesOutputBufferLog(): void
+    {
+        $stubUpdater = $this->createStub(ScheduleUpdater::class);
+        $stubUpdater->method('update')->willReturnCallback(static function (): void {
+            echo '<p>Updating schedule...</p>';
+        });
+
+        $step = new UpdateScheduleStep($stubUpdater);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('<p>Updating schedule...</p>', $result->capturedLog);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/Steps/UpdateStandingsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/UpdateStandingsStepTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StandingsUpdater;
+use Updater\Steps\UpdateStandingsStep;
+
+class UpdateStandingsStepTest extends TestCase
+{
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $stubUpdater = $this->createStub(StandingsUpdater::class);
+        $step = new UpdateStandingsStep($stubUpdater);
+
+        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $stubUpdater = $this->createStub(StandingsUpdater::class);
+        $step = new UpdateStandingsStep($stubUpdater);
+
+        $this->assertSame('Standings updated', $step->getLabel());
+    }
+
+    public function testExecuteCallsUpdateAndReturnsSuccess(): void
+    {
+        $mockUpdater = $this->createMock(StandingsUpdater::class);
+        $mockUpdater->expects($this->once())->method('update');
+
+        $step = new UpdateStandingsStep($mockUpdater);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('Standings updated', $result->label);
+    }
+
+    public function testExecuteCapturesOutputBufferLog(): void
+    {
+        $stubUpdater = $this->createStub(StandingsUpdater::class);
+        $stubUpdater->method('update')->willReturnCallback(static function (): void {
+            echo '<p>Computing standings...</p>';
+        });
+
+        $step = new UpdateStandingsStep($stubUpdater);
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame('<p>Computing standings...</p>', $result->capturedLog);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/UpdaterServiceTest.php
+++ b/ibl5/tests/UpdateAllTheThings/UpdaterServiceTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings;
+
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Contracts\UpdaterServiceInterface;
+use Updater\StepResult;
+use Updater\UpdaterService;
+
+class UpdaterServiceTest extends TestCase
+{
+    private UpdaterService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new UpdaterService();
+    }
+
+    public function testImplementsUpdaterServiceInterface(): void
+    {
+        $this->assertInstanceOf(UpdaterServiceInterface::class, $this->service);
+    }
+
+    public function testRunWithNoStepsReturnsEmptyResults(): void
+    {
+        $results = $this->service->run(
+            static function (PipelineStepInterface $step): void {},
+            static function (StepResult $result): void {},
+        );
+
+        $this->assertSame([], $results);
+        $this->assertSame(0, $this->service->getSuccessCount());
+        $this->assertSame(0, $this->service->getErrorCount());
+    }
+
+    public function testRunExecutesStepsInOrder(): void
+    {
+        $executionOrder = [];
+
+        $step1 = $this->createStub(PipelineStepInterface::class);
+        $step1->method('getLabel')->willReturn('Step 1');
+        $step1->method('execute')->willReturnCallback(static function () use (&$executionOrder): StepResult {
+            $executionOrder[] = 'Step 1';
+            return StepResult::success('Step 1');
+        });
+
+        $step2 = $this->createStub(PipelineStepInterface::class);
+        $step2->method('getLabel')->willReturn('Step 2');
+        $step2->method('execute')->willReturnCallback(static function () use (&$executionOrder): StepResult {
+            $executionOrder[] = 'Step 2';
+            return StepResult::success('Step 2');
+        });
+
+        $this->service->addStep($step1);
+        $this->service->addStep($step2);
+
+        $this->service->run(
+            static function (PipelineStepInterface $step): void {},
+            static function (StepResult $result): void {},
+        );
+
+        $this->assertSame(['Step 1', 'Step 2'], $executionOrder);
+    }
+
+    public function testRunCallsOnStepStartBeforeExecution(): void
+    {
+        $events = [];
+
+        $step = $this->createStub(PipelineStepInterface::class);
+        $step->method('getLabel')->willReturn('Test Step');
+        $step->method('execute')->willReturnCallback(static function () use (&$events): StepResult {
+            $events[] = 'execute';
+            return StepResult::success('Test Step');
+        });
+
+        $this->service->addStep($step);
+
+        $this->service->run(
+            static function (PipelineStepInterface $step) use (&$events): void {
+                $events[] = 'onStart:' . $step->getLabel();
+            },
+            static function (StepResult $result) use (&$events): void {
+                $events[] = 'onComplete:' . $result->label;
+            },
+        );
+
+        $this->assertSame(['onStart:Test Step', 'execute', 'onComplete:Test Step'], $events);
+    }
+
+    public function testRunCountsSuccessesAndErrors(): void
+    {
+        $successStep = $this->createStub(PipelineStepInterface::class);
+        $successStep->method('getLabel')->willReturn('Success');
+        $successStep->method('execute')->willReturn(StepResult::success('Success'));
+
+        $failStep = $this->createStub(PipelineStepInterface::class);
+        $failStep->method('getLabel')->willReturn('Fail');
+        $failStep->method('execute')->willReturn(StepResult::failure('Fail', 'Error'));
+
+        $skipStep = $this->createStub(PipelineStepInterface::class);
+        $skipStep->method('getLabel')->willReturn('Skip');
+        $skipStep->method('execute')->willReturn(StepResult::skipped('Skip', 'No file'));
+
+        $this->service->addStep($successStep);
+        $this->service->addStep($failStep);
+        $this->service->addStep($skipStep);
+
+        $results = $this->service->run(
+            static function (PipelineStepInterface $step): void {},
+            static function (StepResult $result): void {},
+        );
+
+        $this->assertCount(3, $results);
+        $this->assertSame(2, $this->service->getSuccessCount());
+        $this->assertSame(1, $this->service->getErrorCount());
+    }
+
+    public function testRunContinuesAfterStepFailure(): void
+    {
+        $failStep = $this->createStub(PipelineStepInterface::class);
+        $failStep->method('getLabel')->willReturn('Failing');
+        $failStep->method('execute')->willReturn(StepResult::failure('Failing', 'Boom'));
+
+        $afterStep = $this->createStub(PipelineStepInterface::class);
+        $afterStep->method('getLabel')->willReturn('After');
+        $afterStep->method('execute')->willReturn(StepResult::success('After'));
+
+        $this->service->addStep($failStep);
+        $this->service->addStep($afterStep);
+
+        $results = $this->service->run(
+            static function (PipelineStepInterface $step): void {},
+            static function (StepResult $result): void {},
+        );
+
+        $this->assertCount(2, $results);
+        $this->assertFalse($results[0]->success);
+        $this->assertTrue($results[1]->success);
+    }
+
+    public function testRunCatchesExceptionsAndContinues(): void
+    {
+        $throwingStep = $this->createStub(PipelineStepInterface::class);
+        $throwingStep->method('getLabel')->willReturn('Thrower');
+        $throwingStep->method('execute')->willThrowException(new \RuntimeException('Database gone'));
+
+        $afterStep = $this->createStub(PipelineStepInterface::class);
+        $afterStep->method('getLabel')->willReturn('After');
+        $afterStep->method('execute')->willReturn(StepResult::success('After'));
+
+        $this->service->addStep($throwingStep);
+        $this->service->addStep($afterStep);
+
+        $results = $this->service->run(
+            static function (PipelineStepInterface $step): void {},
+            static function (StepResult $result): void {},
+        );
+
+        $this->assertCount(2, $results);
+        $this->assertFalse($results[0]->success);
+        $this->assertSame('Database gone', $results[0]->errorMessage);
+        $this->assertSame('Thrower', $results[0]->label);
+        $this->assertTrue($results[1]->success);
+    }
+
+    public function testRunResetsCountsBetweenRuns(): void
+    {
+        $step = $this->createStub(PipelineStepInterface::class);
+        $step->method('getLabel')->willReturn('Test');
+        $step->method('execute')->willReturn(StepResult::success('Test'));
+
+        $this->service->addStep($step);
+
+        $this->service->run(
+            static function (PipelineStepInterface $step): void {},
+            static function (StepResult $result): void {},
+        );
+
+        $this->assertSame(1, $this->service->getSuccessCount());
+
+        // Run again — counts should reset, not accumulate
+        $this->service->run(
+            static function (PipelineStepInterface $step): void {},
+            static function (StepResult $result): void {},
+        );
+
+        $this->assertSame(1, $this->service->getSuccessCount());
+        $this->assertSame(0, $this->service->getErrorCount());
+    }
+
+    public function testRunReturnsResultsInStepOrder(): void
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            $step = $this->createStub(PipelineStepInterface::class);
+            $step->method('getLabel')->willReturn('Step ' . $i);
+            $step->method('execute')->willReturn(StepResult::success('Step ' . $i));
+            $this->service->addStep($step);
+        }
+
+        $results = $this->service->run(
+            static function (PipelineStepInterface $step): void {},
+            static function (StepResult $result): void {},
+        );
+
+        $this->assertSame('Step 1', $results[0]->label);
+        $this->assertSame('Step 2', $results[1]->label);
+        $this->assertSame('Step 3', $results[2]->label);
+    }
+}

--- a/ibl5/tests/UpdateAllTheThings/UpdaterViewTest.php
+++ b/ibl5/tests/UpdateAllTheThings/UpdaterViewTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\UpdateAllTheThings;
 
 use PHPUnit\Framework\TestCase;
+use Updater\Contracts\UpdaterViewInterface;
 use Updater\UpdaterView;
 
 /**
@@ -20,6 +21,11 @@ class UpdaterViewTest extends TestCase
     protected function setUp(): void
     {
         $this->view = new UpdaterView();
+    }
+
+    public function testImplementsUpdaterViewInterface(): void
+    {
+        $this->assertInstanceOf(UpdaterViewInterface::class, $this->view);
     }
 
     public function testRenderPageOpenReturnsHtmlDoctype(): void


### PR DESCRIPTION
## Summary

- Extract the 340-line procedural `updateAllTheThings.php` into a proper Controller/Service/Step architecture
- Each of the 10 pipeline steps is now a discrete `PipelineStepInterface` implementation, individually testable and with per-step error isolation (one failure doesn't abort the remaining steps)
- Add `StepResult` immutable DTO, `UpdaterService` pipeline orchestrator, and `UpdaterController` for progressive output
- Add 4 interfaces: `PipelineStepInterface`, `UpdaterServiceInterface`, `UpdaterViewInterface`, `UpdaterControllerInterface`
- Existing `UpdaterView` now implements its interface; entry point script reduced to dependency wiring

## Test plan

- [x] 62 new unit tests covering StepResult factories, UpdaterService orchestration (execution order, error isolation, callback invocation, count tracking), and all 10 step classes (happy path, skip conditions, error propagation, output capture)
- [x] Full PHPUnit suite passes: 3386 tests, 17074 assertions, zero warnings
- [x] PHPStan level max: zero errors
- [ ] Run updateAllTheThings.php on staging — verify identical HTML output (same steps, labels, CSS classes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)