### PR TITLE
refactor: make code self-documenting to eliminate context file workarounds

### DIFF
--- a/.claude/rules/core-coding.md
+++ b/.claude/rules/core-coding.md
@@ -10,7 +10,7 @@ Quick reference for frequently-used patterns not covered in CLAUDE.md.
 $repo->getUserByUsername(string $username): ?array
 $repo->getTeamByName(string $teamName): ?array
 $repo->getPlayerByID(int $playerID): ?array
-$repo->getTeamnameFromUsername(?string $username): ?string  // Returns "Free Agents" if null/empty; null if not found
+$repo->getTeamnameFromUsername(?string $username): ?string  // Returns League::FREE_AGENTS_TEAM_NAME if null/empty; null if not found
 $repo->getTidFromTeamname(string $teamName): ?int
 $repo->getTeamTotalSalary(string $teamName): int
 $repo->getTeamDiscordID(string $teamName): ?int

--- a/.claude/rules/php-classes.md
+++ b/.claude/rules/php-classes.md
@@ -91,6 +91,3 @@ Values from `array<string, mixed>` are `mixed`. Before concatenation, casting, o
 
 ### `$_GET`/`$_POST` values are `mixed`
 Superglobal values are `mixed`, not `string`. Use `is_string($_GET['key'])` to narrow before passing to string-typed methods.
-
-### Use `AppPaths::root()` instead of the `IBL5_ROOT` constant
-The `IBL5_ROOT` constant is defined at runtime with `define()`, making it `mixed` to PHPStan. Use `\Bootstrap\AppPaths::root()` instead — it returns `string` directly with no narrowing needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,6 @@ All 30 modules in `ibl5/classes/` follow Repository/Service/View pattern with in
 ### Legacy (Non-IBL) Modules
 - **SiteStatistics:** A legacy PHP-Nuke module for tracking site visitor/page-view statistics. It is **not** basketball- or IBL-related and should be deprioritized against core IBL modules during refactoring or feature work.
 
-### OneOnOneGame Warning
-`classes/OneOnOneGame/` is NOT a representation of how the Jump Shot Basketball (JSB) simulation engine works. It was created as a mini-game by fans of JSB, and may have similarities in logic, but it should not be interpreted as a faithful representation of how the JSB engine works. In terms of using it to understand JSB, pretend it does not exist.
-
 ### Key Patterns
 - **Repository:** Database queries via prepared statements
 - **Service:** Business logic, validation, calculations

--- a/ibl5/classes/Bootstrap/AppPaths.php
+++ b/ibl5/classes/Bootstrap/AppPaths.php
@@ -6,9 +6,6 @@ namespace Bootstrap;
 
 /**
  * Typed path constants for the application.
- *
- * Replaces the runtime-defined IBL5_ROOT constant (which PHPStan sees as mixed)
- * with a typed static method that returns string directly.
  */
 final class AppPaths
 {

--- a/ibl5/classes/Bootstrap/SecurityBootstrap.php
+++ b/ibl5/classes/Bootstrap/SecurityBootstrap.php
@@ -8,7 +8,7 @@ use Bootstrap\Contracts\BootstrapStepInterface;
 use Bootstrap\Contracts\ContainerInterface;
 
 /**
- * Security bootstrap: FB bot redirect, include_secure(), gzip, IBL5_ROOT constant.
+ * Security bootstrap: FB bot redirect, include_secure(), gzip.
  *
  * Extracted from mainfile.php lines 15-85.
  */
@@ -40,10 +40,6 @@ class SecurityBootstrap implements BootstrapStepInterface
     {
         if (!defined('END_TRANSACTION')) {
             define('END_TRANSACTION', 2);
-        }
-
-        if (!defined('IBL5_ROOT')) {
-            define('IBL5_ROOT', dirname(__DIR__, 2));
         }
     }
 

--- a/ibl5/classes/Boxscore.php
+++ b/ibl5/classes/Boxscore.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 class Boxscore
 {
+    /** Maximum player name length in ibl_box_scores.name (varchar(16)) */
+    public const MAX_PLAYER_NAME_LENGTH = 16;
+
     public string $gameDate;
     public int $gameYear;
     public string $gameMonth;

--- a/ibl5/classes/League.php
+++ b/ibl5/classes/League.php
@@ -26,6 +26,7 @@ class League extends BaseMysqliRepository
     const HARD_CAP_MAX = 7000;
 
     const FREE_AGENTS_TEAMID = 0;
+    const FREE_AGENTS_TEAM_NAME = 'Free Agents';
     const MAX_REAL_TEAMID = 28;
     const ROOKIES_TEAMID = 40;
     const SOPHOMORES_TEAMID = 41;

--- a/ibl5/classes/LeagueControlPanel/LeagueControlPanelRepository.php
+++ b/ibl5/classes/LeagueControlPanel/LeagueControlPanelRepository.php
@@ -203,7 +203,7 @@ class LeagueControlPanelRepository extends \BaseMysqliRepository implements Leag
     public function setWaiversToFreeAgents(): bool
     {
         $this->execute(
-            "UPDATE ibl_plr SET teamname = 'Free Agents', bird = 0 WHERE retired <> 1 AND ordinal > " . \JSB::WAIVERS_ORDINAL
+            "UPDATE ibl_plr SET teamname = '" . \League::FREE_AGENTS_TEAM_NAME . "', bird = 0 WHERE retired <> 1 AND ordinal > " . \JSB::WAIVERS_ORDINAL
         );
 
         return true;

--- a/ibl5/classes/OneOnOneGame/OneOnOneGameEngine.php
+++ b/ibl5/classes/OneOnOneGame/OneOnOneGameEngine.php
@@ -10,6 +10,10 @@ use Utilities\HtmlSanitizer;
 /**
  * OneOnOneGameEngine - Simulates One-on-One basketball games
  *
+ * WARNING: This is a fan-created mini-game. It is NOT a representation of how the
+ * Jump Shot Basketball (JSB) simulation engine works. While it uses player ratings,
+ * the game mechanics here are original and should not be used to understand JSB logic.
+ *
  * Implements the game simulation logic using player ratings to determine
  * outcomes for shots, blocks, steals, fouls, and rebounds.
  *

--- a/ibl5/classes/OneOnOneGame/README.md
+++ b/ibl5/classes/OneOnOneGame/README.md
@@ -1,5 +1,7 @@
 # One-on-One Module
 
+> **Note:** This is a fan-created mini-game. It is **not** a representation of how the Jump Shot Basketball (JSB) simulation engine works. The game mechanics here are original and should not be used to understand JSB logic.
+
 The One-on-One module allows users to simulate a one-on-one basketball game between any two players in the league. Games are played to 21 points.
 
 ## Architecture

--- a/ibl5/classes/Player/PlayerPageController.php
+++ b/ibl5/classes/Player/PlayerPageController.php
@@ -92,7 +92,7 @@ class PlayerPageController
         $html .= '</td></tr>';
 
         // Action buttons
-        $userTeamName = $commonRepository->getTeamnameFromUsername($username) ?? 'Free Agents';
+        $userTeamName = $commonRepository->getTeamnameFromUsername($username) ?? \League::FREE_AGENTS_TEAM_NAME;
         $userTeam = \Team::initialize($this->mysqliDb, $userTeamName);
 
         $actionButtons = $this->renderActionButtons($pageService, $player, $playerID, $userTeam, $season);

--- a/ibl5/classes/Player/PlayerPageService.php
+++ b/ibl5/classes/Player/PlayerPageService.php
@@ -54,7 +54,7 @@ class PlayerPageService implements PlayerPageServiceInterface
 
         /** @var \Team $userTeam */
         /** @var \Season $season */
-        return $userTeam->name !== "Free Agents"
+        return $userTeam->name !== \League::FREE_AGENTS_TEAM_NAME
             && $userTeam->hasUsedExtensionThisSeason === 0
             && $player->canRenegotiateContract()
             && $player->teamID === $userTeam->teamID
@@ -77,7 +77,7 @@ class PlayerPageService implements PlayerPageServiceInterface
     {
         /** @var \Team $userTeam */
         /** @var \Season $season */
-        return $userTeam->name !== "Free Agents"
+        return $userTeam->name !== \League::FREE_AGENTS_TEAM_NAME
             && $player->canRookieOption($season->phase)
             && $player->teamID === $userTeam->teamID;
     }

--- a/ibl5/classes/SeasonHighs/SeasonHighsRepository.php
+++ b/ibl5/classes/SeasonHighs/SeasonHighsRepository.php
@@ -64,7 +64,7 @@ class SeasonHighsRepository extends \BaseMysqliRepository implements SeasonHighs
         };
 
         // For player stats (no suffix), JOIN with ibl_plr to get full names
-        // The ibl_box_scores.name field is varchar(16) which truncates longer names
+        // The ibl_box_scores.name field truncates longer names (see Boxscore::MAX_PLAYER_NAME_LENGTH)
         // The ibl_plr.name field is varchar(32) which stores full names
         // Also JOIN with ibl_schedule to get BoxID for linking to box scores
         // Also JOIN with ibl_team_info to get team colors for styled team cell

--- a/ibl5/classes/SeriesRecords/SeriesRecordsController.php
+++ b/ibl5/classes/SeriesRecords/SeriesRecordsController.php
@@ -59,7 +59,7 @@ class SeriesRecordsController implements SeriesRecordsControllerInterface
     public function displayForUser(string $username): void
     {
         $teamName = $this->commonRepository->getTeamnameFromUsername($username);
-        $teamId = ($teamName !== null && $teamName !== 'Free Agents')
+        $teamId = ($teamName !== null && $teamName !== \League::FREE_AGENTS_TEAM_NAME)
             ? ($this->commonRepository->getTidFromTeamname($teamName) ?? 0)
             : 0;
 

--- a/ibl5/classes/Services/CommonMysqliRepository.php
+++ b/ibl5/classes/Services/CommonMysqliRepository.php
@@ -45,12 +45,12 @@ class CommonMysqliRepository extends \BaseMysqliRepository
      * Gets the team name associated with a username
      * 
      * @param string|null $username Username to look up (nullable)
-     * @return string|null Team name if found, "Free Agents" if username is empty, or null if username not found
+     * @return string|null Team name if found, League::FREE_AGENTS_TEAM_NAME if username is empty, or null if not found
      */
     public function getTeamnameFromUsername(?string $username): ?string
     {
         if ($username === null || $username === '') {
-            return "Free Agents";
+            return \League::FREE_AGENTS_TEAM_NAME;
         }
 
         /** @var array{team_name: string}|null $result */

--- a/ibl5/classes/Trading/TradingService.php
+++ b/ibl5/classes/Trading/TradingService.php
@@ -437,7 +437,7 @@ class TradingService implements TradingServiceInterface
 
         foreach ($allTeams as $row) {
             $teamName = $row['team_name'];
-            if ($teamName === 'Free Agents') {
+            if ($teamName === \League::FREE_AGENTS_TEAM_NAME) {
                 continue;
             }
 

--- a/ibl5/mainfile.php
+++ b/ibl5/mainfile.php
@@ -56,11 +56,6 @@ function include_secure($file_name)
     }
 }
 
-// Application root constant — reliable across worktrees and DOCUMENT_ROOT layouts
-if (!defined('IBL5_ROOT')) {
-    define('IBL5_ROOT', __DIR__);
-}
-
 // Check if this file isn't being accessed directly
 
 if (realpath(__FILE__) === realpath($_SERVER['SCRIPT_FILENAME'])) {


### PR DESCRIPTION
## Summary

Makes 4 code patterns self-documenting so their corresponding context file entries (CLAUDE.md, .claude/rules/, memory/) can be removed. This reduces per-conversation token overhead and prevents bugs at the source.

## Changes

### 1.1 — OneOnOneGame JSB Warning
- Added docblock to `OneOnOneGameEngine.php` and updated `README.md` warning it's a fan-created mini-game, not a JSB representation
- **Removed:** CLAUDE.md OneOnOneGame paragraph (5 lines)

### 1.2 — Box Score Name Length Constant
- Added `Boxscore::MAX_PLAYER_NAME_LENGTH = 16` constant documenting the varchar(16) limit
- Updated SeasonHighsRepository comment to reference the constant
- **Removed:** MEMORY.md `ibl_box_scores.name is varchar(16)` entry

### 1.3 — Remove Unused IBL5_ROOT Constant
- Removed both `IBL5_ROOT` definitions (mainfile.php, SecurityBootstrap.php) — no actual usages existed
- Cleaned up AppPaths docblock
- **Removed:** php-classes.md "Use AppPaths::root() instead of IBL5_ROOT" pitfall entry

### 1.4 — League::FREE_AGENTS_TEAM_NAME Constant
- Added `League::FREE_AGENTS_TEAM_NAME = 'Free Agents'` constant
- Updated 6 files to use the constant instead of magic strings
- **Removed:** core-coding.md comment about special getTeamnameFromUsername return value

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests. The refactor is purely structural (constants, docblocks, context file entries) with no behavior changes.

## Verification

- Full PHPUnit suite: 4084 tests, 18950 assertions — all passing
- PHPStan: No errors (level max + strict-rules + bleedingEdge)
- Net change: -8 lines across 17 files