### PR TITLE
refactor: remove 5 more PHP-Nuke functions (~120 lines)

### DIFF
--- a/ibl5/classes/Bootstrap/LegacyFunctions.php
+++ b/ibl5/classes/Bootstrap/LegacyFunctions.php
@@ -61,35 +61,6 @@ function is_user($user)
     return $userSave = $authService->isAuthenticated() ? 1 : 0;
 }
 
-function title($text)
-{
-    OpenTable();
-    echo "<center><span class=\"title\"><strong>$text</strong></span></center>";
-    CloseTable();
-    echo "<br>";
-}
-
-function is_active($module)
-{
-    global $prefix, $db;
-    static $save;
-    if (is_array($save)) {
-        if (isset($save[$module])) {
-            return ($save[$module]);
-        }
-        return 0;
-    }
-    $sql = "SELECT title FROM " . $prefix . "_modules WHERE active=1";
-    $result = $db->sql_query($sql);
-    while ($row = $db->sql_fetchrow($result)) {
-        $save[$row[0]] = 1;
-    }
-    $db->sql_freeresult($result);
-    if (isset($save[$module])) {
-        return ($save[$module]);
-    }
-    return 0;
-}
 
 function render_blocks($side, $blockfile, $title, $content, $bid, $url)
 {
@@ -99,7 +70,16 @@ function render_blocks($side, $blockfile, $title, $content, $bid, $url)
     if (empty($blockfile)) {
         themecenterbox($title, $content);
     } else {
-        blockfileinc($title, $blockfile, 1);
+        $blockfiletitle = $title;
+        if (!file_exists("blocks/" . $blockfile)) {
+            $content = _BLOCKPROBLEM;
+        } else {
+            include "blocks/" . $blockfile;
+        }
+        if (empty($content)) {
+            $content = _BLOCKPROBLEM2;
+        }
+        themecenterbox($blockfiletitle, $content);
     }
 }
 
@@ -170,20 +150,6 @@ function blocks($side)
 }
 
 
-function blockfileinc($title, $blockfile, $side = 0)
-{
-    $blockfiletitle = $title;
-    $file = file_exists("blocks/" . $blockfile . "");
-    if (!$file) {
-        $content = _BLOCKPROBLEM;
-    } else {
-        include "blocks/" . $blockfile . "";
-    }
-    if (empty($content)) {
-        $content = _BLOCKPROBLEM2;
-    }
-    themecenterbox($blockfiletitle, $content);
-}
 
 function cookiedecode($user)
 {
@@ -370,37 +336,6 @@ function formatTimestamp($time)
     $datetime = date(_DATESTRING, $time);
     $datetime = ucfirst($datetime);
     return $datetime;
-}
-
-function get_author($aid)
-{
-    global $prefix, $db;
-    static $users;
-    if (isset($users[$aid]) and is_array($users[$aid])) {
-        $row = $users[$aid];
-    } else {
-        $sql = "SELECT url, email FROM " . $prefix . "_authors WHERE aid='" . $db->db_connect_id->real_escape_string($aid) . "'";
-        $result = $db->sql_query($sql);
-        $row = $db->sql_fetchrow($result);
-        $users[$aid] = $row;
-        $db->sql_freeresult($result);
-    }
-    $aidurl = filter($row['url'], "nohtml");
-    $aidmail = filter($row['email'], "nohtml");
-    if (isset($aidurl) && $aidurl != "http://") {
-        $aid = "<a href=\"" . $aidurl . "\">$aid</a>";
-    } elseif (isset($aidmail)) {
-        $aid = "<a href=\"mailto:" . $aidmail . "\">$aid</a>";
-    } else {
-        $aid = $aid;
-    }
-    return $aid;
-}
-
-function formatAidHeader($aid)
-{
-    $AidHeader = get_author($aid);
-    echo $AidHeader;
 }
 
 

--- a/ibl5/classes/SiteStatistics/StatisticsController.php
+++ b/ibl5/classes/SiteStatistics/StatisticsController.php
@@ -151,7 +151,10 @@ class StatisticsController
         $currentMonth = (int)$parts[1];
         
         \PageLayout\PageLayout::header();
-        \title(HtmlSanitizer::e($sitename) . " " . _STATS);
+        \OpenTable();
+        echo '<center><span class="title"><strong>' . HtmlSanitizer::e($sitename) . ' ' . _STATS . '</strong></span></center>';
+        \CloseTable();
+        echo '<br>';
         \OpenTable();
         
         $monthlyStats = $this->repository->getMonthlyStats($year);
@@ -187,7 +190,10 @@ class StatisticsController
         $currentDate = (int)$parts[0];
         
         \PageLayout\PageLayout::header();
-        \title(HtmlSanitizer::e($sitename) . " " . _STATS);
+        \OpenTable();
+        echo '<center><span class="title"><strong>' . HtmlSanitizer::e($sitename) . ' ' . _STATS . '</strong></span></center>';
+        \CloseTable();
+        echo '<br>';
         \OpenTable();
         
         $dailyStats = $this->repository->getDailyStats($year, $month);
@@ -221,7 +227,10 @@ class StatisticsController
         global $sitename;
         
         \PageLayout\PageLayout::header();
-        \title(HtmlSanitizer::e($sitename) . " " . _STATS);
+        \OpenTable();
+        echo '<center><span class="title"><strong>' . HtmlSanitizer::e($sitename) . ' ' . _STATS . '</strong></span></center>';
+        \CloseTable();
+        echo '<br>';
         \OpenTable();
         
         $hourlyStats = $this->repository->getHourlyStats($year, $month, $date);

--- a/ibl5/classes/SiteStatistics/StatisticsRepository.php
+++ b/ibl5/classes/SiteStatistics/StatisticsRepository.php
@@ -173,8 +173,8 @@ class StatisticsRepository extends \BaseMysqliRepository
      */
     public function getMiscCounts(): array
     {
-        $topicsActive = function_exists('is_active') ? is_active("Topics") : false;
-        $linksActive = function_exists('is_active') ? is_active("Web_Links") : false;
+        $topicsActive = false;
+        $linksActive = false;
 
         /** @var array{users: int, authors: int, stories: int, comments: int}|null $row */
         $row = $this->fetchOne(

--- a/ibl5/classes/SiteStatistics/StatisticsView.php
+++ b/ibl5/classes/SiteStatistics/StatisticsView.php
@@ -58,7 +58,10 @@ class StatisticsView
         global $sitename, $textcolor2;
 
         \PageLayout\PageLayout::header();
-        \title(HtmlSanitizer::e($sitename) . " " . _STATS);
+        \OpenTable();
+        echo '<center><span class="title"><strong>' . HtmlSanitizer::e($sitename) . ' ' . _STATS . '</strong></span></center>';
+        \CloseTable();
+        echo '<br>';
         \OpenTable();
         \OpenTable();
 
@@ -231,7 +234,10 @@ class StatisticsView
         global $sitename;
 
         \PageLayout\PageLayout::header();
-        \title(HtmlSanitizer::e($sitename) . " " . _STATS);
+        \OpenTable();
+        echo '<center><span class="title"><strong>' . HtmlSanitizer::e($sitename) . ' ' . _STATS . '</strong></span></center>';
+        \CloseTable();
+        echo '<br>';
 
         $total++;
         \OpenTable();

--- a/ibl5/index.php
+++ b/ibl5/index.php
@@ -38,7 +38,7 @@ if (str_contains($name, "..") || (isset($file) && str_contains($file, "..")) || 
     $ThemeSel = 'IBL';
     if (file_exists("themes/$ThemeSel/module.php")) {
         include "themes/$ThemeSel/module.php";
-        if (is_active("$default_module") and file_exists("modules/$default_module/" . $mod_file . ".php")) {
+        if (file_exists("modules/$default_module/" . $mod_file . ".php")) {
             $name = $default_module;
         }
     }

--- a/ibl5/mainfile.php
+++ b/ibl5/mainfile.php
@@ -361,37 +361,6 @@ function is_user($user)
     return $userSave = $authService->isAuthenticated() ? 1 : 0;
 }
 
-function title($text)
-{
-    OpenTable();
-    echo "<center><span class=\"title\"><strong>$text</strong></span></center>";
-    CloseTable();
-    echo "<br>";
-}
-
-function is_active($module)
-{
-    global $prefix, $db;
-    static $save;
-    if (is_array($save)) {
-        if (isset($save[$module])) {
-            return ($save[$module]);
-        }
-
-        return 0;
-    }
-    $sql = "SELECT title FROM " . $prefix . "_modules WHERE active=1";
-    $result = $db->sql_query($sql);
-    while ($row = $db->sql_fetchrow($result)) {
-        $save[$row[0]] = 1;
-    }
-    $db->sql_freeresult($result);
-    if (isset($save[$module])) {
-        return ($save[$module]);
-    }
-
-    return 0;
-}
 
 function render_blocks($side, $blockfile, $title, $content, $bid, $url)
 {
@@ -401,7 +370,16 @@ function render_blocks($side, $blockfile, $title, $content, $bid, $url)
     if (empty($blockfile)) {
         themecenterbox($title, $content);
     } else {
-        blockfileinc($title, $blockfile, 1);
+        $blockfiletitle = $title;
+        if (!file_exists("blocks/" . $blockfile)) {
+            $content = _BLOCKPROBLEM;
+        } else {
+            include "blocks/" . $blockfile;
+        }
+        if (empty($content)) {
+            $content = _BLOCKPROBLEM2;
+        }
+        themecenterbox($blockfiletitle, $content);
     }
 }
 
@@ -471,21 +449,6 @@ function blocks($side)
     $db->sql_freeresult($result);
 }
 
-
-function blockfileinc($title, $blockfile, $side = 0)
-{
-    $blockfiletitle = $title;
-    $file = file_exists("blocks/" . $blockfile . "");
-    if (!$file) {
-        $content = _BLOCKPROBLEM;
-    } else {
-        include "blocks/" . $blockfile . "";
-    }
-    if (empty($content)) {
-        $content = _BLOCKPROBLEM2;
-    }
-    themecenterbox($blockfiletitle, $content);
-}
 
 
 function cookiedecode($user)
@@ -701,36 +664,6 @@ function formatTimestamp($time)
     return $datetime;
 }
 
-function get_author($aid)
-{
-    global $prefix, $db;
-    static $users;
-    if (isset($users[$aid]) and is_array($users[$aid])) {
-        $row = $users[$aid];
-    } else {
-        $sql = "SELECT url, email FROM " . $prefix . "_authors WHERE aid='$aid'";
-        $result = $db->sql_query($sql);
-        $row = $db->sql_fetchrow($result);
-        $users[$aid] = $row;
-        $db->sql_freeresult($result);
-    }
-    $aidurl = filter($row['url'], "nohtml");
-    $aidmail = filter($row['email'], "nohtml");
-    if (isset($aidurl) && $aidurl != "http://") {
-        $aid = "<a href=\"" . $aidurl . "\">$aid</a>";
-    } elseif (isset($aidmail)) {
-        $aid = "<a href=\"mailto:" . $aidmail . "\">$aid</a>";
-    } else {
-        $aid = $aid;
-    }
-    return $aid;
-}
-
-function formatAidHeader($aid)
-{
-    $AidHeader = get_author($aid);
-    echo $AidHeader;
-}
 
 if (!defined('FORUM_ADMIN')) {
     $ThemeSel = 'IBL';

--- a/ibl5/themes/IBL/theme.php
+++ b/ibl5/themes/IBL/theme.php
@@ -155,7 +155,7 @@ function themeindex($aid, $informant, $time, $title, $counter, $topic, $thetext,
                 <span class="news-article__meta-item">
                     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
                     ';
-    formatAidHeader($aid);
+    echo \Utilities\HtmlSanitizer::e($aid);
     echo '</span>
                 <span class="news-article__meta-item">
                     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>


### PR DESCRIPTION
## Summary

Removes 5 more legacy PHP-Nuke functions from `mainfile.php` and `LegacyFunctions.php`, continuing the cleanup series (PRs #460, #463, #467).

## Changes

### `blockfileinc()` — inlined into `render_blocks()`
Block file-include logic moved directly into `render_blocks()`. The standalone wrapper function deleted from both bootstrap files.

### `get_author()` + `formatAidHeader()` — replaced with `HtmlSanitizer::e()`
`formatAidHeader($aid)` in `theme.php` replaced with `echo HtmlSanitizer::e($aid)`. This eliminates a `nuke_authors` table query and `filter()` dependency. Both functions deleted from both bootstrap files.

### `title()` — inlined in SiteStatistics
The `OpenTable()/echo/CloseTable()` pattern inlined at all 5 call sites (StatisticsView x2, StatisticsController x3). Function deleted from both bootstrap files.

### `is_active()` — replaced with static values
- `index.php`: Removed `is_active()` check, kept `file_exists()` only
- `StatisticsRepository`: Hardcoded `false` for Topics/Web_Links (neither module exists in IBL)
- Eliminates a `nuke_modules` query via the legacy `$db` wrapper

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.