### PR TITLE
feat: add login redirect for standalone admin pages

### DIFF
--- a/ibl5/includes/buildRedirectUrl.php
+++ b/ibl5/includes/buildRedirectUrl.php
@@ -13,6 +13,22 @@ declare(strict_types=1);
  */
 function buildRedirectUrl(): ?string
 {
+    // Check for standalone page redirect (admin pages outside modules.php)
+    if (isset($_SESSION['redirect_after_login_path']) && is_string($_SESSION['redirect_after_login_path']) && $_SESSION['redirect_after_login_path'] !== '') {
+        $storedPath = $_SESSION['redirect_after_login_path'];
+        unset($_SESSION['redirect_after_login_path']);
+
+        $allowedPaths = [
+            'leagueControlPanel.php',
+            'scripts/updateAllTheThings.php',
+        ];
+
+        $pathOnly = strtok($storedPath, '?');
+        if (is_string($pathOnly) && in_array($pathOnly, $allowedPaths, true)) {
+            return $storedPath;
+        }
+    }
+
     if (!isset($_SESSION['redirect_after_login']) || !is_string($_SESSION['redirect_after_login']) || $_SESSION['redirect_after_login'] === '') {
         return null;
     }

--- a/ibl5/leagueControlPanel.php
+++ b/ibl5/leagueControlPanel.php
@@ -6,7 +6,8 @@ require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
 
 // Auth guard
 if (!is_user($user)) {
-    header('Location: modules.php?name=Your_Account');
+    $_SESSION['redirect_after_login_path'] = 'leagueControlPanel.php';
+    header('Location: modules.php?name=YourAccount');
     exit;
 }
 

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -8,9 +8,17 @@ libxml_use_internal_errors(true);
 // Load mainfile first for authentication
 require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
 
-// SECURITY: Admin-only script - check authentication before proceeding
-if (!function_exists('is_admin') || !is_admin()) {
-    header('HTTP/1.1 403 Forbidden');
+// SECURITY: Redirect logged-out users to login
+if (!function_exists('is_user') || !is_user($user ?? '')) {
+    $_SESSION['redirect_after_login_path'] = 'scripts/updateAllTheThings.php'
+        . (isset($_GET['league']) && $_GET['league'] === League\LeagueContext::LEAGUE_OLYMPICS ? '?league=olympics' : '');
+    header('Location: ../modules.php?name=YourAccount');
+    exit;
+}
+
+// SECURITY: Admin-only — logged-in non-admins get 403
+if (!is_admin()) {
+    http_response_code(403);
     die('Access denied. This script requires administrator privileges.');
 }
 

--- a/ibl5/tests/YourAccount/BuildRedirectUrlTest.php
+++ b/ibl5/tests/YourAccount/BuildRedirectUrlTest.php
@@ -19,7 +19,7 @@ class BuildRedirectUrlTest extends TestCase
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
         }
-        unset($_SESSION['redirect_after_login']);
+        unset($_SESSION['redirect_after_login'], $_SESSION['redirect_after_login_path']);
 
         // Ensure the function is available (defined in includes/buildRedirectUrl.php)
         if (!function_exists('buildRedirectUrl')) {
@@ -29,7 +29,7 @@ class BuildRedirectUrlTest extends TestCase
 
     protected function tearDown(): void
     {
-        unset($_SESSION['redirect_after_login']);
+        unset($_SESSION['redirect_after_login'], $_SESSION['redirect_after_login_path']);
     }
 
     public function testReturnsNullWhenSessionNotSet(): void
@@ -147,5 +147,52 @@ class BuildRedirectUrlTest extends TestCase
         $result = buildRedirectUrl();
 
         $this->assertSame('modules.php?name=Module123', $result);
+    }
+
+    public function testReturnsStandalonePagePath(): void
+    {
+        $_SESSION['redirect_after_login_path'] = 'leagueControlPanel.php';
+
+        $result = buildRedirectUrl();
+
+        $this->assertSame('leagueControlPanel.php', $result);
+    }
+
+    public function testReturnsStandalonePagePathWithQueryString(): void
+    {
+        $_SESSION['redirect_after_login_path'] = 'scripts/updateAllTheThings.php?league=olympics';
+
+        $result = buildRedirectUrl();
+
+        $this->assertSame('scripts/updateAllTheThings.php?league=olympics', $result);
+    }
+
+    public function testRejectsNonWhitelistedStandalonePath(): void
+    {
+        $_SESSION['redirect_after_login_path'] = 'malicious.php';
+
+        $result = buildRedirectUrl();
+
+        $this->assertNull($result);
+    }
+
+    public function testClearsStandalonePathSessionAfterUse(): void
+    {
+        $_SESSION['redirect_after_login_path'] = 'leagueControlPanel.php';
+
+        buildRedirectUrl();
+
+        $this->assertArrayNotHasKey('redirect_after_login_path', $_SESSION);
+    }
+
+    public function testStandalonePathTakesPriorityOverModuleRedirect(): void
+    {
+        $_SESSION['redirect_after_login_path'] = 'leagueControlPanel.php';
+        $_SESSION['redirect_after_login'] = 'name=Trading';
+
+        $result = buildRedirectUrl();
+
+        $this->assertSame('leagueControlPanel.php', $result);
+        $this->assertArrayHasKey('redirect_after_login', $_SESSION);
     }
 }


### PR DESCRIPTION
## Problem

Logged-out users visiting `leagueControlPanel.php` or `scripts/updateAllTheThings.php` were blocked with no way to log in and return. The existing redirect-after-login mechanism (`buildRedirectUrl()`) only handled `modules.php?name=...` URLs.

## Changes

- Extend `buildRedirectUrl()` with new `redirect_after_login_path` session key for standalone page paths, checked before existing module redirect logic
- Add allowlist validation to prevent open-redirect attacks
- Store redirect path in session before redirecting to login in both admin pages
- Split `updateAllTheThings.php` auth into logged-out redirect + non-admin 403
- Fix `leagueControlPanel.php` redirect using wrong module name (`Your_Account` → `YourAccount`)
- Validate league param against `LeagueContext::LEAGUE_OLYMPICS` constant instead of storing arbitrary user input

## Tests

- 5 new tests for standalone path redirect behavior
- Tests cover: allowlist rejection, session cleanup, query string preservation, and priority over module redirects

## Verification

- All 3640 tests pass
- PHPStan clean (level max)