### PR TITLE
fix: block DNS-based domain mirroring via HTTP_HOST check

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,12 @@
 RewriteEngine On
 
+# Redirect unauthorized domains to iblhoops.net
+# Prevents DNS-based mirroring (e.g., zeidconsulting.com pointing at our IP)
+RewriteCond %{HTTP_HOST} !^((www|ibl6)\.)?iblhoops\.net$ [NC]
+RewriteCond %{HTTP_HOST} !^(main\.)?localhost$ [NC]
+RewriteCond %{HTTP_HOST} !^127\.0\.0\.1$ [NC]
+RewriteRule ^ https://iblhoops.net%{REQUEST_URI} [R=301,L]
+
 # Redirect bare domain to /ibl5/
 RewriteCond %{REQUEST_URI} ^/?$
 RewriteRule ^$ /ibl5/index.php [R=301,L]


### PR DESCRIPTION
## Problem

`zeidconsulting.com` has a stale DNS A record pointing at the IBL server IP (`174.138.190.54`). LiteSpeed serves IBL content for any domain that resolves to this IP, causing unintentional site mirroring. No host-checking rule existed in the codebase or git history.

## Solution

Add `HTTP_HOST` rewrite rules to the root `.htaccess` that 301-redirect any request not from a known domain to `https://iblhoops.net`.

**Allowed hosts:**
- `iblhoops.net`, `www.iblhoops.net`, `ibl6.iblhoops.net` (production)
- `localhost`, `main.localhost` (Docker dev)
- `127.0.0.1` (local dev)

The rule fires before PHP executes, so mirrored domains never hit the application layer.

## Manual Testing

After deploy, verify the redirect:
```bash
curl -s -o /dev/null -w '%{http_code} %{redirect_url}' --insecure 'https://zeidconsulting.com/ibl5/index.php'
# Expected: 301 https://iblhoops.net/ibl5/index.php
```