### PR TITLE
fix: keep nav dropdown open for browser auto-fill interaction

### DIFF
--- a/ibl5/design/components/navigation.css
+++ b/ibl5/design/components/navigation.css
@@ -302,36 +302,53 @@
 .group:hover .nav-dropdown-item:nth-of-type(14) { transition-delay: 325ms; }
 
 /* ==========================================================================
-   Desktop Dropdown Click-to-Pin State
-   Clicking a column heading keeps its dropdown open;
-   clicking again (or clicking outside) closes it.
-   Hover behavior is preserved independently.
+   Desktop Dropdown Persistent States
+   nav-pinned: click-to-pin (clicking heading keeps dropdown open)
+   nav-hover:  JS-managed hover (stays open until another menu is hovered)
+   Both override CSS :hover so the dropdown survives mouse leaving the group
+   (e.g., when interacting with browser auto-fill popups).
    ========================================================================== */
 
-.group.nav-pinned > div {
+.group.nav-pinned > div,
+.group.nav-hover > div {
     opacity: 1 !important;
     visibility: visible !important;
 }
 
-.group.nav-pinned .nav-dropdown-item {
+.group.nav-pinned .nav-dropdown-item,
+.group.nav-hover .nav-dropdown-item {
     opacity: 1;
     transform: translateY(0);
 }
 
-.group.nav-pinned .nav-dropdown-item:nth-of-type(1) { transition-delay: 0ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(2) { transition-delay: 25ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(3) { transition-delay: 50ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(4) { transition-delay: 75ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(5) { transition-delay: 100ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(6) { transition-delay: 125ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(7) { transition-delay: 150ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(8) { transition-delay: 175ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(9) { transition-delay: 200ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(10) { transition-delay: 225ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(11) { transition-delay: 250ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(12) { transition-delay: 275ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(13) { transition-delay: 300ms; }
-.group.nav-pinned .nav-dropdown-item:nth-of-type(14) { transition-delay: 325ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(1),
+.group.nav-hover .nav-dropdown-item:nth-of-type(1) { transition-delay: 0ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(2),
+.group.nav-hover .nav-dropdown-item:nth-of-type(2) { transition-delay: 25ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(3),
+.group.nav-hover .nav-dropdown-item:nth-of-type(3) { transition-delay: 50ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(4),
+.group.nav-hover .nav-dropdown-item:nth-of-type(4) { transition-delay: 75ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(5),
+.group.nav-hover .nav-dropdown-item:nth-of-type(5) { transition-delay: 100ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(6),
+.group.nav-hover .nav-dropdown-item:nth-of-type(6) { transition-delay: 125ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(7),
+.group.nav-hover .nav-dropdown-item:nth-of-type(7) { transition-delay: 150ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(8),
+.group.nav-hover .nav-dropdown-item:nth-of-type(8) { transition-delay: 175ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(9),
+.group.nav-hover .nav-dropdown-item:nth-of-type(9) { transition-delay: 200ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(10),
+.group.nav-hover .nav-dropdown-item:nth-of-type(10) { transition-delay: 225ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(11),
+.group.nav-hover .nav-dropdown-item:nth-of-type(11) { transition-delay: 250ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(12),
+.group.nav-hover .nav-dropdown-item:nth-of-type(12) { transition-delay: 275ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(13),
+.group.nav-hover .nav-dropdown-item:nth-of-type(13) { transition-delay: 300ms; }
+.group.nav-pinned .nav-dropdown-item:nth-of-type(14),
+.group.nav-hover .nav-dropdown-item:nth-of-type(14) { transition-delay: 325ms; }
 
 /* ==========================================================================
    Navigation Link Colors (Accessibility Override)

--- a/ibl5/jslib/navigation.js
+++ b/ibl5/jslib/navigation.js
@@ -135,20 +135,37 @@
             });
         });
 
-        // Close pinned dropdowns when clicking outside nav groups
+        // Desktop dropdown hover-to-stay
+        // Keeps dropdown visible via nav-hover class even when mouse leaves
+        // the group (e.g., to interact with browser auto-fill popups).
+        // Only clears when hovering a different menu, clicking outside, or Escape.
+        desktopGroups.forEach(function(group) {
+            group.addEventListener('mouseenter', function() {
+                desktopGroups.forEach(function(other) {
+                    if (other !== group) {
+                        other.classList.remove('nav-hover');
+                    }
+                });
+                group.classList.add('nav-hover');
+            });
+        });
+
+        // Close pinned/hovered dropdowns when clicking outside nav groups
         document.addEventListener('click', function(e) {
             if (!e.target.closest('.group')) {
                 desktopGroups.forEach(function(group) {
                     group.classList.remove('nav-pinned');
+                    group.classList.remove('nav-hover');
                 });
             }
         });
 
-        // Close pinned dropdowns on Escape
+        // Close pinned/hovered dropdowns on Escape
         document.addEventListener('keydown', function(e) {
             if (e.key === 'Escape') {
                 desktopGroups.forEach(function(group) {
                     group.classList.remove('nav-pinned');
+                    group.classList.remove('nav-hover');
                 });
             }
         });


### PR DESCRIPTION
## Problem

The Login dropdown menu uses CSS `group-hover` to control visibility. When a user hovers over Login and the browser shows an auto-fill popup for saved credentials, moving the mouse to the popup causes the dropdown to disappear — because the auto-fill UI renders outside the DOM element, breaking the CSS hover state.

## Solution

Added a JS-managed `nav-hover` class that persists the dropdown's visible state after `mouseenter`. The dropdown only closes when the user:
- Hovers a **different** nav menu item (switches dropdown)
- Clicks outside the navigation
- Presses Escape

This mirrors the existing `nav-pinned` (click-to-pin) behavior but triggered by hover instead of click. The CSS rules are combined to avoid duplication.

## Changes

- **`navigation.css`**: Combined `nav-pinned` and `nav-hover` selectors for dropdown visibility and staggered item animations
- **`navigation.js`**: Added `mouseenter` listeners on desktop nav groups to manage `nav-hover` class; updated click-outside and Escape handlers to also clear `nav-hover`

## Visual Verification

Tested in browser via Chrome DevTools MCP:
1. Hovered Login → dropdown opened with login form
2. Moved mouse away from nav → dropdown stayed open (nav-hover class persisted)
3. Hovered Season → Login closed, Season opened (mutual exclusion works)

## Manual Testing

Open the site when not logged in on Desktop. Hover over Login, then move your mouse to select browser auto-fill credentials. The dropdown should stay open.