### PR TITLE
refactor: route .plr file reading through archive-first resolver (PR 2/3)

### DIFF
--- a/ibl5/classes/PlrParser/Contracts/PlrParserServiceInterface.php
+++ b/ibl5/classes/PlrParser/Contracts/PlrParserServiceInterface.php
@@ -21,6 +21,14 @@ interface PlrParserServiceInterface
     public function processPlrFile(string $filePath): PlrParseResult;
 
     /**
+     * Process raw .plr file contents — parse all players, upsert into DB, assign team names.
+     *
+     * @param string $data Raw .plr file contents (CRLF-separated 607-byte records)
+     * @return PlrParseResult Result summary
+     */
+    public function processPlrData(string $data): PlrParseResult;
+
+    /**
      * Process a .plr file with an explicit ending year, bypassing the Season dependency.
      *
      * In Live mode: upserts players + historical stats (same as processPlrFile).
@@ -35,6 +43,27 @@ interface PlrParserServiceInterface
      */
     public function processPlrFileForYear(
         string $filePath,
+        int $endingYear,
+        PlrImportMode $mode,
+        ?string $snapshotPhase = null,
+        ?string $sourceArchive = null,
+    ): PlrParseResult;
+
+    /**
+     * Process raw .plr file contents with an explicit ending year, bypassing the Season dependency.
+     *
+     * In Live mode: upserts players + historical stats (same as processPlrData).
+     * In Snapshot mode: upserts rating snapshots into ibl_plr_snapshots.
+     *
+     * @param string $data Raw .plr file contents (CRLF-separated 607-byte records)
+     * @param int $endingYear Season ending year for draft year calculation
+     * @param PlrImportMode $mode Import mode (Live or Snapshot)
+     * @param string|null $snapshotPhase Phase label for snapshots (e.g. 'end-of-season')
+     * @param string|null $sourceArchive Source archive filename for snapshots
+     * @return PlrParseResult Result summary
+     */
+    public function processPlrDataForYear(
+        string $data,
         int $endingYear,
         PlrImportMode $mode,
         ?string $snapshotPhase = null,

--- a/ibl5/classes/PlrParser/PlrParserService.php
+++ b/ibl5/classes/PlrParser/PlrParserService.php
@@ -36,25 +36,27 @@ class PlrParserService implements PlrParserServiceInterface
      */
     public function processPlrFile(string $filePath): PlrParseResult
     {
-        $result = new PlrParseResult();
-
-        // Pass 1: Calculate foul baseline
-        $maxFoulRatio = $this->calculateFoulBaseline($filePath);
-        $result->addMessage('Foul baseline calculated (max ratio: ' . \BasketballStats\StatsFormatter::formatWithDecimals($maxFoulRatio, 6) . ')');
-
-        // Pass 2: Parse players and upsert
-        $handle = fopen($filePath, 'rb');
-        if ($handle === false) {
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new PlrParseResult();
             $result->addMessage('ERROR: Could not open PLR file');
             return $result;
         }
 
-        while (!feof($handle)) {
-            $line = fgets($handle);
-            if ($line === false) {
-                break;
-            }
+        return $this->processPlrData($data);
+    }
 
+    /**
+     * @see PlrParserServiceInterface::processPlrData()
+     */
+    public function processPlrData(string $data): PlrParseResult
+    {
+        $result = new PlrParseResult();
+
+        $maxFoulRatio = $this->calculateFoulBaselineFromData($data);
+        $result->addMessage('Foul baseline calculated (max ratio: ' . \BasketballStats\StatsFormatter::formatWithDecimals($maxFoulRatio, 6) . ')');
+
+        foreach (explode("\r\n", $data) as $line) {
             $parsed = PlrLineParser::parse($line);
             if ($parsed === null) {
                 continue;
@@ -65,8 +67,6 @@ class PlrParserService implements PlrParserServiceInterface
             $this->repository->upsertPlayer($derived);
             $result->playersUpserted++;
         }
-
-        fclose($handle);
 
         return $result;
     }
@@ -82,20 +82,24 @@ class PlrParserService implements PlrParserServiceInterface
         if (!is_file($filePath)) {
             return 0.0;
         }
-
-        $handle = fopen($filePath, 'rb');
-        if ($handle === false) {
+        $data = file_get_contents($filePath);
+        if ($data === false) {
             return 0.0;
         }
+        return $this->calculateFoulBaselineFromData($data);
+    }
 
+    /**
+     * Pass 1 (string variant): max foul-per-minute ratio across all players.
+     *
+     * @param string $data Raw .plr file contents (CRLF-separated 607-byte records)
+     * @return float Maximum foul ratio (0.0 if no valid data)
+     */
+    public function calculateFoulBaselineFromData(string $data): float
+    {
         $maxRatio = 0.0;
 
-        while (!feof($handle)) {
-            $line = fgets($handle);
-            if ($line === false) {
-                break;
-            }
-
+        foreach (explode("\r\n", $data) as $line) {
             $realLifeMIN = (int) substr($line, 56, 4);
             $realLifePF = (int) substr($line, 108, 4);
 
@@ -107,7 +111,6 @@ class PlrParserService implements PlrParserServiceInterface
             }
         }
 
-        fclose($handle);
         return $maxRatio;
     }
 
@@ -213,23 +216,32 @@ class PlrParserService implements PlrParserServiceInterface
         ?string $snapshotPhase = null,
         ?string $sourceArchive = null,
     ): PlrParseResult {
-        $result = new PlrParseResult();
-
-        $maxFoulRatio = $this->calculateFoulBaseline($filePath);
-        $result->addMessage('Foul baseline calculated (max ratio: ' . \BasketballStats\StatsFormatter::formatWithDecimals($maxFoulRatio, 6) . ')');
-
-        $handle = fopen($filePath, 'rb');
-        if ($handle === false) {
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new PlrParseResult();
             $result->addMessage('ERROR: Could not open PLR file');
             return $result;
         }
 
-        while (!feof($handle)) {
-            $line = fgets($handle);
-            if ($line === false) {
-                break;
-            }
+        return $this->processPlrDataForYear($data, $endingYear, $mode, $snapshotPhase, $sourceArchive);
+    }
 
+    /**
+     * @see PlrParserServiceInterface::processPlrDataForYear()
+     */
+    public function processPlrDataForYear(
+        string $data,
+        int $endingYear,
+        PlrImportMode $mode,
+        ?string $snapshotPhase = null,
+        ?string $sourceArchive = null,
+    ): PlrParseResult {
+        $result = new PlrParseResult();
+
+        $maxFoulRatio = $this->calculateFoulBaselineFromData($data);
+        $result->addMessage('Foul baseline calculated (max ratio: ' . \BasketballStats\StatsFormatter::formatWithDecimals($maxFoulRatio, 6) . ')');
+
+        foreach (explode("\r\n", $data) as $line) {
             $parsed = PlrLineParser::parse($line);
             if ($parsed === null) {
                 continue;
@@ -242,8 +254,6 @@ class PlrParserService implements PlrParserServiceInterface
                 PlrImportMode::Snapshot => $this->processSnapshotPlayer($derived, $result, $endingYear, $snapshotPhase ?? '', $sourceArchive ?? ''),
             };
         }
-
-        fclose($handle);
 
         return $result;
     }

--- a/ibl5/classes/Updater/Steps/ExtractFromBackupStep.php
+++ b/ibl5/classes/Updater/Steps/ExtractFromBackupStep.php
@@ -26,9 +26,9 @@ use Updater\StepResult;
  */
 final class ExtractFromBackupStep implements PipelineStepInterface
 {
-    /** @var list<string> JSB file extensions to extract (.lge and .sch read directly from archive by JsbSourceResolver) */
+    /** @var list<string> JSB file extensions to extract (.lge, .sch, .plr read directly from archive by JsbSourceResolver) */
     private const EXTENSIONS = [
-        'plr', 'sco',
+        'sco',
     ];
 
     public function __construct(

--- a/ibl5/classes/Updater/Steps/ParsePlayerFileStep.php
+++ b/ibl5/classes/Updater/Steps/ParsePlayerFileStep.php
@@ -4,20 +4,21 @@ declare(strict_types=1);
 
 namespace Updater\Steps;
 
-use PlrParser\PlrParserService;
+use PlrParser\Contracts\PlrParserServiceInterface;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\StepResult;
 
 /**
  * Step 2: Parse player file (.plr).
  *
- * Skips if the .plr file is missing.
+ * Skips if the .plr contents are unavailable from the JSB source resolver.
  */
 class ParsePlayerFileStep implements PipelineStepInterface
 {
     public function __construct(
-        private readonly PlrParserService $service,
-        private readonly string $plrPath,
+        private readonly PlrParserServiceInterface $service,
+        private readonly JsbSourceResolverInterface $sourceResolver,
     ) {
     }
 
@@ -28,11 +29,12 @@ class ParsePlayerFileStep implements PipelineStepInterface
 
     public function execute(): StepResult
     {
-        if (!is_file($this->plrPath)) {
+        $data = $this->sourceResolver->getContents('plr');
+        if ($data === null) {
             return StepResult::skipped($this->getLabel(), 'No IBL5.plr file found (skipped)');
         }
 
-        $plrResult = $this->service->processPlrFile($this->plrPath);
+        $plrResult = $this->service->processPlrData($data);
 
         return StepResult::success($this->getLabel() . ' parsed', $plrResult->summary());
     }

--- a/ibl5/classes/Updater/Steps/SnapshotPlrStep.php
+++ b/ibl5/classes/Updater/Steps/SnapshotPlrStep.php
@@ -7,6 +7,7 @@ namespace Updater\Steps;
 use JsbParser\Contracts\JsbImportRepositoryInterface;
 use PlrParser\Contracts\PlrParserServiceInterface;
 use PlrParser\PlrImportMode;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\StepResult;
 
@@ -25,7 +26,7 @@ final class SnapshotPlrStep implements PipelineStepInterface
         private readonly PlrParserServiceInterface $plrService,
         private readonly JsbImportRepositoryInterface $jsbRepo,
         private readonly int $seasonEndingYear,
-        private readonly string $plrFilePath,
+        private readonly JsbSourceResolverInterface $sourceResolver,
     ) {
     }
 
@@ -36,7 +37,8 @@ final class SnapshotPlrStep implements PipelineStepInterface
 
     public function execute(): StepResult
     {
-        if (!file_exists($this->plrFilePath)) {
+        $data = $this->sourceResolver->getContents('plr');
+        if ($data === null) {
             return StepResult::skipped($this->getLabel(), 'PLR file not found');
         }
 
@@ -44,8 +46,8 @@ final class SnapshotPlrStep implements PipelineStepInterface
             ? 'end-of-season'
             : 'mid-season';
 
-        $result = $this->plrService->processPlrFileForYear(
-            $this->plrFilePath,
+        $result = $this->plrService->processPlrDataForYear(
+            $data,
             $this->seasonEndingYear,
             PlrImportMode::Snapshot,
             $phase,

--- a/ibl5/docs/decisions/0012-archive-first-jsb-reading.md
+++ b/ibl5/docs/decisions/0012-archive-first-jsb-reading.md
@@ -1,5 +1,5 @@
 ---
-description: JSB file reading uses archive-first strategy via JsbSourceResolver — reads .lge and .sch directly from backup ZIP without extracting to disk.
+description: JSB file reading uses archive-first strategy via JsbSourceResolver — reads .lge, .sch, and .plr directly from backup ZIP without extracting to disk.
 last_verified: 2026-04-27
 ---
 
@@ -14,14 +14,14 @@ The `updateAllTheThings.php` pipeline extracted all 14 JSB file types from the b
 
 ## Decision
 
-Introduce `JsbSourceResolver` (archive-first, disk-fallback) and `ArchiveExtractor::extractToString()` so that `.lge` and `.sch` data is read directly from the backup archive without writing to disk. Both `LgeFileParser` and `SchFileParser` gain a `parse(string $data)` method accepting raw bytes, and `LeagueConfigService` gains a `processLgeData(string $data)` sibling to the existing `processLgeFile()`. The disk path remains as a fallback for manual uploads or when no backup archive exists.
+Introduce `JsbSourceResolver` (archive-first, disk-fallback) and `ArchiveExtractor::extractToString()` so that `.lge`, `.sch`, and `.plr` data is read directly from the backup archive without writing to disk. `LgeFileParser` and `SchFileParser` gain a `parse(string $data)` method accepting raw bytes; `LeagueConfigService` gains a `processLgeData(string $data)` sibling to the existing `processLgeFile()`; and `PlrParserService` gains `processPlrData(string $data)` and `processPlrDataForYear(string $data, ...)` siblings to the file-based methods. The disk path remains as a fallback for manual uploads or when no backup archive exists.
 
-`ExtractFromBackupStep` no longer extracts `.lge` or `.sch` (12 extensions instead of 14). Other file types (`.plr`, `.sco`, etc.) continue to be extracted to disk because their consumers are not yet refactored.
+`ExtractFromBackupStep` no longer extracts `.lge`, `.sch`, or `.plr` — only `.sco` remains on the disk-extraction path. Other file types continue to be extracted to disk because their consumers are not yet refactored.
 
 ## Alternatives Considered
 
 - **Extract all to disk, then read** — the status quo. Rejected because: files linger in `ibl5/`, no reason for the I/O round-trip on files already available in the archive.
-- **Read all 14 file types from archive** — full migration. Rejected because: higher blast radius; `.plr` and `.sco` consumers have more complex calling patterns. The resolver pattern makes it easy to extend later.
+- **Read all 14 file types from archive in one PR** — full migration. Rejected because: higher blast radius; `.sco` and the JSB-parser file types have more complex calling patterns. The resolver pattern makes it easy to extend later — `.plr` was the second file type migrated.
 
 ## Consequences
 
@@ -38,3 +38,4 @@ Introduce `JsbSourceResolver` (archive-first, disk-fallback) and `ArchiveExtract
 - `ibl5/classes/LeagueConfig/LgeFileParser.php` — `parse(string $data)` method
 - `ibl5/classes/Utilities/SchFileParser.php` — `parse(string $data)` method
 - `ibl5/classes/LeagueConfig/LeagueConfigService.php` — `processLgeData(string $data)` method
+- `ibl5/classes/PlrParser/PlrParserService.php` — `processPlrData()`, `processPlrDataForYear()`, `calculateFoulBaselineFromData()` methods

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -131,7 +131,6 @@ try {
     // --- Pipeline: register all steps and delegate to controller ---
     $updaterService = new Updater\UpdaterService();
 
-    $defaultPlrPath = $basePath . '/' . $filePrefix . '.plr';
     $defaultScoPath = $basePath . '/' . $filePrefix . '.sco';
 
     $lgeRepo = new LeagueConfig\LeagueConfigRepository($mysqli_db, $leagueContext);
@@ -184,7 +183,7 @@ try {
     echo $view->renderSectionClose();
     flush();
 
-    $updaterService->addStep(new Updater\Steps\ParsePlayerFileStep($plrService, $defaultPlrPath));
+    $updaterService->addStep(new Updater\Steps\ParsePlayerFileStep($plrService, $sourceResolver));
 
     // IBL-only: clean preseason data on first Regular Season sim
     if (!$isOlympics) {
@@ -228,7 +227,7 @@ try {
     // IBL-only: snapshot player stats + refresh materialized ibl_hist table
     if (!$isOlympics) {
         $updaterService->addStep(new Updater\Steps\SnapshotPlrStep(
-            $plrService, $jsbRepo, $season->endingYear, $defaultPlrPath,
+            $plrService, $jsbRepo, $season->endingYear, $sourceResolver,
         ));
         $updaterService->addStep(new Updater\Steps\RefreshIblHistStep($mysqli_db));
     }

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
@@ -253,7 +253,6 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
     protected function buildPipeline(
         Season $season,
         string $schPath,
-        string $plrPath,
         string $scoPath,
     ): UpdaterService {
         $service = new UpdaterService();
@@ -290,7 +289,20 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
         // Step 0: ExtractFromBackupStep — SKIPPED (files pre-placed in temp dir)
         // Step 1: ImportLeagueConfigStep — SKIPPED (pre-seeded via seedLeagueConfig)
 
-        $service->addStep(new Steps\ParsePlayerFileStep($plrService, $plrPath));
+        $tempDir = $this->tempDir;
+        $jsbFileResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $jsbFileResolver->method('getContents')->willReturnCallback(
+            static function (string $ext) use ($tempDir): ?string {
+                $path = $tempDir . '/IBL5.' . $ext;
+                if (is_file($path)) {
+                    $data = file_get_contents($path);
+                    return $data !== false ? $data : null;
+                }
+                return null;
+            },
+        );
+
+        $service->addStep(new Steps\ParsePlayerFileStep($plrService, $jsbFileResolver));
 
         $service->addStep(new Steps\CleanupPreseasonDataStep(
             $boxscoreRepo, $season, $this->db,
@@ -314,19 +326,6 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
             $boxscoreProcessor, $boxscoreRepo, $boxscoreView, $scoPath,
         ));
 
-        $tempDir = $this->tempDir;
-        $jsbFileResolver = $this->createStub(JsbSourceResolverInterface::class);
-        $jsbFileResolver->method('getContents')->willReturnCallback(
-            static function (string $ext) use ($tempDir): ?string {
-                $path = $tempDir . '/IBL5.' . $ext;
-                if (is_file($path)) {
-                    $data = file_get_contents($path);
-                    return $data !== false ? $data : null;
-                }
-                return null;
-            },
-        );
-
         $service->addStep(new Steps\ParseJsbFilesStep($jsbService, $jsbFileResolver, $season->endingYear));
 
         $service->addStep(new Steps\EndOfSeasonImportStep(
@@ -334,7 +333,7 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
         ));
 
         $service->addStep(new Steps\SnapshotPlrStep(
-            $plrService, $jsbRepo, $season->endingYear, $plrPath,
+            $plrService, $jsbRepo, $season->endingYear, $jsbFileResolver,
         ));
 
         $service->addStep(new Steps\RefreshIblHistStep($this->db));

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonPipelineTest.php
@@ -20,13 +20,13 @@ class PreseasonPipelineTest extends PipelineIntegrationTestCase
             ['date_slot' => 33, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 95, 'home_score' => 100],
             ['date_slot' => 33, 'game_index' => 1, 'visitor' => 3, 'home' => 4, 'visitor_score' => 88, 'home_score' => 92],
         ]);
-        $plrPath = $this->buildPlrFile([
+        $this->buildPlrFile([
             ['pid' => 200001, 'name' => 'Preseason Player A', 'teamid' => 1, 'ordinal' => 1],
             ['pid' => 200002, 'name' => 'Preseason Player B', 'teamid' => 2, 'ordinal' => 2],
         ]);
         $scoPath = $this->buildScoFile();
 
-        $pipeline = $this->buildPipeline($season, $schPath, $plrPath, $scoPath);
+        $pipeline = $this->buildPipeline($season, $schPath, $scoPath);
         $results = $this->runPipeline($pipeline);
 
         $this->assertZeroPipelineErrors($pipeline, $results);
@@ -52,13 +52,13 @@ class PreseasonPipelineTest extends PipelineIntegrationTestCase
         $season = $this->buildSeason('Playoffs', 2026);
 
         $schPath = $this->buildSchFile([]);
-        $plrPath = $this->buildPlrFile([
+        $this->buildPlrFile([
             ['pid' => 200001, 'name' => 'Playoff Player A', 'teamid' => 1, 'ordinal' => 1],
             ['pid' => 200002, 'name' => 'Playoff Player B', 'teamid' => 2, 'ordinal' => 2],
         ]);
         $scoPath = $this->buildScoFile();
 
-        $pipeline = $this->buildPipeline($season, $schPath, $plrPath, $scoPath);
+        $pipeline = $this->buildPipeline($season, $schPath, $scoPath);
         $results = $this->runPipeline($pipeline);
 
         $this->assertZeroPipelineErrors($pipeline, $results);

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
@@ -48,13 +48,13 @@ class PreseasonTransitionPipelineTest extends PipelineIntegrationTestCase
             ['date_slot' => 5, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 105, 'home_score' => 98],
             ['date_slot' => 5, 'game_index' => 1, 'visitor' => 3, 'home' => 4, 'visitor_score' => 110, 'home_score' => 102],
         ]);
-        $plrPath = $this->buildPlrFile([
+        $this->buildPlrFile([
             ['pid' => 200001, 'name' => 'Pipeline Player A', 'teamid' => 1, 'ordinal' => 1],
             ['pid' => 200002, 'name' => 'Pipeline Player B', 'teamid' => 2, 'ordinal' => 2],
         ]);
         $scoPath = $this->buildScoFile();
 
-        $pipeline = $this->buildPipeline($season, $schPath, $plrPath, $scoPath);
+        $pipeline = $this->buildPipeline($season, $schPath, $scoPath);
         $results = $this->runPipeline($pipeline);
 
         $this->assertZeroPipelineErrors($pipeline, $results);

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/RegularSeasonPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/RegularSeasonPipelineTest.php
@@ -23,7 +23,7 @@ class RegularSeasonPipelineTest extends PipelineIntegrationTestCase
             ['date_slot' => 104, 'game_index' => 0, 'visitor' => 5, 'home' => 6, 'visitor_score' => 99, 'home_score' => 101],
             ['date_slot' => 104, 'game_index' => 1, 'visitor' => 7, 'home' => 8, 'visitor_score' => 85, 'home_score' => 90],
         ]);
-        $plrPath = $this->buildPlrFile([
+        $this->buildPlrFile([
             ['pid' => 200001, 'name' => 'RS Player A', 'teamid' => 1, 'ordinal' => 1],
             ['pid' => 200002, 'name' => 'RS Player B', 'teamid' => 2, 'ordinal' => 2],
             ['pid' => 200003, 'name' => 'RS Player C', 'teamid' => 3, 'ordinal' => 3],
@@ -31,7 +31,7 @@ class RegularSeasonPipelineTest extends PipelineIntegrationTestCase
         ]);
         $scoPath = $this->buildScoFile();
 
-        $pipeline = $this->buildPipeline($season, $schPath, $plrPath, $scoPath);
+        $pipeline = $this->buildPipeline($season, $schPath, $scoPath);
         $results = $this->runPipeline($pipeline);
 
         $this->assertZeroPipelineErrors($pipeline, $results);

--- a/ibl5/tests/PlrParser/PlrParserServiceTest.php
+++ b/ibl5/tests/PlrParser/PlrParserServiceTest.php
@@ -69,6 +69,32 @@ class PlrParserServiceTest extends TestCase
         $this->assertSame(0.0, $result);
     }
 
+    public function testCalculateFoulBaselineFromDataWithValidData(): void
+    {
+        $line = $this->buildFoulRatioLine(realLifeMIN: 1000, realLifePF: 100);
+
+        $result = $this->service->calculateFoulBaselineFromData($line . "\r\n");
+
+        $this->assertSame(0.1, $result);
+    }
+
+    public function testCalculateFoulBaselineFromDataWithEmptyString(): void
+    {
+        $result = $this->service->calculateFoulBaselineFromData('');
+
+        $this->assertSame(0.0, $result);
+    }
+
+    public function testCalculateFoulBaselineFromDataPicksMaxAcrossLines(): void
+    {
+        $low = $this->buildFoulRatioLine(realLifeMIN: 1000, realLifePF: 50);   // 0.05
+        $high = $this->buildFoulRatioLine(realLifeMIN: 1000, realLifePF: 200); // 0.2
+
+        $result = $this->service->calculateFoulBaselineFromData($low . "\r\n" . $high);
+
+        $this->assertSame(0.2, $result);
+    }
+
     public function testParsePlrLineReturnsNullForPidZero(): void
     {
         // pid field (offset 38, length 6) = 000000
@@ -356,6 +382,50 @@ class PlrParserServiceTest extends TestCase
 
         $this->assertSame(0, $result->playersUpserted);
         unlink($tmpFile);
+    }
+
+    public function testProcessPlrDataWithValidData(): void
+    {
+        $data = $this->buildFullPlrData();
+
+        /** @var PlrParserRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
+        $mockRepo->expects($this->once())->method('upsertPlayer');
+
+        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $result = $service->processPlrData($data);
+
+        $this->assertSame(1, $result->playersUpserted);
+    }
+
+    public function testProcessPlrDataSkipsPidZero(): void
+    {
+        $line = str_repeat(' ', 700);
+        $line = substr_replace($line, '   1', 0, 4);    // ordinal = 1
+        $line = substr_replace($line, '000000', 38, 6); // pid = 0
+
+        /** @var PlrParserRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
+        $mockRepo->expects($this->never())->method('upsertPlayer');
+
+        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $result = $service->processPlrData($line . "\r\n");
+
+        $this->assertSame(0, $result->playersUpserted);
+    }
+
+    public function testProcessPlrDataWithMultiplePlayers(): void
+    {
+        $data = $this->buildFullPlrData() . "\r\n" . $this->buildFullPlrData(pid: 2);
+
+        /** @var PlrParserRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
+        $mockRepo->expects($this->exactly(2))->method('upsertPlayer');
+
+        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $result = $service->processPlrData($data);
+
+        $this->assertSame(2, $result->playersUpserted);
     }
 
     /**
@@ -688,6 +758,42 @@ class PlrParserServiceTest extends TestCase
         unlink($tmpFile);
     }
 
+    public function testProcessPlrDataForYearSnapshotMode(): void
+    {
+        $data = $this->buildFullPlrData();
+
+        /** @var PlrParserRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
+        $mockRepo->expects($this->once())->method('upsertSnapshot');
+        $mockRepo->expects($this->never())->method('upsertPlayer');
+
+        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $result = $service->processPlrDataForYear(
+            $data,
+            2001,
+            PlrImportMode::Snapshot,
+            'end-of-season',
+            '00-01_36_finals',
+        );
+
+        $this->assertSame(1, $result->playersUpserted);
+    }
+
+    public function testProcessPlrDataForYearLiveMode(): void
+    {
+        $data = $this->buildFullPlrData();
+
+        /** @var PlrParserRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
+        $mockRepo->expects($this->once())->method('upsertPlayer');
+        $mockRepo->expects($this->never())->method('upsertSnapshot');
+
+        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $result = $service->processPlrDataForYear($data, 2001, PlrImportMode::Live);
+
+        $this->assertSame(1, $result->playersUpserted);
+    }
+
     /**
      * Create a temp PLR file with one valid player line (all fields populated).
      *
@@ -695,32 +801,49 @@ class PlrParserServiceTest extends TestCase
      */
     private function createFullPlrFile(): string
     {
-        // Build a complete PLR line with valid data
-        $line = str_repeat('0', 700);
-
-        // Key fields to ensure the line passes validation
-        $line = substr_replace($line, '   1', 0, 4);      // ordinal = 1
-        $line = substr_replace($line, str_pad('Test Player', 32), 4, 32);
-        $line = substr_replace($line, '25', 36, 2);         // age
-        $line = substr_replace($line, '000001', 38, 6);     // pid = 1
-        $line = substr_replace($line, ' 1', 44, 2);         // teamid = 1
-        $line = substr_replace($line, '  28', 46, 4);       // peak
-        $line = substr_replace($line, 'PG', 50, 2);         // pos
-        $line = substr_replace($line, '1000', 56, 4);       // realLifeMIN
-        $line = substr_replace($line, ' 100', 108, 4);      // realLifePF
-        $line = substr_replace($line, ' 2', 290, 2);        // currentContractYear
-        $line = substr_replace($line, ' 4', 292, 2);        // totalContractYears
-        $line = substr_replace($line, ' 500', 298, 4);      // contractYear1
-        $line = substr_replace($line, ' 550', 302, 4);      // contractYear2
-        $line = substr_replace($line, ' 5', 286, 2);        // exp
-        $line = substr_replace($line, '75', 550, 2);         // heightInches
-        $line = substr_replace($line, '195', 552, 3);        // weight
-
         $tmpFile = tempnam(sys_get_temp_dir(), 'plr_full_');
         if ($tmpFile === false) {
             throw new \RuntimeException('Failed to create temp file');
         }
-        file_put_contents($tmpFile, $line . "\n");
+        file_put_contents($tmpFile, $this->buildFullPlrData() . "\n");
         return $tmpFile;
+    }
+
+    /**
+     * Build raw PLR file content with one valid player line (all fields populated).
+     */
+    private function buildFullPlrData(int $pid = 1): string
+    {
+        $line = str_repeat('0', 700);
+
+        $line = substr_replace($line, '   1', 0, 4);                               // ordinal = 1
+        $line = substr_replace($line, str_pad('Test Player', 32), 4, 32);
+        $line = substr_replace($line, '25', 36, 2);                                // age
+        $line = substr_replace($line, str_pad((string) $pid, 6, '0', STR_PAD_LEFT), 38, 6);
+        $line = substr_replace($line, ' 1', 44, 2);                                // teamid = 1
+        $line = substr_replace($line, '  28', 46, 4);                              // peak
+        $line = substr_replace($line, 'PG', 50, 2);                                // pos
+        $line = substr_replace($line, '1000', 56, 4);                              // realLifeMIN
+        $line = substr_replace($line, ' 100', 108, 4);                             // realLifePF
+        $line = substr_replace($line, ' 2', 290, 2);                               // currentContractYear
+        $line = substr_replace($line, ' 4', 292, 2);                               // totalContractYears
+        $line = substr_replace($line, ' 500', 298, 4);                             // contractYear1
+        $line = substr_replace($line, ' 550', 302, 4);                             // contractYear2
+        $line = substr_replace($line, ' 5', 286, 2);                               // exp
+        $line = substr_replace($line, '75', 550, 2);                               // heightInches
+        $line = substr_replace($line, '195', 552, 3);                              // weight
+
+        return $line;
+    }
+
+    /**
+     * Build a PLR line populated only with the fields needed for foul-ratio calculation.
+     */
+    private function buildFoulRatioLine(int $realLifeMIN, int $realLifePF): string
+    {
+        $line = str_repeat(' ', 700);
+        $line = substr_replace($line, str_pad((string) $realLifeMIN, 4, ' ', STR_PAD_LEFT), 56, 4);
+        $line = substr_replace($line, str_pad((string) $realLifePF, 4, ' ', STR_PAD_LEFT), 108, 4);
+        return $line;
     }
 }

--- a/ibl5/tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
@@ -75,15 +75,8 @@ class ExtractFromBackupStepTest extends TestCase
             ->willReturn('/tmp/backups/25-26/25-26_15_reg-sim15.zip');
         $this->stubLocator->method('isProperlyNamed')->willReturn(true);
 
-        // Simulate 10 of 13 extensions found in archive
-        $callCount = 0;
-        $this->stubExtractor->method('extractSingleFile')
-            ->willReturnCallback(static function () use (&$callCount): string|false {
-                $callCount++;
-                return $callCount <= 10 ? '/tmp/IBL5.ext' : false;
-            });
-        // Note: extractFiles() builds filenames directly as filePrefix + ext,
-        // not via extractor->jsbFilename(). No jsbFilename stub needed.
+        // EXTENSIONS = ['sco'] — single extension, extraction succeeds
+        $this->stubExtractor->method('extractSingleFile')->willReturn('/tmp/IBL5.sco');
 
         $step = new ExtractFromBackupStep(
             $this->stubLocator,
@@ -95,7 +88,7 @@ class ExtractFromBackupStepTest extends TestCase
         $result = $step->execute();
 
         $this->assertTrue($result->success);
-        $this->assertStringContainsString('Extracted 2 files', $result->detail);
+        $this->assertStringContainsString('Extracted 1 files', $result->detail);
     }
 
     public function testSkipsRenameForProperlyNamedBackup(): void

--- a/ibl5/tests/UpdateAllTheThings/Steps/ParsePlayerFileStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ParsePlayerFileStepTest.php
@@ -5,37 +5,42 @@ declare(strict_types=1);
 namespace Tests\UpdateAllTheThings\Steps;
 
 use PHPUnit\Framework\TestCase;
+use PlrParser\Contracts\PlrParserServiceInterface;
 use PlrParser\PlrParseResult;
-use PlrParser\PlrParserService;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\Steps\ParsePlayerFileStep;
 
 class ParsePlayerFileStepTest extends TestCase
 {
-    private PlrParserService $stubService;
+    private PlrParserServiceInterface $stubService;
+    private JsbSourceResolverInterface $stubResolver;
 
     protected function setUp(): void
     {
-        $this->stubService = $this->createStub(PlrParserService::class);
+        $this->stubService = $this->createStub(PlrParserServiceInterface::class);
+        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
     }
 
     public function testImplementsPipelineStepInterface(): void
     {
-        $step = new ParsePlayerFileStep($this->stubService, '/tmp/IBL5.plr');
+        $step = new ParsePlayerFileStep($this->stubService, $this->stubResolver);
 
         $this->assertInstanceOf(PipelineStepInterface::class, $step);
     }
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $step = new ParsePlayerFileStep($this->stubService, '/tmp/IBL5.plr');
+        $step = new ParsePlayerFileStep($this->stubService, $this->stubResolver);
 
         $this->assertSame('Player file', $step->getLabel());
     }
 
-    public function testSkipsWhenFileNotFound(): void
+    public function testSkipsWhenResolverReturnsNull(): void
     {
-        $step = new ParsePlayerFileStep($this->stubService, '/nonexistent/IBL5.plr');
+        $this->stubResolver->method('getContents')->willReturn(null);
+
+        $step = new ParsePlayerFileStep($this->stubService, $this->stubResolver);
         $result = $step->execute();
 
         $this->assertTrue($result->success);
@@ -47,14 +52,15 @@ class ParsePlayerFileStepTest extends TestCase
         $plrResult = new PlrParseResult();
         $plrResult->playersUpserted = 150;
 
-        $this->stubService->method('processPlrFile')->willReturn($plrResult);
+        $this->stubResolver->method('getContents')->willReturn('plr-bytes');
 
-        $path = tempnam(sys_get_temp_dir(), 'plr_test_');
-        if ($path === false) {
-            $this->fail('Failed to create temp file');
-        }
+        $mockService = $this->createMock(PlrParserServiceInterface::class);
+        $mockService->expects($this->once())
+            ->method('processPlrData')
+            ->with('plr-bytes')
+            ->willReturn($plrResult);
 
-        $step = new ParsePlayerFileStep($this->stubService, $path);
+        $step = new ParsePlayerFileStep($mockService, $this->stubResolver);
         $result = $step->execute();
 
         $this->assertTrue($result->success);

--- a/ibl5/tests/UpdateAllTheThings/Steps/SnapshotPlrStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/SnapshotPlrStepTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use PlrParser\Contracts\PlrParserServiceInterface;
 use PlrParser\PlrImportMode;
 use PlrParser\PlrParseResult;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\Steps\SnapshotPlrStep;
 
@@ -16,20 +17,22 @@ class SnapshotPlrStepTest extends TestCase
 {
     private JsbImportRepositoryInterface $stubJsbRepo;
     private PlrParserServiceInterface $stubPlrService;
+    private JsbSourceResolverInterface $stubResolver;
 
     protected function setUp(): void
     {
         $this->stubJsbRepo = $this->createStub(JsbImportRepositoryInterface::class);
         $this->stubPlrService = $this->createStub(PlrParserServiceInterface::class);
+        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
     }
 
-    private function createStep(string $plrFilePath = '/tmp/nonexistent.plr'): SnapshotPlrStep
+    private function createStep(): SnapshotPlrStep
     {
         return new SnapshotPlrStep(
             $this->stubPlrService,
             $this->stubJsbRepo,
             2026,
-            $plrFilePath,
+            $this->stubResolver,
         );
     }
 
@@ -43,9 +46,11 @@ class SnapshotPlrStepTest extends TestCase
         $this->assertSame('Player snapshot', $this->createStep()->getLabel());
     }
 
-    public function testSkipsWhenPlrFileDoesNotExist(): void
+    public function testSkipsWhenResolverReturnsNull(): void
     {
-        $result = $this->createStep('/nonexistent/path/IBL5.plr')->execute();
+        $this->stubResolver->method('getContents')->willReturn(null);
+
+        $result = $this->createStep()->execute();
 
         $this->assertTrue($result->success);
         $this->assertStringContainsString('not found', $result->detail);
@@ -53,6 +58,7 @@ class SnapshotPlrStepTest extends TestCase
 
     public function testUsesEndOfSeasonPhaseWhenChampionExists(): void
     {
+        $this->stubResolver->method('getContents')->willReturn('plr-bytes');
         $this->stubJsbRepo->method('hasChampionForSeason')->willReturn(true);
 
         $plrResult = new PlrParseResult();
@@ -60,9 +66,9 @@ class SnapshotPlrStepTest extends TestCase
 
         $mockPlrService = $this->createMock(PlrParserServiceInterface::class);
         $mockPlrService->expects($this->once())
-            ->method('processPlrFileForYear')
+            ->method('processPlrDataForYear')
             ->with(
-                $this->anything(),
+                'plr-bytes',
                 2026,
                 PlrImportMode::Snapshot,
                 'end-of-season',
@@ -70,22 +76,16 @@ class SnapshotPlrStepTest extends TestCase
             )
             ->willReturn($plrResult);
 
-        $tmpFile = tempnam(sys_get_temp_dir(), 'plr-test-');
-        self::assertIsString($tmpFile);
+        $step = new SnapshotPlrStep($mockPlrService, $this->stubJsbRepo, 2026, $this->stubResolver);
+        $result = $step->execute();
 
-        try {
-            $step = new SnapshotPlrStep($mockPlrService, $this->stubJsbRepo, 2026, $tmpFile);
-            $result = $step->execute();
-
-            $this->assertTrue($result->success);
-            $this->assertStringContainsString('end-of-season', $result->detail);
-        } finally {
-            unlink($tmpFile);
-        }
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('end-of-season', $result->detail);
     }
 
     public function testUsesMidSeasonPhaseWhenNoChampion(): void
     {
+        $this->stubResolver->method('getContents')->willReturn('plr-bytes');
         $this->stubJsbRepo->method('hasChampionForSeason')->willReturn(false);
 
         $plrResult = new PlrParseResult();
@@ -93,9 +93,9 @@ class SnapshotPlrStepTest extends TestCase
 
         $mockPlrService = $this->createMock(PlrParserServiceInterface::class);
         $mockPlrService->expects($this->once())
-            ->method('processPlrFileForYear')
+            ->method('processPlrDataForYear')
             ->with(
-                $this->anything(),
+                'plr-bytes',
                 2026,
                 PlrImportMode::Snapshot,
                 'mid-season',
@@ -103,38 +103,25 @@ class SnapshotPlrStepTest extends TestCase
             )
             ->willReturn($plrResult);
 
-        $tmpFile = tempnam(sys_get_temp_dir(), 'plr-test-');
-        self::assertIsString($tmpFile);
+        $step = new SnapshotPlrStep($mockPlrService, $this->stubJsbRepo, 2026, $this->stubResolver);
+        $result = $step->execute();
 
-        try {
-            $step = new SnapshotPlrStep($mockPlrService, $this->stubJsbRepo, 2026, $tmpFile);
-            $result = $step->execute();
-
-            $this->assertTrue($result->success);
-            $this->assertStringContainsString('mid-season', $result->detail);
-        } finally {
-            unlink($tmpFile);
-        }
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('mid-season', $result->detail);
     }
 
     public function testReturnsSuccessWithResultSummary(): void
     {
+        $this->stubResolver->method('getContents')->willReturn('plr-bytes');
         $this->stubJsbRepo->method('hasChampionForSeason')->willReturn(false);
 
         $plrResult = new PlrParseResult();
         $plrResult->playersUpserted = 42;
-        $this->stubPlrService->method('processPlrFileForYear')->willReturn($plrResult);
+        $this->stubPlrService->method('processPlrDataForYear')->willReturn($plrResult);
 
-        $tmpFile = tempnam(sys_get_temp_dir(), 'plr-test-');
-        self::assertIsString($tmpFile);
+        $result = $this->createStep()->execute();
 
-        try {
-            $result = $this->createStep($tmpFile)->execute();
-
-            $this->assertTrue($result->success);
-            $this->assertStringContainsString('42 players upserted', $result->detail);
-        } finally {
-            unlink($tmpFile);
-        }
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('42 players upserted', $result->detail);
     }
 }


### PR DESCRIPTION
## Summary

PR 2/3 of the JsbSourceResolver migration. Routes `.plr` files through `JsbSourceResolverInterface::getContents()` instead of extracted-to-disk files, mirroring PR #648 (`.lge`/`.sch`).

After this PR, `ExtractFromBackupStep::EXTENSIONS` is `['sco']` (down from `['plr', 'sco']`). PR 3 will finish the migration by routing `.sco` and reducing it to `[]`.

## Changes

### PlrParserService
- New string-based methods: `processPlrData()`, `processPlrDataForYear()`, `calculateFoulBaselineFromData()`
- File-based methods (`processPlrFile()`, `processPlrFileForYear()`, `calculateFoulBaseline()`) reduced to thin `file_get_contents()` → string-method wrappers
- `PlrParserServiceInterface` adds the two `processPlr*Data` declarations

### Pipeline steps
- `ParsePlayerFileStep`: constructor takes `PlrParserServiceInterface` + `JsbSourceResolverInterface`, reads via resolver, calls `processPlrData()`
- `SnapshotPlrStep`: constructor takes `JsbSourceResolverInterface` (replacing `string $plrFilePath`), reads via resolver, calls `processPlrDataForYear()`

### Disk extraction
- `ExtractFromBackupStep::EXTENSIONS` reduced from `['plr', 'sco']` → `['sco']`
- `scripts/updateAllTheThings.php`: `$defaultPlrPath` removed; both steps now receive `$sourceResolver`

### Two-pass structure preserved
The current code opens `.plr` twice per invocation (foul-baseline scan + main parse). With string-based methods, both passes iterate the same in-memory `explode("\r\n", $data)` array — zero extra I/O cost.

### Tests
- New tests for the three `*FromData` / `*Data` methods (foul-ratio extraction, multi-line, pid=0 skipping, Live + Snapshot modes)
- `ParsePlayerFileStepTest`/`SnapshotPlrStepTest` rewired to stub `JsbSourceResolverInterface` (no more `tempnam`)
- `ExtractFromBackupStepTest` updated for `['sco']` (asserts "Extracted 1 files")
- `PipelineIntegrationTestCase::buildPipeline()` drops `$plrPath` param; the existing JSB resolver stub already covers `.plr` from `$tempDir`. 4 callers updated.

### ADR-0012
Updated to describe `.plr` as archive-first; only `.sco` remains on disk.

## Verification

- `bin/test`: 4967 tests, 27809 assertions, no failures (pre-existing 6 vendor deprecations + 1 unrelated PHPUnit notice in ExtensionServiceTest)
- `composer run analyse`: PHPStan level max + strict-rules — no errors
- `bin/check-docs`: 60 docs verified

## Manual Testing

No manual testing needed — all changes are covered by unit and integration tests.

## Dependency

Branched from `master`. Unblocks PR 3 (`.sco` resolver), which had been skipped previously because this prerequisite was missing.

Generated with [Claude Code](https://claude.ai/code)