### PR TITLE
feat: add accessibility testing via axe-core

### DIFF
--- a/ibl5/bun.lock
+++ b/ibl5/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "ibl5-design",
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.56.0",
         "@tailwindcss/cli": "^4.0.0",
         "tailwindcss": "^4.0.0",
@@ -12,6 +13,8 @@
     },
   },
   "packages": {
+    "@axe-core/playwright": ["@axe-core/playwright@4.11.1", "", { "dependencies": { "axe-core": "~4.11.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -81,6 +84,8 @@
     "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.1.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA=="],
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.18", "", { "os": "win32", "cpu": "x64" }, "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q=="],
+
+    "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 

--- a/ibl5/package.json
+++ b/ibl5/package.json
@@ -9,6 +9,7 @@
     "test:e2e": "bunx playwright test",
     "test:e2e:headed": "bunx playwright test --headed",
     "test:e2e:ui": "bunx playwright test --ui",
+    "test:e2e:a11y": "bunx playwright test tests/e2e/smoke/accessibility.spec.ts",
     "test:e2e:isolated": "./bin/e2e-local.sh",
     "test:e2e:visual": "./bin/visual-regression.sh",
     "test:e2e:visual:update": "./bin/visual-regression.sh --update-snapshots",
@@ -20,8 +21,9 @@
     "wt:list": "cd .. && bin/wt-list"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.56.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/cli": "^4.0.0"
+    "@tailwindcss/cli": "^4.0.0",
+    "tailwindcss": "^4.0.0"
   }
 }

--- a/ibl5/tests/e2e/helpers/accessibility.ts
+++ b/ibl5/tests/e2e/helpers/accessibility.ts
@@ -1,0 +1,47 @@
+import AxeBuilder from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+
+export interface A11yOptions {
+  disableRules?: string[];
+}
+
+/**
+ * Run axe-core WCAG 2.1 AA analysis on the current page.
+ * Throws with a formatted violation report if any issues are found.
+ */
+export async function assertNoA11yViolations(
+  page: Page,
+  context?: string,
+  options?: A11yOptions,
+): Promise<void> {
+  let builder = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']);
+
+  if (options?.disableRules?.length) {
+    builder = builder.disableRules(options.disableRules);
+  }
+
+  const results = await builder.analyze();
+
+  if (results.violations.length === 0) {
+    return;
+  }
+
+  const lines: string[] = [
+    `${results.violations.length} accessibility violation(s)${context ? ` ${context}` : ''}:`,
+    '',
+  ];
+
+  for (const violation of results.violations) {
+    lines.push(`[${violation.impact}] ${violation.id}: ${violation.description}`);
+    const nodes = violation.nodes.slice(0, 3);
+    for (const node of nodes) {
+      lines.push(`  → ${node.target.join(' > ')}`);
+    }
+    if (violation.nodes.length > 3) {
+      lines.push(`  … and ${violation.nodes.length - 3} more`);
+    }
+    lines.push('');
+  }
+
+  throw new Error(lines.join('\n'));
+}

--- a/ibl5/tests/e2e/smoke/accessibility.spec.ts
+++ b/ibl5/tests/e2e/smoke/accessibility.spec.ts
@@ -1,0 +1,72 @@
+import { test as publicTest } from '../fixtures/public';
+import { test as authTest } from '../fixtures/auth';
+import { assertNoA11yViolations, type A11yOptions } from '../helpers/accessibility';
+
+// Site-wide exclusions — explicit a11y debt tracker.
+// Each entry should have a comment explaining why it's excluded.
+const SITE_WIDE_DISABLED_RULES: string[] = [
+  'color-contrast', // PHP-Nuke legacy palette — nearly every page affected
+  'select-name', // PHP-Nuke form selects lack <label> associations
+  'link-name', // Team cell links (ibl-team-cell__name) render as empty <a> tags
+  'scrollable-region-focusable', // table-scroll-container divs not keyboard-focusable
+  'label', // PHP-Nuke form inputs lack <label> associations
+  'image-alt', // Team logos and legacy images missing alt text
+];
+
+const A11Y_OPTIONS: A11yOptions = { disableRules: SITE_WIDE_DISABLED_RULES };
+
+// --- Public pages ---
+
+const publicPages: Array<{ name: string; url: string }> = [
+  { name: 'homepage', url: 'index.php' },
+  { name: 'standings', url: 'modules.php?name=Standings' },
+  { name: 'season leaderboards', url: 'modules.php?name=SeasonLeaderboards' },
+  { name: 'career leaderboards', url: 'modules.php?name=CareerLeaderboards' },
+  { name: 'draft history', url: 'modules.php?name=DraftHistory' },
+  { name: 'cap space', url: 'modules.php?name=CapSpace' },
+  { name: 'player page', url: 'modules.php?name=Player&pa=showpage&pid=1' },
+  { name: 'team page', url: 'modules.php?name=Team&op=team&teamID=1' },
+];
+
+publicTest.describe('Public page accessibility', () => {
+  publicTest.beforeEach(async ({ appState }) => {
+    await appState({ 'Trivia Mode': 'Off' });
+  });
+
+  for (const { name, url } of publicPages) {
+    publicTest(`${name} has no WCAG 2.1 AA violations`, async ({ page }) => {
+      await page.goto(url);
+      await assertNoA11yViolations(page, `on ${url}`, A11Y_OPTIONS);
+    });
+  }
+});
+
+// --- Authenticated pages ---
+
+const authPages: Array<{
+  name: string;
+  url: string;
+  state?: Record<string, string>;
+}> = [
+  { name: 'trading', url: 'modules.php?name=Trading', state: { 'Allow Trades': 'Yes' } },
+  {
+    name: 'free agency',
+    url: 'modules.php?name=FreeAgency',
+    state: { 'Current Season Phase': 'Free Agency' },
+  },
+  { name: 'depth chart entry', url: 'modules.php?name=DepthChartEntry' },
+  { name: 'waivers', url: 'modules.php?name=Waivers' },
+  { name: 'gm contact list', url: 'modules.php?name=GMContactList' },
+];
+
+authTest.describe('Authenticated page accessibility', () => {
+  for (const { name, url, state } of authPages) {
+    authTest(`${name} has no WCAG 2.1 AA violations`, async ({ appState, page }) => {
+      if (state) {
+        await appState(state);
+      }
+      await page.goto(url);
+      await assertNoA11yViolations(page, `on ${url}`, A11Y_OPTIONS);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds automated WCAG 2.1 AA accessibility testing to the E2E suite using `@axe-core/playwright`. Purely additive — no existing files are modified beyond `package.json`.

## Changes

### New Files
- **`tests/e2e/helpers/accessibility.ts`** — Reusable helper wrapping `AxeBuilder` with WCAG 2.1 AA tags (`wcag2a`, `wcag2aa`) and formatted violation reporting (impact, rule ID, description, node selectors)
- **`tests/e2e/smoke/accessibility.spec.ts`** — 13 a11y smoke tests covering 8 public pages and 5 authenticated pages

### Dependencies
- `@axe-core/playwright` ^4.11.1 (devDependency)

### Scripts
- `test:e2e:a11y` — convenience script to run only the a11y tests

## Site-Wide Exclusions (A11y Debt Tracker)

These rules are disabled site-wide due to legacy PHP-Nuke markup. Each is documented in the spec file:

| Rule | Reason |
|------|--------|
| `color-contrast` | PHP-Nuke legacy palette affects nearly every page |
| `select-name` | Form selects lack `<label>` associations |
| `link-name` | Team cell links render as empty `<a>` tags |
| `scrollable-region-focusable` | Scroll containers not keyboard-focusable |
| `label` | Form inputs lack `<label>` associations |
| `image-alt` | Team logos and legacy images missing alt text |

## Manual Testing

No manual testing needed — all changes are covered by E2E tests.