### PR TITLE
test: harden API test suite against flakiness

### DIFF
--- a/ibl5/classes/Api/Middleware/Contracts/ClockInterface.php
+++ b/ibl5/classes/Api/Middleware/Contracts/ClockInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Middleware\Contracts;
+
+interface ClockInterface
+{
+    public function now(): int;
+}

--- a/ibl5/classes/Api/Middleware/RateLimiter.php
+++ b/ibl5/classes/Api/Middleware/RateLimiter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Api\Middleware;
 
+use Api\Middleware\Contracts\ClockInterface;
 use Api\Middleware\Contracts\RateLimiterInterface;
 use Api\Repository\RateLimitRepository;
 
@@ -17,10 +18,12 @@ class RateLimiter implements RateLimiterInterface
     ];
 
     private RateLimitRepository $repository;
+    private ClockInterface $clock;
 
-    public function __construct(RateLimitRepository $repository)
+    public function __construct(RateLimitRepository $repository, ?ClockInterface $clock = null)
     {
         $this->repository = $repository;
+        $this->clock = $clock ?? new SystemClock();
     }
 
     /**
@@ -54,7 +57,7 @@ class RateLimiter implements RateLimiterInterface
                 'Retry-After' => '60',
                 'X-RateLimit-Limit' => (string) $limit,
                 'X-RateLimit-Remaining' => '0',
-                'X-RateLimit-Reset' => (string) (time() + 60),
+                'X-RateLimit-Reset' => (string) ($this->clock->now() + 60),
             ];
         }
 

--- a/ibl5/classes/Api/Middleware/SystemClock.php
+++ b/ibl5/classes/Api/Middleware/SystemClock.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Middleware;
+
+use Api\Middleware\Contracts\ClockInterface;
+
+class SystemClock implements ClockInterface
+{
+    public function now(): int
+    {
+        return time();
+    }
+}

--- a/ibl5/tests/Api/Cache/ETagHandlerTest.php
+++ b/ibl5/tests/Api/Cache/ETagHandlerTest.php
@@ -16,6 +16,11 @@ class ETagHandlerTest extends TestCase
         $this->handler = new ETagHandler();
     }
 
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+    }
+
     public function testGenerateReturnsQuotedMd5(): void
     {
         $etag = $this->handler->generate('2026-01-15 12:00:00');
@@ -95,8 +100,6 @@ class ETagHandlerTest extends TestCase
         $_SERVER['HTTP_IF_NONE_MATCH'] = '"abc123"';
 
         $this->assertTrue($this->handler->matches($etag));
-
-        unset($_SERVER['HTTP_IF_NONE_MATCH']);
     }
 
     public function testMatchesReturnsFalseWhenHeaderDiffers(): void
@@ -105,8 +108,6 @@ class ETagHandlerTest extends TestCase
         $_SERVER['HTTP_IF_NONE_MATCH'] = '"different"';
 
         $this->assertFalse($this->handler->matches($etag));
-
-        unset($_SERVER['HTTP_IF_NONE_MATCH']);
     }
 
     public function testMatchesReturnsFalseWhenNoHeader(): void

--- a/ibl5/tests/Api/Controller/GameListControllerTest.php
+++ b/ibl5/tests/Api/Controller/GameListControllerTest.php
@@ -12,6 +12,7 @@ class GameListControllerTest extends IntegrationTestCase
 {
     public function testHandleCallsResponderWithGameData(): void
     {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 1]]);
         $this->mockDb->setMockData([
             [
                 'game_uuid' => 'game-uuid-1',
@@ -35,7 +36,6 @@ class GameListControllerTest extends IntegrationTestCase
                 'home_score' => 142,
                 'created_at' => '2026-01-01 00:00:00',
                 'updated_at' => '2026-01-15 12:00:00',
-                'total' => 1, // Mock COUNT(*) result reuses same data
             ],
         ]);
 

--- a/ibl5/tests/Api/Controller/LeadersControllerTest.php
+++ b/ibl5/tests/Api/Controller/LeadersControllerTest.php
@@ -12,6 +12,7 @@ class LeadersControllerTest extends IntegrationTestCase
 {
     public function testHandleCallsResponderWithLeaderData(): void
     {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 1]]);
         $this->mockDb->setMockData([
             [
                 'player_uuid' => 'player-uuid-1',
@@ -42,7 +43,6 @@ class LeadersControllerTest extends IntegrationTestCase
                 'team' => 'Celtics',
                 'created_at' => '2025-01-01 00:00:00',
                 'updated_at' => '2026-01-15 12:00:00',
-                'total' => 1, // Mock COUNT(*) result reuses same data
             ],
         ]);
 

--- a/ibl5/tests/Api/Middleware/RateLimiterTest.php
+++ b/ibl5/tests/Api/Middleware/RateLimiterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Api\Middleware;
 
+use Api\Middleware\Contracts\ClockInterface;
 use Api\Middleware\RateLimiter;
 use Api\Repository\RateLimitRepository;
 use PHPUnit\Framework\TestCase;
@@ -56,7 +57,10 @@ class RateLimiterTest extends TestCase
     public function testRejectsRequestOverLimit(): void
     {
         $stubRepo = $this->createStub(RateLimitRepository::class);
-        $rateLimiter = new RateLimiter($stubRepo);
+        $fixedClock = $this->createStub(ClockInterface::class);
+        $fixedClock->method('now')->willReturn(1_700_000_000);
+
+        $rateLimiter = new RateLimiter($stubRepo, $fixedClock);
         $apiKey = $this->makeApiKey();
 
         $stubRepo->method('getRequestCount')->willReturn(61);
@@ -66,7 +70,7 @@ class RateLimiterTest extends TestCase
         $this->assertSame('60', $result['Retry-After']);
         $this->assertSame('60', $result['X-RateLimit-Limit']);
         $this->assertSame('0', $result['X-RateLimit-Remaining']);
-        $this->assertArrayHasKey('X-RateLimit-Reset', $result);
+        $this->assertSame('1700000060', $result['X-RateLimit-Reset']);
     }
 
     public function testElevatedTierHasHigherLimit(): void

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryApiHandlerTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryApiHandlerTest.php
@@ -4,72 +4,19 @@ declare(strict_types=1);
 
 namespace Tests\DepthChartEntry;
 
-use PHPUnit\Framework\TestCase;
 use DepthChartEntry\DepthChartEntryApiHandler;
+use Tests\Integration\IntegrationTestCase;
 
 /**
  * Tests for DepthChartEntryApiHandler
  *
  * Validates display mode whitelist and split parameter support.
  */
-class DepthChartEntryApiHandlerTest extends TestCase
+class DepthChartEntryApiHandlerTest extends IntegrationTestCase
 {
-    private \MockDatabase $mockDb;
-    private object $mockMysqliDb;
-
-    protected function setUp(): void
-    {
-        $this->mockDb = new \MockDatabase();
-        $this->setupMockMysqliDb();
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['mysqli_db']);
-    }
-
-    private function setupMockMysqliDb(): void
-    {
-        $mockDb = $this->mockDb;
-
-        $this->mockMysqliDb = new class($mockDb) extends \mysqli {
-            private \MockDatabase $mockDb;
-            public int $connect_errno = 0;
-            public ?string $connect_error = null;
-
-            public function __construct(\MockDatabase $mockDb)
-            {
-                $this->mockDb = $mockDb;
-            }
-
-            #[\ReturnTypeWillChange]
-            public function prepare(string $query): \MockPreparedStatement|false
-            {
-                return new \MockPreparedStatement($this->mockDb, $query);
-            }
-
-            #[\ReturnTypeWillChange]
-            public function query(string $query, int $resultMode = MYSQLI_STORE_RESULT): \mysqli_result|bool
-            {
-                $result = $this->mockDb->sql_query($query);
-                if ($result instanceof \MockDatabaseResult) {
-                    return false;
-                }
-                return (bool) $result;
-            }
-
-            public function real_escape_string(string $string): string
-            {
-                return addslashes($string);
-            }
-        };
-
-        $GLOBALS['mysqli_db'] = $this->mockMysqliDb;
-    }
-
     public function testCanBeInstantiated(): void
     {
-        $handler = new DepthChartEntryApiHandler($this->mockMysqliDb);
+        $handler = new DepthChartEntryApiHandler($GLOBALS['mysqli_db']);
 
         $this->assertInstanceOf(DepthChartEntryApiHandler::class, $handler);
     }

--- a/ibl5/tests/Integration/IntegrationTestCase.php
+++ b/ibl5/tests/Integration/IntegrationTestCase.php
@@ -99,6 +99,22 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * Execute a callable that writes to stdout, capturing and returning the output.
+     * Cleans the buffer on exception so it never leaks into subsequent tests.
+     */
+    protected function captureOutput(callable $fn): string
+    {
+        ob_start();
+        try {
+            $fn();
+            return (string) ob_get_clean();
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            throw $e;
+        }
+    }
+
+    /**
      * Get all queries executed during the test
      */
     protected function getExecutedQueries(): array

--- a/ibl5/tests/SavedDepthChart/SavedDepthChartApiHandlerTest.php
+++ b/ibl5/tests/SavedDepthChart/SavedDepthChartApiHandlerTest.php
@@ -22,55 +22,45 @@ class SavedDepthChartApiHandlerTest extends IntegrationTestCase
 
     public function testHandleUnknownActionReturnsError(): void
     {
-        ob_start();
-        $this->handler->handle('unknown', 1, 'testuser', []);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('unknown', 1, 'testuser', []));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertSame('Unknown action', $data['error']);
     }
 
     public function testHandleRenameRejectsInvalidId(): void
     {
-        ob_start();
-        $this->handler->handle('rename', 1, 'testuser', ['id' => 0, 'name' => 'Test']);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('rename', 1, 'testuser', ['id' => 0, 'name' => 'Test']));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertSame('Invalid depth chart ID', $data['error']);
     }
 
     public function testHandleRenameRejectsNegativeId(): void
     {
-        ob_start();
-        $this->handler->handle('rename', 1, 'testuser', ['id' => -5, 'name' => 'Test']);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('rename', 1, 'testuser', ['id' => -5, 'name' => 'Test']));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertSame('Invalid depth chart ID', $data['error']);
     }
 
     public function testHandleRenameRejectsEmptyName(): void
     {
-        ob_start();
-        $this->handler->handle('rename', 1, 'testuser', ['id' => 1, 'name' => '']);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('rename', 1, 'testuser', ['id' => 1, 'name' => '']));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertSame('Name cannot be empty', $data['error']);
     }
 
     public function testHandleRenameSuccessReturnsJson(): void
     {
-        ob_start();
-        $this->handler->handle('rename', 1, 'testuser', ['id' => 5, 'name' => 'My DC']);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('rename', 1, 'testuser', ['id' => 5, 'name' => 'My DC']));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertTrue($data['success']);
         $this->assertSame('My DC', $data['name']);
@@ -80,55 +70,45 @@ class SavedDepthChartApiHandlerTest extends IntegrationTestCase
     {
         $longName = str_repeat('a', 150);
 
-        ob_start();
-        $this->handler->handle('rename', 1, 'testuser', ['id' => 5, 'name' => $longName]);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('rename', 1, 'testuser', ['id' => 5, 'name' => $longName]));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertSame(100, mb_strlen($data['name']));
     }
 
     public function testHandleRenameStripsHtmlTags(): void
     {
-        ob_start();
-        $this->handler->handle('rename', 1, 'testuser', ['id' => 5, 'name' => '<b>Bold DC</b>']);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('rename', 1, 'testuser', ['id' => 5, 'name' => '<b>Bold DC</b>']));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertSame('Bold DC', $data['name']);
     }
 
     public function testHandleRenameActiveRejectsEmptyName(): void
     {
-        ob_start();
-        $this->handler->handle('rename-active', 1, 'testuser', ['name' => '']);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('rename-active', 1, 'testuser', ['name' => '']));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertSame('Name cannot be empty', $data['error']);
     }
 
     public function testHandleLoadRejectsInvalidId(): void
     {
-        ob_start();
-        $this->handler->handle('load', 1, 'testuser', ['id' => 0]);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('load', 1, 'testuser', ['id' => 0]));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertSame('Invalid depth chart ID', $data['error']);
     }
 
     public function testHandleLoadRejectsNegativeId(): void
     {
-        ob_start();
-        $this->handler->handle('load', 1, 'testuser', ['id' => -5]);
-        $output = ob_get_clean();
+        $output = $this->captureOutput(fn () => $this->handler->handle('load', 1, 'testuser', ['id' => -5]));
 
-        $data = json_decode((string) $output, true);
+        $data = json_decode($output, true);
         $this->assertIsArray($data);
         $this->assertSame('Invalid depth chart ID', $data['error']);
     }

--- a/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
+++ b/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
@@ -36,15 +36,30 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
         };
     }
 
+    protected function tearDown(): void
+    {
+        $_GET = [];
+    }
+
+    private function captureOutput(callable $fn): string
+    {
+        ob_start();
+        try {
+            $fn();
+            return (string) ob_get_clean();
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            throw $e;
+        }
+    }
+
     public function testHandleReturnsEmptyHtmlWhenTeamIDMissing(): void
     {
         $_GET = [];
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -59,9 +74,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -76,9 +89,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -93,9 +104,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -111,9 +120,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -129,9 +136,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -142,22 +147,16 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
     public function testHandleFallsBackToRatingsWhenDisplayMissing(): void
     {
-        // Valid teamID but no display param — should default to 'ratings'
-        // DB prepare returns false, so we get empty result from the DB,
-        // but the handler should not error
         $_GET = ['teamID' => '1'];
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
 
         $this->assertIsArray($decoded);
-        // DB returns false, so we get empty HTML from the roster query
         $this->assertSame('', $decoded['html']);
     }
 
@@ -167,9 +166,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -184,9 +181,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -201,9 +196,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        ob_end_clean();
+        $this->captureOutput(fn () => $handler->handle());
 
         // Verify the handler doesn't throw an exception
         $this->assertTrue(true);
@@ -211,33 +204,26 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
     public function testHandleAcceptsEmptyAddPids(): void
     {
-        // Empty addPids is valid (showing removals only)
         $_GET = ['teamID' => '1', 'addPids' => '', 'removePids' => '1,2'];
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
 
         $this->assertIsArray($decoded);
-        // DB returns false, so empty HTML
         $this->assertSame('', $decoded['html']);
     }
 
     public function testHandleAcceptsEmptyRemovePids(): void
     {
-        // Empty removePids is valid (showing additions only)
         $_GET = ['teamID' => '1', 'addPids' => '1,2', 'removePids' => ''];
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -248,7 +234,6 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
     public function testBuildCashRowsIgnoredWhenDisplayIsNotContracts(): void
     {
-        // Cash params present but display is 'ratings' — no cash rows should be built
         $_GET = [
             'teamID' => '1',
             'display' => 'ratings',
@@ -262,21 +247,17 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
 
         $this->assertIsArray($decoded);
-        // DB returns false, so empty HTML — but the point is no crash from cash logic
         $this->assertSame('', $decoded['html']);
     }
 
     public function testBuildCashRowsSkippedWhenCashParamsMissing(): void
     {
-        // Contracts display but no cash params — should not crash
         $_GET = [
             'teamID' => '1',
             'display' => 'contracts',
@@ -284,9 +265,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -311,9 +290,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
@@ -338,15 +315,12 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
 
         $this->assertIsArray($decoded);
-        // Over-limit cash defaults to 0, so no cash rows generated
         $this->assertSame('', $decoded['html']);
     }
 
@@ -366,19 +340,12 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $handler = new TradeRosterPreviewApiHandler($this->mockDb);
 
-        ob_start();
-        $handler->handle();
-        $output = (string) ob_get_clean();
+        $output = $this->captureOutput(fn () => $handler->handle());
 
         /** @var array{html: string} $decoded */
         $decoded = json_decode($output, true);
 
         $this->assertIsArray($decoded);
         $this->assertSame('', $decoded['html']);
-    }
-
-    protected function tearDown(): void
-    {
-        $_GET = [];
     }
 }


### PR DESCRIPTION
## Summary

Fixes 5 categories of flakiness risk across 10 API test files. The other 13 of 23 API test files are pure unit tests with zero flakiness risk.

## Changes

### P1: `$_SERVER` state leakage — `ETagHandlerTest.php`
- Add `tearDown()` to unconditionally clean `$_SERVER["HTTP_IF_NONE_MATCH"]`
- Remove inline `unset()` calls that get skipped if an assertion throws

### P2: Output buffer leaks — 2 files, 23 methods
- Add `captureOutput()` helper to `IntegrationTestCase` with try/catch buffer cleanup
- Convert 9 methods in `SavedDepthChartApiHandlerTest` to use inherited helper
- Add private `captureOutput()` to `TradeRosterPreviewApiHandlerTest` (extends `TestCase`, not `IntegrationTestCase`)
- Convert 14 methods in `TradeRosterPreviewApiHandlerTest`

### P3: Non-deterministic `time()` — `RateLimiter`
- Create `ClockInterface` and `SystemClock` for testable time abstraction
- Accept optional `?ClockInterface` in `RateLimiter` constructor (backward compatible)
- Inject fixed clock in `RateLimiterTest`, assert exact `X-RateLimit-Reset` value

### P4: Duplicated mock wiring — `DepthChartEntryApiHandlerTest`
- Extend `IntegrationTestCase` instead of `TestCase`
- Delete 40-line hand-rolled `setupMockMysqliDb()` — reuse inherited mock infrastructure

### P5: Fragile COUNT mock coupling — 2 controller tests
- Use `onQuery("SELECT COUNT", ...)` to separate COUNT from data queries
- Remove `total` key from `setMockData()` rows in `GameListControllerTest` and `LeadersControllerTest`

## Manual Testing
No manual testing needed — all changes are test infrastructure hardening, fully covered by PHPUnit.