### PR TITLE
refactor: rename ibl_gm_tenures.gm_username → gm_display_name

### DIFF
--- a/ibl5/classes/SeasonArchive/Contracts/SeasonArchiveRepositoryInterface.php
+++ b/ibl5/classes/SeasonArchive/Contracts/SeasonArchiveRepositoryInterface.php
@@ -13,8 +13,8 @@ namespace SeasonArchive\Contracts;
  * @phpstan-type AwardRow array{year: int, Award: string, name: string, table_ID: int}
  * @phpstan-type PlayoffRow array{year: int, round: int, winner: string, loser: string, winner_games: int, loser_games: int}
  * @phpstan-type TeamAwardRow array{year: int, name: string, Award: string, ID: int}
- * @phpstan-type GmAwardWithTeamRow array{year: int, Award: string, gm_username: string, team_name: string, table_ID: int}
- * @phpstan-type GmTenureWithTeamRow array{gm_username: string, start_season_year: int, end_season_year: int|null, team_name: string}
+ * @phpstan-type GmAwardWithTeamRow array{year: int, Award: string, gm_display_name: string, team_name: string, table_ID: int}
+ * @phpstan-type GmTenureWithTeamRow array{gm_display_name: string, start_season_year: int, end_season_year: int|null, team_name: string}
  * @phpstan-type HeatWinLossRow array{year: int, currentname: string, namethatyear: string, wins: int, losses: int}
  * @phpstan-type TeamColorRow array{teamid: int, team_name: string, color1: string, color2: string}
  *

--- a/ibl5/classes/SeasonArchive/SeasonArchiveRepository.php
+++ b/ibl5/classes/SeasonArchive/SeasonArchiveRepository.php
@@ -101,9 +101,9 @@ class SeasonArchiveRepository extends BaseMysqliRepository implements SeasonArch
     {
         /** @var list<GmAwardWithTeamRow> */
         return $this->fetchAll(
-            "SELECT ga.year, ga.Award, ga.name AS gm_username, ti.team_name, ga.table_ID
+            "SELECT ga.year, ga.Award, ga.name AS gm_display_name, ti.team_name, ga.table_ID
             FROM ibl_gm_awards ga
-            JOIN ibl_gm_tenures gt ON ga.name = gt.gm_username
+            JOIN ibl_gm_tenures gt ON ga.name = gt.gm_display_name
                 AND ga.year >= gt.start_season_year
                 AND (gt.end_season_year IS NULL OR ga.year <= gt.end_season_year)
             JOIN {$this->teamInfoTable} ti ON gt.franchise_id = ti.teamid
@@ -118,7 +118,7 @@ class SeasonArchiveRepository extends BaseMysqliRepository implements SeasonArch
     {
         /** @var list<GmTenureWithTeamRow> */
         return $this->fetchAll(
-            "SELECT gt.gm_username, gt.start_season_year, gt.end_season_year, ti.team_name
+            "SELECT gt.gm_display_name, gt.start_season_year, gt.end_season_year, ti.team_name
             FROM ibl_gm_tenures gt
             JOIN {$this->teamInfoTable} ti ON gt.franchise_id = ti.teamid
             ORDER BY gt.start_season_year ASC"

--- a/ibl5/classes/SeasonArchive/SeasonArchiveService.php
+++ b/ibl5/classes/SeasonArchive/SeasonArchiveService.php
@@ -283,7 +283,7 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
     {
         foreach ($gmAwards as $award) {
             if ($award['Award'] === 'GM of the Year' && $award['year'] === $year) {
-                return ['name' => $award['gm_username'], 'team' => $award['team_name']];
+                return ['name' => $award['gm_display_name'], 'team' => $award['team_name']];
             }
         }
 
@@ -320,9 +320,9 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
             $conference = $teamConferences[$award['team_name']] ?? '';
 
             if ($conference === 'Eastern') {
-                $east[] = $award['gm_username'];
+                $east[] = $award['gm_display_name'];
             } elseif ($conference === 'Western') {
-                $west[] = $award['gm_username'];
+                $west[] = $award['gm_display_name'];
             }
         }
 
@@ -358,7 +358,7 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
                 continue;
             }
 
-            return $tenure['gm_username'];
+            return $tenure['gm_display_name'];
         }
 
         return '';

--- a/ibl5/classes/Team/Contracts/TeamRepositoryInterface.php
+++ b/ibl5/classes/Team/Contracts/TeamRepositoryInterface.php
@@ -18,7 +18,7 @@ namespace Team\Contracts;
  *
  * @phpstan-type PowerRow array{tid: int, team_name: string, leagueRecord: string, wins: int, losses: int, pct: float|string, conference: string, division: string, confRecord: string, divRecord: string, divGB: float|string|null, homeRecord: string, awayRecord: string, gamesUnplayed: int, ranking: float, last_win: int, last_loss: int, streak_type: string, streak: int, sos: float|string, remaining_sos: float|string}
  * @phpstan-type BannerRow array{year: int, currentname: string, bannername: string, bannertype: int}
- * @phpstan-type GMTenureRow array{id: int, franchise_id: int, gm_username: string, start_season_year: int, end_season_year: int|null, is_mid_season_start: int, is_mid_season_end: int}
+ * @phpstan-type GMTenureRow array{id: int, franchise_id: int, gm_display_name: string, start_season_year: int, end_season_year: int|null, is_mid_season_start: int, is_mid_season_end: int}
  * @phpstan-type GMAwardRow array{year: int, Award: string, name: string, table_ID: int}
  * @phpstan-type TeamAwardRow array{year: int, name: string, Award: string, ID: int}
  * @phpstan-type WinLossRow array{year: int, currentname: string, namethatyear: string, wins: int, losses: int}

--- a/ibl5/classes/Team/Views/AwardsView.php
+++ b/ibl5/classes/Team/Views/AwardsView.php
@@ -62,7 +62,7 @@ class AwardsView
             $start = $tenure['start_season_year'];
             $end = $tenure['end_season_year'];
             $endLabel = $end === null ? 'Present' : (string) $end;
-            $username = HtmlSanitizer::e($tenure['gm_username']);
+            $username = HtmlSanitizer::e($tenure['gm_display_name']);
             $output .= "<li><span class=\"award-year\">$start-$endLabel</span> $username</li>";
         }
 

--- a/ibl5/config/schema-assertions.php
+++ b/ibl5/config/schema-assertions.php
@@ -37,4 +37,7 @@ return [
     new SchemaAssertion('ibl_team_info', 'gm_username'),
     new SchemaAssertion('ibl_settings', 'name'),
     new SchemaAssertion('ibl_settings', 'value'),
+
+    // Migration 099: gm_username → gm_display_name (column stores display names, not usernames)
+    new SchemaAssertion('ibl_gm_tenures', 'gm_display_name'),
 ];

--- a/ibl5/migrations/099_rename_gm_display_name.sql
+++ b/ibl5/migrations/099_rename_gm_display_name.sql
@@ -1,0 +1,109 @@
+-- Migration 099: Rename ibl_gm_tenures.gm_username → gm_display_name
+--
+-- This column stores display names (real names like "A-Jay Nicolas"),
+-- not auth usernames. The old name was misleading. The trigger that
+-- INSERTs into this column is also updated.
+
+ALTER TABLE ibl_gm_tenures CHANGE gm_username gm_display_name VARCHAR(60) NOT NULL;
+
+-- Recreate trigger to use the new column name.
+-- The trigger still fires on nuke_users for now (moved to ibl_team_info in a later migration).
+DROP TRIGGER IF EXISTS trg_gm_tenure_track;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_gm_tenure_track
+AFTER UPDATE ON nuke_users
+FOR EACH ROW
+BEGIN
+  DECLARE v_ending_year   SMALLINT UNSIGNED;
+  DECLARE v_beginning_year SMALLINT UNSIGNED;
+  DECLARE v_phase         VARCHAR(128);
+  DECLARE v_is_mid_season TINYINT(1);
+  DECLARE v_old_franchise INT;
+  DECLARE v_new_franchise INT;
+
+  IF OLD.user_ibl_team <> NEW.user_ibl_team THEN
+
+    -- ===== Dual-write: sync gm_username =====
+
+    -- Clear gm_username on old team
+    IF OLD.user_ibl_team <> '' THEN
+      UPDATE ibl_team_info
+         SET gm_username = NULL,
+             discordID = NULL
+       WHERE team_name = OLD.user_ibl_team
+         AND gm_username = OLD.username;
+    END IF;
+
+    -- Set gm_username and discordID on new team
+    IF NEW.user_ibl_team <> '' THEN
+      UPDATE ibl_team_info
+         SET gm_username = NEW.username,
+             discordID = NEW.discordID
+       WHERE team_name = NEW.user_ibl_team;
+    END IF;
+
+    -- ===== GM tenure tracking (updated column name) =====
+
+    SELECT CAST(value AS UNSIGNED) INTO v_ending_year
+      FROM ibl_settings
+     WHERE name = 'Current Season Ending Year'
+     LIMIT 1;
+
+    SET v_beginning_year = v_ending_year - 1;
+
+    SELECT value INTO v_phase
+      FROM ibl_settings
+     WHERE name = 'Current Season Phase'
+     LIMIT 1;
+
+    SET v_is_mid_season = (v_phase IN ('Regular Season', 'Playoffs', 'HEAT'));
+
+    -- Close the old tenure (if the user was on a real team)
+    IF OLD.user_ibl_team <> '' THEN
+      SELECT teamid INTO v_old_franchise
+        FROM ibl_team_info
+       WHERE team_name = OLD.user_ibl_team
+       LIMIT 1;
+
+      IF v_old_franchise IS NOT NULL THEN
+        UPDATE ibl_gm_tenures
+           SET end_season_year   = v_beginning_year,
+               is_mid_season_end = v_is_mid_season
+         WHERE franchise_id   = v_old_franchise
+           AND gm_display_name = OLD.username
+           AND end_season_year IS NULL;
+      END IF;
+    END IF;
+
+    -- Open a new tenure (if the user is assigned to a real team)
+    IF NEW.user_ibl_team <> '' THEN
+      SELECT teamid INTO v_new_franchise
+        FROM ibl_team_info
+       WHERE team_name = NEW.user_ibl_team
+       LIMIT 1;
+
+      IF v_new_franchise IS NOT NULL THEN
+        INSERT INTO ibl_gm_tenures
+          (franchise_id, gm_display_name, start_season_year, is_mid_season_start)
+        VALUES
+          (v_new_franchise, NEW.username, v_beginning_year, v_is_mid_season);
+      END IF;
+    END IF;
+
+  END IF;
+
+  -- ===== Sync discordID changes (even without team change) =====
+  IF OLD.discordID <> NEW.discordID
+     OR (OLD.discordID IS NULL AND NEW.discordID IS NOT NULL)
+     OR (OLD.discordID IS NOT NULL AND NEW.discordID IS NULL) THEN
+    IF NEW.user_ibl_team <> '' THEN
+      UPDATE ibl_team_info
+         SET discordID = NEW.discordID
+       WHERE team_name = NEW.user_ibl_team;
+    END IF;
+  END IF;
+END$$
+
+DELIMITER ;

--- a/ibl5/tests/DatabaseIntegration/SeasonArchiveRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SeasonArchiveRepositoryTest.php
@@ -164,7 +164,7 @@ class SeasonArchiveRepositoryTest extends DatabaseTestCase
         // Production DB has GM awards data
         self::assertNotEmpty($result);
         $first = $result[0];
-        self::assertArrayHasKey('gm_username', $first);
+        self::assertArrayHasKey('gm_display_name', $first);
         self::assertArrayHasKey('team_name', $first);
         self::assertArrayHasKey('year', $first);
         self::assertArrayHasKey('Award', $first);
@@ -176,7 +176,7 @@ class SeasonArchiveRepositoryTest extends DatabaseTestCase
 
         self::assertNotEmpty($result);
         $first = $result[0];
-        self::assertArrayHasKey('gm_username', $first);
+        self::assertArrayHasKey('gm_display_name', $first);
         self::assertArrayHasKey('team_name', $first);
         self::assertArrayHasKey('start_season_year', $first);
     }

--- a/ibl5/tests/DatabaseIntegration/TeamRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamRepositoryTest.php
@@ -127,7 +127,7 @@ class TeamRepositoryTest extends DatabaseTestCase
         // Insert a test tenure within the transaction
         $this->insertRow('ibl_gm_tenures', [
             'franchise_id' => 1,
-            'gm_username' => 'test_tenure_gm',
+            'gm_display_name' => 'test_tenure_gm',
             'start_season_year' => 2098,
             'end_season_year' => 2099,
             'is_mid_season_start' => 0,
@@ -140,7 +140,7 @@ class TeamRepositoryTest extends DatabaseTestCase
         // Find our inserted tenure
         $found = false;
         foreach ($tenures as $tenure) {
-            if ($tenure['gm_username'] === 'test_tenure_gm') {
+            if ($tenure['gm_display_name'] === 'test_tenure_gm') {
                 self::assertSame(2098, $tenure['start_season_year']);
                 $found = true;
                 break;

--- a/ibl5/tests/DatabaseIntegration/fixtures/db-seed.sql
+++ b/ibl5/tests/DatabaseIntegration/fixtures/db-seed.sql
@@ -175,9 +175,9 @@ INSERT INTO ibl_banners (year, currentname, bannername, bannertype)
 VALUES (2024, 'Metros', 'Metros', 1);
 
 -- GM tenure for Metros franchise
-INSERT INTO ibl_gm_tenures (franchise_id, gm_username, start_season_year, end_season_year, is_mid_season_start, is_mid_season_end)
+INSERT INTO ibl_gm_tenures (franchise_id, gm_display_name, start_season_year, end_season_year, is_mid_season_start, is_mid_season_end)
 VALUES (1, 'testgm', 2020, NULL, 0, 0)
-ON DUPLICATE KEY UPDATE gm_username = VALUES(gm_username);
+ON DUPLICATE KEY UPDATE gm_display_name = VALUES(gm_display_name);
 
 -- Historical player stats (ibl_hist_archive) for franchise history queries
 -- ibl_hist is now a VIEW; the archive table's UNION ALL fallback makes these rows visible.

--- a/ibl5/tests/SeasonArchive/SeasonArchiveServiceTest.php
+++ b/ibl5/tests/SeasonArchive/SeasonArchiveServiceTest.php
@@ -171,8 +171,8 @@ class SeasonArchiveServiceTest extends TestCase
         $this->mockRepository->method('getPlayoffResultsByYear')->willReturn([]);
         $this->mockRepository->method('getTeamAwardsByYear')->willReturn([]);
         $this->mockRepository->method('getAllGmAwardsWithTeams')->willReturn([
-            ['year' => 1990, 'Award' => 'GM of the Year', 'gm_username' => 'Ross Gates', 'team_name' => 'Bulls', 'table_ID' => 8],
-            ['year' => 1993, 'Award' => 'GM of the Year', 'gm_username' => 'Ross Gates', 'team_name' => 'Bulls', 'table_ID' => 9],
+            ['year' => 1990, 'Award' => 'GM of the Year', 'gm_display_name' => 'Ross Gates', 'team_name' => 'Bulls', 'table_ID' => 8],
+            ['year' => 1993, 'Award' => 'GM of the Year', 'gm_display_name' => 'Ross Gates', 'team_name' => 'Bulls', 'table_ID' => 9],
         ]);
         $this->mockRepository->method('getAllGmTenuresWithTeams')->willReturn([]);
         $this->mockRepository->method('getHeatWinLossByYear')->willReturn([]);
@@ -192,7 +192,7 @@ class SeasonArchiveServiceTest extends TestCase
         $this->mockRepository->method('getPlayoffResultsByYear')->willReturn([]);
         $this->mockRepository->method('getTeamAwardsByYear')->willReturn([]);
         $this->mockRepository->method('getAllGmAwardsWithTeams')->willReturn([
-            ['year' => 1990, 'Award' => 'GM of the Year', 'gm_username' => 'Ross Gates', 'team_name' => 'Bulls', 'table_ID' => 8],
+            ['year' => 1990, 'Award' => 'GM of the Year', 'gm_display_name' => 'Ross Gates', 'team_name' => 'Bulls', 'table_ID' => 8],
         ]);
         $this->mockRepository->method('getAllGmTenuresWithTeams')->willReturn([]);
         $this->mockRepository->method('getHeatWinLossByYear')->willReturn([]);
@@ -396,8 +396,8 @@ class SeasonArchiveServiceTest extends TestCase
         $mockRepo->method('getPlayoffResultsByYear')->willReturn([]);
         $mockRepo->method('getTeamAwardsByYear')->willReturn([]);
         $mockRepo->method('getAllGmAwardsWithTeams')->willReturn([
-            ['year' => 1990, 'Award' => 'ASG Head Coach', 'gm_username' => 'Ross Gates', 'team_name' => 'Bulls', 'table_ID' => 1],
-            ['year' => 1990, 'Award' => 'ASG Head Coach', 'gm_username' => 'Brandon Tomyoy', 'team_name' => 'Clippers', 'table_ID' => 2],
+            ['year' => 1990, 'Award' => 'ASG Head Coach', 'gm_display_name' => 'Ross Gates', 'team_name' => 'Bulls', 'table_ID' => 1],
+            ['year' => 1990, 'Award' => 'ASG Head Coach', 'gm_display_name' => 'Brandon Tomyoy', 'team_name' => 'Clippers', 'table_ID' => 2],
         ]);
         $mockRepo->method('getAllGmTenuresWithTeams')->willReturn([]);
         $mockRepo->method('getHeatWinLossByYear')->willReturn([]);
@@ -425,8 +425,8 @@ class SeasonArchiveServiceTest extends TestCase
         $mockRepo->method('getPlayoffResultsByYear')->willReturn([]);
         $mockRepo->method('getTeamAwardsByYear')->willReturn([]);
         $mockRepo->method('getAllGmAwardsWithTeams')->willReturn([
-            ['year' => 2003, 'Award' => 'ASG Co-Head Coach', 'gm_username' => 'RJ Lilley', 'team_name' => 'Grizzlies', 'table_ID' => 1],
-            ['year' => 2003, 'Award' => 'ASG Head Coach', 'gm_username' => 'Mel Baltazar', 'team_name' => 'Sting', 'table_ID' => 2],
+            ['year' => 2003, 'Award' => 'ASG Co-Head Coach', 'gm_display_name' => 'RJ Lilley', 'team_name' => 'Grizzlies', 'table_ID' => 1],
+            ['year' => 2003, 'Award' => 'ASG Head Coach', 'gm_display_name' => 'Mel Baltazar', 'team_name' => 'Sting', 'table_ID' => 2],
         ]);
         $mockRepo->method('getAllGmTenuresWithTeams')->willReturn([]);
         $mockRepo->method('getHeatWinLossByYear')->willReturn([]);
@@ -476,8 +476,8 @@ class SeasonArchiveServiceTest extends TestCase
         $mockRepo->method('getTeamAwardsByYear')->willReturn([]);
         $mockRepo->method('getAllGmAwardsWithTeams')->willReturn([]);
         $mockRepo->method('getAllGmTenuresWithTeams')->willReturn([
-            ['gm_username' => 'Brandon Tomyoy', 'start_season_year' => 1988, 'end_season_year' => null, 'team_name' => 'Clippers'],
-            ['gm_username' => 'Ross Gates', 'start_season_year' => 1988, 'end_season_year' => null, 'team_name' => 'Bulls'],
+            ['gm_display_name' => 'Brandon Tomyoy', 'start_season_year' => 1988, 'end_season_year' => null, 'team_name' => 'Clippers'],
+            ['gm_display_name' => 'Ross Gates', 'start_season_year' => 1988, 'end_season_year' => null, 'team_name' => 'Bulls'],
         ]);
         $mockRepo->method('getHeatWinLossByYear')->willReturn([]);
         $mockRepo->method('getTeamColors')->willReturn([]);
@@ -502,8 +502,8 @@ class SeasonArchiveServiceTest extends TestCase
         $mockRepo->method('getTeamAwardsByYear')->willReturn([]);
         $mockRepo->method('getAllGmAwardsWithTeams')->willReturn([]);
         $mockRepo->method('getAllGmTenuresWithTeams')->willReturn([
-            ['gm_username' => 'Tony (Tek)', 'start_season_year' => 1988, 'end_season_year' => 1999, 'team_name' => 'Lakers'],
-            ['gm_username' => 'Andre Ivarsson', 'start_season_year' => 1999, 'end_season_year' => null, 'team_name' => 'Lakers'],
+            ['gm_display_name' => 'Tony (Tek)', 'start_season_year' => 1988, 'end_season_year' => 1999, 'team_name' => 'Lakers'],
+            ['gm_display_name' => 'Andre Ivarsson', 'start_season_year' => 1999, 'end_season_year' => null, 'team_name' => 'Lakers'],
         ]);
         $mockRepo->method('getHeatWinLossByYear')->willReturn([]);
         $mockRepo->method('getTeamColors')->willReturn([]);

--- a/ibl5/tests/Team/Views/AwardsViewTest.php
+++ b/ibl5/tests/Team/Views/AwardsViewTest.php
@@ -19,7 +19,7 @@ class AwardsViewTest extends TestCase
     public function testGmHistoryRendersBothSections(): void
     {
         $tenures = [
-            ['id' => 1, 'franchise_id' => 1, 'gm_username' => 'JohnGM', 'start_season_year' => 2020, 'end_season_year' => null, 'is_mid_season_start' => 0, 'is_mid_season_end' => 0],
+            ['id' => 1, 'franchise_id' => 1, 'gm_display_name' => 'JohnGM', 'start_season_year' => 2020, 'end_season_year' => null, 'is_mid_season_start' => 0, 'is_mid_season_end' => 0],
         ];
         $awards = [
             ['year' => 2022, 'Award' => 'GM of the Year', 'name' => 'JohnGM', 'table_ID' => 1],
@@ -42,7 +42,7 @@ class AwardsViewTest extends TestCase
     public function testGmHistoryRendersOnlyTenuresWhenNoAwards(): void
     {
         $tenures = [
-            ['id' => 1, 'franchise_id' => 1, 'gm_username' => 'JohnGM', 'start_season_year' => 2020, 'end_season_year' => 2023, 'is_mid_season_start' => 0, 'is_mid_season_end' => 0],
+            ['id' => 1, 'franchise_id' => 1, 'gm_display_name' => 'JohnGM', 'start_season_year' => 2020, 'end_season_year' => 2023, 'is_mid_season_start' => 0, 'is_mid_season_end' => 0],
         ];
 
         $html = $this->view->renderGmHistory($tenures, []);


### PR DESCRIPTION
## Summary

Renames `ibl_gm_tenures.gm_username` to `gm_display_name` to accurately reflect the column's content — it stores display names (e.g. "A-Jay Nicolas", "Holland Wong"), not auth usernames.

This is **PR 1 of 3** in the `nuke_users` removal initiative:
1. **This PR:** Rename the misleading column
2. **PR 2:** Switch all code from `nuke_users` to `auth_users`
3. **PR 3:** Drop `nuke_users` table

## Changes

### Migration (099)
- `ALTER TABLE ibl_gm_tenures CHANGE gm_username gm_display_name VARCHAR(60) NOT NULL`
- Recreated `trg_gm_tenure_track` trigger to use new column name
- Added schema assertion for `gm_display_name`

### PHP
- Updated PHPStan types: `GmAwardWithTeamRow`, `GmTenureWithTeamRow`, `GMTenureRow`
- Updated SQL queries in `SeasonArchiveRepository` (aliases + JOINs)
- Updated array key accesses in `SeasonArchiveService`, `AwardsView`

### Tests
- Updated all test fixtures and assertions to use `gm_display_name`

### Not changed
- `ibl_team_info.gm_username` — stores actual usernames, correctly named

## Manual Testing

No manual testing needed — all changes are covered by unit and integration tests.