### PR TITLE
ci: harden smoke-prod against WAF ban and stale double-fire

### DIFF
--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -38,11 +38,31 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Wait for server stabilization after deploy
+      # Back-to-back deploys each fire a workflow_run. The earlier smoke is
+      # then stale AND burns requests against LiteSpeed's per-IP WAF counter,
+      # which can trip a ban that makes the later smoke fail with blanket 415s.
+      - name: Skip if production tip has advanced past this SHA
+        id: guard
         if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXPECTED="${{ github.event.workflow_run.head_sha }}"
+          ACTUAL=$(gh api "repos/${{ github.repository }}/commits/production" --jq .sha)
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::notice::Stale smoke run — workflow_run sha=$EXPECTED but production tip=$ACTUAL. Skipping."
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Fresh — production tip matches workflow_run sha ($EXPECTED)"
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for server stabilization after deploy
+        if: github.event_name == 'workflow_run' && steps.guard.outputs.stale != 'true'
         run: sleep 15
 
       - name: Run smoke tests
+        if: steps.guard.outputs.stale != 'true'
         run: |
           chmod +x bin/smoke-prod
           bin/smoke-prod "${{ github.event.inputs.base_url || 'https://www.iblhoops.net' }}"

--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -46,14 +46,19 @@ jobs:
         if: github.event_name == 'workflow_run'
         env:
           GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
         run: |
-          EXPECTED="${{ github.event.workflow_run.head_sha }}"
-          ACTUAL=$(gh api "repos/${{ github.repository }}/commits/production" --jq .sha)
-          if [ "$EXPECTED" != "$ACTUAL" ]; then
-            echo "::notice::Stale smoke run — workflow_run sha=$EXPECTED but production tip=$ACTUAL. Skipping."
+          if ! ACTUAL=$(gh api "repos/${REPO}/commits/production" --jq .sha 2>&1); then
+            echo "::warning::Guard API call failed ($ACTUAL) — proceeding with smoke anyway"
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$EXPECTED_SHA" != "$ACTUAL" ]; then
+            echo "::notice::Stale smoke run — workflow_run sha=$EXPECTED_SHA but production tip=$ACTUAL. Skipping."
             echo "stale=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Fresh — production tip matches workflow_run sha ($EXPECTED)"
+            echo "Fresh — production tip matches workflow_run sha ($EXPECTED_SHA)"
             echo "stale=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/bin/smoke-prod
+++ b/bin/smoke-prod
@@ -18,6 +18,13 @@ PASS=0
 FAIL=0
 ERRORS=""
 
+# Identify ourselves — the default curl UA can get classified as a bot by
+# LiteSpeed mod_security and produce a blanket 415 ban on the runner IP.
+USER_AGENT="IBL5-smoke/1.0 (+https://github.com/a-jay85/IBL5)"
+
+# Space requests apart so we stay under the LiteSpeed per-IP WAF threshold.
+INTERCHECK_DELAY="${SMOKE_INTERCHECK_DELAY:-1}"
+
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
 
@@ -26,7 +33,7 @@ check() {
 
     # Single request: capture body to temp file + status code
     local status
-    status=$(curl -sS -w "%{http_code}" --max-time 30 -o "$TMPFILE" "$url" 2>/dev/null) || true
+    status=$(curl -sS -w "%{http_code}" --max-time 30 -A "$USER_AGENT" -o "$TMPFILE" "$url" 2>/dev/null) || true
     # Extract just the HTTP code (last 3 chars of output)
     status="${status: -3}"
     [[ "$status" =~ ^[0-9]+$ ]] || status="000"
@@ -36,7 +43,7 @@ check() {
     if ! echo "$accept" | grep -qw "$status"; then
         echo "  RETRY: $name — HTTP $status, waiting 10s..."
         sleep 10
-        status=$(curl -sS -w "%{http_code}" --max-time 30 -o "$TMPFILE" "$url" 2>/dev/null) || true
+        status=$(curl -sS -w "%{http_code}" --max-time 30 -A "$USER_AGENT" -o "$TMPFILE" "$url" 2>/dev/null) || true
         status="${status: -3}"
         [[ "$status" =~ ^[0-9]+$ ]] || status="000"
     fi
@@ -73,12 +80,19 @@ echo "Smoke testing $BASE ..."
 echo ""
 
 check "Homepage"     "$BASE/ibl5/index.php"                                 "IBL"
+sleep "$INTERCHECK_DELAY"
 check "Standings"    "$BASE/ibl5/modules.php?name=Standings"                "Standings"
+sleep "$INTERCHECK_DELAY"
 check "Team page"    "$BASE/ibl5/modules.php?name=Team&op=team&teamID=1"    "team"
+sleep "$INTERCHECK_DELAY"
 check "Player page"  "$BASE/ibl5/modules.php?name=Player&pa=showpage&pid=1" "player"
+sleep "$INTERCHECK_DELAY"
 check "Login page"   "$BASE/ibl5/modules.php?name=YourAccount"              "Sign In"
-check "API routing"   "$BASE/ibl5/api/v1/season"                             "" "200|401"
+sleep "$INTERCHECK_DELAY"
+check "API routing"  "$BASE/ibl5/api/v1/season"                             "" "200|401"
+sleep "$INTERCHECK_DELAY"
 check "CSS asset"    "$BASE/ibl5/themes/IBL/style/style.css"                ""
+sleep "$INTERCHECK_DELAY"
 check "IBL6 app"     "https://ibl6.iblhoops.net/"                           ""
 
 echo ""


### PR DESCRIPTION
## Context

Follow-up to #604. Incident on 2026-04-11: two back-to-back deploys ([run 24273122941](https://github.com/a-jay85/IBL5/actions/runs/24273122941), [run 24273128893](https://github.com/a-jay85/IBL5/actions/runs/24273128893)) each fired a `workflow_run` event, queueing two smoke runs in my freshly-serialized concurrency group.

- **Smoke A** ran 03:02:19 → 03:03:20 — all 8 OK.
- **Smoke B** started 3 seconds later (03:03:23 → 03:05:05) from the same GHA runner IP and returned **blanket HTTP 415 on all 8 URLs, across both `www.iblhoops.net` and `ibl6.iblhoops.net`, for 80+ seconds** (retries also 415).

That's not a cache/state blip — a 415 on a GET for a static CSS file persisting past a 10s retry, across two different vhosts, is a LiteSpeed `mod_security` per-IP ban. Auto-rollback saw the failure and pushed a spurious revert commit on the #605 feature. Production was force-reset to drop the revert and `smoke-prod.yml` is currently disabled while this PR ships.

## Root cause

Three things combined:

1. **Every deploy fires its own smoke run.** Back-to-back deploys queue back-to-back smokes against the same runner IP. My PR #604 serialized them (correctly), so they run 3 seconds apart.
2. **Default curl User-Agent tripped mod_security's bot classification** — `curl/8.x` is a known bot signature.
3. **Burst rate from the first smoke built up the per-IP counter**, then the second smoke (on the same runner IP 3s later) pushed it over the threshold and ate the ban.

## Changes

### `smoke-prod.yml` — skip stale smoke runs
Added a guard step that calls `gh api repos/.../commits/production` and compares against `github.event.workflow_run.head_sha`. When back-to-back deploys queue, only the latest gets smoke-tested; earlier ones log a `::notice::` and skip. Rollback cannot fire on a skipped smoke (its `if:` checks `needs.smoke.result == 'failure'`, and a job with all-skipped steps reports `success`).

### `bin/smoke-prod` — avoid bot classification
- **Distinct User-Agent** (`IBL5-smoke/1.0 (+https://github.com/a-jay85/IBL5)`) instead of default `curl/8.x`.
- **1-second inter-check sleep** (`$SMOKE_INTERCHECK_DELAY`, overridable) to spread the 8 checks across ~8 seconds instead of <1 second, staying under LiteSpeed's burst counter.
- Incidental: fixed a 1-space indent inconsistency on the API-routing check line.

## Verification

```
$ bin/smoke-prod https://www.iblhoops.net
Smoke testing https://www.iblhoops.net ...

  OK: Homepage
  OK: Standings
  OK: Team page
  OK: Player page
  OK: Login page
  OK: API routing
  OK: CSS asset
  OK: IBL6 app

Results: 8 passed, 0 failed
```

Total wall time is now ~15s (vs <5s previously) — acceptable for a deploy gate.

## Follow-up after merge

`smoke-prod.yml` workflow is currently **disabled**. After this PR lands I'll re-enable with `gh workflow enable smoke-prod.yml`.

## Manual Testing

No manual testing needed — changes are CI-only (GitHub Actions YAML + bash smoke script), verified by running `bin/smoke-prod` against production.