### PR TITLE
refactor: deduplicate CommonMysqliRepository usage across 3 files

### DIFF
--- a/ibl5/classes/Api/Controller/TradeDeclineController.php
+++ b/ibl5/classes/Api/Controller/TradeDeclineController.php
@@ -90,7 +90,8 @@ class TradeDeclineController implements ControllerInterface
         // Look up offering team's GM Discord ID from ibl_team_info
         $offeringTeamDiscordId = '';
         if ($offeringTeam !== '') {
-            $offeringTeamDiscordId = $this->getTeamDiscordId($offeringTeam);
+            $commonRepo = new \Services\CommonMysqliRepository($this->db);
+            $offeringTeamDiscordId = (string) ($commonRepo->getTeamDiscordID($offeringTeam) ?? '');
         }
 
         $responder->success([
@@ -98,39 +99,5 @@ class TradeDeclineController implements ControllerInterface
             'offering_team' => $offeringTeam,
             'offering_gm_discord_id' => $offeringTeamDiscordId,
         ]);
-    }
-
-    /**
-     * Get a team's GM Discord ID from ibl_team_info.
-     */
-    private function getTeamDiscordId(string $teamName): string
-    {
-        $stmt = $this->db->prepare(
-            "SELECT discordID FROM ibl_team_info WHERE team_name = ? LIMIT 1"
-        );
-        if ($stmt === false) {
-            return '';
-        }
-
-        $stmt->bind_param('s', $teamName);
-        if (!$stmt->execute()) {
-            $stmt->close();
-            return '';
-        }
-
-        $result = $stmt->get_result();
-        if ($result === false) {
-            $stmt->close();
-            return '';
-        }
-
-        $row = $result->fetch_assoc();
-        $stmt->close();
-
-        if ($row === null || !isset($row['discordID'])) {
-            return '';
-        }
-
-        return (string) $row['discordID'];
     }
 }

--- a/ibl5/classes/DepthChartEntry/DepthChartEntrySubmissionHandler.php
+++ b/ibl5/classes/DepthChartEntry/DepthChartEntrySubmissionHandler.php
@@ -102,10 +102,7 @@ class DepthChartEntrySubmissionHandler implements DepthChartEntrySubmissionHandl
             }
 
             // Resolve username from team name
-            /** @var string $rawTeamName */
-            $rawTeamName = $postData['Team_Name'] ?? '';
-            // Look up which user owns this team - we need to find from nuke_users
-            $username = $this->resolveUsernameForTeam($teamName);
+            $username = $commonRepo->getUsernameFromTeamname($teamName) ?? '';
             if ($username === '') {
                 return;
             }
@@ -140,33 +137,6 @@ class DepthChartEntrySubmissionHandler implements DepthChartEntrySubmissionHandl
             // Don't fail the main submission if snapshot save fails
             error_log('SavedDepthChart snapshot error: ' . $e->getMessage());
         }
-    }
-
-    /**
-     * Resolve username that owns the given team name
-     */
-    private function resolveUsernameForTeam(string $teamName): string
-    {
-        $query = "SELECT gm_username FROM ibl_team_info WHERE team_name = ? LIMIT 1";
-        $stmt = $this->db->prepare($query);
-        if ($stmt === false) {
-            return '';
-        }
-        $stmt->bind_param('s', $teamName);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        if ($result === false) {
-            $stmt->close();
-            return '';
-        }
-        $row = $result->fetch_assoc();
-        $stmt->close();
-
-        if (!is_array($row) || !isset($row['gm_username'])) {
-            return '';
-        }
-
-        return (string) $row['gm_username'];
     }
 
     /**

--- a/ibl5/classes/Discord.php
+++ b/ibl5/classes/Discord.php
@@ -104,27 +104,9 @@ class Discord
 
     public function getDiscordIDFromTeamname(string $teamname): string
     {
-        $stmt = $this->db->prepare(
-            "SELECT discordID FROM ibl_team_info WHERE team_name = ? LIMIT 1"
-        );
-        if ($stmt === false) {
-            throw new \Exception('Prepare failed: ' . $this->db->error);
-        }
+        $repo = new \Services\CommonMysqliRepository($this->db);
 
-        $stmt->bind_param('s', $teamname);
-        if (!$stmt->execute()) {
-            throw new \Exception('Execute failed: ' . $stmt->error);
-        }
-
-        $result = $stmt->get_result();
-        if ($result === false) {
-            $stmt->close();
-            throw new \Exception('Failed to get result: ' . $stmt->error);
-        }
-        $row = $result->fetch_assoc();
-        $stmt->close();
-
-        return (string)($row['discordID'] ?? '');
+        return (string) ($repo->getTeamDiscordID($teamname) ?? '');
     }
 
     /**


### PR DESCRIPTION
## Summary

Removes ~80 lines of duplicated prepared-statement boilerplate from 3 files that were reimplementing queries already available in `CommonMysqliRepository`.

## Changes

| File | Action |
|------|--------|
| `Discord.php` | Replace `getDiscordIDFromTeamname()` body (~20 lines → 3 lines) with `CommonMysqliRepository::getTeamDiscordID()` |
| `TradeDeclineController.php` | Delete `getTeamDiscordId()` private method (~30 lines), replace call with `CommonMysqliRepository::getTeamDiscordID()` |
| `DepthChartEntrySubmissionHandler.php` | Delete `resolveUsernameForTeam()` private method (~25 lines), replace call with `CommonMysqliRepository::getUsernameFromTeamname()` |

## What's NOT included

- Team performance query duplication (3 files with same SQL but different key names/defaults) — different enough to not warrant forced unification
- `htmlspecialchars` → `HtmlSanitizer::e()` migration (127 occurrences, 33 files) — separate PR

## Manual Testing

No manual testing needed — all changes are covered by unit and integration tests. No public API changes.