### PR TITLE
docs: catch up .md files with PRs #496–#515

### DIFF
--- a/.claude/rules/database-access.md
+++ b/.claude/rules/database-access.md
@@ -49,6 +49,14 @@ mariadb -h 127.0.0.1 --skip-ssl -u root -proot iblhoops_ibl5
 
 **When to use `db-query`:** Use this script to explore the database schema, verify data after making changes, check record counts, and validate your work. This is the preferred method for Claude to query the local database since it's configured for auto-approval in the user's Claude Code settings.
 
+## Migration Runner
+
+```bash
+bin/db-migrate <db-container> <migrations-dir>
+```
+
+Runs pending SQL migrations against a Docker MariaDB container. Tracks applied migrations in `schema_migrations(version VARCHAR PRIMARY KEY)`. Idempotent — skips already-applied migrations. Used internally by `bin/wt-up` to apply migrations after seeding.
+
 ## MariaDB Strict Mode & Triggers
 
 - **NOT NULL columns without DEFAULT reject INSERTs before BEFORE INSERT triggers fire.** If a column is `NOT NULL` with no `DEFAULT`, MariaDB strict mode (enabled by default since 10.2) throws `Field 'x' doesn't have a default value` *before* any BEFORE INSERT trigger can auto-populate it. All uuid columns now have `DEFAULT (UUID())` (migration 065), so uuid is no longer an example of this problem. The rule still applies to other NOT NULL columns without defaults.

--- a/.claude/rules/php-classes.md
+++ b/.claude/rules/php-classes.md
@@ -34,6 +34,11 @@ class MyRepository extends BaseMysqliRepository
 
 **Note:** The `MySQL` class exists only for PHP-Nuke backward compatibility and should not be used in new code.
 
+## API Response Types
+
+- **JSON:** `Api\Response\JsonResponder` — standard API responses (Controller → JsonResponder)
+- **CSV:** `Api\Response\CsvResponder` — streaming CSV with UTF-8 BOM for Excel compatibility (Controller → Transformer → CsvResponder). See `PlayerExportController` for the canonical example.
+
 ## View Rendering Pattern
 Use output buffering with `HtmlSanitizer::e()` for XSS-safe output:
 ```php

--- a/.claude/rules/phpunit-tests.md
+++ b/.claude/rules/phpunit-tests.md
@@ -151,6 +151,31 @@ $this->mockDb->setMockData([['pid' => 1, 'name' => 'Player']]);
 
 `MockDatabase` extends `\mysqli` without a real connection. Accessing `$db->insert_id` (used by `BaseMysqliRepository::getLastInsertId()`) throws "object is already closed". Tests for code paths that INSERT and read `insert_id` (e.g., `createSavedDepthChart()`) cannot use MockDatabase — use DB integration tests instead.
 
+## Module Entry Point Tests
+
+For testing module `index.php` files end-to-end in PHPUnit, extend `ModuleEntryPointTestCase`:
+
+```php
+class ScheduleEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testHandlesInvalidTeamID(): void
+    {
+        $output = $this->runModule('Schedule', get: ['teamID' => 'abc']);
+        $this->assertStringContainsString('Schedule', $output);
+    }
+}
+```
+
+- Extend `Tests\Module\EntryPoints\ModuleEntryPointTestCase` (which extends `IntegrationTestCase`)
+- Use `$this->runModule('ModuleName', get: [...], post: [...])` to include the module's `index.php` and capture output
+- Use `$this->authenticateAs('username')` to simulate an authenticated user
+- Lives in `tests/Module/EntryPoints/`, registered under the "Module Tests" testsuite
+- The class handles double output buffering for `PageLayout::footer()`'s `ob_end_flush()` — do not wrap `runModule()` in your own `ob_start()`
+
+## Mutation Testing
+
+Mutation testing (Infection PHP) runs weekly + on-demand via the `mutation-test` PR label — NOT on every PR. Current thresholds: **100% MSI / 100% Covered MSI**. See `memory/ci-quality-gates.md` for full details.
+
 ## Completion Criteria
 
 **IMPORTANT:** Before considering ANY task involving PHP code complete:

--- a/.claude/rules/playwright-tests.md
+++ b/.claude/rules/playwright-tests.md
@@ -264,7 +264,7 @@ test.describe('Public module flow', () => {
 
 **Allowlisted settings:** `Current Season Phase`, `Current Season Ending Year`, `Allow Trades`, `Allow Waiver Moves`, `Show Draft Link`, `Trivia Mode`, `ASG Voting`, `EOY Voting`, `Free Agency Notifications`.
 
-**Serial mode:** When multiple `describe` blocks in the same file set the same setting to different values, use `test.describe.configure({ mode: 'serial' })` at the file level to prevent interleaving.
+**Serial mode:** Prefer splitting a spec file into read-only (`smoke/` or `flows/`) and submission (`flows/*-submission.spec.ts`) files rather than applying file-level `test.describe.configure({ mode: 'serial' })`. Use serial mode only within a single `describe` block where tests genuinely share state (e.g., a multi-step submission flow). See `voting.spec.ts` / `voting-submission.spec.ts` split as the canonical example.
 
 ## DO:
 1. Check for PHP errors on every page you visit in smoke tests
@@ -323,6 +323,11 @@ if (count > 0) { assertA(); } else { assertB(); }
 // BANNED — true-only guard (silently passes when absent)
 if (count > 0) { await expect(el).toBeVisible(); }
 ```
+
+## Shared Helpers
+
+- **`helpers/navigation.ts`**: `gotoWithRetry(page, url)` — retries up to 5 times with back-off when PHP's built-in server returns blank pages under parallel load. Use instead of bare `page.goto()` in parallel-load-sensitive tests (e.g., mobile tests).
+- **`smoke/htmx.spec.ts`**: Nav marker pattern — set `data-htmx-marker` on `nav.fixed` before an action, then check if the attribute persists to verify HTMX swap (no full reload). Only works for inline-rendering forms (search, depth chart), not forms that redirect via `HX-Redirect`.
 
 ## CI Workflow Notes
 

--- a/.claude/rules/view-rendering.md
+++ b/.claude/rules/view-rendering.md
@@ -7,8 +7,8 @@ paths: "**/*View.php"
 ## Canonical View Examples
 Reference these before building new Views:
 - `FreeAgency/FreeAgencyView.php` — complex tables with sticky columns, team colors, footer rows
-- `PlayerInfo/PlayerInfoView.php` — cards, stats grids, tabbed layouts
-- `ScoParser/ScoParserView.php` — custom component with dedicated CSS
+- `Player/Views/PlayerSeasonStatsView.php` — cards, stats grids, tabbed layouts
+- `Voting/VotingSubmissionView.php` — confirmation/error pages with CSS classes
 
 ## XSS Protection (MANDATORY)
 ALL dynamic content must use `HtmlSanitizer::e()` (short alias) or `HtmlSanitizer::safeHtmlOutput()`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,10 @@ E2E tests do NOT auto-run via hooks — run manually. Requires Docker + `.env.te
 
 ## Architecture
 
-New features should follow the Repository-Service-View pattern. See `ibl5/scripts/scoParser.php` as the canonical refactored example.
+New features should follow the Repository-Service-View pattern. See `Waivers/` (Repository, Service, Processor, Validator, View, Controller) as the canonical refactored example.
 
 ### Interface-Driven Modules
-All 30 modules in `ibl5/classes/` follow Repository/Service/View pattern with interfaces in `Contracts/` subdirectories. See `php-classes.md` for structure details.
+The modules in `ibl5/classes/` follow Repository/Service/View pattern with interfaces in `Contracts/` subdirectories. See `php-classes.md` for structure details.
 
 ### Legacy (Non-IBL) Modules
 - **SiteStatistics:** A legacy PHP-Nuke module for tracking site visitor/page-view statistics. It is **not** basketball- or IBL-related and should be deprioritized against core IBL modules during refactoring or feature work.

--- a/ibl5/docs/DOCKER_SETUP.md
+++ b/ibl5/docs/DOCKER_SETUP.md
@@ -118,10 +118,19 @@ Run multiple worktrees simultaneously, each with its own PHP-Apache container an
 bin/wt-up my-feature              # → http://my-feature.localhost/ibl5/
 
 # With test seed data
-bin/wt-up my-feature --seed       # Also imports ci-seed.sql
+bin/wt-up my-feature --seed       # Import ci-seed.sql (schema + CI seed)
+
+# With production seed data (default if no data flag)
+bin/wt-up my-feature --prod       # Import prod-seed.sql
+
+# Schema only, no seed data
+bin/wt-up my-feature --no-data
 
 # Use PR number as URL
 bin/wt-up my-feature --pr         # → http://pr-42.localhost/ibl5/
+
+# Reinstall vendor after composer.lock changes
+bin/wt-up my-feature --fresh-vendor
 ```
 
 ### Managing Environments
@@ -143,6 +152,7 @@ bin/wt-down --all --volumes
 ### How It Works
 
 - **Traefik** (port 80) routes by `Host` header — `main.localhost` goes to the main repo, `<slug>.localhost` goes to each worktree
+- A single static compose file (`docker/worktree-compose.yml`) is reused for all worktrees — Docker Compose interpolates `${SLUG}`, `${WORKTREE_PATH}`, and `${REPO_ROOT}` from exported environment variables (no per-worktree compose files are generated)
 - Each worktree gets its own MariaDB container with an isolated database
 - `*.localhost` resolves to `127.0.0.1` natively in Chrome and Firefox (RFC 6761)
 - **Safari** requires manual `/etc/hosts` entries (the script prints a reminder)


### PR DESCRIPTION
## Summary

Batch documentation update for deferred .md changes across the last 20 merged PRs.

## Changes

### High Priority — dead references
- **CLAUDE.md**: Replace dead `scoParser.php` canonical example with `Waivers/` module; remove fragile "30 modules" count (now 65+)
- **view-rendering.md**: Replace 2 dead canonical View examples (`PlayerInfoView`, `ScoParserView`) with existing files (`PlayerSeasonStatsView`, `VotingSubmissionView`)

### Medium Priority — missing documentation
- **phpunit-tests.md**: Add `ModuleEntryPointTestCase` pattern (PR #498) and mutation testing section (PR #511)
- **playwright-tests.md**: Clarify serial mode to prefer file splits over file-level serial (PR #505)
- **database-access.md**: Add `bin/db-migrate` CLI tool (PR #500)
- **DOCKER_SETUP.md**: Add missing `wt-up` flags (`--prod`, `--no-data`, `--fresh-vendor`) and native Compose interpolation note (PR #500)

### Low Priority — additions
- **playwright-tests.md**: Add Shared Helpers section (`gotoWithRetry`, HTMX nav marker pattern)
- **php-classes.md**: Add API Response Types section (`JsonResponder`, `CsvResponder` from PR #506)

Also updated `memory/worktree-setup.md` with `bin/db-migrate` reference.

## Manual Testing

No manual testing needed — documentation-only changes.