### PR TITLE
refactor: consolidate E2E test suite shared utilities

### DIFF
--- a/ibl5/tests/e2e/fixtures/auth.ts
+++ b/ibl5/tests/e2e/fixtures/auth.ts
@@ -1,7 +1,7 @@
 import { test as base } from '@playwright/test';
-import { setState, type Settings, type SetStateResult } from '../helpers/test-state';
+import { createAppStateFixture, type SetStateFn } from '../helpers/test-state';
 
-export type SetStateFn = (settings: Settings) => Promise<SetStateResult>;
+export type { SetStateFn };
 
 /**
  * Authenticated test fixture with optional appState control.
@@ -12,31 +12,7 @@ export type SetStateFn = (settings: Settings) => Promise<SetStateResult>;
  *   and automatically restores previous values after each test.
  */
 export const test = base.extend<{ appState: SetStateFn }>({
-  appState: async ({ request }, use) => {
-    const restoreStack: Settings[] = [];
-
-    const setStateFn: SetStateFn = async (settings) => {
-      const result = await setState(request, settings);
-      restoreStack.push(result.previous);
-      return result;
-    };
-
-    await use(setStateFn);
-
-    // Teardown: restore previous values in reverse order
-    for (const previous of restoreStack.reverse()) {
-      // Filter out null values (settings that didn't exist before)
-      const toRestore: Settings = {};
-      for (const [key, value] of Object.entries(previous)) {
-        if (value !== null) {
-          toRestore[key] = value;
-        }
-      }
-      if (Object.keys(toRestore).length > 0) {
-        await setState(request, toRestore);
-      }
-    }
-  },
+  appState: createAppStateFixture(),
 });
 
 export { expect } from '@playwright/test';

--- a/ibl5/tests/e2e/fixtures/public.ts
+++ b/ibl5/tests/e2e/fixtures/public.ts
@@ -1,0 +1,17 @@
+import { test as base } from '@playwright/test';
+import { createAppStateFixture, type SetStateFn } from '../helpers/test-state';
+
+/**
+ * Public (unauthenticated) test fixture with appState control.
+ *
+ * - Uses empty storageState (no auth cookies).
+ * - Provides the same `appState` auto-restore fixture as the auth fixture.
+ */
+export const test = base.extend<{ appState: SetStateFn }>({
+  storageState: async ({}, use) => {
+    await use({ cookies: [], origins: [] });
+  },
+  appState: createAppStateFixture(),
+});
+
+export { expect } from '@playwright/test';

--- a/ibl5/tests/e2e/flows/award-history.spec.ts
+++ b/ibl5/tests/e2e/flows/award-history.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Award History — public page, no authentication required.
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -73,10 +73,7 @@ test.describe('Award History flow', () => {
     await page.locator('#aw_name').fill('zzzznonexistent999');
     await page.locator('.ibl-filter-form').locator('button[type="submit"], input[type="submit"]').first().click();
 
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page);
   });
 
   test('result rows contain player links', async ({ page }) => {
@@ -106,23 +103,11 @@ test.describe('Award History flow', () => {
 
   test('no PHP errors on form and results pages', async ({ page }) => {
     // Check form page
-    let body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Award History form page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Award History form page');
 
     // Check results page
     await page.locator('.ibl-filter-form').locator('button[type="submit"], input[type="submit"]').first().click();
     await expect(page.locator('.ibl-data-table').first()).toBeVisible();
-    body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Award History results page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Award History results page');
   });
 });

--- a/ibl5/tests/e2e/flows/compare-players.spec.ts
+++ b/ibl5/tests/e2e/flows/compare-players.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Compare Players — public, no authentication required.
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -87,23 +87,11 @@ test.describe('Compare Players flow', () => {
 
   test('no PHP errors on compare players pages', async ({ page }) => {
     // Check form page
-    let body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Compare Players form page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Compare Players form page');
 
     // Check results page with valid players
     await submitComparison(page);
 
-    body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Compare Players results page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Compare Players results page');
   });
 });

--- a/ibl5/tests/e2e/flows/depth-chart-changes.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart-changes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures/auth';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Depth Chart Changes — tests the JS change-detection (depth-chart-changes.js).
 // Extends depth-chart.spec.ts with glow/dirty indicator tests.
@@ -161,20 +161,11 @@ test.describe('Depth Chart change detection', () => {
       await page.waitForTimeout(500);
 
       // Page should still be functional (no errors)
-      const body = await page.locator('body').textContent();
-      for (const pattern of PHP_ERROR_PATTERNS) {
-        expect(body).not.toContain(pattern);
-      }
+      await assertNoPhpErrors(page);
     }
   });
 
   test('no PHP errors', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Depth Chart Entry`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Depth Chart Entry');
   });
 });

--- a/ibl5/tests/e2e/flows/depth-chart.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures/auth';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Depth Chart Entry — authenticated page.
 // The roster form may load asynchronously after the page header renders.
@@ -91,11 +91,6 @@ test.describe('Depth Chart Entry flow', () => {
   });
 
   test('no PHP errors', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body, `PHP error "${pattern}" on Depth Chart Entry`).not.toContain(
-        pattern,
-      );
-    }
+    await assertNoPhpErrors(page, 'on Depth Chart Entry');
   });
 });

--- a/ibl5/tests/e2e/flows/franchise-record-book.spec.ts
+++ b/ibl5/tests/e2e/flows/franchise-record-book.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Franchise Record Book — public page, no authentication required.
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -92,24 +92,12 @@ test.describe('Franchise Record Book flow', () => {
   test('no PHP errors on league-wide view', async ({ page }) => {
     await page.goto('modules.php?name=FranchiseRecordBook');
 
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on league-wide Record Book`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on league-wide Record Book');
   });
 
   test('no PHP errors on team view', async ({ page }) => {
     await page.goto('modules.php?name=FranchiseRecordBook&teamid=1');
 
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on team Record Book`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on team Record Book');
   });
 });

--- a/ibl5/tests/e2e/flows/free-agency.spec.ts
+++ b/ibl5/tests/e2e/flows/free-agency.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures/auth';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Free Agency E2E tests — authenticated.
 // Seed data provides 3 free agent players:
@@ -65,10 +65,7 @@ test.describe('Free Agency -- main page', () => {
   });
 
   test('no PHP errors on main page', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body, `PHP error "${pattern}" on Free Agency main page`).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Free Agency main page');
   });
 });
 
@@ -115,10 +112,7 @@ test.describe('Free Agency -- negotiation page', () => {
   });
 
   test('no PHP errors on negotiation page', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body, `PHP error "${pattern}" on negotiation page`).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on negotiation page');
   });
 });
 
@@ -282,9 +276,6 @@ test.describe('Free Agency -- wrong season phase', () => {
   test('page renders without PHP errors in non-FA phase', async ({ appState, page }) => {
     await appState({ 'Current Season Phase': 'Regular Season' });
     await page.goto('modules.php?name=FreeAgency');
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body, `PHP error "${pattern}" in non-FA phase`).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'in non-FA phase');
   });
 });

--- a/ibl5/tests/e2e/flows/leaderboards.spec.ts
+++ b/ibl5/tests/e2e/flows/leaderboards.spec.ts
@@ -1,38 +1,16 @@
-import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
-import { MODULE_INACTIVE_TEXT } from '../helpers/trivia-mode';
-import { setState, type Settings } from '../helpers/test-state';
-import type { APIRequestContext } from '@playwright/test';
+import { test, expect } from '../fixtures/public';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Leaderboards — public, no authentication required.
 // Serial: trivia-on and trivia-off blocks set the same setting (Trivia Mode).
 test.describe.configure({ mode: 'serial' });
-test.use({ storageState: { cookies: [], origins: [] } });
-
-/**
- * Set trivia mode and return a cleanup function.
- * For public tests that don't have the appState fixture.
- */
-async function setTriviaMode(
-  request: APIRequestContext,
-  mode: 'On' | 'Off',
-): Promise<Settings> {
-  const result = await setState(request, { 'Trivia Mode': mode });
-  return result.previous;
-}
 
 // ---- Season Leaderboards: trivia off (normal) ----
 
 test.describe('Season Leaderboards flow', () => {
-  let restoreSettings: Settings;
-
-  test.beforeEach(async ({ request, page }) => {
-    restoreSettings = await setTriviaMode(request, 'Off');
+  test.beforeEach(async ({ appState, page }) => {
+    await appState({ 'Trivia Mode': 'Off' });
     await page.goto('modules.php?name=SeasonLeaderboards');
-  });
-
-  test.afterEach(async ({ request }) => {
-    await setState(request, restoreSettings);
   });
 
   test('page loads with filter form', async ({ page }) => {
@@ -117,47 +95,29 @@ test.describe('Season Leaderboards flow', () => {
   });
 
   test('no PHP errors on season leaderboards', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Season Leaderboards page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Season Leaderboards page');
   });
 });
 
 // ---- Season Leaderboards: trivia on ----
 
 test.describe('Season Leaderboards: trivia mode', () => {
-  let restoreSettings: Settings;
-
-  test.beforeEach(async ({ request, page }) => {
-    restoreSettings = await setTriviaMode(request, 'On');
+  test.beforeEach(async ({ appState, page }) => {
+    await appState({ 'Trivia Mode': 'On' });
     await page.goto('modules.php?name=SeasonLeaderboards');
   });
 
-  test.afterEach(async ({ request }) => {
-    await setState(request, restoreSettings);
-  });
-
   test('module shows inactive message when trivia mode is on', async ({ page }) => {
-    await expect(page.getByText(MODULE_INACTIVE_TEXT)).toBeVisible();
+    await expect(page.getByText("Module isn't active")).toBeVisible();
   });
 });
 
 // ---- Career Leaderboards: trivia off (normal) ----
 
 test.describe('Career Leaderboards flow', () => {
-  let restoreSettings: Settings;
-
-  test.beforeEach(async ({ request, page }) => {
-    restoreSettings = await setTriviaMode(request, 'Off');
+  test.beforeEach(async ({ appState, page }) => {
+    await appState({ 'Trivia Mode': 'Off' });
     await page.goto('modules.php?name=CareerLeaderboards');
-  });
-
-  test.afterEach(async ({ request }) => {
-    await setState(request, restoreSettings);
   });
 
   test('page loads with filter form', async ({ page }) => {
@@ -227,41 +187,23 @@ test.describe('Career Leaderboards flow', () => {
   });
 
   test('no PHP errors on career leaderboards', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Career Leaderboards form page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Career Leaderboards form page');
 
     await page.locator('.ibl-filter-form__submit').click();
     await expect(page.locator('.ibl-data-table').first()).toBeVisible();
-    const resultsBody = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        resultsBody,
-        `PHP error "${pattern}" on Career Leaderboards results page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Career Leaderboards results page');
   });
 });
 
 // ---- Career Leaderboards: trivia on ----
 
 test.describe('Career Leaderboards: trivia mode', () => {
-  let restoreSettings: Settings;
-
-  test.beforeEach(async ({ request, page }) => {
-    restoreSettings = await setTriviaMode(request, 'On');
+  test.beforeEach(async ({ appState, page }) => {
+    await appState({ 'Trivia Mode': 'On' });
     await page.goto('modules.php?name=CareerLeaderboards');
   });
 
-  test.afterEach(async ({ request }) => {
-    await setState(request, restoreSettings);
-  });
-
   test('module shows inactive message when trivia mode is on', async ({ page }) => {
-    await expect(page.getByText(MODULE_INACTIVE_TEXT)).toBeVisible();
+    await expect(page.getByText("Module isn't active")).toBeVisible();
   });
 });

--- a/ibl5/tests/e2e/flows/navigation.spec.ts
+++ b/ibl5/tests/e2e/flows/navigation.spec.ts
@@ -1,16 +1,7 @@
 import { test, expect } from '../fixtures/auth';
-import type { Page } from '@playwright/test';
+import { desktopNav, openMobileMenu } from '../helpers/navigation';
 
 // Authenticated navigation flow tests — verify logged-in user experience.
-
-function desktopNav(page: Page) {
-  return page.locator('.hidden.lg\\:flex').first();
-}
-
-async function openMobileMenu(page: Page) {
-  await page.locator('#nav-hamburger').click();
-  return page.locator('#nav-mobile-menu');
-}
 
 test.describe('Navigation bar (authenticated, desktop)', () => {
   test('my team menu is visible for logged-in users', async ({ page }) => {

--- a/ibl5/tests/e2e/flows/olympics-module-gating.spec.ts
+++ b/ibl5/tests/e2e/flows/olympics-module-gating.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Verify IBL-only modules are gated in Olympics context.
 // These modules should show "not available" or redirect, not crash.
@@ -17,12 +17,9 @@ test.describe('Olympics module gating', () => {
   for (const moduleName of IBL_ONLY_MODULES) {
     test(`${moduleName} is gated in Olympics context`, async ({ page }) => {
       await page.goto(`modules.php?name=${moduleName}&league=olympics`);
-      const body = await page.locator('body').textContent() ?? '';
 
       // Should not show PHP fatal errors
-      for (const pattern of PHP_ERROR_PATTERNS) {
-        expect(body, `PHP error "${pattern}" on ${moduleName}`).not.toContain(pattern);
-      }
+      await assertNoPhpErrors(page, `on ${moduleName}`);
 
       // Should either show a "not available" message or not render the module content
       // (exact gating behavior depends on how each module checks LeagueContext)

--- a/ibl5/tests/e2e/flows/player-database.spec.ts
+++ b/ibl5/tests/e2e/flows/player-database.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Player Database — public page, no authentication required.
 // The results table only appears AFTER submitting a search.
@@ -77,11 +77,6 @@ test.describe('Player Database flow', () => {
     await page.locator('input[name="search_name"]').fill('test');
     await page.locator('.ibl-filter-form__submit').click();
 
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body, `PHP error "${pattern}" after search`).not.toContain(
-        pattern,
-      );
-    }
+    await assertNoPhpErrors(page, 'after search');
   });
 });

--- a/ibl5/tests/e2e/flows/record-holders.spec.ts
+++ b/ibl5/tests/e2e/flows/record-holders.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Record Holders — public page, no authentication required.
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -60,12 +60,6 @@ test.describe('Record Holders flow', () => {
   });
 
   test('no PHP errors', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Record Holders page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Record Holders page');
   });
 });

--- a/ibl5/tests/e2e/flows/search.spec.ts
+++ b/ibl5/tests/e2e/flows/search.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Search — public page, no authentication required.
 // Uses POST-based search form with filter dropdowns.
@@ -44,12 +44,8 @@ test.describe('Search flow', () => {
     // POST form may navigate — wait for search page to re-render
     await page.waitForLoadState('domcontentloaded');
 
-    const body = await page.locator('body').textContent();
-
     // Should either have results or a "no matches" message — no PHP errors
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page);
 
     // Check for result cards, empty state, or the search form re-rendered
     const results = page.locator('.search-result');
@@ -70,10 +66,7 @@ test.describe('Search flow', () => {
 
     await page.waitForLoadState('domcontentloaded');
 
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page);
 
     // User results use compact cards, or we get empty state, or search page
     const results = page.locator('.search-result');
@@ -103,9 +96,7 @@ test.describe('Search flow', () => {
     expect(hasError).toBe(true);
 
     // No PHP errors
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page);
   });
 
   test('many-result search shows pagination', async ({ page }) => {
@@ -113,10 +104,7 @@ test.describe('Search flow', () => {
     await page.locator('input[name="query"]').fill('the');
     await page.locator('.ibl-search__btn').click();
 
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page);
 
     // Check for pagination links
     const pagination = page.locator('.search-pagination');
@@ -148,10 +136,7 @@ test.describe('Search flow', () => {
     await page.goto(href!);
 
     // Should load the next page without errors
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page);
 
     // Should have results on the offset page
     const results = page.locator('.search-result');
@@ -159,12 +144,6 @@ test.describe('Search flow', () => {
   });
 
   test('no PHP errors on form page', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Search form page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Search form page');
   });
 });

--- a/ibl5/tests/e2e/flows/standings.spec.ts
+++ b/ibl5/tests/e2e/flows/standings.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Standings — public, no authentication required.
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -121,12 +121,6 @@ test.describe('Standings page flow', () => {
   });
 
   test('no PHP errors on standings page', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Standings page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Standings page');
   });
 });

--- a/ibl5/tests/e2e/flows/team-page.spec.ts
+++ b/ibl5/tests/e2e/flows/team-page.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Team page — public, no authentication required.
 // Current-season teams use a dropdown (.ibl-view-select), not tabs.
@@ -62,13 +62,7 @@ test.describe('Team page flow', () => {
     const teamIDs = [1, 5, 10, 15];
     for (const teamID of teamIDs) {
       await page.goto(`modules.php?name=Team&op=team&teamID=${teamID}`);
-      const body = await page.locator('body').textContent();
-      for (const pattern of PHP_ERROR_PATTERNS) {
-        expect(
-          body,
-          `PHP error "${pattern}" on team ${teamID}`,
-        ).not.toContain(pattern);
-      }
+      await assertNoPhpErrors(page, `on team ${teamID}`);
     }
   });
 });

--- a/ibl5/tests/e2e/flows/team-stats.spec.ts
+++ b/ibl5/tests/e2e/flows/team-stats.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Team Offense/Defense Stats — public page, no authentication required.
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -87,12 +87,6 @@ test.describe('Team Stats flow', () => {
   });
 
   test('no PHP errors', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Team Stats page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Team Stats page');
   });
 });

--- a/ibl5/tests/e2e/flows/trading.spec.ts
+++ b/ibl5/tests/e2e/flows/trading.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../fixtures/auth';
 import type { Page } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // ---------------------------------------------------------------------------
 // Shared constants & helpers
@@ -602,19 +602,13 @@ test.describe('Trading pages: no PHP errors', () => {
     await page.goto(href!);
     await expect(page.locator('form[name="Trade_Offer"]')).toBeVisible();
 
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page);
   });
 
   test('no PHP errors on trade review page', async ({ appState, page }) => {
     await appState({ 'Allow Trades': 'Yes' });
     await page.goto('modules.php?name=Trading&op=reviewtrade');
 
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page);
   });
 });

--- a/ibl5/tests/e2e/flows/transaction-history.spec.ts
+++ b/ibl5/tests/e2e/flows/transaction-history.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Transaction History — public page, no authentication required.
 // NOTE: The form hidden field uses name=Transaction_History but the module
@@ -91,32 +91,17 @@ test.describe('Transaction History flow', () => {
       await page.goto(`${BASE}&year=${yearValue}&month=1&cat=6`);
 
       // Should show either table or empty state — no PHP errors either way
-      const body = await page.locator('body').textContent();
-      for (const pattern of PHP_ERROR_PATTERNS) {
-        expect(body).not.toContain(pattern);
-      }
+      await assertNoPhpErrors(page);
     }
   });
 
   test('no PHP errors on load and after filtering', async ({ page }) => {
     // Check initial page
-    let body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Transaction History page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Transaction History page');
 
     // Filter and check again
     await page.goto(`${BASE}&cat=2`);
 
-    body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on filtered Transaction History page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on filtered Transaction History page');
   });
 });

--- a/ibl5/tests/e2e/flows/waivers.spec.ts
+++ b/ibl5/tests/e2e/flows/waivers.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures/auth';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Waivers — authenticated page with explicit state control.
 // NOTE: NEVER submit a waiver claim — read-only assertions only.
@@ -13,13 +13,7 @@ test.describe('Waivers flow: closed', () => {
   });
 
   test('page loads without PHP errors', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Waivers page`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Waivers page');
   });
 
   test('shows closed message with no form elements', async ({ page }) => {
@@ -55,12 +49,6 @@ test.describe('Waivers flow: open', () => {
   });
 
   test('page loads without PHP errors', async ({ page }) => {
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(
-        body,
-        `PHP error "${pattern}" on Waivers page (open)`,
-      ).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page, 'on Waivers page (open)');
   });
 });

--- a/ibl5/tests/e2e/helpers/navigation.ts
+++ b/ibl5/tests/e2e/helpers/navigation.ts
@@ -1,0 +1,29 @@
+import type { Page, Locator } from '@playwright/test';
+
+export function desktopNav(page: Page): Locator {
+  return page.locator('.hidden.lg\\:flex').first();
+}
+
+export async function openMobileMenu(page: Page): Promise<Locator> {
+  await page.locator('#nav-hamburger').click();
+  return page.locator('#nav-mobile-menu');
+}
+
+/**
+ * Navigate and verify the page actually rendered content.
+ * Under parallel load, PHP's built-in server can return blank HTML.
+ * Retries up to 4 times with increasing back-off before failing.
+ */
+export async function gotoWithRetry(page: Page, url: string): Promise<void> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    if (attempt > 0) await page.waitForTimeout(attempt * 1000);
+    try {
+      await page.goto(url, { timeout: 15_000 });
+    } catch {
+      continue;
+    }
+    const body = await page.locator('body').innerText();
+    if (body.trim().length >= 20) return;
+  }
+  throw new Error(`Page returned blank content after 5 attempts: ${url}`);
+}

--- a/ibl5/tests/e2e/helpers/php-errors.ts
+++ b/ibl5/tests/e2e/helpers/php-errors.ts
@@ -1,3 +1,6 @@
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
 /**
  * PHP error patterns to check for in page body text.
  * Every smoke test must check visited pages for these patterns.
@@ -9,3 +12,17 @@ export const PHP_ERROR_PATTERNS = [
   'Uncaught',
   'Stack trace:',
 ];
+
+/**
+ * Assert that a page contains no PHP errors.
+ * Extracts body text and checks against all known PHP error patterns.
+ */
+export async function assertNoPhpErrors(page: Page, context?: string): Promise<void> {
+  const body = await page.locator('body').textContent();
+  for (const pattern of PHP_ERROR_PATTERNS) {
+    expect(
+      body,
+      `PHP error "${pattern}" ${context ?? 'found'}`,
+    ).not.toContain(pattern);
+  }
+}

--- a/ibl5/tests/e2e/helpers/test-state.ts
+++ b/ibl5/tests/e2e/helpers/test-state.ts
@@ -40,3 +40,36 @@ export async function setState(
   }
   return (await response.json()) as SetStateResult;
 }
+
+export type SetStateFn = (settings: Settings) => Promise<SetStateResult>;
+
+/**
+ * Creates the appState fixture function for use in both
+ * authenticated and public test fixtures.
+ */
+export function createAppStateFixture() {
+  return async ({ request }: { request: APIRequestContext }, use: (fn: SetStateFn) => Promise<void>) => {
+    const restoreStack: Settings[] = [];
+
+    const setStateFn: SetStateFn = async (settings) => {
+      const result = await setState(request, settings);
+      restoreStack.push(result.previous);
+      return result;
+    };
+
+    await use(setStateFn);
+
+    // Teardown: restore previous values in reverse order
+    for (const previous of restoreStack.reverse()) {
+      const toRestore: Settings = {};
+      for (const [key, value] of Object.entries(previous)) {
+        if (value !== null) {
+          toRestore[key] = value;
+        }
+      }
+      if (Object.keys(toRestore).length > 0) {
+        await setState(request, toRestore);
+      }
+    }
+  };
+}

--- a/ibl5/tests/e2e/helpers/trivia-mode.ts
+++ b/ibl5/tests/e2e/helpers/trivia-mode.ts
@@ -1,9 +1,0 @@
-/**
- * Trivia Mode detection helper.
- *
- * When Trivia Mode is enabled in ibl_settings, ModuleAccessControl hides
- * Player, SeasonLeaderboards, and CareerLeaderboards modules, showing
- * "Sorry, this Module isn't active!" instead.
- */
-
-export const MODULE_INACTIVE_TEXT = "Module isn't active";

--- a/ibl5/tests/e2e/smoke/admin-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/admin-pages.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures/auth';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Admin-only page smoke tests — require roles_mask = 1 (ADMIN) on the test user.
 // If the authenticated user is not an admin, tests skip gracefully.
@@ -65,11 +65,7 @@ test.describe('Admin page smoke tests', () => {
         test.skip(true, 'Test user does not have admin privileges');
       }
 
-      for (const pattern of PHP_ERROR_PATTERNS) {
-        expect(body, `PHP error "${pattern}" found on ${url}`).not.toContain(
-          pattern,
-        );
-      }
+      await assertNoPhpErrors(page, `on ${url}`);
     }
   });
 });

--- a/ibl5/tests/e2e/smoke/auth-pages-extended.spec.ts
+++ b/ibl5/tests/e2e/smoke/auth-pages-extended.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures/auth';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Authenticated page smoke tests — extended coverage.
 
@@ -63,12 +63,7 @@ test.describe('Extended authenticated page smoke tests', () => {
     });
     for (const url of AUTH_URLS) {
       await page.goto(url);
-      const body = await page.locator('body').textContent();
-      for (const pattern of PHP_ERROR_PATTERNS) {
-        expect(body, `PHP error "${pattern}" found on ${url}`).not.toContain(
-          pattern,
-        );
-      }
+      await assertNoPhpErrors(page, `on ${url}`);
     }
   });
 });

--- a/ibl5/tests/e2e/smoke/navigation.spec.ts
+++ b/ibl5/tests/e2e/smoke/navigation.spec.ts
@@ -1,20 +1,11 @@
 import { test, expect } from '@playwright/test';
-import type { Page } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+import { desktopNav, openMobileMenu } from '../helpers/navigation';
 
 // Public navigation tests — no authentication required.
 // The navigation bar renders on every page via themeheader().
 
 test.use({ storageState: { cookies: [], origins: [] } });
-
-function desktopNav(page: Page) {
-  return page.locator('.hidden.lg\\:flex').first();
-}
-
-async function openMobileMenu(page: Page) {
-  await page.locator('#nav-hamburger').click();
-  return page.locator('#nav-mobile-menu');
-}
 
 test.describe('Navigation bar smoke tests (public)', () => {
   test('nav bar is visible on homepage', async ({ page }) => {
@@ -101,10 +92,7 @@ test.describe('Navigation bar smoke tests (public)', () => {
 
   test('no PHP errors on homepage', async ({ page }) => {
     await page.goto('index.php');
-    const body = await page.locator('body').textContent();
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body, `PHP error "${pattern}" found`).not.toContain(pattern);
-    }
+    await assertNoPhpErrors(page);
   });
 });
 

--- a/ibl5/tests/e2e/smoke/olympics-admin.spec.ts
+++ b/ibl5/tests/e2e/smoke/olympics-admin.spec.ts
@@ -1,15 +1,12 @@
 import { test, expect } from '../fixtures/auth';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Olympics admin page — verify pipeline loads in Olympics context.
 test.describe('Olympics admin smoke tests', () => {
   test('updateAllTheThings loads in Olympics context', async ({ page }) => {
     await page.goto('scripts/updateAllTheThings.php?league=olympics');
-    const body = await page.locator('body').textContent();
     // Verify the page indicates Olympics mode in the initialization section
-    expect(body).toContain('Olympics');
-    for (const pattern of PHP_ERROR_PATTERNS) {
-      expect(body, `PHP error "${pattern}" on Olympics pipeline`).not.toContain(pattern);
-    }
+    await expect(page.locator('body')).toContainText('Olympics');
+    await assertNoPhpErrors(page, 'on Olympics pipeline');
   });
 });

--- a/ibl5/tests/e2e/smoke/olympics-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/olympics-pages.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Olympics public pages — verify league-context table resolution works.
 // These pages append ?league=olympics to switch to Olympics context.
@@ -35,10 +35,7 @@ test.describe('Olympics page smoke tests', () => {
   test('no PHP errors on Olympics pages', async ({ page }) => {
     for (const url of OLYMPICS_URLS) {
       await page.goto(url);
-      const body = await page.locator('body').textContent();
-      for (const pattern of PHP_ERROR_PATTERNS) {
-        expect(body, `PHP error "${pattern}" found on ${url}`).not.toContain(pattern);
-      }
+      await assertNoPhpErrors(page, `on ${url}`);
     }
   });
 });

--- a/ibl5/tests/e2e/smoke/public-pages-extended.spec.ts
+++ b/ibl5/tests/e2e/smoke/public-pages-extended.spec.ts
@@ -1,150 +1,39 @@
 import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+import { gotoWithRetry } from '../helpers/navigation';
 
 // Public pages — no authentication required.
 test.use({ storageState: { cookies: [], origins: [] } });
 
-const EXTENDED_PUBLIC_URLS = [
-  'modules.php?name=Schedule',
-  'modules.php?name=Injuries',
-  'modules.php?name=PlayerDatabase',
-  'modules.php?name=ProjectedDraftOrder',
-  'modules.php?name=DraftPickLocator',
-  'modules.php?name=FreeAgencyPreview',
-  'modules.php?name=ContractList',
-  'modules.php?name=PlayerMovement',
-  'modules.php?name=LeagueStarters',
-  'modules.php?name=ComparePlayers',
-  'modules.php?name=SeasonHighs',
-  'modules.php?name=SeriesRecords',
-  'modules.php?name=FranchiseHistory',
-  'modules.php?name=ActivityTracker',
+const PAGES = [
+  { name: 'schedule', url: 'modules.php?name=Schedule', selector: '.schedule-container, .ibl-data-table, table' },
+  { name: 'injuries', url: 'modules.php?name=Injuries', selector: '.ibl-title, h2, h3' },
+  { name: 'player database', url: 'modules.php?name=PlayerDatabase', selector: 'form[name="Search"]' },
+  { name: 'projected draft order', url: 'modules.php?name=ProjectedDraftOrder', selector: '.ibl-title, .ibl-data-table, table' },
+  { name: 'draft pick locator', url: 'modules.php?name=DraftPickLocator', selector: '.ibl-title, table' },
+  { name: 'free agency preview', url: 'modules.php?name=FreeAgencyPreview', selector: '.ibl-data-table, table, .ibl-title' },
+  { name: 'contract list', url: 'modules.php?name=ContractList', selector: '.ibl-data-table, table, .ibl-title' },
+  { name: 'player movement', url: 'modules.php?name=PlayerMovement', selector: '.ibl-title, .ibl-data-table, table, h2, h3' },
+  { name: 'league starters', url: 'modules.php?name=LeagueStarters', selector: '.ibl-data-table, table' },
+  { name: 'compare players', url: 'modules.php?name=ComparePlayers', selector: 'input[name="Player1"], input[name="player1"]' },
+  { name: 'season highs', url: 'modules.php?name=SeasonHighs', selector: '.ibl-data-table, table, .ibl-title' },
+  { name: 'series records', url: 'modules.php?name=SeriesRecords', selector: '.ibl-data-table, table, .ibl-title' },
+  { name: 'franchise history', url: 'modules.php?name=FranchiseHistory', selector: '.ibl-data-table, table, .ibl-title' },
+  { name: 'activity tracker', url: 'modules.php?name=ActivityTracker', selector: '.ibl-data-table, table, .ibl-title' },
 ];
 
-/**
- * Navigate and verify the page actually rendered content.
- * Under parallel load, PHP's built-in server can return blank HTML.
- * Retries up to 4 times with increasing back-off before failing.
- */
-async function gotoWithRetry(
-  page: import('@playwright/test').Page,
-  url: string,
-): Promise<void> {
-  for (let attempt = 0; attempt < 5; attempt++) {
-    if (attempt > 0) await page.waitForTimeout(attempt * 1000);
-    try {
-      await page.goto(url, { timeout: 15_000 });
-    } catch {
-      continue;
-    }
-    const body = await page.locator('body').innerText();
-    if (body.trim().length >= 20) return;
-  }
-  throw new Error(`Page returned blank content after 5 attempts: ${url}`);
-}
-
 test.describe('Extended public page smoke tests', () => {
-  test('schedule loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=Schedule');
-    await expect(
-      page.locator('.schedule-container, .ibl-data-table, table').first(),
-    ).toBeVisible();
-  });
-
-  test('injuries page loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=Injuries');
-    await expect(page.locator('.ibl-title, h2, h3').first()).toBeVisible();
-  });
-
-  test('player database loads with form', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=PlayerDatabase');
-    await expect(page.locator('form[name="Search"]')).toBeVisible();
-  });
-
-  test('projected draft order loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=ProjectedDraftOrder');
-    await expect(
-      page.locator('.ibl-title, .ibl-data-table, table').first(),
-    ).toBeVisible();
-  });
-
-  test('draft pick locator loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=DraftPickLocator');
-    await expect(page.locator('.ibl-title, table').first()).toBeVisible();
-  });
-
-  test('free agency preview loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=FreeAgencyPreview');
-    await expect(
-      page.locator('.ibl-data-table, table, .ibl-title').first(),
-    ).toBeVisible();
-  });
-
-  test('contract list loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=ContractList');
-    await expect(
-      page.locator('.ibl-data-table, table, .ibl-title').first(),
-    ).toBeVisible();
-  });
-
-  test('player movement loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=PlayerMovement');
-    await expect(
-      page.locator('.ibl-title, .ibl-data-table, table, h2, h3').first(),
-    ).toBeVisible();
-  });
-
-  test('league starters loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=LeagueStarters');
-    await expect(
-      page.locator('.ibl-data-table, table').first(),
-    ).toBeVisible();
-  });
-
-  test('compare players loads with form', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=ComparePlayers');
-    await expect(
-      page.locator('input[name="Player1"], input[name="player1"]').first(),
-    ).toBeVisible();
-  });
-
-  test('season highs loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=SeasonHighs');
-    await expect(
-      page.locator('.ibl-data-table, table, .ibl-title').first(),
-    ).toBeVisible();
-  });
-
-  test('series records loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=SeriesRecords');
-    await expect(
-      page.locator('.ibl-data-table, table, .ibl-title').first(),
-    ).toBeVisible();
-  });
-
-  test('franchise history loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=FranchiseHistory');
-    await expect(
-      page.locator('.ibl-data-table, table, .ibl-title').first(),
-    ).toBeVisible();
-  });
-
-  test('activity tracker loads', async ({ page }) => {
-    await gotoWithRetry(page,'modules.php?name=ActivityTracker');
-    await expect(
-      page.locator('.ibl-data-table, table, .ibl-title').first(),
-    ).toBeVisible();
-  });
+  for (const { name, url, selector } of PAGES) {
+    test(`${name} loads`, async ({ page }) => {
+      await gotoWithRetry(page, url);
+      await expect(page.locator(selector).first()).toBeVisible();
+    });
+  }
 
   test('no PHP errors on extended public pages', async ({ page }) => {
-    for (const url of EXTENDED_PUBLIC_URLS) {
+    for (const { url } of PAGES) {
       await page.goto(url);
-      const body = await page.locator('body').textContent();
-      for (const pattern of PHP_ERROR_PATTERNS) {
-        expect(body, `PHP error "${pattern}" found on ${url}`).not.toContain(
-          pattern,
-        );
-      }
+      await assertNoPhpErrors(page, `on ${url}`);
     }
   });
 });

--- a/ibl5/tests/e2e/smoke/public-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/public-pages.spec.ts
@@ -1,23 +1,13 @@
-import { test, expect } from '@playwright/test';
-import { PHP_ERROR_PATTERNS } from '../helpers/php-errors';
-import { setState, type Settings } from '../helpers/test-state';
+import { test, expect } from '../fixtures/public';
+import { assertNoPhpErrors } from '../helpers/php-errors';
 
 // Public pages — no authentication required.
-// These use the base test (not the auth fixture) so they run without login.
-
-test.use({ storageState: { cookies: [], origins: [] } });
+// Uses the public fixture with appState for automatic state restore.
 
 test.describe('Public page smoke tests', () => {
   // Ensure trivia mode is off so modules render normally
-  let restoreSettings: Settings;
-
-  test.beforeEach(async ({ request }) => {
-    const result = await setState(request, { 'Trivia Mode': 'Off' });
-    restoreSettings = result.previous;
-  });
-
-  test.afterEach(async ({ request }) => {
-    await setState(request, restoreSettings);
+  test.beforeEach(async ({ appState }) => {
+    await appState({ 'Trivia Mode': 'Off' });
   });
 
   test('homepage loads', async ({ page }) => {
@@ -81,10 +71,7 @@ test.describe('Public page smoke tests', () => {
 
     for (const url of urls) {
       await page.goto(url);
-      const body = await page.locator('body').textContent();
-      for (const pattern of PHP_ERROR_PATTERNS) {
-        expect(body, `PHP error "${pattern}" found on ${url}`).not.toContain(pattern);
-      }
+      await assertNoPhpErrors(page, `on ${url}`);
     }
   });
 });


### PR DESCRIPTION
## Summary

Refactors the E2E test suite (33 files, ~65 tests) to consolidate duplicated patterns into shared utilities, reducing boilerplate by ~300 lines without changing test behavior.

## Changes

### Shared Helpers
- **`assertNoPhpErrors(page, context?)`** — Replaces the inline 3-4 line PHP error check loop that was duplicated across 24 spec files with a one-liner
- **`helpers/navigation.ts`** — Extracts `desktopNav()`, `openMobileMenu()`, and `gotoWithRetry()` from spec files into a shared module
- **`createAppStateFixture()`** — DRY factory in `helpers/test-state.ts` used by both auth and public fixtures

### Public Test Fixture
- **`fixtures/public.ts`** — New fixture providing `appState` auto-restore for unauthenticated tests (previously only available via auth fixture)
- `fixtures/auth.ts` refactored to use the same shared factory
- `smoke/public-pages.spec.ts` and `flows/leaderboards.spec.ts` converted from manual setState/restore to `appState` fixture

### Data-Driven Tests
- 14 near-identical tests in `smoke/public-pages-extended.spec.ts` converted to a data-driven loop over a `PAGES` array

### Cleanup
- Deleted `helpers/trivia-mode.ts` (single constant, single consumer) — inlined in `flows/leaderboards.spec.ts`

## Verification
- All E2E tests pass (227 passed, transient timeout flakes only)
- No `.only` in any spec file
- Test count unchanged