### PR TITLE
feat: add audit logging to free agency mutations

### DIFF
--- a/ibl5/classes/FreeAgency/FreeAgencyAdminProcessor.php
+++ b/ibl5/classes/FreeAgency/FreeAgencyAdminProcessor.php
@@ -238,6 +238,13 @@ class FreeAgencyAdminProcessor implements FreeAgencyAdminProcessorInterface
         $successCount = $counts['successCount'];
         $errorCount = $counts['errorCount'];
 
+        \Logging\LoggerFactory::getChannel('audit')->info('fa_signings_executed', [
+            'action' => 'fa_signings_executed',
+            'day' => $day,
+            'success_count' => $successCount,
+            'error_count' => $errorCount,
+        ]);
+
         if ($errorCount === 0 && $successCount > 0) {
             return [
                 'success' => true,
@@ -261,6 +268,10 @@ class FreeAgencyAdminProcessor implements FreeAgencyAdminProcessorInterface
     public function clearOffers(): array
     {
         $this->repository->clearAllOffers();
+
+        \Logging\LoggerFactory::getChannel('audit')->info('fa_offers_cleared', [
+            'action' => 'fa_offers_cleared',
+        ]);
 
         return [
             'success' => true,

--- a/ibl5/classes/FreeAgency/FreeAgencyProcessor.php
+++ b/ibl5/classes/FreeAgency/FreeAgencyProcessor.php
@@ -318,6 +318,12 @@ _**{$player->teamName}** GM <@!$playerTeamDiscordID> could not be reached for co
 
         $this->repository->deleteOffer($teamid, $playerID);
 
+        \Logging\LoggerFactory::getChannel('audit')->info('fa_offer_deleted', [
+            'action' => 'fa_offer_deleted',
+            'team_name' => $teamName,
+            'player_id' => $playerID,
+        ]);
+
         return ['success' => true];
     }
 }


### PR DESCRIPTION
## Summary

Add audit logging to free agency mutation methods that were missing it. Follows the established pattern from `WaiversProcessor`, `TradeProcessor`, and `DraftSelectionHandler`.

### Changes

- **`FreeAgencyProcessor::deleteOffers()`** — logs `fa_offer_deleted` with team name and player ID
- **`FreeAgencyAdminProcessor::executeSignings()`** — logs `fa_signings_executed` with day, success count, and error count
- **`FreeAgencyAdminProcessor::clearOffers()`** — logs `fa_offers_cleared`

All log calls use `LoggerFactory::getChannel('audit')->info()` and are placed after the successful mutation, consistent with existing audit logging.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.