### PR TITLE
test: DB integration tests batch 9 — method gaps + negative-path coverage

### DIFF
--- a/ibl5/tests/DatabaseIntegration/ApiInjuriesRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/ApiInjuriesRepositoryTest.php
@@ -109,4 +109,16 @@ class ApiInjuriesRepositoryTest extends DatabaseTestCase
             self::assertGreaterThanOrEqual($injuries[$i], $injuries[$i - 1]);
         }
     }
+
+    // ── Negative path ───────────────────────────────────────────
+
+    public function testGetInjuredPlayersReturnsEmptyWhenNoPlayersInjured(): void
+    {
+        // Clear all injuries within the rolled-back transaction
+        $this->db->query('UPDATE ibl_plr SET injured = 0 WHERE 1=1');
+
+        $result = $this->repo->getInjuredPlayers();
+
+        self::assertSame([], $result);
+    }
 }

--- a/ibl5/tests/DatabaseIntegration/ApiStandingsRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/ApiStandingsRepositoryTest.php
@@ -89,4 +89,11 @@ class ApiStandingsRepositoryTest extends DatabaseTestCase
             }
         }
     }
+
+    // ── Negative path ───────────────────────────────────────────
+
+    public function testGetStandingsReturnsEmptyForNonExistentConference(): void
+    {
+        self::assertSame([], $this->repo->getStandings('ZZ_Nonexistent_Conf'));
+    }
 }

--- a/ibl5/tests/DatabaseIntegration/CapSpaceRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/CapSpaceRepositoryTest.php
@@ -64,4 +64,27 @@ class CapSpaceRepositoryTest extends DatabaseTestCase
             self::assertNotSame($row['cy'], $row['cyt'], 'Found expiring contract that should have been filtered');
         }
     }
+
+    // ── Negative paths ──────────────────────────────────────────
+
+    public function testGetPlayersUnderContractAfterSeasonReturnsEmptyForUnknownTeam(): void
+    {
+        self::assertSame([], $this->repo->getPlayersUnderContractAfterSeason(99999));
+    }
+
+    public function testGetPlayersUnderContractAfterSeasonExcludesPipeNamePlayers(): void
+    {
+        // SQL has AND name NOT LIKE '%|%' — pipe-name players should be excluded
+        $this->insertTestPlayer(200100005, 'Cap|PipeName', [
+            'tid' => 1,
+            'cy' => 1,
+            'cyt' => 3,
+            'cy1' => 1500,
+        ]);
+
+        $players = $this->repo->getPlayersUnderContractAfterSeason(1);
+
+        $pids = array_column($players, 'pid');
+        self::assertNotContains(200100005, $pids);
+    }
 }

--- a/ibl5/tests/DatabaseIntegration/NegotiationRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/NegotiationRepositoryTest.php
@@ -102,4 +102,13 @@ class NegotiationRepositoryTest extends DatabaseTestCase
             self::assertGreaterThanOrEqual(1, $maximums[$key], "Key $key should be >= 1");
         }
     }
+
+    // ── Negative path ───────────────────────────────────────────
+
+    public function testGetPositionSalaryCommitmentReturnsZeroForUnknownTeam(): void
+    {
+        $result = $this->repo->getPositionSalaryCommitment('ZZ_NoTeam_B9', 'PG', 'SomePlayer');
+
+        self::assertSame(0, $result);
+    }
 }

--- a/ibl5/tests/DatabaseIntegration/SeasonQueryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SeasonQueryRepositoryTest.php
@@ -134,4 +134,15 @@ class SeasonQueryRepositoryTest extends DatabaseTestCase
         // Falls back to overall sim number (5) when no sim_dates match the FA date range
         self::assertSame(5, $phaseSimNumber);
     }
+
+    // ── getFreeAgencyNotificationsState ──────────────────────────
+
+    public function testGetFreeAgencyNotificationsStateReturnsString(): void
+    {
+        $this->db->query("REPLACE INTO ibl_settings (name, value) VALUES ('Free Agency Notifications', 'On')");
+
+        $result = $this->repo->getFreeAgencyNotificationsState();
+
+        self::assertSame('On', $result);
+    }
 }

--- a/ibl5/tests/DatabaseIntegration/SeriesRecordsRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SeriesRecordsRepositoryTest.php
@@ -100,4 +100,24 @@ class SeriesRecordsRepositoryTest extends DatabaseTestCase
 
         self::assertGreaterThanOrEqual(28, $result);
     }
+
+    // ── Negative paths ──────────────────────────────────────────
+
+    public function testGetSeriesRecordsReturnsEmptyWhenScheduleIsEmpty(): void
+    {
+        $this->db->query('DELETE FROM ibl_schedule WHERE 1=1');
+
+        $result = $this->repo->getSeriesRecords();
+
+        self::assertSame([], $result);
+    }
+
+    public function testGetMaxTeamIdReturnsZeroWhenScheduleIsEmpty(): void
+    {
+        $this->db->query('DELETE FROM ibl_schedule WHERE 1=1');
+
+        $result = $this->repo->getMaxTeamId();
+
+        self::assertSame(0, $result);
+    }
 }

--- a/ibl5/tests/DatabaseIntegration/TeamQueryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamQueryRepositoryTest.php
@@ -320,4 +320,62 @@ class TeamQueryRepositoryTest extends DatabaseTestCase
         $resultOver = $this->repo->canAddContractWithoutGoingOverHardCap(self::TEST_TID, \League::HARD_CAP_MAX);
         self::assertFalse($resultOver);
     }
+
+    // ── getTotalCurrentSeasonSalaries ───────────────────────────
+
+    public function testGetTotalCurrentSeasonSalariesSumsContracts(): void
+    {
+        // Use a real team with isolated test player. First clear any existing
+        // cy1>0 players on team 28 to get a predictable sum.
+        $this->db->query('UPDATE ibl_plr SET cy1 = 0 WHERE tid = 28');
+
+        $this->insertTestPlayer(200000150, 'TQ CurSal', [
+            'tid' => 28,
+            'cy' => 1,
+            'cyt' => 2,
+            'cy1' => 3000,
+            'cy2' => 3200,
+        ]);
+
+        $rows = $this->repo->getAllPlayersUnderContract(28);
+        $total = $this->repo->getTotalCurrentSeasonSalaries($rows);
+
+        self::assertIsInt($total);
+        self::assertSame(3000, $total);
+    }
+
+    // ── getTotalNextSeasonSalaries ──────────────────────────────
+
+    public function testGetTotalNextSeasonSalariesSumsContracts(): void
+    {
+        $this->db->query('UPDATE ibl_plr SET cy1 = 0 WHERE tid = 28');
+
+        $this->insertTestPlayer(200000151, 'TQ NxtSal', [
+            'tid' => 28,
+            'cy' => 1,
+            'cyt' => 2,
+            'cy1' => 1500,
+            'cy2' => 2200,
+        ]);
+
+        $rows = $this->repo->getAllPlayersUnderContract(28);
+        $total = $this->repo->getTotalNextSeasonSalaries($rows);
+
+        self::assertIsInt($total);
+        self::assertSame(2200, $total);
+    }
+
+    // ── canAddBuyoutWithoutExceedingBuyoutLimit ─────────────────
+
+    public function testCanAddBuyoutWithinLimitReturnsTrue(): void
+    {
+        // Team 99999 has no players → buyout sum is 0, adding 0 is within limit
+        self::assertTrue($this->repo->canAddBuyoutWithoutExceedingBuyoutLimit(99999, 0));
+    }
+
+    public function testCanAddBuyoutExceedingLimitReturnsFalse(): void
+    {
+        // Adding the entire hard cap always exceeds the buyout percentage limit
+        self::assertFalse($this->repo->canAddBuyoutWithoutExceedingBuyoutLimit(99999, \League::HARD_CAP_MAX));
+    }
 }

--- a/ibl5/tests/DatabaseIntegration/TeamRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamRepositoryTest.php
@@ -272,6 +272,122 @@ class TeamRepositoryTest extends DatabaseTestCase
         self::assertSame(1, $roster[0]['teamid']);
     }
 
+    // ── getGMAwards ───────────────────────────────────────────
+
+    public function testGetGMAwardsReturnsRowsForKnownGM(): void
+    {
+        $this->insertRow('ibl_gm_awards', [
+            'name' => 'b9_test_gm',
+            'Award' => 'GM of the Year',
+            'year' => 2099,
+        ]);
+
+        $result = $this->repo->getGMAwards('b9_test_gm');
+
+        self::assertCount(1, $result);
+        self::assertSame('b9_test_gm', $result[0]['name']);
+        self::assertSame('GM of the Year', $result[0]['Award']);
+        self::assertSame(2099, $result[0]['year']);
+    }
+
+    public function testGetGMAwardsReturnsEmptyForUnknownGM(): void
+    {
+        self::assertSame([], $this->repo->getGMAwards('zz_no_such_gm_xyz'));
+    }
+
+    // ── getTeamAccomplishments ──────────────────────────────────
+
+    public function testGetTeamAccomplishmentsReturnsTeamAwardRows(): void
+    {
+        $this->insertTeamAwardRow('B9TestTeam', 'Atlantic Division Title', 2099);
+
+        $result = $this->repo->getTeamAccomplishments('B9TestTeam');
+
+        self::assertNotEmpty($result);
+        self::assertSame('Atlantic Division Title', $result[0]['Award']);
+    }
+
+    public function testGetTeamAccomplishmentsReturnsEmptyForUnknownTeam(): void
+    {
+        self::assertSame([], $this->repo->getTeamAccomplishments('ZZ_Nonexistent_Batch9'));
+    }
+
+    // ── getHEATHistory ──────────────────────────────────────────
+
+    public function testGetHEATHistoryReturnsArrayWithExpectedShape(): void
+    {
+        // ibl_heat_win_loss is a VIEW derived from game_type=3 boxscores.
+        // CI seed may have no HEAT game data — test shape contract only.
+        $result = $this->repo->getHEATHistory('Metros');
+
+        self::assertIsArray($result);
+        if ($result !== []) {
+            self::assertArrayHasKey('year', $result[0]);
+            self::assertArrayHasKey('currentname', $result[0]);
+            self::assertArrayHasKey('namethatyear', $result[0]);
+            self::assertArrayHasKey('wins', $result[0]);
+            self::assertArrayHasKey('losses', $result[0]);
+        }
+    }
+
+    // ── getPlayoffResults ───────────────────────────────────────
+
+    public function testGetPlayoffResultsReturnsPlayoffSeriesData(): void
+    {
+        // Insert 4 playoff boxscores (June = game_type=2 auto-generated).
+        // Team 1 (visitor) wins 3 games, Team 2 (home) wins 1 game.
+        // Total score = sum of all 4 quarters. Visitor wins when v_total > h_total.
+        $games = [
+            ['vTotal' => 100, 'hTotal' => 90],  // visitor (tid=1) wins
+            ['vTotal' => 85,  'hTotal' => 95],   // home (tid=2) wins
+            ['vTotal' => 98,  'hTotal' => 88],   // visitor wins
+            ['vTotal' => 97,  'hTotal' => 92],   // visitor wins
+        ];
+
+        foreach ($games as $i => $g) {
+            $date = sprintf('2099-06-%02d', $i + 1);
+            $this->insertRow('ibl_box_scores_teams', [
+                'Date' => $date,
+                'name' => $i % 2 === 0 ? 'Metros' : 'Sharks',
+                'gameOfThatDay' => 1,
+                'visitorTeamID' => 1,
+                'homeTeamID' => 2,
+                'attendance' => 15000, 'capacity' => 18000,
+                'visitorWins' => 0, 'visitorLosses' => 0,
+                'homeWins' => 0, 'homeLosses' => 0,
+                'visitorQ1points' => (int) ($g['vTotal'] / 4),
+                'visitorQ2points' => (int) ($g['vTotal'] / 4),
+                'visitorQ3points' => (int) ($g['vTotal'] / 4),
+                'visitorQ4points' => $g['vTotal'] - 3 * (int) ($g['vTotal'] / 4),
+                'visitorOTpoints' => 0,
+                'homeQ1points' => (int) ($g['hTotal'] / 4),
+                'homeQ2points' => (int) ($g['hTotal'] / 4),
+                'homeQ3points' => (int) ($g['hTotal'] / 4),
+                'homeQ4points' => $g['hTotal'] - 3 * (int) ($g['hTotal'] / 4),
+                'homeOTpoints' => 0,
+                'game2GM' => 30, 'game2GA' => 60, 'gameFTM' => 15, 'gameFTA' => 20,
+                'game3GM' => 8, 'game3GA' => 22, 'gameORB' => 10, 'gameDRB' => 30,
+                'gameAST' => 20, 'gameSTL' => 8, 'gameTOV' => 12, 'gameBLK' => 5, 'gamePF' => 18,
+            ]);
+        }
+
+        $this->insertFranchiseSeasonRow(1, 2099, 'Metros');
+        $this->insertFranchiseSeasonRow(2, 2099, 'Sharks');
+
+        $result = $this->repo->getPlayoffResults();
+
+        // Find our 2099 series
+        $series2099 = array_filter(
+            $result,
+            static fn (array $r): bool => $r['year'] === 2099,
+        );
+
+        self::assertNotEmpty($series2099);
+        $series = array_values($series2099)[0];
+        self::assertSame(3, $series['winner_games']);
+        self::assertSame(1, $series['loser_games']);
+    }
+
     private function ensureStandingsAndPowerExist(int $tid, string $division, string $conference): void
     {
         // Use REPLACE to ensure data exists within transaction regardless of DB state


### PR DESCRIPTION
## Summary

Completes method-level coverage gaps in 3 repos and adds negative-path tests to 5 repos that previously had only happy-path coverage. 17 new test methods across 8 existing files.

## Tier 1: Untested Method Coverage (10 tests)

| File | Tests Added | Methods Covered |
|------|------------|----------------|
| TeamRepositoryTest | +6 | `getGMAwards`, `getTeamAccomplishments`, `getHEATHistory`, `getPlayoffResults` |
| TeamQueryRepositoryTest | +4 | `getTotalCurrentSeasonSalaries`, `getTotalNextSeasonSalaries`, `canAddBuyoutWithoutExceedingBuyoutLimit` |
| SeasonQueryRepositoryTest | +1 | `getFreeAgencyNotificationsState` |

### Notable: Playoff Results View Test
Inserts 4 `game_type=2` team boxscores (June dates auto-generate `game_type` via STORED GENERATED column) with a 3-1 series split between tid=1 and tid=2. Verifies the full `vw_playoff_series_results` CTE pipeline: `playoff_games → game_results → team_wins → series_meta → final SELECT` with `ibl_franchise_seasons` JOIN for historical team names.

## Tier 2: Negative-Path Coverage (7 tests)

| File | Tests Added | Edge Case |
|------|------------|-----------|
| NegotiationRepositoryTest | +1 | `getPositionSalaryCommitment` returns 0 for unknown team |
| CapSpaceRepositoryTest | +2 | Empty result for unknown team; pipe-name player exclusion filter |
| SeriesRecordsRepositoryTest | +2 | Empty schedule → empty results + `getMaxTeamId` returns 0 |
| ApiInjuriesRepositoryTest | +1 | No injured players → empty array |
| ApiStandingsRepositoryTest | +1 | Non-existent conference → empty array |

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.