### PR TITLE
fix: add schema validation to wt-up after migrations

### DIFF
--- a/bin/wt-up
+++ b/bin/wt-up
@@ -223,6 +223,31 @@ if [ "$SEED_DB" = true ]; then
     fi
 fi
 
+# Validate schema integrity — catches migrations that were marked as applied
+# (via prod-seed backfill) but whose DDL was never actually executed.
+PHP_CONTAINER="ibl5-php-$SLUG"
+echo "Validating schema integrity..."
+RETRIES=0
+MAX_RETRIES=15
+until docker exec "$PHP_CONTAINER" php /var/www/html/ibl5/bin/validate-schema &>/dev/null; do
+    RETRIES=$((RETRIES + 1))
+    if [ "$RETRIES" -ge 2 ]; then
+        # First retry was waiting for PHP container — now it's a real failure
+        echo ""
+        echo "  WARNING: Schema validation failed!"
+        docker exec "$PHP_CONTAINER" php /var/www/html/ibl5/bin/validate-schema 2>&1 || true
+        echo ""
+        echo "  The prod-seed may predate migrations that the code depends on."
+        echo "  Re-run with --fresh-vendor or manually apply the missing migration."
+        echo ""
+        break
+    fi
+    sleep 2
+done
+if [ "$RETRIES" -lt 2 ]; then
+    echo "Schema validation passed."
+fi
+
 echo ""
 echo "================================================"
 echo "  Worktree environment ready!"


### PR DESCRIPTION
## Problem

`wt-up` imports prod-seed, then backfills `schema_migrations` from the prod dump's `migrations` table. If the prod-seed predates a migration, the migration is marked as applied but the DDL was never actually executed — causing runtime errors like `Unknown column 'gm_username'`.

## Root Cause

Discovered when `trading-mobile` worktree failed after login. PR #312 added `gm_username` to `ibl_team_info` via migration 057, but the prod-seed predated that migration. The `schema_migrations` backfill from the prod dump's `migrations` table marked 057 as applied, so `wt-up` skipped it — but the column never existed.

## Fix

Run `bin/validate-schema` via `docker exec` in the PHP container after migrations and seeding complete. This reuses the existing `SchemaValidator` + `config/schema-assertions.php` (the same check that runs in CI via `migration-safety.yml` and post-deployment via `main.yml`).

- Warns but does not block startup
- Displays missing columns and suggests re-running with `--fresh-vendor` or manually applying the migration
- Retries once to handle PHP container startup delay