### PR TITLE
fix: restrict dim_player_snapshot to heat-end phase only

### DIFF
--- a/.claude/rules/duckdb-analytics.md
+++ b/.claude/rules/duckdb-analytics.md
@@ -55,7 +55,7 @@ Rebuild is idempotent — deletes and recreates from scratch. Production export 
 | `dim_team` | 33 | Team master (city, name, colors) |
 | `dim_season` | 20 | Season years with labels ("06-07" format) |
 | `dim_franchise_seasons` | 512 | Historical team city/name per season |
-| `dim_player_snapshot` | ~11K | Per-season TSI snapshots from PLR heat-end/end-of-season |
+| `dim_player_snapshot` | ~11K | Per-season TSI snapshots (heat-end only, 1 row per player-season) |
 | `dim_sim_dates` | 698 | Global simulation date windows (maps sim# to date ranges) |
 
 ### Facts (event-level data)

--- a/ibl5/analytics/schema/01_dimensions.sql
+++ b/ibl5/analytics/schema/01_dimensions.sql
@@ -98,7 +98,7 @@ SELECT
     TRY_CAST(r_foul AS INTEGER) AS r_foul
 FROM read_csv('data/ibl_plr_snapshots.csv', delim='\t', header=true, all_varchar=true,
     null_padding=true, ignore_errors=true, strict_mode=false, quote='')
-WHERE snapshot_phase IN ('heat-end', 'end-of-season');
+WHERE snapshot_phase = 'heat-end';
 
 -- dim_sim_dates: Global simulation date windows (698 sims across 19 seasons)
 -- Maps PLB per-season sim_number to date ranges via season offset calculation.


### PR DESCRIPTION
## Summary

Fixes row duplication in `dim_player_snapshot` introduced in #551.

### Problem

`dim_player_snapshot` included both `heat-end` and `end-of-season` snapshot phases, producing **2 rows per player-season**. Since `fact_player_season` joins to `dim_player_snapshot` on `(pid, season_year)` without a phase filter, every row was doubled (22,264 vs expected 11,890). This cascaded to all downstream aggregates (`agg_tsi_progression`, `agg_player_career`, `agg_team_season_roster`, `agg_playoff_predictor`).

### Fix

Restrict `dim_player_snapshot` to `WHERE snapshot_phase = 'heat-end'` instead of `IN ('heat-end', 'end-of-season')`. Ratings are confirmed identical between the two phases (zero drift across all 19 seasons), so this is safe.

`fact_plr_snapshots` (the full snapshots fact table) retains both phases for completeness.

### Manual Testing

No manual testing needed — DuckDB schema-only change, no web UI impact.