### PR TITLE
fix: add missing dc_canPlayInGame column to olympics depth chart table

### DIFF
--- a/ibl5/migrations/069_fix_missing_dc_canPlayInGame.sql
+++ b/ibl5/migrations/069_fix_missing_dc_canPlayInGame.sql
@@ -1,0 +1,13 @@
+-- Fix: ensure dc_canPlayInGame exists on ibl_olympics_saved_depth_chart_players.
+--
+-- Migration 062 used CHANGE COLUMN IF EXISTS to rename dc_active → dc_canPlayInGame,
+-- but the IF EXISTS guard silently no-oped when dc_active was already gone.
+-- The post-migration schema validator (PR #449) catches this missing column.
+
+-- Attempt the rename in case dc_active still exists on some installations
+ALTER TABLE `ibl_olympics_saved_depth_chart_players`
+    CHANGE COLUMN IF EXISTS `dc_active` `dc_canPlayInGame` TINYINT(4) NOT NULL DEFAULT 1 COMMENT 'Can play in game (1=yes)';
+
+-- If neither column exists, add dc_canPlayInGame directly
+ALTER TABLE `ibl_olympics_saved_depth_chart_players`
+    ADD COLUMN IF NOT EXISTS `dc_canPlayInGame` TINYINT(4) NOT NULL DEFAULT 1 COMMENT 'Can play in game (1=yes)' AFTER `dc_CDepth`;


### PR DESCRIPTION
## Summary

Fixes a production deploy blocker caused by migration 062's `CHANGE COLUMN IF EXISTS` silently no-oping when `dc_active` was already gone from `ibl_olympics_saved_depth_chart_players`.

The post-migration schema validator (PR #449) catches this missing column and blocks all deploys until fixed.

### Fix
Adds migration 069 which:
1. Attempts the rename (`dc_active` → `dc_canPlayInGame`) in case `dc_active` still exists
2. Falls back to `ADD COLUMN IF NOT EXISTS` to create `dc_canPlayInGame` directly

### Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.