### PR TITLE
test: module entry-point coverage — player-data domain (Group A)

### DIFF
--- a/ibl5/tests/Module/EntryPoints/AllStarAppearancesEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/AllStarAppearancesEntryPointTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class AllStarAppearancesEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersAppearancesList(): void
+    {
+        $this->mockDb->setMockData([
+            ['name' => 'Test Player', 'pid' => 1, 'appearances' => 5],
+        ]);
+        $output = $this->runModule('AllStarAppearances');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+
+    public function testRendersWithNoAppearances(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('AllStarAppearances');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/AwardHistoryEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/AwardHistoryEntryPointTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class AwardHistoryEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testEmptyPostRendersFormWithNoResults(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('AwardHistory');
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Player Awards', $output);
+        $this->assertQueryNotExecuted('ibl_awards');
+    }
+
+    public function testPostWithFilterRunsSearch(): void
+    {
+        $this->mockDb->setMockData([
+            ['year' => 2024, 'award' => 'MVP', 'name' => 'Test Player', 'table_id' => 1, 'pid' => 1],
+        ]);
+        $output = $this->runModule('AwardHistory', [], ['name' => 'Test']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+
+    public function testPostWithEmptyFilterRunsSearchWithNoResults(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('AwardHistory', [], ['name' => '']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/AwardHistoryEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/AwardHistoryEntryPointTest.php
@@ -21,7 +21,7 @@ class AwardHistoryEntryPointTest extends ModuleEntryPointTestCase
         $this->mockDb->setMockData([
             ['year' => 2024, 'award' => 'MVP', 'name' => 'Test Player', 'table_id' => 1, 'pid' => 1],
         ]);
-        $output = $this->runModule('AwardHistory', [], ['name' => 'Test']);
+        $output = $this->runModule('AwardHistory', [], ['aw_name' => 'Test']);
 
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('ibl_awards');
@@ -30,7 +30,7 @@ class AwardHistoryEntryPointTest extends ModuleEntryPointTestCase
     public function testPostWithEmptyFilterRunsSearchWithNoResults(): void
     {
         $this->mockDb->setMockData([]);
-        $output = $this->runModule('AwardHistory', [], ['name' => '']);
+        $output = $this->runModule('AwardHistory', [], ['aw_name' => '']);
 
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('ibl_awards');

--- a/ibl5/tests/Module/EntryPoints/ComparePlayersEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/ComparePlayersEntryPointTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+
+/**
+ * ComparePlayers/index.php defines global functions (userinfo, main) that
+ * cannot be redeclared, so each test runs in a separate process.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class ComparePlayersEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testNoPostShowsSearchForm(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('ComparePlayers');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_plr');
+    }
+
+    public function testPostWithBothPlayersRunsComparison(): void
+    {
+        $this->mockDb->setMockData([
+            ['pid' => 1, 'name' => 'Player One', 'pos' => 'G', 'teamid' => 1],
+        ]);
+        $output = $this->runModule(
+            'ComparePlayers',
+            [],
+            ['Player1' => 'Player One', 'Player2' => 'Player Two'],
+        );
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_plr');
+    }
+
+    public function testPostWithEmptyPlayersShowsNotFoundMessage(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule(
+            'ComparePlayers',
+            [],
+            ['Player1' => '', 'Player2' => ''],
+        );
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('not found', $output);
+    }
+
+    public function testPostWithOverlongPlayerNameShowsError(): void
+    {
+        $this->mockDb->setMockData([]);
+        $longName = str_repeat('A', 101);
+        $output = $this->runModule(
+            'ComparePlayers',
+            [],
+            ['Player1' => $longName, 'Player2' => 'Test'],
+        );
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('100 characters', $output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/ComparePlayersEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/ComparePlayersEntryPointTest.php
@@ -26,9 +26,14 @@ class ComparePlayersEntryPointTest extends ModuleEntryPointTestCase
 
     public function testPostWithBothPlayersRunsComparison(): void
     {
-        $this->mockDb->setMockData([
-            ['pid' => 1, 'name' => 'Player One', 'pos' => 'G', 'teamid' => 1],
-        ]);
+        $player1 = ['pid' => 1, 'name' => 'Player One', 'pos' => 'G', 'teamid' => 1, 'color1' => '000000', 'color2' => 'FFFFFF'];
+        $player2 = ['pid' => 2, 'name' => 'Player Two', 'pos' => 'F', 'teamid' => 2, 'color1' => 'FF0000', 'color2' => '000000'];
+        // MockPreparedStatement interpolates bound params into SQL, so 'Player One' appears
+        // literally in the WHERE clause — onQuery routes each lookup to a distinct row.
+        $this->mockDb->onQuery('Player One', [$player1]);
+        $this->mockDb->onQuery('Player Two', [$player2]);
+        $this->mockDb->setMockData([$player1, $player2]); // for getAllPlayerNames()
+
         $output = $this->runModule(
             'ComparePlayers',
             [],

--- a/ibl5/tests/Module/EntryPoints/DraftHistoryEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/DraftHistoryEntryPointTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Module\EntryPoints;
 
-use Tests\WideUnit\Mocks\TestDataFactory;
-
 /**
  * Integration tests for modules/DraftHistory/index.php entry point.
  *
@@ -13,18 +11,6 @@ use Tests\WideUnit\Mocks\TestDataFactory;
  */
 class DraftHistoryEntryPointTest extends ModuleEntryPointTestCase
 {
-    /**
-     * @return array<string, mixed>
-     */
-    private static function fullTeamData(array $overrides = []): array
-    {
-        return array_merge(TestDataFactory::createTeam(), [
-            'used_extension_this_chunk' => 0,
-            'used_extension_this_season' => 0,
-            'league_record' => '10-5',
-        ], $overrides);
-    }
-
     public function testNoParamsShowsLatestDraftYear(): void
     {
         $this->mockDb->setMockData([]);

--- a/ibl5/tests/Module/EntryPoints/InjuriesEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/InjuriesEntryPointTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use Tests\WideUnit\Mocks\TestDataFactory;
+
+class InjuriesEntryPointTest extends ModuleEntryPointTestCase
+{
+    /**
+     * @return array<string, mixed>
+     */
+    private static function fullTeamData(array $overrides = []): array
+    {
+        return array_merge(TestDataFactory::createTeam(), [
+            'used_extension_this_chunk' => 0,
+            'used_extension_this_season' => 0,
+            'league_record' => '10-5',
+        ], $overrides);
+    }
+
+    public function testRendersInjuredPlayersList(): void
+    {
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([
+            TestDataFactory::createPlayer(['injured' => 3, 'injdays' => 3]),
+        ]);
+        $output = $this->runModule('Injuries');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_plr');
+    }
+
+    public function testRendersWithNoInjuredPlayers(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('Injuries');
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/InjuriesEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/InjuriesEntryPointTest.php
@@ -8,18 +8,6 @@ use Tests\WideUnit\Mocks\TestDataFactory;
 
 class InjuriesEntryPointTest extends ModuleEntryPointTestCase
 {
-    /**
-     * @return array<string, mixed>
-     */
-    private static function fullTeamData(array $overrides = []): array
-    {
-        return array_merge(TestDataFactory::createTeam(), [
-            'used_extension_this_chunk' => 0,
-            'used_extension_this_season' => 0,
-            'league_record' => '10-5',
-        ], $overrides);
-    }
-
     public function testRendersInjuredPlayersList(): void
     {
         $this->mockDb->setMockTeamData([self::fullTeamData()]);

--- a/ibl5/tests/Module/EntryPoints/ModuleEntryPointTestCase.php
+++ b/ibl5/tests/Module/EntryPoints/ModuleEntryPointTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Module\EntryPoints;
 
+use Tests\WideUnit\Mocks\TestDataFactory;
 use Tests\WideUnit\WideUnitTestCase;
 
 /**
@@ -191,6 +192,19 @@ abstract class ModuleEntryPointTestCase extends WideUnitTestCase
             'sitename', 'pagetitle', 'slogan', 'name', 'user', 'cookie',
             'currentlang', 'language', 'op', 'pa', 'articlecomm',
         ]);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    protected static function fullTeamData(array $overrides = []): array
+    {
+        return array_merge(TestDataFactory::createTeam(), [
+            'used_extension_this_chunk' => 0,
+            'used_extension_this_season' => 0,
+            'league_record' => '10-5',
+        ], $overrides);
     }
 
     /**

--- a/ibl5/tests/Module/EntryPoints/PlayerDatabaseEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/PlayerDatabaseEntryPointTest.php
@@ -20,7 +20,7 @@ class PlayerDatabaseEntryPointTest extends ModuleEntryPointTestCase
         $this->mockDb->setMockData([
             ['pid' => 1, 'name' => 'Test Player', 'pos' => 'G', 'teamid' => 1],
         ]);
-        $output = $this->runModule('PlayerDatabase', [], ['name' => 'Test']);
+        $output = $this->runModule('PlayerDatabase', [], ['search_name' => 'Test']);
 
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('ibl_plr');
@@ -29,7 +29,7 @@ class PlayerDatabaseEntryPointTest extends ModuleEntryPointTestCase
     public function testPostWithEmptyFiltersRunsSearchWithNoResults(): void
     {
         $this->mockDb->setMockData([]);
-        $output = $this->runModule('PlayerDatabase', [], ['name' => '']);
+        $output = $this->runModule('PlayerDatabase', [], ['search_name' => '']);
 
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('ibl_plr');

--- a/ibl5/tests/Module/EntryPoints/PlayerDatabaseEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/PlayerDatabaseEntryPointTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class PlayerDatabaseEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testEmptyPostRendersDefaultSearchForm(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('PlayerDatabase');
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Player Search', $output);
+    }
+
+    public function testPostWithFilterRunsSearch(): void
+    {
+        $this->mockDb->setMockData([
+            ['pid' => 1, 'name' => 'Test Player', 'pos' => 'G', 'teamid' => 1],
+        ]);
+        $output = $this->runModule('PlayerDatabase', [], ['name' => 'Test']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_plr');
+    }
+
+    public function testPostWithEmptyFiltersRunsSearchWithNoResults(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('PlayerDatabase', [], ['name' => '']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_plr');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/PlayerEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/PlayerEntryPointTest.php
@@ -17,18 +17,6 @@ use Tests\WideUnit\Mocks\TestDataFactory;
 #[PreserveGlobalState(false)]
 class PlayerEntryPointTest extends ModuleEntryPointTestCase
 {
-    /**
-     * @return array<string, mixed>
-     */
-    private static function fullTeamData(array $overrides = []): array
-    {
-        return array_merge(TestDataFactory::createTeam(), [
-            'used_extension_this_chunk' => 0,
-            'used_extension_this_season' => 0,
-            'league_record' => '10-5',
-        ], $overrides);
-    }
-
     public function testMissingPaShowsNothing(): void
     {
         $this->mockDb->setMockData([]);

--- a/ibl5/tests/Module/EntryPoints/PlayerEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/PlayerEntryPointTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use Tests\WideUnit\Mocks\TestDataFactory;
+
+/**
+ * Player/index.php defines global functions (showpage, negotiate, rookieoption,
+ * processrookieoption) that cannot be redeclared, so each test runs in a
+ * separate process.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class PlayerEntryPointTest extends ModuleEntryPointTestCase
+{
+    /**
+     * @return array<string, mixed>
+     */
+    private static function fullTeamData(array $overrides = []): array
+    {
+        return array_merge(TestDataFactory::createTeam(), [
+            'used_extension_this_chunk' => 0,
+            'used_extension_this_season' => 0,
+            'league_record' => '10-5',
+        ], $overrides);
+    }
+
+    public function testMissingPaShowsNothing(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('Player');
+
+        $this->assertSame('', $output);
+    }
+
+    public function testInvalidPaShowsNothing(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('Player', [], [], ['pa' => 'bogus']);
+
+        $this->assertSame('', $output);
+    }
+
+    private function seedShowpageMocks(array $playerOverrides = []): void
+    {
+        $player = TestDataFactory::createPlayer(array_merge(
+            ['pid' => 1, 'name' => 'Test Player', 'teamname' => 'Test Team', 'color1' => 'FF0000', 'color2' => '000000'],
+            $playerOverrides,
+        ));
+
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([$player]);
+
+        // The PlayerRepository JOIN query contains both ibl_plr and ibl_team_info,
+        // so we must route it via onQuery before the team-info special handler fires.
+        $this->mockDb->onQuery('FROM ibl_plr', [$player]);
+        $this->mockDb->onQuery('ibl_hist', []);
+        $this->mockDb->onQuery('ibl_box_scores', []);
+        $this->mockDb->onQuery('ibl_sim_dates', []);
+        $this->mockDb->onQuery('ibl_playoff_career_totals', []);
+        $this->mockDb->onQuery('ibl_settings', [['value' => 'Regular Season']]);
+        $this->mockDb->onQuery('ibl_awards', []);
+        $this->mockDb->onQuery('ibl_draft', []);
+        $this->mockDb->onQuery('COUNT', [['total' => 0]]);
+    }
+
+    public function testShowpageDispatchesAndQueriesPlayer(): void
+    {
+        $this->seedShowpageMocks();
+
+        $output = $this->runModule(
+            'Player',
+            [],
+            [],
+            ['pa' => 'showpage', 'pid' => '1', 'pageView' => null],
+        );
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_plr');
+    }
+
+    public function testShowpageWithNonNumericPidCastsToZero(): void
+    {
+        $this->seedShowpageMocks(['pid' => 0, 'name' => 'Unknown']);
+
+        $output = $this->runModule(
+            'Player',
+            [],
+            [],
+            ['pa' => 'showpage', 'pid' => 'garbage', 'pageView' => null],
+        );
+
+        $this->assertQueryExecuted('ibl_plr');
+    }
+
+    public function testNegotiateRendersNegotiation(): void
+    {
+        $player = TestDataFactory::createPlayer(['pid' => 1]);
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([$player]);
+        $this->mockDb->onQuery('ibl_settings', [['value' => 'Regular Season']]);
+
+        $output = $this->runModule('Player', [], [], ['pa' => 'negotiate', 'pid' => '1']);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testNegotiateWithAuthRendersNegotiation(): void
+    {
+        $this->authenticateAs('testuser');
+        $player = TestDataFactory::createPlayer(['pid' => 1]);
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([$player]);
+        $this->mockDb->onQuery('ibl_settings', [['value' => 'Regular Season']]);
+
+        $output = $this->runModule('Player', [], [], ['pa' => 'negotiate', 'pid' => '1']);
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/PlayerMovementEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/PlayerMovementEntryPointTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class PlayerMovementEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersMovementList(): void
+    {
+        $this->mockDb->setMockData([
+            [
+                'pid' => 1,
+                'name' => 'Moved Player',
+                'old_teamid' => 1,
+                'old_team' => 'Team A',
+                'new_teamid' => 2,
+                'new_team' => 'Team B',
+                'old_city' => 'City A',
+                'old_color1' => '333333',
+                'old_color2' => 'FFFFFF',
+                'new_city' => 'City B',
+                'new_color1' => '000000',
+                'new_color2' => 'FF0000',
+            ],
+        ]);
+        $output = $this->runModule('PlayerMovement');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_hist');
+    }
+
+    public function testRendersWithNoMovements(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('PlayerMovement');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_hist');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/ScheduleEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/ScheduleEntryPointTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Module\EntryPoints;
 
-use Tests\WideUnit\Mocks\TestDataFactory;
-
 /**
  * Integration tests for modules/Schedule/index.php entry point.
  *
@@ -14,18 +12,6 @@ use Tests\WideUnit\Mocks\TestDataFactory;
  */
 class ScheduleEntryPointTest extends ModuleEntryPointTestCase
 {
-    /**
-     * @return array<string, mixed>
-     */
-    private static function fullTeamData(array $overrides = []): array
-    {
-        return array_merge(TestDataFactory::createTeam(), [
-            'used_extension_this_chunk' => 0,
-            'used_extension_this_season' => 0,
-            'league_record' => '10-5',
-        ], $overrides);
-    }
-
     public function testMissingTeamIdShowsLeagueSchedule(): void
     {
         $this->mockDb->setMockData([]);


### PR DESCRIPTION
## Summary

Adds PHPUnit entry-point tests for 6 player-data domain modules:

- **AllStarAppearances** — renders list; empty state
- **AwardHistory** — empty POST shows form; POST with/without filter runs query
- **ComparePlayers** — no POST shows form; POST with both players; empty players; overlong name
- **Injuries** — renders injured list; empty state
- **PlayerDatabase** — default form; filter search; empty filter
- **Player** — missing/invalid pa; showpage dispatch; non-numeric pid cast; negotiate (authenticated + unauthenticated)
- **PlayerMovement** — renders movement list; empty state

Also consolidates the `fullTeamData()` test helper (identical across 4 test classes) into `ModuleEntryPointTestCase`.

## Changes

- `ibl5/tests/Module/EntryPoints/AllStarAppearancesEntryPointTest.php` (new)
- `ibl5/tests/Module/EntryPoints/AwardHistoryEntryPointTest.php` (new)
- `ibl5/tests/Module/EntryPoints/ComparePlayersEntryPointTest.php` (new)
- `ibl5/tests/Module/EntryPoints/InjuriesEntryPointTest.php` (new)
- `ibl5/tests/Module/EntryPoints/PlayerDatabaseEntryPointTest.php` (new)
- `ibl5/tests/Module/EntryPoints/PlayerEntryPointTest.php` (new)
- `ibl5/tests/Module/EntryPoints/PlayerMovementEntryPointTest.php` (new)
- `ibl5/tests/Module/EntryPoints/ModuleEntryPointTestCase.php` — added `fullTeamData()` helper

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.