### PR TITLE
refactor: WP3 remnants — cap space delegation and cache injection

### DIFF
--- a/ibl5/classes/Cache/Contracts/DatabaseCacheInterface.php
+++ b/ibl5/classes/Cache/Contracts/DatabaseCacheInterface.php
@@ -18,7 +18,7 @@ interface DatabaseCacheInterface
      * Returns null on cache miss, expired entry, corrupt JSON, or database error.
      *
      * @param string $key Cache key
-     * @return list<array<string, mixed>>|null Decoded array on hit, null on miss
+     * @return array<mixed>|null Decoded array on hit, null on miss
      */
     public function get(string $key): ?array;
 
@@ -29,7 +29,7 @@ interface DatabaseCacheInterface
      * Silently fails on database errors (prepare failure, encode failure).
      *
      * @param string $key Cache key
-     * @param list<array<string, mixed>> $data Data to cache (must be JSON-encodable)
+     * @param array<mixed> $data Data to cache (must be JSON-encodable)
      * @param int $ttlSeconds Time-to-live in seconds
      */
     public function set(string $key, array $data, int $ttlSeconds): void;

--- a/ibl5/classes/Cache/DatabaseCache.php
+++ b/ibl5/classes/Cache/DatabaseCache.php
@@ -23,7 +23,7 @@ class DatabaseCache implements DatabaseCacheInterface
     /**
      * @see DatabaseCacheInterface::get()
      *
-     * @return list<array<string, mixed>>|null
+     * @return array<mixed>|null
      */
     public function get(string $key): ?array
     {
@@ -59,14 +59,14 @@ class DatabaseCache implements DatabaseCacheInterface
             return null;
         }
 
-        /** @var list<array<string, mixed>> $decoded */
+        /** @var array<mixed> $decoded */
         return $decoded;
     }
 
     /**
      * @see DatabaseCacheInterface::set()
      *
-     * @param list<array<string, mixed>> $data
+     * @param array<mixed> $data
      */
     public function set(string $key, array $data, int $ttlSeconds): void
     {

--- a/ibl5/classes/Negotiation/NegotiationRepository.php
+++ b/ibl5/classes/Negotiation/NegotiationRepository.php
@@ -75,16 +75,8 @@ class NegotiationRepository extends BaseMysqliRepository implements NegotiationR
      */
     public function getTeamCapSpaceNextSeason(string $teamName): int
     {
-        /** @var array{total_salary: int|null}|null $result */
-        $result = $this->fetchOne(
-            "SELECT SUM(next_year_salary) AS total_salary
-             FROM vw_current_salary
-             WHERE teamname = ?",
-            "s",
-            $teamName
-        );
-
-        return \League::HARD_CAP_MAX - (int) ($result['total_salary'] ?? 0);
+        $commonRepo = new \Services\CommonMysqliRepository($this->db);
+        return $commonRepo->getTeamCapSpaceNextSeason($teamName);
     }
 
     /**

--- a/ibl5/classes/RecordHolders/CachedRecordHoldersService.php
+++ b/ibl5/classes/RecordHolders/CachedRecordHoldersService.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace RecordHolders;
 
+use Cache\Contracts\DatabaseCacheInterface;
 use RecordHolders\Contracts\RecordHoldersServiceInterface;
 
 /**
  * CachedRecordHoldersService - Caching decorator for RecordHoldersServiceInterface.
  *
- * Wraps an inner service and caches the getAllRecords() result in the `cache` database table.
- * On cache hit, returns data from the cache without calling the inner service (1 query).
+ * Wraps an inner service and caches the getAllRecords() result via DatabaseCacheInterface.
+ * On cache hit, returns data from the cache without calling the inner service.
  * On cache miss or expiration, delegates to the inner service and stores the result.
  *
  * @phpstan-import-type AllRecordsData from RecordHoldersServiceInterface
@@ -21,12 +22,12 @@ class CachedRecordHoldersService implements RecordHoldersServiceInterface
     private const TTL_SECONDS = 86400; // 24 hours
 
     private RecordHoldersServiceInterface $inner;
-    private \mysqli $db;
+    private DatabaseCacheInterface $cache;
 
-    public function __construct(RecordHoldersServiceInterface $inner, \mysqli $db)
+    public function __construct(RecordHoldersServiceInterface $inner, DatabaseCacheInterface $cache)
     {
         $this->inner = $inner;
-        $this->db = $db;
+        $this->cache = $cache;
     }
 
     /**
@@ -34,13 +35,14 @@ class CachedRecordHoldersService implements RecordHoldersServiceInterface
      */
     public function getAllRecords(): array
     {
-        $cached = $this->readCache();
+        $cached = $this->cache->get(self::CACHE_KEY);
         if ($cached !== null) {
+            /** @var AllRecordsData $cached */
             return $cached;
         }
 
         $records = $this->inner->getAllRecords();
-        $this->writeCache($records);
+        $this->cache->set(self::CACHE_KEY, $records, self::TTL_SECONDS);
 
         return $records;
     }
@@ -48,14 +50,12 @@ class CachedRecordHoldersService implements RecordHoldersServiceInterface
     /**
      * Fetch fresh records from the inner service and atomically replace the cache.
      *
-     * Uses REPLACE INTO so the cache goes directly from old→new with no gap.
-     *
      * @return AllRecordsData
      */
     public function rebuildCache(): array
     {
         $records = $this->inner->getAllRecords();
-        $this->writeCache($records);
+        $this->cache->set(self::CACHE_KEY, $records, self::TTL_SECONDS);
 
         return $records;
     }
@@ -65,80 +65,6 @@ class CachedRecordHoldersService implements RecordHoldersServiceInterface
      */
     public function invalidateCache(): void
     {
-        $stmt = $this->db->prepare("DELETE FROM `cache` WHERE `key` = ?");
-        if ($stmt === false) {
-            return;
-        }
-        $key = self::CACHE_KEY;
-        $stmt->bind_param('s', $key);
-        $stmt->execute();
-        $stmt->close();
-    }
-
-    /**
-     * Read cached data if it exists and hasn't expired.
-     *
-     * @return AllRecordsData|null
-     */
-    private function readCache(): ?array
-    {
-        $stmt = $this->db->prepare("SELECT `value`, `expiration` FROM `cache` WHERE `key` = ?");
-        if ($stmt === false) {
-            return null;
-        }
-        $key = self::CACHE_KEY;
-        $stmt->bind_param('s', $key);
-        $stmt->execute();
-        $result = $stmt->get_result();
-
-        if ($result === false) {
-            $stmt->close();
-            return null;
-        }
-
-        $row = $result->fetch_assoc();
-        $stmt->close();
-
-        if (!is_array($row) || $row === []) {
-            return null;
-        }
-
-        /** @var array{value: string, expiration: int} $row */
-        if ($row['expiration'] < time()) {
-            return null;
-        }
-
-        /** @var mixed $decoded */
-        $decoded = json_decode($row['value'], true);
-        if (!is_array($decoded)) {
-            return null;
-        }
-
-        /** @var AllRecordsData $decoded */
-        return $decoded;
-    }
-
-    /**
-     * Write records data to the cache.
-     *
-     * @param AllRecordsData $records
-     */
-    private function writeCache(array $records): void
-    {
-        $encoded = json_encode($records);
-        if ($encoded === false) {
-            return;
-        }
-
-        $stmt = $this->db->prepare("REPLACE INTO `cache` (`key`, `value`, `expiration`) VALUES (?, ?, ?)");
-        if ($stmt === false) {
-            return;
-        }
-        $key = self::CACHE_KEY;
-        $value = $encoded;
-        $expiration = time() + self::TTL_SECONDS;
-        $stmt->bind_param('ssi', $key, $value, $expiration);
-        $stmt->execute();
-        $stmt->close();
+        $this->cache->delete(self::CACHE_KEY);
     }
 }

--- a/ibl5/modules/RecordHolders/index.php
+++ b/ibl5/modules/RecordHolders/index.php
@@ -17,6 +17,7 @@ if (!defined('MODULE_FILE')) {
     die("You can't access this file directly...");
 }
 
+use Cache\DatabaseCache;
 use RecordHolders\RecordHoldersRepository;
 use RecordHolders\RecordHoldersService;
 use RecordHolders\CachedRecordHoldersService;
@@ -31,7 +32,8 @@ global $mysqli_db;
 
 $repository = new RecordHoldersRepository($mysqli_db);
 $innerService = new RecordHoldersService($repository);
-$service = new CachedRecordHoldersService($innerService, $mysqli_db);
+$cache = new DatabaseCache($mysqli_db);
+$service = new CachedRecordHoldersService($innerService, $cache);
 $view = new RecordHoldersView();
 
 $records = $service->getAllRecords();

--- a/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
@@ -228,11 +228,11 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
  */
 class InMemoryCache implements DatabaseCacheInterface
 {
-    /** @var array<string, array{data: list<array<string, mixed>>, expiration: int}> */
+    /** @var array<string, array{data: array<mixed>, expiration: int}> */
     private array $store = [];
 
     /**
-     * @return list<array<string, mixed>>|null
+     * @return array<mixed>|null
      */
     public function get(string $key): ?array
     {
@@ -249,7 +249,7 @@ class InMemoryCache implements DatabaseCacheInterface
     }
 
     /**
-     * @param list<array<string, mixed>> $data
+     * @param array<mixed> $data
      */
     public function set(string $key, array $data, int $ttlSeconds): void
     {

--- a/ibl5/tests/Negotiation/NegotiationRepositoryTest.php
+++ b/ibl5/tests/Negotiation/NegotiationRepositoryTest.php
@@ -154,6 +154,32 @@ class NegotiationRepositoryTest extends TestCase
     }
 
     // ============================================
+    // GET TEAM CAP SPACE NEXT SEASON TESTS
+    // ============================================
+
+    public function testGetTeamCapSpaceNextSeasonReturnsHardCapWhenNoSalaryData(): void
+    {
+        $repository = new NegotiationRepository($this->mockMysqliDb);
+        $this->mockDb->setMockData([]);
+
+        $result = $repository->getTeamCapSpaceNextSeason('Empty Team');
+
+        $this->assertSame(\League::HARD_CAP_MAX, $result);
+    }
+
+    public function testGetTeamCapSpaceNextSeasonReturnsCapMinusSalary(): void
+    {
+        $repository = new NegotiationRepository($this->mockMysqliDb);
+        $this->mockDb->setMockData([
+            ['total_salary' => 5000]
+        ]);
+
+        $result = $repository->getTeamCapSpaceNextSeason('Test Team');
+
+        $this->assertSame(\League::HARD_CAP_MAX - 5000, $result);
+    }
+
+    // ============================================
     // MULTIPLE INSTANCES TEST
     // ============================================
 

--- a/ibl5/tests/RecordHolders/CachedRecordHoldersServiceTest.php
+++ b/ibl5/tests/RecordHolders/CachedRecordHoldersServiceTest.php
@@ -4,20 +4,27 @@ declare(strict_types=1);
 
 namespace Tests\RecordHolders;
 
+use Cache\Contracts\DatabaseCacheInterface;
 use PHPUnit\Framework\TestCase;
 use RecordHolders\CachedRecordHoldersService;
 use RecordHolders\Contracts\RecordHoldersServiceInterface;
 
 final class CachedRecordHoldersServiceTest extends TestCase
 {
+    private RecordHoldersInMemoryCache $cache;
+
+    protected function setUp(): void
+    {
+        $this->cache = new RecordHoldersInMemoryCache();
+    }
+
     public function testCacheHitReturnsCachedDataWithoutCallingInnerService(): void
     {
         $mockInner = $this->createMock(RecordHoldersServiceInterface::class);
-        $mockDb = new MockCacheDb();
-        $service = new CachedRecordHoldersService($mockInner, $mockDb);
+        $service = new CachedRecordHoldersService($mockInner, $this->cache);
 
         $records = $this->createSampleRecords();
-        $mockDb->setCacheData('record_holders', (string) json_encode($records), time() + 3600);
+        $this->cache->set('record_holders', $records, 3600);
 
         $mockInner->expects($this->never())->method('getAllRecords');
 
@@ -29,8 +36,7 @@ final class CachedRecordHoldersServiceTest extends TestCase
     public function testCacheMissCallsInnerServiceAndStoresResult(): void
     {
         $mockInner = $this->createMock(RecordHoldersServiceInterface::class);
-        $mockDb = new MockCacheDb();
-        $service = new CachedRecordHoldersService($mockInner, $mockDb);
+        $service = new CachedRecordHoldersService($mockInner, $this->cache);
 
         $records = $this->createSampleRecords();
 
@@ -41,20 +47,20 @@ final class CachedRecordHoldersServiceTest extends TestCase
         $result = $service->getAllRecords();
 
         $this->assertSame($records, $result);
-        $this->assertTrue($mockDb->wasWriteCalled());
+        $this->assertNotNull($this->cache->get('record_holders'));
     }
 
     public function testExpiredCacheTriggersRefresh(): void
     {
         $mockInner = $this->createMock(RecordHoldersServiceInterface::class);
-        $mockDb = new MockCacheDb();
-        $service = new CachedRecordHoldersService($mockInner, $mockDb);
+        $service = new CachedRecordHoldersService($mockInner, $this->cache);
 
         $staleRecords = $this->createSampleRecords();
         $freshRecords = $this->createSampleRecords();
         $freshRecords['playerSingleGame']['regularSeason'] = [];
 
-        $mockDb->setCacheData('record_holders', (string) json_encode($staleRecords), time() - 100);
+        // Set with negative TTL to simulate expired entry
+        $this->cache->setWithExpiration('record_holders', $staleRecords, time() - 100);
 
         $mockInner->expects($this->once())
             ->method('getAllRecords')
@@ -65,16 +71,16 @@ final class CachedRecordHoldersServiceTest extends TestCase
         $this->assertSame([], $result['playerSingleGame']['regularSeason']);
     }
 
-    public function testCorruptCacheFallsBackToInnerService(): void
+    public function testCorruptCacheReturnsNullFromGet(): void
     {
+        // With DatabaseCacheInterface, corrupt JSON is handled inside the cache implementation.
+        // If the cache returns null (miss), the service delegates to inner.
         $mockInner = $this->createMock(RecordHoldersServiceInterface::class);
-        $mockDb = new MockCacheDb();
-        $service = new CachedRecordHoldersService($mockInner, $mockDb);
+        $service = new CachedRecordHoldersService($mockInner, $this->cache);
 
         $records = $this->createSampleRecords();
 
-        $mockDb->setCacheData('record_holders', '{invalid json!!!', time() + 3600);
-
+        // Empty cache = miss
         $mockInner->expects($this->once())
             ->method('getAllRecords')
             ->willReturn($records);
@@ -87,22 +93,20 @@ final class CachedRecordHoldersServiceTest extends TestCase
     public function testInvalidateCacheDeletesCacheEntry(): void
     {
         $stubInner = $this->createStub(RecordHoldersServiceInterface::class);
-        $mockDb = new MockCacheDb();
-        $service = new CachedRecordHoldersService($stubInner, $mockDb);
+        $service = new CachedRecordHoldersService($stubInner, $this->cache);
 
         $records = $this->createSampleRecords();
-        $mockDb->setCacheData('record_holders', (string) json_encode($records), time() + 3600);
+        $this->cache->set('record_holders', $records, 3600);
 
         $service->invalidateCache();
 
-        $this->assertTrue($mockDb->wasDeleteCalled());
+        $this->assertNull($this->cache->get('record_holders'));
     }
 
     public function testEmptyCacheCallsInnerService(): void
     {
         $mockInner = $this->createMock(RecordHoldersServiceInterface::class);
-        $mockDb = new MockCacheDb();
-        $service = new CachedRecordHoldersService($mockInner, $mockDb);
+        $service = new CachedRecordHoldersService($mockInner, $this->cache);
 
         $records = $this->createSampleRecords();
 
@@ -115,23 +119,24 @@ final class CachedRecordHoldersServiceTest extends TestCase
         $this->assertSame($records, $result);
     }
 
-    public function testDbPrepareFailureGracefullyFallsBackToInner(): void
+    public function testRebuildCacheAlwaysCallsInnerAndCaches(): void
     {
         $mockInner = $this->createMock(RecordHoldersServiceInterface::class);
-        $mockDb = new MockCacheDb();
-        $service = new CachedRecordHoldersService($mockInner, $mockDb);
+        $service = new CachedRecordHoldersService($mockInner, $this->cache);
 
         $records = $this->createSampleRecords();
 
-        $mockDb->setPrepareShouldFail(true);
+        // Pre-populate cache
+        $this->cache->set('record_holders', $this->createSampleRecords(), 3600);
 
         $mockInner->expects($this->once())
             ->method('getAllRecords')
             ->willReturn($records);
 
-        $result = $service->getAllRecords();
+        $result = $service->rebuildCache();
 
         $this->assertSame($records, $result);
+        $this->assertNotNull($this->cache->get('record_holders'));
     }
 
     /**
@@ -164,150 +169,56 @@ final class CachedRecordHoldersServiceTest extends TestCase
 }
 
 /**
- * Minimal mock of a mysqli-like object for testing the cache layer.
- *
- * Simulates prepare/execute/get_result/fetch_assoc for SELECT, REPLACE, and DELETE
- * queries against the `cache` table.
+ * Simple in-memory implementation of DatabaseCacheInterface for RecordHolders tests.
  */
-class MockCacheDb extends \mysqli
+class RecordHoldersInMemoryCache implements DatabaseCacheInterface
 {
-    /** @var array<string, array{value: string, expiration: int}> */
-    private array $cacheStore = [];
-    private bool $writeCalled = false;
-    private bool $deleteCalled = false;
-    private bool $prepareShouldFail = false;
-
-    public int $connect_errno = 0;
-    public ?string $connect_error = null;
-
-    public function __construct()
-    {
-        // Don't call parent::__construct() to avoid real DB connection
-    }
-
-    public function setCacheData(string $key, string $value, int $expiration): void
-    {
-        $this->cacheStore[$key] = ['value' => $value, 'expiration' => $expiration];
-    }
-
-    public function setPrepareShouldFail(bool $fail): void
-    {
-        $this->prepareShouldFail = $fail;
-    }
-
-    public function wasWriteCalled(): bool
-    {
-        return $this->writeCalled;
-    }
-
-    public function wasDeleteCalled(): bool
-    {
-        return $this->deleteCalled;
-    }
+    /** @var array<string, array{data: array<mixed>, expiration: int}> */
+    private array $store = [];
 
     /**
-     * @return MockCacheStmt|false
+     * @return array<mixed>|null
      */
-    #[\ReturnTypeWillChange]
-    public function prepare(string $query): MockCacheStmt|false
+    public function get(string $key): ?array
     {
-        if ($this->prepareShouldFail) {
-            return false;
-        }
-
-        return new MockCacheStmt($this, $query);
-    }
-
-    /**
-     * @return array{value: string, expiration: int}|null
-     */
-    public function getCacheEntry(string $key): ?array
-    {
-        return $this->cacheStore[$key] ?? null;
-    }
-
-    public function markWriteCalled(): void
-    {
-        $this->writeCalled = true;
-    }
-
-    public function markDeleteCalled(): void
-    {
-        $this->deleteCalled = true;
-    }
-
-    public function deleteKey(string $key): void
-    {
-        unset($this->cacheStore[$key]);
-    }
-}
-
-class MockCacheStmt
-{
-    private MockCacheDb $db;
-    private string $query;
-    private string $boundKey = '';
-
-    public function __construct(MockCacheDb $db, string $query)
-    {
-        $this->db = $db;
-        $this->query = $query;
-    }
-
-    public function bind_param(string $types, mixed &...$params): bool
-    {
-        if ($params !== []) {
-            $this->boundKey = (string) $params[0];
-        }
-        if (str_contains($this->query, 'REPLACE')) {
-            $this->db->markWriteCalled();
-        }
-        return true;
-    }
-
-    public function execute(): bool
-    {
-        if (str_contains($this->query, 'DELETE')) {
-            $this->db->markDeleteCalled();
-            $this->db->deleteKey($this->boundKey);
-        }
-        return true;
-    }
-
-    public function get_result(): MockCacheResult
-    {
-        $entry = $this->db->getCacheEntry($this->boundKey);
-        return new MockCacheResult($entry);
-    }
-
-    public function close(): void
-    {
-    }
-}
-
-class MockCacheResult
-{
-    /** @var array{value: string, expiration: int}|null */
-    private ?array $data;
-    private bool $fetched = false;
-
-    /**
-     * @param array{value: string, expiration: int}|null $data
-     */
-    public function __construct(?array $data)
-    {
-        $this->data = $data;
-    }
-
-    /**
-     * @return array{value: string, expiration: int}|null
-     */
-    public function fetch_assoc(): ?array
-    {
-        if ($this->fetched || $this->data === null) {
+        if (!isset($this->store[$key])) {
             return null;
         }
-        $this->fetched = true;
-        return $this->data;
+
+        if ($this->store[$key]['expiration'] < time()) {
+            unset($this->store[$key]);
+            return null;
+        }
+
+        return $this->store[$key]['data'];
+    }
+
+    /**
+     * @param array<mixed> $data
+     */
+    public function set(string $key, array $data, int $ttlSeconds): void
+    {
+        $this->store[$key] = [
+            'data' => $data,
+            'expiration' => time() + $ttlSeconds,
+        ];
+    }
+
+    /**
+     * Set with an explicit expiration timestamp (for testing expired entries).
+     *
+     * @param array<mixed> $data
+     */
+    public function setWithExpiration(string $key, array $data, int $expiration): void
+    {
+        $this->store[$key] = [
+            'data' => $data,
+            'expiration' => $expiration,
+        ];
+    }
+
+    public function delete(string $key): void
+    {
+        unset($this->store[$key]);
     }
 }


### PR DESCRIPTION
## Summary

Completes the remaining 2 of 5 dedup items from the WP3 codebase audit (PR #355 handled the first 3).

### Changes

**NegotiationRepository cap space delegation**
- `getTeamCapSpaceNextSeason()` body replaced with delegation to `CommonMysqliRepository::getTeamCapSpaceNextSeason()`
- Both computed identical `HARD_CAP_MAX - SUM(next_year_salary)` from `vw_current_salary`

**CachedRecordHoldersService → DatabaseCacheInterface injection**
- Constructor now accepts `DatabaseCacheInterface` instead of raw `\mysqli`
- Deleted 3 private methods (`readCache`, `writeCache`, `invalidateCache`) that duplicated `DatabaseCache` (~78 lines)
- Widened `DatabaseCacheInterface` type signatures from `list<array<string, mixed>>` to `array<mixed>` to support both list-shaped (CareerLeaderboards) and map-shaped (RecordHolders) cached data

**Tests**
- Rewrote `CachedRecordHoldersServiceTest` to use `InMemoryCache` test double (same pattern as `CachedCareerLeaderboardsRepositoryTest`), removing ~150 lines of `MockCacheDb/MockCacheStmt/MockCacheResult`
- Added `getTeamCapSpaceNextSeason()` tests to `NegotiationRepositoryTest`
- Updated `InMemoryCache` PHPDoc in `CachedCareerLeaderboardsRepositoryTest` for widened types

### Stats
- **-143 net lines** (110 added, 253 removed)
- Full PHPUnit suite passes (3865 tests)
- PHPStan clean (level max)

### Manual Testing
No manual testing needed — all changes are covered by unit tests. The Record Holders page behavior is identical (same cache table, same queries via DatabaseCache).