### PR TITLE
test: unit test coverage expansion batch 8 — method-level gaps

### DIFF
--- a/ibl5/tests/CapSpace/CapSpaceServiceTest.php
+++ b/ibl5/tests/CapSpace/CapSpaceServiceTest.php
@@ -130,6 +130,17 @@ class CapSpaceServiceTest extends TestCase
         $this->assertEquals(2025, $result['endingYear']);
     }
 
+    public function testGetDisplayYearsForDraftPhaseShiftsYearsForward(): void
+    {
+        $mockSeason = $this->createMockSeason('Draft', 2024, 2025);
+
+        $result = $this->service->getDisplayYears($mockSeason);
+
+        // Draft is an offseason phase — years shift forward by 1
+        $this->assertEquals(2025, $result['beginningYear']);
+        $this->assertEquals(2026, $result['endingYear']);
+    }
+
     public function testFreeAgencySlotsCalculation(): void
     {
         $mockTeam = $this->createMockTeamWithMleLle(1, 1);

--- a/ibl5/tests/LeagueConfig/LeagueConfigServiceTest.php
+++ b/ibl5/tests/LeagueConfig/LeagueConfigServiceTest.php
@@ -44,4 +44,106 @@ class LeagueConfigServiceTest extends TestCase
         $this->assertArrayHasKey('error', $result);
     }
 
+    // ── crossCheckWithFranchiseSeasons ─────────────────────────────
+
+    public function testCrossCheckReturnsEmptyWhenAllMatch(): void
+    {
+        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo->method('getConfigForSeason')->willReturn([
+            ['team_slot' => 1, 'team_name' => 'Miami'],
+            ['team_slot' => 2, 'team_name' => 'New York'],
+        ]);
+        $stubRepo->method('getFranchiseTeamsBySeason')->willReturn([
+            1 => 'Miami',
+            2 => 'New York',
+        ]);
+
+        $service = new LeagueConfigService($stubRepo);
+        $result = $service->crossCheckWithFranchiseSeasons(2026);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testCrossCheckReturnsErrorWhenNoConfigFound(): void
+    {
+        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo->method('getConfigForSeason')->willReturn([]);
+
+        $service = new LeagueConfigService($stubRepo);
+        $result = $service->crossCheckWithFranchiseSeasons(2026);
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('No league config found', $result[0]);
+    }
+
+    public function testCrossCheckReturnsErrorWhenNoFranchiseDataFound(): void
+    {
+        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo->method('getConfigForSeason')->willReturn([
+            ['team_slot' => 1, 'team_name' => 'Miami'],
+        ]);
+        $stubRepo->method('getFranchiseTeamsBySeason')->willReturn([]);
+
+        $service = new LeagueConfigService($stubRepo);
+        $result = $service->crossCheckWithFranchiseSeasons(2026);
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('No franchise_seasons data', $result[0]);
+    }
+
+    public function testCrossCheckDetectsMissingSlotInFranchiseMap(): void
+    {
+        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo->method('getConfigForSeason')->willReturn([
+            ['team_slot' => 1, 'team_name' => 'Miami'],
+            ['team_slot' => 99, 'team_name' => 'Phantom Team'],
+        ]);
+        $stubRepo->method('getFranchiseTeamsBySeason')->willReturn([
+            1 => 'Miami',
+        ]);
+
+        $service = new LeagueConfigService($stubRepo);
+        $result = $service->crossCheckWithFranchiseSeasons(2026);
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('Slot 99', $result[0]);
+        $this->assertStringContainsString('no matching franchise_id', $result[0]);
+    }
+
+    public function testCrossCheckDetectsNameMismatch(): void
+    {
+        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo->method('getConfigForSeason')->willReturn([
+            ['team_slot' => 1, 'team_name' => 'Miami Heat'],
+        ]);
+        $stubRepo->method('getFranchiseTeamsBySeason')->willReturn([
+            1 => 'Miami Dolphins',
+        ]);
+
+        $service = new LeagueConfigService($stubRepo);
+        $result = $service->crossCheckWithFranchiseSeasons(2026);
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('Miami Heat', $result[0]);
+        $this->assertStringContainsString('Miami Dolphins', $result[0]);
+    }
+
+    public function testCrossCheckDetectsFranchiseNotInLgeFile(): void
+    {
+        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo->method('getConfigForSeason')->willReturn([
+            ['team_slot' => 1, 'team_name' => 'Miami'],
+        ]);
+        $stubRepo->method('getFranchiseTeamsBySeason')->willReturn([
+            1 => 'Miami',
+            2 => 'New York',
+        ]);
+
+        $service = new LeagueConfigService($stubRepo);
+        $result = $service->crossCheckWithFranchiseSeasons(2026);
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('Franchise 2', $result[0]);
+        $this->assertStringContainsString('not present in .lge file', $result[0]);
+    }
 }

--- a/ibl5/tests/TeamSchedule/TeamScheduleServiceTest.php
+++ b/ibl5/tests/TeamSchedule/TeamScheduleServiceTest.php
@@ -98,4 +98,171 @@ class TeamScheduleServiceTest extends TestCase
 
         $this->assertNotSame($service1, $service2);
     }
+
+    // ============================================
+    // getProcessedSchedule() TESTS
+    // ============================================
+
+    public function testProcessedScheduleReturnsEmptyForNoGames(): void
+    {
+        $this->stubRepository->method('getSchedule')->willReturn([]);
+
+        $service = new TeamScheduleService($this->mockMysqliDb, $this->stubRepository);
+        $season = new \Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testProcessedScheduleTracksWinWithGreenColor(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2024-01-10', visitor: 1, home: 2, vScore: 100, hScore: 90),
+        ]);
+
+        $service = new TeamScheduleService($this->mockMysqliDb, $this->stubRepository);
+        $season = new \Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('W', $result[0]['gameResult']);
+        $this->assertSame('green', $result[0]['winLossColor']);
+        $this->assertSame(1, $result[0]['wins']);
+        $this->assertSame(0, $result[0]['losses']);
+    }
+
+    public function testProcessedScheduleTracksLossWithRedColor(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2024-01-10', visitor: 1, home: 2, vScore: 80, hScore: 95),
+        ]);
+
+        $service = new TeamScheduleService($this->mockMysqliDb, $this->stubRepository);
+        $season = new \Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertSame('L', $result[0]['gameResult']);
+        $this->assertSame('red', $result[0]['winLossColor']);
+        $this->assertSame(0, $result[0]['wins']);
+        $this->assertSame(1, $result[0]['losses']);
+    }
+
+    public function testProcessedScheduleCalculatesWinStreak(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2024-01-10', visitor: 1, home: 2, vScore: 100, hScore: 90),
+            $this->makeGameRow('2024-01-12', visitor: 2, home: 1, vScore: 85, hScore: 95),
+        ]);
+
+        $service = new TeamScheduleService($this->mockMysqliDb, $this->stubRepository);
+        $season = new \Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertSame('W 2', $result[1]['streak']);
+    }
+
+    public function testProcessedScheduleResetsStreakOnOppositeResult(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2024-01-10', visitor: 1, home: 2, vScore: 100, hScore: 90),
+            $this->makeGameRow('2024-01-12', visitor: 1, home: 2, vScore: 80, hScore: 95),
+        ]);
+
+        $service = new TeamScheduleService($this->mockMysqliDb, $this->stubRepository);
+        $season = new \Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertSame('W 1', $result[0]['streak']);
+        $this->assertSame('L 1', $result[1]['streak']);
+    }
+
+    public function testProcessedScheduleMarksUnplayedGamesWithEmptyResult(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2024-02-10', visitor: 1, home: 2, vScore: 0, hScore: 0),
+        ]);
+
+        $service = new TeamScheduleService($this->mockMysqliDb, $this->stubRepository);
+        $season = new \Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertTrue($result[0]['isUnplayed']);
+        $this->assertSame('', $result[0]['gameResult']);
+    }
+
+    public function testProcessedScheduleCumulativeRecord(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2024-01-10', visitor: 1, home: 2, vScore: 100, hScore: 90),
+            $this->makeGameRow('2024-01-12', visitor: 1, home: 2, vScore: 80, hScore: 95),
+            $this->makeGameRow('2024-01-14', visitor: 2, home: 1, vScore: 85, hScore: 105),
+        ]);
+
+        $service = new TeamScheduleService($this->mockMysqliDb, $this->stubRepository);
+        $season = new \Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertSame(2, $result[2]['wins']);
+        $this->assertSame(1, $result[2]['losses']);
+    }
+
+    // ============================================
+    // HELPERS
+    // ============================================
+
+    private function setupTeamMockData(): void
+    {
+        $this->mockDb->setMockData([
+            [
+                'teamid' => 2,
+                'team_city' => 'Test City',
+                'team_name' => 'Opponents',
+                'color1' => 'FF0000',
+                'color2' => '0000FF',
+                'arena' => 'Test Arena',
+                'capacity' => 20000,
+                'owner_name' => 'Test Owner',
+                'owner_email' => 'test@test.com',
+                'discordID' => null,
+                'Used_Extension_This_Chunk' => 0,
+                'Used_Extension_This_Season' => 0,
+                'HasMLE' => 0,
+                'HasLLE' => 0,
+                'leagueRecord' => '30-10',
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{Date: string, BoxID: int, Visitor: int, Home: int, VScore: int, HScore: int}
+     */
+    private function makeGameRow(
+        string $date,
+        int $visitor,
+        int $home,
+        int $vScore,
+        int $hScore,
+    ): array {
+        return [
+            'Date' => $date,
+            'BoxID' => 1,
+            'Visitor' => $visitor,
+            'Home' => $home,
+            'VScore' => $vScore,
+            'HScore' => $hScore,
+        ];
+    }
 }


### PR DESCRIPTION
## Summary

Expand 3 existing test files with 14 new test methods covering previously-untested public methods with real business logic.

## Expanded Test Coverage

| Service | Method Tested | New Tests | Category |
|---------|--------------|-----------|----------|
| `LeagueConfigService` | `crossCheckWithFranchiseSeasons()` | 6 | Bidirectional config/franchise cross-check |
| `TeamScheduleService` | `getProcessedSchedule()` | 7 | Win/loss tracking, streaks, unplayed games |
| `CapSpaceService` | `getDisplayYears()` | 1 | Draft phase offseason edge case |
| **Total** | | **14** | |

## Test Strategy Shift

Batches 5-7 focused on untested classes (new test files). This batch shifts to **method-level gap filling** — adding tests for untested public methods within existing, well-structured test files. This is the new coverage frontier since all coverage-counted classes now have test files.

## Manual Testing

No manual testing needed — all changes are covered by unit tests.