### PR TITLE
test: backfill unit tests for PdoConnection and PageLayout

### DIFF
--- a/ibl5/tests/Module/EntryPoints/theme-stubs.php
+++ b/ibl5/tests/Module/EntryPoints/theme-stubs.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 if (!function_exists('themeheader')) {
     function themeheader(): void
     {
-        echo '<body>';
+        echo '<!-- THEMEHEADER_CALLED --><body>';
     }
 }
 
 if (!function_exists('themefooter')) {
     function themefooter(): void
     {
+        echo '<!-- THEMEFOOTER_CALLED -->';
     }
 }
 

--- a/ibl5/tests/Unit/Database/PdoConnectionTest.php
+++ b/ibl5/tests/Unit/Database/PdoConnectionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Database;
+
+use Database\PdoConnection;
+use PHPUnit\Framework\TestCase;
+
+class PdoConnectionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        PdoConnection::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        PdoConnection::reset();
+    }
+
+    public function testSetInstanceStoresPdo(): void
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        PdoConnection::setInstance($pdo);
+        self::assertSame($pdo, PdoConnection::getInstance());
+    }
+
+    public function testGetInstanceReturnsSameInstanceOnRepeatedCalls(): void
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        PdoConnection::setInstance($pdo);
+        $first = PdoConnection::getInstance();
+        $second = PdoConnection::getInstance();
+        self::assertSame($first, $second);
+    }
+
+    public function testResetClearsInstance(): void
+    {
+        $pdoA = new \PDO('sqlite::memory:');
+        $pdoB = new \PDO('sqlite::memory:');
+        PdoConnection::setInstance($pdoA);
+        self::assertSame($pdoA, PdoConnection::getInstance());
+
+        PdoConnection::reset();
+        PdoConnection::setInstance($pdoB);
+        self::assertSame($pdoB, PdoConnection::getInstance());
+    }
+
+    public function testGetInstanceWithoutSetThrowsWhenDbUnreachable(): void
+    {
+        $GLOBALS['dbhost'] = '';
+        $GLOBALS['dbuname'] = '';
+        $GLOBALS['dbpass'] = '';
+        $GLOBALS['dbname'] = '';
+
+        try {
+            $this->expectException(\PDOException::class);
+            PdoConnection::getInstance();
+        } finally {
+            unset($GLOBALS['dbhost'], $GLOBALS['dbuname'], $GLOBALS['dbpass'], $GLOBALS['dbname']);
+        }
+    }
+
+    public function testSetInstanceOverridesPrevious(): void
+    {
+        $pdoA = new \PDO('sqlite::memory:');
+        $pdoB = new \PDO('sqlite::memory:');
+        PdoConnection::setInstance($pdoA);
+        PdoConnection::setInstance($pdoB);
+        self::assertSame($pdoB, PdoConnection::getInstance());
+    }
+}

--- a/ibl5/tests/Unit/PageLayout/PageLayoutTest.php
+++ b/ibl5/tests/Unit/PageLayout/PageLayoutTest.php
@@ -16,9 +16,6 @@ class PageLayoutTest extends TestCase
     /** @var array<string, mixed> */
     private array $savedGlobals;
 
-    /** @var list<string> Global keys injected during tests */
-    private array $injectedGlobalKeys = [];
-
     protected function setUp(): void
     {
         $this->savedServer = $_SERVER;
@@ -34,7 +31,7 @@ class PageLayoutTest extends TestCase
         $legacyPath = dirname(__DIR__, 3) . '/classes/Bootstrap/LegacyFunctions.php';
         require_once $legacyPath;
 
-        $authStub = $this->createStub(\Auth\Contracts\AuthServiceInterface::class);
+        $authStub = static::createStub(\Auth\Contracts\AuthServiceInterface::class);
         $authStub->method('getCookieArray')->willReturn(null);
         $GLOBALS['authService'] = $authStub;
 
@@ -43,7 +40,8 @@ class PageLayoutTest extends TestCase
         $GLOBALS['slogan'] = 'Test Slogan';
         $GLOBALS['name'] = '';
         $GLOBALS['user'] = '';
-        $this->injectedGlobalKeys = ['sitename', 'pagetitle', 'slogan', 'name', 'user', 'authService'];
+
+
 
         $_SESSION = [];
     }
@@ -150,7 +148,7 @@ class PageLayoutTest extends TestCase
         self::assertMatchesRegularExpression('/<!--.*Page Generation.*-->/', $output);
     }
 
-    public function testRenderPageGenerationTimeUsesCustomLabels(): void
+    public function testRenderPageGenerationTimeUsesDefinedLabels(): void
     {
         if (!defined('_PAGEGENERATION')) {
             define('_PAGEGENERATION', 'Generated in:');
@@ -163,8 +161,8 @@ class PageLayoutTest extends TestCase
         PageLayout::renderPageGenerationTime();
         $output = (string) ob_get_clean();
 
-        self::assertStringContainsString('Generated in:', $output);
-        self::assertStringContainsString('secs', $output);
+        self::assertStringContainsString(\_PAGEGENERATION, $output);
+        self::assertStringContainsString(\_SECONDS, $output);
     }
 
     public function testHeaderBoostedShowsAdminPhaseGateNotice(): void

--- a/ibl5/tests/Unit/PageLayout/PageLayoutTest.php
+++ b/ibl5/tests/Unit/PageLayout/PageLayoutTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PageLayout;
+
+use PageLayout\PageLayout;
+use PHPUnit\Framework\TestCase;
+
+class PageLayoutTest extends TestCase
+{
+    /** @var array<string, mixed> */
+    private array $savedServer;
+    /** @var array<string, mixed> */
+    private array $savedSession;
+    /** @var array<string, mixed> */
+    private array $savedGlobals;
+
+    /** @var list<string> Global keys injected during tests */
+    private array $injectedGlobalKeys = [];
+
+    protected function setUp(): void
+    {
+        $this->savedServer = $_SERVER;
+        $this->savedSession = $_SESSION ?? [];
+        $this->savedGlobals = [];
+
+        foreach (['sitename', 'pagetitle', 'slogan', 'name', 'user', 'start_time', 'authService'] as $key) {
+            $this->savedGlobals[$key] = $GLOBALS[$key] ?? '__UNSET__';
+        }
+
+        require_once dirname(__DIR__, 2) . '/Module/EntryPoints/theme-stubs.php';
+
+        $legacyPath = dirname(__DIR__, 3) . '/classes/Bootstrap/LegacyFunctions.php';
+        require_once $legacyPath;
+
+        $authStub = $this->createStub(\Auth\Contracts\AuthServiceInterface::class);
+        $authStub->method('getCookieArray')->willReturn(null);
+        $GLOBALS['authService'] = $authStub;
+
+        $GLOBALS['sitename'] = 'Test Site';
+        $GLOBALS['pagetitle'] = 'Test Page';
+        $GLOBALS['slogan'] = 'Test Slogan';
+        $GLOBALS['name'] = '';
+        $GLOBALS['user'] = '';
+        $this->injectedGlobalKeys = ['sitename', 'pagetitle', 'slogan', 'name', 'user', 'authService'];
+
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->savedServer;
+        $_SESSION = $this->savedSession;
+
+        foreach ($this->savedGlobals as $key => $value) {
+            if ($value === '__UNSET__') {
+                unset($GLOBALS[$key]);
+            } else {
+                $GLOBALS[$key] = $value;
+            }
+        }
+
+        unset($GLOBALS['mysqli_db']);
+    }
+
+    public function testHeaderBoostedRendsTitleOnly(): void
+    {
+        $_SERVER['HTTP_HX_BOOSTED'] = 'true';
+        ob_start();
+        PageLayout::header();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('<title>', $output);
+        self::assertStringContainsString('Test Site', $output);
+        self::assertStringNotContainsString('THEMEHEADER_CALLED', $output);
+        self::assertStringNotContainsString('<!DOCTYPE html>', $output);
+    }
+
+    public function testHeaderBoostedShowsFlashMessage(): void
+    {
+        $_SERVER['HTTP_HX_BOOSTED'] = 'true';
+        $_SESSION['flash_success'] = 'Operation completed';
+        ob_start();
+        PageLayout::header();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('Operation completed', $output);
+        self::assertStringContainsString('ibl-alert--success', $output);
+        self::assertArrayNotHasKey('flash_success', $_SESSION);
+    }
+
+    public function testHeaderNonBoostedCallsThemeHeader(): void
+    {
+        unset($_SERVER['HTTP_HX_BOOSTED']);
+        ob_start();
+        PageLayout::header();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('<!DOCTYPE html>', $output);
+        self::assertStringContainsString('THEMEHEADER_CALLED', $output);
+        self::assertStringContainsString('<title>', $output);
+    }
+
+    public function testHeaderNonBoostedSkipsRecordHitWhenNoDb(): void
+    {
+        unset($_SERVER['HTTP_HX_BOOSTED']);
+        unset($GLOBALS['mysqli_db']);
+        ob_start();
+        PageLayout::header();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('<!DOCTYPE html>', $output);
+    }
+
+    public function testFooterBoostedFlushesBuffer(): void
+    {
+        $_SERVER['HTTP_HX_BOOSTED'] = 'true';
+        ob_start();
+        ob_start();
+        echo 'TEST_BODY';
+        PageLayout::footer();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('TEST_BODY', $output);
+        self::assertStringNotContainsString('THEMEFOOTER_CALLED', $output);
+    }
+
+    public function testFooterNonBoostedCallsThemeFooter(): void
+    {
+        unset($_SERVER['HTTP_HX_BOOSTED']);
+        ob_start();
+        ob_start();
+        echo 'BODY_CONTENT';
+        PageLayout::footer();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('THEMEFOOTER_CALLED', $output);
+        self::assertStringContainsString('</body>', $output);
+        self::assertStringContainsString('</html>', $output);
+    }
+
+    public function testRenderPageGenerationTimeOutputsComment(): void
+    {
+        $GLOBALS['start_time'] = microtime(true) - 1.0;
+        ob_start();
+        PageLayout::renderPageGenerationTime();
+        $output = (string) ob_get_clean();
+
+        self::assertMatchesRegularExpression('/<!--.*Page Generation.*-->/', $output);
+    }
+
+    public function testRenderPageGenerationTimeUsesCustomLabels(): void
+    {
+        if (!defined('_PAGEGENERATION')) {
+            define('_PAGEGENERATION', 'Generated in:');
+        }
+        if (!defined('_SECONDS')) {
+            define('_SECONDS', 'secs');
+        }
+        $GLOBALS['start_time'] = microtime(true) - 0.5;
+        ob_start();
+        PageLayout::renderPageGenerationTime();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('Generated in:', $output);
+        self::assertStringContainsString('secs', $output);
+    }
+
+    public function testHeaderBoostedShowsAdminPhaseGateNotice(): void
+    {
+        $_SERVER['HTTP_HX_BOOSTED'] = 'true';
+        if (!defined('ADMIN_PHASE_GATE_NOTICE')) {
+            define('ADMIN_PHASE_GATE_NOTICE', true);
+        }
+        ob_start();
+        PageLayout::header();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('ibl-alert--warning', $output);
+        self::assertStringContainsString('Admin mode', $output);
+    }
+}


### PR DESCRIPTION
## Summary

Adds direct unit test coverage for two production modules that had none:

- **`Database\PdoConnection`** — 5 tests covering `setInstance()`, `getInstance()` (same-instance guarantee, repeated calls), `reset()`, and the throw-on-unreachable-DB path
- **`PageLayout\PageLayout`** — 8 tests covering the HX-Boosted short-circuit path (title-only, flash messages, admin phase gate notice), non-boosted full theme rendering, `footer()` buffer flush, and `renderPageGenerationTime()`
- **`theme-stubs.php`** — Added `<!-- THEMEHEADER_CALLED -->` / `<!-- THEMEFOOTER_CALLED -->` detection markers (within `if (!function_exists())` guards); existing entry-point tests unaffected

## Changes

- `tests/Unit/Database/PdoConnectionTest.php` — new (5 tests)
- `tests/Unit/PageLayout/PageLayoutTest.php` — new (8 tests)
- `tests/Module/EntryPoints/theme-stubs.php` — updated to add detection markers

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---

Generated with [Claude Code](https://claude.ai/code)