### PR TITLE
test: close coverage gaps for HistArchiver and LCP processor

### DIFF
--- a/ibl5/tests/HistArchiver/HistArchiverServiceTest.php
+++ b/ibl5/tests/HistArchiver/HistArchiverServiceTest.php
@@ -138,6 +138,61 @@ class HistArchiverServiceTest extends TestCase
         $this->assertSame(0, $report->getDiscrepancyCount());
     }
 
+    public function testValidateWithEmptyResultSet(): void
+    {
+        $this->repository->method('getValidationComparison')->with(2026)->willReturn([]);
+
+        $report = $this->service->validatePlrVsBoxScores(2026);
+
+        $this->assertSame(0, $report->totalPlayers);
+        $this->assertSame(0, $report->matchCount);
+        $this->assertSame(0, $report->getDiscrepancyCount());
+    }
+
+    public function testValidateMultiplePlayersWithMixedResults(): void
+    {
+        $this->repository->method('getValidationComparison')->with(2026)->willReturn([
+            $this->makeComparisonRow(1, 'Player One'),
+            $this->makeComparisonRow(2, 'Player Two'),
+            $this->makeComparisonRowWithDiff(3, 'Player Three', column: 'pts', histValue: 1500, bsValue: 1502),
+        ]);
+
+        $report = $this->service->validatePlrVsBoxScores(2026);
+
+        $this->assertSame(3, $report->totalPlayers);
+        $this->assertSame(2, $report->matchCount);
+        $this->assertSame(1, $report->getDiscrepancyCount());
+    }
+
+    public function testValidateMultipleDiscrepanciesOnSamePlayer(): void
+    {
+        $row = $this->makeComparisonRow(1, 'Player One');
+        $row['hist_pts'] = 1500;
+        $row['bs_pts'] = 1502;
+        $row['hist_games'] = 82;
+        $row['bs_games'] = 80;
+        $this->repository->method('getValidationComparison')->with(2026)->willReturn([$row]);
+
+        $report = $this->service->validatePlrVsBoxScores(2026);
+
+        $this->assertSame(1, $report->totalPlayers);
+        $this->assertSame(0, $report->matchCount);
+        $this->assertSame(2, $report->getDiscrepancyCount());
+    }
+
+    public function testArchiveWithNoBoxScores(): void
+    {
+        $this->repository->method('hasChampionForYear')->willReturn(true);
+        $this->repository->method('getRegularSeasonTotals')->willReturn([]);
+        $this->repository->expects($this->never())->method('upsertHistRow');
+
+        $result = $this->service->archiveSeason(2026);
+
+        $this->assertFalse($result->skippedNoChampion);
+        $this->assertSame(0, $result->playersArchived);
+        $this->assertSame(0, $result->rowsUpserted);
+    }
+
     public function testValidateDetectsDiscrepancy(): void
     {
         $this->repository->method('getValidationComparison')->with(2026)->willReturn([

--- a/ibl5/tests/LeagueControlPanel/LeagueControlPanelProcessorTest.php
+++ b/ibl5/tests/LeagueControlPanel/LeagueControlPanelProcessorTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\LeagueControlPanel;
 
+use HistArchiver\Contracts\HistArchiverServiceInterface;
+use HistArchiver\HistArchiveResult;
+use HistArchiver\PlrValidationReport;
 use LeagueControlPanel\Contracts\LeagueControlPanelProcessorInterface;
 use LeagueControlPanel\Contracts\LeagueControlPanelRepositoryInterface;
 use LeagueControlPanel\LeagueControlPanelProcessor;
@@ -344,9 +347,157 @@ class LeagueControlPanelProcessorTest extends TestCase
         $this->assertTrue($result['success']);
     }
 
+    // --- Archive Season Hist ---
+
+    public function testArchiveSeasonHistWhenArchiverNotConfigured(): void
+    {
+        $processor = $this->createProcessorWithStub();
+
+        $result = $processor->dispatch('archive_season_hist', ['season_year' => '2026']);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('not configured', $result['message']);
+    }
+
+    public function testArchiveSeasonHistMissingSeasonYear(): void
+    {
+        $processor = $this->createProcessorWithArchiver($this->createStub(HistArchiverServiceInterface::class));
+
+        $result = $processor->dispatch('archive_season_hist', []);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Invalid season year', $result['message']);
+    }
+
+    public function testArchiveSeasonHistNonDigitSeasonYear(): void
+    {
+        $processor = $this->createProcessorWithArchiver($this->createStub(HistArchiverServiceInterface::class));
+
+        $result = $processor->dispatch('archive_season_hist', ['season_year' => '2026a']);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Invalid season year', $result['message']);
+    }
+
+    public function testArchiveSeasonHistSkipsWhenNoChampion(): void
+    {
+        $archiver = $this->createStub(HistArchiverServiceInterface::class);
+        $archiver->method('archiveSeason')->willReturn(HistArchiveResult::skipped());
+
+        $processor = $this->createProcessorWithArchiver($archiver);
+        $result = $processor->dispatch('archive_season_hist', ['season_year' => '2026']);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('No champion found', $result['message']);
+    }
+
+    public function testArchiveSeasonHistFailsWhenZeroPlayers(): void
+    {
+        $archiver = $this->createStub(HistArchiverServiceInterface::class);
+        $archiver->method('archiveSeason')->willReturn(HistArchiveResult::completed(0, 0, []));
+
+        $processor = $this->createProcessorWithArchiver($archiver);
+        $result = $processor->dispatch('archive_season_hist', ['season_year' => '2026']);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('No players archived', $result['message']);
+    }
+
+    public function testArchiveSeasonHistSuccessNoWarnings(): void
+    {
+        $archiver = $this->createStub(HistArchiverServiceInterface::class);
+        $archiver->method('archiveSeason')->willReturn(HistArchiveResult::completed(3, 3, []));
+
+        $processor = $this->createProcessorWithArchiver($archiver);
+        $result = $processor->dispatch('archive_season_hist', ['season_year' => '2026']);
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('3 players archived', $result['message']);
+        $this->assertStringNotContainsString('warnings', $result['message']);
+    }
+
+    public function testArchiveSeasonHistSuccessWithWarnings(): void
+    {
+        $archiver = $this->createStub(HistArchiverServiceInterface::class);
+        $archiver->method('archiveSeason')->willReturn(
+            HistArchiveResult::completed(2, 2, ['WARNING: x', 'WARNING: y']),
+        );
+
+        $processor = $this->createProcessorWithArchiver($archiver);
+        $result = $processor->dispatch('archive_season_hist', ['season_year' => '2026']);
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('2 players archived', $result['message']);
+        $this->assertStringContainsString('2 warnings', $result['message']);
+    }
+
+    // --- Validate PLR Accuracy ---
+
+    public function testValidatePlrAccuracyWhenArchiverNotConfigured(): void
+    {
+        $processor = $this->createProcessorWithStub();
+
+        $result = $processor->dispatch('validate_plr_accuracy', ['season_year' => '2026']);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('not configured', $result['message']);
+    }
+
+    public function testValidatePlrAccuracyInvalidSeasonYear(): void
+    {
+        $processor = $this->createProcessorWithArchiver($this->createStub(HistArchiverServiceInterface::class));
+
+        $result = $processor->dispatch('validate_plr_accuracy', ['season_year' => 'abc']);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Invalid season year', $result['message']);
+    }
+
+    public function testValidatePlrAccuracyZeroDiscrepancies(): void
+    {
+        $archiver = $this->createStub(HistArchiverServiceInterface::class);
+        $archiver->method('validatePlrVsBoxScores')->willReturn(
+            new PlrValidationReport(totalPlayers: 5, matchCount: 5, discrepancies: []),
+        );
+
+        $processor = $this->createProcessorWithArchiver($archiver);
+        $result = $processor->dispatch('validate_plr_accuracy', ['season_year' => '2026']);
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('All 5 players match', $result['message']);
+    }
+
+    public function testValidatePlrAccuracyWithDiscrepancies(): void
+    {
+        $archiver = $this->createStub(HistArchiverServiceInterface::class);
+        $archiver->method('validatePlrVsBoxScores')->willReturn(
+            new PlrValidationReport(
+                totalPlayers: 5,
+                matchCount: 3,
+                discrepancies: [
+                    ['pid' => 1, 'name' => 'A', 'column' => 'pts', 'hist_value' => 100, 'box_score_value' => 102],
+                    ['pid' => 2, 'name' => 'B', 'column' => 'ast', 'hist_value' => 50, 'box_score_value' => 48],
+                ],
+            ),
+        );
+
+        $processor = $this->createProcessorWithArchiver($archiver);
+        $result = $processor->dispatch('validate_plr_accuracy', ['season_year' => '2026']);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('2 discrepancies', $result['message']);
+        $this->assertStringContainsString('3/5 match', $result['message']);
+    }
+
     private function createProcessorWithStub(): LeagueControlPanelProcessor
     {
         $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
         return new LeagueControlPanelProcessor($stub);
+    }
+
+    private function createProcessorWithArchiver(HistArchiverServiceInterface $archiver): LeagueControlPanelProcessor
+    {
+        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        return new LeagueControlPanelProcessor($stub, $archiver);
     }
 }

--- a/ibl5/tests/e2e/smoke/league-control-panel.spec.ts
+++ b/ibl5/tests/e2e/smoke/league-control-panel.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '../fixtures/auth';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+
+// Archive buttons render only in Preseason and Playoffs phases.
+// LCP is admin-only; test user is admin so no access check needed.
+test.describe.configure({ mode: 'serial' });
+
+const LCP_URL = 'leagueControlPanel.php';
+
+test.describe('League Control Panel smoke tests', () => {
+  test('LCP page loads without PHP errors', async ({ page }) => {
+    await page.goto(LCP_URL);
+    await assertNoPhpErrors(page, 'on LCP');
+  });
+
+  test('archive buttons visible in Playoffs', async ({ appState, page }) => {
+    await appState({ 'Current Season Phase': 'Playoffs' });
+    await page.goto(LCP_URL);
+
+    await expect(page.locator('button[value="archive_season_hist"]')).toBeVisible();
+    await expect(page.locator('button[value="validate_plr_accuracy"]')).toBeVisible();
+  });
+
+  test('archive buttons visible in Preseason', async ({ appState, page }) => {
+    await appState({ 'Current Season Phase': 'Preseason' });
+    await page.goto(LCP_URL);
+
+    await expect(page.locator('button[value="archive_season_hist"]')).toBeVisible();
+    await expect(page.locator('button[value="validate_plr_accuracy"]')).toBeVisible();
+  });
+
+  test('archive buttons NOT visible in Regular Season', async ({ appState, page }) => {
+    await appState({ 'Current Season Phase': 'Regular Season' });
+    await page.goto(LCP_URL);
+
+    await expect(page.locator('button[value="archive_season_hist"]')).toHaveCount(0);
+    await expect(page.locator('button[value="validate_plr_accuracy"]')).toHaveCount(0);
+  });
+
+  test('archive buttons NOT visible in HEAT', async ({ appState, page }) => {
+    await appState({ 'Current Season Phase': 'HEAT' });
+    await page.goto(LCP_URL);
+
+    await expect(page.locator('button[value="archive_season_hist"]')).toHaveCount(0);
+    await expect(page.locator('button[value="validate_plr_accuracy"]')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes all test coverage gaps for PR #324 (HistArchiver module). Adds 20 new tests across unit and E2E layers.

## Changes

### LCP Processor Tests (11 new)
- 7 tests for `archiveSeasonHist` action: not configured, missing/invalid season year, skipped (no champion), zero players, success with and without warnings
- 4 tests for `validatePlrAccuracy` action: not configured, invalid season year, zero discrepancies, discrepancies found

### HistArchiverService Edge Cases (4 new)
- Validate with empty result set (zero players)
- Validate multiple players with mixed match/discrepancy results
- Validate multiple discrepancies on same player (pts + games)
- Archive with champion but no box scores (empty season totals)

### E2E Smoke Tests (5 new)
- LCP page loads without PHP errors
- Archive buttons visible in Playoffs and Preseason phases
- Archive buttons hidden in Regular Season and HEAT phases

## Test Results

All 3788 PHPUnit tests pass. E2E tests verified structurally correct (buttons exist in the View for the tested phases).