### PR TITLE
feat: drop 8 legacy PHP-Nuke tables + replace nuke_main query with constant

### DIFF
--- a/ibl5/index.php
+++ b/ibl5/index.php
@@ -17,8 +17,7 @@ global $prefix, $db;
 $modpath = '';
 define('MODULE_FILE', true);
 $_SERVER['PHP_SELF'] = "modules.php";
-$row = $db->sql_fetchrow($db->sql_query("SELECT main_module from " . $prefix . "_main"));
-$name = $row['main_module'];
+$name = 'News';
 define('HOME_FILE', true);
 
 if (isset($url) and is_admin()) {

--- a/ibl5/migrations/050_drop_legacy_nuke_tables.sql
+++ b/ibl5/migrations/050_drop_legacy_nuke_tables.sql
@@ -1,0 +1,12 @@
+-- Migration 050: Drop empty/trivial legacy PHP-Nuke tables
+-- NOTE: nuke_autonews, nuke_groups, nuke_groups_points, nuke_message,
+-- and nuke_subscriptions are excluded — they still have active PHP callers
+-- in mainfile.php (automated_news, update_points, message_box, paid).
+DROP TABLE IF EXISTS nuke_headlines;
+DROP TABLE IF EXISTS nuke_links_categories;
+DROP TABLE IF EXISTS nuke_links_links;
+DROP TABLE IF EXISTS nuke_links_modrequest;
+DROP TABLE IF EXISTS nuke_links_newlink;
+DROP TABLE IF EXISTS nuke_main;
+DROP TABLE IF EXISTS nuke_queue;
+DROP TABLE IF EXISTS nuke_related;

--- a/ibl5/schema.sql
+++ b/ibl5/schema.sql
@@ -2886,12 +2886,6 @@ CREATE TABLE `nuke_groups_points` (
 DROP TABLE IF EXISTS `nuke_headlines`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_headlines` (
-  `hid` int(11) NOT NULL AUTO_INCREMENT,
-  `sitename` varchar(30) NOT NULL DEFAULT '',
-  `headlinesurl` varchar(200) NOT NULL DEFAULT '',
-  PRIMARY KEY (`hid`)
-) ENGINE=MyISAM AUTO_INCREMENT=27 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2901,13 +2895,6 @@ CREATE TABLE `nuke_headlines` (
 DROP TABLE IF EXISTS `nuke_links_categories`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_links_categories` (
-  `cid` int(11) NOT NULL AUTO_INCREMENT,
-  `title` varchar(50) NOT NULL DEFAULT '',
-  `cdescription` mediumtext NOT NULL,
-  `parentid` int(11) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`cid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2917,25 +2904,6 @@ CREATE TABLE `nuke_links_categories` (
 DROP TABLE IF EXISTS `nuke_links_links`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_links_links` (
-  `lid` int(11) NOT NULL AUTO_INCREMENT,
-  `cid` int(11) NOT NULL DEFAULT 0,
-  `sid` int(11) NOT NULL DEFAULT 0,
-  `title` varchar(100) NOT NULL DEFAULT '',
-  `url` varchar(100) NOT NULL DEFAULT '',
-  `description` mediumtext NOT NULL,
-  `date` datetime DEFAULT NULL,
-  `name` varchar(100) NOT NULL DEFAULT '',
-  `email` varchar(100) NOT NULL DEFAULT '',
-  `hits` int(11) NOT NULL DEFAULT 0,
-  `submitter` varchar(60) NOT NULL DEFAULT '',
-  `linkratingsummary` double(6,4) NOT NULL DEFAULT 0.0000,
-  `totalvotes` int(11) NOT NULL DEFAULT 0,
-  `totalcomments` int(11) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`lid`),
-  KEY `cid` (`cid`),
-  KEY `sid` (`sid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2945,18 +2913,6 @@ CREATE TABLE `nuke_links_links` (
 DROP TABLE IF EXISTS `nuke_links_modrequest`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_links_modrequest` (
-  `requestid` int(11) NOT NULL AUTO_INCREMENT,
-  `lid` int(11) NOT NULL DEFAULT 0,
-  `cid` int(11) NOT NULL DEFAULT 0,
-  `sid` int(11) NOT NULL DEFAULT 0,
-  `title` varchar(100) NOT NULL DEFAULT '',
-  `url` varchar(100) NOT NULL DEFAULT '',
-  `description` mediumtext NOT NULL,
-  `modifysubmitter` varchar(60) NOT NULL DEFAULT '',
-  `brokenlink` int(11) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`requestid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2966,20 +2922,6 @@ CREATE TABLE `nuke_links_modrequest` (
 DROP TABLE IF EXISTS `nuke_links_newlink`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_links_newlink` (
-  `lid` int(11) NOT NULL AUTO_INCREMENT,
-  `cid` int(11) NOT NULL DEFAULT 0,
-  `sid` int(11) NOT NULL DEFAULT 0,
-  `title` varchar(100) NOT NULL DEFAULT '',
-  `url` varchar(100) NOT NULL DEFAULT '',
-  `description` mediumtext NOT NULL,
-  `name` varchar(100) NOT NULL DEFAULT '',
-  `email` varchar(100) NOT NULL DEFAULT '',
-  `submitter` varchar(60) NOT NULL DEFAULT '',
-  PRIMARY KEY (`lid`),
-  KEY `cid` (`cid`),
-  KEY `sid` (`sid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2989,9 +2931,6 @@ CREATE TABLE `nuke_links_newlink` (
 DROP TABLE IF EXISTS `nuke_main`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_main` (
-  `main_module` varchar(255) NOT NULL DEFAULT ''
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3114,20 +3053,6 @@ CREATE TABLE `nuke_poll_desc` (
 DROP TABLE IF EXISTS `nuke_queue`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_queue` (
-  `qid` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `uid` mediumint(9) NOT NULL DEFAULT 0,
-  `uname` varchar(40) NOT NULL DEFAULT '',
-  `subject` varchar(100) NOT NULL DEFAULT '',
-  `story` mediumtext DEFAULT NULL,
-  `storyext` mediumtext NOT NULL,
-  `timestamp` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `topic` varchar(20) NOT NULL DEFAULT '',
-  `alanguage` varchar(30) NOT NULL DEFAULT '',
-  PRIMARY KEY (`qid`),
-  KEY `uid` (`uid`),
-  KEY `uname` (`uname`)
-) ENGINE=MyISAM AUTO_INCREMENT=80 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3151,14 +3076,6 @@ CREATE TABLE `nuke_referer` (
 DROP TABLE IF EXISTS `nuke_related`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_related` (
-  `rid` int(11) NOT NULL AUTO_INCREMENT,
-  `tid` int(11) NOT NULL DEFAULT 0,
-  `name` varchar(30) NOT NULL DEFAULT '',
-  `url` varchar(200) NOT NULL DEFAULT '',
-  PRIMARY KEY (`rid`),
-  KEY `tid` (`tid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -30,8 +30,6 @@ INSERT INTO nuke_config (
   '', '5.11', 0, 0, 0
 );
 
-INSERT INTO nuke_main (main_module) VALUES ('News');
-
 -- Modules referenced by E2E tests (is_active() checks)
 INSERT INTO nuke_modules (title, custom_title, active, view) VALUES
   ('Standings',         'Standings',         1, 0),


### PR DESCRIPTION
## Summary

Drops 8 empty/trivial legacy PHP-Nuke tables that have zero code references and replaces the `nuke_main` DB query in `index.php` with a hardcoded constant.

## Changes

### `index.php`
- Replaced `SELECT main_module FROM nuke_main` query with `$name = 'News'`
- Eliminates a DB round-trip on every homepage load
- The theme override (line 56-61) always replaces this value when the News module is active

### Migration 050
Drops 8 tables with no PHP code references:
- `nuke_headlines`, `nuke_links_categories`, `nuke_links_links`, `nuke_links_modrequest`, `nuke_links_newlink`, `nuke_main`, `nuke_queue`, `nuke_related`

### Excluded Tables
5 tables were excluded from this migration because they have active PHP callers in `mainfile.php`:
- `nuke_autonews` → `automated_news()`
- `nuke_groups` / `nuke_groups_points` → `update_points()`
- `nuke_message` → `message_box()`
- `nuke_subscriptions` → `paid()`

These should be cleaned up in a follow-up PR that also removes the dead code.

### Schema & CI
- Removed 8 CREATE TABLE blocks from `schema.sql`
- Removed `nuke_main` INSERT from CI seed data

## Testing
- Full PHPUnit suite: 3635 tests passing
- PHPStan: clean
- E2E: 222 passed, 12 skipped (expected phase-dependent skips)