### PR TITLE
feat: liveness/progress logging for nightly claude instances

### DIFF
--- a/bin/lib/nightly-stream-filter
+++ b/bin/lib/nightly-stream-filter
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Usage: claude ... --output-format stream-json | nightly-stream-filter <heartbeat_file>
+set -euo pipefail
+
+HEARTBEAT_FILE="${1:?Usage: nightly-stream-filter <heartbeat_file>}"
+TOOL_COUNT=0
+TURN_COUNT=1
+START_EPOCH=$(date +%s)
+
+elapsed_ts() {
+    local now
+    now=$(date +%s)
+    local diff=$(( now - START_EPOCH ))
+    printf '[%02d:%02d:%02d]' $(( diff / 3600 )) $(( (diff % 3600) / 60 )) $(( diff % 60 ))
+}
+
+while IFS= read -r line; do
+    date +%s > "$HEARTBEAT_FILE"
+
+    ev_type=$(printf '%s' "$line" | jq -r '.type // empty' 2>/dev/null) || continue
+    case "$ev_type" in
+        assistant)
+            tool_name=$(printf '%s' "$line" | jq -r '
+                .message.content[]
+                | select(.type=="tool_use")
+                | .name // empty
+            ' 2>/dev/null) || true
+            if [ -n "$tool_name" ]; then
+                TOOL_COUNT=$(( TOOL_COUNT + 1 ))
+                printf '%s tool: %s (#%d, turn %d)\n' "$(elapsed_ts)" "$tool_name" "$TOOL_COUNT" "$TURN_COUNT"
+            fi
+            ;;
+        user)
+            TURN_COUNT=$(( TURN_COUNT + 1 ))
+            ;;
+        result)
+            result_text=$(printf '%s' "$line" | jq -r '.result // empty' 2>/dev/null) || true
+            if [ -n "$result_text" ]; then
+                printf '%s\n' "$result_text"
+            fi
+            stop_reason=$(printf '%s' "$line" | jq -r '.stop_reason // "unknown"' 2>/dev/null) || true
+            num_turns=$(printf '%s' "$line" | jq -r '.num_turns // "?"' 2>/dev/null) || true
+            duration_ms=$(printf '%s' "$line" | jq -r '.duration_ms // "?"' 2>/dev/null) || true
+            printf '%s exit: stop_reason=%s turns=%s tools=%d duration=%sms\n' \
+                "$(elapsed_ts)" "$stop_reason" "$num_turns" "$TOOL_COUNT" "$duration_ms"
+            ;;
+    esac
+done

--- a/bin/nightly-run
+++ b/bin/nightly-run
@@ -41,6 +41,38 @@ MAX_ATTEMPTS=3     # per-plan retry cap within one night (covers impl + postplan
 
 HANDOFF_DIR="$NIGHTLY_DIR/handoff"
 mkdir -p "$LOG_DIR" "$QUEUE_DIR" "$HANDOFF_DIR"
+
+WATCHER_PID=""
+cleanup_watcher() {
+    if [ -n "$WATCHER_PID" ]; then
+        kill "$WATCHER_PID" 2>/dev/null || true
+        wait "$WATCHER_PID" 2>/dev/null || true
+    fi
+    rm -f "$NIGHTLY_DIR/.heartbeat-$$-impl" "$NIGHTLY_DIR/.heartbeat-$$-postplan" 2>/dev/null || true
+}
+trap cleanup_watcher EXIT
+
+run_heartbeat_watcher() {
+    local hb_file=$1 log_file=$2 label=$3
+    while sleep 60; do
+        if [ ! -f "$hb_file" ]; then
+            continue
+        fi
+        local last_epoch now age
+        last_epoch=$(cat "$hb_file" 2>/dev/null) || continue
+        [ -n "$last_epoch" ] || continue
+        now=$(date +%s)
+        age=$(( now - last_epoch ))
+        local ts
+        ts=$(date +%H:%M:%S)
+        if [ "$age" -gt 300 ]; then
+            printf '[%s] WARNING: %s — no events for %ds (possibly stalled)\n' "$ts" "$label" "$age" >> "$log_file"
+        else
+            printf '[%s] heartbeat: %s alive (%ds since last event)\n' "$ts" "$label" "$age" >> "$log_file"
+        fi
+    done
+}
+
 LOG="$LOG_DIR/$(date +%Y-%m-%d).log"
 
 cd "$REPO"
@@ -117,13 +149,33 @@ while true; do
             REMAINING_SECS=300
         fi
         IMPL_LOG_BEFORE=$(wc -l < "$LOG" 2>/dev/null || echo 0)
+        HEARTBEAT_FILE="$NIGHTLY_DIR/.heartbeat-$$-impl"
+        rm -f "$HEARTBEAT_FILE"
+
+        run_heartbeat_watcher "$HEARTBEAT_FILE" "$LOG" "impl:$PLAN_NAME" &
+        WATCHER_PID=$!
+
+        IMPL_STATUS=0
         timeout "$REMAINING_SECS" \
             claude -p "$(cat bin/nightly-prompt-impl)" \
                 --dangerously-skip-permissions \
                 --model claude-opus-4-6 \
                 --max-turns 200 \
+                --output-format stream-json \
+                --verbose \
                 --name "nightly-impl-$(date +%Y-%m-%d-%H%M)" \
-                >> "$LOG" 2>&1 || true
+            2>> "$LOG" \
+            | bin/lib/nightly-stream-filter "$HEARTBEAT_FILE" \
+            >> "$LOG" || IMPL_STATUS=$?
+
+        kill "$WATCHER_PID" 2>/dev/null || true
+        wait "$WATCHER_PID" 2>/dev/null || true
+        WATCHER_PID=""
+        rm -f "$HEARTBEAT_FILE"
+
+        if [ "$IMPL_STATUS" -ne 0 ]; then
+            printf '[%s] claude exited code=%d (impl phase)\n' "$(date +%H:%M:%S)" "$IMPL_STATUS" >> "$LOG"
+        fi
 
         echo "--- Plan #$PLANS_RUN impl finished at $(date) ---" >> "$LOG"
 
@@ -154,6 +206,13 @@ while true; do
             REMAINING_SECS=300
         fi
         PP_LOG_BEFORE=$(wc -l < "$LOG" 2>/dev/null || echo 0)
+        HEARTBEAT_FILE="$NIGHTLY_DIR/.heartbeat-$$-postplan"
+        rm -f "$HEARTBEAT_FILE"
+
+        run_heartbeat_watcher "$HEARTBEAT_FILE" "$LOG" "postplan:$PLAN_NAME" &
+        WATCHER_PID=$!
+
+        PP_STATUS=0
         timeout "$REMAINING_SECS" \
             claude -p "$(cat bin/nightly-prompt-postplan)
 
@@ -161,8 +220,21 @@ PLAN_FILE=$PLAN_NAME" \
                 --dangerously-skip-permissions \
                 --model claude-sonnet-4-6 \
                 --max-turns 120 \
+                --output-format stream-json \
+                --verbose \
                 --name "nightly-postplan-$(date +%Y-%m-%d-%H%M)" \
-                >> "$LOG" 2>&1 || true
+            2>> "$LOG" \
+            | bin/lib/nightly-stream-filter "$HEARTBEAT_FILE" \
+            >> "$LOG" || PP_STATUS=$?
+
+        kill "$WATCHER_PID" 2>/dev/null || true
+        wait "$WATCHER_PID" 2>/dev/null || true
+        WATCHER_PID=""
+        rm -f "$HEARTBEAT_FILE"
+
+        if [ "$PP_STATUS" -ne 0 ]; then
+            printf '[%s] claude exited code=%d (postplan phase)\n' "$(date +%H:%M:%S)" "$PP_STATUS" >> "$LOG"
+        fi
 
         echo "--- Plan #$PLANS_RUN postplan finished at $(date) ---" >> "$LOG"
 


### PR DESCRIPTION
## Summary

Add stream-JSON filtering and heartbeat monitoring to `bin/nightly-run` so that nightly logs show real-time activity instead of hours of silence between plan markers.

## Problem

Between the `--- Plan #N ... at $(date) ---` and `--- Plan #N impl finished ---` markers, there was zero output during potentially hours-long `claude -p` runs. Impossible to distinguish: (1) Claude actively working, (2) Claude stalled silently, (3) Claude exited unexpectedly.

## Solution

### Stream-JSON Filter (`bin/lib/nightly-stream-filter`)
- Reads `--output-format stream-json` from stdin
- Emits `[HH:MM:SS] tool: <name> (#N, turn M)` for each tool call
- Emits result text verbatim (preserving "hit your limit" detection)
- Emits exit metadata: `stop_reason`, turns, tools, duration
- Touches a heartbeat sidecar file on each event

### Background Heartbeat Watcher (`run_heartbeat_watcher()`)
- Checks heartbeat file age every 60s
- Emits "alive" lines when age < 5min
- Emits WARNING lines when age > 5min (stall detection)
- Cleaned up via EXIT trap (no orphan processes)

### Pipeline Changes
- Both impl and postplan phases use `--output-format stream-json --verbose` piped through the filter
- Non-zero exit codes captured and logged separately
- stderr from claude goes directly to log (connection errors, CLI crashes)

## Expected Log Output

```
--- Plan #1: example.md (attempt 1) at Mon May  5 00:03:04 PDT 2026 ---
[00:00:08] tool: Bash (#1, turn 1)
[00:00:12] tool: Read (#2, turn 1)
[00:01:04] heartbeat: impl:example.md alive (46s since last event)
[00:00:25] tool: Bash (#4, turn 2)
Implementation complete. Summary: ...
[00:02:15] exit: stop_reason=end_turn turns=5 tools=8 duration=135021ms
--- Plan #1 impl finished at Mon May  5 00:05:19 PDT 2026 ---
```

## Verification

All 10 verification items were executed during implementation (CLI-executable). Key results:
- Filter correctly emits tool activity lines with elapsed time
- Result text matches `--output-format text` output verbatim
- "hit your limit" substring preserved through the filter pipeline
- Heartbeat sidecar file updated with recent epoch on each event
- Non-zero exit codes propagate through pipefail
- Shellcheck clean (both files)

## Manual Testing

No manual testing needed — all changes are verified by CLI-executable tests and will be validated by the next nightly run.