### PR TITLE
feat: preseason sim dates + September date remap + HEAT cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         unzip \
         default-mysql-client \
-    && docker-php-ext-install mysqli pdo_mysql \
+        libzip-dev \
+    && docker-php-ext-install mysqli pdo_mysql zip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY docker/opcache.ini $PHP_INI_DIR/conf.d/opcache.ini

--- a/ibl5/classes/Boxscore/Boxscore.php
+++ b/ibl5/classes/Boxscore/Boxscore.php
@@ -228,6 +228,8 @@ class Boxscore
                 $this->gameYear = $seasonStartingYear;
                 if ($seasonPhase === "HEAT") {
                     $this->gameMonth = (string) Season::IBL_HEAT_MONTH;
+                } elseif ($seasonPhase === "Preseason") {
+                    $this->gameMonth = sprintf("%02u", (int)$this->gameMonth - 2);
                 }
             }
         }

--- a/ibl5/classes/Boxscore/BoxscoreProcessor.php
+++ b/ibl5/classes/Boxscore/BoxscoreProcessor.php
@@ -495,11 +495,6 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
         /** @var list<string> $messages */
         $messages = [];
 
-        if ($operatingSeasonPhase === 'Preseason') {
-            $messages[] = 'Preseason box scores added. Sim Start/End Dates not updated during Preseason.';
-            return $messages;
-        }
-
         $newSimEndDate = $this->season->getLastBoxScoreDate();
 
         if ($this->season->lastSimEndDate !== '') {

--- a/ibl5/classes/Boxscore/BoxscoreRepository.php
+++ b/ibl5/classes/Boxscore/BoxscoreRepository.php
@@ -40,8 +40,8 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
      */
     public function deletePreseasonBoxScores(int $seasonBeginningYear): bool
     {
-        $startDate = "{$seasonBeginningYear}-11-01";
-        $endDate = "{$seasonBeginningYear}-12-31";
+        $startDate = "{$seasonBeginningYear}-09-01";
+        $endDate = "{$seasonBeginningYear}-10-31";
 
         return $this->deleteBoxScoresForDateRange($startDate, $endDate);
     }

--- a/ibl5/classes/Season/Season.php
+++ b/ibl5/classes/Season/Season.php
@@ -55,6 +55,7 @@ class Season
     private ?string $lastRegularSeasonGameDate = null;
 
     const IBL_OLYMPICS_MONTH = 8;
+    const IBL_PRESEASON_MONTH = 9;
     const IBL_HEAT_MONTH = 10;
     const IBL_REGULAR_SEASON_STARTING_MONTH = 11;
     const IBL_ALL_STAR_MONTH = 02;
@@ -250,6 +251,14 @@ class Season
     public function setLastSimDatesArray(string $newSimNumber, string $newSimStartDate, string $newSimEndDate): int
     {
         return $this->queryRepo->setLastSimDatesArray($newSimNumber, $newSimStartDate, $newSimEndDate);
+    }
+
+    public function reloadSimDates(): void
+    {
+        $arrayLastSimDates = $this->queryRepo->getLastSimDatesArray();
+        $this->lastSimNumber = $arrayLastSimDates["sim"];
+        $this->lastSimStartDate = $arrayLastSimDates["start_date"];
+        $this->lastSimEndDate = $arrayLastSimDates["end_date"];
     }
 
     /**

--- a/ibl5/classes/Season/SeasonQueryRepository.php
+++ b/ibl5/classes/Season/SeasonQueryRepository.php
@@ -247,8 +247,8 @@ class SeasonQueryRepository extends \BaseMysqliRepository implements SeasonQuery
 
         switch ($phase) {
             case 'Preseason':
-                $phaseStartDate = sprintf('%d-%02d-01', $beginningYear, Season::IBL_REGULAR_SEASON_STARTING_MONTH);
-                $phaseEndDate = sprintf('%d-%02d-30', $seasonYear, Season::IBL_REGULAR_SEASON_ENDING_MONTH);
+                $phaseStartDate = sprintf('%d-%02d-01', $beginningYear, Season::IBL_PRESEASON_MONTH);
+                $phaseEndDate = sprintf('%d-%02d-31', $beginningYear, Season::IBL_HEAT_MONTH);
                 break;
             case 'HEAT':
                 $phaseStartDate = sprintf('%d-%02d-01', $beginningYear, Season::IBL_HEAT_MONTH);

--- a/ibl5/classes/SeasonHighs/SeasonHighsService.php
+++ b/ibl5/classes/SeasonHighs/SeasonHighsService.php
@@ -263,8 +263,8 @@ class SeasonHighsService implements SeasonHighsServiceInterface
 
             case 'Preseason':
                 return [
-                    'start' => sprintf('%d-%02d-01', $beginningYear, Season::IBL_REGULAR_SEASON_STARTING_MONTH),
-                    'end' => sprintf('%d-%02d-30', $endingYear, Season::IBL_REGULAR_SEASON_ENDING_MONTH),
+                    'start' => sprintf('%d-%02d-01', $beginningYear, Season::IBL_PRESEASON_MONTH),
+                    'end' => sprintf('%d-%02d-31', $beginningYear, Season::IBL_HEAT_MONTH),
                 ];
 
             case 'HEAT':

--- a/ibl5/classes/Updater/ScheduleUpdater.php
+++ b/ibl5/classes/Updater/ScheduleUpdater.php
@@ -237,6 +237,10 @@ class ScheduleUpdater extends \BaseMysqliRepository {
             if ($this->season->phase === "HEAT" && $month !== Season::IBL_HEAT_MONTH) {
                 continue;
             }
+            if ($this->season->phase === "Preseason" && $month !== null
+                && $month !== Season::IBL_PRESEASON_MONTH && $month !== Season::IBL_HEAT_MONTH) {
+                continue;
+            }
 
             // Compute BoxID: real for played games, placeholder for unplayed
             if ($game['played']) {

--- a/ibl5/classes/Updater/Steps/CleanupPreseasonDataStep.php
+++ b/ibl5/classes/Updater/Steps/CleanupPreseasonDataStep.php
@@ -11,11 +11,11 @@ use Updater\Contracts\PipelineStepInterface;
 use Updater\StepResult;
 
 /**
- * Clean up preseason data on the first Regular Season sim.
+ * Clean up preseason data on the first HEAT sim.
  *
- * Preseason uses real season dates (same Nov-Dec range as Regular Season).
- * When the phase transitions to Regular Season, stale preseason data must
- * be cleared so the RS pipeline can re-import fresh data from JSB files.
+ * Preseason games are stored with Sep-Oct dates. When the phase transitions
+ * to HEAT, stale preseason data must be cleared so the HEAT pipeline can
+ * re-import fresh data from JSB files.
  *
  * IBL-only — Olympics does not have a preseason phase.
  */
@@ -39,12 +39,8 @@ final class CleanupPreseasonDataStep implements PipelineStepInterface
 
     public function execute(): StepResult
     {
-        if ($this->season->phase !== 'Regular Season') {
-            return StepResult::skipped($this->getLabel(), 'Not Regular Season phase');
-        }
-
-        if ($this->cleanupRepo->hasRegularSeasonSimDates($this->season)) {
-            return StepResult::skipped($this->getLabel(), 'Not first Regular Season sim');
+        if ($this->season->phase !== 'HEAT') {
+            return StepResult::skipped($this->getLabel(), 'Not HEAT phase');
         }
 
         if (!$this->cleanupRepo->hasPreseasonBoxScores($this->season->beginningYear)) {
@@ -59,10 +55,15 @@ final class CleanupPreseasonDataStep implements PipelineStepInterface
         $cleaned = [];
 
         $this->boxscoreRepo->deletePreseasonBoxScores($this->season->beginningYear);
-        $cleaned[] = 'box scores (Nov-Dec)';
+        $cleaned[] = 'box scores (Sep-Oct)';
+
+        $this->cleanupRepo->deletePreseasonSimDates($this->season->beginningYear);
+        $cleaned[] = 'sim dates';
 
         $this->cleanupRepo->deletePreseasonJsbData($this->season->endingYear);
         $cleaned[] = 'team awards, JSB history, transactions, season records, PLR snapshots';
+
+        $this->season->reloadSimDates();
 
         return StepResult::success(
             $this->getLabel(),

--- a/ibl5/classes/Updater/Steps/ExtractFromBackupStep.php
+++ b/ibl5/classes/Updater/Steps/ExtractFromBackupStep.php
@@ -63,7 +63,8 @@ final class ExtractFromBackupStep implements PipelineStepInterface
             );
         }
 
-        $extractedCount = $this->extractFiles($archivePath);
+        $missingExtensions = [];
+        $extractedCount = $this->extractFiles($archivePath, $missingExtensions);
         $renameMessage = $this->autoRenameIfNeeded($archivePath, $backupDir);
 
         $archiveName = basename($archivePath);
@@ -78,11 +79,16 @@ final class ExtractFromBackupStep implements PipelineStepInterface
         if ($renameMessage !== null) {
             $messages[] = $renameMessage;
         }
-        $messages[] = sprintf(
+
+        $foundMessage = sprintf(
             '%d of %d file types found in archive',
             $extractedCount,
             count(self::EXTENSIONS),
         );
+        if ($missingExtensions !== []) {
+            $foundMessage .= ' (missing: .' . implode(', .', $missingExtensions) . ')';
+        }
+        $messages[] = $foundMessage;
 
         return StepResult::success($this->getLabel(), $detail, messages: $messages);
     }
@@ -90,9 +96,10 @@ final class ExtractFromBackupStep implements PipelineStepInterface
     /**
      * Extract all JSB files from the archive to the base path.
      *
+     * @param list<string> $missingExtensions Populated with extensions not found in archive
      * @return int Number of files successfully extracted
      */
-    private function extractFiles(string $archivePath): int
+    private function extractFiles(string $archivePath, array &$missingExtensions): int
     {
         $extracted = 0;
 
@@ -106,6 +113,8 @@ final class ExtractFromBackupStep implements PipelineStepInterface
 
             if ($result !== false) {
                 $extracted++;
+            } else {
+                $missingExtensions[] = $ext;
             }
         }
 

--- a/ibl5/classes/Updater/Steps/PreseasonCleanupRepository.php
+++ b/ibl5/classes/Updater/Steps/PreseasonCleanupRepository.php
@@ -11,27 +11,11 @@ use Season\Season;
  */
 final class PreseasonCleanupRepository extends \BaseMysqliRepository
 {
-    public function hasRegularSeasonSimDates(Season $season): bool
-    {
-        $startDate = sprintf('%d-%02d-01', $season->beginningYear, Season::IBL_REGULAR_SEASON_STARTING_MONTH);
-        $endDate = sprintf('%d-%02d-30', $season->endingYear, Season::IBL_PLAYOFF_MONTH);
-
-        /** @var array{cnt: int}|null $row */
-        $row = $this->fetchOne(
-            "SELECT COUNT(*) AS cnt FROM ibl_sim_dates WHERE end_date BETWEEN ? AND ?",
-            "ss",
-            $startDate,
-            $endDate,
-        );
-
-        return $row !== null && $row['cnt'] > 0;
-    }
-
     public function hasPreseasonBoxScores(int $beginningYear): bool
     {
         $boxScoresTable = $this->resolveTable('ibl_box_scores_teams');
-        $startDate = sprintf('%d-11-01', $beginningYear);
-        $endDate = sprintf('%d-12-31', $beginningYear);
+        $startDate = sprintf('%d-09-01', $beginningYear);
+        $endDate = sprintf('%d-10-31', $beginningYear);
 
         /** @var array{cnt: int}|null $row */
         $row = $this->fetchOne(
@@ -42,6 +26,19 @@ final class PreseasonCleanupRepository extends \BaseMysqliRepository
         );
 
         return $row !== null && $row['cnt'] > 0;
+    }
+
+    public function deletePreseasonSimDates(int $beginningYear): void
+    {
+        $startDate = sprintf('%d-09-01', $beginningYear);
+        $endDate = sprintf('%d-10-31', $beginningYear);
+
+        $this->execute(
+            "DELETE FROM ibl_sim_dates WHERE end_date BETWEEN ? AND ?",
+            "ss",
+            $startDate,
+            $endDate,
+        );
     }
 
     public function deletePreseasonJsbData(int $endingYear): void

--- a/ibl5/classes/Utilities/DateParser.php
+++ b/ibl5/classes/Utilities/DateParser.php
@@ -54,6 +54,12 @@ class DateParser
             if ($month === 11) {
                 $month = Season::IBL_HEAT_MONTH;
             }
+        } elseif ($phase === "Preseason") {
+            if ($month === 11) {
+                $month = Season::IBL_PRESEASON_MONTH;
+            } elseif ($month === 12) {
+                $month = Season::IBL_HEAT_MONTH;
+            }
         }
 
         // Olympics override
@@ -62,7 +68,7 @@ class DateParser
         }
 
         // Determine year based on month
-        if ($month < Season::IBL_HEAT_MONTH) {
+        if ($month < Season::IBL_PRESEASON_MONTH) {
             $year = $endingYear;
         } else {
             $year = $beginningYear;

--- a/ibl5/classes/Utilities/IblSeasonDateHelper.php
+++ b/ibl5/classes/Utilities/IblSeasonDateHelper.php
@@ -7,16 +7,16 @@ namespace Utilities;
 /**
  * Shared helper for IBL season date logic.
  *
- * IBL seasons span two calendar years (Oct/Nov-June).
- * HEAT is October, playoffs are June, regular season is Nov-May.
+ * IBL seasons span two calendar years (Sep-June).
+ * Preseason is September, HEAT is October, playoffs are June, regular season is Nov-May.
  */
 final class IblSeasonDateHelper
 {
     /**
      * Convert a date to its IBL season ending year.
      *
-     * Oct-Dec games belong to the season that ends the following year.
-     * Jan-Sep games belong to the season ending that same year.
+     * Sep-Dec games belong to the season that ends the following year.
+     * Jan-Aug games belong to the season ending that same year.
      */
     public static function dateToSeasonEndingYear(string $date): int
     {
@@ -27,13 +27,13 @@ final class IblSeasonDateHelper
         $month = (int) date('n', $timestamp);
         $year = (int) date('Y', $timestamp);
 
-        return $month >= 10 ? $year + 1 : $year;
+        return $month >= 9 ? $year + 1 : $year;
     }
 
     /**
      * Determine the game type from a date.
      *
-     * October → 'heat', June → 'playoffs', all other months → 'regularSeason'.
+     * September → 'preseason', October → 'heat', June → 'playoffs', all other months → 'regularSeason'.
      */
     public static function getGameTypeFromDate(string $date): string
     {
@@ -43,6 +43,9 @@ final class IblSeasonDateHelper
         }
         $month = (int) date('n', $timestamp);
 
+        if ($month === 9) {
+            return 'preseason';
+        }
         if ($month === 10) {
             return 'heat';
         }

--- a/ibl5/classes/Utilities/SeasonPhaseHelper.php
+++ b/ibl5/classes/Utilities/SeasonPhaseHelper.php
@@ -21,6 +21,9 @@ class SeasonPhaseHelper
         if ($phase === "HEAT") {
             return Season::IBL_HEAT_MONTH;
         }
+        if ($phase === "Preseason") {
+            return Season::IBL_PRESEASON_MONTH;
+        }
         return Season::IBL_REGULAR_SEASON_STARTING_MONTH;
     }
 

--- a/ibl5/tests/Boxscore/BoxscoreProcessorTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreProcessorTest.php
@@ -142,7 +142,7 @@ class BoxscoreProcessorTest extends TestCase
         $this->assertStringContainsString('1990-1991 HEAT', $result['messages'][0]);
     }
 
-    public function testProcessScoFilePreseasonSkipsSimDates(): void
+    public function testProcessScoFilePreseasonUpdatesSimDates(): void
     {
         $tmpFile = tempnam(sys_get_temp_dir(), 'sco_test_');
         $this->assertNotFalse($tmpFile);
@@ -161,8 +161,7 @@ class BoxscoreProcessorTest extends TestCase
 
         $this->assertTrue($result['success']);
         $lastMessage = end($result['messages']);
-        $this->assertStringContainsString('Preseason', $lastMessage);
-        $this->assertStringContainsString('not updated', $lastMessage);
+        $this->assertStringNotContainsString('not updated', $lastMessage);
     }
 
     public function testConstructorAcceptsOptionalLeagueContext(): void

--- a/ibl5/tests/Boxscore/BoxscoreRepositoryTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreRepositoryTest.php
@@ -59,8 +59,8 @@ class BoxscoreRepositoryTest extends TestCase
         $this->repository->deletePreseasonBoxScores(2025);
 
         $queries = $this->mockDb->getExecutedQueries();
-        $this->assertStringContainsString('2025-11-01', $queries[0]);
-        $this->assertStringContainsString('2025-12-31', $queries[0]);
+        $this->assertStringContainsString('2025-09-01', $queries[0]);
+        $this->assertStringContainsString('2025-10-31', $queries[0]);
     }
 
     public function testDeleteHeatBoxScoresUsesCorrectDateRange(): void

--- a/ibl5/tests/Boxscore/BoxscoreTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreTest.php
@@ -90,6 +90,24 @@ class BoxscoreTest extends TestCase
         $this->assertSame(2025, $box->gameYear);
     }
 
+    public function testPreseasonPhaseRemapsNovemberToSeptember(): void
+    {
+        $line = $this->makeGameInfoLine(monthCode: '01', dayCode: '05');
+        $box = Boxscore::withGameInfoLine($line, 2026, 'Preseason');
+
+        $this->assertSame('09', $box->gameMonth);
+        $this->assertSame(2025, $box->gameYear);
+    }
+
+    public function testPreseasonPhaseRemapsDecemberToOctober(): void
+    {
+        $line = $this->makeGameInfoLine(monthCode: '02', dayCode: '10');
+        $box = Boxscore::withGameInfoLine($line, 2026, 'Preseason');
+
+        $this->assertSame('10', $box->gameMonth);
+        $this->assertSame(2025, $box->gameYear);
+    }
+
     public function testTeamIdsParsedWithPlusOneOffset(): void
     {
         // Visitor team code "04" → 4+1 = 5, Home team code "09" → 9+1 = 10

--- a/ibl5/tests/DatabaseIntegration/BoxscoreRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BoxscoreRepositoryTest.php
@@ -101,13 +101,13 @@ class BoxscoreRepositoryTest extends DatabaseTestCase
 
     public function testDeletePreseasonBoxScoresRemovesOnlyPreseason(): void
     {
-        $this->insertTeamBoxscoreRow('2024-11-15', 'Metros', 1, 2, 1);
+        $this->insertTeamBoxscoreRow('2024-09-15', 'Metros', 1, 2, 1);
         // Regular season boxscore (Jan) should not be deleted
         $this->insertTeamBoxscoreRow('2025-01-15', 'Metros', 1, 2, 1);
 
         $this->repo->deletePreseasonBoxScores(2024);
 
-        $preseason = $this->repo->findTeamBoxscore('2024-11-15', 2, 1, 1);
+        $preseason = $this->repo->findTeamBoxscore('2024-09-15', 2, 1, 1);
         self::assertNull($preseason);
 
         $regular = $this->repo->findTeamBoxscore('2025-01-15', 2, 1, 1);

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonPipelineTest.php
@@ -39,7 +39,7 @@ class PreseasonPipelineTest extends PipelineIntegrationTestCase
 
         $cleanupResult = $this->findResultByLabel($results, 'Preseason data cleaned');
         self::assertNotNull($cleanupResult);
-        self::assertStringContainsString('Not Regular Season phase', $cleanupResult->detail);
+        self::assertStringContainsString('Not HEAT phase', $cleanupResult->detail);
     }
 
     public function testPlayoffsPipelineCompletes(): void
@@ -65,6 +65,6 @@ class PreseasonPipelineTest extends PipelineIntegrationTestCase
 
         $cleanupResult = $this->findResultByLabel($results, 'Preseason data cleaned');
         self::assertNotNull($cleanupResult);
-        self::assertStringContainsString('Not Regular Season phase', $cleanupResult->detail);
+        self::assertStringContainsString('Not HEAT phase', $cleanupResult->detail);
     }
 }

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
@@ -6,18 +6,18 @@ namespace Tests\DatabaseIntegration\UpdateAllTheThings;
 
 class PreseasonTransitionPipelineTest extends PipelineIntegrationTestCase
 {
-    public function testFirstRegularSeasonSimCleansPreseasonData(): void
+    public function testFirstHeatSimCleansPreseasonData(): void
     {
-        $this->updateSetting('Current Season Phase', 'Regular Season');
+        $this->updateSetting('Current Season Phase', 'HEAT');
         $this->updateSetting('Current Season Ending Year', '2099');
-        $this->seedSimDates(1, '2098-10-15', '2098-10-20');
+        $this->seedSimDates(1, '2098-09-15', '2098-09-20');
         $this->seedLeagueConfig(2099);
 
-        $this->insertTeamBoxscoreRow('2098-12-28', 'PreGame1', 1, 5, 6);
-        $this->insertTeamBoxscoreRow('2098-12-29', 'PreGame2', 1, 7, 8);
+        $this->insertTeamBoxscoreRow('2098-09-28', 'PreGame1', 1, 5, 6);
+        $this->insertTeamBoxscoreRow('2098-10-02', 'PreGame2', 1, 7, 8);
 
-        $this->insertPlayerBoxscoreRow('2098-12-28', 1, 'Test Player One', 'PG', 5, 6, 5);
-        $this->insertPlayerBoxscoreRow('2098-12-29', 2, 'Test Player Two', 'SF', 7, 8, 7);
+        $this->insertPlayerBoxscoreRow('2098-09-28', 1, 'Test Player One', 'PG', 5, 6, 5);
+        $this->insertPlayerBoxscoreRow('2098-10-02', 2, 'Test Player Two', 'SF', 7, 8, 7);
 
         $this->insertRow('ibl_team_awards', [
             'year' => 2099,
@@ -42,7 +42,7 @@ class PreseasonTransitionPipelineTest extends PipelineIntegrationTestCase
             'to_teamid' => 2,
         ]);
 
-        $season = $this->buildSeason('Regular Season', 2099);
+        $season = $this->buildSeason('HEAT', 2099);
 
         $schPath = $this->buildSchFile([
             ['date_slot' => 103, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 105, 'home_score' => 98],
@@ -63,12 +63,12 @@ class PreseasonTransitionPipelineTest extends PipelineIntegrationTestCase
         self::assertNotNull($cleanupResult, 'CleanupPreseasonDataStep should have run');
         self::assertStringContainsString('Cleaned:', $cleanupResult->detail);
 
-        self::assertSame(0, $this->countRows('ibl_box_scores_teams', "game_date BETWEEN '2098-11-01' AND '2098-12-31'"));
-        self::assertSame(0, $this->countRows('ibl_box_scores', "game_date BETWEEN '2098-11-01' AND '2098-12-31'"));
+        self::assertSame(0, $this->countRows('ibl_box_scores_teams', "game_date BETWEEN '2098-09-01' AND '2098-10-31'"));
+        self::assertSame(0, $this->countRows('ibl_box_scores', "game_date BETWEEN '2098-09-01' AND '2098-10-31'"));
         self::assertSame(0, $this->countRows('ibl_team_awards', "year = 2099"));
         self::assertSame(0, $this->countRows('ibl_jsb_history', "season_year = 2099"));
         self::assertSame(0, $this->countRows('ibl_jsb_transactions', "season_year = 2099"));
 
-        self::assertSame(2, $this->countRows('ibl_schedule', "game_date LIKE '2099-01-%'"));
+        self::assertSame(2, $this->countRows('ibl_schedule', "game_date LIKE '2098-10-%'"));
     }
 }

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
@@ -45,8 +45,8 @@ class PreseasonTransitionPipelineTest extends PipelineIntegrationTestCase
         $season = $this->buildSeason('HEAT', 2099);
 
         $schPath = $this->buildSchFile([
-            ['date_slot' => 103, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 105, 'home_score' => 98],
-            ['date_slot' => 103, 'game_index' => 1, 'visitor' => 3, 'home' => 4, 'visitor_score' => 110, 'home_score' => 102],
+            ['date_slot' => 5, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 105, 'home_score' => 98],
+            ['date_slot' => 5, 'game_index' => 1, 'visitor' => 3, 'home' => 4, 'visitor_score' => 110, 'home_score' => 102],
         ]);
         $plrPath = $this->buildPlrFile([
             ['pid' => 200001, 'name' => 'Pipeline Player A', 'teamid' => 1, 'ordinal' => 1],

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/RegularSeasonPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/RegularSeasonPipelineTest.php
@@ -51,7 +51,7 @@ class RegularSeasonPipelineTest extends PipelineIntegrationTestCase
 
         $cleanupResult = $this->findResultByLabel($results, 'Preseason data cleaned');
         self::assertNotNull($cleanupResult);
-        self::assertStringContainsString('Not first Regular Season sim', $cleanupResult->detail);
+        self::assertStringContainsString('Not HEAT phase', $cleanupResult->detail);
 
         $eosResult = $this->findResultByLabel($results, 'End-of-season imports');
         self::assertNotNull($eosResult);

--- a/ibl5/tests/Integration/Mocks/Season.php
+++ b/ibl5/tests/Integration/Mocks/Season.php
@@ -29,6 +29,7 @@ class Season
     public int $simLengthInDays = 7;
 
     const IBL_OLYMPICS_MONTH = 8;
+    const IBL_PRESEASON_MONTH = 9;
     const IBL_HEAT_MONTH = 10;
     const IBL_REGULAR_SEASON_STARTING_MONTH = 11;
     const IBL_ALL_STAR_MONTH = 2;
@@ -209,5 +210,9 @@ class Season
         $this->lastSimStartDate = $newSimStartDate;
         $this->lastSimEndDate = $newSimEndDate;
         return 1;
+    }
+
+    public function reloadSimDates(): void
+    {
     }
 }

--- a/ibl5/tests/UpdateAllTheThings/PowerRankingsUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/PowerRankingsUpdaterTest.php
@@ -63,7 +63,7 @@ class PowerRankingsUpdaterTest extends TestCase
         
         $result = $this->powerRankingsUpdater->publicDetermineMonth();
         
-        $this->assertEquals(Season::IBL_REGULAR_SEASON_STARTING_MONTH, $result);
+        $this->assertEquals(Season::IBL_PRESEASON_MONTH, $result);
     }
 
     public function testDetermineMonthForHEAT(): void

--- a/ibl5/tests/UpdateAllTheThings/ScheduleUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/ScheduleUpdaterTest.php
@@ -89,7 +89,7 @@ class ScheduleUpdaterTest extends TestCase
         $result = $method->invoke($this->scheduleUpdater, 'November 1, 2023');
 
         $this->assertIsArray($result);
-        $this->assertSame(Season::IBL_REGULAR_SEASON_STARTING_MONTH, $result['month']);
+        $this->assertSame(Season::IBL_PRESEASON_MONTH, $result['month']);
     }
 
     /**

--- a/ibl5/tests/Updater/CleanupPreseasonDataStepTest.php
+++ b/ibl5/tests/Updater/CleanupPreseasonDataStepTest.php
@@ -30,7 +30,18 @@ class CleanupPreseasonDataStepTest extends TestCase
         $result = $step->execute();
 
         $this->assertTrue($result->success);
-        $this->assertStringContainsString('Not Regular Season', $result->detail);
+        $this->assertStringContainsString('Not HEAT', $result->detail);
+    }
+
+    public function testSkipsWhenPhaseIsRegularSeason(): void
+    {
+        $season = $this->buildSeason('Regular Season');
+        $step = $this->buildStep($season);
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('Not HEAT', $result->detail);
     }
 
     public function testSkipsWhenPhaseIsPlayoffs(): void
@@ -41,27 +52,13 @@ class CleanupPreseasonDataStepTest extends TestCase
         $result = $step->execute();
 
         $this->assertTrue($result->success);
-        $this->assertStringContainsString('Not Regular Season', $result->detail);
-    }
-
-    public function testSkipsWhenSimDatesExist(): void
-    {
-        $season = $this->buildSeason('Regular Season');
-
-        $this->mockDb->onQuery('SELECT COUNT.*ibl_sim_dates', [['cnt' => 3]]);
-
-        $step = $this->buildStep($season);
-        $result = $step->execute();
-
-        $this->assertTrue($result->success);
-        $this->assertStringContainsString('Not first Regular Season sim', $result->detail);
+        $this->assertStringContainsString('Not HEAT', $result->detail);
     }
 
     public function testSkipsWhenNoPreseasonBoxScores(): void
     {
-        $season = $this->buildSeason('Regular Season');
+        $season = $this->buildSeason('HEAT');
 
-        $this->mockDb->onQuery('SELECT COUNT.*ibl_sim_dates', [['cnt' => 0]]);
         $this->mockDb->onQuery('SELECT COUNT.*ibl_box_scores_teams', [['cnt' => 0]]);
 
         $step = $this->buildStep($season);
@@ -71,11 +68,10 @@ class CleanupPreseasonDataStepTest extends TestCase
         $this->assertStringContainsString('No preseason data to clean', $result->detail);
     }
 
-    public function testCleansPreseasonDataOnFirstRegularSeasonSim(): void
+    public function testCleansPreseasonDataOnFirstHeatSim(): void
     {
-        $season = $this->buildSeason('Regular Season');
+        $season = $this->buildSeason('HEAT');
 
-        $this->mockDb->onQuery('SELECT COUNT.*ibl_sim_dates', [['cnt' => 0]]);
         $this->mockDb->onQuery('SELECT COUNT.*ibl_box_scores_teams', [['cnt' => 42]]);
         $this->mockDb->setReturnTrue(true);
 
@@ -85,12 +81,13 @@ class CleanupPreseasonDataStepTest extends TestCase
         $this->assertTrue($result->success);
         $this->assertStringContainsString('Cleaned:', $result->detail);
         $this->assertStringContainsString('box scores', $result->detail);
+        $this->assertStringContainsString('sim dates', $result->detail);
         $this->assertStringContainsString('team awards', $result->detail);
     }
 
     public function testGetLabelReturnsExpectedString(): void
     {
-        $season = $this->buildSeason('Regular Season');
+        $season = $this->buildSeason('HEAT');
         $step = $this->buildStep($season);
 
         $this->assertSame('Preseason data cleaned', $step->getLabel());

--- a/ibl5/tests/Utilities/SeasonPhaseHelperTest.php
+++ b/ibl5/tests/Utilities/SeasonPhaseHelperTest.php
@@ -28,7 +28,7 @@ class SeasonPhaseHelperTest extends TestCase
     public function testGetMonthForPreseasonPhase(): void
     {
         $result = SeasonPhaseHelper::getMonthForPhase('Preseason');
-        $this->assertEquals(Season::IBL_REGULAR_SEASON_STARTING_MONTH, $result);
+        $this->assertEquals(Season::IBL_PRESEASON_MONTH, $result);
     }
 
     public function testGetMonthForFreeAgencyPhase(): void


### PR DESCRIPTION
## Summary

Three coordinated changes to the Preseason phase:

1. **Sim dates populated during Preseason** — `BoxscoreProcessor::updateSimDates()` no longer skips Preseason, so the Team Pages' Sim Averages tab works during preseason.

2. **September date remap** — Preseason games are now stored with September dates (bleeding into October) instead of November-December. PHP remaps JSB-encoded dates (Nov→Sep, Dec→Oct) during Preseason, following the same pattern as HEAT (Nov→Oct).

3. **Cleanup timing** — Preseason data cleanup moves from the first Regular Season sim to the first HEAT sim. September is exclusively a preseason month, making `hasPreseasonBoxScores()` checking Sep dates a reliable cleanup trigger.

## Changes

### Date Remapping (12 files)
- Add `IBL_PRESEASON_MONTH = 9` constant
- `Boxscore`: remap JSB months during Preseason (Nov→Sep, Dec→Oct)
- `DateParser`: add Preseason month remap + fix year routing (Sep→beginningYear)
- `SeasonPhaseHelper`: `getMonthForPhase('Preseason')` returns 9
- `ScheduleUpdater`: add Preseason month filter (Sep-Oct only)
- `IblSeasonDateHelper`: threshold >=9, add September preseason game type

### Sim Dates
- `BoxscoreProcessor`: remove Preseason early return
- `Season`: add `reloadSimDates()` for post-cleanup refresh

### Cleanup → HEAT Phase
- `CleanupPreseasonDataStep`: trigger on HEAT, add sim_dates cleanup + Season refresh
- `PreseasonCleanupRepository`: remove dead `hasRegularSeasonSimDates()`, add `deletePreseasonSimDates()`, change box score check to Sep-Oct
- `BoxscoreRepository`: change `deletePreseasonBoxScores()` to Sep-Oct range

### Phase Sim Windows
- `SeasonQueryRepository` + `SeasonHighsService`: Preseason case uses Sep-Oct window

## Manual Testing

No manual testing needed — all changes are covered by unit and integration tests.