### PR TITLE
fix: move domain mirroring block to ibl5/.htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,12 +1,5 @@
 RewriteEngine On
 
-# Redirect unauthorized domains to iblhoops.net
-# Prevents DNS-based mirroring (e.g., zeidconsulting.com pointing at our IP)
-RewriteCond %{HTTP_HOST} !^((www|ibl6)\.)?iblhoops\.net$ [NC]
-RewriteCond %{HTTP_HOST} !^(main\.)?localhost$ [NC]
-RewriteCond %{HTTP_HOST} !^127\.0\.0\.1$ [NC]
-RewriteRule ^ https://iblhoops.net%{REQUEST_URI} [R=301,L]
-
 # Redirect bare domain to /ibl5/
 RewriteCond %{REQUEST_URI} ^/?$
 RewriteRule ^$ /ibl5/index.php [R=301,L]

--- a/ibl5/.htaccess
+++ b/ibl5/.htaccess
@@ -1,5 +1,12 @@
 RewriteEngine On
 
+# Redirect unauthorized domains to iblhoops.net
+# Prevents DNS-based mirroring (e.g., zeidconsulting.com pointing at our IP)
+RewriteCond %{HTTP_HOST} !^((www|ibl6)\.)?iblhoops\.net$ [NC]
+RewriteCond %{HTTP_HOST} !^(main\.)?localhost$ [NC]
+RewriteCond %{HTTP_HOST} !^127\.0\.0\.1$ [NC]
+RewriteRule ^ https://iblhoops.net%{REQUEST_URI} [R=301,L]
+
 # Block abusive bot IP ranges
 # PetalBot (Huawei) — 125 requests in a few hours, ignores Crawl-delay
 Deny from 114.119.0.0/16


### PR DESCRIPTION
## Problem

The HTTP_HOST check added in #523 was placed in the root `.htaccess`, which LiteSpeed does not process for `/ibl5/` requests. After deploying #523, `zeidconsulting.com/ibl5/index.php` still returned 200 instead of 301.

The root `.htaccess` only handles the bare-domain redirect (`/ → /ibl5/`). All other active rewrite rules (bot blocking, DirectoryIndex, API routing) live in `ibl5/.htaccess` and work correctly — confirming that's the file LiteSpeed processes for `/ibl5/` paths.

## Solution

- Move the domain mirroring block from root `.htaccess` to `ibl5/.htaccess`
- Remove the ineffective rule from root `.htaccess`

## Manual Testing

After deploy, verify the redirect:
```bash
curl -s -o /dev/null -w '%{http_code} %{redirect_url}' --insecure 'https://zeidconsulting.com/ibl5/index.php'
# Expected: 301 https://iblhoops.net/ibl5/index.php
```