### PR TITLE
fix: make deploy workflow resilient to server-side drift

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Pull latest code on server
         run: |
           ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} '
+            set -e
             cd www
             git fetch origin
             git reset --hard origin/production


### PR DESCRIPTION
## Problem

Every deploy kills IBL6 at the start of the workflow (`pkill -f 'node build/index[.]js'`). If any subsequent step fails, IBL6 never restarts — leaving `ibl6.iblhoops.net` returning 503.

This has been happening for **5+ consecutive deploys** because `git pull origin` fails with:

```
error: Your local changes to the following files would be overwritten by merge:
    ibl5/vendor
Please commit your changes or stash them before you merge.
```

The `ibl5/vendor` symlink was tracked by git, then `composer install --no-dev` on the server replaced it with a real directory full of packages. Incoming commits that remove the tracked symlink can't merge over the dirty file.

## Changes

### 1. Replace `git pull` with `git fetch + reset --hard`
A deploy server should always match the repo exactly. Local drift from `composer install`, migrations, or other tooling should never block a deploy. `git reset --hard origin/production` ensures the server state is authoritative from the repo.

### 2. Add `if: \!\cancelled()` to "Start IBL6"
IBL6 must restart regardless of whether earlier steps (migrations, CSS deploy, IBLbot, etc.) failed. Previously, any mid-workflow failure left the site down until the next successful deploy.

## Manual Testing

No manual testing needed — changes are CI/CD workflow only. The fix will be validated when the next push to `production` triggers the workflow successfully.