### PR TITLE
feat: add post-migration schema validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,14 @@ jobs:
             php ibl5/bin/migrate
           '
 
+      - name: Validate database schema
+        run: |
+          ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} '
+            set -e
+            cd www
+            php ibl5/bin/validate-schema
+          '
+
       - name: Deploy compiled CSS to server
         run: scp -P ${{ secrets.PORT }} -i ~/.ssh/id_deploy ibl5/themes/IBL/style/style.css ${{ secrets.USERNAME }}@${{ secrets.HOST }}:www/ibl5/themes/IBL/style/style.css
 

--- a/ibl5/bin/migrate
+++ b/ibl5/bin/migrate
@@ -38,13 +38,45 @@ if (in_array('--status', $argv, true)) {
     exit(0);
 }
 
+/**
+ * Run post-migration schema validation.
+ *
+ * @return int Exit code (0 = pass, 1 = fail)
+ */
+function validateSchema(\mysqli $db): int
+{
+    $assertionsFile = dirname(__DIR__) . '/config/schema-assertions.php';
+    if (!file_exists($assertionsFile)) {
+        return 0;
+    }
+
+    /** @var list<\Migration\SchemaAssertion> $assertions */
+    $assertions = require $assertionsFile;
+
+    $validator = new \Migration\SchemaValidator($db);
+    $result = $validator->validate($assertions);
+
+    if ($result->passed) {
+        echo "Schema validation passed (" . count($assertions) . " assertions).\n";
+        return 0;
+    }
+
+    echo "SCHEMA VALIDATION FAILED:\n";
+    foreach ($result->missing as $column) {
+        echo "  MISSING: {$column}\n";
+    }
+    echo "\n" . count($result->missing) . " missing column(s) detected.\n";
+    return 1;
+}
+
 // Default: run all pending migrations
 try {
     $pending = $runner->getPending();
 
     if ($pending === []) {
         echo "Nothing to migrate.\n";
-        exit(0);
+        $exitCode = validateSchema($mysqli_db);
+        exit($exitCode);
     }
 
     // Guard: if there are pending migrations but migrate-seed hasn't been run,
@@ -63,7 +95,8 @@ try {
     foreach ($executed as $filename) {
         echo "  - {$filename}\n";
     }
-    exit(0);
+    $exitCode = validateSchema($mysqli_db);
+    exit($exitCode);
 } catch (\RuntimeException $e) {
     echo "Migration failed: " . $e->getMessage() . "\n";
     exit(1);

--- a/ibl5/bin/validate-schema
+++ b/ibl5/bin/validate-schema
@@ -1,0 +1,35 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+if (php_sapi_name() !== 'cli') {
+    http_response_code(403);
+    exit('This script must be run from the command line.');
+}
+
+$_SERVER['DOCUMENT_ROOT'] = dirname(__DIR__, 2);
+require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/vendor/autoload.php';
+include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/config.php';
+include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/db/db.php';
+
+/** @var \mysqli $mysqli_db */
+
+/** @var list<\Migration\SchemaAssertion> $assertions */
+$assertions = require dirname(__DIR__) . '/config/schema-assertions.php';
+
+$validator = new \Migration\SchemaValidator($mysqli_db);
+$result = $validator->validate($assertions);
+
+if ($result->passed) {
+    echo "Schema validation passed (" . count($assertions) . " assertions).\n";
+    exit(0);
+}
+
+echo "SCHEMA VALIDATION FAILED:\n";
+foreach ($result->missing as $column) {
+    echo "  MISSING: {$column}\n";
+}
+echo "\n" . count($result->missing) . " missing column(s) detected.\n";
+echo "Run the appropriate migration or ALTER TABLE to fix.\n";
+exit(1);

--- a/ibl5/classes/Migration/SchemaAssertion.php
+++ b/ibl5/classes/Migration/SchemaAssertion.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migration;
+
+/**
+ * A single schema assertion: verifies that a column exists in a table.
+ */
+final class SchemaAssertion
+{
+    public function __construct(
+        public readonly string $table,
+        public readonly string $column,
+    ) {
+    }
+
+    public function toKey(): string
+    {
+        return $this->table . '.' . $this->column;
+    }
+}

--- a/ibl5/classes/Migration/SchemaValidationResult.php
+++ b/ibl5/classes/Migration/SchemaValidationResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migration;
+
+/**
+ * Result of schema validation: pass/fail with list of missing columns.
+ */
+final class SchemaValidationResult
+{
+    /**
+     * @param list<string> $missing Missing columns as "table.column" strings
+     */
+    public function __construct(
+        public readonly bool $passed,
+        public readonly array $missing,
+    ) {
+    }
+}

--- a/ibl5/classes/Migration/SchemaValidator.php
+++ b/ibl5/classes/Migration/SchemaValidator.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migration;
+
+/**
+ * Validates that the actual database schema matches expected column assertions.
+ *
+ * Uses a single batched INFORMATION_SCHEMA query to check all assertions at once.
+ * Designed to run after migrations to catch silent no-ops (e.g., IF EXISTS guards
+ * that swallowed a failed column rename).
+ */
+class SchemaValidator extends \BaseMysqliRepository
+{
+    /**
+     * Validate that all asserted columns exist in the database.
+     *
+     * @param list<SchemaAssertion> $assertions
+     */
+    public function validate(array $assertions): SchemaValidationResult
+    {
+        if ($assertions === []) {
+            return new SchemaValidationResult(passed: true, missing: []);
+        }
+
+        $expectedKeys = [];
+        $tuples = [];
+
+        foreach ($assertions as $assertion) {
+            $expectedKeys[] = $assertion->toKey();
+            $tuples[] = '(' . $this->quote($assertion->table) . ', ' . $this->quote($assertion->column) . ')';
+        }
+
+        $tupleList = implode(', ', $tuples);
+
+        /** @var list<array{TABLE_NAME: string, COLUMN_NAME: string}> $rows */
+        $rows = $this->fetchAll(
+            "SELECT TABLE_NAME, COLUMN_NAME
+             FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND (TABLE_NAME, COLUMN_NAME) IN ({$tupleList})"
+        );
+
+        $foundKeys = [];
+        foreach ($rows as $row) {
+            $foundKeys[] = $row['TABLE_NAME'] . '.' . $row['COLUMN_NAME'];
+        }
+
+        $missing = array_values(array_diff($expectedKeys, $foundKeys));
+
+        return new SchemaValidationResult(
+            passed: $missing === [],
+            missing: $missing,
+        );
+    }
+
+    private function quote(string $value): string
+    {
+        return "'" . $this->db->real_escape_string($value) . "'";
+    }
+}

--- a/ibl5/config/schema-assertions.php
+++ b/ibl5/config/schema-assertions.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Migration\SchemaAssertion;
+
+/**
+ * Schema assertions: critical columns that must exist in the database.
+ *
+ * Convention: When writing a migration that renames or drops a column that
+ * PHP code depends on, add a SchemaAssertion here for the destination column.
+ * The post-migration validator will catch silent no-ops (e.g., IF EXISTS guards
+ * that swallowed a failed column rename).
+ *
+ * For new migrations: drop `IF EXISTS` from CHANGE COLUMN — let renames fail
+ * loudly if the source column is missing. `IF NOT EXISTS` on CREATE TABLE and
+ * ADD COLUMN remains fine (truly idempotent).
+ *
+ * @return list<SchemaAssertion>
+ */
+return [
+    // Migration 062: dc_active → dc_canPlayInGame (caused production outage)
+    new SchemaAssertion('ibl_plr', 'dc_canPlayInGame'),
+    new SchemaAssertion('ibl_saved_depth_chart_players', 'dc_canPlayInGame'),
+    new SchemaAssertion('ibl_olympics_saved_depth_chart_players', 'dc_canPlayInGame'),
+
+    // Migration 059: reserved-word renames (from → trade_from, to → trade_to)
+    new SchemaAssertion('ibl_trade_info', 'trade_from'),
+    new SchemaAssertion('ibl_trade_info', 'trade_to'),
+
+    // High-usage baseline columns (referenced by many repositories)
+    new SchemaAssertion('ibl_plr', 'pid'),
+    new SchemaAssertion('ibl_plr', 'tid'),
+    new SchemaAssertion('ibl_plr', 'name'),
+    new SchemaAssertion('ibl_team_info', 'teamid'),
+    new SchemaAssertion('ibl_team_info', 'team_name'),
+    new SchemaAssertion('ibl_team_info', 'gm_username'),
+    new SchemaAssertion('ibl_settings', 'name'),
+    new SchemaAssertion('ibl_settings', 'value'),
+];

--- a/ibl5/tests/Migration/MigrationFileIntegrityTest.php
+++ b/ibl5/tests/Migration/MigrationFileIntegrityTest.php
@@ -109,4 +109,68 @@ final class MigrationFileIntegrityTest extends TestCase
             'Baseline schema must be the first migration in sort order'
         );
     }
+
+    /**
+     * Enforce convention: every CHANGE COLUMN IF EXISTS rename should have
+     * a corresponding SchemaAssertion for the destination column.
+     *
+     * This prevents silent no-ops from going undetected (the bug that caused
+     * the dc_canPlayInGame production outage).
+     */
+    public function testChangeColumnRenamesHaveSchemaAssertions(): void
+    {
+        $assertionsFile = dirname(__DIR__, 2) . '/config/schema-assertions.php';
+        self::assertFileExists($assertionsFile, 'Schema assertions config file must exist');
+
+        /** @var list<\Migration\SchemaAssertion> $assertions */
+        $assertions = require $assertionsFile;
+
+        $assertedColumns = [];
+        foreach ($assertions as $assertion) {
+            $assertedColumns[] = $assertion->toKey();
+        }
+
+        $files = glob($this->migrationsDir . '/*.sql') ?: [];
+        $uncovered = [];
+
+        foreach ($files as $file) {
+            $basename = basename($file);
+            // Skip baseline — it defines schema, not renames
+            if ($basename === '000_baseline_schema.sql') {
+                continue;
+            }
+
+            $content = file_get_contents($file);
+            if ($content === false) {
+                continue;
+            }
+
+            // Match: CHANGE COLUMN IF EXISTS `old_name` `new_name`
+            // or:    CHANGE COLUMN IF EXISTS old_name new_name
+            if (preg_match_all(
+                '/ALTER\s+TABLE\s+[`]?(\w+)[`]?\s+.*?CHANGE\s+COLUMN\s+IF\s+EXISTS\s+[`]?\w+[`]?\s+[`]?(\w+)[`]?/si',
+                $content,
+                $matches,
+                PREG_SET_ORDER
+            ) > 0) {
+                foreach ($matches as $match) {
+                    $table = $match[1];
+                    $destColumn = $match[2];
+                    $key = $table . '.' . $destColumn;
+
+                    if (!in_array($key, $assertedColumns, true)) {
+                        $uncovered[] = "{$key} (from {$basename})";
+                    }
+                }
+            }
+        }
+
+        self::assertSame(
+            [],
+            $uncovered,
+            "CHANGE COLUMN IF EXISTS renames without SchemaAssertions:\n  " .
+            implode("\n  ", $uncovered) .
+            "\n\nAdd SchemaAssertion entries in config/schema-assertions.php for these columns."
+        );
+    }
 }

--- a/ibl5/tests/Migration/SchemaValidatorTest.php
+++ b/ibl5/tests/Migration/SchemaValidatorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Migration;
+
+use Migration\SchemaAssertion;
+use Migration\SchemaValidationResult;
+use Migration\SchemaValidator;
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\Mocks\MockDatabase;
+
+final class SchemaValidatorTest extends TestCase
+{
+    private MockDatabase $mockDb;
+
+    protected function setUp(): void
+    {
+        $this->mockDb = new MockDatabase();
+    }
+
+    public function testEmptyAssertionsAlwaysPasses(): void
+    {
+        $validator = new SchemaValidator($this->mockDb);
+        $result = $validator->validate([]);
+
+        $this->assertTrue($result->passed);
+        $this->assertSame([], $result->missing);
+    }
+
+    public function testAllColumnsFoundPasses(): void
+    {
+        $this->mockDb->onQuery('INFORMATION_SCHEMA', [
+            ['TABLE_NAME' => 'ibl_plr', 'COLUMN_NAME' => 'dc_canPlayInGame'],
+            ['TABLE_NAME' => 'ibl_plr', 'COLUMN_NAME' => 'pid'],
+        ]);
+
+        $validator = new SchemaValidator($this->mockDb);
+        $result = $validator->validate([
+            new SchemaAssertion('ibl_plr', 'dc_canPlayInGame'),
+            new SchemaAssertion('ibl_plr', 'pid'),
+        ]);
+
+        $this->assertTrue($result->passed);
+        $this->assertSame([], $result->missing);
+    }
+
+    public function testMissingColumnFails(): void
+    {
+        $this->mockDb->onQuery('INFORMATION_SCHEMA', [
+            ['TABLE_NAME' => 'ibl_plr', 'COLUMN_NAME' => 'pid'],
+        ]);
+
+        $validator = new SchemaValidator($this->mockDb);
+        $result = $validator->validate([
+            new SchemaAssertion('ibl_plr', 'dc_canPlayInGame'),
+            new SchemaAssertion('ibl_plr', 'pid'),
+        ]);
+
+        $this->assertFalse($result->passed);
+        $this->assertSame(['ibl_plr.dc_canPlayInGame'], $result->missing);
+    }
+
+    public function testMultipleMissingColumns(): void
+    {
+        $this->mockDb->onQuery('INFORMATION_SCHEMA', []);
+
+        $validator = new SchemaValidator($this->mockDb);
+        $result = $validator->validate([
+            new SchemaAssertion('ibl_plr', 'dc_canPlayInGame'),
+            new SchemaAssertion('ibl_trade_info', 'trade_from'),
+        ]);
+
+        $this->assertFalse($result->passed);
+        $this->assertCount(2, $result->missing);
+        $this->assertContains('ibl_plr.dc_canPlayInGame', $result->missing);
+        $this->assertContains('ibl_trade_info.trade_from', $result->missing);
+    }
+
+    public function testPartialMatchReportsOnlyMissing(): void
+    {
+        $this->mockDb->onQuery('INFORMATION_SCHEMA', [
+            ['TABLE_NAME' => 'ibl_plr', 'COLUMN_NAME' => 'pid'],
+            ['TABLE_NAME' => 'ibl_team_info', 'COLUMN_NAME' => 'teamid'],
+        ]);
+
+        $validator = new SchemaValidator($this->mockDb);
+        $result = $validator->validate([
+            new SchemaAssertion('ibl_plr', 'pid'),
+            new SchemaAssertion('ibl_plr', 'dc_canPlayInGame'),
+            new SchemaAssertion('ibl_team_info', 'teamid'),
+            new SchemaAssertion('ibl_trade_info', 'trade_from'),
+        ]);
+
+        $this->assertFalse($result->passed);
+        $this->assertSame([
+            'ibl_plr.dc_canPlayInGame',
+            'ibl_trade_info.trade_from',
+        ], $result->missing);
+    }
+
+    public function testSchemaAssertionToKey(): void
+    {
+        $assertion = new SchemaAssertion('ibl_plr', 'dc_canPlayInGame');
+        $this->assertSame('ibl_plr.dc_canPlayInGame', $assertion->toKey());
+    }
+
+    public function testValidationResultProperties(): void
+    {
+        $passed = new SchemaValidationResult(passed: true, missing: []);
+        $this->assertTrue($passed->passed);
+        $this->assertSame([], $passed->missing);
+
+        $failed = new SchemaValidationResult(passed: false, missing: ['ibl_plr.xyz']);
+        $this->assertFalse($failed->passed);
+        $this->assertSame(['ibl_plr.xyz'], $failed->missing);
+    }
+}


### PR DESCRIPTION
## Context

Migration 062 (`dc_active` → `dc_canPlayInGame`) used `CHANGE COLUMN IF EXISTS` which silently no-oped on production. The migration was recorded as applied but the column was never renamed, causing `Unknown column 'dc_canPlayInGame'` at runtime and breaking DepthChartEntry.

**Root cause:** The migration runner only checks `errno !== 0` — a no-op `IF EXISTS` ALTER returns errno=0. Nothing verified the schema *outcome*.

## Changes

### Schema Validator (`SchemaValidator`, `SchemaAssertion`, `SchemaValidationResult`)
- Single batched INFORMATION_SCHEMA query checks all critical columns at once
- Returns pass/fail with list of missing `table.column` entries

### Schema Assertions Config (`config/schema-assertions.php`)
- Curated list of critical columns: dc_canPlayInGame (062 outage), trade_from/trade_to (059 reserved-word renames), high-usage baseline columns
- Convention documented: add an assertion for every renamed/added column that PHP code depends on

### Integration
- `bin/migrate` runs validation after migrations and when none are pending (catches drift on every deploy)
- `bin/validate-schema` standalone CLI
- Deploy workflow adds explicit validation step after migrations

### Convention Enforcement
- `MigrationFileIntegrityTest` scans migrations for `CHANGE COLUMN IF EXISTS` and verifies each destination column has a `SchemaAssertion` — prevents future silent no-ops

## Manual Testing
No manual testing needed — all changes are covered by unit tests. The `bin/validate-schema` CLI can be tested against Docker: `docker exec ibl5-php php /var/www/html/ibl5/bin/validate-schema`