### PR TITLE
refactor: replace empty separator cells with CSS border classes in UI/Tables

### DIFF
--- a/ibl5/classes/UI/Tables/Per36Minutes.php
+++ b/ibl5/classes/UI/Tables/Per36Minutes.php
@@ -74,10 +74,10 @@ class Per36Minutes
             <th class="sep-r-team">36min</th>
             <th>fgm</th>
             <th>fga</th>
-            <th class="sep-r-weak">fgp</th>
+            <th>fgp</th>
             <th>ftm</th>
             <th>fta</th>
-            <th class="sep-r-weak">ftp</th>
+            <th>ftp</th>
             <th>3gm</th>
             <th>3ga</th>
             <th class="sep-r-team">3gp</th>

--- a/ibl5/classes/UI/Tables/PeriodAverages.php
+++ b/ibl5/classes/UI/Tables/PeriodAverages.php
@@ -155,10 +155,10 @@ class PeriodAverages
             <th class="sep-r-team">min</th>
             <th>fgm</th>
             <th>fga</th>
-            <th class="sep-r-weak">fgp</th>
+            <th>fgp</th>
             <th>ftm</th>
             <th>fta</th>
-            <th class="sep-r-weak">ftp</th>
+            <th>ftp</th>
             <th>3gm</th>
             <th>3ga</th>
             <th class="sep-r-team">3gp</th>

--- a/ibl5/classes/UI/Tables/Ratings.php
+++ b/ibl5/classes/UI/Tables/Ratings.php
@@ -42,9 +42,9 @@ class Ratings
             <th>Pos</th>
             <th class="sep-r-team">Age</th>
             <th>2ga</th>
-            <th class="sep-r-weak">2g%</th>
+            <th>2g%</th>
             <th>fta</th>
-            <th class="sep-r-weak">ft%</th>
+            <th>ft%</th>
             <th>3ga</th>
             <th class="sep-r-team">3g%</th>
             <th>orb</th>
@@ -57,7 +57,7 @@ class Ratings
             <th>oo</th>
             <th>do</th>
             <th>po</th>
-            <th class="sep-r-weak">to</th>
+            <th>to</th>
             <th>od</th>
             <th>dd</th>
             <th>pd</th>

--- a/ibl5/classes/UI/Tables/SeasonAverages.php
+++ b/ibl5/classes/UI/Tables/SeasonAverages.php
@@ -47,10 +47,10 @@ class SeasonAverages
             <th class="sep-r-team">min</th>
             <th>fgm</th>
             <th>fga</th>
-            <th class="sep-r-weak">fgp</th>
+            <th>fgp</th>
             <th>ftm</th>
             <th>fta</th>
-            <th class="sep-r-weak">ftp</th>
+            <th>ftp</th>
             <th>3gm</th>
             <th>3ga</th>
             <th class="sep-r-team">3gp</th>

--- a/ibl5/classes/UI/Tables/SeasonTotals.php
+++ b/ibl5/classes/UI/Tables/SeasonTotals.php
@@ -46,9 +46,9 @@ class SeasonTotals
             <th>gs</th>
             <th class="sep-r-team">min</th>
             <th>fgm</th>
-            <th class="sep-r-weak">fga</th>
+            <th>fga</th>
             <th>ftm</th>
-            <th class="sep-r-weak">fta</th>
+            <th>fta</th>
             <th>3gm</th>
             <th class="sep-r-team">3ga</th>
             <th>orb</th>

--- a/ibl5/classes/UI/Tables/SplitStats.php
+++ b/ibl5/classes/UI/Tables/SplitStats.php
@@ -69,10 +69,10 @@ class SplitStats
             <th class="sep-r-team">min</th>
             <th>fgm</th>
             <th>fga</th>
-            <th class="sep-r-weak">fgp</th>
+            <th>fgp</th>
             <th>ftm</th>
             <th>fta</th>
-            <th class="sep-r-weak">ftp</th>
+            <th>ftp</th>
             <th>3gm</th>
             <th>3ga</th>
             <th class="sep-r-team">3gp</th>

--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -2427,7 +2427,7 @@ td.record-book-retired-cell {
 /* Right-border separators — applied to the last cell before a column group boundary.
    Coexists with the empty-cell .sep-team/.sep-weak pattern used by other modules. */
 .team-table td.sep-r-team {
-    border-right: 2px solid var(--team-sep-color);
+    border-right: 2px solid color-mix(in srgb, var(--team-color-primary) 30%, var(--gray-300, #d1d5db));
 }
 
 /* In thead, the sep border must contrast against the dark header background */


### PR DESCRIPTION
## Summary

Replace empty `<td class="sep-team">` and `<td class="sep-weak">` separator cells with `sep-r-team`/`sep-r-weak` right-border classes applied to the preceding data cell, across all 6 shared `UI\Tables` classes used on the Team page, Waivers, Trades, and League Starters.

This mirrors the same pattern already used by the FreeAgency module.

## Changes

### PHP (6 files)
- Empty separator `<td>`/`<th>` cells removed from all 6 table classes
- `sep-r-team` right-border class applied to the preceding data cell at each column group boundary
- `sep-r-weak` right-border class applied to data cells only (not thead `<th>` cells)
- `Ratings.php`: colgroup line also removed (had incorrect column counts)
- `SeasonAverages.php`, `SeasonTotals.php`: tfoot blank+sep cell pairs merged into one `<td class="sep-r-team">`
- `SplitStats.php`: colspan corrected from 25→21

### CSS (`tables.css`)
- `td.sep-r-team` border changed from full `var(--team-sep-color)` to `color-mix(in srgb, var(--team-color-primary) 30%, var(--gray-300, #d1d5db))` — gives a muted tint that matches the subtle feel of thead borders, with a gray floor so light team colors (Pacers gold, Aces tan) remain visible

## Testing

- Full PHPUnit suite passes (3713 tests, 17790 assertions)
- PHPStan clean (no errors)