### PR TITLE
test: expand mobile smoke suite to cover 15 additional pages

### DIFF
--- a/ibl5/tests/e2e/smoke/mobile-auth.spec.ts
+++ b/ibl5/tests/e2e/smoke/mobile-auth.spec.ts
@@ -73,6 +73,19 @@ test.describe('Mobile authenticated page smoke tests', () => {
     await assertNoHorizontalOverflow(page, 'on gm contact list');
   });
 
+  test('voting results — no horizontal overflow on mobile', async ({ appState, page }) => {
+    await appState({ 'ASG Voting': 'Yes' });
+    await page.goto('modules.php?name=VotingResults');
+    await expect(page.getByText('Sign In')).not.toBeVisible();
+    await assertNoHorizontalOverflow(page, 'on voting results');
+  });
+
+  test('your account — no horizontal overflow on mobile', async ({ page }) => {
+    await page.goto('modules.php?name=YourAccount');
+    await expect(page.getByText('Sign In')).not.toBeVisible();
+    await assertNoHorizontalOverflow(page, 'on your account');
+  });
+
   test('no PHP errors on mobile auth pages', async ({ appState, page }) => {
     test.setTimeout(120_000);
     await appState({
@@ -80,7 +93,12 @@ test.describe('Mobile authenticated page smoke tests', () => {
       'Current Season Phase': 'Free Agency',
       'ASG Voting': 'Yes',
     });
-    for (const { url } of AUTH_PAGES) {
+    const urls = [
+      ...AUTH_PAGES.map(p => p.url),
+      'modules.php?name=VotingResults',
+      'modules.php?name=YourAccount',
+    ];
+    for (const url of urls) {
       await gotoWithRetry(page, url);
       await assertNoPhpErrors(page, `on ${url} (mobile)`);
     }

--- a/ibl5/tests/e2e/smoke/mobile-public.spec.ts
+++ b/ibl5/tests/e2e/smoke/mobile-public.spec.ts
@@ -32,6 +32,18 @@ const PAGES = [
   { name: 'series records', url: 'modules.php?name=SeriesRecords', selector: '.ibl-data-table, table, .ibl-title', hasWideTables: false },
   { name: 'franchise history', url: 'modules.php?name=FranchiseHistory', selector: '.ibl-data-table, table, .ibl-title', hasWideTables: false },
   { name: 'activity tracker', url: 'modules.php?name=ActivityTracker', selector: '.ibl-data-table, table, .ibl-title', hasWideTables: true },
+  { name: 'record holders', url: 'modules.php?name=RecordHolders', selector: '.ibl-title, .ibl-data-table, table', hasWideTables: false },
+  { name: 'all-star appearances', url: 'modules.php?name=AllStarAppearances', selector: '.ibl-title, .ibl-data-table, table', hasWideTables: false },
+  { name: 'award history', url: 'modules.php?name=AwardHistory', selector: '.ibl-title, .ibl-data-table, table', hasWideTables: false },
+  { name: 'franchise record book', url: 'modules.php?name=FranchiseRecordBook', selector: '.ibl-title, .ibl-data-table, table', hasWideTables: false },
+  { name: 'team off/def stats', url: 'modules.php?name=TeamOffDefStats', selector: '.ibl-data-table, .ibl-title', hasWideTables: true },
+  { name: 'transaction history', url: 'modules.php?name=TransactionHistory', selector: '.ibl-title, .ibl-data-table, table', hasWideTables: false },
+  { name: 'search', url: 'modules.php?name=Search', selector: 'input[type="radio"]', hasWideTables: false, skipOverflow: true },
+  { name: 'boxscore', url: 'modules.php?name=Boxscore&boxid=1', selector: '.ibl-data-table, table', hasWideTables: false, dataDependentSkip: true },
+  { name: 'season archive', url: 'modules.php?name=SeasonArchive', selector: '.ibl-title, .ibl-data-table, table', hasWideTables: false },
+  { name: 'one-on-one game', url: 'modules.php?name=OneOnOneGame', selector: '#pid1', hasWideTables: false, skipOverflow: true },
+  { name: 'topics', url: 'modules.php?name=Topics', selector: '.ibl-title, table, a', hasWideTables: false, skipOverflow: true },
+  { name: 'news', url: 'modules.php?name=News', selector: '.ibl-title, .story-title, table', hasWideTables: false, dataDependentSkip: true },
 ] as const;
 
 test.describe('Mobile public page smoke tests', () => {
@@ -44,12 +56,12 @@ test.describe('Mobile public page smoke tests', () => {
       test.setTimeout(60_000);
       await gotoWithRetry(page, pageInfo.url);
 
-      // Data-dependent skip for Cap Space
+      // Data-dependent skip — content may not exist in seed data
       if (pageInfo.dataDependentSkip) {
         const table = page.locator(pageInfo.selector).first();
         const visible = await table.isVisible().catch(() => false);
         if (!visible) {
-          test.skip(true, 'Cap Space rendered no table content (local DB state)');
+          test.skip(true, `${pageInfo.name} rendered no content (local DB state)`);
         }
       }
 
@@ -65,9 +77,20 @@ test.describe('Mobile public page smoke tests', () => {
     });
   }
 
+  test('team schedule — no horizontal overflow on mobile', async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWithRetry(page, 'modules.php?name=Schedule&teamID=1');
+    await expect(page.locator('.schedule-container, .schedule-game, table').first()).toBeVisible();
+    await assertNoHorizontalOverflow(page, 'on team schedule');
+  });
+
   test('no PHP errors on mobile public pages', async ({ page }) => {
     test.setTimeout(120_000);
-    for (const { url } of PAGES) {
+    const urls = [
+      ...PAGES.map(p => p.url),
+      'modules.php?name=Schedule&teamID=1',
+    ];
+    for (const url of urls) {
       await gotoWithRetry(page, url);
       await assertNoPhpErrors(page, `on ${url} (mobile)`);
     }


### PR DESCRIPTION
## Summary

Expands the mobile E2E smoke test suite from 30 pages to 45 pages (22→35 public, 8→10 authenticated). All tests run at 375×812 (iPhone SE) viewport checking for horizontal overflow, scroll wrappers, and PHP errors.

## New public pages (13)
- Record Holders, All-Star Appearances, Award History, Franchise Record Book
- Team Off/Def Stats, Transaction History, Search, Boxscore
- Season Archive, One-on-One Game, Topics, News, Team Schedule

## New authenticated pages (2)
- Voting Results (requires ASG Voting state)
- Your Account

## Known overflow pages
Search, One-on-One Game, and Topics have horizontal overflow at 375px — marked with `skipOverflow` for now. These will be addressed in a future mobile usability overhaul.

## Data-dependent skips
Boxscore and News are skipped when seed data doesn't contain the needed records.

## Manual Testing
No manual testing needed — all changes are covered by E2E tests.