### PR TITLE
config: add effort + model frontmatter to skills and commands

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -3,6 +3,7 @@ allowed-tools: Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr comment:*),
   Bash(gh issue view:*), Bash(gh search:*), Bash(gh pr list:*), Bash(gh api:*),
   Bash(git log:*), Bash(git rev-parse:*), Bash(git show:*)
 description: Token-efficient code review for pull requests
+model: sonnet
 ---
 
 Provide a code review for the given pull request. This command optimizes token usage by fetching the diff once and distributing only what each agent needs.

--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -2,6 +2,7 @@
 allowed-tools: Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr comment:*),
   Bash(gh api:*), Bash(git rev-parse:*)
 description: Token-efficient security audit for pull requests
+model: sonnet
 ---
 
 Perform a security audit on the given pull request. This command optimizes token usage by fetching the diff once and distributing it to specialized security agents.

--- a/.claude/skills/basketball-stats/SKILL.md
+++ b/.claude/skills/basketball-stats/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: basketball-stats
 description: Basketball statistics formatting using BasketballStats\StatsFormatter for percentages, averages, and totals. Use when displaying stats, calculating averages, or formatting basketball numbers.
+effort: low
 ---
 
 # Basketball Statistics Formatting

--- a/.claude/skills/contract-rules/SKILL.md
+++ b/.claude/skills/contract-rules/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: contract-rules
 description: IBL CBA salary cap rules including Bird Rights, veteran minimums, and maximum contracts. Use when working on extensions, free agency, negotiations, or salary calculations.
+effort: low
 ---
 
 # IBL Contract Rules (CBA)

--- a/.claude/skills/database-repository/SKILL.md
+++ b/.claude/skills/database-repository/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: database-repository
 description: Database repository pattern using BaseMysqliRepository with prepared statements for IBL5. Use when creating repositories, writing database queries, or extending BaseMysqliRepository.
+effort: low
 ---
 
 # Database Repository Pattern

--- a/.claude/skills/documentation-updates/SKILL.md
+++ b/.claude/skills/documentation-updates/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: documentation-updates
 description: Update IBL5 documentation during pull requests and feature development. Use when updating docs, creating README files, or documenting completed work.
+effort: low
+model: haiku
 ---
 
 # IBL5 Documentation Updates

--- a/.claude/skills/phpunit-testing/SKILL.md
+++ b/.claude/skills/phpunit-testing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: phpunit-testing
 description: PHPUnit 13+ test writing with behavior-focused patterns and mock objects for IBL5. Use when writing tests, creating test files, or reviewing test quality.
+effort: low
 ---
 
 # IBL5 PHPUnit Testing

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security-audit
 description: Security vulnerability patterns for IBL5 PHP code. Use when auditing security, fixing vulnerabilities, or reviewing code for security issues.
+effort: low
 ---
 
 # IBL5 Security Patterns


### PR DESCRIPTION
## Summary

Add Claude Code 2.1.80 frontmatter fields (`effort` and `model`) to skills and commands to reduce token usage and route mechanical tasks to cheaper models.

## Changes

### Effort Frontmatter (`effort: low`)
- 5 reference skills: basketball-stats, contract-rules, database-repository, phpunit-testing, security-audit
- 1 task skill: documentation-updates

### Model Frontmatter
- `model: haiku` — documentation-updates (mechanical checklist)
- `model: sonnet` — code-review and security-audit commands (orchestration where judgment lives in spawned agents)

### Statusline Rate Limits (local only)
Updated `~/.claude/statusline-command.sh` to display Claude.ai subscription rate limits (5-hour and 7-day windows) with color-coded percentages:
- Green: < 70%
- Yellow: 70-89%
- Red: >= 90%

## Manual Testing
- [x] Invoke a reference skill (e.g. `/basketball-stats`) and verify no errors from `effort` field
- [x] Invoke `/code-review` and verify it runs on Sonnet
- [x] Test statusline with `echo '{"model":{"display_name":"Opus"},"workspace":{"current_dir":"/tmp"},"context_window":{"used_percentage":25},"rate_limits":{"five_hour":{"used_percentage":45},"seven_day":{"used_percentage":12}}}' | bash ~/.claude/statusline-command.sh`