### PR TITLE
feat: restore team offense/defense footer stats on all views

### DIFF
--- a/ibl5/classes/TeamOffDefStats/Contracts/TeamOffDefStatsRepositoryInterface.php
+++ b/ibl5/classes/TeamOffDefStats/Contracts/TeamOffDefStatsRepositoryInterface.php
@@ -57,4 +57,16 @@ interface TeamOffDefStatsRepositoryInterface
      * @return array{offense: TeamOffenseStatsRow, defense: TeamDefenseStatsRow}|null Both stats or null
      */
     public function getTeamBothStats(string $teamName, int $seasonYear): ?array;
+
+    /**
+     * Get both offense and defense statistics for a team within a date range
+     *
+     * No game_type filter — includes regular season and playoffs.
+     *
+     * @param string $teamName Team name
+     * @param string $startDate Start date (Y-m-d)
+     * @param string $endDate End date (Y-m-d)
+     * @return array{offense: TeamOffenseStatsRow, defense: TeamDefenseStatsRow}|null Both stats or null
+     */
+    public function getTeamBothStatsForDateRange(string $teamName, string $startDate, string $endDate): ?array;
 }

--- a/ibl5/classes/TeamOffDefStats/TeamOffDefStatsRepository.php
+++ b/ibl5/classes/TeamOffDefStats/TeamOffDefStatsRepository.php
@@ -161,6 +161,56 @@ class TeamOffDefStatsRepository extends \BaseMysqliRepository implements TeamOff
             return null;
         }
 
+        return self::unpackBothStatsRow($row);
+    }
+
+    /**
+     * @see TeamOffDefStatsRepositoryInterface::getTeamBothStatsForDateRange()
+     * @return array{offense: TeamOffenseStatsRow, defense: TeamDefenseStatsRow}|null
+     */
+    public function getTeamBothStatsForDateRange(string $teamName, string $startDate, string $endDate): ?array
+    {
+        /** @var array<string, int|string|null>|null $row */
+        $row = $this->fetchOne(
+            "SELECT
+                tos.teamid AS tos_teamID, tos.name AS tos_name,
+                tos.games AS tos_games, tos.fgm AS tos_fgm, tos.fga AS tos_fga,
+                tos.ftm AS tos_ftm, tos.fta AS tos_fta, tos.tgm AS tos_tgm, tos.tga AS tos_tga,
+                tos.orb AS tos_orb, tos.reb AS tos_reb, tos.ast AS tos_ast, tos.stl AS tos_stl,
+                tos.tvr AS tos_tvr, tos.blk AS tos_blk, tos.pf AS tos_pf,
+                tds.teamid AS tds_teamID, tds.name AS tds_name,
+                tds.games AS tds_games, tds.fgm AS tds_fgm, tds.fga AS tds_fga,
+                tds.ftm AS tds_ftm, tds.fta AS tds_fta, tds.tgm AS tds_tgm, tds.tga AS tds_tga,
+                tds.orb AS tds_orb, tds.reb AS tds_reb, tds.ast AS tds_ast, tds.stl AS tds_stl,
+                tds.tvr AS tds_tvr, tds.blk AS tds_blk, tds.pf AS tds_pf
+            FROM (" . self::buildOffenseSubquery('bst.game_date BETWEEN ? AND ? AND fs.team_name = ?', false) . ") tos
+            JOIN (" . self::buildDefenseSubquery('my.game_date BETWEEN ? AND ? AND fs.team_name = ?', false) . ") tds
+                ON tos.teamid = tds.teamid
+            LIMIT 1",
+            "ssssss",
+            $startDate,
+            $endDate,
+            $teamName,
+            $startDate,
+            $endDate,
+            $teamName
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return self::unpackBothStatsRow($row);
+    }
+
+    /**
+     * Unpack a prefixed tos_/tds_ row into offense/defense arrays.
+     *
+     * @param array<string, int|string|null> $row
+     * @return array{offense: TeamOffenseStatsRow, defense: TeamDefenseStatsRow}
+     */
+    private static function unpackBothStatsRow(array $row): array
+    {
         /** @var TeamOffenseStatsRow $offense */
         $offense = [
             'teamid' => (int) $row['tos_teamID'],
@@ -210,8 +260,10 @@ class TeamOffDefStatsRepository extends \BaseMysqliRepository implements TeamOff
      * Replaces ibl_team_offense_stats view which materializes ALL seasons
      * before filtering.
      */
-    private static function buildOffenseSubquery(string $filterClause): string
+    private static function buildOffenseSubquery(string $filterClause, bool $regularSeasonOnly = true): string
     {
+        $gameTypeFilter = $regularSeasonOnly ? 'bst.game_type = 1 AND ' : '';
+
         return "SELECT fs.franchise_id AS teamid, fs.team_name AS name, bst.season_year,
             CAST(COUNT(*) AS SIGNED) AS games,
             CAST(SUM(bst.game_2gm + bst.game_3gm) AS SIGNED) AS fgm,
@@ -230,7 +282,7 @@ class TeamOffDefStatsRepository extends \BaseMysqliRepository implements TeamOff
         FROM ibl_box_scores_teams bst
         JOIN ibl_franchise_seasons fs
             ON fs.team_name = bst.name AND fs.season_ending_year = bst.season_year
-        WHERE bst.game_type = 1 AND {$filterClause}
+        WHERE {$gameTypeFilter}{$filterClause}
         GROUP BY fs.franchise_id, fs.team_name, bst.season_year";
     }
 
@@ -240,8 +292,10 @@ class TeamOffDefStatsRepository extends \BaseMysqliRepository implements TeamOff
      * Replaces ibl_team_defense_stats view which materializes ALL seasons
      * before filtering.
      */
-    private static function buildDefenseSubquery(string $filterClause): string
+    private static function buildDefenseSubquery(string $filterClause, bool $regularSeasonOnly = true): string
     {
+        $gameTypeFilter = $regularSeasonOnly ? 'my.game_type = 1 AND ' : '';
+
         return "SELECT fs.franchise_id AS teamid, fs.team_name AS name, my.season_year,
             CAST(COUNT(*) AS SIGNED) AS games,
             CAST(SUM(opp.game_2gm + opp.game_3gm) AS SIGNED) AS fgm,
@@ -266,7 +320,7 @@ class TeamOffDefStatsRepository extends \BaseMysqliRepository implements TeamOff
             AND my.name <> opp.name
         JOIN ibl_franchise_seasons fs
             ON fs.team_name = my.name AND fs.season_ending_year = my.season_year
-        WHERE my.game_type = 1 AND {$filterClause}
+        WHERE {$gameTypeFilter}{$filterClause}
         GROUP BY fs.franchise_id, fs.team_name, my.season_year";
     }
 }

--- a/ibl5/classes/UI/Tables/PeriodAverages.php
+++ b/ibl5/classes/UI/Tables/PeriodAverages.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace UI\Tables;
 
+use BasketballStats\StatsFormatter;
 use Player\PlayerImageHelper;
+use TeamOffDefStats\TeamOffDefStatsRepository;
 use Utilities\HtmlSanitizer;
 use Team\Team;
 use Season\Season;
@@ -42,6 +44,9 @@ class PeriodAverages
         if ($endDate instanceof \DateTime) {
             $endDate = $endDate->format('Y-m-d');
         }
+
+        $offDefRepo = new TeamOffDefStatsRepository($db);
+        $bothStats = $offDefRepo->getTeamBothStatsForDateRange($team->name, (string) $startDate, (string) $endDate);
 
         $teamid = (int)$team->teamid;
 
@@ -200,6 +205,61 @@ class PeriodAverages
         </tr>
 <?php endforeach; ?>
     </tbody>
+    <tfoot>
+<?php if ($bothStats !== null):
+    $off = $bothStats['offense'];
+    $def = $bothStats['defense'];
+    $offGames = $off['games'];
+    $defGames = $def['games'];
+    $offPts = StatsFormatter::calculatePoints($off['fgm'], $off['ftm'], $off['tgm']);
+    $defPts = StatsFormatter::calculatePoints($def['fgm'], $def['ftm'], $def['tgm']);
+?>
+        <tr>
+            <td colspan="2"><?= HtmlSanitizer::e($team->name) ?> Offense</td>
+            <td><?= $offGames ?></td>
+            <td class="sep-r-team"></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['fgm'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['fga'], $offGames) ?></td>
+            <td class="sep-r-weak"><?= StatsFormatter::formatPercentage($off['fgm'], $off['fga']) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['ftm'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['fta'], $offGames) ?></td>
+            <td class="sep-r-weak"><?= StatsFormatter::formatPercentage($off['ftm'], $off['fta']) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['tgm'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['tga'], $offGames) ?></td>
+            <td class="sep-r-team"><?= StatsFormatter::formatPercentage($off['tgm'], $off['tga']) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['orb'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['reb'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['ast'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['stl'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['tvr'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['blk'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($off['pf'], $offGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($offPts, $offGames) ?></td>
+        </tr>
+        <tr>
+            <td colspan="2"><?= HtmlSanitizer::e($team->name) ?> Defense</td>
+            <td><?= $defGames ?></td>
+            <td class="sep-r-team"></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['fgm'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['fga'], $defGames) ?></td>
+            <td class="sep-r-weak"><?= StatsFormatter::formatPercentage($def['fgm'], $def['fga']) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['ftm'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['fta'], $defGames) ?></td>
+            <td class="sep-r-weak"><?= StatsFormatter::formatPercentage($def['ftm'], $def['fta']) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['tgm'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['tga'], $defGames) ?></td>
+            <td class="sep-r-team"><?= StatsFormatter::formatPercentage($def['tgm'], $def['tga']) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['orb'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['reb'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['ast'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['stl'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['tvr'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['blk'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($def['pf'], $defGames) ?></td>
+            <td><?= StatsFormatter::formatPerGameAverage($defPts, $defGames) ?></td>
+        </tr>
+<?php endif; ?>
+    </tfoot>
 </table>
         <?php
         return (string) ob_get_clean();

--- a/ibl5/classes/UI/Tables/SeasonAverages.php
+++ b/ibl5/classes/UI/Tables/SeasonAverages.php
@@ -38,8 +38,9 @@ class SeasonAverages
         $playerRows = PlayerRowTransformer::resolveWithStats($db, $result, $yr);
 
         $season = new Season($db);
+        $seasonYear = ($yr !== '') ? (int) $yr : $season->endingYear;
         $offDefRepo = new TeamOffDefStatsRepository($db);
-        $bothStats = $offDefRepo->getTeamBothStats($team->name, $season->endingYear);
+        $bothStats = $offDefRepo->getTeamBothStats($team->name, $seasonYear);
 
         ob_start();
         ?>
@@ -110,7 +111,7 @@ endif; ?>
 <?php endforeach; ?>
     </tbody>
     <tfoot>
-<?php if ($yr === "" && $bothStats !== null):
+<?php if ($bothStats !== null):
     $labelColspan = ($moduleName === "LeagueStarters") ? 3 : 2;
     $off = $bothStats['offense'];
     $def = $bothStats['defense'];

--- a/ibl5/classes/UI/Tables/SeasonTotals.php
+++ b/ibl5/classes/UI/Tables/SeasonTotals.php
@@ -38,8 +38,9 @@ class SeasonTotals
         $playerRows = PlayerRowTransformer::resolveWithStats($db, $result, $yr);
 
         $season = new Season($db);
+        $seasonYear = ($yr !== '') ? (int) $yr : $season->endingYear;
         $offDefRepo = new TeamOffDefStatsRepository($db);
-        $bothStats = $offDefRepo->getTeamBothStats($team->name, $season->endingYear);
+        $bothStats = $offDefRepo->getTeamBothStats($team->name, $seasonYear);
 
         ob_start();
         ?>
@@ -104,7 +105,7 @@ endif; ?>
 <?php endforeach; ?>
     </tbody>
     <tfoot>
-<?php if ($yr === "" && $bothStats !== null):
+<?php if ($bothStats !== null):
     $labelColspan = ($moduleName === "LeagueStarters") ? 3 : 2;
     $off = $bothStats['offense'];
     $def = $bothStats['defense'];

--- a/ibl5/tests/DatabaseIntegration/TeamOffDefStatsRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamOffDefStatsRepositoryTest.php
@@ -138,4 +138,61 @@ class TeamOffDefStatsRepositoryTest extends DatabaseTestCase
             self::assertNull($result);
         }
     }
+
+    public function testGetTeamBothStatsExcludesNonRegularSeason(): void
+    {
+        $this->insertFranchiseSeasonRow(1, 2098, 'Metros');
+        $this->insertFranchiseSeasonRow(2, 2098, 'Stars');
+
+        // June date → game_type=2 (playoffs), NOT regular season
+        $this->insertTeamBoxscoreRow('2098-06-15', 'Metros', 1, 1, 2);
+        $this->insertTeamBoxscoreRow('2098-06-15', 'Stars', 1, 1, 2);
+
+        $result = $this->repo->getTeamBothStats('Metros', 2098);
+
+        self::assertNull($result);
+    }
+
+    public function testGetTeamBothStatsForDateRangeReturnsNullWhenNoData(): void
+    {
+        $result = $this->repo->getTeamBothStatsForDateRange('Metros', '2099-01-01', '2099-01-31');
+
+        self::assertNull($result);
+    }
+
+    public function testGetTeamBothStatsForDateRangeReturnsDataForMatchingDates(): void
+    {
+        $this->insertFranchiseSeasonRow(1, 2099, 'Metros');
+        $this->insertFranchiseSeasonRow(2, 2099, 'Stars');
+
+        $this->insertTeamBoxscoreRow('2099-01-15', 'Metros', 1, 1, 2);
+        $this->insertTeamBoxscoreRow('2099-01-15', 'Stars', 1, 1, 2);
+
+        $result = $this->repo->getTeamBothStatsForDateRange('Metros', '2099-01-10', '2099-01-20');
+
+        self::assertNotNull($result);
+        self::assertArrayHasKey('offense', $result);
+        self::assertArrayHasKey('defense', $result);
+        self::assertSame(1, $result['offense']['games']);
+        self::assertSame(1, $result['defense']['games']);
+    }
+
+    public function testGetTeamBothStatsForDateRangeIncludesAllGameTypes(): void
+    {
+        $this->insertFranchiseSeasonRow(1, 2097, 'Metros');
+        $this->insertFranchiseSeasonRow(2, 2097, 'Stars');
+
+        // June date → game_type=2 (playoffs)
+        $this->insertTeamBoxscoreRow('2097-06-10', 'Metros', 1, 1, 2);
+        $this->insertTeamBoxscoreRow('2097-06-10', 'Stars', 1, 1, 2);
+
+        // getTeamBothStats (regular season only) excludes this
+        $seasonResult = $this->repo->getTeamBothStats('Metros', 2097);
+        self::assertNull($seasonResult);
+
+        // getTeamBothStatsForDateRange includes all game types
+        $rangeResult = $this->repo->getTeamBothStatsForDateRange('Metros', '2097-06-01', '2097-06-30');
+        self::assertNotNull($rangeResult);
+        self::assertSame(1, $rangeResult['offense']['games']);
+    }
 }

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -1011,12 +1011,53 @@ INSERT INTO ibl_schedule (season_year, game_date, visitor_teamid, home_teamid, v
 ON DUPLICATE KEY UPDATE visitor_score=VALUES(visitor_score);
 
 -- ============================================================
--- Box score row for IBL6 URL path (game_of_that_day > 0)
+-- Box score team pairs (offense/defense footer stats)
+-- Each game needs TWO rows (one per team) for the defense subquery self-JOIN.
+-- Generated columns: game_type=1 (regular), =2 (June/playoffs)
+-- season_year: month>=10 → year+1, else year (Feb 2026 → 2026)
 -- ============================================================
 
-INSERT INTO ibl_box_scores_teams (game_date, visitor_teamid, home_teamid, game_of_that_day, name) VALUES
-  ('2026-02-20', 1, 2, 1, 'Metros')
-ON DUPLICATE KEY UPDATE game_of_that_day=VALUES(game_of_that_day);
+-- Regular season pair: 2026-02-20, Metros(visitor=1) vs Stars(home=2), game_type=1
+INSERT INTO ibl_box_scores_teams (game_date, visitor_teamid, home_teamid, game_of_that_day, name,
+  game_2gm, game_2ga, game_ftm, game_fta, game_3gm, game_3ga,
+  game_orb, game_drb, game_ast, game_stl, game_tov, game_blk, game_pf) VALUES
+  ('2026-02-20', 1, 2, 1, 'Metros',
+   28, 55, 18, 22, 10, 25, 9, 28, 22, 7, 11, 4, 16),
+  ('2026-02-20', 1, 2, 1, 'Stars',
+   25, 58, 15, 20, 8, 22, 7, 25, 19, 6, 13, 3, 18)
+ON DUPLICATE KEY UPDATE game_2gm=VALUES(game_2gm), game_2ga=VALUES(game_2ga),
+  game_ftm=VALUES(game_ftm), game_fta=VALUES(game_fta), game_3gm=VALUES(game_3gm),
+  game_3ga=VALUES(game_3ga), game_orb=VALUES(game_orb), game_drb=VALUES(game_drb),
+  game_ast=VALUES(game_ast), game_stl=VALUES(game_stl), game_tov=VALUES(game_tov),
+  game_blk=VALUES(game_blk), game_pf=VALUES(game_pf);
+
+-- Sim-range pair: 2026-03-03 (inside last sim [2026-03-01..2026-03-07]), Metros vs Cougars
+INSERT INTO ibl_box_scores_teams (game_date, visitor_teamid, home_teamid, game_of_that_day, name,
+  game_2gm, game_2ga, game_ftm, game_fta, game_3gm, game_3ga,
+  game_orb, game_drb, game_ast, game_stl, game_tov, game_blk, game_pf) VALUES
+  ('2026-03-03', 1, 3, 1, 'Metros',
+   30, 60, 20, 24, 9, 20, 11, 30, 24, 8, 10, 5, 15),
+  ('2026-03-03', 1, 3, 1, 'Cougars',
+   27, 56, 16, 21, 7, 19, 8, 26, 20, 5, 14, 2, 19)
+ON DUPLICATE KEY UPDATE game_2gm=VALUES(game_2gm), game_2ga=VALUES(game_2ga),
+  game_ftm=VALUES(game_ftm), game_fta=VALUES(game_fta), game_3gm=VALUES(game_3gm),
+  game_3ga=VALUES(game_3ga), game_orb=VALUES(game_orb), game_drb=VALUES(game_drb),
+  game_ast=VALUES(game_ast), game_stl=VALUES(game_stl), game_tov=VALUES(game_tov),
+  game_blk=VALUES(game_blk), game_pf=VALUES(game_pf);
+
+-- Playoffs pair: 2026-06-05 (June → game_type=2), Metros vs Stars
+INSERT INTO ibl_box_scores_teams (game_date, visitor_teamid, home_teamid, game_of_that_day, name,
+  game_2gm, game_2ga, game_ftm, game_fta, game_3gm, game_3ga,
+  game_orb, game_drb, game_ast, game_stl, game_tov, game_blk, game_pf) VALUES
+  ('2026-06-05', 1, 2, 1, 'Metros',
+   26, 52, 14, 18, 11, 28, 10, 27, 21, 9, 12, 6, 17),
+  ('2026-06-05', 1, 2, 1, 'Stars',
+   24, 50, 12, 16, 9, 24, 6, 24, 18, 5, 15, 4, 20)
+ON DUPLICATE KEY UPDATE game_2gm=VALUES(game_2gm), game_2ga=VALUES(game_2ga),
+  game_ftm=VALUES(game_ftm), game_fta=VALUES(game_fta), game_3gm=VALUES(game_3gm),
+  game_3ga=VALUES(game_3ga), game_orb=VALUES(game_orb), game_drb=VALUES(game_drb),
+  game_ast=VALUES(game_ast), game_stl=VALUES(game_stl), game_tov=VALUES(game_tov),
+  game_blk=VALUES(game_blk), game_pf=VALUES(game_pf);
 
 -- ============================================================
 -- Power rankings (covers SOS tier dots, SOS summary)

--- a/ibl5/tests/e2e/flows/team.spec.ts
+++ b/ibl5/tests/e2e/flows/team.spec.ts
@@ -220,3 +220,47 @@ test.describe('Team page: historical year view', () => {
     await assertNoPhpErrors(page, 'on historical year view');
   });
 });
+
+// ===========================================================================
+// Team page: offense/defense footer rows
+// ===========================================================================
+
+publicTest.describe('Team page: offense/defense footer stats', () => {
+  publicTest('avg_s shows offense/defense footer rows', async ({ appState, page }) => {
+    await appState({ 'Current Season Ending Year': '2026' });
+    await page.goto('modules.php?name=Team&op=team&teamid=1');
+    const dropdown = page.locator('.ibl-view-select').first();
+    await dropdown.selectOption('avg_s');
+    const tfoot = page.locator('.ibl-data-table tfoot');
+    await publicExpect(tfoot).toContainText('Metros Offense');
+    await publicExpect(tfoot).toContainText('Metros Defense');
+  });
+
+  publicTest('historical year avg_s shows offense/defense footer', async ({ appState, page }) => {
+    await appState({ 'Current Season Ending Year': '2026' });
+    await page.goto('modules.php?name=Team&op=team&teamid=1&yr=2026&display=avg_s');
+    const tfoot = page.locator('.ibl-data-table tfoot');
+    await publicExpect(tfoot).toContainText('Metros Offense');
+    await publicExpect(tfoot).toContainText('Metros Defense');
+  });
+
+  publicTest('chunk shows offense/defense footer rows', async ({ appState, page }) => {
+    await appState({ 'Current Season Ending Year': '2026' });
+    await page.goto('modules.php?name=Team&op=team&teamid=1');
+    const dropdown = page.locator('.ibl-view-select').first();
+    await dropdown.selectOption('chunk');
+    const tfoot = page.locator('.ibl-data-table tfoot');
+    await publicExpect(tfoot).toContainText('Metros Offense');
+    await publicExpect(tfoot).toContainText('Metros Defense');
+  });
+
+  publicTest('playoffs shows offense/defense footer rows', async ({ appState, page }) => {
+    await appState({ 'Current Season Phase': 'Playoffs', 'Current Season Ending Year': '2026' });
+    await page.goto('modules.php?name=Team&op=team&teamid=1');
+    const dropdown = page.locator('.ibl-view-select').first();
+    await dropdown.selectOption('playoffs');
+    const tfoot = page.locator('.ibl-data-table tfoot');
+    await publicExpect(tfoot).toContainText('Metros Offense');
+    await publicExpect(tfoot).toContainText('Metros Defense');
+  });
+});


### PR DESCRIPTION
## Summary

Restores team offense/defense average statistics on the Team module's Season Averages (`avg_s`), Season Totals (`total_s`), Sim Averages (`chunk`), and Playoffs Averages (`playoffs`) views.

## Changes

### Bug fix: SeasonAverages.php / SeasonTotals.php
- Remove `$yr === '''` gate that hid footer rows on historical year views
- Use `$yr` parameter (when set) for the season year query instead of always using current season

### New: `getTeamBothStatsForDateRange()`
- Parameterize `buildOffenseSubquery()` / `buildDefenseSubquery()` with `$regularSeasonOnly` flag (default `true` preserves existing behavior)
- New date-range method queries offense/defense stats without game_type filter
- Extract `unpackBothStatsRow()` to eliminate row-unpacking duplication

### New: PeriodAverages.php tfoot
- Add `<tfoot>` section with offense/defense per-game averages
- Wired to `getTeamBothStatsForDateRange()` using the period's start/end dates

### Tests
- **Characterization:** `getTeamBothStats` excludes game_type != 1 (pre-impl)
- **Integration:** date-range method null, matching data, all-game-types inclusion
- **E2E:** avg_s, historical avg_s, chunk, playoffs footer row assertions
- **CI seed:** paired `ibl_box_scores_teams` rows for regular season, sim range, and playoffs

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.