### PR TITLE
refactor: remove 5 legacy PHP-Nuke functions (~345 lines)

### DIFF
--- a/ibl5/classes/Bootstrap/LegacyFunctions.php
+++ b/ibl5/classes/Bootstrap/LegacyFunctions.php
@@ -96,14 +96,10 @@ function render_blocks($side, $blockfile, $title, $content, $bid, $url)
     if (!defined('BLOCK_FILE')) {
         define('BLOCK_FILE', true);
     }
-    if (empty($url)) {
-        if (empty($blockfile)) {
-            themecenterbox($title, $content);
-        } else {
-            blockfileinc($title, $blockfile, 1);
-        }
+    if (empty($blockfile)) {
+        themecenterbox($title, $content);
     } else {
-        headlines($bid, 1);
+        blockfileinc($title, $blockfile, 1);
     }
 }
 
@@ -438,18 +434,6 @@ function formatAidHeader($aid)
     echo $AidHeader;
 }
 
-if (!function_exists("themepreview")) {
-    function themepreview($title, $hometext, $bodytext = "", $notes = "")
-    {
-        echo "<b>$title</b><br><br>$hometext";
-        if (!empty($bodytext)) {
-            echo "<br><br>$bodytext";
-        }
-        if (!empty($notes)) {
-            echo "<br><br><b>" . _NOTE . "</b> <i>$notes</i>";
-        }
-    }
-}
 
 function loginbox(): void
 {
@@ -480,160 +464,4 @@ function getTopics($s_sid)
     $topictext = filter($row['topictext'], "nohtml");
 }
 
-function headlines($bid, $cenbox = 0)
-{
-    global $prefix, $db;
-    $bid = intval($bid);
-    $result = $db->sql_query("SELECT title, content, url, refresh, time FROM " . $prefix . "_blocks WHERE bid='$bid'");
-    $row = $db->sql_fetchrow($result);
-    $title = filter($row['title'], "nohtml");
-    $content = filter($row['content']);
-    $url = filter($row['url'], "nohtml");
-    $refresh = intval($row['refresh']);
-    $otime = $row['time'];
-    $past = time() - $refresh;
-    $cont = 0;
-    if ($otime < $past) {
-        $btime = time();
-        $rdf = parse_url($url);
-        $fp = fsockopen($rdf['host'], 80, $errno, $errstr, 15);
-        if (!$fp) {
-            $content = "";
-            $db->sql_query("UPDATE " . $prefix . "_blocks SET content='" . $db->db_connect_id->real_escape_string($content) . "', time='$btime' WHERE bid='$bid'");
-            $cont = 0;
-            themecenterbox($title, $content);
-            return;
-        }
-        if ($fp) {
-            if (!empty($rdf['query'])) {
-                $rdf['query'] = "?" . $rdf['query'];
-            }
 
-            fputs($fp, "GET " . $rdf['path'] . $rdf['query'] . " HTTP/1.0\r\n");
-            fputs($fp, "HOST: " . $rdf['host'] . "\r\n\r\n");
-            $string = "";
-            while (!feof($fp)) {
-                $pagetext = fgets($fp, 300);
-                $string .= chop($pagetext);
-            }
-            fputs($fp, "Connection: close\r\n\r\n");
-            fclose($fp);
-            $items = explode("</item>", $string);
-            $content = "<font class=\"content\">";
-            for ($i = 0; $i < 10; $i++) {
-                $link = preg_replace('/.*<link>/', '', $items[$i]);
-                $link = preg_replace('/<\/link>.*/', '', $link);
-                $title2 = preg_replace('/.*<title>/', '', $items[$i]);
-                $title2 = preg_replace('/<\/title>.*/', '', $title2);
-                $title2 = stripslashes($title2);
-                if (empty($items[$i]) and $cont != 1) {
-                    $content = "";
-                    $db->sql_query("UPDATE " . $prefix . "_blocks SET content='" . $db->db_connect_id->real_escape_string($content) . "', time='$btime' WHERE bid='$bid'");
-                    $cont = 0;
-                    themecenterbox($title, $content);
-                    return;
-                } else {
-                    if (strcmp($link, $title2) and !empty($items[$i])) {
-                        $cont = 1;
-                        $content .= "<strong><big>&middot;</big></strong><a href=\"$link\" target=\"new\">$title2</a><br>\n";
-                    }
-                }
-            }
-
-        }
-        $db->sql_query("UPDATE " . $prefix . "_blocks SET content='" . $db->db_connect_id->real_escape_string($content) . "', time='$btime' WHERE bid='$bid'");
-    }
-    $siteurl = str_replace("http://", "", $url);
-    $siteurl = explode("/", $siteurl);
-    if (($cont == 1) or (!empty($content))) {
-        $content .= "<br><a href=\"http://$siteurl[0]\" target=\"blank\"><b>" . _HREADMORE . "</b></a></font>";
-    } elseif (($cont == 0) or (empty($content))) {
-        $content = "<font class=\"content\">" . _RSSPROBLEM . "</font>";
-    }
-    themecenterbox($title, $content);
-}
-
-function get_theme()
-{
-    global $user, $userinfo, $Default_Theme, $name, $op;
-    if (isset($ThemeSelSave)) {
-        return $ThemeSelSave;
-    }
-
-    if (is_user($user) && ($name != "YourAccount" or $op != "logout")) {
-        getusrinfo($user);
-        if (empty($userinfo['theme'])) {
-            $userinfo['theme'] = $Default_Theme;
-        }
-
-        if (file_exists("themes/" . $userinfo['theme'] . "/theme.php")) {
-            $ThemeSel = $userinfo['theme'];
-        } else {
-            $ThemeSel = $Default_Theme;
-        }
-    } else {
-        $ThemeSel = $Default_Theme;
-    }
-    static $ThemeSelSave;
-    $ThemeSelSave = $ThemeSel;
-    return $ThemeSelSave;
-}
-
-function validate_mail($email)
-{
-    if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
-        OpenTable();
-        echo _ERRORINVEMAIL;
-        CloseTable();
-        die();
-    } else {
-        return $email;
-    }
-}
-
-function redir($content)
-{
-    global $nukeurl;
-    unset($location);
-    $content = filter($content);
-    $links = array();
-    $hrefs = array();
-    $pos = 0;
-    $linkpos = 0;
-    while (!(($pos = strpos($content, "<", $pos)) === false)) {
-        $pos++;
-        $endpos = strpos($content, ">", $pos);
-        $tag = substr($content, $pos, $endpos - $pos);
-        $tag = trim($tag);
-        if (isset($location)) {
-            if (!strcasecmp(strtok($tag, " "), "/A")) {
-                $link = substr($content, $linkpos, $pos - 1 - $linkpos);
-                $links[] = $link;
-                $hrefs[] = $location;
-                unset($location);
-            }
-            $pos = $endpos + 1;
-        } else {
-            if (!strcasecmp(strtok($tag, " "), "A")) {
-                if (preg_match('/HREF[ \t\n\r\v]*=[ \t\n\r\v]*"([^"]*)"/i', $tag, $regs));
-                elseif (preg_match('/HREF[ \t\n\r\v]*=[ \t\n\r\v]*([^ \t\n\r\v]*)/i', $tag, $regs));
-                else{
-                    $regs[1] = "";
-                }
-
-                if ($regs[1]) {
-                    $location = $regs[1];
-                }
-                $pos = $endpos + 1;
-                $linkpos = $pos;
-            } else {
-                $pos = $endpos + 1;
-            }
-        }
-    }
-    for ($i = 0; $i < sizeof($hrefs); $i++) {
-        $url = urlencode($hrefs[$i]);
-        $content = str_replace("<a href=\"$hrefs[$i]\">", "<a href=\"$nukeurl/index.php?url=$url\" target=\"_blank\">", $content);
-    }
-    return ($content);
-}

--- a/ibl5/classes/PageLayout/PageLayout.php
+++ b/ibl5/classes/PageLayout/PageLayout.php
@@ -71,7 +71,7 @@ class PageLayout
         global $slogan;
         /** @var string $name */
         global $name;
-        $ThemeSel = get_theme();
+        $ThemeSel = 'IBL';
 
         // Calculate the correct base path for resources
         $currentFileRaw = $_SERVER['SCRIPT_FILENAME'] ?? '';

--- a/ibl5/classes/Utilities/NukeCompat.php
+++ b/ibl5/classes/Utilities/NukeCompat.php
@@ -142,7 +142,7 @@ class NukeCompat
      */
     public function getTheme(): string
     {
-        return get_theme();
+        return 'IBL';
     }
 
     /**

--- a/ibl5/index.php
+++ b/ibl5/index.php
@@ -35,7 +35,7 @@ $mop = trim($mop);
 if (str_contains($name, "..") || (isset($file) && str_contains($file, "..")) || str_contains($mod_file, "..") || str_contains($mop, "..")) {
     die("You are so cool...");
 } else {
-    $ThemeSel = get_theme();
+    $ThemeSel = 'IBL';
     if (file_exists("themes/$ThemeSel/module.php")) {
         include "themes/$ThemeSel/module.php";
         if (is_active("$default_module") and file_exists("modules/$default_module/" . $mod_file . ".php")) {

--- a/ibl5/mainfile.php
+++ b/ibl5/mainfile.php
@@ -398,14 +398,10 @@ function render_blocks($side, $blockfile, $title, $content, $bid, $url)
     if (!defined('BLOCK_FILE')) {
         define('BLOCK_FILE', true);
     }
-    if (empty($url)) {
-        if (empty($blockfile)) {
-            themecenterbox($title, $content);
-        } else {
-            blockfileinc($title, $blockfile, 1);
-        }
+    if (empty($blockfile)) {
+        themecenterbox($title, $content);
     } else {
-        headlines($bid, 1);
+        blockfileinc($title, $blockfile, 1);
     }
 }
 
@@ -768,22 +764,10 @@ function formatAidHeader($aid)
 }
 
 if (!defined('FORUM_ADMIN')) {
-    $ThemeSel = get_theme();
+    $ThemeSel = 'IBL';
     include_once "themes/$ThemeSel/theme.php";
 }
 
-if (!function_exists("themepreview")) {
-    function themepreview($title, $hometext, $bodytext = "", $notes = "")
-    {
-        echo "<b>$title</b><br><br>$hometext";
-        if (!empty($bodytext)) {
-            echo "<br><br>$bodytext";
-        }
-        if (!empty($notes)) {
-            echo "<br><br><b>" . _NOTE . "</b> <i>$notes</i>";
-        }
-    }
-}
 
 function loginbox(): void
 {
@@ -818,161 +802,7 @@ function getTopics($s_sid)
     $topictext = filter($row['topictext'], "nohtml");
 }
 
-function headlines($bid, $cenbox = 0)
-{
-    global $prefix, $db;
-    $bid = intval($bid);
-    $result = $db->sql_query("SELECT title, content, url, refresh, time FROM " . $prefix . "_blocks WHERE bid='$bid'");
-    $row = $db->sql_fetchrow($result);
-    $title = filter($row['title'], "nohtml");
-    $content = filter($row['content']);
-    $url = filter($row['url'], "nohtml");
-    $refresh = intval($row['refresh']);
-    $otime = $row['time'];
-    $past = time() - $refresh;
-    $cont = 0;
-    if ($otime < $past) {
-        $btime = time();
-        $rdf = parse_url($url);
-        $fp = fsockopen($rdf['host'], 80, $errno, $errstr, 15);
-        if (!$fp) {
-            $content = "";
-            $db->sql_query("UPDATE " . $prefix . "_blocks SET content='$content', time='$btime' WHERE bid='$bid'");
-            $cont = 0;
-            themecenterbox($title, $content);
-            return;
-        }
-        if ($fp) {
-            if (!empty($rdf['query'])) {
-                $rdf['query'] = "?" . $rdf['query'];
-            }
 
-            fputs($fp, "GET " . $rdf['path'] . $rdf['query'] . " HTTP/1.0\r\n");
-            fputs($fp, "HOST: " . $rdf['host'] . "\r\n\r\n");
-            $string = "";
-            while (!feof($fp)) {
-                $pagetext = fgets($fp, 300);
-                $string .= chop($pagetext);
-            }
-            fputs($fp, "Connection: close\r\n\r\n");
-            fclose($fp);
-            $items = explode("</item>", $string);
-            $content = "<font class=\"content\">";
-            for ($i = 0; $i < 10; $i++) {
-                $link = preg_replace('/.*<link>/', '', $items[$i]);
-                $link = preg_replace('/<\/link>.*/', '', $link);
-                $title2 = preg_replace('/.*<title>/', '', $items[$i]);
-                $title2 = preg_replace('/<\/title>.*/', '', $title2);
-                $title2 = stripslashes($title2);
-                if (empty($items[$i]) and $cont != 1) {
-                    $content = "";
-                    $db->sql_query("UPDATE " . $prefix . "_blocks SET content='$content', time='$btime' WHERE bid='$bid'");
-                    $cont = 0;
-                    themecenterbox($title, $content);
-                    return;
-                } else {
-                    if (strcmp($link, $title2) and !empty($items[$i])) {
-                        $cont = 1;
-                        $content .= "<strong><big>&middot;</big></strong><a href=\"$link\" target=\"new\">$title2</a><br>\n";
-                    }
-                }
-            }
 
-        }
-        $db->sql_query("UPDATE " . $prefix . "_blocks SET content='$content', time='$btime' WHERE bid='$bid'");
-    }
-    $siteurl = str_replace("http://", "", $url);
-    $siteurl = explode("/", $siteurl);
-    if (($cont == 1) or (!empty($content))) {
-        $content .= "<br><a href=\"http://$siteurl[0]\" target=\"blank\"><b>" . _HREADMORE . "</b></a></font>";
-    } elseif (($cont == 0) or (empty($content))) {
-        $content = "<font class=\"content\">" . _RSSPROBLEM . "</font>";
-    }
-    themecenterbox($title, $content);
-}
 
-function get_theme()
-{
-    global $user, $userinfo, $Default_Theme, $name, $op;
-    if (isset($ThemeSelSave)) {
-        return $ThemeSelSave;
-    }
-
-    if (is_user($user) && ($name != "YourAccount" or $op != "logout")) {
-        getusrinfo($user);
-        if (empty($userinfo['theme'])) {
-            $userinfo['theme'] = $Default_Theme;
-        }
-
-        if (file_exists("themes/" . $userinfo['theme'] . "/theme.php")) {
-            $ThemeSel = $userinfo['theme'];
-        } else {
-            $ThemeSel = $Default_Theme;
-        }
-    } else {
-        $ThemeSel = $Default_Theme;
-    }
-    static $ThemeSelSave;
-    $ThemeSelSave = $ThemeSel;
-    return $ThemeSelSave;
-}
-
-function validate_mail($email)
-{
-    if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
-        OpenTable();
-        echo _ERRORINVEMAIL;
-        CloseTable();
-        die();
-    } else {
-        return $email;
-    }
-}
-
-function redir($content)
-{
-    global $nukeurl;
-    unset($location);
-    $content = filter($content);
-    $links = array();
-    $hrefs = array();
-    $pos = 0;
-    $linkpos = 0;
-    while (!(($pos = strpos($content, "<", $pos)) === false)) {
-        $pos++;
-        $endpos = strpos($content, ">", $pos);
-        $tag = substr($content, $pos, $endpos - $pos);
-        $tag = trim($tag);
-        if (isset($location)) {
-            if (!strcasecmp(strtok($tag, " "), "/A")) {
-                $link = substr($content, $linkpos, $pos - 1 - $linkpos);
-                $links[] = $link;
-                $hrefs[] = $location;
-                unset($location);
-            }
-            $pos = $endpos + 1;
-        } else {
-            if (!strcasecmp(strtok($tag, " "), "A")) {
-                if (preg_match('/HREF[ \t\n\r\v]*=[ \t\n\r\v]*"([^"]*)"/i', $tag, $regs));
-                elseif (preg_match('/HREF[ \t\n\r\v]*=[ \t\n\r\v]*([^ \t\n\r\v]*)/i', $tag, $regs));
-                else{
-                    $regs[1] = "";
-                }
-
-                if ($regs[1]) {
-                    $location = $regs[1];
-                }
-                $pos = $endpos + 1;
-                $linkpos = $pos;
-            } else {
-                $pos = $endpos + 1;
-            }
-        }
-    }
-    for ($i = 0; $i < sizeof($hrefs); $i++) {
-        $url = urlencode($hrefs[$i]);
-        $content = str_replace("<a href=\"$hrefs[$i]\">", "<a href=\"$nukeurl/index.php?url=$url\" target=\"_blank\">", $content);
-    }
-    return ($content);
-}
 

--- a/ibl5/modules.php
+++ b/ibl5/modules.php
@@ -60,7 +60,7 @@ if (isset($name) && $name == $_REQUEST['name']) {
             die("You are so cool...");
         }
 
-        $ThemeSel = get_theme();
+        $ThemeSel = 'IBL';
         if (file_exists("themes/$ThemeSel/modules/$name/" . $file . ".php")) {
             $modpath = "themes/$ThemeSel/";
         } else {

--- a/ibl5/modules/SiteStatistics/index.php
+++ b/ibl5/modules/SiteStatistics/index.php
@@ -24,7 +24,7 @@ if (!defined('MODULE_FILE')) {
 $module_name = basename(dirname(__FILE__));
 get_lang($module_name);
 $pagetitle = "- " . _STATS;
-$ThemeSel = get_theme();
+$ThemeSel = 'IBL';
 
 // Initialize controller
 $controller = new SiteStatistics\StatisticsController($mysqli_db, $module_name, $ThemeSel);

--- a/ibl5/modules/Topics/index.php
+++ b/ibl5/modules/Topics/index.php
@@ -29,7 +29,7 @@ $pagetitle = "- " . _ACTIVETOPICS;
 
 global $mysqli_db, $prefix, $user_prefix, $tipath, $articlecomm;
 
-$ThemeSel = get_theme();
+$ThemeSel = 'IBL';
 
 // Determine the image path: use theme-specific images if available, fall back to default
 $themePath = (is_dir("themes/{$ThemeSel}/images/topics/"))

--- a/ibl5/phpstan-rules/BanDirectNukeGlobalsRule.php
+++ b/ibl5/phpstan-rules/BanDirectNukeGlobalsRule.php
@@ -27,7 +27,6 @@ final class BanDirectNukeGlobalsRule implements Rule
         'formattimestamp',
         'getusrinfo',
         'loginbox',
-        'get_theme',
         'get_lang',
     ];
 

--- a/ibl5/phpstan-stubs/nuke-globals.stub.php
+++ b/ibl5/phpstan-stubs/nuke-globals.stub.php
@@ -67,8 +67,6 @@ function is_user(mixed $cookie): int { return 0; }
  */
 function cookiedecode(mixed $cookie): ?array { return null; }
 
-/** @return string */
-function get_theme(): string { return ''; }
 
 /** @return void */
 function get_lang(string $module): void {}

--- a/ibl5/themes/IBL/theme.php
+++ b/ibl5/themes/IBL/theme.php
@@ -114,7 +114,7 @@ function themefooter()
 function themeindex($aid, $informant, $time, $title, $counter, $topic, $thetext, $notes, $morelink, $topicname, $topicimage, $topictext)
 {
     global $tipath;
-    $ThemeSel = get_theme();
+    $ThemeSel = 'IBL';
     if (file_exists("themes/$ThemeSel/images/topics/$topicimage")) {
         $t_image = "themes/$ThemeSel/images/topics/$topicimage";
     } else {
@@ -193,7 +193,7 @@ function themeindex($aid, $informant, $time, $title, $counter, $topic, $thetext,
 function themearticle($aid, $informant, $datetime, $title, $thetext, $topic, $topicname, $topicimage, $topictext)
 {
     global $tipath, $anonymous;
-    $ThemeSel = get_theme();
+    $ThemeSel = 'IBL';
     if (file_exists("themes/$ThemeSel/images/topics/$topicimage")) {
         $t_image = "themes/$ThemeSel/images/topics/$topicimage";
     } else {


### PR DESCRIPTION
## Summary

Removes 5 legacy PHP-Nuke functions from `mainfile.php` and `LegacyFunctions.php`, eliminating ~345 lines of dead/vestigial code.

## Changes

### 1. `get_theme()` → hardcoded `"IBL"` (9 callers updated)
Only one theme exists (`themes/IBL/`), making the user-theme-selection logic dead code. All 9 callers now use the literal string `"IBL"`. Function deleted from both bootstrap files, PHPStan stub removed, `BanDirectNukeGlobalsRule` entry removed.

### 2. Dead functions deleted (zero callers each)
- **`redir()`** — legacy URL redirect wrapper for tracking external links
- **`themepreview()`** — unused admin theme preview helper
- **`validate_mail()`** — superseded by `filter_var(FILTER_VALIDATE_EMAIL)`

### 3. `headlines()` RSS fetcher deleted
Raw `fsockopen()` RSS feed parser (~70 lines). Only called from `render_blocks()` when a block has a URL configured — no blocks use this feature. The `else { headlines($bid, 1); }` branch removed from `render_blocks()` in both files.

## Files Changed (11)
- `mainfile.php` — delete 5 functions, replace 1 get_theme() caller
- `LegacyFunctions.php` — delete 5 functions, remove headlines call from render_blocks
- `PageLayout.php`, `index.php`, `modules.php`, `theme.php`, `Topics/index.php`, `SiteStatistics/index.php` — replace get_theme() → "IBL"
- `NukeCompat.php` — update getTheme() wrapper
- `BanDirectNukeGlobalsRule.php` — remove get_theme from banned list
- `nuke-globals.stub.php` — remove get_theme stub

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.