### PR TITLE
fix: improve E2E test timeout resilience

### DIFF
--- a/ibl5/playwright.config.ts
+++ b/ibl5/playwright.config.ts
@@ -27,12 +27,18 @@ export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 2 : 1,
   workers: process.env.CI ? 1 : undefined,
   reporter: [['html', { open: 'never' }], ['list']],
 
+  expect: {
+    timeout: 5_000,
+  },
+
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost/ibl5/',
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },

--- a/ibl5/tests/e2e/auth.setup.ts
+++ b/ibl5/tests/e2e/auth.setup.ts
@@ -21,7 +21,7 @@ setup('authenticate', async ({ page }) => {
 
   // Wait for login redirect — successful login redirects away from YourAccount.
   // "Logout" is inside a collapsed dropdown so we can't check for it directly.
-  await page.waitForURL((url) => !url.href.includes('name=YourAccount'), { timeout: 10_000 });
+  await page.waitForURL((url) => !url.href.includes('name=YourAccount'));
 
   await page.context().storageState({ path: authFile });
 });

--- a/ibl5/tests/e2e/flows/depth-chart.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart.spec.ts
@@ -34,7 +34,7 @@ test.describe('Depth Chart Entry flow', () => {
 
     await expect(
       page.locator('.depth-chart-table').first(),
-    ).toBeVisible({ timeout: 10000 });
+    ).toBeVisible();
 
     // Player rows should have data-pid attributes
     const playerRows = page.locator('.depth-chart-table tr[data-pid]');
@@ -44,7 +44,7 @@ test.describe('Depth Chart Entry flow', () => {
   test('position selects have options', async ({ page }) => {
     const form = page.locator('.depth-chart-form');
     // Wait for form to load
-    if (!(await form.isVisible({ timeout: 10000 }).catch(() => false))) return;
+    if (!(await form.isVisible().catch(() => false))) return;
 
     const posSelect = page.locator('select[name^="pg"]').first();
     if (await posSelect.isVisible()) {
@@ -55,7 +55,7 @@ test.describe('Depth Chart Entry flow', () => {
 
   test('active selects have valid values', async ({ page }) => {
     const form = page.locator('.depth-chart-form');
-    if (!(await form.isVisible({ timeout: 10000 }).catch(() => false))) return;
+    if (!(await form.isVisible().catch(() => false))) return;
 
     const activeSelects = page.locator('select[name^="active"]');
     const count = await activeSelects.count();
@@ -70,7 +70,7 @@ test.describe('Depth Chart Entry flow', () => {
 
   test('reset button prompts confirmation', async ({ page }) => {
     const resetBtn = page.locator('.depth-chart-reset-btn');
-    if (!(await resetBtn.isVisible({ timeout: 10000 }).catch(() => false)))
+    if (!(await resetBtn.isVisible().catch(() => false)))
       return;
 
     let dialogFired = false;
@@ -85,7 +85,7 @@ test.describe('Depth Chart Entry flow', () => {
 
   test('submit button present when form loaded', async ({ page }) => {
     const form = page.locator('.depth-chart-form');
-    if (!(await form.isVisible({ timeout: 10000 }).catch(() => false))) return;
+    if (!(await form.isVisible().catch(() => false))) return;
 
     await expect(page.locator('.depth-chart-submit-btn')).toBeVisible();
   });

--- a/ibl5/tests/e2e/flows/navigation.spec.ts
+++ b/ibl5/tests/e2e/flows/navigation.spec.ts
@@ -38,7 +38,7 @@ test.describe('Navigation bar (authenticated, desktop)', () => {
     const teamPageLink = nav.locator('.nav-dropdown-item', {
       hasText: 'Team Page',
     }).first();
-    await expect(teamPageLink).toBeVisible({ timeout: 3000 });
+    await expect(teamPageLink).toBeVisible();
   });
 
   test('account dropdown shows logout link', async ({ page }) => {
@@ -52,7 +52,7 @@ test.describe('Navigation bar (authenticated, desktop)', () => {
     const logoutLink = nav.locator('.nav-dropdown-item', {
       hasText: 'Logout',
     }).first();
-    await expect(logoutLink).toBeVisible({ timeout: 3000 });
+    await expect(logoutLink).toBeVisible();
   });
 
   test('teams mega-menu shows team links', async ({ page }) => {
@@ -60,7 +60,7 @@ test.describe('Navigation bar (authenticated, desktop)', () => {
     await desktopNav(page).getByRole('button', { name: 'Teams' }).click();
 
     const teamLinks = page.locator('a[href*="teamID="]');
-    await expect(teamLinks.first()).toBeVisible({ timeout: 3000 });
+    await expect(teamLinks.first()).toBeVisible();
     expect(await teamLinks.count()).toBeGreaterThan(0);
   });
 
@@ -72,7 +72,7 @@ test.describe('Navigation bar (authenticated, desktop)', () => {
     const standingsLink = nav.locator('.nav-dropdown-item', {
       hasText: 'Standings',
     }).first();
-    await expect(standingsLink).toBeVisible({ timeout: 3000 });
+    await expect(standingsLink).toBeVisible();
 
     const href = await standingsLink.getAttribute('href');
     await page.goto(href!);
@@ -90,7 +90,7 @@ test.describe('Navigation bar (authenticated, mobile viewport)', () => {
 
     await expect(
       mobileMenu.locator('text=Welcome back'),
-    ).toBeVisible({ timeout: 3000 });
+    ).toBeVisible();
   });
 
   test('my team section appears in mobile panel', async ({ page }) => {
@@ -99,7 +99,7 @@ test.describe('Navigation bar (authenticated, mobile viewport)', () => {
 
     await expect(
       mobileMenu.locator('.mobile-dropdown-btn', { hasText: 'My Team' }).first(),
-    ).toBeVisible({ timeout: 3000 });
+    ).toBeVisible();
   });
 
   test('account section shows Account instead of Login', async ({ page }) => {
@@ -108,7 +108,7 @@ test.describe('Navigation bar (authenticated, mobile viewport)', () => {
 
     await expect(
       mobileMenu.locator('.mobile-dropdown-btn', { hasText: 'Account' }).first(),
-    ).toBeVisible({ timeout: 3000 });
+    ).toBeVisible();
 
     await expect(
       mobileMenu.locator('.mobile-dropdown-btn', { hasText: 'Login' }),
@@ -126,7 +126,7 @@ test.describe('Navigation bar (authenticated, mobile viewport)', () => {
     const teamPageLink = mobileMenu.locator('.mobile-dropdown-link', {
       hasText: 'Team Page',
     }).first();
-    await expect(teamPageLink).toBeVisible({ timeout: 3000 });
+    await expect(teamPageLink).toBeVisible();
   });
 
   test('mobile link navigates to correct page', async ({ page }) => {
@@ -140,7 +140,7 @@ test.describe('Navigation bar (authenticated, mobile viewport)', () => {
     const standingsLink = mobileMenu.locator('.mobile-dropdown-link', {
       hasText: 'Standings',
     }).first();
-    await expect(standingsLink).toBeVisible({ timeout: 3000 });
+    await expect(standingsLink).toBeVisible();
 
     const href = await standingsLink.getAttribute('href');
     await page.goto(href!);

--- a/ibl5/tests/e2e/flows/trading.spec.ts
+++ b/ibl5/tests/e2e/flows/trading.spec.ts
@@ -76,7 +76,8 @@ test.describe('Trading flow', () => {
     // Click first team link in the team selection table
     const firstTeamLink = page.locator('.trading-team-select a').first();
     await expect(firstTeamLink).toBeVisible();
-    await firstTeamLink.click();
+    const href = await firstTeamLink.getAttribute('href');
+    await page.goto(href!);
 
     // Trade form should appear with two roster tables
     await expect(page.locator('form[name="Trade_Offer"]')).toBeVisible();
@@ -86,7 +87,8 @@ test.describe('Trading flow', () => {
 
   test('player checkboxes exist in roster tables', async ({ page }) => {
     const firstTeamLink = page.locator('.trading-team-select a').first();
-    await firstTeamLink.click();
+    const href = await firstTeamLink.getAttribute('href');
+    await page.goto(href!);
 
     await expect(page.locator('form[name="Trade_Offer"]')).toBeVisible();
 
@@ -259,7 +261,7 @@ test.describe('Trade offer form: roster preview interactions', () => {
     await cashInput.dispatchEvent('input');
 
     // Wait for debounced fetch + panel to appear
-    await expect(preview).toBeVisible({ timeout: 5000 });
+    await expect(preview).toBeVisible();
 
     // Contracts tab should be auto-selected
     await expect(
@@ -277,7 +279,7 @@ test.describe('Trade offer form: roster preview interactions', () => {
       .locator('.trading-roster input[type="checkbox"]')
       .first()
       .check();
-    await expect(preview).toBeVisible({ timeout: 5000 });
+    await expect(preview).toBeVisible();
 
     // First logo (user team) should be active initially
     const firstLogo = logos.first();
@@ -305,7 +307,7 @@ test.describe('Trade offer form: roster preview interactions', () => {
       .locator('.trading-roster input[type="checkbox"]')
       .first()
       .check();
-    await expect(preview).toBeVisible({ timeout: 5000 });
+    await expect(preview).toBeVisible();
 
     // Click "Totals" tab
     const totalsTab = preview.locator('.ibl-tab[data-display="total_s"]');
@@ -334,11 +336,11 @@ test.describe('Trade offer form: roster preview interactions', () => {
       }
     }
 
-    await expect(preview).toBeVisible({ timeout: 5000 });
+    await expect(preview).toBeVisible();
 
     // Wait for the table to render (the mock responds with rows)
     const table = preview.locator('table.ibl-data-table');
-    await expect(table).toBeVisible({ timeout: 5000 });
+    await expect(table).toBeVisible();
 
     // The JS classifies rows — check that at least one of each class exists
     const incomingRows = preview.locator('tr.trade-incoming-row');
@@ -431,13 +433,13 @@ test.describe('Trade offer form: cap warnings', () => {
     const warningLogo = page.locator(
       `.trade-roster-preview__logo[data-team-id="${config}"].cap-warning-logo`,
     );
-    await expect(warningLogo).toBeVisible({ timeout: 3000 });
+    await expect(warningLogo).toBeVisible();
 
     // Cap warning banner on the user team's roster header
     const warningBanner = page.locator(
       `.trading-roster[data-team-id="${config}"] thead tr:first-child th.cap-warning-banner`,
     );
-    await expect(warningBanner).toBeVisible({ timeout: 3000 });
+    await expect(warningBanner).toBeVisible();
   });
 });
 
@@ -596,7 +598,8 @@ test.describe('Trading pages: no PHP errors', () => {
     await page.goto('modules.php?name=Trading');
 
     const firstTeamLink = page.locator('.trading-team-select a').first();
-    await firstTeamLink.click();
+    const href = await firstTeamLink.getAttribute('href');
+    await page.goto(href!);
     await expect(page.locator('form[name="Trade_Offer"]')).toBeVisible();
 
     const body = await page.locator('body').textContent();

--- a/ibl5/tests/e2e/smoke/navigation.spec.ts
+++ b/ibl5/tests/e2e/smoke/navigation.spec.ts
@@ -37,7 +37,7 @@ test.describe('Navigation bar smoke tests (public)', () => {
 
     // Static menu buttons (always present regardless of DB state)
     for (const label of ['Season', 'Stats', 'History', 'Community']) {
-      await expect(nav.getByRole('button', { name: label })).toBeVisible({ timeout: 10_000 });
+      await expect(nav.getByRole('button', { name: label })).toBeVisible();
     }
 
     // Teams is database-driven (JOIN ibl_team_info + ibl_standings).
@@ -78,7 +78,7 @@ test.describe('Navigation bar smoke tests (public)', () => {
       '.nav-dropdown-item',
       { hasText: 'Standings' },
     ).first();
-    await expect(standingsLink).toBeVisible({ timeout: 3000 });
+    await expect(standingsLink).toBeVisible();
   });
 
   test('league switcher is inside season dropdown', async ({ page }) => {
@@ -87,7 +87,7 @@ test.describe('Navigation bar smoke tests (public)', () => {
     await nav.getByRole('button', { name: 'Season' }).click();
 
     const leagueSelect = nav.locator('select').first();
-    await expect(leagueSelect).toBeVisible({ timeout: 3000 });
+    await expect(leagueSelect).toBeVisible();
     await expect(leagueSelect.locator('option')).toHaveCount(2);
   });
 
@@ -95,7 +95,7 @@ test.describe('Navigation bar smoke tests (public)', () => {
     await page.goto('/');
     await desktopNav(page).getByRole('button', { name: 'Login' }).click();
 
-    await expect(page.locator('#nav-username')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('#nav-username')).toBeVisible();
     await expect(page.locator('#nav-password')).toBeVisible();
   });
 
@@ -134,7 +134,7 @@ test.describe('Navigation bar smoke tests (mobile viewport)', () => {
     for (const label of ['Season', 'Stats', 'History', 'Community']) {
       await expect(
         mobileMenu.locator('.mobile-dropdown-btn', { hasText: label }).first(),
-      ).toBeVisible({ timeout: 10_000 });
+      ).toBeVisible();
     }
 
     // Teams is database-driven — conditionally check
@@ -155,7 +155,7 @@ test.describe('Navigation bar smoke tests (mobile viewport)', () => {
     const standingsLink = mobileMenu.locator('.mobile-dropdown-link', {
       hasText: 'Standings',
     }).first();
-    await expect(standingsLink).toBeVisible({ timeout: 3000 });
+    await expect(standingsLink).toBeVisible();
   });
 
   test('login section appears for unauthenticated mobile users', async ({ page }) => {
@@ -164,6 +164,6 @@ test.describe('Navigation bar smoke tests (mobile viewport)', () => {
 
     await expect(
       mobileMenu.locator('.mobile-dropdown-btn', { hasText: 'Login' }).first(),
-    ).toBeVisible({ timeout: 3000 });
+    ).toBeVisible();
   });
 });

--- a/ibl5/tests/e2e/smoke/public-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/public-pages.spec.ts
@@ -60,7 +60,7 @@ test.describe('Public page smoke tests', () => {
     await page.goto('modules.php?name=CapSpace');
     // Data-dependent skip: the view may produce no content depending on DB state
     const table = page.locator('.ibl-data-table, .sticky-table, table').first();
-    const visible = await table.isVisible({ timeout: 10_000 }).catch(() => false);
+    const visible = await table.isVisible().catch(() => false);
     if (!visible) {
       test.skip(true, 'Cap Space rendered no table content (local DB state)');
     }


### PR DESCRIPTION
## Summary

Improve E2E test stability by centralizing timeout configuration and fixing navigation anti-patterns.

## Changes

### 1. Global timeouts in `playwright.config.ts`
- `actionTimeout: 10_000` — clicks, fills, checks
- `navigationTimeout: 15_000` — page.goto, waitForURL
- `expect.timeout: 5_000` — toBeVisible, toHaveText, etc.
- Local retries: `0 → 1` to catch MAMP flakes without masking real failures

### 2. Replace `link.click()` navigation anti-pattern
In `trading.spec.ts`, 3 instances of `link.click()` on team links were replaced with `getAttribute('href') + page.goto()`. The `click()` approach triggers Playwright's navigation wait which races with MAMP response time under parallel workers.

### 3. Remove ~28 redundant ad-hoc timeout overrides
Across 7 files, removed scattered `{ timeout: 3000 }`, `{ timeout: 5000 }`, and `{ timeout: 10000 }` overrides that are now covered by global config. Kept only genuinely needed overrides (`{ timeout: 15000 }` for MAMP warmup in depth-chart beforeEach, `{ timeout: 60000 }` for admin pipeline).

## Testing

- Full E2E suite: 246 passed, 8 skipped (data-dependent), 1 pre-existing failure (free-agency offer submission — also fails on master)