### PR TITLE
refactor: codebase consolidation WP-5, WP-6, WP-7

### DIFF
--- a/ibl5/classes/CareerLeaderboards/CachedCareerLeaderboardsRepository.php
+++ b/ibl5/classes/CareerLeaderboards/CachedCareerLeaderboardsRepository.php
@@ -66,7 +66,7 @@ class CachedCareerLeaderboardsRepository implements CareerLeaderboardsRepository
         if ($rows === null) {
             // Cache miss — fetch all rows from the inner repository (no active filter, no limit, default sort)
             $innerResult = $this->inner->getLeaderboards($tableKey, 'pts', 0, 0);
-            $rows = $innerResult['result'];
+            $rows = $innerResult['results'];
             $this->cache->set($cacheKey, $rows, self::TTL_SECONDS);
         }
 
@@ -91,7 +91,7 @@ class CachedCareerLeaderboardsRepository implements CareerLeaderboardsRepository
         }
 
         return [
-            'result' => $rows,
+            'results' => $rows,
             'count' => count($rows),
         ];
     }
@@ -116,7 +116,7 @@ class CachedCareerLeaderboardsRepository implements CareerLeaderboardsRepository
             $innerResult = $this->inner->getLeaderboards($tableKey, 'pts', 0, 0);
             $this->cache->set(
                 self::CACHE_KEY_PREFIX . $tableKey,
-                $innerResult['result'],
+                $innerResult['results'],
                 self::TTL_SECONDS
             );
         }

--- a/ibl5/classes/CareerLeaderboards/CareerLeaderboardsRepository.php
+++ b/ibl5/classes/CareerLeaderboards/CareerLeaderboardsRepository.php
@@ -122,7 +122,7 @@ class CareerLeaderboardsRepository extends \BaseMysqliRepository implements Care
         $rows = $this->fetchAll($query);
 
         return [
-            'result' => $rows,
+            'results' => $rows,
             'count' => count($rows)
         ];
     }

--- a/ibl5/classes/CareerLeaderboards/Contracts/CareerLeaderboardsRepositoryInterface.php
+++ b/ibl5/classes/CareerLeaderboards/Contracts/CareerLeaderboardsRepositoryInterface.php
@@ -11,7 +11,7 @@ namespace CareerLeaderboards\Contracts;
  * multiple table types (regular season, playoffs, H.E.A.T., Olympics, Rookie, Sophomore, All-Star).
  *
  * @phpstan-type CareerStatsRow array{pid: int, name: string, games: int|float|string, minutes: int|float|string, fgm: int|float|string, fga: int|float|string, fgpct?: float|string|null, ftm: int|float|string, fta: int|float|string, ftpct?: float|string|null, tgm: int|float|string, tga: int|float|string, tpct?: float|string|null, orb: int|float|string, reb: int|float|string, ast: int|float|string, stl: int|float|string, tvr: int|float|string, blk: int|float|string, pf: int|float|string, pts: int|float|string, retired: int|string}
- * @phpstan-type LeaderboardResult array{result: list<CareerStatsRow>, count: int}
+ * @phpstan-type LeaderboardResult array{results: list<CareerStatsRow>, count: int}
  */
 interface CareerLeaderboardsRepositoryInterface
 {
@@ -25,7 +25,7 @@ interface CareerLeaderboardsRepositoryInterface
      * @param string $sortColumn Column name to sort by (must be in whitelist)
      * @param int $activeOnly 1 to exclude retired players, 0 to include all
      * @param int $limit Maximum records to return (0 for default cap of 5000)
-     * @return LeaderboardResult Result with keys 'result' and 'count'
+     * @return LeaderboardResult Result with keys 'results' and 'count'
      *
      * **Valid Tables:**
      * - ibl_hist (aggregated by player for regular season totals)

--- a/ibl5/classes/DraftHistory/DraftHistoryView.php
+++ b/ibl5/classes/DraftHistory/DraftHistoryView.php
@@ -128,7 +128,6 @@ class DraftHistoryView implements DraftHistoryViewInterface
 
         foreach ($draftPicks as $pick) {
             $pid = $pick['pid'];
-            $name = HtmlSanitizer::safeHtmlOutput($pick['name']);
             $pos = HtmlSanitizer::safeHtmlOutput($pick['pos']);
             $round = $pick['draftround'];
             $pickNo = $pick['draftpickno'];
@@ -145,12 +144,12 @@ class DraftHistoryView implements DraftHistoryViewInterface
                 $pick['draftedby'],
             );
 
-            $playerThumbnail = PlayerImageHelper::renderThumbnail($pid);
+            $playerLink = PlayerImageHelper::renderPlayerLink((int) $pid, (string) $pick['name']);
 
             $output .= "<tr data-team-id=\"{$teamId}\">
     <td class=\"sticky-col-1\">{$round}</td>
     <td class=\"sticky-col-2\">{$pickNo}</td>
-    <td class=\"name-cell\"><a href=\"./modules.php?name=Player&amp;pa=showpage&amp;pid={$pid}\">{$playerThumbnail}{$name}</a></td>
+    <td class=\"name-cell\">{$playerLink}</td>
     <td>{$pos}</td>
     {$teamCell}
     <td>{$college}</td>
@@ -193,7 +192,6 @@ class DraftHistoryView implements DraftHistoryViewInterface
 
         foreach ($draftPicks as $pick) {
             $pid = $pick['pid'];
-            $name = HtmlSanitizer::safeHtmlOutput($pick['name']);
             $pos = HtmlSanitizer::safeHtmlOutput($pick['pos']);
             $round = $pick['draftround'];
             $pickNo = $pick['draftpickno'];
@@ -202,12 +200,12 @@ class DraftHistoryView implements DraftHistoryViewInterface
             $isRetired = $pick['retired'] !== 0;
 
             $retiredBadge = $isRetired ? ' <span class="draft-retired-badge">(ret.)</span>' : '';
-            $playerThumbnail = PlayerImageHelper::renderThumbnail($pid);
+            $playerLink = PlayerImageHelper::renderPlayerLink((int) $pid, (string) $pick['name']);
 
             $output .= "<tr>
     <td>{$round}</td>
     <td>{$pickNo}</td>
-    <td class=\"name-cell\"><a href=\"./modules.php?name=Player&amp;pa=showpage&amp;pid={$pid}\">{$playerThumbnail}{$name}</a>{$retiredBadge}</td>
+    <td class=\"name-cell\">{$playerLink}{$retiredBadge}</td>
     <td>{$pos}</td>
     <td>{$college}</td>
     <td>{$draftYear}</td>

--- a/ibl5/classes/PlayerDatabase/PlayerDatabaseRepository.php
+++ b/ibl5/classes/PlayerDatabase/PlayerDatabaseRepository.php
@@ -6,6 +6,7 @@ namespace PlayerDatabase;
 
 use BaseMysqliRepository;
 use PlayerDatabase\Contracts\PlayerDatabaseRepositoryInterface;
+use Services\QueryConditions;
 
 /**
  * PlayerDatabaseRepository - Database operations for player search
@@ -72,60 +73,29 @@ class PlayerDatabaseRepository extends BaseMysqliRepository implements PlayerDat
      */
     public function searchPlayers(array $params): array
     {
-        $conditions = ['ibl_plr.pid > 0'];
-        $bindParams = [];
-        $bindTypes = '';
-
+        $baseConditions = ['ibl_plr.pid > 0'];
         if ($params['active'] === 0) {
-            $conditions[] = 'ibl_plr.retired = 0';
+            $baseConditions[] = 'ibl_plr.retired = 0';
         }
+        $qc = new QueryConditions($baseConditions);
 
-        if ($params['search_name'] !== null) {
-            $conditions[] = 'ibl_plr.name LIKE ?';
-            $bindParams[] = '%' . $params['search_name'] . '%';
-            $bindTypes .= 's';
-        }
+        // String filters (LIKE)
+        $nameSearch = is_string($params['search_name']) ? '%' . $params['search_name'] . '%' : null;
+        $qc->addIfNotNull('ibl_plr.name LIKE ?', 's', $nameSearch);
 
-        if ($params['college'] !== null) {
-            $conditions[] = 'ibl_plr.college LIKE ?';
-            $bindParams[] = '%' . $params['college'] . '%';
-            $bindTypes .= 's';
-        }
+        $collegeSearch = is_string($params['college']) ? '%' . $params['college'] . '%' : null;
+        $qc->addIfNotNull('ibl_plr.college LIKE ?', 's', $collegeSearch);
 
-        if ($params['pos'] !== null) {
-            $conditions[] = 'ibl_plr.pos = ?';
-            $bindParams[] = $params['pos'];
-            $bindTypes .= 's';
-        }
+        $qc->addIfNotNull('ibl_plr.pos = ?', 's', is_string($params['pos']) ? $params['pos'] : null);
 
-        if ($params['age'] !== null) {
-            $conditions[] = 'ibl_plr.age <= ?';
-            $bindParams[] = $params['age'];
-            $bindTypes .= 'i';
-        }
+        // Integer filters (range)
+        $qc->addIfNotNull('ibl_plr.age <= ?', 'i', is_int($params['age']) ? $params['age'] : null);
+        $qc->addIfNotNull('ibl_plr.exp >= ?', 'i', is_int($params['exp']) ? $params['exp'] : null);
+        $qc->addIfNotNull('ibl_plr.exp <= ?', 'i', is_int($params['exp_max']) ? $params['exp_max'] : null);
+        $qc->addIfNotNull('ibl_plr.bird >= ?', 'i', is_int($params['bird']) ? $params['bird'] : null);
+        $qc->addIfNotNull('ibl_plr.bird <= ?', 'i', is_int($params['bird_max']) ? $params['bird_max'] : null);
 
-        if ($params['exp'] !== null) {
-            $conditions[] = 'ibl_plr.exp >= ?';
-            $bindParams[] = $params['exp'];
-            $bindTypes .= 'i';
-        }
-        if ($params['exp_max'] !== null) {
-            $conditions[] = 'ibl_plr.exp <= ?';
-            $bindParams[] = $params['exp_max'];
-            $bindTypes .= 'i';
-        }
-
-        if ($params['bird'] !== null) {
-            $conditions[] = 'ibl_plr.bird >= ?';
-            $bindParams[] = $params['bird'];
-            $bindTypes .= 'i';
-        }
-        if ($params['bird_max'] !== null) {
-            $conditions[] = 'ibl_plr.bird <= ?';
-            $bindParams[] = $params['bird_max'];
-            $bindTypes .= 'i';
-        }
-
+        // Rating filters (>= threshold)
         $greaterThanFilters = [
             'Clutch', 'Consistency', 'talent', 'skill', 'intangibles',
             'oo', 'do', 'po', 'to', 'od', 'dd', 'pd', 'td',
@@ -135,24 +105,20 @@ class PlayerDatabaseRepository extends BaseMysqliRepository implements PlayerDat
 
         foreach ($greaterThanFilters as $filter) {
             $filterValue = $params[$filter] ?? null;
-            if ($filterValue !== null) {
+            if (is_int($filterValue)) {
                 $column = self::COLUMN_MAP[$filter];
-                $conditions[] = "ibl_plr.$column >= ?";
-                $bindParams[] = $filterValue;
-                $bindTypes .= 'i';
+                $qc->add("ibl_plr.$column >= ?", 'i', $filterValue);
             }
         }
 
-        $whereClause = implode(' AND ', $conditions);
+        $whereClause = $qc->toWhereClause();
         $query = "SELECT ibl_plr.*, ibl_team_info.team_name AS teamname, ibl_team_info.color1, ibl_team_info.color2
             FROM ibl_plr
             LEFT JOIN ibl_team_info ON ibl_plr.tid = ibl_team_info.teamid
             WHERE $whereClause
             ORDER BY ibl_plr.retired ASC, ibl_plr.ordinal ASC";
 
-        // Use executeQuery from BaseMysqliRepository for dynamic parameter binding
-        // executeQuery handles prepare, bind_param, execute, and error logging
-        $stmt = $this->executeQuery($query, $bindTypes, ...$bindParams);
+        $stmt = $this->executeQuery($query, $qc->getTypes(), ...$qc->getParams());
         $result = $stmt->get_result();
 
         if ($result === false) {

--- a/ibl5/classes/SeasonHighs/SeasonHighsView.php
+++ b/ibl5/classes/SeasonHighs/SeasonHighsView.php
@@ -113,9 +113,7 @@ class SeasonHighsView implements SeasonHighsViewInterface
             // Link player names to their profile page when pid is available
             if (isset($row['pid'])) {
                 $pid = $row['pid'];
-                $playerThumbnail = PlayerImageHelper::renderThumbnail($pid);
-                /** @var string $name */
-                $name = "<a href=\"modules.php?name=Player&amp;pa=showpage&amp;pid={$pid}\">{$playerThumbnail}{$name}</a>";
+                $name = PlayerImageHelper::renderPlayerLink((int) $pid, (string) $row['name']);
 
                 // Build team cell for player stats
                 if ($isPlayerStats) {

--- a/ibl5/modules/CareerLeaderboards/index.php
+++ b/ibl5/modules/CareerLeaderboards/index.php
@@ -64,7 +64,7 @@ if ($filters['submitted'] != null) {
         
         // Render player rows
         $rank = 1;
-        foreach ($leadersData['result'] as $row) {
+        foreach ($leadersData['results'] as $row) {
             $stats = $service->processPlayerRow($row, $tableType);
             echo $view->renderPlayerRow($stats, $rank);
             $rank++;

--- a/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
@@ -46,7 +46,7 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
         $mockInner->expects($this->once())
             ->method('getLeaderboards')
             ->with('ibl_hist', 'pts', 0, 0)
-            ->willReturn(['result' => $rows, 'count' => 3]);
+            ->willReturn(['results' => $rows, 'count' => 3]);
 
         $result = $repository->getLeaderboards('ibl_hist', 'pts', 0, 10);
 
@@ -72,9 +72,9 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
         // Sort by assists
         $result = $repository->getLeaderboards('ibl_hist', 'ast', 0, 0);
 
-        $this->assertSame(1, $result['result'][0]['pid']); // 300 ast
-        $this->assertSame(2, $result['result'][1]['pid']); // 200 ast
-        $this->assertSame(3, $result['result'][2]['pid']); // 100 ast
+        $this->assertSame(1, $result['results'][0]['pid']); // 300 ast
+        $this->assertSame(2, $result['results'][1]['pid']); // 200 ast
+        $this->assertSame(3, $result['results'][2]['pid']); // 100 ast
     }
 
     public function testActiveOnlyFilterExcludesRetiredPlayers(): void
@@ -92,8 +92,8 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
         $result = $repository->getLeaderboards('ibl_hist', 'pts', 1, 0);
 
         $this->assertSame(2, $result['count']);
-        $this->assertSame(1, $result['result'][0]['pid']);
-        $this->assertSame(3, $result['result'][1]['pid']);
+        $this->assertSame(1, $result['results'][0]['pid']);
+        $this->assertSame(3, $result['results'][1]['pid']);
     }
 
     public function testLimitRestrictsResultCount(): void
@@ -142,7 +142,7 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
         $mockInner = $this->createMock(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($mockInner, $this->cache);
 
-        $sampleResult = ['result' => [['pid' => 1, 'name' => 'Test', 'pts' => 100, 'retired' => 0]], 'count' => 1];
+        $sampleResult = ['results' => [['pid' => 1, 'name' => 'Test', 'pts' => 100, 'retired' => 0]], 'count' => 1];
 
         $mockInner->expects($this->exactly(12))
             ->method('getLeaderboards')
@@ -206,8 +206,8 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
         $result = $repository->getLeaderboards('ibl_season_career_avgs', 'pts', 1, 2);
 
         $this->assertSame(2, $result['count']);
-        $this->assertSame(3, $result['result'][0]['pid']); // 300 pts
-        $this->assertSame(4, $result['result'][1]['pid']); // 200 pts
+        $this->assertSame(3, $result['results'][0]['pid']); // 300 pts
+        $this->assertSame(4, $result['results'][1]['pid']); // 200 pts
     }
 
     /**

--- a/ibl5/tests/CareerLeaderboards/CareerLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/CareerLeaderboards/CareerLeaderboardsRepositoryTest.php
@@ -81,7 +81,7 @@ final class CareerLeaderboardsRepositoryTest extends TestCase
         // Should not throw exception and return result array
         $result = $repository->getLeaderboards('ibl_hist', 'pts', 0, 10);
         $this->assertIsArray($result);
-        $this->assertArrayHasKey('result', $result);
+        $this->assertArrayHasKey('results', $result);
         $this->assertArrayHasKey('count', $result);
         $this->assertEquals(2, $result['count']);
     }


### PR DESCRIPTION
## Summary

Implements three remaining work packages from the Codebase Consolidation Audit as a single PR.

### WP-6: Rename `'result'` → `'results'` in CareerLeaderboards

Every other module returning paginated data uses `'results'` (plural). CareerLeaderboards used `'result'` (singular) — a silent footgun for anyone adding a new consumer. Renamed across interface, repository, cached repository, module index, and all tests.

### WP-7: Use `renderPlayerLink()` in SeasonHighsView and DraftHistoryView

Both views manually combined `PlayerImageHelper::renderThumbnail()` + an `<a>` tag — exactly what `renderPlayerLink()` already does (including XSS escaping and pipe-name handling). Replaced with the existing helper, eliminating double-escaping and dead code.

### WP-5: Refactor PlayerDatabaseRepository to use QueryConditions

`QueryConditions` (`Services/QueryConditions.php`) is already used by 3 repos. Replaced the manual `$conditions[]` / `$bindParams[]` / `$bindTypes` pattern in `searchPlayers()` with `QueryConditions`, using proper `is_string()`/`is_int()` narrowing for PHPStan level max compliance.

## Files Changed

- `classes/CareerLeaderboards/` — 3 source files + interface
- `classes/DraftHistory/DraftHistoryView.php`
- `classes/SeasonHighs/SeasonHighsView.php`
- `classes/PlayerDatabase/PlayerDatabaseRepository.php`
- `modules/CareerLeaderboards/index.php`
- `tests/CareerLeaderboards/` — 2 test files

## Manual Testing

- [x] Spot-check CareerLeaderboards page against iblhoops.net
- [x] Spot-check SeasonHighs page — verify player links render with thumbnails
- [x] Spot-check DraftHistory page — verify player links and retired badges
- [x] Spot-check Player Database search results