### PR TITLE
refactor: consolidate Trading error_log() to Monolog and add audit logging

### DIFF
--- a/ibl5/modules/Trading/accepttradeoffer.php
+++ b/ibl5/modules/Trading/accepttradeoffer.php
@@ -12,7 +12,7 @@ try {
 global $mysqli_db;
 
 if (!isset($mysqli_db) || !($mysqli_db instanceof mysqli)) {
-    error_log("Database connection not available");
+    \Logging\LoggerFactory::getChannel('trade')->critical('Database connection not available');
     die("Error: Database connection failed");
 }
 
@@ -43,7 +43,7 @@ if ($offerId !== null) {
             \Utilities\HtmxHelper::redirect('/ibl5/modules.php?name=Trading&op=reviewtrade&result=accept_error&error=' . rawurlencode($result['error'] ?? 'Unknown error'));
         }
     } catch (Exception $e) {
-        error_log("Failed to process trade: " . $e->getMessage());
+        \Logging\LoggerFactory::getChannel('trade')->error('Failed to process trade', ['error' => $e->getMessage()]);
         \Utilities\HtmxHelper::redirect('/ibl5/modules.php?name=Trading&op=reviewtrade&result=accept_error&error=' . rawurlencode($e->getMessage()));
     }
 } else {

--- a/ibl5/modules/Trading/maketradeoffer.php
+++ b/ibl5/modules/Trading/maketradeoffer.php
@@ -12,7 +12,7 @@ try {
 global $mysqli_db;
 
 if (!isset($mysqli_db) || !($mysqli_db instanceof mysqli)) {
-    error_log("Database connection not available");
+    \Logging\LoggerFactory::getChannel('trade')->critical('Database connection not available');
     die("Error: Database connection failed");
 }
 
@@ -55,11 +55,15 @@ try {
     $tradeOffer = new Trading\TradeOffer($mysqli_db);
     $result = $tradeOffer->createTradeOffer($tradeData);
 } catch (Exception $e) {
-    error_log("Failed to create trade offer: " . $e->getMessage());
+    \Logging\LoggerFactory::getChannel('trade')->error('Failed to create trade offer', ['error' => $e->getMessage()]);
     $result = ['success' => false, 'error' => $e->getMessage()];
 }
 
 if ($result['success']) {
+    \Logging\LoggerFactory::getChannel('audit')->info('trade_offer_created', [
+        'offering_team' => $tradeData['offeringTeam'],
+        'listening_team' => $tradeData['listeningTeam'],
+    ]);
     \Utilities\HtmxHelper::redirect('/ibl5/modules.php?name=Trading&op=reviewtrade&result=offer_sent');
 } else {
     // Store checked items and cash amounts in session so the form can restore them

--- a/ibl5/modules/Trading/rejecttradeoffer.php
+++ b/ibl5/modules/Trading/rejecttradeoffer.php
@@ -16,12 +16,12 @@ if (!\Utilities\CsrfGuard::validateSubmittedToken('trade_reject')) {
 }
 
 if (!isset($_POST['offer']) || empty($_POST['offer'])) {
-    error_log("Missing offer ID in POST data");
+    \Logging\LoggerFactory::getChannel('trade')->warning('Missing offer ID in POST data');
     die("Error: Missing trade offer ID");
 }
 
 if (!isset($mysqli_db) || !($mysqli_db instanceof mysqli)) {
-    error_log("Database connection not available");
+    \Logging\LoggerFactory::getChannel('trade')->critical('Database connection not available');
     die("Error: Database connection failed");
 }
 
@@ -39,6 +39,10 @@ if ($tradeRows === []) {
 
 // Delete trade offer
 $repository->deleteTradeOffer($offerId);
+
+\Logging\LoggerFactory::getChannel('audit')->info('trade_offer_rejected', [
+    'offer_id' => $offerId,
+]);
 
 // Attempt Discord notification (gracefully fail if not available)
 try {


### PR DESCRIPTION
## Summary

Consolidates all post-bootstrap `error_log()` calls in the three Trading entry-point files to structured Monolog logging via `LoggerFactory::getChannel('trade')`, and adds audit logging for trade mutations.

## Changes

### error_log() → Monolog consolidation
- **accepttradeoffer.php**: DB connection failure → `critical`, trade processing exception → `error`
- **maketradeoffer.php**: DB connection failure → `critical`, offer creation exception → `error`
- **rejecttradeoffer.php**: Missing offer ID → `warning`, DB connection failure → `critical`

Pre-bootstrap `error_log()` calls (line 8 in each file) are preserved since `LoggerFactory` isn't available before `mainfile.php` loads.

### Audit logging
- `trade_offer_created` on successful offer creation (context: offering/listening teams)
- `trade_offer_rejected` on successful offer rejection (context: offer ID)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.