### PR TITLE
feat: add production smoke test to deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,11 +175,17 @@ jobs:
           sleep 5
 
           for url in https://ibl6.iblhoops.net/ https://iblhoops.net/ibl5/; do
-            status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url")
-            if [ "$status" -ge 200 ] && [ "$status" -lt 400 ]; then
-              echo "✓ $url → $status"
-            else
-              echo "✗ $url → $status"
-              exit 1
-            fi
+            for attempt in 1 2 3; do
+              status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url")
+              if [ "$status" -ge 200 ] && [ "$status" -lt 400 ]; then
+                echo "✓ $url → $status"
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "✗ $url → $status (after 3 attempts)"
+                exit 1
+              fi
+              echo "  $url → $status, retrying in 5s..."
+              sleep 5
+            done
           done


### PR DESCRIPTION
## Problem

The deploy workflow had no verification that production sites are actually responding after deployment. The recent 503 outage (fixed in #509) went undetected for 5+ deploys because nothing checked if IBL6 was actually serving traffic.

## Changes

Adds a smoke test step at the end of the deploy workflow that curls both production sites and verifies they return 2xx/3xx responses:

- **https://ibl6.iblhoops.net/** — SvelteKit frontend
- **https://iblhoops.net/ibl5/** — PHP backend

The step uses `if: \!\cancelled()` so it runs even if earlier steps failed — catching scenarios where IBL6 fails to start. A 5-second wait allows the Node.js process to initialize before probing.

If either site returns a 4xx/5xx, the workflow fails, making the deploy status visible in GitHub.

## Manual Testing

No manual testing needed — changes are CI/CD workflow only. The smoke test will be validated when the next push to `production` triggers the workflow.