### PR TITLE
refactor: add parse(string $data) to all JSB parsers, rewire steps to JsbSourceResolver (PR 1/3)

### DIFF
--- a/.claude/rules/codebase-map.md
+++ b/.claude/rules/codebase-map.md
@@ -1,7 +1,7 @@
 ---
 description: Auto-generated module map of ibl5/classes/ with file counts, roles, and cross-module dependencies.
 paths: ibl5/classes/**/*.php
-last_verified: 2026-04-25
+last_verified: 2026-04-26
 ---
 
 # Codebase Module Map
@@ -121,7 +121,7 @@ FreeAgency -> BaseMysqliRepository Discord League Player Season Team Trading UI 
 FreeAgencyPreview -> Player UI Utilities
 GMContactList -> League UI Utilities
 Injuries -> League Player Season Team UI Utilities
-JsbParser -> League PlrParser Season
+JsbParser -> League PlrParser
 League -> BaseMysqliRepository JSB Season
 LeagueConfig -> League Utilities
 LeagueControlPanel -> Discord JsbParser League Trading Utilities Voting

--- a/IBL6/src/routes/+page.server.ts
+++ b/IBL6/src/routes/+page.server.ts
@@ -6,19 +6,19 @@ import { serializeData } from '$lib/utils/utils';
 export const load: PageServerLoad = async () => {
 	try {
 		const games = await query(`
-			SELECT g.Date as date, g.gameOfThatDay,
+			SELECT g.game_date as date, g.game_of_that_day,
 				away.team_city AS away_city, away.team_name AS away_name,
 				home.team_city AS home_city, home.team_name AS home_name
 			FROM ibl_box_scores_teams g
-			LEFT JOIN ibl_team_info away ON g.visitorTeamID = away.teamid
-			LEFT JOIN ibl_team_info home ON g.homeTeamID = home.teamid
-			ORDER BY g.Date DESC
+			LEFT JOIN ibl_team_info away ON g.visitor_teamid = away.teamid
+			LEFT JOIN ibl_team_info home ON g.home_teamid = home.teamid
+			ORDER BY g.game_date DESC
 			LIMIT 25
 		`);
 
 		const formattedGames = games.map((g) => ({
 			date: g.date,
-			gameOfThatDay: g.gameOfThatDay,
+			gameOfThatDay: g.game_of_that_day,
 			awayTeam: { city: g.away_city, name: g.away_name },
 			homeTeam: { city: g.home_city, name: g.home_name }
 		}));

--- a/IBL6/src/routes/[gameSlug]/boxscore/+page.server.ts
+++ b/IBL6/src/routes/[gameSlug]/boxscore/+page.server.ts
@@ -17,12 +17,12 @@ export const load: PageServerLoad = async ({ params }) => {
 		// Get game info
 		const gameInfo = await query(
 			`SELECT DISTINCT
-				game.Date,
-				game.visitorTeamID as awayTeamId,
-				game.homeTeamID as homeTeamId,
-				game.gameOfThatDay,
-				(game.visitorQ1points + game.visitorQ2points + game.visitorQ3points + game.visitorQ4points + COALESCE(game.visitorOTpoints, 0)) as awayScore,
-				(game.homeQ1points + game.homeQ2points + game.homeQ3points + game.homeQ4points + COALESCE(game.homeOTpoints, 0)) as homeScore,
+				game.game_date,
+				game.visitor_teamid as awayTeamId,
+				game.home_teamid as homeTeamId,
+				game.game_of_that_day,
+				(game.visitor_q1_points + game.visitor_q2_points + game.visitor_q3_points + game.visitor_q4_points + COALESCE(game.visitor_ot_points, 0)) as awayScore,
+				(game.home_q1_points + game.home_q2_points + game.home_q3_points + game.home_q4_points + COALESCE(game.home_ot_points, 0)) as homeScore,
 				away.teamid as away_teamid,
 				away.team_city as away_city,
 				away.team_name as away_name,
@@ -34,10 +34,10 @@ export const load: PageServerLoad = async ({ params }) => {
 				home.color1 as home_color1,
 				home.color2 as home_color2
 			FROM ibl_box_scores_teams game
-			LEFT JOIN ibl_team_info home ON game.homeTeamID = home.teamid
-			LEFT JOIN ibl_team_info away ON game.visitorTeamID = away.teamid
-			WHERE DATE(game.Date) = ?
-			AND game.gameOfThatDay = ?
+			LEFT JOIN ibl_team_info home ON game.home_teamid = home.teamid
+			LEFT JOIN ibl_team_info away ON game.visitor_teamid = away.teamid
+			WHERE DATE(game.game_date) = ?
+			AND game.game_of_that_day = ?
 			LIMIT 1`,
 			[gameDate, gameNumber]
 		);
@@ -51,37 +51,37 @@ export const load: PageServerLoad = async ({ params }) => {
 		// Get players using the recorded teamID (not the player's current team)
 		const players = await query(
 			`SELECT
-				bp.Date,
+				bp.game_date,
 				COALESCE(plr.name, bp.name) as name,
 				bp.pos,
 				bp.pid,
-				bp.teamID as playerTeamId,
+				bp.teamid as playerTeamId,
 				CASE
-					WHEN bp.teamID = ? THEN 1
+					WHEN bp.teamid = ? THEN 1
 					ELSE 0
 				END as isAwayPlayer,
-				bp.gameMIN as min,
+				bp.game_min as min,
 				bp.calc_fg_made as fgm,
-				(bp.game2GA + bp.game3GA) as fga,
-				bp.gameFTM as ftm,
-				bp.gameFTA as fta,
-				bp.game3GM as tpm,
-				bp.game3GA as tpa,
-				bp.gameORB as orb,
-				bp.gameDRB as drb,
-				bp.gameAST as ast,
-				bp.gameSTL as stl,
-				bp.gameTOV as tov,
-				bp.gameBLK as blk,
-				bp.gamePF as pf,
+				(bp.game_2ga + bp.game_3ga) as fga,
+				bp.game_ftm as ftm,
+				bp.game_fta as fta,
+				bp.game_3gm as tpm,
+				bp.game_3ga as tpa,
+				bp.game_orb as orb,
+				bp.game_drb as drb,
+				bp.game_ast as ast,
+				bp.game_stl as stl,
+				bp.game_tov as tov,
+				bp.game_blk as blk,
+				bp.game_pf as pf,
 				bp.calc_rebounds as reb,
 				bp.calc_points as pts
 			FROM ibl_box_scores bp
 			LEFT JOIN ibl_plr plr ON bp.pid = plr.pid
-			WHERE DATE(bp.Date) = ?
-			AND bp.gameOfThatDay = ?
-			AND bp.teamID IN (?, ?)
-			ORDER BY bp.teamID = ? DESC, bp.gameMIN DESC`,
+			WHERE DATE(bp.game_date) = ?
+			AND bp.game_of_that_day = ?
+			AND bp.teamid IN (?, ?)
+			ORDER BY bp.teamid = ? DESC, bp.game_min DESC`,
 			[
 				gameData.awayTeamId,
 				gameDate,
@@ -98,8 +98,8 @@ export const load: PageServerLoad = async ({ params }) => {
 
 		// Transform game data
 		const formattedGame = {
-			date: gameData.Date,
-			gameOfThatDay: gameData.gameOfThatDay,
+			date: gameData.game_date,
+			gameOfThatDay: gameData.game_of_that_day,
 			awayScore: Number(gameData.awayScore) || 0,
 			homeScore: Number(gameData.homeScore) || 0,
 			awayTeamId: gameData.awayTeamId,

--- a/ibl5/classes/Bootstrap/ConfigBootstrap.php
+++ b/ibl5/classes/Bootstrap/ConfigBootstrap.php
@@ -93,7 +93,7 @@ class ConfigBootstrap implements BootstrapStepInterface
 
     private function loadNukeConfig(ContainerInterface $container): void
     {
-        /** @var \Database\MySQL $db */ // @phpstan-ignore varTag.deprecatedClass
+        /** @var \Database\MySQL $db */
         $db = $GLOBALS['db'];
         $rawPrefix = $GLOBALS['prefix'] ?? 'nuke';
         $prefix = is_string($rawPrefix) ? $rawPrefix : 'nuke';
@@ -101,8 +101,8 @@ class ConfigBootstrap implements BootstrapStepInterface
         if (!defined('NUKE_FILE')) {
             define('NUKE_FILE', true);
         }
-        $result = $db->sql_query("SELECT * FROM " . $prefix . "_config"); // @phpstan-ignore method.deprecatedClass
-        $fetchedRow = $db->sql_fetchrow($result); // @phpstan-ignore method.deprecatedClass
+        $result = $db->sql_query("SELECT * FROM " . $prefix . "_config");
+        $fetchedRow = $db->sql_fetchrow($result);
 
         if (!is_array($fetchedRow)) {
             return;

--- a/ibl5/classes/JsbParser/AswFileParser.php
+++ b/ibl5/classes/JsbParser/AswFileParser.php
@@ -43,22 +43,13 @@ class AswFileParser implements AswFileParserInterface
     public const THREE_PT_SCORES_END = 111;
 
     /**
-     * @see AswFileParserInterface::parseFile()
+     * @see AswFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("ASW file not found: {$filePath}");
-        }
-
-        $content = file_get_contents($filePath);
-        if ($content === false) {
-            throw new \RuntimeException("Failed to read ASW file: {$filePath}");
-        }
-
         // Normalize line endings
-        $content = str_replace("\r\n", "\n", $content);
-        $lines = explode("\n", $content);
+        $data = str_replace("\r\n", "\n", $data);
+        $lines = explode("\n", $data);
 
         // Parse roster sections (player IDs)
         $allstar1 = self::parseRosterSection($lines, self::ALLSTAR_1_START, self::ALLSTAR_1_END);
@@ -95,6 +86,23 @@ class AswFileParser implements AswFileParserInterface
                 'three_pt_finals' => $threePtFinals,
             ],
         ];
+    }
+
+    /**
+     * @see AswFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("ASW file not found: {$filePath}");
+        }
+
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            throw new \RuntimeException("Failed to read ASW file: {$filePath}");
+        }
+
+        return self::parse($content);
     }
 
     /**

--- a/ibl5/classes/JsbParser/AwaFileParser.php
+++ b/ibl5/classes/JsbParser/AwaFileParser.php
@@ -70,19 +70,10 @@ class AwaFileParser implements AwaFileParserInterface
     ];
 
     /**
-     * @see AwaFileParserInterface::parseFile()
+     * @see AwaFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("AWA file not found: {$filePath}");
-        }
-
-        $data = file_get_contents($filePath);
-        if ($data === false) {
-            throw new \RuntimeException("Failed to read AWA file: {$filePath}");
-        }
-
         $fileSize = strlen($data);
         $minSize = self::BLOCK_SIZE * 2;
         if ($fileSize < $minSize) {
@@ -108,6 +99,23 @@ class AwaFileParser implements AwaFileParserInterface
             'starting_year' => $startingYear,
             'seasons' => $seasons,
         ];
+    }
+
+    /**
+     * @see AwaFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("AWA file not found: {$filePath}");
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            throw new \RuntimeException("Failed to read AWA file: {$filePath}");
+        }
+
+        return self::parse($data);
     }
 
     /**

--- a/ibl5/classes/JsbParser/CarFileParser.php
+++ b/ibl5/classes/JsbParser/CarFileParser.php
@@ -24,19 +24,10 @@ class CarFileParser implements CarFileParserInterface
     public const PLAYER_COUNT_WIDTH = 4;
 
     /**
-     * @see CarFileParserInterface::parseFile()
+     * @see CarFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("CAR file not found: {$filePath}");
-        }
-
-        $data = file_get_contents($filePath);
-        if ($data === false) {
-            throw new \RuntimeException("Failed to read CAR file: {$filePath}");
-        }
-
         $fileSize = strlen($data);
         if ($fileSize < self::BLOCK_SIZE) {
             throw new \RuntimeException(
@@ -61,6 +52,23 @@ class CarFileParser implements CarFileParserInterface
             'player_count' => $playerCount,
             'players' => $players,
         ];
+    }
+
+    /**
+     * @see CarFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("CAR file not found: {$filePath}");
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            throw new \RuntimeException("Failed to read CAR file: {$filePath}");
+        }
+
+        return self::parse($data);
     }
 
     /**

--- a/ibl5/classes/JsbParser/Contracts/AswFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/AswFileParserInterface.php
@@ -13,6 +13,14 @@ namespace JsbParser\Contracts;
 interface AswFileParserInterface
 {
     /**
+     * Parse raw .asw text data.
+     *
+     * @return array{rosters: array{allstar_1: list<int>, allstar_2: list<int>, rookie_1: list<int>, rookie_2: list<int>, three_point: list<int>, dunk_contest: list<int>}, scores: array{dunk_round1: list<int>, dunk_finals: list<int>, three_pt_round1: list<int>, three_pt_semis: list<int>, three_pt_finals: list<int>}}
+     * @throws \RuntimeException If data cannot be parsed
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .asw file.
      *
      * @param string $filePath Path to the .asw file

--- a/ibl5/classes/JsbParser/Contracts/AwaFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/AwaFileParserInterface.php
@@ -13,6 +13,14 @@ namespace JsbParser\Contracts;
 interface AwaFileParserInterface
 {
     /**
+     * Parse raw .awa binary data.
+     *
+     * @return array{starting_year: int, seasons: list<array{year: int, stat_leaders: array<string, list<array{rank: int, pid: int}>>}>}
+     * @throws \RuntimeException If data has invalid structure
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .awa file.
      *
      * @param string $filePath Path to the .awa file

--- a/ibl5/classes/JsbParser/Contracts/CarFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/CarFileParserInterface.php
@@ -13,6 +13,14 @@ namespace JsbParser\Contracts;
 interface CarFileParserInterface
 {
     /**
+     * Parse raw .car binary bytes.
+     *
+     * @return array{player_count: int, players: list<array{block_index: int, jsb_id: int, name: string, season_count: int, seasons: list<array{year: int, team: string, name: string, position: string, gp: int, min: int, two_gm: int, two_ga: int, ftm: int, fta: int, three_gm: int, three_ga: int, orb: int, drb: int, ast: int, stl: int, to: int, blk: int, pf: int}>}>}
+     * @throws \RuntimeException If data has invalid structure
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .car file.
      *
      * @param string $filePath Path to the .car file

--- a/ibl5/classes/JsbParser/Contracts/DraFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/DraFileParserInterface.php
@@ -14,6 +14,14 @@ namespace JsbParser\Contracts;
 interface DraFileParserInterface
 {
     /**
+     * Parse raw .dra text data.
+     *
+     * @return list<array{draft_year: int, picks: list<array{round: int, pick: int, team_name: string, pos: string, player_name: string}>}>
+     * @throws \RuntimeException If data cannot be parsed
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .dra file.
      *
      * @param string $filePath Path to the .dra file

--- a/ibl5/classes/JsbParser/Contracts/HisFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/HisFileParserInterface.php
@@ -12,10 +12,18 @@ namespace JsbParser\Contracts;
 interface HisFileParserInterface
 {
     /**
+     * Parse raw .his text data.
+     *
+     * @return list<array{year: int, teams: list<array{name: string, wins: int, losses: int, year: int, playoff_result: string, made_playoffs: int, playoff_round_reached: string, won_championship: int}>}>
+     * @throws \RuntimeException If data cannot be parsed
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .his file.
      *
      * @param string $filePath Path to the .his file
-     * @return list<array{year: int, teams: list<array{name: string, wins: int, losses: int, playoff_result: string, made_playoffs: int, playoff_round_reached: string, won_championship: int}>}>
+     * @return list<array{year: int, teams: list<array{name: string, wins: int, losses: int, year: int, playoff_result: string, made_playoffs: int, playoff_round_reached: string, won_championship: int}>}>
      * @throws \RuntimeException If file cannot be read
      */
     public static function parseFile(string $filePath): array;

--- a/ibl5/classes/JsbParser/Contracts/HofFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/HofFileParserInterface.php
@@ -13,6 +13,14 @@ namespace JsbParser\Contracts;
 interface HofFileParserInterface
 {
     /**
+     * Parse raw .hof binary data.
+     *
+     * @return list<array{jsb_pid: int, player_name: string, pos: string, induction_year: int}>
+     * @throws \RuntimeException If data has invalid structure
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .hof file.
      *
      * @param string $filePath Path to the .hof file

--- a/ibl5/classes/JsbParser/Contracts/JsbImportServiceInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/JsbImportServiceInterface.php
@@ -6,7 +6,6 @@ namespace JsbParser\Contracts;
 
 use JsbParser\JsbImportResult;
 use PlrParser\PlrOrdinalMap;
-use Season\Season;
 
 /**
  * Interface for the JSB import orchestration service.
@@ -16,13 +15,12 @@ use Season\Season;
 interface JsbImportServiceInterface
 {
     /**
-     * Process all JSB files for the current season from the base path.
+     * Process raw .car data and upsert records into ibl_hist.
      *
-     * @param string $basePath Path to the ibl5 directory containing IBL5.car, IBL5.trn, etc.
-     * @param Season $season Current season object for year resolution
+     * @param int|null $filterYear If set, only import records for this season year
      * @return JsbImportResult Summary of import results
      */
-    public function processCurrentSeason(string $basePath, Season $season, string $filePrefix = 'IBL5'): JsbImportResult;
+    public function processCarData(string $data, ?int $filterYear = null): JsbImportResult;
 
     /**
      * Process a .car file and upsert records into ibl_hist.
@@ -34,6 +32,14 @@ interface JsbImportServiceInterface
     public function processCarFile(string $filePath, ?int $filterYear = null): JsbImportResult;
 
     /**
+     * Process raw .trn data and upsert records into ibl_jsb_transactions.
+     *
+     * @param string|null $sourceLabel Label for the source_file column
+     * @return JsbImportResult Summary of import results
+     */
+    public function processTrnData(string $data, ?string $sourceLabel = null): JsbImportResult;
+
+    /**
      * Process a .trn file and upsert records into ibl_jsb_transactions.
      *
      * @param string $filePath Path to the .trn file
@@ -41,6 +47,14 @@ interface JsbImportServiceInterface
      * @return JsbImportResult Summary of import results
      */
     public function processTrnFile(string $filePath, ?string $sourceLabel = null): JsbImportResult;
+
+    /**
+     * Process raw .his data and upsert records into ibl_jsb_history.
+     *
+     * @param string|null $sourceLabel Label for the source_file column
+     * @return JsbImportResult Summary of import results
+     */
+    public function processHisData(string $data, ?string $sourceLabel = null): JsbImportResult;
 
     /**
      * Process a .his file and upsert records into ibl_jsb_history.
@@ -52,6 +66,14 @@ interface JsbImportServiceInterface
     public function processHisFile(string $filePath, ?string $sourceLabel = null): JsbImportResult;
 
     /**
+     * Process raw .asw data and upsert records into ibl_jsb_allstar_* tables.
+     *
+     * @param int $seasonYear Season year for the All-Star data
+     * @return JsbImportResult Summary of import results
+     */
+    public function processAswData(string $data, int $seasonYear): JsbImportResult;
+
+    /**
      * Process an .asw file and upsert records into ibl_jsb_allstar_* tables.
      *
      * @param string $filePath Path to the .asw file
@@ -59,6 +81,16 @@ interface JsbImportServiceInterface
      * @return JsbImportResult Summary of import results
      */
     public function processAswFile(string $filePath, int $seasonYear): JsbImportResult;
+
+    /**
+     * Process raw .awa data and upsert stat leader awards into ibl_awards.
+     *
+     * @param string $awaData Raw .awa file contents
+     * @param string $carData Raw .car file contents for PID→name resolution
+     * @param int|null $filterYear If set, only import awards for this season year
+     * @return JsbImportResult Summary of import results
+     */
+    public function processAwaData(string $awaData, string $carData, ?int $filterYear = null): JsbImportResult;
 
     /**
      * Process an .awa file and upsert stat leader awards into ibl_awards.
@@ -74,6 +106,15 @@ interface JsbImportServiceInterface
     public function processAwaFile(string $awaPath, string $carPath, ?int $filterYear = null): JsbImportResult;
 
     /**
+     * Process raw .rcb data and upsert records into ibl_rcb_alltime_records and ibl_rcb_season_records.
+     *
+     * @param int $seasonYear Season year for current season records
+     * @param string|null $sourceLabel Label for the source_file column
+     * @return JsbImportResult Summary of import results
+     */
+    public function processRcbData(string $data, int $seasonYear, ?string $sourceLabel = null): JsbImportResult;
+
+    /**
      * Process an .rcb file and upsert records into ibl_rcb_alltime_records and ibl_rcb_season_records.
      *
      * @param string $filePath Path to the .rcb file
@@ -82,6 +123,23 @@ interface JsbImportServiceInterface
      * @return JsbImportResult Summary of import results
      */
     public function processRcbFile(string $filePath, int $seasonYear, ?string $sourceLabel = null): JsbImportResult;
+
+    /**
+     * Process raw .plb data and upsert depth chart snapshots into ibl_plb_snapshots.
+     *
+     * @param PlrOrdinalMap $map Ordinal map for resolving player identity
+     * @param int $seasonYear Season ending year
+     * @param int $simNumber Archive sequence number
+     * @param string $sourceArchive Archive basename without extension
+     * @return JsbImportResult Summary of import results
+     */
+    public function processPlbData(
+        string $data,
+        PlrOrdinalMap $map,
+        int $seasonYear,
+        int $simNumber,
+        string $sourceArchive,
+    ): JsbImportResult;
 
     /**
      * Process a .plb file and upsert depth chart snapshots into ibl_plb_snapshots.
@@ -102,12 +160,27 @@ interface JsbImportServiceInterface
     ): JsbImportResult;
 
     /**
+     * Process raw .dra data and upsert records into ibl_jsb_draft_results.
+     *
+     * @return JsbImportResult Summary of import results
+     */
+    public function processDraData(string $data): JsbImportResult;
+
+    /**
      * Process a .dra file and upsert records into ibl_jsb_draft_results.
      *
      * @param string $filePath Path to the .dra file
      * @return JsbImportResult Summary of import results
      */
     public function processDraFile(string $filePath): JsbImportResult;
+
+    /**
+     * Process raw .ret data and upsert records into ibl_jsb_retired_players.
+     *
+     * @param int $retirementYear Season ending year when retirements occurred
+     * @return JsbImportResult Summary of import results
+     */
+    public function processRetData(string $data, int $retirementYear): JsbImportResult;
 
     /**
      * Process a .ret file and upsert records into ibl_jsb_retired_players.
@@ -117,6 +190,13 @@ interface JsbImportServiceInterface
      * @return JsbImportResult Summary of import results
      */
     public function processRetFile(string $filePath, int $retirementYear): JsbImportResult;
+
+    /**
+     * Process raw .hof data and upsert records into ibl_jsb_hall_of_fame.
+     *
+     * @return JsbImportResult Summary of import results
+     */
+    public function processHofData(string $data): JsbImportResult;
 
     /**
      * Process a .hof file and upsert records into ibl_jsb_hall_of_fame.

--- a/ibl5/classes/JsbParser/Contracts/PlbFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/PlbFileParserInterface.php
@@ -13,6 +13,14 @@ namespace JsbParser\Contracts;
 interface PlbFileParserInterface
 {
     /**
+     * Parse raw .plb text data.
+     *
+     * @return array<int, list<array{slot_index: int, dc_minutes: int, dc_of: int, dc_df: int, dc_oi: int, dc_di: int, dc_bh: int}>>
+     * @throws \RuntimeException If data cannot be parsed
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .plb file.
      *
      * @param string $filePath Path to the .plb file

--- a/ibl5/classes/JsbParser/Contracts/RcbFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/RcbFileParserInterface.php
@@ -14,6 +14,14 @@ namespace JsbParser\Contracts;
 interface RcbFileParserInterface
 {
     /**
+     * Parse raw .rcb text data.
+     *
+     * @return array{alltime: list<array{scope: string, teamid: int, record_type: string, stat_category: string, ranking: int, player_name: string, car_block_id: int, stat_value: float, stat_raw: int, team_of_record: int|null, season_year: int|null, career_total: int|null}>, currentSeason: list<array{scope: string, teamid: int, context: string, stat_category: string, ranking: int, player_name: string, player_position: string, car_block_id: int, stat_value: int, season_year: int}>}
+     * @throws \RuntimeException If data has invalid structure
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .rcb file.
      *
      * @param string $filePath Path to the .rcb file

--- a/ibl5/classes/JsbParser/Contracts/RetFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/RetFileParserInterface.php
@@ -13,6 +13,14 @@ namespace JsbParser\Contracts;
 interface RetFileParserInterface
 {
     /**
+     * Parse raw .ret text data.
+     *
+     * @return list<array{jsb_pid: int, player_name: string}>
+     * @throws \RuntimeException If data cannot be parsed
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .ret file.
      *
      * @param string $filePath Path to the .ret file

--- a/ibl5/classes/JsbParser/Contracts/TrnFileParserInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/TrnFileParserInterface.php
@@ -12,6 +12,14 @@ namespace JsbParser\Contracts;
 interface TrnFileParserInterface
 {
     /**
+     * Parse raw .trn binary bytes.
+     *
+     * @return array{record_count: int, transactions: list<array{index: int, month: int, day: int, year: int, type: int, pid: int|null, team_id: int|null, games_missed: int|null, injury_description: string|null, trade_items: list<array{marker: int, from_team: int, to_team: int, player_id: int|null, draft_year: int|null}>|null}>}
+     * @throws \RuntimeException If data has invalid structure
+     */
+    public static function parse(string $data): array;
+
+    /**
      * Parse a complete .trn file.
      *
      * @param string $filePath Path to the .trn file

--- a/ibl5/classes/JsbParser/DraFileParser.php
+++ b/ibl5/classes/JsbParser/DraFileParser.php
@@ -15,23 +15,14 @@ use JsbParser\Contracts\DraFileParserInterface;
 class DraFileParser implements DraFileParserInterface
 {
     /**
-     * @see DraFileParserInterface::parseFile()
+     * @see DraFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("DRA file not found: {$filePath}");
-        }
-
-        $raw = file_get_contents($filePath);
-        if ($raw === false) {
-            throw new \RuntimeException("Failed to read DRA file: {$filePath}");
-        }
-
         // Normalize line endings
-        $raw = str_replace("\r\n", "\n", $raw);
-        $raw = str_replace("\r", "\n", $raw);
-        $lines = explode("\n", $raw);
+        $data = str_replace("\r\n", "\n", $data);
+        $data = str_replace("\r", "\n", $data);
+        $lines = explode("\n", $data);
 
         /** @var list<array{draft_year: int, picks: list<array{round: int, pick: int, team_name: string, pos: string, player_name: string}>}> $drafts */
         $drafts = [];
@@ -128,5 +119,22 @@ class DraFileParser implements DraFileParserInterface
         }
 
         return $drafts;
+    }
+
+    /**
+     * @see DraFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("DRA file not found: {$filePath}");
+        }
+
+        $raw = file_get_contents($filePath);
+        if ($raw === false) {
+            throw new \RuntimeException("Failed to read DRA file: {$filePath}");
+        }
+
+        return self::parse($raw);
     }
 }

--- a/ibl5/classes/JsbParser/HisFileParser.php
+++ b/ibl5/classes/JsbParser/HisFileParser.php
@@ -26,22 +26,13 @@ class HisFileParser implements HisFileParserInterface
     private const TEAM_LINE_PATTERN = '/^(.+?)\s+\((\d+)-(\d+)\)\s*(.*?)\s*\((\d{4})\)\s*$/';
 
     /**
-     * @see HisFileParserInterface::parseFile()
+     * @see HisFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("HIS file not found: {$filePath}");
-        }
-
-        $content = file_get_contents($filePath);
-        if ($content === false) {
-            throw new \RuntimeException("Failed to read HIS file: {$filePath}");
-        }
-
         // Normalize line endings (CRLF → LF)
-        $content = str_replace("\r\n", "\n", $content);
-        $lines = explode("\n", $content);
+        $data = str_replace("\r\n", "\n", $data);
+        $lines = explode("\n", $data);
 
         /** @var array<int, list<array{name: string, wins: int, losses: int, year: int, playoff_result: string, made_playoffs: int, playoff_round_reached: string, won_championship: int}>> $seasonMap */
         $seasonMap = [];
@@ -76,6 +67,23 @@ class HisFileParser implements HisFileParserInterface
         }
 
         return $seasons;
+    }
+
+    /**
+     * @see HisFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("HIS file not found: {$filePath}");
+        }
+
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            throw new \RuntimeException("Failed to read HIS file: {$filePath}");
+        }
+
+        return self::parse($content);
     }
 
     /**

--- a/ibl5/classes/JsbParser/HofFileParser.php
+++ b/ibl5/classes/JsbParser/HofFileParser.php
@@ -20,24 +20,15 @@ class HofFileParser implements HofFileParserInterface
     private const BLOCK_SIZE = 500;
 
     /**
-     * @see HofFileParserInterface::parseFile()
+     * @see HofFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("HOF file not found: {$filePath}");
-        }
-
-        $fileSize = filesize($filePath);
-        if ($fileSize !== self::FILE_SIZE) {
+        $dataSize = strlen($data);
+        if ($dataSize !== self::FILE_SIZE) {
             throw new \RuntimeException(
-                "HOF file size mismatch: expected " . self::FILE_SIZE . " bytes, got {$fileSize}"
+                "HOF data size mismatch: expected " . self::FILE_SIZE . " bytes, got {$dataSize}"
             );
-        }
-
-        $raw = file_get_contents($filePath);
-        if ($raw === false) {
-            throw new \RuntimeException("Failed to read HOF file: {$filePath}");
         }
 
         /** @var list<array{jsb_pid: int, player_name: string, pos: string, induction_year: int}> $entries */
@@ -45,7 +36,7 @@ class HofFileParser implements HofFileParserInterface
 
         // Process each 500-byte block
         for ($block = 0; $block < 14; $block++) {
-            $blockData = substr($raw, $block * self::BLOCK_SIZE, self::BLOCK_SIZE);
+            $blockData = substr($data, $block * self::BLOCK_SIZE, self::BLOCK_SIZE);
 
             // Split block by CRLF to get individual entries
             $lines = explode("\r\n", $blockData);
@@ -77,5 +68,22 @@ class HofFileParser implements HofFileParserInterface
         }
 
         return $entries;
+    }
+
+    /**
+     * @see HofFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("HOF file not found: {$filePath}");
+        }
+
+        $raw = file_get_contents($filePath);
+        if ($raw === false) {
+            throw new \RuntimeException("Failed to read HOF file: {$filePath}");
+        }
+
+        return self::parse($raw);
     }
 }

--- a/ibl5/classes/JsbParser/JsbImportService.php
+++ b/ibl5/classes/JsbParser/JsbImportService.php
@@ -7,7 +7,6 @@ namespace JsbParser;
 use JsbParser\Contracts\JsbImportRepositoryInterface;
 use JsbParser\Contracts\JsbImportServiceInterface;
 use PlrParser\PlrOrdinalMap;
-use Season\Season;
 
 /**
  * Orchestrator service for JSB file parsing and database import.
@@ -36,65 +35,14 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * @see JsbImportServiceInterface::processCurrentSeason()
+     * @see JsbImportServiceInterface::processCarData()
      */
-    public function processCurrentSeason(string $basePath, Season $season, string $filePrefix = 'IBL5'): JsbImportResult
-    {
-        $result = new JsbImportResult();
-        $seasonYear = $season->endingYear;
-
-        // Process .trn first (trade data helps with player ID resolution)
-        $trnPath = $basePath . '/' . $filePrefix . '.trn';
-        if (file_exists($trnPath)) {
-            $trnResult = $this->processTrnFile($trnPath, 'current-season');
-            $result->merge($trnResult);
-            $result->addMessage('TRN: ' . $trnResult->summary());
-        }
-
-        // Process .car (uses trade data for mid-season splits)
-        $carPath = $basePath . '/' . $filePrefix . '.car';
-        if (file_exists($carPath)) {
-            $carResult = $this->processCarFile($carPath, $seasonYear);
-            $result->merge($carResult);
-            $result->addMessage('CAR: ' . $carResult->summary());
-        }
-
-        // Process .his
-        $hisPath = $basePath . '/' . $filePrefix . '.his';
-        if (file_exists($hisPath)) {
-            $hisResult = $this->processHisFile($hisPath, 'current-season');
-            $result->merge($hisResult);
-            $result->addMessage('HIS: ' . $hisResult->summary());
-        }
-
-        // Process .asw
-        $aswPath = $basePath . '/' . $filePrefix . '.asw';
-        if (file_exists($aswPath)) {
-            $aswResult = $this->processAswFile($aswPath, $seasonYear);
-            $result->merge($aswResult);
-            $result->addMessage('ASW: ' . $aswResult->summary());
-        }
-
-        // Process .rcb (Record Book)
-        $rcbPath = $basePath . '/' . $filePrefix . '.rcb';
-        if (file_exists($rcbPath)) {
-            $rcbResult = $this->processRcbFile($rcbPath, $seasonYear, 'current-season');
-            $result->merge($rcbResult);
-            $result->addMessage('RCB: ' . $rcbResult->summary());
-        }
-
-        return $result;
-    }
-
-    /**
-     * @see JsbImportServiceInterface::processCarFile()
-     */
-    public function processCarFile(string $filePath, ?int $filterYear = null): JsbImportResult
+    public function processCarData(string $data, ?int $filterYear = null): JsbImportResult
     {
         $result = new JsbImportResult();
 
         try {
-            $parsed = CarFileParser::parseFile($filePath);
+            $parsed = CarFileParser::parse($data);
         } catch (\RuntimeException $e) {
             $result->addError('CAR parse failed: ' . $e->getMessage());
             return $result;
@@ -129,14 +77,35 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * @see JsbImportServiceInterface::processTrnFile()
+     * @see JsbImportServiceInterface::processCarFile()
      */
-    public function processTrnFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
+    public function processCarFile(string $filePath, ?int $filterYear = null): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('CAR file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read CAR file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->processCarData($data, $filterYear);
+    }
+
+    /**
+     * @see JsbImportServiceInterface::processTrnData()
+     */
+    public function processTrnData(string $data, ?string $sourceLabel = null): JsbImportResult
     {
         $result = new JsbImportResult();
 
         try {
-            $parsed = TrnFileParser::parseFile($filePath);
+            $parsed = TrnFileParser::parse($data);
         } catch (\RuntimeException $e) {
             $result->addError('TRN parse failed: ' . $e->getMessage());
             return $result;
@@ -168,14 +137,35 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * @see JsbImportServiceInterface::processHisFile()
+     * @see JsbImportServiceInterface::processTrnFile()
      */
-    public function processHisFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
+    public function processTrnFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('TRN file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read TRN file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->processTrnData($data, $sourceLabel);
+    }
+
+    /**
+     * @see JsbImportServiceInterface::processHisData()
+     */
+    public function processHisData(string $data, ?string $sourceLabel = null): JsbImportResult
     {
         $result = new JsbImportResult();
 
         try {
-            $parsed = HisFileParser::parseFile($filePath);
+            $parsed = HisFileParser::parse($data);
         } catch (\RuntimeException $e) {
             $result->addError('HIS parse failed: ' . $e->getMessage());
             return $result;
@@ -209,14 +199,35 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * @see JsbImportServiceInterface::processAswFile()
+     * @see JsbImportServiceInterface::processHisFile()
      */
-    public function processAswFile(string $filePath, int $seasonYear): JsbImportResult
+    public function processHisFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('HIS file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read HIS file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->processHisData($data, $sourceLabel);
+    }
+
+    /**
+     * @see JsbImportServiceInterface::processAswData()
+     */
+    public function processAswData(string $data, int $seasonYear): JsbImportResult
     {
         $result = new JsbImportResult();
 
         try {
-            $parsed = AswFileParser::parseFile($filePath);
+            $parsed = AswFileParser::parse($data);
         } catch (\RuntimeException $e) {
             $result->addError('ASW parse failed: ' . $e->getMessage());
             return $result;
@@ -291,26 +302,47 @@ class JsbImportService implements JsbImportServiceInterface
         return $result;
     }
 
+    /**
+     * @see JsbImportServiceInterface::processAswFile()
+     */
+    public function processAswFile(string $filePath, int $seasonYear): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('ASW file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read ASW file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->processAswData($data, $seasonYear);
+    }
+
     /** @var list<string> Rank suffixes for award names */
     private const RANK_SUFFIXES = ['(1st)', '(2nd)', '(3rd)', '(4th)', '(5th)'];
 
     /**
-     * @see JsbImportServiceInterface::processAwaFile()
+     * @see JsbImportServiceInterface::processAwaData()
      */
-    public function processAwaFile(string $awaPath, string $carPath, ?int $filterYear = null): JsbImportResult
+    public function processAwaData(string $awaData, string $carData, ?int $filterYear = null): JsbImportResult
     {
         $result = new JsbImportResult();
 
         try {
-            $awaParsed = AwaFileParser::parseFile($awaPath);
+            $awaParsed = AwaFileParser::parse($awaData);
         } catch (\RuntimeException $e) {
             $result->addError('AWA parse failed: ' . $e->getMessage());
             return $result;
         }
 
-        // Build PID → name map from .car file
+        // Build PID → name map from .car data
         try {
-            $carParsed = CarFileParser::parseFile($carPath);
+            $carParsed = CarFileParser::parse($carData);
         } catch (\RuntimeException $e) {
             $result->addError('CAR parse failed (for AWA name resolution): ' . $e->getMessage());
             return $result;
@@ -359,14 +391,36 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * @see JsbImportServiceInterface::processRcbFile()
+     * @see JsbImportServiceInterface::processAwaFile()
      */
-    public function processRcbFile(string $filePath, int $seasonYear, ?string $sourceLabel = null): JsbImportResult
+    public function processAwaFile(string $awaPath, string $carPath, ?int $filterYear = null): JsbImportResult
+    {
+        if (!file_exists($awaPath) || !file_exists($carPath)) {
+            $result = new JsbImportResult();
+            $result->addError('AWA or CAR file not found');
+            return $result;
+        }
+
+        $awaData = file_get_contents($awaPath);
+        $carData = file_get_contents($carPath);
+        if ($awaData === false || $carData === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read AWA or CAR file');
+            return $result;
+        }
+
+        return $this->processAwaData($awaData, $carData, $filterYear);
+    }
+
+    /**
+     * @see JsbImportServiceInterface::processRcbData()
+     */
+    public function processRcbData(string $data, int $seasonYear, ?string $sourceLabel = null): JsbImportResult
     {
         $result = new JsbImportResult();
 
         try {
-            $parsed = RcbFileParser::parseFile($filePath);
+            $parsed = RcbFileParser::parse($data);
         } catch (\RuntimeException $e) {
             $result->addError('RCB parse failed: ' . $e->getMessage());
             return $result;
@@ -422,6 +476,27 @@ class JsbImportService implements JsbImportServiceInterface
         }
 
         return $result;
+    }
+
+    /**
+     * @see JsbImportServiceInterface::processRcbFile()
+     */
+    public function processRcbFile(string $filePath, int $seasonYear, ?string $sourceLabel = null): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('RCB file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read RCB file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->processRcbData($data, $seasonYear, $sourceLabel);
     }
 
     /**
@@ -598,10 +673,10 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * @see JsbImportServiceInterface::processPlbFile()
+     * @see JsbImportServiceInterface::processPlbData()
      */
-    public function processPlbFile(
-        string $filePath,
+    public function processPlbData(
+        string $data,
         PlrOrdinalMap $map,
         int $seasonYear,
         int $simNumber,
@@ -610,7 +685,7 @@ class JsbImportService implements JsbImportServiceInterface
         $result = new JsbImportResult();
 
         try {
-            $parsed = PlbFileParser::parseFile($filePath);
+            $parsed = PlbFileParser::parse($data);
         } catch (\RuntimeException $e) {
             $result->addError('PLB parse failed: ' . $e->getMessage());
             return $result;
@@ -664,6 +739,32 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
+     * @see JsbImportServiceInterface::processPlbFile()
+     */
+    public function processPlbFile(
+        string $filePath,
+        PlrOrdinalMap $map,
+        int $seasonYear,
+        int $simNumber,
+        string $sourceArchive,
+    ): JsbImportResult {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('PLB file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read PLB file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->processPlbData($data, $map, $seasonYear, $simNumber, $sourceArchive);
+    }
+
+    /**
      * Initialize trade group ID counter from existing data.
      */
     private function initTradeGroupId(): void
@@ -677,14 +778,14 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * @see JsbImportServiceInterface::processDraFile()
+     * @see JsbImportServiceInterface::processDraData()
      */
-    public function processDraFile(string $filePath): JsbImportResult
+    public function processDraData(string $data): JsbImportResult
     {
         $result = new JsbImportResult();
 
         try {
-            $parsed = DraFileParser::parseFile($filePath);
+            $parsed = DraFileParser::parse($data);
         } catch (\RuntimeException $e) {
             $result->addError('DRA parse failed: ' . $e->getMessage());
             return $result;
@@ -713,14 +814,35 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * @see JsbImportServiceInterface::processRetFile()
+     * @see JsbImportServiceInterface::processDraFile()
      */
-    public function processRetFile(string $filePath, int $retirementYear): JsbImportResult
+    public function processDraFile(string $filePath): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('DRA file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read DRA file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->processDraData($data);
+    }
+
+    /**
+     * @see JsbImportServiceInterface::processRetData()
+     */
+    public function processRetData(string $data, int $retirementYear): JsbImportResult
     {
         $result = new JsbImportResult();
 
         try {
-            $parsed = RetFileParser::parseFile($filePath);
+            $parsed = RetFileParser::parse($data);
         } catch (\RuntimeException $e) {
             $result->addError('RET parse failed: ' . $e->getMessage());
             return $result;
@@ -748,14 +870,35 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * @see JsbImportServiceInterface::processHofFile()
+     * @see JsbImportServiceInterface::processRetFile()
      */
-    public function processHofFile(string $filePath): JsbImportResult
+    public function processRetFile(string $filePath, int $retirementYear): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('RET file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read RET file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->processRetData($data, $retirementYear);
+    }
+
+    /**
+     * @see JsbImportServiceInterface::processHofData()
+     */
+    public function processHofData(string $data): JsbImportResult
     {
         $result = new JsbImportResult();
 
         try {
-            $parsed = HofFileParser::parseFile($filePath);
+            $parsed = HofFileParser::parse($data);
         } catch (\RuntimeException $e) {
             $result->addError('HOF parse failed: ' . $e->getMessage());
             return $result;
@@ -781,5 +924,26 @@ class JsbImportService implements JsbImportServiceInterface
         }
 
         return $result;
+    }
+
+    /**
+     * @see JsbImportServiceInterface::processHofFile()
+     */
+    public function processHofFile(string $filePath): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('HOF file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read HOF file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->processHofData($data);
     }
 }

--- a/ibl5/classes/JsbParser/PlbFileParser.php
+++ b/ibl5/classes/JsbParser/PlbFileParser.php
@@ -21,22 +21,13 @@ class PlbFileParser implements PlbFileParserInterface
     private const MIN_LINE_LENGTH = 360; // 30 × 12
 
     /**
-     * @see PlbFileParserInterface::parseFile()
+     * @see PlbFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("PLB file not found: {$filePath}");
-        }
-
-        $contents = file_get_contents($filePath);
-        if ($contents === false) {
-            throw new \RuntimeException("Failed to read PLB file: {$filePath}");
-        }
-
         // Normalize line endings (CRLF → LF)
-        $contents = str_replace("\r\n", "\n", $contents);
-        $lines = explode("\n", $contents);
+        $data = str_replace("\r\n", "\n", $data);
+        $lines = explode("\n", $data);
 
         /** @var array<int, list<array{slot_index: int, dc_minutes: int, dc_of: int, dc_df: int, dc_oi: int, dc_di: int, dc_bh: int}>> $result */
         $result = [];
@@ -68,5 +59,22 @@ class PlbFileParser implements PlbFileParserInterface
         }
 
         return $result;
+    }
+
+    /**
+     * @see PlbFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("PLB file not found: {$filePath}");
+        }
+
+        $contents = file_get_contents($filePath);
+        if ($contents === false) {
+            throw new \RuntimeException("Failed to read PLB file: {$filePath}");
+        }
+
+        return self::parse($contents);
     }
 }

--- a/ibl5/classes/JsbParser/RcbFileParser.php
+++ b/ibl5/classes/JsbParser/RcbFileParser.php
@@ -125,23 +125,14 @@ class RcbFileParser implements RcbFileParserInterface
     ];
 
     /**
-     * @see RcbFileParserInterface::parseFile()
+     * @see RcbFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("RCB file not found: {$filePath}");
-        }
-
-        $contents = file_get_contents($filePath);
-        if ($contents === false) {
-            throw new \RuntimeException("Failed to read RCB file: {$filePath}");
-        }
-
         // Split on CRLF (or LF for flexibility)
-        $lines = preg_split('/\r?\n/', $contents);
+        $lines = preg_split('/\r?\n/', $data);
         if ($lines === false) {
-            throw new \RuntimeException("Failed to split RCB file into lines: {$filePath}");
+            throw new \RuntimeException('Failed to split RCB data into lines');
         }
 
         $lineCount = count($lines);
@@ -160,6 +151,23 @@ class RcbFileParser implements RcbFileParserInterface
             'alltime' => $alltime,
             'currentSeason' => $currentSeason,
         ];
+    }
+
+    /**
+     * @see RcbFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("RCB file not found: {$filePath}");
+        }
+
+        $contents = file_get_contents($filePath);
+        if ($contents === false) {
+            throw new \RuntimeException("Failed to read RCB file: {$filePath}");
+        }
+
+        return self::parse($contents);
     }
 
     /**

--- a/ibl5/classes/JsbParser/RetFileParser.php
+++ b/ibl5/classes/JsbParser/RetFileParser.php
@@ -15,23 +15,14 @@ use JsbParser\Contracts\RetFileParserInterface;
 class RetFileParser implements RetFileParserInterface
 {
     /**
-     * @see RetFileParserInterface::parseFile()
+     * @see RetFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("RET file not found: {$filePath}");
-        }
-
-        $raw = file_get_contents($filePath);
-        if ($raw === false) {
-            throw new \RuntimeException("Failed to read RET file: {$filePath}");
-        }
-
         // Normalize line endings
-        $raw = str_replace("\r\n", "\n", $raw);
-        $raw = str_replace("\r", "\n", $raw);
-        $lines = explode("\n", $raw);
+        $data = str_replace("\r\n", "\n", $data);
+        $data = str_replace("\r", "\n", $data);
+        $lines = explode("\n", $data);
 
         /** @var list<array{jsb_pid: int, player_name: string}> $entries */
         $entries = [];
@@ -69,5 +60,22 @@ class RetFileParser implements RetFileParserInterface
         }
 
         return $entries;
+    }
+
+    /**
+     * @see RetFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("RET file not found: {$filePath}");
+        }
+
+        $raw = file_get_contents($filePath);
+        if ($raw === false) {
+            throw new \RuntimeException("Failed to read RET file: {$filePath}");
+        }
+
+        return self::parse($raw);
     }
 }

--- a/ibl5/classes/JsbParser/TrnFileParser.php
+++ b/ibl5/classes/JsbParser/TrnFileParser.php
@@ -47,19 +47,10 @@ class TrnFileParser implements TrnFileParserInterface
     public const TRADE_MARKER_DRAFT_PICK = 1;
 
     /**
-     * @see TrnFileParserInterface::parseFile()
+     * @see TrnFileParserInterface::parse()
      */
-    public static function parseFile(string $filePath): array
+    public static function parse(string $data): array
     {
-        if (!file_exists($filePath)) {
-            throw new \RuntimeException("TRN file not found: {$filePath}");
-        }
-
-        $data = file_get_contents($filePath);
-        if ($data === false) {
-            throw new \RuntimeException("Failed to read TRN file: {$filePath}");
-        }
-
         $fileSize = strlen($data);
         if ($fileSize !== self::FILE_SIZE) {
             throw new \RuntimeException(
@@ -84,6 +75,23 @@ class TrnFileParser implements TrnFileParserInterface
             'record_count' => $recordCount,
             'transactions' => $transactions,
         ];
+    }
+
+    /**
+     * @see TrnFileParserInterface::parseFile()
+     */
+    public static function parseFile(string $filePath): array
+    {
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("TRN file not found: {$filePath}");
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            throw new \RuntimeException("Failed to read TRN file: {$filePath}");
+        }
+
+        return self::parse($data);
     }
 
     /**

--- a/ibl5/classes/Updater/Steps/EndOfSeasonImportStep.php
+++ b/ibl5/classes/Updater/Steps/EndOfSeasonImportStep.php
@@ -7,6 +7,7 @@ namespace Updater\Steps;
 use JsbParser\Contracts\JsbImportRepositoryInterface;
 use JsbParser\JsbImportResult;
 use JsbParser\JsbImportService;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\StepResult;
 
@@ -27,8 +28,7 @@ final class EndOfSeasonImportStep implements PipelineStepInterface
         private readonly JsbImportRepositoryInterface $jsbRepo,
         private readonly JsbImportService $jsbService,
         private readonly int $seasonEndingYear,
-        private readonly string $basePath,
-        private readonly string $filePrefix,
+        private readonly JsbSourceResolverInterface $sourceResolver,
     ) {
     }
 
@@ -65,12 +65,12 @@ final class EndOfSeasonImportStep implements PipelineStepInterface
      */
     private function importDra(JsbImportResult $result, array &$messages): void
     {
-        $path = $this->filePath('dra');
-        if (!file_exists($path)) {
+        $data = $this->sourceResolver->getContents('dra');
+        if ($data === null) {
             return;
         }
 
-        $draResult = $this->jsbService->processDraFile($path);
+        $draResult = $this->jsbService->processDraData($data);
         $result->merge($draResult);
         $messages[] = 'DRA: ' . $draResult->summary();
     }
@@ -80,12 +80,12 @@ final class EndOfSeasonImportStep implements PipelineStepInterface
      */
     private function importRet(JsbImportResult $result, array &$messages): void
     {
-        $path = $this->filePath('ret');
-        if (!file_exists($path)) {
+        $data = $this->sourceResolver->getContents('ret');
+        if ($data === null) {
             return;
         }
 
-        $retResult = $this->jsbService->processRetFile($path, $this->seasonEndingYear);
+        $retResult = $this->jsbService->processRetData($data, $this->seasonEndingYear);
         $result->merge($retResult);
         $messages[] = 'RET: ' . $retResult->summary();
     }
@@ -95,12 +95,12 @@ final class EndOfSeasonImportStep implements PipelineStepInterface
      */
     private function importHof(JsbImportResult $result, array &$messages): void
     {
-        $path = $this->filePath('hof');
-        if (!file_exists($path)) {
+        $data = $this->sourceResolver->getContents('hof');
+        if ($data === null) {
             return;
         }
 
-        $hofResult = $this->jsbService->processHofFile($path);
+        $hofResult = $this->jsbService->processHofData($data);
         $result->merge($hofResult);
         $messages[] = 'HOF: ' . $hofResult->summary();
     }
@@ -110,19 +110,14 @@ final class EndOfSeasonImportStep implements PipelineStepInterface
      */
     private function importAwa(JsbImportResult $result, array &$messages): void
     {
-        $awaPath = $this->filePath('awa');
-        $carPath = $this->filePath('car');
-        if (!file_exists($awaPath) || !file_exists($carPath)) {
+        $awaData = $this->sourceResolver->getContents('awa');
+        $carData = $this->sourceResolver->getContents('car');
+        if ($awaData === null || $carData === null) {
             return;
         }
 
-        $awaResult = $this->jsbService->processAwaFile($awaPath, $carPath, $this->seasonEndingYear);
+        $awaResult = $this->jsbService->processAwaData($awaData, $carData, $this->seasonEndingYear);
         $result->merge($awaResult);
         $messages[] = 'AWA: ' . $awaResult->summary();
-    }
-
-    private function filePath(string $extension): string
-    {
-        return $this->basePath . '/' . $this->filePrefix . '.' . $extension;
     }
 }

--- a/ibl5/classes/Updater/Steps/ExtractFromBackupStep.php
+++ b/ibl5/classes/Updater/Steps/ExtractFromBackupStep.php
@@ -28,8 +28,7 @@ final class ExtractFromBackupStep implements PipelineStepInterface
 {
     /** @var list<string> JSB file extensions to extract (.lge and .sch read directly from archive by JsbSourceResolver) */
     private const EXTENSIONS = [
-        'plr', 'sco', 'car', 'trn', 'his',
-        'asw', 'rcb', 'awa', 'dra', 'ret', 'hof', 'plb',
+        'plr', 'sco',
     ];
 
     public function __construct(

--- a/ibl5/classes/Updater/Steps/ParseJsbFilesStep.php
+++ b/ibl5/classes/Updater/Steps/ParseJsbFilesStep.php
@@ -5,22 +5,23 @@ declare(strict_types=1);
 namespace Updater\Steps;
 
 use JsbParser\JsbImportService;
+use JsbParser\JsbImportResult;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\StepResult;
-use Season\Season;
 
 /**
  * Step 10: Parse JSB engine files (.car, .trn, .his, .asw, .rcb).
  *
- * Wraps JsbImportService::processCurrentSeason() and captures output.
+ * Reads each file from the resolver (archive-first, disk-fallback) and
+ * imports via JsbImportService process*Data() methods.
  */
 class ParseJsbFilesStep implements PipelineStepInterface
 {
     public function __construct(
         private readonly JsbImportService $service,
-        private readonly string $basePath,
-        private readonly Season $season,
-        private readonly string $filePrefix = 'IBL5',
+        private readonly JsbSourceResolverInterface $sourceResolver,
+        private readonly int $seasonYear,
     ) {
     }
 
@@ -31,16 +32,53 @@ class ParseJsbFilesStep implements PipelineStepInterface
 
     public function execute(): StepResult
     {
-        ob_start();
-        $jsbResult = $this->service->processCurrentSeason($this->basePath, $this->season, $this->filePrefix);
-        $log = (string) ob_get_clean();
+        $result = new JsbImportResult();
+
+        // Process .trn first (trade data helps with player ID resolution)
+        $trnData = $this->sourceResolver->getContents('trn');
+        if ($trnData !== null) {
+            $trnResult = $this->service->processTrnData($trnData, 'current-season');
+            $result->merge($trnResult);
+            $result->addMessage('TRN: ' . $trnResult->summary());
+        }
+
+        // Process .car (uses trade data for mid-season splits)
+        $carData = $this->sourceResolver->getContents('car');
+        if ($carData !== null) {
+            $carResult = $this->service->processCarData($carData, $this->seasonYear);
+            $result->merge($carResult);
+            $result->addMessage('CAR: ' . $carResult->summary());
+        }
+
+        // Process .his
+        $hisData = $this->sourceResolver->getContents('his');
+        if ($hisData !== null) {
+            $hisResult = $this->service->processHisData($hisData, 'current-season');
+            $result->merge($hisResult);
+            $result->addMessage('HIS: ' . $hisResult->summary());
+        }
+
+        // Process .asw
+        $aswData = $this->sourceResolver->getContents('asw');
+        if ($aswData !== null) {
+            $aswResult = $this->service->processAswData($aswData, $this->seasonYear);
+            $result->merge($aswResult);
+            $result->addMessage('ASW: ' . $aswResult->summary());
+        }
+
+        // Process .rcb (Record Book)
+        $rcbData = $this->sourceResolver->getContents('rcb');
+        if ($rcbData !== null) {
+            $rcbResult = $this->service->processRcbData($rcbData, $this->seasonYear, 'current-season');
+            $result->merge($rcbResult);
+            $result->addMessage('RCB: ' . $rcbResult->summary());
+        }
 
         return StepResult::success(
             $this->getLabel(),
-            $jsbResult->summary(),
-            capturedLog: $log,
-            messages: $jsbResult->messages,
-            messageErrorCount: $jsbResult->errors,
+            $result->summary(),
+            messages: $result->messages,
+            messageErrorCount: $result->errors,
         );
     }
 }

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -31,6 +31,64 @@ parameters:
 			path: classes/Bootstrap/AutoloaderBootstrap.php
 
 		-
+			rawMessage: '''
+				Call to method sql_fetchrow() of deprecated class Database\MySQL:
+				This class is for PHP-Nuke module backward compatibility only.
+
+				All IBL5 classes in /ibl5/classes/ and scripts in /ibl5/scripts/ have been
+				migrated to modern mysqli with prepared statements via BaseMysqliRepository.
+
+				This class is ONLY used by legacy PHP-Nuke code in:
+				- /ibl5/modules/
+				- /ibl5/admin/modules/
+				- /ibl5/blocks/
+
+				DO NOT use this class for new code. Instead:
+				- Extend BaseMysqliRepository for repository classes
+				- Use $mysqli_db global with prepared statements
+
+				Example:
+				  $stmt = $mysqli_db->prepare("SELECT * FROM table WHERE id = ?");
+				  $stmt->bind_param("i", $id);
+				  $stmt->execute();
+				  $result = $stmt->get_result();
+
+				Scheduled for removal once PHP-Nuke modules are deprecated.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: classes/Bootstrap/ConfigBootstrap.php
+
+		-
+			rawMessage: '''
+				Call to method sql_query() of deprecated class Database\MySQL:
+				This class is for PHP-Nuke module backward compatibility only.
+
+				All IBL5 classes in /ibl5/classes/ and scripts in /ibl5/scripts/ have been
+				migrated to modern mysqli with prepared statements via BaseMysqliRepository.
+
+				This class is ONLY used by legacy PHP-Nuke code in:
+				- /ibl5/modules/
+				- /ibl5/admin/modules/
+				- /ibl5/blocks/
+
+				DO NOT use this class for new code. Instead:
+				- Extend BaseMysqliRepository for repository classes
+				- Use $mysqli_db global with prepared statements
+
+				Example:
+				  $stmt = $mysqli_db->prepare("SELECT * FROM table WHERE id = ?");
+				  $stmt->bind_param("i", $id);
+				  $stmt->execute();
+				  $result = $stmt->get_result();
+
+				Scheduled for removal once PHP-Nuke modules are deprecated.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: classes/Bootstrap/ConfigBootstrap.php
+
+		-
 			rawMessage: Deprecated HTML tag `<b>` found in string literal. Use <strong> instead.
 			identifier: ibl.deprecatedHtmlTag
 			count: 1
@@ -52,6 +110,35 @@ parameters:
 			rawMessage: Direct `require_once` is banned in classes/. All classes under ibl5/classes/ autoload via Composer PSR-4. Remove the statement and rely on autoload instead.
 			identifier: ibl.requireOnce
 			count: 2
+			path: classes/Bootstrap/ConfigBootstrap.php
+
+		-
+			rawMessage: '''
+				PHPDoc tag @var references deprecated class Database\MySQL:
+				This class is for PHP-Nuke module backward compatibility only.
+
+				All IBL5 classes in /ibl5/classes/ and scripts in /ibl5/scripts/ have been
+				migrated to modern mysqli with prepared statements via BaseMysqliRepository.
+
+				This class is ONLY used by legacy PHP-Nuke code in:
+				- /ibl5/modules/
+				- /ibl5/admin/modules/
+				- /ibl5/blocks/
+
+				DO NOT use this class for new code. Instead:
+				- Extend BaseMysqliRepository for repository classes
+				- Use $mysqli_db global with prepared statements
+
+				Example:
+				  $stmt = $mysqli_db->prepare("SELECT * FROM table WHERE id = ?");
+				  $stmt->bind_param("i", $id);
+				  $stmt->execute();
+				  $result = $stmt->get_result();
+
+				Scheduled for removal once PHP-Nuke modules are deprecated.
+			'''
+			identifier: varTag.deprecatedClass
+			count: 1
 			path: classes/Bootstrap/ConfigBootstrap.php
 
 		-

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -216,12 +216,12 @@ try {
         ));
     }
 
-    $updaterService->addStep(new Updater\Steps\ParseJsbFilesStep($jsbService, $basePath, $season, $filePrefix));
+    $updaterService->addStep(new Updater\Steps\ParseJsbFilesStep($jsbService, $sourceResolver, $season->endingYear));
 
     // IBL-only: End-of-season imports when champion exists
     if (!$isOlympics) {
         $updaterService->addStep(new Updater\Steps\EndOfSeasonImportStep(
-            $jsbRepo, $jsbService, $season->endingYear, $basePath, $filePrefix,
+            $jsbRepo, $jsbService, $season->endingYear, $sourceResolver,
         ));
     }
 

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
@@ -314,10 +314,23 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
             $boxscoreProcessor, $boxscoreRepo, $boxscoreView, $scoPath,
         ));
 
-        $service->addStep(new Steps\ParseJsbFilesStep($jsbService, $this->tempDir, $season, 'IBL5'));
+        $tempDir = $this->tempDir;
+        $jsbFileResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $jsbFileResolver->method('getContents')->willReturnCallback(
+            static function (string $ext) use ($tempDir): ?string {
+                $path = $tempDir . '/IBL5.' . $ext;
+                if (is_file($path)) {
+                    $data = file_get_contents($path);
+                    return $data !== false ? $data : null;
+                }
+                return null;
+            },
+        );
+
+        $service->addStep(new Steps\ParseJsbFilesStep($jsbService, $jsbFileResolver, $season->endingYear));
 
         $service->addStep(new Steps\EndOfSeasonImportStep(
-            $jsbRepo, $jsbService, $season->endingYear, $this->tempDir, 'IBL5',
+            $jsbRepo, $jsbService, $season->endingYear, $jsbFileResolver,
         ));
 
         $service->addStep(new Steps\SnapshotPlrStep(

--- a/ibl5/tests/JsbParser/AswFileParserTest.php
+++ b/ibl5/tests/JsbParser/AswFileParserTest.php
@@ -331,4 +331,15 @@ class AswFileParserTest extends TestCase
             unlink($tmpFile);
         }
     }
+
+    public function testParseAcceptsInMemoryData(): void
+    {
+        // 10,000-byte ASW file with all zeros (no valid player IDs)
+        $data = str_repeat("0\r\n", 112) . str_repeat(" ", 10000 - 112 * 3);
+        $data = str_pad($data, 10000);
+        $result = AswFileParser::parse($data);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('rosters', $result);
+        $this->assertArrayHasKey('scores', $result);
+    }
 }

--- a/ibl5/tests/JsbParser/AwaFileParserTest.php
+++ b/ibl5/tests/JsbParser/AwaFileParserTest.php
@@ -342,4 +342,21 @@ class AwaFileParserTest extends TestCase
         }
         return null;
     }
+
+    public function testParseThrowsForTooSmallData(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('need at least');
+        AwaFileParser::parse(str_repeat(' ', 100));
+    }
+
+    public function testParseAcceptsMinimalData(): void
+    {
+        // Two blocks (header + one block): 2000 bytes
+        $data = str_repeat(' ', AwaFileParser::BLOCK_SIZE * 2);
+        $result = AwaFileParser::parse($data);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('seasons', $result);
+        $this->assertSame([], $result['seasons']);
+    }
 }

--- a/ibl5/tests/JsbParser/CarFileParserTest.php
+++ b/ibl5/tests/JsbParser/CarFileParserTest.php
@@ -260,6 +260,24 @@ class CarFileParserTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testParseAcceptsInMemoryData(): void
+    {
+        $seasonRecord = $this->buildSeasonRecord();
+        $playerBlock = $this->buildPlayerBlock(1, 12345, 'Test Player', $seasonRecord);
+        $carData = $this->buildCarFile(1, $playerBlock);
+
+        $result = CarFileParser::parse($carData);
+        $this->assertSame(1, $result['player_count']);
+        $this->assertCount(1, $result['players']);
+    }
+
+    public function testParseThrowsForTooSmallData(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('too small');
+        CarFileParser::parse(str_repeat(' ', 100));
+    }
+
     public function testParseFileThrowsForMissingFile(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/ibl5/tests/JsbParser/DraFileParserTest.php
+++ b/ibl5/tests/JsbParser/DraFileParserTest.php
@@ -201,4 +201,13 @@ class DraFileParserTest extends TestCase
 
         DraFileParser::parseFile('/nonexistent/file.dra');
     }
+
+    public function testParseAcceptsInMemoryData(): void
+    {
+        $data = "***** 2025 rookie draft *****\nRound 1 Pick 1\nLakers: SF John Doe\n";
+        $result = DraFileParser::parse($data);
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertSame(2025, $result[0]['draft_year']);
+    }
 }

--- a/ibl5/tests/JsbParser/HisFileParserTest.php
+++ b/ibl5/tests/JsbParser/HisFileParserTest.php
@@ -280,4 +280,13 @@ class HisFileParserTest extends TestCase
             unlink($tmpFile);
         }
     }
+
+    public function testParseAcceptsInMemoryData(): void
+    {
+        $data = "Detroit (45-37) Championship (2006)\n";
+        $result = HisFileParser::parse($data);
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertSame(2007, $result[0]['year']);
+    }
 }

--- a/ibl5/tests/JsbParser/HofFileParserTest.php
+++ b/ibl5/tests/JsbParser/HofFileParserTest.php
@@ -141,7 +141,7 @@ class HofFileParserTest extends TestCase
 
         try {
             $this->expectException(\RuntimeException::class);
-            $this->expectExceptionMessage('HOF file size mismatch');
+            $this->expectExceptionMessage('HOF data size mismatch');
 
             HofFileParser::parseFile($tmpFile);
         } finally {
@@ -182,5 +182,19 @@ class HofFileParserTest extends TestCase
         $this->expectExceptionMessage('HOF file not found');
 
         HofFileParser::parseFile('/nonexistent/file.hof');
+    }
+
+    public function testParseThrowsForWrongSize(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('HOF data size mismatch');
+        HofFileParser::parse(str_repeat(' ', 100));
+    }
+
+    public function testParseAcceptsValidSizedData(): void
+    {
+        $data = str_repeat(' ', 7000);
+        $result = HofFileParser::parse($data);
+        $this->assertIsArray($result);
     }
 }

--- a/ibl5/tests/JsbParser/JsbImportServiceTest.php
+++ b/ibl5/tests/JsbParser/JsbImportServiceTest.php
@@ -369,4 +369,85 @@ class JsbImportServiceTest extends TestCase
             unlink($tmpFile);
         }
     }
+
+    // ── process*Data() — in-memory variants ─────────────────────
+
+    public function testProcessCarDataReturnsErrorOnInvalidData(): void
+    {
+        $result = $this->makeService()->processCarData('invalid data', 2006);
+        $this->assertSame(1, $result->errors);
+        $this->assertStringContainsString('CAR parse failed', $result->messages[0]);
+    }
+
+    public function testProcessCarDataProcessesMatchingYear(): void
+    {
+        $seasonRecord = $this->buildSeasonRecord(2006);
+        $playerBlock = $this->buildPlayerBlock(1, 100, 'Test Player', $seasonRecord);
+        $carData = $this->buildCarFile(1, $playerBlock);
+
+        $this->stubRepo->method('resolveTeamIdByName')->willReturn(21);
+        $mockResolver = $this->createMock(PlayerIdResolver::class);
+        $mockResolver->expects($this->once())->method('resolve')->willReturn(12345);
+
+        $result = $this->makeService($mockResolver)->processCarData($carData, 2006);
+        $this->assertSame(1, $result->inserted);
+    }
+
+    public function testProcessTrnDataReturnsErrorOnInvalidData(): void
+    {
+        $result = $this->makeService()->processTrnData('invalid data', null);
+        $this->assertSame(1, $result->errors);
+        $this->assertStringContainsString('TRN parse failed', $result->messages[0]);
+    }
+
+    public function testProcessTrnDataProcessesValidData(): void
+    {
+        $trnData = $this->buildTrnFile(0);
+        $this->stubRepo->method('fetchMaxTradeGroupId')->willReturn(1);
+
+        $result = $this->makeService()->processTrnData($trnData, 'test');
+        $this->assertSame(0, $result->errors);
+    }
+
+    public function testProcessHisDataUpsertsPerTeam(): void
+    {
+        $hisContent = "Celtics (50-32) Won First Round (2005)\n"
+            . "Lakers (55-27) Won Championship (2005)\n";
+
+        $this->stubRepo->method('resolveTeamIdByName')->willReturn(1);
+        $this->stubRepo->method('upsertHistoryRecord')->willReturn(1);
+
+        $result = $this->makeService()->processHisData($hisContent, 'test-source');
+        $this->assertSame(2, $result->inserted);
+    }
+
+    public function testProcessRcbDataReturnsErrorOnInvalidData(): void
+    {
+        $result = $this->makeService()->processRcbData('invalid', 2006);
+        $this->assertSame(1, $result->errors);
+        $this->assertStringContainsString('RCB parse failed', $result->messages[0]);
+    }
+
+    public function testProcessDraDataReturnsNoErrorForEmptyData(): void
+    {
+        $result = $this->makeService()->processDraData('');
+        $this->assertSame(0, $result->errors);
+    }
+
+    public function testProcessRetDataParsesEntries(): void
+    {
+        $retData = "John Doe 12345\nJane Smith 67890\n";
+        $this->stubRepo->method('getPlayerName')->willReturn('John Doe');
+        $this->stubRepo->method('upsertRetiredPlayer')->willReturn(1);
+
+        $result = $this->makeService()->processRetData($retData, 2026);
+        $this->assertSame(0, $result->errors);
+        $this->assertSame(2, $result->inserted);
+    }
+
+    public function testProcessHofDataReturnsNoErrorForEmptyData(): void
+    {
+        $result = $this->makeService()->processHofData(str_repeat(' ', 7000));
+        $this->assertSame(0, $result->errors);
+    }
 }

--- a/ibl5/tests/JsbParser/PlbFileParserTest.php
+++ b/ibl5/tests/JsbParser/PlbFileParserTest.php
@@ -186,4 +186,15 @@ class PlbFileParserTest extends TestCase
         $this->assertSame(0, $slot['dc_minutes']);
         $this->assertArrayHasKey('dc_minutes', $slot);
     }
+
+    public function testParseAcceptsInMemoryData(): void
+    {
+        // One team line with 30 slots × 12 chars = 360 chars minimum
+        $line = str_repeat('121212121212', 30); // 360 chars
+        $data = $line . "\n";
+        $result = PlbFileParser::parse($data);
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertCount(30, $result[0]);
+    }
 }

--- a/ibl5/tests/JsbParser/RcbFileParserTest.php
+++ b/ibl5/tests/JsbParser/RcbFileParserTest.php
@@ -558,4 +558,11 @@ class RcbFileParserTest extends TestCase
             'blk' => ['blk'],
         ];
     }
+
+    public function testParseThrowsForTooFewLines(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('expected at least');
+        RcbFileParser::parse('too few lines');
+    }
 }

--- a/ibl5/tests/JsbParser/RetFileParserTest.php
+++ b/ibl5/tests/JsbParser/RetFileParserTest.php
@@ -127,4 +127,14 @@ class RetFileParserTest extends TestCase
 
         RetFileParser::parseFile('/nonexistent/file.ret');
     }
+
+    public function testParseAcceptsInMemoryData(): void
+    {
+        $data = "John Doe 12345\nJane Smith 67890\n";
+        $result = RetFileParser::parse($data);
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertSame(12345, $result[0]['jsb_pid']);
+        $this->assertSame('John Doe', $result[0]['player_name']);
+    }
 }

--- a/ibl5/tests/JsbParser/TrnFileParserTest.php
+++ b/ibl5/tests/JsbParser/TrnFileParserTest.php
@@ -465,4 +465,19 @@ class TrnFileParserTest extends TestCase
             unlink($tmpFile);
         }
     }
+
+    public function testParseAcceptsInMemoryData(): void
+    {
+        $data = str_repeat("\0", TrnFileParser::FILE_SIZE);
+        $result = TrnFileParser::parse($data);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('transactions', $result);
+    }
+
+    public function testParseThrowsForInvalidSize(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid .trn file size');
+        TrnFileParser::parse('too short');
+    }
 }

--- a/ibl5/tests/UpdateAllTheThings/Steps/EndOfSeasonImportStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/EndOfSeasonImportStepTest.php
@@ -8,6 +8,7 @@ use JsbParser\Contracts\JsbImportRepositoryInterface;
 use JsbParser\JsbImportResult;
 use JsbParser\JsbImportService;
 use PHPUnit\Framework\TestCase;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\Steps\EndOfSeasonImportStep;
 
@@ -15,21 +16,22 @@ class EndOfSeasonImportStepTest extends TestCase
 {
     private JsbImportRepositoryInterface $stubRepo;
     private JsbImportService $stubService;
+    private JsbSourceResolverInterface $stubResolver;
 
     protected function setUp(): void
     {
         $this->stubRepo = $this->createStub(JsbImportRepositoryInterface::class);
         $this->stubService = $this->createStub(JsbImportService::class);
+        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
     }
 
-    private function createStep(string $basePath = '/tmp'): EndOfSeasonImportStep
+    private function createStep(): EndOfSeasonImportStep
     {
         return new EndOfSeasonImportStep(
             $this->stubRepo,
             $this->stubService,
             2026,
-            $basePath,
-            'IBL5',
+            $this->stubResolver,
         );
     }
 
@@ -60,48 +62,36 @@ class EndOfSeasonImportStepTest extends TestCase
         $jsbResult = new JsbImportResult();
         $jsbResult->addInserted();
 
-        $this->stubService->method('processDraFile')->willReturn($jsbResult);
-        $this->stubService->method('processRetFile')->willReturn($jsbResult);
-        $this->stubService->method('processHofFile')->willReturn($jsbResult);
-        $this->stubService->method('processAwaFile')->willReturn($jsbResult);
+        $this->stubResolver->method('getContents')->willReturnMap([
+            ['dra', 'dra-data'],
+            ['ret', 'ret-data'],
+            ['hof', 'hof-data'],
+            ['awa', 'awa-data'],
+            ['car', 'car-data'],
+        ]);
 
-        // Use a temp dir with actual files
-        $tmpDir = sys_get_temp_dir() . '/eos-test-' . uniqid();
-        mkdir($tmpDir, 0777, true);
-        foreach (['dra', 'ret', 'hof', 'awa', 'car'] as $ext) {
-            touch($tmpDir . '/IBL5.' . $ext);
-        }
+        $this->stubService->method('processDraData')->willReturn($jsbResult);
+        $this->stubService->method('processRetData')->willReturn($jsbResult);
+        $this->stubService->method('processHofData')->willReturn($jsbResult);
+        $this->stubService->method('processAwaData')->willReturn($jsbResult);
 
-        try {
-            $step = new EndOfSeasonImportStep(
-                $this->stubRepo,
-                $this->stubService,
-                2026,
-                $tmpDir,
-                'IBL5',
-            );
-            $result = $step->execute();
+        $result = $this->createStep()->execute();
 
-            $this->assertTrue($result->success);
-            $this->assertNotEmpty($result->messages);
-        } finally {
-            // Cleanup
-            foreach (glob($tmpDir . '/*') as $file) {
-                unlink($file);
-            }
-            rmdir($tmpDir);
-        }
+        $this->assertTrue($result->success);
+        $this->assertNotEmpty($result->messages);
     }
 
-    public function testSkipsIndividualImportWhenFileNotFound(): void
+    public function testSkipsIndividualImportWhenResolverReturnsNull(): void
     {
         $this->stubRepo->method('hasChampionForSeason')->willReturn(true);
 
-        // Base path has no files — all imports should be silently skipped
-        $result = $this->createStep('/nonexistent/path')->execute();
+        $this->stubResolver->method('getContents')->willReturn(null);
+
+        $result = $this->createStep()->execute();
 
         $this->assertTrue($result->success);
         $this->assertSame(0, $result->messageErrorCount);
+        $this->assertSame([], $result->messages);
     }
 
     public function testErrorsFromIndividualImportAreCollected(): void
@@ -112,27 +102,38 @@ class EndOfSeasonImportStepTest extends TestCase
         $errorResult->addError('Parse failed');
         $errorResult->addError('Another error');
 
-        $this->stubService->method('processDraFile')->willReturn($errorResult);
+        $this->stubResolver->method('getContents')->willReturnMap([
+            ['dra', 'dra-data'],
+            ['ret', null],
+            ['hof', null],
+            ['awa', null],
+            ['car', null],
+        ]);
+        $this->stubService->method('processDraData')->willReturn($errorResult);
 
-        $tmpDir = sys_get_temp_dir() . '/eos-err-' . uniqid();
-        mkdir($tmpDir, 0777, true);
-        touch($tmpDir . '/IBL5.dra');
+        $result = $this->createStep()->execute();
 
-        try {
-            $step = new EndOfSeasonImportStep(
-                $this->stubRepo,
-                $this->stubService,
-                2026,
-                $tmpDir,
-                'IBL5',
-            );
-            $result = $step->execute();
+        $this->assertTrue($result->success);
+        $this->assertSame(2, $result->messageErrorCount);
+    }
 
-            $this->assertTrue($result->success);
-            $this->assertSame(2, $result->messageErrorCount);
-        } finally {
-            unlink($tmpDir . '/IBL5.dra');
-            rmdir($tmpDir);
-        }
+    public function testAwaSkippedWhenCarDataNull(): void
+    {
+        $this->stubRepo->method('hasChampionForSeason')->willReturn(true);
+
+        $jsbResult = new JsbImportResult();
+
+        $this->stubResolver->method('getContents')->willReturnMap([
+            ['dra', null],
+            ['ret', null],
+            ['hof', null],
+            ['awa', 'awa-data'],
+            ['car', null],
+        ]);
+
+        $result = $this->createStep()->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertSame([], $result->messages);
     }
 }

--- a/ibl5/tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
@@ -95,7 +95,7 @@ class ExtractFromBackupStepTest extends TestCase
         $result = $step->execute();
 
         $this->assertTrue($result->success);
-        $this->assertStringContainsString('Extracted 10 files', $result->detail);
+        $this->assertStringContainsString('Extracted 2 files', $result->detail);
     }
 
     public function testSkipsRenameForProperlyNamedBackup(): void

--- a/ibl5/tests/UpdateAllTheThings/Steps/ParseJsbFilesStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ParseJsbFilesStepTest.php
@@ -7,51 +7,65 @@ namespace Tests\UpdateAllTheThings\Steps;
 use JsbParser\JsbImportResult;
 use JsbParser\JsbImportService;
 use PHPUnit\Framework\TestCase;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\Steps\ParseJsbFilesStep;
-use Season\Season;
 
 class ParseJsbFilesStepTest extends TestCase
 {
     private JsbImportService $stubService;
-    private Season $stubSeason;
+    private JsbSourceResolverInterface $stubResolver;
 
     protected function setUp(): void
     {
         $this->stubService = $this->createStub(JsbImportService::class);
-        $this->stubSeason = $this->createStub(Season::class);
+        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
+    }
+
+    private function createStep(): ParseJsbFilesStep
+    {
+        return new ParseJsbFilesStep($this->stubService, $this->stubResolver, 2026);
     }
 
     public function testImplementsPipelineStepInterface(): void
     {
-        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
-
-        $this->assertInstanceOf(PipelineStepInterface::class, $step);
+        $this->assertInstanceOf(PipelineStepInterface::class, $this->createStep());
     }
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
-
-        $this->assertSame('JSB files parsed', $step->getLabel());
+        $this->assertSame('JSB files parsed', $this->createStep()->getLabel());
     }
 
-    public function testExecuteReturnsSuccessWithSummary(): void
+    public function testExecuteReturnsSuccessWhenAllFilesNull(): void
     {
-        $jsbResult = new JsbImportResult();
-        $jsbResult->addMessage('CAR: 150 records');
-        $jsbResult->addMessage('TRN: 10 trades');
+        $this->stubResolver->method('getContents')->willReturn(null);
 
-        $this->stubService->method('processCurrentSeason')->willReturn($jsbResult);
-
-        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
-        $result = $step->execute();
+        $result = $this->createStep()->execute();
 
         $this->assertTrue($result->success);
         $this->assertSame('JSB files parsed', $result->label);
-        $this->assertNotSame('', $result->detail);
-        $this->assertSame(['CAR: 150 records', 'TRN: 10 trades'], $result->messages);
-        $this->assertSame(0, $result->messageErrorCount);
+    }
+
+    public function testExecuteProcessesFilesReturnedByResolver(): void
+    {
+        $jsbResult = new JsbImportResult();
+        $jsbResult->addMessage('TRN: 10 records');
+
+        $this->stubResolver->method('getContents')->willReturnMap([
+            ['trn', 'trn-data'],
+            ['car', null],
+            ['his', null],
+            ['asw', null],
+            ['rcb', null],
+        ]);
+
+        $this->stubService->method('processTrnData')->willReturn($jsbResult);
+
+        $result = $this->createStep()->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertContains('TRN: 10 records', $result->messages);
     }
 
     public function testExecutePassesErrorCountFromResult(): void
@@ -60,30 +74,28 @@ class ParseJsbFilesStepTest extends TestCase
         $jsbResult->addError('Failed to parse player');
         $jsbResult->addError('Unknown team');
 
-        $this->stubService->method('processCurrentSeason')->willReturn($jsbResult);
+        $this->stubResolver->method('getContents')->willReturnMap([
+            ['trn', 'trn-data'],
+            ['car', null],
+            ['his', null],
+            ['asw', null],
+            ['rcb', null],
+        ]);
+        $this->stubService->method('processTrnData')->willReturn($jsbResult);
 
-        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
-        $result = $step->execute();
+        $result = $this->createStep()->execute();
 
         $this->assertTrue($result->success);
         $this->assertSame(2, $result->messageErrorCount);
     }
 
-    public function testExecuteCapturesOutputBufferLog(): void
+    public function testExecuteSkipsFileWhenResolverReturnsNull(): void
     {
-        $jsbResult = new JsbImportResult();
+        $this->stubResolver->method('getContents')->willReturn(null);
 
-        $this->stubService->method('processCurrentSeason')->willReturnCallback(
-            static function () use ($jsbResult): JsbImportResult {
-                echo '<p>Processing JSB...</p>';
-                return $jsbResult;
-            }
-        );
-
-        $step = new ParseJsbFilesStep($this->stubService, '/tmp', $this->stubSeason);
-        $result = $step->execute();
+        $result = $this->createStep()->execute();
 
         $this->assertTrue($result->success);
-        $this->assertSame('<p>Processing JSB...</p>', $result->capturedLog);
+        $this->assertSame([], $result->messages);
     }
 }


### PR DESCRIPTION
## Summary

- **Phase 1A**: Added `parse(string $data): array` to all 10 JsbParser parsers and their `Contracts/` interfaces. `parseFile()` is now a thin wrapper that reads the file and delegates to `parse()`. This follows the `LgeFileParser` canonical pattern.
- **Phase 1B**: Added `process*Data()` overloads to `JsbImportService` (and interface) for all 10 file types. Each `process*File()` delegates to its `process*Data()` counterpart. Deleted `processCurrentSeason()` — logic inlined into `ParseJsbFilesStep`.
- **Phase 1C**: Rewired `ParseJsbFilesStep` and `EndOfSeasonImportStep` to accept a `JsbSourceResolverInterface` (archive-first, disk-fallback) instead of raw file paths. `ExtractFromBackupStep::EXTENSIONS` reduced from 12 types to `['plr', 'sco']`. Updated `updateAllTheThings.php` constructors accordingly.
- **Phase 1D**: Updated all affected tests — step tests stub `JsbSourceResolverInterface`; parser tests cover in-memory `parse()`; service tests cover `process*Data()`.

## Test plan

- [ ] `bin/test` passes — 4939 tests, 27760 assertions, 0 failures
- [ ] PHPStan passes clean — 0 errors
- [ ] `ExtractFromBackupStep::EXTENSIONS` is now `['plr', 'sco']` — remaining file types route through resolver
- [ ] PR 2 (`jsb-resolver-plr`) and PR 3 (`jsb-resolver-sco`) will eliminate the last two extensions

https://claude.ai/code/session_01KobwBnxi815hyUKRpFgFdh

---
_Generated by [Claude Code](https://claude.ai/code/session_01KobwBnxi815hyUKRpFgFdh)_