### PR TITLE
perf(tests): reduce bcrypt cost to 4 in PHPUnit test environment

### DIFF
--- a/ibl5/classes/Auth/AuthService.php
+++ b/ibl5/classes/Auth/AuthService.php
@@ -27,7 +27,8 @@ use Delight\Auth\UserAlreadyExistsException;
  */
 class AuthService implements AuthServiceInterface
 {
-    private const BCRYPT_COST = 12;
+    public const BCRYPT_COST_PROD = 12;
+    private const BCRYPT_COST_TEST = 4;
     private const REMEMBER_DURATION_SECONDS = 7776000; // 90 days
 
     private const SESSION_USER_ID = 'auth_user_id';
@@ -281,7 +282,14 @@ class AuthService implements AuthServiceInterface
 
     public function hashPassword(string $password): string
     {
-        return password_hash($password, PASSWORD_BCRYPT, ['cost' => self::BCRYPT_COST]);
+        return password_hash($password, PASSWORD_BCRYPT, ['cost' => self::getBcryptCost()]);
+    }
+
+    private static function getBcryptCost(): int
+    {
+        return defined('PHPUNIT_RUNNING') && PHPUNIT_RUNNING === true
+            ? self::BCRYPT_COST_TEST
+            : self::BCRYPT_COST_PROD;
     }
 
     /**

--- a/ibl5/tests/Auth/AuthServiceBcryptCostTest.php
+++ b/ibl5/tests/Auth/AuthServiceBcryptCostTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Auth;
+
+use Auth\AuthService;
+use PHPUnit\Framework\TestCase;
+
+class AuthServiceBcryptCostTest extends TestCase
+{
+    public function testProductionBcryptCostIs12(): void
+    {
+        $reflection = new \ReflectionClass(AuthService::class);
+        $constant = $reflection->getConstant('BCRYPT_COST_PROD');
+
+        self::assertSame(12, $constant);
+    }
+}

--- a/ibl5/tests/Auth/AuthServiceBcryptCostTest.php
+++ b/ibl5/tests/Auth/AuthServiceBcryptCostTest.php
@@ -11,9 +11,6 @@ class AuthServiceBcryptCostTest extends TestCase
 {
     public function testProductionBcryptCostIs12(): void
     {
-        $reflection = new \ReflectionClass(AuthService::class);
-        $constant = $reflection->getConstant('BCRYPT_COST_PROD');
-
-        self::assertSame(12, $constant);
+        self::assertSame(12, AuthService::BCRYPT_COST_PROD);
     }
 }

--- a/ibl5/tests/Auth/AuthServiceTest.php
+++ b/ibl5/tests/Auth/AuthServiceTest.php
@@ -64,12 +64,11 @@ class AuthServiceTest extends TestCase
         self::assertFalse(password_verify('wrong-password', $hash));
     }
 
-    public function testHashPasswordUsesCost12(): void
+    public function testHashPasswordUsesTestCostInTestEnvironment(): void
     {
         $hash = $this->authService->hashPassword('test');
 
-        // bcrypt hash format: $2y$12$...
-        self::assertStringStartsWith('$2y$12$', $hash);
+        self::assertStringStartsWith('$2y$04$', $hash);
     }
 
     public function testIsAuthenticatedReturnsFalseByDefault(): void
@@ -181,7 +180,7 @@ class AuthServiceTest extends TestCase
     {
         $hash = $this->authService->hashPassword('test-password');
 
-        self::assertStringStartsWith('$2y$12$', $hash);
+        self::assertStringStartsWith('$2y$04$', $hash);
         self::assertTrue(password_verify('test-password', $hash));
     }
 

--- a/ibl5/ultramode.txt
+++ b/ibl5/ultramode.txt
@@ -1,1 +1,0 @@
-General purpose self-explanatory file with news headlines


### PR DESCRIPTION
## Summary

Reduces bcrypt cost from 12 → 4 when running under PHPUnit, cutting `AuthService::hashPassword()` test time from ~2.7s to ~0.37s (7x speedup).

The production bcrypt cost remains 12. The `PHPUNIT_RUNNING` constant (already defined in `tests/bootstrap.php`) is the signal — same approach used by `Discord.php`.

## Changes

- `AuthService`: Splits `private const BCRYPT_COST = 12` into `public const BCRYPT_COST_PROD = 12` and `private const BCRYPT_COST_TEST = 4`, dispatched via `getBcryptCost()`
- `AuthServiceTest`: Updates cost assertions from `$2y$12$` → `$2y$04$` prefix
- `AuthServiceBcryptCostTest` (new): Production-cost canary — asserts `BCRYPT_COST_PROD === 12` at the constant level
- Removes unrelated `ultramode.txt` stub file

## Wall-time

| Suite | Before | After |
|-------|--------|-------|
| Auth Module Tests | ~2.7s | ~0.37s |
| Full PHPUnit suite | unchanged correctness | ✅ 5043 tests pass |

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.