### PR TITLE
chore: stand up ADR infrastructure with decision-trigger CI gate

### DIFF
--- a/.claude/rules/doc-freshness.md
+++ b/.claude/rules/doc-freshness.md
@@ -18,6 +18,7 @@ CI validates every `.md` under these roots:
 - `.claude/skills/**/SKILL.md`
 - `.claude/commands/*.md`
 - `ibl5/docs/*.md` (non-archive)
+- `ibl5/docs/decisions/*.md` (ADRs — also integrity-checked for bidirectional `Supersedes` / `Superseded by` links across files)
 
 **Out of scope:** `.archive/**`, `ibl5/docs/archive/**`, `worktrees/**`, and any `.md` inside `vendor/` or `node_modules/`. User memory (`~/.claude/projects/.../memory/*.md`) is not repo-tracked; `bin/check-docs --include-memory` sweeps it locally but CI never does.
 

--- a/.claude/rules/php-classes.md
+++ b/.claude/rules/php-classes.md
@@ -6,6 +6,8 @@ last_verified: 2026-04-11
 
 # PHP Class Development Rules
 
+> **Why this exists:** [ADR-0001](../../ibl5/docs/decisions/0001-interface-driven-architecture.md) explains why every module uses Repository/Service/View with `Contracts/` interfaces. [ADR-0005](../../ibl5/docs/decisions/0005-strict-types-enforcement.md) explains the `declare(strict_types=1)` mandate and PHPStan level `max` + strict-rules floor.
+
 ## Interface Standards
 - Method signatures with full PHPDoc
 - `@see InterfaceName::methodName()` instead of duplicating docblocks
@@ -59,6 +61,9 @@ public function renderTable(array $data): string
 ```
 
 ## Statistics Formatting
+
+> **Why this exists:** [ADR-0003](../../ibl5/docs/decisions/0003-statsformatter-mandate.md) explains why `StatsFormatter` is the single source of truth and `number_format()` is banned by `BanNumberFormatRule`.
+
 Use `BasketballStats\StatsFormatter` — `number_format()` is banned by PHPStan:
 - `formatPercentage($made, $attempted)` - FG%, 3P% (3 decimals)
 - `formatPerGameAverage($total, $games)` - PPG, APG (1 decimal)

--- a/.claude/rules/phpunit-tests.md
+++ b/.claude/rules/phpunit-tests.md
@@ -6,6 +6,8 @@ last_verified: 2026-04-11
 
 # PHPUnit Testing Rules
 
+> **Why this exists:** [ADR-0001](../../ibl5/docs/decisions/0001-interface-driven-architecture.md) explains why tests mock `Contracts/` interfaces rather than concrete classes — that split is the entire point of the architecture.
+
 ## PHPUnit 13+ Syntax
 ```bash
 # CORRECT commands (bin/test works from any CWD; vendor/bin/phpunit requires CWD=ibl5/)

--- a/.claude/rules/view-rendering.md
+++ b/.claude/rules/view-rendering.md
@@ -6,6 +6,8 @@ last_verified: 2026-04-11
 
 # View Rendering Rules
 
+> **Why this exists:** [ADR-0002](../../ibl5/docs/decisions/0002-xss-enforcement-via-phpstan.md) explains why XSS is enforced mechanically by the `RequireEscapedOutputRule` PHPStan rule instead of a runtime convention or templating engine.
+
 ## Canonical View Examples
 Reference these before building new Views:
 - `FreeAgency/FreeAgencyView.php` — complex tables with sticky columns, team colors, footer rows

--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -5,6 +5,8 @@ last_verified: 2026-04-11
 
 # Workflow Continuity Rule
 
+> **Why this exists:** [ADR-0004](../../ibl5/docs/decisions/0004-docker-only-dev-environment.md) explains why every worktree runs its own isolated Docker stack; MAMP and native PHP setups are unsupported.
+
 ## Phase 1: Worktree Setup
 
 Before implementation, create a worktree unless one already exists for this task:

--- a/.github/workflows/adr-required.yml
+++ b/.github/workflows/adr-required.yml
@@ -1,0 +1,35 @@
+name: ADR Required
+
+on:
+  pull_request:
+    branches: [ master, develop ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  adr-gate:
+    name: Decision-trigger gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Run bin/adr-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bin/adr-check --pr

--- a/.github/workflows/adr-required.yml
+++ b/.github/workflows/adr-required.yml
@@ -32,4 +32,5 @@ jobs:
       - name: Run bin/adr-check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: bin/adr-check --pr

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,3 +111,6 @@ After refactoring, compare output against iblhoops.net. Results must match exact
 ### Doc Freshness
 Every repo-tracked `.md` that an agent may read is validated by `bin/check-docs` (CI workflow `doc-freshness.yml`). Frontmatter must carry a `description` and a `last_verified` date no older than 60 days. See `.claude/rules/doc-freshness.md` for the schema and the dead-reference rules.
 
+### Architecture Decisions
+Load-bearing decisions are captured as ADRs in `ibl5/docs/decisions/`. PRs that touch mechanical-enforcement surfaces (new PHPStan rule, new `.claude/rules/*.md`, new CI workflow, destructive migration, new `bin/` script ≥ 50 lines, new composer dependency) must add an ADR or a bypass marker — enforced by `bin/adr-check` (CI workflow `adr-required.yml`). See `ibl5/docs/decisions/README.md` for the policy.
+

--- a/bin/adr-check
+++ b/bin/adr-check
@@ -21,7 +21,8 @@ const TRIGGER_DESCRIPTIONS = [
     'new-dependency' => 'new entry under require/require-dev in ibl5/composer.json (runtime dependency)',
 ];
 
-const BYPASS_REGEX = '/<!--\s*no-adr:\s*(.{15,}?)\s*-->/s';
+const BYPASS_REGEX = '/<!--\s*no-adr:\s*(.+?)\s*-->/s';
+const BYPASS_MIN_LENGTH = 15;
 const MIN_TOOL_SCRIPT_LINES = 50;
 
 function usage(): string
@@ -82,7 +83,10 @@ function diffAddedLines(string $mode, string $file): array
     return $added;
 }
 
-/** Returns line count and first line of the file in the diff's "new" side. */
+/**
+ * Read the full contents of a file from the git object store (index for --staged,
+ * HEAD for --pr). Returns [line_count, first_line].
+ */
 function newSideFileInfo(string $mode, string $file): array
 {
     $rev = $mode === 'pr' ? 'HEAD' : '';
@@ -125,9 +129,13 @@ function detectTriggers(string $mode): array
         if (preg_match('#^ibl5/migrations/.+\.sql$#', $file) !== 1) {
             continue;
         }
-        foreach (diffAddedLines($mode, $file) as $line) {
+        // Strip /* ... */ block comments (multi-line) from the added blob before scanning,
+        // so DROP TABLE inside a commented-out block doesn't fire the trigger.
+        $addedBlob = implode("\n", diffAddedLines($mode, $file));
+        $cleaned = (string) preg_replace('#/\*.*?\*/#s', '', $addedBlob);
+        foreach (preg_split('/\r?\n/', $cleaned) ?: [] as $line) {
             $trimmed = ltrim($line);
-            if (str_starts_with($trimmed, '--')) {
+            if ($trimmed === '' || str_starts_with($trimmed, '--')) {
                 continue;
             }
             if (preg_match('/\b(DROP\s+TABLE|DROP\s+COLUMN|DROP\s+INDEX)\b/i', $trimmed) === 1) {
@@ -171,7 +179,17 @@ function fetchPrBody(string $mode, bool $fromStdin): ?string
     if ($mode !== 'pr') {
         return null;
     }
-    [$lines, $exit] = runCmd('gh pr view --json body --jq .body');
+    // GitHub Actions checks out a detached merge commit for pull_request events, so
+    // `gh pr view` without arguments cannot infer the PR. The workflow passes the
+    // number via PR_NUMBER env. Fall back to inference when PR_NUMBER is absent
+    // (local `--pr` usage on a branch checkout).
+    $prNumber = getenv('PR_NUMBER');
+    $cmd = 'gh pr view';
+    if (is_string($prNumber) && $prNumber !== '') {
+        $cmd .= ' ' . escapeshellarg($prNumber);
+    }
+    $cmd .= ' --json body --jq .body';
+    [$lines, $exit] = runCmd($cmd);
     if ($exit !== 0 || $lines === []) {
         return null;
     }
@@ -180,13 +198,17 @@ function fetchPrBody(string $mode, bool $fromStdin): ?string
 
 function extractBypassReason(?string $body): ?string
 {
-    if ($body === null || $body === '') {
+    if ($body === null || $body === '' || $body === 'null') {
         return null;
     }
-    if (preg_match(BYPASS_REGEX, $body, $m) === 1) {
-        return trim($m[1]);
+    if (preg_match(BYPASS_REGEX, $body, $m) !== 1) {
+        return null;
     }
-    return null;
+    $reason = trim($m[1]);
+    if (strlen($reason) < BYPASS_MIN_LENGTH) {
+        return null;
+    }
+    return $reason;
 }
 
 // --- main ---

--- a/bin/adr-check
+++ b/bin/adr-check
@@ -1,0 +1,252 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * bin/adr-check — decision-trigger CI gate for IBL5.
+ * Policy lives in ibl5/docs/decisions/README.md ("When an ADR is Required").
+ *
+ * Exits 0 when either no triggers fire, or triggers fire and the diff adds an
+ * ADR, or the PR body carries a bypass marker. Exits 1 when a trigger fires
+ * without either resolution. Exits 2 on usage error.
+ */
+
+const TRIGGER_DESCRIPTIONS = [
+    'phpstan-rule' => 'new PHPStan custom rule (mechanical enforcement is a decision)',
+    'agent-rule' => 'new .claude/rules/*.md file (operational convention for agents)',
+    'ci-workflow' => 'new .github/workflows/*.yml workflow (process decision)',
+    'destructive-migration' => 'migration containing DROP TABLE/COLUMN/INDEX (irreversible schema change)',
+    'new-tool-script' => 'new bin/ helper script of at least 50 lines (new developer tool)',
+    'new-dependency' => 'new entry under require/require-dev in ibl5/composer.json (runtime dependency)',
+];
+
+const BYPASS_REGEX = '/<!--\s*no-adr:\s*(.{15,}?)\s*-->/s';
+const MIN_TOOL_SCRIPT_LINES = 50;
+
+function usage(): string
+{
+    return <<<USAGE
+Usage: bin/adr-check [options]
+
+Decision-trigger gate: refuses to pass when a diff adds mechanical-enforcement
+surfaces without also adding an ADR (or a bypass marker in the PR body).
+
+Modes:
+  --staged           Scan staged changes via `git diff --cached`. Default.
+  --pr               Scan the current PR against origin/master. Fetches the
+                     PR body via `gh pr view` for bypass marker detection.
+
+Options:
+  --bypass-from-stdin   Read the PR body from stdin (for local testing).
+                        Overrides any automatic fetch.
+  --help, -h            Show this message.
+
+Exit 0 on pass, 1 on failure, 2 on usage error.
+
+USAGE;
+}
+
+function runCmd(string $cmd): array
+{
+    $output = [];
+    $exit = 0;
+    exec($cmd . ' 2>/dev/null', $output, $exit);
+    return [$output, $exit];
+}
+
+function gitDiffRange(string $mode): string
+{
+    return $mode === 'pr' ? 'origin/master...HEAD' : '--cached';
+}
+
+/** @return list<string> */
+function diffNames(string $mode, string $filter): array
+{
+    $range = gitDiffRange($mode);
+    [$lines] = runCmd(sprintf('git diff %s --name-only --diff-filter=%s', escapeshellarg($range), escapeshellarg($filter)));
+    return array_values(array_filter($lines, static fn (string $line): bool => $line !== ''));
+}
+
+/** @return list<string> */
+function diffAddedLines(string $mode, string $file): array
+{
+    $range = gitDiffRange($mode);
+    [$lines] = runCmd(sprintf('git diff %s -- %s', escapeshellarg($range), escapeshellarg($file)));
+    $added = [];
+    foreach ($lines as $line) {
+        if (str_starts_with($line, '+') && !str_starts_with($line, '+++')) {
+            $added[] = substr($line, 1);
+        }
+    }
+    return $added;
+}
+
+/** Returns line count and first line of the file in the diff's "new" side. */
+function newSideFileInfo(string $mode, string $file): array
+{
+    $rev = $mode === 'pr' ? 'HEAD' : '';
+    [$lines] = runCmd(sprintf('git show %s -- %s', escapeshellarg($rev . ':' . $file), escapeshellarg($file)));
+    $first = $lines[0] ?? '';
+    return [count($lines), $first];
+}
+
+/** @return list<array{type: string, file: string}> */
+function detectTriggers(string $mode): array
+{
+    $triggers = [];
+    $added = diffNames($mode, 'A');
+    $modified = diffNames($mode, 'M');
+
+    foreach ($added as $file) {
+        if (preg_match('#^ibl5/phpstan-rules/.+\.php$#', $file) === 1) {
+            $triggers[] = ['type' => 'phpstan-rule', 'file' => $file];
+            continue;
+        }
+        if (preg_match('#^\.claude/rules/.+\.md$#', $file) === 1) {
+            $triggers[] = ['type' => 'agent-rule', 'file' => $file];
+            continue;
+        }
+        if (preg_match('#^\.github/workflows/.+\.ya?ml$#', $file) === 1) {
+            $triggers[] = ['type' => 'ci-workflow', 'file' => $file];
+            continue;
+        }
+        if (preg_match('#^bin/[^/]+$#', $file) === 1) {
+            [$lineCount, $firstLine] = newSideFileInfo($mode, $file);
+            if (str_starts_with($firstLine, '#!') && $lineCount >= MIN_TOOL_SCRIPT_LINES) {
+                $triggers[] = ['type' => 'new-tool-script', 'file' => $file];
+            }
+            continue;
+        }
+    }
+
+    $candidates = array_unique(array_merge($added, $modified));
+    foreach ($candidates as $file) {
+        if (preg_match('#^ibl5/migrations/.+\.sql$#', $file) !== 1) {
+            continue;
+        }
+        foreach (diffAddedLines($mode, $file) as $line) {
+            $trimmed = ltrim($line);
+            if (str_starts_with($trimmed, '--')) {
+                continue;
+            }
+            if (preg_match('/\b(DROP\s+TABLE|DROP\s+COLUMN|DROP\s+INDEX)\b/i', $trimmed) === 1) {
+                $triggers[] = ['type' => 'destructive-migration', 'file' => $file];
+                break;
+            }
+        }
+    }
+
+    foreach ($modified as $file) {
+        if ($file !== 'ibl5/composer.json') {
+            continue;
+        }
+        foreach (diffAddedLines($mode, $file) as $line) {
+            if (preg_match('#"[a-z0-9._-]+/[a-z0-9._-]+"\s*:\s*"#i', $line) === 1) {
+                $triggers[] = ['type' => 'new-dependency', 'file' => $file];
+                break;
+            }
+        }
+    }
+
+    return $triggers;
+}
+
+function hasAddedAdr(string $mode): bool
+{
+    foreach (diffNames($mode, 'A') as $file) {
+        if (preg_match('#^ibl5/docs/decisions/(\d{4})-.+\.md$#', $file, $m) === 1 && $m[1] !== '0000') {
+            return true;
+        }
+    }
+    return false;
+}
+
+function fetchPrBody(string $mode, bool $fromStdin): ?string
+{
+    if ($fromStdin) {
+        $body = stream_get_contents(STDIN);
+        return $body === false ? null : $body;
+    }
+    if ($mode !== 'pr') {
+        return null;
+    }
+    [$lines, $exit] = runCmd('gh pr view --json body --jq .body');
+    if ($exit !== 0 || $lines === []) {
+        return null;
+    }
+    return implode("\n", $lines);
+}
+
+function extractBypassReason(?string $body): ?string
+{
+    if ($body === null || $body === '') {
+        return null;
+    }
+    if (preg_match(BYPASS_REGEX, $body, $m) === 1) {
+        return trim($m[1]);
+    }
+    return null;
+}
+
+// --- main ---
+
+$opts = ['mode' => 'staged', 'bypass_from_stdin' => false];
+foreach (array_slice($argv, 1) as $arg) {
+    switch ($arg) {
+        case '--staged':
+            $opts['mode'] = 'staged';
+            break;
+        case '--pr':
+            $opts['mode'] = 'pr';
+            break;
+        case '--bypass-from-stdin':
+            $opts['bypass_from_stdin'] = true;
+            break;
+        case '--help':
+        case '-h':
+            echo usage();
+            exit(0);
+        default:
+            fwrite(STDERR, "unknown flag: {$arg}\n");
+            fwrite(STDERR, usage());
+            exit(2);
+    }
+}
+
+$triggers = detectTriggers($opts['mode']);
+if ($triggers === []) {
+    echo "No decision-trigger surfaces touched. ADR not required.\n";
+    exit(0);
+}
+
+$adrAdded = hasAddedAdr($opts['mode']);
+$bypassReason = extractBypassReason(fetchPrBody($opts['mode'], $opts['bypass_from_stdin']));
+
+echo "Decision-trigger surfaces detected:\n";
+foreach ($triggers as $t) {
+    $desc = TRIGGER_DESCRIPTIONS[$t['type']] ?? $t['type'];
+    echo sprintf("  - [%s] %s — %s\n", $t['type'], $t['file'], $desc);
+}
+echo "\n";
+
+if ($adrAdded) {
+    echo "PASS: diff adds a new ADR under ibl5/docs/decisions/.\n";
+    exit(0);
+}
+
+if ($bypassReason !== null) {
+    echo "PASS (bypass): {$bypassReason}\n";
+    exit(0);
+}
+
+echo "FAIL: the diff touches decision-trigger surfaces without an accompanying ADR.\n";
+echo "\n";
+echo "Resolve by either:\n";
+echo "  1. Create an ADR: `bin/next-adr \"kebab-title\"` and fill in the template.\n";
+echo "     The new file must be added in this same PR under ibl5/docs/decisions/.\n";
+echo "  2. Add a bypass marker to the PR body (HTML comment):\n";
+echo "     <!-- no-adr: reason at least 15 characters long -->\n";
+echo "\n";
+echo "See ibl5/docs/decisions/README.md for the full policy.\n";
+exit(1);

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -284,11 +284,14 @@ function checkFile(string $path, string $repoRoot, \DateTimeImmutable $today): a
 
 /**
  * Verify ADR bidirectional Supersedes / Superseded-by integrity.
- * If ADR-X has Status: "Superseded by ADR-Y", then ADR-Y must exist and
- * ADR-Y's "## Supersedes" section must reference ADR-X. Referenced ADRs
- * must exist in either direction.
  *
- * @return list<string> diagnostics keyed by relative ADR path
+ * Forward: if ADR-X has `Status: Superseded by ADR-Y`, then ADR-Y must exist
+ * and ADR-Y's `## Supersedes` section must reference ADR-X.
+ *
+ * Reverse: if ADR-Y's `## Supersedes` section references ADR-X, then ADR-X
+ * must exist and ADR-X's `Status` line must say `Superseded by ADR-Y`.
+ *
+ * @return list<string> diagnostic lines, each naming the offending ADR path.
  */
 function checkAdrTransitions(string $repoRoot): array
 {
@@ -361,6 +364,17 @@ function checkAdrTransitions(string $repoRoot): array
         foreach ($claim['supersedes'] as $y) {
             if (!isset($byNum[$y])) {
                 $issues[] = sprintf('%s: ## Supersedes references ADR-%s, but it does not exist', $rel, $y);
+                continue;
+            }
+            $yClaim = $claims[$y] ?? ['supersededBy' => null];
+            if ($yClaim['supersededBy'] !== $num) {
+                $issues[] = sprintf(
+                    '%s: ## Supersedes references ADR-%s, but ADR-%s Status line does not say "Superseded by ADR-%s"',
+                    $rel,
+                    $y,
+                    $y,
+                    $num
+                );
             }
         }
     }

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -17,6 +17,7 @@ const IN_SCOPE_GLOBS = [
     '.claude/skills/*/SKILL.md',
     '.claude/commands/*.md',
     'ibl5/docs/*.md',
+    'ibl5/docs/decisions/*.md',
 ];
 
 const EXCLUDED_RELATIVE_FRAGMENTS = [
@@ -281,6 +282,91 @@ function checkFile(string $path, string $repoRoot, \DateTimeImmutable $today): a
     return $issues;
 }
 
+/**
+ * Verify ADR bidirectional Supersedes / Superseded-by integrity.
+ * If ADR-X has Status: "Superseded by ADR-Y", then ADR-Y must exist and
+ * ADR-Y's "## Supersedes" section must reference ADR-X. Referenced ADRs
+ * must exist in either direction.
+ *
+ * @return list<string> diagnostics keyed by relative ADR path
+ */
+function checkAdrTransitions(string $repoRoot): array
+{
+    $adrDir = $repoRoot . '/ibl5/docs/decisions';
+    if (!is_dir($adrDir)) {
+        return [];
+    }
+    $files = glob($adrDir . '/[0-9][0-9][0-9][0-9]-*.md') ?: [];
+    if ($files === []) {
+        return [];
+    }
+
+    $byNum = [];
+    foreach ($files as $path) {
+        if (!is_file($path)) {
+            continue;
+        }
+        $base = basename($path);
+        if (preg_match('/^(\d{4})-/', $base, $m) !== 1) {
+            continue;
+        }
+        if ($m[1] === '0000') {
+            continue;
+        }
+        $byNum[$m[1]] = $path;
+    }
+
+    $claims = [];
+    foreach ($byNum as $num => $path) {
+        $content = file_get_contents($path);
+        if ($content === false) {
+            continue;
+        }
+        $claim = ['supersededBy' => null, 'supersedes' => []];
+        if (preg_match('/^\*\*Status:\*\*\s*Superseded by ADR-(\d{4})/m', $content, $m) === 1) {
+            $claim['supersededBy'] = $m[1];
+        }
+        $section = '';
+        if (preg_match('/^## Supersedes\s*\r?\n(.+?)^## /ms', $content, $m) === 1) {
+            $section = $m[1];
+        } elseif (preg_match('/^## Supersedes\s*\r?\n(.+)/ms', $content, $m) === 1) {
+            $section = $m[1];
+        }
+        if ($section !== '' && preg_match_all('/ADR-(\d{4})/', $section, $mm) > 0) {
+            $claim['supersedes'] = array_values(array_unique($mm[1]));
+        }
+        $claims[$num] = $claim;
+    }
+
+    $issues = [];
+    foreach ($claims as $num => $claim) {
+        $rel = substr($byNum[$num], strlen($repoRoot) + 1);
+        if ($claim['supersededBy'] !== null) {
+            $y = $claim['supersededBy'];
+            if (!isset($byNum[$y])) {
+                $issues[] = sprintf('%s: claims Superseded by ADR-%s, but ADR-%s does not exist', $rel, $y, $y);
+            } else {
+                $yClaim = $claims[$y] ?? ['supersedes' => []];
+                if (!in_array($num, $yClaim['supersedes'], true)) {
+                    $issues[] = sprintf(
+                        "%s: claims Superseded by ADR-%s, but ADR-%s's ## Supersedes section does not reference ADR-%s",
+                        $rel,
+                        $y,
+                        $y,
+                        $num
+                    );
+                }
+            }
+        }
+        foreach ($claim['supersedes'] as $y) {
+            if (!isset($byNum[$y])) {
+                $issues[] = sprintf('%s: ## Supersedes references ADR-%s, but it does not exist', $rel, $y);
+            }
+        }
+    }
+    return $issues;
+}
+
 /** @param list<string> $files */
 function fixDates(array $files, \DateTimeImmutable $today): int
 {
@@ -368,11 +454,20 @@ foreach ($files as $path) {
     }
 }
 
+$transitionIssues = checkAdrTransitions($root);
+if ($transitionIssues !== []) {
+    echo "FAIL ADR transition integrity\n";
+    foreach ($transitionIssues as $issue) {
+        echo "     - {$issue}\n";
+    }
+    $failures++;
+}
+
 $total = count($files);
 if ($failures === 0) {
     echo "\n{$total} docs verified.\n";
     exit(0);
 }
 
-echo "\n{$failures} of {$total} docs failed.\n";
+echo "\n{$failures} failure(s) across {$total} docs plus ADR transitions.\n";
 exit(1);

--- a/bin/next-adr
+++ b/bin/next-adr
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Create the next ADR file by number, copying 0000-template.md and slugging the title.
+#
+# Usage: bin/next-adr "kebab-title"
+#
+# Checks both the current worktree AND the canonical main repo to avoid
+# numbering collisions when multiple worktrees are adding ADRs concurrently
+# (same defense bin/next-migration uses).
+
+set -euo pipefail
+
+if [ $# -ne 1 ] || [ -z "$1" ]; then
+    echo "Usage: $0 \"kebab-title\"" >&2
+    exit 2
+fi
+
+SLUG="$1"
+
+# Validate slug: lowercase letters, digits, hyphens. No spaces, no uppercase.
+if ! printf '%s' "$SLUG" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'; then
+    echo "Error: slug must be kebab-case (lowercase letters, digits, hyphens)." >&2
+    echo "       Got: $SLUG" >&2
+    exit 2
+fi
+
+WORKTREE_DIR="$(cd "$(dirname "$0")/.." && pwd)/ibl5/docs/decisions"
+CANONICAL_DIR="/Users/ajaynicolas/Documents/GitHub/IBL5/ibl5/docs/decisions"
+
+get_max() {
+    local dir="$1"
+    if [ ! -d "$dir" ]; then
+        return 0
+    fi
+    # List NNNN-*.md files, extract numeric prefix, skip 0000 (template), find max.
+    # `|| true` absorbs the empty-pipeline case under `set -o pipefail`.
+    (
+        ls "$dir"/[0-9][0-9][0-9][0-9]-*.md 2>/dev/null \
+            | sed 's/.*\///' \
+            | grep -oE '^[0-9]+' \
+            | grep -v '^0000$' \
+            | sort -n \
+            | tail -1
+    ) || true
+}
+
+MAX_WT=$(get_max "$WORKTREE_DIR")
+MAX_CANON=$(get_max "$CANONICAL_DIR")
+
+MAX="${MAX_WT:-0}"
+if [ -n "$MAX_CANON" ] && [ "$MAX_CANON" -gt "$MAX" ] 2>/dev/null; then
+    MAX=$MAX_CANON
+fi
+
+NEXT=$((10#$MAX + 1))
+PADDED=$(printf "%04d" "$NEXT")
+
+TEMPLATE="$WORKTREE_DIR/0000-template.md"
+if [ ! -f "$TEMPLATE" ]; then
+    echo "Error: template not found at $TEMPLATE" >&2
+    exit 1
+fi
+
+# Reject slug reuse: an existing ADR with the same slug (any number) is a collision.
+# This catches the common case of invoking next-adr twice with the same title.
+EXISTING=$(ls "$WORKTREE_DIR"/[0-9][0-9][0-9][0-9]-"${SLUG}".md 2>/dev/null | head -1 || true)
+if [ -n "$EXISTING" ]; then
+    echo "Error: an ADR with slug '${SLUG}' already exists at ${EXISTING}." >&2
+    echo "       Pick a distinct kebab-title." >&2
+    exit 1
+fi
+
+TARGET="$WORKTREE_DIR/${PADDED}-${SLUG}.md"
+
+if [ -e "$TARGET" ]; then
+    echo "Error: $TARGET already exists — choose a different slug." >&2
+    exit 1
+fi
+
+cp "$TEMPLATE" "$TARGET"
+echo "$TARGET"

--- a/bin/next-adr
+++ b/bin/next-adr
@@ -24,7 +24,23 @@ if ! printf '%s' "$SLUG" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'; then
 fi
 
 WORKTREE_DIR="$(cd "$(dirname "$0")/.." && pwd)/ibl5/docs/decisions"
-CANONICAL_DIR="/Users/ajaynicolas/Documents/GitHub/IBL5/ibl5/docs/decisions"
+
+# Resolve the main repo's decisions dir so concurrent worktrees don't collide on
+# numbering. In a worktree, .git is a file containing `gitdir: <main>/.git/worktrees/<name>`;
+# dirname -3 backs out to the main repo path. In the main repo itself, .git is a dir
+# and CANONICAL_DIR == WORKTREE_DIR.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -f "$REPO_ROOT/.git" ]; then
+    GITDIR=$(awk '/^gitdir:/ {print $2}' "$REPO_ROOT/.git")
+    if [ -n "$GITDIR" ]; then
+        CANONICAL_ROOT=$(cd "$GITDIR/../../.." && pwd)
+        CANONICAL_DIR="$CANONICAL_ROOT/ibl5/docs/decisions"
+    else
+        CANONICAL_DIR="$WORKTREE_DIR"
+    fi
+else
+    CANONICAL_DIR="$WORKTREE_DIR"
+fi
 
 get_max() {
     local dir="$1"

--- a/ibl5/docs/README.md
+++ b/ibl5/docs/README.md
@@ -24,6 +24,7 @@ This directory is the primary home for all project documentation.
 | [DEVELOPMENT_ENVIRONMENT.md](DEVELOPMENT_ENVIRONMENT.md) | Docker setup, dependency caching, database connection |
 | [DOCUMENTATION_STANDARDS.md](DOCUMENTATION_STANDARDS.md) | Documentation organization and lifecycle |
 | [TESTING_STANDARDS.md](TESTING_STANDARDS.md) | Testing philosophy and conventions |
+| [decisions/README.md](decisions/README.md) | Architecture Decision Records (ADRs) — why each load-bearing decision was made |
 
 ## Project Status
 

--- a/ibl5/docs/decisions/0000-template.md
+++ b/ibl5/docs/decisions/0000-template.md
@@ -1,0 +1,38 @@
+---
+description: Template for new ADRs. Copy with `bin/next-adr "kebab-title"`; do not fill in place.
+last_verified: 2026-04-11
+---
+
+# ADR-NNNN: <Title>
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+**Deciders:** (optional — names or roles)
+
+## Context
+
+Two to four sentences. What forces were in play, what hurt, what the team had tried. Be concrete about the problem — an ADR is only useful if a future reader can reconstruct why the decision mattered at the time.
+
+## Decision
+
+What we chose, stated as a directive. One paragraph max. If the decision is mechanically enforced, cite the enforcement mechanism (PHPStan rule identifier, CI job, hook, `bin/` script).
+
+## Alternatives Considered
+
+- **<Alternative 1>** — one-line description. Rejected because: <one-line reason>.
+- **<Alternative 2>** — one-line description. Rejected because: <one-line reason>.
+- **<Alternative 3>** — one-line description. Rejected because: <one-line reason>.
+
+## Consequences
+
+- Positive: <tradeoff we accepted>.
+- Positive: <tradeoff we accepted>.
+- Negative: <tradeoff we accepted>.
+
+## Supersedes
+
+(Only present when this ADR replaces an earlier one. Remove this section otherwise.) Reference the superseded ADR by number and summarize what changed.
+
+## References
+
+Bulleted list of source files, rules, commits, or prior docs that enforce or illustrate the decision. Use inline backticks for repo paths so `bin/check-docs` validates them.

--- a/ibl5/docs/decisions/0001-interface-driven-architecture.md
+++ b/ibl5/docs/decisions/0001-interface-driven-architecture.md
@@ -43,5 +43,5 @@ Controllers, Processors, and Validators are added as additional sibling classes 
 - `ibl5/docs/ARCHITECTURE_PATTERNS.md` — the how-to (structure, interface standards, reference implementations).
 - `ibl5/docs/REFACTORING_HISTORY.md` — the what-changed timeline for all 30 modules.
 - `ibl5/classes/Waivers/` — canonical example cited in CLAUDE.md.
-- `ibl5/classes/Player/` — the largest module, 30 interfaces + 35 classes + 205 tests.
+- `ibl5/classes/Player/` — the largest module, used as the stress test for the pattern at scale.
 - `.claude/rules/php-classes.md` — the rules file that codifies the convention for agents.

--- a/ibl5/docs/decisions/0001-interface-driven-architecture.md
+++ b/ibl5/docs/decisions/0001-interface-driven-architecture.md
@@ -1,0 +1,47 @@
+---
+description: Why every module in ibl5/classes/ uses interface-driven Repository/Service/View split with Contracts/ subdirs.
+last_verified: 2026-04-11
+---
+
+# ADR-0001: Interface-driven Repository/Service/View architecture
+
+**Status:** Accepted
+**Date:** 2026-04-11
+
+## Context
+
+Before the 30-module refactor, IBL5 was a PHP-Nuke codebase: database queries, business logic, input handling, and HTML rendering were interleaved inside top-level `modules/*.php` files. Nothing could be unit-tested because there were no class boundaries to mock. Security review required reading hundreds of lines of mixed concerns to trace whether a single `$_GET` value reached `echo` or SQL unescaped. Type safety was impossible — everything was mixed `array|string|false` with implicit coercion. The team had tried incremental cleanup for years without a governing structure; the structure always drifted back to the old shape because there was no convention for *where* a new responsibility should live.
+
+## Decision
+
+Every module in `ibl5/classes/<ModuleName>/` is split into three roles with explicit interfaces in a `Contracts/` subdirectory:
+
+- **Repository** — prepared-statement database access, extending `BaseMysqliRepository`.
+- **Service** — business logic, validation, orchestration. Consumes repository interfaces.
+- **View** — HTML rendering via output buffering with `HtmlSanitizer::e()` (see ADR-0002).
+
+Controllers, Processors, and Validators are added as additional sibling classes when a module needs them. Interfaces live in `Contracts/*Interface.php`; concrete classes `implements` them. Tests mock interfaces, not concrete classes — this is the entire point of the split. Architectural boundaries are enforced structurally (naming conventions) and by PHPStan level `max` + `strict-rules` (see ADR-0005), which rejects the type coercion patterns the old code relied on.
+
+## Alternatives Considered
+
+- **Trait-based composition** — mix repository/service/view traits into one class per module. Rejected: traits cannot be mocked in PHPUnit, so every test would hit the real database; and a class with three traits has three responsibilities hiding inside one name, defeating the whole clarity goal.
+- **Factory pattern without interfaces** — a module-level factory builds repository and service instances. Rejected: factories become god objects that know how every class is assembled, and without interfaces the factories still can't be mocked effectively.
+- **Monolithic modules with layered directory structure** — keep procedural code but organize files by layer. Rejected: no compile-time enforcement of layering; regressions always drift inward because nothing mechanical blocks them.
+- **Hexagonal / ports-and-adapters** — full hexagonal architecture with ports between every seam. Rejected: too much ceremony for a single-app codebase with no microservice boundaries; 3 roles is the right granularity for IBL5's scale.
+
+## Consequences
+
+- Positive: every module is unit-testable via interface mocks. `ibl5/tests/Waivers/`, `ibl5/tests/Player/`, and every other module test suite depend on this.
+- Positive: security review can read one `View` file to check XSS, one `Repository` file to check SQL injection, and ignore the rest.
+- Positive: agents can pattern-match new modules from existing ones (`ibl5/classes/Waivers/` is the canonical example cited in CLAUDE.md).
+- Positive: PHPStan enforces the structural contract across every refactored module.
+- Negative: every module now has 6+ files instead of 1. Boilerplate cost accepted as the price of the other properties.
+- Negative: learning curve for contributors coming from procedural PHP. Mitigated by `ibl5/docs/ARCHITECTURE_PATTERNS.md` and the canonical example.
+
+## References
+
+- `ibl5/docs/ARCHITECTURE_PATTERNS.md` — the how-to (structure, interface standards, reference implementations).
+- `ibl5/docs/REFACTORING_HISTORY.md` — the what-changed timeline for all 30 modules.
+- `ibl5/classes/Waivers/` — canonical example cited in CLAUDE.md.
+- `ibl5/classes/Player/` — the largest module, 30 interfaces + 35 classes + 205 tests.
+- `.claude/rules/php-classes.md` — the rules file that codifies the convention for agents.

--- a/ibl5/docs/decisions/0002-xss-enforcement-via-phpstan.md
+++ b/ibl5/docs/decisions/0002-xss-enforcement-via-phpstan.md
@@ -1,0 +1,48 @@
+---
+description: Why XSS is enforced mechanically by a PHPStan custom rule instead of runtime convention or templating.
+last_verified: 2026-04-11
+---
+
+# ADR-0002: XSS enforcement via PHPStan `RequireEscapedOutputRule`
+
+**Status:** Accepted
+**Date:** 2026-04-11
+
+## Context
+
+PHP `echo` and `<?= ?>` output is unsafe by default. Any variable reaching either sink without explicit escaping is an XSS vector. IBL5 has dozens of View classes rendering user-controlled strings (team names, player bios, forum posts). Convention alone — "wrap everything in `HtmlSanitizer::e()`" — does not hold: humans miss it under review, agents miss it when generating new code, and a single unescaped `echo` is enough for a stored XSS. The only robust defense is mechanical: a check that runs before code can merge, refuses to let unescaped output pass, and has zero false negatives on the surface it covers.
+
+## Decision
+
+Every `echo` and `<?= ?>` expression inside any file whose basename ends in `View.php` must pass the `RequireEscapedOutputRule` PHPStan custom rule (identifier `ibl.unescapedOutput`, implemented at `ibl5/phpstan-rules/RequireEscapedOutputRule.php`). Permitted expressions:
+
+- `HtmlSanitizer::e()` or `HtmlSanitizer::safeHtmlOutput()` call.
+- A whitelisted safe-HTML helper from the rule's `SAFE_STATIC_CALLS` list.
+- An `(int)`, `(float)`, or `(bool)` cast (always HTML-safe).
+- A string or numeric literal, or a constant (`true`, `false`, `null`, class constant).
+- A ternary, null-coalesce, or concatenation where every operand is safe.
+
+The rule intentionally does **not** walk into variables or arbitrary function calls — those are unsafe unless explicitly whitelisted. New helpers must be added to `SAFE_STATIC_CALLS` explicitly. The rule runs in PostToolUse hooks during editing and in CI (`.github/workflows/tests.yml` PHPStan job), so a PR cannot merge with an unescaped echo.
+
+## Alternatives Considered
+
+- **Runtime auto-escaping in a View base class** — every `echo` routes through a parent method that escapes. Rejected: easy to bypass with direct `echo`; the rule isn't checked until runtime; slow to catch in CI because coverage is incomplete; and agents still write raw `echo` out of habit.
+- **Full templating engine (Twig, Blade, Plates)** — migrate every View to a template file with auto-escaping. Rejected: whole-codebase migration cost, loss of inline PHP familiarity for the contributors, two-language mental overhead, and the existing `HtmlSanitizer::e()` infrastructure already covers the narrow surface.
+- **Convention + code review** — mandate `HtmlSanitizer::e()` in the style guide, rely on humans to catch misses. Rejected: every previous project that tried this had an XSS in production. Humans and agents both miss it. The convention survives only with mechanical enforcement.
+- **htmlspecialchars() direct calls** — allow the built-in instead of the wrapper. Rejected: `htmlspecialchars()` requires developer discretion about flags (`ENT_QUOTES`, encoding) and can be misconfigured silently. The wrapper locks in the flags and gives us one thing to review.
+
+## Consequences
+
+- Positive: XSS is impossible in View files that pass CI, by construction.
+- Positive: the whitelist is explicit and grep-able — you can find every safe helper by reading one constant in one file.
+- Positive: the rule fires during editing (PostToolUse hook), so agents get immediate feedback instead of merge-time rejection.
+- Positive: security audits no longer need to read View files looking for unescaped output — `_review-rubric.md` explicitly tells reviewers not to re-check this.
+- Negative: adding a new safe helper requires editing `ibl5/phpstan-rules/RequireEscapedOutputRule.php` and updating the whitelist. Deliberate friction — the point is to force a review when the safe-set grows.
+- Negative: the rule only covers files matching `*View.php`. Output from Controllers or other classes is not inspected. Mitigated by the `_review-rubric.md` guidance that echo from non-View files is rare and reviewed manually; expand the rule if a pattern emerges.
+
+## References
+
+- `ibl5/phpstan-rules/RequireEscapedOutputRule.php` — the rule implementation and `SAFE_STATIC_CALLS` whitelist.
+- `.claude/rules/view-rendering.md` — the agent-facing rule file (cites this ADR).
+- `.claude/commands/_review-rubric.md` — the reviewer guidance that excludes re-checking this category.
+- `ibl5/classes/Utilities/HtmlSanitizer.php` — the wrapper that locks in `htmlspecialchars` flags.

--- a/ibl5/docs/decisions/0003-statsformatter-mandate.md
+++ b/ibl5/docs/decisions/0003-statsformatter-mandate.md
@@ -1,0 +1,49 @@
+---
+description: Why a single centralized StatsFormatter is mandatory and number_format() is banned project-wide.
+last_verified: 2026-04-11
+---
+
+# ADR-0003: `StatsFormatter` mandate, `number_format()` banned
+
+**Status:** Accepted
+**Date:** 2026-04-11
+
+## Context
+
+IBL5 renders basketball statistics across 31 modules: points per game, field-goal percentages, per-36 totals, career aggregates, leaderboards, boxscores, team stats, player stats. Each stat category has a canonical format — PPG is one decimal, FG% is three decimals, totals use comma separators, zero-division is a dash not `NaN`. When each module chose its own formatting via direct `number_format()` calls, the output drifted: one screen showed `23.4 PPG`, another showed `23.40 PPG`, a third showed `23,40 PPG` on European locales. Cross-module bugs ("why is Alice's FG% showing as 0.476 on the roster page and 47.6% on the leaderboard?") kept recurring because there was no single source of truth for "how does IBL5 format a percentage." Zero-division guards were inconsistently added; some pages showed `NaN%` when a player had zero attempts.
+
+## Decision
+
+Use `BasketballStats\StatsFormatter` for every stat format in the project. Direct `number_format()` calls are banned by `BanNumberFormatRule` (identifier `ibl.bannedNumberFormat`, implemented at `ibl5/phpstan-rules/BanNumberFormatRule.php`), with one exception: `StatsFormatter.php` itself is allowed to call `number_format()` because it *is* the wrapper. `StatsFormatter`'s public API includes the domain-specific helpers every stat screen needs:
+
+- `formatPercentage($made, $attempted)` — FG%, 3P%, FT%.
+- `formatPerGameAverage($total, $games)` — PPG, RPG, APG, BPG, SPG.
+- `formatPer36Stat($total, $minutes)` — per-36 rate stats.
+- `formatTotal($value)` — career and season totals with comma separators.
+- `formatWithDecimals($value, $decimals)` — custom decimal places where needed.
+- `safeDivide($num, $denom)` — zero-division guard returning a typed default.
+
+The rule fires in PostToolUse and CI; a PR with a new `number_format()` call outside `StatsFormatter.php` cannot merge.
+
+## Alternatives Considered
+
+- **Per-module formatting helpers** — each module has its own `format*` helpers and the style guide says "use the module's helper." Rejected: exactly the drift the project was suffering. 31 modules means 31 drift points, and no mechanical check prevents one more copy.
+- **Third-party number formatter (Symfony NumberFormatter, internationalization libs)** — a PHP package with locale awareness. Rejected: none of the candidates express IBL5's domain semantics (per-36, per-game, zero-division-as-dash), so every call would still need project-specific wrapping. Adds a dependency for zero gain.
+- **Trait mixed into stat-producing classes** — `use StatsFormattingTrait;` and call `$this->formatPercentage()`. Rejected: same drift problem — nothing blocks a contributor from writing `number_format` inline alongside the trait call. No mechanical enforcement, just a suggestion.
+- **Extend `BaseMysqliRepository` with format methods** — bake formatting into the repository layer. Rejected: conflates data access and rendering, violates ADR-0001, and doesn't cover non-repository code paths.
+
+## Consequences
+
+- Positive: one source of truth for every stat format. Changing "percentages should show two decimals, not three" is one line change in one file.
+- Positive: zero-division guards are centralized. `safeDivide` is the only place that handles the edge case, and every caller inherits the fix.
+- Positive: PHPStan rejects new `number_format()` calls during editing — agents learn the convention immediately instead of at code review.
+- Positive: localization is tractable later. If IBL5 ever needs to render numbers in European locale, one file changes.
+- Negative: `StatsFormatter`'s public API is the project's lingua franca — growing it is a design decision, not a drive-by change. Adding a new method requires a PR that also adds test coverage. Deliberate friction.
+- Negative: one-off formatting needs (e.g., rendering a git SHA count) that are not "stats" still have to go through `StatsFormatter::formatWithDecimals` or similar. Slightly awkward; in practice rare.
+
+## References
+
+- `ibl5/classes/BasketballStats/StatsFormatter.php` — the wrapper and canonical API.
+- `ibl5/phpstan-rules/BanNumberFormatRule.php` — the enforcing rule.
+- `.claude/rules/php-classes.md` — the agent-facing cheat sheet listing every public method (cites this ADR).
+- `ibl5/tests/BasketballStats/StatsFormatterTest.php` — the behavioral spec.

--- a/ibl5/docs/decisions/0004-docker-only-dev-environment.md
+++ b/ibl5/docs/decisions/0004-docker-only-dev-environment.md
@@ -1,0 +1,41 @@
+---
+description: Why IBL5 local dev is Docker-only, with MAMP sunset and native PHP stacks rejected.
+last_verified: 2026-04-11
+---
+
+# ADR-0004: Docker-only development environment
+
+**Status:** Accepted
+**Date:** 2026-04-11
+
+## Context
+
+IBL5's original local dev stack was MAMP: macOS-bundled Apache + PHP + MySQL. As the project adopted PHPStan level max, Playwright E2E tests, and git worktrees for parallel work, MAMP's problems compounded: MAMP's PHP version lagged production, MAMP's MySQL was MySQL 5.7 while production ran MariaDB 10.6, Playwright's test runner assumed `http://main.localhost/ibl5/` which meant MAMP's Apache had to be bound to port 80, and git worktrees couldn't run concurrently because only one MAMP Apache can bind port 80 at a time. Every onboarding session burned hours on "why does it work on yours but not mine" drift between MAMP versions. CI ran on Docker MariaDB 10.6, so local PHPUnit tests frequently passed against MAMP but failed on CI against real production-parity databases.
+
+## Decision
+
+Local development uses Docker Compose only. `docker compose up -d` starts PHP-Apache + MariaDB 10.6 + Mailpit + Adminer at `http://main.localhost/ibl5/`. Worktrees use per-worktree Docker stacks via `bin/wt-new <slug>` + `bin/wt-up <slug>` to get their own isolated MariaDB instance, so multiple branches can run in parallel without port conflicts. MAMP is no longer supported; the last MAMP reference was removed from docs in PR #607 as part of the Living Documentation pass. `config.php` reads `DB_HOST` from the environment with a `127.0.0.1` fallback, so the same code works in Docker and in CI without edits.
+
+## Alternatives Considered
+
+- **Keep MAMP, document the drift points** — add checklists to README for version matching. Rejected: every project that tried "be disciplined about MAMP version matching" drifted anyway; onboarding time never improved; CI parity was never achieved.
+- **Native PHP + Homebrew MariaDB** — install PHP 8.4 and MariaDB 10.6 via Homebrew, run without containers. Rejected: each contributor would need the exact same Homebrew formula version; upgrades on one machine break another's tests; port conflicts with worktrees are unsolved; CI still runs Docker, so parity drift returns.
+- **Vagrant VM** — a full VirtualBox VM with provisioned IBL5. Rejected: resource-heavy (multi-gigabyte VMs per contributor), slow boot, Vagrant is a declining technology with fewer macOS Silicon users, and Docker Compose gives us the same reproducibility with a fraction of the footprint.
+- **Remote dev environment (Gitpod, Codespaces)** — run dev in a cloud VM. Rejected: adds a cost center, requires internet for every keystroke, and the Playwright E2E setup still needs local browsers for visual verification.
+
+## Consequences
+
+- Positive: every contributor runs identical PHP version, MariaDB version, Apache config, and request routing. "Works on my machine" is no longer a legitimate diagnosis.
+- Positive: git worktrees can run in parallel — each worktree gets an isolated Docker stack via `bin/wt-up`.
+- Positive: CI parity is automatic. The same `docker-compose.yml` that CI uses is what developers use locally, so PHPUnit and Playwright behave the same in both environments.
+- Positive: Playwright E2E tests can rely on `http://main.localhost/ibl5/` being the single canonical URL.
+- Negative: Docker Desktop is a heavyweight prerequisite for onboarding. Accepted because the alternative was worse.
+- Negative: First-time setup requires creating the shared `ibl5-proxy` Docker network manually. Documented in `ibl5/docs/DOCKER_SETUP.md`.
+- Negative: Running the full dev stack consumes ~2-3 GB RAM. Accepted for the other properties.
+
+## References
+
+- `ibl5/docs/DOCKER_SETUP.md` — the step-by-step onboarding guide.
+- `docker-compose.yml` — the canonical service definition.
+- `bin/wt-new`, `bin/wt-up`, `bin/wt-down` — worktree lifecycle commands that assume Docker.
+- `.claude/rules/workflow-continuity.md` — the agent-facing worktree rule (cites this ADR).

--- a/ibl5/docs/decisions/0005-strict-types-enforcement.md
+++ b/ibl5/docs/decisions/0005-strict-types-enforcement.md
@@ -1,0 +1,48 @@
+---
+description: Why PHPStan level max plus strict-rules plus RequireStrictTypesRule is the non-negotiable type floor.
+last_verified: 2026-04-11
+---
+
+# ADR-0005: Strict types + typed properties enforcement
+
+**Status:** Accepted
+**Date:** 2026-04-11
+
+## Context
+
+Pre-refactor IBL5 ran on PHP's default loose type semantics. `'0' == false`, `null == 0`, `"abc" == 0` all returned true; query results came back as mixed `array|false|null`; and class properties were untyped by default, allowing anything to be assigned to anything. Debugging sessions regularly turned into "the ID comparison failed because `$player->tid` was a string but the int literal matched the loose comparison anyway, except when `tid === 0` because empty string coerces to 0." These bugs were silent: the wrong player got assigned to the wrong team, the wrong contract year was paid out, and nothing crashed until the data hit production. Test coverage didn't help because loose typing made the tests themselves suspect. The team adopted PHPStan incrementally but hit a floor: without `strict_types=1` and without strict-rules, PHPStan's own checks were neutered on the very patterns that were causing incidents.
+
+## Decision
+
+Every PHP file inside `ibl5/classes/` must begin with `declare(strict_types=1);`. This is enforced by the custom rule `RequireStrictTypesRule` (identifier `ibl.missingStrictTypes`, implemented at `ibl5/phpstan-rules/RequireStrictTypesRule.php`). PHPStan runs at `level: max` with `phpstan-strict-rules` and `bleedingEdge` enabled via `ibl5/phpstan.neon`. Additional requirements codified in CLAUDE.md Type Safety section and enforced by stock PHPStan:
+
+- **Typed properties:** every class property declared with a type.
+- **Typed methods:** every parameter and return type declared.
+- **Strict equality:** always `===` / `!==`, never `==` / `!=`.
+- **Null handling:** nullable types (`?string`) and null coalescing (`??`), no implicit null-to-empty.
+
+The rule fires in PostToolUse during editing and in CI via `tests.yml` PHPStan job.
+
+## Alternatives Considered
+
+- **PHPStan level 8 without strict-rules** — the highest built-in level, no custom rules, no strict-rules extension. Rejected: loose `==` still allowed, implicit numeric string conversion still allowed, function parameter coercion still allowed — exactly the patterns causing incidents. Level max plus strict-rules closes those holes.
+- **Gradual typing via `@phpstan-type` aliases** — keep the code untyped but add PHPDoc type aliases. Rejected: doesn't enforce at runtime, splits type knowledge across two places (the PHPDoc and the code), and PHPDoc drift is rampant. The whole point is to make the type the single source of truth.
+- **Runtime `assert()` calls** — sprinkle `assert(is_int($tid))` at function boundaries. Rejected: opt-in per call site, easy to miss, runs at runtime (late), and PHPStan already does this check at analysis time when types are declared.
+- **Psalm instead of PHPStan** — use a competitor static analyzer. Rejected: PHPStan's custom rule API is what lets IBL5 layer domain-specific rules (XSS, SQL injection, require_once, etc.); a mid-project switch would mean rewriting all those rules for Psalm's API.
+
+## Consequences
+
+- Positive: type coercion bugs are caught before commit. `'0' === 0` no longer compiles — PHPStan flags the mismatch.
+- Positive: large-scale refactoring is safe. Renaming a field or changing a return type surfaces every caller through type errors instead of at runtime.
+- Positive: agents writing new code inherit the constraint automatically — the PostToolUse PHPStan run rejects loose patterns before they reach commit.
+- Positive: onboarding is faster because the type system communicates intent. New contributors don't need to guess what `$row['tid']` contains.
+- Negative: PHPStan level max is noisy on legacy code. Modules in `ibl5/classes/SiteStatistics/` are excluded via `phpstan.neon` `excludePaths` because they predate the contract. Deliberate carve-out, not drift.
+- Negative: every new PHPStan major version raises new issues. Accepted as the price of strictness; each PHPStan upgrade is its own focused PR.
+- Negative: PHP's own strict type checking is not as strong as a statically compiled language. `array|string|false` unions still exist for database return types. PHPStan narrows them via `@phpstan-var` and dedicated type guards — see `.claude/rules/php-classes.md` for the patterns.
+
+## References
+
+- `ibl5/phpstan-rules/RequireStrictTypesRule.php` — the `declare(strict_types=1)` enforcer.
+- `ibl5/phpstan.neon` — the level, strict-rules, and bleedingEdge config plus `excludePaths` for legacy carve-outs.
+- `.claude/rules/php-classes.md` — the agent-facing rule file with type-narrowing patterns (cites this ADR).
+- CLAUDE.md Type Safety section — the project-wide directive.

--- a/ibl5/docs/decisions/README.md
+++ b/ibl5/docs/decisions/README.md
@@ -1,0 +1,45 @@
+---
+description: Index of IBL5 Architecture Decision Records (ADRs). Source of truth for every load-bearing decision and its rationale.
+last_verified: 2026-04-11
+---
+
+# IBL5 Architecture Decision Records
+
+Every load-bearing decision in IBL5 is captured here as a numbered ADR so that future contributors (human and agent) can reconstruct *why* we chose X over Y, not just *that* we chose X. Rules in `.claude/rules/` and `ibl5/phpstan-rules/` tell you *what* to do; ADRs tell you *why the rule exists*.
+
+## How to Use
+
+- **Reading:** start with the ADR most relevant to the surface you're touching. Each rule file and each PHPStan custom rule links back to the ADR that justifies it.
+- **Writing:** when you make a new significant decision, create an ADR first — the CI gate (`bin/adr-check`, workflow `adr-required.yml`) blocks PRs that add mechanical-enforcement surfaces without an accompanying ADR. See the "When an ADR is required" section below.
+- **Creating one:** run `bin/next-adr "kebab-title"` from the repo root. It copies `0000-template.md` into the next numbered slot and prints the path. The template is Michael Nygard format, adapted for IBL5's frontmatter schema.
+
+## Index
+
+| # | Title | Status | Summary |
+|---|-------|--------|---------|
+| [0001](0001-interface-driven-architecture.md) | Interface-driven Repository/Service/View architecture | Accepted | Organizing pattern for every module in `ibl5/classes/`; drove the 30-module refactor. |
+| [0002](0002-xss-enforcement-via-phpstan.md) | XSS enforcement via PHPStan `RequireEscapedOutputRule` | Accepted | Shift-left XSS prevention: mechanical CI gate, not runtime convention. |
+| [0003](0003-statsformatter-mandate.md) | `StatsFormatter` mandate, `number_format()` banned | Accepted | Single centralized stat formatter enforced by `BanNumberFormatRule`. |
+| [0004](0004-docker-only-dev-environment.md) | Docker-only development environment | Accepted | MAMP sunset; reproducible dev + CI parity + worktree port isolation. |
+| [0005](0005-strict-types-enforcement.md) | Strict types + typed properties enforcement | Accepted | PHPStan level `max` + `strict-rules` as the floor; type coercion bugs banned mechanically. |
+
+## When an ADR is Required
+
+The CI workflow `adr-required.yml` runs `bin/adr-check` on every PR. An ADR is required if the PR adds any of:
+
+1. A new PHPStan custom rule under `ibl5/phpstan-rules/*.php`.
+2. A new always-loaded or path-conditional agent rule under `.claude/rules/*.md`.
+3. A new CI workflow under `.github/workflows/*.yml`.
+4. A destructive schema migration (`DROP TABLE`, `DROP COLUMN`, or `DROP INDEX` in `ibl5/migrations/*.sql`).
+5. A new `bin/` helper script of at least 50 lines.
+6. A new dependency in `ibl5/composer.json`'s `require` or `require-dev` block.
+
+**Bypass** for changes that genuinely don't need an ADR: add `<!-- no-adr: reason at least 15 chars long -->` as an HTML comment inside the PR body. The reason is logged in CI output for traceability. Silence is not allowed — you must type a reason.
+
+## Template and Tooling
+
+- [`0000-template.md`](0000-template.md) — the Nygard template. Never edit in place.
+- [`bin/next-adr`](../../../bin/next-adr) — creates the next ADR file by number, copying the template and slugging the title.
+- [`bin/adr-check`](../../../bin/adr-check) — the CI gate (also usable locally with `--staged`).
+- [`bin/check-docs`](../../../bin/check-docs) — enforces frontmatter freshness on every ADR and verifies bidirectional `Supersedes` integrity.
+- [`.claude/rules/doc-freshness.md`](../../../.claude/rules/doc-freshness.md) — the frontmatter schema every ADR must satisfy.


### PR DESCRIPTION
## Context

PR #607 applied the Living Documentation Principle's freshness automation. This PR applies the article's **tactical step #1**: \"Document every significant decision in an ADR.\" The pre-existing audit found **zero** ADR infrastructure in IBL5 — load-bearing decisions lived scattered across \`REFACTORING_HISTORY.md\` (what, not why), PHPStan rule docblocks, and commit messages.

The user-critical constraint for this follow-up: **automate the gate or it won't happen**. Manual ADR discipline was never going to survive. So this PR pairs the backfill with a CI gate (\`bin/adr-check\` + \`adr-required.yml\`) that blocks PRs touching mechanical-enforcement surfaces unless they add an ADR or carry a bypass marker.

## What's in this PR

**Backfilled ADRs** (5, Nygard format, frontmatter-validated by \`bin/check-docs\`):

- [ADR-0001](ibl5/docs/decisions/0001-interface-driven-architecture.md) — Interface-driven Repository/Service/View architecture.
- [ADR-0002](ibl5/docs/decisions/0002-xss-enforcement-via-phpstan.md) — XSS enforcement via PHPStan \`RequireEscapedOutputRule\`.
- [ADR-0003](ibl5/docs/decisions/0003-statsformatter-mandate.md) — \`StatsFormatter\` mandate / \`number_format()\` ban.
- [ADR-0004](ibl5/docs/decisions/0004-docker-only-dev-environment.md) — Docker-only dev / MAMP sunset.
- [ADR-0005](ibl5/docs/decisions/0005-strict-types-enforcement.md) — Strict types + typed properties enforcement.

Each ADR names its sources (code, docs, enforcement rule) and the alternatives it rejects.

**Tooling:**

- \`bin/next-adr\` — mirrors \`bin/next-migration\`. One-command ADR creation: \`bin/next-adr \"kebab-title\"\` copies the template to the next numbered slot, rejects slug collisions.
- \`bin/adr-check\` — PHP decision-trigger gate. Modes: \`--staged\` (local) and \`--pr\` (CI). Triggers:
  1. New file under \`ibl5/phpstan-rules/*.php\`
  2. New file under \`.claude/rules/*.md\`
  3. New file under \`.github/workflows/*.yml\`
  4. Migration with \`DROP TABLE\` / \`DROP COLUMN\` / \`DROP INDEX\` in added lines
  5. New \`bin/\` script ≥ 50 LOC with a shebang
  6. New entry under \`require\` / \`require-dev\` in \`ibl5/composer.json\`
- **Bypass marker:** PR body HTML comment \`<!-- no-adr: reason at least 15 chars long -->\`. Reason is echoed to CI logs for traceability.
- \`bin/check-docs\` extended: \`ibl5/docs/decisions/*.md\` is now in the frontmatter scope, and a new \`checkAdrTransitions()\` verifies bidirectional \`Supersedes\` / \`Superseded by\` integrity (bundled from the original out-of-scope list).
- \`.github/workflows/adr-required.yml\` — new required CI check running \`bin/adr-check --pr\`.

**Infrastructure:**

- \`ibl5/docs/decisions/0000-template.md\` — the Nygard template. Never edit in place.
- \`ibl5/docs/decisions/README.md\` — index with status + summary + policy + bypass-marker doc + tooling pointers.

**Cross-references** (targeted; CLAUDE.md token budget unchanged):

- \`.claude/rules/view-rendering.md\` → ADR-0002.
- \`.claude/rules/php-classes.md\` → ADR-0001, ADR-0003, ADR-0005.
- \`.claude/rules/workflow-continuity.md\` → ADR-0004.
- \`.claude/rules/phpunit-tests.md\` → ADR-0001.
- \`CLAUDE.md\` Mandatory Rules: one new \"Architecture Decisions\" section pointing at the decisions index.
- \`ibl5/docs/README.md\`: one new row in the Guides table.
- \`.claude/rules/doc-freshness.md\`: scope list extended.

## Verified

- \`bin/check-docs\`: **51 docs verified** (44 from the previous PR + 5 ADRs + template + decisions README).
- Transition-integrity negative test: temporarily set ADR-0001 \`Status: Superseded by ADR-9999\`, \`bin/check-docs\` fails with \`ADR-9999 does not exist\`; reverted.
- \`bin/adr-check\` scenarios all exercised on the actual staged diff:
  - Green path (ADRs staged alongside triggers): exit 0, \`PASS: diff adds a new ADR\`.
  - Fail path (triggers present, no ADR added): exit 1, diagnostic with resolution instructions.
  - Bypass path (HTML comment on stdin): exit 0, \`PASS (bypass): ...\` with reason echoed.
- \`bin/next-adr\`: green path creates the next file; slug collision is rejected with a clear error.
- \`git grep 'ADR-000' -- ibl5/docs/ .claude/ CLAUDE.md\`: 13 hits across ADRs and cross-references.

## Explicitly deferred

- **ADR-0006** (DuckDB analytics layer) — content-only, deferred.
- **ADR-0007** (ban \`require_once\` in \`classes/**\`) — content-only, deferred.
- **ADR-0008** (cookie-before-header ordering, CsrfGuard \`MAX_TOKENS=10\` incident) — content-only, deferred.
- Rewriting \`REFACTORING_HISTORY.md\` / \`ARCHITECTURE_PATTERNS.md\` to point at the new ADRs.
- Full-repo \"link every rule to its ADR\" sweep.

## Manual Testing

No manual testing needed — \`bin/check-docs\` is the behavioral test for the freshness and transition checks, \`bin/adr-check\` was exercised end-to-end in all three modes (pass, fail, bypass) against the real staged diff, and the CI workflow re-runs both gates on this PR itself.

Generated with [Claude Code](https://claude.ai/code)