### PR TITLE
feat: route .sco file reading through archive-first resolver (PR 3/3)

### DIFF
--- a/ibl5/classes/Boxscore/BoxscoreProcessor.php
+++ b/ibl5/classes/Boxscore/BoxscoreProcessor.php
@@ -47,6 +47,27 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
      */
     public function processScoFile(string $filePath, int $seasonEndingYear, string $seasonPhase, bool $skipSimDates = false): array
     {
+        $data = @file_get_contents($filePath);
+        if ($data === false) {
+            return [
+                'success' => false,
+                'gamesInserted' => 0,
+                'gamesUpdated' => 0,
+                'gamesSkipped' => 0,
+                'linesProcessed' => 0,
+                'messages' => [],
+                'error' => 'Failed to open .sco file',
+            ];
+        }
+
+        return $this->processScoData($data, $seasonEndingYear, $seasonPhase, $skipSimDates);
+    }
+
+    /**
+     * @see BoxscoreProcessorInterface::processScoData()
+     */
+    public function processScoData(string $data, int $seasonEndingYear, string $seasonPhase, bool $skipSimDates = false): array
+    {
         /** @var list<string> $messages */
         $messages = [];
 
@@ -56,8 +77,7 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
 
         $messages[] = "Parsing .sco file for the {$operatingSeasonStartingYear}-{$operatingSeasonEndingYear} {$operatingSeasonPhase}...";
 
-        $scoFile = @fopen($filePath, 'rb');
-        if ($scoFile === false) {
+        if (strlen($data) < ScoFileParser::HEADER_OFFSET_BYTES) {
             return [
                 'success' => false,
                 'gamesInserted' => 0,
@@ -65,23 +85,20 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
                 'gamesSkipped' => 0,
                 'linesProcessed' => 0,
                 'messages' => $messages,
-                'error' => 'Failed to open .sco file',
+                'error' => 'Data too short for .sco format',
             ];
         }
 
-        fseek($scoFile, ScoFileParser::HEADER_OFFSET_BYTES);
-
+        $offset = ScoFileParser::HEADER_OFFSET_BYTES;
         $gamesInserted = 0;
         $gamesUpdated = 0;
         $gamesSkipped = 0;
         $linesProcessed = 0;
         $league = $this->leagueContext !== null ? $this->leagueContext->getCurrentLeague() : 'ibl';
 
-        while (!feof($scoFile)) {
-            $line = fgets($scoFile, ScoFileParser::RECORD_SIZE + 1);
-            if ($line === false) {
-                break;
-            }
+        while ($offset + ScoFileParser::RECORD_SIZE <= strlen($data)) {
+            $line = substr($data, $offset, ScoFileParser::RECORD_SIZE);
+            $offset += ScoFileParser::RECORD_SIZE;
 
             $gameInfoLine = ScoFileParser::extractGameInfo($line);
             $boxscoreGameInfo = Boxscore::withGameInfoLine($gameInfoLine, $operatingSeasonEndingYear, $operatingSeasonPhase, $league);
@@ -95,7 +112,6 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
 
             $gameLinesProcessed = $this->processGameLine($line, $boxscoreGameInfo);
 
-            // Only count the game if data was actually written to the DB
             if ($gameLinesProcessed > 0) {
                 if ($upsertAction === 'update') {
                     $gamesUpdated++;
@@ -110,8 +126,6 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
                 flush();
             }
         }
-
-        fclose($scoFile);
 
         $messages[] = "Number of .sco lines processed: {$linesProcessed}";
         $messages[] = "Games inserted: {$gamesInserted} | Games updated: {$gamesUpdated} | Games skipped: {$gamesSkipped}";
@@ -138,10 +152,27 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
         string $filePath,
         int $seasonEndingYear,
     ): array {
+        $data = @file_get_contents($filePath);
+        if ($data === false) {
+            return [
+                'success' => false,
+                'messages' => ['Failed to open .sco file for All-Star games'],
+            ];
+        }
+
+        return $this->processAllStarGamesData($data, $seasonEndingYear);
+    }
+
+    /**
+     * @see BoxscoreProcessorInterface::processAllStarGamesData()
+     */
+    public function processAllStarGamesData(
+        string $data,
+        int $seasonEndingYear,
+    ): array {
         /** @var list<string> $messages */
         $messages = [];
 
-        // Olympics doesn't have All-Star games
         if ($this->leagueContext !== null && $this->leagueContext->isOlympics()) {
             return [
                 'success' => true,
@@ -152,7 +183,6 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
 
         $operatingSeasonEndingYear = $seasonEndingYear > 0 ? $seasonEndingYear : $this->season->endingYear;
 
-        // Check if regular season has progressed past All-Star Weekend
         $lastBoxScoreDate = $this->season->getLastBoxScoreDate();
         $allStarCutoff = sprintf('%d-%02d-%02d', $operatingSeasonEndingYear, Season::IBL_ALL_STAR_MONTH, Season::IBL_ALL_STAR_BREAK_END_DAY);
 
@@ -164,30 +194,18 @@ class BoxscoreProcessor implements BoxscoreProcessorInterface
             ];
         }
 
-        $scoFile = @fopen($filePath, 'rb');
-        if ($scoFile === false) {
-            return [
-                'success' => false,
-                'messages' => ['Failed to open .sco file for All-Star games'],
-            ];
-        }
+        $risingStarsLine = strlen($data) >= ScoFileParser::RECORD_SIZE
+            ? substr($data, 0, ScoFileParser::RECORD_SIZE)
+            : null;
+        $allStarLine = strlen($data) >= ScoFileParser::RECORD_SIZE * 2
+            ? substr($data, ScoFileParser::RECORD_SIZE, ScoFileParser::RECORD_SIZE)
+            : null;
 
-        fseek($scoFile, 0);
-
-        // Block 0: Rising Stars Game (bytes 0–1999)
-        $risingStarsLine = fgets($scoFile, ScoFileParser::RECORD_SIZE + 1);
-        // Block 1: All-Star Game (bytes 2000–3999)
-        $allStarLine = fgets($scoFile, ScoFileParser::RECORD_SIZE + 1);
-
-        fclose($scoFile);
-
-        // Process Rising Stars Game
-        if ($risingStarsLine !== false && trim(ScoFileParser::extractGameInfo($risingStarsLine)) !== '') {
+        if ($risingStarsLine !== null && trim(ScoFileParser::extractGameInfo($risingStarsLine)) !== '') {
             $this->processRisingStarsGame($risingStarsLine, $operatingSeasonEndingYear, $messages);
         }
 
-        // Process All-Star Game (inserted with default placeholder names)
-        if ($allStarLine !== false && trim(ScoFileParser::extractGameInfo($allStarLine)) !== '') {
+        if ($allStarLine !== null && trim(ScoFileParser::extractGameInfo($allStarLine)) !== '') {
             $this->processAllStarGame($allStarLine, $operatingSeasonEndingYear, $messages);
         }
 

--- a/ibl5/classes/Boxscore/Contracts/BoxscoreProcessorInterface.php
+++ b/ibl5/classes/Boxscore/Contracts/BoxscoreProcessorInterface.php
@@ -37,6 +37,19 @@ interface BoxscoreProcessorInterface
     public function processScoFile(string $filePath, int $seasonEndingYear, string $seasonPhase, bool $skipSimDates = false): array;
 
     /**
+     * Process .sco data from a string and insert/update boxscore records
+     *
+     * Same as processScoFile() but accepts raw binary data instead of a file path.
+     *
+     * @param string $data Raw .sco file contents (must be at least HEADER_OFFSET_BYTES long)
+     * @param int $seasonEndingYear Season ending year (0 to use current season)
+     * @param string $seasonPhase Season phase (empty to use current phase)
+     * @param bool $skipSimDates When true, skip updating ibl_sim_dates
+     * @return array{success: bool, gamesInserted: int, gamesUpdated: int, gamesSkipped: int, linesProcessed: int, messages: list<string>, error?: string}
+     */
+    public function processScoData(string $data, int $seasonEndingYear, string $seasonPhase, bool $skipSimDates = false): array;
+
+    /**
      * Process All-Star Weekend games from the first 4000 bytes of a .sco file
      *
      * Block 0 (bytes 0–1999): Rising Stars Game (Rookies vs Sophomores)
@@ -48,6 +61,20 @@ interface BoxscoreProcessorInterface
      */
     public function processAllStarGames(
         string $filePath,
+        int $seasonEndingYear,
+    ): array;
+
+    /**
+     * Process All-Star Weekend games from raw .sco data
+     *
+     * Same as processAllStarGames() but accepts raw binary data instead of a file path.
+     *
+     * @param string $data Raw .sco file contents (first 4000 bytes used)
+     * @param int $seasonEndingYear Season ending year
+     * @return array{success: bool, messages: list<string>, skipped?: string}
+     */
+    public function processAllStarGamesData(
+        string $data,
         int $seasonEndingYear,
     ): array;
 }

--- a/ibl5/classes/Updater/Steps/ExtractFromBackupStep.php
+++ b/ibl5/classes/Updater/Steps/ExtractFromBackupStep.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Updater\Steps;
 
 use BulkImport\BackupArchiveLocator;
-use BulkImport\Contracts\ArchiveExtractorInterface;
 use BulkImport\Contracts\BackupArchiveLocatorInterface;
 use Season\Season;
 use Updater\Contracts\PipelineStepInterface;
@@ -26,17 +25,13 @@ use Updater\StepResult;
  */
 final class ExtractFromBackupStep implements PipelineStepInterface
 {
-    /** @var list<string> JSB file extensions to extract (.lge, .sch, .plr read directly from archive by JsbSourceResolver) */
-    private const EXTENSIONS = [
-        'sco',
-    ];
+    /** @var list<string> JSB file extensions to extract (all types now read directly from archive by JsbSourceResolver) */
+    private const EXTENSIONS = [];
 
     public function __construct(
         private readonly BackupArchiveLocatorInterface $locator,
-        private readonly ArchiveExtractorInterface $extractor,
         private readonly Season $season,
         private readonly string $basePath,
-        private readonly string $filePrefix,
     ) {
     }
 
@@ -93,31 +88,17 @@ final class ExtractFromBackupStep implements PipelineStepInterface
     }
 
     /**
-     * Extract all JSB files from the archive to the base path.
+     * Extract JSB files from the archive to the base path.
+     *
+     * All file types are now read directly from archive by JsbSourceResolver,
+     * so EXTENSIONS is empty and this always returns 0.
      *
      * @param list<string> $missingExtensions Populated with extensions not found in archive
      * @return int Number of files successfully extracted
      */
     private function extractFiles(string $archivePath, array &$missingExtensions): int
     {
-        $extracted = 0;
-
-        foreach (self::EXTENSIONS as $ext) {
-            $filename = $this->filePrefix . '.' . $ext;
-            $result = $this->extractor->extractSingleFile(
-                $archivePath,
-                $filename,
-                $this->basePath,
-            );
-
-            if ($result !== false) {
-                $extracted++;
-            } else {
-                $missingExtensions[] = $ext;
-            }
-        }
-
-        return $extracted;
+        return 0;
     }
 
     /**

--- a/ibl5/classes/Updater/Steps/ProcessAllStarGamesStep.php
+++ b/ibl5/classes/Updater/Steps/ProcessAllStarGamesStep.php
@@ -7,13 +7,15 @@ namespace Updater\Steps;
 use Boxscore\BoxscoreProcessor;
 use Boxscore\BoxscoreRepository;
 use Boxscore\BoxscoreView;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\StepResult;
 
 /**
  * Step 9: Process All-Star games from .sco file.
  *
- * Skips if the .sco file is missing. Also checks for All-Star team renaming needs.
+ * Reads .sco data via the archive-first resolver. Skips if no .sco source is available.
+ * Also checks for All-Star team renaming needs.
  */
 class ProcessAllStarGamesStep implements PipelineStepInterface
 {
@@ -21,7 +23,7 @@ class ProcessAllStarGamesStep implements PipelineStepInterface
         private readonly BoxscoreProcessor $processor,
         private readonly BoxscoreRepository $boxscoreRepo,
         private readonly BoxscoreView $view,
-        private readonly string $scoPath,
+        private readonly JsbSourceResolverInterface $sourceResolver,
     ) {
     }
 
@@ -32,11 +34,12 @@ class ProcessAllStarGamesStep implements PipelineStepInterface
 
     public function execute(): StepResult
     {
-        if (!is_file($this->scoPath)) {
+        $data = $this->sourceResolver->getContents('sco');
+        if ($data === null) {
             return StepResult::skipped('All-Star games', 'No IBL5.sco file found (skipped)');
         }
 
-        $allStarResult = $this->processor->processAllStarGames($this->scoPath, 0);
+        $allStarResult = $this->processor->processAllStarGamesData($data, 0);
         $inlineHtml = $this->view->renderAllStarLog($allStarResult);
 
         $pendingDefaults = $this->boxscoreRepo->findAllStarGamesWithDefaultNames();

--- a/ibl5/classes/Updater/Steps/ProcessBoxscoresStep.php
+++ b/ibl5/classes/Updater/Steps/ProcessBoxscoresStep.php
@@ -6,20 +6,21 @@ namespace Updater\Steps;
 
 use Boxscore\BoxscoreProcessor;
 use Boxscore\BoxscoreView;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\StepResult;
 
 /**
  * Step 8: Process boxscores from .sco file.
  *
- * Skips if the .sco file is missing.
+ * Reads .sco data via the archive-first resolver. Skips if no .sco source is available.
  */
 class ProcessBoxscoresStep implements PipelineStepInterface
 {
     public function __construct(
         private readonly BoxscoreProcessor $processor,
         private readonly BoxscoreView $view,
-        private readonly string $scoPath,
+        private readonly JsbSourceResolverInterface $sourceResolver,
     ) {
     }
 
@@ -30,11 +31,12 @@ class ProcessBoxscoresStep implements PipelineStepInterface
 
     public function execute(): StepResult
     {
-        if (!is_file($this->scoPath)) {
+        $data = $this->sourceResolver->getContents('sco');
+        if ($data === null) {
             return StepResult::skipped('Boxscores', 'No IBL5.sco file found (skipped)');
         }
 
-        $scoResult = $this->processor->processScoFile($this->scoPath, 0, '');
+        $scoResult = $this->processor->processScoData($data, 0, '');
         $inlineHtml = $this->view->renderParseLog($scoResult);
 
         return StepResult::success($this->getLabel(), inlineHtml: $inlineHtml);

--- a/ibl5/docs/decisions/0012-archive-first-jsb-reading.md
+++ b/ibl5/docs/decisions/0012-archive-first-jsb-reading.md
@@ -1,12 +1,13 @@
 ---
-description: JSB file reading uses archive-first strategy via JsbSourceResolver — reads .lge, .sch, and .plr directly from backup ZIP without extracting to disk.
-last_verified: 2026-04-27
+description: JSB file reading uses archive-first strategy via JsbSourceResolver — reads all JSB file types directly from backup ZIP without extracting to disk.
+last_verified: 2026-05-03
 ---
 
 # ADR-0012: Archive-first JSB file reading
 
 **Status:** Accepted
 **Date:** 2026-04-25
+**Updated:** 2026-05-03
 
 ## Context
 
@@ -14,19 +15,24 @@ The `updateAllTheThings.php` pipeline extracted all 14 JSB file types from the b
 
 ## Decision
 
-Introduce `JsbSourceResolver` (archive-first, disk-fallback) and `ArchiveExtractor::extractToString()` so that `.lge`, `.sch`, and `.plr` data is read directly from the backup archive without writing to disk. `LgeFileParser` and `SchFileParser` gain a `parse(string $data)` method accepting raw bytes; `LeagueConfigService` gains a `processLgeData(string $data)` sibling to the existing `processLgeFile()`; and `PlrParserService` gains `processPlrData(string $data)` and `processPlrDataForYear(string $data, ...)` siblings to the file-based methods. The disk path remains as a fallback for manual uploads or when no backup archive exists.
+Introduce `JsbSourceResolver` (archive-first, disk-fallback) and `ArchiveExtractor::extractToString()` so that all JSB file data is read directly from the backup archive without writing to disk. Parsers and services gain `*Data(string $data)` sibling methods to their file-based counterparts. The disk path remains as a fallback for manual uploads or when no backup archive exists.
 
-`ExtractFromBackupStep` no longer extracts `.lge`, `.sch`, or `.plr` — only `.sco` remains on the disk-extraction path. Other file types continue to be extracted to disk because their consumers are not yet refactored.
+The migration was completed in three PRs:
+
+1. **PR 1 (#648):** Routed `.lge`, `.sch`, and 10 JSB-parser file types through `JsbSourceResolverInterface`.
+2. **PR 2 (#653):** Routed `.plr` files — `PlrParserService` gained `processPlrData()` and `processPlrDataForYear()`.
+3. **PR 3:** Routed `.sco` files — `BoxscoreProcessor` gained `processScoData()` and `processAllStarGamesData()`. `ExtractFromBackupStep::EXTENSIONS` is now empty; no file types are extracted to disk.
 
 ## Alternatives Considered
 
 - **Extract all to disk, then read** — the status quo. Rejected because: files linger in `ibl5/`, no reason for the I/O round-trip on files already available in the archive.
-- **Read all 14 file types from archive in one PR** — full migration. Rejected because: higher blast radius; `.sco` and the JSB-parser file types have more complex calling patterns. The resolver pattern makes it easy to extend later — `.plr` was the second file type migrated.
+- **Read all 14 file types from archive in one PR** — full migration. Rejected because: higher blast radius; `.sco` and `.plr` have more complex calling patterns. The resolver pattern made it easy to extend incrementally.
 
 ## Consequences
 
-- Positive: `.lge` and `.sch` no longer written to the web-accessible `ibl5/` directory during pipeline runs.
-- Positive: `parse(string $data)` on both parsers makes them testable without disk I/O.
+- Positive: No JSB files are written to the web-accessible `ibl5/` directory during pipeline runs.
+- Positive: `*Data(string $data)` methods on parsers/services make them testable without disk I/O.
+- Positive: `ExtractFromBackupStep` no longer extracts any files — it only handles backup locating and auto-renaming.
 - Negative: `ArchiveExtractorInterface` gained a new method (`extractToString`), breaking any out-of-tree implementations.
 - Negative: RAR archives still require a temp file for `extractToString()` (shell tools cannot stream to PHP memory).
 
@@ -35,6 +41,7 @@ Introduce `JsbSourceResolver` (archive-first, disk-fallback) and `ArchiveExtract
 - `ibl5/classes/Updater/JsbSourceResolver.php` — archive-first resolver
 - `ibl5/classes/Updater/Contracts/JsbSourceResolverInterface.php` — resolver contract
 - `ibl5/classes/BulkImport/Contracts/ArchiveExtractorInterface.php` — `extractToString()` addition
+- `ibl5/classes/Boxscore/BoxscoreProcessor.php` — `processScoData()`, `processAllStarGamesData()` methods
 - `ibl5/classes/LeagueConfig/LgeFileParser.php` — `parse(string $data)` method
 - `ibl5/classes/Utilities/SchFileParser.php` — `parse(string $data)` method
 - `ibl5/classes/LeagueConfig/LeagueConfigService.php` — `processLgeData(string $data)` method

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -131,8 +131,6 @@ try {
     // --- Pipeline: register all steps and delegate to controller ---
     $updaterService = new Updater\UpdaterService();
 
-    $defaultScoPath = $basePath . '/' . $filePrefix . '.sco';
-
     $lgeRepo = new LeagueConfig\LeagueConfigRepository($mysqli_db, $leagueContext);
     $lgeService = new LeagueConfig\LeagueConfigService($lgeRepo);
     $lgeView = new LeagueConfig\LeagueConfigView();
@@ -154,7 +152,7 @@ try {
     $archiveExtractor = new BulkImport\ArchiveExtractor();
     $backupLocator = new BulkImport\BackupArchiveLocator($archiveExtractor);
     $updaterService->addStep(new Updater\Steps\ExtractFromBackupStep(
-        $backupLocator, $archiveExtractor, $season, $basePath, $filePrefix,
+        $backupLocator, $season, $basePath,
     ));
 
     // JsbSourceResolver reads .lge/.sch directly from archive (disk-fallback)
@@ -205,13 +203,13 @@ try {
     ));
 
     $updaterService->addStep(new Updater\Steps\ProcessBoxscoresStep(
-        $boxscoreProcessor, $boxscoreView, $defaultScoPath,
+        $boxscoreProcessor, $boxscoreView, $sourceResolver,
     ));
 
     // IBL-only: All-Star games don't exist in Olympics
     if (!$isOlympics) {
         $updaterService->addStep(new Updater\Steps\ProcessAllStarGamesStep(
-            $boxscoreProcessor, $boxscoreRepo, $boxscoreView, $defaultScoPath,
+            $boxscoreProcessor, $boxscoreRepo, $boxscoreView, $sourceResolver,
         ));
         $updaterService->addStep(new Updater\Steps\RefreshPlayoffSeriesResultsStep($mysqli_db));
         $updaterService->addStep(new Updater\Steps\RefreshTeamSeasonRecordsStep($mysqli_db));

--- a/ibl5/tests/Boxscore/BoxscoreProcessorTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreProcessorTest.php
@@ -191,7 +191,7 @@ class BoxscoreProcessorTest extends TestCase
         $olympicsContext->method('getTableName')->willReturnArgument(0);
 
         $processor = new BoxscoreProcessor($this->mockDb, null, null, $olympicsContext);
-        $result = $processor->processAllStarGames('/nonexistent/file.sco', 2025);
+        $result = $processor->processAllStarGamesData('dummy data', 2025);
 
         $this->assertTrue($result['success']);
         $this->assertSame('Olympics context', $result['skipped']);
@@ -543,24 +543,23 @@ class BoxscoreProcessorTest extends TestCase
 
     // --- processAllStarGames tests ---
 
-    public function testProcessAllStarGamesSkipsBeforeCutoff(): void
+    public function testProcessAllStarGamesDataSkipsBeforeCutoff(): void
     {
         $mockDb = new \MockDatabase();
         $mockDb->setReturnTrue(true);
 
         $repository = new BoxscoreRepository($mockDb);
         $seasonStub = $this->createStub(Season::class);
-        // Last box score date is before the All-Star cutoff (Feb 4)
         $seasonStub->method('getLastBoxScoreDate')->willReturn('2026-01-15');
 
         $processor = new BoxscoreProcessor($mockDb, $repository, $seasonStub);
-        $result = $processor->processAllStarGames('/nonexistent/file.sco', 2026);
+        $result = $processor->processAllStarGamesData('dummy data', 2026);
 
         $this->assertTrue($result['success']);
         $this->assertSame('All-Star Weekend not yet reached', $result['skipped']);
     }
 
-    public function testProcessAllStarGamesSkipsWhenNoBoxScoreDateExists(): void
+    public function testProcessAllStarGamesDataSkipsWhenNoBoxScoreDateExists(): void
     {
         $mockDb = new \MockDatabase();
         $mockDb->setReturnTrue(true);
@@ -570,10 +569,53 @@ class BoxscoreProcessorTest extends TestCase
         $seasonStub->method('getLastBoxScoreDate')->willReturn('');
 
         $processor = new BoxscoreProcessor($mockDb, $repository, $seasonStub);
-        $result = $processor->processAllStarGames('/nonexistent/file.sco', 2026);
+        $result = $processor->processAllStarGamesData('dummy data', 2026);
 
         $this->assertTrue($result['success']);
         $this->assertSame('All-Star Weekend not yet reached', $result['skipped']);
+    }
+
+    public function testProcessScoDataReturnsErrorForTooShortData(): void
+    {
+        $mockDb = new \MockDatabase();
+        $mockDb->setReturnTrue(true);
+
+        $repository = new BoxscoreRepository($mockDb);
+        $seasonStub = $this->createStub(Season::class);
+        $seasonStub->lastSimEndDate = '';
+
+        $processor = new BoxscoreProcessor($mockDb, $repository, $seasonStub);
+        $result = $processor->processScoData('too short', 2026, 'Regular Season');
+
+        $this->assertFalse($result['success']);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsString('too short', $result['error']);
+    }
+
+    public function testProcessScoDataInsertsNewGame(): void
+    {
+        $mockDb = new \MockDatabase();
+        $mockDb->setReturnTrue(true);
+        $mockDb->onQuery('(?s)SELECT.*ibl_box_scores_teams.*WHERE', []);
+
+        $repository = new BoxscoreRepository($mockDb);
+        $seasonStub = $this->createStub(Season::class);
+        $seasonStub->lastSimEndDate = '';
+        $seasonStub->method('getLastBoxScoreDate')->willReturn('2026-01-11');
+        $seasonStub->method('getFirstBoxScoreDate')->willReturn('2026-01-11');
+        $seasonStub->method('setLastSimDatesArray')->willReturn(1);
+
+        $scoFile = $this->buildScoFileWithOneGame($this->buildGameInfoLine(3, 10));
+        $data = file_get_contents($scoFile);
+        $this->assertNotFalse($data);
+
+        $processor = new BoxscoreProcessor($mockDb, $repository, $seasonStub);
+        $result = $processor->processScoData($data, 2026, 'Regular Season/Playoffs', skipSimDates: true);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(1, $result['gamesInserted']);
+        $this->assertSame(0, $result['gamesSkipped']);
+        $this->assertGreaterThan(0, $result['linesProcessed']);
     }
 
     // --- Helper methods ---

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
@@ -253,7 +253,6 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
     protected function buildPipeline(
         Season $season,
         string $schPath,
-        string $scoPath,
     ): UpdaterService {
         $service = new UpdaterService();
 
@@ -319,11 +318,11 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
         ));
 
         $service->addStep(new Steps\ProcessBoxscoresStep(
-            $boxscoreProcessor, $boxscoreView, $scoPath,
+            $boxscoreProcessor, $boxscoreView, $jsbFileResolver,
         ));
 
         $service->addStep(new Steps\ProcessAllStarGamesStep(
-            $boxscoreProcessor, $boxscoreRepo, $boxscoreView, $scoPath,
+            $boxscoreProcessor, $boxscoreRepo, $boxscoreView, $jsbFileResolver,
         ));
 
         $service->addStep(new Steps\ParseJsbFilesStep($jsbService, $jsbFileResolver, $season->endingYear));

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonPipelineTest.php
@@ -24,9 +24,9 @@ class PreseasonPipelineTest extends PipelineIntegrationTestCase
             ['pid' => 200001, 'name' => 'Preseason Player A', 'teamid' => 1, 'ordinal' => 1],
             ['pid' => 200002, 'name' => 'Preseason Player B', 'teamid' => 2, 'ordinal' => 2],
         ]);
-        $scoPath = $this->buildScoFile();
+        $this->buildScoFile();
 
-        $pipeline = $this->buildPipeline($season, $schPath, $scoPath);
+        $pipeline = $this->buildPipeline($season, $schPath);
         $results = $this->runPipeline($pipeline);
 
         $this->assertZeroPipelineErrors($pipeline, $results);
@@ -56,9 +56,9 @@ class PreseasonPipelineTest extends PipelineIntegrationTestCase
             ['pid' => 200001, 'name' => 'Playoff Player A', 'teamid' => 1, 'ordinal' => 1],
             ['pid' => 200002, 'name' => 'Playoff Player B', 'teamid' => 2, 'ordinal' => 2],
         ]);
-        $scoPath = $this->buildScoFile();
+        $this->buildScoFile();
 
-        $pipeline = $this->buildPipeline($season, $schPath, $scoPath);
+        $pipeline = $this->buildPipeline($season, $schPath);
         $results = $this->runPipeline($pipeline);
 
         $this->assertZeroPipelineErrors($pipeline, $results);

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
@@ -52,9 +52,9 @@ class PreseasonTransitionPipelineTest extends PipelineIntegrationTestCase
             ['pid' => 200001, 'name' => 'Pipeline Player A', 'teamid' => 1, 'ordinal' => 1],
             ['pid' => 200002, 'name' => 'Pipeline Player B', 'teamid' => 2, 'ordinal' => 2],
         ]);
-        $scoPath = $this->buildScoFile();
+        $this->buildScoFile();
 
-        $pipeline = $this->buildPipeline($season, $schPath, $scoPath);
+        $pipeline = $this->buildPipeline($season, $schPath);
         $results = $this->runPipeline($pipeline);
 
         $this->assertZeroPipelineErrors($pipeline, $results);

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/RegularSeasonPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/RegularSeasonPipelineTest.php
@@ -29,9 +29,9 @@ class RegularSeasonPipelineTest extends PipelineIntegrationTestCase
             ['pid' => 200003, 'name' => 'RS Player C', 'teamid' => 3, 'ordinal' => 3],
             ['pid' => 200004, 'name' => 'RS Player D', 'teamid' => 4, 'ordinal' => 4],
         ]);
-        $scoPath = $this->buildScoFile();
+        $this->buildScoFile();
 
-        $pipeline = $this->buildPipeline($season, $schPath, $scoPath);
+        $pipeline = $this->buildPipeline($season, $schPath);
         $results = $this->runPipeline($pipeline);
 
         $this->assertZeroPipelineErrors($pipeline, $results);

--- a/ibl5/tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\UpdateAllTheThings\Steps;
 
-use BulkImport\Contracts\ArchiveExtractorInterface;
 use BulkImport\Contracts\BackupArchiveLocatorInterface;
 use PHPUnit\Framework\TestCase;
 use Season\Season;
@@ -14,13 +13,11 @@ use Updater\Steps\ExtractFromBackupStep;
 class ExtractFromBackupStepTest extends TestCase
 {
     private BackupArchiveLocatorInterface $stubLocator;
-    private ArchiveExtractorInterface $stubExtractor;
     private Season $stubSeason;
 
     protected function setUp(): void
     {
         $this->stubLocator = $this->createStub(BackupArchiveLocatorInterface::class);
-        $this->stubExtractor = $this->createStub(ArchiveExtractorInterface::class);
         $this->stubSeason = $this->createStub(Season::class);
         $this->stubSeason->beginningYear = 2025;
         $this->stubSeason->endingYear = 2026;
@@ -30,10 +27,8 @@ class ExtractFromBackupStepTest extends TestCase
     {
         $step = new ExtractFromBackupStep(
             $this->stubLocator,
-            $this->stubExtractor,
             $this->stubSeason,
             '/tmp',
-            'IBL5',
         );
 
         $this->assertInstanceOf(PipelineStepInterface::class, $step);
@@ -43,10 +38,8 @@ class ExtractFromBackupStepTest extends TestCase
     {
         $step = new ExtractFromBackupStep(
             $this->stubLocator,
-            $this->stubExtractor,
             $this->stubSeason,
             '/tmp',
-            'IBL5',
         );
 
         $this->assertSame('Backup extracted', $step->getLabel());
@@ -58,10 +51,8 @@ class ExtractFromBackupStepTest extends TestCase
 
         $step = new ExtractFromBackupStep(
             $this->stubLocator,
-            $this->stubExtractor,
             $this->stubSeason,
             '/tmp',
-            'IBL5',
         );
         $result = $step->execute();
 
@@ -69,26 +60,21 @@ class ExtractFromBackupStepTest extends TestCase
         $this->assertStringContainsString('No backup found', $result->detail);
     }
 
-    public function testExtractsFilesFromBackup(): void
+    public function testExtractsZeroFilesFromBackup(): void
     {
         $this->stubLocator->method('findLatestArchive')
             ->willReturn('/tmp/backups/25-26/25-26_15_reg-sim15.zip');
         $this->stubLocator->method('isProperlyNamed')->willReturn(true);
 
-        // EXTENSIONS = ['sco'] — single extension, extraction succeeds
-        $this->stubExtractor->method('extractSingleFile')->willReturn('/tmp/IBL5.sco');
-
         $step = new ExtractFromBackupStep(
             $this->stubLocator,
-            $this->stubExtractor,
             $this->stubSeason,
             '/tmp',
-            'IBL5',
         );
         $result = $step->execute();
 
         $this->assertTrue($result->success);
-        $this->assertStringContainsString('Extracted 1 files', $result->detail);
+        $this->assertStringContainsString('Extracted 0 files', $result->detail);
     }
 
     public function testSkipsRenameForProperlyNamedBackup(): void
@@ -96,47 +82,17 @@ class ExtractFromBackupStepTest extends TestCase
         $this->stubLocator->method('findLatestArchive')
             ->willReturn('/tmp/backups/25-26/25-26_15_reg-sim15.zip');
         $this->stubLocator->method('isProperlyNamed')->willReturn(true);
-        $this->stubExtractor->method('extractSingleFile')->willReturn(false);
-        // Note: extractFiles() builds filenames directly as filePrefix + ext,
-        // not via extractor->jsbFilename(). No jsbFilename stub needed.
 
         $step = new ExtractFromBackupStep(
             $this->stubLocator,
-            $this->stubExtractor,
             $this->stubSeason,
             '/tmp',
-            'IBL5',
         );
         $result = $step->execute();
 
         $this->assertTrue($result->success);
-        // No rename message in messages for properly named files
         foreach ($result->messages as $msg) {
             $this->assertStringNotContainsString('renamed from', $msg);
         }
-    }
-
-    public function testHandlesMissingFilesInArchiveGracefully(): void
-    {
-        $this->stubLocator->method('findLatestArchive')
-            ->willReturn('/tmp/backups/25-26/25-26_15_reg-sim15.zip');
-        $this->stubLocator->method('isProperlyNamed')->willReturn(true);
-
-        // All extractions fail (no files in archive)
-        $this->stubExtractor->method('extractSingleFile')->willReturn(false);
-        // Note: extractFiles() builds filenames directly as filePrefix + ext,
-        // not via extractor->jsbFilename(). No jsbFilename stub needed.
-
-        $step = new ExtractFromBackupStep(
-            $this->stubLocator,
-            $this->stubExtractor,
-            $this->stubSeason,
-            '/tmp',
-            'IBL5',
-        );
-        $result = $step->execute();
-
-        $this->assertTrue($result->success);
-        $this->assertStringContainsString('Extracted 0 files', $result->detail);
     }
 }

--- a/ibl5/tests/UpdateAllTheThings/Steps/ProcessAllStarGamesStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ProcessAllStarGamesStepTest.php
@@ -8,6 +8,7 @@ use Boxscore\BoxscoreProcessor;
 use Boxscore\BoxscoreRepository;
 use Boxscore\BoxscoreView;
 use PHPUnit\Framework\TestCase;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\Steps\ProcessAllStarGamesStep;
 
@@ -16,12 +17,14 @@ class ProcessAllStarGamesStepTest extends TestCase
     private BoxscoreProcessor $stubProcessor;
     private BoxscoreRepository $stubRepo;
     private BoxscoreView $stubView;
+    private JsbSourceResolverInterface $stubResolver;
 
     protected function setUp(): void
     {
         $this->stubProcessor = $this->createStub(BoxscoreProcessor::class);
         $this->stubRepo = $this->createStub(BoxscoreRepository::class);
         $this->stubView = $this->createStub(BoxscoreView::class);
+        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
     }
 
     public function testImplementsPipelineStepInterface(): void
@@ -30,7 +33,7 @@ class ProcessAllStarGamesStepTest extends TestCase
             $this->stubProcessor,
             $this->stubRepo,
             $this->stubView,
-            '/tmp/IBL5.sco',
+            $this->stubResolver,
         );
 
         $this->assertInstanceOf(PipelineStepInterface::class, $step);
@@ -42,19 +45,21 @@ class ProcessAllStarGamesStepTest extends TestCase
             $this->stubProcessor,
             $this->stubRepo,
             $this->stubView,
-            '/tmp/IBL5.sco',
+            $this->stubResolver,
         );
 
         $this->assertSame('All-Star games processed', $step->getLabel());
     }
 
-    public function testSkipsWhenFileNotFound(): void
+    public function testSkipsWhenResolverReturnsNull(): void
     {
+        $this->stubResolver->method('getContents')->willReturn(null);
+
         $step = new ProcessAllStarGamesStep(
             $this->stubProcessor,
             $this->stubRepo,
             $this->stubView,
-            '/nonexistent/IBL5.sco',
+            $this->stubResolver,
         );
         $result = $step->execute();
 
@@ -64,23 +69,19 @@ class ProcessAllStarGamesStepTest extends TestCase
 
     public function testSuccessfulProcessingWithoutPendingRenames(): void
     {
-        $this->stubProcessor->method('processAllStarGames')->willReturn([
+        $this->stubResolver->method('getContents')->willReturn('sco data');
+        $this->stubProcessor->method('processAllStarGamesData')->willReturn([
             'success' => true,
             'messages' => [],
         ]);
         $this->stubRepo->method('findAllStarGamesWithDefaultNames')->willReturn([]);
         $this->stubView->method('renderAllStarLog')->willReturn('<div>All-Star OK</div>');
 
-        $path = tempnam(sys_get_temp_dir(), 'sco_test_');
-        if ($path === false) {
-            $this->fail('Failed to create temp file');
-        }
-
         $step = new ProcessAllStarGamesStep(
             $this->stubProcessor,
             $this->stubRepo,
             $this->stubView,
-            $path,
+            $this->stubResolver,
         );
         $result = $step->execute();
 
@@ -91,7 +92,8 @@ class ProcessAllStarGamesStepTest extends TestCase
 
     public function testSuccessfulProcessingWithPendingRenames(): void
     {
-        $this->stubProcessor->method('processAllStarGames')->willReturn([
+        $this->stubResolver->method('getContents')->willReturn('sco data');
+        $this->stubProcessor->method('processAllStarGamesData')->willReturn([
             'success' => true,
             'messages' => [],
         ]);
@@ -102,16 +104,11 @@ class ProcessAllStarGamesStepTest extends TestCase
         $this->stubView->method('renderAllStarLog')->willReturn('<div>Log</div>');
         $this->stubView->method('renderAllStarRenameUI')->willReturn('<div>Rename UI</div>');
 
-        $path = tempnam(sys_get_temp_dir(), 'sco_test_');
-        if ($path === false) {
-            $this->fail('Failed to create temp file');
-        }
-
         $step = new ProcessAllStarGamesStep(
             $this->stubProcessor,
             $this->stubRepo,
             $this->stubView,
-            $path,
+            $this->stubResolver,
         );
         $result = $step->execute();
 

--- a/ibl5/tests/UpdateAllTheThings/Steps/ProcessBoxscoresStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ProcessBoxscoresStepTest.php
@@ -7,6 +7,7 @@ namespace Tests\UpdateAllTheThings\Steps;
 use Boxscore\BoxscoreProcessor;
 use Boxscore\BoxscoreView;
 use PHPUnit\Framework\TestCase;
+use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Contracts\PipelineStepInterface;
 use Updater\Steps\ProcessBoxscoresStep;
 
@@ -14,30 +15,34 @@ class ProcessBoxscoresStepTest extends TestCase
 {
     private BoxscoreProcessor $stubProcessor;
     private BoxscoreView $stubView;
+    private JsbSourceResolverInterface $stubResolver;
 
     protected function setUp(): void
     {
         $this->stubProcessor = $this->createStub(BoxscoreProcessor::class);
         $this->stubView = $this->createStub(BoxscoreView::class);
+        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
     }
 
     public function testImplementsPipelineStepInterface(): void
     {
-        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, '/tmp/IBL5.sco');
+        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, $this->stubResolver);
 
         $this->assertInstanceOf(PipelineStepInterface::class, $step);
     }
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, '/tmp/IBL5.sco');
+        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, $this->stubResolver);
 
         $this->assertSame('Boxscores processed', $step->getLabel());
     }
 
-    public function testSkipsWhenFileNotFound(): void
+    public function testSkipsWhenResolverReturnsNull(): void
     {
-        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, '/nonexistent/IBL5.sco');
+        $this->stubResolver->method('getContents')->willReturn(null);
+
+        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, $this->stubResolver);
         $result = $step->execute();
 
         $this->assertTrue($result->success);
@@ -55,15 +60,11 @@ class ProcessBoxscoresStepTest extends TestCase
             'messages' => [],
         ];
 
-        $this->stubProcessor->method('processScoFile')->willReturn($scoResult);
+        $this->stubResolver->method('getContents')->willReturn('sco data');
+        $this->stubProcessor->method('processScoData')->willReturn($scoResult);
         $this->stubView->method('renderParseLog')->willReturn('<div>10 games inserted</div>');
 
-        $path = tempnam(sys_get_temp_dir(), 'sco_test_');
-        if ($path === false) {
-            $this->fail('Failed to create temp file');
-        }
-
-        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, $path);
+        $step = new ProcessBoxscoresStep($this->stubProcessor, $this->stubView, $this->stubResolver);
         $result = $step->execute();
 
         $this->assertTrue($result->success);


### PR DESCRIPTION
## Summary

Routes `.sco` file reading through `JsbSourceResolverInterface` (archive-first, disk-fallback), completing the 3-PR JsbSourceResolver migration series.

### Changes

- **BoxscoreProcessor**: Added `processScoData()` and `processAllStarGamesData()` string-based methods; file-based methods reduced to thin wrappers
- **ProcessBoxscoresStep**: Now injects `JsbSourceResolverInterface` instead of `string $scoPath`
- **ProcessAllStarGamesStep**: Now injects `JsbSourceResolverInterface` instead of `string $scoPath`
- **ExtractFromBackupStep**: `EXTENSIONS` emptied — no JSB file types are extracted to disk
- **ADR-0012**: Updated to reflect completion of the 3-PR migration series
- Full test coverage for new data methods and rewired step constructors

### Files Changed (15)

| Area | Files |
|------|-------|
| Boxscore | `BoxscoreProcessor.php`, `BoxscoreProcessorInterface.php` |
| Updater Steps | `ProcessBoxscoresStep.php`, `ProcessAllStarGamesStep.php`, `ExtractFromBackupStep.php` |
| Script | `updateAllTheThings.php` |
| ADR | `0012-archive-first-jsb-reading.md` |
| Tests (8) | `BoxscoreProcessorTest.php`, `ProcessBoxscoresStepTest.php`, `ProcessAllStarGamesStepTest.php`, `ExtractFromBackupStepTest.php`, `PipelineIntegrationTestCase.php`, `PreseasonPipelineTest.php`, `PreseasonTransitionPipelineTest.php`, `RegularSeasonPipelineTest.php` |

## Manual Testing

No manual testing needed — all changes are covered by unit and integration tests.

## Related

- PR 1/3: #648 (merged) — JsbParser file types
- PR 2/3: #653 (merged) — .plr files
- ADR: [0012-archive-first-jsb-reading](ibl5/docs/decisions/0012-archive-first-jsb-reading.md)