### PR TITLE
feat: use named Docker volume for worktree vendor instead of bind mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM php:8.4-apache
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libonig-dev \
         curl \
+        unzip \
     && docker-php-ext-install mysqli pdo pdo_mysql mbstring opcache \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 COPY docker/opcache.ini $PHP_INI_DIR/conf.d/opcache.ini
 

--- a/bin/wt-up
+++ b/bin/wt-up
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Start a Docker environment for a worktree with its own PHP-Apache + MariaDB.
-# Usage: bin/wt-up <worktree-name> [--pr] [--seed] [--prod] [--no-data]
+# Usage: bin/wt-up <worktree-name> [--pr] [--seed] [--prod] [--no-data] [--fresh-vendor]
 
 set -euo pipefail
 
@@ -10,6 +10,7 @@ USE_PR=false
 SEED_DB=false
 PROD_DB=false
 NO_DATA=false
+FRESH_VENDOR=false
 
 # Wrapper to suppress MariaDB "password on command line" warning
 db_exec() {
@@ -26,6 +27,7 @@ for arg in "$@"; do
         --seed) SEED_DB=true ;;
         --prod) PROD_DB=true ;;
         --no-data) NO_DATA=true ;;
+        --fresh-vendor) FRESH_VENDOR=true ;;
         -*) echo "Unknown option: $arg" >&2; exit 1 ;;
         *) WORKTREE_NAME="$arg" ;;
     esac
@@ -39,6 +41,7 @@ if [ -z "$WORKTREE_NAME" ]; then
     echo "  --seed     Import ci-seed.sql for test data (schema + CI seed)" >&2
     echo "  --prod     Import prod-seed.sql (default if no data flag given)" >&2
     echo "  --no-data  Schema only, no seed data" >&2
+    echo "  --fresh-vendor  Remove vendor volume and reinstall (use after composer.lock changes)" >&2
     exit 1
 fi
 
@@ -95,14 +98,11 @@ if [ ! -s "$STYLE_CSS" ]; then
     cp "$REPO_ROOT/ibl5/themes/IBL/style/style.css" "$STYLE_CSS" 2>/dev/null || true
 fi
 
-# Replace vendor symlink with a real directory so Docker's bind mount overlays it.
-# When vendor is a symlink, Docker follows it and the separate vendor bind mount
-# in the compose template is ignored — causing autoloader paths to resolve to the
-# host filesystem path (which doesn't exist inside the container).
+# Remove vendor symlink if present — named volume mounts over this path.
+# The symlink is created by wt-new for host-side tools; Docker doesn't need it.
 VENDOR_DIR="$WORKTREE_PATH/ibl5/vendor"
 if [ -L "$VENDOR_DIR" ]; then
     rm "$VENDOR_DIR"
-    mkdir -p "$VENDOR_DIR"
 fi
 
 # Copy config.php into worktree (can't use bind mount — VirtioFS fails on nested mounts)
@@ -134,14 +134,16 @@ ENV_FILE_FLAG=""
 if [ -f "$REPO_ROOT/.env" ]; then
     ENV_FILE_FLAG="--env-file $REPO_ROOT/.env"
 fi
-docker compose -f "$COMPOSE_FILE" $ENV_FILE_FLAG -p "ibl5-$SLUG" up -d --build
 
-# Fix autoloader paths inside the container.
-# vendor/ is bind-mounted from the host, so PHP's realpath() resolves it to the
-# host filesystem path (e.g. /Users/.../ibl5/vendor). Composer's generated
-# autoloader uses dirname(realpath(__DIR__)) which then points to a host path
-# that doesn't exist inside the container. Regenerating the autoloader inside
-# the container fixes all paths to use /var/www/html/ibl5/classes.
+# --fresh-vendor: remove vendor volume so entrypoint re-runs composer install.
+# DB volume is preserved — only vendor is reset.
+if [ "$FRESH_VENDOR" = true ]; then
+    echo "Removing vendor volume for fresh install..."
+    docker compose -f "$COMPOSE_FILE" $ENV_FILE_FLAG -p "ibl5-$SLUG" down 2>/dev/null || true
+    docker volume rm "ibl5-${SLUG}_vendor-${SLUG}-data" 2>/dev/null || true
+fi
+
+docker compose -f "$COMPOSE_FILE" $ENV_FILE_FLAG -p "ibl5-$SLUG" up -d --build
 
 # Wait for MariaDB to be healthy
 echo "Waiting for MariaDB (db-$SLUG) to be ready..."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,26 +1,27 @@
 #!/bin/sh
-# Validate vendor/ before Apache starts.
-# Catches broken symlinks, missing autoload, or other corruption.
+# Ensure vendor/ is populated before Apache starts.
+# On first run (named volume empty), runs composer install automatically.
+# On subsequent runs, detects autoload.php and skips install immediately.
 
-VENDOR="/var/www/html/ibl5/vendor/autoload.php"
-LOGS_DIR="/var/www/html/ibl5/logs"
+APP_DIR="/var/www/html/ibl5"
+VENDOR="$APP_DIR/vendor/autoload.php"
+LOGS_DIR="$APP_DIR/logs"
 
 # Ensure logs/ directory exists and is writable by www-data (Apache user).
-# In CI and Docker, the ibl5/ volume is mounted from the host, so directory
-# ownership may not match the container's www-data user.
 mkdir -p "$LOGS_DIR"
 chown www-data:www-data "$LOGS_DIR"
 
-if [ -L "/var/www/html/ibl5/vendor" ] && [ ! -e "/var/www/html/ibl5/vendor" ]; then
-    echo "ERROR: ibl5/vendor is a broken symlink."
-    echo "Fix: rm ibl5/vendor && composer install"
-    echo "Then: docker compose restart php"
+# Detect broken symlink (shouldn't happen with named volume, but guard anyway)
+if [ -L "$APP_DIR/vendor" ] && [ ! -e "$APP_DIR/vendor" ]; then
+    echo "ERROR: $APP_DIR/vendor is a broken symlink."
     exit 1
-elif [ ! -f "$VENDOR" ]; then
-    echo "ERROR: $VENDOR not found."
-    echo "Fix: cd ibl5 && composer install"
-    echo "Then: docker compose restart php"
-    exit 1
+fi
+
+# Run composer install if vendor is missing or incomplete
+if [ ! -f "$VENDOR" ]; then
+    echo "vendor/autoload.php not found — running composer install..."
+    cd "$APP_DIR" && composer install --no-interaction --no-progress --prefer-dist --no-dev
+    echo "composer install complete."
 fi
 
 exec "$@"

--- a/docker/worktree-compose.template.yml
+++ b/docker/worktree-compose.template.yml
@@ -8,7 +8,7 @@ services:
       E2E_TESTING: 1
     volumes:
       - {{WORKTREE_PATH}}/ibl5:/var/www/html/ibl5
-      - {{REPO_ROOT}}/ibl5/vendor:/var/www/html/ibl5/vendor
+      - vendor-{{SLUG}}-data:/var/www/html/ibl5/vendor
     depends_on:
       db-{{SLUG}}:
         condition: service_healthy
@@ -42,6 +42,7 @@ services:
 
 volumes:
   db-{{SLUG}}-data:
+  vendor-{{SLUG}}-data:
 
 networks:
   ibl5-proxy:


### PR DESCRIPTION
## Problem

Worktree Docker containers broke whenever git operations (rebase, checkout) recreated the vendor symlink. Docker's VirtioFS can't resolve host-path symlinks inside the container, causing `vendor/autoload.php` not found errors. The existing fix (`wt-up` replacing the symlink with an empty dir + bind mount) was fragile and had a stale autoloader-path comment with no implementation.

## Solution

Each worktree container now manages its own vendor via a **named Docker volume**. Composer is added to the Docker image so the entrypoint auto-installs on first start (~15-20s one-time). Subsequent starts skip install (volume persists).

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Add `unzip` + `COPY --from=composer:2` for Composer binary |
| `docker/entrypoint.sh` | Replace fail-loudly guards with auto-install logic |
| `docker/worktree-compose.template.yml` | Named volume replaces vendor bind mount |
| `bin/wt-up` | Simplify vendor handling, add `--fresh-vendor` flag, remove stale comment |

## Startup behavior

| Scenario | Vendor install? | Time |
|----------|----------------|------|
| First `wt-up` for a worktree | Yes (named volume empty) | +15-20s one-time |
| Subsequent `wt-up` (volume exists) | No (autoload.php found) | ~1s |
| `wt-up --fresh-vendor` | Yes (volume removed) | +15-20s |
| Main repo `docker compose up` | No (real vendor on host) | ~1s |

## What's unaffected

- **Main `docker-compose.yml`**: mounts real `./ibl5` with real vendor dir — no behavioral change
- **`wt-down`**: still restores vendor symlink for host-side PHPStan/PHPUnit
- **`wt-cleanup`**: `--volumes` flag removes both DB and vendor volumes automatically
- **CI**: runs `composer install` on the runner before Docker starts — entrypoint skips install

## Manual Testing

No manual testing needed — all steps verified by Claude Code:
1. Fresh `wt-up`: composer auto-installed 10 packages, site returned 200
2. Container restart: no composer install in logs (volume persisted)
3. `--fresh-vendor`: volume removed, composer reinstalled from scratch
4. `wt-down`: vendor symlink restored for host-side tools
5. `main.localhost`: returns 200, unaffected by changes

- [ ] Run `bin/wt-up <name>` on a fresh worktree — verify composer install runs in container logs
- [ ] Restart the container — verify no composer install (volume persisted)
- [ ] Run `bin/wt-up <name> --fresh-vendor` — verify vendor is reinstalled
- [ ] Run `bin/wt-down <name>` — verify vendor symlink is restored
- [ ] Visit `http://main.localhost/ibl5/` — verify main Docker unaffected
