### PR TITLE
fix: check future years only when deleting outdated buyouts/cash

### DIFF
--- a/ibl5/classes/LeagueControlPanel/Contracts/LeagueControlPanelRepositoryInterface.php
+++ b/ibl5/classes/LeagueControlPanel/Contracts/LeagueControlPanelRepositoryInterface.php
@@ -191,8 +191,8 @@ interface LeagueControlPanelRepositoryInterface
     /**
      * Delete buyouts and cash considerations whose remaining contract year salaries are all zero.
      *
-     * A record is "outdated" when every salary field from the current contract year onward is 0,
-     * meaning all obligations have been fulfilled and the placeholder can be safely removed.
+     * A record is "outdated" when every salary field for future contract years (after the current
+     * year) is 0, meaning no money is owed or received in any upcoming season.
      *
      * @return int Number of deleted rows
      */

--- a/ibl5/classes/LeagueControlPanel/LeagueControlPanelRepository.php
+++ b/ibl5/classes/LeagueControlPanel/LeagueControlPanelRepository.php
@@ -321,12 +321,12 @@ class LeagueControlPanelRepository extends \BaseMysqliRepository implements Leag
         return $this->execute(
             "DELETE FROM ibl_plr
             WHERE (name LIKE '%|%Buyout%' OR name LIKE '%|%Cash%')
-              AND (cy > 1 OR cy1 = 0)
-              AND (cy > 2 OR cy2 = 0)
-              AND (cy > 3 OR cy3 = 0)
-              AND (cy > 4 OR cy4 = 0)
-              AND (cy > 5 OR cy5 = 0)
-              AND (cy > 6 OR cy6 = 0)"
+              AND (cy >= 1 OR cy1 = 0)
+              AND (cy >= 2 OR cy2 = 0)
+              AND (cy >= 3 OR cy3 = 0)
+              AND (cy >= 4 OR cy4 = 0)
+              AND (cy >= 5 OR cy5 = 0)
+              AND (cy >= 6 OR cy6 = 0)"
         );
     }
 

--- a/ibl5/tests/DatabaseIntegration/LeagueControlPanelRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/LeagueControlPanelRepositoryTest.php
@@ -258,15 +258,33 @@ class LeagueControlPanelRepositoryTest extends DatabaseTestCase
         self::assertNull($this->fetchPlayerByPid(200100041));
     }
 
+    public function testDeleteOutdatedBuyoutsAndCashDeletesCurrentYearOnlyCash(): void
+    {
+        // Cash with money only in current year (cy1) and no future years — should be deleted
+        $this->insertTestPlayer(200100045, '| Cash from Test Current', [
+            'tid' => 1,
+            'cy' => 1,
+            'cyt' => 1,
+            'cy1' => -500,
+            'cy2' => 0,
+        ]);
+
+        $count = $this->repo->deleteOutdatedBuyoutsAndCash();
+
+        self::assertSame(1, $count);
+        self::assertNull($this->fetchPlayerByPid(200100045));
+    }
+
     public function testDeleteOutdatedBuyoutsAndCashPreservesActiveBuyout(): void
     {
-        // Buyout with money still owed in current year — should NOT be deleted
+        // Buyout with money still owed in a future year — should NOT be deleted
         $this->insertTestPlayer(200100042, '| Active Buyout', [
             'tid' => 1,
             'cy' => 2,
             'cyt' => 4,
             'cy1' => 0,
             'cy2' => 300,
+            'cy3' => 300,
         ]);
 
         $count = $this->repo->deleteOutdatedBuyoutsAndCash();


### PR DESCRIPTION
## Summary

Fixes the delete outdated buyouts/cash button (#565) to only check **future** contract year salaries, not the current year. The current year's salary is already on the books and shouldn't prevent deletion.

## Problem

The SQL used `cy > N` which included the current year's salary in the check. For example, `| Cash from Pacers` (cy=1, cy1=-242, cy2-cy6=0) was preserved even though it has no future obligations.

## Fix

Changed `cy > N` to `cy >= N` in all 6 conditions:

```sql
-- Before: includes current year in check
AND (cy > 1 OR cy1 = 0)

-- After: skips current year, only checks future years
AND (cy >= 1 OR cy1 = 0)
```

When `cy=1`, `cy >= 1` is true, so cy1 is skipped (current year). Only cy2-cy6 (future years) are checked.

## Test Updates

- Added `testDeleteOutdatedBuyoutsAndCashDeletesCurrentYearOnlyCash` — verifies that a record with money only in the current year (no future years) is correctly deleted
- Updated active buyout preservation test to use a non-zero future year (`cy3=300`)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.