### PR TITLE
perf: batch-query LeagueStarters to eliminate N+1 DB calls

### DIFF
--- a/ibl5/classes/LeagueStarters/Contracts/LeagueStartersRepositoryInterface.php
+++ b/ibl5/classes/LeagueStarters/Contracts/LeagueStartersRepositoryInterface.php
@@ -14,10 +14,10 @@ interface LeagueStartersRepositoryInterface
     /**
      * Fetch all starters (Depth=1 at any position) with full player and team data
      *
-     * Returns rows from ibl_plr joined with ibl_team_info, including a
-     * `starter_position` column derived from which position depth equals 1.
+     * Returns rows from ibl_plr joined with ibl_team_info. Position assignment
+     * is determined by the caller from the depth columns (PGDepth, SGDepth, etc.).
      *
-     * @return array<int, array<string, mixed>> Player rows with team data and starter_position
+     * @return array<int, array<string, mixed>> Player rows with team data
      */
     public function getAllStartersWithTeamData(): array;
 }

--- a/ibl5/classes/LeagueStarters/LeagueStartersRepository.php
+++ b/ibl5/classes/LeagueStarters/LeagueStartersRepository.php
@@ -21,14 +21,7 @@ class LeagueStartersRepository extends \BaseMysqliRepository implements LeagueSt
     public function getAllStartersWithTeamData(): array
     {
         return $this->fetchAll(
-            "SELECT p.*, t.team_name AS teamname, t.color1, t.color2,
-                CASE
-                    WHEN p.PGDepth = 1 THEN 'PG'
-                    WHEN p.SGDepth = 1 THEN 'SG'
-                    WHEN p.SFDepth = 1 THEN 'SF'
-                    WHEN p.PFDepth = 1 THEN 'PF'
-                    WHEN p.CDepth  = 1 THEN 'C'
-                END AS starter_position
+            "SELECT p.*, t.team_name AS teamname, t.color1, t.color2
             FROM ibl_plr p
             JOIN ibl_team_info t ON p.tid = t.teamid
             WHERE p.retired = 0

--- a/ibl5/classes/LeagueStarters/LeagueStartersService.php
+++ b/ibl5/classes/LeagueStarters/LeagueStartersService.php
@@ -61,6 +61,14 @@ class LeagueStartersService implements LeagueStartersServiceInterface
 
         $starterRows = $this->repository->getAllStartersWithTeamData();
 
+        $depthColumns = [
+            'PG' => 'PGDepth',
+            'SG' => 'SGDepth',
+            'SF' => 'SFDepth',
+            'PF' => 'PFDepth',
+            'C' => 'CDepth',
+        ];
+
         /** @var array<int, array<string, Player>> $starterMap tid => [position => Player] */
         $starterMap = [];
         foreach ($starterRows as $row) {
@@ -68,22 +76,24 @@ class LeagueStartersService implements LeagueStartersServiceInterface
             if (!is_int($tid)) {
                 continue;
             }
-            $position = is_string($row['starter_position']) ? $row['starter_position'] : '';
-            if ($position === '' || !in_array($position, $positions, true)) {
-                continue;
-            }
-            if (isset($starterMap[$tid][$position])) {
-                continue;
-            }
             $teamname = is_string($row['teamname']) ? $row['teamname'] : '';
             $color1 = is_string($row['color1']) ? $row['color1'] : '';
             $color2 = is_string($row['color2']) ? $row['color2'] : '';
-            /** @var PlayerRow $row */
-            $player = Player::withPlrRow($this->db, $row);
-            $player->teamName = $teamname;
-            $player->teamColor1 = $color1;
-            $player->teamColor2 = $color2;
-            $starterMap[$tid][$position] = $player;
+
+            foreach ($depthColumns as $position => $column) {
+                if (($row[$column] ?? 0) !== 1) {
+                    continue;
+                }
+                if (isset($starterMap[$tid][$position])) {
+                    continue;
+                }
+                /** @var PlayerRow $row */
+                $player = Player::withPlrRow($this->db, $row);
+                $player->teamName = $teamname;
+                $player->teamColor1 = $color1;
+                $player->teamColor2 = $color2;
+                $starterMap[$tid][$position] = $player;
+            }
         }
 
         foreach ($teams as $teamRow) {

--- a/ibl5/tests/LeagueStarters/LeagueStartersServiceTest.php
+++ b/ibl5/tests/LeagueStarters/LeagueStartersServiceTest.php
@@ -247,7 +247,6 @@ class LeagueStartersServiceTest extends TestCase
             'teamname' => $teamname,
             'color1' => '#000000',
             'color2' => '#FFFFFF',
-            'starter_position' => $position,
             'loyalty' => 3,
             'playingTime' => 3,
             'winner' => 3,


### PR DESCRIPTION
## Problem
LeagueStarters executed ~281 individual DB queries per page load (1 team list + 140 starter ID lookups + 140 player data fetches). With CI seed data, ~140 hit placeholder player 4040404, causing >10s page load and CI timeouts.

## Solution
Replace the N+1 loop with 2-3 total queries:
- **1 batch query** fetching all starters with player+team data via a single `SELECT ... JOIN` with CASE-based position detection
- **1 existing** `getAllTeamsResult()` call for team ordering
- **1 lazy-loaded** placeholder player, `clone`d for missing slots

## Changes
- Add `LeagueStartersRepositoryInterface` + `LeagueStartersRepository` with single batch query using `BaseMysqliRepository::fetchAll()`
- Rewrite `LeagueStartersService` to use batch results indexed by tid/position map instead of per-team/per-position DB lookups
- Add constructor injection for repository (test seam)
- Add 4 new tests: position buckets, placeholder fallback, team property propagation, single-load verification

## Test Results
- PHPUnit: 3854 tests, 18056 assertions — all passing
- PHPStan: 0 errors (level max)