### PR TITLE
fix: restore vendor symlink after Docker teardown

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -8,6 +8,17 @@
 #   bin/test --testsuite "Module"     # Single suite
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$SCRIPT_DIR/../ibl5" || exit 1
+IBL5_DIR="$SCRIPT_DIR/../ibl5"
+cd "$IBL5_DIR" || exit 1
+
+# Auto-heal vendor symlink if empty (wt-up replaces it with an empty dir for Docker)
+if [ ! -d "vendor/bin" ]; then
+    MAIN_VENDOR=$(echo "$IBL5_DIR" | sed 's|/worktrees/.*/ibl5|/ibl5/vendor|')
+    if [ -d "$MAIN_VENDOR/bin" ]; then
+        chmod -N vendor 2>/dev/null  # clear Docker's deny-delete ACL
+        rm -rf vendor
+        ln -sf "$MAIN_VENDOR" vendor
+    fi
+fi
 
 exec vendor/bin/phpunit --no-progress --no-output --testdox-summary "$@"

--- a/bin/wt-down
+++ b/bin/wt-down
@@ -81,6 +81,17 @@ teardown_worktree() {
     fi
 
     rm -f "$compose_file"
+
+    # Restore vendor symlink so host-side tools (PHPStan, PHPUnit) work again.
+    # wt-up replaces the symlink with an empty dir for Docker bind mounts;
+    # without this restore, vendor/bin/* is missing after teardown.
+    local vendor_dir="$wt_path/ibl5/vendor"
+    if [ -d "$vendor_dir" ] && [ ! -L "$vendor_dir" ] && [ -d "$REPO_ROOT/ibl5/vendor/bin" ]; then
+        chmod -N "$vendor_dir" 2>/dev/null  # clear Docker's deny-delete ACL
+        rm -rf "$vendor_dir"
+        ln -sf "$REPO_ROOT/ibl5/vendor" "$vendor_dir"
+    fi
+
     echo "  Done."
 }
 


### PR DESCRIPTION
## Problem

`bin/wt-up` replaces the `vendor/` symlink with an empty directory (required for Docker bind mounts), but `bin/wt-down` never restores it. After Docker teardown, `vendor/bin/*` is missing and PHPStan/PHPUnit cannot run from the host. 4 of 5 active worktrees had broken empty `vendor/` directories.

An additional complication: Docker sets a macOS ACL (`deny delete`) on the empty vendor directory, so `rm -rf` fails without `chmod -N` first.

## Changes

### `bin/wt-down`
- Restore vendor symlink to main repo after `docker compose down`
- Clear Docker's deny-delete ACL before removing the directory

### `bin/test`
- Auto-heal vendor symlink if `vendor/bin/` is missing when running from a worktree
- Same ACL-clearing pattern

### PostToolUse hooks (`.claude/settings.local.json`, not in this PR)
- Updated PHPStan and PHPUnit hooks to auto-heal vendor symlinks
- Hooks now derive `ibl5/` directory from the edited file path (not hardcoded)

## Manual Testing

No manual testing needed — changes are to shell scripts with no PHP code. Verified PHPStan and PHPUnit run successfully in worktrees after the fix.