### PR TITLE
feat: upgrade Topics search bar to full-featured search form

### DIFF
--- a/ibl5/classes/Topics/Contracts/TopicsViewInterface.php
+++ b/ibl5/classes/Topics/Contracts/TopicsViewInterface.php
@@ -8,6 +8,13 @@ namespace Topics\Contracts;
  * Interface for the Topics view.
  *
  * Defines methods for rendering the topics listing page.
+ *
+ * @phpstan-type SearchFilterData array{
+ *     topics: list<array{topicId: int, topicText: string}>,
+ *     categories: list<array{catId: int, title: string}>,
+ *     authors: list<string>,
+ *     articleComm: bool
+ * }
  */
 interface TopicsViewInterface
 {
@@ -29,7 +36,8 @@ interface TopicsViewInterface
      *     }>
      * }> $topics Array of topic data with articles
      * @param string $themePath Path prefix for topic images
+     * @param SearchFilterData $searchFilters Search filter data for the form
      * @return string Rendered HTML
      */
-    public function render(array $topics, string $themePath): string;
+    public function render(array $topics, string $themePath, array $searchFilters): string;
 }

--- a/ibl5/classes/Topics/TopicsView.php
+++ b/ibl5/classes/Topics/TopicsView.php
@@ -29,6 +29,42 @@ if (!defined('_MORE')) {
 if (!defined('_NONEWSYET')) {
     define('_NONEWSYET', 'No news yet');
 }
+if (!defined('_ALLTOPICS')) {
+    define('_ALLTOPICS', 'All Topics');
+}
+if (!defined('_ARTICLES')) {
+    define('_ARTICLES', 'All Categories');
+}
+if (!defined('_ALLAUTHORS')) {
+    define('_ALLAUTHORS', 'All Authors');
+}
+if (!defined('_ALL')) {
+    define('_ALL', 'Any Date');
+}
+if (!defined('_WEEK')) {
+    define('_WEEK', 'Week');
+}
+if (!defined('_WEEKS')) {
+    define('_WEEKS', 'Weeks');
+}
+if (!defined('_MONTH')) {
+    define('_MONTH', 'Month');
+}
+if (!defined('_MONTHS')) {
+    define('_MONTHS', 'Months');
+}
+if (!defined('_SEARCHON')) {
+    define('_SEARCHON', 'Search on:');
+}
+if (!defined('_SSTORIES')) {
+    define('_SSTORIES', 'Stories');
+}
+if (!defined('_SCOMMENTS')) {
+    define('_SCOMMENTS', 'Comments');
+}
+if (!defined('_SUSERS')) {
+    define('_SUSERS', 'Users');
+}
 
 /**
  * View class for rendering the Topics listing page.
@@ -37,6 +73,7 @@ if (!defined('_NONEWSYET')) {
  * article count, total reads, and a list of recent articles.
  *
  * @phpstan-type TopicData array{topicId: int, topicName: string, topicImage: string, topicText: string, storyCount: int, totalReads: int, recentArticles: array<int, array{sid: int, title: string, catId: int, catTitle: string}>}
+ * @phpstan-import-type SearchFilterData from Contracts\TopicsViewInterface
  *
  * @see TopicsViewInterface
  */
@@ -46,15 +83,16 @@ class TopicsView implements TopicsViewInterface
      * @see TopicsViewInterface::render()
      *
      * @param array<int, TopicData> $topics
+     * @param SearchFilterData $searchFilters
      */
-    public function render(array $topics, string $themePath): string
+    public function render(array $topics, string $themePath, array $searchFilters): string
     {
         if ($topics === []) {
             return $this->renderEmptyState();
         }
 
         $output = $this->renderPageHeader();
-        $output .= $this->renderSearchForm();
+        $output .= $this->renderSearchForm($searchFilters);
         $output .= $this->renderTopicsGrid($topics, $themePath);
 
         return $output;
@@ -74,19 +112,167 @@ class TopicsView implements TopicsViewInterface
     }
 
     /**
-     * Render the search form.
+     * Render the full search form with filter dropdowns and type radio buttons.
+     *
+     * @param SearchFilterData $searchFilters
      */
-    private function renderSearchForm(): string
+    private function renderSearchForm(array $searchFilters): string
     {
-        $search = HtmlSanitizer::safeHtmlOutput(_SEARCH);
+        $output = '<form action="modules.php?name=Search" method="post" class="topics-search search-form">';
 
-        return '<form action="modules.php?name=Search" method="post" class="topics-search">
-        <div class="ibl-search">
-            <svg class="ibl-search__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-            <input type="text" name="query" class="ibl-search__input" placeholder="Search articles...">
-            <button type="submit" class="ibl-search__btn">' . $search . '</button>
-        </div>
-    </form>';
+        // Search input row
+        $output .= '<div class="search-form__input-row">';
+        $output .= '<div class="ibl-search search-form__search-bar">';
+        $output .= '<svg class="ibl-search__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>';
+        $output .= '<input type="text" name="query" class="ibl-search__input" placeholder="Search articles...">';
+        $safeSearch = HtmlSanitizer::safeHtmlOutput(_SEARCH);
+        $output .= '<button type="submit" class="ibl-search__btn">' . $safeSearch . '</button>';
+        $output .= '</div></div>';
+
+        // Filter row
+        $output .= '<div class="search-form__filters">';
+        $output .= $this->renderTopicSelect($searchFilters['topics']);
+        $output .= $this->renderCategorySelect($searchFilters['categories']);
+        $output .= $this->renderAuthorSelect($searchFilters['authors']);
+        $output .= $this->renderDaysSelect();
+        $output .= '</div>';
+
+        // Search type radio buttons
+        $output .= '<div class="search-form__types">';
+        $safeSearchOn = HtmlSanitizer::safeHtmlOutput(_SEARCHON);
+        $output .= '<span class="search-form__types-label">' . $safeSearchOn . '</span>';
+        /** @var string $storiesLabel */
+        $storiesLabel = _SSTORIES;
+        $output .= $this->renderTypeRadio('stories', $storiesLabel, 'stories');
+
+        if ($searchFilters['articleComm']) {
+            /** @var string $commentsLabel */
+            $commentsLabel = _SCOMMENTS;
+            $output .= $this->renderTypeRadio('comments', $commentsLabel, 'stories');
+        }
+
+        /** @var string $usersLabel */
+        $usersLabel = _SUSERS;
+        $output .= $this->renderTypeRadio('users', $usersLabel, 'stories');
+        $output .= '</div>';
+
+        $output .= '</form>';
+
+        return $output;
+    }
+
+    /**
+     * Render the topic filter dropdown.
+     *
+     * @param list<array{topicId: int, topicText: string}> $topics
+     */
+    private function renderTopicSelect(array $topics): string
+    {
+        $output = '<select name="topic" class="search-form__select">';
+        $safeAllTopics = HtmlSanitizer::safeHtmlOutput(_ALLTOPICS);
+        $output .= '<option value="">' . $safeAllTopics . '</option>';
+
+        foreach ($topics as $topic) {
+            $topicId = $topic['topicId'];
+            $topicText = HtmlSanitizer::safeHtmlOutput($topic['topicText']);
+            $output .= '<option value="' . $topicId . '">' . $topicText . '</option>';
+        }
+
+        $output .= '</select>';
+        return $output;
+    }
+
+    /**
+     * Render the category filter dropdown.
+     *
+     * @param list<array{catId: int, title: string}> $categories
+     */
+    private function renderCategorySelect(array $categories): string
+    {
+        $output = '<select name="category" class="search-form__select">';
+        $safeArticles = HtmlSanitizer::safeHtmlOutput(_ARTICLES);
+        $output .= '<option value="0">' . $safeArticles . '</option>';
+
+        foreach ($categories as $cat) {
+            $catId = $cat['catId'];
+            $title = HtmlSanitizer::safeHtmlOutput($cat['title']);
+            $output .= '<option value="' . $catId . '">' . $title . '</option>';
+        }
+
+        $output .= '</select>';
+        return $output;
+    }
+
+    /**
+     * Render the author filter dropdown.
+     *
+     * @param list<string> $authors
+     */
+    private function renderAuthorSelect(array $authors): string
+    {
+        $output = '<select name="author" class="search-form__select">';
+        $safeAllAuthors = HtmlSanitizer::safeHtmlOutput(_ALLAUTHORS);
+        $output .= '<option value="">' . $safeAllAuthors . '</option>';
+
+        foreach ($authors as $authorName) {
+            $safe = HtmlSanitizer::safeHtmlOutput($authorName);
+            $output .= '<option value="' . $safe . '">' . $safe . '</option>';
+        }
+
+        $output .= '</select>';
+        return $output;
+    }
+
+    /**
+     * Render the date range filter dropdown.
+     */
+    private function renderDaysSelect(): string
+    {
+        /** @var string $allLabel */
+        $allLabel = _ALL;
+        /** @var string $weekLabel */
+        $weekLabel = _WEEK;
+        /** @var string $weeksLabel */
+        $weeksLabel = _WEEKS;
+        /** @var string $monthLabel */
+        $monthLabel = _MONTH;
+        /** @var string $monthsLabel */
+        $monthsLabel = _MONTHS;
+
+        /** @var array<int, string> $options */
+        $options = [
+            0 => $allLabel,
+            7 => '1 ' . $weekLabel,
+            14 => '2 ' . $weeksLabel,
+            30 => '1 ' . $monthLabel,
+            60 => '2 ' . $monthsLabel,
+            90 => '3 ' . $monthsLabel,
+        ];
+
+        $output = '<select name="days" class="search-form__select">';
+
+        foreach ($options as $value => $label) {
+            $safeLabel = HtmlSanitizer::safeHtmlOutput($label);
+            $output .= '<option value="' . $value . '">' . $safeLabel . '</option>';
+        }
+
+        $output .= '</select>';
+        return $output;
+    }
+
+    /**
+     * Render a search type radio button.
+     */
+    private function renderTypeRadio(string $value, string $label, string $selectedType): string
+    {
+        $checked = ($value === $selectedType) ? ' checked' : '';
+        $id = 'search-type-' . $value;
+
+        $safeLabel = HtmlSanitizer::safeHtmlOutput($label);
+        return '<label class="search-form__type" for="' . $id . '">
+            <input type="radio" name="type" value="' . $value . '" id="' . $id . '"' . $checked . '>
+            <span class="search-form__type-label">' . $safeLabel . '</span>
+        </label>';
     }
 
     /**

--- a/ibl5/design/components/existing-components.css
+++ b/ibl5/design/components/existing-components.css
@@ -1424,7 +1424,7 @@ table.sortable thead th {
 }
 
 .topics-search {
-    max-width: 480px;
+    max-width: 640px;
     margin: 0 auto var(--space-8);
 }
 

--- a/ibl5/modules/Topics/index.php
+++ b/ibl5/modules/Topics/index.php
@@ -18,6 +18,7 @@ if (!defined('MODULE_FILE')) {
     die("You can't access this file directly...");
 }
 
+use Search\SearchRepository;
 use Topics\TopicsRepository;
 use Topics\TopicsView;
 
@@ -26,7 +27,7 @@ get_lang($module_name);
 
 $pagetitle = "- " . _ACTIVETOPICS;
 
-global $mysqli_db, $prefix, $tipath;
+global $mysqli_db, $prefix, $user_prefix, $tipath, $articlecomm;
 
 $ThemeSel = get_theme();
 
@@ -37,12 +38,21 @@ $themePath = (is_dir("themes/{$ThemeSel}/images/topics/"))
 
 // Initialize services
 $service = new TopicsRepository($mysqli_db, $prefix);
+$searchRepo = new SearchRepository($mysqli_db, $prefix, $user_prefix);
 $view = new TopicsView();
 
 // Get topics data
 $topics = $service->getTopicsWithArticles();
 
+// Get search filter data
+$searchFilters = [
+    'topics' => $searchRepo->getTopics(),
+    'categories' => $searchRepo->getCategories(),
+    'authors' => $searchRepo->getAuthors(),
+    'articleComm' => (bool) ($articlecomm ?? false),
+];
+
 // Render page
 PageLayout\PageLayout::header();
-echo $view->render($topics, $themePath);
+echo $view->render($topics, $themePath, $searchFilters);
 PageLayout\PageLayout::footer();

--- a/ibl5/tests/Topics/TopicsViewTest.php
+++ b/ibl5/tests/Topics/TopicsViewTest.php
@@ -15,9 +15,18 @@ class TopicsViewTest extends TestCase
 {
     private TopicsView $view;
 
+    /** @var array{topics: list<array{topicId: int, topicText: string}>, categories: list<array{catId: int, title: string}>, authors: list<string>, articleComm: bool} */
+    private array $searchFilters;
+
     protected function setUp(): void
     {
         $this->view = new TopicsView();
+        $this->searchFilters = [
+            'topics' => [['topicId' => 1, 'topicText' => 'IBL News']],
+            'categories' => [['catId' => 1, 'title' => 'Trades']],
+            'authors' => ['admin'],
+            'articleComm' => false,
+        ];
     }
 
     public function testImplementsViewInterface(): void
@@ -27,7 +36,7 @@ class TopicsViewTest extends TestCase
 
     public function testRenderShowsEmptyStateWhenNoTopics(): void
     {
-        $html = $this->view->render([], 'themes/IBL/images/topics/');
+        $html = $this->view->render([], 'themes/IBL/images/topics/', $this->searchFilters);
 
         $this->assertStringContainsString('ibl-empty-state', $html);
     }
@@ -36,7 +45,7 @@ class TopicsViewTest extends TestCase
     {
         $topics = [self::createTopic()];
 
-        $html = $this->view->render($topics, 'themes/IBL/images/topics/');
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
 
         $this->assertStringContainsString('Active Topics', $html);
     }
@@ -45,17 +54,62 @@ class TopicsViewTest extends TestCase
     {
         $topics = [self::createTopic()];
 
-        $html = $this->view->render($topics, 'themes/IBL/images/topics/');
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
 
         $this->assertStringContainsString('<form', $html);
         $this->assertStringContainsString('Search', $html);
+    }
+
+    public function testRenderShowsFilterDropdowns(): void
+    {
+        $topics = [self::createTopic()];
+
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
+
+        $this->assertStringContainsString('search-form__select', $html);
+        $this->assertStringContainsString('name="topic"', $html);
+        $this->assertStringContainsString('name="category"', $html);
+        $this->assertStringContainsString('name="author"', $html);
+        $this->assertStringContainsString('name="days"', $html);
+    }
+
+    public function testRenderShowsSearchTypeRadios(): void
+    {
+        $topics = [self::createTopic()];
+
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
+
+        $this->assertStringContainsString('name="type"', $html);
+        $this->assertStringContainsString('value="stories"', $html);
+        $this->assertStringContainsString('value="users"', $html);
+        $this->assertStringContainsString('checked', $html);
+    }
+
+    public function testRenderShowsCommentsRadioWhenArticleCommEnabled(): void
+    {
+        $topics = [self::createTopic()];
+        $filters = $this->searchFilters;
+        $filters['articleComm'] = true;
+
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $filters);
+
+        $this->assertStringContainsString('value="comments"', $html);
+    }
+
+    public function testRenderHidesCommentsRadioWhenArticleCommDisabled(): void
+    {
+        $topics = [self::createTopic()];
+
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
+
+        $this->assertStringNotContainsString('value="comments"', $html);
     }
 
     public function testRenderShowsTopicName(): void
     {
         $topics = [self::createTopic(['topicText' => 'Basketball News'])];
 
-        $html = $this->view->render($topics, 'themes/IBL/images/topics/');
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
 
         $this->assertStringContainsString('Basketball News', $html);
     }
@@ -64,7 +118,7 @@ class TopicsViewTest extends TestCase
     {
         $topics = [self::createTopic(['topicImage' => 'basketball.gif'])];
 
-        $html = $this->view->render($topics, 'themes/IBL/images/topics/');
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
 
         $this->assertStringContainsString('basketball.gif', $html);
     }
@@ -73,7 +127,7 @@ class TopicsViewTest extends TestCase
     {
         $topics = [self::createTopic(['storyCount' => 42])];
 
-        $html = $this->view->render($topics, 'themes/IBL/images/topics/');
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
 
         $this->assertStringContainsString('42', $html);
     }
@@ -87,7 +141,7 @@ class TopicsViewTest extends TestCase
             ],
         ])];
 
-        $html = $this->view->render($topics, 'themes/IBL/images/topics/');
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
 
         $this->assertStringContainsString('Test Article', $html);
         $this->assertStringContainsString('sid=100', $html);
@@ -97,7 +151,7 @@ class TopicsViewTest extends TestCase
     {
         $topics = [self::createTopic(['storyCount' => 15])];
 
-        $html = $this->view->render($topics, 'themes/IBL/images/topics/');
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
 
         $this->assertStringContainsString('More', $html);
     }
@@ -106,9 +160,30 @@ class TopicsViewTest extends TestCase
     {
         $topics = [self::createTopic(['storyCount' => 0])];
 
-        $html = $this->view->render($topics, 'themes/IBL/images/topics/');
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $this->searchFilters);
 
         $this->assertStringContainsString('No news yet', $html);
+    }
+
+    public function testRenderPopulatesFilterDropdownOptions(): void
+    {
+        $topics = [self::createTopic()];
+        $filters = [
+            'topics' => [
+                ['topicId' => 5, 'topicText' => 'Trade News'],
+                ['topicId' => 8, 'topicText' => 'Draft Coverage'],
+            ],
+            'categories' => [['catId' => 3, 'title' => 'Extensions']],
+            'authors' => ['commissioner', 'admin'],
+            'articleComm' => false,
+        ];
+
+        $html = $this->view->render($topics, 'themes/IBL/images/topics/', $filters);
+
+        $this->assertStringContainsString('Trade News', $html);
+        $this->assertStringContainsString('Draft Coverage', $html);
+        $this->assertStringContainsString('Extensions', $html);
+        $this->assertStringContainsString('commissioner', $html);
     }
 
     /**

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -70,7 +70,8 @@ INSERT INTO nuke_modules (title, custom_title, active, view) VALUES
   ('FreeAgencyPreview',   'FreeAgencyPreview',   1, 0),
   ('Draft',               'Draft',               1, 0),
   ('TeamOffDefStats',     'TeamOffDefStats',     1, 0),
-  ('Transaction',         'Transaction',         1, 0);
+  ('Transaction',         'Transaction',         1, 0),
+  ('Topics',              'Topics',              1, 0);
 
 -- ============================================================
 -- IBL season bootstrap
@@ -661,6 +662,32 @@ INSERT INTO ibl_schedule (Year, Date, Visitor, Home, VScore, HScore, BoxID, uuid
   (2026, '2026-03-08', 1, 2,  0, 0, 0, 'sched-uuid-0001'),
   (2026, '2026-03-10', 3, 1,  0, 0, 0, 'sched-uuid-0002'),
   (2026, '2026-03-12', 1, 14, 0, 0, 0, 'sched-uuid-0003');
+
+-- ============================================================
+-- Topics (nuke_topics) for Topics module E2E tests
+-- PK is `id`, topicid is an auto-increment index
+-- ============================================================
+
+INSERT INTO nuke_topics (topicid, topicname, topicimage, topictext, counter, id) VALUES
+  (1, 'IBL',      'IBL.gif',      'IBL News',      10, 1),
+  (2, 'Trades',   'trades.gif',   'Trade News',     5, 2),
+  (3, 'Draft',    'draft.gif',    'Draft Coverage',  3, 3);
+
+-- Stories linked to topics (for topic card article lists)
+INSERT INTO nuke_stories (catid, aid, title, time, hometext, bodytext, topic) VALUES
+  (0, 'admin', 'Metros win season opener',             '2026-03-05 10:00:00', 'Great start to the season', '', 1),
+  (0, 'admin', 'Stars acquire top free agent',          '2026-03-04 10:00:00', 'Big move for the Stars',    '', 1),
+  (0, 'admin', 'Blockbuster trade shakes up the league', '2026-03-03 10:00:00', 'Three-team deal completed',  '', 2);
+
+-- Categories for search filter dropdown
+INSERT INTO nuke_stories_cat (catid, title) VALUES
+  (15, 'General')
+ON DUPLICATE KEY UPDATE title = VALUES(title);
+
+-- Authors for search filter dropdown (admin already used in stories above)
+INSERT INTO nuke_authors (aid, name) VALUES
+  ('admin', 'Admin')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
 
 -- ============================================================
 -- NOTE: Test user (nuke_users + auth_users) is created by the

--- a/ibl5/tests/e2e/flows/search.spec.ts
+++ b/ibl5/tests/e2e/flows/search.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import {
+  assertSearchFormPresent,
+  assertFilterDropdownsPresent,
+  assertSearchTypeRadiosPresent,
+} from '../helpers/search-form-assertions';
 
 // Search — public page, no authentication required.
 // Uses POST-based search form with filter dropdowns.
@@ -14,27 +19,17 @@ test.describe('Search flow', () => {
     const searchPage = page.locator('.search-page');
     await expect(searchPage).toBeVisible();
 
-    const searchInput = page.locator('input[name="query"]');
-    await expect(searchInput).toBeVisible();
+    await assertSearchFormPresent(page);
   });
 
   test('filter selects present', async ({ page }) => {
-    const selects = page.locator('.search-form__select');
-    // Should have topic, category, author, days dropdowns
-    expect(await selects.count()).toBeGreaterThanOrEqual(3);
+    await assertFilterDropdownsPresent(page);
   });
 
   test('type radio buttons present with stories as default', async ({
     page,
   }) => {
-    const radios = page.locator('input[name="type"]');
-    expect(await radios.count()).toBeGreaterThanOrEqual(2);
-
-    // Stories should be checked by default
-    const storiesRadio = page.locator(
-      'input[name="type"][value="stories"]',
-    );
-    await expect(storiesRadio).toBeChecked();
+    await assertSearchTypeRadiosPresent(page);
   });
 
   test('searching for common term returns results or empty state', async ({ page }) => {

--- a/ibl5/tests/e2e/flows/topics.spec.ts
+++ b/ibl5/tests/e2e/flows/topics.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+import {
+  assertSearchFormPresent,
+  assertFilterDropdownsPresent,
+  assertSearchTypeRadiosPresent,
+  assertSearchSubmitsTo,
+} from '../helpers/search-form-assertions';
+
+// Topics — public page, no authentication required.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('Topics flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('modules.php?name=Topics');
+  });
+
+  test('page loads with title', async ({ page }) => {
+    await expect(page.locator('.ibl-title').first()).toBeVisible();
+  });
+
+  test('topic cards or empty state render', async ({ page }) => {
+    const grid = page.locator('.topics-grid');
+    const emptyState = page.locator('.ibl-empty-state');
+    const hasGrid = (await grid.count()) > 0;
+    const hasEmpty = (await emptyState.count()) > 0;
+
+    expect(hasGrid || hasEmpty).toBe(true);
+
+    if (hasGrid) {
+      expect(await page.locator('.topic-card').count()).toBeGreaterThan(0);
+    }
+  });
+
+  test('search form present with filters and radios', async ({ page }) => {
+    // Skip if no topics (empty state has no search form)
+    const grid = page.locator('.topics-grid');
+    if ((await grid.count()) === 0) {
+      test.skip(true, 'No topics rendered — search form not shown');
+    }
+
+    await assertSearchFormPresent(page);
+    await assertFilterDropdownsPresent(page);
+    await assertSearchTypeRadiosPresent(page);
+  });
+
+  test('search form submits to Search module', async ({ page }) => {
+    const grid = page.locator('.topics-grid');
+    if ((await grid.count()) === 0) {
+      test.skip(true, 'No topics rendered — search form not shown');
+    }
+
+    await assertSearchSubmitsTo(page, 'trade', 'name=Search');
+  });
+
+  test('topic card links work', async ({ page }) => {
+    const topicLinks = page.locator('.topic-card__title a');
+    if ((await topicLinks.count()) === 0) {
+      test.skip(true, 'No topic card links available');
+    }
+
+    const href = await topicLinks.first().getAttribute('href');
+    expect(href).toContain('name=News');
+    expect(href).toContain('topic=');
+  });
+
+  test('no PHP errors', async ({ page }) => {
+    await assertNoPhpErrors(page, 'on Topics page');
+  });
+});

--- a/ibl5/tests/e2e/helpers/search-form-assertions.ts
+++ b/ibl5/tests/e2e/helpers/search-form-assertions.ts
@@ -1,0 +1,43 @@
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * Assert the full search form is present (input + submit button).
+ */
+export async function assertSearchFormPresent(page: Page): Promise<void> {
+  await expect(page.locator('input[name="query"]')).toBeVisible();
+  await expect(page.locator('.ibl-search__btn').first()).toBeVisible();
+}
+
+/**
+ * Assert filter dropdowns are present (topic, category, author, days).
+ */
+export async function assertFilterDropdownsPresent(page: Page): Promise<void> {
+  const selects = page.locator('.search-form__select');
+  expect(await selects.count()).toBeGreaterThanOrEqual(3);
+}
+
+/**
+ * Assert search type radio buttons are present with stories checked by default.
+ */
+export async function assertSearchTypeRadiosPresent(page: Page): Promise<void> {
+  const radios = page.locator('input[name="type"]');
+  expect(await radios.count()).toBeGreaterThanOrEqual(2);
+
+  const storiesRadio = page.locator('input[name="type"][value="stories"]');
+  await expect(storiesRadio).toBeChecked();
+}
+
+/**
+ * Assert search form submits and navigates to expected URL.
+ */
+export async function assertSearchSubmitsTo(
+  page: Page,
+  query: string,
+  expectedUrlPart: string,
+): Promise<void> {
+  await page.locator('input[name="query"]').fill(query);
+  await page.locator('.ibl-search__btn').first().click();
+  await page.waitForLoadState('domcontentloaded');
+  expect(page.url()).toContain(expectedUrlPart);
+}

--- a/ibl5/tests/e2e/smoke/public-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/public-pages.spec.ts
@@ -67,6 +67,7 @@ test.describe('Public page smoke tests', () => {
       'modules.php?name=CapSpace',
       'modules.php?name=Player&pa=showpage&pid=1',
       'modules.php?name=Team&op=team&teamID=1',
+      'modules.php?name=Topics',
     ];
 
     for (const url of urls) {


### PR DESCRIPTION
## Summary

Upgrades the Topics module search bar from a simple single-input form to the full-featured search form used by the Search module, with filter dropdowns (topic, category, author, date range) and search type radio buttons (stories, comments, users).

## Changes

### Search Form Upgrade
- Replace simple search input with full Search module form
- Add filter dropdowns: topic, category, author, date range
- Add search type radio buttons: stories, comments, users
- Reuse `SearchRepository` for filter data (`getTopics`, `getCategories`, `getAuthors`)
- Reuse existing `search-form__*` CSS classes from Search module
- Widen `.topics-search` max-width from 480px to 640px for wider form

### E2E Tests
- Add Topics E2E test suite (page load, cards, search form, filters, radios, links, PHP errors)
- Create shared `search-form-assertions.ts` helper
- Refactor `search.spec.ts` to use shared helpers
- Add Topics to public pages smoke test PHP error check
- Add CI seed data: `nuke_topics`, linked stories, categories, authors

### Unit Tests
- Update all TopicsViewTest `render()` calls with new `searchFilters` parameter
- Add tests for filter dropdowns, radio buttons, articleComm toggle, and dropdown option population

## Verification
- PHPUnit: 3692 tests, 17743 assertions — all pass
- PHPStan: No errors (level max)
