### PR TITLE
fix: copy error-reporting.ini into Docker image to suppress PHP 8.4 deprecation notices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY docker/opcache.ini $PHP_INI_DIR/conf.d/opcache.ini
+COPY docker/error-reporting.ini $PHP_INI_DIR/conf.d/error-reporting.ini
 
 RUN a2enmod rewrite headers
 


### PR DESCRIPTION
## Problem

`docker/error-reporting.ini` existed with `E_DEPRECATED` suppression but was never `COPY`'d into the Docker image. PHP 8.4 deprecation notices from `delight-im/db` (implicit nullable parameters) rendered as visible text on every page in local worktree environments.

## Fix

Added `COPY` directive for `error-reporting.ini` alongside existing `opcache.ini`. The INI sets `error_reporting = E_ALL & ~E_DEPRECATED` at the PHP engine level, suppressing notices before any PHP code executes.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.