### PR TITLE
ci: append failure summary to bottom of PHPUnit output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,14 +69,11 @@ jobs:
         if [ $PHPUNIT_EXIT -ne 0 ]; then
           echo ""
           echo "════════════════════════════════════════"
-          echo "  FAILING TESTS"
+          echo "  FAILURE SUMMARY"
           echo "════════════════════════════════════════"
-          sed 's/\x1b\[[0-9;]*m//g' /tmp/phpunit-output.txt | grep '✘' || true
+          sed 's/\x1b\[[0-9;]*m//g' /tmp/phpunit-output.txt | awk '/✔/{show=0} /✘/{show=1} show' || true
           echo ""
-          echo "════════════════════════════════════════"
-          echo "  FAILURE DETAILS"
-          echo "════════════════════════════════════════"
-          sed 's/\x1b\[[0-9;]*m//g' /tmp/phpunit-output.txt | awk '/^There (was|were) [0-9]+ (failure|error)/,0' || true
+          sed 's/\x1b\[[0-9;]*m//g' /tmp/phpunit-output.txt | awk '/^FAILURES!$/,0' || true
           echo "════════════════════════════════════════"
         fi
         exit $PHPUNIT_EXIT


### PR DESCRIPTION
## Problem
GitHub Actions auto-scrolls to the bottom of step output. With `--testdox`, there are hundreds of passing test lines, making it hard to find failures.

## Solution
- Wrap full PHPUnit output in a `::group::` block (collapsed by default when viewing a failed step)
- On failure, append a **FAILING TESTS** section (test names with ✘) and **FAILURE DETAILS** section (assertion messages + file:line) outside the group
- Strip ANSI color codes so the summary is clean for copy-paste

When a test fails, GitHub shows:
1. Collapsed "Full PHPUnit output" group (expandable if needed)
2. Immediately visible failure summary at the bottom

No behavior change when all tests pass.