### PR TITLE
feat: bump Infection mutation thresholds to 100% MSI and 100% Covered MSI

### DIFF
--- a/ibl5/infection.json5
+++ b/ibl5/infection.json5
@@ -24,8 +24,8 @@
     },
     "testFramework": "phpunit",
     "testFrameworkOptions": "",
-    "minMsi": 75,
-    "minCoveredMsi": 90,
+    "minMsi": 100,
+    "minCoveredMsi": 100,
     "threads": 4,
     "logs": {
         "text": "infection.log",


### PR DESCRIPTION
## Summary

Raises the Infection PHP mutation testing thresholds to reflect the perfect scores achieved after expanding coverage to PlrParser and JsbParser in PR #507.

## Changes

- `minMsi`: 75 → 100
- `minCoveredMsi`: 90 → 100

## Background

After PR #507 added PlrParser and JsbParser to mutation scope, the CI run ([job 68454972534](https://github.com/a-jay85/IBL5/actions/runs/23518071518/job/68454972534)) achieved **100% MSI / 100% Covered Code MSI** across **11,097 mutants**. These thresholds lock in that result so any future regression in mutation coverage will fail CI.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.