### PR TITLE
test: mutation hardening batch 11 — PlayerContractCalculator null paths

### DIFF
--- a/ibl5/tests/Player/PlayerContractCalculatorTest.php
+++ b/ibl5/tests/Player/PlayerContractCalculatorTest.php
@@ -580,4 +580,42 @@ class PlayerContractCalculatorTest extends TestCase
         $this->assertCount(6, $longBuyout);
         $this->assertCount(2, $shortBuyout);
     }
+
+    // ── Mutation hardening: null contractCurrentYear ────────────
+
+    public function testGetCurrentSeasonSalaryWithNullContractCurrentYear(): void
+    {
+        $playerData = new PlayerData();
+        // contractCurrentYear is null → defaults to 0 via null coalescing
+        // Year 0 falls into getSalaryForYear year=0 branch → returns contractYear1Salary ?? 0
+        $playerData->contractYear1Salary = 750;
+
+        $result = $this->calculator->getCurrentSeasonSalary($playerData);
+
+        // Year 0 → defaults to year 1 salary
+        $this->assertSame(750, $result);
+    }
+
+    public function testGetNextSeasonSalaryWithNullContractCurrentYear(): void
+    {
+        $playerData = new PlayerData();
+        // contractCurrentYear null → 0 + 1 = 1 → returns contractYear1Salary
+        $playerData->contractYear1Salary = 500;
+
+        $result = $this->calculator->getNextSeasonSalary($playerData);
+
+        $this->assertSame(500, $result);
+    }
+
+    public function testGetSalaryForYearBeyondSixReturnsZero(): void
+    {
+        $playerData = new PlayerData();
+        $playerData->contractCurrentYear = 6;
+        $playerData->contractYear6Salary = 3000;
+
+        // Next season after year 6 = year 7 → off the books → 0
+        $result = $this->calculator->getNextSeasonSalary($playerData);
+
+        $this->assertSame(0, $result);
+    }
 }


### PR DESCRIPTION
## Summary

Third mutation hardening pass targeting PlayerContractCalculator (67% MSI, 34 escaped mutants). Adds null `contractCurrentYear` edge cases to exercise null-coalescing default paths.

## Changes

- 3 new tests: null `contractCurrentYear` for getCurrentSeasonSalary and getNextSeasonSalary, plus year 7+ boundary test
- All escaped mutants on lines 19, 27, 37 are `?? 0` → `?? -1`/`?? 1` mutations on `contractCurrentYear`

## Manual Testing

No manual testing needed — all changes are covered by unit tests.