### PR TITLE
restore: faprep.php — Free Agent Prep report page

### DIFF
--- a/ibl5/faprep.php
+++ b/ibl5/faprep.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/mainfile.php';
+
+use Utilities\HtmlSanitizer;
+
+/** @var mysqli $mysqli_db */
+
+$query = <<<'SQL'
+SELECT ordinal, name, age, teamname, pos, coach, loyalty, playingTime,
+       winner, tradition, security, exp, sta
+FROM ibl_plr
+WHERE retired = 0
+ORDER BY ordinal ASC
+SQL;
+
+$result = $mysqli_db->query($query);
+$rows = $result instanceof mysqli_result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+
+?>
+<html>
+<head>
+    <title>Free Agent Prep</title>
+</head>
+<body>
+<table>
+<tr>
+    <th>ordinal</th>
+    <th>name</th>
+    <th>age</th>
+    <th>teamname</th>
+    <th>pos</th>
+    <th>coach</th>
+    <th>loyalty</th>
+    <th>playingTime</th>
+    <th>winner</th>
+    <th>tradition</th>
+    <th>security</th>
+    <th>exp</th>
+    <th>Sta</th>
+</tr>
+<?php foreach ($rows as $row): ?>
+<tr>
+    <td><?= HtmlSanitizer::e($row['ordinal']) ?></td>
+    <td><?= HtmlSanitizer::e($row['name']) ?></td>
+    <td><?= HtmlSanitizer::e($row['age']) ?></td>
+    <td><?= HtmlSanitizer::e($row['teamname']) ?></td>
+    <td><?= HtmlSanitizer::e($row['pos']) ?></td>
+    <td><?= HtmlSanitizer::e($row['coach']) ?></td>
+    <td><?= HtmlSanitizer::e($row['loyalty']) ?></td>
+    <td><?= HtmlSanitizer::e($row['playingTime']) ?></td>
+    <td><?= HtmlSanitizer::e($row['winner']) ?></td>
+    <td><?= HtmlSanitizer::e($row['tradition']) ?></td>
+    <td><?= HtmlSanitizer::e($row['security']) ?></td>
+    <td><?= HtmlSanitizer::e($row['exp']) ?></td>
+    <td><?= HtmlSanitizer::e($row['sta']) ?></td>
+</tr>
+<?php endforeach; ?>
+</table>
+</body>
+</html>


### PR DESCRIPTION
Restores the standalone Free Agent Prep page deleted in 996b8669
("Delete deprecated scripts from root directory"). Modernized with
strict_types, mysqli, and HtmlSanitizer XSS protection.

https://claude.ai/code/session_01Xemg77Xh6e1bLQgZZPn5fS