### PR TITLE
refactor: inline render_blocks() and FixQuotes() into parent functions

### DIFF
--- a/ibl5/classes/Bootstrap/LegacyFunctions.php
+++ b/ibl5/classes/Bootstrap/LegacyFunctions.php
@@ -62,27 +62,6 @@ function is_user($user)
 }
 
 
-function render_blocks($side, $blockfile, $title, $content, $bid, $url)
-{
-    if (!defined('BLOCK_FILE')) {
-        define('BLOCK_FILE', true);
-    }
-    if (empty($blockfile)) {
-        themecenterbox($title, $content);
-    } else {
-        $blockfiletitle = $title;
-        if (!file_exists("blocks/" . $blockfile)) {
-            $content = _BLOCKPROBLEM;
-        } else {
-            include "blocks/" . $blockfile;
-        }
-        if (empty($content)) {
-            $content = _BLOCKPROBLEM2;
-        }
-        themecenterbox($blockfiletitle, $content);
-    }
-}
-
 function blocks($side)
 {
     global $storynum, $prefix, $multilingual, $currentlang, $db, $user;
@@ -134,14 +113,28 @@ function blocks($side)
                 }
             }
             if (empty($row['bkey'])) {
-                if ($view == 0) {
-                    render_blocks($side, $blockfile, $title, $content, $bid, $url);
-                } elseif ($view == 1 and is_user($user) || is_admin()) {
-                    render_blocks($side, $blockfile, $title, $content, $bid, $url);
-                } elseif ($view == 2 and is_admin()) {
-                    render_blocks($side, $blockfile, $title, $content, $bid, $url);
-                } elseif ($view == 3 and !is_user($user) || is_admin()) {
-                    render_blocks($side, $blockfile, $title, $content, $bid, $url);
+                $shouldRender = ($view == 0)
+                    || ($view == 1 and is_user($user) || is_admin())
+                    || ($view == 2 and is_admin())
+                    || ($view == 3 and !is_user($user) || is_admin());
+                if ($shouldRender) {
+                    if (!defined('BLOCK_FILE')) {
+                        define('BLOCK_FILE', true);
+                    }
+                    if (empty($blockfile)) {
+                        themecenterbox($title, $content);
+                    } else {
+                        $blockfiletitle = $title;
+                        if (!file_exists("blocks/" . $blockfile)) {
+                            $content = _BLOCKPROBLEM;
+                        } else {
+                            include "blocks/" . $blockfile;
+                        }
+                        if (empty($content)) {
+                            $content = _BLOCKPROBLEM2;
+                        }
+                        themecenterbox($blockfiletitle, $content);
+                    }
                 }
             }
         }
@@ -174,13 +167,6 @@ function getusrinfo($user)
     return null;
 }
 
-function FixQuotes($what = "")
-{
-    while (stristr($what, "\\\\'")) {
-        $what = str_replace("\\\\'", "'", $what);
-    }
-    return $what;
-}
 
 function check_words($Message)
 {
@@ -317,7 +303,11 @@ function filter($what, $strip = "", $save = "", $type = "")
         $what = check_html($what, $strip);
         $what = addslashes($what);
     } else {
-        $what = stripslashes(FixQuotes($what));
+        $fixedWhat = $what;
+        while (stristr($fixedWhat, "\\\\'")) {
+            $fixedWhat = str_replace("\\\\'", "'", $fixedWhat);
+        }
+        $what = stripslashes($fixedWhat);
         $what = check_words($what);
         $what = check_html($what, $strip);
     }

--- a/ibl5/mainfile.php
+++ b/ibl5/mainfile.php
@@ -362,27 +362,6 @@ function is_user($user)
 }
 
 
-function render_blocks($side, $blockfile, $title, $content, $bid, $url)
-{
-    if (!defined('BLOCK_FILE')) {
-        define('BLOCK_FILE', true);
-    }
-    if (empty($blockfile)) {
-        themecenterbox($title, $content);
-    } else {
-        $blockfiletitle = $title;
-        if (!file_exists("blocks/" . $blockfile)) {
-            $content = _BLOCKPROBLEM;
-        } else {
-            include "blocks/" . $blockfile;
-        }
-        if (empty($content)) {
-            $content = _BLOCKPROBLEM2;
-        }
-        themecenterbox($blockfiletitle, $content);
-    }
-}
-
 function blocks($side)
 {
     global $storynum, $prefix, $multilingual, $currentlang, $db, $user;
@@ -434,14 +413,28 @@ function blocks($side)
                 }
             }
             if (empty($row['bkey'])) {
-                if ($view == 0) {
-                    render_blocks($side, $blockfile, $title, $content, $bid, $url);
-                } elseif ($view == 1 and is_user($user) || is_admin()) {
-                    render_blocks($side, $blockfile, $title, $content, $bid, $url);
-                } elseif ($view == 2 and is_admin()) {
-                    render_blocks($side, $blockfile, $title, $content, $bid, $url);
-                } elseif ($view == 3 and !is_user($user) || is_admin()) {
-                    render_blocks($side, $blockfile, $title, $content, $bid, $url);
+                $shouldRender = ($view == 0)
+                    || ($view == 1 and is_user($user) || is_admin())
+                    || ($view == 2 and is_admin())
+                    || ($view == 3 and !is_user($user) || is_admin());
+                if ($shouldRender) {
+                    if (!defined('BLOCK_FILE')) {
+                        define('BLOCK_FILE', true);
+                    }
+                    if (empty($blockfile)) {
+                        themecenterbox($title, $content);
+                    } else {
+                        $blockfiletitle = $title;
+                        if (!file_exists("blocks/" . $blockfile)) {
+                            $content = _BLOCKPROBLEM;
+                        } else {
+                            include "blocks/" . $blockfile;
+                        }
+                        if (empty($content)) {
+                            $content = _BLOCKPROBLEM2;
+                        }
+                        themecenterbox($blockfiletitle, $content);
+                    }
                 }
             }
         }
@@ -476,13 +469,6 @@ function getusrinfo($user)
     return null;
 }
 
-function FixQuotes($what = "")
-{
-    while (stristr($what, "\\\\'")) {
-        $what = str_replace("\\\\'", "'", $what);
-    }
-    return $what;
-}
 
 function check_words($Message)
 {
@@ -639,7 +625,11 @@ function filter($what, $strip = "", $save = "", $type = "")
         $what = check_html($what, $strip);
         $what = addslashes($what);
     } else {
-        $what = stripslashes(FixQuotes($what));
+        $fixedWhat = $what;
+        while (stristr($fixedWhat, "\\\\'")) {
+            $fixedWhat = str_replace("\\\\'", "'", $fixedWhat);
+        }
+        $what = stripslashes($fixedWhat);
         $what = check_words($what);
         $what = check_html($what, $strip);
     }


### PR DESCRIPTION
## Summary

Inlines 2 internal-only PHP-Nuke helper functions into their parent functions and deletes the standalone definitions. Continuing the cleanup series (PRs #460, #463, #467, #471).

## Changes

### `render_blocks()` → inlined into `blocks()`
- Replaced 4 identical `render_blocks()` calls with a single `$shouldRender` visibility check + inlined block rendering logic
- Deleted the standalone function from both `mainfile.php` and `LegacyFunctions.php`

### `FixQuotes()` → inlined into `filter()`
- Inlined the `while`/`str_replace` loop at the single call site in `filter()`
- Deleted the standalone function from both files

### Skipped
`check_words()` and `delQuotes()` were originally planned but skipped — inlining would duplicate 20+ lines at multiple call sites or add 60 lines to already-long functions. They will be removed when `filter()` and `check_html()` are eventually deleted.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.