### PR TITLE
migration: convert remaining MyISAM nuke_* tables to InnoDB

### DIFF
--- a/ibl5/migrations/066_convert_nuke_tables_to_innodb.sql
+++ b/ibl5/migrations/066_convert_nuke_tables_to_innodb.sql
@@ -1,4 +1,4 @@
--- Migration 065: Convert remaining MyISAM nuke_* tables to InnoDB
+-- Migration 066: Convert remaining MyISAM nuke_* tables to InnoDB
 --
 -- Completes the engine migration started in 001. No MyISAM-specific features
 -- are in use. ALTER TABLE preserves all indexes, triggers, and data.


### PR DESCRIPTION
## Summary

Adds migration 065 converting all 21 remaining `nuke_*` tables from MyISAM to InnoDB, completing the engine migration started in migration 001.

## Details

- All 21 tables are legacy PHP-Nuke CMS tables
- No MyISAM-specific features were in use (no FULLTEXT indexes, INSERT DELAYED, LOCK TABLES)
- `ALTER TABLE ... ENGINE=InnoDB` preserves all indexes, triggers, and data
- `nuke_config` retains its latin1 charset — engine change only
- `trg_gm_tenure_track` trigger on `nuke_users` is preserved
- Naturally idempotent: running on already-InnoDB tables is a no-op

## Tables Converted

`nuke_antiflood`, `nuke_authors`, `nuke_banned_ip`, `nuke_blocks`, `nuke_comments`, `nuke_config`, `nuke_counter`, `nuke_modules`, `nuke_optimize_gain`, `nuke_pages`, `nuke_pages_categories`, `nuke_poll_desc`, `nuke_session`, `nuke_stats_date`, `nuke_stats_hour`, `nuke_stats_month`, `nuke_stats_year`, `nuke_stories`, `nuke_stories_cat`, `nuke_topics`, `nuke_users`

## Verification

- Migration applied successfully against Docker MariaDB
- Zero MyISAM tables remain after migration
- `trg_gm_tenure_track` trigger verified intact

## Manual Testing

No manual testing needed — SQL-only migration with no PHP changes. Verified against Docker MariaDB.