### PR TITLE
refactor: remove online() function and drop nuke_session table

### DIFF
--- a/ibl5/classes/Bootstrap/LegacyFunctions.php
+++ b/ibl5/classes/Bootstrap/LegacyFunctions.php
@@ -169,37 +169,6 @@ function blocks($side)
     $db->sql_freeresult($result);
 }
 
-function online()
-{
-    global $user, $cookie, $prefix, $db;
-    $ip = $_SERVER['REMOTE_ADDR'];
-    if (is_user($user)) {
-        cookiedecode($user);
-        $uname = $cookie[1];
-        $guest = 0;
-    } else {
-        $uname = $ip;
-        $guest = 1;
-    }
-    if (mt_rand(1, 100) === 1) {
-        $past = time() - 3600;
-        $sql = "DELETE FROM " . $prefix . "_session WHERE time < '$past'";
-        $db->sql_query($sql);
-    }
-    $sql = "SELECT time FROM " . $prefix . "_session WHERE uname='" . $db->db_connect_id->real_escape_string($uname) . "'";
-    $result = $db->sql_query($sql);
-    $ctime = time();
-    if (!empty($uname)) {
-        $uname = substr($uname, 0, 25);
-        $row = $db->sql_fetchrow($result);
-        if ($row) {
-            $db->sql_query("UPDATE " . $prefix . "_session SET uname='" . $db->db_connect_id->real_escape_string($uname) . "', time='$ctime', host_addr='" . $db->db_connect_id->real_escape_string($ip) . "', guest='$guest' WHERE uname='" . $db->db_connect_id->real_escape_string($uname) . "'");
-        } else {
-            $db->sql_query("INSERT INTO " . $prefix . "_session (uname, time, host_addr, guest) VALUES ('" . $db->db_connect_id->real_escape_string($uname) . "', '$ctime', '" . $db->db_connect_id->real_escape_string($ip) . "', '$guest')");
-        }
-    }
-    $db->sql_freeresult($result);
-}
 
 function blockfileinc($title, $blockfile, $side = 0)
 {

--- a/ibl5/classes/PageLayout/PageLayout.php
+++ b/ibl5/classes/PageLayout/PageLayout.php
@@ -11,8 +11,6 @@ class PageLayout
     public static function header(): void
     {
         // Populate $cookie/$user globals for all request types.
-        // online() does this for full page loads, but boosted requests
-        // skip online() — modules still need $cookie for team lookups.
         /** @var string $user */
         global $user;
         cookiedecode($user);
@@ -22,7 +20,6 @@ class PageLayout
             return;
         }
 
-        online();
         self::renderHead();
         if (isset($GLOBALS['mysqli_db']) && $GLOBALS['mysqli_db'] instanceof \mysqli) {
             (new \SiteStatistics\StatisticsRepository($GLOBALS['mysqli_db']))->recordHit();

--- a/ibl5/classes/Utilities/NukeCompat.php
+++ b/ibl5/classes/Utilities/NukeCompat.php
@@ -161,13 +161,6 @@ class NukeCompat
         blocks($position);
     }
 
-    /**
-     * Track online users.
-     */
-    public function online(): void
-    {
-        online();
-    }
 
     /**
      * Output the theme header.

--- a/ibl5/mainfile.php
+++ b/ibl5/mainfile.php
@@ -471,37 +471,6 @@ function blocks($side)
     $db->sql_freeresult($result);
 }
 
-function online()
-{
-    global $user, $cookie, $prefix, $db;
-    $ip = $_SERVER['REMOTE_ADDR'];
-    if (is_user($user)) {
-        cookiedecode($user);
-        $uname = $cookie[1];
-        $guest = 0;
-    } else {
-        $uname = $ip;
-        $guest = 1;
-    }
-    if (mt_rand(1, 100) === 1) {
-        $past = time() - 3600;
-        $sql = "DELETE FROM " . $prefix . "_session WHERE time < '$past'";
-        $db->sql_query($sql);
-    }
-    $sql = "SELECT time FROM " . $prefix . "_session WHERE uname='" . addslashes($uname) . "'";
-    $result = $db->sql_query($sql);
-    $ctime = time();
-    if (!empty($uname)) {
-        $uname = substr($uname, 0, 25);
-        $row = $db->sql_fetchrow($result);
-        if ($row) {
-            $db->sql_query("UPDATE " . $prefix . "_session SET uname='" . addslashes($uname) . "', time='$ctime', host_addr='$ip', guest='$guest' WHERE uname='" . addslashes($uname) . "'");
-        } else {
-            $db->sql_query("INSERT INTO " . $prefix . "_session (uname, time, host_addr, guest) VALUES ('" . addslashes($uname) . "', '$ctime', '$ip', '$guest')");
-        }
-    }
-    $db->sql_freeresult($result);
-}
 
 function blockfileinc($title, $blockfile, $side = 0)
 {

--- a/ibl5/migrations/070_drop_nuke_session.sql
+++ b/ibl5/migrations/070_drop_nuke_session.sql
@@ -1,0 +1,4 @@
+-- Drop the legacy PHP-Nuke session tracking table.
+-- This table was only written to by the online() function (now removed)
+-- and was never read for display purposes.
+DROP TABLE IF EXISTS nuke_session;

--- a/ibl5/modules/LeagueStarters/index.php
+++ b/ibl5/modules/LeagueStarters/index.php
@@ -39,7 +39,7 @@ $view = new LeagueStartersView($mysqli_db, $season, $module_name);
 $startersByPosition = $service->getAllStartersByPosition();
 $display = $_REQUEST['display'] ?? 'ratings';
 
-// Render header first (populates $cookie via online() → cookiedecode())
+// Render header first (populates $cookie via cookiedecode())
 PageLayout\PageLayout::header();
 
 $username = strval($cookie[1] ?? '');

--- a/ibl5/modules/NextSim/index.php
+++ b/ibl5/modules/NextSim/index.php
@@ -43,7 +43,7 @@ if (!is_user($user)) {
         $teamPowerRankings[$tid] = (float)$data['ranking'];
     }
 
-    // Render header first (populates $cookie via online() → cookiedecode())
+    // Render header first (populates $cookie via cookiedecode())
     PageLayout\PageLayout::header();
 
     $username = strval($cookie[1] ?? '');

--- a/ibl5/modules/YourAccount/index.php
+++ b/ibl5/modules/YourAccount/index.php
@@ -273,13 +273,6 @@ function logout()
         'httponly' => true,
         'samesite' => 'Strict',
     ]);
-    // Remove session record
-    if ($r_username !== null) {
-        $stmt = $mysqli_db->prepare("DELETE FROM " . $prefix . "_session WHERE uname = ?");
-        $stmt->bind_param('s', $r_username);
-        $stmt->execute();
-        $stmt->close();
-    }
     $user = "";
     $cookie = "";
     $_SESSION['flash_success'] = 'You have successfully logged out.';
@@ -407,12 +400,6 @@ function login($username, $user_password)
     $rememberMe = isset($_POST['remember_me']) && $_POST['remember_me'] === '1';
     if ($authService->attempt($username, $user_password, $rememberMe)) {
         $uname = $_SERVER['REMOTE_ADDR'];
-
-        // Clean up guest session for this IP
-        $stmtDelSession = $mysqli_db->prepare("DELETE FROM " . $prefix . "_session WHERE uname = ? AND guest = '1'");
-        $stmtDelSession->bind_param('s', $uname);
-        $stmtDelSession->execute();
-        $stmtDelSession->close();
 
         // Record last IP
         $stmtUpdateIp = $mysqli_db->prepare("UPDATE " . $prefix . "_users SET last_ip = ? WHERE username = ?");

--- a/ibl5/phpstan-stubs/nuke-globals.stub.php
+++ b/ibl5/phpstan-stubs/nuke-globals.stub.php
@@ -77,8 +77,6 @@ function include_secure(string $file): void {}
 /** @return void */
 function blocks(string $position): void {}
 
-/** @return void */
-function online(): void {}
 
 /** @return void */
 function themeheader(): void {}


### PR DESCRIPTION
## Summary

Removes the legacy PHP-Nuke `online()` session tracking function and drops the `nuke_session` table. This function ran on every page load, executing 4+ database queries to track who was online — but **nothing in the codebase ever reads the table**. There is no "users online" display anywhere.

## Changes

### `online()` removal
- **`PageLayout::header()`**: Remove `online()` call — `cookiedecode($user)` was already called 7 lines earlier, making the call inside `online()` redundant
- **`mainfile.php`**: Delete function (~30 lines)
- **`LegacyFunctions.php`**: Delete duplicate function (~30 lines)
- **`NukeCompat.php`**: Delete `online()` wrapper method (zero callers)
- **`nuke-globals.stub.php`**: Remove PHPStan stub

### `nuke_session` table cleanup
- **`YourAccount/index.php`**: Remove 2 DELETE queries (logout session cleanup + login guest cleanup)
- **Migration 070**: `DROP TABLE IF EXISTS nuke_session`

### Comment updates
- **NextSim**, **LeagueStarters**: Update comments to reflect `cookiedecode()` is called directly

## Performance impact

Eliminates 4+ DB queries per full page load:
- 1 SELECT (check session exists)
- 1 INSERT or UPDATE (write session record)
- 1% chance: 1 DELETE (expire old sessions)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.