### PR TITLE
test: expand mutation test coverage for PlrParser and JsbParser

### DIFF
--- a/ibl5/infection.json5
+++ b/ibl5/infection.json5
@@ -8,7 +8,7 @@
             "*Controller*", "*Handler*",
             "*/Contracts/*",
             "SiteStatistics", "Bootstrap", "Database", "Auth", "Cache",
-            "JsbParser", "PlrParser", "Scripts", "Discord",
+            "Scripts", "Discord",
             "OneOnOneGame", "UI.php", "Game.php", "JSB.php"
         ]
     },

--- a/ibl5/tests/JsbParser/AswFileParserTest.php
+++ b/ibl5/tests/JsbParser/AswFileParserTest.php
@@ -288,6 +288,30 @@ class AswFileParserTest extends TestCase
         }
     }
 
+    public function testZeroPlayerIdsAreFilteredFromRosters(): void
+    {
+        // Interleave zeros between real PIDs — the parser must exclude them
+        $lines = array_fill(0, AswFileParser::TOTAL_DATA_LINES, '0');
+        $lines[AswFileParser::ALLSTAR_1_START] = '1001';
+        $lines[AswFileParser::ALLSTAR_1_START + 1] = '0';
+        $lines[AswFileParser::ALLSTAR_1_START + 2] = '1002';
+
+        $content = implode("\r\n", $lines) . "\r\n";
+        if (strlen($content) < AswFileParser::FILE_SIZE) {
+            $content = str_pad($content, AswFileParser::FILE_SIZE);
+        }
+
+        $tmpFile = $this->writeTmpAswFile($content);
+
+        try {
+            $result = AswFileParser::parseFile($tmpFile);
+
+            $this->assertSame([1001, 1002], $result['rosters']['allstar_1']);
+        } finally {
+            unlink($tmpFile);
+        }
+    }
+
     public function testParseFileReturnsCorrectScoreValues(): void
     {
         $aswData = $this->buildAswFile(

--- a/ibl5/tests/JsbParser/HisFileParserTest.php
+++ b/ibl5/tests/JsbParser/HisFileParserTest.php
@@ -144,6 +144,42 @@ class HisFileParserTest extends TestCase
         $this->assertSame('first round', $result['playoff_round_reached']);
     }
 
+    public function testParseTeamLineWithFinals(): void
+    {
+        $line = 'Heat (60-22) lose to the Clippers (62-20) 4 games to 2 in the finals (2001)';
+        $result = HisFileParser::parseTeamLine($line);
+
+        $this->assertNotNull($result);
+        $this->assertSame('Heat', $result['name']);
+        $this->assertSame(1, $result['made_playoffs']);
+        $this->assertSame(0, $result['won_championship']);
+        $this->assertSame('finals', $result['playoff_round_reached']);
+    }
+
+    public function testParseTeamLineWithSecondRound(): void
+    {
+        $line = 'Lakers (54-28) lose in the 2nd round (2001)';
+        $result = HisFileParser::parseTeamLine($line);
+
+        $this->assertNotNull($result);
+        $this->assertSame('Lakers', $result['name']);
+        $this->assertSame(1, $result['made_playoffs']);
+        $this->assertSame(0, $result['won_championship']);
+        $this->assertSame('second round', $result['playoff_round_reached']);
+    }
+
+    public function testParseTeamLineWithGenericPlayoff(): void
+    {
+        $line = 'Nets (45-37) make the Playoffs (2001)';
+        $result = HisFileParser::parseTeamLine($line);
+
+        $this->assertNotNull($result);
+        $this->assertSame('Nets', $result['name']);
+        $this->assertSame(1, $result['made_playoffs']);
+        $this->assertSame(0, $result['won_championship']);
+        $this->assertSame('first round', $result['playoff_round_reached']);
+    }
+
     public function testParseTeamLineNoPlayoffs(): void
     {
         $line = 'Celtics (24-58) (1988)';

--- a/ibl5/tests/JsbParser/TrnFileParserTest.php
+++ b/ibl5/tests/JsbParser/TrnFileParserTest.php
@@ -128,6 +128,39 @@ class TrnFileParserTest extends TestCase
     }
 
     /**
+     * Build a trade record with draft pick items (marker=1).
+     *
+     * @param int $month Transaction month
+     * @param int $day Transaction day
+     * @param int $year Transaction year
+     * @param list<array{draft_year: int, from_team: int, to_team: int}> $items Draft pick trade items
+     */
+    private function buildDraftPickTradeRecord(int $month, int $day, int $year, array $items): string
+    {
+        $record = str_repeat(' ', TrnFileParser::RECORD_SIZE);
+
+        // Common header
+        $record = substr_replace($record, str_pad((string) $month, 2, ' ', STR_PAD_LEFT), 17, 2);
+        $record = substr_replace($record, str_pad((string) $day, 2, ' ', STR_PAD_LEFT), 19, 2);
+        $record = substr_replace($record, str_pad((string) $year, 4, ' ', STR_PAD_LEFT), 21, 4);
+        $record = substr_replace($record, (string) TrnFileParser::TYPE_TRADE, 26, 1);
+
+        // Draft pick items starting at offset 27
+        $tradeOffset = 27;
+        foreach ($items as $item) {
+            // marker(1) + draft_year(6) + from_team(6) + to_team(6) = 19 bytes
+            $itemStr = '1'; // marker = draft pick
+            $itemStr .= str_pad((string) $item['draft_year'], 6, ' ', STR_PAD_LEFT);
+            $itemStr .= str_pad((string) $item['from_team'], 6, ' ', STR_PAD_LEFT);
+            $itemStr .= str_pad((string) $item['to_team'], 6, ' ', STR_PAD_LEFT);
+            $record = substr_replace($record, $itemStr, $tradeOffset, TrnFileParser::TRADE_ITEM_SIZE);
+            $tradeOffset += TrnFileParser::TRADE_ITEM_SIZE;
+        }
+
+        return $record;
+    }
+
+    /**
      * Write synthetic data to a temp file and return the path.
      */
     private function writeTmpTrnFile(string $data): string
@@ -278,6 +311,47 @@ class TrnFileParserTest extends TestCase
             $this->assertIsArray($waiver);
             $this->assertSame(8, $waiver['team_id']);
             $this->assertSame(9999, $waiver['pid']);
+        } finally {
+            unlink($tmpFile);
+        }
+    }
+
+    public function testParsesDraftPickTradeItems(): void
+    {
+        $tradeRecord = $this->buildDraftPickTradeRecord(3, 15, 2007, [
+            ['draft_year' => 2008, 'from_team' => 5, 'to_team' => 10],
+            ['draft_year' => 2009, 'from_team' => 10, 'to_team' => 5],
+        ]);
+        $trnData = $this->buildTrnFile(1, [$tradeRecord]);
+        $tmpFile = $this->writeTmpTrnFile($trnData);
+
+        try {
+            $result = TrnFileParser::parseFile($tmpFile);
+
+            $trades = array_filter(
+                $result['transactions'],
+                static fn (array $t): bool => $t['type'] === TrnFileParser::TYPE_TRADE
+                    && is_array($t['trade_items'])
+                    && $t['trade_items'] !== []
+            );
+
+            $this->assertNotEmpty($trades, 'Should find at least one trade record with draft pick items');
+
+            $trade = reset($trades);
+            $this->assertIsArray($trade);
+            $this->assertIsArray($trade['trade_items']);
+            $this->assertCount(2, $trade['trade_items']);
+
+            $item = $trade['trade_items'][0];
+            $this->assertSame(TrnFileParser::TRADE_MARKER_DRAFT_PICK, $item['marker']);
+            $this->assertSame(2008, $item['draft_year']);
+            $this->assertSame(5, $item['from_team']);
+            $this->assertSame(10, $item['to_team']);
+            $this->assertNull($item['player_id']);
+
+            $item2 = $trade['trade_items'][1];
+            $this->assertSame(TrnFileParser::TRADE_MARKER_DRAFT_PICK, $item2['marker']);
+            $this->assertSame(2009, $item2['draft_year']);
         } finally {
             unlink($tmpFile);
         }

--- a/ibl5/tests/PlrParser/PlrParserServiceTest.php
+++ b/ibl5/tests/PlrParser/PlrParserServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\PlrParser;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PlrParser\Contracts\PlrParserRepositoryInterface;
 use PlrParser\PlrParserService;
@@ -284,6 +285,45 @@ class PlrParserServiceTest extends TestCase
         $derived = $this->service->computeDerivedFields($raw, 0.0);
 
         $this->assertSame(0, $derived['ratingFOUL']);
+    }
+
+    public function testParsePlrLineAcceptsOrdinalExactly1440(): void
+    {
+        $line = $this->buildPlrLine(['ordinal' => 1440, 'pid' => 12345]);
+
+        $result = $this->service->parsePlrLine($line);
+
+        $this->assertNotNull($result);
+        $this->assertSame(1440, $result['ordinal']);
+    }
+
+    #[DataProvider('contractYearSalaryProvider')]
+    public function testComputeDerivedFieldsSalaryForContractYears3Through6(int $contractYear, int $expectedSalary): void
+    {
+        $raw = $this->buildRawParsedData([
+            'currentContractYear' => $contractYear,
+            'contractYear3' => 600,
+            'contractYear4' => 650,
+            'contractYear5' => 700,
+            'contractYear6' => 750,
+        ]);
+
+        $derived = $this->service->computeDerivedFields($raw, 0.1);
+
+        $this->assertSame($expectedSalary, $derived['currentSeasonSalary']);
+    }
+
+    /**
+     * @return array<string, array{int, int}>
+     */
+    public static function contractYearSalaryProvider(): array
+    {
+        return [
+            'contract year 3' => [3, 600],
+            'contract year 4' => [4, 650],
+            'contract year 5' => [5, 700],
+            'contract year 6' => [6, 750],
+        ];
     }
 
     public function testProcessPlrFileWithValidFile(): void


### PR DESCRIPTION
## Summary

Removes `JsbParser` and `PlrParser` from Infection mutation testing excludes, bringing ~3,500 LOC of pure parser business logic under mutation coverage. Adds 7 targeted tests to kill confirmed surviving mutants and maintain MSI thresholds.

## Changes

### Config
- Removed `JsbParser` and `PlrParser` from `infection.json5` excludes array
- Existing `*Repository*` and `*/Contracts/*` globs continue to exclude non-testable files

### New Tests (10 test cases across 4 files)

| File | Tests Added | Mutant Killed |
|------|------------|---------------|
| `PlrParserServiceTest` | ordinal=1440 boundary | `> 1440` → `>= 1440` |
| `PlrParserServiceTest` | contract years 3-6 (data provider, 4 cases) | `contractYear` key mutation |
| `HisFileParserTest` | finals round | `finals` branch with negation guards |
| `HisFileParserTest` | second round | Dead `(second\|2nd)` regex branch |
| `HisFileParserTest` | generic playoff | `playoff` fallback branch |
| `TrnFileParserTest` | draft pick trade items | `TRADE_MARKER_DRAFT_PICK` branch |
| `AswFileParserTest` | zero-value filtering | `> 0` → `>= 0` in parseRosterSection |

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.