### PR TITLE
deps: upgrade PHPMailer v6 → v7

### DIFF
--- a/ibl5/classes/Mail/MailService.php
+++ b/ibl5/classes/Mail/MailService.php
@@ -133,7 +133,7 @@ class MailService implements MailServiceInterface
             $mail->Host = $this->smtpConfig['host'];
             $mail->Port = $this->smtpConfig['port'];
             $mail->SMTPSecure = $this->smtpConfig['encryption'];
-            $mail->SMTPAuth = true;
+            $mail->SMTPAuth = $this->smtpConfig['username'] !== '';
             $mail->Username = $this->smtpConfig['username'];
             $mail->Password = $this->smtpConfig['password'];
 

--- a/ibl5/composer.json
+++ b/ibl5/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": ">=8.4",
-        "phpmailer/phpmailer": "^6.9",
+        "phpmailer/phpmailer": "^7.0",
         "delight-im/auth": "^9.0"
     },
     "require-dev": {

--- a/ibl5/composer.lock
+++ b/ibl5/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69c5dea67b2eeb3ff7d465fddd22e976",
+    "content-hash": "bcab756952213565af0a31a1c665d193",
     "packages": [
         {
             "name": "delight-im/auth",
@@ -347,16 +347,16 @@
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v6.12.0",
+            "version": "v7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "d1ac35d784bf9f5e61b424901d5a014967f15b12"
+                "reference": "ebf1655bd5b99b3f97e1a3ec0a69e5f4cd7ea088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/d1ac35d784bf9f5e61b424901d5a014967f15b12",
-                "reference": "d1ac35d784bf9f5e61b424901d5a014967f15b12",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/ebf1655bd5b99b3f97e1a3ec0a69e5f4cd7ea088",
+                "reference": "ebf1655bd5b99b3f97e1a3ec0a69e5f4cd7ea088",
                 "shasum": ""
             },
             "require": {
@@ -370,13 +370,14 @@
                 "doctrine/annotations": "^1.2.6 || ^1.13.3",
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcompatibility/php-compatibility": "^9.3.5",
-                "roave/security-advisories": "dev-latest",
-                "squizlabs/php_codesniffer": "^3.7.2",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "squizlabs/php_codesniffer": "^3.13.5",
                 "yoast/phpunit-polyfills": "^1.0.4"
             },
             "suggest": {
                 "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+                "directorytree/imapengine": "For uploading sent messages via IMAP, see gmail example",
+                "ext-imap": "Needed to support advanced email address parsing according to RFC822",
                 "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
                 "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
                 "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
@@ -416,7 +417,7 @@
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
             "support": {
                 "issues": "https://github.com/PHPMailer/PHPMailer/issues",
-                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.12.0"
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v7.0.2"
             },
             "funding": [
                 {
@@ -424,7 +425,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-15T16:49:08+00:00"
+            "time": "2026-01-09T18:02:33+00:00"
         }
     ],
     "packages-dev": [

--- a/ibl5/tests/Mail/MailServiceSmtpIntegrationTest.php
+++ b/ibl5/tests/Mail/MailServiceSmtpIntegrationTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Mail;
+
+use Mail\MailService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration test for MailService SMTP transport via Mailpit.
+ *
+ * Requires Mailpit running on localhost:1025 (SMTP) and localhost:8025 (API).
+ * Skips automatically if Mailpit is not reachable.
+ *
+ * @group integration
+ * @group mailpit
+ */
+class MailServiceSmtpIntegrationTest extends TestCase
+{
+    private const MAILPIT_SMTP_HOST = 'localhost';
+    private const MAILPIT_SMTP_PORT = 1025;
+    private const MAILPIT_API_URL = 'http://localhost:8025/api/v1';
+
+    private MailService $service;
+
+    protected function setUp(): void
+    {
+        if (!$this->isMailpitReachable()) {
+            $this->markTestSkipped('Mailpit is not reachable at localhost:1025');
+        }
+
+        $this->deleteAllMailpitMessages();
+
+        $this->service = new MailService([
+            'transport' => 'smtp',
+            'smtp' => [
+                'host' => self::MAILPIT_SMTP_HOST,
+                'port' => self::MAILPIT_SMTP_PORT,
+                'encryption' => '',
+                'username' => '',
+                'password' => '',
+            ],
+            'default_from_email' => 'noreply@iblhoops.net',
+            'default_from_name' => 'IBL',
+        ]);
+    }
+
+    public function testSmtpSendDelivers(): void
+    {
+        $recipient = 'testuser@example.com';
+        $subject = 'IBL Test Email ' . uniqid();
+        $body = 'This is a test email body.';
+        $fromEmail = 'sender@iblhoops.net';
+        $fromName = 'IBL Mailer';
+
+        $result = $this->service->send($recipient, $subject, $body, $fromEmail, $fromName);
+
+        $this->assertTrue($result, 'MailService::send() should return true on successful SMTP delivery');
+
+        $messages = $this->getMailpitMessages();
+        $this->assertCount(1, $messages, 'Mailpit should have received exactly 1 message');
+
+        $message = $messages[0];
+        $this->assertSame($subject, $message['Subject']);
+        $this->assertSame($recipient, $message['To'][0]['Address']);
+        $this->assertSame($fromEmail, $message['From']['Address']);
+        $this->assertSame($fromName, $message['From']['Name']);
+    }
+
+    public function testSmtpSendUsesDefaultFromName(): void
+    {
+        $recipient = 'testuser@example.com';
+        $subject = 'Default Name Test ' . uniqid();
+
+        $result = $this->service->send($recipient, $subject, 'Body text', 'sender@iblhoops.net');
+
+        $this->assertTrue($result);
+
+        $messages = $this->getMailpitMessages();
+        $this->assertCount(1, $messages);
+        $this->assertSame('IBL', $messages[0]['From']['Name']);
+    }
+
+    public function testSmtpSendPlainTextBody(): void
+    {
+        $recipient = 'testuser@example.com';
+        $subject = 'Body Check ' . uniqid();
+        $body = "Line 1\nLine 2\nLine 3";
+
+        $result = $this->service->send($recipient, $subject, $body, 'sender@iblhoops.net');
+
+        $this->assertTrue($result);
+
+        $messages = $this->getMailpitMessages();
+        $this->assertCount(1, $messages);
+
+        $messageId = $messages[0]['ID'];
+        $fullMessage = $this->getMailpitMessage($messageId);
+        $this->assertStringContainsString('Line 1', $fullMessage['Text']);
+        $this->assertStringContainsString('Line 3', $fullMessage['Text']);
+    }
+
+    private function isMailpitReachable(): bool
+    {
+        $socket = @fsockopen(self::MAILPIT_SMTP_HOST, self::MAILPIT_SMTP_PORT, $errno, $errstr, 2);
+        if ($socket === false) {
+            return false;
+        }
+        fclose($socket);
+        return true;
+    }
+
+    private function deleteAllMailpitMessages(): void
+    {
+        $ch = curl_init(self::MAILPIT_API_URL . '/messages');
+        if ($ch === false) {
+            return;
+        }
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_exec($ch);
+        unset($ch);
+    }
+
+    /**
+     * @return list<array{ID: string, Subject: string, From: array{Address: string, Name: string}, To: list<array{Address: string, Name: string}>}>
+     */
+    private function getMailpitMessages(): array
+    {
+        $ch = curl_init(self::MAILPIT_API_URL . '/messages');
+        if ($ch === false) {
+            $this->fail('Failed to initialize curl for Mailpit API');
+        }
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $response = curl_exec($ch);
+        unset($ch);
+
+        if (!is_string($response)) {
+            $this->fail('Mailpit API returned non-string response');
+        }
+
+        $data = json_decode($response, true);
+        if (!is_array($data) || !isset($data['messages'])) {
+            $this->fail('Mailpit API returned unexpected format');
+        }
+
+        /** @var list<array{ID: string, Subject: string, From: array{Address: string, Name: string}, To: list<array{Address: string, Name: string}>}> */
+        return $data['messages'];
+    }
+
+    /**
+     * @return array{Text: string, HTML: string}
+     */
+    private function getMailpitMessage(string $id): array
+    {
+        $ch = curl_init(self::MAILPIT_API_URL . '/message/' . $id);
+        if ($ch === false) {
+            $this->fail('Failed to initialize curl for Mailpit message API');
+        }
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $response = curl_exec($ch);
+        unset($ch);
+
+        if (!is_string($response)) {
+            $this->fail('Mailpit message API returned non-string response');
+        }
+
+        $data = json_decode($response, true);
+        if (!is_array($data)) {
+            $this->fail('Mailpit message API returned unexpected format');
+        }
+
+        /** @var array{Text: string, HTML: string} */
+        return $data;
+    }
+}


### PR DESCRIPTION
## Summary

Upgrade PHPMailer from `^6.9` (v6.12.0) to `^7.0` (v7.0.2).

PHPMailer v7.0 is functionally identical to v6.11.1 — the major version bump exists solely because three language-related members (`$language`, `lang()`, `setLanguage()`) became `static`, which is a BC break only for subclasses. Our codebase uses PHPMailer via composition only (`MailService::sendViaSmtp()`), so no API changes are needed.

## Changes

### Composer
- `"phpmailer/phpmailer": "^6.9"` → `"^7.0"`

### Bug Fix
- `MailService::sendViaSmtp()` now sets `SMTPAuth` conditionally based on whether a username is configured, instead of hardcoding `true`. This fixes SMTP delivery against unauthenticated servers like Mailpit.

### Tests
- New `MailServiceSmtpIntegrationTest` (3 tests) verifying the SMTP transport path end-to-end via Mailpit:
  - Email delivery with custom from name
  - Default from-name fallback
  - Plain-text body content preservation
- Tests skip automatically when Mailpit is not reachable (requires Docker)

## Manual Testing

No manual testing needed — all changes are covered by unit and integration tests. The existing 11 MailServiceTest tests also pass unchanged.