### PR TITLE
ci: raise coverage threshold from 45% to 70%

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Check coverage threshold
       working-directory: ibl5
-      run: php bin/check-coverage coverage/clover.xml 45
+      run: php bin/check-coverage coverage/clover.xml 70
 
     - name: Upload coverage report
       if: always()


### PR DESCRIPTION
## Coverage Ratchet

Actual coverage is **72.50%**, but the CI threshold has been stuck at **45%** since PR #338 — a 27-point gap that prevents the gate from catching regressions.

### Changes
- Raises `check-coverage` threshold from 45% to 70% (2.5% buffer below current)

### Why
The threshold was set to 45% when non-testable code was first excluded from the denominator. Coverage has since grown to 72.50%, but the threshold was never ratcheted up. A PR could drop coverage by 25 percentage points and CI would still pass.