### PR TITLE
infra: dockerize PHP-Apache to replace MAMP dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ playwright-report/
 test-results/
 **/playwright/.auth/
 ibl5/.env.test
-docker-compose.yml
+docker-compose.override.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Classes autoload from `ibl5/classes/`. Never use `require_once`.
 - 51 InnoDB tables with foreign keys, 84 legacy MyISAM tables, 23 database views
 - **Native types enabled:** `MYSQLI_OPT_INT_AND_FLOAT_NATIVE` is set on `$mysqli_db`. See `core-coding.md` for type comparison rules. The legacy `$db` connection does NOT have native types.
 - **Docker MariaDB:** Start the database with `docker compose up -d` from the repo root. See `database-access.md` for connection details and the auto-approved `./bin/db-query` wrapper.
+- **Docker PHP-Apache:** `docker compose up -d` also starts a PHP 8.4 Apache container serving the site at `http://localhost/ibl5/`. The `DB_HOST` env var is set to `mariadb` in the container; `config.php` uses `getenv('DB_HOST') ?: '127.0.0.1'` so it works both inside Docker and on the host. See `ibl5/docs/DOCKER_SETUP.md` for full details.
 - **CLI MariaDB access:** `mariadb -h 127.0.0.1 --skip-ssl -u root -proot iblhoops_ibl5`. For quick queries, prefer the `./bin/db-query "SQL"` wrapper.
 
 ## Git & Commits

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM php:8.4-apache
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libonig-dev \
+    && docker-php-ext-install mysqli pdo pdo_mysql mbstring \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN a2enmod rewrite headers
+
+RUN echo '<Directory /var/www/html>\n\
+    AllowOverride All\n\
+    Require all granted\n\
+</Directory>' > /etc/apache2/conf-available/ibl5.conf \
+    && a2enconf ibl5
+
+RUN cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  mariadb:
+    image: mariadb:10.6
+    container_name: ibl5-mariadb
+    restart: unless-stopped
+    ports:
+      - "3306:3306"
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: iblhoops_ibl5
+      MARIADB_USER: iblhoops_chibul
+      MARIADB_PASSWORD: "whereWTFhappens19!"
+    volumes:
+      - ibl5-mariadb-data:/var/lib/mysql
+
+  php:
+    build: .
+    container_name: ibl5-php
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    environment:
+      DB_HOST: mariadb
+    volumes:
+      - ./ibl5:/var/www/html/ibl5
+    depends_on:
+      - mariadb
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: ibl5-mailpit
+    restart: unless-stopped
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+
+  adminer:
+    image: adminer:latest
+    container_name: ibl5-adminer
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      ADMINER_DEFAULT_SERVER: mariadb
+    depends_on:
+      - mariadb
+
+volumes:
+  ibl5-mariadb-data:

--- a/ibl5/config.php.example
+++ b/ibl5/config.php.example
@@ -38,7 +38,7 @@ if (stristr(htmlentities($_SERVER['PHP_SELF']), "config.php")) {
 #                    email if set.
 ######################################################################
 
-$dbhost = "localhost";
+$dbhost = getenv('DB_HOST') ?: 'localhost';
 $dbuname = "iblhoops_";
 $dbpass = "password";
 $dbname = "iblhoops_";

--- a/ibl5/config/mail.config.example.php
+++ b/ibl5/config/mail.config.example.php
@@ -13,6 +13,16 @@
  *   'log'  - Write emails to error_log (safe for local development)
  */
 
+// Docker development with Mailpit (http://localhost:8025):
+// 'transport' => 'smtp',
+// 'smtp' => [
+//     'host' => 'mailpit',
+//     'port' => 1025,
+//     'encryption' => '',
+//     'username' => '',
+//     'password' => '',
+// ],
+
 return [
     // Transport method: 'smtp', 'mail', or 'log'
     'transport' => 'log',

--- a/ibl5/docs/DOCKER_SETUP.md
+++ b/ibl5/docs/DOCKER_SETUP.md
@@ -1,0 +1,91 @@
+# Docker Development Setup
+
+The entire IBL5 dev stack runs via Docker Compose: PHP-Apache, MariaDB, Mailpit (email testing), and Adminer (DB browser).
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- [Bun](https://bun.sh/) (for CSS builds, PHPUnit, and Playwright)
+
+## Quick Start
+
+```bash
+# From repo root
+docker compose up -d --build
+
+# Or from ibl5/
+bun run docker:up
+```
+
+The site is available at **http://localhost/ibl5/**.
+
+## Services
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| PHP-Apache | http://localhost/ibl5/ | Application |
+| MariaDB | localhost:3306 | Database |
+| Mailpit | http://localhost:8025 | Email testing UI |
+| Adminer | http://localhost:8080 | Database browser |
+
+### Adminer Login
+
+- System: MySQL
+- Server: `mariadb`
+- Username: `root`
+- Password: `root`
+- Database: `iblhoops_ibl5`
+
+## Port 80 Conflict
+
+If MAMP is running, stop it before starting Docker (both use port 80). To switch back to MAMP:
+
+```bash
+docker compose down   # or: bun run docker:down
+# Then start MAMP
+```
+
+The `config.php` change (`getenv('DB_HOST') ?: '127.0.0.1'`) ensures both environments work without editing config files.
+
+## Development Workflow
+
+Tools that run on the **host** (not inside Docker):
+
+- **CSS:** `bun run css:watch` — file changes are instantly visible via the bind mount
+- **PHPUnit:** `cd ibl5 && vendor/bin/phpunit` — connects to Docker MariaDB on localhost:3306
+- **Playwright:** `bun run test:e2e` — hits http://localhost/ibl5/ served by Docker PHP
+- **PHPStan:** `cd ibl5 && composer run analyse`
+
+Code edits on the host are immediately reflected in the container (bind mount: `./ibl5 -> /var/www/html/ibl5`).
+
+## Email Testing with Mailpit
+
+To capture outgoing emails in Mailpit, update `ibl5/config/mail.config.php`:
+
+```php
+'transport' => 'smtp',
+'smtp' => [
+    'host' => 'mailpit',
+    'port' => 1025,
+    'encryption' => '',
+    'username' => '',
+    'password' => '',
+],
+```
+
+All sent emails appear in the Mailpit UI at http://localhost:8025.
+
+## Convenience Scripts
+
+```bash
+bun run docker:up     # Start all containers
+bun run docker:down   # Stop all containers
+bun run docker:logs   # Follow PHP container logs
+```
+
+## Container Logs
+
+```bash
+docker compose logs -f php      # PHP-Apache logs
+docker compose logs -f mariadb  # Database logs
+```

--- a/ibl5/package.json
+++ b/ibl5/package.json
@@ -9,7 +9,10 @@
     "test:e2e": "bunx playwright test",
     "test:e2e:headed": "bunx playwright test --headed",
     "test:e2e:ui": "bunx playwright test --ui",
-    "test:e2e:isolated": "./bin/e2e-local.sh"
+    "test:e2e:isolated": "./bin/e2e-local.sh",
+    "docker:up": "cd .. && docker compose up -d",
+    "docker:down": "cd .. && docker compose down",
+    "docker:logs": "cd .. && docker compose logs -f php"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.0",


### PR DESCRIPTION
## Summary

Adds a PHP 8.4-Apache Docker container so the entire dev stack runs via `docker compose up -d` — no MAMP installation needed. Also adds Mailpit (email testing) and Adminer (DB browser) as lightweight bonus services.

## Changes

### Docker Services
- **Dockerfile** — PHP 8.4-Apache with mysqli, pdo, mbstring, mod_rewrite
- **docker-compose.yml** — 4 services: mariadb, php, mailpit, adminer
- **php container** serves site at `http://localhost/ibl5/` via bind mount

### Config
- **config.php.example** — `getenv('DB_HOST') ?: 'localhost'` for Docker/host compatibility
- **mail.config.example.php** — Mailpit SMTP preset as comments
- **.gitignore** — track `docker-compose.yml`, ignore `docker-compose.override.yml`

### Developer Experience
- **package.json** — `docker:up`, `docker:down`, `docker:logs` scripts
- **docs/DOCKER_SETUP.md** — full setup guide
- **CLAUDE.md** — Docker PHP-Apache note

## Testing

- PHPUnit: 3687 tests pass (host connects to Docker MariaDB as before)
- No PHP code changes — infrastructure only
- `config.php` and `configOlympics.php` (gitignored) updated with `getenv()` fallback