### PR TITLE
test: add HTMX boost E2E verification helpers and tests

### DIFF
--- a/ibl5/tests/e2e/flows/auth.spec.ts
+++ b/ibl5/tests/e2e/flows/auth.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures/public';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { setNavMarker, assertNavMarkerGone } from '../helpers/htmx';
 
 // Login/Logout flow — uses public (unauthenticated) fixture throughout.
 // IMPORTANT: Do NOT use the auth fixture here. The logout test destroys the
@@ -65,6 +66,37 @@ test.describe('Login page', () => {
 
     // Should be on a different page now
     expect(page.url()).not.toContain('name=YourAccount');
+  });
+
+  test('login form performs full page reload (not HTMX boost)', async ({
+    page,
+  }) => {
+    const username = process.env.IBL_TEST_USER;
+    const password = process.env.IBL_TEST_PASS;
+
+    expect(username, 'IBL_TEST_USER must be set in .env.test').toBeTruthy();
+    expect(password, 'IBL_TEST_PASS must be set in .env.test').toBeTruthy();
+
+    await page.goto('modules.php?name=YourAccount');
+
+    // Mark nav before login — if it survives, HTMX boosted the form (wrong).
+    // If it's gone after login, a full page reload occurred (correct).
+    await setNavMarker(page);
+
+    const loginForm = page.locator('form', {
+      has: page.locator('#login-username'),
+    });
+    await loginForm.locator('#login-username').fill(username!);
+    await loginForm.locator('#login-password').fill(password!);
+    await loginForm.locator('button[type="submit"]').click();
+
+    await page.waitForURL(
+      (url) => !url.href.includes('name=YourAccount'),
+      { timeout: 10000 },
+    );
+
+    // Full page reload re-renders the entire DOM including nav — marker should be gone
+    await assertNavMarkerGone(page);
   });
 
   test('invalid credentials show error', async ({ page }) => {

--- a/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures/auth';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { setNavMarker, assertNavMarkerPersists } from '../helpers/htmx';
 
 // Depth Chart submission flow — tests that interact with the form.
 // Serial: submission tests depend on form state.
@@ -55,6 +56,8 @@ test.describe('Depth Chart submission', () => {
     await expect(form).toBeVisible({ timeout: 15000 });
 
     // Submit the current depth chart (already valid from seed data)
+    await setNavMarker(page);
+
     const submitBtn = page.locator('.depth-chart-buttons .depth-chart-submit-btn');
     await expect(submitBtn).toBeVisible();
     await submitBtn.click();
@@ -69,6 +72,7 @@ test.describe('Depth Chart submission', () => {
     const hasError = body?.match(/must have|active players|position/i);
 
     expect(hasSuccess || hasError).toBeTruthy();
+    await assertNavMarkerPersists(page);
     await assertNoPhpErrors(page, 'after depth chart submission');
   });
 

--- a/ibl5/tests/e2e/flows/trading-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/trading-submission.spec.ts
@@ -675,6 +675,14 @@ test.describe('Trade submission: accept and reject', () => {
     await expect(page.locator('.ibl-alert--success')).toBeVisible();
     await assertNoPhpErrors(page, 'after accept');
 
+    // Verify browser back/forward works after form submission redirect
+    const acceptedUrl = page.url();
+    await page.goBack();
+    await page.waitForURL(/reviewtrade/, { timeout: 10000 });
+    await page.goForward();
+    await page.waitForURL(/trade_accepted/, { timeout: 10000 });
+    expect(page.url()).toBe(acceptedUrl);
+
     // Clean up offer A if it still exists
     if (setupDone && offerAId > 0) {
       await rejectOfferSafe(request, offerAId, offeringTeam, listeningTeam);

--- a/ibl5/tests/e2e/helpers/htmx.ts
+++ b/ibl5/tests/e2e/helpers/htmx.ts
@@ -1,0 +1,35 @@
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * Mark the fixed nav element with a data attribute.
+ * Call BEFORE the action that should be intercepted by HTMX.
+ */
+export async function setNavMarker(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const navEl = document.querySelector('nav.fixed');
+    if (navEl) navEl.setAttribute('data-htmx-marker', '1');
+  });
+}
+
+/**
+ * Assert the nav marker still exists — nav was NOT re-rendered,
+ * confirming HTMX boosted the navigation (no full page reload).
+ */
+export async function assertNavMarkerPersists(page: Page): Promise<void> {
+  const marker = await page.evaluate(() => {
+    return document.querySelector('nav.fixed')?.getAttribute('data-htmx-marker');
+  });
+  expect(marker, 'nav marker should persist (HTMX boost, no full reload)').toBe('1');
+}
+
+/**
+ * Assert the nav marker is gone — nav WAS re-rendered,
+ * confirming a full page reload occurred (hx-boost="false" worked).
+ */
+export async function assertNavMarkerGone(page: Page): Promise<void> {
+  const marker = await page.evaluate(() => {
+    return document.querySelector('nav.fixed')?.getAttribute('data-htmx-marker');
+  });
+  expect(marker, 'nav marker should be gone (full page reload)').toBeNull();
+}

--- a/ibl5/tests/e2e/smoke/htmx.spec.ts
+++ b/ibl5/tests/e2e/smoke/htmx.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { setNavMarker, assertNavMarkerPersists } from '../helpers/htmx';
 
 // Public HTMX navigation tests — no authentication required.
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -15,11 +16,7 @@ test.describe('HTMX hx-boost navigation', () => {
     const nav = page.locator('nav.fixed').first();
     await expect(nav).toBeVisible();
 
-    // Mark the nav with a data attribute so we can verify it wasn't re-rendered
-    await page.evaluate(() => {
-      const navEl = document.querySelector('nav.fixed');
-      if (navEl) navEl.setAttribute('data-htmx-marker', '1');
-    });
+    await setNavMarker(page);
 
     // Click a visible boosted link within site-content (exclude topic icon links
     // which are absolutely-positioned image links that may not render visibly)
@@ -31,12 +28,7 @@ test.describe('HTMX hx-boost navigation', () => {
     await contentLink.click();
     await page.waitForURL(/modules\.php/);
 
-    // Verify the nav marker persists (nav was NOT re-rendered)
-    const marker = await page.evaluate(() => {
-      const navEl = document.querySelector('nav.fixed');
-      return navEl?.getAttribute('data-htmx-marker');
-    });
-    expect(marker).toBe('1');
+    await assertNavMarkerPersists(page);
   });
 
   test('URL updates via pushState on boosted navigation', async ({ page }) => {
@@ -109,11 +101,7 @@ test.describe('HTMX hx-boost navigation', () => {
     // Navigate to Search page which has a public POST form
     await page.goto('modules.php?name=Search');
 
-    // Mark the nav to verify it persists (no full reload)
-    await page.evaluate(() => {
-      const navEl = document.querySelector('nav.fixed');
-      if (navEl) navEl.setAttribute('data-htmx-marker', '1');
-    });
+    await setNavMarker(page);
 
     // Fill in search query and submit the form
     const searchInput = page.locator('input[name="query"]').first();
@@ -125,17 +113,10 @@ test.describe('HTMX hx-boost navigation', () => {
     await expect(submitBtn).toBeVisible();
     await submitBtn.click();
 
-    // Wait for HTMX to swap content — the search renders results inline,
-    // so wait for the results content to appear in site-content
-    await expect(page.locator('#site-content').first()).toBeVisible({ timeout: 10000 });
-    // Wait for search results or "no results" message to render
-    await page.waitForTimeout(1000);
+    // Wait for HTMX to swap content — search renders results inline.
+    // The search form re-renders after swap, so wait for it to appear.
+    await expect(page.locator('.search-form').first()).toBeVisible({ timeout: 10000 });
 
-    // Verify the nav marker persists (nav was NOT re-rendered = no full page reload)
-    const marker = await page.evaluate(() => {
-      const navEl = document.querySelector('nav.fixed');
-      return navEl?.getAttribute('data-htmx-marker');
-    });
-    expect(marker).toBe('1');
+    await assertNavMarkerPersists(page);
   });
 });


### PR DESCRIPTION
## Summary

Adds automated E2E tests covering the manual testing steps from PR #491 (HTMX form boost). Introduces shared helpers for the nav marker pattern and adds assertions to existing tests.

## Changes

### New: `tests/e2e/helpers/htmx.ts`
- `setNavMarker(page)` — marks `nav.fixed` with a data attribute before an action
- `assertNavMarkerPersists(page)` — verifies nav survived (HTMX swap, no full reload)
- `assertNavMarkerGone(page)` — verifies nav was re-rendered (full page reload)

### Refactored: `htmx.spec.ts`
- Link and form boost tests now use shared helpers instead of inline `page.evaluate`
- Replaced `waitForTimeout(1000)` anti-pattern with proper `.search-form` visibility assertion

### New assertions in existing tests
- **Depth chart submission:** Nav marker persists after form submit (inline render, no redirect)
- **Login form:** Nav marker is gone after login (proves `hx-boost="false"` opt-out works)
- **Trading accept:** Browser back/forward works after form submission redirect

### Key discovery
`HX-Redirect` triggers `window.location.href = url` (full browser navigation), so nav marker assertions are not applicable to forms that redirect (trading, waivers, free agency). They only apply to forms that render inline (search, depth chart).

## Manual Testing Checklist (from PR #491)

| Step | Automated? | How |
|------|-----------|-----|
| Submit trade offer → no broken HTML | Already covered | Existing E2E checks success banner |
| Accept/reject trade → works | Already covered | Existing E2E checks banners + back/forward |
| Depth chart submit → in-place | New assertion | Nav marker persists (no full reload) |
| Waiver claim → in-place | Blocked | Pre-existing CI 500 bug |
| Login → full page reload | New test | Nav marker gone (hx-boost=false works) |
| Back/forward after form | New assertion | Trading accept: goBack/goForward |

## Manual Testing

No manual testing needed — all changes are covered by E2E tests.