### PR TITLE
fix: narrow preseason cleanup date range to prevent HEAT sim data overwrite

### DIFF
--- a/ibl5/classes/Boxscore/BoxscoreRepository.php
+++ b/ibl5/classes/Boxscore/BoxscoreRepository.php
@@ -41,7 +41,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
     public function deletePreseasonBoxScores(int $seasonBeginningYear): bool
     {
         $startDate = "{$seasonBeginningYear}-09-01";
-        $endDate = "{$seasonBeginningYear}-10-31";
+        $endDate = "{$seasonBeginningYear}-09-30";
 
         return $this->deleteBoxScoresForDateRange($startDate, $endDate);
     }

--- a/ibl5/classes/Boxscore/Contracts/BoxscoreRepositoryInterface.php
+++ b/ibl5/classes/Boxscore/Contracts/BoxscoreRepositoryInterface.php
@@ -16,8 +16,7 @@ interface BoxscoreRepositoryInterface
     /**
      * Delete preseason boxscores for both players and teams
      *
-     * Removes all boxscore records from November through December
-     * of the given season beginning year.
+     * Removes all preseason boxscore records (September) of the given season beginning year.
      *
      * @param int $seasonBeginningYear The year the season starts (e.g., 2024 for 2024-25 season)
      * @return bool True if both deletions succeeded, false otherwise

--- a/ibl5/classes/Updater/Steps/CleanupPreseasonDataStep.php
+++ b/ibl5/classes/Updater/Steps/CleanupPreseasonDataStep.php
@@ -55,7 +55,7 @@ final class CleanupPreseasonDataStep implements PipelineStepInterface
         $cleaned = [];
 
         $this->boxscoreRepo->deletePreseasonBoxScores($this->season->beginningYear);
-        $cleaned[] = 'box scores (Sep-Oct)';
+        $cleaned[] = 'box scores (Sep)';
 
         $this->cleanupRepo->deletePreseasonSimDates($this->season->beginningYear);
         $cleaned[] = 'sim dates';

--- a/ibl5/classes/Updater/Steps/CleanupPreseasonDataStep.php
+++ b/ibl5/classes/Updater/Steps/CleanupPreseasonDataStep.php
@@ -13,7 +13,7 @@ use Updater\StepResult;
 /**
  * Clean up preseason data on the first HEAT sim.
  *
- * Preseason games are stored with Sep-Oct dates. When the phase transitions
+ * Preseason games are stored with September dates. When the phase transitions
  * to HEAT, stale preseason data must be cleared so the HEAT pipeline can
  * re-import fresh data from JSB files.
  *

--- a/ibl5/classes/Updater/Steps/PreseasonCleanupRepository.php
+++ b/ibl5/classes/Updater/Steps/PreseasonCleanupRepository.php
@@ -15,7 +15,7 @@ final class PreseasonCleanupRepository extends \BaseMysqliRepository
     {
         $boxScoresTable = $this->resolveTable('ibl_box_scores_teams');
         $startDate = sprintf('%d-09-01', $beginningYear);
-        $endDate = sprintf('%d-10-31', $beginningYear);
+        $endDate = sprintf('%d-09-30', $beginningYear);
 
         /** @var array{cnt: int}|null $row */
         $row = $this->fetchOne(
@@ -31,7 +31,7 @@ final class PreseasonCleanupRepository extends \BaseMysqliRepository
     public function deletePreseasonSimDates(int $beginningYear): void
     {
         $startDate = sprintf('%d-09-01', $beginningYear);
-        $endDate = sprintf('%d-10-31', $beginningYear);
+        $endDate = sprintf('%d-09-30', $beginningYear);
 
         $this->execute(
             "DELETE FROM ibl_sim_dates WHERE end_date BETWEEN ? AND ?",

--- a/ibl5/tests/Boxscore/BoxscoreRepositoryTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreRepositoryTest.php
@@ -60,7 +60,7 @@ class BoxscoreRepositoryTest extends TestCase
 
         $queries = $this->mockDb->getExecutedQueries();
         $this->assertStringContainsString('2025-09-01', $queries[0]);
-        $this->assertStringContainsString('2025-10-31', $queries[0]);
+        $this->assertStringContainsString('2025-09-30', $queries[0]);
     }
 
     public function testDeleteHeatBoxScoresUsesCorrectDateRange(): void

--- a/ibl5/tests/DatabaseIntegration/PreseasonCleanupRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/PreseasonCleanupRepositoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use Updater\Steps\PreseasonCleanupRepository;
+
+class PreseasonCleanupRepositoryTest extends DatabaseTestCase
+{
+    private PreseasonCleanupRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new PreseasonCleanupRepository($this->db);
+    }
+
+    public function testHasPreseasonBoxScoresReturnsFalseWithOnlyOctoberData(): void
+    {
+        $this->insertTeamBoxscoreRow('2098-10-15', 'OctGame', 1, 5, 6);
+
+        self::assertFalse($this->repo->hasPreseasonBoxScores(2098));
+    }
+
+    public function testHasPreseasonBoxScoresReturnsTrueWithSeptemberData(): void
+    {
+        $this->insertTeamBoxscoreRow('2098-09-20', 'SepGame', 1, 5, 6);
+
+        self::assertTrue($this->repo->hasPreseasonBoxScores(2098));
+    }
+
+    public function testDeletePreseasonSimDatesPreservesOctoberRows(): void
+    {
+        $this->insertRow('ibl_sim_dates', [
+            'sim' => 900,
+            'start_date' => '2098-09-20',
+            'end_date' => '2098-09-25',
+        ]);
+        $this->insertRow('ibl_sim_dates', [
+            'sim' => 901,
+            'start_date' => '2098-10-05',
+            'end_date' => '2098-10-10',
+        ]);
+
+        $this->repo->deletePreseasonSimDates(2098);
+
+        $result = $this->db->query("SELECT sim FROM ibl_sim_dates WHERE sim IN (900, 901)");
+        self::assertNotFalse($result);
+        $rows = $result->fetch_all(MYSQLI_ASSOC);
+        $result->free();
+
+        $sims = array_column($rows, 'sim');
+        self::assertNotContains(900, $sims, 'September sim date should be deleted');
+        self::assertContains(901, $sims, 'October sim date should be preserved');
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PreseasonTransitionPipelineTest.php
@@ -63,12 +63,46 @@ class PreseasonTransitionPipelineTest extends PipelineIntegrationTestCase
         self::assertNotNull($cleanupResult, 'CleanupPreseasonDataStep should have run');
         self::assertStringContainsString('Cleaned:', $cleanupResult->detail);
 
-        self::assertSame(0, $this->countRows('ibl_box_scores_teams', "game_date BETWEEN '2098-09-01' AND '2098-10-31'"));
-        self::assertSame(0, $this->countRows('ibl_box_scores', "game_date BETWEEN '2098-09-01' AND '2098-10-31'"));
+        self::assertSame(0, $this->countRows('ibl_box_scores_teams', "game_date BETWEEN '2098-09-01' AND '2098-09-30'"));
+        self::assertSame(0, $this->countRows('ibl_box_scores', "game_date BETWEEN '2098-09-01' AND '2098-09-30'"));
+        self::assertGreaterThan(0, $this->countRows('ibl_box_scores_teams', "game_date BETWEEN '2098-10-01' AND '2098-10-31'"));
+        self::assertGreaterThan(0, $this->countRows('ibl_box_scores', "game_date BETWEEN '2098-10-01' AND '2098-10-31'"));
         self::assertSame(0, $this->countRows('ibl_team_awards', "year = 2099"));
         self::assertSame(0, $this->countRows('ibl_jsb_history', "season_year = 2099"));
         self::assertSame(0, $this->countRows('ibl_jsb_transactions', "season_year = 2099"));
 
         self::assertSame(2, $this->countRows('ibl_schedule', "game_date LIKE '2098-10-%'"));
+    }
+
+    public function testSecondHeatSimSkipsCleanupWhenNoSeptemberData(): void
+    {
+        $this->updateSetting('Current Season Phase', 'HEAT');
+        $this->updateSetting('Current Season Ending Year', '2099');
+        $this->seedLeagueConfig(2099);
+
+        $this->seedSimDates(5, '2098-10-01', '2098-10-07');
+        $this->insertTeamBoxscoreRow('2098-10-02', 'HeatGame1', 1, 5, 6);
+
+        $season = $this->buildSeason('HEAT', 2099);
+
+        $schPath = $this->buildSchFile([
+            ['date_slot' => 5, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 105, 'home_score' => 98],
+            ['date_slot' => 6, 'game_index' => 0, 'visitor' => 3, 'home' => 4, 'visitor_score' => 110, 'home_score' => 102],
+        ]);
+        $this->buildPlrFile([
+            ['pid' => 200001, 'name' => 'Pipeline Player A', 'teamid' => 1, 'ordinal' => 1],
+            ['pid' => 200002, 'name' => 'Pipeline Player B', 'teamid' => 2, 'ordinal' => 2],
+        ]);
+        $this->buildScoFile();
+
+        $pipeline = $this->buildPipeline($season, $schPath);
+        $results = $this->runPipeline($pipeline);
+        $this->assertZeroPipelineErrors($pipeline, $results);
+
+        $cleanupResult = $this->findResultByLabel($results, 'Preseason data cleaned');
+        self::assertNotNull($cleanupResult);
+        self::assertSame('No preseason data to clean', $cleanupResult->detail, 'Cleanup should be skipped when no September box scores exist');
+
+        self::assertSame(1, $this->countRows('ibl_sim_dates', "sim = 5"), 'Existing HEAT sim dates must be preserved');
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `CleanupPreseasonDataStep` used a Sep 1 – Oct 31 date range, causing it to match and destroy October (HEAT) data on subsequent HEAT sim runs. Narrowed to Sep 1 – Sep 30 so that once the first HEAT sim cleans September preseason artifacts, the `hasPreseasonBoxScores()` guard returns false on all subsequent HEAT runs.

## Changes

- **PreseasonCleanupRepository** — narrowed `hasPreseasonBoxScores()` and `deletePreseasonSimDates()` from Oct 31 to Sep 30
- **BoxscoreRepository** — narrowed `deletePreseasonBoxScores()` from Oct 31 to Sep 30
- **CleanupPreseasonDataStep** — updated log message from `(Sep-Oct)` to `(Sep)`
- **BoxscoreRepositoryInterface** — fixed incorrect docblock (was "November through December")

## Tests

- New `PreseasonCleanupRepositoryTest` (3 integration tests verifying September-only scope)
- New `testSecondHeatSimSkipsCleanupWhenNoSeptemberData` pipeline integration test
- Updated existing pipeline test to assert October data is preserved
- Updated `BoxscoreRepositoryTest` assertion to match new date range

## Manual Testing

No manual testing needed — all changes are covered by unit and integration tests.