### PR TITLE
fix: catch waiver submission errors + CI PHP error logging

### DIFF
--- a/ibl5/classes/Waivers/WaiversController.php
+++ b/ibl5/classes/Waivers/WaiversController.php
@@ -94,15 +94,26 @@ class WaiversController implements WaiversControllerInterface
 
         // PRG: Process POST submission, then redirect
         if (isset($_POST['Action']) && ($_POST['Action'] === 'add' || $_POST['Action'] === 'waive')) {
+            $postAction = is_string($_POST['Action']) ? $_POST['Action'] : 'add';
+
             if (!\Utilities\CsrfGuard::validateSubmittedToken('waivers')) {
-                $postAction = is_string($_POST['Action']) ? $_POST['Action'] : 'add';
                 header('Location: modules.php?name=Waivers&action=' . rawurlencode($postAction) . '&error=' . rawurlencode('Invalid or expired form submission. Please try again.'));
                 exit;
             }
-            /** @var array<string, string> $postData */
-            $postData = $_POST;
-            $result = $this->processWaiverSubmission($postData);
-            $postAction = $_POST['Action'];
+
+            try {
+                /** @var array<string, string> $postData */
+                $postData = $_POST;
+                $result = $this->processWaiverSubmission($postData);
+            } catch (\Throwable $e) {
+                \Logging\LoggerFactory::getChannel('audit')->error('waiver_submission_error', [
+                    'error' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]);
+                $result = ['success' => false, 'error' => 'An unexpected error occurred: ' . $e->getMessage()];
+            }
+
             if ($result['success'] === true) {
                 $resultParam = $result['result'] ?? '';
                 header('Location: modules.php?name=Waivers&action=' . rawurlencode($postAction) . '&result=' . rawurlencode($resultParam));


### PR DESCRIPTION
## Problem

The waivers form POST returns HTTP 500 with empty body in CI. The `ob_start('ob_gzhandler')` in mainfile.php swallows the error text when PHP fatally errors during gzip-buffered output. The old E2E test masked this by matching the pre-redirect URL immediately.

## Changes

1. **WaiversController**: Wrap `processWaiverSubmission()` in try/catch to convert uncaught exceptions into proper error redirects instead of bare 500s
2. **e2e-tests.yml**: Add PHP error log file (`/tmp/php_errors.log`) and dump step on failure
3. **waivers-submission.spec.ts**: Full form submission test with POST response capture

## How to verify

If the try/catch surfaces the error, the test will show the exception message in the URL. If a deeper issue persists, the PHP error log dump in CI will capture it.