### PR TITLE
ci: add .dockerignore and concurrency controls

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.claude
+worktrees
+ibl5/node_modules
+ibl5/tests
+ibl5/fixtures
+ibl5/vendor
+*.md

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,10 @@ on:
       - '**/*.js'
       - '**/*.jsx'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,10 @@ on:
     branches: [master]
     types: [opened, synchronize, reopened, labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     name: Visual Regression

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - 'ibl5/migrations/**.sql'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   idempotency-check:
     name: Bash/PHP Runner Idempotency

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,10 @@ on:
       - '**.php'
       - 'ibl5/migrations/**.sql'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: PHPUnit Tests


### PR DESCRIPTION
## Summary

Two low-effort CI improvements:

### .dockerignore
Excludes `.git`, `.github`, `.claude`, `worktrees`, `node_modules`, `tests`, `fixtures`, `vendor`, and markdown files from Docker build context. The Dockerfile only needs `docker/opcache.ini`, `docker/entrypoint.sh`, and generates the Apache config inline — everything else is noise. Reduces build context from hundreds of MB to just the files needed.

### Concurrency Controls
Adds `concurrency` groups with `cancel-in-progress: true` to four workflows:
- `tests.yml` (PHPUnit, PHPStan, audits, DB integration)
- `e2e-tests.yml` (Playwright visual regression + functional)
- `migration-safety.yml` (migration idempotency)
- `codeql.yml` (JS/TS static analysis)

When a new push supersedes a previous one on the same branch, the stale run is cancelled instead of running to completion.

**Not added to:** `main.yml` (deployments must never cancel), `rebase-prs.yml` (must complete), `cache-dependencies.yml` (scheduled), `mutation.yml` (on-demand).

## Manual Testing

No manual testing needed — all changes are CI configuration. The concurrency behavior will be verified organically when the next PR has multiple pushes.