### PR TITLE
refactor: add typed array shapes to API repositories

### DIFF
--- a/ibl5/classes/Api/Controller/GameBoxscoreController.php
+++ b/ibl5/classes/Api/Controller/GameBoxscoreController.php
@@ -57,7 +57,6 @@ class GameBoxscoreController implements ControllerInterface
             return;
         }
 
-        /** @phpstan-ignore argument.type (DB view guarantees array shape) */
         $gameData = $gameTransformer->transform($game);
 
         $visitorTeamStats = null;
@@ -66,7 +65,6 @@ class GameBoxscoreController implements ControllerInterface
         $homePlayers = [];
 
         foreach ($teamRows as $teamRow) {
-            /** @phpstan-ignore argument.type (DB row guarantees array shape) */
             $transformed = $boxscoreTransformer->transformTeamStats($teamRow);
             if ($visitorTeamStats === null) {
                 $visitorTeamStats = $transformed;
@@ -77,7 +75,6 @@ class GameBoxscoreController implements ControllerInterface
 
         foreach ($playerRows as $playerRow) {
             $playerTid = is_int($playerRow['player_tid'] ?? null) ? $playerRow['player_tid'] : 0;
-            /** @phpstan-ignore argument.type (DB row guarantees array shape) */
             $transformedPlayer = $boxscoreTransformer->transformPlayerLine($playerRow);
             if ($playerTid === $visitorTeamId) {
                 $visitorPlayers[] = $transformedPlayer;

--- a/ibl5/classes/Api/Controller/GameDetailController.php
+++ b/ibl5/classes/Api/Controller/GameDetailController.php
@@ -42,7 +42,6 @@ class GameDetailController implements ControllerInterface
             return;
         }
 
-        /** @phpstan-ignore argument.type (DB view guarantees array shape) */
         $data = $transformer->transform($row);
         $responder->success($data, [], 200, $etag->getHeaders($tag));
     }

--- a/ibl5/classes/Api/Controller/GameListController.php
+++ b/ibl5/classes/Api/Controller/GameListController.php
@@ -58,7 +58,6 @@ class GameListController implements ControllerInterface
         $total = $repo->countGames($filters);
         $rows = $repo->getGames($paginator, $filters);
 
-        /** @phpstan-ignore argument.type (DB view guarantees array shape) */
         $data = array_map([$transformer, 'transform'], $rows);
 
         $tag = $etag->generateFromCollection($rows);

--- a/ibl5/classes/Api/Controller/InjuriesController.php
+++ b/ibl5/classes/Api/Controller/InjuriesController.php
@@ -30,7 +30,6 @@ class InjuriesController implements ControllerInterface
 
         $rows = $repo->getInjuredPlayers();
 
-        /** @phpstan-ignore argument.type (DB row guarantees array shape) */
         $data = array_map([$transformer, 'transform'], $rows);
 
         $tag = $etag->generateFromCollection($rows);

--- a/ibl5/classes/Api/Controller/LeadersController.php
+++ b/ibl5/classes/Api/Controller/LeadersController.php
@@ -48,7 +48,6 @@ class LeadersController implements ControllerInterface
         $total = $repo->countLeaders($filters);
         $rows = $repo->getLeaders($paginator, $filters);
 
-        /** @phpstan-ignore argument.type (DB row guarantees array shape) */
         $data = array_map([$transformer, 'transform'], $rows);
 
         $tag = $etag->generateFromCollection($rows);

--- a/ibl5/classes/Api/Controller/PlayerDetailController.php
+++ b/ibl5/classes/Api/Controller/PlayerDetailController.php
@@ -42,7 +42,6 @@ class PlayerDetailController implements ControllerInterface
             return;
         }
 
-        /** @phpstan-ignore argument.type (DB view guarantees array shape) */
         $data = $transformer->transformDetail($row);
         $responder->success($data, [], 200, $etag->getHeaders($tag));
     }

--- a/ibl5/classes/Api/Controller/PlayerHistoryController.php
+++ b/ibl5/classes/Api/Controller/PlayerHistoryController.php
@@ -35,7 +35,6 @@ class PlayerHistoryController implements ControllerInterface
             return;
         }
 
-        /** @phpstan-ignore argument.type (DB row guarantees array shape) */
         $data = array_map([$transformer, 'transformSeason'], $rows);
 
         $tag = $etag->generateFromCollection($rows);

--- a/ibl5/classes/Api/Controller/PlayerListController.php
+++ b/ibl5/classes/Api/Controller/PlayerListController.php
@@ -46,7 +46,6 @@ class PlayerListController implements ControllerInterface
         $total = $repo->countPlayers($filters);
         $rows = $repo->getPlayers($paginator, $filters);
 
-        /** @phpstan-ignore argument.type (DB view guarantees array shape) */
         $data = array_map([$transformer, 'transform'], $rows);
 
         $tag = $etag->generateFromCollection($rows);

--- a/ibl5/classes/Api/Controller/PlayerStatsController.php
+++ b/ibl5/classes/Api/Controller/PlayerStatsController.php
@@ -42,7 +42,6 @@ class PlayerStatsController implements ControllerInterface
             return;
         }
 
-        /** @phpstan-ignore argument.type (DB view guarantees array shape) */
         $data = $transformer->transformCareer($row);
         $responder->success($data, [], 200, $etag->getHeaders($tag));
     }

--- a/ibl5/classes/Api/Controller/StandingsController.php
+++ b/ibl5/classes/Api/Controller/StandingsController.php
@@ -30,7 +30,6 @@ class StandingsController implements ControllerInterface
         $etag = new ETagHandler();
 
         $rows = $repo->getStandings($conference);
-        /** @phpstan-ignore argument.type (DB view guarantees array shape) */
         $data = array_map([$transformer, 'transform'], $rows);
 
         $tag = $etag->generateFromCollection($rows);

--- a/ibl5/classes/Api/Controller/TeamDetailController.php
+++ b/ibl5/classes/Api/Controller/TeamDetailController.php
@@ -41,7 +41,6 @@ class TeamDetailController implements ControllerInterface
             return;
         }
 
-        /** @phpstan-ignore argument.type (DB query guarantees array shape) */
         $data = $transformer->transformDetail($row);
         $responder->success($data, [], 200, $etag->getHeaders($tag));
     }

--- a/ibl5/classes/Api/Controller/TeamListController.php
+++ b/ibl5/classes/Api/Controller/TeamListController.php
@@ -35,7 +35,6 @@ class TeamListController implements ControllerInterface
         $total = $repo->countTeams();
         $rows = $repo->getTeams($paginator);
 
-        /** @phpstan-ignore argument.type (DB query guarantees array shape) */
         $data = array_map([$transformer, 'transform'], $rows);
 
         $tag = $etag->generateFromCollection($rows);

--- a/ibl5/classes/Api/Controller/TeamRosterController.php
+++ b/ibl5/classes/Api/Controller/TeamRosterController.php
@@ -42,7 +42,6 @@ class TeamRosterController implements ControllerInterface
         }
 
         $rows = $repo->getPlayers($paginator, $filters);
-        /** @phpstan-ignore argument.type (DB view guarantees array shape) */
         $data = array_map([$transformer, 'transform'], $rows);
 
         $tag = $etag->generateFromCollection($rows);

--- a/ibl5/classes/Api/Repository/ApiGameRepository.php
+++ b/ibl5/classes/Api/Repository/ApiGameRepository.php
@@ -7,6 +7,11 @@ namespace Api\Repository;
 use Api\Pagination\Paginator;
 use League\LeagueContext;
 
+/**
+ * @phpstan-type GameViewRow array{game_uuid: string, season_year: int, game_date: string, game_status: string, box_score_id: int, game_of_that_day: int, visitor_uuid: string, visitor_city: string, visitor_name: string, visitor_full_name: string, visitor_score: int, visitor_team_id: int, home_uuid: string, home_city: string, home_name: string, home_full_name: string, home_score: int, home_team_id: int, ...}
+ * @phpstan-type BoxscoreTeamRow array{name: string, visitorQ1points: int, visitorQ2points: int, visitorQ3points: int, visitorQ4points: int, visitorOTpoints: int, homeQ1points: int, homeQ2points: int, homeQ3points: int, homeQ4points: int, homeOTpoints: int, gameMIN: int|null, game2GM: int, game2GA: int, gameFTM: int, gameFTA: int, game3GM: int, game3GA: int, gameORB: int, gameDRB: int, gameAST: int, gameSTL: int, gameTOV: int, gameBLK: int, gamePF: int, attendance: int, capacity: int, visitorWins: int, visitorLosses: int, homeWins: int, homeLosses: int, calc_points: int, calc_rebounds: int, calc_fg_made: int, ...}
+ * @phpstan-type BoxscorePlayerRow array{player_uuid: string|null, name: string, pos: string, gameMIN: int, game2GM: int, game2GA: int, gameFTM: int, gameFTA: int, game3GM: int, game3GA: int, gameORB: int, gameDRB: int, gameAST: int, gameSTL: int, gameTOV: int, gameBLK: int, gamePF: int, calc_points: int, calc_rebounds: int, calc_fg_made: int, player_tid: int|null, ...}
+ */
 class ApiGameRepository extends \BaseMysqliRepository
 {
     private string $boxScoresTable;
@@ -23,7 +28,7 @@ class ApiGameRepository extends \BaseMysqliRepository
      * Get paginated list of games from the schedule view.
      *
      * @param array<string, string> $filters Optional filters (season, status, team, date, date_start, date_end)
-     * @return array<int, array<string, mixed>>
+     * @return list<GameViewRow>
      */
     public function getGames(Paginator $paginator, array $filters = []): array
     {
@@ -41,6 +46,7 @@ class ApiGameRepository extends \BaseMysqliRepository
         $params[] = $paginator->getLimit();
         $params[] = $paginator->getOffset();
 
+        /** @var list<GameViewRow> */
         return $this->fetchAll($query, $types, ...$params);
     }
 
@@ -68,10 +74,11 @@ class ApiGameRepository extends \BaseMysqliRepository
     /**
      * Get a single game by UUID.
      *
-     * @return array<string, mixed>|null
+     * @return GameViewRow|null
      */
     public function getGameByUuid(string $uuid): ?array
     {
+        /** @var GameViewRow|null */
         return $this->fetchOne(
             'SELECT * FROM vw_schedule_upcoming WHERE game_uuid = ?',
             's',
@@ -82,10 +89,11 @@ class ApiGameRepository extends \BaseMysqliRepository
     /**
      * Get team box score stats for a game identified by date and team IDs.
      *
-     * @return array<int, array<string, mixed>>
+     * @return list<BoxscoreTeamRow>
      */
     public function getBoxscoreTeams(int $visitorTeamId, int $homeTeamId, string $date): array
     {
+        /** @var list<BoxscoreTeamRow> */
         return $this->fetchAll(
             "SELECT * FROM {$this->boxScoresTeamsTable} WHERE visitorTeamID = ? AND homeTeamID = ? AND Date = ? ORDER BY id ASC",
             'iis',
@@ -98,10 +106,11 @@ class ApiGameRepository extends \BaseMysqliRepository
     /**
      * Get player box score lines for a game identified by date and team IDs.
      *
-     * @return array<int, array<string, mixed>>
+     * @return list<BoxscorePlayerRow>
      */
     public function getBoxscorePlayers(int $visitorTid, int $homeTid, string $date): array
     {
+        /** @var list<BoxscorePlayerRow> */
         return $this->fetchAll(
             "SELECT b.*, COALESCE(p.name, b.name) AS name, p.uuid AS player_uuid, p.tid AS player_tid
              FROM {$this->boxScoresTable} b

--- a/ibl5/classes/Api/Repository/ApiInjuriesRepository.php
+++ b/ibl5/classes/Api/Repository/ApiInjuriesRepository.php
@@ -4,15 +4,19 @@ declare(strict_types=1);
 
 namespace Api\Repository;
 
+/**
+ * @phpstan-type InjuredPlayerRow array{player_uuid: string, pid: int, name: string, pos: string, injured: int, teamid: int|null, team_uuid: string|null, team_city: string|null, team_name: string|null}
+ */
 class ApiInjuriesRepository extends \BaseMysqliRepository
 {
     /**
      * Get all currently injured active players with team information.
      *
-     * @return array<int, array<string, mixed>>
+     * @return list<InjuredPlayerRow>
      */
     public function getInjuredPlayers(): array
     {
+        /** @var list<InjuredPlayerRow> */
         return $this->fetchAll(
             'SELECT p.uuid AS player_uuid, p.pid, p.name, p.pos, p.injured,
                     t.teamid, t.uuid AS team_uuid, t.team_city, t.team_name

--- a/ibl5/classes/Api/Repository/ApiLeadersRepository.php
+++ b/ibl5/classes/Api/Repository/ApiLeadersRepository.php
@@ -6,6 +6,9 @@ namespace Api\Repository;
 
 use Api\Pagination\Paginator;
 
+/**
+ * @phpstan-type LeaderRow array{player_uuid: string, pid: int, name: string, teamid: int, team_uuid: string|null, team_city: string|null, team_name: string|null, year: int, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, blk: int, tvr: int, pf: int, pts: int, ...}
+ */
 class ApiLeadersRepository extends \BaseMysqliRepository
 {
     /**
@@ -32,7 +35,7 @@ class ApiLeadersRepository extends \BaseMysqliRepository
      * Get paginated list of statistical leaders.
      *
      * @param array<string, string> $filters Optional filters (season, category, min_games)
-     * @return array<int, array<string, mixed>>
+     * @return list<LeaderRow>
      */
     public function getLeaders(Paginator $paginator, array $filters = []): array
     {
@@ -57,6 +60,7 @@ class ApiLeadersRepository extends \BaseMysqliRepository
         $params[] = $paginator->getLimit();
         $params[] = $paginator->getOffset();
 
+        /** @var list<LeaderRow> */
         return $this->fetchAll($query, $types, ...$params);
     }
 

--- a/ibl5/classes/Api/Repository/ApiPlayerRepository.php
+++ b/ibl5/classes/Api/Repository/ApiPlayerRepository.php
@@ -6,13 +6,16 @@ namespace Api\Repository;
 
 use Api\Pagination\Paginator;
 
+/**
+ * @phpstan-type PlayerCurrentRow array{player_uuid: string, pid: int, name: string, position: string, age: int, htft: int, htin: int, experience: int, bird_rights: int, teamid: int|null, team_uuid: string|null, team_city: string|null, team_name: string|null, full_team_name: string|null, current_salary: int, year1_salary: int, year2_salary: int, games_played: int, minutes_played: int, field_goals_made: int, field_goals_attempted: int, free_throws_made: int, free_throws_attempted: int, three_pointers_made: int, three_pointers_attempted: int, offensive_rebounds: int, defensive_rebounds: int, assists: int, steals: int, turnovers: int, blocks: int, personal_fouls: int, points_per_game: float|null, fg_percentage: float|null, ft_percentage: float|null, three_pt_percentage: float|null, ...}
+ */
 class ApiPlayerRepository extends \BaseMysqliRepository
 {
     /**
      * Get paginated list of players from the API view.
      *
      * @param array<string, string> $filters Optional filters (position, team UUID, search)
-     * @return array<int, array<string, mixed>>
+     * @return list<PlayerCurrentRow>
      */
     public function getPlayers(Paginator $paginator, array $filters = []): array
     {
@@ -46,6 +49,7 @@ class ApiPlayerRepository extends \BaseMysqliRepository
         $params[] = $paginator->getLimit();
         $params[] = $paginator->getOffset();
 
+        /** @var list<PlayerCurrentRow> */
         return $this->fetchAll($query, $types, ...$params);
     }
 
@@ -89,10 +93,11 @@ class ApiPlayerRepository extends \BaseMysqliRepository
     /**
      * Get a single player by UUID from the API view.
      *
-     * @return array<string, mixed>|null
+     * @return PlayerCurrentRow|null
      */
     public function getPlayerByUuid(string $uuid): ?array
     {
+        /** @var PlayerCurrentRow|null */
         return $this->fetchOne(
             'SELECT * FROM vw_player_current WHERE player_uuid = ?',
             's',

--- a/ibl5/classes/Api/Repository/ApiPlayerStatsRepository.php
+++ b/ibl5/classes/Api/Repository/ApiPlayerStatsRepository.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Api\Repository;
 
+/**
+ * @phpstan-type CareerStatsRow array{player_uuid: string, pid: int, name: string, career_games: int, career_minutes: int, career_points: int|float, career_rebounds: int, career_assists: int, career_steals: int, career_blocks: int, ppg_career: float|null, rpg_career: float|null, apg_career: float|null, fg_pct_career: float|null, ft_pct_career: float|null, three_pt_pct_career: float|null, playoff_minutes: int, draft_year: int|null, draft_round: int|null, draft_pick: int|null, drafted_by_team: string|null, draft_team_id: int|null, ...}
+ * @phpstan-type SeasonHistoryRow array{player_uuid: string, pid: int, name: string, year: int, teamid: int, team: string, team_uuid: string|null, team_city: string|null, team_name: string|null, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, blk: int, tvr: int, pf: int, pts: int, salary: int, ...}
+ */
 class ApiPlayerStatsRepository extends \BaseMysqliRepository
 {
     /**
      * Get career stats for a player by UUID from the career stats view.
      *
-     * @return array<string, mixed>|null
+     * @return CareerStatsRow|null
      */
     public function getCareerStats(string $playerUuid): ?array
     {
+        /** @var CareerStatsRow|null */
         return $this->fetchOne(
             'SELECT v.*, dt.teamid AS draft_team_id
              FROM vw_player_career_stats v
@@ -26,10 +31,11 @@ class ApiPlayerStatsRepository extends \BaseMysqliRepository
     /**
      * Get season-by-season history for a player by UUID.
      *
-     * @return array<int, array<string, mixed>>
+     * @return list<SeasonHistoryRow>
      */
     public function getSeasonHistory(string $playerUuid): array
     {
+        /** @var list<SeasonHistoryRow> */
         return $this->fetchAll(
             'SELECT h.*, p.uuid AS player_uuid, t.uuid AS team_uuid, t.team_city, t.team_name
              FROM ibl_hist h

--- a/ibl5/classes/Api/Repository/ApiStandingsRepository.php
+++ b/ibl5/classes/Api/Repository/ApiStandingsRepository.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Api\Repository;
 
+/**
+ * @phpstan-type StandingsViewRow array{teamid: int, team_uuid: string, team_city: string, team_name: string, full_team_name: string, conference: string, division: string, league_record: string, conference_record: string, division_record: string, home_record: string, away_record: string, win_percentage: float|null, conference_games_back: string|null, division_games_back: string|null, games_remaining: int, clinched_conference: int, clinched_division: int, clinched_playoffs: int, ...}
+ */
 class ApiStandingsRepository extends \BaseMysqliRepository
 {
     /**
      * Get all standings, optionally filtered by conference.
      *
-     * @return array<int, array<string, mixed>>
+     * @return list<StandingsViewRow>
      */
     public function getStandings(?string $conference = null): array
     {
         if ($conference !== null) {
+            /** @var list<StandingsViewRow> */
             return $this->fetchAll(
                 'SELECT * FROM vw_team_standings WHERE conference = ? ORDER BY win_percentage DESC, full_team_name ASC',
                 's',
@@ -21,6 +25,7 @@ class ApiStandingsRepository extends \BaseMysqliRepository
             );
         }
 
+        /** @var list<StandingsViewRow> */
         return $this->fetchAll(
             'SELECT * FROM vw_team_standings ORDER BY conference ASC, win_percentage DESC, full_team_name ASC'
         );

--- a/ibl5/classes/Api/Repository/ApiTeamRepository.php
+++ b/ibl5/classes/Api/Repository/ApiTeamRepository.php
@@ -7,6 +7,10 @@ namespace Api\Repository;
 use Api\Pagination\Paginator;
 use League\LeagueContext;
 
+/**
+ * @phpstan-type TeamListRow array{teamid: int, uuid: string, team_city: string, team_name: string, owner_name: string, arena: string, conference: string|null, division: string|null, discordID: int|null}
+ * @phpstan-type TeamDetailRow array{teamid: int, uuid: string, team_city: string, team_name: string, owner_name: string, arena: string, conference: string|null, division: string|null, discordID: int|null, league_record: string|null, conference_record: string|null, division_record: string|null, home_wins: int|null, home_losses: int|null, away_wins: int|null, away_losses: int|null, win_percentage: float|null, conference_games_back: string|null, division_games_back: string|null, games_remaining: int|null}
+ */
 class ApiTeamRepository extends \BaseMysqliRepository
 {
     private string $teamInfoTable;
@@ -22,12 +26,13 @@ class ApiTeamRepository extends \BaseMysqliRepository
     /**
      * Get paginated list of teams.
      *
-     * @return array<int, array<string, mixed>>
+     * @return list<TeamListRow>
      */
     public function getTeams(Paginator $paginator): array
     {
         $orderBy = $paginator->getOrderByClause();
 
+        /** @var list<TeamListRow> */
         return $this->fetchAll(
             "SELECT t.teamid, t.uuid, t.team_city, t.team_name, t.owner_name, t.arena,
                     s.conference, s.division,
@@ -62,10 +67,11 @@ class ApiTeamRepository extends \BaseMysqliRepository
     /**
      * Get a single team by UUID with standings data.
      *
-     * @return array<string, mixed>|null
+     * @return TeamDetailRow|null
      */
     public function getTeamByUuid(string $uuid): ?array
     {
+        /** @var TeamDetailRow|null */
         return $this->fetchOne(
             "SELECT t.teamid, t.uuid, t.team_city, t.team_name, t.owner_name, t.arena,
                     s.conference, s.division,

--- a/ibl5/classes/Api/Transformer/BoxscoreTransformer.php
+++ b/ibl5/classes/Api/Transformer/BoxscoreTransformer.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Api\Transformer;
 
+/**
+ * @phpstan-import-type BoxscoreTeamRow from \Api\Repository\ApiGameRepository
+ * @phpstan-import-type BoxscorePlayerRow from \Api\Repository\ApiGameRepository
+ */
 class BoxscoreTransformer
 {
     /**
      * Transform a team box score row from ibl_box_scores_teams.
      *
-     * @param array{name: string, visitorQ1points: int, visitorQ2points: int, visitorQ3points: int, visitorQ4points: int, visitorOTpoints: int, homeQ1points: int, homeQ2points: int, homeQ3points: int, homeQ4points: int, homeOTpoints: int, gameMIN: int|null, game2GM: int, game2GA: int, gameFTM: int, gameFTA: int, game3GM: int, game3GA: int, gameORB: int, gameDRB: int, gameAST: int, gameSTL: int, gameTOV: int, gameBLK: int, gamePF: int, attendance: int, capacity: int, visitorWins: int, visitorLosses: int, homeWins: int, homeLosses: int, calc_points: int, calc_rebounds: int, calc_fg_made: int} $row
+     * @param BoxscoreTeamRow $row
      * @return array<string, mixed>
      */
     public function transformTeamStats(array $row): array
@@ -54,7 +58,7 @@ class BoxscoreTransformer
     /**
      * Transform a player box score line from ibl_box_scores.
      *
-     * @param array{player_uuid: string|null, name: string, pos: string, gameMIN: int, game2GM: int, game2GA: int, gameFTM: int, gameFTA: int, game3GM: int, game3GA: int, gameORB: int, gameDRB: int, gameAST: int, gameSTL: int, gameTOV: int, gameBLK: int, gamePF: int, calc_points: int, calc_rebounds: int, calc_fg_made: int} $row
+     * @param BoxscorePlayerRow $row
      * @return array<string, mixed>
      */
     public function transformPlayerLine(array $row): array

--- a/ibl5/classes/Api/Transformer/GameTransformer.php
+++ b/ibl5/classes/Api/Transformer/GameTransformer.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Api\Transformer;
 
+/**
+ * @phpstan-import-type GameViewRow from \Api\Repository\ApiGameRepository
+ */
 class GameTransformer
 {
     /**
      * Transform a game row from vw_schedule_upcoming for list/detail endpoints.
      *
-     * @param array{game_uuid: string, season_year: int, game_date: string, game_status: string, box_score_id: int, game_of_that_day: int, visitor_uuid: string, visitor_city: string, visitor_name: string, visitor_full_name: string, visitor_score: int, visitor_team_id: int, home_uuid: string, home_city: string, home_name: string, home_full_name: string, home_score: int, home_team_id: int} $row
+     * @param GameViewRow $row
      * @return array<string, mixed>
      */
     public function transform(array $row): array

--- a/ibl5/classes/Api/Transformer/InjuryTransformer.php
+++ b/ibl5/classes/Api/Transformer/InjuryTransformer.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Api\Transformer;
 
+/**
+ * @phpstan-import-type InjuredPlayerRow from \Api\Repository\ApiInjuriesRepository
+ */
 class InjuryTransformer
 {
     /**
      * Transform an injured player row.
      *
-     * @param array{player_uuid: string, pid: int, name: string, pos: string, injured: int, teamid: int|null, team_uuid: string|null, team_city: string|null, team_name: string|null} $row
+     * @param InjuredPlayerRow $row
      * @return array<string, mixed>
      */
     public function transform(array $row): array

--- a/ibl5/classes/Api/Transformer/LeaderTransformer.php
+++ b/ibl5/classes/Api/Transformer/LeaderTransformer.php
@@ -6,12 +6,15 @@ namespace Api\Transformer;
 
 use BasketballStats\StatsFormatter;
 
+/**
+ * @phpstan-import-type LeaderRow from \Api\Repository\ApiLeadersRepository
+ */
 class LeaderTransformer
 {
     /**
      * Transform a leader row from ibl_hist joined with player and team tables.
      *
-     * @param array{player_uuid: string, pid: int, name: string, teamid: int, team_uuid: string|null, team_city: string|null, team_name: string|null, year: int, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, blk: int, tvr: int, pf: int, pts: int} $row
+     * @param LeaderRow $row
      * @return array<string, mixed>
      */
     public function transform(array $row): array

--- a/ibl5/classes/Api/Transformer/PlayerStatsTransformer.php
+++ b/ibl5/classes/Api/Transformer/PlayerStatsTransformer.php
@@ -6,12 +6,16 @@ namespace Api\Transformer;
 
 use BasketballStats\StatsFormatter;
 
+/**
+ * @phpstan-import-type CareerStatsRow from \Api\Repository\ApiPlayerStatsRepository
+ * @phpstan-import-type SeasonHistoryRow from \Api\Repository\ApiPlayerStatsRepository
+ */
 class PlayerStatsTransformer
 {
     /**
      * Transform a career stats row from vw_player_career_stats.
      *
-     * @param array{player_uuid: string, pid: int, name: string, career_games: int, career_minutes: int, career_points: int|float, career_rebounds: int, career_assists: int, career_steals: int, career_blocks: int, ppg_career: float|null, rpg_career: float|null, apg_career: float|null, fg_pct_career: float|null, ft_pct_career: float|null, three_pt_pct_career: float|null, playoff_minutes: int, draft_year: int|null, draft_round: int|null, draft_pick: int|null, drafted_by_team: string|null, draft_team_id: int|null} $row
+     * @param CareerStatsRow $row
      * @return array<string, mixed>
      */
     public function transformCareer(array $row): array
@@ -53,7 +57,7 @@ class PlayerStatsTransformer
     /**
      * Transform a season history row from ibl_hist.
      *
-     * @param array{player_uuid: string, pid: int, name: string, year: int, teamid: int, team: string, team_uuid: string|null, team_city: string|null, team_name: string|null, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, blk: int, tvr: int, pf: int, pts: int, salary: int} $row
+     * @param SeasonHistoryRow $row
      * @return array<string, mixed>
      */
     public function transformSeason(array $row): array

--- a/ibl5/classes/Api/Transformer/PlayerTransformer.php
+++ b/ibl5/classes/Api/Transformer/PlayerTransformer.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Api\Transformer;
 
+/**
+ * @phpstan-import-type PlayerCurrentRow from \Api\Repository\ApiPlayerRepository
+ */
 class PlayerTransformer
 {
     /**
      * Transform a player row from vw_player_current for list endpoints.
      *
-     * @param array{player_uuid: string, pid: int, name: string, position: string, age: int, htft: int, htin: int, experience: int, teamid: int|null, team_uuid: string|null, team_city: string|null, team_name: string|null, full_team_name: string|null, current_salary: int, year1_salary: int, year2_salary: int, games_played: int, points_per_game: float|null, fg_percentage: float|null, ft_percentage: float|null, three_pt_percentage: float|null} $row
+     * @param PlayerCurrentRow $row
      * @return array<string, mixed>
      */
     public function transform(array $row): array
@@ -41,7 +44,7 @@ class PlayerTransformer
     /**
      * Transform a player row for detail endpoints (includes full stats).
      *
-     * @param array{player_uuid: string, pid: int, name: string, position: string, age: int, htft: int, htin: int, experience: int, bird_rights: int, teamid: int|null, team_uuid: string|null, team_city: string|null, team_name: string|null, full_team_name: string|null, current_salary: int, year1_salary: int, year2_salary: int, games_played: int, minutes_played: int, field_goals_made: int, field_goals_attempted: int, free_throws_made: int, free_throws_attempted: int, three_pointers_made: int, three_pointers_attempted: int, offensive_rebounds: int, defensive_rebounds: int, assists: int, steals: int, turnovers: int, blocks: int, personal_fouls: int, points_per_game: float|null, fg_percentage: float|null, ft_percentage: float|null, three_pt_percentage: float|null} $row
+     * @param PlayerCurrentRow $row
      * @return array<string, mixed>
      */
     public function transformDetail(array $row): array

--- a/ibl5/classes/Api/Transformer/StandingsTransformer.php
+++ b/ibl5/classes/Api/Transformer/StandingsTransformer.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Api\Transformer;
 
+/**
+ * @phpstan-import-type StandingsViewRow from \Api\Repository\ApiStandingsRepository
+ */
 class StandingsTransformer
 {
     /**
      * Transform a standings row from vw_team_standings.
      *
-     * @param array{teamid: int, team_uuid: string, team_city: string, team_name: string, full_team_name: string, conference: string, division: string, league_record: string, conference_record: string, division_record: string, home_record: string, away_record: string, win_percentage: float|null, conference_games_back: string|null, division_games_back: string|null, games_remaining: int, clinched_conference: int, clinched_division: int, clinched_playoffs: int} $row
+     * @param StandingsViewRow $row
      * @return array<string, mixed>
      */
     public function transform(array $row): array

--- a/ibl5/classes/Api/Transformer/TeamTransformer.php
+++ b/ibl5/classes/Api/Transformer/TeamTransformer.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Api\Transformer;
 
+/**
+ * @phpstan-import-type TeamListRow from \Api\Repository\ApiTeamRepository
+ * @phpstan-import-type TeamDetailRow from \Api\Repository\ApiTeamRepository
+ */
 class TeamTransformer
 {
     /**
      * Transform a team row for list endpoints.
      *
-     * @param array{teamid: int, uuid: string, team_city: string, team_name: string, owner_name: string, arena: string, conference: string|null, division: string|null, discordID: int|null} $row
+     * @param TeamListRow $row
      * @return array<string, mixed>
      */
     public function transform(array $row): array
@@ -31,7 +35,7 @@ class TeamTransformer
     /**
      * Transform a team row for detail endpoint (includes standings/power data).
      *
-     * @param array{teamid: int, uuid: string, team_city: string, team_name: string, owner_name: string, arena: string, conference: string|null, division: string|null, discordID: int|null, league_record: string|null, conference_record: string|null, division_record: string|null, home_wins: int|null, home_losses: int|null, away_wins: int|null, away_losses: int|null, win_percentage: float|null, conference_games_back: string|null, division_games_back: string|null, games_remaining: int|null} $row
+     * @param TeamDetailRow $row
      * @return array<string, mixed>
      */
     public function transformDetail(array $row): array

--- a/ibl5/classes/Injuries/InjuriesService.php
+++ b/ibl5/classes/Injuries/InjuriesService.php
@@ -35,11 +35,9 @@ class InjuriesService implements InjuriesServiceInterface
         $season = new \Season($this->db);
         $injuredPlayers = [];
 
-        /** @var array<int, array<string, mixed>> $injuredRows */
         $injuredRows = $this->league->getInjuredPlayersResult();
 
         foreach ($injuredRows as $injuredPlayerRow) {
-            /** @phpstan-ignore argument.type (PlayerRow from SELECT * matches withPlrRow expectation) */
             $player = Player::withPlrRow($this->db, $injuredPlayerRow);
             $playerID = $player->playerID ?? 0;
             $team = Team::initialize($this->db, $playerID > 0 ? ($player->teamID ?? 0) : 0);

--- a/ibl5/classes/League.php
+++ b/ibl5/classes/League.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 /**
  * League - IBL league-wide operations and queries
- * 
+ *
  * Extends BaseMysqliRepository for standardized database access.
  * Provides league configuration, voting candidates, and team operations.
- * 
+ *
  * @see BaseMysqliRepository For base class documentation and error codes
+ * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
  */
 class League extends BaseMysqliRepository
 {
@@ -75,7 +76,7 @@ class League extends BaseMysqliRepository
      * Get All-Star voting candidates for a conference/position
      *
      * @param string $votingCategory Voting category (e.g., 'EC-CF', 'WC-CB')
-     * @return array<int, array<string, mixed>> All matching players
+     * @return list<PlayerRow> All matching players
      */
     public function getAllStarCandidatesResult(string $votingCategory): array
     {
@@ -100,16 +101,18 @@ class League extends BaseMysqliRepository
           AND p.stats_gm > '14'
         ORDER BY p.name";
 
+        /** @var list<PlayerRow> */
         return $this->fetchAll($query);
     }
 
     /**
      * Get all injured players
      *
-     * @return array<int, array<string, mixed>> All injured players
+     * @return list<PlayerRow> All injured players
      */
     public function getInjuredPlayersResult(): array
     {
+        /** @var list<PlayerRow> */
         return $this->fetchAll(
             "SELECT *
             FROM ibl_plr
@@ -123,10 +126,11 @@ class League extends BaseMysqliRepository
      * Get all free agents for the season
      *
      * @param Season $season Current season
-     * @return array<int, array<string, mixed>> All free agent players
+     * @return list<PlayerRow> All free agent players
      */
     public function getFreeAgentsResult(Season $season): array
     {
+        /** @var list<PlayerRow> */
         return $this->fetchAll(
             "SELECT *
             FROM ibl_plr
@@ -141,10 +145,11 @@ class League extends BaseMysqliRepository
     /**
      * Get all waived players
      *
-     * @return array<int, array<string, mixed>> All waived players
+     * @return list<PlayerRow> All waived players
      */
     public function getWaivedPlayersResult(): array
     {
+        /** @var list<PlayerRow> */
         return $this->fetchAll(
             "SELECT *
             FROM ibl_plr
@@ -161,10 +166,11 @@ class League extends BaseMysqliRepository
     /**
      * Get MVP award candidates
      *
-     * @return array<int, array<string, mixed>> All MVP candidates
+     * @return list<PlayerRow> All MVP candidates
      */
     public function getMVPCandidatesResult(): array
     {
+        /** @var list<PlayerRow> */
         return $this->fetchAll(
             "SELECT p.*, t.team_name AS teamname, t.team_city, t.color1, t.color2
             FROM ibl_plr p
@@ -179,10 +185,11 @@ class League extends BaseMysqliRepository
     /**
      * Get Sixth Person of the Year award candidates
      *
-     * @return array<int, array<string, mixed>> All Sixth Person candidates
+     * @return list<PlayerRow> All Sixth Person candidates
      */
     public function getSixthPersonOfTheYearCandidatesResult(): array
     {
+        /** @var list<PlayerRow> */
         return $this->fetchAll(
             "SELECT p.*, t.team_name AS teamname, t.team_city, t.color1, t.color2
             FROM ibl_plr p
@@ -198,10 +205,11 @@ class League extends BaseMysqliRepository
     /**
      * Get Rookie of the Year award candidates
      *
-     * @return array<int, array<string, mixed>> All Rookie of the Year candidates
+     * @return list<PlayerRow> All Rookie of the Year candidates
      */
     public function getRookieOfTheYearCandidatesResult(): array
     {
+        /** @var list<PlayerRow> */
         return $this->fetchAll(
             "SELECT p.*, t.team_name AS teamname, t.team_city, t.color1, t.color2
             FROM ibl_plr p

--- a/ibl5/classes/Player/Contracts/PlayerRepositoryInterface.php
+++ b/ibl5/classes/Player/Contracts/PlayerRepositoryInterface.php
@@ -14,6 +14,7 @@ use Player\PlayerData;
  *
  * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
  *
+ * @phpstan-type HistoricalPlayerRow array{pid: ?int, year: ?int, name: ?string, team: ?string, teamid: ?int, salary: ?int, r_2ga: ?int, r_2gp: ?int, r_fta: ?int, r_ftp: ?int, r_3ga: ?int, r_3gp: ?int, r_orb: ?int, r_drb: ?int, r_ast: ?int, r_stl: ?int, r_blk: ?int, r_tvr: ?int, r_oo: ?int, r_od: ?int, r_do: ?int, r_dd: ?int, r_po: ?int, r_pd: ?int, r_to: ?int, r_td: ?int, ...}
  * @phpstan-type AwardRow array{year: int, name: string, Award: string}
  * @phpstan-type PlayerNewsRow array{sid: int, title: string, time: string}
  * @phpstan-type OneOnOneWinRow array{gameid: int, winner: string, loser: string, winscore: int, lossscore: int, loser_pid: ?int}
@@ -56,7 +57,7 @@ interface PlayerRepositoryInterface
      * into a PlayerData object representing a player in a previous season.
      * Similar to fillFromCurrentRow but handles historical data structure.
      * 
-     * @param array{pid: ?int, year: ?int, name: ?string, team: ?string, teamid: ?int, salary: ?int, r_2ga: ?int, r_2gp: ?int, r_fta: ?int, r_ftp: ?int, r_3ga: ?int, r_3gp: ?int, r_orb: ?int, r_drb: ?int, r_ast: ?int, r_stl: ?int, r_blk: ?int, r_tvr: ?int, r_oo: ?int, r_od: ?int, r_do: ?int, r_dd: ?int, r_po: ?int, r_pd: ?int, r_to: ?int, r_td: ?int, ...} $histRow Database row from ibl_hist
+     * @param HistoricalPlayerRow $histRow Database row from ibl_hist
      * @return PlayerData Fully populated PlayerData object with historical data
      */
     public function fillFromHistoricalRow(array $histRow): PlayerData;

--- a/ibl5/classes/Player/Player.php
+++ b/ibl5/classes/Player/Player.php
@@ -14,6 +14,7 @@ use Player\Contracts\PlayerInterface;
  *
  * @see PlayerInterface
  * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
+ * @phpstan-import-type HistoricalPlayerRow from \Player\Contracts\PlayerRepositoryInterface
  */
 class Player implements PlayerInterface
 {
@@ -296,14 +297,13 @@ class Player implements PlayerInterface
      * Create a Player instance from a historical player row
      *
      * @param \mysqli $db Database connection
-     * @param array<string, mixed> $plrRow Historical player row data
+     * @param HistoricalPlayerRow $plrRow Historical player row data
      * @return self Populated Player instance
      */
     public static function withHistoricalPlrRow(\mysqli $db, array $plrRow): self
     {
         $instance = new self();
         $instance->initialize($db);
-        /** @phpstan-ignore argument.type (HistoricalRow from SELECT * has all required fields) */
         $instance->playerData = $instance->repository->fillFromHistoricalRow($plrRow);
         $instance->syncPropertiesFromPlayerData();
         return $instance;

--- a/ibl5/classes/Player/PlayerRepository.php
+++ b/ibl5/classes/Player/PlayerRepository.php
@@ -13,6 +13,7 @@ use Player\Contracts\PlayerRepositoryInterface;
  * Extends BaseMysqliRepository for standardized prepared statement handling.
  *
  * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
+ * @phpstan-import-type HistoricalPlayerRow from PlayerRepositoryInterface
  * @phpstan-import-type AwardRow from PlayerRepositoryInterface
  * @phpstan-import-type PlayerNewsRow from PlayerRepositoryInterface
  * @phpstan-import-type OneOnOneWinRow from PlayerRepositoryInterface
@@ -245,7 +246,7 @@ class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryI
     /**
      * Fill a PlayerData object from a historical player row
      *
-     * @param array{pid: ?int, year: ?int, name: ?string, team: ?string, teamid: ?int, salary: ?int, r_2ga: ?int, r_2gp: ?int, r_fta: ?int, r_ftp: ?int, r_3ga: ?int, r_3gp: ?int, r_orb: ?int, r_drb: ?int, r_ast: ?int, r_stl: ?int, r_blk: ?int, r_tvr: ?int, r_oo: ?int, r_od: ?int, r_do: ?int, r_dd: ?int, r_po: ?int, r_pd: ?int, r_to: ?int, r_td: ?int, ...} $plrRow
+     * @param HistoricalPlayerRow $plrRow
      */
     public function fillFromHistoricalRow(array $plrRow): PlayerData
     {

--- a/ibl5/classes/UI/Tables/PlayerRowTransformer.php
+++ b/ibl5/classes/UI/Tables/PlayerRowTransformer.php
@@ -15,6 +15,7 @@ use Player\PlayerStats;
  * across SeasonTotals, SeasonAverages, Per36Minutes, and Ratings.
  *
  * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
+ * @phpstan-import-type HistoricalPlayerRow from \Player\Contracts\PlayerRepositoryInterface
  */
 class PlayerRowTransformer
 {
@@ -51,7 +52,7 @@ class PlayerRowTransformer
                 if (!is_array($plrRow)) {
                     continue;
                 }
-                /** @var array<string, mixed> $plrRow */
+                /** @var HistoricalPlayerRow $plrRow */
                 $player = Player::withHistoricalPlrRow($db, $plrRow);
                 /** @var PlayerStats $playerStats */
                 $playerStats = PlayerStats::withHistoricalPlrRow($db, $plrRow);
@@ -95,7 +96,7 @@ class PlayerRowTransformer
                 if (!is_array($plrRow)) {
                     continue;
                 }
-                /** @var array<string, mixed> $plrRow */
+                /** @var HistoricalPlayerRow $plrRow */
                 $player = Player::withHistoricalPlrRow($db, $plrRow);
             }
 

--- a/ibl5/classes/Voting/VotingBallotService.php
+++ b/ibl5/classes/Voting/VotingBallotService.php
@@ -13,6 +13,7 @@ use Voting\Contracts\VotingBallotViewInterface;
  * VotingBallotService - Assembles ballot candidate data for voting
  *
  * @phpstan-import-type BallotCategory from VotingBallotViewInterface
+ * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
  *
  * @see VotingBallotServiceInterface For the interface contract
  */
@@ -81,14 +82,13 @@ class VotingBallotService implements VotingBallotServiceInterface
      * @param string $code Category code
      * @param string $title Display title
      * @param string $instruction Voter instruction
-     * @param array<int, array<string, mixed>> $rows Raw player rows
+     * @param list<PlayerRow> $rows Raw player rows
      * @return BallotCategory
      */
     private function buildPlayerCategory(string $code, string $title, string $instruction, array $rows): array
     {
         $candidates = [];
         foreach ($rows as $row) {
-            /** @phpstan-ignore argument.type (League methods return full PlayerRow arrays from SELECT * queries) */
             $player = Player::withPlrRow($this->db, $row);
             $playerStats = PlayerStats::withPlrRow($this->db, $row);
             $candidates[] = [

--- a/ibl5/classes/Waivers/Contracts/WaiversProcessorInterface.php
+++ b/ibl5/classes/Waivers/Contracts/WaiversProcessorInterface.php
@@ -9,12 +9,13 @@ use Season;
 
 /**
  * WaiversProcessorInterface - Contract for waiver wire business logic
- * 
+ *
  * Defines the business logic operations for waiver wire transactions. Handles
  * salary calculations, contract determination, and timing calculations for
  * the waiver claiming process.
- * 
+ *
  * @package Waivers\Contracts
+ * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
  */
 interface WaiversProcessorInterface
 {
@@ -89,11 +90,7 @@ interface WaiversProcessorInterface
      * Analyzes a player's existing contract situation to determine what
      * contract terms apply when signing them from waivers.
      * 
-     * @param array{cy: int, cyt: int, cy1: int, cy2: int, cy3: int, cy4: int, cy5: int, cy6: int, exp: int} $playerData Player data array with keys:
-     *   - 'cy': int - Current contract year (0-based)
-     *   - 'cyt': int - Total contract years
-     *   - 'cy1'-'cy6': int - Salary for each contract year
-     *   - 'exp': int - Years of experience
+     * @param PlayerRow $playerData Player data array with contract fields (cy, cyt, cy1-cy6, exp)
      * @param Season $season Season object for phase determination
      * @return array{hasExistingContract: bool, salary: int} Contract determination result:
      *   - 'hasExistingContract': bool - Whether player has remaining contract

--- a/ibl5/classes/Waivers/WaiversController.php
+++ b/ibl5/classes/Waivers/WaiversController.php
@@ -183,7 +183,7 @@ class WaiversController implements WaiversControllerInterface
 
         $season = new \Season($this->db);
         /** @var array{hasExistingContract: bool, salary: int} $contractData */
-        $contractData = $this->processor->determineContractData($player, $season); /** @phpstan-ignore argument.type (PlayerRow has all contract fields) */
+        $contractData = $this->processor->determineContractData($player, $season);
         $playerSalary = $contractData['salary'];
 
         if (!$this->validator->validateAdd($playerID, $healthyRosterSlots, $totalSalary, $playerSalary)) {
@@ -334,8 +334,7 @@ class WaiversController implements WaiversControllerInterface
         }
 
         foreach ($result as $playerRow) {
-            /** @phpstan-ignore argument.type (PlayerRow from SELECT * matches withPlrRow expectation) */
-            $player = Player::withPlrRow($this->db, $playerRow);
+                $player = Player::withPlrRow($this->db, $playerRow);
             $contract = $this->processor->getPlayerContractDisplay($player, $season);
             $waitTime = '';
 

--- a/ibl5/classes/Waivers/WaiversProcessor.php
+++ b/ibl5/classes/Waivers/WaiversProcessor.php
@@ -12,6 +12,7 @@ use Waivers\Contracts\WaiversProcessorInterface;
 
 /**
  * @see WaiversProcessorInterface
+ * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
  */
 class WaiversProcessor implements WaiversProcessorInterface
 {
@@ -87,7 +88,7 @@ class WaiversProcessor implements WaiversProcessorInterface
     /**
      * @see WaiversProcessorInterface::determineContractData()
      *
-     * @param array{cy: int, cyt: int, cy1: int, cy2: int, cy3: int, cy4: int, cy5: int, cy6: int, exp: int} $playerData
+     * @param PlayerRow $playerData
      * @return array{hasExistingContract: bool, salary: int}
      */
     public function determineContractData(array $playerData, Season $season): array


### PR DESCRIPTION
## Summary

Add `@phpstan-type` aliases on API repository classes so array shapes flow cleanly from repository → controller → transformer without `@phpstan-ignore argument.type` suppressions. PHPDoc-only refactoring with zero runtime changes.

## Changes

### API Layer (14 suppressions removed)
- **7 repositories**: Define typed array shapes (`PlayerCurrentRow`, `TeamListRow`, `TeamDetailRow`, `GameViewRow`, `BoxscoreTeamRow`, `BoxscorePlayerRow`, `StandingsViewRow`, `LeaderRow`, `InjuredPlayerRow`, `CareerStatsRow`, `SeasonHistoryRow`) and update return types
- **8 transformers**: Replace inline `@param` array shapes with `@phpstan-import-type` from repositories (single source of truth)
- **13 controllers**: Remove 15 `@phpstan-ignore argument.type` suppressions

### Non-API Layer (5 suppressions removed)
- **League.php**: Import `PlayerRow`, type 7 methods returning `SELECT * FROM ibl_plr`
- **Player.php / PlayerRepositoryInterface / PlayerRepository**: Define and use `HistoricalPlayerRow` type alias
- **WaiversController**: Remove 2 suppressions (contract data + player factory)
- **WaiversProcessor/Interface**: Accept `PlayerRow` instead of narrow contract shape
- **InjuriesService**: Remove suppression + redundant `@var`
- **VotingBallotService**: Import `PlayerRow`, type `buildPlayerCategory` param

## Verification
- PHPStan: 0 errors (level max, strict-rules, bleedingEdge)
- PHPUnit: 3881 tests, 18455 assertions — all passing
- Zero `@phpstan-ignore argument.type` in any modified files

## Manual Testing
No manual testing needed — all changes are PHPDoc annotations only with zero runtime behavior changes.