### PR TITLE
test: module entry-point coverage — transactions domain (Group D)

### DIFF
--- a/ibl5/tests/Module/EntryPoints/ActivityTrackerEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/ActivityTrackerEntryPointTest.php
@@ -16,12 +16,4 @@ class ActivityTrackerEntryPointTest extends ModuleEntryPointTestCase
         $this->assertQueryExecuted('ibl_team_info');
     }
 
-    public function testHandlesEmptyActivityData(): void
-    {
-        $this->mockDb->setMockData([]);
-
-        $output = $this->runModule('ActivityTracker');
-
-        $this->assertNotEmpty($output);
-    }
 }

--- a/ibl5/tests/Module/EntryPoints/ActivityTrackerEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/ActivityTrackerEntryPointTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class ActivityTrackerEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersTeamActivity(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('ActivityTracker');
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_team_info');
+    }
+
+    public function testHandlesEmptyActivityData(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('ActivityTracker');
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/FreeAgencyEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/FreeAgencyEntryPointTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use Tests\WideUnit\Mocks\TestDataFactory;
+
+/**
+ * FreeAgency/index.php delegates to FreeAgencyController::handleRequest()
+ * which uses is_user() (static-cached). Separate processes prevent the
+ * static cache from leaking between tests.
+ *
+ * Unauthenticated paths are not tested here because loginbox() calls die(),
+ * which terminates the test process. Covered by E2E flows instead.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class FreeAgencyEntryPointTest extends ModuleEntryPointTestCase
+{
+    private function seedSeasonMocks(): void
+    {
+        $this->mockDb->onQuery('ibl_settings', [
+            ['name' => 'Current Season Phase', 'value' => 'Free Agency'],
+            ['name' => 'Current Season Ending Year', 'value' => '2026'],
+            ['name' => 'Allow Trades', 'value' => 'Yes'],
+            ['name' => 'Allow Waiver Moves', 'value' => 'Yes'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', [
+            ['sim' => 1, 'start_date' => '2025-11-01', 'end_date' => '2025-11-07'],
+        ]);
+    }
+
+    public function testDefaultActionRendersDisplayPage(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->onQuery('FROM ibl_plr', []);
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('FreeAgency', [], [], array_merge($this->dbGlobals(), [
+            'user' => $GLOBALS['user'],
+            'pa' => '',
+            'pid' => '0',
+        ]));
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testNegotiateActionRendersNegotiationPage(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->onQuery('FROM ibl_plr', [TestDataFactory::createPlayer([
+            'pid' => 1,
+            'teamname' => 'Test Team',
+            'color1' => 'FF0000',
+            'color2' => '000000',
+            'nickname' => '',
+            'loyalty' => 50,
+            'playing_time' => 50,
+            'winner' => 50,
+            'tradition' => 50,
+            'security' => 50,
+        ])]);
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('FreeAgency', [], [], array_merge($this->dbGlobals(), [
+            'user' => $GLOBALS['user'],
+            'pa' => 'negotiate',
+            'pid' => '1',
+        ]));
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testUnknownActionFallsToDisplay(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->onQuery('FROM ibl_plr', []);
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('FreeAgency', [], [], array_merge($this->dbGlobals(), [
+            'user' => $GLOBALS['user'],
+            'pa' => 'bogus',
+            'pid' => '0',
+        ]));
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/FreeAgencyPreviewEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/FreeAgencyPreviewEntryPointTest.php
@@ -29,13 +29,4 @@ class FreeAgencyPreviewEntryPointTest extends ModuleEntryPointTestCase
         $this->assertNotEmpty($output);
     }
 
-    public function testHandlesEmptyFreeAgentsList(): void
-    {
-        $this->seedSeasonMocks();
-        $this->mockDb->setMockData([]);
-
-        $output = $this->runModule('FreeAgencyPreview');
-
-        $this->assertNotEmpty($output);
-    }
 }

--- a/ibl5/tests/Module/EntryPoints/FreeAgencyPreviewEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/FreeAgencyPreviewEntryPointTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class FreeAgencyPreviewEntryPointTest extends ModuleEntryPointTestCase
+{
+    private function seedSeasonMocks(string $endingYear = '2026'): void
+    {
+        $this->mockDb->onQuery('ibl_settings', [
+            ['name' => 'Current Season Phase', 'value' => 'Regular Season'],
+            ['name' => 'Current Season Ending Year', 'value' => $endingYear],
+            ['name' => 'Allow Trades', 'value' => 'Yes'],
+            ['name' => 'Allow Waiver Moves', 'value' => 'Yes'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', [
+            ['sim' => 1, 'start_date' => '2025-11-01', 'end_date' => '2025-11-07'],
+        ]);
+    }
+
+    public function testRendersUpcomingFreeAgents(): void
+    {
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('FreeAgencyPreview');
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testHandlesEmptyFreeAgentsList(): void
+    {
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('FreeAgencyPreview');
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/TradingEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/TradingEntryPointTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+
+/**
+ * Trading/index.php defines global functions (tradeoffer, tradereview,
+ * reviewtrade, offertrade) that cannot be redeclared, and is_user() has
+ * a static cache. Each test runs in a separate process.
+ *
+ * POST handlers (offertrade submit, reviewtrade accept/reject) call
+ * HtmxHelper::redirect() → exit() and are skipped. Covered by
+ * Plans 03b/03c real-DB tests + E2E flows.
+ *
+ * Unauthenticated GET paths call loginbox() → die() and are skipped
+ * except for roster-preview-api which returns JSON without die().
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class TradingEntryPointTest extends ModuleEntryPointTestCase
+{
+    private function seedSeasonMocks(string $phase = 'Free Agency'): void
+    {
+        $this->mockDb->onQuery('ibl_settings', [
+            ['name' => 'Current Season Phase', 'value' => $phase],
+            ['name' => 'Current Season Ending Year', 'value' => '2026'],
+            ['name' => 'Allow Trades', 'value' => 'Yes'],
+            ['name' => 'Allow Waiver Moves', 'value' => 'Yes'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', [
+            ['sim' => 1, 'start_date' => '2025-11-01', 'end_date' => '2025-11-07'],
+        ]);
+    }
+
+    public function testDefaultOpRendersTradeReview(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Trading', [], [], [
+            'user' => $GLOBALS['user'],
+            'op' => '',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpReviewtradeRendersReviewView(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Trading', [], [], [
+            'user' => $GLOBALS['user'],
+            'op' => 'reviewtrade',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpReviewtradeWithResultParam(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Trading', ['result' => 'success'], [], [
+            'user' => $GLOBALS['user'],
+            'op' => 'reviewtrade',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpReviewtradeWithErrorParam(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Trading', ['error' => 'invalid'], [], [
+            'user' => $GLOBALS['user'],
+            'op' => 'reviewtrade',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpRosterPreviewApiReturnsJson(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Trading', ['teamid' => '1'], [], array_merge($this->dbGlobals(), [
+            'user' => $GLOBALS['user'],
+            'op' => 'roster-preview-api',
+        ]));
+
+        $decoded = json_decode($output, true);
+        $this->assertIsArray($decoded);
+    }
+
+    public function testOpRosterPreviewApiWithoutAuthReturnsEmptyJson(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Trading', [], [], [
+            'user' => '',
+            'op' => 'roster-preview-api',
+        ]);
+
+        $decoded = json_decode($output, true);
+        $this->assertIsArray($decoded);
+        $this->assertSame('', $decoded['html']);
+    }
+
+    public function testUnknownOpFallsToDefault(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Trading', [], [], [
+            'user' => $GLOBALS['user'],
+            'op' => 'bogus',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOffertradeWithSessionFormData(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+        $_SESSION['tradeFormData'] = ['players' => [1, 2]];
+
+        $output = $this->runModule('Trading', [], [], [
+            'user' => $GLOBALS['user'],
+            'op' => 'offertrade',
+            'partner' => '',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/TransactionHistoryEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/TransactionHistoryEntryPointTest.php
@@ -71,4 +71,31 @@ class TransactionHistoryEntryPointTest extends ModuleEntryPointTestCase
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('nuke_stories');
     }
+
+    public function testOutOfRangeCategoryIgnored(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('TransactionHistory', ['cat' => '999']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('nuke_stories');
+    }
+
+    public function testMonthThirteenIgnored(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('TransactionHistory', ['month' => '13']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('nuke_stories');
+    }
+
+    public function testZeroMonthIgnored(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('TransactionHistory', ['month' => '0']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('nuke_stories');
+    }
 }

--- a/ibl5/tests/Module/EntryPoints/WaiversEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/WaiversEntryPointTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+
+/**
+ * Waivers/index.php defines a global function waivers() that cannot be
+ * redeclared, so each test runs in a separate process.
+ *
+ * Unauthenticated paths are not tested here because loginbox() calls die(),
+ * which terminates the test process. Covered by E2E flows instead.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class WaiversEntryPointTest extends ModuleEntryPointTestCase
+{
+    private function seedSeasonMocks(): void
+    {
+        $this->mockDb->onQuery('ibl_settings', [
+            ['name' => 'Current Season Phase', 'value' => 'Regular Season'],
+            ['name' => 'Current Season Ending Year', 'value' => '2026'],
+            ['name' => 'Allow Trades', 'value' => 'Yes'],
+            ['name' => 'Allow Waiver Moves', 'value' => 'Yes'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', [
+            ['sim' => 1, 'start_date' => '2025-11-01', 'end_date' => '2025-11-07'],
+        ]);
+    }
+
+    public function testRendersWaiversPageForAuthenticatedGm(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->onQuery('auth_users', [
+            ['user_id' => 1, 'username' => 'testgm', 'user_email' => 'test@test.com'],
+        ]);
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Waivers', [], [], [
+            'user' => $GLOBALS['user'],
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+}


### PR DESCRIPTION
## Summary

Adds entry-point tests for six transaction modules using `ModuleEntryPointTestCase::runModule()`.

**New test files:**
- `ActivityTrackerEntryPointTest` — activity query coverage
- `FreeAgencyEntryPointTest` — dispatch across display / negotiate / unknown-action arms (authenticated paths; unauthenticated paths call `die()` and are covered by E2E)
- `FreeAgencyPreviewEntryPointTest` — season-mocked render
- `TradingEntryPointTest` — all GET arms: reviewtrade, roster-preview-api (returns JSON), offertrade (with session form draft), unknown op
- `WaiversEntryPointTest` — authenticated GM render

**Extended:**
- `TransactionHistoryEntryPointTest` — three additional edge cases: out-of-range category, month=13, month=0

**POST handlers skipped:** `processoffer`, `deleteoffer`, `Trading::offertrade` POST sub-arm all call `HtmxHelper::redirect() → exit()`. Covered by Plans 03b/03c real-DB tests + existing E2E flows.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---

Generated with [Claude Code](https://claude.ai/code)
<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>