### PR TITLE
perf: fix N+1 query patterns in free agency and trading

### DIFF
--- a/ibl5/classes/FreeAgency/Contracts/FreeAgencyAdminRepositoryInterface.php
+++ b/ibl5/classes/FreeAgency/Contracts/FreeAgencyAdminRepositoryInterface.php
@@ -107,6 +107,14 @@ interface FreeAgencyAdminRepositoryInterface
     public function insertNewsStory(string $title, string $homeText, string $bodyText): int;
 
     /**
+     * Get demand values for multiple players in a single query
+     *
+     * @param list<int> $playerIds Player IDs to look up
+     * @return array<int, DemandRow> Demand rows keyed by player ID
+     */
+    public function getPlayerDemandsBatch(array $playerIds): array;
+
+    /**
      * Clear all offers from the free agency offers table
      */
     public function clearAllOffers(): void;

--- a/ibl5/classes/FreeAgency/FreeAgencyAdminProcessor.php
+++ b/ibl5/classes/FreeAgency/FreeAgencyAdminProcessor.php
@@ -47,6 +47,13 @@ class FreeAgencyAdminProcessor implements FreeAgencyAdminProcessorInterface
 
         $processedPlayers = [];
 
+        // Pre-load all demands in a single batch query to avoid N+1
+        $playerIds = array_values(array_unique(array_map(
+            static fn (array $row): int => $row['pid'],
+            $offers
+        )));
+        $demandsMap = $this->repository->getPlayerDemandsBatch($playerIds);
+
         foreach ($offers as $row) {
             /** @var OfferRow $row */
             $playerName = $row['name'];
@@ -92,8 +99,8 @@ class FreeAgencyAdminProcessor implements FreeAgencyAdminProcessorInterface
             // Build extended news text for all offers
             $newsBodyText .= "The {$offeringTeamName} offered {$playerName} a {$offerYears}-year deal worth a total of {$offerTotal} million dollars.<br>\n";
 
-            // Get demands for this player
-            $demands = $this->getPlayerDemands($playerId, $day);
+            // Get demands for this player (from pre-loaded batch)
+            $demands = $this->calculateDemandValue($demandsMap[$playerId] ?? null, $day);
 
             // Check if offer is auto-rejected (under half of demands)
             if ($perceivedValue <= $demands / 2) {
@@ -304,15 +311,12 @@ class FreeAgencyAdminProcessor implements FreeAgencyAdminProcessorInterface
     }
 
     /**
-     * Get player demands adjusted for the current day
+     * Calculate day-adjusted demand value from pre-loaded demand data
      *
-     * Fetches raw demand data from repository and applies the day-adjusted
-     * demand calculation formula.
+     * @param array{dem1: int, dem2: int, dem3: int, dem4: int, dem5: int, dem6: int}|null $demRow
      */
-    private function getPlayerDemands(int $playerID, int $day): float
+    private function calculateDemandValue(?array $demRow, int $day): float
     {
-        $demRow = $this->repository->getPlayerDemands($playerID);
-
         if ($demRow === null) {
             return 0.0;
         }

--- a/ibl5/classes/FreeAgency/FreeAgencyAdminRepository.php
+++ b/ibl5/classes/FreeAgency/FreeAgencyAdminRepository.php
@@ -54,6 +54,42 @@ class FreeAgencyAdminRepository extends BaseMysqliRepository implements FreeAgen
     }
 
     /**
+     * @see FreeAgencyAdminRepositoryInterface::getPlayerDemandsBatch()
+     *
+     * @return array<int, DemandRow>
+     */
+    public function getPlayerDemandsBatch(array $playerIds): array
+    {
+        if ($playerIds === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($playerIds), '?'));
+        $types = str_repeat('i', count($playerIds));
+
+        /** @var list<array{pid: int, dem1: int, dem2: int, dem3: int, dem4: int, dem5: int, dem6: int}> $rows */
+        $rows = $this->fetchAll(
+            "SELECT pid, dem1, dem2, dem3, dem4, dem5, dem6 FROM ibl_demands WHERE pid IN ({$placeholders})",
+            $types,
+            ...$playerIds
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['pid']] = [
+                'dem1' => $row['dem1'],
+                'dem2' => $row['dem2'],
+                'dem3' => $row['dem3'],
+                'dem4' => $row['dem4'],
+                'dem5' => $row['dem5'],
+                'dem6' => $row['dem6'],
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
      * @see FreeAgencyAdminRepositoryInterface::updatePlayerContract()
      */
     public function updatePlayerContract(

--- a/ibl5/classes/Services/CommonMysqliRepository.php
+++ b/ibl5/classes/Services/CommonMysqliRepository.php
@@ -291,6 +291,29 @@ class CommonMysqliRepository extends \BaseMysqliRepository
     }
 
     /**
+     * Gets both current and next-year salary totals for a team in a single query
+     *
+     * @param string $teamName Team name
+     * @return array{current: int, nextYear: int} Salary totals in thousands
+     */
+    public function getTeamSalarySummary(string $teamName): array
+    {
+        /** @var array{current_salary: int|null, next_year_salary: int|null}|null $result */
+        $result = $this->fetchOne(
+            "SELECT SUM(current_salary) AS current_salary, SUM(next_year_salary) AS next_year_salary
+            FROM vw_current_salary
+            WHERE teamname = ?",
+            "s",
+            $teamName
+        );
+
+        return [
+            'current' => (int) ($result['current_salary'] ?? 0),
+            'nextYear' => (int) ($result['next_year_salary'] ?? 0),
+        ];
+    }
+
+    /**
      * Gets cap space for next season for a team
      *
      * @param string $teamName Team name

--- a/ibl5/classes/Trading/Contracts/TradeCashRepositoryInterface.php
+++ b/ibl5/classes/Trading/Contracts/TradeCashRepositoryInterface.php
@@ -103,6 +103,14 @@ interface TradeCashRepositoryInterface
     public function clearTradeCash(): int;
 
     /**
+     * Get cash transactions for multiple offer IDs in a single query
+     *
+     * @param list<int> $offerIds Trade offer IDs to look up
+     * @return array<string, TradeCashRow> Cash rows keyed by "{offerId}:{sendingTeam}"
+     */
+    public function getCashTransactionsByOfferIds(array $offerIds): array;
+
+    /**
      * Delete trade cash by offer ID
      *
      * @param int $offerId Trade offer ID

--- a/ibl5/classes/Trading/Contracts/TradingRepositoryInterface.php
+++ b/ibl5/classes/Trading/Contracts/TradingRepositoryInterface.php
@@ -144,6 +144,22 @@ interface TradingRepositoryInterface
     public function getPlayerById(int $playerId): ?array;
 
     /**
+     * Get multiple players by their IDs in a single query
+     *
+     * @param list<int> $playerIds Player IDs to look up
+     * @return array<int, PlayerRow> Player rows keyed by pid
+     */
+    public function getPlayersByIds(array $playerIds): array;
+
+    /**
+     * Get multiple draft picks by their IDs in a single query
+     *
+     * @param list<int> $pickIds Pick IDs to look up
+     * @return array<int, DraftPickRow> Pick rows keyed by pickid
+     */
+    public function getDraftPicksByIds(array $pickIds): array;
+
+    /**
      * Check if a player ID exists in the database
      *
      * @param int $playerId Player ID to check

--- a/ibl5/classes/Trading/TradeCashRepository.php
+++ b/ibl5/classes/Trading/TradeCashRepository.php
@@ -189,6 +189,36 @@ class TradeCashRepository extends BaseMysqliRepository implements TradeCashRepos
     }
 
     /**
+     * @see TradeCashRepositoryInterface::getCashTransactionsByOfferIds()
+     *
+     * @return array<string, TradeCashRow>
+     */
+    public function getCashTransactionsByOfferIds(array $offerIds): array
+    {
+        if ($offerIds === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($offerIds), '?'));
+        $types = str_repeat('i', count($offerIds));
+
+        /** @var list<TradeCashRow> $rows */
+        $rows = $this->fetchAll(
+            "SELECT * FROM ibl_trade_cash WHERE tradeOfferID IN ({$placeholders})",
+            $types,
+            ...$offerIds
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $key = $row['tradeOfferID'] . ':' . $row['sendingTeam'];
+            $result[$key] = $row;
+        }
+
+        return $result;
+    }
+
+    /**
      * @see TradeCashRepositoryInterface::deleteTradeCashByOfferId()
      */
     public function deleteTradeCashByOfferId(int $offerId): int

--- a/ibl5/classes/Trading/TradingRepository.php
+++ b/ibl5/classes/Trading/TradingRepository.php
@@ -222,6 +222,64 @@ class TradingRepository extends BaseMysqliRepository implements TradingRepositor
     }
 
     /**
+     * @see TradingRepositoryInterface::getPlayersByIds()
+     *
+     * @return array<int, PlayerRow>
+     */
+    public function getPlayersByIds(array $playerIds): array
+    {
+        if ($playerIds === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($playerIds), '?'));
+        $types = str_repeat('i', count($playerIds));
+
+        /** @var list<PlayerRow> $rows */
+        $rows = $this->fetchAll(
+            "SELECT * FROM ibl_plr WHERE pid IN ({$placeholders})",
+            $types,
+            ...$playerIds
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['pid']] = $row;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @see TradingRepositoryInterface::getDraftPicksByIds()
+     *
+     * @return array<int, DraftPickRow>
+     */
+    public function getDraftPicksByIds(array $pickIds): array
+    {
+        if ($pickIds === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($pickIds), '?'));
+        $types = str_repeat('i', count($pickIds));
+
+        /** @var list<DraftPickRow> $rows */
+        $rows = $this->fetchAll(
+            "SELECT * FROM ibl_draft_picks WHERE pickid IN ({$placeholders})",
+            $types,
+            ...$pickIds
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['pickid']] = $row;
+        }
+
+        return $result;
+    }
+
+    /**
      * @see TradingRepositoryInterface::playerIdExists()
      */
     public function playerIdExists(int $playerId): bool

--- a/ibl5/classes/Trading/TradingService.php
+++ b/ibl5/classes/Trading/TradingService.php
@@ -181,6 +181,28 @@ class TradingService implements TradingServiceInterface
      */
     private function groupTradeOffers(array $allTradeRows, string $userTeam, int $seasonEndingYear): array
     {
+        // Pre-load all players, picks, and cash in batch to avoid N+1 queries
+        $playerIds = [];
+        $pickIds = [];
+        $offerIds = [];
+        foreach ($allTradeRows as $row) {
+            $from = $row['trade_from'];
+            $to = $row['trade_to'];
+            if ($from !== $userTeam && $to !== $userTeam) {
+                continue;
+            }
+            if ($row['itemtype'] === TradeItemType::Player->value) {
+                $playerIds[] = $row['itemid'];
+            } elseif ($row['itemtype'] === TradeItemType::DraftPick->value) {
+                $pickIds[] = $row['itemid'];
+            } elseif ($row['itemtype'] === TradeItemType::Cash->value) {
+                $offerIds[] = $row['tradeofferid'];
+            }
+        }
+        $playersMap = $this->repository->getPlayersByIds(array_values(array_unique($playerIds)));
+        $picksMap = $this->repository->getDraftPicksByIds(array_values(array_unique($pickIds)));
+        $cashMap = $this->cashRepository->getCashTransactionsByOfferIds(array_values(array_unique($offerIds)));
+
         $tradeOffers = [];
 
         foreach ($allTradeRows as $row) {
@@ -209,14 +231,16 @@ class TradingService implements TradingServiceInterface
             }
 
             if ($itemType === TradeItemType::Cash->value) {
-                $cashItems = $this->resolveCashItems($from, $to, $offerId, $seasonEndingYear);
+                $cashItems = $this->resolveCashItemsFromMap($from, $to, $offerId, $seasonEndingYear, $cashMap);
                 array_push($tradeOffers[$offerId]['items'], ...$cashItems);
             } else {
-                $tradeOffers[$offerId]['items'][] = $this->resolveTradeItem(
+                $tradeOffers[$offerId]['items'][] = $this->resolveTradeItemFromMaps(
                     $itemId,
                     $itemType,
                     $from,
-                    $to
+                    $to,
+                    $playersMap,
+                    $picksMap
                 );
 
                 // Collect player PIDs for roster preview (classify by sending team)
@@ -234,32 +258,50 @@ class TradingService implements TradingServiceInterface
     }
 
     /**
-     * Resolve a non-cash trade item into a displayable description
+     * Resolve a non-cash trade item from pre-loaded maps
      *
-     * @param int $itemId Item ID
-     * @param string $itemType Item type ('0' for pick, '1' for player)
-     * @param string $from Sending team
-     * @param string $to Receiving team
+     * @param array<int, PlayerRow> $playersMap
+     * @param array<int, DraftPickRow> $picksMap
      * @return array{type: string, description: string, notes: string|null, from: string, to: string}
      */
-    private function resolveTradeItem(int $itemId, string $itemType, string $from, string $to): array
+    private function resolveTradeItemFromMaps(int $itemId, string $itemType, string $from, string $to, array $playersMap, array $picksMap): array
     {
         if ($itemType === TradeItemType::DraftPick->value) {
-            return $this->resolvePickItem($itemId, $from, $to);
+            $pick = $picksMap[$itemId] ?? null;
+            $description = '';
+            $notes = null;
+
+            if ($pick !== null) {
+                $notes = $pick['notes'] ?? null;
+                if ($notes === '') {
+                    $notes = null;
+                }
+                $description = "The {$from} send the {$pick['teampick']} {$pick['year']} Round {$pick['round']} draft pick to the {$to}.";
+            }
+
+            return ['type' => 'pick', 'description' => $description, 'notes' => $notes, 'from' => $from, 'to' => $to];
         }
 
         // itemtype === Player
-        return $this->resolvePlayerItem($itemId, $from, $to);
+        $player = $playersMap[$itemId] ?? null;
+        $description = '';
+
+        if ($player !== null) {
+            $description = "The {$from} send {$player['pos']} {$player['name']} to the {$to}.";
+        }
+
+        return ['type' => 'player', 'description' => $description, 'notes' => null, 'from' => $from, 'to' => $to];
     }
 
     /**
-     * Resolve a cash trade item into per-year line items with season labels
+     * Resolve cash items from a pre-loaded cash map
      *
+     * @param array<string, TradeCashRow> $cashMap Keyed by "{offerId}:{sendingTeam}"
      * @return list<array{type: string, description: string, notes: string|null, from: string, to: string}>
      */
-    private function resolveCashItems(string $from, string $to, int $offerId, int $seasonEndingYear): array
+    private function resolveCashItemsFromMap(string $from, string $to, int $offerId, int $seasonEndingYear, array $cashMap): array
     {
-        $cashDetails = $this->cashRepository->getCashTransactionByOffer($offerId, $from);
+        $cashDetails = $cashMap[$offerId . ':' . $from] ?? null;
         $items = [];
 
         if ($cashDetails !== null) {
@@ -285,62 +327,6 @@ class TradingService implements TradingServiceInterface
         }
 
         return $items;
-    }
-
-    /**
-     * Resolve a draft pick trade item
-     *
-     * @return array{type: string, description: string, notes: string|null, from: string, to: string}
-     */
-    private function resolvePickItem(int $itemId, string $from, string $to): array
-    {
-        $pick = $this->repository->getDraftPickById($itemId);
-        $description = '';
-        $notes = null;
-
-        if ($pick !== null) {
-            $pickTeam = $pick['teampick'];
-            $pickYear = $pick['year'];
-            $pickRound = $pick['round'];
-            $notes = $pick['notes'] ?? null;
-            if ($notes === '') {
-                $notes = null;
-            }
-            $description = "The {$from} send the {$pickTeam} {$pickYear} Round {$pickRound} draft pick to the {$to}.";
-        }
-
-        return [
-            'type' => 'pick',
-            'description' => $description,
-            'notes' => $notes,
-            'from' => $from,
-            'to' => $to,
-        ];
-    }
-
-    /**
-     * Resolve a player trade item
-     *
-     * @return array{type: string, description: string, notes: string|null, from: string, to: string}
-     */
-    private function resolvePlayerItem(int $itemId, string $from, string $to): array
-    {
-        $player = $this->repository->getPlayerById($itemId);
-        $description = '';
-
-        if ($player !== null) {
-            $playerName = $player['name'];
-            $playerPos = $player['pos'];
-            $description = "The {$from} send {$playerPos} {$playerName} to the {$to}.";
-        }
-
-        return [
-            'type' => 'player',
-            'description' => $description,
-            'notes' => null,
-            'from' => $from,
-            'to' => $to,
-        ];
     }
 
     /**
@@ -391,6 +377,13 @@ class TradingService implements TradingServiceInterface
             $cashStartYear = 2;
         }
 
+        // Batch-load all cash transactions for preview data
+        $offerIds = array_values(array_unique(array_map(
+            static fn (int $id): int => $id,
+            array_keys($tradeOffers)
+        )));
+        $cashMap = $this->cashRepository->getCashTransactionsByOfferIds($offerIds);
+
         /** @var array<int, array{from: string, to: string, approval: string, oppositeTeam: string, hasHammer: bool, items: list<array{type: string, description: string, notes: string|null, from: string, to: string}>, previewData: array{fromPids: list<int>, toPids: list<int>, fromTeamId: int, toTeamId: int, fromColor1: string, toColor1: string, fromCash: array<int, int>, toCash: array<int, int>, cashStartYear: int, cashEndYear: int, seasonEndingYear: int}}> $enriched */
         $enriched = [];
 
@@ -401,9 +394,9 @@ class TradingService implements TradingServiceInterface
             $fromTeamData = $teamLookup[$fromTeam] ?? ['teamid' => 0, 'color1' => '000000'];
             $toTeamData = $teamLookup[$toTeam] ?? ['teamid' => 0, 'color1' => '000000'];
 
-            // Get cash amounts for each direction
-            $fromCashRow = $this->cashRepository->getCashTransactionByOffer($offerId, $fromTeam);
-            $toCashRow = $this->cashRepository->getCashTransactionByOffer($offerId, $toTeam);
+            // Look up cash from pre-loaded batch map
+            $fromCashRow = $cashMap[$offerId . ':' . $fromTeam] ?? null;
+            $toCashRow = $cashMap[$offerId . ':' . $toTeam] ?? null;
 
             $fromCash = [];
             $toCash = [];

--- a/ibl5/tests/FreeAgency/FreeAgencyAdminProcessorTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyAdminProcessorTest.php
@@ -153,6 +153,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
     {
         $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([]);
+        $stub->method('getPlayerDemandsBatch')->willReturn([]);
 
         $processor = new FreeAgencyAdminProcessor($stub, $this->mockDb);
         $result = $processor->processDay(1);
@@ -179,8 +180,8 @@ class FreeAgencyAdminProcessorTest extends TestCase
         // Demands: dem1=1000, rest 0 → total=1000, years=1
         // day 1: demands = (1000/1)*((11-1)/10) = 1000
         // perceived value 1.0 <= 1000/2 = 500 → auto-reject
-        $stub->method('getPlayerDemands')->willReturn([
-            'dem1' => 1000, 'dem2' => 0, 'dem3' => 0, 'dem4' => 0, 'dem5' => 0, 'dem6' => 0,
+        $stub->method('getPlayerDemandsBatch')->willReturn([
+            100 => ['dem1' => 1000, 'dem2' => 0, 'dem3' => 0, 'dem4' => 0, 'dem5' => 0, 'dem6' => 0],
         ]);
 
         $processor = new FreeAgencyAdminProcessor($stub, $this->mockDb);

--- a/ibl5/tests/Services/CommonMysqliRepositoryTest.php
+++ b/ibl5/tests/Services/CommonMysqliRepositoryTest.php
@@ -77,4 +77,28 @@ class CommonMysqliRepositoryTest extends IntegrationTestCase
 
         $this->assertNull($result);
     }
+
+    // ============================================
+    // getTeamSalarySummary() tests
+    // ============================================
+
+    public function testGetTeamSalarySummaryReturnsBothSalaryTotals(): void
+    {
+        $this->mockDb->setMockData([['current_salary' => 5000, 'next_year_salary' => 4500]]);
+
+        $result = $this->repository->getTeamSalarySummary('Metros');
+
+        $this->assertSame(5000, $result['current']);
+        $this->assertSame(4500, $result['nextYear']);
+    }
+
+    public function testGetTeamSalarySummaryReturnsZerosForEmptyTeam(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getTeamSalarySummary('Empty Team');
+
+        $this->assertSame(0, $result['current']);
+        $this->assertSame(0, $result['nextYear']);
+    }
 }

--- a/ibl5/tests/Trading/TradingServiceTest.php
+++ b/ibl5/tests/Trading/TradingServiceTest.php
@@ -208,8 +208,8 @@ class TradingServiceTest extends TestCase
                 ['tradeofferid' => 1, 'itemid' => 100, 'itemtype' => '1', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
                 ['tradeofferid' => 2, 'itemid' => 200, 'itemtype' => '1', 'trade_from' => 'Heat', 'trade_to' => 'Bulls', 'approval' => 'Bulls', 'created_at' => '', 'updated_at' => ''],
             ]);
-        $mockRepo->method('getPlayerById')
-            ->willReturn(['name' => 'Test Player', 'pos' => 'PG']);
+        $mockRepo->method('getPlayersByIds')
+            ->willReturn([100 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 100], 200 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 200]]);
         $mockRepo->expects($this->once())->method('getAllTeamsWithCity')
             ->willReturn([]);
 
@@ -235,8 +235,8 @@ class TradingServiceTest extends TestCase
                 ['tradeofferid' => 1, 'itemid' => 100, 'itemtype' => '1', 'trade_from' => 'Celtics', 'trade_to' => 'Lakers', 'approval' => 'Lakers', 'created_at' => '', 'updated_at' => ''],
                 ['tradeofferid' => 2, 'itemid' => 200, 'itemtype' => '1', 'trade_from' => 'Lakers', 'trade_to' => 'Heat', 'approval' => 'Heat', 'created_at' => '', 'updated_at' => ''],
             ]);
-        $mockRepo->method('getPlayerById')
-            ->willReturn(['name' => 'Test Player', 'pos' => 'PG']);
+        $mockRepo->method('getPlayersByIds')
+            ->willReturn([100 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 100], 200 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 200]]);
         $mockRepo->expects($this->once())->method('getAllTeamsWithCity')
             ->willReturn([]);
 
@@ -287,9 +287,9 @@ class TradingServiceTest extends TestCase
         $mockRepo->method('getAllTradeOffers')->willReturn([
             ['tradeofferid' => 1, 'itemid' => 0, 'itemtype' => 'cash', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockCashRepo->method('getCashTransactionByOffer')->willReturn([
-            'tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
-            'cy1' => 100, 'cy2' => 200, 'cy3' => 150, 'cy4' => null, 'cy5' => null, 'cy6' => null,
+        $mockCashRepo->method('getCashTransactionsByOfferIds')->willReturn([
+            '1:Lakers' => ['tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
+                'cy1' => 100, 'cy2' => 200, 'cy3' => 150, 'cy4' => null, 'cy5' => null, 'cy6' => null],
         ]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([]);
 
@@ -314,9 +314,9 @@ class TradingServiceTest extends TestCase
         $mockRepo->method('getAllTradeOffers')->willReturn([
             ['tradeofferid' => 1, 'itemid' => 0, 'itemtype' => 'cash', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockCashRepo->method('getCashTransactionByOffer')->willReturn([
-            'tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
-            'cy1' => 0, 'cy2' => 200, 'cy3' => 0, 'cy4' => 0, 'cy5' => 300, 'cy6' => 0,
+        $mockCashRepo->method('getCashTransactionsByOfferIds')->willReturn([
+            '1:Lakers' => ['tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
+                'cy1' => 0, 'cy2' => 200, 'cy3' => 0, 'cy4' => 0, 'cy5' => 300, 'cy6' => 0],
         ]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([]);
 
@@ -340,9 +340,9 @@ class TradingServiceTest extends TestCase
         $mockRepo->method('getAllTradeOffers')->willReturn([
             ['tradeofferid' => 1, 'itemid' => 0, 'itemtype' => 'cash', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockCashRepo->method('getCashTransactionByOffer')->willReturn([
-            'tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
-            'cy1' => 100, 'cy2' => 200, 'cy3' => 0, 'cy4' => 150, 'cy5' => null, 'cy6' => null,
+        $mockCashRepo->method('getCashTransactionsByOfferIds')->willReturn([
+            '1:Lakers' => ['tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
+                'cy1' => 100, 'cy2' => 200, 'cy3' => 0, 'cy4' => 150, 'cy5' => null, 'cy6' => null],
         ]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([]);
 
@@ -380,9 +380,9 @@ class TradingServiceTest extends TestCase
         $mockRepo->method('getAllTradeOffers')->willReturn([
             ['tradeofferid' => 1, 'itemid' => 0, 'itemtype' => 'cash', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockCashRepo->method('getCashTransactionByOffer')->willReturn([
-            'tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
-            'cy1' => 0, 'cy2' => 0, 'cy3' => 0, 'cy4' => 0, 'cy5' => 0, 'cy6' => 0,
+        $mockCashRepo->method('getCashTransactionsByOfferIds')->willReturn([
+            '1:Lakers' => ['tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
+                'cy1' => 0, 'cy2' => 0, 'cy3' => 0, 'cy4' => 0, 'cy5' => 0, 'cy6' => 0],
         ]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([]);
 
@@ -404,7 +404,7 @@ class TradingServiceTest extends TestCase
         $mockRepo->method('getAllTradeOffers')->willReturn([
             ['tradeofferid' => 1, 'itemid' => 0, 'itemtype' => 'cash', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockCashRepo->method('getCashTransactionByOffer')->willReturn(null);
+        $mockCashRepo->method('getCashTransactionsByOfferIds')->willReturn([]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([]);
 
         $service = new TradingService($mockRepo, $mockCommon, $this->mockDb, $mockCashRepo);
@@ -425,9 +425,9 @@ class TradingServiceTest extends TestCase
         $mockRepo->method('getAllTradeOffers')->willReturn([
             ['tradeofferid' => 1, 'itemid' => 0, 'itemtype' => 'cash', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockCashRepo->method('getCashTransactionByOffer')->willReturn([
-            'tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
-            'cy1' => 500, 'cy2' => null, 'cy3' => null, 'cy4' => null, 'cy5' => null, 'cy6' => null,
+        $mockCashRepo->method('getCashTransactionsByOfferIds')->willReturn([
+            '1:Lakers' => ['tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
+                'cy1' => 500, 'cy2' => null, 'cy3' => null, 'cy4' => null, 'cy5' => null, 'cy6' => null],
         ]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([]);
 
@@ -457,8 +457,8 @@ class TradingServiceTest extends TestCase
             ['tradeofferid' => 1, 'itemid' => 100, 'itemtype' => '1', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
             ['tradeofferid' => 1, 'itemid' => 200, 'itemtype' => '1', 'trade_from' => 'Celtics', 'trade_to' => 'Lakers', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockRepo->method('getPlayerById')
-            ->willReturn(['name' => 'Test Player', 'pos' => 'PG']);
+        $mockRepo->method('getPlayersByIds')
+            ->willReturn([100 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 100], 200 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 200]]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([
             ['teamid' => 1, 'team_name' => 'Lakers', 'team_city' => 'Los Angeles', 'color1' => '552583', 'color2' => 'FDB927'],
             ['teamid' => 2, 'team_name' => 'Celtics', 'team_city' => 'Boston', 'color1' => '007A33', 'color2' => 'FFFFFF'],
@@ -483,8 +483,8 @@ class TradingServiceTest extends TestCase
         $mockRepo->method('getAllTradeOffers')->willReturn([
             ['tradeofferid' => 1, 'itemid' => 100, 'itemtype' => '1', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockRepo->method('getPlayerById')
-            ->willReturn(['name' => 'Test Player', 'pos' => 'PG']);
+        $mockRepo->method('getPlayersByIds')
+            ->willReturn([100 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 100], 200 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 200]]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([
             ['teamid' => 1, 'team_name' => 'Lakers', 'team_city' => 'Los Angeles', 'color1' => '552583', 'color2' => 'FDB927'],
             ['teamid' => 2, 'team_name' => 'Celtics', 'team_city' => 'Boston', 'color1' => '007A33', 'color2' => 'FFFFFF'],
@@ -511,15 +511,15 @@ class TradingServiceTest extends TestCase
         $mockRepo->method('getAllTradeOffers')->willReturn([
             ['tradeofferid' => 1, 'itemid' => 100, 'itemtype' => '1', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockRepo->method('getPlayerById')
-            ->willReturn(['name' => 'Test Player', 'pos' => 'PG']);
+        $mockRepo->method('getPlayersByIds')
+            ->willReturn([100 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 100], 200 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 200]]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([
             ['teamid' => 1, 'team_name' => 'Lakers', 'team_city' => 'Los Angeles', 'color1' => '552583', 'color2' => 'FDB927'],
             ['teamid' => 2, 'team_name' => 'Celtics', 'team_city' => 'Boston', 'color1' => '007A33', 'color2' => 'FFFFFF'],
         ]);
-        $mockCashRepo->method('getCashTransactionByOffer')->willReturnMap([
-            [1, 'Lakers', ['tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics', 'cy1' => 300, 'cy2' => null, 'cy3' => null, 'cy4' => null, 'cy5' => null, 'cy6' => null]],
-            [1, 'Celtics', null],
+        $mockCashRepo->method('getCashTransactionsByOfferIds')->willReturn([
+            '1:Lakers' => ['tradeOfferID' => 1, 'sendingTeam' => 'Lakers', 'receivingTeam' => 'Celtics',
+                'cy1' => 300, 'cy2' => null, 'cy3' => null, 'cy4' => null, 'cy5' => null, 'cy6' => null],
         ]);
 
         $service = new TradingService($mockRepo, $mockCommon, $this->mockDb, $mockCashRepo);
@@ -542,8 +542,8 @@ class TradingServiceTest extends TestCase
         $mockRepo->method('getAllTradeOffers')->willReturn([
             ['tradeofferid' => 1, 'itemid' => 100, 'itemtype' => '1', 'trade_from' => 'Lakers', 'trade_to' => 'Celtics', 'approval' => 'Celtics', 'created_at' => '', 'updated_at' => ''],
         ]);
-        $mockRepo->method('getPlayerById')
-            ->willReturn(['name' => 'Test Player', 'pos' => 'PG']);
+        $mockRepo->method('getPlayersByIds')
+            ->willReturn([100 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 100], 200 => ['name' => 'Test Player', 'pos' => 'PG', 'pid' => 200]]);
         $mockRepo->method('getAllTeamsWithCity')->willReturn([
             ['teamid' => 1, 'team_name' => 'Lakers', 'team_city' => 'Los Angeles', 'color1' => '552583', 'color2' => 'FDB927'],
         ]);


### PR DESCRIPTION
## Summary

Fixes N+1 query patterns identified in the WP4 codebase audit. These occur in two high-traffic code paths: free agency offer processing and trade review.

### Changes

**FreeAgencyAdminProcessor — batch demand loading**
- Added `getPlayerDemandsBatch()` to `FreeAgencyAdminRepositoryInterface`/`FreeAgencyAdminRepository`
- Pre-loads all player demands in a single `WHERE IN` query before the `processDay()` loop
- Eliminates 1 query per offer (20-40 offers on busy FA days)

**TradingService — batch item resolution**
- Added `getPlayersByIds()`, `getDraftPicksByIds()` to `TradingRepositoryInterface`/`TradingRepository`
- Added `getCashTransactionsByOfferIds()` to `TradeCashRepositoryInterface`/`TradeCashRepository`
- Pre-loads all players, picks, and cash transactions before the `groupTradeOffers()` loop
- Pre-loads all cash before `enrichOffersWithPreviewData()` loop
- Eliminates 3+ queries per trade item across 20-40 items

**CommonMysqliRepository — combined salary query**
- Added `getTeamSalarySummary()` returning both current and next-year salary totals in one query (vs two separate queries)

### Stats
- **+315 / -114 lines** (12 files changed)
- Full PHPUnit suite passes (3865 tests)
- PHPStan clean (level max)

### Manual Testing
No manual testing needed — all changes are internal query optimizations with no UI or behavior changes. Existing unit tests verify the same output with batch-loaded data.