### PR TITLE
refactor: extract shared date helper and remove dead RecordHolders methods

### DIFF
--- a/ibl5/classes/RecordHolders/Contracts/RecordHoldersRepositoryInterface.php
+++ b/ibl5/classes/RecordHolders/Contracts/RecordHoldersRepositoryInterface.php
@@ -125,25 +125,6 @@ namespace RecordHolders\Contracts;
 interface RecordHoldersRepositoryInterface
 {
     /**
-     * Get the top player single-game record for a stat.
-     *
-     * @param string $statExpression SQL expression for the stat
-     * @param string $dateFilter SQL WHERE clause for date filtering
-     * @return list<PlayerSingleGameRecord>
-     */
-    public function getTopPlayerSingleGame(string $statExpression, string $dateFilter): array;
-
-    /**
-     * Get the top player full-season average for a stat.
-     *
-     * @param string $statColumn Column name in ibl_hist for the stat
-     * @param string $gamesColumn Column name for games played
-     * @param int $minGames Minimum games required
-     * @return list<PlayerSeasonRecord>
-     */
-    public function getTopSeasonAverage(string $statColumn, string $gamesColumn, int $minGames = 50): array;
-
-    /**
      * Get all quadruple doubles in IBL history.
      *
      * @return list<QuadrupleDoubleRecord>
@@ -156,16 +137,6 @@ interface RecordHoldersRepositoryInterface
      * @return list<AllStarRecord>
      */
     public function getMostAllStarAppearances(): array;
-
-    /**
-     * Get the top team single-game record for a stat.
-     *
-     * @param string $statExpression SQL expression for the stat
-     * @param string $dateFilter SQL WHERE clause for date filtering
-     * @param string $order Sort direction ('DESC' or 'ASC')
-     * @return list<TeamSingleGameRecord>
-     */
-    public function getTopTeamSingleGame(string $statExpression, string $dateFilter, string $order = 'DESC'): array;
 
     /**
      * Get the top team half scoring record.

--- a/ibl5/classes/RecordHolders/RecordBreakingDetector.php
+++ b/ibl5/classes/RecordHolders/RecordBreakingDetector.php
@@ -7,6 +7,7 @@ namespace RecordHolders;
 use RecordHolders\Contracts\RecordBreakingDetectorInterface;
 use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
 use Utilities\BoxScoreUrlBuilder;
+use Utilities\IblSeasonDateHelper;
 
 /**
  * RecordBreakingDetector - Detects and announces broken/tied all-time IBL records.
@@ -249,7 +250,7 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
 
         foreach ($allQuadDoubles as $qd) {
             if (isset($targetDates[$qd['date']])) {
-                $gameType = $this->getGameTypeFromDate($qd['date']);
+                $gameType = IblSeasonDateHelper::getGameTypeFromDate($qd['date']);
                 $gameTypeLabel = self::GAME_TYPE_LABELS[$gameType] ?? 'regular season';
                 $announcements[] = $this->formatQuadrupleDoubleMessage(
                     $qd['name'],
@@ -316,7 +317,7 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
         /** @var array<string, list<string>> $grouped */
         $grouped = [];
         foreach ($dates as $date) {
-            $gameType = $this->getGameTypeFromDate($date);
+            $gameType = IblSeasonDateHelper::getGameTypeFromDate($date);
             $grouped[$gameType][] = $date;
         }
         return $grouped;
@@ -430,26 +431,6 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
     {
         \Discord::postToChannel('#trades', $message);
         \Discord::postToChannel('#general-chat', $message);
-    }
-
-    /**
-     * Determine the game type from a date.
-     */
-    private function getGameTypeFromDate(string $date): string
-    {
-        $timestamp = strtotime($date);
-        if ($timestamp === false) {
-            return 'regularSeason';
-        }
-        $month = (int) date('n', $timestamp);
-
-        if ($month === 10) {
-            return 'heat';
-        }
-        if ($month === 6) {
-            return 'playoffs';
-        }
-        return 'regularSeason';
     }
 
     /**

--- a/ibl5/classes/RecordHolders/RecordHoldersRepository.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersRepository.php
@@ -6,6 +6,7 @@ namespace RecordHolders;
 
 use League\LeagueContext;
 use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
+use Utilities\IblSeasonDateHelper;
 
 /**
  * RecordHoldersRepository - Data access layer for all-time IBL records.
@@ -62,114 +63,6 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
     }
 
     /**
-     * @see RecordHoldersRepositoryInterface::getTopPlayerSingleGame()
-     *
-     * @return list<PlayerSingleGameRecord>
-     */
-    public function getTopPlayerSingleGame(string $statExpression, string $dateFilter): array
-    {
-        $query = "SELECT
-                bs.pid,
-                p.name,
-                h.teamid AS tid,
-                h.team AS team_name,
-                bs.Date AS `date`,
-                COALESCE(sch.BoxID, 0) AS BoxID,
-                COALESCE(bst.gameOfThatDay, 0) AS gameOfThatDay,
-                CASE WHEN h.teamid = bs.visitorTID THEN bs.homeTID ELSE bs.visitorTID END AS oppTid,
-                opp.team_name AS opp_team_name,
-                {$statExpression} AS value
-            FROM {$this->boxScoresTable} bs
-            JOIN ibl_plr p ON p.pid = bs.pid
-            JOIN ibl_hist h ON h.pid = bs.pid AND h.year = ({$this->seasonYearExpression()})
-            LEFT JOIN {$this->scheduleTable} sch ON sch.Date = bs.Date
-                AND sch.Visitor = bs.visitorTID AND sch.Home = bs.homeTID
-            LEFT JOIN (
-                SELECT Date, visitorTeamID, homeTeamID, MIN(gameOfThatDay) AS gameOfThatDay
-                FROM {$this->boxScoresTeamsTable}
-                GROUP BY Date, visitorTeamID, homeTeamID
-            ) bst ON bst.Date = bs.Date AND bst.visitorTeamID = bs.visitorTID AND bst.homeTeamID = bs.homeTID
-            LEFT JOIN {$this->teamInfoTable} opp ON opp.teamid = CASE
-                WHEN h.teamid = bs.visitorTID THEN bs.homeTID
-                ELSE bs.visitorTID END
-            WHERE {$dateFilter}
-                AND bs.visitorTID BETWEEN 1 AND " . \League::MAX_REAL_TEAMID . "
-                AND bs.homeTID BETWEEN 1 AND " . \League::MAX_REAL_TEAMID . "
-            ORDER BY value DESC, bs.Date ASC
-            LIMIT 5";
-
-        $rows = $this->fetchAll($query);
-
-        /** @var list<PlayerSingleGameRecord> $records */
-        $records = [];
-        foreach ($rows as $row) {
-            /** @var array{pid: int, name: string, tid: int, team_name: string, date: string, BoxID: int, gameOfThatDay: int, oppTid: int, opp_team_name: string, value: int} $row */
-            $records[] = [
-                'pid' => $row['pid'],
-                'name' => $row['name'],
-                'tid' => $row['tid'],
-                'team_name' => $row['team_name'],
-                'date' => $row['date'],
-                'BoxID' => $row['BoxID'],
-                'gameOfThatDay' => $row['gameOfThatDay'],
-                'oppTid' => $row['oppTid'],
-                'opp_team_name' => $row['opp_team_name'],
-                'value' => $row['value'],
-            ];
-        }
-
-        return $records;
-    }
-
-    /**
-     * @see RecordHoldersRepositoryInterface::getTopSeasonAverage()
-     *
-     * @return list<PlayerSeasonRecord>
-     */
-    public function getTopSeasonAverage(string $statColumn, string $gamesColumn, int $minGames = 50): array
-    {
-        $safeColumn = preg_replace('/[^a-zA-Z0-9_]/', '', $statColumn);
-        if ($safeColumn === null || $safeColumn === '') {
-            return [];
-        }
-        $safeGames = preg_replace('/[^a-zA-Z0-9_]/', '', $gamesColumn);
-        if ($safeGames === null || $safeGames === '') {
-            return [];
-        }
-
-        $query = "SELECT
-                h.pid,
-                h.name,
-                h.teamid,
-                h.team,
-                h.year,
-                ROUND(h.{$safeColumn} / h.{$safeGames}, 1) AS value
-            FROM ibl_hist h
-            WHERE h.{$safeGames} >= ?
-                AND h.teamid BETWEEN 1 AND " . \League::MAX_REAL_TEAMID . "
-            ORDER BY value DESC
-            LIMIT 5";
-
-        $rows = $this->fetchAll($query, 'i', $minGames);
-
-        /** @var list<PlayerSeasonRecord> $records */
-        $records = [];
-        foreach ($rows as $row) {
-            /** @var array{pid: int, name: string, teamid: int, team: string, year: int, value: float} $row */
-            $records[] = [
-                'pid' => $row['pid'],
-                'name' => $row['name'],
-                'teamid' => $row['teamid'],
-                'team' => $row['team'],
-                'year' => $row['year'],
-                'value' => $row['value'],
-            ];
-        }
-
-        return $records;
-    }
-
-    /**
      * @see RecordHoldersRepositoryInterface::getQuadrupleDoubles()
      *
      * @return list<QuadrupleDoubleRecord>
@@ -193,7 +86,7 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                 bs.gameBLK AS blocks
             FROM {$this->boxScoresTable} bs
             JOIN ibl_plr p ON p.pid = bs.pid
-            JOIN ibl_hist h ON h.pid = bs.pid AND h.year = ({$this->seasonYearExpression()})
+            JOIN ibl_hist h ON h.pid = bs.pid AND h.year = (" . self::SEASON_YEAR_EXPRESSION . ")
             LEFT JOIN {$this->scheduleTable} sch ON sch.Date = bs.Date
                 AND sch.Visitor = bs.visitorTID AND sch.Home = bs.homeTID
             LEFT JOIN (
@@ -267,58 +160,6 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                 'name' => $row['name'],
                 'pid' => $row['pid'] !== null ? (int) $row['pid'] : null,
                 'appearances' => $row['appearances'],
-            ];
-        }
-
-        return $records;
-    }
-
-    /**
-     * @see RecordHoldersRepositoryInterface::getTopTeamSingleGame()
-     *
-     * @return list<TeamSingleGameRecord>
-     */
-    public function getTopTeamSingleGame(string $statExpression, string $dateFilter, string $order = 'DESC'): array
-    {
-        $safeOrder = $order === 'ASC' ? 'ASC' : 'DESC';
-
-        $query = "SELECT
-                t.teamid AS tid,
-                t.team_name,
-                bs.Date AS `date`,
-                COALESCE(sch.BoxID, 0) AS BoxID,
-                COALESCE(bs.gameOfThatDay, 0) AS gameOfThatDay,
-                CASE WHEN t.teamid = bs.visitorTeamID THEN bs.homeTeamID ELSE bs.visitorTeamID END AS oppTid,
-                opp.team_name AS opp_team_name,
-                {$statExpression} AS value
-            FROM {$this->boxScoresTeamsTable} bs
-            JOIN {$this->teamInfoTable} t ON t.team_name = bs.name
-            LEFT JOIN {$this->scheduleTable} sch ON sch.Date = bs.Date
-                AND sch.Visitor = bs.visitorTeamID AND sch.Home = bs.homeTeamID
-            LEFT JOIN {$this->teamInfoTable} opp ON opp.teamid = CASE
-                WHEN t.teamid = bs.visitorTeamID THEN bs.homeTeamID
-                ELSE bs.visitorTeamID END
-            WHERE {$dateFilter}
-                AND bs.visitorTeamID BETWEEN 1 AND " . \League::MAX_REAL_TEAMID . "
-                AND bs.homeTeamID BETWEEN 1 AND " . \League::MAX_REAL_TEAMID . "
-            ORDER BY value {$safeOrder}, bs.Date ASC
-            LIMIT 5";
-
-        $rows = $this->fetchAll($query);
-
-        /** @var list<TeamSingleGameRecord> $records */
-        $records = [];
-        foreach ($rows as $row) {
-            /** @var array{tid: int, team_name: string, date: string, BoxID: int, gameOfThatDay: int, oppTid: int, opp_team_name: string, value: int} $row */
-            $records[] = [
-                'tid' => $row['tid'],
-                'team_name' => $row['team_name'],
-                'date' => $row['date'],
-                'BoxID' => $row['BoxID'],
-                'gameOfThatDay' => $row['gameOfThatDay'],
-                'oppTid' => $row['oppTid'],
-                'opp_team_name' => $row['opp_team_name'],
-                'value' => $row['value'],
             ];
         }
 
@@ -613,8 +454,8 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
         $records = [];
         foreach ($bestStreaks as $tid => $data) {
             if ($data['streak'] === $maxStreak && $maxStreak > 0) {
-                $startYear = $this->dateToSeasonEndingYear($data['start']);
-                $endYear = $this->dateToSeasonEndingYear($data['end']);
+                $startYear = IblSeasonDateHelper::dateToSeasonEndingYear($data['start']);
+                $endYear = IblSeasonDateHelper::dateToSeasonEndingYear($data['end']);
                 $records[] = [
                     'team_name' => $this->resolveTeamName($tid),
                     'streak' => $data['streak'],
@@ -653,7 +494,7 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
             $visitorScore = $row['visitorScore'];
             $homeScore = $row['homeScore'];
             $visitorWon = $visitorScore > $homeScore;
-            $seasonYear = $this->dateToSeasonEndingYear($date);
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($date);
 
             foreach ([$visitorTid, $homeTid] as $tid) {
                 $key = $tid . '-' . $seasonYear;
@@ -795,7 +636,7 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                     {$expression} AS value
                 FROM {$this->boxScoresTable} bs
                 JOIN ibl_plr p ON p.pid = bs.pid
-                JOIN ibl_hist h ON h.pid = bs.pid AND h.year = ({$this->seasonYearExpression()})
+                JOIN ibl_hist h ON h.pid = bs.pid AND h.year = (" . self::SEASON_YEAR_EXPRESSION . ")
                 LEFT JOIN {$this->scheduleTable} sch ON sch.Date = bs.Date
                     AND sch.Visitor = bs.visitorTID AND sch.Home = bs.homeTID
                 LEFT JOIN (
@@ -1091,28 +932,4 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
         return array_map(static fn(array $row): string => $row['Date'], $rows);
     }
 
-    /**
-     * Get the season ending year from a date string.
-     *
-     * Oct-Dec: season ends next year. Jan-Jun: season ends this year.
-     */
-    private function dateToSeasonEndingYear(string $date): int
-    {
-        $timestamp = strtotime($date);
-        if ($timestamp === false) {
-            return 0;
-        }
-        $month = (int) date('n', $timestamp);
-        $year = (int) date('Y', $timestamp);
-
-        return $month >= 10 ? $year + 1 : $year;
-    }
-
-    /**
-     * SQL expression to derive season ending year from box score date.
-     */
-    private function seasonYearExpression(): string
-    {
-        return self::SEASON_YEAR_EXPRESSION;
-    }
 }

--- a/ibl5/classes/RecordHolders/RecordHoldersService.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersService.php
@@ -6,6 +6,7 @@ namespace RecordHolders;
 
 use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
 use RecordHolders\Contracts\RecordHoldersServiceInterface;
+use Utilities\IblSeasonDateHelper;
 
 /**
  * RecordHoldersService - Business logic for all-time IBL record holders.
@@ -189,7 +190,7 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         $formatted = [];
         foreach ($dbRecords as $record) {
             $teamAbbr = $this->getTeamAbbreviation($record['tid']);
-            $seasonYear = $this->dateToSeasonEndingYear($record['date']);
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
             $formatted[] = [
                 'pid' => $record['pid'],
                 'name' => $record['name'],
@@ -219,8 +220,8 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         $formatted = [];
 
         foreach ($dbRecords as $record) {
-            $gameType = $this->getGameTypeFromDate($record['date']);
-            $seasonYear = $this->dateToSeasonEndingYear($record['date']);
+            $gameType = IblSeasonDateHelper::getGameTypeFromDate($record['date']);
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
             $teamAbbr = $this->getTeamAbbreviation($record['tid']);
 
             // Build multi-line amount string
@@ -403,7 +404,7 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         /** @var list<FormattedTeamGameRecord> $formatted */
         $formatted = [];
         foreach ($dbRecords as $record) {
-            $seasonYear = $this->dateToSeasonEndingYear($record['date']);
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
             $formatted[] = [
                 'teamAbbr' => $this->getTeamAbbreviation($record['tid']),
                 'teamTid' => $record['tid'],
@@ -430,7 +431,7 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         /** @var list<FormattedTeamGameRecord> $formatted */
         $formatted = [];
         foreach ($dbRecords as $record) {
-            $seasonYear = $this->dateToSeasonEndingYear($record['date']);
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
             $formatted[] = [
                 'teamAbbr' => $this->getTeamAbbreviation($record['winner_tid']),
                 'teamTid' => $record['winner_tid'],
@@ -740,38 +741,4 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         return $beginYear . '-' . $endYearShort;
     }
 
-    /**
-     * Convert a date to its IBL season ending year.
-     */
-    private function dateToSeasonEndingYear(string $date): int
-    {
-        $timestamp = strtotime($date);
-        if ($timestamp === false) {
-            return 0;
-        }
-        $month = (int) date('n', $timestamp);
-        $year = (int) date('Y', $timestamp);
-
-        return $month >= 10 ? $year + 1 : $year;
-    }
-
-    /**
-     * Determine the game type from a date.
-     */
-    private function getGameTypeFromDate(string $date): string
-    {
-        $timestamp = strtotime($date);
-        if ($timestamp === false) {
-            return 'regularSeason';
-        }
-        $month = (int) date('n', $timestamp);
-
-        if ($month === 10) {
-            return 'heat';
-        }
-        if ($month === 6) {
-            return 'playoffs';
-        }
-        return 'regularSeason';
-    }
 }

--- a/ibl5/classes/Utilities/IblSeasonDateHelper.php
+++ b/ibl5/classes/Utilities/IblSeasonDateHelper.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utilities;
+
+/**
+ * Shared helper for IBL season date logic.
+ *
+ * IBL seasons span two calendar years (Oct/Nov-June).
+ * HEAT is October, playoffs are June, regular season is Nov-May.
+ */
+final class IblSeasonDateHelper
+{
+    /**
+     * Convert a date to its IBL season ending year.
+     *
+     * Oct-Dec games belong to the season that ends the following year.
+     * Jan-Sep games belong to the season ending that same year.
+     */
+    public static function dateToSeasonEndingYear(string $date): int
+    {
+        $timestamp = strtotime($date);
+        if ($timestamp === false) {
+            return 0;
+        }
+        $month = (int) date('n', $timestamp);
+        $year = (int) date('Y', $timestamp);
+
+        return $month >= 10 ? $year + 1 : $year;
+    }
+
+    /**
+     * Determine the game type from a date.
+     *
+     * October → 'heat', June → 'playoffs', all other months → 'regularSeason'.
+     */
+    public static function getGameTypeFromDate(string $date): string
+    {
+        $timestamp = strtotime($date);
+        if ($timestamp === false) {
+            return 'regularSeason';
+        }
+        $month = (int) date('n', $timestamp);
+
+        if ($month === 10) {
+            return 'heat';
+        }
+        if ($month === 6) {
+            return 'playoffs';
+        }
+        return 'regularSeason';
+    }
+}

--- a/ibl5/tests/RecordHolders/RecordHoldersRepositoryTest.php
+++ b/ibl5/tests/RecordHolders/RecordHoldersRepositoryTest.php
@@ -24,36 +24,6 @@ final class RecordHoldersRepositoryTest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function testGetTopPlayerSingleGameQueriesBoxScores(): void
-    {
-        $this->mockDb->setMockData([]);
-
-        $this->repository->getTopPlayerSingleGame(
-            '(bs.game2GM * 2 + bs.gameFTM + bs.game3GM * 3)',
-            'MONTH(bs.Date) IN (11, 12, 1, 2, 3, 4, 5)'
-        );
-
-        $this->assertQueryExecuted('ibl_box_scores');
-        $this->assertQueryExecuted('ibl_plr');
-        $this->assertQueryExecuted('ibl_hist');
-    }
-
-    public function testGetTopSeasonAverageQueriesHistoryTable(): void
-    {
-        $this->mockDb->setMockData([]);
-
-        $this->repository->getTopSeasonAverage('pts', 'games', 50);
-
-        $this->assertQueryExecuted('ibl_hist');
-    }
-
-    public function testGetTopSeasonAverageRejectsInvalidColumnName(): void
-    {
-        $result = $this->repository->getTopSeasonAverage('pts; DROP TABLE', 'games', 50);
-
-        $this->assertSame([], $result);
-    }
-
     public function testGetQuadrupleDoublesQueriesForFourCategories(): void
     {
         $this->mockDb->setMockData([]);
@@ -72,31 +42,6 @@ final class RecordHoldersRepositoryTest extends IntegrationTestCase
 
         $this->assertQueryExecuted('ibl_awards');
         $this->assertQueryExecuted('Conference All-Star');
-    }
-
-    public function testGetTopTeamSingleGameQueriesTeamBoxScores(): void
-    {
-        $this->mockDb->setMockData([]);
-
-        $this->repository->getTopTeamSingleGame(
-            '(bs.game2GM * 2 + bs.gameFTM + bs.game3GM * 3)',
-            'MONTH(bs.Date) IN (11, 12, 1, 2, 3, 4, 5)'
-        );
-
-        $this->assertQueryExecuted('ibl_box_scores_teams');
-    }
-
-    public function testGetTopTeamSingleGameAcceptsAscOrder(): void
-    {
-        $this->mockDb->setMockData([]);
-
-        $this->repository->getTopTeamSingleGame(
-            '(bs.game2GM * 2 + bs.gameFTM + bs.game3GM * 3)',
-            '1=1',
-            'ASC'
-        );
-
-        $this->assertQueryExecuted('ASC');
     }
 
     public function testGetTopTeamHalfScoreQueriesQuarterPoints(): void
@@ -135,35 +80,6 @@ final class RecordHoldersRepositoryTest extends IntegrationTestCase
 
         $this->assertQueryExecuted('vw_team_awards');
         $this->assertQueryExecuted('Division');
-    }
-
-    public function testGetTopPlayerSingleGameReturnsFormattedRecords(): void
-    {
-        $this->mockDb->setMockData([
-            [
-                'pid' => 927,
-                'name' => 'Bob Pettit',
-                'tid' => 14,
-                'team_name' => 'Timberwolves',
-                'date' => '1996-01-16',
-                'BoxID' => 0,
-                'gameOfThatDay' => 0,
-                'oppTid' => 20,
-                'opp_team_name' => 'Grizzlies',
-                'value' => 80,
-            ],
-        ]);
-
-        $result = $this->repository->getTopPlayerSingleGame(
-            '(bs.game2GM * 2 + bs.gameFTM + bs.game3GM * 3)',
-            'MONTH(bs.Date) IN (11, 12, 1, 2, 3, 4, 5)'
-        );
-
-        $this->assertCount(1, $result);
-        $this->assertSame(927, $result[0]['pid']);
-        $this->assertSame('Bob Pettit', $result[0]['name']);
-        $this->assertSame(14, $result[0]['tid']);
-        $this->assertSame(80, $result[0]['value']);
     }
 
     public function testGetMostAllStarAppearancesReturnsFormattedRecords(): void

--- a/ibl5/tests/Utilities/IblSeasonDateHelperTest.php
+++ b/ibl5/tests/Utilities/IblSeasonDateHelperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Utilities;
+
+use PHPUnit\Framework\TestCase;
+use Utilities\IblSeasonDateHelper;
+
+final class IblSeasonDateHelperTest extends TestCase
+{
+    public function testOctoberDateReturnsNextYear(): void
+    {
+        $this->assertSame(2026, IblSeasonDateHelper::dateToSeasonEndingYear('2025-10-15'));
+    }
+
+    public function testNovemberDateReturnsNextYear(): void
+    {
+        $this->assertSame(2026, IblSeasonDateHelper::dateToSeasonEndingYear('2025-11-01'));
+    }
+
+    public function testDecemberDateReturnsNextYear(): void
+    {
+        $this->assertSame(2026, IblSeasonDateHelper::dateToSeasonEndingYear('2025-12-20'));
+    }
+
+    public function testJanuaryDateReturnsSameYear(): void
+    {
+        $this->assertSame(2026, IblSeasonDateHelper::dateToSeasonEndingYear('2026-01-16'));
+    }
+
+    public function testJuneDateReturnsSameYear(): void
+    {
+        $this->assertSame(2026, IblSeasonDateHelper::dateToSeasonEndingYear('2026-06-10'));
+    }
+
+    public function testInvalidDateReturnsZero(): void
+    {
+        $this->assertSame(0, IblSeasonDateHelper::dateToSeasonEndingYear('not-a-date'));
+    }
+
+    public function testEmptyDateReturnsZero(): void
+    {
+        $this->assertSame(0, IblSeasonDateHelper::dateToSeasonEndingYear(''));
+    }
+
+    public function testOctoberDateReturnsHeat(): void
+    {
+        $this->assertSame('heat', IblSeasonDateHelper::getGameTypeFromDate('2025-10-15'));
+    }
+
+    public function testJuneDateReturnsPlayoffs(): void
+    {
+        $this->assertSame('playoffs', IblSeasonDateHelper::getGameTypeFromDate('2026-06-10'));
+    }
+
+    public function testJanuaryDateReturnsRegularSeason(): void
+    {
+        $this->assertSame('regularSeason', IblSeasonDateHelper::getGameTypeFromDate('2026-01-16'));
+    }
+
+    public function testMarchDateReturnsRegularSeason(): void
+    {
+        $this->assertSame('regularSeason', IblSeasonDateHelper::getGameTypeFromDate('2026-03-05'));
+    }
+
+    public function testInvalidDateReturnsRegularSeason(): void
+    {
+        $this->assertSame('regularSeason', IblSeasonDateHelper::getGameTypeFromDate('not-a-date'));
+    }
+
+    public function testEmptyDateReturnsRegularSeason(): void
+    {
+        $this->assertSame('regularSeason', IblSeasonDateHelper::getGameTypeFromDate(''));
+    }
+}


### PR DESCRIPTION
## Summary

The RecordHolders module is the most token-expensive module for Claude to work with. `RecordHoldersRepository.php` (1,118 lines) was the largest single file in the codebase. This PR reduces it by ~16% through dead code removal and deduplication.

## Changes

### Shared Helper: `Utilities\IblSeasonDateHelper`
- New static helper with `dateToSeasonEndingYear()` and `getGameTypeFromDate()`
- Replaces 3 duplicate private implementations across Repository, Service, and RecordBreakingDetector

### Dead Code Removal
- `getTopPlayerSingleGame()` — superseded by `getTopPlayerSingleGameBatch()`
- `getTopSeasonAverage()` — superseded by `getTopSeasonAverageBatch()`
- `getTopTeamSingleGame()` — superseded by `getTopTeamSingleGameBatch()`
- Removed 3 interface signatures and 6 test methods for deleted methods

### Minor Cleanup
- Inlined trivial `seasonYearExpression()` wrapper with `self::SEASON_YEAR_EXPRESSION`

## Impact

| File | Before | After | Delta |
|------|--------|-------|-------|
| RecordHoldersRepository.php | 1,118 | ~935 | **-183** |
| RecordHoldersRepositoryInterface.php | 272 | ~243 | **-29** |
| RecordHoldersService.php | 777 | ~745 | **-32** |
| RecordBreakingDetector.php | 468 | ~452 | **-16** |
| RecordHoldersRepositoryTest.php | 326 | ~242 | **-84** |
| IblSeasonDateHelper.php (new) | 0 | 54 | +54 |
| IblSeasonDateHelperTest.php (new) | 0 | 76 | +76 |

**Net: -218 lines**

## What Stays Unchanged
- All batch methods, consumer files, CachedRecordHoldersService, and RecordHoldersView
- No public interface changes for consumers