### PR TITLE
feat: add Olympics JSB file compatibility to import pipeline

### DIFF
--- a/ibl5/classes/Boxscore.php
+++ b/ibl5/classes/Boxscore.php
@@ -181,7 +181,7 @@ class Boxscore
     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
     }
 
-    protected function fillGameInfo(string $gameInfoLine, int $seasonEndingYear, string $seasonPhase): void
+    protected function fillGameInfo(string $gameInfoLine, int $seasonEndingYear, string $seasonPhase, string $league = 'ibl'): void
     {
         $this->gameYear = $seasonEndingYear;
         $this->gameMonth = sprintf("%02u", intval(substr($gameInfoLine, 0, 2)) + 10); // sprintf() prepends 0 if the result isn't in double-digits
@@ -206,25 +206,31 @@ class Boxscore
         $this->homeQ4points = substr($gameInfoLine, 52, 3);
         $this->homeOTpoints = substr($gameInfoLine, 55, 3);
 
-        $seasonStartingYear = $seasonEndingYear - 1;
-        if ((int)$this->gameMonth > 12 && (int)$this->gameMonth !== JSB::PLAYOFF_MONTH) {
-            $this->gameMonth = sprintf("%02u", (int)$this->gameMonth - 12);
-        } elseif ((int)$this->gameMonth === JSB::PLAYOFF_MONTH) {
-            $this->gameMonth = sprintf("%02u", (int)$this->gameMonth - 16); // This hacks the Playoffs to be in "June"
-        } elseif ((int)$this->gameMonth > 10) {
-            $this->gameYear = $seasonStartingYear;
-            if ($seasonPhase === "HEAT") {
-                $this->gameMonth = (string) Season::IBL_HEAT_MONTH;
+        // Olympics: all games occur in August of the ending year
+        if (strtolower($league) === 'olympics') {
+            $this->gameMonth = sprintf("%02u", Season::IBL_OLYMPICS_MONTH);
+            $this->gameYear = $seasonEndingYear;
+        } else {
+            $seasonStartingYear = $seasonEndingYear - 1;
+            if ((int)$this->gameMonth > 12 && (int)$this->gameMonth !== JSB::PLAYOFF_MONTH) {
+                $this->gameMonth = sprintf("%02u", (int)$this->gameMonth - 12);
+            } elseif ((int)$this->gameMonth === JSB::PLAYOFF_MONTH) {
+                $this->gameMonth = sprintf("%02u", (int)$this->gameMonth - 16); // This hacks the Playoffs to be in "June"
+            } elseif ((int)$this->gameMonth > 10) {
+                $this->gameYear = $seasonStartingYear;
+                if ($seasonPhase === "HEAT") {
+                    $this->gameMonth = (string) Season::IBL_HEAT_MONTH;
+                }
             }
         }
 
         $this->gameDate = $this->gameYear . '-' . $this->gameMonth . '-' . $this->gameDay;
     }
 
-    public static function withGameInfoLine(string $gameInfoLine, int $seasonEndingYear, string $seasonPhase): self
+    public static function withGameInfoLine(string $gameInfoLine, int $seasonEndingYear, string $seasonPhase, string $league = 'ibl'): self
     {
         $instance = new self();
-        $instance->fillGameInfo($gameInfoLine, $seasonEndingYear, $seasonPhase);
+        $instance->fillGameInfo($gameInfoLine, $seasonEndingYear, $seasonPhase, $league);
         return $instance;
     }
 

--- a/ibl5/classes/Boxscore/BoxscoreProcessor.php
+++ b/ibl5/classes/Boxscore/BoxscoreProcessor.php
@@ -73,6 +73,7 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
         $gamesUpdated = 0;
         $gamesSkipped = 0;
         $linesProcessed = 0;
+        $league = $this->leagueContext !== null ? $this->leagueContext->getCurrentLeague() : 'ibl';
 
         while (!feof($scoFile)) {
             $line = fgets($scoFile, 2001);
@@ -81,7 +82,7 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
             }
 
             $gameInfoLine = substr($line, 0, 58);
-            $boxscoreGameInfo = \Boxscore::withGameInfoLine($gameInfoLine, $operatingSeasonEndingYear, $operatingSeasonPhase);
+            $boxscoreGameInfo = \Boxscore::withGameInfoLine($gameInfoLine, $operatingSeasonEndingYear, $operatingSeasonPhase, $league);
 
             $upsertAction = $this->processGameUpsert($boxscoreGameInfo);
 

--- a/ibl5/classes/JsbParser/Contracts/JsbImportServiceInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/JsbImportServiceInterface.php
@@ -20,7 +20,7 @@ interface JsbImportServiceInterface
      * @param \Season $season Current season object for year resolution
      * @return JsbImportResult Summary of import results
      */
-    public function processCurrentSeason(string $basePath, \Season $season): JsbImportResult;
+    public function processCurrentSeason(string $basePath, \Season $season, string $filePrefix = 'IBL5'): JsbImportResult;
 
     /**
      * Process a .car file and upsert records into ibl_hist.

--- a/ibl5/classes/JsbParser/JsbImportRepository.php
+++ b/ibl5/classes/JsbParser/JsbImportRepository.php
@@ -5,15 +5,44 @@ declare(strict_types=1);
 namespace JsbParser;
 
 use JsbParser\Contracts\JsbImportRepositoryInterface;
+use League\LeagueContext;
 
 /**
  * Repository for database operations related to JSB file imports.
  *
  * Handles upserts into ibl_hist, ibl_jsb_transactions, ibl_jsb_history,
  * ibl_jsb_allstar_rosters, and ibl_jsb_allstar_scores tables.
+ * League-aware: resolves table names through LeagueContext when provided.
  */
 class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepositoryInterface
 {
+    private string $histTable;
+    private string $jsbHistoryTable;
+    private string $jsbTransactionsTable;
+    private string $rcbAlltimeTable;
+    private string $rcbSeasonTable;
+    private string $plrTable;
+    private string $teamInfoTable;
+
+    public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
+    {
+        parent::__construct($db);
+        $this->histTable = self::resolveTable($leagueContext, 'ibl_hist');
+        $this->jsbHistoryTable = self::resolveTable($leagueContext, 'ibl_jsb_history');
+        $this->jsbTransactionsTable = self::resolveTable($leagueContext, 'ibl_jsb_transactions');
+        $this->rcbAlltimeTable = self::resolveTable($leagueContext, 'ibl_rcb_alltime_records');
+        $this->rcbSeasonTable = self::resolveTable($leagueContext, 'ibl_rcb_season_records');
+        $this->plrTable = self::resolveTable($leagueContext, 'ibl_plr');
+        $this->teamInfoTable = self::resolveTable($leagueContext, 'ibl_team_info');
+    }
+
+    private static function resolveTable(?LeagueContext $leagueContext, string $iblTableName): string
+    {
+        return $leagueContext !== null
+            ? $leagueContext->getTableName($iblTableName)
+            : $iblTableName;
+    }
+
     /**
      * JSB team ID → team name mapping for historical team names.
      *
@@ -81,7 +110,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertHistRecord(array $record): int
     {
         return $this->execute(
-            'INSERT INTO ibl_hist
+            "INSERT INTO {$this->histTable}
                 (pid, name, year, team, teamid, games, minutes, fgm, fga, ftm, fta, tgm, tga, orb, reb, ast, stl, blk, tvr, pf, pts)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
@@ -102,7 +131,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
                 blk = VALUES(blk),
                 tvr = VALUES(tvr),
                 pf = VALUES(pf),
-                pts = VALUES(pts)',
+                pts = VALUES(pts)",
             'isisiiiiiiiiiiiiiiiii',
             $record['pid'],
             $record['name'],
@@ -134,7 +163,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertTransaction(array $record): int
     {
         return $this->execute(
-            'INSERT INTO ibl_jsb_transactions
+            "INSERT INTO {$this->jsbTransactionsTable}
                 (season_year, transaction_month, transaction_day, transaction_type,
                  pid, player_name, from_teamid, to_teamid,
                  injury_games_missed, injury_description, trade_group_id,
@@ -147,7 +176,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
                 trade_group_id = VALUES(trade_group_id),
                 is_draft_pick = VALUES(is_draft_pick),
                 draft_pick_year = VALUES(draft_pick_year),
-                source_file = VALUES(source_file)',
+                source_file = VALUES(source_file)",
             'iiiiisiiisiiis',
             $record['season_year'],
             $record['transaction_month'],
@@ -172,7 +201,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertHistoryRecord(array $record): int
     {
         return $this->execute(
-            'INSERT INTO ibl_jsb_history
+            "INSERT INTO {$this->jsbHistoryTable}
                 (season_year, team_name, teamid, wins, losses, made_playoffs,
                  playoff_result, playoff_round_reached, won_championship, source_file)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -184,7 +213,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
                 playoff_result = VALUES(playoff_result),
                 playoff_round_reached = VALUES(playoff_round_reached),
                 won_championship = VALUES(won_championship),
-                source_file = VALUES(source_file)',
+                source_file = VALUES(source_file)",
             'isiiiissss',
             $record['season_year'],
             $record['team_name'],
@@ -266,7 +295,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
 
         // Try direct lookup first
         $row = $this->fetchOne(
-            'SELECT teamid FROM ibl_team_info WHERE team_name = ? LIMIT 1',
+            "SELECT teamid FROM {$this->teamInfoTable} WHERE team_name = ? LIMIT 1",
             's',
             $teamName
         );
@@ -282,7 +311,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
         if (isset(self::TEAM_NAME_ALIASES[$teamName])) {
             $aliasName = self::TEAM_NAME_ALIASES[$teamName];
             $row = $this->fetchOne(
-                'SELECT teamid FROM ibl_team_info WHERE team_name = ? LIMIT 1',
+                "SELECT teamid FROM {$this->teamInfoTable} WHERE team_name = ? LIMIT 1",
                 's',
                 $aliasName
             );
@@ -295,9 +324,9 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
             }
         }
 
-        // Try looking in ibl_hist for historical team names
+        // Try looking in hist table for historical team names
         $row = $this->fetchOne(
-            'SELECT teamid FROM ibl_hist WHERE team = ? AND teamid > 0 LIMIT 1',
+            "SELECT teamid FROM {$this->histTable} WHERE team = ? AND teamid > 0 LIMIT 1",
             's',
             $teamName
         );
@@ -321,7 +350,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function fetchMaxTradeGroupId(): int
     {
         $row = $this->fetchOne(
-            'SELECT COALESCE(MAX(trade_group_id), 0) AS max_id FROM ibl_jsb_transactions',
+            "SELECT COALESCE(MAX(trade_group_id), 0) AS max_id FROM {$this->jsbTransactionsTable}",
             ''
         );
 
@@ -340,7 +369,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertRcbAlltimeRecord(array $record): int
     {
         return $this->execute(
-            'INSERT INTO ibl_rcb_alltime_records
+            "INSERT INTO {$this->rcbAlltimeTable}
                 (scope, team_id, record_type, stat_category, ranking,
                  player_name, car_block_id, pid, stat_value, stat_raw,
                  team_of_record, season_year, career_total, source_file)
@@ -354,7 +383,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
                 team_of_record = VALUES(team_of_record),
                 season_year = VALUES(season_year),
                 career_total = VALUES(career_total),
-                source_file = VALUES(source_file)',
+                source_file = VALUES(source_file)",
             'sissisiidiiiis',
             $record['scope'],
             $record['team_id'],
@@ -379,7 +408,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertRcbSeasonRecord(array $record): int
     {
         return $this->execute(
-            'INSERT INTO ibl_rcb_season_records
+            "INSERT INTO {$this->rcbSeasonTable}
                 (season_year, scope, team_id, context, stat_category, ranking,
                  player_name, player_position, car_block_id, pid,
                  stat_value, record_season_year, source_file)
@@ -391,7 +420,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
                 pid = VALUES(pid),
                 stat_value = VALUES(stat_value),
                 record_season_year = VALUES(record_season_year),
-                source_file = VALUES(source_file)',
+                source_file = VALUES(source_file)",
             'isississiiiis',
             $record['season_year'],
             $record['scope'],
@@ -418,7 +447,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function getPlayerName(int $pid): ?string
     {
         $row = $this->fetchOne(
-            'SELECT name FROM ibl_plr WHERE pid = ? LIMIT 1',
+            "SELECT name FROM {$this->plrTable} WHERE pid = ? LIMIT 1",
             'i',
             $pid
         );

--- a/ibl5/classes/JsbParser/JsbImportService.php
+++ b/ibl5/classes/JsbParser/JsbImportService.php
@@ -35,13 +35,13 @@ class JsbImportService implements JsbImportServiceInterface
     /**
      * @see JsbImportServiceInterface::processCurrentSeason()
      */
-    public function processCurrentSeason(string $basePath, \Season $season): JsbImportResult
+    public function processCurrentSeason(string $basePath, \Season $season, string $filePrefix = 'IBL5'): JsbImportResult
     {
         $result = new JsbImportResult();
         $seasonYear = $season->beginningYear;
 
         // Process .trn first (trade data helps with player ID resolution)
-        $trnPath = $basePath . '/IBL5.trn';
+        $trnPath = $basePath . '/' . $filePrefix . '.trn';
         if (file_exists($trnPath)) {
             $trnResult = $this->processTrnFile($trnPath, 'current-season');
             $result->merge($trnResult);
@@ -49,7 +49,7 @@ class JsbImportService implements JsbImportServiceInterface
         }
 
         // Process .car (uses trade data for mid-season splits)
-        $carPath = $basePath . '/IBL5.car';
+        $carPath = $basePath . '/' . $filePrefix . '.car';
         if (file_exists($carPath)) {
             $carResult = $this->processCarFile($carPath, $seasonYear);
             $result->merge($carResult);
@@ -57,7 +57,7 @@ class JsbImportService implements JsbImportServiceInterface
         }
 
         // Process .his
-        $hisPath = $basePath . '/IBL5.his';
+        $hisPath = $basePath . '/' . $filePrefix . '.his';
         if (file_exists($hisPath)) {
             $hisResult = $this->processHisFile($hisPath, 'current-season');
             $result->merge($hisResult);
@@ -65,7 +65,7 @@ class JsbImportService implements JsbImportServiceInterface
         }
 
         // Process .asw
-        $aswPath = $basePath . '/IBL5.asw';
+        $aswPath = $basePath . '/' . $filePrefix . '.asw';
         if (file_exists($aswPath)) {
             $aswResult = $this->processAswFile($aswPath, $seasonYear);
             $result->merge($aswResult);
@@ -73,7 +73,7 @@ class JsbImportService implements JsbImportServiceInterface
         }
 
         // Process .rcb (Record Book)
-        $rcbPath = $basePath . '/IBL5.rcb';
+        $rcbPath = $basePath . '/' . $filePrefix . '.rcb';
         if (file_exists($rcbPath)) {
             $rcbResult = $this->processRcbFile($rcbPath, $seasonYear, 'current-season');
             $result->merge($rcbResult);

--- a/ibl5/classes/JsbParser/PlayerIdResolver.php
+++ b/ibl5/classes/JsbParser/PlayerIdResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace JsbParser;
 
+use League\LeagueContext;
+
 /**
  * Resolves player names from .car files to database PIDs.
  *
@@ -12,10 +14,14 @@ namespace JsbParser;
  * 2. Exact name match in ibl_hist for the same year + team
  * 3. Exact name match in ibl_plr without team constraint (for traded players)
  * 4. Fuzzy name match (Levenshtein ≤ 2) for encoding differences
+ *
+ * League-aware: resolves table names through LeagueContext when provided.
  */
 class PlayerIdResolver
 {
     private \mysqli $db;
+    private string $plrTable;
+    private string $histTable;
 
     /**
      * Cache of resolved name+team+year → pid.
@@ -23,9 +29,18 @@ class PlayerIdResolver
      */
     private array $cache = [];
 
-    public function __construct(\mysqli $db)
+    public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         $this->db = $db;
+        $this->plrTable = self::resolveTable($leagueContext, 'ibl_plr');
+        $this->histTable = self::resolveTable($leagueContext, 'ibl_hist');
+    }
+
+    private static function resolveTable(?LeagueContext $leagueContext, string $iblTableName): string
+    {
+        return $leagueContext !== null
+            ? $leagueContext->getTableName($iblTableName)
+            : $iblTableName;
     }
 
     /**
@@ -84,7 +99,7 @@ class PlayerIdResolver
     private function findInHist(string $name, string $team, int $year): ?int
     {
         $stmt = $this->db->prepare(
-            'SELECT pid FROM ibl_hist WHERE name = ? AND team = ? AND year = ? LIMIT 1'
+            "SELECT pid FROM {$this->histTable} WHERE name = ? AND team = ? AND year = ? LIMIT 1"
         );
         if ($stmt === false) {
             return null;
@@ -106,7 +121,7 @@ class PlayerIdResolver
     private function findInPlr(string $name, int $teamId): ?int
     {
         $stmt = $this->db->prepare(
-            'SELECT pid FROM ibl_plr WHERE name = ? AND tid = ? LIMIT 1'
+            "SELECT pid FROM {$this->plrTable} WHERE name = ? AND tid = ? LIMIT 1"
         );
         if ($stmt === false) {
             return null;
@@ -128,7 +143,7 @@ class PlayerIdResolver
     private function findInHistByNameOnly(string $name, int $year): ?int
     {
         $stmt = $this->db->prepare(
-            'SELECT pid FROM ibl_hist WHERE name = ? AND year = ? LIMIT 1'
+            "SELECT pid FROM {$this->histTable} WHERE name = ? AND year = ? LIMIT 1"
         );
         if ($stmt === false) {
             return null;
@@ -150,7 +165,7 @@ class PlayerIdResolver
     private function findInPlrByNameOnly(string $name): ?int
     {
         $stmt = $this->db->prepare(
-            'SELECT pid FROM ibl_plr WHERE name = ? LIMIT 1'
+            "SELECT pid FROM {$this->plrTable} WHERE name = ? LIMIT 1"
         );
         if ($stmt === false) {
             return null;

--- a/ibl5/classes/League/LeagueContext.php
+++ b/ibl5/classes/League/LeagueContext.php
@@ -165,6 +165,17 @@ class LeagueContext
     }
 
     /**
+     * Get the file prefix for JSB engine files in the current league.
+     *
+     * IBL files are named IBL5.lge, IBL5.plr, etc.
+     * Olympics files are named Olympics.lge, Olympics.plr, etc.
+     */
+    public function getFilePrefix(): string
+    {
+        return $this->isOlympics() ? 'Olympics' : 'IBL5';
+    }
+
+    /**
      * Resolve table name based on current league context
      *
      * For IBL context, returns the input table name unchanged.
@@ -185,6 +196,12 @@ class LeagueContext
             'ibl_power' => 'ibl_olympics_power',
             'ibl_team_info' => 'ibl_olympics_team_info',
             'ibl_league_config' => 'ibl_olympics_league_config',
+            'ibl_plr' => 'ibl_olympics_plr',
+            'ibl_hist' => 'ibl_olympics_hist',
+            'ibl_jsb_history' => 'ibl_olympics_jsb_history',
+            'ibl_jsb_transactions' => 'ibl_olympics_jsb_transactions',
+            'ibl_rcb_alltime_records' => 'ibl_olympics_rcb_alltime_records',
+            'ibl_rcb_season_records' => 'ibl_olympics_rcb_season_records',
             default => $iblTableName,
         };
     }

--- a/ibl5/classes/PlrParser/PlrParserRepository.php
+++ b/ibl5/classes/PlrParser/PlrParserRepository.php
@@ -4,15 +4,34 @@ declare(strict_types=1);
 
 namespace PlrParser;
 
+use League\LeagueContext;
 use PlrParser\Contracts\PlrParserRepositoryInterface;
 
 /**
  * Repository for PLR file database operations using prepared statements.
  *
  * Handles upserts into ibl_plr and ibl_hist tables.
+ * League-aware: resolves table names through LeagueContext when provided.
  */
 class PlrParserRepository extends \BaseMysqliRepository implements PlrParserRepositoryInterface
 {
+    private string $plrTable;
+    private string $histTable;
+
+    public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
+    {
+        parent::__construct($db);
+        $this->plrTable = self::resolveTable($leagueContext, 'ibl_plr');
+        $this->histTable = self::resolveTable($leagueContext, 'ibl_hist');
+    }
+
+    private static function resolveTable(?LeagueContext $leagueContext, string $iblTableName): string
+    {
+        return $leagueContext !== null
+            ? $leagueContext->getTableName($iblTableName)
+            : $iblTableName;
+    }
+
     /**
      * @see PlrParserRepositoryInterface::upsertPlayer()
      *
@@ -20,7 +39,7 @@ class PlrParserRepository extends \BaseMysqliRepository implements PlrParserRepo
      */
     public function upsertPlayer(array $data): int
     {
-        $query = "INSERT INTO ibl_plr
+        $query = "INSERT INTO {$this->plrTable}
             (`ordinal`, `name`, `age`, `pid`, `tid`, `peak`, `pos`,
              `oo`, `od`, `do`, `dd`, `po`, `pd`, `to`, `td`,
              `Clutch`, `Consistency`,
@@ -345,7 +364,7 @@ class PlrParserRepository extends \BaseMysqliRepository implements PlrParserRepo
      */
     public function upsertHistoricalStats(array $data): int
     {
-        $query = "INSERT INTO ibl_hist
+        $query = "INSERT INTO {$this->histTable}
             (`pid`, `name`, `year`, `team`, `teamid`,
              `games`, `minutes`, `fgm`, `fga`, `ftm`, `fta`, `tgm`, `tga`,
              `orb`, `reb`, `ast`, `stl`, `blk`, `tvr`, `pf`, `pts`,

--- a/ibl5/classes/Updater/ScheduleUpdater.php
+++ b/ibl5/classes/Updater/ScheduleUpdater.php
@@ -135,7 +135,8 @@ class ScheduleUpdater extends \BaseMysqliRepository {
 
         $ibl5RootRaw = defined('IBL5_ROOT') ? IBL5_ROOT : null;
         $ibl5Root = is_string($ibl5RootRaw) ? $ibl5RootRaw : '.';
-        $schFilePath = $ibl5Root . '/IBL5.sch';
+        $filePrefix = $this->leagueContext !== null ? $this->leagueContext->getFilePrefix() : 'IBL5';
+        $schFilePath = $ibl5Root . '/' . $filePrefix . '.sch';
 
         $games = SchFileParser::parseFile($schFilePath);
 

--- a/ibl5/classes/Updater/Steps/ParseJsbFilesStep.php
+++ b/ibl5/classes/Updater/Steps/ParseJsbFilesStep.php
@@ -19,6 +19,7 @@ class ParseJsbFilesStep implements PipelineStepInterface
         private readonly JsbImportService $service,
         private readonly string $basePath,
         private readonly \Season $season,
+        private readonly string $filePrefix = 'IBL5',
     ) {
     }
 
@@ -30,7 +31,7 @@ class ParseJsbFilesStep implements PipelineStepInterface
     public function execute(): StepResult
     {
         ob_start();
-        $jsbResult = $this->service->processCurrentSeason($this->basePath, $this->season);
+        $jsbResult = $this->service->processCurrentSeason($this->basePath, $this->season, $this->filePrefix);
         $log = (string) ob_get_clean();
 
         return StepResult::success(

--- a/ibl5/docs/OLYMPICS_SCHEMA_NOTES.md
+++ b/ibl5/docs/OLYMPICS_SCHEMA_NOTES.md
@@ -1,0 +1,71 @@
+# Olympics Schema Notes
+
+## Table Pairs
+
+Olympics tables mirror their IBL counterparts. The pipeline writes to the correct table based on `LeagueContext`.
+
+| IBL Table | Olympics Table | Purpose |
+|-----------|---------------|---------|
+| `ibl_box_scores` | `ibl_olympics_box_scores` | Player box scores |
+| `ibl_box_scores_teams` | `ibl_olympics_box_scores_teams` | Team box scores |
+| `ibl_schedule` | `ibl_olympics_schedule` | Game schedule |
+| `ibl_standings` | `ibl_olympics_standings` | Team standings |
+| `ibl_power` | `ibl_olympics_power` | Power rankings |
+| `ibl_team_info` | `ibl_olympics_team_info` | Team metadata |
+| `ibl_league_config` | `ibl_olympics_league_config` | League configuration from .lge |
+| `ibl_plr` | `ibl_olympics_plr` | Player data from .plr |
+| `ibl_hist` | `ibl_olympics_hist` | Career/historical stats from .car/.plr |
+| `ibl_jsb_history` | `ibl_olympics_jsb_history` | Season W-L records from .his |
+| `ibl_jsb_transactions` | `ibl_olympics_jsb_transactions` | Transactions from .trn |
+| `ibl_rcb_alltime_records` | `ibl_olympics_rcb_alltime_records` | All-time records from .rcb |
+| `ibl_rcb_season_records` | `ibl_olympics_rcb_season_records` | Season records from .rcb |
+
+### Shared Tables
+
+- `ibl_sim_dates` — shared between IBL and Olympics. Olympics games occur in August (no overlap with IBL Oct-Jun season).
+
+### Not Mapped
+
+- `ibl_jsb_allstar_rosters` / `ibl_jsb_allstar_scores` — Olympics has no All-Star Weekend.
+- `ibl_olympics_stats` — different schema from `ibl_hist`, populated by a different mechanism.
+
+## File Prefix Convention
+
+JSB engine files use different prefixes per league:
+
+| League | Prefix | Example |
+|--------|--------|---------|
+| IBL | `IBL5` | `IBL5.lge`, `IBL5.plr`, `IBL5.sco` |
+| Olympics | `Olympics` | `Olympics.lge`, `Olympics.plr`, `Olympics.sco` |
+
+`LeagueContext::getFilePrefix()` returns the correct prefix. All file path construction in the pipeline uses this method.
+
+## Olympics Date Mapping
+
+All Olympics game dates map to **August** of the ending year:
+
+- `.sch` dates: `DateParser::extractDate()` maps to `Season::IBL_OLYMPICS_MONTH` (8)
+- `.sco` dates: `Boxscore::fillGameInfo()` overrides month to August when `$league === 'olympics'`
+
+This ensures no date overlap with IBL games (October-June).
+
+## Backfill Instructions
+
+To import historical Olympics data:
+
+```
+updateAllTheThings.php?league=olympics&season_year=2003
+```
+
+1. Copy Olympics files to `ibl5/`: `Olympics.{lge,plr,sco,sch,car,trn,his,rcb}`
+2. Ensure `ibl_olympics_team_info` is populated (the `.lge` import step handles this)
+3. Run the pipeline URL above
+4. Verify data in Olympics tables
+5. Remove copied Olympics files from `ibl5/`
+
+## Migrations
+
+| Migration | Tables Created |
+|-----------|---------------|
+| `043_align_olympics_schemas.sql` | box_scores, box_scores_teams, schedule, standings, power, team_info, league_config |
+| `044_olympics_jsb_tables.sql` | plr, hist, jsb_history, jsb_transactions, rcb_alltime_records, rcb_season_records |

--- a/ibl5/migrations/044_olympics_jsb_tables.sql
+++ b/ibl5/migrations/044_olympics_jsb_tables.sql
@@ -1,0 +1,162 @@
+-- Migration 044: Create Olympics equivalents of JSB import tables
+-- These tables mirror their IBL counterparts for Olympics league data.
+-- The .plr, .car, .trn, .his, and .rcb file parsers write to these
+-- when running in Olympics context.
+
+-- Olympics player file table (mirrors ibl_plr)
+-- IBL-specific columns (contracts, bird rights) are populated by JSB engine
+-- but not displayed for Olympics.
+CREATE TABLE IF NOT EXISTS `ibl_olympics_plr` LIKE `ibl_plr`;
+
+-- Olympics career/historical stats (mirrors ibl_hist)
+-- Distinct from ibl_olympics_stats (different schema — .car import needs
+-- ratings/salary columns that ibl_olympics_stats lacks).
+CREATE TABLE IF NOT EXISTS `ibl_olympics_hist` (
+  `pid` int NOT NULL DEFAULT '0',
+  `name` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `year` smallint unsigned NOT NULL DEFAULT '0',
+  `team` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `teamid` int NOT NULL DEFAULT '0',
+  `games` smallint unsigned NOT NULL DEFAULT '0',
+  `minutes` mediumint unsigned NOT NULL DEFAULT '0',
+  `fgm` smallint unsigned NOT NULL DEFAULT '0',
+  `fga` smallint unsigned NOT NULL DEFAULT '0',
+  `ftm` smallint unsigned NOT NULL DEFAULT '0',
+  `fta` smallint unsigned NOT NULL DEFAULT '0',
+  `tgm` smallint unsigned NOT NULL DEFAULT '0',
+  `tga` smallint unsigned NOT NULL DEFAULT '0',
+  `orb` smallint unsigned NOT NULL DEFAULT '0',
+  `reb` smallint unsigned NOT NULL DEFAULT '0',
+  `ast` smallint unsigned NOT NULL DEFAULT '0',
+  `stl` smallint unsigned NOT NULL DEFAULT '0',
+  `blk` smallint unsigned NOT NULL DEFAULT '0',
+  `tvr` smallint unsigned NOT NULL DEFAULT '0',
+  `pf` smallint unsigned NOT NULL DEFAULT '0',
+  `pts` smallint unsigned NOT NULL DEFAULT '0',
+  `r_2ga` int NOT NULL DEFAULT '0',
+  `r_2gp` int NOT NULL DEFAULT '0',
+  `r_fta` int NOT NULL DEFAULT '0',
+  `r_ftp` int NOT NULL DEFAULT '0',
+  `r_3ga` int NOT NULL DEFAULT '0',
+  `r_3gp` int NOT NULL DEFAULT '0',
+  `r_orb` int NOT NULL DEFAULT '0',
+  `r_drb` int NOT NULL DEFAULT '0',
+  `r_ast` int NOT NULL DEFAULT '0',
+  `r_stl` int NOT NULL DEFAULT '0',
+  `r_blk` int NOT NULL DEFAULT '0',
+  `r_tvr` int NOT NULL DEFAULT '0',
+  `r_oo` int NOT NULL DEFAULT '0',
+  `r_do` int NOT NULL DEFAULT '0',
+  `r_po` int NOT NULL DEFAULT '0',
+  `r_to` int NOT NULL DEFAULT '0',
+  `r_od` int NOT NULL DEFAULT '0',
+  `r_dd` int NOT NULL DEFAULT '0',
+  `r_pd` int NOT NULL DEFAULT '0',
+  `r_td` int NOT NULL DEFAULT '0',
+  `salary` int NOT NULL DEFAULT '0',
+  `nuke_iblhist` int NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`nuke_iblhist`),
+  UNIQUE KEY `unique_composite_key` (`pid`,`name`,`year`),
+  KEY `idx_pid_year` (`pid`,`year`),
+  KEY `idx_team_year` (`team`,`year`),
+  KEY `idx_teamid_year` (`teamid`,`year`),
+  KEY `idx_year` (`year`),
+  KEY `idx_pid_year_team` (`pid`,`year`,`team`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Olympics JSB history (mirrors ibl_jsb_history)
+CREATE TABLE IF NOT EXISTS `ibl_olympics_jsb_history` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `season_year` smallint unsigned NOT NULL,
+  `team_name` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `teamid` int DEFAULT NULL,
+  `wins` smallint unsigned NOT NULL DEFAULT '0',
+  `losses` smallint unsigned NOT NULL DEFAULT '0',
+  `made_playoffs` tinyint unsigned NOT NULL DEFAULT '0',
+  `playoff_result` text COLLATE utf8mb4_unicode_ci,
+  `playoff_round_reached` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `won_championship` tinyint unsigned NOT NULL DEFAULT '0',
+  `source_file` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_season_team` (`season_year`,`team_name`),
+  KEY `idx_teamid` (`teamid`),
+  KEY `idx_season` (`season_year`),
+  KEY `idx_champion` (`won_championship`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Olympics JSB transactions (mirrors ibl_jsb_transactions)
+CREATE TABLE IF NOT EXISTS `ibl_olympics_jsb_transactions` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `season_year` smallint unsigned NOT NULL,
+  `transaction_month` tinyint unsigned NOT NULL,
+  `transaction_day` tinyint unsigned NOT NULL,
+  `transaction_type` tinyint unsigned NOT NULL,
+  `pid` int NOT NULL DEFAULT '0',
+  `player_name` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `from_teamid` int NOT NULL DEFAULT '0',
+  `to_teamid` int NOT NULL DEFAULT '0',
+  `injury_games_missed` smallint unsigned DEFAULT NULL,
+  `injury_description` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `trade_group_id` int unsigned DEFAULT NULL,
+  `is_draft_pick` tinyint unsigned NOT NULL DEFAULT '0',
+  `draft_pick_year` smallint unsigned DEFAULT NULL,
+  `source_file` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_season_record` (`season_year`,`transaction_month`,`transaction_day`,`transaction_type`,`pid`,`from_teamid`,`to_teamid`),
+  KEY `idx_season` (`season_year`),
+  KEY `idx_type` (`transaction_type`),
+  KEY `idx_pid` (`pid`),
+  KEY `idx_trade_group` (`trade_group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Olympics RCB all-time records (mirrors ibl_rcb_alltime_records)
+CREATE TABLE IF NOT EXISTS `ibl_olympics_rcb_alltime_records` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `scope` enum('league','team') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_id` tinyint unsigned NOT NULL DEFAULT '0',
+  `record_type` enum('single_season','career') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `stat_category` enum('ppg','pts','rpg','trb','apg','ast','spg','stl','bpg','blk','fg_pct','ft_pct','three_pct') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `ranking` tinyint unsigned NOT NULL,
+  `player_name` varchar(33) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `car_block_id` smallint unsigned DEFAULT NULL,
+  `pid` int DEFAULT NULL,
+  `stat_value` decimal(10,4) NOT NULL,
+  `stat_raw` int NOT NULL,
+  `team_of_record` tinyint unsigned DEFAULT NULL,
+  `season_year` smallint unsigned DEFAULT NULL,
+  `career_total` int DEFAULT NULL,
+  `source_file` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_record` (`scope`,`team_id`,`record_type`,`stat_category`,`ranking`),
+  KEY `idx_pid` (`pid`),
+  KEY `idx_team` (`team_id`),
+  KEY `idx_stat_type` (`stat_category`,`record_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Olympics RCB season records (mirrors ibl_rcb_season_records)
+CREATE TABLE IF NOT EXISTS `ibl_olympics_rcb_season_records` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `season_year` smallint unsigned NOT NULL,
+  `scope` enum('league','team') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_id` tinyint unsigned NOT NULL DEFAULT '0',
+  `context` enum('home','away') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `stat_category` enum('pts','reb','ast','stl','blk','two_gm','three_gm','ftm') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `ranking` tinyint unsigned NOT NULL,
+  `player_name` varchar(33) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `player_position` varchar(2) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `car_block_id` smallint unsigned DEFAULT NULL,
+  `pid` int DEFAULT NULL,
+  `stat_value` smallint unsigned NOT NULL,
+  `record_season_year` smallint unsigned NOT NULL,
+  `source_file` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_record` (`season_year`,`scope`,`team_id`,`context`,`stat_category`,`ranking`),
+  KEY `idx_pid` (`pid`),
+  KEY `idx_season` (`season_year`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -96,18 +96,37 @@ try {
     flush();
 
     $season = new \Season($mysqli_db);
+
+    // Olympics league context setup
+    $leagueContext = null;
+    $getLeague = $_GET['league'] ?? null;
+    if (is_string($getLeague) && strtolower($getLeague) === 'olympics') {
+        $leagueContext = new \League\LeagueContext();
+        $leagueContext->setLeague('olympics');
+    }
+
+    // Season year override for historical imports (e.g., Olympics 2003)
+    $seasonYearOverride = isset($_GET['season_year']) && is_string($_GET['season_year'])
+        ? (int) $_GET['season_year'] : null;
+    if ($seasonYearOverride !== null && $seasonYearOverride > 1900 && $seasonYearOverride < 2100) {
+        $season->endingYear = $seasonYearOverride;
+        $season->beginningYear = $seasonYearOverride - 1;
+    }
+
     echo $view->renderInitStatus('Season initialized');
     flush();
 
-    $scheduleUpdater = new Updater\ScheduleUpdater($mysqli_db, $season);
+    $filePrefix = $leagueContext !== null ? $leagueContext->getFilePrefix() : 'IBL5';
+
+    $scheduleUpdater = new Updater\ScheduleUpdater($mysqli_db, $season, $leagueContext);
     echo $view->renderInitStatus('ScheduleUpdater initialized');
     flush();
 
-    $standingsUpdater = new Updater\StandingsUpdater($mysqli_db, $season);
+    $standingsUpdater = new Updater\StandingsUpdater($mysqli_db, $season, $leagueContext);
     echo $view->renderInitStatus('StandingsUpdater initialized');
     flush();
 
-    $powerRankingsUpdater = new Updater\PowerRankingsUpdater($mysqli_db, $season);
+    $powerRankingsUpdater = new Updater\PowerRankingsUpdater($mysqli_db, $season, null, $leagueContext);
     echo $view->renderInitStatus('PowerRankingsUpdater initialized');
     flush();
 
@@ -117,25 +136,25 @@ try {
     // --- Pipeline: register all steps and delegate to controller ---
     $updaterService = new Updater\UpdaterService();
 
-    $defaultLgePath = $basePath . '/IBL5.lge';
-    $defaultPlrPath = $basePath . '/IBL5.plr';
-    $defaultScoPath = $basePath . '/IBL5.sco';
+    $defaultLgePath = $basePath . '/' . $filePrefix . '.lge';
+    $defaultPlrPath = $basePath . '/' . $filePrefix . '.plr';
+    $defaultScoPath = $basePath . '/' . $filePrefix . '.sco';
 
-    $lgeRepo = new LeagueConfig\LeagueConfigRepository($mysqli_db);
+    $lgeRepo = new LeagueConfig\LeagueConfigRepository($mysqli_db, $leagueContext);
     $lgeService = new LeagueConfig\LeagueConfigService($lgeRepo);
     $lgeView = new LeagueConfig\LeagueConfigView();
 
-    $plrRepo = new PlrParser\PlrParserRepository($mysqli_db);
+    $plrRepo = new PlrParser\PlrParserRepository($mysqli_db, $leagueContext);
     $plrService = new PlrParser\PlrParserService($plrRepo, $commonRepository, $season);
 
-    $boxscoreProcessor = new Boxscore\BoxscoreProcessor($mysqli_db);
-    $boxscoreRepo = new Boxscore\BoxscoreRepository($mysqli_db);
+    $boxscoreProcessor = new Boxscore\BoxscoreProcessor($mysqli_db, null, null, $leagueContext);
+    $boxscoreRepo = new Boxscore\BoxscoreRepository($mysqli_db, $leagueContext);
     $boxscoreView = new Boxscore\BoxscoreView();
 
     $savedDcRepo = new SavedDepthChart\SavedDepthChartRepository($mysqli_db);
 
-    $jsbRepo = new JsbParser\JsbImportRepository($mysqli_db);
-    $jsbResolver = new JsbParser\PlayerIdResolver($mysqli_db);
+    $jsbRepo = new JsbParser\JsbImportRepository($mysqli_db, $leagueContext);
+    $jsbResolver = new JsbParser\PlayerIdResolver($mysqli_db, $leagueContext);
     $jsbService = new JsbParser\JsbImportService($jsbRepo, $jsbResolver);
 
     $updaterService->addStep(new Updater\Steps\ImportLeagueConfigStep(
@@ -155,7 +174,7 @@ try {
     $updaterService->addStep(new Updater\Steps\ProcessAllStarGamesStep(
         $boxscoreProcessor, $boxscoreRepo, $boxscoreView, $defaultScoPath,
     ));
-    $updaterService->addStep(new Updater\Steps\ParseJsbFilesStep($jsbService, $basePath, $season));
+    $updaterService->addStep(new Updater\Steps\ParseJsbFilesStep($jsbService, $basePath, $season, $filePrefix));
 
     $controller = new Updater\UpdaterController($updaterService, $view);
     $controller->run();

--- a/ibl5/tests/Boxscore/BoxscoreDateMappingTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreDateMappingTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Boxscore;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Boxscore date mapping, particularly Olympics league handling.
+ *
+ * The .sco binary encodes months as offsets from October (0=Oct, 1=Nov, ...).
+ * For Olympics, all dates should map to August of the ending year.
+ */
+class BoxscoreDateMappingTest extends TestCase
+{
+    /**
+     * Build a minimal 58-char game info line for testing.
+     *
+     * Format: 2-char month offset, 2-char day offset, 2-char game#,
+     * 2-char visitor, 2-char home, 5-char attendance, 5-char capacity,
+     * then W/L and quarter scores to fill 58 chars total.
+     */
+    private function buildGameInfoLine(int $monthOffset = 0, int $dayOffset = 14): string
+    {
+        // Month offset (0=Oct), day offset (0=day 1), game#=0, visitor=0, home=1
+        $line = sprintf('%02d', $monthOffset)  // month offset from Oct
+              . sprintf('%02d', $dayOffset)     // day offset (0-indexed)
+              . '00'                            // game of that day
+              . '00'                            // visitor team (0-indexed → tid 1)
+              . '01'                            // home team (0-indexed → tid 2)
+              . '18000'                         // attendance
+              . '20000'                         // capacity
+              . '1005'                          // visitor wins/losses
+              . '0510'                          // home wins/losses
+              . '025030028027000'               // visitor quarter scores (5x3 chars)
+              . '022031025030000';              // home quarter scores (5x3 chars)
+
+        return $line;
+    }
+
+    public function testOlympicsLeagueMapsAllDatesToAugust(): void
+    {
+        $gameInfoLine = $this->buildGameInfoLine(0, 14); // month offset 0 = October in IBL
+        $boxscore = \Boxscore::withGameInfoLine($gameInfoLine, 2003, 'Regular Season/Playoffs', 'olympics');
+
+        $this->assertSame('08', $boxscore->gameMonth);
+        $this->assertSame(2003, $boxscore->gameYear);
+        $this->assertStringStartsWith('2003-08-', $boxscore->gameDate);
+    }
+
+    public function testOlympicsLeagueUsesEndingYear(): void
+    {
+        $gameInfoLine = $this->buildGameInfoLine(2, 5); // month offset 2 = December in IBL
+        $boxscore = \Boxscore::withGameInfoLine($gameInfoLine, 2005, 'Regular Season/Playoffs', 'olympics');
+
+        $this->assertSame(2005, $boxscore->gameYear);
+        $this->assertSame('08', $boxscore->gameMonth);
+    }
+
+    public function testIblLeaguePreservesOriginalDateLogic(): void
+    {
+        // Month offset 1 = November (10+1=11), should be in starting year
+        $gameInfoLine = $this->buildGameInfoLine(1, 10);
+        $boxscore = \Boxscore::withGameInfoLine($gameInfoLine, 2026, 'Regular Season/Playoffs', 'ibl');
+
+        $this->assertSame('11', $boxscore->gameMonth);
+        $this->assertSame(2025, $boxscore->gameYear); // Starting year for November
+    }
+
+    public function testDefaultLeagueParameterUsesIblLogic(): void
+    {
+        // Default (no league param) should behave like IBL
+        $gameInfoLine = $this->buildGameInfoLine(1, 10);
+        $boxscore = \Boxscore::withGameInfoLine($gameInfoLine, 2026, 'Regular Season/Playoffs');
+
+        $this->assertSame('11', $boxscore->gameMonth);
+        $this->assertSame(2025, $boxscore->gameYear);
+    }
+
+    public function testOlympicsLeagueIsCaseInsensitive(): void
+    {
+        $gameInfoLine = $this->buildGameInfoLine(0, 1);
+        $boxscore = \Boxscore::withGameInfoLine($gameInfoLine, 2003, 'Regular Season/Playoffs', 'Olympics');
+
+        $this->assertSame('08', $boxscore->gameMonth);
+        $this->assertSame(2003, $boxscore->gameYear);
+    }
+}

--- a/ibl5/tests/League/LeagueContextTest.php
+++ b/ibl5/tests/League/LeagueContextTest.php
@@ -341,8 +341,6 @@ class LeagueContextTest extends TestCase
     {
         $_SESSION['current_league'] = 'olympics';
 
-        $this->assertSame('ibl_plr', $this->leagueContext->getTableName('ibl_plr'));
-        $this->assertSame('ibl_hist', $this->leagueContext->getTableName('ibl_hist'));
         $this->assertSame('some_other_table', $this->leagueContext->getTableName('some_other_table'));
     }
 
@@ -351,5 +349,48 @@ class LeagueContextTest extends TestCase
         // No league set — defaults to IBL
         $this->assertSame('ibl_schedule', $this->leagueContext->getTableName('ibl_schedule'));
         $this->assertSame('ibl_power', $this->leagueContext->getTableName('ibl_power'));
+    }
+
+    public function testGetTableNameReturnsOlympicsJsbTableMappings(): void
+    {
+        $_SESSION['current_league'] = 'olympics';
+
+        $this->assertSame('ibl_olympics_plr', $this->leagueContext->getTableName('ibl_plr'));
+        $this->assertSame('ibl_olympics_hist', $this->leagueContext->getTableName('ibl_hist'));
+        $this->assertSame('ibl_olympics_jsb_history', $this->leagueContext->getTableName('ibl_jsb_history'));
+        $this->assertSame('ibl_olympics_jsb_transactions', $this->leagueContext->getTableName('ibl_jsb_transactions'));
+        $this->assertSame('ibl_olympics_rcb_alltime_records', $this->leagueContext->getTableName('ibl_rcb_alltime_records'));
+        $this->assertSame('ibl_olympics_rcb_season_records', $this->leagueContext->getTableName('ibl_rcb_season_records'));
+    }
+
+    public function testGetTableNameReturnsIblJsbTableNamesForIblContext(): void
+    {
+        $_SESSION['current_league'] = 'ibl';
+
+        $this->assertSame('ibl_plr', $this->leagueContext->getTableName('ibl_plr'));
+        $this->assertSame('ibl_hist', $this->leagueContext->getTableName('ibl_hist'));
+        $this->assertSame('ibl_jsb_history', $this->leagueContext->getTableName('ibl_jsb_history'));
+        $this->assertSame('ibl_jsb_transactions', $this->leagueContext->getTableName('ibl_jsb_transactions'));
+        $this->assertSame('ibl_rcb_alltime_records', $this->leagueContext->getTableName('ibl_rcb_alltime_records'));
+        $this->assertSame('ibl_rcb_season_records', $this->leagueContext->getTableName('ibl_rcb_season_records'));
+    }
+
+    // ---- getFilePrefix() tests ----
+
+    public function testGetFilePrefixReturnsIbl5ForIblContext(): void
+    {
+        $_SESSION['current_league'] = 'ibl';
+        $this->assertSame('IBL5', $this->leagueContext->getFilePrefix());
+    }
+
+    public function testGetFilePrefixReturnsOlympicsForOlympicsContext(): void
+    {
+        $_SESSION['current_league'] = 'olympics';
+        $this->assertSame('Olympics', $this->leagueContext->getFilePrefix());
+    }
+
+    public function testGetFilePrefixReturnsIbl5ByDefault(): void
+    {
+        $this->assertSame('IBL5', $this->leagueContext->getFilePrefix());
     }
 }


### PR DESCRIPTION
## Summary

- Adds full Olympics league support to the JSB file import pipeline, enabling import of `.plr`, `.car`, `.trn`, `.his`, and `.rcb` files for Olympics seasons
- Creates 6 new Olympics database tables mirroring their IBL counterparts (plr, hist, jsb_history, jsb_transactions, rcb_alltime_records, rcb_season_records)
- Adds `LeagueContext::getFilePrefix()` and expands table mappings so the pipeline writes to the correct Olympics tables when `?league=olympics` is specified
- Olympics boxscore dates are mapped to August of the ending year, matching the existing `.sch` date parsing behavior

## Changes

### Schema (migration 044)
- `ibl_olympics_plr` — player data from `.plr`
- `ibl_olympics_hist` — career stats from `.car`
- `ibl_olympics_jsb_history` — season W-L records from `.his`
- `ibl_olympics_jsb_transactions` — transactions from `.trn`
- `ibl_olympics_rcb_alltime_records` — all-time records from `.rcb`
- `ibl_olympics_rcb_season_records` — season records from `.rcb`

### Pipeline
- `JsbImportRepository`, `PlrParserRepository`, `PlayerIdResolver` — league-aware table resolution
- `JsbImportService`, `ParseJsbFilesStep` — configurable file prefix (`IBL5` vs `Olympics`)
- `ScheduleUpdater` — uses `getFilePrefix()` for `.sch` path
- `Boxscore` — Olympics date mapping (all games → August)
- `updateAllTheThings.php` — `?league=olympics&season_year=YYYY` support

### Tests
- `BoxscoreDateMappingTest` — Olympics and IBL date logic
- `LeagueContextTest` — JSB table mappings + `getFilePrefix()`

### Documentation
- `OLYMPICS_SCHEMA_NOTES.md` — table pairs, file prefixes, date mapping, backfill instructions

## Test plan

- [x] Full PHPUnit suite passes (3617 tests, 17569 assertions)
- [x] PHPStan level max passes with no errors
- [ ] Run `updateAllTheThings.php?league=olympics&season_year=2003` with Olympics files to verify end-to-end import
- [ ] Verify Olympics tables populated with correct data (August dates, 28 teams)
- [x] Verify IBL pipeline unchanged (no `?league` param → same behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)