### PR TITLE
test: module entry-point coverage — team/franchise domain (Group B)

### DIFF
--- a/ibl5/tests/Module/EntryPoints/CapSpaceEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/CapSpaceEntryPointTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class CapSpaceEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->onQuery('ibl_settings', [['value' => 'Regular Season']]);
+        $this->mockDb->onQuery('ibl_sim_dates', []);
+    }
+
+    public function testRendersCapData(): void
+    {
+        $this->mockDb->setMockData([]);
+        $this->mockDb->onQuery('ibl_team_info', []);
+        $this->mockDb->onQuery('ibl_plr', []);
+        $output = $this->runModule('CapSpace');
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/ContractListEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/ContractListEntryPointTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class ContractListEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersAllContracts(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('ContractList');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_plr');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/FranchiseHistoryEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/FranchiseHistoryEntryPointTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class FranchiseHistoryEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->onQuery('ibl_settings', [['value' => 'Regular Season']]);
+        $this->mockDb->onQuery('ibl_sim_dates', []);
+    }
+
+    public function testRendersFranchiseHistory(): void
+    {
+        $this->mockDb->setMockData([]);
+        $this->mockDb->onQuery('vw_franchise_summary', []);
+        $this->mockDb->onQuery('ibl_team_win_loss', []);
+        $this->mockDb->onQuery('vw_playoff_series_results', []);
+        $this->mockDb->onQuery('ibl_heat_win_loss', []);
+        $output = $this->runModule('FranchiseHistory');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_team_info');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/FranchiseRecordBookEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/FranchiseRecordBookEntryPointTest.php
@@ -109,4 +109,22 @@ class FranchiseRecordBookEntryPointTest extends ModuleEntryPointTestCase
         // isRealFranchise(29) === false → league path
         $this->assertQueryExecuted('ibl_rcb');
     }
+
+    public function testOpApiWithValidTeamidReturnsContent(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('FranchiseRecordBook', ['op' => 'api', 'teamid' => '5']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_rcb');
+    }
+
+    public function testOpApiWithoutTeamidReturnsLeagueContent(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('FranchiseRecordBook', ['op' => 'api']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_rcb');
+    }
 }

--- a/ibl5/tests/Module/EntryPoints/GMContactListEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/GMContactListEntryPointTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class GMContactListEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersAllTeamGmContacts(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('GMContactList');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_team_info');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/TeamEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/TeamEntryPointTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use Tests\WideUnit\Mocks\TestDataFactory;
+
+class TeamEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->onQuery('ibl_settings', [['value' => 'Regular Season']]);
+        $this->mockDb->onQuery('ibl_schedule', []);
+        $this->mockDb->onQuery('ibl_sim_dates', []);
+
+        $lcStub = $this->createStub(\League\LeagueContext::class);
+        $lcStub->method('getConfig')->willReturn(['images_path' => 'images/']);
+        $GLOBALS['leagueContext'] = $lcStub;
+    }
+
+    private function seedTeamPageMocks(): void
+    {
+        $team = self::fullTeamData([
+            'teamid' => 1,
+            'team_name' => 'Miami Heat',
+            'league_record' => '10-5',
+        ]);
+        $this->mockDb->setMockTeamData([$team]);
+        $this->mockDb->setMockData([]);
+        // Power/standings query returns null so currentSeasonData is skipped
+        $this->mockDb->onQuery('ibl_power', []);
+        $this->mockDb->onQuery('ibl_plr', []);
+        $this->mockDb->onQuery('ibl_box_scores', []);
+        $this->mockDb->onQuery('ibl_hist', []);
+        $this->mockDb->onQuery('ibl_awards', []);
+        $this->mockDb->onQuery('ibl_draft', []);
+        $this->mockDb->onQuery('COUNT', [['total' => 0]]);
+        $this->mockDb->onQuery('split_stats', []);
+        $this->mockDb->onQuery('ibl_playoff_career_totals', []);
+    }
+
+    public function testDefaultOpRendersMenu(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('Team', [], [], ['op' => '']);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testUnknownOpFallsToMenu(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('Team', [], [], ['op' => 'bogus']);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpTeamWithValidTeamidRendersTeamPage(): void
+    {
+        $this->seedTeamPageMocks();
+
+        $output = $this->runModule('Team', [], [], ['op' => 'team', 'teamid' => 1]);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_team_info');
+    }
+
+    public function testOpTeamWithTeamid0ShowsErrorMessage(): void
+    {
+        $this->mockDb->setMockTeamData([]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Team', [], [], ['op' => 'team', 'teamid' => 0]);
+
+        $this->assertStringContainsString('Team not found', $output);
+    }
+
+    public function testOpApiReturnsHtmlOutput(): void
+    {
+        $team = self::fullTeamData(['teamid' => 1, 'team_name' => 'Miami Heat']);
+        $this->mockDb->setMockTeamData([$team]);
+        $this->mockDb->setMockData([]);
+        $this->mockDb->onQuery('ibl_plr', []);
+        $this->mockDb->onQuery('ibl_box_scores', []);
+        $this->mockDb->onQuery('ibl_hist', []);
+        $this->mockDb->onQuery('split_stats', []);
+        $this->mockDb->onQuery('ibl_playoff_career_totals', []);
+
+        $output = $this->runModule(
+            'Team',
+            ['op' => 'api', 'teamid' => '1', 'display' => 'ratings'],
+            [],
+            ['op' => 'api'],
+        );
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/TeamOffDefStatsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/TeamOffDefStatsEntryPointTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class TeamOffDefStatsEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->onQuery('ibl_settings', [['value' => 'Regular Season']]);
+        $this->mockDb->onQuery('ibl_sim_dates', []);
+    }
+
+    public function testRendersDefaultTeamStats(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('TeamOffDefStats');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_box_scores');
+    }
+}


### PR DESCRIPTION
## Summary

Add entry-point smoke tests for six team/franchise modules (Group B of the test-audit series):

- **Team** — default op, `op=team` with valid/zero teamid, `op=api`, unknown op fallback
- **TeamOffDefStats** — default stats render
- **FranchiseHistory** — renders franchise history with seeded mocks
- **FranchiseRecordBook** — adds two `op=api` test cases (with and without teamid)
- **GMContactList** — renders GM contact list, queries `ibl_team_info`
- **ContractList** — renders all contracts, queries `ibl_plr`
- **CapSpace** — renders cap data for Regular Season phase

## Changes

- `tests/Module/EntryPoints/CapSpaceEntryPointTest.php` (new)
- `tests/Module/EntryPoints/ContractListEntryPointTest.php` (new)
- `tests/Module/EntryPoints/FranchiseHistoryEntryPointTest.php` (new)
- `tests/Module/EntryPoints/FranchiseRecordBookEntryPointTest.php` (extended: +2 `op=api` tests)
- `tests/Module/EntryPoints/GMContactListEntryPointTest.php` (new)
- `tests/Module/EntryPoints/TeamEntryPointTest.php` (new)
- `tests/Module/EntryPoints/TeamOffDefStatsEntryPointTest.php` (new)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.