### PR TITLE
test(a11y): expand accessibility coverage to 48 pages

### DIFF
--- a/ibl5/classes/TeamSchedule/TeamScheduleView.php
+++ b/ibl5/classes/TeamSchedule/TeamScheduleView.php
@@ -276,7 +276,7 @@ class TeamScheduleView implements TeamScheduleViewInterface
             $html .= ' <span class="schedule-game__record">(' . $safeVisitorRecord . ')</span>';
         }
         $html .= '</span></a>';
-        $html .= '<a href="' . $visitorUrl . '" class="schedule-game__logo-link">';
+        $html .= '<a href="' . $visitorUrl . '" class="schedule-game__logo-link" aria-label="' . $safeVisitorName . '">';
         $html .= '<img class="schedule-game__logo" src="images/logo/new' . $visitorTeamId . '.png" alt="" width="25" height="25" loading="lazy">';
         $html .= '</a>';
 
@@ -298,7 +298,7 @@ class TeamScheduleView implements TeamScheduleViewInterface
         // Home logo + team (same as League Schedule)
         $safeHomeName = HtmlSanitizer::safeHtmlOutput($homeName);
         $safeHomeRecord = HtmlSanitizer::safeHtmlOutput($homeRecord);
-        $html .= '<a href="' . $homeUrl . '" class="schedule-game__logo-link">';
+        $html .= '<a href="' . $homeUrl . '" class="schedule-game__logo-link" aria-label="' . $safeHomeName . '">';
         $html .= '<img class="schedule-game__logo" src="images/logo/new' . $homeTeamId . '.png" alt="" width="25" height="25" loading="lazy">';
         $html .= '</a>';
         $html .= '<a href="' . $homeUrl . '" class="schedule-game__team-link">';

--- a/ibl5/tests/e2e/smoke/accessibility.spec.ts
+++ b/ibl5/tests/e2e/smoke/accessibility.spec.ts
@@ -45,6 +45,10 @@ const publicPages: Array<{ name: string; url: string }> = [
   { name: 'search', url: 'modules.php?name=Search' },
   { name: 'topics', url: 'modules.php?name=Topics' },
   { name: 'voting results', url: 'modules.php?name=VotingResults' },
+  { name: 'news index', url: 'modules.php?name=News' },
+  { name: 'news categories', url: 'modules.php?name=News&file=categories' },
+  { name: 'news article', url: 'modules.php?name=News&file=article&sid=1' },
+  { name: 'team schedule', url: 'modules.php?name=Schedule&teamID=1' },
 ];
 
 publicTest.describe('Public page accessibility', () => {
@@ -80,6 +84,16 @@ const authPages: Array<{
   { name: 'draft', url: 'modules.php?name=Draft', state: { 'Show Draft Link': 'Yes' } },
   { name: 'next sim', url: 'modules.php?name=NextSim' },
   { name: 'your account', url: 'modules.php?name=YourAccount' },
+  {
+    name: 'voting ASG ballot',
+    url: 'modules.php?name=Voting',
+    state: { 'Current Season Phase': 'Regular Season', 'ASG Voting': 'Yes' },
+  },
+  {
+    name: 'voting EOY ballot',
+    url: 'modules.php?name=Voting',
+    state: { 'Current Season Phase': 'Free Agency', 'EOY Voting': 'Yes' },
+  },
 ];
 
 authTest.describe('Authenticated page accessibility', () => {


### PR DESCRIPTION
## Summary

Expand the axe-core accessibility test suite from 42 to 48 pages, adding 6 new entries (4 public, 2 authenticated). Fix one `link-name` violation discovered during the expansion.

## New pages

### Public (+4)
- **News index** — `modules.php?name=News`
- **News categories** — `modules.php?name=News&file=categories`
- **News article** — `modules.php?name=News&file=article&sid=1`
- **Team schedule** — `modules.php?name=Schedule&teamID=1` (team-specific variant)

### Authenticated (+2)
- **Voting ASG ballot** — `modules.php?name=Voting` (Regular Season + ASG Voting)
- **Voting EOY ballot** — `modules.php?name=Voting` (Free Agency + EOY Voting)

## Accessibility fix

Added `aria-label` to team logo links in `TeamScheduleView` — the `<a>` tags wrapping logo `<img>` elements had no discernible text (the `<img>` uses `alt=""` since it's decorative alongside a text link). This matches the existing pattern in `LeagueScheduleView` which already had `aria-label` attributes.

## Manual Testing

No manual testing needed — all changes are covered by E2E accessibility tests.