### PR TITLE
fix: use multi-way aggregate H2H for draft order tiebreakers

### DIFF
--- a/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderService.php
+++ b/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderService.php
@@ -200,6 +200,7 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
      * Sort teams by record for draft order (worst first).
      *
      * Tiebreaker loser gets the earlier (better) pick in both lottery and playoff contexts.
+     * Uses multi-way aggregate H2H for groups of 3+ teams with the same pct.
      *
      * @param list<StandingsRow> $teams
      * @param array<int, array<int, int>> $h2h
@@ -208,24 +209,97 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
      */
     private function sortTeamsByRecord(array $teams, array $h2h, array $pointDiffs): array
     {
-        usort($teams, function (array $a, array $b) use ($h2h, $pointDiffs): int {
-            // Ascending pct (worst first)
-            $pctDiff = $a['pct'] <=> $b['pct'];
-            if ($pctDiff !== 0) {
-                return $pctDiff;
-            }
+        // Step 1: Sort by pct ascending (worst first)
+        usort($teams, static fn (array $a, array $b): int => $a['pct'] <=> $b['pct']);
 
-            // applyTiebreakers returns negative if A wins (better team).
-            // For draft order: tiebreaker LOSER gets earlier pick.
-            // Negate so the winner sorts later (higher index = later pick).
-            return -$this->applyTiebreakers($a, $b, $h2h, $pointDiffs, 'better_wins');
-        });
-
-        return $teams;
+        // Step 2: Resolve tied groups using multi-way aggregate H2H
+        return $this->resolveTiedGroups($teams, $h2h, $pointDiffs);
     }
 
     /**
-     * Apply NBA tiebreakers between two teams.
+     * Walk the pct-sorted list, identify consecutive same-pct groups, and sort each.
+     *
+     * @param list<StandingsRow> $teams
+     * @param array<int, array<int, int>> $h2h
+     * @param array<int, float> $pointDiffs
+     * @return list<StandingsRow>
+     */
+    private function resolveTiedGroups(array $teams, array $h2h, array $pointDiffs): array
+    {
+        $result = [];
+        $i = 0;
+        $count = count($teams);
+
+        while ($i < $count) {
+            $groupStart = $i;
+            $currentPct = $teams[$i]['pct'];
+
+            // Find end of consecutive same-pct group
+            while ($i < $count && $teams[$i]['pct'] === $currentPct) {
+                $i++;
+            }
+
+            $group = array_slice($teams, $groupStart, $i - $groupStart);
+
+            if (count($group) > 1) {
+                $group = $this->sortTiedGroup($group, $h2h, $pointDiffs);
+            }
+
+            array_push($result, ...$group);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sort a group of teams with the same pct using aggregate H2H then fallback tiebreakers.
+     *
+     * For draft order: worse aggregate H2H → earlier (better) pick.
+     *
+     * @param list<StandingsRow> $group
+     * @param array<int, array<int, int>> $h2h
+     * @param array<int, float> $pointDiffs
+     * @return list<StandingsRow>
+     */
+    private function sortTiedGroup(array $group, array $h2h, array $pointDiffs): array
+    {
+        $tids = array_map(static fn (array $t): int => $t['tid'], $group);
+
+        // Compute each team's aggregate H2H win pct against all other teams in the group
+        /** @var array<int, float> */
+        $aggregateH2HPct = [];
+        foreach ($group as $team) {
+            $totalWins = 0;
+            $totalLosses = 0;
+            foreach ($tids as $opponentTid) {
+                if ($opponentTid === $team['tid']) {
+                    continue;
+                }
+                $totalWins += $h2h[$team['tid']][$opponentTid] ?? 0;
+                $totalLosses += $h2h[$opponentTid][$team['tid']] ?? 0;
+            }
+            $aggregateH2HPct[$team['tid']] = $this->safeWinPct($totalWins, $totalLosses);
+        }
+
+        // Sort ascending by aggregate H2H pct (worse H2H → earlier draft pick)
+        // For sub-ties, fall through to non-H2H tiebreakers
+        usort($group, function (array $a, array $b) use ($aggregateH2HPct, $pointDiffs): int {
+            $h2hDiff = $aggregateH2HPct[$a['tid']] <=> $aggregateH2HPct[$b['tid']];
+            if ($h2hDiff !== 0) {
+                return $h2hDiff;
+            }
+
+            // Sub-tie: use non-H2H tiebreakers (negated for draft order)
+            return -$this->applyNonH2HTiebreakers($a, $b, $pointDiffs);
+        });
+
+        return $group;
+    }
+
+    /**
+     * Apply NBA tiebreakers between two teams (pairwise H2H + remaining tiebreakers).
+     *
+     * Used by playoff seeding. Draft order uses multi-way aggregate H2H instead.
      *
      * Returns negative if A wins the tiebreaker, positive if B wins.
      *
@@ -237,21 +311,34 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
      */
     private function applyTiebreakers(array $a, array $b, array $h2h, array $pointDiffs, string $direction): int
     {
-        // 1. Head-to-head record
+        // 1. Head-to-head record (pairwise)
         $aWinsVsB = $h2h[$a['tid']][$b['tid']] ?? 0;
         $bWinsVsA = $h2h[$b['tid']][$a['tid']] ?? 0;
         if ($aWinsVsB !== $bWinsVsA) {
-            return $direction === 'better_wins' ? ($bWinsVsA <=> $aWinsVsB) : ($aWinsVsB <=> $bWinsVsA);
+            return $bWinsVsA <=> $aWinsVsB;
         }
 
+        // 2-6. Non-H2H tiebreakers
+        return $this->applyNonH2HTiebreakers($a, $b, $pointDiffs);
+    }
+
+    /**
+     * Apply non-H2H tiebreakers: division winner, division record, conference record,
+     * point differential, alphabetical.
+     *
+     * Returns negative if A is the better team, positive if B is better.
+     *
+     * @param StandingsRow $a
+     * @param StandingsRow $b
+     * @param array<int, float> $pointDiffs
+     */
+    private function applyNonH2HTiebreakers(array $a, array $b, array $pointDiffs): int
+    {
         // 2. Division winner status
         $aDivWinner = ($a['clinchedDivision'] ?? 0) === 1;
         $bDivWinner = ($b['clinchedDivision'] ?? 0) === 1;
         if ($aDivWinner !== $bDivWinner) {
-            if ($direction === 'better_wins') {
-                return $aDivWinner ? -1 : 1;
-            }
-            return $bDivWinner ? -1 : 1;
+            return $aDivWinner ? -1 : 1;
         }
 
         // 3. Division record (same-division teams only)
@@ -260,7 +347,7 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
             $bDivPct = $this->safeWinPct($b['divWins'], $b['divLosses']);
             $divDiff = $bDivPct <=> $aDivPct;
             if ($divDiff !== 0) {
-                return $direction === 'better_wins' ? $divDiff : -$divDiff;
+                return $divDiff;
             }
         }
 
@@ -269,7 +356,7 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
         $bConfPct = $this->safeWinPct($b['confWins'], $b['confLosses']);
         $confDiff = $bConfPct <=> $aConfPct;
         if ($confDiff !== 0) {
-            return $direction === 'better_wins' ? $confDiff : -$confDiff;
+            return $confDiff;
         }
 
         // 5. Point differential
@@ -277,7 +364,7 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
         $bNetPts = $pointDiffs[$b['tid']] ?? 0.0;
         $ptsDiff = $bNetPts <=> $aNetPts;
         if ($ptsDiff !== 0) {
-            return $direction === 'better_wins' ? $ptsDiff : -$ptsDiff;
+            return $ptsDiff;
         }
 
         // Fallback: alphabetical by team name (for deterministic ordering)

--- a/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderServiceTest.php
+++ b/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderServiceTest.php
@@ -382,6 +382,54 @@ class ProjectedDraftOrderServiceTest extends TestCase
         $this->assertSame('BB0001', $pick1['ownerColor2']);
     }
 
+    public function testThreeWayTieUsesAggregateH2H(): void
+    {
+        $standings = $this->buildThreeWayTiedStandings();
+        $games = [
+            // Team A (301) vs Team B (302): A wins 1, B wins 4
+            ['Visitor' => 301, 'VScore' => 100, 'Home' => 302, 'HScore' => 90],
+            ['Visitor' => 302, 'VScore' => 100, 'Home' => 301, 'HScore' => 90],
+            ['Visitor' => 302, 'VScore' => 100, 'Home' => 301, 'HScore' => 90],
+            ['Visitor' => 302, 'VScore' => 100, 'Home' => 301, 'HScore' => 90],
+            ['Visitor' => 302, 'VScore' => 100, 'Home' => 301, 'HScore' => 90],
+            // Team A (301) vs Team C (303): A wins 1, C wins 2
+            ['Visitor' => 301, 'VScore' => 100, 'Home' => 303, 'HScore' => 90],
+            ['Visitor' => 303, 'VScore' => 100, 'Home' => 301, 'HScore' => 90],
+            ['Visitor' => 303, 'VScore' => 100, 'Home' => 301, 'HScore' => 90],
+            // Team B (302) vs Team C (303): B wins 2, C wins 2
+            ['Visitor' => 302, 'VScore' => 100, 'Home' => 303, 'HScore' => 90],
+            ['Visitor' => 302, 'VScore' => 100, 'Home' => 303, 'HScore' => 90],
+            ['Visitor' => 303, 'VScore' => 100, 'Home' => 302, 'HScore' => 90],
+            ['Visitor' => 303, 'VScore' => 100, 'Home' => 302, 'HScore' => 90],
+        ];
+
+        // Aggregate H2H:
+        // Team A: 2W-6L (.250) → earliest pick
+        // Team C: 4W-3L (.571) → middle
+        // Team B: 6W-3L (.667) → latest pick
+
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($standings);
+        $this->stubRepository->method('getPlayedGames')->willReturn($games);
+        $this->stubRepository->method('getPickOwnership')->willReturn([]);
+        $this->stubRepository->method('getPointDifferentials')->willReturn([]);
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        $lotteryNames = array_column(array_slice($result['round1'], 0, 12), 'teamName');
+        $posA = array_search('TiedTeamA', $lotteryNames, true);
+        $posB = array_search('TiedTeamB', $lotteryNames, true);
+        $posC = array_search('TiedTeamC', $lotteryNames, true);
+
+        $this->assertNotFalse($posA);
+        $this->assertNotFalse($posB);
+        $this->assertNotFalse($posC);
+
+        // Worse aggregate H2H → earlier (better) draft pick
+        // Team A (.250) before Team C (.571) before Team B (.667)
+        $this->assertLessThan($posC, $posA, 'Team A (worst H2H) should pick before Team C');
+        $this->assertLessThan($posB, $posC, 'Team C should pick before Team B (best H2H)');
+    }
+
     // =========================================================================
     // Helper methods to build test fixtures
     // =========================================================================
@@ -656,6 +704,40 @@ class ProjectedDraftOrderServiceTest extends TestCase
             for ($i = 0; $i < 7; $i++) {
                 $wins = 50 - ($i * 5);
                 $teams[] = $this->makeStandingsRow($tid++, $div . 'Fill' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build 28-team standings with three tied non-playoff teams (25-57) in Eastern Atlantic.
+     *
+     * @return list<array{tid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, confWins: int|null, confLosses: int|null, divWins: int|null, divLosses: int|null, clinchedDivision: int|null, color1: string, color2: string}>
+     */
+    private function buildThreeWayTiedStandings(): array
+    {
+        $teams = [];
+        $tid = 1;
+
+        // Eastern Atlantic: 4 strong playoff teams + 3 tied weak teams
+        for ($i = 0; $i < 4; $i++) {
+            $teams[] = $this->makeStandingsRow($tid++, 'EATop' . ($i + 1), 60 - ($i * 3), 22 + ($i * 3), 'Eastern', 'Atlantic');
+        }
+        $teams[] = $this->makeStandingsRow(301, 'TiedTeamA', 25, 57, 'Eastern', 'Atlantic');
+        $teams[] = $this->makeStandingsRow(302, 'TiedTeamB', 25, 57, 'Eastern', 'Atlantic');
+        $teams[] = $this->makeStandingsRow(303, 'TiedTeamC', 25, 57, 'Eastern', 'Atlantic');
+
+        // Eastern Central: 7 strong teams
+        for ($i = 0; $i < 7; $i++) {
+            $teams[] = $this->makeStandingsRow($tid++, 'ECTop' . ($i + 1), 55 - ($i * 3), 27 + ($i * 3), 'Eastern', 'Central');
+        }
+
+        // Western: 14 teams
+        foreach (['Midwest', 'Pacific'] as $div) {
+            for ($i = 0; $i < 7; $i++) {
+                $wins = 50 - ($i * 5);
+                $teams[] = $this->makeStandingsRow($tid++, $div . 'T' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
             }
         }
 


### PR DESCRIPTION
## Summary

- Replace pairwise H2H tiebreaker in draft order with multi-way aggregate H2H for correct 3+ way tie resolution
- Extract `applyNonH2HTiebreakers` to share logic between draft order and playoff seeding paths
- Add `testThreeWayTieUsesAggregateH2H` test covering asymmetric three-team tie scenario

## Test plan

- [x] New test: three teams with identical records and asymmetric H2H → correct aggregate ordering
- [x] Existing pairwise H2H test still passes (2-team aggregate is identical to pairwise)
- [x] Full PHPUnit suite: 3357 tests, 17010 assertions — all pass
- [x] PHPStan level max: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)