### PR TITLE
feat: add --my-cnf flag to analytics-export for running on prod

### DIFF
--- a/bin/analytics-build
+++ b/bin/analytics-build
@@ -2,10 +2,12 @@
 # Full rebuild of the DuckDB analytics database.
 # Idempotent: deletes and recreates from scratch every time.
 #
-# Usage: bin/analytics-build [--writeback] [--skip-export] [--local]
+# Usage: bin/analytics-build [--writeback] [--skip-export] [--local | --my-cnf]
 #   --writeback    After building, export writeback CSVs and import to MariaDB
 #   --skip-export  Skip the MariaDB → CSV export step (use existing CSVs)
 #   --local        Force local Docker connection (ignore REMOTE_* in .env)
+#   --my-cnf       Use ~/.my.cnf for credentials (for running on prod, where
+#                  neither root/root local Docker nor REMOTE_* in .env applies)
 
 set -euo pipefail
 
@@ -18,15 +20,22 @@ DUCKDB="$ANALYTICS_DIR/duckdb"
 WRITEBACK=false
 SKIP_EXPORT=false
 FORCE_LOCAL=false
+USE_MY_CNF=false
 
 for arg in "$@"; do
     case "$arg" in
         --writeback)   WRITEBACK=true ;;
         --skip-export) SKIP_EXPORT=true ;;
         --local)       FORCE_LOCAL=true ;;
+        --my-cnf)      USE_MY_CNF=true ;;
         *)             echo "Unknown argument: $arg" >&2; exit 1 ;;
     esac
 done
+
+if [ "$USE_MY_CNF" = true ] && [ "$FORCE_LOCAL" = true ]; then
+    echo "Error: --my-cnf and --local are mutually exclusive" >&2
+    exit 1
+fi
 
 # Verify DuckDB binary exists
 if [ ! -x "$DUCKDB" ]; then
@@ -43,6 +52,8 @@ if [ "$SKIP_EXPORT" = false ]; then
     EXPORT_ARGS=""
     if [ "$FORCE_LOCAL" = true ]; then
         EXPORT_ARGS="--local"
+    elif [ "$USE_MY_CNF" = true ]; then
+        EXPORT_ARGS="--my-cnf"
     fi
     # shellcheck disable=SC2086
     "$REPO_ROOT/bin/analytics-export" $EXPORT_ARGS

--- a/bin/analytics-export
+++ b/bin/analytics-export
@@ -2,10 +2,12 @@
 # Export MariaDB tables to CSV for DuckDB analytics.
 # Dumps tables to ibl5/analytics/data/*.csv with headers.
 #
-# Usage: bin/analytics-export [--local]
-#   --local  Force local Docker connection (ignore REMOTE_* in .env)
+# Usage: bin/analytics-export [--local | --my-cnf]
+#   --local   Force local Docker connection (ignore REMOTE_* in .env)
+#   --my-cnf  Use ~/.my.cnf for credentials (for running on prod, where
+#             neither root/root local Docker nor REMOTE_* in .env applies)
 #
-# Connection: reads REMOTE_* from .env for production, falls back to local Docker.
+# Connection priority: --my-cnf > --local > REMOTE_* in .env > local Docker.
 # Output: ibl5/analytics/data/*.csv + export_manifest.json
 
 set -euo pipefail
@@ -14,30 +16,56 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DATA_DIR="$REPO_ROOT/ibl5/analytics/data"
 
 FORCE_LOCAL=false
+USE_MY_CNF=false
 for arg in "$@"; do
     case "$arg" in
-        --local) FORCE_LOCAL=true ;;
-        *)       echo "Unknown argument: $arg" >&2; exit 1 ;;
+        --local)  FORCE_LOCAL=true ;;
+        --my-cnf) USE_MY_CNF=true ;;
+        *)        echo "Unknown argument: $arg" >&2; exit 1 ;;
     esac
 done
 
-# Source .env for database credentials (skip if --local)
+if [ "$USE_MY_CNF" = true ] && [ "$FORCE_LOCAL" = true ]; then
+    echo "Error: --my-cnf and --local are mutually exclusive" >&2
+    exit 1
+fi
+
+# Source .env for database credentials (skip if --local or --my-cnf)
 ENV_FILE="$REPO_ROOT/.env"
-if [ -f "$ENV_FILE" ] && [ "$FORCE_LOCAL" = false ]; then
+if [ -f "$ENV_FILE" ] && [ "$FORCE_LOCAL" = false ] && [ "$USE_MY_CNF" = false ]; then
     set -a
     # shellcheck disable=SC1090
     source "$ENV_FILE"
     set +a
 fi
 
-# Determine connection mode
-if [ "$FORCE_LOCAL" = false ] && [ -n "${REMOTE_HOST:-}" ] && [ "$REMOTE_HOST" != "localhost" ] && [ "$REMOTE_HOST" != "127.0.0.1" ]; then
+# Determine connection mode. CONN_ARGS is the per-invocation argument array
+# passed to every mariadb call; DB_PASS_VAL is exported via MYSQL_PWD only
+# when not using --my-cnf (which reads credentials from the config file).
+CONN_ARGS=()
+if [ "$USE_MY_CNF" = true ]; then
+    MY_CNF_PATH="$HOME/.my.cnf"
+    if [ ! -f "$MY_CNF_PATH" ]; then
+        echo "Error: --my-cnf specified but $MY_CNF_PATH does not exist" >&2
+        exit 1
+    fi
+    DB_HOST="localhost"
+    DB_PORT="3306"
+    DB_USER_VAL="(.my.cnf)"
+    DB_PASS_VAL=""
+    DB_NAME="${REMOTE_DATABASE:-iblhoops_ibl5}"
+    EXTRA_OPTS=""
+    # --defaults-file MUST be the first argument to mariadb
+    CONN_ARGS=("--defaults-file=$MY_CNF_PATH" "--skip-ssl")
+    echo "Mode: .my.cnf ($MY_CNF_PATH → $DB_NAME)"
+elif [ "$FORCE_LOCAL" = false ] && [ -n "${REMOTE_HOST:-}" ] && [ "$REMOTE_HOST" != "localhost" ] && [ "$REMOTE_HOST" != "127.0.0.1" ]; then
     DB_HOST="$REMOTE_HOST"
     DB_PORT="${REMOTE_PORT:-3306}"
     DB_USER_VAL="$REMOTE_USER"
     DB_PASS_VAL="$REMOTE_PASSWORD"
     DB_NAME="${REMOTE_DATABASE:-iblhoops_ibl5}"
     EXTRA_OPTS="--compress"
+    CONN_ARGS=("-h" "$DB_HOST" "-P" "$DB_PORT" "--skip-ssl" "-u" "$DB_USER_VAL")
     echo "Mode: remote production ($DB_HOST:$DB_PORT)"
 else
     DB_HOST="127.0.0.1"
@@ -46,14 +74,14 @@ else
     DB_PASS_VAL="root"
     DB_NAME="iblhoops_ibl5"
     EXTRA_OPTS=""
+    CONN_ARGS=("-h" "$DB_HOST" "-P" "$DB_PORT" "--skip-ssl" "-u" "$DB_USER_VAL")
     echo "Mode: local Docker ($DB_HOST)"
 fi
 
 # Helper: run a mariadb query (tab-separated, no column names)
 db_query() {
     # shellcheck disable=SC2086
-    MYSQL_PWD="$DB_PASS_VAL" mariadb -h "$DB_HOST" -P "$DB_PORT" --skip-ssl \
-        -u "$DB_USER_VAL" $EXTRA_OPTS "$DB_NAME" -N -B -e "$1"
+    MYSQL_PWD="$DB_PASS_VAL" mariadb "${CONN_ARGS[@]}" $EXTRA_OPTS "$DB_NAME" -N -B -e "$1"
 }
 
 # Helper: export a table to CSV with header row
@@ -65,15 +93,13 @@ export_table() {
 
     # Export data with header (-B includes column names as first row)
     # shellcheck disable=SC2086
-    MYSQL_PWD="$DB_PASS_VAL" mariadb -h "$DB_HOST" -P "$DB_PORT" --skip-ssl \
-        -u "$DB_USER_VAL" $EXTRA_OPTS "$DB_NAME" -B -e "$query" > "$outfile"
+    MYSQL_PWD="$DB_PASS_VAL" mariadb "${CONN_ARGS[@]}" $EXTRA_OPTS "$DB_NAME" -B -e "$query" > "$outfile"
 
     # If file is empty (table had 0 rows, MariaDB omits header), write header from SHOW COLUMNS
     if [ ! -s "$outfile" ]; then
         # Get column names and join with tabs
         # shellcheck disable=SC2086
-        MYSQL_PWD="$DB_PASS_VAL" mariadb -h "$DB_HOST" -P "$DB_PORT" --skip-ssl \
-            -u "$DB_USER_VAL" $EXTRA_OPTS "$DB_NAME" -N -B \
+        MYSQL_PWD="$DB_PASS_VAL" mariadb "${CONN_ARGS[@]}" $EXTRA_OPTS "$DB_NAME" -N -B \
             -e "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='$DB_NAME' AND TABLE_NAME='$table' ORDER BY ORDINAL_POSITION" \
             | paste -s -d'	' - > "$outfile"
     fi


### PR DESCRIPTION
## Problem

`bin/analytics-build` supported two connection modes for exporting MariaDB to CSV: (a) remote production via `REMOTE_*` in `.env`, or (b) local Docker using hard-coded `root/root`. Neither works when running the script directly on production: prod has no `.env` file, and the root user isn't set up for local connections there. The script falls through to `root/root` and fails with `Access denied for user 'root'@'localhost'`.

This blocked keeping the prod DuckDB in sync on-host. Previously I worked around it by building DuckDB locally and `scp`-ing the file to prod — which only works as long as the local dev MariaDB is an exact mirror of prod.

## Fix

New `--my-cnf` flag that uses `~/.my.cnf` for credentials via `mariadb --defaults-file`. This is the idiomatic way for ops users to store DB credentials on a server — `iblhoops_jordan` on prod already has one at `~/.my.cnf` with the right grants.

Connection priority: `--my-cnf` > `--local` > `REMOTE_*` in `.env` > local Docker default. `--my-cnf` and `--local` are mutually exclusive (enforced with an explicit error). Missing `~/.my.cnf` is detected up front rather than bubbling up as an Access denied error.

Refactored `db_query` and `export_table` helpers to use a shared `CONN_ARGS` array instead of duplicating `-h/-P/-u` for every `mariadb` invocation, so adding the new mode didn't require a fourth copy of the args list.

`bin/analytics-build` passes `--my-cnf` through to `analytics-export`.

## Verification

- **Local Docker**: tested via `HOME=/tmp/fake-home bin/analytics-export --my-cnf` with a synthetic `~/.my.cnf` pointing at `127.0.0.1` as `root/root`. Exported all 16 tables successfully.
- **Prod**: tested via scp'd copy + `bin/analytics-build --my-cnf` directly on iblhoops.net. Exported 16 tables from prod MariaDB through `~/.my.cnf`, built the full 89 MB DuckDB file with all 22 populated tables (dim_player=1,543, fact_plr_snapshots=403,517, fact_player_game=587,926, etc.).
- **Error handling**: `--local --my-cnf` fails fast with "mutually exclusive". Missing `~/.my.cnf` fails fast with a clear message.

## Manual Testing

No manual testing needed — verified on both local Docker and live production hosts during development.