### PR TITLE
feat: make ArchiveExtractor detect RAR via magic bytes + bsdtar fallback

### DIFF
--- a/ibl5/classes/BulkImport/ArchiveExtractor.php
+++ b/ibl5/classes/BulkImport/ArchiveExtractor.php
@@ -47,6 +47,28 @@ final class ArchiveExtractor implements ArchiveExtractorInterface
 
     public function detectFormat(string $archivePath): string
     {
+        // Prefer magic bytes over extension: a handful of historical backups
+        // have `.zip` extensions but are actually RAR v5 files, and ZipArchive
+        // rejects them with no useful diagnostic (the importer just reports
+        // "IBL5.plr not found").
+        $fh = @fopen($archivePath, 'rb');
+        if ($fh !== false) {
+            $magic = fread($fh, 7);
+            fclose($fh);
+
+            if (is_string($magic)) {
+                // RAR v4/v5 signature: "Rar!\x1A\x07"
+                if (str_starts_with($magic, "Rar!\x1A\x07")) {
+                    return 'rar';
+                }
+                // ZIP local-file header "PK\x03\x04" or empty-archive "PK\x05\x06"
+                if (str_starts_with($magic, "PK\x03\x04") || str_starts_with($magic, "PK\x05\x06")) {
+                    return 'zip';
+                }
+            }
+        }
+
+        // Unreadable or unknown magic: fall back to extension guess.
         $ext = strtolower(pathinfo($archivePath, PATHINFO_EXTENSION));
 
         return $ext === 'rar' ? 'rar' : 'zip';
@@ -270,6 +292,23 @@ final class ArchiveExtractor implements ArchiveExtractorInterface
             $cmd = sprintf(
                 '%s e -so %s %s > %s 2>/dev/null',
                 escapeshellarg($sevenZipBin),
+                escapeshellarg($archivePath),
+                escapeshellarg($filename),
+                escapeshellarg($targetPath)
+            );
+            exec($cmd, $output, $exitCode);
+            if ($exitCode === 0 && file_exists($targetPath) && filesize($targetPath) > 0) {
+                return $targetPath;
+            }
+        }
+
+        // libarchive's bsdtar handles RAR v5 natively and ships with macOS.
+        // Useful as a fallback on dev workstations where unrar/7z aren't installed.
+        $bsdtarBin = $this->findBinary('bsdtar');
+        if ($bsdtarBin !== null) {
+            $cmd = sprintf(
+                '%s -xOf %s %s > %s 2>/dev/null',
+                escapeshellarg($bsdtarBin),
                 escapeshellarg($archivePath),
                 escapeshellarg($filename),
                 escapeshellarg($targetPath)


### PR DESCRIPTION
## Problem

`bulkPlrSnapshotImport.php` silently skipped 17/692 historical archives with `"IBL5.plr not found in archive"`. Root-cause triage:

| Cat | Count | Cause | Rescuable? |
|---|---|---|---|
| A | 7 | Real RAR v5 archives with `.rar` extension. `extractFromRar()` shells out to `unrar` / `7z`, neither installed on macOS or the cPanel prod host. | ✅ with `bsdtar` |
| B | 2 | Real RAR v5 archives with `.zip` extension. `detectFormat()` dispatched on extension only, so they were routed to `extractFromZip()` which can't read RAR and failed with no signal. | ✅ with magic-byte detection + `bsdtar` |
| C | 8 | Real ZIP archives genuinely missing `IBL5.plr` (backup packaging error at source; only `IBL5.car` is present). | ❌ would need a `.car` parser (separate future work) |

## Fix

1. **`detectFormat()`** now reads the first 7 bytes and switches on magic bytes:
   - `"Rar!\x1A\x07"` → RAR v4/v5
   - `"PK\x03\x04"` / `"PK\x05\x06"` → ZIP
   - Unreadable or unknown → fall back to the existing extension-based guess.
2. **`extractFromRar()`** adds `bsdtar -xOf` as a third CLI fallback after `unrar` and `7z`. First binary on `$PATH` that returns exit 0 with non-empty output wins.

Order stays `unrar` → `7z` → `bsdtar`. Native RAR tools are still preferred where available; `bsdtar` fills the gap on libarchive-based hosts (macOS dev workstations; also useful for any Linux host with only libarchive installed).

## Rescue run (already performed, outside this PR)

After merging locally for testing, I re-ran `bulkPlrSnapshotImport.php`:

- 692/692 attempted, **684 processed** (up from 675), **8 `not found` errors** (down from 17 — only Category C remains).
- 9 rescued archives contributed **5,369 new rows** to `ibl_plr_snapshots`. Local grew 405,851 → 411,220.
- Delta upserted to prod MariaDB via `mariadb-dump --where --insert-ignore | ssh mariadb`. Prod now also at 411,220.
- Local + prod DuckDBs rebuilt from the new MariaDB state.
- `ibl_hist` total row count and blank-rating count both **unchanged** (7,961 / 112) — rescued rows feed existing `(pid, year)` `ROW_NUMBER()` partitions rather than adding new ones.

## Verification

- Full PHPUnit suite green (4,724 tests, 21,438 assertions).
- Manual extractor test against 4 representative archives — one from each category plus a baseline — all classify and extract correctly:
  - Real RAR (`.rar` ext): `detectFormat=rar`, extracts 999,395 bytes
  - Mislabeled RAR (`.zip` ext): `detectFormat=rar` via magic bytes, extracts 1,000,003 bytes
  - Real ZIP baseline: `detectFormat=zip`, extracts 1,000,003 bytes
  - Category C (`.plr` missing): `detectFormat=zip` correctly, extraction fails as expected

## Manual Testing

No manual testing needed — the fix is verified by the full PHPUnit suite, the 4-category extractor sanity test, and the completed rescue run that now has real rows in both local and prod `ibl_plr_snapshots`.

## Follow-up not in this PR

- **Category C (8 archives missing `IBL5.plr`)** — requires building a JSB `.car` parser under `ibl5/classes/JsbParser/`. Separate task.
- **Pre-1999 PID namespace mismatch** — `ibl_hist_archive` rows for 1989-1998 use "modern cycle" PIDs (3585, 5262, 5935) while the corresponding snapshots use "original cycle" PIDs (137, 164, 246). Both PID sets exist in `ibl_plr`, so per the user's rule ("delete if they don't match `ibl_plr`; keep otherwise") no deletion happens. The 111 blank rows in 1989-1998 remain a known gap.