### PR TITLE
fix: strip macOS ACLs before worktree removal

### DIFF
--- a/bin/cleanup
+++ b/bin/cleanup
@@ -224,6 +224,8 @@ if [ "$ALL" = true ]; then
                     "$REPO_ROOT/bin/wt-down" "$dir_name" --force 2>/dev/null || true
                 fi
                 echo "  Removing orphan: $dir_name"
+                # Docker on macOS sets deny-delete ACLs on bind-mount dirs (e.g. ibl5/backups)
+                chmod -R -N "$dir" 2>/dev/null || true
                 rm -rf "$dir"
             fi
             CLEANED=$((CLEANED + 1))

--- a/bin/wt-remove
+++ b/bin/wt-remove
@@ -65,5 +65,7 @@ if [ -f "$WT_PATH/.wt-slug" ]; then
 fi
 
 echo "Removing worktree '$NAME'..."
+# Docker on macOS sets deny-delete ACLs on bind-mount dirs (e.g. ibl5/backups)
+chmod -R -N "$WT_PATH" 2>/dev/null || true
 git worktree remove --force "$WT_PATH"
 echo "Done. Worktree '$NAME' removed."


### PR DESCRIPTION
## Problem

Docker on macOS sets `deny delete` ACLs on directories it creates inside bind mounts (e.g. `ibl5/backups`). This causes `rm -rf` and `git worktree remove --force` to fail with "Permission denied" during cleanup, leaving orphaned directories behind.

Surfaced via `bin/merge-master-to-prod` which calls `bin/cleanup --all`.

## Changes

- **bin/cleanup**: strip ACLs (`chmod -R -N`) before `rm -rf` in orphan removal path
- **bin/wt-remove**: strip ACLs before `git worktree remove --force`