### PR TITLE
test: add DB integration tests for Waivers, RookieOption, Extension, FreeAgency

### DIFF
--- a/ibl5/tests/DatabaseIntegration/Extension/ExtensionRepositoryIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Extension/ExtensionRepositoryIntegrationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Extension;
+
+use Extension\ExtensionRepository;
+use PHPUnit\Framework\Attributes\Group;
+use Services\CommonMysqliRepository;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+#[Group('database')]
+class ExtensionRepositoryIntegrationTest extends DatabaseTestCase
+{
+    private ExtensionRepository $repository;
+    private CommonMysqliRepository $commonRepository;
+
+    private const TEST_PID_BASE = 200060300;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = new ExtensionRepository($this->db);
+        $this->commonRepository = new CommonMysqliRepository($this->db);
+    }
+
+    public function testSaveAcceptedExtensionUpdatesPlayerContract(): void
+    {
+        $pid = self::TEST_PID_BASE + 1;
+        $playerName = 'Extension Accept';
+        $this->insertTestPlayer($pid, $playerName, [
+            'teamid' => 1,
+            'cy' => 2,
+            'cyt' => 3,
+            'salary_yr1' => 500,
+            'salary_yr2' => 600,
+            'salary_yr3' => 700,
+            'salary_yr4' => 0,
+            'salary_yr5' => 0,
+            'salary_yr6' => 0,
+            'exp' => 5,
+            'bird' => 3,
+        ]);
+
+        $offer = [
+            'year1' => 800,
+            'year2' => 850,
+            'year3' => 900,
+            'year4' => 0,
+            'year5' => 0,
+        ];
+        $currentSalary = 700;
+
+        $this->repository->saveAcceptedExtension(
+            $playerName,
+            'Metros',
+            $offer,
+            $currentSalary,
+            2.55,
+            4,
+            '800 850 900'
+        );
+
+        $player = $this->commonRepository->getPlayerByID($pid);
+        $this->assertNotNull($player);
+        $this->assertSame(1, $player['cy']);
+        $this->assertSame(4, $player['cyt']);
+        $this->assertSame($currentSalary, $player['salary_yr1']);
+        $this->assertSame(800, $player['salary_yr2']);
+        $this->assertSame(850, $player['salary_yr3']);
+        $this->assertSame(900, $player['salary_yr4']);
+        $this->assertSame(0, $player['salary_yr5']);
+        $this->assertSame(0, $player['salary_yr6']);
+    }
+
+    public function testSaveAcceptedExtensionMarksTeamFlags(): void
+    {
+        $pid = self::TEST_PID_BASE + 2;
+        $playerName = 'Extension Flags';
+        $this->insertTestPlayer($pid, $playerName, ['teamid' => 1]);
+
+        $offer = [
+            'year1' => 800,
+            'year2' => 850,
+            'year3' => 900,
+            'year4' => 0,
+            'year5' => 0,
+        ];
+
+        $this->repository->saveAcceptedExtension(
+            $playerName,
+            'Metros',
+            $offer,
+            500,
+            2.55,
+            4,
+            '800 850 900'
+        );
+
+        $team = $this->commonRepository->getTeamByName('Metros');
+        $this->assertNotNull($team);
+        $this->assertSame(1, $team['used_extension_this_season']);
+    }
+
+    public function testMarkExtensionUsedThisSimSetsChunkFlag(): void
+    {
+        $teamBefore = $this->commonRepository->getTeamByName('Metros');
+        $this->assertNotNull($teamBefore);
+        $this->assertSame(0, $teamBefore['used_extension_this_chunk']);
+
+        $this->repository->markExtensionUsedThisSim('Metros');
+
+        $teamAfter = $this->commonRepository->getTeamByName('Metros');
+        $this->assertNotNull($teamAfter);
+        $this->assertSame(1, $teamAfter['used_extension_this_chunk']);
+    }
+
+    public function testUpdatePlayerContractSetsCorrectYears(): void
+    {
+        $pid = self::TEST_PID_BASE + 3;
+        $playerName = 'Five Year Ext';
+        $this->insertTestPlayer($pid, $playerName, [
+            'teamid' => 1,
+            'cy' => 3,
+            'cyt' => 3,
+            'salary_yr1' => 400,
+            'salary_yr2' => 0,
+            'salary_yr3' => 0,
+            'salary_yr4' => 0,
+            'salary_yr5' => 0,
+            'salary_yr6' => 0,
+            'exp' => 7,
+        ]);
+
+        $offer = [
+            'year1' => 500,
+            'year2' => 550,
+            'year3' => 600,
+            'year4' => 650,
+            'year5' => 700,
+        ];
+
+        $this->repository->updatePlayerContract($playerName, $offer, 400);
+
+        $player = $this->commonRepository->getPlayerByID($pid);
+        $this->assertNotNull($player);
+        $this->assertSame(1, $player['cy']);
+        $this->assertSame(6, $player['cyt']);
+        $this->assertSame(400, $player['salary_yr1']);
+        $this->assertSame(500, $player['salary_yr2']);
+        $this->assertSame(550, $player['salary_yr3']);
+        $this->assertSame(600, $player['salary_yr4']);
+        $this->assertSame(650, $player['salary_yr5']);
+        $this->assertSame(700, $player['salary_yr6']);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/FreeAgency/FreeAgencyRepositoryIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/FreeAgency/FreeAgencyRepositoryIntegrationTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\FreeAgency;
+
+use FreeAgency\FreeAgencyAdminRepository;
+use FreeAgency\FreeAgencyRepository;
+use PHPUnit\Framework\Attributes\Group;
+use Services\CommonMysqliRepository;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+#[Group('database')]
+class FreeAgencyRepositoryIntegrationTest extends DatabaseTestCase
+{
+    private FreeAgencyRepository $repository;
+    private FreeAgencyAdminRepository $adminRepository;
+    private CommonMysqliRepository $commonRepository;
+
+    private const TEST_PID_BASE = 200060400;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = new FreeAgencyRepository($this->db);
+        $this->adminRepository = new FreeAgencyAdminRepository($this->db);
+        $this->commonRepository = new CommonMysqliRepository($this->db);
+    }
+
+    public function testSaveOfferInsertsNewOffer(): void
+    {
+        $pid = self::TEST_PID_BASE + 1;
+        $this->insertTestPlayer($pid, 'FA Target', ['teamid' => 0, 'cy' => 0, 'cyt' => 0, 'salary_yr1' => 0]);
+
+        $offerData = [
+            'playerName' => 'FA Target',
+            'pid' => $pid,
+            'teamName' => 'Metros',
+            'teamid' => 1,
+            'offer1' => 500,
+            'offer2' => 550,
+            'offer3' => 600,
+            'offer4' => 0,
+            'offer5' => 0,
+            'offer6' => 0,
+            'modifier' => 1.0,
+            'random' => 0.5,
+            'perceivedValue' => 1650.0,
+            'mle' => 0,
+            'lle' => 0,
+            'offerType' => 0,
+        ];
+
+        $result = $this->repository->saveOffer($offerData);
+
+        $this->assertTrue($result);
+
+        $existing = $this->repository->getExistingOffer(1, $pid);
+        $this->assertNotNull($existing);
+        $this->assertSame(500, $existing['offer1']);
+        $this->assertSame(550, $existing['offer2']);
+        $this->assertSame(600, $existing['offer3']);
+    }
+
+    public function testSaveOfferReplacesExistingOffer(): void
+    {
+        $pid = self::TEST_PID_BASE + 2;
+        $this->insertTestPlayer($pid, 'FA Replace', ['teamid' => 0, 'cy' => 0, 'cyt' => 0, 'salary_yr1' => 0]);
+
+        $this->insertFaOfferRow($pid, 1, 'FA Replace', 'Metros', [
+            'offer1' => 400,
+            'offer2' => 0,
+        ]);
+
+        $newOfferData = [
+            'playerName' => 'FA Replace',
+            'pid' => $pid,
+            'teamName' => 'Metros',
+            'teamid' => 1,
+            'offer1' => 700,
+            'offer2' => 750,
+            'offer3' => 800,
+            'offer4' => 0,
+            'offer5' => 0,
+            'offer6' => 0,
+            'modifier' => 1.2,
+            'random' => 0.7,
+            'perceivedValue' => 2250.0,
+            'mle' => 0,
+            'lle' => 0,
+            'offerType' => 0,
+        ];
+
+        $result = $this->repository->saveOffer($newOfferData);
+
+        $this->assertTrue($result);
+
+        $existing = $this->repository->getExistingOffer(1, $pid);
+        $this->assertNotNull($existing);
+        $this->assertSame(700, $existing['offer1']);
+        $this->assertSame(750, $existing['offer2']);
+        $this->assertSame(800, $existing['offer3']);
+    }
+
+    public function testExecuteSigningsTransactionallyUpdatesPlayerContracts(): void
+    {
+        $pid1 = self::TEST_PID_BASE + 3;
+        $pid2 = self::TEST_PID_BASE + 4;
+        $this->insertTestPlayer($pid1, 'FA Signing 1', [
+            'teamid' => 0, 'cy' => 0, 'cyt' => 0,
+            'salary_yr1' => 0, 'salary_yr2' => 0, 'salary_yr3' => 0,
+            'salary_yr4' => 0, 'salary_yr5' => 0, 'salary_yr6' => 0,
+        ]);
+        $this->insertTestPlayer($pid2, 'FA Signing 2', [
+            'teamid' => 0, 'cy' => 0, 'cyt' => 0,
+            'salary_yr1' => 0, 'salary_yr2' => 0, 'salary_yr3' => 0,
+            'salary_yr4' => 0, 'salary_yr5' => 0, 'salary_yr6' => 0,
+        ]);
+
+        $signings = [
+            [
+                'playerId' => $pid1,
+                'teamId' => 1,
+                'teamName' => 'Metros',
+                'offerYears' => 3,
+                'offers' => [
+                    'offer1' => 500, 'offer2' => 550, 'offer3' => 600,
+                    'offer4' => 0, 'offer5' => 0, 'offer6' => 0,
+                ],
+                'usedMle' => false,
+                'usedLle' => false,
+            ],
+            [
+                'playerId' => $pid2,
+                'teamId' => 2,
+                'teamName' => 'Stars',
+                'offerYears' => 2,
+                'offers' => [
+                    'offer1' => 300, 'offer2' => 350, 'offer3' => 0,
+                    'offer4' => 0, 'offer5' => 0, 'offer6' => 0,
+                ],
+                'usedMle' => false,
+                'usedLle' => false,
+            ],
+        ];
+
+        $result = $this->adminRepository->executeSigningsTransactionally(
+            $signings,
+            'FA Signings',
+            'Players signed',
+            'Details of signings'
+        );
+
+        $this->assertSame(3, $result['successCount']);
+        $this->assertSame(0, $result['errorCount']);
+
+        $player1 = $this->commonRepository->getPlayerByID($pid1);
+        $this->assertNotNull($player1);
+        $this->assertSame(1, $player1['teamid']);
+        $this->assertSame(3, $player1['cyt']);
+        $this->assertSame(500, $player1['salary_yr1']);
+        $this->assertSame(550, $player1['salary_yr2']);
+        $this->assertSame(600, $player1['salary_yr3']);
+        $this->assertSame(1, $player1['fa_signing_flag']);
+
+        $player2 = $this->commonRepository->getPlayerByID($pid2);
+        $this->assertNotNull($player2);
+        $this->assertSame(2, $player2['teamid']);
+        $this->assertSame(2, $player2['cyt']);
+        $this->assertSame(300, $player2['salary_yr1']);
+    }
+
+    public function testExecuteSigningsWithMleMarksTeamFlag(): void
+    {
+        $pid = self::TEST_PID_BASE + 5;
+        $this->insertTestPlayer($pid, 'MLE Signing', [
+            'teamid' => 0, 'cy' => 0, 'cyt' => 0,
+            'salary_yr1' => 0, 'salary_yr2' => 0, 'salary_yr3' => 0,
+            'salary_yr4' => 0, 'salary_yr5' => 0, 'salary_yr6' => 0,
+        ]);
+
+        $this->setTeamMle('Metros', 1);
+
+        $signings = [
+            [
+                'playerId' => $pid,
+                'teamId' => 1,
+                'teamName' => 'Metros',
+                'offerYears' => 1,
+                'offers' => [
+                    'offer1' => 450, 'offer2' => 0, 'offer3' => 0,
+                    'offer4' => 0, 'offer5' => 0, 'offer6' => 0,
+                ],
+                'usedMle' => true,
+                'usedLle' => false,
+            ],
+        ];
+
+        $this->adminRepository->executeSigningsTransactionally(
+            $signings,
+            'MLE Signing',
+            'MLE used',
+            'Details'
+        );
+
+        $team = $this->commonRepository->getTeamByName('Metros');
+        $this->assertNotNull($team);
+        $this->assertSame(0, $team['has_mle']);
+    }
+
+    private function setTeamMle(string $teamName, int $value): void
+    {
+        $stmt = $this->db->prepare("UPDATE ibl_team_info SET has_mle = ? WHERE team_name = ?");
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('is', $value, $teamName);
+        $stmt->execute();
+        $stmt->close();
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/RookieOption/RookieOptionControllerIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/RookieOption/RookieOptionControllerIntegrationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\RookieOption;
+
+use PHPUnit\Framework\Attributes\Group;
+use RookieOption\RookieOptionRepository;
+use Services\CommonMysqliRepository;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+#[Group('database')]
+class RookieOptionControllerIntegrationTest extends DatabaseTestCase
+{
+    private RookieOptionRepository $repository;
+    private CommonMysqliRepository $commonRepository;
+
+    private const TEST_PID_BASE = 200060200;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = new RookieOptionRepository($this->db);
+        $this->commonRepository = new CommonMysqliRepository($this->db);
+    }
+
+    public function testRound1OptionSetsSalaryYr4(): void
+    {
+        $pid = self::TEST_PID_BASE + 1;
+        $this->insertTestPlayer($pid, 'Round1 Rookie', [
+            'teamid' => 1,
+            'draftround' => 1,
+            'exp' => 2,
+            'cy' => 1,
+            'cyt' => 3,
+            'salary_yr1' => 200,
+            'salary_yr2' => 250,
+            'salary_yr3' => 300,
+            'salary_yr4' => 0,
+        ]);
+
+        $result = $this->repository->updatePlayerRookieOption($pid, 1, 400);
+
+        $this->assertTrue($result);
+
+        $player = $this->commonRepository->getPlayerByID($pid);
+        $this->assertNotNull($player);
+        $this->assertSame(400, $player['salary_yr4']);
+        $this->assertSame(200, $player['salary_yr1']);
+        $this->assertSame(250, $player['salary_yr2']);
+        $this->assertSame(300, $player['salary_yr3']);
+    }
+
+    public function testRound2OptionSetsSalaryYr3(): void
+    {
+        $pid = self::TEST_PID_BASE + 2;
+        $this->insertTestPlayer($pid, 'Round2 Rookie', [
+            'teamid' => 1,
+            'draftround' => 2,
+            'exp' => 1,
+            'cy' => 1,
+            'cyt' => 2,
+            'salary_yr1' => 100,
+            'salary_yr2' => 150,
+            'salary_yr3' => 0,
+        ]);
+
+        $result = $this->repository->updatePlayerRookieOption($pid, 2, 200);
+
+        $this->assertTrue($result);
+
+        $player = $this->commonRepository->getPlayerByID($pid);
+        $this->assertNotNull($player);
+        $this->assertSame(200, $player['salary_yr3']);
+        $this->assertSame(100, $player['salary_yr1']);
+        $this->assertSame(150, $player['salary_yr2']);
+    }
+
+    public function testOptionDoesNotAffectOtherSalaryFields(): void
+    {
+        $pid = self::TEST_PID_BASE + 3;
+        $this->insertTestPlayer($pid, 'Salary Isolation', [
+            'teamid' => 1,
+            'draftround' => 1,
+            'exp' => 3,
+            'cy' => 1,
+            'cyt' => 3,
+            'salary_yr1' => 300,
+            'salary_yr2' => 350,
+            'salary_yr3' => 400,
+            'salary_yr4' => 0,
+            'salary_yr5' => 0,
+            'salary_yr6' => 0,
+        ]);
+
+        $this->repository->updatePlayerRookieOption($pid, 1, 500);
+
+        $player = $this->commonRepository->getPlayerByID($pid);
+        $this->assertNotNull($player);
+        $this->assertSame(500, $player['salary_yr4']);
+        $this->assertSame(300, $player['salary_yr1']);
+        $this->assertSame(350, $player['salary_yr2']);
+        $this->assertSame(400, $player['salary_yr3']);
+        $this->assertSame(0, $player['salary_yr5']);
+        $this->assertSame(0, $player['salary_yr6']);
+    }
+
+    public function testOptionForNonExistentPlayerReturnsFalse(): void
+    {
+        $result = $this->repository->updatePlayerRookieOption(999999999, 1, 400);
+
+        $this->assertFalse($result);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/Waivers/WaiversProcessorIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Waivers/WaiversProcessorIntegrationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Waivers;
+
+use PHPUnit\Framework\Attributes\Group;
+use Services\CommonMysqliRepository;
+use Services\NewsService;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+use Waivers\WaiversProcessor;
+use Waivers\WaiversRepository;
+use Waivers\WaiversValidator;
+
+#[Group('database')]
+class WaiversProcessorIntegrationTest extends DatabaseTestCase
+{
+    private WaiversProcessor $processor;
+    private CommonMysqliRepository $commonRepository;
+
+    private const TEST_PID_BASE = 200060100;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_SERVER['SERVER_NAME'] = 'localhost';
+
+        $repository = new WaiversRepository($this->db);
+        $this->commonRepository = new CommonMysqliRepository($this->db);
+        $validator = new WaiversValidator();
+        $newsService = new NewsService($this->db);
+
+        $this->processor = new WaiversProcessor(
+            $repository,
+            $this->commonRepository,
+            $validator,
+            $newsService,
+            $this->db
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['SERVER_NAME']);
+        parent::tearDown();
+    }
+
+    public function testDropPlayerSetsOrdinalAndDroptime(): void
+    {
+        $pid = self::TEST_PID_BASE + 1;
+        $this->insertTestPlayer($pid, 'Waiver Drop Test', [
+            'teamid' => 1,
+            'ordinal' => 5,
+            'droptime' => 0,
+        ]);
+
+        $result = $this->processor->processDrop($pid, 'Metros', 5, 3000);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('player_dropped', $result['result']);
+
+        $player = $this->commonRepository->getPlayerByID($pid);
+        $this->assertNotNull($player);
+        $this->assertSame(1000, $player['ordinal']);
+        $this->assertGreaterThan(0, $player['droptime']);
+    }
+
+    public function testSignPlayerWithoutExistingContract(): void
+    {
+        $pid = self::TEST_PID_BASE + 2;
+        $this->insertTestPlayer($pid, 'Waiver FA Pickup', [
+            'teamid' => 0,
+            'cy' => 0,
+            'cyt' => 0,
+            'salary_yr1' => 0,
+            'salary_yr2' => 0,
+            'exp' => 5,
+            'bird' => 0,
+            'ordinal' => 1000,
+            'droptime' => 1000000,
+        ]);
+
+        $result = $this->processor->processAdd($pid, 'Metros', 4, 3000);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('player_added', $result['result']);
+
+        $player = $this->commonRepository->getPlayerByID($pid);
+        $this->assertNotNull($player);
+        $this->assertSame(1, $player['teamid']);
+        $this->assertSame(800, $player['ordinal']);
+        $this->assertSame(0, $player['droptime']);
+        $this->assertSame(0, $player['bird']);
+        $this->assertSame(0, $player['cy']);
+        $this->assertSame(1, $player['cyt']);
+        $vetMin = \ContractRules::getVeteranMinimumSalary(5);
+        $this->assertSame($vetMin, $player['salary_yr1']);
+        $this->assertSame(0, $player['salary_yr2']);
+    }
+
+    public function testSignPlayerWithExistingContractPreservesContract(): void
+    {
+        $pid = self::TEST_PID_BASE + 3;
+        $this->insertTestPlayer($pid, 'Waiver Contract Keep', [
+            'teamid' => 0,
+            'cy' => 1,
+            'cyt' => 3,
+            'salary_yr1' => 500,
+            'salary_yr2' => 600,
+            'salary_yr3' => 700,
+            'exp' => 4,
+            'bird' => 2,
+            'ordinal' => 1000,
+            'droptime' => 1000000,
+        ]);
+
+        $result = $this->processor->processAdd($pid, 'Metros', 4, 3000);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('player_added', $result['result']);
+
+        $player = $this->commonRepository->getPlayerByID($pid);
+        $this->assertNotNull($player);
+        $this->assertSame(1, $player['teamid']);
+        $this->assertSame(800, $player['ordinal']);
+        $this->assertSame(0, $player['droptime']);
+        $this->assertSame(0, $player['bird']);
+        $this->assertSame(1, $player['cy']);
+        $this->assertSame(3, $player['cyt']);
+        $this->assertSame(500, $player['salary_yr1']);
+        $this->assertSame(600, $player['salary_yr2']);
+        $this->assertSame(700, $player['salary_yr3']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds four DB integration test files, one per workflow, as the next batch in the test-audit-03 series (Waivers, Extension, RookieOption, FreeAgency).

Each test file connects to a real MariaDB instance, inserts isolated test players using the `TEST_PID_BASE` range convention (`200060100–200060499`), exercises the real Repository/Processor/Controller classes, and asserts on final DB state.

## Changes

- `tests/DatabaseIntegration/Waivers/WaiversProcessorIntegrationTest.php` — drop/add player flows via real `WaiversProcessor`, verifies ordinal, droptime, teamid, salary, bird
- `tests/DatabaseIntegration/RookieOption/RookieOptionControllerIntegrationTest.php` — round-1/round-2 option salary slot targeting, non-existent player returns false
- `tests/DatabaseIntegration/Extension/ExtensionRepositoryIntegrationTest.php` — accepted extension updates salary years, marks team flags, updatePlayerContract targets correct year slots
- `tests/DatabaseIntegration/FreeAgency/FreeAgencyRepositoryIntegrationTest.php` — saveOffer insert/replace, executeSigningsTransactionally contract update + MLE flag teardown

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.