### PR TITLE
fix(deps): override undici to 6.24.1 to resolve Dependabot alerts

### DIFF
--- a/ibl5/IBLbot/package-lock.json
+++ b/ibl5/IBLbot/package-lock.json
@@ -2542,9 +2542,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/ibl5/IBLbot/package.json
+++ b/ibl5/IBLbot/package.json
@@ -19,6 +19,9 @@
     "dotenv": "^16.4.7",
     "express": "^4.22.1"
   },
+  "overrides": {
+    "undici": "6.24.1"
+  },
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

Override undici to 6.24.1 via npm `overrides` in IBLbot's package.json. discord.js 14.25.1 (latest stable) pins undici to 6.21.3, and no stable discord.js release includes the security fixes.

## Security Fixes

Resolves 5 open Dependabot alerts:
- Unbounded Memory Consumption in WebSocket permessage-deflate Decompression
- Unhandled Exception in WebSocket Client Due to Invalid server_max_window_bits Validation
- CRLF Injection via `upgrade` option
- Malicious WebSocket 64-bit length overflows parser
- HTTP Request/Response Smuggling

## Changes

- `package.json`: Added `overrides` section to force undici 6.24.1
- `package-lock.json`: Updated resolved undici version

## Verification

- `npm ls undici` confirms 6.24.1 is installed
- `npm audit` shows no undici vulnerabilities remaining
- TypeScript build passes (`npm run build`)