### PR TITLE
test: module entry-point coverage — misc/admin domain (Group F)

### DIFF
--- a/ibl5/tests/Module/EntryPoints/ApiKeysEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/ApiKeysEntryPointTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * ApiKeys/index.php calls loginbox() (→ die()) for unauthenticated users.
+ * Unauthenticated path covered by E2E — same pattern as FreeAgency.
+ *
+ * The module also calls $authService->getUserId() and getUsername(),
+ * which the base authenticateAs() doesn't stub. Tests override the
+ * auth stub locally.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class ApiKeysEntryPointTest extends ModuleEntryPointTestCase
+{
+    private function authenticateWithUserId(string $username, int $userId): void
+    {
+        $this->authenticateAs($username);
+
+        $authStub = $this->createStub(\Auth\Contracts\AuthServiceInterface::class);
+        $authStub->method('isAuthenticated')->willReturn(true);
+        $authStub->method('isAdmin')->willReturn(false);
+        $authStub->method('getCookieArray')->willReturn([$username, $username, '']);
+        $authStub->method('getUserId')->willReturn($userId);
+        $authStub->method('getUsername')->willReturn($username);
+        $GLOBALS['authService'] = $authStub;
+    }
+
+    public function testMainOpRendersApiKeyListForAuthenticatedUser(): void
+    {
+        $this->authenticateWithUserId('testgm', 1);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('ApiKeys', [], [], array_merge($this->dbGlobals(), [
+            'user' => $GLOBALS['user'],
+        ]));
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testGenerateOpRequiresPostMethod(): void
+    {
+        $this->authenticateWithUserId('testgm', 1);
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('ApiKeys', ['op' => 'generate'], [], array_merge($this->dbGlobals(), [
+            'user' => $GLOBALS['user'],
+        ]));
+
+        // GET to generate redirects to main (header('Location: ...'); return;)
+        $this->assertEmpty($output);
+    }
+
+    public function testRevokeOpRequiresPostMethod(): void
+    {
+        $this->authenticateWithUserId('testgm', 1);
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('ApiKeys', ['op' => 'revoke'], [], array_merge($this->dbGlobals(), [
+            'user' => $GLOBALS['user'],
+        ]));
+
+        // GET to revoke redirects to main (header('Location: ...'); return;)
+        $this->assertEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/SearchEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/SearchEntryPointTest.php
@@ -103,4 +103,13 @@ class SearchEntryPointTest extends ModuleEntryPointTestCase
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('nuke_stories');
     }
+
+    public function testQueryWithSpecialCharsEscaped(): void
+    {
+        $this->mockDb->setMockData([]);
+        $output = $this->runModule('Search', [], [], ['query' => '<script>alert(1)</script>']);
+
+        $this->assertNotEmpty($output);
+        $this->assertStringNotContainsString('<script>', $output);
+    }
 }

--- a/ibl5/tests/Module/EntryPoints/SiteStatisticsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/SiteStatisticsEntryPointTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+/**
+ * SiteStatistics is a legacy PHP-Nuke module that uses global language
+ * constants from language/lang-english.php (loaded by mainfile.php, not
+ * get_lang()). We pre-define the ones the view needs.
+ */
+class SiteStatisticsEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $langFile = dirname(__DIR__, 3) . '/language/lang-english.php';
+        if (file_exists($langFile)) {
+            include_once $langFile;
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function siteStatsGlobals(): array
+    {
+        return array_merge($this->dbGlobals(), [
+            'startdate' => '01-01-2020',
+        ]);
+    }
+
+    public function testDefaultOpRendersOverview(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('SiteStatistics', [], [], $this->siteStatsGlobals());
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('_counter');
+    }
+
+    public function testOpStatsRendersDetailedStats(): void
+    {
+        $this->mockDb->onQuery('_stats_month', [
+            ['year' => 2024, 'month' => 6, 'hits' => 1000],
+        ]);
+        $this->mockDb->onQuery('_stats_date', [
+            ['year' => 2024, 'month' => 6, 'date' => 15, 'hits' => 100],
+        ]);
+        $this->mockDb->onQuery('_stats_hour', [
+            ['year' => 2024, 'month' => 6, 'date' => 15, 'hour' => 12, 'hits' => 50],
+        ]);
+        $this->mockDb->onQuery('_stats_year', [
+            ['year' => 2024, 'hits' => 5000],
+        ]);
+        $this->mockDb->setMockData([['count' => 10000, 'type' => 'total', 'var' => 'hits']]);
+
+        $output = $this->runModule('SiteStatistics', ['op' => 'Stats'], [], $this->siteStatsGlobals());
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('_counter');
+    }
+
+    public function testOpYearlyStatsRendersYearlyView(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('SiteStatistics', ['op' => 'YearlyStats', 'year' => '2024'], [], $this->siteStatsGlobals());
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('_stats_month');
+    }
+
+    public function testInvalidYearCastsToZero(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('SiteStatistics', ['op' => 'YearlyStats', 'year' => 'garbage'], [], $this->siteStatsGlobals());
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('_stats_month');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/TopicsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/TopicsEntryPointTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class TopicsEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersTopicList(): void
+    {
+        $this->mockDb->setMockData([
+            ['topicid' => 1, 'topicname' => 'IBL News', 'topicimage' => 'ibl.png', 'topictext' => 'IBL'],
+        ]);
+
+        $output = $this->runModule('Topics');
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testHandlesEmptyTopicList(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Topics');
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/TrainingCampRatingsDiffEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/TrainingCampRatingsDiffEntryPointTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * TrainingCampRatingsDiff/index.php is auth-gated (loginbox() → die() for
+ * unauthenticated). Unauthenticated path covered by E2E.
+ *
+ * Filters: ?year= (ctype_digit), ?tid= (ctype_digit), ?status= (in_array).
+ * Invalid values are silently rejected (null/empty), not errors.
+ *
+ * Requires separate processes because is_user() has a static cache.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class TrainingCampRatingsDiffEntryPointTest extends ModuleEntryPointTestCase
+{
+    /** @return array<string, mixed> */
+    private function tcGlobals(): array
+    {
+        return array_merge($this->dbGlobals(), [
+            'user' => $GLOBALS['user'],
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticateAs('testgm');
+        $this->mockDb->onQuery('ibl_settings', [
+            ['name' => 'Current Season Phase', 'value' => 'Regular Season'],
+            ['name' => 'Current Season Ending Year', 'value' => '2026'],
+            ['name' => 'Allow Trades', 'value' => 'Yes'],
+            ['name' => 'Allow Waiver Moves', 'value' => 'Yes'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', [
+            ['sim' => 1, 'start_date' => '2025-11-01', 'end_date' => '2025-11-07'],
+        ]);
+        $this->mockDb->setMockData([]);
+    }
+
+    public function testRendersDefaultRatingsDiff(): void
+    {
+        $output = $this->runModule('TrainingCampRatingsDiff', [], [], $this->tcGlobals());
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testWithYearFilterAppliesYear(): void
+    {
+        $output = $this->runModule('TrainingCampRatingsDiff', ['year' => '2024'], [], $this->tcGlobals());
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testRejectsNonDigitYear(): void
+    {
+        $output = $this->runModule('TrainingCampRatingsDiff', ['year' => 'garbage'], [], $this->tcGlobals());
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testWithTidFilterAppliesTeam(): void
+    {
+        $output = $this->runModule('TrainingCampRatingsDiff', ['tid' => '1'], [], $this->tcGlobals());
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testWithStatusFilterAppliesStatus(): void
+    {
+        $output = $this->runModule('TrainingCampRatingsDiff', ['status' => 'signed'], [], $this->tcGlobals());
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testRejectsInvalidStatus(): void
+    {
+        $output = $this->runModule('TrainingCampRatingsDiff', ['status' => 'garbage'], [], $this->tcGlobals());
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/VotingEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/VotingEntryPointTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Voting/index.php delegates to main($user) which calls loginbox() for
+ * unauthenticated users (loginbox() calls die()). Unauthenticated path
+ * is covered by E2E — same pattern as FreeAgency.
+ *
+ * Requires separate processes because is_user() has a static cache.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class VotingEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testDefaultRendersVotingPageForGm(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->mockDb->onQuery('ibl_settings', [
+            ['name' => 'Current Season Phase', 'value' => 'Regular Season'],
+            ['name' => 'Current Season Ending Year', 'value' => '2026'],
+            ['name' => 'Allow Trades', 'value' => 'Yes'],
+            ['name' => 'Allow Waiver Moves', 'value' => 'Yes'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', [
+            ['sim' => 1, 'start_date' => '2025-11-01', 'end_date' => '2025-11-07'],
+        ]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('Voting', [], [], array_merge($this->dbGlobals(), [
+            'user' => $GLOBALS['user'],
+        ]));
+
+        $this->assertNotEmpty($output);
+        $this->assertQueryExecuted('ibl_team_info');
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/VotingResultsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/VotingResultsEntryPointTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class VotingResultsEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersVotingResults(): void
+    {
+        $this->mockDb->onQuery('ibl_settings', [
+            ['name' => 'Current Season Phase', 'value' => 'Regular Season'],
+            ['name' => 'Current Season Ending Year', 'value' => '2026'],
+            ['name' => 'Allow Trades', 'value' => 'Yes'],
+            ['name' => 'Allow Waiver Moves', 'value' => 'Yes'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', [
+            ['sim' => 1, 'start_date' => '2025-11-01', 'end_date' => '2025-11-07'],
+        ]);
+        $this->mockDb->setMockData([['category' => 'MVP', 'player' => 'Test', 'votes' => 10]]);
+
+        $output = $this->runModule('VotingResults', [], [], $this->dbGlobals());
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testHandlesEmptyResults(): void
+    {
+        $this->mockDb->onQuery('ibl_settings', [
+            ['name' => 'Current Season Phase', 'value' => 'Regular Season'],
+            ['name' => 'Current Season Ending Year', 'value' => '2026'],
+            ['name' => 'Allow Trades', 'value' => 'Yes'],
+            ['name' => 'Allow Waiver Moves', 'value' => 'Yes'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', [
+            ['sim' => 1, 'start_date' => '2025-11-01', 'end_date' => '2025-11-07'],
+        ]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('VotingResults', [], [], $this->dbGlobals());
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/YourAccountEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/YourAccountEntryPointTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * YourAccount/index.php is a large switch over $op. Most arms are POST handlers
+ * that call exit() or header()+die() — those are covered by Auth tests + E2E.
+ *
+ * Authenticated default branch calls header('Location: ...'); exit; — not testable
+ * in PHPUnit. Tested as unauthenticated only.
+ *
+ * Uses RunTestsInSeparateProcesses because is_user() has a static cache and
+ * multiple ops manipulate session/cookie state.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class YourAccountEntryPointTest extends ModuleEntryPointTestCase
+{
+    /** @return array<string, mixed> */
+    private function accountGlobals(): array
+    {
+        return array_merge($this->dbGlobals(), [
+            'authService' => $GLOBALS['authService'],
+            'user' => $GLOBALS['user'],
+            'cookie' => $GLOBALS['cookie'],
+            'nukeurl' => 'http://localhost',
+            'sitename' => 'IBL Test',
+            'adminmail' => 'admin@test.com',
+            'minpass' => 5,
+        ]);
+    }
+
+    public function testDefaultOpRendersLoginPageForUnauthenticated(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('YourAccount', [], [], $this->accountGlobals());
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpPassLostRendersResetForm(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('YourAccount', [], [], array_merge($this->accountGlobals(), [
+            'op' => 'pass_lost',
+        ]));
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpNewUserRendersRegistrationForm(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('YourAccount', [], [], array_merge($this->accountGlobals(), [
+            'op' => 'new_user',
+        ]));
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testOpConfirmEmailWithTokenRendersStatus(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule(
+            'YourAccount',
+            ['selector' => 'abc123', 'token' => 'xyz789', 'op' => 'confirm_email'],
+            [],
+            array_merge($this->accountGlobals(), ['op' => 'confirm_email']),
+        );
+
+        $this->assertNotEmpty($output);
+    }
+
+    public function testUnknownOpFallsToDefault(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('YourAccount', [], [], array_merge($this->accountGlobals(), [
+            'op' => 'bogus',
+        ]));
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/theme-stubs.php
+++ b/ibl5/tests/Module/EntryPoints/theme-stubs.php
@@ -28,3 +28,24 @@ if (!function_exists('themecenterbox')) {
     {
     }
 }
+
+if (!function_exists('OpenTable')) {
+    function OpenTable(): void
+    {
+        echo '<div class="stub-table">';
+    }
+}
+
+if (!function_exists('OpenTable2')) {
+    function OpenTable2(): void
+    {
+        echo '<div class="stub-table">';
+    }
+}
+
+if (!function_exists('CloseTable')) {
+    function CloseTable(): void
+    {
+        echo '</div>';
+    }
+}


### PR DESCRIPTION
## Summary

Adds PHPUnit entry-point tests for 6 misc/admin modules:

- **ApiKeys** — authenticated renders key list; GET to generate/revoke redirects (POST required)
- **Search** — XSS special-char escaping test added to existing suite
- **SiteStatistics** — legacy PHP-Nuke module: default, Stats, YearlyStats ops; invalid year input
- **Topics** — renders list; handles empty list
- **TrainingCampRatingsDiff** — auth-gated; year/tid/status filters; rejects invalid inputs
- **Voting** — auth-gated; renders for GM
- **VotingResults** — renders results; handles empty results
- **YourAccount** — unauthenticated paths (default, pass_lost, new_user, confirm_email, unknown op)
- **theme-stubs.php** — adds OpenTable/OpenTable2/CloseTable stubs needed by legacy modules

All tests use `ModuleEntryPointTestCase`'s mock DB harness with `RunTestsInSeparateProcesses` where static caches require isolation.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.