### PR TITLE
refactor: drop nuke_comments table and remove comment search

### DIFF
--- a/ibl5/classes/Search/SearchRepository.php
+++ b/ibl5/classes/Search/SearchRepository.php
@@ -139,47 +139,8 @@ class SearchRepository extends BaseMysqliRepository implements SearchRepositoryI
      */
     public function searchComments(string $query, int $offset = 0, int $limit = 10): array
     {
-        if (strlen($query) < 3) {
-            return ['results' => [], 'hasMore' => false];
-        }
-
-        $likeQuery = '%' . $query . '%';
-        $sql = "SELECT c.tid, c.sid, c.subject, c.date, c.name,
-                       s.title AS article_title,
-                       COALESCE(rc.reply_count, 0) AS reply_count
-                FROM {$this->prefix}_comments c
-                LEFT JOIN {$this->prefix}_stories s ON c.sid = s.sid
-                LEFT JOIN (
-                    SELECT pid, COUNT(*) AS reply_count
-                    FROM {$this->prefix}_comments
-                    GROUP BY pid
-                ) rc ON rc.pid = c.tid
-                WHERE (c.subject LIKE ? OR c.comment LIKE ?)
-                ORDER BY c.date DESC
-                LIMIT ?, ?";
-
-        /** @var list<CommentDbRow> $rows */
-        $rows = $this->fetchAll($sql, 'ssii', $likeQuery, $likeQuery, $offset, $limit + 1);
-        $hasMore = count($rows) > $limit;
-
-        if ($hasMore) {
-            array_pop($rows);
-        }
-
-        $results = [];
-        foreach ($rows as $row) {
-            $results[] = [
-                'tid' => $row['tid'],
-                'sid' => $row['sid'],
-                'subject' => $row['subject'],
-                'date' => $row['date'],
-                'name' => $row['name'],
-                'articleTitle' => $row['article_title'] ?? '',
-                'replyCount' => $row['reply_count'],
-            ];
-        }
-
-        return ['results' => $results, 'hasMore' => $hasMore];
+        // Comment system removed — nuke_comments table dropped
+        return ['results' => [], 'hasMore' => false];
     }
 
     /**

--- a/ibl5/classes/SiteStatistics/StatisticsRepository.php
+++ b/ibl5/classes/SiteStatistics/StatisticsRepository.php
@@ -176,19 +176,18 @@ class StatisticsRepository extends \BaseMysqliRepository
         $topicsActive = false;
         $linksActive = false;
 
-        /** @var array{users: int, stories: int, comments: int}|null $row */
+        /** @var array{users: int, stories: int}|null $row */
         $row = $this->fetchOne(
             "SELECT
                 (SELECT COUNT(*) FROM {$this->userPrefix}_users) AS users,
-                (SELECT COUNT(*) FROM {$this->prefix}_stories) AS stories,
-                (SELECT COUNT(*) FROM {$this->prefix}_comments) AS comments"
+                (SELECT COUNT(*) FROM {$this->prefix}_stories) AS stories"
         );
 
         $counts = [
             'users' => intval($row['users'] ?? 0),
             'authors' => 0,
             'stories' => intval($row['stories'] ?? 0),
-            'comments' => intval($row['comments'] ?? 0),
+            'comments' => 0,
             'topics' => 0,
             'links' => 0,
             'linkCategories' => 0,

--- a/ibl5/migrations/073_drop_nuke_comments.sql
+++ b/ibl5/migrations/073_drop_nuke_comments.sql
@@ -1,0 +1,4 @@
+-- Drop the legacy PHP-Nuke article comment table.
+-- Comment system was already removed (News/article.php:80).
+-- searchComments() now returns empty results; comment count hardcoded to 0.
+DROP TABLE IF EXISTS nuke_comments;

--- a/ibl5/tests/DatabaseIntegration/SearchRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SearchRepositoryTest.php
@@ -65,9 +65,9 @@ class SearchRepositoryTest extends DatabaseTestCase
 
     // ── searchComments ──────────────────────────────────────────
 
-    public function testSearchCommentsReturnsEmptyForShortQuery(): void
+    public function testSearchCommentsAlwaysReturnsEmpty(): void
     {
-        $result = $this->repo->searchComments('ab');
+        $result = $this->repo->searchComments('test query');
 
         self::assertSame([], $result['results']);
         self::assertFalse($result['hasMore']);

--- a/ibl5/tests/Search/SearchRepositoryTest.php
+++ b/ibl5/tests/Search/SearchRepositoryTest.php
@@ -85,33 +85,12 @@ class SearchRepositoryTest extends IntegrationTestCase
         $this->assertCount(10, $result['results']);
     }
 
-    public function testSearchCommentsReturnsEmptyForShortQuery(): void
+    public function testSearchCommentsAlwaysReturnsEmpty(): void
     {
-        $result = $this->repository->searchComments('ab');
+        $result = $this->repository->searchComments('test query');
 
         $this->assertSame([], $result['results']);
         $this->assertFalse($result['hasMore']);
-    }
-
-    public function testSearchCommentsReturnsResults(): void
-    {
-        $this->mockDb->setMockData([
-            [
-                'tid' => 1,
-                'sid' => 10,
-                'subject' => 'Test Comment',
-                'date' => '2024-01-15 12:00:00',
-                'name' => 'testuser',
-                'article_title' => 'Article Title',
-                'reply_count' => 2,
-            ],
-        ]);
-
-        $result = $this->repository->searchComments('test');
-
-        $this->assertCount(1, $result['results']);
-        $this->assertSame('Test Comment', $result['results'][0]['subject']);
-        $this->assertSame(2, $result['results'][0]['replyCount']);
     }
 
     public function testSearchUsersReturnsEmptyForShortQuery(): void


### PR DESCRIPTION
## Summary

Drops the `nuke_comments` table — the PHP-Nuke article comment system was already deprecated and removed (`News/article.php:80`: "Comment system removed — was deprecated and insecure"). No comments exist in the database and no UI creates them. The 3 remaining code references are cleaned up.

## Changes

- **`SearchRepository::searchComments()`** — returns empty results instead of querying dropped table. Method kept for interface compatibility.
- **`StatisticsRepository::getMiscCounts()`** — removes `nuke_comments` COUNT subquery, hardcodes `0`
- **Migration 073** — `DROP TABLE IF EXISTS nuke_comments`
- **Tests** — updated to expect empty results

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.