### PR TITLE
ci: exclude non-testable code from coverage measurement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Check coverage threshold
       working-directory: ibl5
-      run: php bin/check-coverage coverage/clover.xml 35
+      run: php bin/check-coverage coverage/clover.xml 55
 
     - name: Upload coverage report
       if: always()

--- a/ibl5/phpunit.ci.xml
+++ b/ibl5/phpunit.ci.xml
@@ -145,5 +145,27 @@
         <include>
             <directory>classes</directory>
         </include>
+        <exclude>
+            <!-- Interfaces — zero executable statements -->
+            <directory>classes/*/Contracts</directory>
+            <!-- Repositories — need live DB, not unit-testable -->
+            <directory suffix="Repository.php">classes</directory>
+            <!-- Views — HTML output, covered by E2E tests -->
+            <directory suffix="View.php">classes</directory>
+            <directory suffix="ViewHelper.php">classes</directory>
+            <directory suffix="FormComponents.php">classes</directory>
+            <!-- Controllers/Handlers — HTTP glue -->
+            <directory suffix="Controller.php">classes</directory>
+            <directory suffix="Handler.php">classes</directory>
+            <!-- Legacy modules not under active development -->
+            <directory>classes/SiteStatistics</directory>
+            <directory>classes/OneOnOneGame</directory>
+            <directory>classes/Database</directory>
+            <!-- Legacy god-class files -->
+            <file>classes/MySQL.php</file>
+            <file>classes/UI.php</file>
+            <file>classes/Game.php</file>
+            <file>classes/JSB.php</file>
+        </exclude>
     </source>
 </phpunit>

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -248,5 +248,27 @@
         <include>
             <directory>classes</directory>
         </include>
+        <exclude>
+            <!-- Interfaces — zero executable statements -->
+            <directory>classes/*/Contracts</directory>
+            <!-- Repositories — need live DB, not unit-testable -->
+            <directory suffix="Repository.php">classes</directory>
+            <!-- Views — HTML output, covered by E2E tests -->
+            <directory suffix="View.php">classes</directory>
+            <directory suffix="ViewHelper.php">classes</directory>
+            <directory suffix="FormComponents.php">classes</directory>
+            <!-- Controllers/Handlers — HTTP glue -->
+            <directory suffix="Controller.php">classes</directory>
+            <directory suffix="Handler.php">classes</directory>
+            <!-- Legacy modules not under active development -->
+            <directory>classes/SiteStatistics</directory>
+            <directory>classes/OneOnOneGame</directory>
+            <directory>classes/Database</directory>
+            <!-- Legacy god-class files -->
+            <file>classes/MySQL.php</file>
+            <file>classes/UI.php</file>
+            <file>classes/Game.php</file>
+            <file>classes/JSB.php</file>
+        </exclude>
     </source>
 </phpunit>


### PR DESCRIPTION
## Summary

Excludes ~409 structurally non-unit-testable files from the PHPUnit coverage denominator, giving an honest metric of how well actual business logic (Services, Validators, Calculators) is tested.

## Changes

### Coverage Exclusions (`phpunit.xml` + `phpunit.ci.xml`)
- **Interfaces** (`*/Contracts/`) — zero executable statements
- **Repositories** (`*Repository.php`) — need live DB, not unit-testable
- **Views** (`*View.php`, `*ViewHelper.php`, `*FormComponents.php`) — HTML output, covered by E2E
- **Controllers/Handlers** (`*Controller.php`, `*Handler.php`) — HTTP glue
- **Legacy modules** (SiteStatistics, OneOnOneGame, Database)
- **Legacy god-classes** (MySQL.php, UI.php, Game.php, JSB.php)

### Threshold
- Raised from 35% to 55% — calibrated to the smaller, meaningful denominator

## Why

Coverage was 36.21% against a 35% threshold — barely passing and not meaningful. The denominator included ~400 files that are structurally untestable in unit tests (~66% of `classes/`). Excluding them focuses the metric on actual testable business logic.

No code changes — config only.