### PR TITLE
security: block DotBot (Moz) SEO crawler in robots.txt

### DIFF
--- a/ibl5/robots.txt
+++ b/ibl5/robots.txt
@@ -33,3 +33,6 @@ Disallow: /
 
 User-agent: SemrushBot
 Disallow: /
+
+User-agent: DotBot
+Disallow: /


### PR DESCRIPTION
## Problem

DotBot (opensiteexplorer.org/dotbot) — Moz's SEO crawler — made 23 requests in the latest visitor log snapshot. Aggressive SEO bot similar to AhrefsBot, SemrushBot, and MJ12bot which are already blocked.

## Changes

Add `User-agent: DotBot` / `Disallow: /` to `ibl5/robots.txt`.

## Manual Testing

No manual testing needed — robots.txt-only change.