### PR TITLE
fix: analytics scripts macOS + Docker compat

### DIFF
--- a/bin/analytics-build
+++ b/bin/analytics-build
@@ -2,9 +2,10 @@
 # Full rebuild of the DuckDB analytics database.
 # Idempotent: deletes and recreates from scratch every time.
 #
-# Usage: bin/analytics-build [--writeback] [--skip-export]
+# Usage: bin/analytics-build [--writeback] [--skip-export] [--local]
 #   --writeback    After building, export writeback CSVs and import to MariaDB
 #   --skip-export  Skip the MariaDB → CSV export step (use existing CSVs)
+#   --local        Force local Docker connection (ignore REMOTE_* in .env)
 
 set -euo pipefail
 
@@ -16,11 +17,13 @@ DUCKDB="$ANALYTICS_DIR/duckdb"
 
 WRITEBACK=false
 SKIP_EXPORT=false
+FORCE_LOCAL=false
 
 for arg in "$@"; do
     case "$arg" in
         --writeback)   WRITEBACK=true ;;
         --skip-export) SKIP_EXPORT=true ;;
+        --local)       FORCE_LOCAL=true ;;
         *)             echo "Unknown argument: $arg" >&2; exit 1 ;;
     esac
 done
@@ -37,7 +40,12 @@ START_TIME=$(date +%s)
 # Step 1: Export MariaDB → CSV
 if [ "$SKIP_EXPORT" = false ]; then
     echo "=== Step 1: Exporting MariaDB → CSV ==="
-    "$REPO_ROOT/bin/analytics-export"
+    EXPORT_ARGS=""
+    if [ "$FORCE_LOCAL" = true ]; then
+        EXPORT_ARGS="--local"
+    fi
+    # shellcheck disable=SC2086
+    "$REPO_ROOT/bin/analytics-export" $EXPORT_ARGS
 else
     echo "=== Step 1: Skipping export (using existing CSVs) ==="
 fi
@@ -79,7 +87,7 @@ echo ""
 
 # Print table row counts
 "$DUCKDB" "$DB_FILE" -c "
-SELECT table_name, estimated_row_count
+SELECT table_name, estimated_size
 FROM duckdb_tables()
 WHERE schema_name = 'main'
 ORDER BY table_name;

--- a/bin/analytics-export
+++ b/bin/analytics-export
@@ -2,7 +2,8 @@
 # Export MariaDB tables to CSV for DuckDB analytics.
 # Dumps tables to ibl5/analytics/data/*.csv with headers.
 #
-# Usage: bin/analytics-export
+# Usage: bin/analytics-export [--local]
+#   --local  Force local Docker connection (ignore REMOTE_* in .env)
 #
 # Connection: reads REMOTE_* from .env for production, falls back to local Docker.
 # Output: ibl5/analytics/data/*.csv + export_manifest.json
@@ -12,9 +13,17 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DATA_DIR="$REPO_ROOT/ibl5/analytics/data"
 
-# Source .env for database credentials
+FORCE_LOCAL=false
+for arg in "$@"; do
+    case "$arg" in
+        --local) FORCE_LOCAL=true ;;
+        *)       echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+# Source .env for database credentials (skip if --local)
 ENV_FILE="$REPO_ROOT/.env"
-if [ -f "$ENV_FILE" ]; then
+if [ -f "$ENV_FILE" ] && [ "$FORCE_LOCAL" = false ]; then
     set -a
     # shellcheck disable=SC1090
     source "$ENV_FILE"
@@ -22,7 +31,7 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 # Determine connection mode
-if [ -n "${REMOTE_HOST:-}" ] && [ "$REMOTE_HOST" != "localhost" ] && [ "$REMOTE_HOST" != "127.0.0.1" ]; then
+if [ "$FORCE_LOCAL" = false ] && [ -n "${REMOTE_HOST:-}" ] && [ "$REMOTE_HOST" != "localhost" ] && [ "$REMOTE_HOST" != "127.0.0.1" ]; then
     DB_HOST="$REMOTE_HOST"
     DB_PORT="${REMOTE_PORT:-3306}"
     DB_USER_VAL="$REMOTE_USER"
@@ -54,15 +63,20 @@ export_table() {
     local query="${2:-SELECT * FROM \`$table\`}"
     local outfile="$DATA_DIR/${table}.csv"
 
-    # Get column names for header
-    local header
-    header=$(MYSQL_PWD="$DB_PASS_VAL" mariadb -h "$DB_HOST" -P "$DB_PORT" --skip-ssl \
-        -u "$DB_USER_VAL" $EXTRA_OPTS "$DB_NAME" -B -e "$query LIMIT 0" 2>/dev/null | head -1)
-
-    # Export data (tab-separated)
-    echo "$header" > "$outfile"
+    # Export data with header (-B includes column names as first row)
+    # shellcheck disable=SC2086
     MYSQL_PWD="$DB_PASS_VAL" mariadb -h "$DB_HOST" -P "$DB_PORT" --skip-ssl \
-        -u "$DB_USER_VAL" $EXTRA_OPTS "$DB_NAME" -N -B -e "$query" >> "$outfile"
+        -u "$DB_USER_VAL" $EXTRA_OPTS "$DB_NAME" -B -e "$query" > "$outfile"
+
+    # If file is empty (table had 0 rows, MariaDB omits header), write header from SHOW COLUMNS
+    if [ ! -s "$outfile" ]; then
+        # Get column names and join with tabs
+        # shellcheck disable=SC2086
+        MYSQL_PWD="$DB_PASS_VAL" mariadb -h "$DB_HOST" -P "$DB_PORT" --skip-ssl \
+            -u "$DB_USER_VAL" $EXTRA_OPTS "$DB_NAME" -N -B \
+            -e "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='$table' ORDER BY ORDINAL_POSITION" \
+            | paste -s -d'	' - > "$outfile"
+    fi
 
     local count
     count=$(($(wc -l < "$outfile") - 1))
@@ -76,8 +90,9 @@ echo ""
 echo "Exporting tables..."
 START_TIME=$(date +%s)
 
-# Track row counts for manifest
-declare -A COUNTS
+# Track row counts for manifest (temp file for Bash 3.x compat — no associative arrays)
+COUNTS_FILE=$(mktemp)
+trap 'rm -f "$COUNTS_FILE"' EXIT
 
 # Core tables
 TABLES=(
@@ -98,14 +113,14 @@ TABLES=(
 
 for table in "${TABLES[@]}"; do
     count=$(export_table "$table")
-    COUNTS[$table]=$count
+    echo "$table $count" >> "$COUNTS_FILE"
 done
 
 # Phase 2 dependent: ibl_plr_snapshots
 SNAPSHOTS_EXISTS=$(db_query "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='$DB_NAME' AND table_name='ibl_plr_snapshots'")
 if [ "$SNAPSHOTS_EXISTS" -gt 0 ]; then
     count=$(export_table "ibl_plr_snapshots")
-    COUNTS[ibl_plr_snapshots]=$count
+    echo "ibl_plr_snapshots $count" >> "$COUNTS_FILE"
     echo "  (Phase 2: ibl_plr_snapshots included)"
 else
     echo "  (Phase 2: ibl_plr_snapshots not found, skipping)"
@@ -123,14 +138,14 @@ MANIFEST="$DATA_DIR/export_manifest.json"
     echo "  \"elapsed_seconds\": $ELAPSED,"
     echo "  \"tables\": {"
     first=true
-    for table in "${!COUNTS[@]}"; do
+    while read -r tbl cnt; do
         if [ "$first" = true ]; then
             first=false
         else
             echo ","
         fi
-        printf "    \"%s\": %s" "$table" "${COUNTS[$table]}"
-    done
+        printf "    \"%s\": %s" "$tbl" "$cnt"
+    done < "$COUNTS_FILE"
     echo ""
     echo "  }"
     echo "}"

--- a/ibl5/analytics/queries/tsi_progression.sql
+++ b/ibl5/analytics/queries/tsi_progression.sql
@@ -12,20 +12,20 @@ SELECT '    Controlled for starting FGP 40-55' AS '';
 -- Development phase: far from peak (age_relative_to_peak <= -3)
 -- Controlled for starting FGP range 40-55
 SELECT
-    tsi_band,
-    ROUND(AVG(delta_r_2gp), 2) AS "Δ FGP/yr",
-    ROUND(AVG(delta_r_ftp), 2) AS "Δ FTP/yr",
-    ROUND(AVG(delta_r_ast), 2) AS "Δ AST/yr",
-    ROUND(AVG(delta_r_stl), 2) AS "Δ STL/yr",
+    p.tsi_band,
+    ROUND(AVG(p.delta_r_2gp), 2) AS "Δ FGP/yr",
+    ROUND(AVG(p.delta_r_ftp), 2) AS "Δ FTP/yr",
+    ROUND(AVG(p.delta_r_ast), 2) AS "Δ AST/yr",
+    ROUND(AVG(p.delta_r_stl), 2) AS "Δ STL/yr",
     COUNT(*) AS n
 FROM agg_tsi_progression p
 JOIN fact_player_season prev
     ON p.pid = prev.pid AND prev.season_year = p.season_year - 1
 WHERE p.development_phase = 'far_from_peak'
     AND prev.r_2gp BETWEEN 40 AND 55
-GROUP BY tsi_band
+GROUP BY p.tsi_band
 ORDER BY
-    CASE tsi_band WHEN 'low' THEN 1 WHEN 'mid' THEN 2 WHEN 'high' THEN 3 WHEN 'elite' THEN 4 END;
+    CASE p.tsi_band WHEN 'low' THEN 1 WHEN 'mid' THEN 2 WHEN 'high' THEN 3 WHEN 'elite' THEN 4 END;
 
 SELECT '' AS '';
 SELECT '=== TSI Progression: Near Peak (±2 years) ===' AS '';
@@ -33,18 +33,18 @@ SELECT '    Controlled for starting FGP 40-55' AS '';
 
 -- Near peak (age_relative_to_peak between -2 and 2)
 SELECT
-    tsi_band,
-    ROUND(AVG(delta_r_2gp), 2) AS "Δ FGP/yr",
-    ROUND(AVG(delta_r_ftp), 2) AS "Δ FTP/yr",
+    p.tsi_band,
+    ROUND(AVG(p.delta_r_2gp), 2) AS "Δ FGP/yr",
+    ROUND(AVG(p.delta_r_ftp), 2) AS "Δ FTP/yr",
     COUNT(*) AS n
 FROM agg_tsi_progression p
 JOIN fact_player_season prev
     ON p.pid = prev.pid AND prev.season_year = p.season_year - 1
 WHERE p.development_phase = 'near_peak'
     AND prev.r_2gp BETWEEN 40 AND 55
-GROUP BY tsi_band
+GROUP BY p.tsi_band
 ORDER BY
-    CASE tsi_band WHEN 'low' THEN 1 WHEN 'mid' THEN 2 WHEN 'high' THEN 3 WHEN 'elite' THEN 4 END;
+    CASE p.tsi_band WHEN 'low' THEN 1 WHEN 'mid' THEN 2 WHEN 'high' THEN 3 WHEN 'elite' THEN 4 END;
 
 SELECT '' AS '';
 SELECT '=== TSI Progression: Post Peak ===' AS '';

--- a/ibl5/analytics/schema/01_dimensions.sql
+++ b/ibl5/analytics/schema/01_dimensions.sql
@@ -4,109 +4,101 @@
 -- dim_player: Player master with computed TSI fields
 CREATE OR REPLACE TABLE dim_player AS
 SELECT
-    pid,
+    TRY_CAST(pid AS INTEGER) AS pid,
     name,
-    age,
-    peak,
-    talent,
-    skill,
-    intangibles,
-    (talent + skill + intangibles)::INTEGER AS tsi_sum,
+    TRY_CAST(age AS INTEGER) AS age,
+    TRY_CAST(peak AS INTEGER) AS peak,
+    TRY_CAST(talent AS INTEGER) AS talent,
+    TRY_CAST(skill AS INTEGER) AS skill,
+    TRY_CAST(intangibles AS INTEGER) AS intangibles,
+    (TRY_CAST(talent AS INTEGER) + TRY_CAST(skill AS INTEGER) + TRY_CAST(intangibles AS INTEGER)) AS tsi_sum,
     CASE
-        WHEN (talent + skill + intangibles) <= 6  THEN 'low'
-        WHEN (talent + skill + intangibles) <= 9  THEN 'mid'
-        WHEN (talent + skill + intangibles) <= 12 THEN 'high'
+        WHEN (TRY_CAST(talent AS INTEGER) + TRY_CAST(skill AS INTEGER) + TRY_CAST(intangibles AS INTEGER)) <= 6  THEN 'low'
+        WHEN (TRY_CAST(talent AS INTEGER) + TRY_CAST(skill AS INTEGER) + TRY_CAST(intangibles AS INTEGER)) <= 9  THEN 'mid'
+        WHEN (TRY_CAST(talent AS INTEGER) + TRY_CAST(skill AS INTEGER) + TRY_CAST(intangibles AS INTEGER)) <= 12 THEN 'high'
         ELSE 'elite'
     END AS tsi_band,
-    retired,
-    exp,
+    TRY_CAST(retired AS INTEGER) AS retired,
+    TRY_CAST(exp AS INTEGER) AS exp,
     -- Current contract salary (cy indicates current year of contract)
-    CASE cy
-        WHEN 1 THEN cy1 WHEN 2 THEN cy2 WHEN 3 THEN cy3
-        WHEN 4 THEN cy4 WHEN 5 THEN cy5 WHEN 6 THEN cy6
+    CASE TRY_CAST(cy AS INTEGER)
+        WHEN 1 THEN TRY_CAST(cy1 AS INTEGER) WHEN 2 THEN TRY_CAST(cy2 AS INTEGER) WHEN 3 THEN TRY_CAST(cy3 AS INTEGER)
+        WHEN 4 THEN TRY_CAST(cy4 AS INTEGER) WHEN 5 THEN TRY_CAST(cy5 AS INTEGER) WHEN 6 THEN TRY_CAST(cy6 AS INTEGER)
         ELSE 0
     END AS current_salary,
-    tid,
-    draftround,
-    draftyear,
-    draftpickno
+    TRY_CAST(tid AS INTEGER) AS tid,
+    TRY_CAST(draftround AS INTEGER) AS draftround,
+    TRY_CAST(draftyear AS INTEGER) AS draftyear,
+    TRY_CAST(draftpickno AS INTEGER) AS draftpickno
 FROM read_csv('data/ibl_plr.csv', delim='\t', header=true, all_varchar=true,
-    columns={
-        'pid': 'INTEGER', 'name': 'VARCHAR', 'age': 'INTEGER', 'peak': 'INTEGER',
-        'talent': 'INTEGER', 'skill': 'INTEGER', 'intangibles': 'INTEGER',
-        'retired': 'INTEGER', 'exp': 'INTEGER', 'tid': 'INTEGER',
-        'cy': 'INTEGER', 'cy1': 'INTEGER', 'cy2': 'INTEGER', 'cy3': 'INTEGER',
-        'cy4': 'INTEGER', 'cy5': 'INTEGER', 'cy6': 'INTEGER',
-        'draftround': 'INTEGER', 'draftyear': 'INTEGER', 'draftpickno': 'INTEGER'
-    },
-    null_padding=true, ignore_errors=true);
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='');
 
 -- dim_team: Team master
 CREATE OR REPLACE TABLE dim_team AS
 SELECT
-    teamid,
+    TRY_CAST(teamid AS INTEGER) AS teamid,
     team_name,
     team_city,
     color1,
     color2
 FROM read_csv('data/ibl_team_info.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true)
-WHERE CAST(teamid AS INTEGER) IS NOT NULL;
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='')
+WHERE TRY_CAST(teamid AS INTEGER) IS NOT NULL;
 
 -- dim_season: Distinct season years from ibl_hist
 CREATE OR REPLACE TABLE dim_season AS
 SELECT DISTINCT
-    CAST(year AS INTEGER) AS season_year,
+    TRY_CAST(year AS INTEGER) AS season_year,
     -- Season label: "06-07" format (season spans Oct of prior year to Jun of this year)
-    LPAD(CAST((CAST(year AS INTEGER) - 1) % 100 AS VARCHAR), 2, '0') || '-' ||
-    LPAD(CAST(CAST(year AS INTEGER) % 100 AS VARCHAR), 2, '0') AS season_label
+    LPAD(TRY_CAST((TRY_CAST(year AS INTEGER) - 1) % 100 AS VARCHAR), 2, '0') || '-' ||
+    LPAD(TRY_CAST(TRY_CAST(year AS INTEGER) % 100 AS VARCHAR), 2, '0') AS season_label
 FROM read_csv('data/ibl_hist.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true)
-WHERE CAST(year AS INTEGER) > 0
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='')
+WHERE TRY_CAST(year AS INTEGER) IS NOT NULL AND TRY_CAST(year AS INTEGER) > 0
 ORDER BY season_year;
 
 -- dim_franchise_seasons: Historical team identity tracking
 CREATE OR REPLACE TABLE dim_franchise_seasons AS
 SELECT
-    CAST(franchise_id AS INTEGER) AS franchise_id,
-    CAST(season_year AS INTEGER) AS season_year,
-    CAST(season_ending_year AS INTEGER) AS season_ending_year,
+    TRY_CAST(franchise_id AS INTEGER) AS franchise_id,
+    TRY_CAST(season_year AS INTEGER) AS season_year,
+    TRY_CAST(season_ending_year AS INTEGER) AS season_ending_year,
     team_city,
     team_name
 FROM read_csv('data/ibl_franchise_seasons.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true);
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='');
 
 -- Snapshot of TSI per season (Phase 2 dependent — load if available)
 CREATE OR REPLACE TABLE dim_player_snapshot AS
 SELECT
-    CAST(pid AS INTEGER) AS pid,
+    TRY_CAST(pid AS INTEGER) AS pid,
     name,
-    CAST(season_year AS INTEGER) AS season_year,
+    TRY_CAST(season_year AS INTEGER) AS season_year,
     snapshot_phase,
-    CAST(tid AS INTEGER) AS tid,
-    CAST(age AS INTEGER) AS age,
+    TRY_CAST(tid AS INTEGER) AS tid,
+    TRY_CAST(age AS INTEGER) AS age,
     pos,
-    CAST(peak AS INTEGER) AS peak,
-    CAST(talent AS INTEGER) AS talent,
-    CAST(skill AS INTEGER) AS skill,
-    CAST(intangibles AS INTEGER) AS intangibles,
-    (CAST(talent AS INTEGER) + CAST(skill AS INTEGER) + CAST(intangibles AS INTEGER))::INTEGER AS tsi_sum,
+    TRY_CAST(peak AS INTEGER) AS peak,
+    TRY_CAST(talent AS INTEGER) AS talent,
+    TRY_CAST(skill AS INTEGER) AS skill,
+    TRY_CAST(intangibles AS INTEGER) AS intangibles,
+    (TRY_CAST(talent AS INTEGER) + TRY_CAST(skill AS INTEGER) + TRY_CAST(intangibles AS INTEGER)) AS tsi_sum,
     CASE
-        WHEN (CAST(talent AS INTEGER) + CAST(skill AS INTEGER) + CAST(intangibles AS INTEGER)) <= 6  THEN 'low'
-        WHEN (CAST(talent AS INTEGER) + CAST(skill AS INTEGER) + CAST(intangibles AS INTEGER)) <= 9  THEN 'mid'
-        WHEN (CAST(talent AS INTEGER) + CAST(skill AS INTEGER) + CAST(intangibles AS INTEGER)) <= 12 THEN 'high'
+        WHEN (TRY_CAST(talent AS INTEGER) + TRY_CAST(skill AS INTEGER) + TRY_CAST(intangibles AS INTEGER)) <= 6  THEN 'low'
+        WHEN (TRY_CAST(talent AS INTEGER) + TRY_CAST(skill AS INTEGER) + TRY_CAST(intangibles AS INTEGER)) <= 9  THEN 'mid'
+        WHEN (TRY_CAST(talent AS INTEGER) + TRY_CAST(skill AS INTEGER) + TRY_CAST(intangibles AS INTEGER)) <= 12 THEN 'high'
         ELSE 'elite'
     END AS tsi_band,
-    CAST(r_2ga AS INTEGER) AS r_2ga, CAST(r_2gp AS INTEGER) AS r_2gp,
-    CAST(r_fta AS INTEGER) AS r_fta, CAST(r_ftp AS INTEGER) AS r_ftp,
-    CAST(r_3ga AS INTEGER) AS r_3ga, CAST(r_3gp AS INTEGER) AS r_3gp,
-    CAST(r_orb AS INTEGER) AS r_orb, CAST(r_drb AS INTEGER) AS r_drb,
-    CAST(r_ast AS INTEGER) AS r_ast, CAST(r_stl AS INTEGER) AS r_stl,
-    CAST(r_to AS INTEGER)  AS r_to,  CAST(r_blk AS INTEGER) AS r_blk,
-    CAST(r_foul AS INTEGER) AS r_foul
+    TRY_CAST(r_fga AS INTEGER) AS r_fga, TRY_CAST(r_fgp AS INTEGER) AS r_fgp,
+    TRY_CAST(r_fta AS INTEGER) AS r_fta, TRY_CAST(r_ftp AS INTEGER) AS r_ftp,
+    TRY_CAST(r_tga AS INTEGER) AS r_tga, TRY_CAST(r_tgp AS INTEGER) AS r_tgp,
+    TRY_CAST(r_orb AS INTEGER) AS r_orb, TRY_CAST(r_drb AS INTEGER) AS r_drb,
+    TRY_CAST(r_ast AS INTEGER) AS r_ast, TRY_CAST(r_stl AS INTEGER) AS r_stl,
+    TRY_CAST(r_to AS INTEGER)  AS r_to,  TRY_CAST(r_blk AS INTEGER) AS r_blk,
+    TRY_CAST(r_foul AS INTEGER) AS r_foul
 FROM read_csv('data/ibl_plr_snapshots.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true)
-WHERE snapshot_phase = 'preseason';
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='')
+WHERE snapshot_phase IN ('preseason', 'end-of-season');
 
 -- Summary
 SELECT 'dim_player' AS table_name, COUNT(*) AS row_count FROM dim_player

--- a/ibl5/analytics/schema/02_facts.sql
+++ b/ibl5/analytics/schema/02_facts.sql
@@ -6,50 +6,50 @@
 CREATE OR REPLACE TABLE fact_player_season AS
 WITH hist_raw AS (
     SELECT
-        CAST(pid AS INTEGER) AS pid,
+        TRY_CAST(pid AS INTEGER) AS pid,
         name,
-        CAST(year AS INTEGER) AS season_year,
+        TRY_CAST(year AS INTEGER) AS season_year,
         team,
-        CAST(teamid AS INTEGER) AS teamid,
-        CAST(games AS INTEGER) AS games,
-        CAST(minutes AS INTEGER) AS minutes,
-        CAST(fgm AS INTEGER) AS fgm,
-        CAST(fga AS INTEGER) AS fga,
-        CAST(ftm AS INTEGER) AS ftm,
-        CAST(fta AS INTEGER) AS fta,
-        CAST(tgm AS INTEGER) AS tgm,
-        CAST(tga AS INTEGER) AS tga,
-        CAST(orb AS INTEGER) AS orb,
-        CAST(reb AS INTEGER) AS reb,
-        CAST(ast AS INTEGER) AS ast,
-        CAST(stl AS INTEGER) AS stl,
-        CAST(blk AS INTEGER) AS blk,
-        CAST(tvr AS INTEGER) AS tvr,
-        CAST(pf AS INTEGER) AS pf,
-        CAST(pts AS INTEGER) AS pts,
-        CAST(r_2ga AS INTEGER) AS r_2ga,
-        CAST(r_2gp AS INTEGER) AS r_2gp,
-        CAST(r_fta AS INTEGER) AS r_fta,
-        CAST(r_ftp AS INTEGER) AS r_ftp,
-        CAST(r_3ga AS INTEGER) AS r_3ga,
-        CAST(r_3gp AS INTEGER) AS r_3gp,
-        CAST(r_orb AS INTEGER) AS r_orb,
-        CAST(r_drb AS INTEGER) AS r_drb,
-        CAST(r_ast AS INTEGER) AS r_ast,
-        CAST(r_stl AS INTEGER) AS r_stl,
-        CAST(r_blk AS INTEGER) AS r_blk,
-        CAST(r_tvr AS INTEGER) AS r_tvr,
-        CAST(r_oo AS INTEGER)  AS r_oo,
-        CAST(r_do AS INTEGER)  AS r_do,
-        CAST(r_po AS INTEGER)  AS r_po,
-        CAST(r_to AS INTEGER)  AS r_to,
-        CAST(r_od AS INTEGER)  AS r_od,
-        CAST(r_dd AS INTEGER)  AS r_dd,
-        CAST(r_pd AS INTEGER)  AS r_pd,
-        CAST(r_td AS INTEGER)  AS r_td,
-        CAST(salary AS INTEGER) AS salary
+        TRY_CAST(teamid AS INTEGER) AS teamid,
+        TRY_CAST(games AS INTEGER) AS games,
+        TRY_CAST(minutes AS INTEGER) AS minutes,
+        TRY_CAST(fgm AS INTEGER) AS fgm,
+        TRY_CAST(fga AS INTEGER) AS fga,
+        TRY_CAST(ftm AS INTEGER) AS ftm,
+        TRY_CAST(fta AS INTEGER) AS fta,
+        TRY_CAST(tgm AS INTEGER) AS tgm,
+        TRY_CAST(tga AS INTEGER) AS tga,
+        TRY_CAST(orb AS INTEGER) AS orb,
+        TRY_CAST(reb AS INTEGER) AS reb,
+        TRY_CAST(ast AS INTEGER) AS ast,
+        TRY_CAST(stl AS INTEGER) AS stl,
+        TRY_CAST(blk AS INTEGER) AS blk,
+        TRY_CAST(tvr AS INTEGER) AS tvr,
+        TRY_CAST(pf AS INTEGER) AS pf,
+        TRY_CAST(pts AS INTEGER) AS pts,
+        TRY_CAST(r_2ga AS INTEGER) AS r_2ga,
+        TRY_CAST(r_2gp AS INTEGER) AS r_2gp,
+        TRY_CAST(r_fta AS INTEGER) AS r_fta,
+        TRY_CAST(r_ftp AS INTEGER) AS r_ftp,
+        TRY_CAST(r_3ga AS INTEGER) AS r_3ga,
+        TRY_CAST(r_3gp AS INTEGER) AS r_3gp,
+        TRY_CAST(r_orb AS INTEGER) AS r_orb,
+        TRY_CAST(r_drb AS INTEGER) AS r_drb,
+        TRY_CAST(r_ast AS INTEGER) AS r_ast,
+        TRY_CAST(r_stl AS INTEGER) AS r_stl,
+        TRY_CAST(r_blk AS INTEGER) AS r_blk,
+        TRY_CAST(r_tvr AS INTEGER) AS r_tvr,
+        TRY_CAST(r_oo AS INTEGER)  AS r_oo,
+        TRY_CAST(r_do AS INTEGER)  AS r_do,
+        TRY_CAST(r_po AS INTEGER)  AS r_po,
+        TRY_CAST(r_to AS INTEGER)  AS r_to,
+        TRY_CAST(r_od AS INTEGER)  AS r_od,
+        TRY_CAST(r_dd AS INTEGER)  AS r_dd,
+        TRY_CAST(r_pd AS INTEGER)  AS r_pd,
+        TRY_CAST(r_td AS INTEGER)  AS r_td,
+        TRY_CAST(salary AS INTEGER) AS salary
     FROM read_csv('data/ibl_hist.csv', delim='\t', header=true, all_varchar=true,
-        null_padding=true, ignore_errors=true)
+        null_padding=true, ignore_errors=true, strict_mode=false, quote='')
 )
 SELECT
     h.*,
@@ -89,144 +89,144 @@ LEFT JOIN dim_player_snapshot s ON h.pid = s.pid AND h.season_year = s.season_ye
 -- fact_player_game: Game-level player box scores
 CREATE OR REPLACE TABLE fact_player_game AS
 SELECT
-    CAST(id AS INTEGER) AS id,
-    CAST(Date AS DATE) AS game_date,
-    CAST(pid AS INTEGER) AS pid,
+    TRY_CAST(id AS INTEGER) AS id,
+    TRY_CAST(Date AS DATE) AS game_date,
+    TRY_CAST(pid AS INTEGER) AS pid,
     name,
     pos,
-    CAST(teamID AS INTEGER) AS team_id,
-    CAST(visitorTID AS INTEGER) AS visitor_tid,
-    CAST(homeTID AS INTEGER) AS home_tid,
-    CAST(gameMIN AS INTEGER) AS minutes,
-    CAST(game2GM AS INTEGER) AS fg2_made,
-    CAST(game2GA AS INTEGER) AS fg2_att,
-    CAST(gameFTM AS INTEGER) AS ft_made,
-    CAST(gameFTA AS INTEGER) AS ft_att,
-    CAST(game3GM AS INTEGER) AS fg3_made,
-    CAST(game3GA AS INTEGER) AS fg3_att,
-    CAST(gameORB AS INTEGER) AS orb,
-    CAST(gameDRB AS INTEGER) AS drb,
-    CAST(gameAST AS INTEGER) AS ast,
-    CAST(gameSTL AS INTEGER) AS stl,
-    CAST(gameTOV AS INTEGER) AS tov,
-    CAST(gameBLK AS INTEGER) AS blk,
-    CAST(gamePF AS INTEGER)  AS pf,
-    CAST(game_type AS INTEGER) AS game_type,
-    CAST(season_year AS INTEGER) AS season_year,
-    CAST(calc_points AS INTEGER) AS points,
-    CAST(calc_rebounds AS INTEGER) AS rebounds,
-    CAST(attendance AS INTEGER) AS attendance,
+    TRY_CAST(teamID AS INTEGER) AS team_id,
+    TRY_CAST(visitorTID AS INTEGER) AS visitor_tid,
+    TRY_CAST(homeTID AS INTEGER) AS home_tid,
+    TRY_CAST(gameMIN AS INTEGER) AS minutes,
+    TRY_CAST(game2GM AS INTEGER) AS fg2_made,
+    TRY_CAST(game2GA AS INTEGER) AS fg2_att,
+    TRY_CAST(gameFTM AS INTEGER) AS ft_made,
+    TRY_CAST(gameFTA AS INTEGER) AS ft_att,
+    TRY_CAST(game3GM AS INTEGER) AS fg3_made,
+    TRY_CAST(game3GA AS INTEGER) AS fg3_att,
+    TRY_CAST(gameORB AS INTEGER) AS orb,
+    TRY_CAST(gameDRB AS INTEGER) AS drb,
+    TRY_CAST(gameAST AS INTEGER) AS ast,
+    TRY_CAST(gameSTL AS INTEGER) AS stl,
+    TRY_CAST(gameTOV AS INTEGER) AS tov,
+    TRY_CAST(gameBLK AS INTEGER) AS blk,
+    TRY_CAST(gamePF AS INTEGER)  AS pf,
+    TRY_CAST(game_type AS INTEGER) AS game_type,
+    TRY_CAST(season_year AS INTEGER) AS season_year,
+    TRY_CAST(calc_points AS INTEGER) AS points,
+    TRY_CAST(calc_rebounds AS INTEGER) AS rebounds,
+    TRY_CAST(attendance AS INTEGER) AS attendance,
     -- Game type label
-    CASE CAST(game_type AS INTEGER)
+    CASE TRY_CAST(game_type AS INTEGER)
         WHEN 1 THEN 'regular'
         WHEN 2 THEN 'playoffs'
         WHEN 3 THEN 'preseason'
         ELSE 'other'
     END AS game_type_label
 FROM read_csv('data/ibl_box_scores.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true);
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='');
 
 -- fact_team_season: Team season records from JSB history
 CREATE OR REPLACE TABLE fact_team_season AS
 SELECT
-    CAST(id AS INTEGER) AS id,
-    CAST(season_year AS INTEGER) AS season_year,
+    TRY_CAST(id AS INTEGER) AS id,
+    TRY_CAST(season_year AS INTEGER) AS season_year,
     team_name,
-    CAST(teamid AS INTEGER) AS teamid,
-    CAST(wins AS INTEGER) AS wins,
-    CAST(losses AS INTEGER) AS losses,
-    CASE WHEN (CAST(wins AS INTEGER) + CAST(losses AS INTEGER)) > 0
-        THEN ROUND(CAST(wins AS INTEGER) * 1.0 / (CAST(wins AS INTEGER) + CAST(losses AS INTEGER)), 3)
+    TRY_CAST(teamid AS INTEGER) AS teamid,
+    TRY_CAST(wins AS INTEGER) AS wins,
+    TRY_CAST(losses AS INTEGER) AS losses,
+    CASE WHEN (TRY_CAST(wins AS INTEGER) + TRY_CAST(losses AS INTEGER)) > 0
+        THEN ROUND(TRY_CAST(wins AS INTEGER) * 1.0 / (TRY_CAST(wins AS INTEGER) + TRY_CAST(losses AS INTEGER)), 3)
     END AS win_pct,
-    CAST(made_playoffs AS INTEGER) AS made_playoffs,
+    TRY_CAST(made_playoffs AS INTEGER) AS made_playoffs,
     playoff_result,
     playoff_round_reached,
-    CAST(won_championship AS INTEGER) AS won_championship
+    TRY_CAST(won_championship AS INTEGER) AS won_championship
 FROM read_csv('data/ibl_jsb_history.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true);
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='');
 
 -- fact_team_game: Team-level game box scores
 CREATE OR REPLACE TABLE fact_team_game AS
 SELECT
-    CAST(id AS INTEGER) AS id,
-    CAST(Date AS DATE) AS game_date,
-    CAST(visitorTeamID AS INTEGER) AS visitor_tid,
-    CAST(homeTeamID AS INTEGER) AS home_tid,
-    CAST(game_type AS INTEGER) AS game_type,
-    CAST(season_year AS INTEGER) AS season_year,
-    CAST(attendance AS INTEGER) AS attendance,
-    CAST(capacity AS INTEGER) AS capacity,
+    TRY_CAST(id AS INTEGER) AS id,
+    TRY_CAST(Date AS DATE) AS game_date,
+    TRY_CAST(visitorTeamID AS INTEGER) AS visitor_tid,
+    TRY_CAST(homeTeamID AS INTEGER) AS home_tid,
+    TRY_CAST(game_type AS INTEGER) AS game_type,
+    TRY_CAST(season_year AS INTEGER) AS season_year,
+    TRY_CAST(attendance AS INTEGER) AS attendance,
+    TRY_CAST(capacity AS INTEGER) AS capacity,
     -- Quarter scores
-    CAST(visitorQ1points AS INTEGER) AS visitor_q1,
-    CAST(visitorQ2points AS INTEGER) AS visitor_q2,
-    CAST(visitorQ3points AS INTEGER) AS visitor_q3,
-    CAST(visitorQ4points AS INTEGER) AS visitor_q4,
-    CAST(visitorOTpoints AS INTEGER) AS visitor_ot,
-    CAST(homeQ1points AS INTEGER) AS home_q1,
-    CAST(homeQ2points AS INTEGER) AS home_q2,
-    CAST(homeQ3points AS INTEGER) AS home_q3,
-    CAST(homeQ4points AS INTEGER) AS home_q4,
-    CAST(homeOTpoints AS INTEGER) AS home_ot,
+    TRY_CAST(visitorQ1points AS INTEGER) AS visitor_q1,
+    TRY_CAST(visitorQ2points AS INTEGER) AS visitor_q2,
+    TRY_CAST(visitorQ3points AS INTEGER) AS visitor_q3,
+    TRY_CAST(visitorQ4points AS INTEGER) AS visitor_q4,
+    TRY_CAST(visitorOTpoints AS INTEGER) AS visitor_ot,
+    TRY_CAST(homeQ1points AS INTEGER) AS home_q1,
+    TRY_CAST(homeQ2points AS INTEGER) AS home_q2,
+    TRY_CAST(homeQ3points AS INTEGER) AS home_q3,
+    TRY_CAST(homeQ4points AS INTEGER) AS home_q4,
+    TRY_CAST(homeOTpoints AS INTEGER) AS home_ot,
     -- Totals
-    CAST(calc_points AS INTEGER) AS total_points,
-    CAST(calc_rebounds AS INTEGER) AS total_rebounds
+    TRY_CAST(calc_points AS INTEGER) AS total_points,
+    TRY_CAST(calc_rebounds AS INTEGER) AS total_rebounds
 FROM read_csv('data/ibl_box_scores_teams.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true);
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='');
 
 -- Awards tables
 CREATE OR REPLACE TABLE fact_player_awards AS
 SELECT
-    CAST(year AS INTEGER) AS season_year,
+    TRY_CAST(year AS INTEGER) AS season_year,
     Award AS award,
     name AS player_name
 FROM read_csv('data/ibl_awards.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true);
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='');
 
 CREATE OR REPLACE TABLE fact_team_awards AS
 SELECT
-    CAST(year AS INTEGER) AS season_year,
+    TRY_CAST(year AS INTEGER) AS season_year,
     name AS team_name,
     Award AS award
 FROM read_csv('data/ibl_team_awards.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true);
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='');
 
 -- Transactions
 CREATE OR REPLACE TABLE fact_transactions AS
 SELECT
-    CAST(id AS INTEGER) AS id,
-    CAST(season_year AS INTEGER) AS season_year,
-    CAST(transaction_month AS INTEGER) AS transaction_month,
-    CAST(transaction_day AS INTEGER) AS transaction_day,
-    CAST(transaction_type AS INTEGER) AS transaction_type,
-    CASE CAST(transaction_type AS INTEGER)
+    TRY_CAST(id AS INTEGER) AS id,
+    TRY_CAST(season_year AS INTEGER) AS season_year,
+    TRY_CAST(transaction_month AS INTEGER) AS transaction_month,
+    TRY_CAST(transaction_day AS INTEGER) AS transaction_day,
+    TRY_CAST(transaction_type AS INTEGER) AS transaction_type,
+    CASE TRY_CAST(transaction_type AS INTEGER)
         WHEN 1 THEN 'injury'
         WHEN 2 THEN 'trade'
         WHEN 3 THEN 'waiver_claim'
         WHEN 4 THEN 'waiver_release'
         ELSE 'unknown'
     END AS transaction_label,
-    CAST(pid AS INTEGER) AS pid,
+    TRY_CAST(pid AS INTEGER) AS pid,
     player_name,
-    CAST(from_teamid AS INTEGER) AS from_teamid,
-    CAST(to_teamid AS INTEGER) AS to_teamid,
-    CAST(injury_games_missed AS INTEGER) AS injury_games_missed,
+    TRY_CAST(from_teamid AS INTEGER) AS from_teamid,
+    TRY_CAST(to_teamid AS INTEGER) AS to_teamid,
+    TRY_CAST(injury_games_missed AS INTEGER) AS injury_games_missed,
     injury_description,
-    CAST(trade_group_id AS INTEGER) AS trade_group_id,
-    CAST(is_draft_pick AS INTEGER) AS is_draft_pick,
-    CAST(draft_pick_year AS INTEGER) AS draft_pick_year
+    TRY_CAST(trade_group_id AS INTEGER) AS trade_group_id,
+    TRY_CAST(is_draft_pick AS INTEGER) AS is_draft_pick,
+    TRY_CAST(draft_pick_year AS INTEGER) AS draft_pick_year
 FROM read_csv('data/ibl_jsb_transactions.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true);
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='');
 
 -- All-Star rosters
 CREATE OR REPLACE TABLE fact_allstar_rosters AS
 SELECT
-    CAST(season_year AS INTEGER) AS season_year,
+    TRY_CAST(season_year AS INTEGER) AS season_year,
     event_type,
-    CAST(roster_slot AS INTEGER) AS roster_slot,
-    CAST(pid AS INTEGER) AS pid,
+    TRY_CAST(roster_slot AS INTEGER) AS roster_slot,
+    TRY_CAST(pid AS INTEGER) AS pid,
     player_name
 FROM read_csv('data/ibl_jsb_allstar_rosters.csv', delim='\t', header=true, all_varchar=true,
-    null_padding=true, ignore_errors=true);
+    null_padding=true, ignore_errors=true, strict_mode=false, quote='');
 
 -- Summary
 SELECT 'fact_player_season' AS table_name, COUNT(*) AS row_count FROM fact_player_season

--- a/ibl5/analytics/schema/03_aggregates.sql
+++ b/ibl5/analytics/schema/03_aggregates.sql
@@ -112,12 +112,11 @@ CREATE OR REPLACE TABLE agg_draft_cohort AS
 WITH player_first_season AS (
     SELECT
         pid,
-        MIN(season_year) AS first_season_year,
+        first_season AS first_season_year,
         career_ppg,
         career_seasons,
         tsi_sum
     FROM agg_player_career
-    GROUP BY pid, career_ppg, career_seasons, tsi_sum
 )
 SELECT
     first_season_year,


### PR DESCRIPTION
## Summary

Fixes DuckDB analytics layer (#546) to work on macOS with Docker — the original was developed against remote production with Bash 4+.

## Bugs Fixed

### Shell Scripts (`bin/`)
- **Bash 3.x compat**: `declare -A` (associative arrays) requires Bash 4+; macOS ships 3.2. Replaced with temp file approach.
- **`--local` flag**: `.env` has `REMOTE_HOST=iblhoops.net`, so scripts always connected to production. Added `--local` flag to force Docker connection.
- **Empty table headers**: MariaDB batch mode omits headers for 0-row results. Added fallback via `information_schema.COLUMNS`.
- **DuckDB 1.2 API**: `estimated_row_count` → `estimated_size` in `duckdb_tables()`.

### DuckDB Schema
- **CSV parsing failures**: Added `strict_mode=false, quote=''` to all `read_csv()` calls — fixes sniffing errors on wide CSVs with special characters.
- **Literal NULL strings**: Replaced all `CAST()` with `TRY_CAST()` — Docker seed data has literal `'NULL'` strings that crash `CAST()`.
- **Column schema mismatch**: `dim_player` used `columns={}` listing 20 columns but `ibl_plr` has 144. Removed `columns` param, let DuckDB auto-detect.
- **Wrong column names**: `dim_player_snapshot` referenced `r_2ga/r_2gp/r_3ga/r_3gp` but `ibl_plr_snapshots` uses `r_fga/r_fgp/r_tga/r_tgp`.
- **Missing snapshot phase**: Only `end-of-season` snapshots exist (not `preseason`). Filter now accepts both.
- **Broken aggregate**: `agg_draft_cohort` referenced `season_year` which doesn't exist on `agg_player_career` — fixed to `first_season`.

### Named Queries
- **Ambiguous columns**: `tsi_progression.sql` JOINs created unqualified `tsi_band` references. Added table aliases.

## Testing

Full end-to-end build completes in ~2s against Docker:
```
bin/analytics-build --local
```

All 18 tables load, 14/15 validations pass (age range FAIL expected for retired players), all 7 named queries execute cleanly.