### PR TITLE
security: escape $sitename in StatisticsController title() calls

### DIFF
--- a/ibl5/classes/SiteStatistics/StatisticsController.php
+++ b/ibl5/classes/SiteStatistics/StatisticsController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SiteStatistics;
 
+use Utilities\HtmlSanitizer;
+
 /**
  * Controller for site statistics module
  * Orchestrates data retrieval, processing, and view rendering
@@ -149,7 +151,7 @@ class StatisticsController
         $currentMonth = (int)$parts[1];
         
         \PageLayout\PageLayout::header();
-        \title("$sitename " . _STATS);
+        \title(HtmlSanitizer::e($sitename) . " " . _STATS);
         \OpenTable();
         
         $monthlyStats = $this->repository->getMonthlyStats($year);
@@ -185,7 +187,7 @@ class StatisticsController
         $currentDate = (int)$parts[0];
         
         \PageLayout\PageLayout::header();
-        \title("$sitename " . _STATS);
+        \title(HtmlSanitizer::e($sitename) . " " . _STATS);
         \OpenTable();
         
         $dailyStats = $this->repository->getDailyStats($year, $month);
@@ -219,7 +221,7 @@ class StatisticsController
         global $sitename;
         
         \PageLayout\PageLayout::header();
-        \title("$sitename " . _STATS);
+        \title(HtmlSanitizer::e($sitename) . " " . _STATS);
         \OpenTable();
         
         $hourlyStats = $this->repository->getHourlyStats($year, $month, $date);


### PR DESCRIPTION
## Summary

Follow-up to PR #390. The code review caught 3 additional unescaped `\\title()` calls in StatisticsController that pass `$sitename` directly — the same XSS pattern fixed in StatisticsView.php.

## Changes

- Added `use Utilities\HtmlSanitizer` to StatisticsController
- Wrapped `$sitename` with `HtmlSanitizer::e()` in `showYearlyStats()`, `showMonthlyStats()`, and `showDailyStats()`

## Manual Testing
No manual testing needed — mechanical escaping, no behavior change.