### PR TITLE
test: mobile smoke phase 2 — sub-page variants and nav interaction tests

### DIFF
--- a/ibl5/tests/e2e/smoke/mobile-nav.spec.ts
+++ b/ibl5/tests/e2e/smoke/mobile-nav.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { openMobileMenu, gotoWithRetry } from '../helpers/navigation';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+test.use({ viewport: { width: 375, height: 812 } });
+
+test.describe('Mobile nav interaction tests', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoWithRetry(page, 'index.php');
+  });
+
+  test('overlay closes menu', async ({ page }) => {
+    await openMobileMenu(page);
+    await expect(page.locator('#nav-mobile-menu')).toBeVisible();
+    // Overlay is z-40, menu panel is z-50 on the right — click the exposed left side
+    await page.locator('#nav-overlay').click({ position: { x: 20, y: 400 } });
+    await expect(page.locator('#nav-mobile-menu')).not.toBeVisible();
+  });
+
+  test('escape key closes menu', async ({ page }) => {
+    await openMobileMenu(page);
+    await expect(page.locator('#nav-mobile-menu')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#nav-mobile-menu')).not.toBeVisible();
+  });
+
+  test('exclusive dropdowns — opening one closes the other', async ({ page }) => {
+    await openMobileMenu(page);
+
+    // Open "Season" dropdown and verify "Standings" link is visible
+    await page.getByRole('button', { name: /season/i }).click();
+    await expect(page.locator('#nav-mobile-menu').getByText('Standings').first()).toBeVisible();
+
+    // Open "Stats" dropdown — "Standings" should no longer be visible
+    await page.getByRole('button', { name: /stats/i }).click();
+    await expect(page.locator('#nav-mobile-menu').getByText('Standings').first()).not.toBeVisible();
+  });
+
+  test('body scroll lock when menu is open', async ({ page }) => {
+    await openMobileMenu(page);
+    const overflow = await page.evaluate(() => getComputedStyle(document.body).overflow);
+    expect(overflow).toBe('hidden');
+  });
+
+  test('league switcher present in mobile menu', async ({ page }) => {
+    await openMobileMenu(page);
+    await page.getByRole('button', { name: /season/i }).click();
+    await expect(page.locator('#mobile-league-select')).toBeAttached();
+  });
+
+  test('aria-expanded toggles on hamburger', async ({ page }) => {
+    const hamburger = page.locator('#nav-hamburger');
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+    await hamburger.click();
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('nav link navigates to correct page', async ({ page }) => {
+    await openMobileMenu(page);
+    await page.getByRole('button', { name: /season/i }).click();
+    const standingsLink = page.locator('#nav-mobile-menu').getByRole('link', { name: 'Standings' });
+    const href = await standingsLink.getAttribute('href');
+    expect(href).toBeTruthy();
+    await gotoWithRetry(page, href!);
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
+  });
+});

--- a/ibl5/tests/e2e/smoke/mobile-public.spec.ts
+++ b/ibl5/tests/e2e/smoke/mobile-public.spec.ts
@@ -84,11 +84,50 @@ test.describe('Mobile public page smoke tests', () => {
     await assertNoHorizontalOverflow(page, 'on team schedule');
   });
 
+  test('draft history year detail — no horizontal overflow on mobile', async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWithRetry(page, 'modules.php?name=DraftHistory&year=2026');
+    // CI seed has 2026 draft picks; local DB may not — skip if no table rendered
+    const table = page.locator('.ibl-data-table').first();
+    const visible = await table.isVisible().catch(() => false);
+    if (!visible) {
+      test.skip(true, 'draft history year 2026 has no data (local DB state)');
+    }
+    await expect(table).toBeVisible();
+    await assertNoHorizontalOverflow(page, 'on draft history year detail');
+    await assertScrollWrappersPresent(page, 'on draft history year detail');
+  });
+
+  test('draft history team view — no horizontal overflow on mobile', async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWithRetry(page, 'modules.php?name=DraftHistory&teamID=1');
+    await expect(page.locator('.ibl-title').first()).toBeVisible();
+    await assertNoHorizontalOverflow(page, 'on draft history team view');
+  });
+
+  test('franchise record book team view — no horizontal overflow on mobile', async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWithRetry(page, 'modules.php?name=FranchiseRecordBook&teamid=1');
+    await expect(page.locator('.ibl-title, .ibl-data-table, table').first()).toBeVisible();
+    await assertNoHorizontalOverflow(page, 'on franchise record book team view');
+  });
+
+  test('season archive year detail — no horizontal overflow on mobile', async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWithRetry(page, 'modules.php?name=SeasonArchive&year=2026');
+    await expect(page.locator('.ibl-title').first()).toBeVisible();
+    await assertNoHorizontalOverflow(page, 'on season archive year detail');
+  });
+
   test('no PHP errors on mobile public pages', async ({ page }) => {
     test.setTimeout(120_000);
     const urls = [
       ...PAGES.map(p => p.url),
       'modules.php?name=Schedule&teamID=1',
+      'modules.php?name=DraftHistory&year=2026',
+      'modules.php?name=DraftHistory&teamID=1',
+      'modules.php?name=FranchiseRecordBook&teamid=1',
+      'modules.php?name=SeasonArchive&year=2026',
     ];
     for (const url of urls) {
       await gotoWithRetry(page, url);


### PR DESCRIPTION
## Summary

Adds 11 new E2E tests expanding mobile smoke coverage:

### Sub-page variant tests (mobile-public.spec.ts)
4 tests for module render paths completely different from the index views already covered:
- **Draft history year detail** — `DraftHistory&year=2026` (dataDependentSkip for local DB without 2026 draft picks)
- **Draft history team view** — `DraftHistory&teamID=1` (`renderTeamHistory()` path)
- **Franchise record book team view** — `FranchiseRecordBook&teamid=1`
- **Season archive year detail** — `SeasonArchive&year=2026`

All 4 URLs added to the PHP error batch test.

### Mobile nav interaction tests (mobile-nav.spec.ts, new file)
7 tests for mobile menu dismiss mechanisms, dropdown behavior, and ARIA:
1. Overlay click closes menu (clicks exposed left side — overlay z-40 behind menu z-50)
2. Escape key closes menu
3. Exclusive dropdowns — opening one collapses the other
4. Body scroll lock (`overflow: hidden`) when menu is open
5. League switcher (`#mobile-league-select`) present in Season dropdown
6. `aria-expanded` toggles on hamburger button
7. Nav link navigates to correct page (getAttribute + goto pattern per playwright-tests.md)

### Manual Testing
No manual testing needed — all changes are covered by E2E tests.