### PR TITLE
fix: stabilize flaky E2E tests and add News link accessibility labels

### DIFF
--- a/ibl5/tests/e2e/flows/career-leaderboards.spec.ts
+++ b/ibl5/tests/e2e/flows/career-leaderboards.spec.ts
@@ -61,14 +61,33 @@ test.describe('Career Leaderboards flow', () => {
   });
 
   test('include/exclude retirees toggle changes results', async ({ page }) => {
+    // Raise display limit so the single seeded retiree is not truncated below
+    // the default top-N cutoff (default ranks would leave both counts equal).
+    // Wait for the HTMX-boosted POST response between submissions — otherwise
+    // the row count reads the previous render.
+    await page.locator('input[name="display"]').fill('500');
     await page.locator('select[name="active"]').selectOption('0');
-    await page.locator('.ibl-filter-form__submit').click();
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('CareerLeaderboards') && r.request().method() === 'POST'),
+      page.locator('.ibl-filter-form__submit').click(),
+    ]);
     await expect(page.locator('.ibl-data-table').first()).toBeVisible();
     const withRetireesCount = await page.locator('.ibl-data-table').first().locator('tbody tr').count();
 
+    await page.locator('input[name="display"]').fill('500');
     await page.locator('select[name="active"]').selectOption('1');
-    await page.locator('.ibl-filter-form__submit').click();
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('CareerLeaderboards') && r.request().method() === 'POST'),
+      page.locator('.ibl-filter-form__submit').click(),
+    ]);
     await expect(page.locator('.ibl-data-table').first()).toBeVisible();
+    // Poll the row count to let HTMX finish the swap before we read.
+    await expect
+      .poll(
+        async () =>
+          page.locator('.ibl-data-table').first().locator('tbody tr').count(),
+      )
+      .toBeLessThan(withRetireesCount);
     const withoutRetireesCount = await page.locator('.ibl-data-table').first().locator('tbody tr').count();
 
     expect(withRetireesCount).toBeGreaterThan(0);

--- a/ibl5/tests/e2e/flows/trading-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/trading-submission.spec.ts
@@ -649,7 +649,10 @@ test.describe('Trade submission: accept and reject', () => {
       rejectBtn.click(),
     ]);
 
-    await expect(page.locator('.ibl-alert--warning')).toBeVisible();
+    // Scope by text — admin phase-gate notice may share .ibl-alert--warning.
+    await expect(
+      page.locator('.ibl-alert--warning').filter({ hasText: 'already' }),
+    ).toBeVisible();
   });
 
   test('accept offer via UI', async ({ appState, page, request }) => {

--- a/ibl5/tests/e2e/flows/trading.spec.ts
+++ b/ibl5/tests/e2e/flows/trading.spec.ts
@@ -690,8 +690,14 @@ test.describe('Trading: result banners', () => {
       page,
       'modules.php?name=Trading&op=reviewtrade&result=already_processed',
     );
-    await expect(page.locator('.ibl-alert--warning')).toBeVisible();
-    await expect(page.locator('.ibl-alert--warning')).toContainText(
+    // Scope by text — the admin phase-gate notice ("Admin mode: …") shares
+    // the .ibl-alert--warning class and bleeds in when a prior parallel test
+    // switched the shared session to Olympics (Trading is IBL-only).
+    const banner = page.locator('.ibl-alert--warning').filter({
+      hasText: 'already been accepted',
+    });
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(
       'already been accepted, declined, or withdrawn',
     );
   });

--- a/ibl5/themes/IBL/theme.php
+++ b/ibl5/themes/IBL/theme.php
@@ -138,9 +138,11 @@ function themeindex($aid, $informant, $time, $title, $counter, $topic, $thetext,
 
     $articleClass = $isTransaction ? 'news-article news-article--transaction' : 'news-article';
 
+    $topicLinkLabel = $safeTopictext !== '' ? $safeTopictext : 'View topic';
+
     $topicIconHtml = '';
     if (!empty($t_image) && file_exists($t_image)) {
-        $topicIconHtml = '<a href="modules.php?name=News&amp;new_topic=' . (int)$topic . '" class="news-article__topic-icon-link"><img src="' . \Utilities\HtmlSanitizer::safeHtmlOutput($t_image) . '" alt="' . $safeTopictext . '" class="news-article__topic-icon" loading="lazy"></a>';
+        $topicIconHtml = '<a href="modules.php?name=News&amp;new_topic=' . (int)$topic . '" class="news-article__topic-icon-link" aria-label="' . $topicLinkLabel . '"><img src="' . \Utilities\HtmlSanitizer::safeHtmlOutput($t_image) . '" alt="' . $safeTopictext . '" class="news-article__topic-icon" loading="lazy"></a>';
     }
 
     echo '<article class="' . $articleClass . '">
@@ -182,7 +184,7 @@ function themeindex($aid, $informant, $time, $title, $counter, $topic, $thetext,
     echo '</div>
         <footer class="news-article__footer">
             <div>' . $morelink . '</div>
-            <a href="modules.php?name=News&amp;new_topic=' . (int)$topic . '" class="news-article__link">
+            <a href="modules.php?name=News&amp;new_topic=' . (int)$topic . '" class="news-article__link" aria-label="' . $topicLinkLabel . '">
                 ' . $safeTopictext . '
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
             </a>
@@ -223,9 +225,11 @@ function themearticle($aid, $informant, $datetime, $title, $thetext, $topic, $to
         }
     }
 
+    $topicLinkLabel = $safeTopictext !== '' ? $safeTopictext : 'View topic';
+
     $topicIconHtml = '';
     if (!empty($t_image) && file_exists($t_image)) {
-        $topicIconHtml = '<a href="modules.php?name=News&amp;new_topic=' . (int)$topic . '" class="news-article__topic-icon-link"><img src="' . \Utilities\HtmlSanitizer::safeHtmlOutput($t_image) . '" alt="' . $safeTopictext . '" class="news-article__topic-icon" loading="lazy"></a>';
+        $topicIconHtml = '<a href="modules.php?name=News&amp;new_topic=' . (int)$topic . '" class="news-article__topic-icon-link" aria-label="' . $topicLinkLabel . '"><img src="' . \Utilities\HtmlSanitizer::safeHtmlOutput($t_image) . '" alt="' . $safeTopictext . '" class="news-article__topic-icon" loading="lazy"></a>';
     }
 
     echo '<article class="news-article" style="max-width: 900px;">
@@ -250,7 +254,7 @@ function themearticle($aid, $informant, $datetime, $title, $thetext, $topic, $to
 
     echo '</div>
         <footer class="news-article__footer">
-            <a href="modules.php?name=News&amp;new_topic=' . (int)$topic . '" class="news-article__link">
+            <a href="modules.php?name=News&amp;new_topic=' . (int)$topic . '" class="news-article__link" aria-label="' . _TOPIC . ': ' . $topicLinkLabel . '">
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>
                 ' . _TOPIC . ': ' . $safeTopictext . '
             </a>


### PR DESCRIPTION
## Summary

Addresses three hard failures observed when running the full Playwright E2E suite locally in a worktree-isolated Docker environment:

### E2E test fixes

- **`trading.spec.ts` / `trading-submission.spec.ts`** — Scope `.ibl-alert--warning` selector by text content.
  Parallel Playwright workers share a single `PHPSESSID` via `playwright/.auth/user.json`, so any Olympics-bound test that calls `?league=olympics` sets `$_SESSION['current_league']='olympics'` for every worker. When later Trading tests run, `LeagueContext::isModuleEnabled('Trading')` returns `false`, `modules.php` defines `ADMIN_PHASE_GATE_NOTICE`, and `PageLayout` renders a second `.ibl-alert--warning` banner, breaking strict-mode selectors.

- **`career-leaderboards.spec.ts`** — Fill `display=500` and await the HTMX-boosted POST response between submissions. The prior click/count pattern read stale row counts because the `hx-boost="true"` container turns the form submit into an AJAX swap rather than a navigation, so `toBeVisible()` returned immediately against the previous table. Also raises the limit so the single seeded retiree is not truncated below the default top-N cutoff.

### Accessibility

- **`themes/IBL/theme.php`** — Add `aria-label` fallbacks on `.news-article__topic-icon-link` and `.news-article__link` (in both `themeindex` and `themearticle`). Some seeded news topics have an empty `$topictext`, which left those links with only an icon/SVG and no accessible name. Axe flagged `link-name` violations on the News index and News categories pages.

## Verification

Full E2E suite ran **3 times in a row** locally against a freshly re-seeded worktree Docker stack (`bin/wt-up e2e-tests-local-pass --seed` + `bin/e2e-wt.sh e2e-tests-local-pass`):

| Run | Passed | Hard failures | Flaky (pass-on-retry) |
|-----|-------:|--------------:|----------------------:|
| 1   | 940    | 0             | 4                     |
| 2   | 940    | 0             | 4                     |
| 3   | 940    | 0             | 4                     |

Remaining flakiness (`trading-submission.spec.ts` reject-offer CSRF timeout, `season-leaderboards` sort/limit races, `topics.spec.ts`, `league-schedule`/`league-control-panel`) is pre-existing and consistently passes on retry.

## Manual Testing

No manual testing needed — all changes are covered by E2E tests.