### PR TITLE
style: refactor Draft Pick Locator to use team logos and unified table styling

### DIFF
--- a/ibl5/classes/DraftPickLocator/DraftPickLocatorView.php
+++ b/ibl5/classes/DraftPickLocator/DraftPickLocatorView.php
@@ -67,14 +67,14 @@ class DraftPickLocatorView implements DraftPickLocatorViewInterface
         for ($i = 0; $i < 6; $i++) {
             $year = $currentEndingYear + $i;
             $safeYear = HtmlSanitizer::safeHtmlOutput((string)$year);
-            $html .= '<th colspan="2">' . $safeYear . '</th>';
+            $html .= '<th colspan="2" class="draft-pick-year-sep">' . $safeYear . '</th>';
         }
         $html .= '</tr>';
 
         // Second header row - round labels
         $html .= '<tr>';
         for ($i = 0; $i < 6; $i++) {
-            $html .= '<th>R1</th><th>R2</th>';
+            $html .= '<th class="draft-pick-year-sep">R1</th><th>R2</th>';
         }
         $html .= '</tr>';
 
@@ -141,14 +141,16 @@ class DraftPickLocatorView implements DraftPickLocatorViewInterface
             $isOwn = ($ownerOfPick === $team['teamName']);
             $ownerInfo = $teamColorMap[$ownerOfPick] ?? null;
 
+            $yearSepClass = ($pick['round'] === 1) ? ' draft-pick-year-sep' : '';
+
             if ($isOwn) {
-                $html .= '<td class="draft-pick-own">';
+                $html .= '<td class="draft-pick-own' . $yearSepClass . '">';
             } else {
                 if ($ownerInfo !== null) {
                     $bgColor = HtmlSanitizer::safeHtmlOutput($ownerInfo['color1']);
-                    $html .= '<td class="draft-pick-traded" style="background-color: #' . $bgColor . ';">';
+                    $html .= '<td class="draft-pick-traded' . $yearSepClass . '" style="background-color: #' . $bgColor . ';">';
                 } else {
-                    $html .= '<td class="draft-pick-traded">';
+                    $html .= '<td class="draft-pick-traded' . $yearSepClass . '">';
                 }
             }
 

--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -1680,6 +1680,11 @@ td.ibl-team-cell--colored {
     border-right: 1px solid var(--gray-100);
 }
 
+/* Year group separator — heavier left border between each year's R1/R2 pair */
+.draft-pick-table .draft-pick-year-sep {
+    border-left: 1px solid var(--gray-300);
+}
+
 /* Pick matrix cells: column borders, uniform square sizing */
 .draft-pick-own,
 .draft-pick-traded {


### PR DESCRIPTION
## Summary

- Replaces text team names in the Draft Pick Locator matrix with team logo images for better visual clarity
- Aligns `.draft-pick-table` styling to match `.ibl-data-table` appearance (header gradient, row striping, hover)
- Fixes `responsive-tables.js` to skip tables inside `.sticky-scroll-wrapper`, preventing broken sticky scroll behavior
- Removes now-unnecessary `processDraftPickCells()` from `name-abbreviation.js` (logos don't need text abbreviation)
- Updates CSS architecture docs and CSS_TABLE_MAP with sticky-scroll gotcha

## Test plan

- [x] Verify Draft Pick Locator renders team logos instead of text names
- [x] Verify traded picks show owning team's logo on colored background
- [x] Verify sticky header + sticky first column still works on mobile
- [x] Verify `responsive-tables.js` doesn't interfere with sticky-scroll tables
- [x] PHPUnit tests pass (DraftPickLocatorViewTest updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)