### PR TITLE
test: mutation hardening batch 10 — FreeAgencyCapCalculator + ExtensionOfferEvaluator

### DIFF
--- a/ibl5/tests/Extension/ExtensionOfferEvaluatorTest.php
+++ b/ibl5/tests/Extension/ExtensionOfferEvaluatorTest.php
@@ -580,4 +580,50 @@ class ExtensionOfferEvaluatorTest extends TestCase
         // Assert
         $this->assertEquals(120, $millions); // 12000 / 100 = 120 million
     }
+
+    // ============================================
+    // NULL-COALESCING EDGE CASES (mutation hardening)
+    // ============================================
+
+    public function testCalculateWinnerModifierWithMissingTeamFactors(): void
+    {
+        // Empty team factors → wins ?? 0, losses ?? 0 → winDiff = 0
+        $result = $this->evaluator->calculateWinnerModifier([], ['winner' => 3]);
+
+        $this->assertSame(0.0, $result);
+    }
+
+    public function testCalculateWinnerModifierWithMissingPreference(): void
+    {
+        // Missing 'winner' key → defaults to 1, so (1-1) = 0 → modifier = 0
+        $result = $this->evaluator->calculateWinnerModifier(
+            ['wins' => 50, 'losses' => 32],
+            []
+        );
+
+        $this->assertSame(0.0, $result);
+    }
+
+    public function testCalculateTraditionModifierWithMissingTeamFactors(): void
+    {
+        $result = $this->evaluator->calculateTraditionModifier([], ['tradition' => 3]);
+
+        $this->assertSame(0.0, $result);
+    }
+
+    public function testCalculateLoyaltyModifierWithMissingPreference(): void
+    {
+        // Missing 'loyalty' key → defaults to 1, so (1-1) = 0
+        $result = $this->evaluator->calculateLoyaltyModifier([]);
+
+        $this->assertSame(0.0, $result);
+    }
+
+    public function testCalculatePlayingTimeModifierWithMissingData(): void
+    {
+        // Missing money_committed → defaults to 0; missing playingTime → defaults to 1
+        $result = $this->evaluator->calculatePlayingTimeModifier([], []);
+
+        $this->assertSame(0.0, $result);
+    }
 }

--- a/ibl5/tests/FreeAgency/FreeAgencyCapCalculatorTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyCapCalculatorTest.php
@@ -75,11 +75,13 @@ class FreeAgencyCapCalculatorTest extends TestCase
         // Act
         $result = $calculator->calculateTeamCapMetrics();
 
-        // Assert - Should have full cap space and max roster spots
-        $this->assertEquals(0, $result['totalSalaries'][0]);
-        $this->assertEquals(\League::SOFT_CAP_MAX, $result['softCapSpace'][0]);
-        $this->assertEquals(\League::HARD_CAP_MAX, $result['hardCapSpace'][0]);
-        $this->assertEquals(\Team::ROSTER_SPOTS_MAX, $result['rosterSpots'][0]);
+        // Assert - Should have full cap space and max roster spots (ALL 6 years)
+        for ($i = 0; $i < 6; $i++) {
+            $this->assertEquals(0, $result['totalSalaries'][$i], "totalSalaries year $i should be 0");
+            $this->assertEquals(\League::SOFT_CAP_MAX, $result['softCapSpace'][$i], "softCapSpace year $i");
+            $this->assertEquals(\League::HARD_CAP_MAX, $result['hardCapSpace'][$i], "hardCapSpace year $i");
+            $this->assertEquals(\Team::ROSTER_SPOTS_MAX, $result['rosterSpots'][$i], "rosterSpots year $i");
+        }
     }
 
     /**
@@ -109,15 +111,20 @@ class FreeAgencyCapCalculatorTest extends TestCase
         // Act
         $result = $calculator->calculateTeamCapMetrics();
 
-        // Assert - Offers should count toward cap and roster spots
+        // Assert - Offers should count toward cap and roster spots (ALL 6 years)
         $this->assertEquals(800, $result['totalSalaries'][0]);
         $this->assertEquals(850, $result['totalSalaries'][1]);
         $this->assertEquals(900, $result['totalSalaries'][2]);
+        $this->assertEquals(0, $result['totalSalaries'][3]);
+        $this->assertEquals(0, $result['totalSalaries'][4]);
+        $this->assertEquals(0, $result['totalSalaries'][5]);
 
         $this->assertEquals(\Team::ROSTER_SPOTS_MAX - 1, $result['rosterSpots'][0]);
         $this->assertEquals(\Team::ROSTER_SPOTS_MAX - 1, $result['rosterSpots'][1]);
         $this->assertEquals(\Team::ROSTER_SPOTS_MAX - 1, $result['rosterSpots'][2]);
         $this->assertEquals(\Team::ROSTER_SPOTS_MAX, $result['rosterSpots'][3]);
+        $this->assertEquals(\Team::ROSTER_SPOTS_MAX, $result['rosterSpots'][4]);
+        $this->assertEquals(\Team::ROSTER_SPOTS_MAX, $result['rosterSpots'][5]);
     }
 
     /**


### PR DESCRIPTION
## Summary

Second mutation hardening pass targeting FreeAgencyCapCalculator (50% MSI) and ExtensionOfferEvaluator (58% MSI).

## Changes

- **FreeAgencyCapCalculatorTest:** Assert all 6 years of totalSalaries, softCapSpace, hardCapSpace, rosterSpots — previously only years 1-3 were checked, allowing mutations on years 4-6 initial values to escape
- **ExtensionOfferEvaluatorTest:** 5 new tests with empty/missing teamFactors and playerPreferences — exercises all null-coalescing default paths that previously had zero coverage

## Manual Testing

No manual testing needed — all changes are covered by unit tests.