### PR TITLE
fix: add retry logic and stabilization delay to production smoke test

### DIFF
--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Wait for server stabilization after deploy
+        if: github.event_name == 'workflow_run'
+        run: sleep 15
+
       - name: Run smoke tests
         run: |
           chmod +x bin/smoke-prod

--- a/bin/smoke-prod
+++ b/bin/smoke-prod
@@ -5,7 +5,7 @@
 # Default: https://www.iblhoops.net
 #
 # Checks 7 public URLs for:
-#   - HTTP 200 status
+#   - HTTP 200 status (retries once on 5xx after 10s)
 #   - Expected content in response body
 #   - Absence of PHP error messages
 #
@@ -30,6 +30,15 @@ check() {
     # Extract just the HTTP code (last 3 chars of output)
     status="${status: -3}"
     [[ "$status" =~ ^[0-9]+$ ]] || status="000"
+
+    # Retry once on 5xx — transient during deploys (autoloader regeneration)
+    if [ "$status" -ge 500 ] 2>/dev/null; then
+        echo "  RETRY: $name — HTTP $status, waiting 10s..."
+        sleep 10
+        status=$(curl -sS -w "%{http_code}" --max-time 30 -o "$TMPFILE" "$url" 2>/dev/null) || true
+        status="${status: -3}"
+        [[ "$status" =~ ^[0-9]+$ ]] || status="000"
+    fi
 
     # Check if status is in the accepted list (pipe-separated, e.g., "200|401")
     if ! echo "$accept" | grep -qw "$status"; then


### PR DESCRIPTION
## Summary

Prevents false-positive auto-rollbacks caused by transient 503s during deploys.

### Root cause

The deploy workflow does `git reset --hard` + `composer install --optimize-autoloader` on the live server. During autoloader regeneration (~2-3s), PHP requests can't autoload classes → 503. The `smoke-prod` workflow fires immediately after deploy completion and sometimes hits this window.

This caused PR #531's correct CTE optimization to be auto-reverted despite the code being sound.

### Changes

| File | Change |
|------|--------|
| `bin/smoke-prod` | Retry once after 10s on 5xx responses before marking as failed |
| `.github/workflows/smoke-prod.yml` | 15s stabilization delay for post-deploy triggers (`workflow_run`) |

### Follow-up

After this merges, the revert of PR #531 on the `production` branch should be reverted to re-land the CTE optimization.