### PR TITLE
ci: add Playwright/node_modules caching and PHPStan CI job

### DIFF
--- a/.github/workflows/cache-dependencies.yml
+++ b/.github/workflows/cache-dependencies.yml
@@ -1,44 +1,47 @@
-name: Cache PHP Dependencies
+name: Cache Dependencies
 
-# This workflow ensures the vendor directory is always cached for GitHub Copilot Agent
-# It runs on schedule and can also be triggered manually
+# This workflow ensures vendor, node_modules, and Playwright browsers are always
+# cached for CI workflows. Runs on schedule and when dependency files change.
 
 on:
   # Run daily to keep cache fresh
   schedule:
     - cron: '0 0 * * *'  # Daily at midnight UTC
-  
+
   # Allow manual trigger
   workflow_dispatch:
-  
+
   # Run when dependencies change
   push:
     paths:
       - 'ibl5/composer.json'
       - 'ibl5/composer.lock'
+      - 'ibl5/bun.lock'
+      - 'ibl5/package.json'
     branches:
       - master
       - develop
 
 jobs:
   cache-dependencies:
-    name: Pre-cache PHP Dependencies
+    name: Pre-cache Dependencies
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      
+
+      # --- PHP Dependencies ---
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
           extensions: mbstring, intl, pdo, pdo_mysql
-      
+
       - name: Get Composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      
+
       - name: Cache Composer dependencies
         uses: actions/cache@v5
         with:
@@ -46,7 +49,7 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('ibl5/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
-      
+
       - name: Cache vendor directory
         uses: actions/cache@v5
         id: vendor-cache
@@ -55,46 +58,83 @@ jobs:
           key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-vendor-
-      
-      - name: Install dependencies
+
+      - name: Install Composer dependencies
         if: steps.vendor-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
-        run: |
-          echo "Installing Composer dependencies..."
-          # Prefer cache over network downloads to avoid timeouts
-          # The composer cache (@v4 above) will be checked first automatically
-          composer install --no-progress --no-interaction
-      
+        run: composer install --no-progress --no-interaction
+
       - name: Verify PHPUnit
         working-directory: ibl5
         run: |
           if [ -f "vendor/bin/phpunit" ]; then
-            echo "✅ PHPUnit cached successfully"
+            echo "PHPUnit cached successfully"
             vendor/bin/phpunit --version
           else
-            echo "❌ PHPUnit not found!"
+            echo "PHPUnit not found!"
             exit 1
           fi
-      
+
+      # --- JS Dependencies ---
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        id: node-modules-cache
+        with:
+          path: ibl5/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
+
+      - name: Install JS dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        working-directory: ibl5
+        run: bun install
+
+      # --- Playwright Browsers ---
+      - name: Get Playwright version
+        id: playwright-version
+        working-directory: ibl5
+        run: echo "version=$(bunx playwright --version)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ibl5
+        run: bunx playwright install chromium --with-deps
+
+      # --- Summary ---
       - name: Cache summary
         run: |
           echo "## Cache Update Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### PHP" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.vendor-cache.outputs.cache-hit }}" == "true" ]; then
-            echo "✅ Vendor cache was already up-to-date" >> $GITHUB_STEP_SUMMARY
+            echo "- Vendor cache: already up-to-date" >> $GITHUB_STEP_SUMMARY
           else
-            echo "✅ Vendor cache has been updated" >> $GITHUB_STEP_SUMMARY
+            echo "- Vendor cache: updated" >> $GITHUB_STEP_SUMMARY
           fi
+          echo "- Key: \`${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Cache key: \`${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "### JavaScript" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.node-modules-cache.outputs.cache-hit }}" == "true" ]; then
+            echo "- node_modules cache: already up-to-date" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- node_modules cache: updated" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "- Key: \`${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Installed Tools" >> $GITHUB_STEP_SUMMARY
-          echo "- PHP: $(php --version | head -n 1)" >> $GITHUB_STEP_SUMMARY
-          echo "- Composer: $(composer --version)" >> $GITHUB_STEP_SUMMARY
-          cd ibl5
-          if [ -f "vendor/bin/phpunit" ]; then
-            echo "- PHPUnit: $(vendor/bin/phpunit --version)" >> $GITHUB_STEP_SUMMARY
+          echo "### Playwright" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" == "true" ]; then
+            echo "- Browser cache: already up-to-date" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Browser cache: updated" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ -f "vendor/bin/phpcs" ]; then
-            echo "- PHP_CodeSniffer: $(vendor/bin/phpcs --version)" >> $GITHUB_STEP_SUMMARY
-          fi
+          echo "- Version: ${{ steps.playwright-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Key: \`${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,18 +35,53 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      # --- Dependency Caching ---
+      - name: Cache vendor directory
+        uses: actions/cache@v5
+        with:
+          path: ibl5/vendor
+          key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-vendor-
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: ibl5/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install JS dependencies
         working-directory: ibl5
         run: bun install
 
+      - name: Get Playwright version
+        id: playwright-version
+        working-directory: ibl5
+        run: echo "version=$(bunx playwright --version)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: bunx playwright install chromium --with-deps
+
+      - name: Install Playwright system deps
+        run: bunx playwright install-deps chromium
+        working-directory: ibl5
 
       - name: Install Composer dependencies
         working-directory: ibl5
         run: composer install --no-interaction --no-progress --prefer-dist
 
+      # --- Database Setup ---
       - name: Import database schema
         run: |
           # Strip DEFINER clauses that reference the production user
@@ -88,6 +123,7 @@ jobs:
           echo "Test user created: $user\n";
           PHPSCRIPT
 
+      # --- App Setup ---
       - name: Create config.php
         working-directory: ibl5
         run: |
@@ -131,6 +167,7 @@ jobs:
           echo "Server failed to start"
           exit 1
 
+      # --- Run Tests ---
       - name: Run E2E tests
         working-directory: ibl5
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,3 +55,34 @@ jobs:
           --testdox \
           --no-coverage \
           --colors=always
+
+  phpstan:
+    name: PHPStan Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+        extensions: mbstring, intl, mysqli
+        coverage: none
+
+    - name: Cache vendor directory
+      uses: actions/cache@v5
+      with:
+        path: ibl5/vendor
+        key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-vendor-
+
+    - name: Install dependencies
+      working-directory: ibl5
+      run: composer install --no-progress --no-interaction
+
+    - name: Run PHPStan
+      working-directory: ibl5
+      run: composer run analyse


### PR DESCRIPTION
## Summary

Adds dependency caching across CI workflows and introduces PHPStan static analysis as a CI check.

## Changes

### cache-dependencies.yml
- Add Playwright browser caching keyed by Playwright version
- Add node_modules caching keyed by bun.lock hash
- Add `bun.lock` and `package.json` to push trigger paths
- Fix stale comment referencing `@v4` (was actually `@v5`)
- Rename workflow from 'Cache PHP Dependencies' to 'Cache Dependencies'

### e2e-tests.yml
- Add cache restore steps for vendor, node_modules, and Playwright browsers
- Make Playwright browser install conditional on cache miss
- Add separate `install-deps` step for OS packages (needed even with cached browsers)

### tests.yml
- Add PHPStan Analysis as a parallel job alongside PHPUnit Tests
- Runs at level max with strict-rules and bleedingEdge (matches local config)

## Expected Impact
- E2E workflow: ~28s savings on Playwright browser install (cache hit)
- E2E workflow: faster Composer/Bun installs via cache restore
- Tests workflow: PHPStan catches type errors before merge (no added wall-clock time — runs in parallel)

## Verification
- First PR run populates caches; subsequent runs should restore them
- PHPStan job should pass (matches local analysis)
- E2E tests should pass with cached dependencies