### PR TITLE
test: add integration tests for 6 high-risk repositories (Batch 1)

### DIFF
--- a/ibl5/tests/DatabaseIntegration/AllStarAppearancesRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/AllStarAppearancesRepositoryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use AllStarAppearances\AllStarAppearancesRepository;
+
+class AllStarAppearancesRepositoryTest extends DatabaseTestCase
+{
+    private AllStarAppearancesRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new AllStarAppearancesRepository($this->db);
+    }
+
+    public function testReturnsAllStarPlayerWithCorrectAppearanceCount(): void
+    {
+        $this->insertAwardRow('ASA TestStar', 'Eastern Conference All-Star', 2020);
+        $this->insertAwardRow('ASA TestStar', 'Western Conference All-Star', 2021);
+        $this->insertAwardRow('ASA TestStar', 'Eastern Conference All-Star', 2022);
+
+        $results = $this->repo->getAllStarAppearances();
+
+        $found = $this->findByName($results, 'ASA TestStar');
+        self::assertNotNull($found, 'Expected ASA TestStar in results');
+        self::assertSame(3, $found['appearances']);
+    }
+
+    public function testExcludesNonAllStarAwards(): void
+    {
+        $this->insertAwardRow('ASA NonStar', 'MVP', 2020);
+        $this->insertAwardRow('ASA NonStar', 'Defensive Player of the Year', 2021);
+
+        $results = $this->repo->getAllStarAppearances();
+
+        $found = $this->findByName($results, 'ASA NonStar');
+        self::assertNull($found, 'Non-all-star awards should be excluded');
+    }
+
+    public function testCountsBothConferenceAllStarAwards(): void
+    {
+        $this->insertAwardRow('ASA DualConf', 'Eastern Conference All-Star', 2020);
+        $this->insertAwardRow('ASA DualConf', 'Western Conference All-Star', 2021);
+
+        $results = $this->repo->getAllStarAppearances();
+
+        $found = $this->findByName($results, 'ASA DualConf');
+        self::assertNotNull($found);
+        self::assertSame(2, $found['appearances']);
+    }
+
+    public function testOrderedByAppearancesDescThenNameAsc(): void
+    {
+        $this->insertAwardRow('ASA Zeta', 'Eastern Conference All-Star', 2020);
+        $this->insertAwardRow('ASA Zeta', 'Eastern Conference All-Star', 2021);
+        $this->insertAwardRow('ASA Zeta', 'Eastern Conference All-Star', 2022);
+        $this->insertAwardRow('ASA Alpha', 'Western Conference All-Star', 2020);
+        $this->insertAwardRow('ASA Alpha', 'Western Conference All-Star', 2021);
+        $this->insertAwardRow('ASA Beta', 'Eastern Conference All-Star', 2020);
+
+        $results = $this->repo->getAllStarAppearances();
+
+        $testNames = [];
+        foreach ($results as $row) {
+            if (str_starts_with($row['name'], 'ASA ')) {
+                $testNames[] = $row['name'];
+            }
+        }
+
+        // Zeta has 3, Alpha has 2, Beta has 1
+        // Same count: Alpha before Zeta (alpha sort)
+        $zetaPos = array_search('ASA Zeta', $testNames, true);
+        $alphaPos = array_search('ASA Alpha', $testNames, true);
+        $betaPos = array_search('ASA Beta', $testNames, true);
+
+        self::assertNotFalse($zetaPos);
+        self::assertNotFalse($alphaPos);
+        self::assertNotFalse($betaPos);
+        self::assertLessThan($alphaPos, $zetaPos, 'Zeta (3) should be before Alpha (2)');
+        self::assertLessThan($betaPos, $alphaPos, 'Alpha (2) should be before Beta (1)');
+    }
+
+    public function testPidResolvedFromHistJoin(): void
+    {
+        $pid = 200130001;
+        $this->insertTestPlayer($pid, 'ASA HistPlyr');
+        $this->insertAwardRow('ASA HistPlyr', 'Eastern Conference All-Star', 2020);
+        $this->insertHistRow($pid, 'ASA HistPlyr', 2020);
+
+        $results = $this->repo->getAllStarAppearances();
+
+        $found = $this->findByName($results, 'ASA HistPlyr');
+        self::assertNotNull($found);
+        self::assertSame($pid, $found['pid']);
+    }
+
+    public function testPidNullWhenPlayerNotInHist(): void
+    {
+        $this->insertAwardRow('ASA NoHist', 'Western Conference All-Star', 2020);
+
+        $results = $this->repo->getAllStarAppearances();
+
+        $found = $this->findByName($results, 'ASA NoHist');
+        self::assertNotNull($found);
+        self::assertNull($found['pid']);
+    }
+
+    public function testResultRowHasExpectedKeys(): void
+    {
+        $this->insertAwardRow('ASA KeyCheck', 'Eastern Conference All-Star', 2020);
+
+        $results = $this->repo->getAllStarAppearances();
+
+        $found = $this->findByName($results, 'ASA KeyCheck');
+        self::assertNotNull($found);
+        self::assertArrayHasKey('name', $found);
+        self::assertArrayHasKey('pid', $found);
+        self::assertArrayHasKey('appearances', $found);
+    }
+
+    public function testMultiplePlayersReturnedWithCorrectCounts(): void
+    {
+        $this->insertAwardRow('ASA Player A', 'Eastern Conference All-Star', 2020);
+        $this->insertAwardRow('ASA Player A', 'Eastern Conference All-Star', 2021);
+        $this->insertAwardRow('ASA Player B', 'Western Conference All-Star', 2020);
+
+        $results = $this->repo->getAllStarAppearances();
+
+        $a = $this->findByName($results, 'ASA Player A');
+        $b = $this->findByName($results, 'ASA Player B');
+        self::assertNotNull($a);
+        self::assertNotNull($b);
+        self::assertSame(2, $a['appearances']);
+        self::assertSame(1, $b['appearances']);
+    }
+
+    public function testReturnsArrayOfResults(): void
+    {
+        $results = $this->repo->getAllStarAppearances();
+        self::assertIsArray($results);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $results
+     * @return array<string, mixed>|null
+     */
+    private function findByName(array $results, string $name): ?array
+    {
+        foreach ($results as $row) {
+            if ($row['name'] === $name) {
+                return $row;
+            }
+        }
+        return null;
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/AwardHistoryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/AwardHistoryRepositoryTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use AwardHistory\AwardHistoryRepository;
+
+class AwardHistoryRepositoryTest extends DatabaseTestCase
+{
+    private AwardHistoryRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new AwardHistoryRepository($this->db);
+    }
+
+    public function testNoFiltersReturnsAllAwards(): void
+    {
+        $this->insertAwardRow('AWH TestPlyr', 'MVP', 2020);
+
+        $result = $this->repo->searchAwards($this->buildParams());
+
+        self::assertArrayHasKey('results', $result);
+        self::assertArrayHasKey('count', $result);
+        self::assertGreaterThanOrEqual(1, $result['count']);
+    }
+
+    public function testFilterByYearExactMatch(): void
+    {
+        $this->insertAwardRow('AWH YearTest', 'MVP', 2095);
+
+        $result = $this->repo->searchAwards($this->buildParams(['year' => 2095]));
+
+        self::assertSame(1, $result['count']);
+        self::assertSame('AWH YearTest', $result['results'][0]['name']);
+        self::assertSame(2095, $result['results'][0]['year']);
+    }
+
+    public function testFilterByAwardLikePattern(): void
+    {
+        $this->insertAwardRow('AWH AwardLike', 'Most Valuable Player', 2020);
+
+        $result = $this->repo->searchAwards($this->buildParams(['award' => 'Most Valuable']));
+
+        $found = $this->findByName($result['results'], 'AWH AwardLike');
+        self::assertNotNull($found);
+        self::assertSame('Most Valuable Player', $found['Award']);
+    }
+
+    public function testFilterByNameLikePattern(): void
+    {
+        $this->insertAwardRow('AWH NameLike', 'DPOY', 2020);
+
+        $result = $this->repo->searchAwards($this->buildParams(['name' => 'AWH Name']));
+
+        $found = $this->findByName($result['results'], 'AWH NameLike');
+        self::assertNotNull($found);
+    }
+
+    public function testCombinedYearAndNameFilter(): void
+    {
+        $this->insertAwardRow('AWH Combined', 'MVP', 2096);
+        $this->insertAwardRow('AWH Combined', 'DPOY', 2097);
+
+        $result = $this->repo->searchAwards($this->buildParams(['year' => 2096, 'name' => 'AWH Combined']));
+
+        self::assertSame(1, $result['count']);
+        self::assertSame(2096, $result['results'][0]['year']);
+    }
+
+    public function testCombinedAwardAndYearFilter(): void
+    {
+        $this->insertAwardRow('AWH ComboAY', 'Sixth Man', 2096);
+        $this->insertAwardRow('AWH ComboAY2', 'MVP', 2096);
+
+        $result = $this->repo->searchAwards($this->buildParams(['year' => 2096, 'award' => 'Sixth']));
+
+        self::assertSame(1, $result['count']);
+        self::assertSame('AWH ComboAY', $result['results'][0]['name']);
+    }
+
+    public function testSortByName(): void
+    {
+        $this->insertAwardRow('AWH Zulu', 'MVP', 2098);
+        $this->insertAwardRow('AWH Alpha', 'MVP', 2098);
+
+        $result = $this->repo->searchAwards($this->buildParams(['year' => 2098, 'sortby' => 1]));
+
+        self::assertGreaterThanOrEqual(2, $result['count']);
+        self::assertSame('AWH Alpha', $result['results'][0]['name']);
+    }
+
+    public function testSortByAward(): void
+    {
+        $this->insertAwardRow('AWH SortAwd', 'DPOY', 2099);
+        $this->insertAwardRow('AWH SortAwd2', 'MVP', 2099);
+
+        $result = $this->repo->searchAwards($this->buildParams(['year' => 2099, 'sortby' => 2]));
+
+        self::assertGreaterThanOrEqual(2, $result['count']);
+        self::assertSame('DPOY', $result['results'][0]['Award']);
+    }
+
+    public function testSortByYear(): void
+    {
+        $this->insertAwardRow('AWH SortYr', 'MVP', 2092);
+        $this->insertAwardRow('AWH SortYr', 'MVP', 2091);
+
+        $result = $this->repo->searchAwards($this->buildParams(['name' => 'AWH SortYr', 'sortby' => 3]));
+
+        self::assertSame(2, $result['count']);
+        self::assertSame(2091, $result['results'][0]['year']);
+    }
+
+    public function testInvalidSortbyDefaultsToYear(): void
+    {
+        $this->insertAwardRow('AWH BadSort', 'MVP', 2093);
+        $this->insertAwardRow('AWH BadSort', 'MVP', 2092);
+
+        $result = $this->repo->searchAwards($this->buildParams(['name' => 'AWH BadSort', 'sortby' => 999]));
+
+        self::assertSame(2, $result['count']);
+        // Default sort is 'year' ASC
+        self::assertSame(2092, $result['results'][0]['year']);
+    }
+
+    public function testLeftJoinPopulatesPidForKnownPlayer(): void
+    {
+        $pid = 200120001;
+        $this->insertTestPlayer($pid, 'AWH PidKnown');
+        $this->insertAwardRow('AWH PidKnown', 'MVP', 2020);
+
+        $result = $this->repo->searchAwards($this->buildParams(['name' => 'AWH PidKnown']));
+
+        self::assertSame(1, $result['count']);
+        self::assertSame($pid, $result['results'][0]['pid']);
+    }
+
+    public function testPidNullForPlayersNotInPlr(): void
+    {
+        $this->insertAwardRow('AWH NoPid', 'MVP', 2020);
+
+        $result = $this->repo->searchAwards($this->buildParams(['name' => 'AWH NoPid']));
+
+        self::assertSame(1, $result['count']);
+        self::assertNull($result['results'][0]['pid']);
+    }
+
+    public function testCountMatchesResultsArrayLength(): void
+    {
+        $this->insertAwardRow('AWH Count1', 'MVP', 2094);
+        $this->insertAwardRow('AWH Count2', 'DPOY', 2094);
+
+        $result = $this->repo->searchAwards($this->buildParams(['year' => 2094]));
+
+        self::assertSame(count($result['results']), $result['count']);
+    }
+
+    public function testNoMatchReturnsEmptyResults(): void
+    {
+        $result = $this->repo->searchAwards($this->buildParams(['year' => 9999]));
+
+        self::assertSame(0, $result['count']);
+        self::assertSame([], $result['results']);
+    }
+
+    public function testResultRowHasExpectedKeys(): void
+    {
+        $this->insertAwardRow('AWH KeyTest', 'MVP', 2020);
+
+        $result = $this->repo->searchAwards($this->buildParams(['name' => 'AWH KeyTest']));
+
+        self::assertSame(1, $result['count']);
+        $row = $result['results'][0];
+        self::assertArrayHasKey('year', $row);
+        self::assertArrayHasKey('Award', $row);
+        self::assertArrayHasKey('name', $row);
+        self::assertArrayHasKey('table_ID', $row);
+        self::assertArrayHasKey('pid', $row);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function buildParams(array $overrides = []): array
+    {
+        return array_merge([
+            'year' => null,
+            'award' => null,
+            'name' => null,
+            'sortby' => 3,
+        ], $overrides);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $results
+     * @return array<string, mixed>|null
+     */
+    private function findByName(array $results, string $name): ?array
+    {
+        foreach ($results as $row) {
+            if ($row['name'] === $name) {
+                return $row;
+            }
+        }
+        return null;
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/DatabaseTestCase.php
+++ b/ibl5/tests/DatabaseIntegration/DatabaseTestCase.php
@@ -368,6 +368,47 @@ abstract class DatabaseTestCase extends TestCase
         return $this->insertRow('ibl_draft_picks', array_merge($defaults, $overrides));
     }
 
+    /**
+     * Insert a schedule row into ibl_schedule with auto-generated uuid.
+     *
+     * @param array<string, int|string> $overrides Column overrides
+     */
+    protected function insertScheduleRow(
+        int $year,
+        string $date,
+        int $visitorTid,
+        int $visitorScore,
+        int $homeTid,
+        int $homeScore,
+        int $boxId = 0,
+        array $overrides = [],
+    ): int {
+        $defaults = [
+            'Year' => $year,
+            'Date' => $date,
+            'Visitor' => $visitorTid,
+            'VScore' => $visitorScore,
+            'Home' => $homeTid,
+            'HScore' => $homeScore,
+            'BoxID' => $boxId,
+            'uuid' => sprintf('sched-%s-%s', $date, bin2hex(random_bytes(6))),
+        ];
+
+        return $this->insertRow('ibl_schedule', array_merge($defaults, $overrides));
+    }
+
+    /**
+     * Insert an award row into ibl_awards.
+     */
+    protected function insertAwardRow(string $playerName, string $award, int $year): int
+    {
+        return $this->insertRow('ibl_awards', [
+            'name' => $playerName,
+            'Award' => $award,
+            'year' => $year,
+        ]);
+    }
+
     private function requireEnv(string $name): string
     {
         $value = getenv($name);

--- a/ibl5/tests/DatabaseIntegration/LeagueScheduleRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/LeagueScheduleRepositoryTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use LeagueSchedule\LeagueScheduleRepository;
+
+class LeagueScheduleRepositoryTest extends DatabaseTestCase
+{
+    private LeagueScheduleRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new LeagueScheduleRepository($this->db);
+    }
+
+    public function testGetAllGamesReturnsInsertedScheduleRow(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-01-15', 1, 100, 2, 95);
+
+        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found);
+        self::assertSame(1, $found['Visitor']);
+        self::assertSame(2, $found['Home']);
+    }
+
+    public function testGameWithBoxScoreHasNonZeroGameOfThatDay(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-02-15', 1, 100, 2, 95);
+        $this->insertTeamBoxscoreRow('2090-02-15', 'test-game', 3, 1, 2);
+
+        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found);
+        self::assertSame(3, $found['gameOfThatDay']);
+    }
+
+    public function testGameWithoutBoxScoreHasZeroGameOfThatDay(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-03-15', 3, 80, 4, 90);
+
+        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found);
+        self::assertSame(0, $found['gameOfThatDay']);
+    }
+
+    public function testMultipleBstRowsReturnsMinGameOfThatDay(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-04-15', 1, 105, 2, 98);
+        $this->insertTeamBoxscoreRow('2090-04-15', 'game-a', 5, 1, 2);
+        $this->insertTeamBoxscoreRow('2090-04-15', 'game-b', 2, 1, 2);
+
+        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found);
+        self::assertSame(2, $found['gameOfThatDay']);
+    }
+
+    public function testResultRowHasAllRequiredKeys(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-05-15', 1, 90, 2, 85);
+
+        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found);
+        $expectedKeys = ['SchedID', 'Date', 'Visitor', 'VScore', 'Home', 'HScore', 'BoxID', 'gameOfThatDay'];
+        foreach ($expectedKeys as $key) {
+            self::assertArrayHasKey($key, $found, "Missing key: $key");
+        }
+    }
+
+    public function testOrderedByDateAscSchedIdAsc(): void
+    {
+        $schedId1 = $this->insertScheduleRow(2090, '2090-06-20', 1, 90, 2, 85);
+        $schedId2 = $this->insertScheduleRow(2090, '2090-06-15', 3, 90, 4, 85);
+
+        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+
+        $pos1 = null;
+        $pos2 = null;
+        foreach ($results as $i => $row) {
+            if ($row['SchedID'] === $schedId1) {
+                $pos1 = $i;
+            }
+            if ($row['SchedID'] === $schedId2) {
+                $pos2 = $i;
+            }
+        }
+        self::assertNotNull($pos1);
+        self::assertNotNull($pos2);
+        // June 15 before June 20
+        self::assertLessThan($pos1, $pos2);
+    }
+
+    public function testGetTeamRecordsKeyedByIntTid(): void
+    {
+        $records = $this->repo->getTeamRecords();
+
+        self::assertIsArray($records);
+        foreach ($records as $tid => $record) {
+            self::assertIsInt($tid);
+            self::assertIsString($record);
+            break;
+        }
+    }
+
+    public function testGetTeamRecordsContainsAllSeededTeams(): void
+    {
+        $records = $this->repo->getTeamRecords();
+
+        // CI seed has 28 real teams
+        self::assertGreaterThanOrEqual(28, count($records));
+    }
+
+    public function testGetTeamRecordsReflectsSeededStandings(): void
+    {
+        $records = $this->repo->getTeamRecords();
+
+        // Seed standings have team 1 (Metros) — verify it exists and has a record string
+        self::assertArrayHasKey(1, $records);
+        self::assertMatchesRegularExpression('/^\d+-\d+$/', $records[1]);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $results
+     * @return array<string, mixed>|null
+     */
+    private function findBySchedId(array $results, int $schedId): ?array
+    {
+        foreach ($results as $row) {
+            if ($row['SchedID'] === $schedId) {
+                return $row;
+            }
+        }
+        return null;
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/PlayerDatabaseRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/PlayerDatabaseRepositoryTest.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use PlayerDatabase\PlayerDatabaseRepository;
+
+class PlayerDatabaseRepositoryTest extends DatabaseTestCase
+{
+    private PlayerDatabaseRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new PlayerDatabaseRepository($this->db);
+    }
+
+    public function testSearchByNameLikeReturnsMatch(): void
+    {
+        $this->insertTestPlayer(200100001, 'PDB NameTest', ['oo' => 70]);
+
+        $result = $this->repo->searchPlayers($this->buildParams(['search_name' => 'PDB Name']));
+
+        self::assertGreaterThanOrEqual(1, $result['count']);
+        $found = $this->findByPid($result['results'], 200100001);
+        self::assertNotNull($found);
+        self::assertSame('PDB NameTest', $found['name']);
+    }
+
+    public function testFilterByPositionExactMatch(): void
+    {
+        $this->insertTestPlayer(200100002, 'PDB PosTest', ['pos' => 'C']);
+        $this->insertTestPlayer(200100003, 'PDB PosOther', ['pos' => 'PG']);
+
+        $result = $this->repo->searchPlayers($this->buildParams(['search_name' => 'PDB Pos', 'pos' => 'C']));
+
+        $found = $this->findByPid($result['results'], 200100002);
+        $notFound = $this->findByPid($result['results'], 200100003);
+        self::assertNotNull($found);
+        self::assertNull($notFound);
+    }
+
+    public function testActiveFilterExcludesRetiredPlayers(): void
+    {
+        $this->insertTestPlayer(200100004, 'PDB ActiveP', ['retired' => 0]);
+        $this->insertTestPlayer(200100005, 'PDB Retired', ['retired' => 1]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB ',
+            'active' => 0,
+        ]));
+
+        $active = $this->findByPid($result['results'], 200100004);
+        $retired = $this->findByPid($result['results'], 200100005);
+        self::assertNotNull($active);
+        self::assertNull($retired);
+    }
+
+    public function testActiveNullIncludesRetiredPlayers(): void
+    {
+        $this->insertTestPlayer(200100006, 'PDB InclRet', ['retired' => 1]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB InclRet',
+            'active' => null,
+        ]));
+
+        $found = $this->findByPid($result['results'], 200100006);
+        self::assertNotNull($found);
+    }
+
+    public function testAgeUpperBoundFilter(): void
+    {
+        $this->insertTestPlayer(200100007, 'PDB Young', ['age' => 22]);
+        $this->insertTestPlayer(200100008, 'PDB Old', ['age' => 35]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB ',
+            'age' => 25,
+        ]));
+
+        $young = $this->findByPid($result['results'], 200100007);
+        $old = $this->findByPid($result['results'], 200100008);
+        self::assertNotNull($young);
+        self::assertNull($old);
+    }
+
+    public function testExpMinimumFilter(): void
+    {
+        $this->insertTestPlayer(200100009, 'PDB ExpHigh', ['exp' => 10]);
+        $this->insertTestPlayer(200100010, 'PDB ExpLow', ['exp' => 2]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB Exp',
+            'exp' => 5,
+        ]));
+
+        $high = $this->findByPid($result['results'], 200100009);
+        $low = $this->findByPid($result['results'], 200100010);
+        self::assertNotNull($high);
+        self::assertNull($low);
+    }
+
+    public function testExpMaximumFilter(): void
+    {
+        $this->insertTestPlayer(200100011, 'PDB ExpMax', ['exp' => 3]);
+        $this->insertTestPlayer(200100012, 'PDB ExpOver', ['exp' => 10]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB Exp',
+            'exp_max' => 5,
+        ]));
+
+        $within = $this->findByPid($result['results'], 200100011);
+        $over = $this->findByPid($result['results'], 200100012);
+        self::assertNotNull($within);
+        self::assertNull($over);
+    }
+
+    public function testBirdRangeFilters(): void
+    {
+        $this->insertTestPlayer(200100013, 'PDB BirdIn', ['bird' => 3]);
+        $this->insertTestPlayer(200100014, 'PDB BirdOut', ['bird' => 0]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB Bird',
+            'bird' => 2,
+            'bird_max' => 4,
+        ]));
+
+        $inRange = $this->findByPid($result['results'], 200100013);
+        $outRange = $this->findByPid($result['results'], 200100014);
+        self::assertNotNull($inRange);
+        self::assertNull($outRange);
+    }
+
+    public function testRatingThresholdOo(): void
+    {
+        $this->insertTestPlayer(200100015, 'PDB OoHigh', ['oo' => 80]);
+        $this->insertTestPlayer(200100016, 'PDB OoLow', ['oo' => 30]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB Oo',
+            'oo' => 50,
+        ]));
+
+        $high = $this->findByPid($result['results'], 200100015);
+        $low = $this->findByPid($result['results'], 200100016);
+        self::assertNotNull($high);
+        self::assertNull($low);
+    }
+
+    public function testReservedWordColumnFilterDo(): void
+    {
+        $this->insertTestPlayer(200100017, 'PDB DoHigh', ['do' => 85]);
+        $this->insertTestPlayer(200100018, 'PDB DoLow', ['do' => 20]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB Do',
+            'do' => 50,
+        ]));
+
+        $high = $this->findByPid($result['results'], 200100017);
+        $low = $this->findByPid($result['results'], 200100018);
+        self::assertNotNull($high);
+        self::assertNull($low);
+    }
+
+    public function testReservedWordColumnFilterTo(): void
+    {
+        $this->insertTestPlayer(200100019, 'PDB ToHigh', ['to' => 75]);
+        $this->insertTestPlayer(200100020, 'PDB ToLow', ['to' => 10]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB To',
+            'to' => 50,
+        ]));
+
+        $high = $this->findByPid($result['results'], 200100019);
+        $low = $this->findByPid($result['results'], 200100020);
+        self::assertNotNull($high);
+        self::assertNull($low);
+    }
+
+    public function testMultipleFiltersAppliedSimultaneously(): void
+    {
+        $this->insertTestPlayer(200100001, 'PDB MultiOK', ['pos' => 'SG', 'age' => 25, 'exp' => 5, 'oo' => 70]);
+        $this->insertTestPlayer(200100002, 'PDB MultiFl', ['pos' => 'C', 'age' => 25, 'exp' => 5, 'oo' => 70]);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB Multi',
+            'pos' => 'SG',
+            'age' => 30,
+            'exp' => 3,
+            'oo' => 60,
+        ]));
+
+        $ok = $this->findByPid($result['results'], 200100001);
+        $fail = $this->findByPid($result['results'], 200100002);
+        self::assertNotNull($ok);
+        self::assertNull($fail);
+    }
+
+    public function testResultIncludesTeamnameFromLeftJoin(): void
+    {
+        $this->insertTestPlayer(200100001, 'PDB TeamJoin', ['tid' => 1]);
+
+        $result = $this->repo->searchPlayers($this->buildParams(['search_name' => 'PDB TeamJoin']));
+
+        $found = $this->findByPid($result['results'], 200100001);
+        self::assertNotNull($found);
+        self::assertArrayHasKey('teamname', $found);
+        self::assertSame('Metros', $found['teamname']);
+    }
+
+    public function testGetPlayerByIdReturnsCorrectRow(): void
+    {
+        $this->insertTestPlayer(200100001, 'PDB ById');
+
+        $row = $this->repo->getPlayerById(200100001);
+
+        self::assertNotNull($row);
+        self::assertSame(200100001, $row['pid']);
+        self::assertSame('PDB ById', $row['name']);
+    }
+
+    public function testGetPlayerByIdReturnsNullForUnknown(): void
+    {
+        $row = $this->repo->getPlayerById(999999999);
+
+        self::assertNull($row);
+    }
+
+    public function testResultOrderedByRetiredThenOrdinal(): void
+    {
+        $this->insertTestPlayer(200100001, 'PDB OrdHigh', ['ordinal' => 200, 'retired' => 0]);
+        $this->insertTestPlayer(200100002, 'PDB OrdLow', ['ordinal' => 100, 'retired' => 0]);
+
+        $result = $this->repo->searchPlayers($this->buildParams(['search_name' => 'PDB Ord']));
+
+        self::assertGreaterThanOrEqual(2, $result['count']);
+        // ordinal 100 should come before ordinal 200 (ASC)
+        $positions = [];
+        foreach ($result['results'] as $i => $row) {
+            if ($row['pid'] === 200100001 || $row['pid'] === 200100002) {
+                $positions[$row['pid']] = $i;
+            }
+        }
+        self::assertLessThan($positions[200100001], $positions[200100002]);
+    }
+
+    public function testCollegeLikeFilter(): void
+    {
+        $this->insertTestPlayer(200100001, 'PDB College', ['college' => 'Duke University']);
+        $this->insertTestPlayer(200100002, 'PDB NoColl', ['college' => 'Stanford']);
+
+        $result = $this->repo->searchPlayers($this->buildParams([
+            'search_name' => 'PDB ',
+            'college' => 'Duke',
+        ]));
+
+        $duke = $this->findByPid($result['results'], 200100001);
+        $stanford = $this->findByPid($result['results'], 200100002);
+        self::assertNotNull($duke);
+        self::assertNull($stanford);
+    }
+
+    public function testCountMatchesResultsArrayLength(): void
+    {
+        $this->insertTestPlayer(200100001, 'PDB CntTest');
+
+        $result = $this->repo->searchPlayers($this->buildParams(['search_name' => 'PDB CntTest']));
+
+        self::assertSame(count($result['results']), $result['count']);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function buildParams(array $overrides = []): array
+    {
+        $defaults = [
+            'active' => 0,
+            'search_name' => null,
+            'pos' => null,
+            'age' => null,
+            'exp' => null,
+            'exp_max' => null,
+            'bird' => null,
+            'bird_max' => null,
+            'college' => null,
+            'oo' => null,
+            'do' => null,
+            'po' => null,
+            'to' => null,
+            'od' => null,
+            'dd' => null,
+            'pd' => null,
+            'td' => null,
+            'talent' => null,
+            'skill' => null,
+            'intangibles' => null,
+            'Clutch' => null,
+            'Consistency' => null,
+            'r_fga' => null,
+            'r_fgp' => null,
+            'r_fta' => null,
+            'r_ftp' => null,
+            'r_tga' => null,
+            'r_tgp' => null,
+            'r_orb' => null,
+            'r_drb' => null,
+            'r_ast' => null,
+            'r_stl' => null,
+            'r_blk' => null,
+            'r_to' => null,
+            'r_foul' => null,
+        ];
+
+        return array_merge($defaults, $overrides);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $results
+     * @return array<string, mixed>|null
+     */
+    private function findByPid(array $results, int $pid): ?array
+    {
+        foreach ($results as $row) {
+            if ($row['pid'] === $pid) {
+                return $row;
+            }
+        }
+        return null;
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/PlayerMovementRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/PlayerMovementRepositoryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use PlayerMovement\PlayerMovementRepository;
+
+class PlayerMovementRepositoryTest extends DatabaseTestCase
+{
+    private PlayerMovementRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new PlayerMovementRepository($this->db);
+    }
+
+    public function testReturnsMovedPlayer(): void
+    {
+        $pid = 200110001;
+        $this->insertTestPlayer($pid, 'PMV Moved', ['tid' => 2]);
+        $this->insertHistRow($pid, 'PMV Moved', 2020, ['teamid' => 1, 'team' => 'Metros']);
+
+        $results = $this->repo->getPlayerMovements(2020);
+
+        $found = $this->findByPid($results, $pid);
+        self::assertNotNull($found, 'Player who moved should appear in results');
+        self::assertSame(1, $found['old_teamid']);
+        self::assertSame(2, $found['new_teamid']);
+    }
+
+    public function testExcludesNonMovedPlayer(): void
+    {
+        $pid = 200110002;
+        $this->insertTestPlayer($pid, 'PMV Stayed', ['tid' => 1]);
+        $this->insertHistRow($pid, 'PMV Stayed', 2020, ['teamid' => 1]);
+
+        $results = $this->repo->getPlayerMovements(2020);
+
+        $found = $this->findByPid($results, $pid);
+        self::assertNull($found, 'Player who stayed should not appear');
+    }
+
+    public function testMovementRowHasExpectedKeys(): void
+    {
+        $pid = 200110003;
+        $this->insertTestPlayer($pid, 'PMV Keys', ['tid' => 2]);
+        $this->insertHistRow($pid, 'PMV Keys', 2020, ['teamid' => 1]);
+
+        $results = $this->repo->getPlayerMovements(2020);
+
+        $found = $this->findByPid($results, $pid);
+        self::assertNotNull($found);
+        $expectedKeys = [
+            'pid', 'name', 'old_teamid', 'old_team', 'new_teamid', 'new_team',
+            'old_city', 'old_color1', 'old_color2', 'new_city', 'new_color1', 'new_color2',
+        ];
+        foreach ($expectedKeys as $key) {
+            self::assertArrayHasKey($key, $found, "Missing key: $key");
+        }
+    }
+
+    public function testFreeAgentMovementIncluded(): void
+    {
+        $pid = 200110004;
+        // Current team is Free Agents (tid=0), previously on team 3
+        $this->insertTestPlayer($pid, 'PMV FreeAgent', ['tid' => 0]);
+        $this->insertHistRow($pid, 'PMV FreeAgent', 2020, ['teamid' => 3, 'team' => 'Stallions']);
+
+        $results = $this->repo->getPlayerMovements(2020);
+
+        $found = $this->findByPid($results, $pid);
+        self::assertNotNull($found, 'Free agent movement should be included');
+        self::assertSame(3, $found['old_teamid']);
+        self::assertSame(0, $found['new_teamid']);
+    }
+
+    public function testFiltersToRequestedYearOnly(): void
+    {
+        $pid = 200110005;
+        $this->insertTestPlayer($pid, 'PMV YearFilt', ['tid' => 2]);
+        $this->insertHistRow($pid, 'PMV YearFilt', 2019, ['teamid' => 1]);
+
+        $results = $this->repo->getPlayerMovements(2020);
+
+        $found = $this->findByPid($results, $pid);
+        self::assertNull($found, 'Player with hist in different year should not appear');
+    }
+
+    public function testNoMovementsForUnknownYearReturnsEmpty(): void
+    {
+        $results = $this->repo->getPlayerMovements(9999);
+
+        // Filter out any seed data movements
+        $testResults = array_filter(
+            $results,
+            static fn (array $row): bool => str_starts_with($row['name'], 'PMV '),
+        );
+        self::assertCount(0, $testResults);
+    }
+
+    public function testOrderedByNewTeamName(): void
+    {
+        // Player 1 moves to Sharks (tid=2), Player 2 moves to Metros (tid=1)
+        // Seed: tid=1=Metros, tid=2=Sharks — Metros < Sharks alphabetically
+        $pid1 = 200110006;
+        $pid2 = 200110007;
+        $this->insertTestPlayer($pid1, 'PMV OrderA', ['tid' => 2]);
+        $this->insertHistRow($pid1, 'PMV OrderA', 2087, ['teamid' => 1, 'team' => 'Metros']);
+        $this->insertTestPlayer($pid2, 'PMV OrderB', ['tid' => 1]);
+        $this->insertHistRow($pid2, 'PMV OrderB', 2087, ['teamid' => 2, 'team' => 'Sharks']);
+
+        $results = $this->repo->getPlayerMovements(2087);
+
+        // Filter to only test players to avoid seed data ordering issues
+        $testResults = array_values(array_filter(
+            $results,
+            static fn (array $row): bool => str_starts_with($row['name'], 'PMV Order'),
+        ));
+        self::assertCount(2, $testResults);
+        // Metros sorts before Sharks alphabetically
+        self::assertSame($pid2, $testResults[0]['pid'], 'Player moving to Metros should be first');
+        self::assertSame($pid1, $testResults[1]['pid'], 'Player moving to Sharks should be second');
+    }
+
+    public function testCorrectCountMatchesOnlyMovedPlayers(): void
+    {
+        $pid1 = 200110008;
+        $pid2 = 200110009;
+        $pid3 = 200110010;
+        // Two moved, one stayed
+        $this->insertTestPlayer($pid1, 'PMV CntMov1', ['tid' => 2]);
+        $this->insertHistRow($pid1, 'PMV CntMov1', 2088, ['teamid' => 1]);
+        $this->insertTestPlayer($pid2, 'PMV CntMov2', ['tid' => 3]);
+        $this->insertHistRow($pid2, 'PMV CntMov2', 2088, ['teamid' => 1]);
+        $this->insertTestPlayer($pid3, 'PMV CntStay', ['tid' => 1]);
+        $this->insertHistRow($pid3, 'PMV CntStay', 2088, ['teamid' => 1]);
+
+        $results = $this->repo->getPlayerMovements(2088);
+
+        $testResults = array_filter(
+            $results,
+            static fn (array $row): bool => str_starts_with($row['name'], 'PMV Cnt'),
+        );
+        self::assertCount(2, $testResults);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $results
+     * @return array<string, mixed>|null
+     */
+    private function findByPid(array $results, int $pid): ?array
+    {
+        foreach ($results as $row) {
+            if ($row['pid'] === $pid) {
+                return $row;
+            }
+        }
+        return null;
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/TeamScheduleRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamScheduleRepositoryTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use TeamSchedule\TeamScheduleRepository;
+
+class TeamScheduleRepositoryTest extends DatabaseTestCase
+{
+    private TeamScheduleRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new TeamScheduleRepository($this->db);
+    }
+
+    public function testGetScheduleReturnsGamesWhereTeamIsVisitor(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-01-10', 5, 100, 6, 95);
+
+        $results = $this->repo->getSchedule(5);
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found, 'Team as visitor should appear');
+    }
+
+    public function testGetScheduleReturnsGamesWhereTeamIsHome(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-01-11', 5, 90, 6, 100);
+
+        $results = $this->repo->getSchedule(6);
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found, 'Team as home should appear');
+    }
+
+    public function testGetScheduleExcludesUnrelatedTeams(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-01-12', 5, 90, 6, 100);
+
+        $results = $this->repo->getSchedule(7);
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNull($found, 'Unrelated team should not see this game');
+    }
+
+    public function testGetSchedulePopulatesGameOfThatDayWhenBstExists(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-02-10', 5, 105, 6, 98);
+        $this->insertTeamBoxscoreRow('2090-02-10', 'ts-game', 2, 5, 6);
+
+        $results = $this->repo->getSchedule(5);
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found);
+        self::assertSame(2, $found['gameOfThatDay']);
+    }
+
+    public function testGetScheduleNullGameOfThatDayWhenNoBst(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-03-10', 5, 80, 6, 90);
+
+        $results = $this->repo->getSchedule(5);
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found);
+        // TeamSchedule does NOT normalize null to 0 (unlike LeagueSchedule)
+        self::assertNull($found['gameOfThatDay']);
+    }
+
+    public function testGetScheduleOrderedByDateAsc(): void
+    {
+        $schedId1 = $this->insertScheduleRow(2090, '2090-04-20', 5, 100, 6, 90);
+        $schedId2 = $this->insertScheduleRow(2090, '2090-04-10', 5, 95, 7, 85);
+
+        $results = $this->repo->getSchedule(5);
+
+        $pos1 = null;
+        $pos2 = null;
+        foreach ($results as $i => $row) {
+            if ($row['SchedID'] === $schedId1) {
+                $pos1 = $i;
+            }
+            if ($row['SchedID'] === $schedId2) {
+                $pos2 = $i;
+            }
+        }
+        self::assertNotNull($pos1);
+        self::assertNotNull($pos2);
+        // April 10 before April 20
+        self::assertLessThan($pos1, $pos2);
+    }
+
+    public function testGetScheduleReturnsBothHomeAndAwayGames(): void
+    {
+        $schedIdAway = $this->insertScheduleRow(2090, '2090-05-01', 5, 100, 6, 95);
+        $schedIdHome = $this->insertScheduleRow(2090, '2090-05-02', 7, 90, 5, 105);
+
+        $results = $this->repo->getSchedule(5);
+
+        $foundAway = $this->findBySchedId($results, $schedIdAway);
+        $foundHome = $this->findBySchedId($results, $schedIdHome);
+        self::assertNotNull($foundAway);
+        self::assertNotNull($foundHome);
+    }
+
+    public function testGetProjectedGamesReturnsGamesInDateRange(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-06-15', 5, 0, 6, 0);
+
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-06-10', '2090-06-20');
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found, 'Game in range should be returned');
+    }
+
+    public function testGetProjectedGamesExcludesGameExactlyOnLastSimEndDate(): void
+    {
+        // ADDDATE excludes lastSimEndDate itself — uses day after
+        $schedId = $this->insertScheduleRow(2090, '2090-07-10', 5, 0, 6, 0);
+
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-07-10', '2090-07-20');
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNull($found, 'Game on lastSimEndDate should be excluded by ADDDATE');
+    }
+
+    public function testGetProjectedGamesIncludesGameDayAfterLastSimEndDate(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-07-11', 5, 0, 6, 0);
+
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-07-10', '2090-07-20');
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNotNull($found, 'Game day after lastSimEndDate should be included');
+    }
+
+    public function testGetProjectedGamesExcludesGameAfterProjectedEnd(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-08-25', 5, 0, 6, 0);
+
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-08-01', '2090-08-20');
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNull($found, 'Game after projected end should be excluded');
+    }
+
+    public function testGetProjectedGamesFiltersToRequestedTeamOnly(): void
+    {
+        $schedId = $this->insertScheduleRow(2090, '2090-09-15', 7, 0, 8, 0);
+
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-09-10', '2090-09-20');
+
+        $found = $this->findBySchedId($results, $schedId);
+        self::assertNull($found, 'Game for different team should be excluded');
+    }
+
+    public function testGetProjectedGamesEmptyWhenNoGamesInRange(): void
+    {
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2099-01-01', '2099-01-10');
+
+        // Filter to only test data
+        $testResults = array_filter(
+            $results,
+            static fn (array $row): bool => $row['Year'] === 2099,
+        );
+        self::assertCount(0, $testResults);
+    }
+
+    public function testGetProjectedGamesOrderedByDateAsc(): void
+    {
+        $schedId1 = $this->insertScheduleRow(2090, '2090-10-20', 5, 0, 6, 0);
+        $schedId2 = $this->insertScheduleRow(2090, '2090-10-15', 5, 0, 7, 0);
+
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-10-10', '2090-10-25');
+
+        $pos1 = null;
+        $pos2 = null;
+        foreach ($results as $i => $row) {
+            if ($row['SchedID'] === $schedId1) {
+                $pos1 = $i;
+            }
+            if ($row['SchedID'] === $schedId2) {
+                $pos2 = $i;
+            }
+        }
+        self::assertNotNull($pos1);
+        self::assertNotNull($pos2);
+        // Oct 15 before Oct 20
+        self::assertLessThan($pos1, $pos2);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $results
+     * @return array<string, mixed>|null
+     */
+    private function findBySchedId(array $results, int $schedId): ?array
+    {
+        foreach ($results as $row) {
+            if ($row['SchedID'] === $schedId) {
+                return $row;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Adds database integration tests for the 6 highest-risk untested repositories — those with complex dynamic SQL, multi-table JOINs, or aggregation logic where mocked unit tests can't catch real query issues.

## New Test Files (72 tests total)

| Test File | Repository | Tests | Complexity |
|-----------|-----------|-------|------------|
| AllStarAppearancesRepositoryTest | AllStarAppearances | 9 | GROUP BY COUNT, LEFT JOIN ibl_hist for pid |
| AwardHistoryRepositoryTest | AwardHistory | 15 | Dynamic LIKE filters, sort column mapping |
| PlayerDatabaseRepositoryTest | PlayerDatabase | 18 | 25+ dynamic WHERE filters via QueryConditions |
| PlayerMovementRepositoryTest | PlayerMovement | 8 | 4-table JOIN, cross-season teamid mismatch |
| LeagueScheduleRepositoryTest | LeagueSchedule | 9 | LEFT JOIN subquery with MIN aggregation |
| TeamScheduleRepositoryTest | TeamSchedule | 13 | Date range BETWEEN with ADDDATE boundary |

## DatabaseTestCase Helpers

- `insertScheduleRow()` — builds uuid automatically, returns SchedID
- `insertAwardRow()` — minimal helper for ibl_awards inserts

## Key Edge Cases Covered

- ADDDATE boundary exclusion (TeamSchedule projected games)
- NULL normalization difference: LeagueSchedule normalizes to 0, TeamSchedule preserves null
- Reserved word column filters (`do`, `to`) with backtick escaping
- FK constraint: ibl_hist requires ibl_plr entry (fk_hist_player)
- pid resolution via LEFT JOIN (null when player not in hist/plr)

## Manual Testing

No manual testing needed — all changes are integration test files only.