### PR TITLE
fix: disable auth throttling in E2E test environments

### DIFF
--- a/ibl5/classes/Auth/AuthService.php
+++ b/ibl5/classes/Auth/AuthService.php
@@ -60,7 +60,7 @@ class AuthService implements AuthServiceInterface
     private function getAuth(): Auth
     {
         if ($this->auth === null) {
-            $this->auth = new Auth(PdoConnection::getInstance(), null, 'auth_', true);
+            $this->auth = new Auth(PdoConnection::getInstance(), null, 'auth_', getenv('E2E_TESTING') !== '1');
         }
         return $this->auth;
     }

--- a/ibl5/tests/e2e/auth.setup.ts
+++ b/ibl5/tests/e2e/auth.setup.ts
@@ -15,7 +15,10 @@ setup('authenticate', async ({ page, request }) => {
 
   // Clear auth throttling before login — repeated test runs accumulate
   // failed attempts that trigger "Too many login attempts" and block auth.
-  await request.delete('test-state.php?action=clear-throttle');
+  const throttleResp = await request.delete('test-state.php?action=clear-throttle');
+  if (!throttleResp.ok()) {
+    console.warn(`Failed to clear auth throttle (HTTP ${throttleResp.status()}) — login may fail if throttled`);
+  }
 
   await page.goto('modules.php?name=YourAccount');
   const loginForm = page.locator('form', { has: page.locator('#login-username') });


### PR DESCRIPTION
## Problem

E2E auth setup fails when `auth_users_throttling` table accumulates entries across test runs. The existing `clear-throttle` mechanism in `auth.setup.ts` silently fails when `.env.test` isn't readable inside Docker (symlink to host path doesn't resolve).

## Fix

**Disable throttling at the source:** When `E2E_TESTING=1` is set, pass `throttling: false` to the delight-im/auth constructor. This means no throttle rows are ever written in test environments — eliminates the problem entirely rather than cleaning up after it.

**Make failures loud:** The `auth.setup.ts` clear-throttle request now logs a warning if the DELETE fails, instead of silently swallowing the response.

## Changes

- `AuthService.php`: `getenv('E2E_TESTING') !== '1'` controls the throttling constructor parameter
- `auth.setup.ts`: Check response status and `console.warn` on failure