### PR TITLE
fix: improve API e2e test robustness

### DIFF
--- a/ibl5/test-state.php
+++ b/ibl5/test-state.php
@@ -72,7 +72,16 @@ $ALLOWLIST = [
 ];
 
 $method = $_SERVER['REQUEST_METHOD'];
+$action = $_GET['action'] ?? '';
 header('Content-Type: application/json');
+
+// DELETE ?action=clear-throttle — clear auth throttling for E2E login
+if ($method === 'DELETE' && $action === 'clear-throttle') {
+    $db->query('DELETE FROM auth_users_throttling WHERE 1=1');
+    echo json_encode(['cleared' => $db->affected_rows]);
+    $db->close();
+    exit;
+}
 
 if ($method === 'GET') {
     $result = $db->query('SELECT name, value FROM ibl_settings');

--- a/ibl5/tests/e2e/auth.setup.ts
+++ b/ibl5/tests/e2e/auth.setup.ts
@@ -2,7 +2,7 @@ import { test as setup, expect } from '@playwright/test';
 
 const authFile = 'playwright/.auth/user.json';
 
-setup('authenticate', async ({ page }) => {
+setup('authenticate', async ({ page, request }) => {
   const username = process.env.IBL_TEST_USER;
   const password = process.env.IBL_TEST_PASS;
 
@@ -12,6 +12,10 @@ setup('authenticate', async ({ page }) => {
       'Copy .env.test.example to .env.test and fill in your credentials.'
     );
   }
+
+  // Clear auth throttling before login — repeated test runs accumulate
+  // failed attempts that trigger "Too many login attempts" and block auth.
+  await request.delete('test-state.php?action=clear-throttle');
 
   await page.goto('modules.php?name=YourAccount');
   const loginForm = page.locator('form', { has: page.locator('#login-username') });

--- a/ibl5/tests/e2e/flows/api.spec.ts
+++ b/ibl5/tests/e2e/flows/api.spec.ts
@@ -272,16 +272,13 @@ test.describe('API v1 — response envelope validation', () => {
   });
 
   test('Content-Type header is application/json', async ({ request }) => {
-    // Retry — PHP built-in server in CI can serve HTML homepage under load
+    // Verify JSON Content-Type regardless of auth status (200 or 401).
+    // Retry — PHP built-in server in CI can serve HTML homepage under load.
     let lastContentType = '';
     for (let attempt = 0; attempt < 3; attempt++) {
       const response = await request.get(`${BASE_URL}/season`, {
         headers: authHeaders,
       });
-      if (response.status() === 401) {
-        test.skip(true, 'API key not configured — 401 response');
-        return;
-      }
 
       lastContentType = response.headers()['content-type'] ?? '';
       if (lastContentType.includes('json')) {
@@ -327,8 +324,12 @@ test.describe('API v1 — ETag caching', () => {
     const response = await request.get(`${BASE_URL}/standings`, {
       headers: authHeaders,
     });
+
     if (response.status() === 401) {
-      test.skip(true, 'API key not configured — 401 response');
+      // Without a valid API key, verify the 401 error structure instead.
+      // ETag is a 200-only feature — this validates the auth path works.
+      const body = await response.json();
+      expect(body).toHaveProperty('error');
       return;
     }
     expect(response.status()).toBe(200);
@@ -363,11 +364,10 @@ test.describe('API v1 — error handling', () => {
         await new Promise((r) => setTimeout(r, 200));
         continue;
       }
-      if (lastStatus === 401) {
-        const body = await response.json();
-        expect(body).toHaveProperty('error');
-        expect(body.error).toBeTruthy();
-      }
+      expect(lastStatus, 'Empty API key should return 401').toBe(401);
+      const body = await response.json();
+      expect(body).toHaveProperty('error');
+      expect(body.error).toBeTruthy();
       return;
     }
     expect(lastStatus, '/season (unauth) returned non-JSON after 5 attempts').toBe(401);


### PR DESCRIPTION
## Problem

API e2e tests kept failing due to auth throttling. Repeated test runs accumulate failed login attempts in `auth_users_throttling`, triggering "Too many login attempts" which blocks the auth setup and cascades to fail all 43 downstream tests.

Additionally, two tests used `test.skip()` (banned anti-pattern) and one test had a silent-pass bug.

## Changes

### Auth Throttling Self-Healing
- **test-state.php**: Add `DELETE ?action=clear-throttle` endpoint to clear the `auth_users_throttling` table
- **auth.setup.ts**: Call the clear-throttle endpoint before login so every test run starts with a clean throttling state

### Remove `test.skip()` Anti-Pattern
- **Content-Type test**: Verify JSON Content-Type for both 200 and 401 responses instead of skipping when API key is absent
- **ETag test**: Validate 401 error structure when API key is absent instead of skipping; preserves full ETag/304 validation when key exists

### Fix Silent-Pass Bug
- **Unauthenticated request test**: Always assert 401 status on JSON responses. Previously, non-401 JSON responses silently passed without any assertion.

## Testing

- All 44 API e2e tests pass with single worker (`--workers=1`)
- All 44 pass with default 4 workers
- 0 skipped (previously 2 were skipped)