### PR TITLE
test: promote Trading & Negotiation to DB integration tests

### DIFF
--- a/ibl5/tests/DatabaseIntegration/Negotiation/NegotiationProcessorIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Negotiation/NegotiationProcessorIntegrationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Negotiation;
+
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+use Negotiation\NegotiationProcessor;
+
+/**
+ * Integration tests for NegotiationProcessor against real MariaDB.
+ *
+ * NegotiationProcessor is read-only — it queries DB state and returns HTML.
+ * No transaction management inside the processor, so DatabaseTestCase's
+ * begin_transaction/rollback isolation works without modification.
+ *
+ * Season\Season is aliased to a mock by the PHPUnit bootstrap, so tests
+ * that need a specific phase inject a Season object with the phase set.
+ */
+#[Group('database')]
+class NegotiationProcessorIntegrationTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_SERVER['SERVER_NAME'] = 'localhost';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['SERVER_NAME']);
+        parent::tearDown();
+    }
+
+    public function testSuccessfulNegotiationShowsDemandsForm(): void
+    {
+        $pid = 200050001;
+        $this->seedEligiblePlayer($pid, 'Nego Test Star', 1, 'PG', 5);
+
+        $processor = new NegotiationProcessor($this->db);
+        $output = $processor->processNegotiation($pid, 'Metros', 'nego_');
+
+        self::assertStringContainsString('Nego Test Star', $output);
+        self::assertStringNotContainsString('not available during free agency', $output);
+        self::assertStringNotContainsString('is not on your team', $output);
+    }
+
+    public function testFreeAgencyPhaseBlocksNegotiation(): void
+    {
+        $pid = 200050002;
+        $this->seedEligiblePlayer($pid, 'Nego Test FA Block', 1, 'SG', 4);
+
+        $season = new \Season\Season($this->db);
+        $season->phase = 'Free Agency';
+
+        $processor = new NegotiationProcessor($this->db, $season);
+        $output = $processor->processNegotiation($pid, 'Metros', 'nego_');
+
+        self::assertStringContainsString('not available during free agency', $output);
+    }
+
+    public function testNegotiationRejectsForeignTeamPlayer(): void
+    {
+        $pid = 200050003;
+        $this->seedEligiblePlayer($pid, 'Nego Test Foreign', 2, 'SF', 3);
+
+        $processor = new NegotiationProcessor($this->db);
+        $output = $processor->processNegotiation($pid, 'Metros', 'nego_');
+
+        self::assertStringContainsString('is not on your team', $output);
+    }
+
+    public function testDemandsReflectPlayerRatings(): void
+    {
+        $lowPid = 200050004;
+        $highPid = 200050005;
+
+        $this->seedEligiblePlayer($lowPid, 'Nego Lowly', 1, 'PG', 5, 30);
+        $this->seedEligiblePlayer($highPid, 'Nego Elite', 1, 'SG', 7, 95);
+
+        $processor = new NegotiationProcessor($this->db);
+        $lowOutput = $processor->processNegotiation($lowPid, 'Metros', 'nego_');
+        $highOutput = $processor->processNegotiation($highPid, 'Metros', 'nego_');
+
+        self::assertStringContainsString('Nego Lowly', $lowOutput);
+        self::assertStringContainsString('Nego Elite', $highOutput);
+        self::assertNotSame($lowOutput, $highOutput);
+    }
+
+    private function seedEligiblePlayer(
+        int $pid,
+        string $name,
+        int $teamId,
+        string $pos,
+        int $exp,
+        int $ratingBase = 60,
+    ): void {
+        $this->insertTestPlayer($pid, $name, [
+            'teamid' => $teamId,
+            'pos' => $pos,
+            'exp' => $exp,
+            'bird' => min($exp, 3),
+            'cy' => 1,
+            'cyt' => 1,
+            'salary_yr1' => 1500,
+            'salary_yr2' => 0,
+            'r_fga' => $ratingBase,
+            'r_fgp' => $ratingBase,
+            'r_fta' => $ratingBase,
+            'r_ftp' => $ratingBase,
+            'r_3ga' => $ratingBase,
+            'r_3gp' => $ratingBase,
+            'r_orb' => $ratingBase,
+            'r_drb' => $ratingBase,
+            'r_ast' => $ratingBase,
+            'r_stl' => $ratingBase,
+            'r_tvr' => $ratingBase,
+            'r_blk' => $ratingBase,
+            'r_foul' => $ratingBase,
+            'oo' => $ratingBase,
+            'od' => $ratingBase,
+            'r_drive_off' => $ratingBase,
+            'dd' => $ratingBase,
+            'po' => $ratingBase,
+            'pd' => $ratingBase,
+            'r_trans_off' => $ratingBase,
+            'td' => $ratingBase,
+        ]);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/Negotiation/NegotiationProcessorIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Negotiation/NegotiationProcessorIntegrationTest.php
@@ -8,16 +8,6 @@ use PHPUnit\Framework\Attributes\Group;
 use Tests\DatabaseIntegration\DatabaseTestCase;
 use Negotiation\NegotiationProcessor;
 
-/**
- * Integration tests for NegotiationProcessor against real MariaDB.
- *
- * NegotiationProcessor is read-only — it queries DB state and returns HTML.
- * No transaction management inside the processor, so DatabaseTestCase's
- * begin_transaction/rollback isolation works without modification.
- *
- * Season\Season is aliased to a mock by the PHPUnit bootstrap, so tests
- * that need a specific phase inject a Season object with the phase set.
- */
 #[Group('database')]
 class NegotiationProcessorIntegrationTest extends DatabaseTestCase
 {

--- a/ibl5/tests/DatabaseIntegration/Trading/TradeProcessorIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Trading/TradeProcessorIntegrationTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Trading;
+
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+use Trading\TradeItemType;
+use Trading\TradeProcessor;
+
+/**
+ * Integration tests for TradeProcessor against real MariaDB.
+ *
+ * TradeProcessor::processTrade() calls begin_transaction() internally, which
+ * implicitly commits DatabaseTestCase's outer transaction. To preserve test
+ * isolation we commit the outer tx in setUp and do explicit cleanup in tearDown.
+ */
+#[Group('database')]
+class TradeProcessorIntegrationTest extends DatabaseTestCase
+{
+    private TradeProcessor $processor;
+
+    /** @var list<int> PIDs of test-created players (for tearDown cleanup) */
+    private array $createdPids = [];
+
+    /** @var list<int> Auto-increment IDs from ibl_draft_picks (for tearDown cleanup) */
+    private array $createdPickIds = [];
+
+    /** @var list<int> Auto-increment IDs from ibl_trade_offers (for tearDown cleanup) */
+    private array $createdOfferIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->db->commit();
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        $this->processor = new TradeProcessor($this->db);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!isset($this->db)) {
+            return;
+        }
+
+        $this->db->query("DELETE FROM ibl_trade_queue");
+        $this->db->query("DELETE FROM ibl_cash_considerations WHERE label LIKE 'Cash to%' OR label LIKE 'Cash from%'");
+        $this->db->query("DELETE FROM nuke_stories WHERE sid > 2");
+
+        foreach ($this->createdOfferIds as $offerId) {
+            $this->db->query("DELETE FROM ibl_trade_info WHERE tradeofferid = $offerId");
+            $this->db->query("DELETE FROM ibl_trade_cash WHERE trade_offer_id = $offerId");
+            $this->db->query("DELETE FROM ibl_trade_offers WHERE id = $offerId");
+        }
+
+        foreach ($this->createdPickIds as $pickId) {
+            $this->db->query("DELETE FROM ibl_draft_picks WHERE pickid = $pickId");
+        }
+
+        foreach ($this->createdPids as $pid) {
+            $this->db->query("DELETE FROM ibl_plr WHERE pid = $pid");
+        }
+
+        unset($_SERVER['SERVER_NAME']);
+
+        try {
+            $this->db->close();
+        } catch (\Throwable) {
+        }
+    }
+
+    // ── Scenario 1: Player-for-player ──────────────────────────
+
+    public function testPlayerForPlayerTradeTransfersOwnership(): void
+    {
+        $pidA = 200040001;
+        $pidB = 200040002;
+        $this->seedPlayer($pidA, 'Trade Test A', 1, 'PG');
+        $this->seedPlayer($pidB, 'Trade Test B', 2, 'SF');
+
+        $offerId = $this->seedPendingTrade([
+            ['id' => $pidA, 'type' => TradeItemType::Player->value, 'from' => 'Metros', 'to' => 'Stars'],
+            ['id' => $pidB, 'type' => TradeItemType::Player->value, 'from' => 'Stars', 'to' => 'Metros'],
+        ]);
+
+        $result = $this->processor->processTrade($offerId);
+
+        self::assertTrue($result['success']);
+        self::assertSame(2, $this->getPlayerTeamId($pidA));
+        self::assertSame(1, $this->getPlayerTeamId($pidB));
+    }
+
+    // ── Scenario 2: Player-for-pick ────────────────────────────
+
+    public function testPlayerForPickTradeTransfersPickOwnership(): void
+    {
+        $pid = 200040003;
+        $this->seedPlayer($pid, 'Trade Test C', 1, 'SG');
+        $pickId = $this->seedPick(2, 'Stars', 2, 'Stars', 2028, 1);
+
+        $offerId = $this->seedPendingTrade([
+            ['id' => $pid, 'type' => TradeItemType::Player->value, 'from' => 'Metros', 'to' => 'Stars'],
+            ['id' => $pickId, 'type' => TradeItemType::DraftPick->value, 'from' => 'Stars', 'to' => 'Metros'],
+        ]);
+
+        $result = $this->processor->processTrade($offerId);
+
+        self::assertTrue($result['success']);
+        self::assertSame(2, $this->getPlayerTeamId($pid));
+        self::assertSame(1, $this->getPickOwnerTeamId($pickId));
+    }
+
+    // ── Scenario 3: Cash consideration ─────────────────────────
+
+    public function testCashConsiderationCreatesPairedRecords(): void
+    {
+        $pidA = 200040004;
+        $pidB = 200040005;
+        $this->seedPlayer($pidA, 'Trade Test D', 1, 'C');
+        $this->seedPlayer($pidB, 'Trade Test E', 2, 'PF');
+
+        $offerId = $this->seedPendingTrade([
+            ['id' => $pidA, 'type' => TradeItemType::Player->value, 'from' => 'Metros', 'to' => 'Stars'],
+            ['id' => $pidB, 'type' => TradeItemType::Player->value, 'from' => 'Stars', 'to' => 'Metros'],
+            ['id' => 0, 'type' => TradeItemType::Cash->value, 'from' => 'Metros', 'to' => 'Stars'],
+        ]);
+
+        $this->insertTradeCashRow($offerId, 'Metros', 'Stars', [
+            'salary_yr1' => 200,
+            'salary_yr2' => 200,
+        ]);
+
+        $result = $this->processor->processTrade($offerId);
+
+        self::assertTrue($result['success']);
+
+        $stmt = $this->db->prepare(
+            "SELECT teamid, label, salary_yr1 FROM ibl_cash_considerations WHERE label LIKE 'Cash to Stars' OR label LIKE 'Cash from Metros'"
+        );
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+
+        self::assertCount(2, $rows);
+
+        $positive = array_values(array_filter($rows, static fn (array $r): bool => $r['salary_yr1'] > 0));
+        $negative = array_values(array_filter($rows, static fn (array $r): bool => $r['salary_yr1'] < 0));
+
+        self::assertCount(1, $positive);
+        self::assertCount(1, $negative);
+        self::assertSame(200, $positive[0]['salary_yr1']);
+        self::assertSame(-200, $negative[0]['salary_yr1']);
+    }
+
+    // ── Scenario 4: Invalid offer ID ───────────────────────────
+
+    public function testInvalidOfferIdReturnsError(): void
+    {
+        $result = $this->processor->processTrade(999999);
+
+        self::assertFalse($result['success']);
+        self::assertArrayHasKey('error', $result);
+    }
+
+    // ── Scenario 5: Multi-asset trade ──────────────────────────
+
+    public function testMultiAssetTradeTransfersAllAssets(): void
+    {
+        $pidA = 200040006;
+        $pidB = 200040007;
+        $pidC = 200040008;
+        $this->seedPlayer($pidA, 'Multi Test A', 1, 'PG');
+        $this->seedPlayer($pidB, 'Multi Test B', 2, 'SG');
+        $this->seedPlayer($pidC, 'Multi Test C', 2, 'C');
+        $pickId = $this->seedPick(1, 'Metros', 1, 'Metros', 2029, 1);
+
+        $offerId = $this->seedPendingTrade([
+            ['id' => $pidA, 'type' => TradeItemType::Player->value, 'from' => 'Metros', 'to' => 'Stars'],
+            ['id' => $pickId, 'type' => TradeItemType::DraftPick->value, 'from' => 'Metros', 'to' => 'Stars'],
+            ['id' => $pidB, 'type' => TradeItemType::Player->value, 'from' => 'Stars', 'to' => 'Metros'],
+            ['id' => $pidC, 'type' => TradeItemType::Player->value, 'from' => 'Stars', 'to' => 'Metros'],
+        ]);
+
+        $result = $this->processor->processTrade($offerId);
+
+        self::assertTrue($result['success']);
+        self::assertSame(2, $this->getPlayerTeamId($pidA));
+        self::assertSame(2, $this->getPickOwnerTeamId($pickId));
+        self::assertSame(1, $this->getPlayerTeamId($pidB));
+        self::assertSame(1, $this->getPlayerTeamId($pidC));
+        self::assertStringContainsString('Multi Test A', $result['storytext']);
+        self::assertStringContainsString('Multi Test B', $result['storytext']);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────
+
+    private function seedPlayer(int $pid, string $name, int $teamId, string $pos): void
+    {
+        $this->insertTestPlayer($pid, $name, [
+            'teamid' => $teamId,
+            'pos' => $pos,
+            'cy' => 1,
+            'cyt' => 3,
+            'salary_yr1' => 1500,
+            'salary_yr2' => 1600,
+        ]);
+        $this->createdPids[] = $pid;
+    }
+
+    private function seedPick(int $ownerTid, string $ownerName, int $teampickTid, string $teampickName, int $year, int $round): int
+    {
+        $id = $this->insertDraftPickRow($ownerTid, $teampickTid, $year, $round, [
+            'ownerofpick' => $ownerName,
+            'teampick' => $teampickName,
+        ]);
+        $this->createdPickIds[] = $id;
+        return $id;
+    }
+
+    /**
+     * @param list<array{id: int, type: string, from: string, to: string}> $items
+     */
+    private function seedPendingTrade(array $items): int
+    {
+        $offerId = $this->insertTradeOfferRow();
+        $this->createdOfferIds[] = $offerId;
+
+        foreach ($items as $item) {
+            $this->insertTradeInfoRow($offerId, $item['id'], $item['type'], $item['from'], $item['to']);
+        }
+
+        return $offerId;
+    }
+
+    private function getPlayerTeamId(int $pid): int
+    {
+        $stmt = $this->db->prepare("SELECT teamid FROM ibl_plr WHERE pid = ?");
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('i', $pid);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row !== null ? (int) $row['teamid'] : -1;
+    }
+
+    private function getPickOwnerTeamId(int $pickId): int
+    {
+        $stmt = $this->db->prepare("SELECT owner_teamid FROM ibl_draft_picks WHERE pickid = ?");
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('i', $pickId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row !== null ? (int) $row['owner_teamid'] : -1;
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/Trading/TradeProcessorIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Trading/TradeProcessorIntegrationTest.php
@@ -9,13 +9,7 @@ use Tests\DatabaseIntegration\DatabaseTestCase;
 use Trading\TradeItemType;
 use Trading\TradeProcessor;
 
-/**
- * Integration tests for TradeProcessor against real MariaDB.
- *
- * TradeProcessor::processTrade() calls begin_transaction() internally, which
- * implicitly commits DatabaseTestCase's outer transaction. To preserve test
- * isolation we commit the outer tx in setUp and do explicit cleanup in tearDown.
- */
+/** processTrade() commits internally — can't use DatabaseTestCase's outer-tx rollback; tearDown does manual cleanup. */
 #[Group('database')]
 class TradeProcessorIntegrationTest extends DatabaseTestCase
 {
@@ -218,9 +212,7 @@ class TradeProcessorIntegrationTest extends DatabaseTestCase
         return $id;
     }
 
-    /**
-     * @param list<array{id: int, type: string, from: string, to: string}> $items
-     */
+    /** @param list<array{id: int, type: string, from: string, to: string}> $items */
     private function seedPendingTrade(array $items): int
     {
         $offerId = $this->insertTradeOfferRow();

--- a/ibl5/tests/DatabaseIntegration/fixtures/db-seed.sql
+++ b/ibl5/tests/DatabaseIntegration/fixtures/db-seed.sql
@@ -298,9 +298,42 @@ INSERT INTO ibl_rcb_season_records (season_year, scope, teamid, context, stat_ca
 VALUES (2025, 'league', 0, 'home', 'pts', 1, 'Test Player One', 'PG', 45, 2025)
 ON DUPLICATE KEY UPDATE player_name = VALUES(player_name);
 
--- Draft picks: needed by TeamQuery getDraftPicks()
+-- Additional players: needed by Trading/Negotiation integration tests
+INSERT INTO ibl_plr (pid, name, age, teamid, pos, stamina, exp, bird, cy, cyt, salary_yr1, salary_yr2, retired, ordinal, droptime, uuid)
+VALUES (3, 'Test Player Three', 25, 2, 'SF', 85, 4, 2, 1, 3, 1200, 1300, 0, 2, 0, 'cccccccc-cccc-cccc-cccc-cccccccccccc')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+
+INSERT INTO ibl_plr (pid, name, age, teamid, pos, stamina, exp, bird, cy, cyt, salary_yr1, salary_yr2, retired, ordinal, droptime, uuid)
+VALUES (4, 'Test Player Four', 30, 2, 'C', 75, 8, 3, 2, 4, 2000, 2200, 0, 3, 0, 'dddddddd-dddd-dddd-dddd-dddddddddddd')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+
+INSERT INTO ibl_plr (pid, name, age, teamid, pos, stamina, exp, bird, cy, cyt, salary_yr1, salary_yr2, retired, ordinal, droptime, uuid)
+VALUES (5, 'Test Player Five', 23, 3, 'SG', 90, 2, 1, 1, 2, 800, 900, 0, 1, 0, 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+
+INSERT INTO ibl_plr (pid, name, age, teamid, pos, stamina, exp, bird, cy, cyt, salary_yr1, salary_yr2, retired, ordinal, droptime, uuid)
+VALUES (6, 'Test Player Six', 28, 3, 'PF', 80, 6, 3, 1, 3, 1800, 1900, 0, 2, 0, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+
+-- Draft picks: needed by TeamQuery getDraftPicks() and Trading integration tests
 INSERT INTO ibl_draft_picks (ownerofpick, owner_teamid, teampick, teampick_teamid, year, round, notes)
 VALUES ('Metros', 1, 'Metros', 1, 2025, 1, 'Own pick')
+ON DUPLICATE KEY UPDATE notes = VALUES(notes);
+
+INSERT INTO ibl_draft_picks (ownerofpick, owner_teamid, teampick, teampick_teamid, year, round, notes)
+VALUES ('Metros', 1, 'Metros', 1, 2027, 1, 'Future 1st')
+ON DUPLICATE KEY UPDATE notes = VALUES(notes);
+
+INSERT INTO ibl_draft_picks (ownerofpick, owner_teamid, teampick, teampick_teamid, year, round, notes)
+VALUES ('Stars', 2, 'Stars', 2, 2027, 1, 'Own pick')
+ON DUPLICATE KEY UPDATE notes = VALUES(notes);
+
+INSERT INTO ibl_draft_picks (ownerofpick, owner_teamid, teampick, teampick_teamid, year, round, notes)
+VALUES ('Cougars', 3, 'Cougars', 3, 2027, 1, 'Own pick')
+ON DUPLICATE KEY UPDATE notes = VALUES(notes);
+
+INSERT INTO ibl_draft_picks (ownerofpick, owner_teamid, teampick, teampick_teamid, year, round, notes)
+VALUES ('Diesels', 4, 'Diesels', 4, 2027, 2, 'Own pick')
 ON DUPLICATE KEY UPDATE notes = VALUES(notes);
 
 -- Cache: needed by RecordHolders getLastAnnouncedDate()


### PR DESCRIPTION
## Summary

Promotes the Trading and Negotiation processor tests from MockDatabase WideUnit tests to real MariaDB DB integration tests. These processors perform multi-step mutations that the mock database cannot faithfully reproduce (implicit transaction commits, FK-constrained inserts, LAST_INSERT_ID).

## Changes

- **New:** `tests/DatabaseIntegration/Trading/TradeProcessorIntegrationTest.php` — 5 scenarios: player-for-player, player-for-pick, cash consideration, invalid offer ID, multi-asset trade
- **New:** `tests/DatabaseIntegration/Negotiation/NegotiationProcessorIntegrationTest.php` — 4 scenarios: successful negotiation form, FA phase blocked, foreign team player rejection, demands based on ratings
- **Modified:** `tests/DatabaseIntegration/fixtures/db-seed.sql` — adds 4 more seed players (tids 2-3) and 4 draft picks needed by the new tests

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.