### PR TITLE
test: expand database integration test suite (Tier 1)

### DIFF
--- a/ibl5/classes/SavedDepthChart/SavedDepthChartRepository.php
+++ b/ibl5/classes/SavedDepthChart/SavedDepthChartRepository.php
@@ -44,7 +44,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
                 "INSERT INTO {$this->headerTable}
                     (tid, username, name, phase, season_year, sim_start_date, sim_number_start, is_active)
                  VALUES (?, ?, ?, ?, ?, ?, ?, 1)",
-                "isssissi",
+                "isssisi",
                 $tid,
                 $username,
                 $name,

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -244,6 +244,10 @@
             <directory>tests/Settings</directory>
         </testsuite>
     </testsuites>
+    <!-- Database Integration Tests (tests/DatabaseIntegration/) are NOT registered
+         as a suite. They require a running MariaDB and env vars:
+         DB_HOST, DB_USER, DB_PASS, DB_NAME.
+         Run explicitly via: vendor/bin/phpunit tests/DatabaseIntegration/ -->
     <source baseline="phpunit-baseline.xml">
         <include>
             <directory>classes</directory>

--- a/ibl5/tests/DatabaseIntegration/BoxscoreRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BoxscoreRepositoryTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use Boxscore\BoxscoreRepository;
+
+class BoxscoreRepositoryTest extends DatabaseTestCase
+{
+    private BoxscoreRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new BoxscoreRepository($this->db);
+    }
+
+    public function testFindTeamBoxscoreReturnsRow(): void
+    {
+        $this->insertTeamBoxscoreRow('2025-01-15', 'Metros', 1, 2, 1);
+
+        $row = $this->repo->findTeamBoxscore('2025-01-15', 2, 1, 1);
+
+        self::assertNotNull($row);
+        self::assertArrayHasKey('visitorQ1points', $row);
+        self::assertArrayHasKey('homeQ1points', $row);
+    }
+
+    public function testFindTeamBoxscoreReturnsNullForMissing(): void
+    {
+        $row = $this->repo->findTeamBoxscore('2099-01-01', 2, 1, 1);
+
+        self::assertNull($row);
+    }
+
+    public function testInsertTeamBoxscoreCreatesRow(): void
+    {
+        $this->repo->insertTeamBoxscore(
+            '2025-02-01', 'Metros', 1, 2, 1,
+            10000, 15000, 20, 10, 25, 5,
+            28, 24, 22, 30, 0,
+            20, 22, 18, 25, 0,
+            30, 60, 15, 20, 8, 22, 10, 30, 20, 8, 12, 5, 18
+        );
+
+        $row = $this->repo->findTeamBoxscore('2025-02-01', 2, 1, 1);
+        self::assertNotNull($row);
+        self::assertSame(28, $row['visitorQ1points']);
+        self::assertSame(20, $row['homeQ1points']);
+    }
+
+    public function testInsertPlayerBoxscoreCreatesRow(): void
+    {
+        $this->repo->insertPlayerBoxscore(
+            '2025-02-01', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            'Test Player One', 'PG', 1, 2, 1, 1,
+            10000, 15000, 20, 10, 25, 5,
+            1, 32, 8, 15, 4, 5, 2, 6, 2, 5, 6, 1, 3, 1, 2
+        );
+
+        $stmt = $this->db->prepare(
+            "SELECT name, pid, gameMIN FROM ibl_box_scores WHERE Date = '2025-02-01' AND pid = 1"
+        );
+        self::assertNotFalse($stmt);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        self::assertNotNull($row);
+        self::assertSame('Test Player One', $row['name']);
+        self::assertSame(1, $row['pid']);
+        self::assertSame(32, $row['gameMIN']);
+    }
+
+    public function testDeleteTeamBoxscoresByGameRemovesRows(): void
+    {
+        $this->insertTeamBoxscoreRow('2025-03-01', 'Metros', 1, 2, 1);
+
+        $deleted = $this->repo->deleteTeamBoxscoresByGame('2025-03-01', 2, 1, 1);
+
+        self::assertGreaterThan(0, $deleted);
+
+        $row = $this->repo->findTeamBoxscore('2025-03-01', 2, 1, 1);
+        self::assertNull($row);
+    }
+
+    public function testDeletePlayerBoxscoresByGameRemovesRows(): void
+    {
+        $this->repo->insertPlayerBoxscore(
+            '2025-03-01', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            'Test Player One', 'PG', 1, 2, 1, 1,
+            10000, 15000, 20, 10, 25, 5,
+            1, 30, 7, 14, 3, 4, 1, 5, 1, 4, 5, 1, 2, 1, 3
+        );
+
+        $deleted = $this->repo->deletePlayerBoxscoresByGame('2025-03-01', 2, 1);
+
+        self::assertGreaterThan(0, $deleted);
+    }
+
+    public function testDeletePreseasonBoxScoresRemovesOnlyPreseason(): void
+    {
+        // Preseason uses year 9998, month 11
+        $this->insertTeamBoxscoreRow('9998-11-15', 'Metros', 1, 2, 1);
+        // Regular season boxscore should not be deleted
+        $this->insertTeamBoxscoreRow('2025-01-15', 'Metros', 1, 2, 1);
+
+        $this->repo->deletePreseasonBoxScores();
+
+        $preseason = $this->repo->findTeamBoxscore('9998-11-15', 2, 1, 1);
+        self::assertNull($preseason);
+
+        $regular = $this->repo->findTeamBoxscore('2025-01-15', 2, 1, 1);
+        self::assertNotNull($regular);
+    }
+
+    public function testFindAllStarTeamNamesReturnsNames(): void
+    {
+        // Insert two team boxscore rows for All-Star teams (visitor=50, home=51)
+        $this->insertRow('ibl_box_scores_teams', [
+            'Date' => '2025-02-15',
+            'name' => 'Team West',
+            'gameOfThatDay' => 1,
+            'visitorTeamID' => 50,
+            'homeTeamID' => 51,
+            'attendance' => 20000,
+            'capacity' => 20000,
+            'visitorWins' => 0,
+            'visitorLosses' => 0,
+            'homeWins' => 0,
+            'homeLosses' => 0,
+            'visitorQ1points' => 30,
+            'visitorQ2points' => 28,
+            'visitorQ3points' => 32,
+            'visitorQ4points' => 35,
+            'visitorOTpoints' => 0,
+            'homeQ1points' => 25,
+            'homeQ2points' => 30,
+            'homeQ3points' => 28,
+            'homeQ4points' => 32,
+            'homeOTpoints' => 0,
+            'game2GM' => 40,
+            'game2GA' => 80,
+            'gameFTM' => 20,
+            'gameFTA' => 25,
+            'game3GM' => 12,
+            'game3GA' => 30,
+            'gameORB' => 15,
+            'gameDRB' => 35,
+            'gameAST' => 25,
+            'gameSTL' => 10,
+            'gameTOV' => 15,
+            'gameBLK' => 6,
+            'gamePF' => 20,
+        ]);
+        $this->insertRow('ibl_box_scores_teams', [
+            'Date' => '2025-02-15',
+            'name' => 'Team East',
+            'gameOfThatDay' => 1,
+            'visitorTeamID' => 50,
+            'homeTeamID' => 51,
+            'attendance' => 20000,
+            'capacity' => 20000,
+            'visitorWins' => 0,
+            'visitorLosses' => 0,
+            'homeWins' => 0,
+            'homeLosses' => 0,
+            'visitorQ1points' => 25,
+            'visitorQ2points' => 30,
+            'visitorQ3points' => 28,
+            'visitorQ4points' => 32,
+            'visitorOTpoints' => 0,
+            'homeQ1points' => 30,
+            'homeQ2points' => 28,
+            'homeQ3points' => 32,
+            'homeQ4points' => 35,
+            'homeOTpoints' => 0,
+            'game2GM' => 38,
+            'game2GA' => 78,
+            'gameFTM' => 18,
+            'gameFTA' => 23,
+            'game3GM' => 10,
+            'game3GA' => 28,
+            'gameORB' => 12,
+            'gameDRB' => 33,
+            'gameAST' => 22,
+            'gameSTL' => 8,
+            'gameTOV' => 13,
+            'gameBLK' => 5,
+            'gamePF' => 18,
+        ]);
+
+        $names = $this->repo->findAllStarTeamNames('2025-02-15');
+
+        self::assertNotNull($names);
+        self::assertSame('Team West', $names['awayName']);
+        self::assertSame('Team East', $names['homeName']);
+    }
+
+    public function testFindAllStarTeamNamesReturnsNullWhenMissing(): void
+    {
+        $names = $this->repo->findAllStarTeamNames('2099-02-15');
+
+        self::assertNull($names);
+    }
+
+    public function testRenameAllStarTeamUpdatesName(): void
+    {
+        $id = $this->insertRow('ibl_box_scores_teams', [
+            'Date' => '2025-02-16',
+            'name' => 'Team Away',
+            'gameOfThatDay' => 1,
+            'visitorTeamID' => 50,
+            'homeTeamID' => 51,
+            'attendance' => 20000,
+            'capacity' => 20000,
+            'visitorWins' => 0,
+            'visitorLosses' => 0,
+            'homeWins' => 0,
+            'homeLosses' => 0,
+            'visitorQ1points' => 30,
+            'visitorQ2points' => 28,
+            'visitorQ3points' => 32,
+            'visitorQ4points' => 35,
+            'visitorOTpoints' => 0,
+            'homeQ1points' => 25,
+            'homeQ2points' => 30,
+            'homeQ3points' => 28,
+            'homeQ4points' => 32,
+            'homeOTpoints' => 0,
+            'game2GM' => 40,
+            'game2GA' => 80,
+            'gameFTM' => 20,
+            'gameFTA' => 25,
+            'game3GM' => 12,
+            'game3GA' => 30,
+            'gameORB' => 15,
+            'gameDRB' => 35,
+            'gameAST' => 25,
+            'gameSTL' => 10,
+            'gameTOV' => 15,
+            'gameBLK' => 6,
+            'gamePF' => 20,
+        ]);
+
+        $affected = $this->repo->renameAllStarTeam($id, 'Team LeBron');
+
+        self::assertSame(1, $affected);
+
+        $stmt = $this->db->prepare("SELECT name FROM ibl_box_scores_teams WHERE id = ?");
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        self::assertNotNull($row);
+        self::assertSame('Team LeBron', $row['name']);
+    }
+
+}

--- a/ibl5/tests/DatabaseIntegration/DatabaseTestCase.php
+++ b/ibl5/tests/DatabaseIntegration/DatabaseTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\DatabaseIntegration;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,7 +13,9 @@ use PHPUnit\Framework\TestCase;
  * - Connects via env vars: DB_HOST, DB_USER, DB_PASS, DB_NAME
  * - Sets MYSQLI_OPT_INT_AND_FLOAT_NATIVE to match production
  * - Wraps each test in begin_transaction() / rollback() for isolation
+ * - Excluded from default PHPUnit suite via #[Group('database')]
  */
+#[Group('database')]
 abstract class DatabaseTestCase extends TestCase
 {
     protected \mysqli $db;
@@ -89,6 +92,46 @@ abstract class DatabaseTestCase extends TestCase
         $stmt->close();
 
         return $id;
+    }
+
+    protected function insertTeamBoxscoreRow(string $date, string $name, int $gameOfDay, int $visitorTid, int $homeTid): int
+    {
+        return $this->insertRow('ibl_box_scores_teams', [
+            'Date' => $date,
+            'name' => $name,
+            'gameOfThatDay' => $gameOfDay,
+            'visitorTeamID' => $visitorTid,
+            'homeTeamID' => $homeTid,
+            'attendance' => 10000,
+            'capacity' => 15000,
+            'visitorWins' => 20,
+            'visitorLosses' => 10,
+            'homeWins' => 25,
+            'homeLosses' => 5,
+            'visitorQ1points' => 20,
+            'visitorQ2points' => 22,
+            'visitorQ3points' => 18,
+            'visitorQ4points' => 25,
+            'visitorOTpoints' => 0,
+            'homeQ1points' => 28,
+            'homeQ2points' => 24,
+            'homeQ3points' => 22,
+            'homeQ4points' => 30,
+            'homeOTpoints' => 0,
+            'game2GM' => 30,
+            'game2GA' => 60,
+            'gameFTM' => 15,
+            'gameFTA' => 20,
+            'game3GM' => 8,
+            'game3GA' => 22,
+            'gameORB' => 10,
+            'gameDRB' => 30,
+            'gameAST' => 20,
+            'gameSTL' => 8,
+            'gameTOV' => 12,
+            'gameBLK' => 5,
+            'gamePF' => 18,
+        ]);
     }
 
     private function requireEnv(string $name): string

--- a/ibl5/tests/DatabaseIntegration/LeagueControlPanelRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/LeagueControlPanelRepositoryTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use LeagueControlPanel\LeagueControlPanelRepository;
+
+class LeagueControlPanelRepositoryTest extends DatabaseTestCase
+{
+    private LeagueControlPanelRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new LeagueControlPanelRepository($this->db);
+    }
+
+    public function testGetSettingReturnsValue(): void
+    {
+        $value = $this->repo->getSetting('Phase');
+
+        self::assertSame('Regular Season', $value);
+    }
+
+    public function testGetSettingReturnsNullForUnknown(): void
+    {
+        $value = $this->repo->getSetting('Nonexistent Setting');
+
+        self::assertNull($value);
+    }
+
+    public function testGetBulkSettingsReturnsMultiple(): void
+    {
+        $settings = $this->repo->getBulkSettings(['Phase', 'Allow Trades']);
+
+        self::assertCount(2, $settings);
+        self::assertSame('Regular Season', $settings['Phase']);
+        self::assertSame('Yes', $settings['Allow Trades']);
+    }
+
+    public function testGetBulkSettingsReturnsEmptyForEmptyInput(): void
+    {
+        $settings = $this->repo->getBulkSettings([]);
+
+        self::assertSame([], $settings);
+    }
+
+    public function testGetSimLengthInDaysReturnsInt(): void
+    {
+        $days = $this->repo->getSimLengthInDays();
+
+        self::assertSame(3, $days);
+    }
+
+    public function testUpdateSettingChangesValue(): void
+    {
+        $this->repo->updateSetting('Allow Trades', 'No');
+
+        $value = $this->repo->getSetting('Allow Trades');
+        self::assertSame('No', $value);
+    }
+
+    public function testSetSeasonPhaseUpdatesSetting(): void
+    {
+        $this->repo->setSeasonPhase('Playoffs');
+
+        $value = $this->repo->getSetting('Current Season Phase');
+        self::assertSame('Playoffs', $value);
+    }
+
+    public function testSetSeasonPhasePreseasonDisablesDraftLink(): void
+    {
+        $this->repo->setSeasonPhase('Preseason');
+
+        $value = $this->repo->getSetting('Current Season Phase');
+        self::assertSame('Preseason', $value);
+
+        $draftLink = $this->repo->getSetting('Show Draft Link');
+        self::assertSame('Off', $draftLink);
+    }
+
+    public function testSetSimLengthInDaysUpdatesValue(): void
+    {
+        $this->repo->setSimLengthInDays(5);
+
+        $value = $this->repo->getSimLengthInDays();
+        self::assertSame(5, $value);
+    }
+
+    public function testSetAllowTradesUpdatesValue(): void
+    {
+        $this->repo->setAllowTrades('No');
+
+        $value = $this->repo->getSetting('Allow Trades');
+        self::assertSame('No', $value);
+    }
+
+    public function testSetAllowWaiversUpdatesValue(): void
+    {
+        $this->repo->setAllowWaivers('No');
+
+        $value = $this->repo->getSetting('Allow Waiver Moves');
+        self::assertSame('No', $value);
+    }
+
+    public function testResetAllStarVotingClearsVotes(): void
+    {
+        $result = $this->repo->resetAllStarVoting();
+
+        self::assertTrue($result);
+
+        $asgVoting = $this->repo->getSetting('ASG Voting');
+        self::assertSame('Yes', $asgVoting);
+    }
+
+    public function testResetEndOfYearVotingClearsVotes(): void
+    {
+        $result = $this->repo->resetEndOfYearVoting();
+
+        self::assertTrue($result);
+
+        $eoyVoting = $this->repo->getSetting('EOY Voting');
+        self::assertSame('Yes', $eoyVoting);
+    }
+
+    public function testResetAllContractExtensionsZeroesFlags(): void
+    {
+        // Set a non-zero value first
+        $this->db->query("UPDATE ibl_team_info SET Used_Extension_This_Season = 1 WHERE teamid = 1");
+
+        $result = $this->repo->resetAllContractExtensions();
+        self::assertTrue($result);
+
+        $stmt = $this->db->prepare("SELECT Used_Extension_This_Season FROM ibl_team_info WHERE teamid = 1");
+        self::assertNotFalse($stmt);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        self::assertNotNull($row);
+        self::assertSame(0, $row['Used_Extension_This_Season']);
+    }
+
+    public function testResetAllMlesAndLlesResetsFlags(): void
+    {
+        // Set to 0 first
+        $this->db->query("UPDATE ibl_team_info SET HasMLE = 0, HasLLE = 0 WHERE teamid = 1");
+
+        $result = $this->repo->resetAllMlesAndLles();
+        self::assertTrue($result);
+
+        $stmt = $this->db->prepare("SELECT HasMLE, HasLLE FROM ibl_team_info WHERE teamid = 1");
+        self::assertNotFalse($stmt);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        self::assertNotNull($row);
+        self::assertSame(1, $row['HasMLE']);
+        self::assertSame(1, $row['HasLLE']);
+    }
+
+    public function testSetFreeAgencyNotificationsUpdatesValue(): void
+    {
+        $this->repo->setFreeAgencyNotifications('No');
+
+        $value = $this->repo->getSetting('Free Agency Notifications');
+        self::assertSame('No', $value);
+    }
+
+    public function testActivateTriviaModeUpdatesValue(): void
+    {
+        $this->repo->activateTriviaMode();
+
+        $value = $this->repo->getSetting('Trivia Mode');
+        self::assertSame('On', $value);
+    }
+
+    public function testDeactivateTriviaModeUpdatesValue(): void
+    {
+        $this->repo->activateTriviaMode();
+        $this->repo->deactivateTriviaMode();
+
+        $value = $this->repo->getSetting('Trivia Mode');
+        self::assertSame('Off', $value);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/SavedDepthChartRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SavedDepthChartRepositoryTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use SavedDepthChart\SavedDepthChartRepository;
+
+class SavedDepthChartRepositoryTest extends DatabaseTestCase
+{
+    private SavedDepthChartRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new SavedDepthChartRepository($this->db);
+    }
+
+    public function testCreateSavedDepthChartReturnsInsertId(): void
+    {
+        $id = $this->repo->createSavedDepthChart(
+            1, 'testgm', 'My DC', 'Regular Season', 2024, '2024-01-15', 10
+        );
+
+        self::assertGreaterThan(0, $id);
+    }
+
+    public function testCreateSavedDepthChartWithoutNameSucceeds(): void
+    {
+        $id = $this->repo->createSavedDepthChart(
+            1, 'testgm', null, 'Regular Season', 2024, '2024-01-15', 10
+        );
+
+        self::assertGreaterThan(0, $id);
+
+        $chart = $this->repo->getSavedDepthChartById($id, 1);
+        self::assertNotNull($chart);
+        self::assertNull($chart['name']);
+    }
+
+    public function testGetSavedDepthChartsForTeamReturnsRows(): void
+    {
+        $this->repo->createSavedDepthChart(1, 'testgm', 'DC One', 'Regular Season', 2024, '2024-01-15', 10);
+        $this->repo->createSavedDepthChart(1, 'testgm', 'DC Two', 'Regular Season', 2024, '2024-02-15', 20);
+
+        $charts = $this->repo->getSavedDepthChartsForTeam(1);
+
+        self::assertGreaterThanOrEqual(2, count($charts));
+        // Ordered by created_at DESC — most recent first
+        self::assertSame('DC Two', $charts[0]['name']);
+    }
+
+    public function testGetSavedDepthChartByIdReturnsRow(): void
+    {
+        $id = $this->repo->createSavedDepthChart(1, 'testgm', 'Test DC', 'Regular Season', 2024, '2024-01-15', 10);
+
+        $chart = $this->repo->getSavedDepthChartById($id, 1);
+
+        self::assertNotNull($chart);
+        self::assertSame('Test DC', $chart['name']);
+        self::assertSame(1, $chart['tid']);
+        self::assertSame('testgm', $chart['username']);
+    }
+
+    public function testGetSavedDepthChartByIdReturnsNullForWrongTeam(): void
+    {
+        $id = $this->repo->createSavedDepthChart(1, 'testgm', 'Test DC', 'Regular Season', 2024, '2024-01-15', 10);
+
+        $chart = $this->repo->getSavedDepthChartById($id, 2);
+
+        self::assertNull($chart);
+    }
+
+    public function testSaveDepthChartPlayersInsertsRows(): void
+    {
+        $dcId = $this->repo->createSavedDepthChart(1, 'testgm', 'DC', 'Regular Season', 2024, '2024-01-15', 10);
+
+        $snapshots = [
+            [
+                'pid' => 1,
+                'player_name' => 'Test Player One',
+                'ordinal' => 1,
+                'dc_PGDepth' => 1,
+                'dc_SGDepth' => 0,
+                'dc_SFDepth' => 0,
+                'dc_PFDepth' => 0,
+                'dc_CDepth' => 0,
+                'dc_canPlayInGame' => 1,
+                'dc_minutes' => 32,
+                'dc_of' => 5,
+                'dc_df' => 5,
+                'dc_oi' => 3,
+                'dc_di' => 3,
+                'dc_bh' => 4,
+            ],
+        ];
+
+        $this->repo->saveDepthChartPlayers($dcId, $snapshots);
+
+        $players = $this->repo->getPlayersForDepthChart($dcId);
+
+        self::assertCount(1, $players);
+        self::assertSame(1, $players[0]['pid']);
+        self::assertSame('Test Player One', $players[0]['player_name']);
+        self::assertSame(32, $players[0]['dc_minutes']);
+    }
+
+    public function testUpdateDepthChartPlayersReplacesRows(): void
+    {
+        $dcId = $this->repo->createSavedDepthChart(1, 'testgm', 'DC', 'Regular Season', 2024, '2024-01-15', 10);
+
+        $original = [
+            [
+                'pid' => 1, 'player_name' => 'Test Player One', 'ordinal' => 1,
+                'dc_PGDepth' => 1, 'dc_SGDepth' => 0, 'dc_SFDepth' => 0, 'dc_PFDepth' => 0, 'dc_CDepth' => 0,
+                'dc_canPlayInGame' => 1, 'dc_minutes' => 32, 'dc_of' => 5, 'dc_df' => 5, 'dc_oi' => 3, 'dc_di' => 3, 'dc_bh' => 4,
+            ],
+        ];
+        $this->repo->saveDepthChartPlayers($dcId, $original);
+
+        $updated = [
+            [
+                'pid' => 1, 'player_name' => 'Test Player One', 'ordinal' => 1,
+                'dc_PGDepth' => 1, 'dc_SGDepth' => 2, 'dc_SFDepth' => 0, 'dc_PFDepth' => 0, 'dc_CDepth' => 0,
+                'dc_canPlayInGame' => 1, 'dc_minutes' => 36, 'dc_of' => 6, 'dc_df' => 4, 'dc_oi' => 3, 'dc_di' => 3, 'dc_bh' => 4,
+            ],
+        ];
+        $this->repo->updateDepthChartPlayers($dcId, $updated);
+
+        $players = $this->repo->getPlayersForDepthChart($dcId);
+
+        self::assertCount(1, $players);
+        self::assertSame(36, $players[0]['dc_minutes']);
+        self::assertSame(2, $players[0]['dc_SGDepth']);
+    }
+
+    public function testDeactivateForTeamSetsInactive(): void
+    {
+        $id = $this->repo->createSavedDepthChart(1, 'testgm', 'DC', 'Regular Season', 2024, '2024-01-15', 10);
+
+        $chart = $this->repo->getSavedDepthChartById($id, 1);
+        self::assertNotNull($chart);
+        self::assertSame(1, $chart['is_active']);
+
+        $this->repo->deactivateForTeam(1, '2024-02-15', 20);
+
+        $chart = $this->repo->getSavedDepthChartById($id, 1);
+        self::assertNotNull($chart);
+        self::assertSame(0, $chart['is_active']);
+    }
+
+    public function testDeactivateOthersForTeamKeepsOneActive(): void
+    {
+        $id1 = $this->repo->createSavedDepthChart(1, 'testgm', 'DC One', 'Regular Season', 2024, '2024-01-15', 10);
+        $id2 = $this->repo->createSavedDepthChart(1, 'testgm', 'DC Two', 'Regular Season', 2024, '2024-02-15', 20);
+
+        $this->repo->deactivateOthersForTeam(1, $id2, '2024-03-15', 30);
+
+        $chart1 = $this->repo->getSavedDepthChartById($id1, 1);
+        $chart2 = $this->repo->getSavedDepthChartById($id2, 1);
+
+        self::assertNotNull($chart1);
+        self::assertNotNull($chart2);
+        self::assertSame(0, $chart1['is_active']);
+        self::assertSame(1, $chart2['is_active']);
+    }
+
+    public function testUpdateNameChangesName(): void
+    {
+        $id = $this->repo->createSavedDepthChart(1, 'testgm', 'Old Name', 'Regular Season', 2024, '2024-01-15', 10);
+
+        $result = $this->repo->updateName($id, 1, 'New Name');
+
+        self::assertTrue($result);
+
+        $chart = $this->repo->getSavedDepthChartById($id, 1);
+        self::assertNotNull($chart);
+        self::assertSame('New Name', $chart['name']);
+    }
+
+    public function testUpdateNameReturnsFalseForWrongTeam(): void
+    {
+        $id = $this->repo->createSavedDepthChart(1, 'testgm', 'Name', 'Regular Season', 2024, '2024-01-15', 10);
+
+        $result = $this->repo->updateName($id, 2, 'New Name');
+
+        self::assertFalse($result);
+    }
+
+    public function testGetMostRecentDepthChartReturnsLatest(): void
+    {
+        $this->repo->createSavedDepthChart(1, 'testgm', 'DC Old', 'Regular Season', 2024, '2024-01-15', 10);
+        $id2 = $this->repo->createSavedDepthChart(1, 'testgm', 'DC New', 'Regular Season', 2024, '2024-02-15', 20);
+
+        $latest = $this->repo->getMostRecentDepthChart(1);
+
+        self::assertNotNull($latest);
+        self::assertSame($id2, $latest['id']);
+        self::assertSame('DC New', $latest['name']);
+    }
+
+    public function testGetActiveDepthChartForTeamReturnsActive(): void
+    {
+        $id = $this->repo->createSavedDepthChart(1, 'testgm', 'Active DC', 'Regular Season', 2024, '2024-01-15', 10);
+
+        $active = $this->repo->getActiveDepthChartForTeam(1);
+
+        self::assertNotNull($active);
+        self::assertSame($id, $active['id']);
+        self::assertSame(1, $active['is_active']);
+    }
+
+    public function testGetActiveDepthChartReturnsNullWhenAllInactive(): void
+    {
+        $this->repo->createSavedDepthChart(1, 'testgm', 'DC', 'Regular Season', 2024, '2024-01-15', 10);
+        $this->repo->deactivateForTeam(1, '2024-02-15', 20);
+
+        $active = $this->repo->getActiveDepthChartForTeam(1);
+
+        self::assertNull($active);
+    }
+
+    public function testExtendActiveDepthChartsUpdatesExpiry(): void
+    {
+        $id = $this->repo->createSavedDepthChart(1, 'testgm', 'DC', 'Regular Season', 2024, '2024-01-15', 10);
+
+        $affected = $this->repo->extendActiveDepthCharts('2024-03-01', 30);
+
+        self::assertGreaterThan(0, $affected);
+
+        $chart = $this->repo->getSavedDepthChartById($id, 1);
+        self::assertNotNull($chart);
+        self::assertSame('2024-03-01', $chart['sim_end_date']);
+        self::assertSame(30, $chart['sim_number_end']);
+    }
+
+    public function testReactivateSetsActive(): void
+    {
+        $id = $this->repo->createSavedDepthChart(1, 'testgm', 'DC', 'Regular Season', 2024, '2024-01-15', 10);
+        $this->repo->deactivateForTeam(1, '2024-02-15', 20);
+
+        $result = $this->repo->reactivate($id, 1);
+
+        self::assertTrue($result);
+
+        $chart = $this->repo->getSavedDepthChartById($id, 1);
+        self::assertNotNull($chart);
+        self::assertSame(1, $chart['is_active']);
+    }
+
+    public function testReactivateReturnsFalseForWrongTeam(): void
+    {
+        $id = $this->repo->createSavedDepthChart(1, 'testgm', 'DC', 'Regular Season', 2024, '2024-01-15', 10);
+        $this->repo->deactivateForTeam(1, '2024-02-15', 20);
+
+        $result = $this->repo->reactivate($id, 2);
+
+        self::assertFalse($result);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/TeamRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamRepositoryTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use Team\TeamRepository;
+
+class TeamRepositoryTest extends DatabaseTestCase
+{
+    private TeamRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new TeamRepository($this->db);
+    }
+
+    public function testGetTeamReturnsRowForKnownTeam(): void
+    {
+        // Team 1 exists in production data — just verify structure
+        $team = $this->repo->getTeam(1);
+
+        self::assertNotNull($team);
+        self::assertSame(1, $team['teamid']);
+        self::assertArrayHasKey('team_name', $team);
+        self::assertArrayHasKey('team_city', $team);
+        self::assertArrayHasKey('color1', $team);
+    }
+
+    public function testGetTeamReturnsNullForUnknown(): void
+    {
+        $team = $this->repo->getTeam(99999);
+
+        self::assertNull($team);
+    }
+
+    public function testGetTeamPowerDataReturnsJoinedRow(): void
+    {
+        $this->ensureStandingsAndPowerExist(1, 'Atlantic', 'Eastern');
+
+        // Get team name for teamid=1
+        $stmt = $this->db->prepare("SELECT team_name FROM ibl_team_info WHERE teamid = 1");
+        self::assertNotFalse($stmt);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        self::assertNotNull($row);
+
+        /** @var string $teamName */
+        $teamName = $row['team_name'];
+
+        $power = $this->repo->getTeamPowerData($teamName);
+
+        self::assertNotNull($power);
+        self::assertArrayHasKey('tid', $power);
+        self::assertArrayHasKey('team_name', $power);
+        self::assertArrayHasKey('wins', $power);
+        self::assertArrayHasKey('losses', $power);
+        self::assertArrayHasKey('conference', $power);
+        self::assertArrayHasKey('division', $power);
+        self::assertArrayHasKey('ranking', $power);
+        self::assertArrayHasKey('streak_type', $power);
+        self::assertArrayHasKey('sos', $power);
+    }
+
+    public function testGetTeamPowerDataReturnsNullForUnknown(): void
+    {
+        $power = $this->repo->getTeamPowerData('Nonexistent Team');
+
+        self::assertNull($power);
+    }
+
+    public function testGetDivisionStandingsReturnsTeamsInDivision(): void
+    {
+        // Ensure standings + power data exists for a test division
+        $this->ensureStandingsAndPowerExist(1, 'Atlantic', 'Eastern');
+
+        $standings = $this->repo->getDivisionStandings('Atlantic');
+
+        self::assertNotEmpty($standings);
+        foreach ($standings as $r) {
+            self::assertSame('Atlantic', $r['division']);
+            self::assertArrayHasKey('ranking', $r);
+        }
+    }
+
+    public function testGetConferenceStandingsReturnsTeamsInConference(): void
+    {
+        $this->ensureStandingsAndPowerExist(1, 'Atlantic', 'Eastern');
+
+        $standings = $this->repo->getConferenceStandings('Eastern');
+
+        self::assertNotEmpty($standings);
+        foreach ($standings as $r) {
+            self::assertSame('Eastern', $r['conference']);
+        }
+    }
+
+    public function testGetChampionshipBannersReturnsRows(): void
+    {
+        // Insert a test banner within the transaction
+        $this->insertRow('ibl_banners', [
+            'year' => 2099,
+            'currentname' => 'TestBannerTeam',
+            'bannername' => 'TestBannerTeam',
+            'bannertype' => 1,
+        ]);
+
+        $banners = $this->repo->getChampionshipBanners('TestBannerTeam');
+
+        self::assertNotEmpty($banners);
+        self::assertSame(2099, $banners[0]['year']);
+        self::assertSame('TestBannerTeam', $banners[0]['currentname']);
+    }
+
+    public function testGetChampionshipBannersReturnsEmptyForUnknown(): void
+    {
+        $banners = $this->repo->getChampionshipBanners('ZZZ_Nonexistent_Team');
+
+        self::assertSame([], $banners);
+    }
+
+    public function testGetGMTenuresReturnsRows(): void
+    {
+        // Insert a test tenure within the transaction
+        $this->insertRow('ibl_gm_tenures', [
+            'franchise_id' => 1,
+            'gm_username' => 'test_tenure_gm',
+            'start_season_year' => 2098,
+            'end_season_year' => 2099,
+            'is_mid_season_start' => 0,
+            'is_mid_season_end' => 0,
+        ]);
+
+        $tenures = $this->repo->getGMTenures(1);
+
+        self::assertNotEmpty($tenures);
+        // Find our inserted tenure
+        $found = false;
+        foreach ($tenures as $tenure) {
+            if ($tenure['gm_username'] === 'test_tenure_gm') {
+                self::assertSame(2098, $tenure['start_season_year']);
+                $found = true;
+                break;
+            }
+        }
+        self::assertTrue($found, 'Inserted GM tenure not found');
+    }
+
+    public function testGetRegularSeasonHistoryDependsOnBoxscoreView(): void
+    {
+        // ibl_team_win_loss is a VIEW derived from ibl_box_scores_teams.
+        // Insert a regular season boxscore (month 01 = game_type 1)
+        $this->insertTeamBoxscoreRow('2098-01-15', 'TestHistTeam', 1, 2, 1);
+
+        // The view joins with ibl_team_info, so get team_name for teamid=1
+        $stmt = $this->db->prepare("SELECT team_name FROM ibl_team_info WHERE teamid = 1");
+        self::assertNotFalse($stmt);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        self::assertNotNull($row);
+
+        /** @var string $teamName */
+        $teamName = $row['team_name'];
+        $history = $this->repo->getRegularSeasonHistory($teamName);
+
+        self::assertNotEmpty($history);
+        self::assertArrayHasKey('year', $history[0]);
+        self::assertArrayHasKey('wins', $history[0]);
+        self::assertArrayHasKey('losses', $history[0]);
+    }
+
+    public function testGetRosterUnderContractReturnsContractedPlayers(): void
+    {
+        // Team 1 should have players in production data
+        $roster = $this->repo->getRosterUnderContract(1);
+
+        self::assertNotEmpty($roster);
+        foreach ($roster as $player) {
+            self::assertSame(1, $player['tid']);
+            self::assertSame(0, $player['retired']);
+        }
+    }
+
+    public function testGetFreeAgentsReturnsPlayersWithHighOrdinal(): void
+    {
+        // Insert a free agent player with high ordinal in the transaction
+        $this->insertRow('ibl_plr', [
+            'pid' => 99990,
+            'name' => 'Test Free Agent',
+            'age' => 25,
+            'tid' => 0,
+            'pos' => 'SG',
+            'sta' => 70,
+            'exp' => 2,
+            'bird' => 0,
+            'cy' => 0,
+            'cyt' => 0,
+            'cy1' => 0,
+            'cy2' => 0,
+            'retired' => 0,
+            'ordinal' => 1000,
+            'droptime' => 0,
+            'uuid' => '99990000-0000-0000-0000-000000000000',
+        ]);
+
+        $freeAgents = $this->repo->getFreeAgents();
+
+        self::assertNotEmpty($freeAgents);
+        foreach ($freeAgents as $player) {
+            self::assertGreaterThan(959, $player['ordinal']);
+            self::assertSame(0, $player['retired']);
+        }
+    }
+
+    public function testGetAllTeamsReturnsOnlyRealTeams(): void
+    {
+        $teams = $this->repo->getAllTeams();
+
+        self::assertNotEmpty($teams);
+        foreach ($teams as $team) {
+            self::assertGreaterThanOrEqual(1, $team['teamid']);
+            self::assertLessThanOrEqual(\League::MAX_REAL_TEAMID, $team['teamid']);
+        }
+    }
+
+    public function testGetFranchiseSeasonsReturnsRows(): void
+    {
+        $seasons = $this->repo->getFranchiseSeasons(1);
+
+        // Production DB should have franchise season data
+        self::assertNotEmpty($seasons);
+        self::assertSame(1, $seasons[0]['franchise_id']);
+        self::assertArrayHasKey('season_year', $seasons[0]);
+        self::assertArrayHasKey('team_city', $seasons[0]);
+        self::assertArrayHasKey('team_name', $seasons[0]);
+    }
+
+    public function testGetHistoricalRosterReturnsRows(): void
+    {
+        // Insert a test hist row in the transaction
+        $this->insertRow('ibl_hist', [
+            'pid' => 1,
+            'name' => 'Test Hist Player',
+            'year' => 2098,
+            'team' => 'TestTeam',
+            'teamid' => 1,
+            'games' => 50,
+            'minutes' => 1600,
+            'fgm' => 300,
+            'fga' => 600,
+            'ftm' => 100,
+            'fta' => 120,
+            'tgm' => 50,
+            'tga' => 130,
+            'orb' => 40,
+            'reb' => 200,
+            'ast' => 150,
+            'stl' => 50,
+            'blk' => 20,
+            'tvr' => 80,
+            'pf' => 100,
+            'pts' => 750,
+            'salary' => 1500,
+        ]);
+
+        $roster = $this->repo->getHistoricalRoster(1, '2098');
+
+        self::assertNotEmpty($roster);
+        self::assertSame(1, $roster[0]['teamid']);
+    }
+
+    private function ensureStandingsAndPowerExist(int $tid, string $division, string $conference): void
+    {
+        // Use REPLACE to ensure data exists within transaction regardless of DB state
+        $this->db->query("DELETE FROM ibl_power WHERE TeamID = $tid");
+        $this->db->query("DELETE FROM ibl_standings WHERE tid = $tid");
+        $this->insertRow('ibl_standings', [
+            'tid' => $tid,
+            'team_name' => 'TestTeam',
+            'wins' => 30,
+            'losses' => 20,
+            'pct' => 0.600,
+            'leagueRecord' => '30-20',
+            'conference' => $conference,
+            'division' => $division,
+            'confRecord' => '18-12',
+            'confGB' => 0.0,
+            'divRecord' => '8-4',
+            'divGB' => 0.0,
+            'homeRecord' => '18-7',
+            'awayRecord' => '12-13',
+            'gamesUnplayed' => 32,
+        ]);
+        $this->insertRow('ibl_power', [
+            'TeamID' => $tid,
+            'ranking' => 75.5,
+            'last_win' => 7,
+            'last_loss' => 3,
+            'streak_type' => 'W',
+            'streak' => 3,
+            'sos' => 0.510,
+            'remaining_sos' => 0.490,
+        ]);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/TransactionHistoryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TransactionHistoryRepositoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use TransactionHistory\TransactionHistoryRepository;
+
+/**
+ * Tests TransactionHistoryRepository against real MariaDB.
+ *
+ * Note: nuke_stories uses MyISAM, so inserts are NOT rolled back by transaction.
+ * Tests only read seed data — no writes to MyISAM tables.
+ */
+class TransactionHistoryRepositoryTest extends DatabaseTestCase
+{
+    private TransactionHistoryRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new TransactionHistoryRepository($this->db);
+    }
+
+    public function testGetAvailableYearsReturnsDistinctYears(): void
+    {
+        $years = $this->repo->getAvailableYears();
+
+        self::assertNotEmpty($years);
+        // Seed has entries from 2024 and 2023
+        self::assertContains(2024, $years);
+        self::assertContains(2023, $years);
+        // Should be descending
+        self::assertGreaterThanOrEqual($years[1], $years[0]);
+    }
+
+    public function testGetTransactionsReturnsAllWithNoFilters(): void
+    {
+        $transactions = $this->repo->getTransactions(null, null, null);
+
+        self::assertNotEmpty($transactions);
+        self::assertArrayHasKey('sid', $transactions[0]);
+        self::assertArrayHasKey('catid', $transactions[0]);
+        self::assertArrayHasKey('title', $transactions[0]);
+        self::assertArrayHasKey('time', $transactions[0]);
+    }
+
+    public function testGetTransactionsFiltersByCategory(): void
+    {
+        $transactions = $this->repo->getTransactions(1, null, null);
+
+        self::assertNotEmpty($transactions);
+        foreach ($transactions as $row) {
+            // nuke_stories.catid is INT — native types enabled, returns int
+            self::assertSame(1, $row['catid']);
+        }
+    }
+
+    public function testGetTransactionsFiltersByYear(): void
+    {
+        $transactions = $this->repo->getTransactions(null, 2024, null);
+
+        self::assertNotEmpty($transactions);
+        foreach ($transactions as $row) {
+            self::assertStringStartsWith('2024-', $row['time']);
+        }
+    }
+
+    public function testGetTransactionsFiltersByYearAndMonth(): void
+    {
+        $transactions = $this->repo->getTransactions(null, 2024, 3);
+
+        self::assertNotEmpty($transactions);
+        foreach ($transactions as $row) {
+            self::assertStringStartsWith('2024-03-', $row['time']);
+        }
+    }
+
+    public function testGetTransactionsReturnsEmptyForNoMatches(): void
+    {
+        $transactions = $this->repo->getTransactions(null, 1900, null);
+
+        self::assertSame([], $transactions);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/fixtures/db-seed.sql
+++ b/ibl5/tests/DatabaseIntegration/fixtures/db-seed.sql
@@ -37,3 +37,108 @@ ON DUPLICATE KEY UPDATE value = VALUES(value);
 INSERT INTO ibl_settings (name, value)
 VALUES ('Phase', 'Regular Season')
 ON DUPLICATE KEY UPDATE value = VALUES(value);
+
+-- Additional settings needed by LeagueControlPanel tests
+INSERT INTO ibl_settings (name, value)
+VALUES ('Current Season Phase', 'Regular Season')
+ON DUPLICATE KEY UPDATE value = VALUES(value);
+
+INSERT INTO ibl_settings (name, value)
+VALUES ('Sim Length in Days', '3')
+ON DUPLICATE KEY UPDATE value = VALUES(value);
+
+INSERT INTO ibl_settings (name, value)
+VALUES ('Allow Waiver Moves', 'Yes')
+ON DUPLICATE KEY UPDATE value = VALUES(value);
+
+INSERT INTO ibl_settings (name, value)
+VALUES ('Show Draft Link', 'Off')
+ON DUPLICATE KEY UPDATE value = VALUES(value);
+
+INSERT INTO ibl_settings (name, value)
+VALUES ('ASG Voting', 'No')
+ON DUPLICATE KEY UPDATE value = VALUES(value);
+
+INSERT INTO ibl_settings (name, value)
+VALUES ('EOY Voting', 'No')
+ON DUPLICATE KEY UPDATE value = VALUES(value);
+
+INSERT INTO ibl_settings (name, value)
+VALUES ('Free Agency Notifications', 'Yes')
+ON DUPLICATE KEY UPDATE value = VALUES(value);
+
+INSERT INTO ibl_settings (name, value)
+VALUES ('Trivia Mode', 'Off')
+ON DUPLICATE KEY UPDATE value = VALUES(value);
+
+-- Standings: Metros and Sharks in same division/conference
+INSERT INTO ibl_standings (tid, team_name, pct, leagueRecord, wins, losses, conference, confRecord, confGB, division, divRecord, divGB, homeRecord, awayRecord, gamesUnplayed)
+VALUES (1, 'Metros', 0.600, '30-20', 30, 20, 'Eastern', '18-12', 0.0, 'Atlantic', '8-4', 0.0, '18-7', '12-13', 32)
+ON DUPLICATE KEY UPDATE team_name = VALUES(team_name), wins = VALUES(wins), losses = VALUES(losses);
+
+INSERT INTO ibl_standings (tid, team_name, pct, leagueRecord, wins, losses, conference, confRecord, confGB, division, divRecord, divGB, homeRecord, awayRecord, gamesUnplayed)
+VALUES (2, 'Sharks', 0.400, '20-30', 20, 30, 'Western', '10-18', 5.0, 'Pacific', '4-8', 3.0, '12-13', '8-17', 32)
+ON DUPLICATE KEY UPDATE team_name = VALUES(team_name), wins = VALUES(wins), losses = VALUES(losses);
+
+-- Power ratings for both teams
+INSERT INTO ibl_power (TeamID, ranking, last_win, last_loss, streak_type, streak, sos, remaining_sos)
+VALUES (1, 75.5, 7, 3, 'W', 3, 0.510, 0.490)
+ON DUPLICATE KEY UPDATE ranking = VALUES(ranking);
+
+INSERT INTO ibl_power (TeamID, ranking, last_win, last_loss, streak_type, streak, sos, remaining_sos)
+VALUES (2, 45.2, 4, 6, 'L', 2, 0.480, 0.520)
+ON DUPLICATE KEY UPDATE ranking = VALUES(ranking);
+
+-- Championship banner for Metros
+INSERT INTO ibl_banners (year, currentname, bannername, bannertype)
+VALUES (2024, 'Metros', 'Metros', 1);
+
+-- GM tenure for Metros franchise
+INSERT INTO ibl_gm_tenures (franchise_id, gm_username, start_season_year, end_season_year, is_mid_season_start, is_mid_season_end)
+VALUES (1, 'testgm', 2020, NULL, 0, 0)
+ON DUPLICATE KEY UPDATE gm_username = VALUES(gm_username);
+
+-- Historical player stats (ibl_hist) for franchise history queries
+INSERT INTO ibl_hist (pid, name, year, team, teamid, games, minutes, fgm, fga, ftm, fta, tgm, tga, orb, reb, ast, stl, blk, tvr, pf, pts, salary)
+VALUES (1, 'Test Player One', 2024, 'Metros', 1, 50, 1600, 300, 600, 100, 120, 50, 130, 40, 200, 150, 50, 20, 80, 100, 750, 1500)
+ON DUPLICATE KEY UPDATE games = VALUES(games);
+
+-- Franchise seasons for historical name lookups
+INSERT INTO ibl_franchise_seasons (franchise_id, season_year, season_ending_year, team_city, team_name)
+VALUES (1, 2023, 2024, 'New York', 'Metros')
+ON DUPLICATE KEY UPDATE team_name = VALUES(team_name);
+
+-- nuke_modules: Draft module entry (needed by setSeasonPhase/setShowDraftLink tests)
+-- Note: nuke_modules uses MyISAM — not covered by transaction rollback.
+-- Tests that modify this table must clean up manually.
+INSERT INTO nuke_modules (title, custom_title, active, view, inmenu, mod_group, admins)
+VALUES ('Draft', 'Draft', 1, 0, 1, 0, '')
+ON DUPLICATE KEY UPDATE active = 1;
+
+-- ASG voting rows for Metros and Sharks
+INSERT INTO ibl_votes_ASG (teamid, team_city, team_name, East_F1)
+VALUES (1, 'New York', 'Metros', 'Some Player')
+ON DUPLICATE KEY UPDATE East_F1 = VALUES(East_F1);
+
+INSERT INTO ibl_votes_ASG (teamid, team_city, team_name, West_F1)
+VALUES (2, 'San Diego', 'Sharks', 'Another Player')
+ON DUPLICATE KEY UPDATE West_F1 = VALUES(West_F1);
+
+-- EOY voting rows for Metros and Sharks
+INSERT INTO ibl_votes_EOY (teamid, team_city, team_name, MVP_1)
+VALUES (1, 'New York', 'Metros', 'Some Player')
+ON DUPLICATE KEY UPDATE MVP_1 = VALUES(MVP_1);
+
+INSERT INTO ibl_votes_EOY (teamid, team_city, team_name, MVP_1)
+VALUES (2, 'San Diego', 'Sharks', 'Another Player')
+ON DUPLICATE KEY UPDATE MVP_1 = VALUES(MVP_1);
+
+-- Transaction history entries (nuke_stories with transaction categories)
+-- Note: nuke_stories uses MyISAM — not covered by transaction rollback.
+INSERT INTO nuke_stories (sid, catid, aid, title, time, hometext, comments, counter, topic, informant, ihome, acomm, haspoll, pollID, score, ratings)
+VALUES (1, 1, 'admin', 'Metros sign Test Player One', '2024-03-15 12:00:00', 'Details...', 0, 0, 1, '', 0, 0, 0, 0, 0, 0)
+ON DUPLICATE KEY UPDATE title = VALUES(title);
+
+INSERT INTO nuke_stories (sid, catid, aid, title, time, hometext, comments, counter, topic, informant, ihome, acomm, haspoll, pollID, score, ratings)
+VALUES (2, 2, 'admin', 'Sharks trade for draft pick', '2023-07-10 14:30:00', 'Details...', 0, 0, 1, '', 0, 0, 0, 0, 0, 0)
+ON DUPLICATE KEY UPDATE title = VALUES(title);


### PR DESCRIPTION
## Summary

Expands the `tests/DatabaseIntegration/` suite from 3 test files (~20 tests) to 8 test files (~87 tests), covering the 5 highest-impact repositories identified in the database integration test expansion plan.

## New Test Coverage

| Repository | Tests | Write Methods Tested |
|---|---|---|
| **TeamRepository** | 15 | — (read-only) |
| **LeagueControlPanelRepository** | 18 | 12 (settings updates, voting resets, MLE/LLE resets) |
| **BoxscoreRepository** | 10 | 7 (insert/delete team & player boxscores) |
| **SavedDepthChartRepository** | 18 | 8 (create, save players, activate/deactivate, extend) |
| **TransactionHistoryRepository** | 5 | — (read-only, validates QueryConditions builder) |

## Bug Fix

Found a real bug during testing: `SavedDepthChartRepository::createSavedDepthChart()` had a bind types string `"isssissi"` (8 chars) for 7 bind parameters — the extra `i` was for the hardcoded literal `1` in the VALUES clause. This would have caused a runtime error whenever a named depth chart was created through the database. Fixed to `"isssisi"`.

## Infrastructure Changes

- **DatabaseTestCase**: Added `#[Group('database')]` attribute so DB tests are excluded from default PHPUnit runs. Moved shared `insertTeamBoxscoreRow()` helper to base class.
- **phpunit.xml**: Added comment documenting that DatabaseIntegration tests are not in the default suite.
- **db-seed.sql**: Expanded with standings, power ratings, banners, GM tenures, voting rows, additional settings, franchise seasons, and transaction history seed data.

## Running the Tests

```bash
# DB integration tests require a running MariaDB:
cd ibl5 && DB_HOST=127.0.0.1 DB_USER=root DB_PASS=root DB_NAME=iblhoops_ibl5 \
  vendor/bin/phpunit tests/DatabaseIntegration/ --no-progress --no-output --testdox-summary
```

## Manual Testing

No manual testing needed — all changes are test infrastructure.