### PR TITLE
feat: weekly production log review via GitHub Action

### DIFF
--- a/.github/workflows/log-review.yml
+++ b/.github/workflows/log-review.yml
@@ -1,0 +1,94 @@
+name: Weekly Log Review
+
+on:
+  # Sunday ~9am ET (13:00 UTC; ~8am EST in winter). Offset from :00.
+  schedule:
+    - cron: '57 12 * * 0'
+
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Fetch & Notify
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+        env:
+          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Fetch log digest
+        id: digest
+        run: |
+          chmod +x bin/log-fetch-prod
+          DIGEST=$(bin/log-fetch-prod \
+            --ssh-host "${{ secrets.USERNAME }}@${{ secrets.HOST }}" \
+            --ssh-port "${{ secrets.PORT }}" \
+            --ssh-key ~/.ssh/id_deploy)
+          echo "$DIGEST"
+          # Store in file for next step (multi-line output)
+          echo "$DIGEST" > /tmp/log-digest.txt
+
+      - name: Build Discord summary
+        id: summary
+        run: |
+          DIGEST=$(cat /tmp/log-digest.txt)
+
+          # Extract key metrics
+          TOTAL=$(echo "$DIGEST" | grep "^Total entries:" | sed 's/Total entries: //')
+          PERIOD=$(echo "$DIGEST" | grep "^Period:" | sed 's/Period: //')
+          WARNINGS=$(echo "$DIGEST" | awk '/^--- Severity Counts ---$/,/^$/' | grep WARNING | awk '{print $1}')
+          ERRORS=$(echo "$DIGEST" | awk '/^--- Severity Counts ---$/,/^$/' | grep -E 'ERROR|CRITICAL|ALERT|EMERGENCY' | awk '{sum+=$1} END {print sum+0}')
+          SLOW=$(echo "$DIGEST" | grep "^--- Slow Queries" | sed -n 's/.*(\([0-9]*\) total.*/\1/p')
+
+          # Top 3 deduplicated messages (preserve full message text)
+          TOP_ISSUES=$(echo "$DIGEST" \
+            | awk '/^--- Deduplicated Messages/,/^$/' \
+            | grep -v "^---" | grep -v "^$" \
+            | head -3 \
+            | sed 's/^ */  /')
+
+          # Top 3 slow query repos
+          TOP_SLOW=$(echo "$DIGEST" \
+            | awk '/^--- Slow Queries/,/^$/' \
+            | grep "hits" \
+            | head -3 \
+            | sed 's/^ */  /')
+
+          # Build message (Discord DM limit: 2000 chars)
+          {
+            echo "Weekly Log Review ($PERIOD)"
+            echo "Total: ${TOTAL:-0} entries | Warnings: ${WARNINGS:-0} | Errors: ${ERRORS:-0}"
+            echo ""
+            echo "Top issues:"
+            echo "${TOP_ISSUES:-  (none)}"
+            echo ""
+            echo "Slow queries ($SLOW total):"
+            echo "${TOP_SLOW:-  (none)}"
+            echo ""
+            echo "Full digest: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } | tee /tmp/discord-msg.txt
+
+      - name: Send Discord DM
+        env:
+          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
+        run: |
+          MSG=$(cat /tmp/discord-msg.txt)
+
+          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
+            '{content: {receivingUserDiscordID: $id, message: $msg}}')
+
+          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
+            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
+            || echo "::warning::IBLbot notification failed (bot may be down)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,22 +46,7 @@ jobs:
       - name: Stop IBL6 to free resources for deploy
         run: |
           ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} '
-            if pkill -f "node build/index[.]js"; then
-              echo "SIGTERM sent, waiting for process to exit..."
-              for i in $(seq 1 10); do
-                if ! pgrep -f "node build/index[.]js" > /dev/null 2>&1; then
-                  echo "IBL6 stopped gracefully"
-                  exit 0
-                fi
-                sleep 1
-              done
-              echo "Process still alive after 10s, sending SIGKILL..."
-              pkill -9 -f "node build/index[.]js" || true
-              sleep 1
-              echo "IBL6 force-killed"
-            else
-              echo "IBL6 was not running"
-            fi
+            pm2 stop ibl6 2>/dev/null && echo "IBL6 stopped" || echo "IBL6 was not running"
           '
 
       - name: Pull latest code on server
@@ -138,19 +123,11 @@ jobs:
             echo "Registering slash commands..."
             npm run deploy-commands
 
-            echo "Stopping old bot process..."
-            if [ -f bot.pid ] && kill -0 "$(cat bot.pid)" 2>/dev/null; then
-              kill "$(cat bot.pid)"
-              sleep 2
-            fi
+            echo "Restarting IBLbot via PM2..."
+            pm2 restart iblbot --update-env
+            pm2 save
 
-            echo "Starting new bot process..."
-            mkdir -p logs
-            setsid node dist/index.js > logs/bot.log 2>&1 < /dev/null &
-            echo $! > bot.pid
-            sleep 1
-
-            echo "IBLbot deployed successfully (PID: $(cat bot.pid))"
+            echo "IBLbot deployed successfully (PID: $(pm2 pid iblbot))"
           '
 
       - name: Check for IBL6 changes
@@ -190,11 +167,28 @@ jobs:
           ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} '
             cd www/IBL6
             mkdir -p logs
-            setsid env PORT=3001 UV_THREADPOOL_SIZE=2 node --max-old-space-size=128 build/index.js > logs/ibl6.log 2>&1 < /dev/null &
-            echo $! > ibl6.pid
-            sleep 1
-            echo "IBL6 started (PID: $(cat ibl6.pid))"
+            pm2 restart ibl6 --update-env 2>/dev/null \
+              || pm2 start ecosystem.config.cjs --only ibl6
+            pm2 save
+            echo "IBL6 started (PID: $(pm2 pid ibl6))"
           '
+
+      - name: Smoke test IBL6
+        if: ${{ !cancelled() }}
+        run: |
+          for i in 1 2 3; do
+            if curl -fsS --max-time 10 https://ibl6.iblhoops.net/ >/dev/null 2>&1; then
+              echo "IBL6 smoke test passed (attempt $i)"
+              exit 0
+            fi
+            echo "Attempt $i failed, waiting 5s..."
+            sleep 5
+          done
+          echo "Smoke test failed after 3 attempts, restarting IBL6..."
+          ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} 'pm2 restart ibl6'
+          sleep 5
+          curl -fsS --max-time 10 https://ibl6.iblhoops.net/ >/dev/null 2>&1
+          echo "IBL6 recovered after restart"
 
   notify-deploy-failure:
     name: Notify Deploy Failure

--- a/IBL6/ecosystem.config.cjs
+++ b/IBL6/ecosystem.config.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  apps: [
+    {
+      name: 'ibl6',
+      script: 'build/index.js',
+      cwd: '/home/iblhoops/public_html/IBL6',
+      node_args: '--max-old-space-size=128',
+      env: {
+        PORT: 3001,
+        UV_THREADPOOL_SIZE: 2
+      },
+      log_date_format: 'YYYY-MM-DD HH:mm:ss',
+      out_file: 'logs/ibl6-out.log',
+      error_file: 'logs/ibl6-error.log',
+      merge_logs: true
+    }
+  ]
+};

--- a/bin/log-fetch-prod
+++ b/bin/log-fetch-prod
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Fetch and aggregate production logs into a compact digest.
+#
+# Runs all aggregation server-side via SSH to minimize data transfer.
+# Output is plain text, ~500-2000 tokens for a typical week.
+#
+# Usage:
+#   bin/log-fetch-prod                     # WARNING+ from past 7 days (local SSH via .env)
+#   bin/log-fetch-prod --all-levels        # All levels
+#   bin/log-fetch-prod --days 14           # Past 14 days
+#   bin/log-fetch-prod --ssh-host USER@HOST --ssh-port 22 --ssh-key ~/.ssh/id  # CI mode
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DAYS=7
+ALL_LEVELS=false
+SSH_HOST=""
+SSH_PORT=""
+SSH_KEY=""
+MAX_MESSAGES=50
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all-levels) ALL_LEVELS=true; shift ;;
+    --days) DAYS="$2"; shift 2 ;;
+    --ssh-host) SSH_HOST="$2"; shift 2 ;;
+    --ssh-port) SSH_PORT="$2"; shift 2 ;;
+    --ssh-key) SSH_KEY="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Fall back to .env for local use
+if [ -z "$SSH_HOST" ]; then
+  # Try repo root first, then git toplevel (worktrees resolve to main repo)
+  ENV_FILE="${REPO_ROOT}/.env"
+  if [ ! -f "$ENV_FILE" ]; then
+    GIT_ROOT="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')" || true
+    if [ -n "$GIT_ROOT" ] && [ -f "$GIT_ROOT/.env" ]; then
+      ENV_FILE="$GIT_ROOT/.env"
+    else
+      echo "FAILED: No --ssh-host and no .env found." >&2
+      exit 1
+    fi
+  fi
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  SSH_HOST="${PROD_SSH_HOST}"
+fi
+
+# Build SSH command args
+SSH_ARGS=""
+if [ -n "$SSH_PORT" ]; then
+  SSH_ARGS="$SSH_ARGS -p $SSH_PORT"
+fi
+if [ -n "$SSH_KEY" ]; then
+  SSH_ARGS="$SSH_ARGS -i $SSH_KEY"
+fi
+
+# Build date list for the past N days (Linux date -d, macOS date -v fallback)
+DATE_LIST=""
+for i in $(seq 0 $((DAYS - 1))); do
+  if d=$(date -d "$i days ago" +%Y-%m-%d 2>/dev/null); then
+    DATE_LIST="$DATE_LIST $d"
+  elif d=$(date -v-"${i}"d +%Y-%m-%d 2>/dev/null); then
+    DATE_LIST="$DATE_LIST $d"
+  else
+    echo "FAILED: Cannot compute dates on this platform." >&2
+    exit 1
+  fi
+done
+DATE_LIST=$(echo "$DATE_LIST" | xargs)
+
+# Build the file list for the remote side
+FILE_LIST=""
+for d in $DATE_LIST; do
+  FILE_LIST="$FILE_LIST ibl5-$d.log"
+done
+
+# Determine minimum level filter
+if [ "$ALL_LEVELS" = true ]; then
+  LEVEL_FILTER=0
+else
+  LEVEL_FILTER=300
+fi
+
+# Compute display date range (oldest .. newest)
+DATE_FROM=$(echo "$DATE_LIST" | awk '{print $NF}')
+DATE_TO=$(echo "$DATE_LIST" | awk '{print $1}')
+
+# Run aggregation server-side via SSH
+# shellcheck disable=SC2086
+ssh $SSH_ARGS "$SSH_HOST" bash << REMOTE
+  set -e
+  cd www/ibl5/logs 2>/dev/null || cd ~/www/ibl5/logs 2>/dev/null || {
+    echo "FAILED: Cannot find log directory on production." >&2
+    exit 1
+  }
+
+  # Collect matching log files that exist
+  FILES=""
+  for f in $FILE_LIST; do
+    [ -f "\$f" ] && FILES="\$FILES \$f"
+  done
+
+  if [ -z "\$FILES" ]; then
+    echo "No log files found for the requested date range."
+    exit 0
+  fi
+
+  TOTAL_LINES=\$(cat \$FILES | wc -l | tr -d ' ')
+
+  if command -v jq >/dev/null 2>&1; then
+    # === jq path (full aggregation) ===
+
+    echo "=== IBL5 Production Log Digest ==="
+    echo "Period: $DATE_FROM to $DATE_TO"
+    echo "Total entries: \$TOTAL_LINES"
+    echo ""
+
+    # Section 1: Severity counts
+    echo "--- Severity Counts ---"
+    cat \$FILES | jq -r '.level_name // "UNKNOWN"' 2>/dev/null | sort | uniq -c | sort -rn
+    echo ""
+
+    # Section 2: Channel counts
+    echo "--- Channel Counts ---"
+    cat \$FILES | jq -r '.channel // "unknown"' 2>/dev/null | sort | uniq -c | sort -rn
+    echo ""
+
+    # Section 3: Deduplicated messages at the configured level threshold
+    echo "--- Deduplicated Messages (level >= $LEVEL_FILTER) ---"
+    cat \$FILES \
+      | jq -r "select(.level >= $LEVEL_FILTER) | [.channel // \"?\", .level_name // \"?\", .message // \"?\", .datetime // \"?\", (.context | tostring)] | @tsv" 2>/dev/null \
+      | awk -F'\t' '
+        {
+          key = \$1 "|" \$2 "|" \$3
+          count[key]++
+          if (!(key in first_ts)) first_ts[key] = \$4
+          last_ts[key] = \$4
+          if (!(key in sample_ctx)) sample_ctx[key] = \$5
+        }
+        END {
+          for (key in count) {
+            printf "%6d\t%s\t[%s .. %s]\tctx=%s\n", count[key], key, first_ts[key], last_ts[key], sample_ctx[key]
+          }
+        }
+      ' \
+      | sort -rn \
+      | head -n $MAX_MESSAGES
+
+    TOTAL_UNIQUE=\$(cat \$FILES \
+      | jq -r "select(.level >= $LEVEL_FILTER) | (.channel // \"?\") + \"|\" + (.level_name // \"?\") + \"|\" + (.message // \"?\")" 2>/dev/null \
+      | sort -u | wc -l | tr -d ' ')
+    if [ "\$TOTAL_UNIQUE" -gt $MAX_MESSAGES ]; then
+      echo "  ... and \$((\$TOTAL_UNIQUE - $MAX_MESSAGES)) more unique patterns"
+    fi
+    echo ""
+
+    # Section 4: Slow queries aggregated by repository
+    SLOW_COUNT=\$(cat \$FILES | jq -c 'select(.channel == "perf" and .message == "slow_query")' 2>/dev/null | wc -l | tr -d ' ')
+    echo "--- Slow Queries (\$SLOW_COUNT total, by repository) ---"
+    if [ "\$SLOW_COUNT" -gt 0 ]; then
+      cat \$FILES \
+        | jq -r 'select(.channel == "perf" and .message == "slow_query") | "\(.context.elapsed_ms // 0) \(.context.repository // "?")"' 2>/dev/null \
+        | awk '{
+            repo = \$2; ms = \$1 + 0
+            count[repo]++
+            total[repo] += ms
+            if (ms > max[repo]) max[repo] = ms
+          }
+          END {
+            for (r in count) {
+              printf "%4d hits  max=%dms  avg=%dms  %s\n", count[r], max[r], total[r]/count[r], r
+            }
+          }' \
+        | sort -rn \
+        | head -20
+    else
+      echo "  (none)"
+    fi
+
+  else
+    # === grep+awk fallback (no jq — dedup via awk on extracted fields) ===
+
+    echo "=== IBL5 Production Log Digest (no jq) ==="
+    echo "Period: $DATE_FROM to $DATE_TO"
+    echo "Total entries: \$TOTAL_LINES"
+    echo ""
+
+    echo "--- Severity Counts ---"
+    grep -ohE '"level_name":"[A-Z]+"' \$FILES 2>/dev/null \
+      | sed 's/"level_name":"//;s/"//' | sort | uniq -c | sort -rn || true
+    echo ""
+
+    echo "--- Channel Counts ---"
+    grep -ohE '"channel":"[a-z_]+"' \$FILES 2>/dev/null \
+      | sed 's/"channel":"//;s/"//' | sort | uniq -c | sort -rn || true
+    echo ""
+
+    # Deduplicated messages: extract channel|level|message, then sort|uniq
+    if [ "$ALL_LEVELS" = "true" ]; then
+      GREP_PATTERN='"level_name":"[A-Z]+"'
+      echo "--- Deduplicated Messages (all levels) ---"
+    else
+      GREP_PATTERN='"level_name":"(WARNING|ERROR|CRITICAL|ALERT|EMERGENCY)"'
+      echo "--- Deduplicated Messages (WARNING+) ---"
+    fi
+    grep -hE "\$GREP_PATTERN" \$FILES 2>/dev/null \
+      | while IFS= read -r line; do
+          ch=\$(echo "\$line" | sed -n 's/.*"channel":"\([^"]*\)".*/\1/p')
+          lv=\$(echo "\$line" | sed -n 's/.*"level_name":"\([^"]*\)".*/\1/p')
+          msg=\$(echo "\$line" | sed -n 's/.*"message":"\([^"]*\)".*/\1/p')
+          echo "\${ch}|\${lv}|\${msg}"
+        done \
+      | sort | uniq -c | sort -rn \
+      | head -$MAX_MESSAGES || true
+    echo ""
+
+    # Slow queries: aggregate by repository (count, max ms)
+    SLOW_COUNT=\$(grep -h '"slow_query"' \$FILES 2>/dev/null | wc -l | tr -d ' ')
+    echo "--- Slow Queries (\$SLOW_COUNT total, by repository) ---"
+    if [ "\$SLOW_COUNT" -gt 0 ]; then
+      grep -h '"slow_query"' \$FILES 2>/dev/null \
+        | sed -n 's/.*"elapsed_ms":\([0-9]*\)[^,]*.*"repository":"\([^"]*\)".*/\1 \2/p' \
+        | awk '{
+            repo = \$2; ms = \$1 + 0
+            count[repo]++
+            total[repo] += ms
+            if (ms > max[repo]) max[repo] = ms
+          }
+          END {
+            for (r in count) {
+              printf "%4d hits  max=%dms  avg=%dms  %s\n", count[r], max[r], total[r]/count[r], r
+            }
+          }' \
+        | sort -rn \
+        | head -20
+    else
+      echo "  (none)"
+    fi
+  fi
+REMOTE

--- a/ibl5/docs/decisions/0013-weekly-log-review-workflow.md
+++ b/ibl5/docs/decisions/0013-weekly-log-review-workflow.md
@@ -1,0 +1,37 @@
+---
+description: ADR for weekly production log review via GitHub Action and Discord DM notification.
+last_verified: 2026-04-26
+---
+
+# ADR-0013: Weekly Log Review Workflow
+
+**Status:** Accepted
+**Date:** 2026-04-26
+
+## Context
+
+Production logs (Monolog JSON, daily rotation, 30-day retention) were never reviewed systematically. Slow queries, recurring warnings, and error patterns went unnoticed until they caused visible user-facing problems. The existing monitoring (smoke-prod health checks) only catches hard failures, not gradual degradation.
+
+## Decision
+
+Add a weekly GitHub Action (`log-review.yml`) that SSHes to production, runs `bin/log-fetch-prod` to aggregate logs server-side into a compact digest, and sends the summary as a Discord DM via IBLbot. The digest script runs all aggregation remotely to minimize data transfer, with a `jq` fast path and a `grep`/`sed`/`awk` fallback for hosts without `jq`.
+
+## Alternatives Considered
+
+- **Claude Code scheduled routine (CronCreate)** — Runs locally with full SSH access. Rejected because: 7-day auto-expiry makes it unreliable for persistent monitoring.
+- **Claude Code remote routine (/schedule)** — Persistent but runs on Anthropic infrastructure. Rejected because: no SSH access to production server.
+- **Cron job on production server** — No token cost, fully persistent. Rejected because: no Claude analysis in the loop, and server-side cron management is manual.
+
+## Consequences
+
+- Positive: Weekly visibility into slow queries and error patterns with zero manual effort.
+- Positive: Reuses existing CI secrets and SSH/Discord patterns from smoke-prod.
+- Negative: No AI-powered analysis in the automated loop (digest is plain text, not interpreted). Analysis requires manual review or a follow-up local Claude session.
+
+## References
+
+- `.github/workflows/log-review.yml` — the weekly workflow
+- `bin/log-fetch-prod` — server-side log aggregation script
+- `.github/workflows/smoke-prod.yml` — SSH and Discord DM patterns reused
+- `ibl5/classes/Logging/LoggerFactory.php` — log format and channel configuration
+- `ibl5/classes/BaseMysqliRepository.php` — slow query logging (channel `perf`)


### PR DESCRIPTION
## Summary

Adds a weekly GitHub Action that SSHes to production, aggregates Monolog JSON logs into a compact digest, and sends a Discord DM summary via IBLbot.

## New Files

- `bin/log-fetch-prod` — SSH + server-side log aggregation (jq fast path, grep/sed/awk fallback)
- `.github/workflows/log-review.yml` — weekly cron (Sunday ~9am ET), Discord DM notification
- `ibl5/docs/decisions/0013-weekly-log-review-workflow.md` — ADR

## How It Works

1. GitHub Action runs weekly (Sunday ~9am ET) or via manual dispatch
2. SSHes to prod using existing deploy key secrets
3. `bin/log-fetch-prod` runs all aggregation server-side to minimize data transfer
4. Outputs: severity counts, channel counts, deduplicated WARNING+ messages, slow queries by repository
5. Builds a short Discord DM summary (top issues + link to full digest in workflow run)
6. Sends via IBLbot's `/discordDM` endpoint (same pattern as smoke-prod)

## Sample Digest Output (from this week's prod logs)

```
=== IBL5 Production Log Digest (no jq) ===
Period: 2026-04-20 to 2026-04-26
Total entries: 1051

--- Severity Counts ---
    970 WARNING
     81 INFO

--- Deduplicated Messages (WARNING+) ---
    954 perf|WARNING|slow_query
     16 app|WARNING|ExtensionRepository::getMoneyCommittedAtPosition failed

--- Slow Queries (954 total, by repository) ---
 678 hits  max=885ms  avg=256ms  Team\\TeamRepository
 206 hits  max=534ms  avg=265ms  Player\\PlayerStatsRepository
  50 hits  max=727ms  avg=504ms  SeasonHighs\\SeasonHighsRepository
```

## Secrets Required

Uses existing GitHub secrets (same as smoke-prod): `PRIVATE_KEY`, `HOST`, `PORT`, `USERNAME`, `OWNER_DISCORD_ID`

## Manual Testing

No manual testing needed — verified `bin/log-fetch-prod` against production SSH. Workflow will be validated via `workflow_dispatch` after merge.