### PR TITLE
fix: remove tracked vendor symlink that breaks worktree Docker

### DIFF
--- a/ibl5/.gitignore
+++ b/ibl5/.gitignore
@@ -17,7 +17,9 @@ bun.lockb
 .DS_Store
 Thumbs.db
 
-# PHP
+# PHP — "vendor" (no slash) catches the symlink created by bin/wt-new;
+# "vendor/" catches the directory form. Both are needed so git never tracks either.
+vendor
 vendor/
 composer.lock
 

--- a/ibl5/vendor
+++ b/ibl5/vendor
@@ -1,1 +1,0 @@
-/Users/ajaynicolas/Documents/GitHub/IBL5/ibl5/vendor


### PR DESCRIPTION
## Problem
- `ibl5/vendor` was tracked by git as a symlink (mode 120000)
- `bin/wt-up` replaces the symlink with an empty dir so Docker's bind mount overlay works correctly
- Any git operation (rebase, checkout, merge) restored the tracked symlink, causing Docker's VirtioFS to see an unresolvable host path → `vendor/autoload.php` not found

## Fix
- Remove `ibl5/vendor` from git tracking (`git rm --cached`)
- Add bare `vendor` pattern (no trailing slash) to `ibl5/.gitignore` so the symlink form is also ignored — `vendor/` only matches directories, not symlinks

## Testing
- Verified `git check-ignore -v ibl5/vendor` now matches the new pattern
- Verified worktree Docker container serves pages after fix