### PR TITLE
perf: use CTE for gameOfThatDay lookup in RecordHolders queries

### DIFF
--- a/ibl5/classes/RecordHolders/RecordHoldersRepository.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersRepository.php
@@ -70,7 +70,12 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
      */
     public function getQuadrupleDoubles(): array
     {
-        $query = "SELECT
+        $query = "WITH _game_of_day AS (
+                SELECT Date, visitorTeamID, homeTeamID, MIN(gameOfThatDay) AS gameOfThatDay
+                FROM {$this->boxScoresTeamsTable}
+                GROUP BY Date, visitorTeamID, homeTeamID
+            )
+            SELECT
                 bs.pid,
                 p.name,
                 h.teamid AS tid,
@@ -90,11 +95,8 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
             JOIN ibl_hist h ON h.pid = bs.pid AND h.year = (" . self::SEASON_YEAR_EXPRESSION . ")
             LEFT JOIN {$this->scheduleTable} sch ON sch.Date = bs.Date
                 AND sch.Visitor = bs.visitorTID AND sch.Home = bs.homeTID
-            LEFT JOIN (
-                SELECT Date, visitorTeamID, homeTeamID, MIN(gameOfThatDay) AS gameOfThatDay
-                FROM {$this->boxScoresTeamsTable}
-                GROUP BY Date, visitorTeamID, homeTeamID
-            ) bst ON bst.Date = bs.Date AND bst.visitorTeamID = bs.visitorTID AND bst.homeTeamID = bs.homeTID
+            LEFT JOIN _game_of_day bst ON bst.Date = bs.Date
+                AND bst.visitorTeamID = bs.visitorTID AND bst.homeTeamID = bs.homeTID
             LEFT JOIN {$this->teamInfoTable} opp ON opp.teamid = CASE
                 WHEN h.teamid = bs.visitorTID THEN bs.homeTID
                 ELSE bs.visitorTID END
@@ -240,7 +242,12 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
      */
     public function getLargestMarginOfVictory(string $dateFilter): array
     {
-        $query = "SELECT
+        $query = "WITH _game_of_day AS (
+                SELECT Date, visitorTeamID, homeTeamID, MIN(gameOfThatDay) AS gameOfThatDay
+                FROM {$this->boxScoresTeamsTable}
+                GROUP BY Date, visitorTeamID, homeTeamID
+            )
+            SELECT
                 winner_t.teamid AS winner_tid,
                 winner_t.team_name AS winner_name,
                 loser_t.teamid AS loser_tid,
@@ -269,11 +276,8 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
             JOIN {$this->teamInfoTable} loser_t ON loser_t.teamid = sub.loser_id
             LEFT JOIN {$this->scheduleTable} sch ON sch.Date = sub.Date
                 AND sch.Visitor = sub.visitorTeamID AND sch.Home = sub.homeTeamID
-            LEFT JOIN (
-                SELECT Date, visitorTeamID, homeTeamID, MIN(gameOfThatDay) AS gameOfThatDay
-                FROM {$this->boxScoresTeamsTable}
-                GROUP BY Date, visitorTeamID, homeTeamID
-            ) bst ON bst.Date = sub.Date AND bst.visitorTeamID = sub.visitorTeamID AND bst.homeTeamID = sub.homeTeamID
+            LEFT JOIN _game_of_day bst ON bst.Date = sub.Date
+                AND bst.visitorTeamID = sub.visitorTeamID AND bst.homeTeamID = sub.homeTeamID
             ORDER BY sub.margin DESC, sub.Date ASC
             LIMIT 5";
 
@@ -640,11 +644,8 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                 JOIN ibl_hist h ON h.pid = bs.pid AND h.year = (" . self::SEASON_YEAR_EXPRESSION . ")
                 LEFT JOIN {$this->scheduleTable} sch ON sch.Date = bs.Date
                     AND sch.Visitor = bs.visitorTID AND sch.Home = bs.homeTID
-                LEFT JOIN (
-                    SELECT Date, visitorTeamID, homeTeamID, MIN(gameOfThatDay) AS gameOfThatDay
-                    FROM {$this->boxScoresTeamsTable}
-                    GROUP BY Date, visitorTeamID, homeTeamID
-                ) bst ON bst.Date = bs.Date AND bst.visitorTeamID = bs.visitorTID AND bst.homeTeamID = bs.homeTID
+                LEFT JOIN _game_of_day bst ON bst.Date = bs.Date
+                    AND bst.visitorTeamID = bs.visitorTID AND bst.homeTeamID = bs.homeTID
                 LEFT JOIN {$this->teamInfoTable} opp ON opp.teamid = CASE
                     WHEN h.teamid = bs.visitorTID THEN bs.homeTID
                     ELSE bs.visitorTID END
@@ -655,7 +656,13 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                 LIMIT 5)";
         }
 
-        $query = implode("\nUNION ALL\n", $unions);
+        // CTE materializes gameOfThatDay lookup once instead of per UNION ALL branch
+        $cte = "WITH _game_of_day AS (
+            SELECT Date, visitorTeamID, homeTeamID, MIN(gameOfThatDay) AS gameOfThatDay
+            FROM {$this->boxScoresTeamsTable}
+            GROUP BY Date, visitorTeamID, homeTeamID
+        )\n";
+        $query = $cte . implode("\nUNION ALL\n", $unions);
         $rows = $this->fetchAll($query);
 
         /** @var array<string, list<PlayerSingleGameRecord>> $results */


### PR DESCRIPTION
## Summary

The `gameOfThatDay` materialized subquery (`SELECT Date, visitorTeamID, homeTeamID, MIN(gameOfThatDay) FROM ibl_box_scores_teams GROUP BY ...`) was duplicated inside each UNION ALL branch of `getTopPlayerSingleGameBatch()`, causing MariaDB to re-execute the full aggregation **9 times per call** (27 times total across 3 game types on a cache miss).

### Fix

Move the subquery to a `WITH` CTE (`_game_of_day`) so it materializes once per query execution.

### Methods changed

| Method | Impact |
|--------|--------|
| `getTopPlayerSingleGameBatch()` | 9 branches now share 1 CTE (was 9× materialization) |
| `getQuadrupleDoubles()` | Consistency (was 1 execution anyway) |
| `getLargestMarginOfVictory()` | Consistency (was 1 execution anyway) |

### Context

RecordHolders has a 24h database cache (`CachedRecordHoldersService`), so these queries only fire on cache miss (~once/day). This CTE optimization reduces the cache-miss cost. The cache remains the primary performance strategy.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.