### PR TITLE
test: module entry-point coverage — draft/sim domain (Group E)

### DIFF
--- a/ibl5/tests/Module/EntryPoints/DepthChartEntryEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/DepthChartEntryEntryPointTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+
+/**
+ * DepthChartEntry/index.php defines global functions (userinfo, main, submit,
+ * tabApi, nextSimApi, api) that cannot be redeclared, and is_user() has a
+ * static cache. Each test runs in a separate process.
+ *
+ * Skipped:
+ * - op=submit (POST handler with redirect) — covered by E2E flows.
+ * - op=api with JSON body via php://input — runModule() doesn't support
+ *   raw-body injection. GET-style api() is tested instead.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class DepthChartEntryEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testDefaultOpRendersDepthChartForGm(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('DepthChartEntry', [], [], [
+            'user' => $GLOBALS['user'],
+            'op' => '',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpTabApiReturnsHtml(): void
+    {
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('DepthChartEntry', ['teamid' => '1', 'display' => 'ratings'], [], [
+            'op' => 'tab-api',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpNextsimApiReturnsHtml(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('DepthChartEntry', ['teamid' => '1'], [], [
+            'user' => $GLOBALS['user'],
+            'op' => 'nextsim-api',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpApiWithoutAuthReturnsUnauthorizedJson(): void
+    {
+        $output = $this->runModule('DepthChartEntry', [], [], [
+            'user' => '',
+            'op' => 'api',
+        ]);
+
+        $decoded = json_decode($output, true);
+        $this->assertIsArray($decoded);
+        $this->assertSame('Unauthorized', $decoded['error']);
+    }
+
+    public function testUnknownOpFallsToMain(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('DepthChartEntry', [], [], [
+            'user' => $GLOBALS['user'],
+            'op' => 'bogus',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/DraftEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/DraftEntryPointTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+
+/**
+ * Draft/index.php defines global functions (userinfo, main) that cannot be
+ * redeclared, and is_user() has a static cache. Each test runs in a separate
+ * process.
+ *
+ * Unauthenticated path calls loginbox() → die() and is skipped here.
+ * Covered by E2E flows.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class DraftEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testDefaultOpRendersDraftBoard(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Draft', [], [], [
+            'user' => $GLOBALS['user'],
+            'op' => '',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testUnknownOpFallsToMain(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Draft', [], [], [
+            'user' => $GLOBALS['user'],
+            'op' => 'bogus',
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/DraftHistoryEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/DraftHistoryEntryPointTest.php
@@ -7,7 +7,8 @@ namespace Tests\Module\EntryPoints;
 /**
  * Integration tests for modules/DraftHistory/index.php entry point.
  *
- * Exercises (int) $_GET['teamid'] and (int) $_REQUEST['year'] type-casting boundaries.
+ * Exercises (int) $_GET['teamid'] and (int) $_REQUEST['year'] type-casting boundaries,
+ * plus the HTMX API handler (op=api) which returns HTML fragments.
  */
 class DraftHistoryEntryPointTest extends ModuleEntryPointTestCase
 {
@@ -88,6 +89,41 @@ class DraftHistoryEntryPointTest extends ModuleEntryPointTestCase
 
         $this->assertNotEmpty($output);
         // teamid=0 fails > 0 guard, falls to year view
+        $this->assertQueryExecuted('draftyear');
+    }
+
+    public function testOpApiReturnsHtmlFragment(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('DraftHistory', ['op' => 'api']);
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('draftyear');
+    }
+
+    public function testOpApiWithValidYearReturnsHtml(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('DraftHistory', ['op' => 'api', 'year' => '2020']);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpApiWithNonNumericYearFallsBackToLatest(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('DraftHistory', ['op' => 'api', 'year' => 'garbage']);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testNonNumericTeamIdCastsToZero(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('DraftHistory', ['teamid' => 'garbage']);
+
+        $this->assertNotEmpty($output);
+        // (int)'garbage' === 0, fails > 0 guard, falls to year view
         $this->assertQueryExecuted('draftyear');
     }
 }

--- a/ibl5/tests/Module/EntryPoints/DraftPickLocatorEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/DraftPickLocatorEntryPointTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class DraftPickLocatorEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersDraftPickLocator(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('DraftPickLocator');
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/LeagueStartersEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/LeagueStartersEntryPointTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use Tests\WideUnit\Mocks\TestDataFactory;
+
+class LeagueStartersEntryPointTest extends ModuleEntryPointTestCase
+{
+    private function seedPlayerData(): void
+    {
+        $this->mockDb->onQuery('ibl_plr', [TestDataFactory::createPlayer(['pid' => 4040404, 'name' => 'Placeholder'])]);
+    }
+
+    public function testDefaultRendersLeagueStartersPage(): void
+    {
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->seedPlayerData();
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('LeagueStarters');
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpApiReturnsHtmlFragment(): void
+    {
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->seedPlayerData();
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('LeagueStarters', ['op' => 'api', 'display' => 'ratings']);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testDisplayParamValidatesAgainstWhitelist(): void
+    {
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->seedPlayerData();
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('LeagueStarters', ['display' => 'total_s']);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testInvalidDisplayParamDefaultsToRatings(): void
+    {
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->seedPlayerData();
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('LeagueStarters', ['display' => 'bogus']);
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/LeagueStartersEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/LeagueStartersEntryPointTest.php
@@ -8,17 +8,16 @@ use Tests\WideUnit\Mocks\TestDataFactory;
 
 class LeagueStartersEntryPointTest extends ModuleEntryPointTestCase
 {
-    private function seedPlayerData(): void
+    protected function setUp(): void
     {
+        parent::setUp();
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
         $this->mockDb->onQuery('ibl_plr', [TestDataFactory::createPlayer(['pid' => 4040404, 'name' => 'Placeholder'])]);
+        $this->mockDb->setMockData([]);
     }
 
     public function testDefaultRendersLeagueStartersPage(): void
     {
-        $this->mockDb->setMockTeamData([self::fullTeamData()]);
-        $this->seedPlayerData();
-        $this->mockDb->setMockData([]);
-
         $output = $this->runModule('LeagueStarters');
 
         $this->assertNotEmpty($output);
@@ -26,10 +25,6 @@ class LeagueStartersEntryPointTest extends ModuleEntryPointTestCase
 
     public function testOpApiReturnsHtmlFragment(): void
     {
-        $this->mockDb->setMockTeamData([self::fullTeamData()]);
-        $this->seedPlayerData();
-        $this->mockDb->setMockData([]);
-
         $output = $this->runModule('LeagueStarters', ['op' => 'api', 'display' => 'ratings']);
 
         $this->assertNotEmpty($output);
@@ -37,10 +32,6 @@ class LeagueStartersEntryPointTest extends ModuleEntryPointTestCase
 
     public function testDisplayParamValidatesAgainstWhitelist(): void
     {
-        $this->mockDb->setMockTeamData([self::fullTeamData()]);
-        $this->seedPlayerData();
-        $this->mockDb->setMockData([]);
-
         $output = $this->runModule('LeagueStarters', ['display' => 'total_s']);
 
         $this->assertNotEmpty($output);
@@ -48,10 +39,6 @@ class LeagueStartersEntryPointTest extends ModuleEntryPointTestCase
 
     public function testInvalidDisplayParamDefaultsToRatings(): void
     {
-        $this->mockDb->setMockTeamData([self::fullTeamData()]);
-        $this->seedPlayerData();
-        $this->mockDb->setMockData([]);
-
         $output = $this->runModule('LeagueStarters', ['display' => 'bogus']);
 
         $this->assertNotEmpty($output);

--- a/ibl5/tests/Module/EntryPoints/NextSimEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/NextSimEntryPointTest.php
@@ -29,17 +29,4 @@ class NextSimEntryPointTest extends ModuleEntryPointTestCase
 
         $this->assertNotEmpty($output);
     }
-
-    public function testHandlesNoUpcomingGames(): void
-    {
-        $this->authenticateAs('testgm');
-        $this->mockDb->setMockTeamData([self::fullTeamData()]);
-        $this->mockDb->setMockData([]);
-
-        $output = $this->runModule('NextSim', [], [], [
-            'user' => $GLOBALS['user'],
-        ]);
-
-        $this->assertNotEmpty($output);
-    }
 }

--- a/ibl5/tests/Module/EntryPoints/NextSimEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/NextSimEntryPointTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+
+/**
+ * NextSim/index.php uses is_user() with a static cache and loginbox() → die()
+ * for unauthenticated access. Each test runs in a separate process.
+ *
+ * Unauthenticated path calls loginbox() → die() and is skipped here.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class NextSimEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersNextSimSchedule(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('NextSim', [], [], [
+            'user' => $GLOBALS['user'],
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testHandlesNoUpcomingGames(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->mockDb->setMockTeamData([self::fullTeamData()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('NextSim', [], [], [
+            'user' => $GLOBALS['user'],
+        ]);
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/ProjectedDraftOrderEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/ProjectedDraftOrderEntryPointTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class ProjectedDraftOrderEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersProjectedOrderWhenNotFinalized(): void
+    {
+        $this->mockDb->onQuery('Draft Order Finalized', [['value' => 'No']]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('ProjectedDraftOrder');
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Projected Draft Order', $output);
+    }
+
+    public function testRendersFinalizedOrderWhenFinalized(): void
+    {
+        $this->mockDb->onQuery('Draft Order Finalized', [['value' => 'Yes']]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('ProjectedDraftOrder');
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Draft Order', $output);
+        $this->assertStringNotContainsString('Projected Draft Order', $output);
+    }
+}

--- a/ibl5/tests/WideUnit/Mocks/Season.php
+++ b/ibl5/tests/WideUnit/Mocks/Season.php
@@ -219,4 +219,9 @@ class Season
     public function reloadSimDates(): void
     {
     }
+
+    public function getPhaseSpecificSimNumber(): int
+    {
+        return $this->lastSimNumber;
+    }
 }


### PR DESCRIPTION
## Summary

Adds PHPUnit entry-point tests for 6 draft/sim modules using `ModuleEntryPointTestCase`. Extends the existing `DraftHistoryEntryPointTest` with 4 new tests for the `op=api` handler. Adds `getPhaseSpecificSimNumber()` to the mock `Season` class required by `NextSim`.

## Modules covered

| Module | New tests | Notes |
|--------|-----------|-------|
| `Draft` | 2 | GM auth + unknown-op fallback |
| `DraftHistory` | 4 | Extends existing; api handler + type-casting boundaries |
| `DraftPickLocator` | 1 | Single-page, no dispatcher |
| `ProjectedDraftOrder` | 2 | Finalized vs. projected branch |
| `NextSim` | 1 | GM-gated; separate-process isolation |
| `DepthChartEntry` | 5 | Multi-arm dispatcher: tab-api, nextsim-api, api (JSON), default |
| `LeagueStarters` | 4 | op=api + display whitelist validation |

## What changed

- 6 new test files in `tests/Module/EntryPoints/`
- 4 tests added to existing `DraftHistoryEntryPointTest`
- `tests/WideUnit/Mocks/Season.php`: added `getPhaseSpecificSimNumber()` stub (required by NextSim index)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)
<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>