### PR TITLE
feat: add Player Export link to navigation menu

### DIFF
--- a/ibl5/classes/Navigation/NavigationMenuBuilder.php
+++ b/ibl5/classes/Navigation/NavigationMenuBuilder.php
@@ -37,6 +37,7 @@ class NavigationMenuBuilder implements NavigationMenuBuilderInterface
                     ['label' => 'Schedule', 'url' => 'modules.php?name=Schedule'],
                     ['label' => 'Injuries', 'url' => 'modules.php?name=Injuries'],
                     ['label' => 'Player Database', 'url' => 'modules.php?name=PlayerDatabase'],
+                    ['label' => 'Player Export', 'url' => 'modules.php?name=PlayerExportGuide'],
                     $this->config->isDraftOrderFinalized
                         ? ['label' => 'Draft Order', 'url' => 'modules.php?name=ProjectedDraftOrder', 'badge' => 'FINAL']
                         : ['label' => 'Projected Draft Order', 'url' => 'modules.php?name=ProjectedDraftOrder'],


### PR DESCRIPTION
## Summary

Adds "Player Export" link to the Season section of the navigation menu, directly after "Player Database". This was planned as part of the CSV Player Export feature (PRs #492 + #506) but was missed during implementation.

Links to `modules.php?name=PlayerExportGuide` — the Google Sheets IMPORTDATA how-to page created in #506.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.