### PR TITLE
fix: remap JSB playoff transaction month 10 → 6

### DIFF
--- a/ibl5/classes/JsbParser/TrnFileParser.php
+++ b/ibl5/classes/JsbParser/TrnFileParser.php
@@ -32,6 +32,16 @@ class TrnFileParser implements TrnFileParserInterface
     public const TYPE_WAIVER_CLAIM = 3;
     public const TYPE_WAIVER_RELEASE = 4;
 
+    /**
+     * JSB encodes playoff transactions with month=10 internally.
+     * This does NOT correspond to IBL calendar October (Season::IBL_HEAT_MONTH).
+     * During parsing, this value is remapped to Season::IBL_PLAYOFF_MONTH (6).
+     *
+     * This is a simple value remap, unrelated to SchFileParser::dateSlotToMonthDay()
+     * which converts positional month offsets (0=Oct, 1=Nov...) via modular arithmetic.
+     */
+    public const JSB_PLAYOFF_MONTH = 10;
+
     // Trade item markers
     public const TRADE_MARKER_PLAYER = 0;
     public const TRADE_MARKER_DRAFT_PICK = 1;
@@ -100,6 +110,11 @@ class TrnFileParser implements TrnFileParserInterface
         $day = (int) $dayStr;
         $year = ((int) $yearStr) + 1; // JSB stores season beginning year; convert to ending year
         $type = (int) $typeStr;
+
+        // Remap JSB's internal playoff month encoding to IBL calendar month
+        if ($month === self::JSB_PLAYOFF_MONTH) {
+            $month = \Season\Season::IBL_PLAYOFF_MONTH;
+        }
 
         if ($month === 0 || $year === 0 || $type === 0) {
             return null;

--- a/ibl5/classes/JsbParser/TrnFileWriter.php
+++ b/ibl5/classes/JsbParser/TrnFileWriter.php
@@ -47,6 +47,18 @@ class TrnFileWriter implements TrnFileWriterInterface
     }
 
     /**
+     * Convert IBL calendar month to JSB binary format month.
+     * Reverses the parse-time remap of JSB_PLAYOFF_MONTH → IBL_PLAYOFF_MONTH.
+     */
+    private static function toJsbMonth(int $month): int
+    {
+        if ($month === \Season\Season::IBL_PLAYOFF_MONTH) {
+            return TrnFileParser::JSB_PLAYOFF_MONTH;
+        }
+        return $month;
+    }
+
+    /**
      * @see TrnFileWriterInterface::buildInjuryRecord()
      */
     public static function buildInjuryRecord(
@@ -61,7 +73,7 @@ class TrnFileWriter implements TrnFileWriterInterface
         $record = str_repeat(' ', TrnFileParser::RECORD_SIZE);
 
         // Common header at offsets 17-26
-        $record = substr_replace($record, str_pad((string) $month, 2, ' ', STR_PAD_LEFT), 17, 2);
+        $record = substr_replace($record, str_pad((string) self::toJsbMonth($month), 2, ' ', STR_PAD_LEFT), 17, 2);
         $record = substr_replace($record, str_pad((string) $day, 2, ' ', STR_PAD_LEFT), 19, 2);
         $record = substr_replace($record, str_pad((string) $year, 4, ' ', STR_PAD_LEFT), 21, 4);
         $record = substr_replace($record, (string) TrnFileParser::TYPE_INJURY, 26, 1);
@@ -83,7 +95,7 @@ class TrnFileWriter implements TrnFileWriterInterface
         $record = str_repeat(' ', TrnFileParser::RECORD_SIZE);
 
         // Common header
-        $record = substr_replace($record, str_pad((string) $month, 2, ' ', STR_PAD_LEFT), 17, 2);
+        $record = substr_replace($record, str_pad((string) self::toJsbMonth($month), 2, ' ', STR_PAD_LEFT), 17, 2);
         $record = substr_replace($record, str_pad((string) $day, 2, ' ', STR_PAD_LEFT), 19, 2);
         $record = substr_replace($record, str_pad((string) $year, 4, ' ', STR_PAD_LEFT), 21, 4);
         $record = substr_replace($record, (string) TrnFileParser::TYPE_TRADE, 26, 1);
@@ -127,7 +139,7 @@ class TrnFileWriter implements TrnFileWriterInterface
         $record = str_repeat(' ', TrnFileParser::RECORD_SIZE);
 
         // Common header
-        $record = substr_replace($record, str_pad((string) $month, 2, ' ', STR_PAD_LEFT), 17, 2);
+        $record = substr_replace($record, str_pad((string) self::toJsbMonth($month), 2, ' ', STR_PAD_LEFT), 17, 2);
         $record = substr_replace($record, str_pad((string) $day, 2, ' ', STR_PAD_LEFT), 19, 2);
         $record = substr_replace($record, str_pad((string) $year, 4, ' ', STR_PAD_LEFT), 21, 4);
         $record = substr_replace($record, (string) $type, 26, 1);

--- a/ibl5/migrations/107_fix_playoff_transaction_month.sql
+++ b/ibl5/migrations/107_fix_playoff_transaction_month.sql
@@ -1,0 +1,9 @@
+-- Fix playoff transaction months: JSB stores month=10 for playoffs,
+-- but IBL calendar defines playoffs as month=6 (Season::IBL_PLAYOFF_MONTH).
+-- Month 10 is IBL_HEAT_MONTH (October preseason tournament). There are
+-- no actual HEAT transactions in the database, so all month=10 rows are
+-- playoff transactions that need remapping.
+
+UPDATE ibl_jsb_transactions
+SET transaction_month = 6
+WHERE transaction_month = 10;

--- a/ibl5/tests/JsbParser/TrnFileParserTest.php
+++ b/ibl5/tests/JsbParser/TrnFileParserTest.php
@@ -420,6 +420,25 @@ class TrnFileParserTest extends TestCase
         }
     }
 
+    public function testParseRecordRemapsJsbPlayoffMonthToIblPlayoffMonth(): void
+    {
+        $record = $this->buildInjuryRecord(10, 5, 2006, 1234, 5, 3, 'Playoff injury');
+        $result = TrnFileParser::parseRecord($record, 0);
+
+        $this->assertNotNull($result);
+        $this->assertSame(\Season\Season::IBL_PLAYOFF_MONTH, $result['month']);
+        $this->assertSame(5, $result['day']);
+    }
+
+    public function testParseRecordDoesNotRemapNonPlayoffMonths(): void
+    {
+        $record = $this->buildInjuryRecord(11, 3, 2006, 5678, 12, 8, 'Regular season injury');
+        $result = TrnFileParser::parseRecord($record, 0);
+
+        $this->assertNotNull($result);
+        $this->assertSame(11, $result['month']);
+    }
+
     public function testInjuryGamesMissedAreReasonable(): void
     {
         $injury1 = $this->buildInjuryRecord(10, 1, 2006, 1000, 5, 5, 'Minor bruise');

--- a/ibl5/tests/JsbParser/TrnFileWriterTest.php
+++ b/ibl5/tests/JsbParser/TrnFileWriterTest.php
@@ -212,6 +212,30 @@ class TrnFileWriterTest extends TestCase
         }
     }
 
+    public function testPlayoffMonthRoundTrip(): void
+    {
+        // Write with IBL playoff month (6), which Writer converts to JSB month (10) in binary
+        $record = TrnFileWriter::buildInjuryRecord(6, 15, 2006, 1234, 5, 3, 'Playoff injury');
+        $data = TrnFileWriter::generate([$record]);
+
+        $tmpFile = $this->writeTmpFile($data);
+        try {
+            $result = TrnFileParser::parseFile($tmpFile);
+
+            $injuries = array_values(array_filter(
+                $result['transactions'],
+                static fn (array $t): bool => $t['type'] === TrnFileParser::TYPE_INJURY
+            ));
+
+            $this->assertCount(1, $injuries);
+            // Writer converts 6→10, Parser converts 10→6: round-trip preserves the value
+            $this->assertSame(\Season\Season::IBL_PLAYOFF_MONTH, $injuries[0]['month']);
+            $this->assertSame(15, $injuries[0]['day']);
+        } finally {
+            unlink($tmpFile);
+        }
+    }
+
     public function testEmptyFileGeneration(): void
     {
         $data = TrnFileWriter::generate([]);


### PR DESCRIPTION
## Summary

JSB stores playoff transactions with `month=10` internally, but the IBL calendar defines month 10 as HEAT (October preseason) and month 6 as playoffs (June). The import pipeline stored the raw JSB value without remapping, so all 17 seasons (1989-2007) of playoff injuries, trades, and waivers showed `transaction_month=10` instead of `6`.

## Changes

- **TrnFileParser**: Add `JSB_PLAYOFF_MONTH` constant; remap month 10 → 6 at parse time in `parseRecord()`
- **TrnFileWriter**: Add `toJsbMonth()` reverse mapping (6 → 10) for writing back to `.trn` binary format
- **Migration 107**: UPDATE all existing `ibl_jsb_transactions` rows from `transaction_month=10` to `transaction_month=6`
- **Tests**: Remap test, non-remap test, and round-trip test

## Why not unify with SchFileParser?

`SchFileParser::dateSlotToMonthDay()` converts positional offsets (0-11, where 0=October) to calendar months via modular arithmetic. The TRN fix is a single-value remap (10→6). Different problems, different solutions.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.