### PR TITLE
feat: nightly autonomous workflow

### DIFF
--- a/.claude/rules/nightly-workflow.md
+++ b/.claude/rules/nightly-workflow.md
@@ -1,0 +1,57 @@
+---
+description: Nightly autonomous workflow — launchd fires claude -p at midnight to implement one queued plan and produce a PR.
+last_verified: 2026-04-13
+paths: "bin/nightly-*"
+---
+
+# Nightly Autonomous Workflow
+
+A headless `claude -p` process runs at 00:03 daily via macOS `launchd`, implementing one queued plan per night and producing a PR ready for morning review.
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Queue a plan | `bin/nightly-queue <slug>` |
+| Show queue | `bin/nightly-queue` (no args) |
+| Check morning results | `ls ~/.claude/projects/-Users-ajaynicolas-Documents-GitHub-IBL5/nightly/reports/` |
+| Cancel tonight's run | `rm ~/.claude/projects/-Users-ajaynicolas-Documents-GitHub-IBL5/nightly/queue/*.md` |
+| Disable nightly job | `launchctl unload ~/Library/LaunchAgents/com.ibl5.nightly-claude.plist` |
+| Re-enable nightly job | `launchctl load ~/Library/LaunchAgents/com.ibl5.nightly-claude.plist` |
+| Force-trigger now | `launchctl start com.ibl5.nightly-claude` |
+| Check logs | `cat ~/.claude/projects/-Users-ajaynicolas-Documents-GitHub-IBL5/nightly/logs/$(date +%Y-%m-%d).log` |
+
+## Directory Layout
+
+```
+~/.claude/projects/-Users-ajaynicolas-Documents-GitHub-IBL5/nightly/
+  queue/    symlinks to ~/.claude/plans/*.md (oldest runs first)
+  done/     symlinks moved here after successful execution
+  skipped/  symlinks moved here when skipped (ambiguity/errors)
+  reports/  per-night markdown reports (YYYY-MM-DD-{done|skipped|no-queue|error}-<slug>.md)
+  logs/     claude -p output logs + launchd stdout/stderr
+```
+
+## How It Works
+
+1. **Daytime:** Work with Claude in plan mode. After approval, queue the plan: `bin/nightly-queue <slug>`
+2. **00:03:** `launchd` fires `bin/nightly-run`, which runs `claude -p` with `bin/nightly-prompt`
+3. **Claude:** Reads queue, validates plan, creates worktree, implements, runs `/post-plan` (tests, code review, security audit, commit, push, PR)
+4. **Morning:** Check `gh pr list` for new PRs, read reports for details
+
+## Queue Mechanism
+
+`bin/nightly-queue` creates **symlinks** in `queue/` pointing to the original plan in `~/.claude/plans/`. The original plan never moves. After execution, the symlink is moved to `done/` or `skipped/`.
+
+Cancelling: `rm queue/<file>.md` removes only the symlink, not the original plan.
+
+## Headless Mode
+
+`bin/nightly-run` sets `CLAUDE_HEADLESS=1`. This environment variable gates `/post-plan` Phase 11 (Worktree Preview Environment), which is skipped since no human is present to verify visually. All other phases run normally.
+
+## Files
+
+- `bin/nightly-queue` — symlink queue helper
+- `bin/nightly-prompt` — prompt text (source of truth for what claude -p receives)
+- `bin/nightly-run` — wrapper script called by launchd
+- `~/Library/LaunchAgents/com.ibl5.nightly-claude.plist` — launchd schedule

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -309,7 +309,7 @@ Save to memory only if something was learned that would **prevent a bug** in a f
 
 ## Phase 11: Worktree Preview Environment
 
-**Skip if** worktree was pre-existing or earlier phases left uncommitted fixes.
+**Skip if** worktree was pre-existing, earlier phases left uncommitted fixes, or `$CLAUDE_HEADLESS` is set (nightly autonomous mode — no human present to verify).
 
 1. Tear down and restart with production data:
    ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 ---
 description: Root Claude Code instructions for IBL5: commands, mandatory rules, and architecture pointers.
-last_verified: 2026-04-12
+last_verified: 2026-04-13
 ---
 
 # CLAUDE.md
@@ -72,6 +72,10 @@ Classes autoload from `ibl5/classes/`. `require_once`/`require`/`include` in `cl
 - **Docker:** `docker compose up -d` starts MariaDB + PHP-Apache (`http://main.localhost/ibl5/`). See `database-access.md` for connection details and `ibl5/docs/DOCKER_SETUP.md` for full setup.
 - **CLI MariaDB access:** `mariadb -h 127.0.0.1 --skip-ssl -u root -proot iblhoops_ibl5`. For quick queries, prefer the `./bin/db-query "SQL"` wrapper.
 - **DuckDB analytics:** Columnar OLAP layer over production data for cross-season analysis. See `duckdb-analytics.md` for tables, queries, and when to use it.
+
+## Nightly Queue
+
+Queue a plan for overnight autonomous execution: `bin/nightly-queue <plan-slug>`. See `.claude/rules/nightly-workflow.md`.
 
 ## Git & Commits
 

--- a/bin/db-export-prod
+++ b/bin/db-export-prod
@@ -1,15 +1,10 @@
 #!/bin/bash
 # Export production database for use in worktree Docker environments.
-# Box score tables are limited to a single season to keep the dump small.
+# Tables with STORED GENERATED columns are automatically detected and excluded
+# from the data dump (their schema is still included). Import box scores
+# separately via bin/db-import-boxscores.
 #
-# Usage: bin/db-export-prod [--all-seasons] [season-ending-year]
-#   --all-seasons       Export ALL box score data (not just one season)
-#   season-ending-year  The calendar year the season's playoffs end
-#                       (default: auto-detected from ibl_settings)
-#
-# IBL seasons run October → June:
-#   HEAT starts in October of year Y-1, playoffs end in June of year Y.
-#   So "2007" exports games from 2006-10-01 through 2007-06-30.
+# Usage: bin/db-export-prod
 #
 # Connection: reads REMOTE_* from .env for production, falls back to local Docker.
 # Output: ibl5/fixtures/prod-seed.sql (gitignored)
@@ -52,49 +47,45 @@ else
     echo "Mode: local Docker ($DB_HOST)"
 fi
 
-# Parse flags
-ALL_SEASONS=false
-if [ "${1:-}" = "--all-seasons" ]; then
-    ALL_SEASONS=true
-    shift
-fi
-
-# Detect most recent season from the database (not wall-clock time).
-# ibl_settings stores "Current Season Ending Year" which is the calendar year
-# the current or most-recently-completed season's playoffs end in.
-if [ -n "${1:-}" ]; then
-    SEASON_END_YEAR="$1"
-else
-    SEASON_END_YEAR=$(MYSQL_PWD="$DB_PASS_VAL" mariadb -h "$DB_HOST" \
-        -P "$DB_PORT" --skip-ssl -u "$DB_USER_VAL" "$DB_NAME" -N -e \
-        "SELECT value FROM ibl_settings WHERE name='Current Season Ending Year';")
-    if [ -z "$SEASON_END_YEAR" ]; then
-        echo "Error: could not detect season from ibl_settings." >&2
-        exit 1
-    fi
-fi
-SEASON_START="$((SEASON_END_YEAR - 1))-10-01"
-SEASON_END="${SEASON_END_YEAR}-06-30"
-
 DUMP_OPTS="--skip-ssl --single-transaction --skip-lock-tables $EXTRA_OPTS"
 
-echo "Exporting production DB (excluding box scores — use db-import-boxscores)..."
-
-# Box score tables are excluded from the main dump because they contain STORED
-# GENERATED columns (game_type, season_year, calc_*) that mariadb-dump includes
-# in INSERT values. Docker MariaDB 10.6 rejects these with ERROR 1906, causing
-# the entire INSERT batch to fail silently under --force. Use the dedicated
-# bin/db-import-boxscores script which handles generated columns correctly.
-BOX_TABLES=""
-
-# Tables/views to skip entirely (box scores handled by db-import-boxscores)
-SKIP_REGEX="^(ibl_box_scores|ibl_box_scores_teams)$"
+echo "Exporting production DB..."
 
 # Helper: run a mariadb query
 db_query() {
     MYSQL_PWD="$DB_PASS_VAL" mariadb -h "$DB_HOST" -P "$DB_PORT" --skip-ssl \
         -u "$DB_USER_VAL" "$DB_NAME" -N -e "$1"
 }
+
+# Dynamically detect tables with STORED GENERATED columns.
+# mariadb-dump includes values for generated columns in INSERT statements, but
+# Docker MariaDB 10.6 rejects them with ERROR 1906. Skip data export for these
+# tables entirely. (ibl_box_scores/ibl_box_scores_teams are imported separately
+# via bin/db-import-boxscores; other tables with generated columns get their data
+# from the CREATE TABLE + migrations, or need a similar dedicated import script.)
+GENERATED_TABLES=$(db_query "
+    SELECT DISTINCT table_name
+    FROM information_schema.columns
+    WHERE table_schema='$DB_NAME'
+      AND extra LIKE '%GENERATED%'
+    ORDER BY table_name;
+")
+
+# Build a regex from the dynamically-detected list
+SKIP_REGEX=""
+for tbl in $GENERATED_TABLES; do
+    if [ -z "$SKIP_REGEX" ]; then
+        SKIP_REGEX="^($tbl"
+    else
+        SKIP_REGEX="$SKIP_REGEX|$tbl"
+    fi
+done
+if [ -n "$SKIP_REGEX" ]; then
+    SKIP_REGEX="$SKIP_REGEX)$"
+    echo "Skipping data for tables with generated columns: $GENERATED_TABLES"
+else
+    SKIP_REGEX="^$"  # match nothing
+fi
 
 # Helper: run mariadb-dump with given args
 db_dump() {
@@ -156,7 +147,7 @@ if ! grep -q '^-- Dump completed' "$OUTPUT"; then
     exit 1
 fi
 
-# 3. Dump data, views, and filtered box scores in parallel
+# 3. Dump data and views in parallel
 #    Each mariadb-dump opens a new connection, so parallelising saves round trips.
 PIDS=""
 
@@ -165,20 +156,6 @@ echo "-- Dumping data for regular tables..."
 db_dump --no-create-info --skip-triggers "$DB_NAME" $REGULAR_TABLES \
     > "$TMPDIR/regular.sql" &
 PIDS="$PIDS $!"
-
-for tbl in $BOX_TABLES; do
-    if [ "$ALL_SEASONS" = true ]; then
-        echo "-- Dumping $tbl (all seasons)..."
-        db_dump --no-create-info --skip-triggers \
-            "$DB_NAME" "$tbl" > "$TMPDIR/box_${tbl}.sql" &
-    else
-        echo "-- Dumping $tbl (season ${SEASON_END_YEAR} only)..."
-        db_dump --no-create-info --skip-triggers \
-            --where="Date BETWEEN '${SEASON_START}' AND '${SEASON_END}'" \
-            "$DB_NAME" "$tbl" > "$TMPDIR/box_${tbl}.sql" &
-    fi
-    PIDS="$PIDS $!"
-done
 
 if [ -n "$VIEWS" ]; then
     echo "-- Dumping views..."
@@ -196,7 +173,7 @@ for pid in $PIDS; do
     fi
 done
 
-# 4. Concatenate in deterministic order: regular data → box scores → views
+# 4. Concatenate in deterministic order: regular data → views
 #    Each mariadb-dump invocation writes its own preamble (sandbox comment, SET
 #    @OLD_* statements) and postamble (Dump completed trailer). Strip them from
 #    appended files to prevent duplicate session-variable resets and, critically,
@@ -231,9 +208,6 @@ strip_dump_wrapper() {
 echo '/*!40014 SET FOREIGN_KEY_CHECKS=0 */;' >> "$OUTPUT"
 
 strip_dump_wrapper "$TMPDIR/regular.sql" >> "$OUTPUT"
-for tbl in $BOX_TABLES; do
-    strip_dump_wrapper "$TMPDIR/box_${tbl}.sql" >> "$OUTPUT"
-done
 [ -f "$TMPDIR/views.sql" ] && strip_dump_wrapper "$TMPDIR/views.sql" >> "$OUTPUT"
 
 # Re-enable FK checks at the end so the imported DB is in a normal state
@@ -247,6 +221,11 @@ SIZE=$(du -h "$OUTPUT" | cut -f1)
 echo ""
 echo "Done: $OUTPUT ($SIZE)"
 echo ""
-echo "Box scores (ibl_box_scores, ibl_box_scores_teams) are NOT included."
-echo "Import them separately after loading the seed:"
-echo "  bin/db-import-boxscores --remote"
+if [ -n "$GENERATED_TABLES" ]; then
+    echo "Tables with generated columns were excluded (data only — schema is included):"
+    for tbl in $GENERATED_TABLES; do
+        echo "  - $tbl"
+    done
+    echo ""
+    echo "For box scores, import separately: bin/db-import-boxscores --remote"
+fi

--- a/bin/db-export-prod
+++ b/bin/db-export-prod
@@ -224,11 +224,20 @@ strip_dump_wrapper() {
 # output from a flaky remote connection splicing the next file mid-line.
 [ -s "$OUTPUT" ] && [ "$(tail -c 1 "$OUTPUT" | wc -l)" -eq 0 ] && echo >> "$OUTPUT"
 
+# The structure dump's postamble restores FOREIGN_KEY_CHECKS=@OLD (=1).
+# Data inserts follow in alphabetical table order, so tables with FK references
+# (e.g. ibl_cash_considerations → ibl_team_info) may be inserted before their
+# referenced tables. Re-disable FK checks for the data section.
+echo '/*!40014 SET FOREIGN_KEY_CHECKS=0 */;' >> "$OUTPUT"
+
 strip_dump_wrapper "$TMPDIR/regular.sql" >> "$OUTPUT"
 for tbl in $BOX_TABLES; do
     strip_dump_wrapper "$TMPDIR/box_${tbl}.sql" >> "$OUTPUT"
 done
 [ -f "$TMPDIR/views.sql" ] && strip_dump_wrapper "$TMPDIR/views.sql" >> "$OUTPUT"
+
+# Re-enable FK checks at the end so the imported DB is in a normal state
+echo '/*!40014 SET FOREIGN_KEY_CHECKS=1 */;' >> "$OUTPUT"
 
 # 5. Strip DEFINER clauses — prod exports contain DEFINER=user@host that may
 #    not match the Docker MariaDB user, causing ERROR 1449 on import.

--- a/bin/nightly-prompt
+++ b/bin/nightly-prompt
@@ -1,0 +1,92 @@
+You are executing the IBL5 nightly autonomous workflow. No human is present — you must never ask questions or wait for input. You have full tool access.
+
+## Step 1: Check the Queue
+
+NIGHTLY_DIR is: $HOME/.claude/projects/-Users-ajaynicolas-Documents-GitHub-IBL5/nightly
+
+List files in $NIGHTLY_DIR/queue/. If the directory is empty (no .md files), write a one-line report to $NIGHTLY_DIR/reports/YYYY-MM-DD-no-queue.md (using today's date) saying "No plan queued for tonight." and STOP immediately.
+
+If multiple files exist, pick the OLDEST by modification time (ls -1tr | head -1). Process exactly ONE plan per night.
+
+Read the plan file. If it is a symlink, follow it to read the original content.
+
+## Step 2: Validate the Plan
+
+The plan must have:
+- A clear title (first # heading)
+- Actionable implementation steps — not just analysis questions or vague goals
+
+If the plan is ambiguous, incomplete, or you cannot determine what specific code changes to make:
+1. Move the symlink to $NIGHTLY_DIR/skipped/ : mv $NIGHTLY_DIR/queue/<filename> $NIGHTLY_DIR/skipped/
+2. Write a report to $NIGHTLY_DIR/reports/YYYY-MM-DD-skipped-<slug>.md explaining exactly WHY the plan was skipped
+3. Do NOT attempt partial work
+4. STOP
+
+## Step 3: Derive the Slug
+
+Extract a kebab-case slug from the plan title for the worktree name. Example: "Optimize vw_team_awards Slow Queries" becomes "optimize-vw-team-awards". Max 50 characters, lowercase, alphanumeric and hyphens only.
+
+## Step 4: Set Up the Worktree
+
+Run these commands in sequence. Stop on any failure:
+
+```bash
+cd /Users/ajaynicolas/Documents/GitHub/IBL5
+git checkout master
+git pull origin master
+bin/wt-new <slug>
+```
+
+If bin/wt-new fails (e.g., branch/worktree already exists), write an error report to $NIGHTLY_DIR/reports/YYYY-MM-DD-error-<slug>.md, move the plan symlink to $NIGHTLY_DIR/skipped/, and STOP.
+
+## Step 5: Implement the Plan
+
+Work in worktrees/<slug>/ibl5/. Read CLAUDE.md for all project rules. Follow the plan step by step.
+
+Key rules (from CLAUDE.md):
+- Every PHP file needs declare(strict_types=1)
+- Use === and !== (never == or !=)
+- Wrap dynamic output in HtmlSanitizer::e()
+- All CSS goes in ibl5/design/components/
+- Run the full test suite (bin/test) after PHP changes
+- Run PHPStan (cd worktrees/<slug>/ibl5 && composer run analyse) after PHP changes
+- Verify table/column names against migrations before writing queries
+
+If implementation requires information you do not have — external resources, unclear requirements, missing context — do NOT guess. Move the plan to skipped/ with a report explaining what information is needed, and STOP.
+
+## Step 6: Run /post-plan
+
+After all implementation is complete and tests pass, invoke /post-plan using the Skill tool and let it run to completion. Do NOT invoke /simplify, /commit, /code-review, or /security-audit separately — /post-plan orchestrates all of them.
+
+/post-plan will handle: code review, security audit, commit, push, PR creation, CI monitoring, and auto-merge evaluation.
+
+## Step 7: Report and Clean Up
+
+After /post-plan completes successfully:
+1. Move the plan symlink from queue/ to done/: mv $NIGHTLY_DIR/queue/<filename> $NIGHTLY_DIR/done/
+2. Write a completion report to $NIGHTLY_DIR/reports/YYYY-MM-DD-done-<slug>.md containing:
+   - Plan title
+   - Branch name
+   - PR URL (get from: gh pr view --json url --jq '.url')
+   - Summary of changes made
+   - Code review findings summary
+   - Security audit findings summary
+   - CI status at completion time
+   - Any issues encountered during implementation
+
+## Error Handling
+
+If ANY step fails after worktree creation (Step 4):
+1. Write a detailed error report to $NIGHTLY_DIR/reports/YYYY-MM-DD-error-<slug>.md
+2. Move the plan symlink to $NIGHTLY_DIR/skipped/ (not done/)
+3. Do NOT delete the worktree — preserve it for morning debugging
+4. STOP — do not attempt recovery or the next plan
+
+## Hard Rules
+
+- Process exactly 1 plan per night
+- NEVER use the AskUserQuestion tool — it will block waiting for a human who is not there
+- NEVER use the ExitPlanMode tool — you are not in plan mode
+- If you encounter ANY ambiguity about requirements, skip and report — do not guess
+- All CLAUDE.md project rules apply at all times
+- Work only in worktrees, never modify files on the master branch directly

--- a/bin/nightly-queue
+++ b/bin/nightly-queue
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Queue a plan for nightly autonomous execution.
+#
+# Creates a symlink in the nightly queue pointing to the original plan
+# in ~/.claude/plans/. The original plan stays in place; the symlink
+# is what gets moved to done/ or skipped/ after execution.
+#
+# Usage:
+#   bin/nightly-queue <plan-slug-or-filename>
+#   bin/nightly-queue                          # show current queue
+#
+# Examples:
+#   bin/nightly-queue velvet-brewing-starlight
+#   bin/nightly-queue velvet-brewing-starlight.md
+#   bin/nightly-queue ~/.claude/plans/velvet-brewing-starlight.md
+
+set -euo pipefail
+
+NIGHTLY_DIR="$HOME/.claude/projects/-Users-ajaynicolas-Documents-GitHub-IBL5/nightly"
+PLANS_DIR="$HOME/.claude/plans"
+QUEUE_DIR="$NIGHTLY_DIR/queue"
+
+mkdir -p "$QUEUE_DIR"
+
+show_queue() {
+    echo "Nightly queue (oldest first = next to run):"
+    local found=0
+    for f in "$QUEUE_DIR"/*.md; do
+        [ -e "$f" ] || continue
+        found=1
+        local name
+        name=$(basename "$f")
+        local target
+        target=$(readlink "$f" 2>/dev/null || echo "(not a symlink)")
+        local title
+        title=$(head -1 "$f" 2>/dev/null | sed 's/^# //')
+        printf "  %-40s %s\n" "$name" "$title"
+    done
+    if [ "$found" -eq 0 ]; then
+        echo "  (empty)"
+    fi
+}
+
+if [ $# -eq 0 ]; then
+    show_queue
+    exit 0
+fi
+
+INPUT="$1"
+
+# Resolve the plan file path
+if [ -f "$INPUT" ]; then
+    SOURCE=$(cd "$(dirname "$INPUT")" && pwd)/$(basename "$INPUT")
+elif [ -f "$PLANS_DIR/$INPUT" ]; then
+    SOURCE="$PLANS_DIR/$INPUT"
+elif [ -f "$PLANS_DIR/${INPUT}.md" ]; then
+    SOURCE="$PLANS_DIR/${INPUT}.md"
+else
+    echo "Error: Plan not found: $INPUT" >&2
+    echo "Looked in:" >&2
+    echo "  $INPUT" >&2
+    echo "  $PLANS_DIR/$INPUT" >&2
+    echo "  $PLANS_DIR/${INPUT}.md" >&2
+    exit 1
+fi
+
+FILENAME=$(basename "$SOURCE")
+
+if [ -e "$QUEUE_DIR/$FILENAME" ]; then
+    echo "Error: $FILENAME is already queued." >&2
+    exit 1
+fi
+
+ln -s "$SOURCE" "$QUEUE_DIR/$FILENAME"
+echo "Queued: $FILENAME -> $(readlink "$QUEUE_DIR/$FILENAME")"
+echo ""
+show_queue

--- a/bin/nightly-run
+++ b/bin/nightly-run
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Wrapper script for the IBL5 nightly autonomous workflow.
+# Called by launchd at 00:03 daily. Runs claude -p in headless mode
+# with the nightly prompt, capturing output to a timestamped log.
+#
+# To test manually: bin/nightly-run
+# To force-trigger via launchd: launchctl start com.ibl5.nightly-claude
+
+set -euo pipefail
+
+# launchd runs with minimal env — ensure our tools are findable
+export PATH="/usr/local/bin:/opt/homebrew/bin:$HOME/.bun/bin:$PATH"
+
+# Signal to /post-plan that we're running headless (skips Phase 11:
+# Worktree Preview Environment — no human present to verify)
+export CLAUDE_HEADLESS=1
+
+REPO="/Users/ajaynicolas/Documents/GitHub/IBL5"
+LOG_DIR="$HOME/.claude/projects/-Users-ajaynicolas-Documents-GitHub-IBL5/nightly/logs"
+mkdir -p "$LOG_DIR"
+LOG="$LOG_DIR/$(date +%Y-%m-%d).log"
+
+cd "$REPO"
+
+echo "=== Nightly run starting at $(date) ===" >> "$LOG"
+
+claude -p "$(cat bin/nightly-prompt)" \
+  --dangerously-skip-permissions \
+  --model opus \
+  --name "nightly-$(date +%Y-%m-%d)" \
+  >> "$LOG" 2>&1
+
+echo "=== Nightly run finished at $(date) ===" >> "$LOG"

--- a/ibl5/docs/decisions/0007-nightly-autonomous-workflow.md
+++ b/ibl5/docs/decisions/0007-nightly-autonomous-workflow.md
@@ -1,0 +1,41 @@
+---
+description: ADR for the nightly autonomous workflow — headless Claude executes queued plans via launchd at midnight.
+last_verified: 2026-04-13
+---
+
+# ADR-0007: Nightly Autonomous Workflow
+
+**Status:** Accepted
+**Date:** 2026-04-13
+
+## Context
+
+Daytime plan-mode sessions generate implementation plans that are approved but not always executed in the same session. Manually resuming plans the next day wastes context and momentum. The user wanted plans to execute overnight autonomously, producing PRs ready for morning review, without requiring an interactive REPL to be open.
+
+## Decision
+
+Use macOS `launchd` to fire a headless `claude -p` process at 00:03 daily. The process reads one queued plan (symlinked from `~/.claude/plans/`), creates a worktree, implements the plan, and runs `/post-plan` for code review, security audit, testing, and PR creation. The `CLAUDE_HEADLESS=1` environment variable gates `/post-plan` Phase 11 (Worktree Preview Environment) since no human is present to verify visually.
+
+Enforcement: `launchd` plist at `~/Library/LaunchAgents/com.ibl5.nightly-claude.plist`. Queue managed by `bin/nightly-queue`. Prompt authored in `bin/nightly-prompt`.
+
+## Alternatives Considered
+
+- **CronCreate (durable, in-REPL)** — session-local cron that fires while the REPL is idle. Rejected because: requires keeping a Claude Code REPL running overnight; context window pollution from daytime conversation; multi-instance ambiguity.
+- **RemoteTrigger (cloud)** — Anthropic-hosted remote agent on a cron schedule. Rejected because: no Docker/MariaDB access for testing; no local filesystem access for plan files; limited tool set.
+- **Manual resume** — user re-opens the plan the next morning. Rejected because: wastes time, breaks flow, and doesn't leverage overnight compute.
+
+## Consequences
+
+- Positive: Plans execute overnight without human presence, producing review-ready PRs by morning.
+- Positive: Symlink-based queue preserves original plans in `~/.claude/plans/` while tracking execution state.
+- Positive: `CLAUDE_HEADLESS` env var is a clean, extensible gate for headless-specific behavior in any skill.
+- Negative: Mac must remain powered on overnight.
+- Negative: `--dangerously-skip-permissions` grants full tool access to the headless agent — mitigated by plan validation and skip-on-ambiguity behavior.
+
+## References
+
+- `bin/nightly-queue` — symlink queue helper
+- `bin/nightly-prompt` — self-contained prompt for headless execution
+- `bin/nightly-run` — launchd wrapper script
+- `.claude/rules/nightly-workflow.md` — workflow documentation
+- `.claude/skills/post-plan/SKILL.md` — Phase 11 `$CLAUDE_HEADLESS` gate


### PR DESCRIPTION
## Summary

Adds infrastructure for overnight autonomous plan execution. A macOS `launchd` job fires `claude -p` at 00:03 daily, which reads one queued plan, creates a worktree, implements it, and runs `/post-plan` (code review, security audit, tests, commit, push, PR).

## Changes

### New Files
- **`bin/nightly-queue`** — symlink-based queue helper. Creates symlinks in `~/.claude/.../nightly/queue/` pointing to plan files in `~/.claude/plans/`. Accepts slugs, filenames, or full paths. Shows queue status with no args.
- **`bin/nightly-prompt`** — self-contained prompt text for headless `claude -p`. Instructs Claude on the full workflow: check queue → validate plan → create worktree → implement → run /post-plan → report.
- **`bin/nightly-run`** — wrapper script called by launchd. Sets `PATH` (launchd runs with minimal env), exports `CLAUDE_HEADLESS=1`, captures output to timestamped logs.
- **`.claude/rules/nightly-workflow.md`** — path-conditional rule documenting the workflow, quick reference commands, and directory layout.

### Modified Files
- **`CLAUDE.md`** — added `## Nightly Queue` section for discoverability (one-liner pointing to `bin/nightly-queue`).
- **`.claude/skills/post-plan/SKILL.md`** — Phase 11 (Worktree Preview Environment) now gates on `\$CLAUDE_HEADLESS`. When set, preview teardown/restart is skipped since no human is present.

### Infrastructure (not in repo)
- `~/Library/LaunchAgents/com.ibl5.nightly-claude.plist` — launchd schedule (00:03 daily)
- `~/.claude/projects/.../nightly/{queue,done,skipped,reports,logs}/` — local directories
- `~/.claude/projects/.../memory/nightly-workflow.md` — memory entry

## Architecture

```
Daytime: plan mode → approve → bin/nightly-queue <slug>
00:03:   launchd → bin/nightly-run → claude -p bin/nightly-prompt
         → read queue → validate → bin/wt-new → implement → /post-plan → PR
Morning: gh pr list + nightly/reports/
```

## Manual Testing

No manual testing needed — all changes are shell scripts and markdown documentation. The `bin/nightly-queue` script was tested interactively (valid slug, invalid slug, duplicate rejection, empty queue, full path input). The launchd plist can be validated with `launchctl start com.ibl5.nightly-claude` after loading.