### PR TITLE
ci: prevent deploy↔smoke races and retry transient 4xx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,28 +196,6 @@ jobs:
             echo "IBL6 started (PID: $(cat ibl6.pid))"
           '
 
-      - name: Smoke test production
-        if: ${{ !cancelled() }}
-        run: |
-          echo "Waiting for services to be ready..."
-          sleep 5
-
-          for url in https://ibl6.iblhoops.net/ https://iblhoops.net/ibl5/; do
-            for attempt in 1 2 3; do
-              status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url")
-              if [ "$status" -ge 200 ] && [ "$status" -lt 400 ]; then
-                echo "✓ $url → $status"
-                break
-              fi
-              if [ "$attempt" -eq 3 ]; then
-                echo "✗ $url → $status (after 3 attempts)"
-                exit 1
-              fi
-              echo "  $url → $status, retrying in 5s..."
-              sleep 5
-            done
-          done
-
   notify-deploy-failure:
     name: Notify Deploy Failure
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -21,7 +21,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-smoke
+  # Shared with main.yml so a new deploy can't race an in-flight smoke run.
+  group: production-deploy
   cancel-in-progress: false
 
 jobs:

--- a/bin/smoke-prod
+++ b/bin/smoke-prod
@@ -4,8 +4,8 @@
 # Usage: bin/smoke-prod [base_url]
 # Default: https://www.iblhoops.net
 #
-# Checks 7 public URLs for:
-#   - HTTP 200 status (retries once on 5xx after 10s)
+# Checks 8 public URLs for:
+#   - HTTP 200 status (retries once on any unexpected status after 10s)
 #   - Expected content in response body
 #   - Absence of PHP error messages
 #
@@ -31,8 +31,9 @@ check() {
     status="${status: -3}"
     [[ "$status" =~ ^[0-9]+$ ]] || status="000"
 
-    # Retry once on 5xx — transient during deploys (autoloader regeneration)
-    if [ "$status" -ge 500 ] 2>/dev/null; then
+    # Retry once on any unexpected status — transient during deploys,
+    # LSCache purge windows, or brief LiteSpeed WAF blips.
+    if ! echo "$accept" | grep -qw "$status"; then
         echo "  RETRY: $name — HTTP $status, waiting 10s..."
         sleep 10
         status=$(curl -sS -w "%{http_code}" --max-time 30 -o "$TMPFILE" "$url" 2>/dev/null) || true
@@ -78,6 +79,7 @@ check "Player page"  "$BASE/ibl5/modules.php?name=Player&pa=showpage&pid=1" "pla
 check "Login page"   "$BASE/ibl5/modules.php?name=YourAccount"              "Sign In"
 check "API routing"   "$BASE/ibl5/api/v1/season"                             "" "200|401"
 check "CSS asset"    "$BASE/ibl5/themes/IBL/style/style.css"                ""
+check "IBL6 app"     "https://ibl6.iblhoops.net/"                           ""
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Context

Production smoke run [24270007867](https://github.com/a-jay85/IBL5/actions/runs/24270007867) failed with **7 × HTTP 415** across every URL (including static `style.css`) in a ~900ms window. The triggering commit only touched `.yml` files, so no production code actually changed.

## Root cause

Two problems compounding:

1. **Deploy ↔ smoke race.** `main.yml` uses concurrency group `production-deploy`, but `smoke-prod.yml` used `production-smoke`. A second deploy can start on the server while `smoke-prod.yml` is mid-run. The live `style.css` has `last-modified: 2026-04-11T00:17:37Z` — **59 seconds after** the failed smoke at `00:16:38Z`, consistent with a concurrent second deploy rewriting files during the smoke run. LiteSpeed/LSCache returned 415 during the purge window.
2. **Retry only fired on 5xx.** A `415` on a static CSS `GET` is never a legitimate origin response — always transient — but `bin/smoke-prod` only retried on 5xx, so the 415s sailed through.

## Changes

- **`.github/workflows/smoke-prod.yml`**: share `production-deploy` concurrency group with `main.yml` so deploys and smoke runs strictly serialize. A new deploy now queues behind an in-flight smoke test, and vice versa.
- **`.github/workflows/main.yml`**: remove the inline "Smoke test production" step (lines 199-219). It was fully subsumed by `bin/smoke-prod` for IBL5 and its IBL6 coverage is now moved into `bin/smoke-prod`. Removing it also improves auto-rollback coverage — inline failures prevented the `workflow_run`-keyed rollback job from firing at all.
- **`bin/smoke-prod`**: retry once on **any** unexpected status (not just 5xx); add `IBL6 app` check against `https://ibl6.iblhoops.net/` to replace the inline coverage.

## Verification

Ran against production locally:

\`\`\`
Smoke testing https://www.iblhoops.net ...

  OK: Homepage
  OK: Standings
  OK: Team page
  OK: Player page
  OK: Login page
  OK: API routing
  OK: CSS asset
  OK: IBL6 app

Results: 8 passed, 0 failed
\`\`\`

## Manual Testing

No manual testing needed — changes are limited to CI workflow YAML and a bash smoke script, both verified against production.