### PR TITLE
refactor: split nightly-run into two-agent architecture

### DIFF
--- a/.claude/rules/nightly-workflow.md
+++ b/.claude/rules/nightly-workflow.md
@@ -1,12 +1,12 @@
 ---
-description: Nightly autonomous workflow — launchd fires claude -p at midnight, looping through queued plans with time guards and incremental checkpoints.
-last_verified: 2026-04-26
+description: Nightly autonomous workflow — launchd fires claude -p at midnight, running two context-isolated agents per plan (implementation + post-plan) with time guards and incremental checkpoints.
+last_verified: 2026-05-01
 paths: "bin/nightly-*"
 ---
 
 # Nightly Autonomous Workflow
 
-A headless `claude -p` process runs at 00:03 daily via macOS `launchd`. It loops through all queued plans — one fresh `claude -p` invocation per plan — until the queue is empty or the ~4h45m time guard is exceeded.
+A headless `claude -p` process runs at 00:03 daily via macOS `launchd`. It loops through all queued plans — two fresh `claude -p` invocations per plan (implementation, then post-plan) — until the queue is empty or the ~4h45m time guard is exceeded.
 
 ## Quick Reference
 
@@ -28,6 +28,7 @@ A headless `claude -p` process runs at 00:03 daily via macOS `launchd`. It loops
   queue/    symlinks to ~/.claude/plans/*.md (oldest runs first)
   done/     symlinks moved here after successful execution
   skipped/  symlinks moved here when skipped (ambiguity/errors/poison-pill)
+  handoff/  JSON files bridging state from implementation to post-plan agent
   reports/  per-night markdown reports (YYYY-MM-DD-{done|skipped|no-queue|error}-<slug>.md)
   logs/     claude -p output logs + launchd stdout/stderr
 ```
@@ -36,10 +37,19 @@ A headless `claude -p` process runs at 00:03 daily via macOS `launchd`. It loops
 
 1. **Daytime:** Work with Claude in plan mode. After approval, queue the plan: `bin/nightly-queue <slug>`
 2. **00:03:** `launchd` fires `bin/nightly-run`
-3. **Loop:** For each queued plan (oldest first), `nightly-run` fires a fresh `claude -p` with `bin/nightly-prompt`. Each invocation gets a clean context window.
-4. **Per plan:** Claude creates a worktree (or resumes an existing one), implements, makes incremental checkpoint commits, runs `/post-plan` (tests, code review, security audit, commit, push, PR)
-5. **Guards:** The loop stops when the queue is empty or 4 hours have elapsed. Plans that fail twice are moved to `skipped/` as poison pills.
-6. **Morning:** Check `gh pr list` for new PRs, read reports for details
+3. **Loop:** For each queued plan (oldest first), `nightly-run` fires two `claude -p` invocations sequentially:
+   - **Implementation agent** (`bin/nightly-prompt-impl`): creates worktree, implements the plan, makes checkpoint commits, writes a handoff file
+   - **Post-plan agent** (`bin/nightly-prompt-postplan`): reads the handoff file, runs `/post-plan` (code review, security audit, PR, CI monitoring, auto-merge), writes the completion report
+4. **Guards:** The loop stops when the queue is empty or ~4h45m have elapsed. Plans that fail 3 times are moved to `skipped/` as poison pills.
+5. **Morning:** Check `gh pr list` for new PRs, read reports for details
+
+## Context Isolation
+
+The two-agent architecture provides complete context isolation between implementation and review:
+
+- **No implementation bleed:** The post-plan agent starts with a clean 200K context — no stale variable names, abandoned approaches, or debugging artifacts from implementation.
+- **No reviewer bias:** The post-plan agent (and its review sub-agents) never sees the implementation journey — only the final diff. This prevents anchoring on the author's reasoning.
+- **Token efficiency:** Both agents use Opus 4.6 with 200K context (`--model claude-opus-4-6`), which is sufficient for appropriately-scoped plans and cheaper than 1M context.
 
 ## Queue Mechanism
 
@@ -49,22 +59,43 @@ Cancelling: `rm queue/<file>.md` removes only the symlink, not the original plan
 
 ## Multi-Plan Loop
 
-`bin/nightly-run` loops through the queue, firing a fresh `claude -p` per plan. Each invocation processes exactly one plan, then exits. The bash loop provides:
+`bin/nightly-run` loops through the queue, firing two `claude -p` invocations per plan. The bash loop provides:
 
-- **Time guard:** Won't start a new plan if >4h45m have elapsed (configurable via `MAX_ELAPSED` in `bin/nightly-run`)
-- **Poison-pill protection:** Tracks attempts per plan via `.attempts` sidecar files. After 2 failures in one night, the plan is moved to `skipped/` with a report. Prevents one bad plan from consuming the entire window.
-- **Turn cap:** `--max-turns 200` per invocation prevents runaway tool-call loops
+- **Two-phase execution:** Implementation agent writes a JSON handoff file to `handoff/`; post-plan agent reads it. The bash loop checks for the handoff file between phases — if it exists, implementation is skipped (resume scenario).
+- **Per-phase usage-limit detection:** After each `claude -p` invocation, the loop checks for "hit your limit" in the log. If detected, the attempt counter is decremented (usage limits are transient, not failures) and the loop breaks.
+- **Time guard:** Won't start a new plan (or post-plan phase) if >4h45m have elapsed (configurable via `MAX_ELAPSED` in `bin/nightly-run`)
+- **Poison-pill protection:** Tracks attempts per plan via `.attempts` sidecar files. After 3 failures in one night, the plan is moved to `skipped/` with a report.
+- **Turn caps:** Implementation: `--max-turns 200`. Post-plan: `--max-turns 120`.
+
+## Handoff Mechanism
+
+The implementation agent writes a JSON file to `handoff/<plan-filename>.json` after completing all work:
+
+```json
+{
+  "slug": "optimize-vw-team-awards",
+  "worktree": "/Users/ajaynicolas/GitHub/IBL5/worktrees/optimize-vw-team-awards",
+  "branch": "optimize-vw-team-awards",
+  "plan_file": "optimize-vw-team-awards-slow-queries.md",
+  "plan_title": "Optimize vw_team_awards Slow Queries",
+  "completed_at": "2026-05-01T02:15:00Z"
+}
+```
+
+The bash loop passes the plan filename to the post-plan prompt. The post-plan agent reads the handoff file to learn the slug, worktree path, and branch. On successful completion, the post-plan agent deletes the handoff file. Orphaned handoff files (plan no longer in queue) are cleaned up at the end of the session.
 
 ## Incremental Checkpoints
 
-Each `claude -p` invocation commits and pushes after major milestones (migration applied, PHP sweep done, tests passing). If the session dies mid-plan — usage limit, crash, timeout — the branch has the latest checkpoint. The next invocation detects the existing worktree and resumes from where it left off.
+The implementation agent commits and pushes after major milestones (migration applied, PHP sweep done, tests passing). If the session dies mid-plan — usage limit, crash, timeout — the branch has the latest checkpoint. The next invocation detects the existing worktree and resumes from where it left off.
 
 ## Resume
 
-When a plan's worktree already exists (from a previous interrupted run), Claude checks the branch state:
-- **Commits ahead of master:** Reads commit messages to determine what's done, continues from there
-- **Branch merged on master:** Stale worktree — removes it and starts fresh
-- **No commits ahead:** Treats as fresh worktree, starts implementation
+Resume behavior depends on which phase was interrupted:
+
+- **Implementation interrupted (no handoff file):** The implementation agent detects the existing worktree, reads commit messages to determine progress, and continues from the last checkpoint.
+- **Implementation complete, post-plan interrupted (handoff file exists):** The bash loop sees the handoff file and skips the implementation agent entirely, going straight to the post-plan agent.
+- **Branch merged on master:** Stale worktree — removes it and starts fresh.
+- **No commits ahead:** Treats as fresh worktree, starts implementation.
 
 ## 11am Resume
 
@@ -79,7 +110,8 @@ The resume plist lives at `~/Library/LaunchAgents/com.ibl5.nightly-resume.plist`
 ## Files
 
 - `bin/nightly-queue` — symlink queue helper
-- `bin/nightly-prompt` — prompt text (source of truth for what claude -p receives)
-- `bin/nightly-run` — wrapper script called by launchd (loop + time guard + 11am resume)
+- `bin/nightly-prompt-impl` — implementation agent prompt (Steps 1-7: queue check through handoff file)
+- `bin/nightly-prompt-postplan` — post-plan agent prompt (reads handoff, runs /post-plan, reports, cleans up)
+- `bin/nightly-run` — wrapper script called by launchd (loop + two-phase execution + time guard + 11am resume)
 - `~/Library/LaunchAgents/com.ibl5.nightly-claude.plist` — launchd schedule (00:03 daily)
 - `~/Library/LaunchAgents/com.ibl5.nightly-resume.plist` — one-shot resume (created dynamically, self-cleaning)

--- a/bin/nightly-prompt-impl
+++ b/bin/nightly-prompt-impl
@@ -1,24 +1,38 @@
-You are executing the IBL5 nightly autonomous workflow. No human is present — you must never ask questions or wait for input. You have full tool access.
+You are executing the IBL5 nightly autonomous workflow — IMPLEMENTATION PHASE. No human is present — you must never ask questions or wait for input. You have full tool access.
 
-The outer bash loop in bin/nightly-run fires a fresh claude -p per plan. You handle exactly ONE plan per invocation. The loop handles queue iteration and time guards.
+The outer bash loop in bin/nightly-run fires two claude -p invocations per plan: one for implementation (you), one for post-plan review (a separate agent). You handle IMPLEMENTATION ONLY for exactly ONE plan per invocation.
+
+Do NOT invoke /post-plan, /simplify, /commit, /code-review, or /security-audit. Your job ends after writing the handoff file.
 
 ## Step 1: Check the Queue
 
 NIGHTLY_DIR is: $HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/nightly
 
-List files in $NIGHTLY_DIR/queue/. If the directory is empty (no .md files), write a one-line report to $NIGHTLY_DIR/reports/YYYY-MM-DD-no-queue.md (using today's date) saying "No plan queued for tonight." and STOP immediately.
-
-If multiple files exist, pick the OLDEST by modification time (ls -1tr | head -1).
+List files in $NIGHTLY_DIR/queue/. Pick the OLDEST .md file by modification time (ls -1tr | head -1).
 
 Read the plan file. If it is a symlink, follow it to read the original content.
 
-## Step 2: Validate the Plan
+## Step 2: Check for Existing Handoff
+
+Check if a handoff file already exists for this plan:
+
+```bash
+PLAN_NAME=$(basename <plan-file>)
+HANDOFF_FILE="$NIGHTLY_DIR/handoff/${PLAN_NAME}.json"
+if [ -f "$HANDOFF_FILE" ]; then
+    echo "HANDOFF EXISTS — implementation already complete"
+fi
+```
+
+If the handoff file exists, implementation was already completed by a previous session. Log "Implementation already complete — handoff file exists" and STOP immediately. The bash loop will invoke the post-plan agent.
+
+## Step 3: Validate the Plan
 
 The plan must have:
 - A clear title (first # heading)
 - Actionable implementation steps — not just analysis questions or vague goals
 
-Scope is NEVER grounds to skip. Large file counts, multi-module cascades, migrations, ADRs, doc updates, and visual verification are all in-bounds — attempt the full plan. If you run out of session budget, commit and push what you have and let /post-plan open a draft PR; do not pre-emptively skip on size.
+Scope is NEVER grounds to skip. Large file counts, multi-module cascades, migrations, ADRs, doc updates, and visual verification are all in-bounds — attempt the full plan. If you run out of session budget, commit and push what you have; the post-plan agent will open a draft PR.
 
 Skip ONLY when the plan is genuinely ambiguous: unclear requirements, missing external context, or you cannot determine what specific code changes to make. In that case:
 1. Move the symlink to $NIGHTLY_DIR/skipped/ : mv $NIGHTLY_DIR/queue/<filename> $NIGHTLY_DIR/skipped/
@@ -26,11 +40,11 @@ Skip ONLY when the plan is genuinely ambiguous: unclear requirements, missing ex
 3. Do NOT attempt partial work
 4. STOP
 
-## Step 3: Derive the Slug
+## Step 4: Derive the Slug
 
 Extract a kebab-case slug from the plan title for the worktree name. Example: "Optimize vw_team_awards Slow Queries" becomes "optimize-vw-team-awards". Max 50 characters, lowercase, alphanumeric and hyphens only.
 
-## Step 4: Set Up the Worktree (or Resume)
+## Step 5: Set Up the Worktree (or Resume)
 
 First, check if a worktree already exists for this slug:
 
@@ -66,9 +80,9 @@ git log --oneline origin/master..HEAD
 
 - If the branch is already merged on origin/master (git log shows nothing or branch doesn't exist on remote), this is a stale worktree. Remove it with `bin/wt-rm <slug>` and start fresh (run the "Fresh start" path above).
 - If there are commits ahead of master, this is a partial implementation. Read the commit messages and the plan to determine what steps are already complete. Continue from where the previous session left off — do NOT redo completed work.
-- If the worktree exists but has no commits ahead of master (just created, never committed), treat it as a fresh worktree and start implementation from Step 5.
+- If the worktree exists but has no commits ahead of master (just created, never committed), treat it as a fresh worktree and start implementation from Step 6.
 
-## Step 5: Implement the Plan
+## Step 6: Implement the Plan
 
 Work in worktrees/<slug>/ibl5/. CLAUDE.md is auto-loaded — follow all project rules. Follow the plan step by step.
 
@@ -90,44 +104,54 @@ git commit -m "<type>: <what this checkpoint covers>"
 git push origin <slug>
 ```
 
-Do NOT wait for /post-plan to make the first commit. /post-plan will add a final commit with any remaining changes (from simplify, code review fixes, etc.) on top of your checkpoints.
-
 If implementation requires information you do not have — external resources, unclear requirements, missing context — do NOT guess. Move the plan to skipped/ with a report explaining what information is needed, and STOP.
 
-## Step 6: Run /post-plan
+## Step 7: Write Handoff File
 
-After all implementation is complete and tests pass, invoke /post-plan using the Skill tool and let it run to completion. Do NOT invoke /simplify, /commit, /code-review, or /security-audit separately — /post-plan orchestrates all of them.
+After all implementation is complete and the final checkpoint is pushed, write a handoff file so the post-plan agent can pick up:
 
-/post-plan will handle: code review, security audit, commit, push, PR creation, CI monitoring, and auto-merge evaluation.
+```bash
+NIGHTLY_DIR="$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/nightly"
+mkdir -p "$NIGHTLY_DIR/handoff"
+cat <<'HANDOFF_EOF' > "$NIGHTLY_DIR/handoff/<plan-filename>.json"
+{
+  "slug": "<slug>",
+  "worktree": "/Users/ajaynicolas/GitHub/IBL5/worktrees/<slug>",
+  "branch": "<slug>",
+  "plan_file": "<plan-filename>",
+  "plan_title": "<title from the plan>",
+  "completed_at": "<current ISO-8601 timestamp>"
+}
+HANDOFF_EOF
+```
 
-## Step 7: Report and Clean Up
+Replace all `<placeholder>` values with actual values. The `plan_file` field must match the filename in $NIGHTLY_DIR/queue/ exactly (including .md extension).
 
-After /post-plan completes successfully:
-1. Move the plan symlink from queue/ to done/: mv $NIGHTLY_DIR/queue/<filename> $NIGHTLY_DIR/done/
-2. Write a completion report to $NIGHTLY_DIR/reports/YYYY-MM-DD-done-<slug>.md containing:
-   - Plan title
-   - Branch name
-   - PR URL (get from: gh pr view --json url --jq '.url')
-   - Summary of changes made
-   - Code review findings summary
-   - Security audit findings summary
-   - CI status at completion time
-   - Any issues encountered during implementation
+After writing the handoff file, verify it exists and contains valid JSON:
+
+```bash
+cat "$NIGHTLY_DIR/handoff/<plan-filename>.json" | python3 -m json.tool > /dev/null
+echo "Handoff file written successfully"
+```
+
+STOP after writing and verifying the handoff file. The bash loop will fire the post-plan agent next.
 
 ## Error Handling
 
-If ANY step fails after worktree creation (Step 4):
+If ANY step fails after worktree creation (Step 5):
 1. Commit and push whatever work exists on the branch (incremental checkpoint — do not lose progress)
 2. Write a detailed error report to $NIGHTLY_DIR/reports/YYYY-MM-DD-error-<slug>.md
 3. Move the plan symlink to $NIGHTLY_DIR/skipped/ (not done/)
 4. Do NOT delete the worktree — preserve it for morning debugging or resume
-5. STOP
+5. Do NOT write a handoff file — this signals failure to the bash loop
+6. STOP
 
 ## Hard Rules
 
 - Process exactly 1 plan per invocation (the outer loop handles queue iteration)
 - NEVER use the AskUserQuestion tool — it will block waiting for a human who is not there
 - NEVER use the ExitPlanMode tool — you are not in plan mode
+- NEVER invoke /post-plan — a separate agent handles that
 - If you encounter ANY ambiguity about requirements, skip and report — do not guess
 - All CLAUDE.md project rules apply at all times
 - Work only in worktrees, never modify files on the master branch directly

--- a/bin/nightly-prompt-postplan
+++ b/bin/nightly-prompt-postplan
@@ -1,0 +1,81 @@
+You are executing the IBL5 nightly autonomous workflow — POST-PLAN PHASE. No human is present — you must never ask questions or wait for input. You have full tool access.
+
+A separate implementation agent has already completed all code changes for this plan. Your job is ONLY to run /post-plan, write the completion report, and clean up. Do NOT re-implement anything or modify the implementation.
+
+## Step 1: Read Handoff File
+
+NIGHTLY_DIR is: $HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/nightly
+
+The plan filename is provided at the end of this prompt as PLAN_FILE=<filename>. Read the handoff file:
+
+```bash
+cat "$NIGHTLY_DIR/handoff/<PLAN_FILE>.json"
+```
+
+Parse the JSON to extract: slug, worktree path, branch name, plan title, plan filename.
+
+If the handoff file does not exist or is invalid JSON, write an error report to $NIGHTLY_DIR/reports/YYYY-MM-DD-error-unknown.md and STOP.
+
+## Step 2: Enter Worktree
+
+Change into the worktree directory from the handoff file:
+
+```bash
+cd <worktree-path>
+git log --oneline origin/master..HEAD
+```
+
+Verify the worktree exists and the branch has commits ahead of master. If not, write an error report and STOP — the implementation agent may have failed silently.
+
+## Step 3: Run /post-plan
+
+Invoke /post-plan using the Skill tool and let it run to completion. Do NOT invoke /simplify, /commit, /code-review, or /security-audit separately — /post-plan orchestrates all of them.
+
+/post-plan will handle: code review, security audit, commit, push, PR creation, CI monitoring, and auto-merge evaluation.
+
+## Step 4: Report and Clean Up
+
+After /post-plan completes successfully:
+
+1. Move the plan symlink from queue/ to done/:
+   ```bash
+   mv "$NIGHTLY_DIR/queue/<plan-filename>" "$NIGHTLY_DIR/done/"
+   ```
+
+2. Write a completion report to $NIGHTLY_DIR/reports/YYYY-MM-DD-done-<slug>.md containing:
+   - Plan title
+   - Branch name
+   - PR URL (get from: gh pr view --json url --jq '.url')
+   - Summary of changes made
+   - Code review findings summary
+   - Security audit findings summary
+   - CI status at completion time
+   - Any issues encountered
+
+3. Delete the handoff file:
+   ```bash
+   rm "$NIGHTLY_DIR/handoff/<plan-filename>.json"
+   ```
+
+## Error Handling
+
+If ANY step fails:
+1. Write a detailed error report to $NIGHTLY_DIR/reports/YYYY-MM-DD-error-<slug>.md
+2. Move the plan symlink to $NIGHTLY_DIR/skipped/ (not done/):
+   ```bash
+   mv "$NIGHTLY_DIR/queue/<plan-filename>" "$NIGHTLY_DIR/skipped/"
+   ```
+3. Delete the handoff file (the branch has committed work for manual recovery):
+   ```bash
+   rm -f "$NIGHTLY_DIR/handoff/<plan-filename>.json"
+   ```
+4. Do NOT delete the worktree — preserve it for morning debugging
+5. STOP
+
+## Hard Rules
+
+- NEVER use the AskUserQuestion tool — it will block waiting for a human who is not there
+- NEVER use the ExitPlanMode tool — you are not in plan mode
+- NEVER re-implement or modify the implementation code — only run /post-plan
+- If /post-plan fails, report the error and stop — do not retry within this invocation
+- All CLAUDE.md project rules apply at all times

--- a/bin/nightly-run
+++ b/bin/nightly-run
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Wrapper script for the IBL5 nightly autonomous workflow.
 # Called by launchd at 00:03 daily. Loops through queued plans,
-# firing a fresh claude -p per plan until the queue is empty
-# or the time guard is exceeded.
+# firing two claude -p invocations per plan (implementation + post-plan)
+# until the queue is empty or the time guard is exceeded.
 #
 # If plans remain in the queue when the loop exits (time guard or
 # usage limit), schedules a one-shot 11am PT resume via launchd.
@@ -25,9 +25,10 @@ LOG_DIR="$NIGHTLY_DIR/logs"
 QUEUE_DIR="$NIGHTLY_DIR/queue"
 RESUME_PLIST="$HOME/Library/LaunchAgents/com.ibl5.nightly-resume.plist"
 MAX_ELAPSED=17100  # ~4h45m — stops around 4:45am, leaves headroom in the 5h usage window
-MAX_ATTEMPTS=2     # per-plan retry cap within one night
+MAX_ATTEMPTS=3     # per-plan retry cap within one night (covers impl + postplan phases)
 
-mkdir -p "$LOG_DIR" "$QUEUE_DIR"
+HANDOFF_DIR="$NIGHTLY_DIR/handoff"
+mkdir -p "$LOG_DIR" "$QUEUE_DIR" "$HANDOFF_DIR"
 LOG="$LOG_DIR/$(date +%Y-%m-%d).log"
 
 cd "$REPO"
@@ -48,6 +49,9 @@ while true; do
     if ! ls "$QUEUE_DIR"/*.md &>/dev/null; then
         if [ "$PLANS_RUN" -eq 0 ]; then
             echo "Queue empty — nothing to run." >> "$LOG"
+            mkdir -p "$NIGHTLY_DIR/reports"
+            echo "No plan queued for tonight." \
+                > "$NIGHTLY_DIR/reports/$(date +%Y-%m-%d)-no-queue.md"
         else
             echo "Queue drained after $PLANS_RUN plan(s)." >> "$LOG"
         fi
@@ -91,35 +95,78 @@ while true; do
     PLANS_RUN=$(( PLANS_RUN + 1 ))
     echo "--- Plan #$PLANS_RUN: $PLAN_NAME (attempt $(( ATTEMPTS + 1 ))) at $(date) ---" >> "$LOG"
 
-    # timeout kills the process tree if claude -p hangs (stuck tool call,
-    # MCP server won't exit, etc.) so the loop can recover and continue.
-    REMAINING_SECS=$(( MAX_ELAPSED - $(( $(date +%s) - START )) ))
-    if [ "$REMAINING_SECS" -lt 300 ]; then
-        REMAINING_SECS=300
-    fi
-    LOG_LINE_BEFORE=$(wc -l < "$LOG" 2>/dev/null || echo 0)
-    timeout "$REMAINING_SECS" \
-        claude -p "$(cat bin/nightly-prompt)" \
-            --dangerously-skip-permissions \
-            --model opus \
-            --max-turns 200 \
-            --name "nightly-$(date +%Y-%m-%d-%H%M)" \
-            >> "$LOG" 2>&1 || true
+    # --- Phase 1: Implementation ---
+    # Skip if handoff file exists (resume: impl done, postplan pending)
+    HANDOFF_FILE="$HANDOFF_DIR/${PLAN_NAME}.json"
 
-    echo "--- Plan #$PLANS_RUN finished at $(date) ---" >> "$LOG"
-
-    # Usage-limit exits are transient — don't count them as failures.
-    # Undo the attempt increment and stop the loop so the 11am resume
-    # picks up the remaining queue after the limit resets.
-    if tail -n +"$((LOG_LINE_BEFORE + 1))" "$LOG" | grep -q "hit your limit"; then
-        echo "Usage limit reached — not counting as a failed attempt, stopping loop." >> "$LOG"
-        CURRENT=$(cat "$ATTEMPT_FILE")
-        if [ "$CURRENT" -le 1 ]; then
-            rm -f "$ATTEMPT_FILE"
-        else
-            echo $(( CURRENT - 1 )) > "$ATTEMPT_FILE"
+    if [ -f "$HANDOFF_FILE" ]; then
+        echo "Handoff exists — skipping impl, proceeding to post-plan." >> "$LOG"
+    else
+        REMAINING_SECS=$(( MAX_ELAPSED - $(( $(date +%s) - START )) ))
+        if [ "$REMAINING_SECS" -lt 300 ]; then
+            REMAINING_SECS=300
         fi
-        break
+        IMPL_LOG_BEFORE=$(wc -l < "$LOG" 2>/dev/null || echo 0)
+        timeout "$REMAINING_SECS" \
+            claude -p "$(cat bin/nightly-prompt-impl)" \
+                --dangerously-skip-permissions \
+                --model claude-opus-4-6 \
+                --max-turns 200 \
+                --name "nightly-impl-$(date +%Y-%m-%d-%H%M)" \
+                >> "$LOG" 2>&1 || true
+
+        echo "--- Plan #$PLANS_RUN impl finished at $(date) ---" >> "$LOG"
+
+        # Usage-limit check after implementation
+        if tail -n +"$((IMPL_LOG_BEFORE + 1))" "$LOG" | grep -q "hit your limit"; then
+            echo "Usage limit during impl — stopping loop." >> "$LOG"
+            CURRENT=$(cat "$ATTEMPT_FILE")
+            if [ "$CURRENT" -le 1 ]; then
+                rm -f "$ATTEMPT_FILE"
+            else
+                echo $(( CURRENT - 1 )) > "$ATTEMPT_FILE"
+            fi
+            break
+        fi
+    fi
+
+    # --- Phase 2: Post-Plan (only if handoff file exists) ---
+    if [ -f "$HANDOFF_FILE" ]; then
+        # Re-check time guard before starting post-plan
+        ELAPSED=$(( $(date +%s) - START ))
+        if [ "$ELAPSED" -gt "$MAX_ELAPSED" ]; then
+            echo "Time guard between phases — will resume postplan next run." >> "$LOG"
+            break
+        fi
+
+        REMAINING_SECS=$(( MAX_ELAPSED - $(( $(date +%s) - START )) ))
+        if [ "$REMAINING_SECS" -lt 300 ]; then
+            REMAINING_SECS=300
+        fi
+        PP_LOG_BEFORE=$(wc -l < "$LOG" 2>/dev/null || echo 0)
+        timeout "$REMAINING_SECS" \
+            claude -p "$(cat bin/nightly-prompt-postplan)
+
+PLAN_FILE=$PLAN_NAME" \
+                --dangerously-skip-permissions \
+                --model claude-opus-4-6 \
+                --max-turns 120 \
+                --name "nightly-postplan-$(date +%Y-%m-%d-%H%M)" \
+                >> "$LOG" 2>&1 || true
+
+        echo "--- Plan #$PLANS_RUN postplan finished at $(date) ---" >> "$LOG"
+
+        # Usage-limit check after post-plan
+        if tail -n +"$((PP_LOG_BEFORE + 1))" "$LOG" | grep -q "hit your limit"; then
+            echo "Usage limit during postplan — stopping loop." >> "$LOG"
+            CURRENT=$(cat "$ATTEMPT_FILE")
+            if [ "$CURRENT" -le 1 ]; then
+                rm -f "$ATTEMPT_FILE"
+            else
+                echo $(( CURRENT - 1 )) > "$ATTEMPT_FILE"
+            fi
+            break
+        fi
     fi
 
     # If the plan moved out of queue/ (to done/ or skipped/), clean up its attempt file
@@ -134,6 +181,15 @@ for af in "$QUEUE_DIR"/*.attempts; do
     PLAN_FOR_ATTEMPT="${af%.attempts}"
     if [ ! -e "$PLAN_FOR_ATTEMPT" ]; then
         rm -f "$af"
+    fi
+done
+
+# Clean up orphaned handoff files (plan no longer in queue)
+for hf in "$HANDOFF_DIR"/*.json; do
+    [ -e "$hf" ] || continue
+    PLAN_FOR_HANDOFF="$QUEUE_DIR/$(basename "${hf%.json}")"
+    if [ ! -e "$PLAN_FOR_HANDOFF" ]; then
+        rm -f "$hf"
     fi
 done
 

--- a/ibl5/docs/decisions/0007-nightly-autonomous-workflow.md
+++ b/ibl5/docs/decisions/0007-nightly-autonomous-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: ADR for the nightly autonomous workflow — headless Claude executes queued plans via launchd at midnight.
-last_verified: 2026-04-13
+last_verified: 2026-05-01
 ---
 
 # ADR-0007: Nightly Autonomous Workflow
@@ -14,9 +14,9 @@ Daytime plan-mode sessions generate implementation plans that are approved but n
 
 ## Decision
 
-Use macOS `launchd` to fire a headless `claude -p` process at 00:03 daily. The process reads one queued plan (symlinked from `~/.claude/plans/`), creates a worktree, implements the plan, and runs `/post-plan` for code review, security audit, testing, and PR creation. The `CLAUDE_HEADLESS=1` environment variable gates `/post-plan` Phase 11 (Worktree Preview Environment) since no human is present to verify visually.
+Use macOS `launchd` to fire a headless `claude -p` process at 00:03 daily. For each queued plan, two context-isolated agents run sequentially: an implementation agent (`bin/nightly-prompt-impl`) creates a worktree and implements the plan, then a post-plan agent (`bin/nightly-prompt-postplan`) runs `/post-plan` for code review, security audit, testing, and PR creation. A JSON handoff file bridges state between agents. The `CLAUDE_HEADLESS=1` environment variable gates `/post-plan` Phase 11 (Worktree Preview Environment) since no human is present to verify visually.
 
-Enforcement: `launchd` plist at `~/Library/LaunchAgents/com.ibl5.nightly-claude.plist`. Queue managed by `bin/nightly-queue`. Prompt authored in `bin/nightly-prompt`.
+Enforcement: `launchd` plist at `~/Library/LaunchAgents/com.ibl5.nightly-claude.plist`. Queue managed by `bin/nightly-queue`. Prompts authored in `bin/nightly-prompt-impl` and `bin/nightly-prompt-postplan`.
 
 ## Alternatives Considered
 
@@ -35,7 +35,8 @@ Enforcement: `launchd` plist at `~/Library/LaunchAgents/com.ibl5.nightly-claude.
 ## References
 
 - `bin/nightly-queue` — symlink queue helper
-- `bin/nightly-prompt` — self-contained prompt for headless execution
+- `bin/nightly-prompt-impl` — implementation agent prompt (queue check through handoff file)
+- `bin/nightly-prompt-postplan` — post-plan agent prompt (reads handoff, runs /post-plan, reports)
 - `bin/nightly-run` — launchd wrapper script
 - `.claude/rules/nightly-workflow.md` — workflow documentation
 - `.claude/skills/post-plan/SKILL.md` — Phase 11 `$CLAUDE_HEADLESS` gate


### PR DESCRIPTION
## Summary

Split the single `claude -p` invocation per plan into two context-isolated Opus 4.6 (200K) agents:

1. **Implementation agent** (`bin/nightly-prompt-impl`): queue check → validate → worktree → implement → handoff file
2. **Post-plan agent** (`bin/nightly-prompt-postplan`): read handoff → run /post-plan → report → cleanup

A JSON handoff file in `nightly/handoff/` bridges state between agents. The bash loop fires both sequentially per plan cycle.

## Motivation

- **Token efficiency**: 200K context (`--model claude-opus-4-6`) instead of 1M
- **Context isolation**: implementation artifacts don't pollute review context
- **Reviewer independence**: post-plan agent sees only the final diff, not the implementation journey
- **Reduced hallucinations**: fresh 200K window for each phase prevents stale context bleed

## Changes

- Split `bin/nightly-prompt` → `bin/nightly-prompt-impl` + `bin/nightly-prompt-postplan`
- Modified `bin/nightly-run`: two `claude -p` invocations per plan, per-phase usage-limit detection, inter-phase time guard, handoff file skip logic, orphaned handoff cleanup
- `--model opus` → `--model claude-opus-4-6` (explicit 200K)
- `--max-turns 200` for impl, `120` for postplan
- `MAX_ATTEMPTS` 2 → 3 (extra failure surface)
- No-queue report moved from agent prompt to bash loop
- Updated `.claude/rules/nightly-workflow.md` and ADR-0007

## Resume behavior

- **Impl interrupted (no handoff)**: next run detects worktree, reads commits, continues
- **Impl done, postplan interrupted (handoff exists)**: bash skips impl agent, runs postplan directly
- **Usage limit mid-phase**: attempt counter decremented, 11am resume picks up

## Manual Testing

No manual testing needed — all changes are covered by static verification (bash syntax, doc freshness, grep assertions).