### PR TITLE
feat: auto-upsert team awards on clinch and draft lottery

### DIFF
--- a/ibl5/classes/ProjectedDraftOrder/Contracts/ProjectedDraftOrderRepositoryInterface.php
+++ b/ibl5/classes/ProjectedDraftOrder/Contracts/ProjectedDraftOrderRepositoryInterface.php
@@ -64,4 +64,9 @@ interface ProjectedDraftOrderRepositoryInterface
      * Check if any player has been drafted for the given year.
      */
     public function isDraftStarted(int $year): bool;
+
+    /**
+     * Upsert the IBL Draft Lottery Winners award for the team that owns the #1 pick.
+     */
+    public function upsertLotteryWinnerAward(int $year, string $teamName): void;
 }

--- a/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderRepository.php
+++ b/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderRepository.php
@@ -150,4 +150,17 @@ class ProjectedDraftOrderRepository extends \BaseMysqliRepository implements Pro
 
         return $row !== null;
     }
+
+    /** @see ProjectedDraftOrderRepositoryInterface::upsertLotteryWinnerAward() */
+    public function upsertLotteryWinnerAward(int $year, string $teamName): void
+    {
+        $this->execute(
+            "INSERT INTO ibl_team_awards (year, name, Award)
+             VALUES (?, ?, 'IBL Draft Lottery Winners')
+             ON DUPLICATE KEY UPDATE name = VALUES(name)",
+            "is",
+            $year,
+            $teamName,
+        );
+    }
 }

--- a/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderService.php
+++ b/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderService.php
@@ -201,6 +201,14 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
         }
 
         $this->repository->saveFinalDraftOrder($seasonYear, $picks);
+
+        // Upsert the Draft Lottery Winner award for the team that owns pick #1
+        $firstTeamName = $teamMap[$lotteryTeamIds[0]]['team_name'] ?? '';
+        $pickOwnershipRows = $this->repository->getPickOwnership($seasonYear);
+        $pickOwnership = $this->buildPickOwnershipMap($pickOwnershipRows);
+        $ownership = $pickOwnership[$firstTeamName][1] ?? null;
+        $ownerName = $ownership !== null ? $ownership['ownerName'] : $firstTeamName;
+        $this->repository->upsertLotteryWinnerAward($seasonYear, $ownerName);
     }
 
     /**

--- a/ibl5/classes/Updater/StandingsUpdater.php
+++ b/ibl5/classes/Updater/StandingsUpdater.php
@@ -33,11 +33,38 @@ use Utilities\StandingsGrouper;
  * @phpstan-type TeamMapping array{conference: string, division: string, teamName: string}
  */
 class StandingsUpdater extends \BaseMysqliRepository {
+    /** @var array<string, string> */
+    private const REGION_AWARD_MAP = [
+        'Atlantic' => 'Atlantic Division Champions',
+        'Central'  => 'Central Division Champions',
+        'Midwest'  => 'Midwest Division Champions',
+        'Pacific'  => 'Pacific Division Champions',
+        'Eastern'  => 'Eastern Conference Champions',
+        'Western'  => 'Western Conference Champions',
+    ];
+
     private \Season $season;
 
     public function __construct(\mysqli $db, \Season $season, ?LeagueContext $leagueContext = null) {
         parent::__construct($db, $leagueContext);
         $this->season = $season;
+    }
+
+    private function upsertTeamAward(string $teamName, string $awardName): void
+    {
+        if ($this->leagueContext !== null) {
+            return;
+        }
+
+        $this->execute(
+            "INSERT INTO ibl_team_awards (year, name, Award)
+             VALUES (?, ?, ?)
+             ON DUPLICATE KEY UPDATE name = VALUES(name)",
+            "iss",
+            $this->season->endingYear,
+            $teamName,
+            $awardName
+        );
     }
 
     protected function extractWins(string $record): int {
@@ -501,6 +528,11 @@ class StandingsUpdater extends \BaseMysqliRepository {
                 $winningestTeamName
             );
             echo "The {$winningestTeamName} have clinched the {$region} {$grouping}!";
+
+            $awardName = self::REGION_AWARD_MAP[$region] ?? null;
+            if ($awardName !== null) {
+                $this->upsertTeamAward($winningestTeamName, $awardName);
+            }
         }
     }
 

--- a/ibl5/migrations/056_team_awards_auto_increment_unique_key.sql
+++ b/ibl5/migrations/056_team_awards_auto_increment_unique_key.sql
@@ -1,0 +1,5 @@
+-- Migration 056: Add AUTO_INCREMENT to ibl_team_awards.ID and UNIQUE KEY on (year, Award)
+-- This enables idempotent upserts via INSERT ... ON DUPLICATE KEY UPDATE
+
+ALTER TABLE ibl_team_awards MODIFY COLUMN ID int(11) NOT NULL AUTO_INCREMENT;
+ALTER TABLE ibl_team_awards ADD UNIQUE KEY uk_year_award (year, Award);

--- a/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderServiceTest.php
+++ b/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderServiceTest.php
@@ -521,6 +521,81 @@ class ProjectedDraftOrderServiceTest extends TestCase
         $service->saveLotteryOrder(2026, $reversedLottery);
     }
 
+    public function testSaveLotteryOrderUpsertsLotteryWinnerAward(): void
+    {
+        $standings = $this->buildFullLeagueStandings();
+        /** @var ProjectedDraftOrderRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(ProjectedDraftOrderRepositoryInterface::class);
+        $mockRepo->method('getAllTeamsWithStandings')->willReturn($standings);
+        $mockRepo->method('getPlayedGames')->willReturn([]);
+        $mockRepo->method('getPickOwnership')->willReturn([]);
+        $mockRepo->method('getPointDifferentials')->willReturn([]);
+        // Get the projected order to know which teams are in lottery
+        $tempService = new ProjectedDraftOrderService($mockRepo);
+        $projected = $tempService->calculateDraftOrder(2026);
+        $lotteryTids = [];
+        for ($i = 0; $i < 12; $i++) {
+            $lotteryTids[] = $projected['round1'][$i]['teamId'];
+        }
+
+        // Since no pick ownership override, the original team name is the winner
+        $firstTeamTid = $lotteryTids[0];
+        $firstTeamRow = null;
+        foreach ($standings as $row) {
+            if ($row['tid'] === $firstTeamTid) {
+                $firstTeamRow = $row;
+                break;
+            }
+        }
+        $this->assertNotNull($firstTeamRow);
+
+        $mockRepo->expects($this->once())
+            ->method('upsertLotteryWinnerAward')
+            ->with(2026, $firstTeamRow['team_name']);
+
+        $service = new ProjectedDraftOrderService($mockRepo);
+        $service->saveLotteryOrder(2026, $lotteryTids);
+    }
+
+    public function testSaveLotteryOrderUpsertsLotteryWinnerWithTradedPick(): void
+    {
+        $standings = $this->buildFullLeagueStandings();
+        /** @var ProjectedDraftOrderRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(ProjectedDraftOrderRepositoryInterface::class);
+        $mockRepo->method('getAllTeamsWithStandings')->willReturn($standings);
+        $mockRepo->method('getPlayedGames')->willReturn([]);
+        $mockRepo->method('getPointDifferentials')->willReturn([]);
+        // Get the projected order to know which teams are in lottery
+        $tempService = new ProjectedDraftOrderService($mockRepo);
+        $projected = $tempService->calculateDraftOrder(2026);
+        $lotteryTids = [];
+        for ($i = 0; $i < 12; $i++) {
+            $lotteryTids[] = $projected['round1'][$i]['teamId'];
+        }
+
+        $firstTeamTid = $lotteryTids[0];
+        $firstTeamName = '';
+        foreach ($standings as $row) {
+            if ($row['tid'] === $firstTeamTid) {
+                $firstTeamName = $row['team_name'];
+                break;
+            }
+        }
+
+        // First team's pick is traded to Team1
+        $mockRepo->method('getPickOwnership')->willReturn([
+            ['ownerofpick' => 'Team1', 'teampick' => $firstTeamName, 'round' => 1, 'notes' => 'via trade'],
+        ]);
+
+        // The award should go to Team1 (the owner), not the original team
+        $mockRepo->expects($this->once())
+            ->method('upsertLotteryWinnerAward')
+            ->with(2026, 'Team1');
+
+        $service = new ProjectedDraftOrderService($mockRepo);
+        $service->saveLotteryOrder(2026, $lotteryTids);
+    }
+
     public function testSaveLotteryOrderThrowsOnInvalidTeamId(): void
     {
         $this->configureStubWithFullLeague();

--- a/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
@@ -90,6 +90,7 @@ class StandingsUpdaterTest extends TestCase
 
     protected function tearDown(): void
     {
+        $this->mockDb->clearQueryPatterns();
         unset($this->updater, $this->mockDb, $this->mockSeason);
     }
 
@@ -524,6 +525,122 @@ class StandingsUpdaterTest extends TestCase
             }
         }
         return null;
+    }
+
+    public function testClinchDivisionUpsertsTeamAward(): void
+    {
+        $this->mockDb->setReturnTrue(true);
+        $clinchData = [
+            ['tid' => 1, 'team_name' => 'Celtics', 'homeWins' => 40, 'homeLosses' => 1, 'awayWins' => 40, 'awayLosses' => 1, 'wins' => 80],
+            ['tid' => 2, 'team_name' => 'Heat', 'homeWins' => 1, 'homeLosses' => 40, 'awayWins' => 1, 'awayLosses' => 40, 'wins' => 2],
+        ];
+        // Route clinch-check queries ([\s\S] matches across newlines unlike .)
+        $this->mockDb->onQuery('ORDER BY wins DESC', $clinchData);
+        $this->mockDb->onQuery('ORDER BY losses ASC', [['losses' => 80]]);
+        $this->mockDb->onQuery('ORDER BY losses DESC', [['losses' => 80]]);
+        $this->mockDb->onQuery('ORDER BY pct DESC', $clinchData);
+        $this->mockDb->onQuery('gamesUnplayed', [['maxLeft' => 0]]);
+        $this->updater->setTestTeamMap($this->defaultTeamMap);
+        $this->updater->setTestGames([]);
+
+        ob_start();
+        $this->updater->update();
+        ob_end_clean();
+
+        $queries = $this->mockDb->getExecutedQueries();
+        $awardQueries = array_filter($queries, static function (string $q): bool {
+            return stripos($q, 'ibl_team_awards') !== false;
+        });
+
+        $this->assertNotEmpty($awardQueries, 'Expected at least one ibl_team_awards upsert query');
+    }
+
+    public function testClinchConferenceUpsertsTeamAward(): void
+    {
+        $this->mockDb->setReturnTrue(true);
+        $clinchData = [
+            ['tid' => 1, 'team_name' => 'Celtics', 'homeWins' => 40, 'homeLosses' => 1, 'awayWins' => 40, 'awayLosses' => 1, 'wins' => 80],
+            ['tid' => 2, 'team_name' => 'Heat', 'homeWins' => 1, 'homeLosses' => 40, 'awayWins' => 1, 'awayLosses' => 40, 'wins' => 2],
+        ];
+        $this->mockDb->onQuery('ORDER BY wins DESC', $clinchData);
+        $this->mockDb->onQuery('ORDER BY losses ASC', [['losses' => 80]]);
+        $this->mockDb->onQuery('ORDER BY losses DESC', [['losses' => 80]]);
+        $this->mockDb->onQuery('ORDER BY pct DESC', $clinchData);
+        $this->mockDb->onQuery('gamesUnplayed', [['maxLeft' => 0]]);
+        $this->updater->setTestTeamMap($this->defaultTeamMap);
+        $this->updater->setTestGames([]);
+
+        ob_start();
+        $this->updater->update();
+        ob_end_clean();
+
+        $queries = $this->mockDb->getExecutedQueries();
+        $awardQueries = array_values(array_filter($queries, static function (string $q): bool {
+            return stripos($q, 'ibl_team_awards') !== false;
+        }));
+
+        $conferenceAwardFound = false;
+        foreach ($awardQueries as $q) {
+            if (stripos($q, 'Conference Champions') !== false) {
+                $conferenceAwardFound = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($conferenceAwardFound, 'Expected a Conference Champions award upsert');
+    }
+
+    public function testOlympicsSkipsTeamAwardUpsert(): void
+    {
+        $olympicsContext = $this->createStub(\League\LeagueContext::class);
+        $olympicsContext->method('getTableName')->willReturnCallback(
+            static function (string $table): string {
+                return match ($table) {
+                    'ibl_standings' => 'ibl_olympics_standings',
+                    'ibl_schedule' => 'ibl_olympics_schedule',
+                    'ibl_league_config' => 'ibl_olympics_league_config',
+                    default => $table,
+                };
+            }
+        );
+
+        $updater = new TestableStandingsUpdater($this->mockDb, $this->mockSeason, $olympicsContext);
+        $updater->setTestTeamMap($this->defaultTeamMap);
+        $updater->setTestGames([]);
+        $this->mockDb->setReturnTrue(true);
+        $clinchData = [
+            ['tid' => 1, 'team_name' => 'Celtics', 'homeWins' => 40, 'homeLosses' => 1, 'awayWins' => 40, 'awayLosses' => 1, 'wins' => 80],
+            ['tid' => 2, 'team_name' => 'Heat', 'homeWins' => 1, 'homeLosses' => 40, 'awayWins' => 1, 'awayLosses' => 40, 'wins' => 2],
+        ];
+        $this->mockDb->onQuery('ORDER BY wins DESC', $clinchData);
+        $this->mockDb->onQuery('ORDER BY losses ASC', [['losses' => 80]]);
+        $this->mockDb->onQuery('ORDER BY losses DESC', [['losses' => 80]]);
+        $this->mockDb->onQuery('ORDER BY pct DESC', $clinchData);
+        $this->mockDb->onQuery('gamesUnplayed', [['maxLeft' => 0]]);
+
+        ob_start();
+        $updater->update();
+        ob_end_clean();
+
+        $queries = $this->mockDb->getExecutedQueries();
+        $awardQueries = array_filter($queries, static function (string $q): bool {
+            return stripos($q, 'ibl_team_awards') !== false;
+        });
+
+        $this->assertEmpty($awardQueries, 'Olympics context should not upsert team awards');
+    }
+
+    public function testRegionAwardMapCoversAllSixRegions(): void
+    {
+        $reflection = new ReflectionClass(StandingsUpdater::class);
+        $constant = $reflection->getConstant('REGION_AWARD_MAP');
+        $this->assertIsArray($constant);
+        $this->assertCount(6, $constant);
+
+        $expectedRegions = ['Atlantic', 'Central', 'Midwest', 'Pacific', 'Eastern', 'Western'];
+        foreach ($expectedRegions as $region) {
+            $this->assertArrayHasKey($region, $constant, "REGION_AWARD_MAP missing region: {$region}");
+        }
     }
 
     public function testConstructorAcceptsOptionalLeagueContext(): void


### PR DESCRIPTION
## Summary

Automatically upserts division/conference champion awards when teams clinch in `StandingsUpdater`, and upserts the Draft Lottery Winner award when the lottery order is saved in `ProjectedDraftOrderService`.

## Changes

### Migration
- `056_team_awards_auto_increment_unique_key.sql`: Adds AUTO_INCREMENT to `ibl_team_awards.ID` and a `UNIQUE KEY uk_year_award (year, Award)` to enable idempotent upserts

### Clinching Awards (StandingsUpdater)
- `REGION_AWARD_MAP` constant maps all 6 regions (4 divisions + 2 conferences) to award names
- `upsertTeamAward()` method performs `INSERT ... ON DUPLICATE KEY UPDATE` with Olympics guard
- Called from `checkIfRegionIsClinched()` when magic number <= 0

### Draft Lottery Winner (ProjectedDraftOrderService)
- `upsertLotteryWinnerAward()` added to repository interface and implementation
- Called from `saveLotteryOrder()` after saving the final draft order
- Resolves pick #1 ownership to award the correct team (handles traded picks)

## Tests
- StandingsUpdater: division clinch upsert, conference clinch upsert, Olympics skip, region map coverage (4 tests)
- ProjectedDraftOrderService: lottery winner upsert, traded pick lottery winner (2 tests)