### PR TITLE
test: add mobile sub-page variant smoke tests

### DIFF
--- a/ibl5/tests/e2e/smoke/mobile-subpages.spec.ts
+++ b/ibl5/tests/e2e/smoke/mobile-subpages.spec.ts
@@ -61,13 +61,16 @@ test.describe('Player stat view mobile smoke tests', () => {
       const url = `${PLAYER_BASE_URL}&${view.param}`;
       await gotoWithRetry(page, url);
 
+      const content = page.locator('.player-stats-card, h2, h3').first();
+
       if (view.dataDependentSkip) {
-        const content = page.locator('.ibl-data-table, .player-stats-card, h2, h3').first();
         const visible = await content.isVisible().catch(() => false);
         if (!visible) {
           test.skip(true, `player ${view.name} rendered no content (seed data)`);
         }
       }
+
+      await expect(content).toBeVisible();
 
       if (!('skipOverflow' in view)) {
         await assertNoHorizontalOverflow(page, `on player ${view.name}`);
@@ -112,14 +115,16 @@ test.describe('Team display mode mobile smoke tests', () => {
       const url = `${TEAM_BASE_URL}&${view.param}`;
       await gotoWithRetry(page, url);
 
+      const content = page.locator('.ibl-data-table, table, h2, h3').first();
+
       if (view.dataDependentSkip) {
-        const content = page.locator('.ibl-data-table, table, h2, h3').first();
         const visible = await content.isVisible().catch(() => false);
         if (!visible) {
           test.skip(true, `team ${view.name} rendered no content (seed data)`);
         }
       }
 
+      await expect(content).toBeVisible();
       await assertNoHorizontalOverflow(page, `on team ${view.name}`);
 
       if (view.hasWideTables) {


### PR DESCRIPTION
## Summary

Adds 26 new Playwright E2E tests for mobile sub-page variants (375x812 viewport), covering Player stat views, Team display modes, and Olympics league-context pages.

### Player stat view tests (9 tests)
- 7 overflow tests across pageView variants (Awards & News, RS Totals, RS Averages, Playoff Totals, HEAT Totals, Ratings & Salary, Sim Stats)
- 1 scroll container test for RS Totals (`.player-stats-card` scrollability)
- 1 PHP error loop across all 7 URLs

### Team display mode tests (10 tests)
- 8 overflow tests across display variants (Season Totals, Contracts, Averages, Per 36 Min, Sim Averages, Split Home, Playoffs, Historical 2024)
- 1 scroll container test for Season Totals
- 1 PHP error loop across all 8 URLs

### Olympics mobile tests (7 tests)
- 4 content-length assertions (matching desktop `olympics-pages.spec.ts` pattern)
- 2 overflow tests (Standings + Team, with skip guard)
- 1 PHP error loop across all 4 URLs

### Design decisions
- Player RS Totals/Averages use `skipOverflow` — their tables live inside `.player-stats-card` (with `overflow-x: auto`), not `.table-scroll-container`, and cause pre-existing body-level overflow
- `dataDependentSkip` guards on pages requiring playoff stats, HEAT stats, box scores, or historical data not present in CI seed

## Manual Testing
No manual testing needed — all changes are E2E test additions with no PHP or CSS modifications.