### PR TITLE
ci: add production smoke test suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,3 +147,9 @@ jobs:
             sleep 1
             echo "IBL6 started (PID: $(cat ibl6.pid))"
           '
+
+      - name: Post-deploy smoke test
+        run: |
+          sleep 10
+          chmod +x bin/smoke-prod
+          bin/smoke-prod https://www.iblhoops.net

--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -1,0 +1,36 @@
+name: Production Smoke Test
+
+on:
+  # Run after deploy completes
+  workflow_run:
+    workflows: ["Build and Deploy"]
+    types: [completed]
+
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to test'
+        default: 'https://www.iblhoops.net'
+
+  # Daily health check at 8am UTC
+  schedule:
+    - cron: '0 8 * * *'
+
+jobs:
+  smoke:
+    name: Production Health Check
+    runs-on: ubuntu-latest
+    # Skip if triggered by a failed deploy
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run smoke tests
+        run: |
+          chmod +x bin/smoke-prod
+          bin/smoke-prod "${{ github.event.inputs.base_url || 'https://www.iblhoops.net' }}"

--- a/bin/smoke-prod
+++ b/bin/smoke-prod
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Production smoke test — lightweight HTTP checks against the live site.
+#
+# Usage: bin/smoke-prod [base_url]
+# Default: https://www.iblhoops.net
+#
+# Checks 7 public URLs for:
+#   - HTTP 200 status
+#   - Expected content in response body
+#   - Absence of PHP error messages
+#
+# Exit code: 0 if all pass, 1 if any fail.
+
+set -euo pipefail
+
+BASE="${1:-https://www.iblhoops.net}"
+PASS=0
+FAIL=0
+ERRORS=""
+
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+check() {
+    local name="$1" url="$2" expect="${3:-}" accept="${4:-200}"
+
+    # Single request: capture body to temp file + status code
+    local status
+    status=$(curl -sS -w "%{http_code}" --max-time 30 -o "$TMPFILE" "$url" 2>/dev/null) || true
+    # Extract just the HTTP code (last 3 chars of output)
+    status="${status: -3}"
+    [[ "$status" =~ ^[0-9]+$ ]] || status="000"
+
+    # Check if status is in the accepted list (pipe-separated, e.g., "200|401")
+    if ! echo "$accept" | grep -qw "$status"; then
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  FAIL: $name — HTTP $status (expected $accept)"
+        return
+    fi
+
+    # Check content (only if expect is non-empty)
+    if [ -n "$expect" ]; then
+        # Check for PHP errors
+        if grep -qiE "Fatal error|Parse error|Warning:|Uncaught|Stack trace:" "$TMPFILE"; then
+            FAIL=$((FAIL + 1))
+            ERRORS="${ERRORS}\n  FAIL: $name — PHP error detected"
+            return
+        fi
+
+        # Check for expected content
+        if ! grep -qi "$expect" "$TMPFILE"; then
+            FAIL=$((FAIL + 1))
+            ERRORS="${ERRORS}\n  FAIL: $name — missing expected content: $expect"
+            return
+        fi
+    fi
+
+    PASS=$((PASS + 1))
+    echo "  OK: $name"
+}
+
+echo "Smoke testing $BASE ..."
+echo ""
+
+check "Homepage"     "$BASE/ibl5/index.php"                                 "IBL"
+check "Standings"    "$BASE/ibl5/modules.php?name=Standings"                "Standings"
+check "Team page"    "$BASE/ibl5/modules.php?name=Team&op=team&teamID=1"    "team"
+check "Player page"  "$BASE/ibl5/modules.php?name=Player&pa=showpage&pid=1" "player"
+check "Login page"   "$BASE/ibl5/modules.php?name=YourAccount"              "Sign In"
+check "API routing"   "$BASE/ibl5/api/v1/season"                             "" "200|401"
+check "CSS asset"    "$BASE/ibl5/themes/IBL/style/style.css"                ""
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "\nFailures:$ERRORS"
+    exit 1
+fi

--- a/ibl5/package.json
+++ b/ibl5/package.json
@@ -19,7 +19,8 @@
     "wt:up": "cd .. && bin/wt-up",
     "wt:down": "cd .. && bin/wt-down",
     "wt:list": "cd .. && bin/wt-list",
-    "lighthouse": "bunx @lhci/cli autorun"
+    "lighthouse": "bunx @lhci/cli autorun",
+    "smoke:prod": "cd .. && bin/smoke-prod"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",


### PR DESCRIPTION
## Summary

Adds a lightweight production smoke test suite that verifies the live site is healthy after deploys and on a daily schedule.

### What It Does

`bin/smoke-prod` runs 7 curl-based HTTP checks in ~30 seconds:

| Check | URL | Validates |
|-------|-----|-----------|
| Homepage | `/ibl5/index.php` | Server up, PHP running, DB connected, template rendering |
| Standings | `/ibl5/modules.php?name=Standings` | Module system, database queries |
| Team page | `/ibl5/modules.php?name=Team&op=team&teamID=1` | Dynamic routing, team data |
| Player page | `/ibl5/modules.php?name=Player&pa=showpage&pid=1` | Player module, stats |
| Login page | `/ibl5/modules.php?name=YourAccount` | Auth UI rendering |
| API routing | `/ibl5/api/v1/season` | API middleware chain (accepts 200 or 401) |
| CSS asset | `/ibl5/themes/IBL/style/style.css` | Build artifacts deployed |

Each check verifies HTTP status, absence of PHP errors, and expected content keywords.

### Triggers

1. **Post-deploy** — runs automatically after the "Build and Deploy" workflow completes
2. **Manual** — `gh workflow run smoke-prod.yml` with optional custom URL
3. **Daily** — 8am UTC health check via cron schedule
4. **Inline** — post-deploy step added to `main.yml` deploy job

### Usage

```bash
bin/smoke-prod                              # Test production (default)
bin/smoke-prod http://main.localhost         # Test local Docker
bin/smoke-prod https://staging.example.com   # Test any environment
```

## Manual Testing

- [x] Verified against production: 7/7 pass
- [x] Verified against local Docker: 7/7 pass
- [ ] After merge, trigger manually via Actions tab to confirm the workflow runs in CI