### PR TITLE
docs: rewrite STRATEGIC_PRIORITIES.md to reflect current codebase state

### DIFF
--- a/ibl5/docs/STRATEGIC_PRIORITIES.md
+++ b/ibl5/docs/STRATEGIC_PRIORITIES.md
@@ -1,331 +1,94 @@
 # Strategic Development Priorities for IBL5
 
-**Last Updated:** March 2, 2026
-**Status:** 31/31 IBL modules refactored (100% complete) ✅
+**Last Updated:** March 25, 2026
 
-## Executive Summary
+## Current State
 
-All IBL modules are now **complete** ✅, marking a major milestone with **100% of IBL modules refactored**. The test suite has grown to 4393 tests with ~80% coverage.
+IBL5 has completed its full-stack modernization from a PHP-Nuke monolith to an interface-driven architecture with Repository/Service/View separation, a REST API layer, HTMX-powered frontend, and comprehensive CI/CD. The codebase is in **maturation mode** — the architecture is established, and work focuses on extending capabilities, hardening quality gates, and retiring legacy debt.
 
-### Progress
-- ✅ **31 modules refactored** (100% complete)
-- ✅ **3370 total tests** passing
-- ✅ **~80% test coverage** (goal achieved ✅)
-- ✅ **63 integration test methods** across 6 workflow suites (Draft, Extension, FreeAgency, Negotiation, Trading, Waivers)
-- ✅ **All core, admin, and display modules complete**
+### What's Built
 
-### Phase Transition: From Refactoring to Maturation
+- **All IBL modules** follow Repository/Service/View pattern with `Contracts/` interfaces
+- **REST API** with 17 controllers, API key auth, rate limiting, ETag caching, pagination, CSV export
+- **Security stack**: CSP + HSTS + X-Frame-Options headers, CSRF on all forms, `HtmlSanitizer::e()` on all output, prepared statements everywhere
+- **HTMX frontend**: boosted navigation (SPA-like), tab switching via `hx-get`, partial-page loading, form boost
+- **Test pyramid**: PHPUnit (unit + integration + module entry point), Playwright E2E (functional + visual regression), Infection mutation testing at 100% MSI
+- **CI/CD**: PHPUnit + PHPStan + Playwright + Lighthouse + CodeQL + migration safety + mutation testing + production smoke tests + auto-rebase
+- **Docker dev environment**: multi-worktree with Traefik routing, isolated DBs, automated migration runner
+- **IBL6 SvelteKit frontend** in early development (`IBL6/`)
 
-With 96% of IBL modules refactored, the project transitions from **refactoring mode** to **maturation mode**. New strategic priorities focus on:
+### Quality Gates (enforced by CI)
 
-1. **Test Coverage** - Push from 56% to 80%
-2. **API Development** - Build REST API for refactored modules
-3. **Security Hardening** - Complete security audit and CSRF protection
-4. **Performance Optimization** - Query optimization and caching
-5. **Documentation** - API docs, deployment guides, developer onboarding
-
----
-
-## Completed Refactorings (Last 4)
-
-### 31. LeagueControlPanel Module ✅ (March 2, 2026)
-
-**Achievements:**
-- 4 classes + 4 interfaces created with separation of concerns
-- Reduced module code: 353 → 31 lines (91% reduction)
-- 56 comprehensive unit tests (148 assertions)
-- Admin authentication guard with login redirect and 403 access control
-- CSS extracted to design/components/league-control-panel.css
-- Replaced fragile button-label dispatching with stable snake_case action keys
-- PRG (Post-Redirect-Get) pattern for form submissions
-- XSS protection with HtmlSanitizer::e() on all output
-
-**Classes Created:**
-1. LeagueControlPanelRepository - Database operations (team info/logo updates)
-2. LeagueControlPanelService - Business logic (validation, team updates)
-3. LeagueControlPanelProcessor - Form processing (action routing, PRG pattern)
-4. LeagueControlPanelView - HTML rendering (team management forms)
-
-**Security Features:**
-- Admin-only access with login guard
-- HTTP 403 error on unauthorized access
-- HTML sanitization on all output
-- XSS protection for team names and logos
-
-**Documentation:** `ibl5/classes/LeagueControlPanel/README.md`
+- PHPStan level `max` with `strict-rules` and `bleedingEdge` — zero errors
+- PHPUnit — full suite green, zero skips
+- Coverage threshold — 70% (ratcheted; actual ~72%)
+- Mutation testing — 100% MSI / 100% Covered MSI (weekly + on-demand)
+- Playwright E2E — 4-shard parallel, visual regression baselines
+- Lighthouse — performance audits on every PR
 
 ---
 
-## Earlier Completed Refactorings
+## Active Priorities
 
-### 22. One-on-One Module ✅ (January 9, 2026)
+### 1. PHP-Nuke Legacy Retirement
 
-**Achievements:**
-- 7 classes + 4 interfaces created with separation of concerns
-- Reduced module code: 907 → 112 lines (88% reduction)
-- 75 comprehensive tests (168 assertions)
-- Complete basketball game simulation engine
-- Four shot types, defensive mechanics, rebounding, fouls
-- Play-by-play text generation with randomized commentary
-- Discord integration for game announcements
-- XSS protection with HtmlSanitizer
+The baseline schema still defines ~20 `nuke_*` tables. Nine DROP migrations have shipped so far (`nuke_session`, `nuke_antiflood`, `nuke_banned_ip`, `nuke_modules`, `nuke_comments`, plus 5 others). Each drop requires auditing code references, migrating any live reads to IBL-native tables (`ibl_settings`, `ibl_users`), and removing dead writes.
 
-**Game Mechanics:**
-```php
-// Game simulation includes:
-- Shot selection (three-pointer, outside two, drive, post)
-- Defensive actions (blocking, stealing)
-- Rebounding (offensive and defensive)
-- Fouls and turnovers
-- Games played to 21 points
-```
+**Remaining work:**
+- Audit and drop remaining `nuke_*` tables where code references are dead
+- Migrate live `nuke_stories` / `nuke_users` reads to IBL-native equivalents
+- Remove PHP-Nuke framework functions still called from bootstrap (`mainfile.php`)
+- Goal: eliminate `nuke_*` dependency entirely so the schema only contains `ibl_*` and `auth_*` tables
 
-**Classes Created:**
-1. OneOnOneRepository - Database operations (game history)
-2. OneOnOneGameEngine - Basketball simulation engine
-3. OneOnOneService - Game orchestration
-4. OneOnOneView - HTML rendering
-5. OneOnOneTextGenerator - Play-by-play commentary
-6. OneOnOneGameResult - Game result DTO
-7. OneOnOnePlayerStats - Player statistics DTO
+### 2. IBL6 Frontend (SvelteKit)
 
-**Documentation:** `ibl5/classes/OneOnOneGame/README.md`
+A SvelteKit frontend (`IBL6/`) is under early development, deployed at `ibl6.iblhoops.net`. It consumes the REST API built in the IBL5 backend.
 
----
+**Remaining work:**
+- Build out routes for core pages (teams, players, standings, schedule)
+- Replace PHP-rendered pages with SvelteKit equivalents as they mature
+- The REST API continues to expand to serve IBL6's needs
 
-### 21. Series_Records Module ✅ (January 2026)
+### 3. HTMX Expansion
 
-**Achievements:**
-- 5 classes + 4 interfaces with separation of concerns
-- 29 comprehensive tests
-- Historical series data display
+HTMX is partially adopted — boosted navigation, tab switching, and form boost are in place. Several modules still do full page reloads for form submissions.
 
----
+**Remaining work:**
+- Convert remaining full-reload forms to HTMX inline rendering where appropriate
+- Add `hx-get` partial loading to more data-heavy pages (leaderboards, player database)
+- Evaluate `HX-Location` for SPA-preserving form redirects (currently uses `HX-Redirect` which triggers full page reload)
 
-### 20. AwardHistory Module ✅ (January 2026)
+### 4. Test Coverage Expansion
 
-**Achievements:**
-- 4 classes + 4 interfaces with separation of concerns
-- 55 comprehensive tests
-- Award history display and management
+Coverage is at ~72% with the 70% CI threshold. The test suite is mature (PHPUnit, Playwright, mutation testing all enforced), but there are still gaps in integration test coverage for some modules.
+
+**Remaining work:**
+- Ratchet coverage threshold as new tests are added (next target: 75%)
+- Add module entry point tests for untested modules (using `ModuleEntryPointTestCase`)
+- Expand E2E coverage for form submission flows that currently only have read-only tests
+
+### 5. API Maturation
+
+The REST API has 17 controllers covering players, teams, games, standings, schedule, leaders, injuries, trade actions, and CSV export. Auth (API keys), rate limiting, ETag caching, and pagination are all in place.
+
+**Remaining work:**
+- OpenAPI/Swagger documentation generation
+- Additional endpoints as IBL6 frontend needs arise
+- Consider JWT auth alongside API keys for user-scoped operations
 
 ---
 
-## Earlier Completed Refactorings
+## Lower Priority / Future
 
-### 15. PlayerDatabase Module ✅ (November 28, 2025)
-
-**Achievements:**
-- 4 classes created with separation of concerns
-- Reduced module code: 462 → 73 lines (84% reduction)
-- 54 comprehensive tests (210 assertions)
-- **CRITICAL**: Fixed SQL injection vulnerability (15+ injection points)
-- Complete security hardening with prepared statements
-- XSS protection with htmlspecialchars() on all output
-
-**Security Issue Fixed:**
-```php
-// BEFORE: SQL Injection Vulnerable
-$query .= " AND name LIKE '%$search_name%'";
-
-// AFTER: Prepared Statements
-$conditions[] = 'name LIKE ?';
-$stmt->bind_param($bindTypes, ...$bindParams);
-```
-
-**Classes Created:**
-1. PlayerDatabaseValidator - Input validation, sanitization, whitelist enforcement
-2. PlayerDatabaseRepository - Database queries with 100% prepared statements
-3. PlayerDatabaseService - Business logic, data transformation
-4. PlayerDatabaseView - HTML rendering with output buffering
-
-**Documentation:** `ibl5/classes/PlayerDatabase/README.md`
-
-### 14. Free Agency Module ✅ (November 21, 2025)
-
-**Achievements:**
-- 7 classes created with separation of concerns
-- Reduced module code: 2,232 → 102 lines (95.4% reduction)
-- 11 comprehensive tests covering validation, calculation, and processing
-- Complete security hardening with prepared statements
-
-## NEW Strategic Priorities (Post-Refactoring Phase)
-
-### Priority 1: Test Coverage Push ⭐⭐⭐⭐⭐ (CRITICAL)
-
-**Current Status:** ~80% → **Target:** 80% ✅
-
-**Completed:**
-- ✅ 2892 tests passing
-- ✅ 63 integration test methods across 6 workflow suites
-- ✅ Waivers integration tests (25 test methods) - add/drop workflows, cap validation, timing
-- ✅ Draft, Extension, FreeAgency, Negotiation, Trading integration tests
-
-**Remaining Focus Areas:**
-- Add integration tests for: DepthChartEntry, RookieOption, Standings/Schedule
-- Edge case testing for all validators and processors
-- Security testing (XSS, SQL injection, CSRF)
-
-**Estimated Effort:** 1-2 weeks
-
-**Success Metrics:**
-- 80%+ code coverage achieved
-- All public methods have tests
-- All critical workflows have integration tests
-- Zero skipped tests
+- **Performance optimization**: Query analysis, Redis caching layer, page fragment caching. Not urgent — current page loads are acceptable.
+- **PowerRankings module**: The only display module without `Contracts/` interfaces. Low impact, refactor opportunistically.
+- **Generic PHP-Nuke modules** (Web_Links, Your_Account, News, Content, etc.): Will be replaced by IBL6 SvelteKit equivalents rather than refactored in PHP.
 
 ---
 
-### Priority 2: REST API Development ⭐⭐⭐⭐⭐ (HIGH VALUE)
+## Completed Milestones
 
-**Goal:** Build modern REST API for refactored modules
-
-**Phase 1 - Core Endpoints:**
-- `/api/v1/players` - Player data (CRUD)
-- `/api/v1/teams` - Team data and rosters
-- `/api/v1/stats` - Statistics queries
-- `/api/v1/standings` - League standings
-- `/api/v1/schedule` - Game schedule
-
-**Phase 2 - Advanced Features:**
-- JWT authentication
-- Rate limiting (Redis-based)
-- Request validation middleware
-- Response caching (ETags using `updated_at` timestamps)
-- OpenAPI/Swagger documentation
-
-**Infrastructure:**
-- Leverage existing database views (`vw_player_current`, etc.)
-- Use UUIDs for public identifiers (already in place)
-- PSR-7/PSR-15 middleware pattern
-
-**Estimated Effort:** 3-4 weeks
-
-**Success Metrics:**
-- 15+ API endpoints operational
-- Full OpenAPI documentation
-- < 100ms response times (90th percentile)
-- Authentication and rate limiting active
-
----
-
-### Priority 3: Security Audit & Hardening ⭐⭐⭐⭐ (CRITICAL)
-
-**Goal:** Complete security review and implement missing protections
-
-**Audit Scope:**
-- XSS vulnerabilities in remaining legacy code
-- SQL injection review (verify all queries use prepared statements)
-- Authentication weaknesses
-- Session management
-- File upload vulnerabilities
-
-**Hardening Tasks:**
-- Implement CSRF protection (token-based)
-- Add security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options)
-- Dependency vulnerability scanning (Composer audit)
-- Input validation review across all modules
-- Password hashing audit (bcrypt/Argon2)
-
-**Estimated Effort:** 1-2 weeks
-
-**Success Metrics:**
-- Zero critical/high vulnerabilities
-- OWASP Top 10 compliance
-- Security headers on all responses
-- CSRF protection on all state-changing operations
-
----
-
-### Priority 4: Performance Optimization ⭐⭐⭐⭐ (MEDIUM PRIORITY)
-
-**Goal:** Optimize database queries and implement caching
-
-**Database Optimization:**
-- Query analysis and EXPLAIN plans
-- Index optimization for hot paths
-- Reduce N+1 queries
-- Implement query result caching
-
-**Caching Strategy:**
-- Redis/Memcached integration
-- Page fragment caching
-- API response caching
-- Session storage optimization
-
-**Estimated Effort:** 2 weeks
-
-**Success Metrics:**
-- Page load times < 500ms (90th percentile)
-- Database query count reduced by 30%
-- Cache hit rate > 80%
-
----
-
-### Priority 5: CapSpace Module ✅ (COMPLETE)
-
-**Status:** All 30 IBL modules refactored (100% complete) 🎉
-
-**Achieved:**
-- ✅ 30/30 modules refactored with Repository/Service/View architecture
-- ✅ Interface-driven design across all modules
-- ✅ Comprehensive unit and integration tests
-- ✅ **Achievement unlocked:** 100% IBL core modules refactored!
-
----
-
-## Lower Priority Items
-
-### Optional Display Modules (Low Priority)
-These simple information display modules may not require full refactoring:
-- Franchise_History (103 lines), Power_Rankings (90 lines)
-- Next_Sim (95 lines), League_Starters (85 lines), Draft_Pick_Locator (81 lines), Injuries (57 lines)
-
-Note: Team_Schedule module removed (January 2026) - functionality consolidated into unified Schedule module.
-
-**Recommendation:** Refactor only if time permits after priorities 1-5
-
-### Generic PHP-Nuke Modules (Do Not Refactor)
-Web_Links, Your_Account, News, AutoTheme, Content, etc. (81,000+ lines total)
-
-**Recommendation:** Replace with Laravel equivalents during eventual framework migration
-
-## Development Timeline
-
-**Completed Work (2025-2026):**
-- October 2025: 13 modules refactored (Player, Statistics, Team, Draft, Waivers, Extension, RookieOption, Trading, Negotiation, DepthChartEntry, Voting, Schedule, Season_Leaders)
-- November 2025: Free Agency, PlayerDatabase (SQL injection fixed), Compare_Players, Leaderboards
-- December 2025: Standings, League_Stats, AwardHistory, Series_Records
-- January 9, 2026: **One-on-One complete** (88% code reduction, game simulation)
-- **Current Status:** 22/23 IBL modules refactored (96% complete)
-
-**Recommended Next 3-4 Months (2026):**
-
-**Month 1 (January-February):**
-- Week 1-2: Test coverage push (56% → 70%)
-- Week 3-4: CapSpace refactoring + remaining test coverage (70% → 80%)
-- **Milestone:** 100% IBL modules refactored, 80% test coverage
-
-**Month 2 (February-March):**
-- Week 1-2: REST API Phase 1 (core endpoints)
-- Week 3-4: REST API Phase 2 (authentication, rate limiting)
-- **Milestone:** 15+ API endpoints operational
-
-**Month 3 (March-April):**
-- Week 1: Security audit (XSS, SQL injection, CSRF)
-- Week 2-3: Security hardening implementation
-- Week 4: Documentation and API guides
-- **Milestone:** Zero critical vulnerabilities, full API documentation
-
-**Month 4 (April-May):**
-- Week 1-2: Performance optimization (database queries, caching)
-- Week 3-4: Production deployment preparation
-- **Milestone:** Production-ready API with monitoring
-
-**Success Metrics:**
-- ✅ All IBL modules refactored (31/31 complete - 100%!)
-- ✅ 80% test coverage achieved
-- 🎯 REST API operational with 15+ endpoints
-- 🎯 Zero critical security vulnerabilities
-- 🎯 Page load times < 500ms (90th percentile)
-- 🎯 Complete API documentation (OpenAPI/Swagger)
+- **Oct 2025 – Mar 2026**: All IBL modules refactored to Repository/Service/View with interfaces
+- **Jan 2026**: 80% test coverage target achieved; all display modules refactored
+- **Feb 2026**: REST API launched with auth, rate limiting, caching
+- **Mar 2026**: HTMX frontend phases 1-3 shipped; mutation testing at 100% MSI; 9 legacy `nuke_*` tables dropped; TradingRepository god class split; CSV player export; production deploy smoke tests; worktree Docker simplification


### PR DESCRIPTION
## Summary

Full rewrite of STRATEGIC_PRIORITIES.md. The previous version was frozen at March 2, 2026 with stale counts, completed TODO lists presented as future work, and aspirational timelines that are now in the past.

### Removed
- Fragile counts (test counts, module counts, assertion counts) that go stale after every PR
- Completed refactoring changelogs (duplicated from REFACTORING_HISTORY.md)
- Aspirational timelines (Jan–May 2026) that have already passed
- Priorities already achieved (test coverage 80%, security headers, CSRF, API with 17 controllers)

### Added
- **Current State** section: what's actually built (architecture, API, security stack, HTMX, test pyramid, CI/CD, Docker, IBL6)
- **Quality Gates**: CI-enforced thresholds — no fragile counts, just what CI checks
- **Active Priorities**: PHP-Nuke legacy retirement, IBL6 frontend, HTMX expansion, test coverage ratcheting, API maturation
- **Completed Milestones**: one-line summaries by month (detail lives in REFACTORING_HISTORY.md)

### Result
332 lines → 94 lines. No information that will go stale without a code change to match.

## Manual Testing

No manual testing needed — documentation-only changes.