### PR TITLE
fix: restore position depth ordinals, remove dead role fields

### DIFF
--- a/ibl5/classes/DepthChartEntry/Contracts/DepthChartEntryProcessorInterface.php
+++ b/ibl5/classes/DepthChartEntry/Contracts/DepthChartEntryProcessorInterface.php
@@ -27,18 +27,16 @@ interface DepthChartEntryProcessorInterface
      * 2. For each player, sanitize and validate all 13 depth chart fields
      * 3. Count active players (where canPlayInGame=1)
      *
-     * Position depth columns (pg-c) and minutes are dead fields in JSB — they arrive
-     * as 0 from hidden form inputs. Position depth counting and starter detection
-     * are no longer performed; pos_1-pos_5, hasStarterAtMultiplePositions, and
-     * nameOfProblemStarter are always returned as zero/false/empty for backward compat.
+     * Position depth columns (pg-c) map to CSV columns 1-5 which JSB reads for
+     * lineup selection. Minutes (min) maps to CSV column 7. The OF/DF/OI/DI/BH
+     * columns (CSV 8-12) are dead storage in JSB — hardcoded to 0 in the output.
      *
      * **Sanitization Rules Applied:**
      * - Player names: trim whitespace, remove HTML tags via strip_tags()
-     * - Depth values (pg-c): clamped to 0-5 range (dead field, always 0)
+     * - Depth values (pg-c): clamped to 0-5 range (lineup priority: 1=starter, 2-5=bench depth)
      * - Can Play In Game: normalized to 0 or 1
-     * - Minutes: clamped to 0-40 range (dead field, always 0)
-     * - Focus values (OF/DF): clamped to 0-3 range
-     * - Settings (OI/DI/BH): clamped to 0-2 range (negatives are dead in JSB)
+     * - Minutes: clamped to 0-40 range
+     * - OF/DF/OI/DI/BH: hardcoded to 0 (dead storage in JSB)
      * - Injury flag: converted to int (0 or 1)
      * 
      * @param array<string, mixed> $postData Raw POST data from form submission ($_POST)

--- a/ibl5/classes/DepthChartEntry/Contracts/DepthChartEntryViewInterface.php
+++ b/ibl5/classes/DepthChartEntry/Contracts/DepthChartEntryViewInterface.php
@@ -23,15 +23,14 @@ interface DepthChartEntryViewInterface
     public function renderTeamLogo(int $teamID): void;
 
     /**
-     * Render role priority dropdown options (0 to max)
+     * Render position depth dropdown options (0-5)
      *
-     * Unified for all 5 role slots. Value 0 displays as "—" (not assigned),
-     * values 1+ display as their numeric value.
+     * Options: No(0), 1st(1), 2nd(2), 3rd(3), 4th(4), ok(5).
+     * Maps directly to JSB lineup priority (lower = higher priority).
      *
-     * @param int $selectedValue Currently selected value
-     * @param int $maxValue Maximum option value (2 for BH/DI/OI, 3 for DF/OF)
+     * @param int $selectedValue Currently selected depth value (0-5)
      */
-    public function renderRolePriorityOptions(int $selectedValue, int $maxValue): void;
+    public function renderPositionDepthOptions(int $selectedValue): void;
 
     /**
      * Render the help section explaining how depth charts work.
@@ -48,8 +47,8 @@ interface DepthChartEntryViewInterface
     /**
      * Render complete depth chart form header with table structure
      *
-     * Renders an 8-column table: Pos, Player, Active, PG, SG, SF, PF, C.
-     * The PG-C columns are role slot assignments (mapped to BH/DI/OI/DF/OF form fields).
+     * Renders an 8-column table: Pos, Player, Active, PG, SG, SF, PF, C, Min.
+     * The PG-C columns are position depth assignments (0-5 priority).
      *
      * @param string $teamName Team name to embed in hidden form field
      * @param int $teamID Team ID
@@ -60,9 +59,8 @@ interface DepthChartEntryViewInterface
     /**
      * Render a single player row in the depth chart form
      *
-     * Renders an 8-cell row: Pos, Player (with hidden fields for dead fields),
-     * Active checkbox, Minutes number input (0-40), and 5 role slot selects.
-     * Position depth columns (pg-c) are rendered as hidden inputs with value 0.
+     * Renders an 8-cell row: Pos, Player, Active checkbox, 5 position depth
+     * selects (PG/SG/SF/PF/C with 0-5 options), and Minutes number input (0-40).
      *
      * Player array must include 'quality_score' key (float) for the lineup preview.
      *
@@ -88,7 +86,7 @@ interface DepthChartEntryViewInterface
      * Render depth chart submission result page
      *
      * Shows submitted values in a confirmation table with columns:
-     * Name, Active, PG, SG, SF, PF, C (role slot values).
+     * Name, Active, PG, SG, SF, PF, C, Min (position depth values).
      *
      * @param string $teamName Team name displayed at top of result
      * @param list<ProcessedPlayerData> $playerData Player data submitted
@@ -105,7 +103,7 @@ interface DepthChartEntryViewInterface
     /**
      * Render mobile card view for all players
      *
-     * Renders a card-based layout with a single 5-column role slot grid per card.
+     * Renders a card-based layout with position depth steppers (0-5) per card.
      * All inputs are rendered disabled; JavaScript enables them on mobile viewports.
      *
      * @param list<PlayerRow> $players All players on the team roster

--- a/ibl5/classes/DepthChartEntry/DepthChartEntryProcessor.php
+++ b/ibl5/classes/DepthChartEntry/DepthChartEntryProcessor.php
@@ -23,6 +23,13 @@ class DepthChartEntryProcessor implements DepthChartEntryProcessorInterface
     {
         $activePlayers = 0;
         $playerData = [];
+        $pos1 = 0;
+        $pos2 = 0;
+        $pos3 = 0;
+        $pos4 = 0;
+        $pos5 = 0;
+        $hasStarterAtMultiplePositions = false;
+        $nameOfProblemStarter = '';
 
         for ($i = 1; $i <= $maxPlayers; $i++) {
             if (!isset($postData['Name' . $i])) {
@@ -42,11 +49,11 @@ class DepthChartEntryProcessor implements DepthChartEntryProcessorInterface
                 'c' => $this->sanitizeDepthValue($this->extractIntValue($postData, 'c' . $i)),
                 'canPlayInGame' => $this->sanitizeActiveValue($this->extractIntValue($postData, 'canPlayInGame' . $i)),
                 'min' => $this->sanitizeMinutesValue($this->extractIntValue($postData, 'min' . $i)),
-                'of' => $this->sanitizeFocusValue($this->extractIntValue($postData, 'OF' . $i)),
-                'df' => $this->sanitizeFocusValue($this->extractIntValue($postData, 'DF' . $i)),
-                'oi' => $this->sanitizeSettingValue($this->extractIntValue($postData, 'OI' . $i)),
-                'di' => $this->sanitizeSettingValue($this->extractIntValue($postData, 'DI' . $i)),
-                'bh' => $this->sanitizeSettingValue($this->extractIntValue($postData, 'BH' . $i)),
+                'of' => 0,
+                'df' => 0,
+                'oi' => 0,
+                'di' => 0,
+                'bh' => 0,
                 'injury' => $injury
             ];
 
@@ -55,18 +62,57 @@ class DepthChartEntryProcessor implements DepthChartEntryProcessorInterface
             if ($player['canPlayInGame'] === 1) {
                 $activePlayers++;
             }
+
+            if ($injury === 0) {
+                if ($player['pg'] > 0) {
+                    $pos1++;
+                }
+                if ($player['sg'] > 0) {
+                    $pos2++;
+                }
+                if ($player['sf'] > 0) {
+                    $pos3++;
+                }
+                if ($player['pf'] > 0) {
+                    $pos4++;
+                }
+                if ($player['c'] > 0) {
+                    $pos5++;
+                }
+            }
+
+            $startCount = 0;
+            if ($player['pg'] === 1) {
+                $startCount++;
+            }
+            if ($player['sg'] === 1) {
+                $startCount++;
+            }
+            if ($player['sf'] === 1) {
+                $startCount++;
+            }
+            if ($player['pf'] === 1) {
+                $startCount++;
+            }
+            if ($player['c'] === 1) {
+                $startCount++;
+            }
+            if ($startCount > 1) {
+                $hasStarterAtMultiplePositions = true;
+                $nameOfProblemStarter = $player['name'];
+            }
         }
 
         return [
             'playerData' => $playerData,
             'activePlayers' => $activePlayers,
-            'pos_1' => 0,
-            'pos_2' => 0,
-            'pos_3' => 0,
-            'pos_4' => 0,
-            'pos_5' => 0,
-            'hasStarterAtMultiplePositions' => false,
-            'nameOfProblemStarter' => ''
+            'pos_1' => $pos1,
+            'pos_2' => $pos2,
+            'pos_3' => $pos3,
+            'pos_4' => $pos4,
+            'pos_5' => $pos5,
+            'hasStarterAtMultiplePositions' => $hasStarterAtMultiplePositions,
+            'nameOfProblemStarter' => $nameOfProblemStarter
         ];
     }
     
@@ -107,15 +153,6 @@ class DepthChartEntryProcessor implements DepthChartEntryProcessorInterface
         return max(0, min(40, $value));
     }
 
-    private function sanitizeFocusValue(int $value): int
-    {
-        return max(0, min(3, $value));
-    }
-
-    private function sanitizeSettingValue(int $value): int
-    {
-        return max(0, min(2, $value));
-    }
     
     /**
      * @see DepthChartEntryProcessorInterface::generateCsvContent()

--- a/ibl5/classes/DepthChartEntry/DepthChartEntryRepository.php
+++ b/ibl5/classes/DepthChartEntry/DepthChartEntryRepository.php
@@ -47,32 +47,24 @@ class DepthChartEntryRepository extends \BaseMysqliRepository implements DepthCh
         $c = $depthChartValues['c'];
         $active = $depthChartValues['canPlayInGame'];
         $min = $depthChartValues['min'];
-        $of = $depthChartValues['of'];
-        $df = $depthChartValues['df'];
-        $oi = $depthChartValues['oi'];
-        $di = $depthChartValues['di'];
-        $bh = $depthChartValues['bh'];
-        
-        // Use a single UPDATE statement to update all depth chart columns at once
-        // This is more efficient and handles the case where values don't change
-        // (MySQL returns 0 affected rows when updating to the same value, which is not an error)
+
         try {
             $this->execute(
-                "UPDATE ibl_plr SET 
-                    dc_PGDepth = ?, 
-                    dc_SGDepth = ?, 
-                    dc_SFDepth = ?, 
-                    dc_PFDepth = ?, 
-                    dc_CDepth = ?, 
+                "UPDATE ibl_plr SET
+                    dc_PGDepth = ?,
+                    dc_SGDepth = ?,
+                    dc_SFDepth = ?,
+                    dc_PFDepth = ?,
+                    dc_CDepth = ?,
                     dc_canPlayInGame = ?,
-                    dc_minutes = ?, 
-                    dc_of = ?, 
-                    dc_df = ?, 
-                    dc_oi = ?, 
-                    dc_di = ?, 
-                    dc_bh = ? 
+                    dc_minutes = ?,
+                    dc_of = 0,
+                    dc_df = 0,
+                    dc_oi = 0,
+                    dc_di = 0,
+                    dc_bh = 0
                 WHERE name = ?",
-                "iiiiiiiiiiiis",
+                "iiiiiiis",
                 $pg,
                 $sg,
                 $sf,
@@ -80,19 +72,11 @@ class DepthChartEntryRepository extends \BaseMysqliRepository implements DepthCh
                 $c,
                 $active,
                 $min,
-                $of,
-                $df,
-                $oi,
-                $di,
-                $bh,
                 $playerName
             );
-            
-            // Success: the query executed without throwing an exception
-            // Note: We don't check affected_rows because it returns 0 when values don't change
+
             return true;
         } catch (\RuntimeException $e) {
-            // If an exception was thrown, the query failed (e.g., player doesn't exist)
             return false;
         }
     }

--- a/ibl5/classes/DepthChartEntry/DepthChartEntryValidator.php
+++ b/ibl5/classes/DepthChartEntry/DepthChartEntryValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DepthChartEntry;
 
 use DepthChartEntry\Contracts\DepthChartEntryValidatorInterface;
+use Utilities\HtmlSanitizer;
 
 /**
  * @phpstan-import-type ProcessedSubmission from Contracts\DepthChartEntryProcessorInterface
@@ -28,9 +29,11 @@ class DepthChartEntryValidator implements DepthChartEntryValidatorInterface
         if ($phase === 'Playoffs') {
             $minActivePlayers = 10;
             $maxActivePlayers = 12;
+            $minPerPosition = 2;
         } else {
             $minActivePlayers = 12;
             $maxActivePlayers = 12;
+            $minPerPosition = 3;
         }
 
         $this->validateActivePlayerCount(
@@ -38,6 +41,16 @@ class DepthChartEntryValidator implements DepthChartEntryValidatorInterface
             $minActivePlayers,
             $maxActivePlayers
         );
+
+        $this->validatePositionDepth($depthChartData, $minPerPosition);
+
+        if ($depthChartData['hasStarterAtMultiplePositions']) {
+            $this->errors[] = [
+                'type' => 'multiple_starting_positions',
+                'message' => HtmlSanitizer::safeHtmlOutput($depthChartData['nameOfProblemStarter']) . ' is set as starter (1st) at multiple positions.',
+                'detail' => 'Please press the "Back" button on your browser and set this player as 1st at only one position.'
+            ];
+        }
 
         return $this->errors === [];
     }
@@ -58,6 +71,27 @@ class DepthChartEntryValidator implements DepthChartEntryValidatorInterface
                 'message' => "You can't have more than $max active players in your lineup; you have $activePlayers.",
                 'detail' => "Please press the \"Back\" button on your browser and deactivate " . ($activePlayers - $max) . " player(s)."
             ];
+        }
+    }
+
+    /**
+     * @param ProcessedSubmission $depthChartData
+     */
+    private function validatePositionDepth(array $depthChartData, int $minPerPosition): void
+    {
+        $positionNames = ['PG', 'SG', 'SF', 'PF', 'C'];
+        $positionKeys = ['pos_1', 'pos_2', 'pos_3', 'pos_4', 'pos_5'];
+
+        foreach ($positionKeys as $index => $key) {
+            $count = $depthChartData[$key];
+            if ($count < $minPerPosition) {
+                $posName = $positionNames[$index];
+                $this->errors[] = [
+                    'type' => 'position_depth',
+                    'message' => "You need at least $minPerPosition non-injured players assigned to {$posName}; you have $count.",
+                    'detail' => "Please press the \"Back\" button on your browser and assign more players to the {$posName} position."
+                ];
+            }
         }
     }
     

--- a/ibl5/classes/DepthChartEntry/DepthChartEntryValidator.php
+++ b/ibl5/classes/DepthChartEntry/DepthChartEntryValidator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace DepthChartEntry;
 
 use DepthChartEntry\Contracts\DepthChartEntryValidatorInterface;
-use Utilities\HtmlSanitizer;
 
 /**
  * @phpstan-import-type ProcessedSubmission from Contracts\DepthChartEntryProcessorInterface
@@ -47,7 +46,7 @@ class DepthChartEntryValidator implements DepthChartEntryValidatorInterface
         if ($depthChartData['hasStarterAtMultiplePositions']) {
             $this->errors[] = [
                 'type' => 'multiple_starting_positions',
-                'message' => HtmlSanitizer::safeHtmlOutput($depthChartData['nameOfProblemStarter']) . ' is set as starter (1st) at multiple positions.',
+                'message' => $depthChartData['nameOfProblemStarter'] . ' is set as starter (1st) at multiple positions.',
                 'detail' => 'Please press the "Back" button on your browser and set this player as 1st at only one position.'
             ];
         }

--- a/ibl5/classes/DepthChartEntry/DepthChartEntryView.php
+++ b/ibl5/classes/DepthChartEntry/DepthChartEntryView.php
@@ -15,16 +15,12 @@ use Utilities\HtmlSanitizer;
  */
 class DepthChartEntryView implements DepthChartEntryViewInterface
 {
-    /**
-     * Role slot display labels mapped to their HTML form field names.
-     * PG slot = dc_bh (form field BH), SG slot = dc_di (form field DI), etc.
-     */
-    private const ROLE_SLOTS = [
-        ['label' => 'PG', 'field' => 'BH', 'dbKey' => 'dc_bh', 'max' => 2],
-        ['label' => 'SG', 'field' => 'DI', 'dbKey' => 'dc_di', 'max' => 2],
-        ['label' => 'SF', 'field' => 'OI', 'dbKey' => 'dc_oi', 'max' => 2],
-        ['label' => 'PF', 'field' => 'DF', 'dbKey' => 'dc_df', 'max' => 3],
-        ['label' => 'C',  'field' => 'OF', 'dbKey' => 'dc_of', 'max' => 3],
+    private const POSITION_SLOTS = [
+        ['label' => 'PG', 'field' => 'pg', 'dbKey' => 'dc_PGDepth'],
+        ['label' => 'SG', 'field' => 'sg', 'dbKey' => 'dc_SGDepth'],
+        ['label' => 'SF', 'field' => 'sf', 'dbKey' => 'dc_SFDepth'],
+        ['label' => 'PF', 'field' => 'pf', 'dbKey' => 'dc_PFDepth'],
+        ['label' => 'C',  'field' => 'c',  'dbKey' => 'dc_CDepth'],
     ];
 
     /**
@@ -43,24 +39,22 @@ class DepthChartEntryView implements DepthChartEntryViewInterface
     }
 
     /**
-     * Render role priority dropdown options (0 to max).
-     * Unified for all 5 role slots: BH/DI/OI use max=2, DF/OF use max=3.
+     * Render position depth dropdown options (0-5).
      *
      * Label convention:
-     *   0 → "—"  (unassigned; falls back to player's position string)
-     *   1 → "S"  (starter; JSB's dc=1 pass-2 sort strictly dominates dc=2+)
-     *   2+ → "#N" (successive backups in the per-slot ladder)
+     *   0 → "No"  (not assigned to this position)
+     *   1 → "1st" (starter — highest lineup priority)
+     *   2 → "2nd" (first backup)
+     *   3 → "3rd" (second backup)
+     *   4 → "4th" (third backup)
+     *   5 → "ok"  (emergency depth)
      */
-    public function renderRolePriorityOptions(int $selectedValue, int $maxValue): void
+    public function renderPositionDepthOptions(int $selectedValue): void
     {
-        for ($i = 0; $i <= $maxValue; $i++) {
+        $labels = ['No', '1st', '2nd', '3rd', '4th', 'ok'];
+        for ($i = 0; $i <= 5; $i++) {
             $selected = ($selectedValue === $i) ? ' SELECTED' : '';
-            $label = match (true) {
-                $i === 0 => '&mdash;',
-                $i === 1 => 'S',
-                default  => '#' . $i,
-            };
-            echo "<option value=\"{$i}\"{$selected}>{$label}</option>";
+            echo "<option value=\"{$i}\"{$selected}>{$labels[$i]}</option>";
         }
     }
 
@@ -74,40 +68,40 @@ class DepthChartEntryView implements DepthChartEntryViewInterface
 <div class="dc-help-section__content">
 <ol>
 <li>Each row in the table is one of your players.</li>
-<li>The five columns – <strong>PG SG SF PF C</strong> – are the five lineup slots you fill.</li>
-<li>For each slot, tell the sim who you want to play there:</li>
+<li>The five columns &ndash; <strong>PG SG SF PF C</strong> &ndash; are the five lineup slots you fill.</li>
+<li>For each slot, set the player&rsquo;s depth priority:</li>
 </ol>
 <table class="ibl-data-table dc-help-table">
 <thead><tr><th>Option</th><th>Meaning</th></tr></thead>
 <tbody>
-<tr><td><strong>S</strong></td><td>Starter</td></tr>
-<tr><td><strong>#2</strong></td><td>Main backup</td></tr>
-<tr><td><strong>#3</strong></td><td>Second backup</td></tr>
-<tr><td><strong>&mdash;</strong></td><td>N/A (use for deep bench)</td></tr>
+<tr><td><strong>1st</strong></td><td>Starter (highest lineup priority)</td></tr>
+<tr><td><strong>2nd</strong></td><td>First backup</td></tr>
+<tr><td><strong>3rd</strong></td><td>Second backup</td></tr>
+<tr><td><strong>4th</strong></td><td>Third backup</td></tr>
+<tr><td><strong>ok</strong></td><td>Emergency depth</td></tr>
+<tr><td><strong>No</strong></td><td>Not assigned to this position</td></tr>
 </tbody>
 </table>
-</p>
-<p><strong>To put a player in the slot you want:</strong></p>
+<p><strong>To set your lineup:</strong></p>
 <ol>
-<li>Set <strong>one</strong> player to <strong>S</strong> for each position.</li>
-<li>Set <strong>#2</strong> for players you want to sub in first.</li>
-<li>Set <strong>#3</strong> for player(s) after that.</li>
-<li>You can pick different backups for each slot.</li>
+<li>Set <strong>one</strong> player to <strong>1st</strong> for each position.</li>
+<li>Set <strong>2nd</strong> for players you want to sub in first.</li>
+<li>Set <strong>3rd</strong>/<strong>4th</strong> for deeper backups.</li>
+<li>A player can back up multiple positions (e.g. 2nd at PG and 3rd at SG).</li>
 <li>Set <strong>Min</strong> to control how long each player is on the floor.</li>
 <li>Starters usually want 30&ndash;40; bench players want lower numbers.</li>
-<li>Players with 0 minutes will only come in if everyone above them is unavailable.</li>
 </ol>
 <p><strong>Projected Lineup:</strong><br></p>
 <p>If a name appears in <em>italic gray</em>, it means you didn&rsquo;t assign
 enough players to that slot, so the sim is falling back on a backup automatically.
-<br>Add a <strong>#2</strong> or <strong>#3</strong> to the player you actually want there.</p>
-<p><strong>Note:</strong> a starter only plays their <strong>one</strong> slot –
+<br>Add a <strong>2nd</strong> or <strong>3rd</strong> to the player you actually want there.</p>
+<p><strong>Note:</strong> a starter (1st) only plays their <strong>one</strong> slot &ndash;
 starters are locked to that slot and removed from every other slot&rsquo;s
-ladder. If you want one backup to cover multiple slots, set <strong>#2</strong> or
-<strong>#3</strong> on them in several columns and leave <strong>S</strong> off &mdash;
+ladder. If you want one backup to cover multiple slots, set <strong>2nd</strong> or
+<strong>3rd</strong> on them in several columns and leave <strong>1st</strong> off &mdash;
 then they&rsquo;ll appear as a backup in each slot&rsquo;s ladder.</p>
 <p>The sim fills slots in order <strong>PG &rarr; SG &rarr; SF &rarr; PF &rarr; C</strong>,
-so if two slots both have a viable <strong>S</strong> pick that includes the same player,
+so if two slots both have a viable <strong>1st</strong> pick that includes the same player,
 the earlier slot in that order claims them.</p>
 </div>
 </details>';
@@ -140,7 +134,7 @@ the earlier slot in that order claims them.</p>
                     <th>Player</th>
                     <th>Active</th>';
 
-        foreach (self::ROLE_SLOTS as $slot) {
+        foreach (self::POSITION_SLOTS as $slot) {
             $labelHtml = HtmlSanitizer::safeHtmlOutput($slot['label']);
             echo '<th>' . $labelHtml . '</th>';
         }
@@ -215,11 +209,6 @@ the earlier slot in that order claims them.</p>
                 <input type=\"hidden\" name=\"pid{$depthCount}\" value=\"{$player_pid}\">
                 <input type=\"hidden\" name=\"Injury{$depthCount}\" value=\"{$player_inj}\">
                 <input type=\"hidden\" name=\"Name{$depthCount}\" value=\"{$player_name_html}\">
-                <input type=\"hidden\" name=\"pg{$depthCount}\" value=\"0\">
-                <input type=\"hidden\" name=\"sg{$depthCount}\" value=\"0\">
-                <input type=\"hidden\" name=\"sf{$depthCount}\" value=\"0\">
-                <input type=\"hidden\" name=\"pf{$depthCount}\" value=\"0\">
-                <input type=\"hidden\" name=\"c{$depthCount}\" value=\"0\">
                 <a href=\"./modules.php?name=Player&amp;pa=showpage&amp;pid={$player_pid}\">{$thumbnail}{$player_name_html}</a>
             </td>";
 
@@ -234,19 +223,20 @@ the earlier slot in that order claims them.</p>
         echo "<input type=\"checkbox\" name=\"canPlayInGame{$depthCount}\" value=\"1\" class=\"dc-active-cb\"{$activeCheckedAttr} aria-label=\"Active status for {$player_name_html}\">";
         echo "</td>";
 
-        // Role slot columns (PG/SG/SF/PF/C mapped to BH/DI/OI/DF/OF form fields)
-        foreach (self::ROLE_SLOTS as $slot) {
+        foreach (self::POSITION_SLOTS as $slot) {
             /** @var int $dcValue */
             $dcValue = $player[$slot['dbKey']] ?? 0;
-            // Clamp negative legacy values to 0
             if ($dcValue < 0) {
                 $dcValue = 0;
             }
+            if ($dcValue > 5) {
+                $dcValue = 5;
+            }
             $fieldName = $slot['field'] . $depthCount;
-            $ariaLabel = $slot['label'] . ' slot for ' . $player_name_html;
+            $ariaLabel = $slot['label'] . ' depth for ' . $player_name_html;
 
             echo "<td><select name=\"{$fieldName}\" aria-label=\"{$ariaLabel}\">";
-            $this->renderRolePriorityOptions($dcValue, $slot['max']);
+            $this->renderPositionDepthOptions($dcValue);
             echo "</select><span class=\"dc-score-debug\"></span></td>";
         }
 
@@ -275,7 +265,7 @@ function resetDepthChart() {
     var form = document.forms['DepthChartEntry'];
     if (!form) return;
 
-    // Reset role slot selects (BH/DI/OI/DF/OF) to 0
+    // Reset position depth selects to 0
     var selects = form.getElementsByTagName('select');
     for (var i = 0; i < selects.length; i++) {
         selects[i].value = '0';
@@ -377,23 +367,24 @@ JAVASCRIPT;
             <th>Name</th>
             <th>Active</th>';
 
-        foreach (self::ROLE_SLOTS as $slot) {
+        foreach (self::POSITION_SLOTS as $slot) {
             $labelHtml = HtmlSanitizer::safeHtmlOutput($slot['label']);
             echo '<th>' . $labelHtml . '</th>';
         }
 
-        echo '</tr></thead><tbody>';
+        echo '<th>Min</th></tr></thead><tbody>';
 
         foreach ($playerData as $player) {
             $nameHtml = HtmlSanitizer::safeHtmlOutput($player['name']);
             echo '<tr>
                 <td>' . $nameHtml . '</td>
                 <td>' . $player['canPlayInGame'] . '</td>
-                <td>' . $player['bh'] . '</td>
-                <td>' . $player['di'] . '</td>
-                <td>' . $player['oi'] . '</td>
-                <td>' . $player['df'] . '</td>
-                <td>' . $player['of'] . '</td>
+                <td>' . $player['pg'] . '</td>
+                <td>' . $player['sg'] . '</td>
+                <td>' . $player['sf'] . '</td>
+                <td>' . $player['pf'] . '</td>
+                <td>' . $player['c'] . '</td>
+                <td>' . $player['min'] . '</td>
             </tr>';
         }
 
@@ -455,15 +446,9 @@ JAVASCRIPT;
         echo "<span class=\"dc-card__pos-badge\">{$posHtml}</span>";
         echo "<a href=\"./modules.php?name=Player&amp;pa=showpage&amp;pid={$pid}\" class=\"dc-card__name\">{$nameHtml}</a>";
 
-        // Hidden fields (disabled — JS enables on mobile)
         echo "<input type=\"hidden\" name=\"pid{$depthCount}\" value=\"{$pid}\" disabled>";
         echo "<input type=\"hidden\" name=\"Injury{$depthCount}\" value=\"{$injured}\" disabled>";
         echo "<input type=\"hidden\" name=\"Name{$depthCount}\" value=\"{$nameHtml}\" disabled>";
-        echo "<input type=\"hidden\" name=\"pg{$depthCount}\" value=\"0\" disabled>";
-        echo "<input type=\"hidden\" name=\"sg{$depthCount}\" value=\"0\" disabled>";
-        echo "<input type=\"hidden\" name=\"sf{$depthCount}\" value=\"0\" disabled>";
-        echo "<input type=\"hidden\" name=\"pf{$depthCount}\" value=\"0\" disabled>";
-        echo "<input type=\"hidden\" name=\"c{$depthCount}\" value=\"0\" disabled>";
         // Active checkbox — native checkbox styled with an orange accent to
         // match the desktop view. Hidden input submits "0" when unchecked; the
         // checkbox submits "1" when checked. Both share the same field name so
@@ -479,21 +464,21 @@ JAVASCRIPT;
         echo '<div class="dc-card__body">';
         echo '<div class="dc-card__settings-grid">';
 
-        foreach (self::ROLE_SLOTS as $slot) {
+        $depthLabels = ['No', '1st', '2nd', '3rd', '4th', 'ok'];
+        foreach (self::POSITION_SLOTS as $slot) {
             /** @var int $dcValue */
             $dcValue = $player[$slot['dbKey']] ?? 0;
             if ($dcValue < 0) {
                 $dcValue = 0;
             }
+            if ($dcValue > 5) {
+                $dcValue = 5;
+            }
             $fieldName = $slot['field'] . $depthCount;
             $labelHtml = HtmlSanitizer::safeHtmlOutput($slot['label']);
-            $valueLabel = match (true) {
-                $dcValue === 0 => '&mdash;',
-                $dcValue === 1 => 'S',
-                default        => '#' . $dcValue,
-            };
-            $slotAria = $labelHtml . ' slot for ' . $nameHtml;
-            $slotAriaRaw = $slot['label'] . ' slot for ' . $name;
+            $valueLabel = $depthLabels[$dcValue];
+            $slotAria = $labelHtml . ' depth for ' . $nameHtml;
+            $slotAriaRaw = $slot['label'] . ' depth for ' . $name;
 
             echo "<div class=\"dc-card__field\">";
             echo "<span class=\"dc-card__field-label\">{$labelHtml}</span>";
@@ -505,7 +490,7 @@ JAVASCRIPT;
             echo '<select name="' . HtmlSanitizer::e($fieldName)
                 . '" class="dc-card__field-select" aria-label="'
                 . HtmlSanitizer::e($slotAriaRaw) . '" disabled>';
-            $this->renderRolePriorityOptions($dcValue, $slot['max']);
+            $this->renderPositionDepthOptions($dcValue);
             echo '</select></div>';
         }
 

--- a/ibl5/jslib/depth-chart-changes.js
+++ b/ibl5/jslib/depth-chart-changes.js
@@ -6,12 +6,12 @@
  * to any field whose current value differs from the original.
  *
  * Tracked fields:
- *   - <select>          role slots BH/DI/OI/DF/OF (+ saved-DC dropdown is excluded)
+ *   - <select>          position depth slots pg/sg/sf/pf/c (+ saved-DC dropdown is excluded)
  *   - <input type=number> minutes target (min<N>)
  *   - <input type=checkbox> active toggle (canPlayInGame<N>)
  *
  * Glow intensity scales with the magnitude of the change:
- *   - Role slot fields (BH/DI/OI/DF/OF): inversely proportional to value
+ *   - Position depth fields (pg/sg/sf/pf/c): proportional to value (1st=strongest)
  *   - Categorical (canPlayInGame, minutes): always level 1
  *
  * Exposes window.IBL_recalculateDepthChartGlows() for use after loading a saved
@@ -21,7 +21,7 @@
     'use strict';
 
     var GLOW_CLASSES = ['dc-glow-1', 'dc-glow-2', 'dc-glow-3', 'dc-glow-4', 'dc-glow-5'];
-    var ROLE_SLOT_PREFIXES = { BH: 1, DI: 1, OI: 1, OF: 1, DF: 1 };
+    var POSITION_DEPTH_PREFIXES = { pg: 1, sg: 1, sf: 1, pf: 1, c: 1 };
     var MIN_FIELD_RE = /^min\d+$/;
     var MINUTES_MAX = 40;
 
@@ -30,7 +30,7 @@
 
     /**
      * Strip trailing digits from a field name to determine field type.
-     * "BH3" → "BH", "canPlayInGame5" → "canPlayInGame", "min2" → "min"
+     * "pg3" → "pg", "canPlayInGame5" → "canPlayInGame", "min2" → "min"
      */
     function getFieldPrefix(name) {
         return name.replace(/\d+$/, '');
@@ -44,19 +44,15 @@
             return 0;
         }
 
-        // Role slot fields (BH, DI, OI, OF, DF): intensity inversely proportional
-        // to value — #1 (highest bonus) gets strongest glow, #3 gets weakest
-        if (ROLE_SLOT_PREFIXES[fieldPrefix]) {
+        if (POSITION_DEPTH_PREFIXES[fieldPrefix]) {
             var val = parseInt(current, 10);
             if (val === 0) {
-                // Changed from assigned to unassigned
                 return 1;
             }
-            // val=1 → glow 3 (strongest), val=2 → glow 2, val=3 → glow 1 (weakest)
-            return Math.max(4 - val, 1);
+            // val=1 (starter) → glow 5 (strongest), val=5 → glow 1 (weakest)
+            return Math.max(6 - val, 1);
         }
 
-        // Categorical fields (canPlayInGame, min): always level 1
         return 1;
     }
 
@@ -153,7 +149,7 @@
     }
 
     /**
-     * Return all tracked fields within the form: role slot selects, minutes
+     * Return all tracked fields within the form: position depth selects, minutes
      * number inputs, and canPlayInGame checkboxes. Hidden inputs (including
      * the canPlayInGame unchecked-fallback) are excluded.
      */

--- a/ibl5/jslib/depth-chart-lineup-preview.js
+++ b/ibl5/jslib/depth-chart-lineup-preview.js
@@ -189,15 +189,15 @@
     'use strict';
 
     /**
-     * The 5 role slots, mapping display label to form field prefix and
-     * the position used for fallback matching.
+     * The 5 position depth slots, mapping display label to form field prefix
+     * and the position used for fallback matching.
      */
     var SLOTS = [
-        { label: 'PG', field: 'BH', fallbackPos: 'PG' },
-        { label: 'SG', field: 'DI', fallbackPos: 'SG' },
-        { label: 'SF', field: 'OI', fallbackPos: 'SF' },
-        { label: 'PF', field: 'DF', fallbackPos: 'PF' },
-        { label: 'C',  field: 'OF', fallbackPos: 'C'  }
+        { label: 'PG', field: 'pg', fallbackPos: 'PG' },
+        { label: 'SG', field: 'sg', fallbackPos: 'SG' },
+        { label: 'SF', field: 'sf', fallbackPos: 'SF' },
+        { label: 'PF', field: 'pf', fallbackPos: 'PF' },
+        { label: 'C',  field: 'c',  fallbackPos: 'C'  }
     ];
 
     // The dispatcher walks sort1, sort2, sort3, +0x4ca0 backup, etc. (5

--- a/ibl5/jslib/depth-chart-mobile.js
+++ b/ibl5/jslib/depth-chart-mobile.js
@@ -41,7 +41,7 @@
     /**
      * Sync form values from source container to target container.
      * Fields in both views share names, so we sync:
-     *   - <select> role slots (BH/DI/OI/DF/OF)
+     *   - <select> position depth slots (pg/sg/sf/pf/c)
      *   - <input type="number"> minutes (min<N>)
      *   - <input type="checkbox"> canPlayInGame<N>
      * The sibling hidden <input> for canPlayInGame is untouched — it always
@@ -95,15 +95,10 @@
         }
     }
 
-    /**
-     * Label for a given role-slot value. Mirrors the PHP match in
-     * DepthChartEntryView::renderMobilePlayerCard() so the JS-rendered
-     * stepper labels stay in sync with the PHP-rendered initial labels.
-     */
+    var DEPTH_LABELS = ['No', '1st', '2nd', '3rd', '4th', 'ok'];
+
     function stepperLabel(value) {
-        if (value === 0) return '\u2014';
-        if (value === 1) return 'S';
-        return '#' + value;
+        return DEPTH_LABELS[value] || 'No';
     }
 
     /**
@@ -204,7 +199,7 @@
             })(checkboxes[i]);
         }
 
-        // Card field change listeners — sync role slot selects and minutes
+        // Card field change listeners — sync position depth selects and minutes
         // number inputs to desktop immediately. Checkboxes are handled by
         // the dedicated loop above.
         mobileEl.addEventListener('change', function (e) {
@@ -221,8 +216,8 @@
             }
         });
 
-        // Stepper arrow taps — dispatch on the kind of field. Role slots
-        // have a hidden <select> whose options are cycled with wrap-around
+        // Stepper arrow taps — dispatch on the kind of field. Position depth
+        // slots have a hidden <select> whose options are cycled with wrap-around
         // (up=promote toward starter, down=demote). The MIN column has a
         // number input that is clamped between its [min,max] attributes
         // and stepped one unit at a time (up=more minutes, down=fewer —

--- a/ibl5/jslib/saved-depth-charts.js
+++ b/ibl5/jslib/saved-depth-charts.js
@@ -139,18 +139,16 @@
                 if (!pidInput) continue;
                 var depthCount = pidInput.name.replace('pid', '');
 
-                // Position depth columns (pg/sg/sf/pf/c) are dead hidden inputs — ignore
-
                 // Active status (checkbox) + minutes (number input, clamped to 0-40)
                 setFieldValue(form, 'canPlayInGame' + depthCount, player.dc_canPlayInGame);
                 setFieldValue(form, 'min' + depthCount, Math.max(0, Math.min(40, player.dc_minutes)));
 
-                // Role slot values (clamp negatives to 0 for legacy saved DCs)
-                setFieldValue(form, 'OF' + depthCount, Math.max(0, player.dc_of));
-                setFieldValue(form, 'DF' + depthCount, Math.max(0, player.dc_df));
-                setFieldValue(form, 'OI' + depthCount, Math.max(0, player.dc_oi));
-                setFieldValue(form, 'DI' + depthCount, Math.max(0, player.dc_di));
-                setFieldValue(form, 'BH' + depthCount, Math.max(0, player.dc_bh));
+                // Position depth values (clamp to 0-5)
+                setFieldValue(form, 'pg' + depthCount, Math.max(0, Math.min(5, player.dc_PGDepth)));
+                setFieldValue(form, 'sg' + depthCount, Math.max(0, Math.min(5, player.dc_SGDepth)));
+                setFieldValue(form, 'sf' + depthCount, Math.max(0, Math.min(5, player.dc_SFDepth)));
+                setFieldValue(form, 'pf' + depthCount, Math.max(0, Math.min(5, player.dc_PFDepth)));
+                setFieldValue(form, 'c' + depthCount, Math.max(0, Math.min(5, player.dc_CDepth)));
 
                 // Mark traded players
                 if (!player.isOnCurrentRoster) {
@@ -213,7 +211,7 @@
 
         /**
          * Apply a value to every form field sharing the given name. Handles
-         * SELECT (role slots), INPUT[type=number] (minutes), and
+         * SELECT (position depth), INPUT[type=number] (minutes), and
          * INPUT[type=checkbox] (canPlayInGame). Hidden inputs sharing the
          * canPlayInGame name are intentionally left alone — they always carry
          * "0" so the form still posts 0 when the checkbox is unchecked.

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -125,7 +125,7 @@ parameters:
 		-
 			rawMessage: 'Unescaped output in View. Wrap the expression in HtmlSanitizer::e() (or another whitelisted safe helper), or cast it to (int)/(float)/(bool) if it is numeric.'
 			identifier: ibl.unescapedOutput
-			count: 34
+			count: 29
 			path: classes/DepthChartEntry/DepthChartEntryView.php
 
 		-

--- a/ibl5/tests/DatabaseIntegration/DepthChartEntryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/DepthChartEntryRepositoryTest.php
@@ -62,11 +62,6 @@ class DepthChartEntryRepositoryTest extends DatabaseTestCase
             'c' => 0,
             'canPlayInGame' => 1,
             'min' => 32,
-            'of' => 5,
-            'df' => 4,
-            'oi' => 3,
-            'di' => 2,
-            'bh' => 1,
         ];
 
         $result = $this->repo->updatePlayerDepthChart('DC Update Plyr', $depthChartValues);
@@ -93,11 +88,12 @@ class DepthChartEntryRepositoryTest extends DatabaseTestCase
         self::assertSame(0, $row['dc_CDepth']);
         self::assertSame(1, $row['dc_canPlayInGame']);
         self::assertSame(32, $row['dc_minutes']);
-        self::assertSame(5, $row['dc_of']);
-        self::assertSame(4, $row['dc_df']);
-        self::assertSame(3, $row['dc_oi']);
-        self::assertSame(2, $row['dc_di']);
-        self::assertSame(1, $row['dc_bh']);
+        // Role columns are hardcoded to 0 in the SQL
+        self::assertSame(0, $row['dc_of']);
+        self::assertSame(0, $row['dc_df']);
+        self::assertSame(0, $row['dc_oi']);
+        self::assertSame(0, $row['dc_di']);
+        self::assertSame(0, $row['dc_bh']);
     }
 
     public function testUpdatePlayerDepthChartReturnsTrueOnSuccess(): void
@@ -106,8 +102,7 @@ class DepthChartEntryRepositoryTest extends DatabaseTestCase
 
         $result = $this->repo->updatePlayerDepthChart('DC Success Plyr', [
             'pg' => 1, 'sg' => 0, 'sf' => 0, 'pf' => 0, 'c' => 0,
-            'canPlayInGame' => 1, 'min' => 20, 'of' => 3, 'df' => 3,
-            'oi' => 2, 'di' => 2, 'bh' => 1,
+            'canPlayInGame' => 1, 'min' => 20,
         ]);
 
         self::assertTrue($result);

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryProcessorTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryProcessorTest.php
@@ -728,4 +728,69 @@ class DepthChartEntryProcessorTest extends TestCase
         // CSV also shows numeric values
         $this->assertStringContainsString('Human Readable Test,1,2,3,0,4,1,30,0,0,0,0,0', $csv);
     }
+
+    public function testPositionDepthValuesAppearInCorrectCsvColumns(): void
+    {
+        $cases = [
+            ['pg', 1, 1],
+            ['sg', 2, 2],
+            ['sf', 1, 3],
+            ['pf', 3, 4],
+            ['c', 5, 5],
+        ];
+
+        foreach ($cases as [$positionField, $depthValue, $expectedColumn]) {
+            $postData = [
+                'Name1' => 'Kevin Martin',
+                'pg1' => '0',
+                'sg1' => '0',
+                'sf1' => '0',
+                'pf1' => '0',
+                'c1' => '0',
+                'canPlayInGame1' => '1',
+                'min1' => '40',
+                'Injury1' => '0',
+            ];
+            $postData[$positionField . '1'] = (string) $depthValue;
+
+            $result = $this->processor->processSubmission($postData, 15);
+            $csv = $this->processor->generateCsvContent($result['playerData']);
+
+            $lines = explode("\n", trim($csv));
+            $this->assertCount(2, $lines);
+
+            $dataColumns = str_getcsv($lines[1], ',', '"', '');
+            $this->assertSame(
+                (string) $depthValue,
+                $dataColumns[$expectedColumn],
+                "Position {$positionField} depth value should appear in CSV column {$expectedColumn}"
+            );
+        }
+    }
+
+    public function testFormSubmissionToCSvRoundTripPreservesPositionDepth(): void
+    {
+        $postData = [
+            'Name1' => 'Kevin Martin',
+            'pg1' => '0',
+            'sg1' => '0',
+            'sf1' => '1',
+            'pf1' => '0',
+            'c1' => '0',
+            'canPlayInGame1' => '1',
+            'min1' => '40',
+            'Injury1' => '0',
+        ];
+
+        $result = $this->processor->processSubmission($postData, 15);
+
+        $this->assertSame(1, $result['playerData'][0]['sf']);
+        $this->assertSame(0, $result['playerData'][0]['pg']);
+
+        $csv = $this->processor->generateCsvContent($result['playerData']);
+        $this->assertStringContainsString('Kevin Martin,0,0,1,0,0,1,40,0,0,0,0,0', $csv);
+
+        $headerColumns = str_getcsv(explode("\n", $csv)[0], ',', '"', '');
+        $this->assertSame('SF', $headerColumns[3]);
+    }
 }

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryProcessorTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryProcessorTest.php
@@ -28,11 +28,6 @@ class DepthChartEntryProcessorTest extends TestCase
             'c1' => '0',
             'canPlayInGame1' => '1',
             'min1' => '30',
-            'OF1' => '0',
-            'DF1' => '1',
-            'OI1' => '0',
-            'DI1' => '0',
-            'BH1' => '0',
             'Injury1' => '0',
             'Name2' => 'Player Two',
             'pg2' => '2',
@@ -42,20 +37,21 @@ class DepthChartEntryProcessorTest extends TestCase
             'c2' => '0',
             'canPlayInGame2' => '1',
             'min2' => '25',
-            'OF2' => '0',
-            'DF2' => '0',
-            'OI2' => '1',
-            'DI2' => '0',
-            'BH2' => '0',
             'Injury2' => '0'
         ];
-        
+
         $result = $this->processor->processSubmission($postData, 15);
-        
+
         $this->assertEquals(2, count($result['playerData']));
         $this->assertEquals(2, $result['activePlayers']);
-        $this->assertEquals(0, $result['pos_1']);  // Position depth counting removed
+        $this->assertEquals(2, $result['pos_1']);  // Both players have pg > 0
         $this->assertFalse($result['hasStarterAtMultiplePositions']);
+        // Role slots are hardcoded to 0
+        $this->assertEquals(0, $result['playerData'][0]['of']);
+        $this->assertEquals(0, $result['playerData'][0]['df']);
+        $this->assertEquals(0, $result['playerData'][0]['oi']);
+        $this->assertEquals(0, $result['playerData'][0]['di']);
+        $this->assertEquals(0, $result['playerData'][0]['bh']);
     }
     
     public function testDetectsMultipleStartingPositions()
@@ -69,18 +65,13 @@ class DepthChartEntryProcessorTest extends TestCase
             'c1' => '0',
             'canPlayInGame1' => '1',
             'min1' => '30',
-            'OF1' => '0',
-            'DF1' => '0',
-            'OI1' => '0',
-            'DI1' => '0',
-            'BH1' => '0',
             'Injury1' => '0'
         ];
-        
+
         $result = $this->processor->processSubmission($postData, 15);
-        
-        $this->assertFalse($result['hasStarterAtMultiplePositions']);
-        $this->assertEquals('', $result['nameOfProblemStarter']);
+
+        $this->assertTrue($result['hasStarterAtMultiplePositions']);
+        $this->assertEquals('Player One', $result['nameOfProblemStarter']);
     }
     
     public function testExcludesInjuredPlayersFromPositionCount()
@@ -94,16 +85,11 @@ class DepthChartEntryProcessorTest extends TestCase
             'c1' => '0',
             'canPlayInGame1' => '1',
             'min1' => '30',
-            'OF1' => '0',
-            'DF1' => '0',
-            'OI1' => '0',
-            'DI1' => '0',
-            'BH1' => '0',
             'Injury1' => '15'  // Injured
         ];
-        
+
         $result = $this->processor->processSubmission($postData, 15);
-        
+
         $this->assertEquals(0, $result['pos_1']);  // Injured player not counted
         $this->assertEquals(1, $result['activePlayers']);  // Still counts as active
     }
@@ -121,17 +107,17 @@ class DepthChartEntryProcessorTest extends TestCase
                 'canPlayInGame' => '1',
                 'min' => '30',
                 'of' => '0',
-                'df' => '1',
+                'df' => '0',
                 'oi' => '0',
                 'di' => '0',
                 'bh' => '0'
             ]
         ];
-        
+
         $csv = $this->processor->generateCsvContent($playerData);
-        
+
         $this->assertStringContainsString('Name,PG,SG,SF,PF,C,ACTIVE,MIN,OF,DF,OI,DI,BH', $csv);
-        $this->assertStringContainsString('Player One,1,0,0,0,0,1,30,0,1,0,0,0', $csv);
+        $this->assertStringContainsString('Player One,1,0,0,0,0,1,30,0,0,0,0,0', $csv);
     }
     
 
@@ -147,38 +133,31 @@ class DepthChartEntryProcessorTest extends TestCase
             'c1' => '0',
             'canPlayInGame1' => '2',  // Invalid (should be 0 or 1)
             'min1' => '100',  // Out of range (should be capped at 40)
-            'OF1' => '10',  // Out of range (should be capped at 3)
-            'DF1' => '-5',  // Out of range (should be 0)
-            'OI1' => '10',  // Out of range (should be capped at 2)
-            'DI1' => '-10',  // Out of range (should be clamped to 0)
-            'BH1' => '5',  // Out of range (should be capped at 2)
             'Injury1' => '0'
         ];
-        
+
         $result = $this->processor->processSubmission($postData, 15);
-        
+
         // Player name should have script tags removed (but not the content)
         $this->assertStringNotContainsString('<script>', $result['playerData'][0]['name']);
         $this->assertStringNotContainsString('</script>', $result['playerData'][0]['name']);
-        
+
         // Depth values should be capped at 5
         $this->assertEquals(5, $result['playerData'][0]['pg']);
         $this->assertEquals(0, $result['playerData'][0]['sg']);
-        
+
         // Active should be 0 (invalid value)
         $this->assertEquals(0, $result['playerData'][0]['canPlayInGame']);
-        
+
         // Minutes should be capped at 40
         $this->assertEquals(40, $result['playerData'][0]['min']);
-        
-        // Focus values should be capped at 3 and 0
-        $this->assertEquals(3, $result['playerData'][0]['of']);
+
+        // Role slots are hardcoded to 0 regardless of input
+        $this->assertEquals(0, $result['playerData'][0]['of']);
         $this->assertEquals(0, $result['playerData'][0]['df']);
-        
-        // Setting values should be capped between 0 and 2
-        $this->assertEquals(2, $result['playerData'][0]['oi']);
+        $this->assertEquals(0, $result['playerData'][0]['oi']);
         $this->assertEquals(0, $result['playerData'][0]['di']);
-        $this->assertEquals(2, $result['playerData'][0]['bh']);
+        $this->assertEquals(0, $result['playerData'][0]['bh']);
     }
     
     public function testHandlesMissingOptionalFields()
@@ -192,16 +171,11 @@ class DepthChartEntryProcessorTest extends TestCase
             'c1' => '0',
             'canPlayInGame1' => '1',
             'min1' => '30',
-            'OF1' => '0',
-            'DF1' => '0',
-            'OI1' => '0',
-            'DI1' => '0',
-            'BH1' => '0'
             // Injury1 is missing
         ];
-        
+
         $result = $this->processor->processSubmission($postData, 15);
-        
+
         $this->assertEquals(1, count($result['playerData']));
         $this->assertEquals('Player One', $result['playerData'][0]['name']);
         $this->assertEquals(0, $result['playerData'][0]['injury']);
@@ -222,11 +196,6 @@ class DepthChartEntryProcessorTest extends TestCase
             'c1' => '0',
             'canPlayInGame1' => '1',
             'min1' => '',  // blank minutes — reset state
-            'OF1' => '0',
-            'DF1' => '0',
-            'OI1' => '0',
-            'DI1' => '0',
-            'BH1' => '0',
             'Injury1' => '0'
         ];
 
@@ -248,17 +217,17 @@ class DepthChartEntryProcessorTest extends TestCase
                 'canPlayInGame' => 1,
                 'min' => 30,
                 'of' => 0,
-                'df' => 1,
-                'oi' => -1,
-                'di' => 2,
-                'bh' => -2
+                'df' => 0,
+                'oi' => 0,
+                'di' => 0,
+                'bh' => 0
             ]
         ];
-        
+
         $csv = $this->processor->generateCsvContent($playerData);
-        
+
         $this->assertStringContainsString('Player, Jr.', $csv);
-        $this->assertStringContainsString('1,0,0,0,0,1,30,0,1,-1,2,-2', $csv);
+        $this->assertStringContainsString('1,0,0,0,0,1,30,0,0,0,0,0', $csv);
     }
     
     public function testCountsAllPositionTypesCorrectly()
@@ -272,35 +241,30 @@ class DepthChartEntryProcessorTest extends TestCase
             'c1' => '5',
             'canPlayInGame1' => '1',
             'min1' => '30',
-            'OF1' => '0',
-            'DF1' => '0',
-            'OI1' => '0',
-            'DI1' => '0',
-            'BH1' => '0',
             'Injury1' => '0'
         ];
 
         $result = $this->processor->processSubmission($postData, 15);
 
-        // Position depth counting removed — always returns 0
-        $this->assertEquals(0, $result['pos_1']);
-        $this->assertEquals(0, $result['pos_2']);
-        $this->assertEquals(0, $result['pos_3']);
-        $this->assertEquals(0, $result['pos_4']);
-        $this->assertEquals(0, $result['pos_5']);
+        // Position depth counting restored — counts non-injured players with depth > 0
+        $this->assertEquals(1, $result['pos_1']);
+        $this->assertEquals(1, $result['pos_2']);
+        $this->assertEquals(1, $result['pos_3']);
+        $this->assertEquals(1, $result['pos_4']);
+        $this->assertEquals(1, $result['pos_5']);
     }
 
     // --- Merged from DepthChartEntryDataConsistencyTest ---
 
     /**
-     * Tests data consistency for settings fields (OF, DF, OI, DI, BH)
+     * Tests data consistency for position depth fields (pg, sg, sf, pf, c)
      * Tests DepthChartEntryProcessor and DepthChartEntryView together.
      */
     public function testFormDisplaysCorrectDatabaseValuesForAllSettings()
     {
-        $view = new DepthChartEntryView($this->processor);
+        $view = new DepthChartEntryView();
 
-        // Simulate a player record from the database with various setting values
+        // Simulate a player record from the database with various depth values
         $playerFromDb = [
             'pid' => 1,
             'name' => 'Test Player',
@@ -308,17 +272,17 @@ class DepthChartEntryProcessorTest extends TestCase
             'injured' => 0,
             'sta' => 50,
             'dc_PGDepth' => 1,
-            'dc_SGDepth' => 0,
+            'dc_SGDepth' => 3,
             'dc_SFDepth' => 0,
-            'dc_PFDepth' => 0,
+            'dc_PFDepth' => 2,
             'dc_CDepth' => 0,
             'dc_canPlayInGame' => 1,
             'dc_minutes' => 30,
-            'dc_of' => 2,      // Role slot C priority 2
-            'dc_df' => 1,      // Role slot PF priority 1
-            'dc_oi' => 1,      // Role slot SF priority 1
-            'dc_di' => 2,      // Role slot SG priority 2
-            'dc_bh' => 0       // Role slot PG unassigned
+            'dc_of' => 0,
+            'dc_df' => 0,
+            'dc_oi' => 0,
+            'dc_di' => 0,
+            'dc_bh' => 0
         ];
 
         ob_start();
@@ -326,75 +290,51 @@ class DepthChartEntryProcessorTest extends TestCase
         $html = ob_get_clean();
 
         // Verify the HTML contains select elements with correct field names
-        $this->assertStringContainsString('name="OF1"', $html);
-        $this->assertStringContainsString('name="DF1"', $html);
-        $this->assertStringContainsString('name="OI1"', $html);
-        $this->assertStringContainsString('name="DI1"', $html);
-        $this->assertStringContainsString('name="BH1"', $html);
+        $this->assertStringContainsString('name="pg1"', $html);
+        $this->assertStringContainsString('name="sg1"', $html);
+        $this->assertStringContainsString('name="sf1"', $html);
+        $this->assertStringContainsString('name="pf1"', $html);
+        $this->assertStringContainsString('name="c1"', $html);
 
         // Verify the correct values are selected
-        $this->assertStringContainsString('value="2" SELECTED', $html, 'OF (C slot) should have value 2 selected');
-        $this->assertStringContainsString('value="1" SELECTED', $html, 'DF (PF slot) should have value 1 selected');
-        // Note: value="2" will match both OF and DI, so we check the pattern more carefully
-        $matches = [];
-        preg_match_all('/value="2" SELECTED/', $html, $matches);
-        $this->assertGreaterThanOrEqual(2, count($matches[0]), 'Should have at least 2 occurrences of value="2" SELECTED (for DI and OF)');
-        $this->assertStringContainsString('value="0" SELECTED', $html, 'BH should have value 0 selected');
+        $this->assertStringContainsString('value="1" SELECTED', $html, 'PG depth should have value 1 selected');
+        $this->assertStringContainsString('value="3" SELECTED', $html, 'SG depth should have value 3 selected');
+        $this->assertStringContainsString('value="2" SELECTED', $html, 'PF depth should have value 2 selected');
+        $this->assertStringContainsString('value="0" SELECTED', $html, 'SF/C depth should have value 0 selected');
     }
 
     /**
-     * Test that POST data with various settings values is correctly processed
+     * Test that role fields (OF, DF, OI, DI, BH) are hardcoded to 0 regardless of input
      */
-    public function testPostDataWithVariousSettingsIsProcessedCorrectly()
+    public function testRoleFieldsAreHardcodedToZero()
     {
-        $testCases = [
-            // Test case 1: All positive values
-            [
-                'input' => ['OF1' => '3', 'DF1' => '2', 'OI1' => '2', 'DI1' => '1', 'BH1' => '1'],
-                'expected' => ['of' => 3, 'df' => 2, 'oi' => 2, 'di' => 1, 'bh' => 1]
-            ],
-            // Test case 2: Negative values clamp to 0
-            [
-                'input' => ['OF1' => '0', 'DF1' => '0', 'OI1' => '-2', 'DI1' => '-2', 'BH1' => '-2'],
-                'expected' => ['of' => 0, 'df' => 0, 'oi' => 0, 'di' => 0, 'bh' => 0]
-            ],
-            // Test case 3: Mixed values (negatives clamp to 0)
-            [
-                'input' => ['OF1' => '1', 'DF1' => '3', 'OI1' => '-1', 'DI1' => '0', 'BH1' => '2'],
-                'expected' => ['of' => 1, 'df' => 3, 'oi' => 0, 'di' => 0, 'bh' => 2]
-            ],
-            // Test case 4: Zero values
-            [
-                'input' => ['OF1' => '0', 'DF1' => '0', 'OI1' => '0', 'DI1' => '0', 'BH1' => '0'],
-                'expected' => ['of' => 0, 'df' => 0, 'oi' => 0, 'di' => 0, 'bh' => 0]
-            ]
+        // Even if POST data contains OF/DF/OI/DI/BH keys, the processor ignores them
+        $postData = [
+            'Name1' => 'Test Player',
+            'pg1' => '1',
+            'sg1' => '0',
+            'sf1' => '0',
+            'pf1' => '0',
+            'c1' => '0',
+            'canPlayInGame1' => '1',
+            'min1' => '30',
+            'OF1' => '3',
+            'DF1' => '2',
+            'OI1' => '2',
+            'DI1' => '1',
+            'BH1' => '1',
+            'Injury1' => '0'
         ];
 
-        foreach ($testCases as $index => $testCase) {
-            $postData = array_merge(
-                [
-                    'Name1' => 'Test Player',
-                    'pg1' => '1',
-                    'sg1' => '0',
-                    'sf1' => '0',
-                    'pf1' => '0',
-                    'c1' => '0',
-                    'canPlayInGame1' => '1',
-                    'min1' => '30',
-                    'Injury1' => '0'
-                ],
-                $testCase['input']
-            );
+        $result = $this->processor->processSubmission($postData, 15);
+        $player = $result['playerData'][0];
 
-            $result = $this->processor->processSubmission($postData, 15);
-            $player = $result['playerData'][0];
-
-            $this->assertEquals($testCase['expected']['of'], $player['of'], "Test case $index: OF mismatch");
-            $this->assertEquals($testCase['expected']['df'], $player['df'], "Test case $index: DF mismatch");
-            $this->assertEquals($testCase['expected']['oi'], $player['oi'], "Test case $index: OI mismatch");
-            $this->assertEquals($testCase['expected']['di'], $player['di'], "Test case $index: DI mismatch");
-            $this->assertEquals($testCase['expected']['bh'], $player['bh'], "Test case $index: BH mismatch");
-        }
+        // All role fields are hardcoded to 0 — dead storage in JSB
+        $this->assertEquals(0, $player['of'], 'OF should always be 0');
+        $this->assertEquals(0, $player['df'], 'DF should always be 0');
+        $this->assertEquals(0, $player['oi'], 'OI should always be 0');
+        $this->assertEquals(0, $player['di'], 'DI should always be 0');
+        $this->assertEquals(0, $player['bh'], 'BH should always be 0');
     }
 
     /**
@@ -412,11 +352,11 @@ class DepthChartEntryProcessorTest extends TestCase
                 'c' => 0,
                 'canPlayInGame' => 1,
                 'min' => 30,
-                'of' => 3,
-                'df' => 2,
-                'oi' => -2,
-                'di' => 2,
-                'bh' => -1
+                'of' => 0,
+                'df' => 0,
+                'oi' => 0,
+                'di' => 0,
+                'bh' => 0
             ],
             [
                 'name' => 'Player 2',
@@ -441,7 +381,7 @@ class DepthChartEntryProcessorTest extends TestCase
         $this->assertStringContainsString('Name,PG,SG,SF,PF,C,ACTIVE,MIN,OF,DF,OI,DI,BH', $csv);
 
         // Verify Player 1 data
-        $this->assertStringContainsString('Player 1,1,0,0,0,0,1,30,3,2,-2,2,-1', $csv);
+        $this->assertStringContainsString('Player 1,1,0,0,0,0,1,30,0,0,0,0,0', $csv);
 
         // Verify Player 2 data
         $this->assertStringContainsString('Player 2,0,1,0,0,0,1,25,0,0,0,0,0', $csv);
@@ -451,9 +391,9 @@ class DepthChartEntryProcessorTest extends TestCase
      * Test the complete round-trip for a player:
      * Form display -> User sees values -> Submits -> CSV generated -> Form reloaded
      */
-    public function testCompleteRoundTripPreservesSettingsValues()
+    public function testCompleteRoundTripPreservesPositionDepthValues()
     {
-        $view = new DepthChartEntryView($this->processor);
+        $view = new DepthChartEntryView();
 
         // Step 1: Player has these values in database
         $dbPlayer = [
@@ -464,16 +404,16 @@ class DepthChartEntryProcessorTest extends TestCase
             'sta' => 60,
             'dc_PGDepth' => 0,
             'dc_SGDepth' => 1,
-            'dc_SFDepth' => 0,
+            'dc_SFDepth' => 2,
             'dc_PFDepth' => 0,
-            'dc_CDepth' => 0,
+            'dc_CDepth' => 3,
             'dc_canPlayInGame' => 1,
             'dc_minutes' => 35,
-            'dc_of' => 1,   // C slot priority 1
-            'dc_df' => 3,   // PF slot priority 3
-            'dc_oi' => 2,   // SF slot priority 2
-            'dc_di' => 1,   // SG slot priority 1
-            'dc_bh' => 0    // PG slot unassigned
+            'dc_of' => 0,
+            'dc_df' => 0,
+            'dc_oi' => 0,
+            'dc_di' => 0,
+            'dc_bh' => 0
         ];
 
         // Step 2: Form displays these values (capture HTML)
@@ -486,16 +426,11 @@ class DepthChartEntryProcessorTest extends TestCase
             'Name1' => 'Round Trip Player',
             'pg1' => '0',
             'sg1' => '1',
-            'sf1' => '0',
+            'sf1' => '2',
             'pf1' => '0',
-            'c1' => '0',
+            'c1' => '3',
             'canPlayInGame1' => '1',
             'min1' => '35',
-            'OF1' => '1',
-            'DF1' => '3',
-            'OI1' => '2',
-            'DI1' => '1',
-            'BH1' => '0',
             'Injury1' => '0'
         ];
 
@@ -508,22 +443,25 @@ class DepthChartEntryProcessorTest extends TestCase
 
         // Step 6: Verify consistency
 
-        // Form should have shown the correct values (checking field names exist)
-        $this->assertStringContainsString('name="OF1"', $formHtml);
-        $this->assertStringContainsString('name="DF1"', $formHtml);
-        $this->assertStringContainsString('name="OI1"', $formHtml);
-        $this->assertStringContainsString('name="DI1"', $formHtml);
-        $this->assertStringContainsString('name="BH1"', $formHtml);
+        // Form should have shown the correct field names
+        $this->assertStringContainsString('name="pg1"', $formHtml);
+        $this->assertStringContainsString('name="sg1"', $formHtml);
+        $this->assertStringContainsString('name="sf1"', $formHtml);
+        $this->assertStringContainsString('name="pf1"', $formHtml);
+        $this->assertStringContainsString('name="c1"', $formHtml);
 
-        // Processed data should match POST data
-        $this->assertEquals(1, $processedPlayer['of'], 'Processed OF should be 1');
-        $this->assertEquals(3, $processedPlayer['df'], 'Processed DF should be 3');
-        $this->assertEquals(2, $processedPlayer['oi'], 'Processed OI should be 2');
-        $this->assertEquals(1, $processedPlayer['di'], 'Processed DI should be 1');
-        $this->assertEquals(0, $processedPlayer['bh'], 'Processed BH should be 0');
+        // Processed data should match POST data for position depth
+        $this->assertEquals(0, $processedPlayer['pg'], 'Processed PG should be 0');
+        $this->assertEquals(1, $processedPlayer['sg'], 'Processed SG should be 1');
+        $this->assertEquals(2, $processedPlayer['sf'], 'Processed SF should be 2');
+        $this->assertEquals(0, $processedPlayer['pf'], 'Processed PF should be 0');
+        $this->assertEquals(3, $processedPlayer['c'], 'Processed C should be 3');
+        // Role fields always 0
+        $this->assertEquals(0, $processedPlayer['of']);
+        $this->assertEquals(0, $processedPlayer['df']);
 
         // CSV should match processed data
-        $this->assertStringContainsString('Round Trip Player,0,1,0,0,0,1,35,1,3,2,1,0', $csv, 'CSV should match processed data exactly');
+        $this->assertStringContainsString('Round Trip Player,0,1,2,0,3,1,35,0,0,0,0,0', $csv, 'CSV should match processed data exactly');
 
         // The key test: if we load the form again with the processed data as if it came from database,
         // it should show the same selected values
@@ -540,11 +478,11 @@ class DepthChartEntryProcessorTest extends TestCase
             'dc_CDepth' => $processedPlayer['c'],
             'dc_canPlayInGame' => $processedPlayer['canPlayInGame'],
             'dc_minutes' => $processedPlayer['min'],
-            'dc_of' => $processedPlayer['of'],
-            'dc_df' => $processedPlayer['df'],
-            'dc_oi' => $processedPlayer['oi'],
-            'dc_di' => $processedPlayer['di'],
-            'dc_bh' => $processedPlayer['bh']
+            'dc_of' => 0,
+            'dc_df' => 0,
+            'dc_oi' => 0,
+            'dc_di' => 0,
+            'dc_bh' => 0
         ];
 
         ob_start();
@@ -552,22 +490,21 @@ class DepthChartEntryProcessorTest extends TestCase
         $reloadedFormHtml = ob_get_clean();
 
         // The reloaded form should show the same selected values
-        $this->assertStringContainsString('value="1" SELECTED', $reloadedFormHtml, 'OF=1 should be selected on reload');
-        $this->assertStringContainsString('value="3" SELECTED', $reloadedFormHtml, 'DF=3 should be selected on reload');
-        $this->assertStringContainsString('value="2" SELECTED', $reloadedFormHtml, 'OI=2 should be selected on reload');
-        // Note: Both OF and DI have value 1, so we just check that value="1" SELECTED exists
-        $this->assertStringContainsString('value="0" SELECTED', $reloadedFormHtml, 'BH=0 should be selected on reload');
+        $this->assertStringContainsString('value="1" SELECTED', $reloadedFormHtml, 'SG=1 should be selected on reload');
+        $this->assertStringContainsString('value="2" SELECTED', $reloadedFormHtml, 'SF=2 should be selected on reload');
+        $this->assertStringContainsString('value="3" SELECTED', $reloadedFormHtml, 'C=3 should be selected on reload');
+        $this->assertStringContainsString('value="0" SELECTED', $reloadedFormHtml, 'PG/PF=0 should be selected on reload');
     }
 
     /**
-     * Test for a specific edge case: when settings have the value 0,
-     * ensure it's not confused with empty/null/false
+     * Test for a specific edge case: when position depth values are 0,
+     * ensure they're not confused with empty/null/false
      */
     public function testZeroValuesAreHandledCorrectly()
     {
-        $view = new DepthChartEntryView($this->processor);
+        $view = new DepthChartEntryView();
 
-        // Player with all zero settings
+        // Player with all zero position depths except C=1
         $player = [
             'pid' => 1,
             'name' => 'Zero Settings Player',
@@ -581,11 +518,11 @@ class DepthChartEntryProcessorTest extends TestCase
             'dc_CDepth' => 1,
             'dc_canPlayInGame' => 1,
             'dc_minutes' => 20,
-            'dc_of' => 0,    // Auto
-            'dc_df' => 0,    // Auto
-            'dc_oi' => 0,    // Neutral
-            'dc_di' => 0,    // Neutral
-            'dc_bh' => 0     // Neutral
+            'dc_of' => 0,
+            'dc_df' => 0,
+            'dc_oi' => 0,
+            'dc_di' => 0,
+            'dc_bh' => 0
         ];
 
         ob_start();
@@ -593,18 +530,18 @@ class DepthChartEntryProcessorTest extends TestCase
         $html = ob_get_clean();
 
         // Count how many times "value=\"0\" SELECTED" appears
-        // Should be 5 times: the 5 role slot selects (BH,DI,OI,DF,OF) all at 0
-        // Position fields are now hidden inputs, not selects
+        // Should be 4 times: the 4 position depth selects (PG,SG,SF,PF) all at 0
+        // C has value 1 selected
         $count = substr_count($html, 'value="0" SELECTED');
-        $this->assertEquals(5, $count, 'Role slot fields with value 0 should be selected');
+        $this->assertEquals(4, $count, 'Position depth fields with value 0 should be selected');
 
-        // More specifically, verify that the settings fields have value 0
-        // Check for the specific pattern of settings dropdowns with value 0 selected
-        $this->assertMatchesRegularExpression('/<select name="OF\d+"[^>]*>.*?value="0" SELECTED/s', $html, 'OF should have value 0 selected');
-        $this->assertMatchesRegularExpression('/<select name="DF\d+"[^>]*>.*?value="0" SELECTED/s', $html, 'DF should have value 0 selected');
-        $this->assertMatchesRegularExpression('/<select name="OI\d+"[^>]*>.*?value="0" SELECTED/s', $html, 'OI should have value 0 selected');
-        $this->assertMatchesRegularExpression('/<select name="DI\d+"[^>]*>.*?value="0" SELECTED/s', $html, 'DI should have value 0 selected');
-        $this->assertMatchesRegularExpression('/<select name="BH\d+"[^>]*>.*?value="0" SELECTED/s', $html, 'BH should have value 0 selected');
+        // Verify that position depth dropdowns have value 0 selected
+        $this->assertMatchesRegularExpression('/<select name="pg\d+"[^>]*>.*?value="0" SELECTED/s', $html, 'PG should have value 0 selected');
+        $this->assertMatchesRegularExpression('/<select name="sg\d+"[^>]*>.*?value="0" SELECTED/s', $html, 'SG should have value 0 selected');
+        $this->assertMatchesRegularExpression('/<select name="sf\d+"[^>]*>.*?value="0" SELECTED/s', $html, 'SF should have value 0 selected');
+        $this->assertMatchesRegularExpression('/<select name="pf\d+"[^>]*>.*?value="0" SELECTED/s', $html, 'PF should have value 0 selected');
+        // C should have value 1 selected
+        $this->assertMatchesRegularExpression('/<select name="c\d+"[^>]*>.*?value="1" SELECTED/s', $html, 'C should have value 1 selected');
     }
 
     // --- Merged from DepthChartEntryConfirmationTest ---
@@ -615,22 +552,22 @@ class DepthChartEntryProcessorTest extends TestCase
      */
     public function testConfirmationPageMatchesCsvExport()
     {
-        $view = new DepthChartEntryView($this->processor);
+        $view = new DepthChartEntryView();
 
         $playerData = [
             [
                 'name' => 'Test Player',
                 'pg' => 1,
-                'sg' => 0,
+                'sg' => 2,
                 'sf' => 0,
-                'pf' => 0,
+                'pf' => 3,
                 'c' => 0,
                 'canPlayInGame' => 1,
                 'min' => 30,
-                'of' => 2,
-                'df' => 1,
-                'oi' => -1,
-                'di' => 2,
+                'of' => 0,
+                'df' => 0,
+                'oi' => 0,
+                'di' => 0,
                 'bh' => 0
             ]
         ];
@@ -644,16 +581,16 @@ class DepthChartEntryProcessorTest extends TestCase
         $csv = $this->processor->generateCsvContent($playerData);
 
         // The CSV should contain these exact values
-        $this->assertStringContainsString('Test Player,1,0,0,0,0,1,30,2,1,-1,2,0', $csv);
+        $this->assertStringContainsString('Test Player,1,2,0,3,0,1,30,0,0,0,0,0', $csv);
 
         // The confirmation page should also display these same values
         $this->assertStringContainsString('Test Player', $confirmationHtml);
 
-        // Verify each value appears in the HTML in the correct context
-        // Confirmation page now shows: Name, Active, PG(BH), SG(DI), SF(OI), PF(DF), C(OF)
-        $this->assertMatchesRegularExpression('/<td>1<\/td>/', $confirmationHtml, 'Active or DF value 1 should appear');
-        $this->assertMatchesRegularExpression('/<td>2<\/td>/', $confirmationHtml, 'OF or DI value 2 should appear');
-        $this->assertMatchesRegularExpression('/<td>-1<\/td>/', $confirmationHtml, 'OI value -1 should appear');
+        // Verify position depth values appear in the confirmation table
+        $this->assertMatchesRegularExpression('/<td>1<\/td>/', $confirmationHtml, 'PG value 1 should appear');
+        $this->assertMatchesRegularExpression('/<td>2<\/td>/', $confirmationHtml, 'SG value 2 should appear');
+        $this->assertMatchesRegularExpression('/<td>3<\/td>/', $confirmationHtml, 'PF value 3 should appear');
+        $this->assertMatchesRegularExpression('/<td>30<\/td>/', $confirmationHtml, 'Min value 30 should appear');
     }
 
     /**
@@ -661,23 +598,18 @@ class DepthChartEntryProcessorTest extends TestCase
      */
     public function testAllThreeOutputsReceiveSameProcessedData()
     {
-        $view = new DepthChartEntryView($this->processor);
+        $view = new DepthChartEntryView();
 
         // Simulate form submission
         $postData = [
             'Name1' => 'Consistency Test Player',
             'pg1' => '2',
             'sg1' => '1',
-            'sf1' => '0',
+            'sf1' => '3',
             'pf1' => '0',
-            'c1' => '0',
+            'c1' => '4',
             'canPlayInGame1' => '1',
             'min1' => '35',
-            'OF1' => '3',
-            'DF1' => '2',
-            'OI1' => '2',
-            'DI1' => '1',
-            'BH1' => '0',
             'Injury1' => '0'
         ];
 
@@ -714,14 +646,14 @@ class DepthChartEntryProcessorTest extends TestCase
         $this->assertStringContainsString($expectedCsvLine, $csvContent, 'CSV should contain exact values from processed data');
 
         // Verify confirmation page contains key values in table cells
-        // Confirmation page shows: Name, Active, BH, DI, OI, DF, OF
+        // Confirmation page shows: Name, Active, PG, SG, SF, PF, C, Min
         $valuesToCheck = [
             $player['canPlayInGame'],
-            $player['of'],
-            $player['df'],
-            $player['oi'],
-            $player['di'],
-            $player['bh']
+            $player['pg'],
+            $player['sg'],
+            $player['sf'],
+            $player['c'],
+            $player['min'],
         ];
 
         foreach ($valuesToCheck as $value) {
@@ -734,44 +666,43 @@ class DepthChartEntryProcessorTest extends TestCase
         $this->assertArrayHasKey('sg', $player);
         $this->assertArrayHasKey('of', $player);
         $this->assertArrayHasKey('df', $player);
-        $this->assertArrayHasKey('oi', $player);
-        $this->assertArrayHasKey('di', $player);
-        $this->assertArrayHasKey('bh', $player);
 
-        // Verify the values match what was submitted (negatives clamped to 0)
+        // Verify the position depth values match what was submitted
         $this->assertEquals(2, $player['pg']);
         $this->assertEquals(1, $player['sg']);
+        $this->assertEquals(3, $player['sf']);
+        $this->assertEquals(4, $player['c']);
         $this->assertEquals(35, $player['min']);
-        $this->assertEquals(3, $player['of']);
-        $this->assertEquals(2, $player['df']);
-        $this->assertEquals(2, $player['oi']);
-        $this->assertEquals(1, $player['di']);
+        // Role fields always 0
+        $this->assertEquals(0, $player['of']);
+        $this->assertEquals(0, $player['df']);
+        $this->assertEquals(0, $player['oi']);
+        $this->assertEquals(0, $player['di']);
         $this->assertEquals(0, $player['bh']);
     }
 
     /**
-     * Test what a user would actually see: numeric codes vs human-readable labels.
-     * The FORM shows "Drive" but the CONFIRMATION and CSV show "2" — this is by design.
+     * Test that the confirmation page and CSV show numeric position depth values.
      */
     public function testUserSeesNumericCodesInConfirmationAndCsv()
     {
-        $view = new DepthChartEntryView($this->processor);
+        $view = new DepthChartEntryView();
 
         $playerData = [
             [
                 'name' => 'Human Readable Test',
                 'pg' => 1,
-                'sg' => 0,
-                'sf' => 0,
+                'sg' => 2,
+                'sf' => 3,
                 'pf' => 0,
-                'c' => 0,
+                'c' => 4,
                 'canPlayInGame' => 1,
                 'min' => 30,
-                'of' => 2,  // This is "Drive" in the form dropdown
-                'df' => 1,  // This is "Outside" in the form dropdown
-                'oi' => -1,
-                'di' => 2,
-                'bh' => 0   // This is "-" (dash) in the form dropdown for value 0
+                'of' => 0,
+                'df' => 0,
+                'oi' => 0,
+                'di' => 0,
+                'bh' => 0
             ]
         ];
 
@@ -783,19 +714,18 @@ class DepthChartEntryProcessorTest extends TestCase
         // Generate CSV
         $csv = $this->processor->generateCsvContent($playerData);
 
-        // The confirmation page shows NUMERIC VALUES, not human-readable labels
-        $this->assertStringContainsString('<td>2</td>', $confirmationHtml, 'Confirmation shows numeric value 2 for OF');
-        $this->assertStringContainsString('<td>1</td>', $confirmationHtml, 'Confirmation shows numeric value 1 for DF');
-        $this->assertStringContainsString('<td>-1</td>', $confirmationHtml, 'Confirmation shows numeric value -1 for OI');
-        $this->assertStringContainsString('<td>0</td>', $confirmationHtml, 'Confirmation shows numeric value 0 for BH');
+        // The confirmation page shows NUMERIC VALUES for position depth
+        $this->assertStringContainsString('<td>1</td>', $confirmationHtml, 'Confirmation shows numeric value 1 for PG');
+        $this->assertStringContainsString('<td>2</td>', $confirmationHtml, 'Confirmation shows numeric value 2 for SG');
+        $this->assertStringContainsString('<td>3</td>', $confirmationHtml, 'Confirmation shows numeric value 3 for SF');
+        $this->assertStringContainsString('<td>4</td>', $confirmationHtml, 'Confirmation shows numeric value 4 for C');
+        $this->assertStringContainsString('<td>30</td>', $confirmationHtml, 'Confirmation shows numeric value 30 for Min');
 
-        // Confirmation should NOT contain human-readable labels like "Drive", "Outside", etc.
-        $this->assertStringNotContainsString('Drive', $confirmationHtml);
-        $this->assertStringNotContainsString('Outside', $confirmationHtml);
+        // Confirmation should NOT contain human-readable labels
+        $this->assertStringNotContainsString('1st', $confirmationHtml);
+        $this->assertStringNotContainsString('2nd', $confirmationHtml);
 
         // CSV also shows numeric values
-        $this->assertStringContainsString(',2,', $csv, 'CSV shows numeric value 2 for OF');
-        $this->assertStringContainsString(',1,', $csv, 'CSV shows numeric value 1 for DF');
-        $this->assertStringContainsString(',-1,', $csv, 'CSV shows numeric value -1 for OI');
+        $this->assertStringContainsString('Human Readable Test,1,2,3,0,4,1,30,0,0,0,0,0', $csv);
     }
 }

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryRepositoryTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryRepositoryTest.php
@@ -60,24 +60,19 @@ class DepthChartEntryRepositoryTest extends TestCase
             'c' => 0,
             'canPlayInGame' => 1,
             'min' => 30,
-            'of' => 2,
-            'df' => 1,
-            'oi' => 1,
-            'di' => -1,
-            'bh' => 0,
         ];
-        
+
         // Set affected rows to 1 to simulate successful update
         $this->mockDb->setAffectedRows(1);
-        
+
         $result = $this->repository->updatePlayerDepthChart($playerName, $depthChartValues);
 
         $this->assertTrue($result);
-        
+
         // Verify the query was executed
         $queries = $this->mockDb->getExecutedQueries();
         $this->assertNotEmpty($queries);
-        
+
         // Verify the UPDATE statement contains all the expected fields
         $lastQuery = end($queries);
         $this->assertStringContainsString('UPDATE ibl_plr SET', $lastQuery);
@@ -88,11 +83,12 @@ class DepthChartEntryRepositoryTest extends TestCase
         $this->assertStringContainsString('dc_CDepth', $lastQuery);
         $this->assertStringContainsString('dc_canPlayInGame', $lastQuery);
         $this->assertStringContainsString('dc_minutes', $lastQuery);
-        $this->assertStringContainsString('dc_of', $lastQuery);
-        $this->assertStringContainsString('dc_df', $lastQuery);
-        $this->assertStringContainsString('dc_oi', $lastQuery);
-        $this->assertStringContainsString('dc_di', $lastQuery);
-        $this->assertStringContainsString('dc_bh', $lastQuery);
+        // Role columns are hardcoded to 0 in SQL, not bound as parameters
+        $this->assertStringContainsString('dc_of = 0', $lastQuery);
+        $this->assertStringContainsString('dc_df = 0', $lastQuery);
+        $this->assertStringContainsString('dc_oi = 0', $lastQuery);
+        $this->assertStringContainsString('dc_di = 0', $lastQuery);
+        $this->assertStringContainsString('dc_bh = 0', $lastQuery);
         $this->assertStringContainsString("WHERE name = '$playerName'", $lastQuery);
     }
 
@@ -109,11 +105,6 @@ class DepthChartEntryRepositoryTest extends TestCase
             'c' => 0,
             'canPlayInGame' => 1,
             'min' => 30,
-            'of' => 0,
-            'df' => 0,
-            'oi' => 0,
-            'di' => 0,
-            'bh' => 0,
         ];
         
         // Set affected rows to 0 to simulate no change (values already match)
@@ -138,11 +129,6 @@ class DepthChartEntryRepositoryTest extends TestCase
             'c' => '0',
             'canPlayInGame' => '1',
             'min' => '30',
-            'of' => '2',
-            'df' => '1',
-            'oi' => '1',
-            'di' => '-1',
-            'bh' => '0',
         ];
         
         $this->mockDb->setAffectedRows(1);
@@ -152,35 +138,34 @@ class DepthChartEntryRepositoryTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testUpdatePlayerDepthChartHandlesNegativeValues(): void
+    public function testUpdatePlayerDepthChartHardcodesRoleSlotsToZero(): void
     {
-        // Test that negative values for oi, di, bh are handled correctly
+        // Role slots (of, df, oi, di, bh) are now hardcoded to 0 in SQL
         $playerName = 'Test Player';
         $depthChartValues = [
-            'pg' => 0,
-            'sg' => 0,
+            'pg' => 1,
+            'sg' => 2,
             'sf' => 0,
             'pf' => 0,
-            'c' => 0,
+            'c' => 3,
             'canPlayInGame' => 1,
             'min' => 30,
-            'of' => 0,
-            'df' => 0,
-            'oi' => -2,  // Negative value
-            'di' => -2,  // Negative value
-            'bh' => -2,  // Negative value
         ];
-        
+
         $this->mockDb->setAffectedRows(1);
-        
+
         $result = $this->repository->updatePlayerDepthChart($playerName, $depthChartValues);
 
         $this->assertTrue($result);
-        
-        // Verify negative values are in the query
+
+        // Verify role columns are hardcoded to 0 in the query
         $queries = $this->mockDb->getExecutedQueries();
         $lastQuery = end($queries);
-        $this->assertStringContainsString('-2', $lastQuery);
+        $this->assertStringContainsString('dc_of = 0', $lastQuery);
+        $this->assertStringContainsString('dc_df = 0', $lastQuery);
+        $this->assertStringContainsString('dc_oi = 0', $lastQuery);
+        $this->assertStringContainsString('dc_di = 0', $lastQuery);
+        $this->assertStringContainsString('dc_bh = 0', $lastQuery);
     }
 
     public function testUpdateTeamHistorySuccessfullyUpdatesTimestamps(): void
@@ -250,11 +235,12 @@ class DepthChartEntryRepositoryTest extends TestCase
     /**
      * Verifies the exact mapping between processed array keys and database column names.
      * Documents the required field-to-column correspondence for the UPDATE query.
+     * Role columns (dc_of, dc_df, dc_oi, dc_di, dc_bh) are hardcoded to 0 in SQL.
      */
     public function testDatabaseUpdateQueryMapsFieldsCorrectly()
     {
-        // The processed data uses these lowercase keys
-        $processedPlayerData = [
+        // The processed data uses these lowercase keys for bound parameters
+        $boundFields = [
             'pg' => 1,
             'sg' => 2,
             'sf' => 0,
@@ -262,93 +248,56 @@ class DepthChartEntryRepositoryTest extends TestCase
             'c' => 0,
             'canPlayInGame' => 1,
             'min' => 30,
-            'of' => 2,
-            'df' => 1,
-            'oi' => -1,
-            'di' => 2,
-            'bh' => 0
         ];
 
-        // The database has these column names (from schema)
-        $expectedDatabaseColumns = [
-            'dc_PGDepth',  // Should get value from $processedPlayerData['pg']
-            'dc_SGDepth',  // Should get value from $processedPlayerData['sg']
-            'dc_SFDepth',  // Should get value from $processedPlayerData['sf']
-            'dc_PFDepth',  // Should get value from $processedPlayerData['pf']
-            'dc_CDepth',   // Should get value from $processedPlayerData['c']
-            'dc_canPlayInGame',   // Should get value from $processedPlayerData['canPlayInGame']
-            'dc_minutes',  // Should get value from $processedPlayerData['min']
-            'dc_of',       // Should get value from $processedPlayerData['of']
-            'dc_df',       // Should get value from $processedPlayerData['df']
-            'dc_oi',       // Should get value from $processedPlayerData['oi']
-            'dc_di',       // Should get value from $processedPlayerData['di']
-            'dc_bh'        // Should get value from $processedPlayerData['bh']
+        // The database columns that receive bound parameter values
+        $boundDatabaseColumns = [
+            'dc_PGDepth',        // from $processedPlayerData['pg']
+            'dc_SGDepth',        // from $processedPlayerData['sg']
+            'dc_SFDepth',        // from $processedPlayerData['sf']
+            'dc_PFDepth',        // from $processedPlayerData['pf']
+            'dc_CDepth',         // from $processedPlayerData['c']
+            'dc_canPlayInGame',  // from $processedPlayerData['canPlayInGame']
+            'dc_minutes',        // from $processedPlayerData['min']
         ];
 
-        // Verify the expected columns match the processed data keys
-        $this->assertEquals(12, count($expectedDatabaseColumns), 'Should have 12 database columns to update');
-        $this->assertEquals(12, count($processedPlayerData), 'Should have 12 fields in processed data');
+        // Hardcoded columns (always 0 in SQL, not bound)
+        $hardcodedColumns = ['dc_of', 'dc_df', 'dc_oi', 'dc_di', 'dc_bh'];
 
-        // This documents the mapping that SHOULD exist in the code
-        $expectedMapping = [
-            'pg' => 'dc_PGDepth',
-            'sg' => 'dc_SGDepth',
-            'sf' => 'dc_SFDepth',
-            'pf' => 'dc_PFDepth',
-            'c' => 'dc_CDepth',
-            'canPlayInGame' => 'dc_canPlayInGame',
-            'min' => 'dc_minutes',
-            'of' => 'dc_of',
-            'df' => 'dc_df',
-            'oi' => 'dc_oi',
-            'di' => 'dc_di',
-            'bh' => 'dc_bh'
-        ];
+        $this->assertEquals(7, count($boundDatabaseColumns), 'Should have 7 bound database columns');
+        $this->assertEquals(7, count($boundFields), 'Should have 7 bound fields');
+        $this->assertEquals(5, count($hardcodedColumns), 'Should have 5 hardcoded columns');
 
-        // Verify all keys in processed data have a corresponding database column
-        foreach ($processedPlayerData as $key => $value) {
-            $this->assertArrayHasKey($key, $expectedMapping, "Processed data key '$key' should have a database column mapping");
-        }
-
-        // The bind_param order in the code should match this exact sequence
-        $expectedBindParamTypes = 'iiiiiiiiiiiis'; // 12 integers + 1 string (player name)
+        // The bind_param order: 7 integers + 1 string (player name) = "iiiiiiis"
+        $expectedBindParamTypes = 'iiiiiiis';
         $expectedBindParamValues = [
-            $processedPlayerData['pg'],      // position 1: dc_PGDepth
-            $processedPlayerData['sg'],      // position 2: dc_SGDepth
-            $processedPlayerData['sf'],      // position 3: dc_SFDepth
-            $processedPlayerData['pf'],      // position 4: dc_PFDepth
-            $processedPlayerData['c'],       // position 5: dc_CDepth
-            $processedPlayerData['canPlayInGame'],  // position 6: dc_canPlayInGame
-            $processedPlayerData['min'],     // position 7: dc_minutes
-            $processedPlayerData['of'],      // position 8: dc_of
-            $processedPlayerData['df'],      // position 9: dc_df
-            $processedPlayerData['oi'],      // position 10: dc_oi
-            $processedPlayerData['di'],      // position 11: dc_di
-            $processedPlayerData['bh'],      // position 12: dc_bh
-            'Test Player'                     // position 13: name (WHERE clause)
+            $boundFields['pg'],             // position 1: dc_PGDepth
+            $boundFields['sg'],             // position 2: dc_SGDepth
+            $boundFields['sf'],             // position 3: dc_SFDepth
+            $boundFields['pf'],             // position 4: dc_PFDepth
+            $boundFields['c'],              // position 5: dc_CDepth
+            $boundFields['canPlayInGame'],  // position 6: dc_canPlayInGame
+            $boundFields['min'],            // position 7: dc_minutes
+            'Test Player'                   // position 8: name (WHERE clause)
         ];
 
-        $this->assertEquals(13, count($expectedBindParamValues), 'Should have 13 bind parameters (12 updates + 1 WHERE)');
-        $this->assertEquals(13, strlen($expectedBindParamTypes), 'Bind param type string should have 13 characters');
+        $this->assertEquals(8, count($expectedBindParamValues), 'Should have 8 bind parameters (7 updates + 1 WHERE)');
+        $this->assertEquals(8, strlen($expectedBindParamTypes), 'Bind param type string should have 8 characters');
 
         // Verify the values are what we expect
         $this->assertEquals(1, $expectedBindParamValues[0], 'First param should be pg value');
         $this->assertEquals(2, $expectedBindParamValues[1], 'Second param should be sg value');
         $this->assertEquals(30, $expectedBindParamValues[6], 'Seventh param should be min value');
-        $this->assertEquals(2, $expectedBindParamValues[7], 'Eighth param should be of value');
-        $this->assertEquals(1, $expectedBindParamValues[8], 'Ninth param should be df value');
-        $this->assertEquals(-1, $expectedBindParamValues[9], 'Tenth param should be oi value');
-        $this->assertEquals(2, $expectedBindParamValues[10], 'Eleventh param should be di value');
-        $this->assertEquals(0, $expectedBindParamValues[11], 'Twelfth param should be bh value');
+        $this->assertEquals('Test Player', $expectedBindParamValues[7], 'Eighth param should be player name');
     }
 
     /**
-     * Tests that negative values for intensity settings are preserved correctly.
-     * OF/DF are unsigned but OI/DI/BH must support negative values.
+     * Tests that role columns are hardcoded to 0 — they no longer receive bound values.
      */
-    public function testNegativeIntensityValuesArePreservedInDatabaseUpdate()
+    public function testRoleColumnsAreHardcodedToZeroInSql()
     {
-        $processedPlayerData = [
+        // The processed data no longer includes of/df/oi/di/bh as bound params
+        $depthChartValues = [
             'pg' => 0,
             'sg' => 0,
             'sf' => 0,
@@ -356,21 +305,21 @@ class DepthChartEntryRepositoryTest extends TestCase
             'c' => 1,
             'canPlayInGame' => 1,
             'min' => 20,
-            'of' => 0,     // unsigned: 0-3
-            'df' => 0,     // unsigned: 0-3
-            'oi' => -2,    // signed: -2 to 2
-            'di' => -1,    // signed: -2 to 2
-            'bh' => -2     // signed: -2 to 2
         ];
 
-        // Verify that negative values are maintained
-        $this->assertEquals(-2, $processedPlayerData['oi']);
-        $this->assertEquals(-1, $processedPlayerData['di']);
-        $this->assertEquals(-2, $processedPlayerData['bh']);
+        $this->mockDb->setAffectedRows(1);
 
-        // These values should be passed directly to the database without modification
-        // The database columns dc_oi, dc_di, dc_bh are defined as tinyint (signed)
-        // so they can store negative values
+        $result = $this->repository->updatePlayerDepthChart('Test Player', $depthChartValues);
+        $this->assertTrue($result);
+
+        // Verify the SQL hardcodes role columns to 0
+        $queries = $this->mockDb->getExecutedQueries();
+        $lastQuery = end($queries);
+        $this->assertStringContainsString('dc_of = 0', $lastQuery);
+        $this->assertStringContainsString('dc_df = 0', $lastQuery);
+        $this->assertStringContainsString('dc_oi = 0', $lastQuery);
+        $this->assertStringContainsString('dc_di = 0', $lastQuery);
+        $this->assertStringContainsString('dc_bh = 0', $lastQuery);
     }
 
     /**
@@ -378,27 +327,23 @@ class DepthChartEntryRepositoryTest extends TestCase
      */
     public function testCompleteDataFlowFromFormToDatabase()
     {
-        // Step 1: User submits form with these POST values
+        // Step 1: User submits form with these POST values (all lowercase)
         $postFieldNames = [
-            'pg1' => '1',      // lowercase position field
-            'sg1' => '2',      // lowercase position field
+            'pg1' => '1',
+            'sg1' => '2',
             'sf1' => '0',
             'pf1' => '0',
             'c1' => '0',
-            'canPlayInGame1' => '1',   // lowercase
-            'min1' => '30',     // lowercase
-            'OF1' => '2',       // UPPERCASE
-            'DF1' => '1',       // UPPERCASE
-            'OI1' => '-1',      // UPPERCASE with negative value
-            'DI1' => '2',       // UPPERCASE
-            'BH1' => '0'        // UPPERCASE
+            'canPlayInGame1' => '1',
+            'min1' => '30',
         ];
 
         // Step 2: Processor converts POST to processed array with lowercase keys
-        $processedKeys = ['pg', 'sg', 'sf', 'pf', 'c', 'canPlayInGame', 'min', 'of', 'df', 'oi', 'di', 'bh'];
+        // Role fields (of, df, oi, di, bh) are hardcoded to 0 by the processor
+        $processedBoundKeys = ['pg', 'sg', 'sf', 'pf', 'c', 'canPlayInGame', 'min'];
 
-        // Step 3: Repository maps processed array to database columns
-        $databaseColumns = [
+        // Step 3: Repository maps bound fields to database columns; role columns hardcoded to 0
+        $boundDatabaseColumns = [
             'dc_PGDepth',
             'dc_SGDepth',
             'dc_SFDepth',
@@ -406,38 +351,34 @@ class DepthChartEntryRepositoryTest extends TestCase
             'dc_CDepth',
             'dc_canPlayInGame',
             'dc_minutes',
-            'dc_of',
-            'dc_df',
-            'dc_oi',
-            'dc_di',
-            'dc_bh'
         ];
+        $hardcodedColumns = ['dc_of', 'dc_df', 'dc_oi', 'dc_di', 'dc_bh'];
 
         // Verify the counts match
-        $this->assertEquals(count($processedKeys), count($databaseColumns), 'Number of processed keys should match database columns');
+        $this->assertEquals(count($processedBoundKeys), count($boundDatabaseColumns), 'Number of bound keys should match bound database columns');
+        $this->assertEquals(5, count($hardcodedColumns), 'Should have 5 hardcoded columns');
 
-        // Verify the mapping chain (documented for reference)
+        // Verify the mapping chain for position depth fields
         $completeChain = [
             'pg' => ['POST' => 'pg1', 'processed' => 'pg', 'database' => 'dc_PGDepth'],
-            'of' => ['POST' => 'OF1', 'processed' => 'of', 'database' => 'dc_of'],
-            'df' => ['POST' => 'DF1', 'processed' => 'df', 'database' => 'dc_df'],
-            'oi' => ['POST' => 'OI1', 'processed' => 'oi', 'database' => 'dc_oi'],
-            'di' => ['POST' => 'DI1', 'processed' => 'di', 'database' => 'dc_di'],
-            'bh' => ['POST' => 'BH1', 'processed' => 'bh', 'database' => 'dc_bh']
+            'sg' => ['POST' => 'sg1', 'processed' => 'sg', 'database' => 'dc_SGDepth'],
+            'sf' => ['POST' => 'sf1', 'processed' => 'sf', 'database' => 'dc_SFDepth'],
+            'pf' => ['POST' => 'pf1', 'processed' => 'pf', 'database' => 'dc_PFDepth'],
+            'c' => ['POST' => 'c1', 'processed' => 'c', 'database' => 'dc_CDepth'],
         ];
 
-        // This chain documents how data flows through the system
-        $this->assertCount(6, $completeChain, 'Should have documented chain for 6 key fields');
+        $this->assertCount(5, $completeChain, 'Should have documented chain for 5 position depth fields');
     }
 
     /**
      * Regression test: Ensure that the order of parameters in bind_param
      * matches the order of columns in the UPDATE statement.
+     * Role columns (dc_of through dc_bh) are hardcoded to 0 and not bound.
      */
     public function testBindParamOrderMatchesUpdateStatementOrder()
     {
-        // The UPDATE statement has columns in this order:
-        $updateColumnOrder = [
+        // The UPDATE statement has bound columns in this order:
+        $boundColumnOrder = [
             1 => 'dc_PGDepth',
             2 => 'dc_SGDepth',
             3 => 'dc_SFDepth',
@@ -445,11 +386,6 @@ class DepthChartEntryRepositoryTest extends TestCase
             5 => 'dc_CDepth',
             6 => 'dc_canPlayInGame',
             7 => 'dc_minutes',
-            8 => 'dc_of',
-            9 => 'dc_df',
-            10 => 'dc_oi',
-            11 => 'dc_di',
-            12 => 'dc_bh'
         ];
 
         // The bind_param call should pass values in this EXACT same order
@@ -461,18 +397,14 @@ class DepthChartEntryRepositoryTest extends TestCase
             5 => 'c',
             6 => 'canPlayInGame',
             7 => 'min',
-            8 => 'of',
-            9 => 'df',
-            10 => 'oi',
-            11 => 'di',
-            12 => 'bh'
         ];
 
         // If these orders don't match, data will be stored in wrong columns
-        $this->assertCount(12, $updateColumnOrder);
-        $this->assertCount(12, $bindParamOrder);
+        $this->assertCount(7, $boundColumnOrder);
+        $this->assertCount(7, $bindParamOrder);
 
         // This test documents the critical requirement:
-        // The Nth value in bind_param must correspond to the Nth column in UPDATE statement
+        // The Nth value in bind_param must correspond to the Nth bound column in UPDATE statement
+        // Role columns (dc_of, dc_df, dc_oi, dc_di, dc_bh) are hardcoded to 0 in SQL
     }
 }

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryValidatorTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryValidatorTest.php
@@ -114,12 +114,12 @@ class DepthChartEntryValidatorTest extends TestCase
         $this->assertStringContainsString('at least 12 active players', $errorHtml);
     }
     
-    public function testValidatesActivePlayerCountOnly()
+    public function testValidatesActivePlayerCountPositionDepthAndMultiStarter()
     {
         $depthChartData = [
             'activePlayers' => 8,  // Too few for Regular Season (min 12)
-            'pos_1' => 1,
-            'pos_2' => 1,
+            'pos_1' => 1,         // Too few PG (need 3)
+            'pos_2' => 1,         // Too few SG (need 3)
             'pos_3' => 3,
             'pos_4' => 3,
             'pos_5' => 3,
@@ -131,8 +131,12 @@ class DepthChartEntryValidatorTest extends TestCase
 
         $this->assertFalse($result);
         $errors = $this->validator->getErrors();
-        $this->assertCount(1, $errors);
+        // Should have: active_players_min + 2 position_depth + multiple_starting_positions
+        $this->assertCount(4, $errors);
         $this->assertEquals('active_players_min', $errors[0]['type']);
+        $this->assertEquals('position_depth', $errors[1]['type']);
+        $this->assertEquals('position_depth', $errors[2]['type']);
+        $this->assertEquals('multiple_starting_positions', $errors[3]['type']);
     }
     
     public function testEdgeCaseExactlyAtMinimumRequirements()
@@ -192,13 +196,13 @@ class DepthChartEntryValidatorTest extends TestCase
         $this->assertEmpty($this->validator->getErrors());
     }
     
-    public function testPassesValidationRegardlessOfPositionDepth()
+    public function testFailsValidationWithInsufficientPositionDepth()
     {
         $depthChartData = [
             'activePlayers' => 12,
             'pos_1' => 3,
             'pos_2' => 3,
-            'pos_3' => 1,  // Low position depth is no longer validated
+            'pos_3' => 1,  // Below minimum of 3 for regular season
             'pos_4' => 3,
             'pos_5' => 3,
             'hasStarterAtMultiplePositions' => false,
@@ -207,7 +211,32 @@ class DepthChartEntryValidatorTest extends TestCase
 
         $result = $this->validator->validate($depthChartData, 'Regular Season');
 
-        $this->assertTrue($result);
-        $this->assertEmpty($this->validator->getErrors());
+        $this->assertFalse($result);
+        $errors = $this->validator->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertEquals('position_depth', $errors[0]['type']);
+        $this->assertStringContainsString('SF', $errors[0]['message']);
+    }
+
+    public function testFailsValidationWithMultipleStartingPositions()
+    {
+        $depthChartData = [
+            'activePlayers' => 12,
+            'pos_1' => 3,
+            'pos_2' => 3,
+            'pos_3' => 3,
+            'pos_4' => 3,
+            'pos_5' => 3,
+            'hasStarterAtMultiplePositions' => true,
+            'nameOfProblemStarter' => 'John Doe'
+        ];
+
+        $result = $this->validator->validate($depthChartData, 'Regular Season');
+
+        $this->assertFalse($result);
+        $errors = $this->validator->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertEquals('multiple_starting_positions', $errors[0]['type']);
+        $this->assertStringContainsString('John Doe', $errors[0]['message']);
     }
 }

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryViewTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryViewTest.php
@@ -671,4 +671,63 @@ class DepthChartEntryViewTest extends TestCase
         // HtmlSanitizer uses ENT_HTML5, so `'` becomes `&apos;` (not `&#039;`).
         $this->assertStringContainsString('O&apos;Brien', $output);
     }
+
+    public function testPositionDepthSelectsShowCorrectOptionLabels(): void
+    {
+        $player = $this->buildTestPlayer();
+        $player['dc_SFDepth'] = 3;
+
+        ob_start();
+        $this->view->renderPlayerRow($player, 1);
+        $output = (string) ob_get_clean();
+
+        $expectedLabels = ['No', '1st', '2nd', '3rd', '4th', 'ok'];
+
+        foreach (['pg', 'sg', 'sf', 'pf', 'c'] as $field) {
+            preg_match('/<select name="' . $field . '1"[^>]*>(.*?)<\/select>/s', $output, $matches);
+            $this->assertNotEmpty($matches, "Position depth select for {$field} not found");
+            $selectHtml = $matches[1];
+
+            foreach ($expectedLabels as $i => $label) {
+                $this->assertMatchesRegularExpression(
+                    '/value="' . $i . '"[^>]*>' . preg_quote($label, '/') . '<\/option>/',
+                    $selectHtml,
+                    "Position {$field}: option {$i} should have label '{$label}'"
+                );
+            }
+        }
+    }
+
+    public function testPositionDepthSelectsHaveSixOptions(): void
+    {
+        $player = $this->buildTestPlayer();
+
+        ob_start();
+        $this->view->renderPlayerRow($player, 1);
+        $output = (string) ob_get_clean();
+
+        preg_match('/<select name="pg1"[^>]*>(.*?)<\/select>/s', $output, $matches);
+        $this->assertNotEmpty($matches);
+        $optionCount = substr_count($matches[1], '<option');
+        $this->assertSame(6, $optionCount, 'Position depth should have exactly 6 options (No/1st/2nd/3rd/4th/ok)');
+    }
+
+    public function testPositionDepthSelectPreselectsCorrectValue(): void
+    {
+        $player = $this->buildTestPlayer();
+        $player['dc_SFDepth'] = 1;
+        $player['dc_PGDepth'] = 0;
+
+        ob_start();
+        $this->view->renderPlayerRow($player, 1);
+        $output = (string) ob_get_clean();
+
+        preg_match('/<select name="sf1"[^>]*>(.*?)<\/select>/s', $output, $matches);
+        $this->assertNotEmpty($matches);
+        $this->assertMatchesRegularExpression('/value="1" SELECTED[^>]*>1st<\/option>/', $matches[1]);
+
+        preg_match('/<select name="pg1"[^>]*>(.*?)<\/select>/s', $output, $matches);
+        $this->assertNotEmpty($matches);
+        $this->assertMatchesRegularExpression('/value="0" SELECTED[^>]*>No<\/option>/', $matches[1]);
+    }
 }

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryViewTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryViewTest.php
@@ -89,11 +89,12 @@ class DepthChartEntryViewTest extends TestCase
         $this->assertStringContainsString('name="c1"', $output);
         $this->assertStringContainsString('name="canPlayInGame1"', $output);
         $this->assertStringContainsString('name="min1"', $output);
-        $this->assertStringContainsString('name="OF1"', $output);
-        $this->assertStringContainsString('name="DF1"', $output);
-        $this->assertStringContainsString('name="OI1"', $output);
-        $this->assertStringContainsString('name="DI1"', $output);
-        $this->assertStringContainsString('name="BH1"', $output);
+        // Role fields (OF, DF, OI, DI, BH) are no longer rendered
+        $this->assertStringNotContainsString('name="OF1"', $output);
+        $this->assertStringNotContainsString('name="DF1"', $output);
+        $this->assertStringNotContainsString('name="OI1"', $output);
+        $this->assertStringNotContainsString('name="DI1"', $output);
+        $this->assertStringNotContainsString('name="BH1"', $output);
     }
 
     public function testRenderPlayerRowContainsHiddenFields(): void
@@ -356,11 +357,12 @@ class DepthChartEntryViewTest extends TestCase
         $this->assertStringContainsString('name="c1"', $output);
         $this->assertStringContainsString('name="canPlayInGame1"', $output);
         $this->assertStringContainsString('name="min1"', $output);
-        $this->assertStringContainsString('name="OF1"', $output);
-        $this->assertStringContainsString('name="DF1"', $output);
-        $this->assertStringContainsString('name="OI1"', $output);
-        $this->assertStringContainsString('name="DI1"', $output);
-        $this->assertStringContainsString('name="BH1"', $output);
+        // Role fields (OF, DF, OI, DI, BH) are no longer rendered
+        $this->assertStringNotContainsString('name="OF1"', $output);
+        $this->assertStringNotContainsString('name="DF1"', $output);
+        $this->assertStringNotContainsString('name="OI1"', $output);
+        $this->assertStringNotContainsString('name="DI1"', $output);
+        $this->assertStringNotContainsString('name="BH1"', $output);
     }
 
     public function testRenderMobileViewActiveCheckboxChecked(): void
@@ -445,29 +447,29 @@ class DepthChartEntryViewTest extends TestCase
     public function testRenderMobileViewStepperInitialLabelMatchesDcValue(): void
     {
         $player = $this->buildTestPlayer();
-        $player['dc_bh'] = 1; // PG slot → starter label "S"
-        $player['dc_df'] = 2; // PF slot → backup label "#2"
+        $player['dc_PGDepth'] = 1; // PG depth → starter label "1st"
+        $player['dc_SFDepth'] = 2; // SF depth → backup label "2nd"
 
         ob_start();
         $this->view->renderMobileView([$player], ['PG', 'SG', 'SF', 'PF', 'C']);
         $output = (string) ob_get_clean();
 
         // Initial labels are rendered server-side so stepper values are
-        // correct before any JS runs. &mdash; is the unassigned label.
+        // correct before any JS runs. "No" is the unassigned label.
         $this->assertMatchesRegularExpression(
-            '/dc-card__stepper-value[^>]*>S</',
+            '/dc-card__stepper-value[^>]*>1st</',
             $output,
-            'PG slot with dc_bh=1 should render initial label "S"'
+            'PG slot with depth=1 should render initial label "1st"'
         );
         $this->assertMatchesRegularExpression(
-            '/dc-card__stepper-value[^>]*>#2</',
+            '/dc-card__stepper-value[^>]*>2nd</',
             $output,
-            'PF slot with dc_df=2 should render initial label "#2"'
+            'SF slot with depth=2 should render initial label "2nd"'
         );
         $this->assertMatchesRegularExpression(
-            '/dc-card__stepper-value[^>]*>&mdash;</',
+            '/dc-card__stepper-value[^>]*>No</',
             $output,
-            'Unassigned slots should render the em-dash label'
+            'Unassigned slots should render the "No" label'
         );
     }
 
@@ -479,12 +481,12 @@ class DepthChartEntryViewTest extends TestCase
         $this->view->renderMobileView([$player], ['PG', 'SG', 'SF', 'PF', 'C']);
         $output = (string) ob_get_clean();
 
-        // aria-labels include direction + slot + player name so screen
+        // aria-labels include direction + position + player name so screen
         // readers announce the action and its target.
-        $this->assertStringContainsString('aria-label="Previous PG slot for Unique Player"', $output);
-        $this->assertStringContainsString('aria-label="Next PG slot for Unique Player"', $output);
-        $this->assertStringContainsString('aria-label="Previous C slot for Unique Player"', $output);
-        $this->assertStringContainsString('aria-label="Next C slot for Unique Player"', $output);
+        $this->assertStringContainsString('aria-label="Previous PG depth for Unique Player"', $output);
+        $this->assertStringContainsString('aria-label="Next PG depth for Unique Player"', $output);
+        $this->assertStringContainsString('aria-label="Previous C depth for Unique Player"', $output);
+        $this->assertStringContainsString('aria-label="Next C depth for Unique Player"', $output);
     }
 
     public function testRenderMobileViewStepperButtonsAreTypeButton(): void
@@ -582,15 +584,13 @@ class DepthChartEntryViewTest extends TestCase
         $this->assertStringContainsString('Must have 12 active players.', $output);
     }
 
-    public function testRenderSubmissionResultHasAllRoleSlotHeaders(): void
+    public function testRenderSubmissionResultHasAllPositionHeaders(): void
     {
         ob_start();
         $this->view->renderSubmissionResult('Metros', [], true);
         $output = (string) ob_get_clean();
 
-        // Relabeled columns per the redesign: PG/SG/SF/PF/C map to
-        // bh/di/oi/df/of respectively. Verify the confirmation table echoes
-        // the form's column headers so the GM can cross-check what was saved.
+        // Confirmation table shows position depth columns matching the form
         $this->assertStringContainsString('<th>Name</th>', $output);
         $this->assertStringContainsString('<th>Active</th>', $output);
         $this->assertStringContainsString('<th>PG</th>', $output);
@@ -598,31 +598,29 @@ class DepthChartEntryViewTest extends TestCase
         $this->assertStringContainsString('<th>SF</th>', $output);
         $this->assertStringContainsString('<th>PF</th>', $output);
         $this->assertStringContainsString('<th>C</th>', $output);
+        $this->assertStringContainsString('<th>Min</th>', $output);
     }
 
     public function testRenderSubmissionResultEmitsSubmittedValuesInCorrectColumns(): void
     {
-        // Two players with distinct, non-trivial values per column so the
+        // Two players with distinct, non-trivial position depth values so the
         // assertions can't pass by accident on a default-zero row.
+        // Columns: Name, Active, PG, SG, SF, PF, C, Min
         $players = [
-            $this->buildProcessedPlayer(
-                name: 'Player One',
-                canPlayInGame: 1,
-                bh: 1,  // PG column
-                di: 2,  // SG column
-                oi: 0,  // SF column
-                df: 0,  // PF column
-                of: 0,  // C column
-            ),
-            $this->buildProcessedPlayer(
-                name: 'Player Two',
-                canPlayInGame: 0,
-                bh: 0,
-                di: 0,
-                oi: 3,
-                df: 1,
-                of: 2,
-            ),
+            [
+                'name' => 'Player One',
+                'pg' => 1, 'sg' => 2, 'sf' => 0, 'pf' => 0, 'c' => 3,
+                'canPlayInGame' => 1, 'min' => 30,
+                'of' => 0, 'df' => 0, 'oi' => 0, 'di' => 0, 'bh' => 0,
+                'injury' => 0,
+            ],
+            [
+                'name' => 'Player Two',
+                'pg' => 0, 'sg' => 0, 'sf' => 3, 'pf' => 1, 'c' => 2,
+                'canPlayInGame' => 0, 'min' => 25,
+                'of' => 0, 'df' => 0, 'oi' => 0, 'di' => 0, 'bh' => 0,
+                'injury' => 0,
+            ],
         ];
 
         ob_start();
@@ -634,18 +632,17 @@ class DepthChartEntryViewTest extends TestCase
         $this->assertStringContainsString('Player Two', $output);
 
         // Extract the two <tr> bodies from the confirmation table and verify
-        // each contains the exact values submitted. Using regex keeps the
-        // test resilient to whitespace noise in the view's heredoc-style
-        // echo while still asserting per-cell positioning.
+        // each contains the exact values submitted.
+        // Columns: Name, Active, PG, SG, SF, PF, C, Min
         $this->assertMatchesRegularExpression(
-            '/<tr>\s*<td>Player One<\/td>\s*<td>1<\/td>\s*<td>1<\/td>\s*<td>2<\/td>\s*<td>0<\/td>\s*<td>0<\/td>\s*<td>0<\/td>\s*<\/tr>/',
+            '/<tr>\s*<td>Player One<\/td>\s*<td>1<\/td>\s*<td>1<\/td>\s*<td>2<\/td>\s*<td>0<\/td>\s*<td>0<\/td>\s*<td>3<\/td>\s*<td>30<\/td>\s*<\/tr>/',
             $output,
-            'Player One row should be: Active=1, PG=1, SG=2, SF=0, PF=0, C=0',
+            'Player One row should be: Active=1, PG=1, SG=2, SF=0, PF=0, C=3, Min=30',
         );
         $this->assertMatchesRegularExpression(
-            '/<tr>\s*<td>Player Two<\/td>\s*<td>0<\/td>\s*<td>0<\/td>\s*<td>0<\/td>\s*<td>3<\/td>\s*<td>1<\/td>\s*<td>2<\/td>\s*<\/tr>/',
+            '/<tr>\s*<td>Player Two<\/td>\s*<td>0<\/td>\s*<td>0<\/td>\s*<td>0<\/td>\s*<td>3<\/td>\s*<td>1<\/td>\s*<td>2<\/td>\s*<td>25<\/td>\s*<\/tr>/',
             $output,
-            'Player Two row should be: Active=0, PG=0, SG=0, SF=0, PF=3, PF=1, C=2',
+            'Player Two row should be: Active=0, PG=0, SG=0, SF=3, PF=1, C=2, Min=25',
         );
     }
 

--- a/ibl5/tests/Integration/DepthChartEntry/DepthChartEntryIntegrationTest.php
+++ b/ibl5/tests/Integration/DepthChartEntry/DepthChartEntryIntegrationTest.php
@@ -107,11 +107,6 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
             'c1' => '0',
             'canPlayInGame1' => '1',
             'min1' => '32',
-            'OF1' => '2',
-            'DF1' => '1',
-            'OI1' => '1',
-            'DI1' => '2',
-            'BH1' => '0',
             'Injury1' => '0'
         ];
         $this->mockDb->setAffectedRows(1);
@@ -130,17 +125,18 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
         $this->assertEquals(0, $playerData['c']);
         $this->assertEquals(1, $playerData['canPlayInGame']);
         $this->assertEquals(32, $playerData['min']);
-        $this->assertEquals(2, $playerData['of']);
-        $this->assertEquals(1, $playerData['df']);
-        $this->assertEquals(1, $playerData['oi']);
-        $this->assertEquals(2, $playerData['di']);
+        // Role fields hardcoded to 0
+        $this->assertEquals(0, $playerData['of']);
+        $this->assertEquals(0, $playerData['df']);
+        $this->assertEquals(0, $playerData['oi']);
+        $this->assertEquals(0, $playerData['di']);
         $this->assertEquals(0, $playerData['bh']);
 
         // Assert - Database update succeeded and included correct data
         $this->assertTrue($updateResult);
         $this->assertQueryExecuted('UPDATE ibl_plr');
         $this->assertQueryExecuted('dc_PGDepth');
-        $this->assertQueryExecuted('dc_of');
+        $this->assertQueryExecuted('dc_of = 0');
         $this->assertQueryExecuted("name = 'John Smith'");
     }
 
@@ -240,19 +236,21 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
      * @group depthchart
      * @group validation-failure
      */
-    public function testWorkflowPassesWithReducedPositionDepth(): void
+    public function testWorkflowFailsWithReducedPositionDepth(): void
     {
-        // Arrange - Valid active count but only 2 PG depth
-        // Position depth validation has been removed, so this should pass
+        // Arrange - Valid active count but only 2 PG depth (need 3 for regular season)
         $postData = $this->createPostDataWithInsufficientPositionDepth('PG');
 
         // Act
         $result = $this->processor->processSubmission($postData, 15);
         $isValid = $this->validator->validate($result, 'Regular Season');
 
-        // Assert - No position depth validation, so it passes
-        $this->assertTrue($isValid);
-        $this->assertEmpty($this->validator->getErrors());
+        // Assert - Position depth validation catches insufficient PG depth
+        $this->assertFalse($isValid);
+        $errors = $this->validator->getErrors();
+        $this->assertNotEmpty($errors);
+        $this->assertEquals('position_depth', $errors[0]['type']);
+        $this->assertStringContainsString('PG', $errors[0]['message']);
     }
 
     /**
@@ -260,22 +258,24 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
      * @group depthchart
      * @group validation-failure
      */
-    public function testWorkflowPassesWithMultipleStartingPositions(): void
+    public function testWorkflowFailsWithMultipleStartingPositions(): void
     {
         // Arrange - One player starting at both PG and SG
-        // Multiple-starter validation has been removed, so this should pass
         $postData = $this->createPostDataWithMultipleStarter();
 
         // Act
         $result = $this->processor->processSubmission($postData, 15);
         $isValid = $this->validator->validate($result, 'Regular Season');
 
-        // Assert - No multiple-starter validation
-        $this->assertTrue($isValid);
-        $this->assertEmpty($this->validator->getErrors());
-        // Starter detection removed — always returns defaults
-        $this->assertFalse($result['hasStarterAtMultiplePositions']);
-        $this->assertEquals('', $result['nameOfProblemStarter']);
+        // Assert - Multiple-starter validation catches the issue
+        $this->assertFalse($isValid);
+        $errors = $this->validator->getErrors();
+        $this->assertNotEmpty($errors);
+        // Find the multiple_starting_positions error
+        $multiStarterErrors = array_filter($errors, static fn (array $e): bool => $e['type'] === 'multiple_starting_positions');
+        $this->assertNotEmpty($multiStarterErrors, 'Should have a multiple_starting_positions error');
+        $this->assertTrue($result['hasStarterAtMultiplePositions']);
+        $this->assertEquals('Multi Starter', $result['nameOfProblemStarter']);
     }
 
     /**
@@ -433,7 +433,6 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
         $depthChartValues = [
             'pg' => 1, 'sg' => 2, 'sf' => 3, 'pf' => 4, 'c' => 5,
             'canPlayInGame' => 1, 'min' => 35,
-            'of' => 2, 'df' => 1, 'oi' => -1, 'di' => 2, 'bh' => 0
         ];
         $this->mockDb->setAffectedRows(1);
 
@@ -445,7 +444,7 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
         $queries = $this->getExecutedQueries();
         $lastQuery = end($queries);
 
-        // Verify all fields are in the query
+        // Verify bound fields are in the query
         $this->assertStringContainsString('dc_PGDepth', $lastQuery);
         $this->assertStringContainsString('dc_SGDepth', $lastQuery);
         $this->assertStringContainsString('dc_SFDepth', $lastQuery);
@@ -453,11 +452,12 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
         $this->assertStringContainsString('dc_CDepth', $lastQuery);
         $this->assertStringContainsString('dc_canPlayInGame', $lastQuery);
         $this->assertStringContainsString('dc_minutes', $lastQuery);
-        $this->assertStringContainsString('dc_of', $lastQuery);
-        $this->assertStringContainsString('dc_df', $lastQuery);
-        $this->assertStringContainsString('dc_oi', $lastQuery);
-        $this->assertStringContainsString('dc_di', $lastQuery);
-        $this->assertStringContainsString('dc_bh', $lastQuery);
+        // Role columns are hardcoded to 0 in SQL
+        $this->assertStringContainsString('dc_of = 0', $lastQuery);
+        $this->assertStringContainsString('dc_df = 0', $lastQuery);
+        $this->assertStringContainsString('dc_oi = 0', $lastQuery);
+        $this->assertStringContainsString('dc_di = 0', $lastQuery);
+        $this->assertStringContainsString('dc_bh = 0', $lastQuery);
     }
 
     /**
@@ -472,7 +472,6 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
         $depthChartValues = [
             'pg' => 0, 'sg' => 0, 'sf' => 0, 'pf' => 0, 'c' => 0,
             'canPlayInGame' => 1, 'min' => 0,
-            'of' => 0, 'df' => 0, 'oi' => 0, 'di' => 0, 'bh' => 0
         ];
         $this->mockDb->setAffectedRows(0); // No rows affected
 
@@ -492,9 +491,9 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
     {
         // Arrange
         $players = [
-            ['name' => 'Player 1', 'pg' => 1, 'sg' => 0, 'sf' => 0, 'pf' => 0, 'c' => 0, 'canPlayInGame' => 1, 'min' => 30, 'of' => 0, 'df' => 0, 'oi' => 0, 'di' => 0, 'bh' => 0],
-            ['name' => 'Player 2', 'pg' => 0, 'sg' => 1, 'sf' => 0, 'pf' => 0, 'c' => 0, 'canPlayInGame' => 1, 'min' => 28, 'of' => 0, 'df' => 0, 'oi' => 0, 'di' => 0, 'bh' => 0],
-            ['name' => 'Player 3', 'pg' => 0, 'sg' => 0, 'sf' => 1, 'pf' => 0, 'c' => 0, 'canPlayInGame' => 1, 'min' => 32, 'of' => 0, 'df' => 0, 'oi' => 0, 'di' => 0, 'bh' => 0],
+            ['name' => 'Player 1', 'pg' => 1, 'sg' => 0, 'sf' => 0, 'pf' => 0, 'c' => 0, 'canPlayInGame' => 1, 'min' => 30],
+            ['name' => 'Player 2', 'pg' => 0, 'sg' => 1, 'sf' => 0, 'pf' => 0, 'c' => 0, 'canPlayInGame' => 1, 'min' => 28],
+            ['name' => 'Player 3', 'pg' => 0, 'sg' => 0, 'sf' => 1, 'pf' => 0, 'c' => 0, 'canPlayInGame' => 1, 'min' => 32],
         ];
         $this->mockDb->setAffectedRows(1);
 
@@ -551,11 +550,6 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
             'sf1' => '3', 'pf1' => '0', 'c1' => '0',
             'canPlayInGame1' => '999', // Should normalize to 0 (not 1)
             'min1' => '100',    // Should clamp to 40
-            'OF1' => '10',      // Should clamp to 3
-            'DF1' => '-10',     // Should clamp to 0
-            'OI1' => '10',      // Should clamp to 2
-            'DI1' => '-10',     // Should clamp to 0 (negative clamped to 0)
-            'BH1' => '0',
             'Injury1' => '0'
         ];
 
@@ -568,10 +562,11 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
         $this->assertEquals(0, $player['sg'], 'SG depth should clamp to 0');
         $this->assertEquals(0, $player['canPlayInGame'], 'Active should be 0 or 1');
         $this->assertEquals(40, $player['min'], 'Minutes should clamp to 40');
-        $this->assertEquals(3, $player['of'], 'OF should clamp to 3');
-        $this->assertEquals(0, $player['df'], 'DF should clamp to 0');
-        $this->assertEquals(2, $player['oi'], 'OI should clamp to 2');
-        $this->assertEquals(0, $player['di'], 'DI should clamp to 0 (range is [0, 2])');
+        // Role fields hardcoded to 0 regardless of input
+        $this->assertEquals(0, $player['of'], 'OF should always be 0');
+        $this->assertEquals(0, $player['df'], 'DF should always be 0');
+        $this->assertEquals(0, $player['oi'], 'OI should always be 0');
+        $this->assertEquals(0, $player['di'], 'DI should always be 0');
     }
 
     /**
@@ -579,17 +574,13 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
      * @group depthchart
      * @group sanitization
      */
-    public function testProcessorClampsNegativeSettingValuesToZero(): void
+    public function testProcessorHardcodesRoleFieldsToZero(): void
     {
-        // Arrange - Negative setting values now clamp to 0 (range is [0, 2])
+        // Arrange - Role fields (OF/DF/OI/DI/BH) are always 0 regardless of input
         $postData = [
             'Name1' => 'Test',
             'pg1' => '1', 'sg1' => '0', 'sf1' => '0', 'pf1' => '0', 'c1' => '0',
             'canPlayInGame1' => '1', 'min1' => '30',
-            'OF1' => '2', 'DF1' => '1',
-            'OI1' => '-2',  // Clamped to 0
-            'DI1' => '-1',  // Clamped to 0
-            'BH1' => '-2',  // Clamped to 0
             'Injury1' => '0'
         ];
         $this->mockDb->setAffectedRows(1);
@@ -599,7 +590,9 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
         $player = $result['playerData'][0];
         $this->repository->updatePlayerDepthChart($player['name'], $player);
 
-        // Assert - Negative values clamped to 0
+        // Assert - Role fields always 0
+        $this->assertEquals(0, $player['of']);
+        $this->assertEquals(0, $player['df']);
         $this->assertEquals(0, $player['oi']);
         $this->assertEquals(0, $player['di']);
         $this->assertEquals(0, $player['bh']);
@@ -615,21 +608,23 @@ class DepthChartEntryIntegrationTest extends IntegrationTestCase
      * @group depthchart
      * @group errors
      */
-    public function testValidatorReportsActivePlayerError(): void
+    public function testValidatorReportsMultipleErrors(): void
     {
-        // Arrange - Data with too few active players
+        // Arrange - Data with too few active players and insufficient position depth
         $postData = $this->createPostDataWithMultipleIssues();
 
         // Act
         $result = $this->processor->processSubmission($postData, 15);
         $isValid = $this->validator->validate($result, 'Regular Season');
 
-        // Assert - Only active player count validation remains
+        // Assert - Multiple validation errors
         $this->assertFalse($isValid);
         $errors = $this->validator->getErrors();
 
-        $this->assertCount(1, $errors, 'Should have active player error');
+        // Should have active_players_min + position_depth errors for positions below 3
+        $this->assertNotEmpty($errors);
         $this->assertEquals('active_players_min', $errors[0]['type']);
+        // Additional position_depth errors may follow depending on depth distribution
     }
 
     /**

--- a/ibl5/tests/e2e/flows/depth-chart-entry-mobile.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart-entry-mobile.spec.ts
@@ -76,17 +76,15 @@ test.describe('Depth Chart Entry: mobile card view', () => {
     await checkbox.click();
   });
 
-  test('role slot selects are enabled on mobile', async ({ page }) => {
-    // Position selects (pg/sg/sf/pf/c) are now hidden inputs; role slot
-    // selects use field names BH, DI, OI, DF, OF for PG/SG/SF/PF/C columns.
-    const bhSelects = page.locator('.dc-mobile-cards select[name^="BH"]');
-    await expect(bhSelects.first()).toBeEnabled();
+  test('position depth selects are enabled on mobile', async ({ page }) => {
+    // Position depth selects use field names pg, sg, sf, pf, c.
+    const pgSelects = page.locator('.dc-mobile-cards select[name^="pg"]');
+    await expect(pgSelects.first()).toBeEnabled();
   });
 
   test('settings grid has 6 columns per card', async ({ page }) => {
-    // The old pos-grid is gone; a single settings-grid holds all 5 role
-    // slots (BH/DI/OI/DF/OF = PG/SG/SF/PF/C) followed by the Min column
-    // on the right edge, for 6 fields total.
+    // The settings-grid holds all 5 position depth fields (pg/sg/sf/pf/c)
+    // followed by the Min column on the right edge, for 6 fields total.
     const firstGrid = page.locator('.dc-card__settings-grid').first();
     const fields = firstGrid.locator('.dc-card__field');
     await expect(fields).toHaveCount(6);
@@ -95,11 +93,11 @@ test.describe('Depth Chart Entry: mobile card view', () => {
   test('position stepper cycles through options on tap', async ({ page }) => {
     // The mobile position control is a vertical stepper (up-arrow / value
     // label / down-arrow) over a visually hidden <select>. Tapping the
-    // arrows should cycle through the role-priority options, wrap around
+    // arrows should cycle through the position depth options, wrap around
     // at the bounds, and keep the underlying <select> in sync so form
     // submission and the desktop-sync path still work.
     const firstCard = page.locator('.dc-card').first();
-    // Field 0 is the PG (BH) slot — first stepper on the card. The "Min"
+    // Field 0 is the PG (pg) depth — first stepper on the card. The "Min"
     // column now sits at the far right (field index 5).
     const pgField = firstCard.locator('.dc-card__field').nth(0);
 
@@ -118,10 +116,12 @@ test.describe('Depth Chart Entry: mobile card view', () => {
     await expect(hiddenSelect).toBeHidden();
 
     const optionCount = await hiddenSelect.locator('option').count();
-    expect(optionCount).toBeGreaterThanOrEqual(3);
+    expect(optionCount).toBeGreaterThanOrEqual(6);
 
-    // Mirror the PHP label convention: 0 → em dash, 1 → "S", N → "#N".
-    const labelFor = (v: number) => (v === 0 ? '—' : v === 1 ? 'S' : `#${v}`);
+    // Mirror the PHP label convention: 0 → "No", 1 → "1st", 2 → "2nd",
+    // 3 → "3rd", 4 → "4th", 5 → "ok".
+    const depthLabels = ['No', '1st', '2nd', '3rd', '4th', 'ok'];
+    const labelFor = (v: number) => depthLabels[v] ?? String(v);
 
     const startValue = Number(await hiddenSelect.inputValue());
 
@@ -148,9 +148,9 @@ test.describe('Depth Chart Entry: mobile card view', () => {
 
   test('minutes stepper increments and clamps at 0/40', async ({ page }) => {
     // The Min column (rightmost field, nth(5)) is a number input wrapped
-    // in the same stepper chrome as the role slots. Up arrow increments
+    // in the same stepper chrome as the position depths. Up arrow increments
     // (more minutes), down arrow decrements (fewer minutes) — the opposite
-    // direction from the role slot stepper because minutes is a numeric
+    // direction from the position depth stepper because minutes is a numeric
     // quantity rather than a depth-chart rank. The value is clamped to
     // the input's [min, max] attributes (0-40) instead of wrapping.
     const firstCard = page.locator('.dc-card').first();
@@ -202,7 +202,7 @@ test.describe('Depth Chart Entry: mobile card view', () => {
     await minInput.dispatchEvent('change');
   });
 
-  test('changing a card role slot triggers glow', async ({ page }) => {
+  test('changing a card position depth triggers glow', async ({ page }) => {
     // Tapping a stepper arrow cycles the hidden <select> and dispatches
     // a bubbling change event — the glow highlighter in
     // depth-chart-changes.js listens for that on the form.
@@ -359,7 +359,7 @@ test.describe('DCE mobile: saved depth chart loading', () => {
     expect(optCount, 'Saved DC dropdown should have at least 2 options').toBeGreaterThanOrEqual(2);
 
     // Ensure mobile cards are ready before loading a saved config
-    await expect(page.locator('.dc-mobile-cards select[name^="BH"]').first()).toBeEnabled();
+    await expect(page.locator('.dc-mobile-cards select[name^="pg"]').first()).toBeEnabled();
 
     // Select the second option (first saved config)
     await dropdown.selectOption({ index: 1 });
@@ -413,7 +413,7 @@ test.describe('DCE mobile: resize sync', () => {
     await page.goto('modules.php?name=DepthChartEntry');
     await page.waitForLoadState('networkidle');
 
-    // Change the first card's PG (BH) slot by tapping the stepper down
+    // Change the first card's PG (pg) depth by tapping the stepper down
     // arrow. The underlying <select> is display:none on mobile, so we
     // can't call selectOption() on it — we drive the stepper UI instead.
     const firstCard = page.locator('.dc-card').first();
@@ -431,7 +431,7 @@ test.describe('DCE mobile: resize sync', () => {
     await page.waitForTimeout(200); // debounce
 
     // Desktop table should now show the changed value
-    const desktopSelect = page.locator('.depth-chart-table select[name^="BH"]').first();
+    const desktopSelect = page.locator('.depth-chart-table select[name^="pg"]').first();
     await expect(desktopSelect).toBeEnabled();
     const desktopValue = await desktopSelect.inputValue();
     expect(desktopValue).toBe(newValue);

--- a/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
@@ -104,6 +104,7 @@ test.describe('Depth Chart submission', () => {
       'SF',
       'PF',
       'C',
+      'Min',
     ]);
 
     // At least one player row should be rendered.

--- a/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
@@ -14,9 +14,9 @@ test.describe('Depth Chart submission', () => {
     const form = page.locator('.depth-chart-form');
     await expect(form).toBeVisible({ timeout: 15000 });
 
-    // Role slot selects (BH = PG column) should be present and visible
-    const bhSelects = page.locator('select[name^="BH"]');
-    await expect(bhSelects.first()).toBeVisible();
+    // Position depth selects (pg = PG column) should be present and visible
+    const pgSelects = page.locator('select[name^="pg"]');
+    await expect(pgSelects.first()).toBeVisible();
 
     // Active checkboxes should be pre-populated — at least one player is active.
     // The desktop `.dc-active-cb` class disambiguates from the mobile
@@ -33,19 +33,19 @@ test.describe('Depth Chart submission', () => {
     expect(hasActive).toBe(true);
   });
 
-  test('change a role slot assignment', async ({ page }) => {
+  test('change a position depth assignment', async ({ page }) => {
     const form = page.locator('.depth-chart-form');
     await expect(form).toBeVisible({ timeout: 15000 });
 
-    // Find a BH (PG role slot) select with value "0" and change it to "2" (backup)
-    const bhSelects = page.locator('select[name^="BH"]');
-    const count = await bhSelects.count();
+    // Find a pg (PG position depth) select with value "0" and change it to "2" (2nd)
+    const pgSelects = page.locator('select[name^="pg"]');
+    const count = await pgSelects.count();
 
     for (let i = 0; i < count; i++) {
-      const val = await bhSelects.nth(i).inputValue();
+      const val = await pgSelects.nth(i).inputValue();
       if (val === '0') {
-        await bhSelects.nth(i).selectOption('2');
-        const newVal = await bhSelects.nth(i).inputValue();
+        await pgSelects.nth(i).selectOption('2');
+        const newVal = await pgSelects.nth(i).inputValue();
         expect(newVal).toBe('2');
         break;
       }
@@ -58,14 +58,14 @@ test.describe('Depth Chart submission', () => {
     const form = page.locator('.depth-chart-form');
     await expect(form).toBeVisible({ timeout: 15000 });
 
-    // Set a distinctive BH (PG) value on the first desktop player row so we
+    // Set a distinctive pg (PG) value on the first desktop player row so we
     // can verify the confirmation page echoes back exactly what was POSTed.
     // Scoping to `.depth-chart-table` avoids colliding with the mobile
     // card duplicates that share the same input names.
-    const firstBh = page
-      .locator('.depth-chart-table select[name^="BH"]')
+    const firstPg = page
+      .locator('.depth-chart-table select[name^="pg"]')
       .first();
-    await firstBh.selectOption('1');
+    await firstPg.selectOption('1');
 
     // Submit the current depth chart
     const submitBtn = page.locator('.depth-chart-buttons .depth-chart-submit-btn');
@@ -132,8 +132,8 @@ test.describe('Depth Chart submission', () => {
     const optCount = await options.count();
     expect(optCount, 'Saved DC dropdown should have at least 2 options').toBeGreaterThanOrEqual(2);
 
-    // Ensure first BH select is ready before loading a saved config
-    await expect(page.locator('select[name^="BH"]').first()).toBeEnabled();
+    // Ensure first pg select is ready before loading a saved config
+    await expect(page.locator('select[name^="pg"]').first()).toBeEnabled();
 
     // Select the second option (first saved config)
     await dropdown.selectOption({ index: 1 });

--- a/ibl5/tests/e2e/flows/depth-chart-entry.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart-entry.spec.ts
@@ -37,15 +37,14 @@ test.describe('Depth Chart Entry flow', () => {
     await expect(playerRows.first()).toBeVisible();
   });
 
-  test('role slot selects have options', async ({ page }) => {
+  test('position depth selects have options', async ({ page }) => {
     const form = page.locator('.depth-chart-form');
     await expect(form).toBeVisible({ timeout: 15000 });
 
-    // Position selects (pg/sg/sf/pf/c) are now hidden inputs; role slot
-    // selects use field names BH, DI, OI, DF, OF for PG/SG/SF/PF/C columns.
-    const roleSelect = page.locator('select[name^="BH"]').first();
-    await expect(roleSelect).toBeVisible();
-    const options = roleSelect.locator('option');
+    // Position depth selects use field names pg, sg, sf, pf, c.
+    const depthSelect = page.locator('select[name^="pg"]').first();
+    await expect(depthSelect).toBeVisible();
+    const options = depthSelect.locator('option');
     await expect(options.first()).toBeAttached();
   });
 
@@ -96,11 +95,11 @@ test.describe('Depth Chart Entry flow', () => {
     await expect(form).toBeVisible({ timeout: 15000 });
 
     // Mutate form state so reset has something to revert. Desktop and mobile
-    // cards share the same input names (name="BH1" etc.), so every locator
+    // cards share the same input names (name="pg1" etc.), so every locator
     // must scope to `.depth-chart-table` to avoid strict-mode violations
     // against the mobile card's disabled duplicates.
-    const firstBh = page.locator('.depth-chart-table select[name^="BH"]').first();
-    await firstBh.selectOption('1');
+    const firstPg = page.locator('.depth-chart-table select[name^="pg"]').first();
+    await firstPg.selectOption('1');
 
     const firstMin = page
       .locator('.depth-chart-table input[type="number"][name^="min"]')
@@ -122,7 +121,7 @@ test.describe('Depth Chart Entry flow', () => {
 
     await page.locator('.depth-chart-buttons .depth-chart-reset-btn').click();
 
-    // All role slot selects should now be 0.
+    // All position depth selects should now be 0.
     const nonZeroSelects = await page.evaluate(() => {
       const form = document.forms.namedItem('DepthChartEntry');
       if (!form) return -1;
@@ -156,7 +155,7 @@ test.describe('Depth Chart Entry flow', () => {
     expect(uncheckedActive).toBe(0);
   });
 
-  test('lineup preview recalculates when a role slot value changes', async ({
+  test('lineup preview recalculates when a position depth value changes', async ({
     page,
   }) => {
     const form = page.locator('.depth-chart-form');
@@ -177,8 +176,8 @@ test.describe('Depth Chart Entry flow', () => {
     // preview.js re-renders via `container.innerHTML = html`, which replaces
     // the entire childList subtree — the observer fires even when the new
     // HTML is byte-identical, so we get a clean "recalculate happened"
-    // signal without depending on the BH change producing a visible diff.
-    // (For many rosters a BH=0→1 promotion produces identical output
+    // signal without depending on the pg change producing a visible diff.
+    // (For many rosters a pg=0→1 promotion produces identical output
     // because the new candidate's score doesn't beat the incumbents.)
     await page.evaluate(() => {
       const container = document.getElementById('dc-lineup-preview');
@@ -196,12 +195,12 @@ test.describe('Depth Chart Entry flow', () => {
       w.__ibl_preview_observer = observer;
     });
 
-    // Change a desktop BH select (scoped to `.depth-chart-table` to avoid
+    // Change a desktop pg select (scoped to `.depth-chart-table` to avoid
     // strict-mode collisions with the mobile card duplicates). Any change
     // triggers the delegated form listener in depth-chart-lineup-preview.js.
-    const firstBh = page.locator('.depth-chart-table select[name^="BH"]').first();
-    const originalBh = await firstBh.inputValue();
-    await firstBh.selectOption(originalBh === '0' ? '1' : '0');
+    const firstPg = page.locator('.depth-chart-table select[name^="pg"]').first();
+    const originalPg = await firstPg.inputValue();
+    await firstPg.selectOption(originalPg === '0' ? '1' : '0');
 
     await expect
       .poll(
@@ -239,7 +238,7 @@ test.describe('Depth Chart Entry flow', () => {
     // any rendered annotation (e.g. starter is also the dump-to-last entry
     // when bench-scan can't fill 3 backups), the recalculate still fires and
     // the wiring is what we're verifying. The number-input listener is on a
-    // separate code path from the role-slot SELECT listener covered above.
+    // separate code path from the position-depth SELECT listener covered above.
     await page.evaluate(() => {
       const container = document.getElementById('dc-lineup-preview');
       if (!container) return;
@@ -332,13 +331,13 @@ test.describe('Depth Chart Entry flow', () => {
                 pos: 'SG',
                 dc_canPlayInGame: 1,
                 dc_minutes: 34,
-                dc_bh: 1,
-                dc_di: 2,
-                // BH/DI/OI selects clamp to max=2 (see renderRolePriorityOptions),
-                // so we use 2 here — any value >2 would silently drop to blank.
-                dc_oi: 2,
-                dc_df: 0,
-                dc_of: 0,
+                dc_PGDepth: 1,
+                dc_SGDepth: 2,
+                // Position depth selects go up to 5 (No/1st/2nd/3rd/4th/ok),
+                // so we use 3 here to test a midrange value.
+                dc_SFDepth: 3,
+                dc_PFDepth: 0,
+                dc_CDepth: 0,
                 isOnCurrentRoster: true,
               },
               {
@@ -347,11 +346,11 @@ test.describe('Depth Chart Entry flow', () => {
                 pos: 'PF',
                 dc_canPlayInGame: 0,
                 dc_minutes: 18,
-                dc_bh: 0,
-                dc_di: 0,
-                dc_oi: 0,
-                dc_df: 1,
-                dc_of: 2,
+                dc_PGDepth: 0,
+                dc_SGDepth: 0,
+                dc_SFDepth: 0,
+                dc_PFDepth: 1,
+                dc_CDepth: 2,
                 isOnCurrentRoster: true,
               },
             ],
@@ -389,13 +388,13 @@ test.describe('Depth Chart Entry flow', () => {
                   )
                 )?.checked ?? null;
               return {
-                p1_bh: val(`BH${counts.p1}`),
-                p1_di: val(`DI${counts.p1}`),
-                p1_oi: val(`OI${counts.p1}`),
+                p1_pg: val(`pg${counts.p1}`),
+                p1_sg: val(`sg${counts.p1}`),
+                p1_sf: val(`sf${counts.p1}`),
                 p1_min: val(`min${counts.p1}`),
                 p1_active: cb(`canPlayInGame${counts.p1}`),
-                p2_df: val(`DF${counts.p2}`),
-                p2_of: val(`OF${counts.p2}`),
+                p2_pf: val(`pf${counts.p2}`),
+                p2_c: val(`c${counts.p2}`),
                 p2_min: val(`min${counts.p2}`),
                 p2_active: cb(`canPlayInGame${counts.p2}`),
               };
@@ -406,13 +405,13 @@ test.describe('Depth Chart Entry flow', () => {
         { timeout: 5000 },
       )
       .toEqual({
-        p1_bh: '1',
-        p1_di: '2',
-        p1_oi: '2',
+        p1_pg: '1',
+        p1_sg: '2',
+        p1_sf: '3',
         p1_min: '34',
         p1_active: true,
-        p2_df: '1',
-        p2_of: '2',
+        p2_pf: '1',
+        p2_c: '2',
         p2_min: '18',
         p2_active: false,
       });


### PR DESCRIPTION
## Summary

JSB 5.60's lineup selection reads CSV columns 1-5 (PG/SG/SF/PF/C depth priority) for the 5-pass lineup algorithm. Commit 4c782799 (PR #586) accidentally removed these position depth fields and kept only the role fields (OF/DF/OI/DI/BH) which map to CSV columns 8-12 — confirmed dead storage via exhaustive binary grep of the decompiled engine.

This restores the position depth dropdowns (0-5: No/1st/2nd/3rd/4th/ok) and removes the dead role selects.

## What changed

| File | Change |
|------|--------|
| DepthChartEntryView.php | Replace ROLE_SLOTS with POSITION_SLOTS (0-5 selects), remove hidden dead inputs, update help section and mobile steppers |
| DepthChartEntryProcessor.php | Hardcode of/df/oi/di/bh to 0, restore position counting and multi-starter detection |
| DepthChartEntryValidator.php | Add validatePositionDepth() and multi-starter rejection |
| DepthChartEntryRepository.php | Hardcode dead columns to 0 in SQL, reduce bind params 13→8 |
| depth-chart-\*.js | Update field mappings (BH→pg etc.), stepper labels, glow prefixes |
| phpstan-baseline.neon | Adjust unescaped output count (29 vs 34, fewer hidden inputs) |
| 6 test files | Update characterization tests for new behavior |

## CSV format — before and after

**Before (broken):**
```
Name,PG,SG,SF,PF,C,ACTIVE,MIN,OF,DF,OI,DI,BH
Kevin Martin,0,0,0,0,0,1,40,0,0,1,0,0
```
Cols 1-5 = always 0 (hidden inputs). Cols 8-12 = role values (dead storage).

**After (fixed):**
```
Name,PG,SG,SF,PF,C,ACTIVE,MIN,OF,DF,OI,DI,BH
Kevin Martin,0,0,1,0,0,1,40,0,0,0,0,0
```
Cols 1-5 = position depth values (1st=1 at SF). Cols 8-12 = hardcoded 0.

## Manual Testing

All items below are now covered by automated tests:

| Manual test | Automated coverage |
|---|---|
| PG/SG/SF/PF/C dropdowns show No/1st/2nd/3rd/4th/ok options | **PHPUnit** `testPositionDepthSelectsShowCorrectOptionLabels` + `testPositionDepthSelectsHaveSixOptions` |
| Submit with sf=1 → CSV column 3 is 1 | **PHPUnit** `testPositionDepthValuesAppearInCorrectCsvColumns` + `testFormSubmissionToCSvRoundTripPreservesPositionDepth` |
| Mobile card view shows position depth steppers | **Playwright** `depth-chart-entry-mobile.spec.ts` → `position stepper cycles through options on tap` (pre-existing) |
| Projected Lineup preview updates live | **Playwright** `depth-chart-entry.spec.ts` → `lineup preview recalculates when a role slot value changes` (pre-existing) |