### PR TITLE
test: module entry-point coverage — season/stats domain (Group C)

### DIFF
--- a/ibl5/tests/Module/EntryPoints/CareerLeaderboardsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/CareerLeaderboardsEntryPointTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class CareerLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->setMockData([]);
+        $this->mockDb->onQuery('cache', []);
+    }
+
+    private function globals(): array
+    {
+        return ['mysqli_db' => $GLOBALS['mysqli_db']];
+    }
+
+    public function testNotSubmittedRendersFilterForm(): void
+    {
+        $output = $this->runModule('CareerLeaderboards', [], [], $this->globals());
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Career Leaderboards', $output);
+        $this->assertQueryNotExecuted('ibl_hist');
+    }
+
+    public function testSubmittedRunsLeaderboardQuery(): void
+    {
+        $output = $this->runModule('CareerLeaderboards', [], [
+            'submitted' => '1',
+            'boards_type' => 'Regular Season Totals',
+            'sort_cat' => 'Points',
+            'active' => '0',
+            'display' => '50',
+        ], $this->globals());
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_hist');
+    }
+
+    public function testActiveOnlyFilterApplied(): void
+    {
+        $output = $this->runModule('CareerLeaderboards', [], [
+            'submitted' => '1',
+            'boards_type' => 'Regular Season Totals',
+            'sort_cat' => 'Points',
+            'active' => '1',
+            'display' => '50',
+        ], $this->globals());
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_hist');
+    }
+
+    public function testInvalidBoardsTypeFallsBackGracefully(): void
+    {
+        $output = $this->runModule('CareerLeaderboards', [], [
+            'submitted' => '1',
+            'boards_type' => 'garbage',
+            'sort_cat' => 'Points',
+            'active' => '0',
+            'display' => '50',
+        ], $this->globals());
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Career Leaderboards', $output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/CareerLeaderboardsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/CareerLeaderboardsEntryPointTest.php
@@ -13,14 +13,9 @@ class CareerLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
         $this->mockDb->onQuery('cache', []);
     }
 
-    private function globals(): array
-    {
-        return ['mysqli_db' => $GLOBALS['mysqli_db']];
-    }
-
     public function testNotSubmittedRendersFilterForm(): void
     {
-        $output = $this->runModule('CareerLeaderboards', [], [], $this->globals());
+        $output = $this->runModule('CareerLeaderboards', [], [], $this->dbGlobals());
 
         $this->assertNotEmpty($output);
         $this->assertStringContainsString('Career Leaderboards', $output);
@@ -35,7 +30,7 @@ class CareerLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
             'sort_cat' => 'Points',
             'active' => '0',
             'display' => '50',
-        ], $this->globals());
+        ], $this->dbGlobals());
 
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('ibl_hist');
@@ -49,7 +44,7 @@ class CareerLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
             'sort_cat' => 'Points',
             'active' => '1',
             'display' => '50',
-        ], $this->globals());
+        ], $this->dbGlobals());
 
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('ibl_hist');
@@ -63,7 +58,7 @@ class CareerLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
             'sort_cat' => 'Points',
             'active' => '0',
             'display' => '50',
-        ], $this->globals());
+        ], $this->dbGlobals());
 
         $this->assertNotEmpty($output);
         $this->assertStringContainsString('Career Leaderboards', $output);

--- a/ibl5/tests/Module/EntryPoints/ModuleEntryPointTestCase.php
+++ b/ibl5/tests/Module/EntryPoints/ModuleEntryPointTestCase.php
@@ -207,6 +207,12 @@ abstract class ModuleEntryPointTestCase extends WideUnitTestCase
         ], $overrides);
     }
 
+    /** @return array<string, mixed> */
+    protected function dbGlobals(): array
+    {
+        return ['mysqli_db' => $GLOBALS['mysqli_db']];
+    }
+
     /**
      * Set the auth stub to simulate an authenticated user.
      */

--- a/ibl5/tests/Module/EntryPoints/RecordHoldersEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/RecordHoldersEntryPointTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class RecordHoldersEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->setMockData([]);
+        $this->mockDb->onQuery('cache', []);
+    }
+
+    public function testRendersAllThreeRecordCategories(): void
+    {
+        $output = $this->runModule('RecordHolders');
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Regular Season', $output);
+        $this->assertStringContainsString('Playoffs', $output);
+        $this->assertStringContainsString('H.E.A.T.', $output);
+    }
+
+    public function testHandlesEmptyRecords(): void
+    {
+        $output = $this->runModule('RecordHolders');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/SeasonArchiveEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/SeasonArchiveEntryPointTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class SeasonArchiveEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->setMockData([]);
+    }
+
+    public function testNoYearShowsSeasonIndex(): void
+    {
+        $output = $this->runModule('SeasonArchive');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+
+    public function testValidYearShowsDetail(): void
+    {
+        $this->mockDb->onQuery('ibl_awards', [
+            ['year' => 2020, 'award' => 'MVP', 'name' => 'Test Player', 'table_id' => 1],
+        ]);
+        $this->mockDb->onQuery('vw_playoff_series_results', []);
+        $this->mockDb->onQuery('ibl_team_awards', []);
+        $this->mockDb->onQuery('ibl_box_scores_teams', []);
+        $this->mockDb->onQuery('ibl_gm_awards', []);
+        $this->mockDb->onQuery('ibl_gm_tenures', []);
+        $this->mockDb->onQuery('ibl_heat_win_loss', []);
+
+        $output = $this->runModule('SeasonArchive', ['year' => '2020']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+
+    public function testInvalidYearStringCastsToZeroAndShowsIndex(): void
+    {
+        $output = $this->runModule('SeasonArchive', ['year' => 'garbage']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+
+    public function testYearWithNoMatchingSeasonRendersFallback(): void
+    {
+        $output = $this->runModule('SeasonArchive', ['year' => '1800']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/SeasonHighsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/SeasonHighsEntryPointTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class SeasonHighsEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->onQuery('ibl_settings', [['value' => 'Regular Season']]);
+        $this->mockDb->onQuery('ibl_sim_dates', []);
+        $this->mockDb->onQuery('ibl_schedule', []);
+        $this->mockDb->setMockData([]);
+    }
+
+    public function testRendersWithDefaultPhase(): void
+    {
+        $output = $this->runModule('SeasonHighs');
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Regular Season', $output);
+    }
+
+    public function testRendersWithExplicitPhase(): void
+    {
+        $output = $this->runModule('SeasonHighs', ['seasonPhase' => 'Playoffs']);
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Playoffs', $output);
+    }
+
+    public function testRendersWithEmptyPhaseFallsBackToCurrent(): void
+    {
+        $output = $this->runModule('SeasonHighs', ['seasonPhase' => '']);
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Regular Season', $output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/SeasonLeaderboardsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/SeasonLeaderboardsEntryPointTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class SeasonLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->setMockData([]);
+        $this->mockDb->onQuery('cache', []);
+    }
+
+    private function globals(): array
+    {
+        return ['mysqli_db' => $GLOBALS['mysqli_db']];
+    }
+
+    public function testEmptyPostRendersFilterFormAndDefaultLeaderboard(): void
+    {
+        $output = $this->runModule('SeasonLeaderboards', [], [], $this->globals());
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Season Leaders', $output);
+        $this->assertQueryExecuted('ibl_hist');
+    }
+
+    public function testPostWithFiltersRunsLeaderboardQuery(): void
+    {
+        $output = $this->runModule('SeasonLeaderboards', [], [
+            'year' => '2024',
+            'team' => '1',
+            'sortby' => 'PPG',
+            'limit' => '50',
+        ], $this->globals());
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_hist');
+    }
+
+    public function testPostWithStringTeamCastsToInt(): void
+    {
+        $output = $this->runModule('SeasonLeaderboards', [], [
+            'year' => '2024',
+            'team' => 'garbage',
+            'sortby' => 'PPG',
+            'limit' => '50',
+        ], $this->globals());
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_hist');
+    }
+
+    public function testPostWithDefaultSortby(): void
+    {
+        $output = $this->runModule('SeasonLeaderboards', [], [
+            'year' => '2024',
+            'team' => '0',
+            'limit' => '25',
+        ], $this->globals());
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Season Leaders', $output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/SeasonLeaderboardsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/SeasonLeaderboardsEntryPointTest.php
@@ -13,14 +13,9 @@ class SeasonLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
         $this->mockDb->onQuery('cache', []);
     }
 
-    private function globals(): array
-    {
-        return ['mysqli_db' => $GLOBALS['mysqli_db']];
-    }
-
     public function testEmptyPostRendersFilterFormAndDefaultLeaderboard(): void
     {
-        $output = $this->runModule('SeasonLeaderboards', [], [], $this->globals());
+        $output = $this->runModule('SeasonLeaderboards', [], [], $this->dbGlobals());
 
         $this->assertNotEmpty($output);
         $this->assertStringContainsString('Season Leaders', $output);
@@ -34,7 +29,7 @@ class SeasonLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
             'team' => '1',
             'sortby' => 'PPG',
             'limit' => '50',
-        ], $this->globals());
+        ], $this->dbGlobals());
 
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('ibl_hist');
@@ -47,7 +42,7 @@ class SeasonLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
             'team' => 'garbage',
             'sortby' => 'PPG',
             'limit' => '50',
-        ], $this->globals());
+        ], $this->dbGlobals());
 
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('ibl_hist');
@@ -59,7 +54,7 @@ class SeasonLeaderboardsEntryPointTest extends ModuleEntryPointTestCase
             'year' => '2024',
             'team' => '0',
             'limit' => '25',
-        ], $this->globals());
+        ], $this->dbGlobals());
 
         $this->assertNotEmpty($output);
         $this->assertStringContainsString('Season Leaders', $output);

--- a/ibl5/tests/Module/EntryPoints/StandingsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/StandingsEntryPointTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class StandingsEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->onQuery('ibl_settings', [['value' => 'Regular Season']]);
+        $this->mockDb->onQuery('ibl_sim_dates', []);
+        $this->mockDb->onQuery('ibl_schedule', []);
+        $this->mockDb->setMockData([]);
+    }
+
+    public function testRendersStandingsWithEndingYear(): void
+    {
+        $output = $this->runModule('Standings');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_standings');
+    }
+
+    public function testRendersZeroTeamsGracefully(): void
+    {
+        $output = $this->runModule('Standings');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_power');
+    }
+}


### PR DESCRIPTION
## Summary

Adds PHPUnit entry-point integration tests for the season/stats module group (Group C):

- `CareerLeaderboardsEntryPointTest` — filter form render, leaderboard query execution, active-only filter, invalid boards_type fallback
- `RecordHoldersEntryPointTest` — all three record categories rendered, awards query executed
- `SeasonArchiveEntryPointTest` — no-year index, valid year detail, invalid year cast, unknown year fallback
- `SeasonHighsEntryPointTest` — default phase, explicit phase, empty phase fallback
- `SeasonLeaderboardsEntryPointTest` — empty POST default render, filtered POST, string team cast, default sortby
- `StandingsEntryPointTest` — standings query, power rankings query

Also extracts the duplicated `globals(): array` helper (returning `mysqli_db` global) into `ModuleEntryPointTestCase::dbGlobals()` so future tests can reuse it.

## Changes

- 6 new test files in `tests/Module/EntryPoints/`
- `ModuleEntryPointTestCase`: adds `protected dbGlobals(): array` helper

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.