### PR TITLE
test: DB integration tests batch 2 — SeriesRecords, FreeAgencyDemand, DepthChartEntry, Shared

### DIFF
--- a/ibl5/tests/DatabaseIntegration/DatabaseTestCase.php
+++ b/ibl5/tests/DatabaseIntegration/DatabaseTestCase.php
@@ -522,6 +522,19 @@ abstract class DatabaseTestCase extends TestCase
         $this->insertRow('ibl_demands', array_merge($defaults, $overrides));
     }
 
+    /**
+     * Insert a row into ibl_team_awards (team-level awards, not individual player awards).
+     * Returns the auto-increment ID.
+     */
+    protected function insertTeamAwardRow(string $teamName, string $award, int $year): int
+    {
+        return $this->insertRow('ibl_team_awards', [
+            'year' => $year,
+            'name' => $teamName,
+            'Award' => $award,
+        ]);
+    }
+
     private function requireEnv(string $name): string
     {
         $value = getenv($name);

--- a/ibl5/tests/DatabaseIntegration/DepthChartEntryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/DepthChartEntryRepositoryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use DepthChartEntry\DepthChartEntryRepository;
+
+/**
+ * Tests DepthChartEntryRepository against real MariaDB — player roster queries,
+ * depth chart column updates, and team history timestamp updates.
+ */
+class DepthChartEntryRepositoryTest extends DatabaseTestCase
+{
+    private DepthChartEntryRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new DepthChartEntryRepository($this->db);
+    }
+
+    // ── getPlayersOnTeam ────────────────────────────────────────
+
+    public function testGetPlayersOnTeamReturnsActivePlayers(): void
+    {
+        $this->insertTestPlayer(200080001, 'DC Active P1', ['tid' => 1, 'retired' => 0, 'ordinal' => 1]);
+        $this->insertTestPlayer(200080002, 'DC Active P2', ['tid' => 1, 'retired' => 0, 'ordinal' => 2]);
+
+        $players = $this->repo->getPlayersOnTeam(1);
+
+        $pids = array_column($players, 'pid');
+        self::assertContains(200080001, $pids);
+        self::assertContains(200080002, $pids);
+    }
+
+    public function testGetPlayersOnTeamExcludesRetiredAndWaiverOrdinal(): void
+    {
+        // Retired player (retired=1)
+        $this->insertTestPlayer(200080003, 'DC Retired', ['tid' => 1, 'retired' => 1, 'ordinal' => 1]);
+        // Waiver-ordinal player (ordinal=999, above WAIVERS_ORDINAL=960)
+        $this->insertTestPlayer(200080004, 'DC Waiver Ord', ['tid' => 1, 'retired' => 0, 'ordinal' => 999]);
+
+        $players = $this->repo->getPlayersOnTeam(1);
+
+        $pids = array_column($players, 'pid');
+        self::assertNotContains(200080003, $pids);
+        self::assertNotContains(200080004, $pids);
+    }
+
+    // ── updatePlayerDepthChart ──────────────────────────────────
+
+    public function testUpdatePlayerDepthChartSetsAllColumns(): void
+    {
+        $this->insertTestPlayer(200080005, 'DC Update Plyr', ['tid' => 1]);
+
+        $depthChartValues = [
+            'pg' => 3,
+            'sg' => 2,
+            'sf' => 1,
+            'pf' => 0,
+            'c' => 0,
+            'canPlayInGame' => 1,
+            'min' => 32,
+            'of' => 5,
+            'df' => 4,
+            'oi' => 3,
+            'di' => 2,
+            'bh' => 1,
+        ];
+
+        $result = $this->repo->updatePlayerDepthChart('DC Update Plyr', $depthChartValues);
+
+        self::assertTrue($result);
+
+        $stmt = $this->db->prepare(
+            'SELECT dc_PGDepth, dc_SGDepth, dc_SFDepth, dc_PFDepth, dc_CDepth,
+                    dc_canPlayInGame, dc_minutes, dc_of, dc_df, dc_oi, dc_di, dc_bh
+             FROM ibl_plr WHERE pid = ?'
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('i', $pid);
+        $pid = 200080005;
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        self::assertNotNull($row);
+        self::assertSame(3, $row['dc_PGDepth']);
+        self::assertSame(2, $row['dc_SGDepth']);
+        self::assertSame(1, $row['dc_SFDepth']);
+        self::assertSame(0, $row['dc_PFDepth']);
+        self::assertSame(0, $row['dc_CDepth']);
+        self::assertSame(1, $row['dc_canPlayInGame']);
+        self::assertSame(32, $row['dc_minutes']);
+        self::assertSame(5, $row['dc_of']);
+        self::assertSame(4, $row['dc_df']);
+        self::assertSame(3, $row['dc_oi']);
+        self::assertSame(2, $row['dc_di']);
+        self::assertSame(1, $row['dc_bh']);
+    }
+
+    public function testUpdatePlayerDepthChartReturnsTrueOnSuccess(): void
+    {
+        $this->insertTestPlayer(200080006, 'DC Success Plyr', ['tid' => 1]);
+
+        $result = $this->repo->updatePlayerDepthChart('DC Success Plyr', [
+            'pg' => 1, 'sg' => 0, 'sf' => 0, 'pf' => 0, 'c' => 0,
+            'canPlayInGame' => 1, 'min' => 20, 'of' => 3, 'df' => 3,
+            'oi' => 2, 'di' => 2, 'bh' => 1,
+        ]);
+
+        self::assertTrue($result);
+    }
+
+    // ── updateTeamHistory ───────────────────────────────────────
+
+    public function testUpdateTeamHistoryUpdatesTimestamps(): void
+    {
+        $result = $this->repo->updateTeamHistory('Metros');
+
+        self::assertTrue($result);
+
+        $stmt = $this->db->prepare('SELECT depth, sim_depth FROM ibl_team_info WHERE team_name = ?');
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('s', $tn);
+        $tn = 'Metros';
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        self::assertNotNull($row);
+        // Timestamps should be within the last 5 seconds
+        $now = time();
+        $depth = strtotime($row['depth']);
+        $simDepth = strtotime($row['sim_depth']);
+        self::assertNotFalse($depth);
+        self::assertNotFalse($simDepth);
+        self::assertLessThanOrEqual(5, $now - $depth);
+        self::assertLessThanOrEqual(5, $now - $simDepth);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/FreeAgencyDemandRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/FreeAgencyDemandRepositoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use FreeAgency\FreeAgencyDemandRepository;
+
+/**
+ * Tests FreeAgencyDemandRepository against real MariaDB — team performance
+ * lookups, position salary commitment via vw_current_salary, and player demands.
+ */
+class FreeAgencyDemandRepositoryTest extends DatabaseTestCase
+{
+    private FreeAgencyDemandRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new FreeAgencyDemandRepository($this->db);
+    }
+
+    // ── getTeamPerformance ──────────────────────────────────────
+
+    public function testGetTeamPerformanceReturnsPerformanceData(): void
+    {
+        // Metros is in the seed — set known Contract values within the transaction
+        $stmt = $this->db->prepare(
+            'UPDATE ibl_team_info SET Contract_Wins = ?, Contract_Losses = ?, Contract_AvgW = ?, Contract_AvgL = ? WHERE team_name = ?'
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('iiiis', $w, $l, $aw, $al, $tn);
+        $w = 45;
+        $l = 37;
+        $aw = 42;
+        $al = 40;
+        $tn = 'Metros';
+        $stmt->execute();
+        $stmt->close();
+
+        $result = $this->repo->getTeamPerformance('Metros');
+
+        self::assertSame(45, $result['wins']);
+        self::assertSame(37, $result['losses']);
+        self::assertSame(42, $result['tradWins']);
+        self::assertSame(40, $result['tradLosses']);
+    }
+
+    public function testGetTeamPerformanceReturnsZerosForUnknownTeam(): void
+    {
+        $result = $this->repo->getTeamPerformance('NoSuchTeam9999');
+
+        self::assertSame(0, $result['wins']);
+        self::assertSame(0, $result['losses']);
+        self::assertSame(0, $result['tradWins']);
+        self::assertSame(0, $result['tradLosses']);
+    }
+
+    // ── getPositionSalaryCommitment ─────────────────────────────
+
+    public function testGetPositionSalaryCommitmentReturnsSumExcludingPlayer(): void
+    {
+        // Insert two PG players on Metros (tid=1) with known salaries
+        // vw_current_salary computes next_year_salary: when cy=1, next_year=cy2
+        $this->insertTestPlayer(200070001, 'FA Demand PG1', [
+            'tid' => 1, 'pos' => 'PG', 'cy' => 1, 'cyt' => 3, 'cy1' => 1500, 'cy2' => 1600,
+        ]);
+        $this->insertTestPlayer(200070002, 'FA Demand PG2', [
+            'tid' => 1, 'pos' => 'PG', 'cy' => 1, 'cyt' => 3, 'cy1' => 2000, 'cy2' => 2100,
+        ]);
+
+        // Exclude player 200070001 — should return only 200070002's next_year_salary (2100)
+        $result = $this->repo->getPositionSalaryCommitment('Metros', 'PG', 200070001);
+
+        // Result includes any pre-existing PG players on Metros + our test player 200070002
+        self::assertGreaterThanOrEqual(2100, $result);
+    }
+
+    // ── getPlayerDemands ────────────────────────────────────────
+
+    public function testGetPlayerDemandsReturnsDemandValues(): void
+    {
+        $this->insertTestPlayer(200070003, 'FA Demand Plyr');
+        $this->insertDemandRow('FA Demand Plyr', 200070003, ['dem1' => 3000, 'dem3' => 2500]);
+
+        $result = $this->repo->getPlayerDemands(200070003);
+
+        self::assertSame(3000, $result['dem1']);
+        self::assertSame(2500, $result['dem3']);
+        self::assertSame(0, $result['dem2']);
+    }
+
+    public function testGetPlayerDemandsReturnsZerosWhenNotFound(): void
+    {
+        $result = $this->repo->getPlayerDemands(999999999);
+
+        self::assertSame(0, $result['dem1']);
+        self::assertSame(0, $result['dem2']);
+        self::assertSame(0, $result['dem3']);
+        self::assertSame(0, $result['dem4']);
+        self::assertSame(0, $result['dem5']);
+        self::assertSame(0, $result['dem6']);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/SeriesRecordsRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SeriesRecordsRepositoryTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use SeriesRecords\SeriesRecordsRepository;
+
+/**
+ * Tests SeriesRecordsRepository against real MariaDB — team listings,
+ * series records via vw_series_records (derived from ibl_schedule),
+ * and max team ID lookups.
+ */
+class SeriesRecordsRepositoryTest extends DatabaseTestCase
+{
+    private SeriesRecordsRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new SeriesRecordsRepository($this->db);
+    }
+
+    // ── getTeamsForSeriesRecords ─────────────────────────────────
+
+    public function testGetTeamsForSeriesRecordsReturns28Teams(): void
+    {
+        $teams = $this->repo->getTeamsForSeriesRecords();
+
+        self::assertCount(28, $teams);
+        self::assertArrayHasKey('teamid', $teams[0]);
+        self::assertArrayHasKey('team_city', $teams[0]);
+        self::assertArrayHasKey('team_name', $teams[0]);
+        self::assertArrayHasKey('color1', $teams[0]);
+        self::assertArrayHasKey('color2', $teams[0]);
+    }
+
+    // ── getSeriesRecords ────────────────────────────────────────
+
+    public function testGetSeriesRecordsReturnsRecordsFromScheduleData(): void
+    {
+        // Team 1 beats Team 2 at home (HScore > VScore)
+        $this->insertScheduleRow(2099, '2099-01-15', 2, 90, 1, 100);
+        // Team 2 beats Team 1 at home (HScore > VScore)
+        $this->insertScheduleRow(2099, '2099-01-20', 1, 85, 2, 95);
+
+        $records = $this->repo->getSeriesRecords();
+
+        // Find the record for team 1 vs team 2
+        $found1v2 = null;
+        $found2v1 = null;
+        foreach ($records as $row) {
+            if ($row['self'] === 1 && $row['opponent'] === 2) {
+                $found1v2 = $row;
+            }
+            if ($row['self'] === 2 && $row['opponent'] === 1) {
+                $found2v1 = $row;
+            }
+        }
+
+        // Team 1 won 1 game at home vs team 2
+        self::assertNotNull($found1v2);
+        self::assertGreaterThanOrEqual(1, $found1v2['wins']);
+
+        // Team 2 won 1 game at home vs team 1
+        self::assertNotNull($found2v1);
+        self::assertGreaterThanOrEqual(1, $found2v1['wins']);
+    }
+
+    public function testGetSeriesRecordsResultsAreOrderedBySelfThenOpponent(): void
+    {
+        $records = $this->repo->getSeriesRecords();
+
+        if (count($records) < 2) {
+            // Not enough data to verify ordering — insert some
+            $this->insertScheduleRow(2099, '2099-02-01', 2, 80, 1, 100);
+            $records = $this->repo->getSeriesRecords();
+        }
+
+        // Verify ordering: self ASC, then opponent ASC
+        for ($i = 1, $count = count($records); $i < $count; $i++) {
+            $prev = $records[$i - 1];
+            $curr = $records[$i];
+            self::assertTrue(
+                $prev['self'] < $curr['self']
+                || ($prev['self'] === $curr['self'] && $prev['opponent'] <= $curr['opponent']),
+                "Records not ordered by self, opponent at index $i"
+            );
+        }
+    }
+
+    // ── getMaxTeamId ────────────────────────────────────────────
+
+    public function testGetMaxTeamIdReturnsIntegerResult(): void
+    {
+        // Insert a schedule row with a known Visitor team ID
+        $this->insertScheduleRow(2099, '2099-03-01', 28, 90, 1, 100);
+
+        $result = $this->repo->getMaxTeamId();
+
+        self::assertGreaterThanOrEqual(28, $result);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/SharedRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SharedRepositoryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use Shared\SharedRepository;
+
+/**
+ * Tests SharedRepository against real MariaDB — team award counts via
+ * vw_team_awards, draft pick ownership lookups, and contract extension resets.
+ */
+class SharedRepositoryTest extends DatabaseTestCase
+{
+    private SharedRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new SharedRepository($this->db);
+    }
+
+    // ── getNumberOfTitles ───────────────────────────────────────
+
+    public function testGetNumberOfTitlesCountsMatchingAwards(): void
+    {
+        $this->insertTeamAwardRow('Metros', 'Eastern Division Champion', 2097);
+        $this->insertTeamAwardRow('Metros', 'Eastern Division Champion', 2098);
+
+        $result = $this->repo->getNumberOfTitles('Metros', 'Division');
+
+        // At least our 2 inserted rows (may include pre-existing production data)
+        self::assertGreaterThanOrEqual(2, $result);
+    }
+
+    public function testGetNumberOfTitlesReturnsZeroForNoMatches(): void
+    {
+        $result = $this->repo->getNumberOfTitles('NoSuchTeam9999', 'Division');
+
+        self::assertSame(0, $result);
+    }
+
+    // ── getCurrentOwnerOfDraftPick ──────────────────────────────
+
+    public function testGetCurrentOwnerOfDraftPickReturnsOwner(): void
+    {
+        $this->insertDraftPickRow(1, 2, 2099, 1, ['ownerofpick' => 'Metros', 'teampick' => 'Stars']);
+
+        $result = $this->repo->getCurrentOwnerOfDraftPick(2099, 1, 2);
+
+        self::assertSame('Metros', $result);
+    }
+
+    public function testGetCurrentOwnerOfDraftPickReturnsNullWhenNotFound(): void
+    {
+        $result = $this->repo->getCurrentOwnerOfDraftPick(9999, 9, 99);
+
+        self::assertNull($result);
+    }
+
+    // ── resetSimContractExtensionAttempts ────────────────────────
+
+    public function testResetSimContractExtensionAttemptsSetsToZero(): void
+    {
+        // Set Used_Extension_This_Chunk=1 for Metros within the transaction
+        $stmt = $this->db->prepare('UPDATE ibl_team_info SET Used_Extension_This_Chunk = 1 WHERE team_name = ?');
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('s', $tn);
+        $tn = 'Metros';
+        $stmt->execute();
+        $stmt->close();
+
+        $this->repo->resetSimContractExtensionAttempts();
+
+        $stmt = $this->db->prepare('SELECT Used_Extension_This_Chunk FROM ibl_team_info WHERE team_name = ?');
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('s', $tn);
+        $tn = 'Metros';
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        self::assertNotNull($row);
+        self::assertSame(0, $row['Used_Extension_This_Chunk']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 19 database integration tests across 4 previously untested repositories (batch 2 of 5 in the DB integration test expansion).

### New Test Coverage

| Repository | Tests | Key Behaviors Verified |
|-----------|-------|----------------------|
| SeriesRecordsRepository | 4 | Team listings via fetchAllRealTeams; series records via vw_series_records (ibl_schedule-derived view); ordering verification; getMaxTeamId |
| FreeAgencyDemandRepository | 5 | Team performance from ibl_team_info; position salary commitment via vw_current_salary with player exclusion; demand lookups with zero-default fallback |
| DepthChartEntryRepository | 5 | Active roster queries with retired/waiver-ordinal filtering; 12 dc_* column updates; team history timestamps |
| SharedRepository | 5 | Team award counts via vw_team_awards with LIKE pattern; draft pick ownership; contract extension reset |

### DatabaseTestCase Helper Added
- `insertTeamAwardRow()` — insert into `ibl_team_awards` (team-level awards, distinct from individual `ibl_awards`)

### Coverage Impact
DB integration tests: 414 → 433 (+19 tests)

### Manual Testing
No manual testing needed — all changes are database integration tests verified against real MariaDB.