### PR TITLE
fix: allow archive access for users with session cookie

### DIFF
--- a/ibl5/.htaccess
+++ b/ibl5/.htaccess
@@ -2,6 +2,7 @@ RewriteEngine On
 
 # Return 410 Gone for dead legacy paths — prevents bots from consuming workers
 RewriteRule ^ibl/IBL/.*\.htm$ - [R=410,L]
+# Archive: allow access for users with a session cookie, 410 for cookieless bots
 RewriteCond %{HTTP_COOKIE} !PHPSESSID [NC]
 RewriteRule ^ibl/archive/.*\.htm$ - [R=410,L]
 RewriteRule ^iblforum/ - [R=410,L]


### PR DESCRIPTION
## Summary

Restores access to `/ibl/archive/*.htm` files for legitimate site visitors while keeping bots blocked.

PR #537 added a blanket 410 Gone for all archive requests to stop aggressive crawlers from consuming PHP workers. The archive files still exist on production and are useful to real users. This adds a `RewriteCond` that checks for the `PHPSESSID` session cookie — present on every real user's browser (set by `session_start()` in mainfile.php with a 6-month lifetime) but absent from bot/crawler requests.

## Changes

- `ibl5/.htaccess`: Add `RewriteCond %{HTTP_COOKIE} !PHPSESSID [NC]` before the archive 410 rule
- Other 410 rules (IBL/*.htm, iblforum/, online/team.php) remain unconditional

## Manual Testing

- **Bot (no cookie):** `curl -o /dev/null -s -w '%{http_code}' https://iblhoops.net/ibl5/ibl/archive/anyfile.htm` → should return 410
- **User (with cookie):** `curl -o /dev/null -s -w '%{http_code}' -b 'PHPSESSID=test123' https://iblhoops.net/ibl5/ibl/archive/anyfile.htm` → should return 200 (or 404 if file doesn't exist, but not 410)
- **Other 410s unaffected:** `curl -o /dev/null -s -w '%{http_code}' https://iblhoops.net/ibl5/ibl/IBL/foo.htm` → should still return 410