### PR TITLE
feat: drop 5 remaining legacy PHP-Nuke tables + remove dead code

### DIFF
--- a/ibl5/classes/PageLayout/PageLayout.php
+++ b/ibl5/classes/PageLayout/PageLayout.php
@@ -21,7 +21,6 @@ class PageLayout
             echo '<div class="ibl-alert ibl-alert--success">' . $flashMessage . '</div>';
         }
         if (defined('HOME_FILE')) {
-            message_box();
             blocks("Center");
         }
     }

--- a/ibl5/classes/Utilities/NukeCompat.php
+++ b/ibl5/classes/Utilities/NukeCompat.php
@@ -112,14 +112,6 @@ class NukeCompat
     }
 
     /**
-     * Display the message box.
-     */
-    public function messageBox(): void
-    {
-        message_box();
-    }
-
-    /**
      * Track online users.
      */
     public function online(): void

--- a/ibl5/includes/counter.php
+++ b/ibl5/includes/counter.php
@@ -72,7 +72,6 @@ if (str_contains($_SERVER["HTTP_USER_AGENT"], "Win")) {
 /* Save on the databases the obtained values */
 
 $db->sql_query("UPDATE " . $prefix . "_counter SET count=count+1 WHERE (type='total' AND var='hits') OR (var='$browser' AND type='browser') OR (var='$os' AND type='os')");
-update_points(13);
 
 /* Start Detailed Statistics */
 

--- a/ibl5/mainfile.php
+++ b/ibl5/mainfile.php
@@ -352,30 +352,6 @@ function is_user($user)
     return $userSave = $authService->isAuthenticated() ? 1 : 0;
 }
 
-function update_points($id)
-{
-    global $user_prefix, $prefix, $db, $user;
-    if (is_user($user)) {
-        if (!is_array($user)) {
-            $cookie = cookiedecode($user);
-            $username = trim($cookie[1]);
-        } else {
-            $username = trim($user[1]);
-        }
-        $username = substr(htmlspecialchars(str_replace("\'", "'", trim($username))), 0, 25);
-        $username = rtrim($username, "\\");
-        $username = str_replace("'", "\'", $username);
-        if ($db->sql_numrows($db->sql_query("SELECT * FROM " . $prefix . "_groups")) > 0) {
-            $id = intval($id);
-            $result = $db->sql_query("SELECT points FROM " . $prefix . "_groups_points WHERE id='$id'");
-            list($points) = $db->sql_fetchrow($result);
-            $db->sql_freeresult($result);
-            $rpoints = intval($points);
-            $db->sql_query("UPDATE " . $user_prefix . "_users SET points=points+" . $rpoints . " WHERE username='$username'");
-        }
-    }
-}
-
 function title($text)
 {
     OpenTable();
@@ -464,7 +440,7 @@ function blocks($side)
         $action = substr($action, 0, 1);
         $now = time();
         $sub = intval($row['subscription']);
-        if ($sub == 0 or ($sub == 1 and !paid())) {
+        if ($sub == 0 or $sub == 1) {
             if ($expire != 0 and $expire <= $now) {
                 if ($action == "d") {
                     $db->sql_query("UPDATE " . $prefix . "_blocks SET active='0', expire='0' WHERE bid='$bid'");
@@ -488,83 +464,6 @@ function blocks($side)
         }
     }
     $db->sql_freeresult($result);
-}
-
-function message_box()
-{
-    global $bgcolor1, $bgcolor2, $user, $cookie, $textcolor2, $prefix, $multilingual, $currentlang, $db;
-    if ($multilingual == 1) {
-        $querylang = "AND (mlanguage='$currentlang' OR mlanguage='')";
-    } else {
-        $querylang = "";
-    }
-    $result = $db->sql_query("SELECT mid, title, content, date, expire, view FROM " . $prefix . "_message WHERE active='1' $querylang");
-    if ($numrows = $db->sql_numrows($result) == 0) {
-        return;
-    } else {
-        while ($row = $db->sql_fetchrow($result)) {
-            $mid = intval($row['mid']);
-            $title = filter($row['title'], "nohtml");
-            if ($row['content'] != NULL) {
-                $content = filter($row['content']);
-            } else {
-                $content = $row['content'];
-            }
-            $mdate = $row['date'];
-            $expire = intval($row['expire']);
-            $view = intval($row['view']);
-            if (!empty($title) && !empty($content)) {
-                if ($expire == 0) {
-                    $remain = _UNLIMITED;
-                } else {
-                    $etime = (($mdate + $expire) - time()) / 3600;
-                    $etime = (int) $etime;
-                    if ($etime < 1) {
-                        $remain = _EXPIRELESSHOUR;
-                    } else {
-                        $remain = "" . _EXPIREIN . " $etime " . _HOURS . "";
-                    }
-                }
-                if ($view == 5 and paid()) {
-                    OpenTable();
-                    echo "<center><font class=\"option\" color=\"$textcolor2\"><b>$title</b></font></center><br>\n"
-                        . "<font class=\"content\">$content</font>";
-                    CloseTable();
-                    echo "<br>";
-                } elseif ($view == 4 and is_admin()) {
-                    OpenTable();
-                    echo "<center><font class=\"option\" color=\"$textcolor2\"><b>$title</b></font></center><br>\n"
-                        . "<font class=\"content\">$content</font>";
-                    CloseTable();
-                    echo "<br>";
-                } elseif ($view == 3 and is_user($user) || is_admin()) {
-                    OpenTable();
-                    echo "<center><font class=\"option\" color=\"$textcolor2\"><b>$title</b></font></center><br>\n"
-                        . "<font class=\"content\">$content</font>";
-                    CloseTable();
-                    echo "<br>";
-                } elseif ($view == 2 and !is_user($user) || is_admin()) {
-                    OpenTable();
-                    echo "<center><font class=\"option\" color=\"$textcolor2\"><b>$title</b></font></center><br>\n"
-                        . "<font class=\"content\">$content</font>";
-                    CloseTable();
-                    echo "<br>";
-                } elseif ($view == 1) {
-                    OpenTable();
-                    echo "<center><font class=\"option\" color=\"$textcolor2\"><b>$title</b></font></center><br>\n"
-                        . "<font class=\"content\">$content</font>";
-                    CloseTable();
-                    echo "<br>";
-                }
-                if ($expire != 0) {
-                    $past = time() - $expire;
-                    if ($mdate < $past) {
-                        $db->sql_query("UPDATE " . $prefix . "_message SET active='0' WHERE mid='$mid'");
-                    }
-                }
-            }
-        }
-    }
 }
 
 function online()
@@ -983,68 +882,6 @@ function headlines($bid, $cenbox = 0)
     themecenterbox($title, $content);
 }
 
-function automated_news()
-{
-    global $prefix, $multilingual, $currentlang, $db;
-    if ($multilingual == 1) {
-        $querylang = "WHERE (alanguage='$currentlang' OR alanguage='')";
-    } else {
-        $querylang = "";
-    }
-    $today = getdate();
-    $day = $today['mday'];
-    if ($day < 10) {
-        $day = "0$day";
-    }
-    $month = $today['mon'];
-    if ($month < 10) {
-        $month = "0$month";
-    }
-    $year = $today['year'];
-    $hour = $today['hours'];
-    $min = $today['minutes'];
-    $sec = "00";
-    $result = $db->sql_query("SELECT anid, time FROM " . $prefix . "_autonews $querylang");
-    while ($row = $db->sql_fetchrow($result)) {
-        $anid = intval($row['anid']);
-        $time = $row['time'];
-        preg_match('/([0-9]{4})-([0-9]{1,2})-([0-9]{1,2}) ([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})/', $time, $date);
-        if (($date[1] <= $year) and ($date[2] <= $month) and ($date[3] <= $day)) {
-            if (($date[4] < $hour) and ($date[5] >= $min) or ($date[4] <= $hour) and ($date[5] <= $min)) {
-                $result2 = $db->sql_query("SELECT * FROM " . $prefix . "_autonews WHERE anid='$anid'");
-                while ($row2 = $db->sql_fetchrow($result2)) {
-                    $num = $db->sql_numrows($db->sql_query("SELECT sid FROM " . $prefix . "_stories WHERE title='$row2[title]'"));
-                    if ($num == 0) {
-                        $title = $row2['title'];
-                        $hometext = filter($row2['hometext']);
-                        $bodytext = filter($row2['bodytext']);
-                        $notes = filter($row2['notes']);
-                        $catid2 = intval($row2['catid']);
-                        $aid2 = filter($row2['aid'], "nohtml");
-                        $time2 = $row2['time'];
-                        $topic2 = intval($row2['topic']);
-                        $informant2 = filter($row2['informant'], "nohtml");
-                        $ihome2 = intval($row2['ihome']);
-                        $alanguage2 = $row2['alanguage'];
-                        $acomm2 = intval($row2['acomm']);
-                        $associated2 = $row2['associated'];
-                        // Prepare and filter variables to be saved
-                        $hometext = filter($hometext, "", 1);
-                        $bodytext = filter($bodytext, "", 1);
-                        $notes = filter($notes, "", 1);
-                        $aid2 = filter($aid2, "nohtml", 1);
-                        $informant2 = filter($informant2, "nohtml", 1);
-                        $db->sql_query("DELETE FROM " . $prefix . "_autonews WHERE anid='$anid'");
-                        $db->sql_query("INSERT INTO " . $prefix . "_stories (catid, aid, title, time, hometext, bodytext, comments, counter, topic, informant, notes, ihome, alanguage, acomm, haspoll, pollID, associated) VALUES ('$catid2', '$aid2', '$title', '$time2', '$hometext', '$bodytext', '0', '0', '$topic2', '$informant2', '$notes', '$ihome2', '$alanguage2', '$acomm2', '0', '0', '$associated2')");
-                    }
-                }
-                $db->sql_freeresult($result2);
-            }
-        }
-    }
-    $db->sql_freeresult($result);
-}
-
 function get_theme()
 {
     global $user, $userinfo, $Default_Theme, $name, $op;
@@ -1080,43 +917,6 @@ function validate_mail($email)
         die();
     } else {
         return $email;
-    }
-}
-
-function paid()
-{
-    static $result = null;
-    if ($result !== null) {
-        return $result;
-    }
-    global $db, $user, $cookie, $adminmail, $sitename, $nukeurl, $subscription_url, $user_prefix, $prefix;
-    if (is_user($user)) {
-        if (!empty($subscription_url)) {
-            $renew = "" . _SUBRENEW . " $subscription_url";
-        } else {
-            $renew = "";
-        }
-        cookiedecode($user);
-        $sql = "SELECT * FROM " . $prefix . "_subscriptions WHERE userid='$cookie[0]'";
-        $result = $db->sql_query($sql);
-        $numrows = $db->sql_numrows($result);
-        $row = $db->sql_fetchrow($result);
-        if ($numrows == 0) {
-            return $result = 0;
-        } elseif ($numrows != 0) {
-            $time = time();
-            if ($row['subscription_expire'] <= $time) {
-                $db->sql_query("DELETE FROM " . $prefix . "_subscriptions WHERE userid='$cookie[0]' AND id='" . intval($row['id']) . "'");
-                $from = "$sitename <$adminmail>";
-                $subject = "$sitename: " . _SUBEXPIRED . "";
-                $body = "" . _HELLO . " $cookie[1]:\n\n" . _SUBSCRIPTIONAT . " $sitename " . _HASEXPIRED . "\n$renew\n\n" . _HOPESERVED . "\n\n$sitename " . _TEAM . "\n$nukeurl";
-                $row = $db->sql_fetchrow($db->sql_query("SELECT user_email FROM " . $user_prefix . "_users WHERE id='$cookie[0]' AND nickname='$cookie[1]' AND password='$cookie[2]'"));
-                mail($row['user_email'], $subject, $body, "From: $from\nX-Mailer: PHP/" . phpversion());
-            }
-            return $result = 1;
-        }
-    } else {
-        return $result = 0;
     }
 }
 

--- a/ibl5/migrations/051_drop_remaining_nuke_tables.sql
+++ b/ibl5/migrations/051_drop_remaining_nuke_tables.sql
@@ -1,0 +1,8 @@
+-- Migration 051: Drop remaining empty legacy PHP-Nuke tables
+-- Associated dead code (update_points, automated_news, message_box, paid)
+-- removed in this same changeset.
+DROP TABLE IF EXISTS nuke_autonews;
+DROP TABLE IF EXISTS nuke_groups;
+DROP TABLE IF EXISTS nuke_groups_points;
+DROP TABLE IF EXISTS nuke_message;
+DROP TABLE IF EXISTS nuke_subscriptions;

--- a/ibl5/modules/News/categories.php
+++ b/ibl5/modules/News/categories.php
@@ -22,7 +22,6 @@ get_lang($module_name);
 define('INDEX_FILE', true);
 $categories = 1;
 $cat = $catid;
-automated_news();
 
 function theindex($catid)
 {

--- a/ibl5/modules/News/index.php
+++ b/ibl5/modules/News/index.php
@@ -31,7 +31,6 @@ function theindex($new_topic = "0")
         $querylang = "";
     }
     PageLayout\PageLayout::header();
-    automated_news();
     if (isset($userinfo['storynum']) and $user_news == 1) {
         $storynum = $userinfo['storynum'];
     } else {

--- a/ibl5/phpstan-stubs/nuke-globals.stub.php
+++ b/ibl5/phpstan-stubs/nuke-globals.stub.php
@@ -80,9 +80,6 @@ function include_secure(string $file): void {}
 function blocks(string $position): void {}
 
 /** @return void */
-function message_box(): void {}
-
-/** @return void */
 function online(): void {}
 
 /** @return void */

--- a/ibl5/schema.sql
+++ b/ibl5/schema.sql
@@ -2678,32 +2678,6 @@ CREATE TABLE `nuke_authors` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `nuke_autonews`
---
-
-DROP TABLE IF EXISTS `nuke_autonews`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_autonews` (
-  `anid` int(11) NOT NULL AUTO_INCREMENT,
-  `catid` int(11) NOT NULL DEFAULT 0,
-  `aid` varchar(30) NOT NULL DEFAULT '',
-  `title` varchar(80) NOT NULL DEFAULT '',
-  `time` varchar(19) NOT NULL DEFAULT '',
-  `hometext` mediumtext NOT NULL,
-  `bodytext` mediumtext NOT NULL,
-  `topic` int(11) NOT NULL DEFAULT 1,
-  `informant` varchar(20) NOT NULL DEFAULT '',
-  `notes` mediumtext NOT NULL,
-  `ihome` int(11) NOT NULL DEFAULT 0,
-  `alanguage` varchar(30) NOT NULL DEFAULT '',
-  `acomm` int(11) NOT NULL DEFAULT 0,
-  `associated` mediumtext NOT NULL,
-  PRIMARY KEY (`anid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
 -- Table structure for table `nuke_banned_ip`
 --
 
@@ -2850,36 +2824,6 @@ CREATE TABLE `nuke_counter` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `nuke_groups`
---
-
-DROP TABLE IF EXISTS `nuke_groups`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_groups` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL DEFAULT '',
-  `description` mediumtext NOT NULL,
-  `points` int(11) NOT NULL DEFAULT 0,
-  KEY `id` (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `nuke_groups_points`
---
-
-DROP TABLE IF EXISTS `nuke_groups_points`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_groups_points` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `points` int(11) NOT NULL DEFAULT 0,
-  KEY `id` (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=22 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
 -- Table structure for table `nuke_headlines`
 --
 
@@ -2931,26 +2875,6 @@ DROP TABLE IF EXISTS `nuke_links_newlink`;
 DROP TABLE IF EXISTS `nuke_main`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `nuke_message`
---
-
-DROP TABLE IF EXISTS `nuke_message`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_message` (
-  `mid` int(11) NOT NULL AUTO_INCREMENT,
-  `title` varchar(100) NOT NULL DEFAULT '',
-  `content` mediumtext NOT NULL,
-  `date` varchar(14) NOT NULL DEFAULT '',
-  `expire` int(11) NOT NULL DEFAULT 0,
-  `active` int(11) NOT NULL DEFAULT 1,
-  `view` int(11) NOT NULL DEFAULT 1,
-  `mlanguage` varchar(30) NOT NULL DEFAULT '',
-  PRIMARY KEY (`mid`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3202,21 +3126,6 @@ CREATE TABLE `nuke_stories_cat` (
   `counter` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`catid`)
 ) ENGINE=MyISAM AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `nuke_subscriptions`
---
-
-DROP TABLE IF EXISTS `nuke_subscriptions`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `nuke_subscriptions` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `userid` int(11) DEFAULT 0,
-  `subscription_expire` varchar(50) NOT NULL DEFAULT '',
-  KEY `id` (`id`,`userid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
## Summary

Follows up on PR #288 which dropped 8 empty legacy PHP-Nuke tables. This PR removes the remaining 5 tables that had active PHP callers in `mainfile.php`. All 5 tables are confirmed empty/trivial on production, making their calling functions no-ops.

## Tables Dropped (Migration 051)

| Table | Used By | Why It's a No-Op |
|-------|---------|------------------|
| `nuke_groups` | `update_points()` | Empty → numrows check fails → skips |
| `nuke_groups_points` | `update_points()` | Empty → never reached |
| `nuke_message` | `message_box()` | Empty → numrows==0 → early return |
| `nuke_autonews` | `automated_news()` | Empty → while loop never executes |
| `nuke_subscriptions` | `paid()` | Empty → numrows==0 → returns 0 |

## Dead Code Removed

### 4 Functions from `mainfile.php` (~200 lines)
- `update_points()` — group points system (never active)
- `message_box()` — site-wide message display (no messages)
- `automated_news()` — scheduled news publishing (no scheduled items)
- `paid()` — subscription check (no subscribers)

### Callers Removed
- `includes/counter.php`: `update_points(13)`
- `modules/News/index.php`: `automated_news()`
- `modules/News/categories.php`: `automated_news()`
- `classes/PageLayout/PageLayout.php`: `message_box()`
- `classes/Utilities/NukeCompat.php`: `messageBox()` method
- `phpstan-stubs/nuke-globals.stub.php`: `message_box()` stub

### Simplified
- `blocks()` subscription check: `paid()` always returned 0, so `\!paid()` was always true — simplified `if ($sub == 0 or ($sub == 1 and \!paid()))` to `if ($sub == 0 or $sub == 1)`

## Verification

- Full PHPUnit suite passes (3635 tests, 17619 assertions)
- PHPStan clean (level max + strict-rules + bleedingEdge)
- No remaining code references to removed functions (confirmed via grep)
- `schema.sql` updated to remove 5 CREATE TABLE blocks