### PR TITLE
fix: stack trading roster cards when one is collapsed

### DIFF
--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -1819,6 +1819,13 @@ td.ibl-team-cell--colored {
     border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
+/* When one roster is collapsed and the other is open, stack vertically
+   so the expanded table gets full width instead of being squeezed to 50% */
+.team-cards-row:has(.trading-roster-details:not([open])):has(.trading-roster-details[open]) .trading-layout__card {
+    flex-basis: 100%;
+    max-width: 100%;
+}
+
 /* ---------- Checkbox tap targets ---------- */
 
 .trading-roster input[type="checkbox"] {


### PR DESCRIPTION
## Problem
When one team's roster is collapsed via the `<details>` toggle, the other team's table was squeezed into 50% of the width (the side-by-side flex layout), making columns overflow and text get cut off.

## Fix
Added a single CSS rule using `:has()` to detect when one roster `<details>` is collapsed and the other is open. When this state is detected, both `.trading-layout__card` elements switch to `flex-basis: 100%`, causing the flex-wrap to stack them vertically. The expanded roster gets full page width.

```css
.team-cards-row:has(.trading-roster-details:not([open])):has(.trading-roster-details[open]) .trading-layout__card {
    flex-basis: 100%;
    max-width: 100%;
}
```

## Behavior
- **Both open:** side-by-side (unchanged)
- **One collapsed:** stacked vertically — collapsed summary bar full-width, expanded roster full-width
- **Both collapsed:** side-by-side (unchanged)

## Testing
Verified visually at 1024px viewport width in Chrome DevTools MCP.