### PR TITLE
feat: add admin fixture to CI seed with real bcrypt hashes

### DIFF
--- a/.claude/rules/browser-login.md
+++ b/.claude/rules/browser-login.md
@@ -1,6 +1,6 @@
 ---
-description: Dev auto-login setup: localhost sessions are pre-authenticated via DEV_AUTO_LOGIN; do not navigate to login forms.
-last_verified: 2026-04-11
+description: Dev auto-login setup: localhost sessions are pre-authenticated via DEV_AUTO_LOGIN; do not navigate to login forms. Identity matrix for all test layers.
+last_verified: 2026-05-04
 ---
 
 # Browser Auto-Login
@@ -10,3 +10,13 @@ You are automatically authenticated as the user in `ibl5/.env.test` (`DEV_AUTO_L
 
 - Do NOT navigate to login forms or enter credentials — the session is pre-authenticated on first page load.
 - If you see a login page, `.env.test` may be misconfigured or Docker needs restarting.
+
+## Identity Matrix
+
+| Layer | User | Source | Used by |
+|-------|------|--------|---------|
+| Local browser dev | A-Jay (or per-developer) | `.env.test` `DEV_AUTO_LOGIN` | Localhost browsing on real dev DB |
+| CI E2E browser | Configured at runtime | `secrets.IBL_TEST_USER` / `IBL_TEST_PASS` | Playwright in CI |
+| DatabaseIntegration tests | testadmin / testgm | `tests/DatabaseIntegration/Fixtures/db-seed.sql` | PHPUnit `#[Group('database')]` tests |
+
+These layers do not need to share usernames. Each is independently scoped.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
               - 'ibl5/phpunit.xml'
               - 'ibl5/phpstan.neon'
               - 'ibl5/phpstan-rules/**'
-              - 'ibl5/tests/DatabaseIntegration/fixtures/**'
+              - 'ibl5/tests/DatabaseIntegration/Fixtures/**'
               - '.github/workflows/tests.yml'
             shell:
               - 'bin/**'
@@ -239,7 +239,7 @@ jobs:
 
     - name: Import seed data
       working-directory: ibl5
-      run: mysql -h 127.0.0.1 -u root -proot ibl5 < tests/DatabaseIntegration/fixtures/db-seed.sql
+      run: mysql -h 127.0.0.1 -u root -proot ibl5 < tests/DatabaseIntegration/Fixtures/db-seed.sql
 
     - name: Run database integration tests
       working-directory: ibl5

--- a/ibl5/tests/DatabaseIntegration/Fixtures/AdminFixtureTest.php
+++ b/ibl5/tests/DatabaseIntegration/Fixtures/AdminFixtureTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Fixtures;
+
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+#[Group('database')]
+class AdminFixtureTest extends DatabaseTestCase
+{
+    public function testAdminUserSeeded(): void
+    {
+        $row = $this->db->query(
+            "SELECT id, username, roles_mask, status FROM auth_users WHERE username = '" . SeedUsers::ADMIN_USERNAME . "'"
+        )->fetch_assoc();
+
+        self::assertNotNull($row, 'testadmin user must exist in CI seed');
+        self::assertSame(SeedUsers::ADMIN_ID, (int) $row['id']);
+        self::assertSame(1, (int) $row['roles_mask'], 'testadmin must have ADMIN role bit set');
+        self::assertSame(0, (int) $row['status'], 'testadmin must have status = NORMAL (0)');
+    }
+
+    public function testAdminPasswordVerifies(): void
+    {
+        $row = $this->db->query(
+            "SELECT password FROM auth_users WHERE username = '" . SeedUsers::ADMIN_USERNAME . "'"
+        )->fetch_assoc();
+
+        self::assertNotNull($row);
+        self::assertTrue(
+            password_verify(SeedUsers::ADMIN_PASSWORD, $row['password']),
+            'Seeded admin password hash must verify against the documented test password'
+        );
+    }
+
+    public function testGmUserStillSeeded(): void
+    {
+        $row = $this->db->query(
+            "SELECT id, roles_mask FROM auth_users WHERE username = '" . SeedUsers::GM_USERNAME . "'"
+        )->fetch_assoc();
+
+        self::assertNotNull($row);
+        self::assertSame(SeedUsers::GM_ID, (int) $row['id']);
+        self::assertSame(0, (int) $row['roles_mask']);
+    }
+
+    public function testGmPasswordVerifies(): void
+    {
+        $row = $this->db->query(
+            "SELECT password FROM auth_users WHERE username = '" . SeedUsers::GM_USERNAME . "'"
+        )->fetch_assoc();
+
+        self::assertNotNull($row);
+        self::assertTrue(
+            password_verify(SeedUsers::GM_PASSWORD, $row['password']),
+            'Seeded GM password hash must verify against the documented test password'
+        );
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/Fixtures/SeedUsers.php
+++ b/ibl5/tests/DatabaseIntegration/Fixtures/SeedUsers.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Fixtures;
+
+final class SeedUsers
+{
+    public const ADMIN_ID = 2;
+    public const ADMIN_USERNAME = 'testadmin';
+    public const ADMIN_PASSWORD = 'test-password';
+
+    public const GM_ID = 1;
+    public const GM_USERNAME = 'testgm';
+    public const GM_PASSWORD = 'gm-password';
+}

--- a/ibl5/tests/DatabaseIntegration/Fixtures/db-seed.sql
+++ b/ibl5/tests/DatabaseIntegration/Fixtures/db-seed.sql
@@ -48,10 +48,18 @@ INSERT INTO ibl_plr (pid, name, age, teamid, pos, stamina, exp, bird, cy, cyt, s
 VALUES (2, 'Test Player Two', 22, 0, 'SF', 75, 1, 0, 0, 0, 0, 0, 0, 1000, 0, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 ON DUPLICATE KEY UPDATE name = VALUES(name);
 
--- Users: one GM mapped to Metros (via auth_users + ibl_team_info.gm_username)
+-- Users: GM (non-admin) and admin fixtures
+-- Passwords are real bcrypt cost-4 hashes — password_verify() works against them.
+-- GM fixture: testgm/gm-password (non-admin, cost 4)
 INSERT INTO auth_users (id, email, password, username, status, verified, resettable, roles_mask, registered, last_login, force_logout)
-VALUES (1, 'test@example.com', '$2y$12$placeholder_hash_for_tests_only..', 'testgm', 0, 1, 1, 0, UNIX_TIMESTAMP(), NULL, 0)
-ON DUPLICATE KEY UPDATE username = VALUES(username);
+VALUES (1, 'test@example.com', '$2y$04$iQGtQtp3qeQH98Q.kx99c..rREmkgak7Xq9/uLjpJQubS3Bgm3gHi', 'testgm', 0, 1, 1, 0, UNIX_TIMESTAMP(), NULL, 0)
+ON DUPLICATE KEY UPDATE username = VALUES(username), password = VALUES(password);
+
+-- Admin fixture: testadmin/test-password (bcrypt cost 4 for fast tests)
+-- roles_mask = 1 grants ADMIN role (Delight\Auth\Role::ADMIN)
+INSERT INTO auth_users (id, email, password, username, status, verified, resettable, roles_mask, registered, last_login, force_logout)
+VALUES (2, 'admin@example.com', '$2y$04$mFS8uV7f1CVkCMug3cn9Rup8sGVb0qUDlZsgKB.E/x/ADAHt1S.yu', 'testadmin', 0, 1, 1, 1, UNIX_TIMESTAMP(), NULL, 0)
+ON DUPLICATE KEY UPDATE roles_mask = VALUES(roles_mask), password = VALUES(password);
 
 -- Settings: commonly read by services
 INSERT INTO ibl_settings (name, value)


### PR DESCRIPTION
## Summary

Adds a permanent `testadmin` user to the `DatabaseIntegration` CI seed alongside the existing `testgm` fixture. Replaces the placeholder hash for `testgm` with a real bcrypt cost-4 hash so `password_verify()` works in tests.

Key changes:
- **`db-seed.sql`**: Add `testadmin` row (`id=2`, `roles_mask=1`, real bcrypt hash). Rename fixture directory `fixtures/` → `Fixtures/` (case fix).
- **`SeedUsers.php`**: New constants holder for seed user usernames, passwords, and IDs — single source of truth for all fixture-aware tests.
- **`AdminFixtureTest.php`**: PHPUnit tests verifying both users are correctly seeded with proper roles and verifiable passwords.
- **`.github/workflows/tests.yml`**: Fix path case (`fixtures/` → `Fixtures/`) in seed import and path filter.
- **`browser-login.md`**: Add Identity Matrix documenting the three independent auth layers (local dev, CI E2E, DatabaseIntegration PHPUnit).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)