### PR TITLE
refactor: replace DOCUMENT_ROOT paths with __DIR__ for worktree support

### DIFF
--- a/ibl5/block.php
+++ b/ibl5/block.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * - All user input sanitized
  */
 
-require_once $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require_once __DIR__ . '/mainfile.php';
 
 global $mysqli_db;
 

--- a/ibl5/classes/PageLayout/PageLayout.php
+++ b/ibl5/classes/PageLayout/PageLayout.php
@@ -41,11 +41,12 @@ class PageLayout
         // Calculate the correct base path for resources
         $currentFileRaw = $_SERVER['SCRIPT_FILENAME'] ?? '';
         $currentFile = is_string($currentFileRaw) ? $currentFileRaw : '';
+
+        // Use IBL5_ROOT (set by mainfile.php) for reliable path calculation across worktrees
         $docRootRaw = $_SERVER['DOCUMENT_ROOT'] ?? '';
         $documentRoot = is_string($docRootRaw) ? $docRootRaw : '';
-
-        // Calculate how many directory levels deep we are from the application root
-        $iblRoot = $documentRoot . '/ibl5';
+        $ibl5RootRaw = defined('IBL5_ROOT') ? IBL5_ROOT : null;
+        $iblRoot = is_string($ibl5RootRaw) ? $ibl5RootRaw : $documentRoot . '/ibl5';
         $relativePath = '';
 
         // If we're in a subdirectory of ibl5, calculate the relative path back to root

--- a/ibl5/classes/Updater/ScheduleUpdater.php
+++ b/ibl5/classes/Updater/ScheduleUpdater.php
@@ -111,9 +111,9 @@ class ScheduleUpdater extends \BaseMysqliRepository {
 
         $this->preloadTeamNameMap();
 
-        $documentRootRaw = $_SERVER['DOCUMENT_ROOT'] ?? '';
-        $documentRoot = is_string($documentRootRaw) ? $documentRootRaw : '';
-        $schFilePath = $documentRoot . '/ibl5/IBL5.sch';
+        $ibl5RootRaw = defined('IBL5_ROOT') ? IBL5_ROOT : null;
+        $ibl5Root = is_string($ibl5RootRaw) ? $ibl5RootRaw : '.';
+        $schFilePath = $ibl5Root . '/IBL5.sch';
 
         $games = SchFileParser::parseFile($schFilePath);
 

--- a/ibl5/index.php
+++ b/ibl5/index.php
@@ -11,7 +11,7 @@
 /* the Free Software Foundation; either version 2 of the License.       */
 /************************************************************************/
 
-require_once $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require_once __DIR__ . '/mainfile.php';
 global $prefix, $db;
 
 $modpath = '';

--- a/ibl5/leagueControlPanel.php
+++ b/ibl5/leagueControlPanel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/mainfile.php';
 $season = new Season($mysqli_db);
 
 $queryString = "";

--- a/ibl5/mainfile.php
+++ b/ibl5/mainfile.php
@@ -54,6 +54,11 @@ function include_secure($file_name)
     }
 }
 
+// Application root constant — reliable across worktrees and DOCUMENT_ROOT layouts
+if (!defined('IBL5_ROOT')) {
+    define('IBL5_ROOT', __DIR__);
+}
+
 // Check if this file isn't being accessed directly
 
 if (realpath(__FILE__) === realpath($_SERVER['SCRIPT_FILENAME'])) {
@@ -81,6 +86,21 @@ if (isset($_SERVER['HTTP_USER_AGENT']) && strstr($_SERVER['HTTP_USER_AGENT'], 'c
 
 // Load Composer autoloader for IBL5 classes and third-party packages
 require_once __DIR__ . '/vendor/autoload.php';
+
+// In git worktrees, vendor/ is symlinked to the main repo. Composer resolves __DIR__
+// through the symlink, so it loads classes from the main repo instead of the worktree.
+// Prepend the worktree's classes/ directory so modified files are used at runtime.
+if (is_link(__DIR__ . '/vendor')) {
+    $worktreeClasses = realpath(__DIR__ . '/classes');
+    if ($worktreeClasses !== false) {
+        spl_autoload_register(static function (string $class) use ($worktreeClasses): void {
+            $file = $worktreeClasses . '/' . str_replace('\\', '/', $class) . '.php';
+            if (file_exists($file)) {
+                require $file;
+            }
+        }, true, true);
+    }
+}
 
 // SECURITY: Configure secure session cookie parameters before session_start()
 if (session_status() === PHP_SESSION_NONE) {

--- a/ibl5/modules.php
+++ b/ibl5/modules.php
@@ -13,7 +13,7 @@
 /************************************************************************/
 
 define('MODULE_FILE', true);
-require_once $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require_once __DIR__ . '/mainfile.php';
 
 if (isset($name) && $name == $_REQUEST['name']) {
     $name = trim($name);

--- a/ibl5/modules/Draft/draft_selection.php
+++ b/ibl5/modules/Draft/draft_selection.php
@@ -1,6 +1,6 @@
 <?php
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../../mainfile.php';
 
 global $mysqli_db;
 

--- a/ibl5/modules/Player/extension.php
+++ b/ibl5/modules/Player/extension.php
@@ -1,6 +1,6 @@
 <?php
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../../mainfile.php';
 
 global $mysqli_db;
 

--- a/ibl5/modules/Trading/accepttradeoffer.php
+++ b/ibl5/modules/Trading/accepttradeoffer.php
@@ -1,7 +1,7 @@
 <?php
 
 try {
-    require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+    require __DIR__ . '/../../mainfile.php';
 } catch (Exception $e) {
     error_log("Failed to load mainfile.php: " . $e->getMessage());
     die("Error loading system files. Please contact the administrator.");

--- a/ibl5/modules/Trading/maketradeoffer.php
+++ b/ibl5/modules/Trading/maketradeoffer.php
@@ -1,7 +1,7 @@
 <?php
 
 try {
-    require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+    require __DIR__ . '/../../mainfile.php';
 } catch (Exception $e) {
     error_log("Failed to load mainfile.php: " . $e->getMessage());
     die("Error loading system files. Please contact the administrator.");

--- a/ibl5/modules/Trading/rejecttradeoffer.php
+++ b/ibl5/modules/Trading/rejecttradeoffer.php
@@ -1,7 +1,7 @@
 <?php
 
 try {
-    require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+    require __DIR__ . '/../../mainfile.php';
 } catch (Exception $e) {
     error_log("Failed to load mainfile.php: " . $e->getMessage());
     die("Error loading system files. Please contact the administrator.");

--- a/ibl5/modules/Voting/ASGVote.php
+++ b/ibl5/modules/Voting/ASGVote.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../../mainfile.php';
 
 use Utilities\HtmlSanitizer;
 

--- a/ibl5/modules/Voting/EOYVote.php
+++ b/ibl5/modules/Voting/EOYVote.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../../mainfile.php';
 
 use Utilities\HtmlSanitizer;
 

--- a/ibl5/scripts/allStarRename.php
+++ b/ibl5/scripts/allStarRename.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../mainfile.php';
 
 // SECURITY: Admin-only endpoint
 if (!function_exists('is_admin') || !is_admin($admin)) {

--- a/ibl5/scripts/engParser.php
+++ b/ibl5/scripts/engParser.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
  * Parses the .eng file from JSB simulation to read player energy values.
  */
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/vendor/autoload.php';
-include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/config.php';
-include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/db/db.php';
+require __DIR__ . '/../vendor/autoload.php';
+include __DIR__ . '/../config.php';
+include __DIR__ . '/../db/db.php';
 
 use Scripts\MaintenanceRepository;
 
@@ -21,7 +21,7 @@ if ($leagueFileName === null) {
     die("Unable to find League File Name setting");
 }
 
-$engFilePath = $_SERVER['DOCUMENT_ROOT'] . "/ibl5/$leagueFileName.eng";
+$engFilePath = __DIR__ . "/../$leagueFileName.eng";
 if (!file_exists($engFilePath)) {
     die("Energy file not found: $engFilePath");
 }

--- a/ibl5/scripts/jsbExport.php
+++ b/ibl5/scripts/jsbExport.php
@@ -76,7 +76,7 @@ if (!isset($_POST['confirmed'])) {
     exit();
 }
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../mainfile.php';
 
 use JsbParser\JsbExportRepository;
 use JsbParser\JsbExportService;
@@ -86,7 +86,7 @@ $repository = new JsbExportRepository($mysqli_db);
 $service = new JsbExportService($repository);
 $season = new Season($mysqli_db);
 
-$basePath = $_SERVER['DOCUMENT_ROOT'] . '/ibl5';
+$basePath = __DIR__ . '/..';
 $plrInput = $basePath . '/IBL5.plr';
 $plrOutput = $basePath . '/IBL5_export.plr';
 $trnOutput = $basePath . '/IBL5_export.trn';

--- a/ibl5/scripts/plrAdvanceBirdYears.php
+++ b/ibl5/scripts/plrAdvanceBirdYears.php
@@ -1,6 +1,6 @@
 <?php
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../mainfile.php';
 
 $plrFile = fopen("IBL5.plr", "rb+");
 while (!feof($plrFile)) {

--- a/ibl5/scripts/plrAdvanceYearsOfExperience.php
+++ b/ibl5/scripts/plrAdvanceYearsOfExperience.php
@@ -1,6 +1,6 @@
 <?php
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../mainfile.php';
 
 $plrFile = fopen("IBL5.plr", "rb+");
 while (!feof($plrFile)) {

--- a/ibl5/scripts/plrDropUnsignedFreeAgentsToWaivers.php
+++ b/ibl5/scripts/plrDropUnsignedFreeAgentsToWaivers.php
@@ -1,6 +1,6 @@
 <?php
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../mainfile.php';
 
 $plrFile = fopen("IBL5.plr", "rb+");
 while (!feof($plrFile)) {

--- a/ibl5/scripts/plrScratchpad.php
+++ b/ibl5/scripts/plrScratchpad.php
@@ -1,6 +1,6 @@
 <?php
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../mainfile.php';
 
 $plrFile = fopen("IBL5.plr", "rb+");
 while (!feof($plrFile)) {

--- a/ibl5/scripts/tradition.php
+++ b/ibl5/scripts/tradition.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
  * used in free agency calculations.
  */
 
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/vendor/autoload.php';
-include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/config.php';
-include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/db/db.php';
+require __DIR__ . '/../vendor/autoload.php';
+include __DIR__ . '/../config.php';
+include __DIR__ . '/../db/db.php';
 
 use Scripts\MaintenanceRepository;
 

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -6,7 +6,7 @@ error_reporting(E_ALL);
 libxml_use_internal_errors(true);
 
 // Load mainfile first for authentication
-require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
+require __DIR__ . '/../mainfile.php';
 
 // SECURITY: Admin-only script - check authentication before proceeding
 if (!function_exists('is_admin') || !is_admin()) {
@@ -45,9 +45,10 @@ global $mysqli_db;
 
 $view = new Updater\UpdaterView();
 
-$stylesheetPath = '/ibl5/themes/IBL/style/style.css';
+$stylesheetRelative = 'themes/IBL/style/style.css';
 /** @var int|false $stylesheetMtime */
-$stylesheetMtime = filemtime($_SERVER['DOCUMENT_ROOT'] . $stylesheetPath);
+$stylesheetMtime = filemtime(__DIR__ . '/../' . $stylesheetRelative);
+$stylesheetPath = '../' . $stylesheetRelative;
 $cacheBuster = $stylesheetMtime !== false ? '?v=' . $stylesheetMtime : '';
 
 echo $view->renderPageOpen($stylesheetPath . $cacheBuster);
@@ -80,7 +81,7 @@ set_exception_handler(function (\Throwable $exception) use ($view): void {
 $successCount = 0;
 $errorCount = 0;
 
-$basePath = $_SERVER['DOCUMENT_ROOT'] . '/ibl5';
+$basePath = __DIR__ . '/..';
 
 try {
     // --- Initialization ---


### PR DESCRIPTION
## Summary

- Replace all `$_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php'` bootstrap paths with `__DIR__`-relative paths across 23 PHP entry-point files
- Add `IBL5_ROOT` constant and worktree-aware prepend autoloader to `mainfile.php` so symlinked `vendor/` loads worktree classes at runtime
- Update `PageLayout` and `ScheduleUpdater` to use `IBL5_ROOT` instead of `DOCUMENT_ROOT` for file-path resolution

This enables git worktrees to be previewed in the browser at `http://localhost/worktrees/<name>/ibl5/` with no Apache/MAMP configuration changes. Production is unaffected — the prepend autoloader only activates when `vendor/` is a symlink.

## Test plan

- [x] Full PHPUnit suite passes (3357 tests, 17010 assertions)
- [x] PHPStan clean (0 errors)
- [x] Manual: verify `http://localhost/ibl5/` still works (main site)
- [x] Manual: create a worktree and verify `http://localhost/worktrees/<name>/ibl5/` loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)