### PR TITLE
feat: auto-start css:watch for worktree Docker environments

### DIFF
--- a/bin/wt-down
+++ b/bin/wt-down
@@ -73,6 +73,16 @@ teardown_worktree() {
         env_flag="--env-file $REPO_ROOT/.env"
     fi
 
+    # Stop CSS watcher if running
+    local css_pid_file="$wt_path/.css-watch.pid"
+    if [ -f "$css_pid_file" ]; then
+        local css_pid
+        css_pid=$(cat "$css_pid_file")
+        kill "$css_pid" 2>/dev/null || true
+        rm -f "$css_pid_file" "$wt_path/.css-watch.log"
+        echo "  Stopped CSS watcher (PID $css_pid)"
+    fi
+
     echo "Stopping environment: $slug (worktree: $wt_name, project: $project)..."
     if [ "$REMOVE_VOLUMES" = true ]; then
         docker compose -f "$compose_file" $env_flag -p "$project" down -v

--- a/bin/wt-up
+++ b/bin/wt-up
@@ -84,6 +84,12 @@ if ! docker ps --format '{{.Names}}' | grep -q '^ibl5-traefik$'; then
     echo "         (from $REPO_ROOT)"
 fi
 
+# Ensure node_modules symlink exists for CSS tooling
+NODE_MODULES="$WORKTREE_PATH/ibl5/node_modules"
+if [ ! -d "$NODE_MODULES" ]; then
+    ln -sf "$REPO_ROOT/ibl5/node_modules" "$NODE_MODULES"
+fi
+
 # Build CSS for the worktree
 STYLE_CSS="$WORKTREE_PATH/ibl5/themes/IBL/style/style.css"
 # Replace symlink with real file so Docker can mount the worktree cleanly
@@ -97,6 +103,20 @@ if [ ! -s "$STYLE_CSS" ]; then
     echo "CSS build failed or empty — copying from main repo..."
     cp "$REPO_ROOT/ibl5/themes/IBL/style/style.css" "$STYLE_CSS" 2>/dev/null || true
 fi
+
+# Kill any existing CSS watcher for this worktree
+CSS_PID_FILE="$WORKTREE_PATH/.css-watch.pid"
+if [ -f "$CSS_PID_FILE" ]; then
+    OLD_PID=$(cat "$CSS_PID_FILE")
+    kill "$OLD_PID" 2>/dev/null || true
+    rm -f "$CSS_PID_FILE"
+fi
+
+# Start CSS watcher in background so source changes auto-rebuild
+echo "Starting CSS watcher..."
+(cd "$WORKTREE_PATH/ibl5" && exec bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css --watch) \
+    > "$WORKTREE_PATH/.css-watch.log" 2>&1 &
+echo $! > "$CSS_PID_FILE"
 
 # Remove vendor symlink if present — named volume mounts over this path.
 # The symlink is created by wt-new for host-side tools; Docker doesn't need it.
@@ -256,6 +276,9 @@ echo ""
 echo "  URL:     http://$SLUG.localhost/ibl5/"
 echo "  Adminer: http://localhost:8082 (server: db-$SLUG)"
 echo "  DB CLI:  docker exec -it $DB_CONTAINER $DB_CMD"
+if [ -f "$CSS_PID_FILE" ]; then
+    echo "  CSS:     Watcher running (PID $(cat "$CSS_PID_FILE"), log: .css-watch.log)"
+fi
 echo ""
 
 # Safari warning


### PR DESCRIPTION
## Problem
CSS source changes in worktrees (via cherry-pick, git pull, manual edits) are not reflected in Docker containers until someone manually rebuilds `style.css`. This caused stale CSS serving after commits to branches with Docker running.

## Fix
`bin/wt-up` now starts a background `css:watch` process (host-side, not in Docker) that watches the worktree's `design/` directory and auto-rebuilds to `themes/IBL/style/style.css`. Since Docker bind-mounts the worktree directory, changes are immediately visible in the browser.

### Changes
- **`wt-up`**: Ensures `node_modules` symlink exists, starts `css:watch` in background, saves PID
- **`wt-down`**: Kills CSS watcher and cleans up PID/log files during teardown

### Output
```
  URL:     http://my-worktree.localhost/ibl5/
  Adminer: http://localhost:8082 (server: db-my-worktree)
  DB CLI:  docker exec -it ibl5-db-my-worktree ...
  CSS:     Watcher running (PID 12345, log: .css-watch.log)
```