### PR TITLE
feat: add Monolog request context processors for log enrichment

### DIFF
--- a/ibl5/classes/Logging/LoggerFactory.php
+++ b/ibl5/classes/Logging/LoggerFactory.php
@@ -11,6 +11,9 @@ use Monolog\Handler\RotatingFileHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Level;
 use Monolog\Logger;
+use Monolog\Processor\ProcessorInterface;
+use Monolog\Processor\UidProcessor;
+use Monolog\Processor\WebProcessor;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -38,6 +41,9 @@ class LoggerFactory implements LoggerFactoryInterface
     /** @var list<\Monolog\Handler\HandlerInterface> */
     private array $handlers;
 
+    /** @var list<ProcessorInterface> */
+    private array $processors;
+
     /** @var LoggingConfig */
     private const DEFAULT_CONFIG = [
         'log_dir' => null,
@@ -47,10 +53,12 @@ class LoggerFactory implements LoggerFactoryInterface
 
     /**
      * @param list<\Monolog\Handler\HandlerInterface> $handlers
+     * @param list<ProcessorInterface> $processors
      */
-    private function __construct(array $handlers)
+    private function __construct(array $handlers, array $processors = [])
     {
         $this->handlers = $handlers;
+        $this->processors = $processors;
         self::$instance = $this;
     }
 
@@ -103,7 +111,13 @@ class LoggerFactory implements LoggerFactoryInterface
             $handlers[] = $cliHandler;
         }
 
-        return new self($handlers);
+        $processors = [
+            new UidProcessor(7),
+            new WebProcessor(),
+            new UserContextProcessor(),
+        ];
+
+        return new self($handlers, $processors);
     }
 
     /**
@@ -125,6 +139,9 @@ class LoggerFactory implements LoggerFactoryInterface
             $logger = new Logger($channel);
             foreach ($this->handlers as $handler) {
                 $logger->pushHandler($handler);
+            }
+            foreach ($this->processors as $processor) {
+                $logger->pushProcessor($processor);
             }
             $this->channels[$channel] = $logger;
         }

--- a/ibl5/classes/Logging/UserContextProcessor.php
+++ b/ibl5/classes/Logging/UserContextProcessor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Logging;
+
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+
+/**
+ * Adds authenticated user context to log records from the PHP session.
+ *
+ * Reads $_SESSION lazily at log-emission time so the processor can be
+ * constructed before AuthService resolves the session. In CLI or
+ * unauthenticated contexts the extra keys are simply omitted.
+ */
+class UserContextProcessor implements ProcessorInterface
+{
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $userId = $_SESSION['auth_user_id'] ?? null;
+        $username = $_SESSION['auth_username'] ?? null;
+
+        if (is_int($userId) && $userId > 0) {
+            $record->extra['user_id'] = $userId;
+        }
+
+        if (is_string($username) && $username !== '') {
+            $record->extra['username'] = $username;
+        }
+
+        return $record;
+    }
+}

--- a/ibl5/tests/Logging/LoggerFactoryTest.php
+++ b/ibl5/tests/Logging/LoggerFactoryTest.php
@@ -108,4 +108,24 @@ class LoggerFactoryTest extends TestCase
 
         $this->assertSame('discord', $logger->getName());
     }
+
+    public function testFromConfigAttachesProcessors(): void
+    {
+        $factory = LoggerFactory::fromConfig();
+
+        /** @var Logger $logger */
+        $logger = $factory->channel('app');
+
+        $this->assertCount(3, $logger->getProcessors());
+    }
+
+    public function testForTestsHasNoProcessors(): void
+    {
+        $factory = LoggerFactory::forTests();
+
+        /** @var Logger $logger */
+        $logger = $factory->channel('test');
+
+        $this->assertCount(0, $logger->getProcessors());
+    }
 }

--- a/ibl5/tests/Logging/UserContextProcessorTest.php
+++ b/ibl5/tests/Logging/UserContextProcessorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Logging;
+
+use Logging\UserContextProcessor;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\TestCase;
+
+class UserContextProcessorTest extends TestCase
+{
+    private UserContextProcessor $processor;
+
+    /** @var array<string, mixed> */
+    private array $originalSession;
+
+    protected function setUp(): void
+    {
+        $this->processor = new UserContextProcessor();
+        $this->originalSession = $_SESSION ?? [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = $this->originalSession;
+    }
+
+    public function testAddsUserContextWhenAuthenticated(): void
+    {
+        $_SESSION['auth_user_id'] = 42;
+        $_SESSION['auth_username'] = 'jsmith';
+
+        $record = ($this->processor)($this->createRecord());
+
+        $this->assertSame(42, $record->extra['user_id']);
+        $this->assertSame('jsmith', $record->extra['username']);
+    }
+
+    public function testOmitsContextWhenUnauthenticated(): void
+    {
+        $_SESSION = [];
+
+        $record = ($this->processor)($this->createRecord());
+
+        $this->assertArrayNotHasKey('user_id', $record->extra);
+        $this->assertArrayNotHasKey('username', $record->extra);
+    }
+
+    public function testRejectsWrongTypes(): void
+    {
+        $_SESSION['auth_user_id'] = '5';
+        $_SESSION['auth_username'] = 123;
+
+        $record = ($this->processor)($this->createRecord());
+
+        $this->assertArrayNotHasKey('user_id', $record->extra);
+        $this->assertArrayNotHasKey('username', $record->extra);
+    }
+
+    public function testPreservesExistingExtra(): void
+    {
+        $_SESSION['auth_user_id'] = 1;
+        $_SESSION['auth_username'] = 'admin';
+
+        $record = $this->createRecord(['foo' => 'bar']);
+        $result = ($this->processor)($record);
+
+        $this->assertSame('bar', $result->extra['foo']);
+        $this->assertSame(1, $result->extra['user_id']);
+        $this->assertSame('admin', $result->extra['username']);
+    }
+
+    /**
+     * @param array<string, mixed> $extra
+     */
+    private function createRecord(array $extra = []): LogRecord
+    {
+        return new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'test',
+            level: Level::Info,
+            message: 'test message',
+            extra: $extra,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds three Monolog processors to automatically enrich every log entry with request context. Zero changes to existing log call sites — processors run globally via LoggerFactory.

## Processors

| Processor | Source | Fields Added | CLI Behavior |
|-----------|--------|-------------|--------------|
| UidProcessor | Built-in | `extra.uid` (7-char hex) | Always active |
| WebProcessor | Built-in | `extra.url`, `ip`, `http_method`, `server`, `referrer` | Auto-skips |
| UserContextProcessor | Custom | `extra.username`, `extra.user_id` | Auto-skips |

## Design Decisions

- **Reuse built-in processors** — UidProcessor and WebProcessor are battle-tested Monolog components
- **Lazy session reads** — UserContextProcessor reads `$_SESSION` at log-emission time, not factory construction time, so it works even though LoggerFactory initializes before AuthService
- **Type-safe** — `is_int()`/`is_string()` narrowing on session values (PHPStan level max)
- **Test isolation** — `forTests()` passes empty processor list; NullHandler already discards output

## Example JSON Output

```json
{
  "extra": {
    "uid": "3f2a9c1",
    "url": "/ibl5/modules.php?name=Team",
    "ip": "203.0.113.42",
    "http_method": "GET",
    "server": "main.localhost",
    "referrer": null,
    "username": "john",
    "user_id": 8
  }
}
```

## Testing

- 4 new UserContextProcessor tests (authenticated, unauthenticated, wrong types, extra preservation)
- 2 new LoggerFactory tests (processor attachment for fromConfig vs forTests)
- Full suite: 4193 tests, 19515 assertions — all passing

## Manual Testing

No manual testing needed — all changes are covered by unit tests.