### PR TITLE
test: tier-2 e2e hardening PR-A — non-admin CI user + test-state cleanup endpoints

### DIFF
--- a/.github/actions/setup-docker-e2e/action.yml
+++ b/.github/actions/setup-docker-e2e/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: 'E2E test password (required when with-playwright is true)'
     required: false
     default: ''
+  test-user-regular:
+    description: 'Non-admin E2E test username (optional; enables role-gating tests)'
+    required: false
+    default: ''
+  test-pass-regular:
+    description: 'Non-admin E2E test password (optional; enables role-gating tests)'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -117,6 +125,36 @@ runs:
 
         $db->close();
         echo "Test user created: $user\n";
+        PHPSCRIPT
+
+    - name: Create regular (non-admin) test user
+      if: inputs.with-playwright == 'true' && inputs.test-user-regular != ''
+      shell: bash
+      env:
+        IBL_TEST_USER_REGULAR: ${{ inputs.test-user-regular }}
+        IBL_TEST_PASS_REGULAR: ${{ inputs.test-pass-regular }}
+      run: |
+        docker compose -f docker-compose.ci.yml exec \
+          -e IBL_TEST_USER_REGULAR="$IBL_TEST_USER_REGULAR" \
+          -e IBL_TEST_PASS_REGULAR="$IBL_TEST_PASS_REGULAR" \
+          -T php php <<'PHPSCRIPT'
+        <?php
+        $hash = password_hash(getenv('IBL_TEST_PASS_REGULAR'), PASSWORD_BCRYPT);
+        $user = getenv('IBL_TEST_USER_REGULAR');
+        $email = 'ci-test-regular@example.com';
+        $db = new mysqli('mariadb', 'root', 'root', 'ibl5');
+
+        // roles_mask = 0 grants no roles — authenticated non-admin.
+        // No ibl_team_info.gm_username assignment: this user has no team,
+        // exercising the "authenticated, no franchise" code path that
+        // Phase 3 role-gating tests depend on.
+        $stmt = $db->prepare("INSERT INTO auth_users (email, password, username, status, verified, resettable, roles_mask, registered, force_logout) VALUES (?, ?, ?, 0, 1, 1, 0, ?, 0)");
+        $time = time();
+        $stmt->bind_param('sssi', $email, $hash, $user, $time);
+        $stmt->execute();
+
+        $db->close();
+        echo "Regular test user created: $user\n";
         PHPSCRIPT
 
     - name: Wait for Playwright image

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -114,6 +114,8 @@ jobs:
           with-playwright: 'true'
           test-user: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
           test-pass: ${{ secrets.IBL_TEST_PASS || 'ci-e2e-pass-not-secret' }}
+          test-user-regular: ${{ secrets.IBL_TEST_USER_REGULAR || 'ci-e2e-regular' }}
+          test-pass-regular: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
 
       # --- Run Tests ---
       # Visual regression runs in its own job — before functional E2E tests which modify
@@ -124,6 +126,8 @@ jobs:
         env:
           IBL_TEST_USER: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
           IBL_TEST_PASS: ${{ secrets.IBL_TEST_PASS || 'ci-e2e-pass-not-secret' }}
+          IBL_TEST_USER_REGULAR: ${{ secrets.IBL_TEST_USER_REGULAR || 'ci-e2e-regular' }}
+          IBL_TEST_PASS_REGULAR: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
         run: |
           docker run --rm \
             --network ibl5-e2e \
@@ -133,6 +137,8 @@ jobs:
             -e "BASE_URL=http://php/ibl5/" \
             -e "IBL_TEST_USER=$IBL_TEST_USER" \
             -e "IBL_TEST_PASS=$IBL_TEST_PASS" \
+            -e "IBL_TEST_USER_REGULAR=$IBL_TEST_USER_REGULAR" \
+            -e "IBL_TEST_PASS_REGULAR=$IBL_TEST_PASS_REGULAR" \
             -e "HOME=/tmp" \
             mcr.microsoft.com/playwright:v1.60.0-jammy \
             npx playwright test --config=playwright.visual.config.ts
@@ -143,6 +149,8 @@ jobs:
         env:
           IBL_TEST_USER: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
           IBL_TEST_PASS: ${{ secrets.IBL_TEST_PASS || 'ci-e2e-pass-not-secret' }}
+          IBL_TEST_USER_REGULAR: ${{ secrets.IBL_TEST_USER_REGULAR || 'ci-e2e-regular' }}
+          IBL_TEST_PASS_REGULAR: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
         run: |
           docker run --rm \
             --network ibl5-e2e \
@@ -152,6 +160,8 @@ jobs:
             -e "BASE_URL=http://php/ibl5/" \
             -e "IBL_TEST_USER=$IBL_TEST_USER" \
             -e "IBL_TEST_PASS=$IBL_TEST_PASS" \
+            -e "IBL_TEST_USER_REGULAR=$IBL_TEST_USER_REGULAR" \
+            -e "IBL_TEST_PASS_REGULAR=$IBL_TEST_PASS_REGULAR" \
             -e "HOME=/tmp" \
             mcr.microsoft.com/playwright:v1.60.0-jammy \
             npx playwright test --config=playwright.visual.config.ts --update-snapshots
@@ -298,12 +308,16 @@ jobs:
           with-playwright: 'true'
           test-user: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
           test-pass: ${{ secrets.IBL_TEST_PASS || 'ci-e2e-pass-not-secret' }}
+          test-user-regular: ${{ secrets.IBL_TEST_USER_REGULAR || 'ci-e2e-regular' }}
+          test-pass-regular: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
 
       # --- Run Sharded Tests ---
       - name: Run E2E tests (shard ${{ matrix.shard-index }}/${{ matrix.total-shards }})
         env:
           IBL_TEST_USER: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
           IBL_TEST_PASS: ${{ secrets.IBL_TEST_PASS || 'ci-e2e-pass-not-secret' }}
+          IBL_TEST_USER_REGULAR: ${{ secrets.IBL_TEST_USER_REGULAR || 'ci-e2e-regular' }}
+          IBL_TEST_PASS_REGULAR: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
         run: |
           docker run --rm \
             --network ibl5-e2e \
@@ -313,6 +327,8 @@ jobs:
             -e "BASE_URL=http://php/ibl5/" \
             -e "IBL_TEST_USER=$IBL_TEST_USER" \
             -e "IBL_TEST_PASS=$IBL_TEST_PASS" \
+            -e "IBL_TEST_USER_REGULAR=$IBL_TEST_USER_REGULAR" \
+            -e "IBL_TEST_PASS_REGULAR=$IBL_TEST_PASS_REGULAR" \
             -e "HOME=/tmp" \
             mcr.microsoft.com/playwright:v1.60.0-jammy \
             npx playwright test \

--- a/ibl5/.env.test.example
+++ b/ibl5/.env.test.example
@@ -1,4 +1,9 @@
 IBL_TEST_USER=your_test_username
 IBL_TEST_PASS=your_test_password
+# Optional: non-admin user for role-gating tests. Without these,
+# auth-regular.setup.ts is skipped and any spec importing
+# fixtures/auth-regular.ts will error.
+IBL_TEST_USER_REGULAR=
+IBL_TEST_PASS_REGULAR=
 E2E_TESTING=1
 DEV_AUTO_LOGIN=

--- a/ibl5/eslint.config.js
+++ b/ibl5/eslint.config.js
@@ -60,13 +60,14 @@ export default [
     },
   },
   {
-    // The base fixture, auth.setup.ts, and the Playwright config legitimately
-    // import from @playwright/test — base.ts owns the watcher override;
-    // auth.setup.ts runs before any fixture is established; the configs need
-    // defineConfig from the package root.
+    // The base fixture, auth.setup.ts, auth-regular.setup.ts, and the Playwright
+    // configs legitimately import from @playwright/test — base.ts owns the
+    // watcher override; the auth setup files run before any fixture is
+    // established; the configs need defineConfig from the package root.
     files: [
       'tests/e2e/fixtures/base.ts',
       'tests/e2e/auth.setup.ts',
+      'tests/e2e/auth-regular.setup.ts',
       'playwright.config.ts',
       'playwright.visual.config.ts',
     ],

--- a/ibl5/playwright.config.ts
+++ b/ibl5/playwright.config.ts
@@ -46,7 +46,10 @@ export default defineConfig({
   projects: [
     {
       name: 'setup',
-      testMatch: /auth\.setup\.ts/,
+      // Matches both auth.setup.ts (admin) and auth-regular.setup.ts (non-admin).
+      // The regular setup is skipped at runtime when IBL_TEST_USER_REGULAR is
+      // unset (local devs can opt out) — see auth-regular.setup.ts.
+      testMatch: /auth(-regular)?\.setup\.ts$/,
     },
     {
       name: 'chromium',
@@ -55,7 +58,7 @@ export default defineConfig({
         storageState: 'playwright/.auth/user.json',
       },
       dependencies: ['setup'],
-      testIgnore: [/auth\.setup\.ts/, /visual-regression/],
+      testIgnore: [/auth\.setup\.ts/, /auth-regular\.setup\.ts/, /visual-regression/],
     },
   ],
 });

--- a/ibl5/test-state.php
+++ b/ibl5/test-state.php
@@ -84,6 +84,76 @@ if ($method === 'DELETE' && $action === 'clear-throttle') {
     exit;
 }
 
+// DELETE ?action=reset-extension&pid=N — reset rolling player's contract back
+// to seed values after a contract-extension submission test. Scaffolded for
+// PR-B's contract-extension flow; pid=30 (Extension Vet, Metros) is the only
+// supported player today since it's the seed fixture for that test. See
+// tests/e2e/fixtures/ci-seed.sql for the source-of-truth values.
+if ($method === 'DELETE' && $action === 'reset-extension') {
+    $pid = (int)($_GET['pid'] ?? 0);
+    if ($pid !== 30) {
+        http_response_code(400);
+        echo json_encode(['error' => 'reset-extension only supports pid=30 (Extension Vet seed)']);
+        $db->close();
+        exit;
+    }
+    $stmt = $db->prepare(
+        'UPDATE ibl_plr SET cy = 2, cyt = 2,
+            salary_yr1 = 1500, salary_yr2 = 1650,
+            salary_yr3 = 0, salary_yr4 = 0, salary_yr5 = 0, salary_yr6 = 0
+         WHERE pid = ?'
+    );
+    $stmt->bind_param('i', $pid);
+    $stmt->execute();
+    $reset = $stmt->affected_rows > 0 ? 1 : 0;
+    $stmt->close();
+    echo json_encode(['reset' => $reset]);
+    $db->close();
+    exit;
+}
+
+// DELETE ?action=reset-draft-order&year=N — clear ibl_draft_picks for one
+// season year, allowing repeat runs of the ProjectedDraftOrder save_order test.
+if ($method === 'DELETE' && $action === 'reset-draft-order') {
+    $year = (int)($_GET['year'] ?? 0);
+    if ($year < 1900 || $year > 2200) {
+        http_response_code(400);
+        echo json_encode(['error' => 'reset-draft-order requires a valid year']);
+        $db->close();
+        exit;
+    }
+    $stmt = $db->prepare('DELETE FROM ibl_draft_picks WHERE year = ?');
+    $stmt->bind_param('i', $year);
+    $stmt->execute();
+    $cleared = $stmt->affected_rows;
+    $stmt->close();
+    echo json_encode(['cleared' => $cleared]);
+    $db->close();
+    exit;
+}
+
+// DELETE ?action=delete-test-user&username=NAME — remove a registration-test
+// user from auth_users. Refuses to delete usernames that do not start with
+// the `e2e_` prefix so the endpoint cannot wipe real accounts even if
+// E2E_TESTING is mistakenly enabled in a non-test environment.
+if ($method === 'DELETE' && $action === 'delete-test-user') {
+    $username = (string)($_GET['username'] ?? '');
+    if (!str_starts_with($username, 'e2e_')) {
+        http_response_code(400);
+        echo json_encode(['error' => 'delete-test-user only accepts usernames starting with e2e_']);
+        $db->close();
+        exit;
+    }
+    $stmt = $db->prepare('DELETE FROM auth_users WHERE username = ?');
+    $stmt->bind_param('s', $username);
+    $stmt->execute();
+    $deleted = $stmt->affected_rows;
+    $stmt->close();
+    echo json_encode(['deleted' => $deleted]);
+    $db->close();
+    exit;
+}
+
 if ($method === 'GET') {
     $result = $db->query('SELECT name, value FROM ibl_settings');
     $settings = [];

--- a/ibl5/tests/api-e2e/test-state-cleanup-safety.test.ts
+++ b/ibl5/tests/api-e2e/test-state-cleanup-safety.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Safety-gate tests for the new test-state.php DELETE cleanup endpoints.
+ * The delete-test-user endpoint must refuse to wipe accounts whose
+ * username does not start with the `e2e_` prefix — a defense-in-depth
+ * check in case E2E_TESTING leaks into a non-test environment.
+ *
+ * Verification row 13 of the Tier 2 E2E hardening plan.
+ */
+
+import { describe, test, expect } from 'vitest';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://main.localhost/ibl5/';
+const stateUrl = `${BASE_URL.replace(/\/$/, '')}/test-state.php`;
+
+describe('test-state.php cleanup safety gates', () => {
+  test('delete-test-user refuses usernames without e2e_ prefix', async () => {
+    for (const evil of ['admin', 'A-Jay', 'commish', 'root', '']) {
+      const url = `${stateUrl}?action=delete-test-user&username=${encodeURIComponent(evil)}`;
+      const res = await fetch(url, { method: 'DELETE' });
+      expect(res.status, `username "${evil}" must be refused`).toBe(400);
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+    }
+  });
+
+  test('delete-test-user accepts e2e_ prefix and returns deleted count', async () => {
+    // No row with this username exists — endpoint should succeed with deleted=0.
+    const url = `${stateUrl}?action=delete-test-user&username=e2e_nonexistent_user`;
+    const res = await fetch(url, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('deleted');
+    expect(body.deleted).toBe(0);
+  });
+
+  test('reset-extension refuses pids other than 30', async () => {
+    for (const pid of [0, 1, 29, 31, 100]) {
+      const res = await fetch(`${stateUrl}?action=reset-extension&pid=${pid}`, { method: 'DELETE' });
+      expect(res.status, `pid=${pid} must be refused`).toBe(400);
+    }
+  });
+
+  test('reset-extension accepts pid=30 and reports reset status', async () => {
+    const res = await fetch(`${stateUrl}?action=reset-extension&pid=30`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('reset');
+    expect([0, 1]).toContain(body.reset);
+  });
+
+  test('reset-draft-order refuses out-of-range years', async () => {
+    for (const year of [0, 1899, 2201, 9999]) {
+      const res = await fetch(`${stateUrl}?action=reset-draft-order&year=${year}`, { method: 'DELETE' });
+      expect(res.status, `year=${year} must be refused`).toBe(400);
+    }
+  });
+
+  test('reset-draft-order accepts a plausible season year', async () => {
+    const res = await fetch(`${stateUrl}?action=reset-draft-order&year=2026`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('cleared');
+    expect(typeof body.cleared).toBe('number');
+  });
+});

--- a/ibl5/tests/api-e2e/test-state-existing-paths.test.ts
+++ b/ibl5/tests/api-e2e/test-state-existing-paths.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Characterization tests for ibl5/test-state.php — verifies the existing
+ * GET, POST, and `DELETE action=clear-throttle` paths keep responding with
+ * the same shapes after PR-A adds new DELETE actions
+ * (reset-extension, reset-draft-order, delete-test-user).
+ *
+ * Verification row 12 of the Tier 2 E2E hardening plan.
+ *
+ * Path note: the plan literally said `tests/api/test-state-existing-paths.spec.ts`,
+ * but `vitest.api.config.ts` only includes `tests/api-e2e/**!/!*.test.ts`. Placed
+ * under api-e2e/ with the .test.ts suffix so the existing vitest job picks it up.
+ */
+
+import { describe, test, expect } from 'vitest';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://main.localhost/ibl5/';
+const stateUrl = `${BASE_URL.replace(/\/$/, '')}/test-state.php`;
+
+describe('test-state.php existing endpoints', () => {
+  test('GET returns the ibl_settings dictionary', async () => {
+    const res = await fetch(stateUrl);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body).toBeTypeOf('object');
+    expect(body).not.toBeNull();
+  });
+
+  test('POST with an allow-listed setting returns previous + applied', async () => {
+    const res = await fetch(stateUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ 'Allow Trades': 'Yes' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('previous');
+    expect(body).toHaveProperty('applied');
+    expect(body.applied).toEqual({ 'Allow Trades': 'Yes' });
+  });
+
+  test('POST with an unknown setting returns 400', async () => {
+    const res = await fetch(stateUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ 'Not A Real Setting': 'x' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  test('DELETE action=clear-throttle returns cleared count', async () => {
+    const res = await fetch(`${stateUrl}?action=clear-throttle`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('cleared');
+    expect(typeof body.cleared).toBe('number');
+  });
+
+  test('unsupported method returns 405', async () => {
+    const res = await fetch(stateUrl, { method: 'PUT' });
+    expect(res.status).toBe(405);
+  });
+});

--- a/ibl5/tests/e2e/auth-regular.setup.ts
+++ b/ibl5/tests/e2e/auth-regular.setup.ts
@@ -1,0 +1,50 @@
+import { test as setup } from '@playwright/test';
+
+// Setup file — runs before any fixture is established, so the direct
+// `@playwright/test` import (instead of fixtures/base) is the documented
+// exception per eslint.config.js. See auth.setup.ts for the admin equivalent.
+
+const authFile = 'playwright/.auth/regular.json';
+
+setup('authenticate regular (non-admin) user', async ({ page, request }) => {
+  const username = process.env.IBL_TEST_USER_REGULAR;
+  const password = process.env.IBL_TEST_PASS_REGULAR;
+
+  // Skip (don't fail) when the non-admin credentials are unset so the admin
+  // setup project still publishes user.json and the admin suite stays green
+  // for local devs who haven't opted into the role-gating tests. Specs that
+  // import fixtures/auth-regular will fail loudly when regular.json is absent.
+  setup.skip(!username || !password, 'IBL_TEST_USER_REGULAR / IBL_TEST_PASS_REGULAR not set');
+
+  const throttleResp = await request.delete('test-state.php?action=clear-throttle');
+  if (!throttleResp.ok()) {
+    console.warn(`Failed to clear auth throttle (HTTP ${throttleResp.status()}) — login may fail if throttled`);
+  }
+
+  // DEV_AUTO_LOGIN (PHP) auto-authenticates whichever user the developer's
+  // .env.test names — usually an admin. Set `_no_auto_login` BEFORE the
+  // first navigation so the login form actually renders for our non-admin
+  // credentials. Without this, a dev with DEV_AUTO_LOGIN=A-Jay would write
+  // the admin's session into regular.json. Same cookie pattern as
+  // tests/e2e/helpers/public-storage-state.ts.
+  const baseUrl = process.env.BASE_URL ?? 'http://main.localhost/ibl5/';
+  await page.context().addCookies([
+    { name: '_no_auto_login', value: '1', domain: new URL(baseUrl).hostname, path: '/' },
+  ]);
+
+  await page.goto('modules.php?name=YourAccount');
+
+  const loginForm = page.locator('form', { has: page.locator('#login-username') });
+  await loginForm.locator('#login-username').fill(username);
+  await loginForm.locator('#login-password').fill(password);
+
+  // Submit and wait for the redirect off YourAccount atomically. Without
+  // the Promise.all, fast PHP responses can complete the navigation before
+  // the waiter installs and the test then times out on the resolved URL.
+  await Promise.all([
+    page.waitForURL((url) => !url.href.includes('name=YourAccount'), { timeout: 20_000 }),
+    loginForm.locator('button[type="submit"]').click(),
+  ]);
+
+  await page.context().storageState({ path: authFile });
+});

--- a/ibl5/tests/e2e/fixtures/auth-regular.ts
+++ b/ibl5/tests/e2e/fixtures/auth-regular.ts
@@ -1,0 +1,24 @@
+import { test as base } from './base';
+import { createCookieStateFixture, type SetStateFn } from '../helpers/test-state';
+
+export type { SetStateFn };
+
+/**
+ * Authenticated non-admin fixture.
+ *
+ * Contrast with fixtures/auth.ts: that one uses an admin storage state
+ * (roles_mask=1), so requests bypass ModuleAccessControl gating and
+ * phase/trivia/admin checks always succeed. This fixture uses a
+ * roles_mask=0 user with no ibl_team_info row — the "authenticated
+ * non-admin without a franchise" path. Use this for tests that need
+ * the gating logic to actually run (e.g., asserting a phase-restricted
+ * module is hidden, or that an admin-only endpoint returns 403).
+ *
+ * Logout tests must use fixtures/public.ts instead.
+ */
+export const test = base.extend<{ appState: SetStateFn }>({
+  storageState: 'playwright/.auth/regular.json',
+  appState: createCookieStateFixture(),
+});
+
+export { expect } from './base';

--- a/ibl5/tests/e2e/fixtures/auth-regular.ts
+++ b/ibl5/tests/e2e/fixtures/auth-regular.ts
@@ -15,9 +15,20 @@ export type { SetStateFn };
  * module is hidden, or that an admin-only endpoint returns 403).
  *
  * Logout tests must use fixtures/public.ts instead.
+ *
+ * When IBL_TEST_USER_REGULAR is unset (local dev hasn't opted in),
+ * auth-regular.setup.ts skips and the file at playwright/.auth/regular.json
+ * is either absent or stale. Fall back to an empty storage state so the
+ * fixture itself doesn't error during loading — consumer specs guard
+ * their bodies with `test.skip()` against the same env var so the
+ * assertions don't run against an unauthenticated session.
  */
+const REGULAR_STORAGE_STATE = process.env.IBL_TEST_USER_REGULAR
+  ? 'playwright/.auth/regular.json'
+  : { cookies: [], origins: [] };
+
 export const test = base.extend<{ appState: SetStateFn }>({
-  storageState: 'playwright/.auth/regular.json',
+  storageState: REGULAR_STORAGE_STATE,
   appState: createCookieStateFixture(),
 });
 

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -1582,9 +1582,14 @@ LEFT JOIN ibl_franchise_seasons fs
 WHERE snap.rn = 1;
 
 -- ============================================================
--- Non-admin user for phase-gating E2E tests (Batch C prep)
--- Username: E2E-Regular — no team, no admin privileges.
--- Password hash is set at CI runtime (same pattern as primary test user).
--- To activate: add IBL_TEST_USER_REGULAR / IBL_TEST_PASS_REGULAR
--- GitHub secrets and a user-creation step in e2e-tests.yml.
+-- Non-admin user for phase-gating E2E tests:
+-- Created at CI runtime by the "Create regular (non-admin) test user"
+-- step in .github/actions/setup-docker-e2e/action.yml.
+-- Credentials read from IBL_TEST_USER_REGULAR / IBL_TEST_PASS_REGULAR
+-- (defaults: 'ci-e2e-regular' / 'e2e-regular-pass'). The password
+-- default is kept ≤20 chars because the login form has maxlength=20
+-- (see YourAccountView.php) — longer defaults get silently truncated
+-- by Playwright's fill() and login fails.
+-- roles_mask=0, no ibl_team_info row — exercises the authenticated
+-- non-admin "no franchise" code path.
 -- ============================================================

--- a/ibl5/tests/e2e/smoke/auth-regular-user-provisioned.spec.ts
+++ b/ibl5/tests/e2e/smoke/auth-regular-user-provisioned.spec.ts
@@ -1,0 +1,52 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures/base';
+
+/**
+ * Verifies the CI-provisioned non-admin user actually exists in auth_users
+ * with non-admin privileges. Independent of auth-regular.setup.ts so a
+ * setup-file regression doesn't mask a provisioning regression.
+ *
+ * Test classification: API-test (Tier 2 plan, verification row 3).
+ * Uses the base fixture (no storageState) and manually sets `_no_auto_login`
+ * to opt out of DevAutoLogin so the login form renders.
+ */
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+async function loginViaForm(page: Page, username: string, password: string): Promise<void> {
+  await page.goto('modules.php?name=YourAccount');
+  const loginForm = page.locator('form', { has: page.locator('#login-username') });
+  await loginForm.locator('#login-username').fill(username);
+  await loginForm.locator('#login-password').fill(password);
+  await Promise.all([
+    page.waitForURL((url) => !url.href.includes('name=YourAccount'), { timeout: 20_000 }),
+    loginForm.locator('button[type="submit"]').click(),
+  ]);
+}
+
+test.describe('Regular (non-admin) test user provisioning', () => {
+  test.beforeEach(async ({ page, request }) => {
+    const baseUrl = process.env.BASE_URL ?? 'http://main.localhost/ibl5/';
+    await page.context().addCookies([
+      { name: '_no_auto_login', value: '1', domain: new URL(baseUrl).hostname, path: '/' },
+    ]);
+    await request.delete('test-state.php?action=clear-throttle');
+  });
+
+  test('regular user can authenticate via login form POST', async ({ page }) => {
+    const username = process.env.IBL_TEST_USER_REGULAR;
+    const password = process.env.IBL_TEST_PASS_REGULAR;
+    test.skip(!username || !password, 'IBL_TEST_USER_REGULAR/PASS not configured');
+    await loginViaForm(page, username!, password!);
+    expect(page.url()).not.toContain('name=YourAccount');
+  });
+
+  test('regular user is denied admin pages (roles_mask=0)', async ({ page }) => {
+    const username = process.env.IBL_TEST_USER_REGULAR;
+    const password = process.env.IBL_TEST_PASS_REGULAR;
+    test.skip(!username || !password, 'IBL_TEST_USER_REGULAR/PASS not configured');
+    await loginViaForm(page, username!, password!);
+    const response = await page.goto('scripts/updateAllTheThings.php');
+    expect(response?.status(), 'regular user must NOT have admin privileges').toBe(403);
+  });
+});

--- a/ibl5/tests/e2e/smoke/auth-regular.spec.ts
+++ b/ibl5/tests/e2e/smoke/auth-regular.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '../fixtures/auth-regular';
+
+/**
+ * Verifies playwright/.auth/regular.json was produced by auth-regular.setup.ts
+ * and that the chromium project picks it up when the auth-regular fixture is
+ * imported. Together with the existing admin smoke tests, this confirms both
+ * storage states coexist (verification row 4 of the Tier 2 plan).
+ */
+
+test.describe('Regular user smoke', () => {
+  test('non-admin storage state authenticates a normal page', async ({ page }) => {
+    await page.goto('index.php');
+    // Authenticated users never see the sign-in CTA in the navbar.
+    await expect(page.getByText('Sign In')).toBeHidden();
+  });
+
+  test('non-admin user gets 403 on admin entry point', async ({ page }) => {
+    const response = await page.goto('scripts/updateAllTheThings.php');
+    expect(response?.status()).toBe(403);
+  });
+});

--- a/ibl5/tests/e2e/smoke/auth-regular.spec.ts
+++ b/ibl5/tests/e2e/smoke/auth-regular.spec.ts
@@ -5,9 +5,19 @@ import { test, expect } from '../fixtures/auth-regular';
  * and that the chromium project picks it up when the auth-regular fixture is
  * imported. Together with the existing admin smoke tests, this confirms both
  * storage states coexist (verification row 4 of the Tier 2 plan).
+ *
+ * Skips when IBL_TEST_USER_REGULAR is unset: auth-regular.setup.ts also
+ * skips in that case, leaving regular.json absent or stale — running these
+ * assertions against an unauthenticated session would assert the wrong
+ * behavior (admin gates return 200 with a login prompt, not 403).
  */
 
 test.describe('Regular user smoke', () => {
+  test.skip(
+    !process.env.IBL_TEST_USER_REGULAR || !process.env.IBL_TEST_PASS_REGULAR,
+    'IBL_TEST_USER_REGULAR / IBL_TEST_PASS_REGULAR not set — regular.json is not freshly authenticated',
+  );
+
   test('non-admin storage state authenticates a normal page', async ({ page }) => {
     await page.goto('index.php');
     // Authenticated users never see the sign-in CTA in the navbar.


### PR DESCRIPTION
PR-A of the Tier 2 E2E hardening plan (`/Users/ajaynicolas/.claude/plans/tier-2-e2e-hardening.md`). Lands the CI/Playwright infrastructure for a non-admin test user plus the shared `test-state.php` cleanup endpoints that PR-B will consume. No new role-gating or submission specs ship here — that's PR-B.

## What changes

### CI: provision a non-admin test user
- `.github/actions/setup-docker-e2e/action.yml` — two new inputs (`test-user-regular`, `test-pass-regular`) and a new step that inserts a `roles_mask=0` row into `auth_users` with no `ibl_team_info.gm_username` assignment. Exercises the "authenticated non-admin, no franchise" code path that Phase 3 of PR-B depends on.
- `.github/workflows/e2e-tests.yml` — threads `IBL_TEST_USER_REGULAR` / `IBL_TEST_PASS_REGULAR` through both action calls and three docker exec env blocks (visual-regression, baseline-regen, sharded e2e).
- `ibl5/.env.test.example` — adds placeholders for local devs.
- `ibl5/tests/e2e/fixtures/ci-seed.sql` — replaces the now-stale placeholder comment with one pointing at the action.yml step that actually creates the user at CI runtime.

### Playwright wiring
- `tests/e2e/auth-regular.setup.ts` — mirror of `auth.setup.ts`. Two safety adjustments vs the plan:
  - `setup.skip()` when env vars are unset (instead of `throw`), so admin tests stay green for devs who haven't opted in.
  - Sets `_no_auto_login` cookie before the first navigation so `DEV_AUTO_LOGIN=A-Jay` (typical local config) doesn't write the admin's session into `regular.json`.
  - Uses `Promise.all([waitForURL, click])` to avoid the install-after-navigate race on fast PHP responses.
- `tests/e2e/fixtures/auth-regular.ts` — extends `base`, overrides `storageState` to `playwright/.auth/regular.json`. JSDoc contrasts with `fixtures/auth.ts` (admin bypasses ModuleAccessControl; regular does not).
- `playwright.config.ts` — broadens setup `testMatch` to `/auth(-regular)?\.setup\.ts$/`, adds the new setup file to chromium `testIgnore`.
- `eslint.config.js` — allowlists `auth-regular.setup.ts` for the `@playwright/test` direct-import exception (same as `auth.setup.ts`).

### `test-state.php` cleanup endpoints (scaffolded — consumed by PR-B)
Three new DELETE actions, all gated by `E2E_TESTING`:
- `action=reset-extension&pid=30` — restores Extension Vet's contract row to its ci-seed.sql values. Only pid=30 is accepted (advisor explicitly recommended hardcoding over building flexibility for hypothetical future pids).
- `action=reset-draft-order&year=N` — `DELETE FROM ibl_draft_picks WHERE year=?` with a sanity range check (1900-2200).
- `action=delete-test-user&username=NAME` — refuses any username that doesn't start with `e2e_`. Defense-in-depth against `E2E_TESTING` leaking into a non-test environment.

### Verification specs
- `tests/e2e/smoke/auth-regular-user-provisioned.spec.ts` — API-test (verification row 3). Logs in via form POST and asserts the user is provisioned with `roles_mask=0` (403 on admin URL).
- `tests/e2e/smoke/auth-regular.spec.ts` — E2E (verification row 4). Uses the regular-user storage state to load a normal page + admin URL returns 403.
- `tests/api-e2e/test-state-existing-paths.test.ts` — Vitest characterization (verification row 12). Locks the existing GET/POST/clear-throttle response shapes.
- `tests/api-e2e/test-state-cleanup-safety.test.ts` — Vitest (verification row 13). Refuses bad input on every new DELETE action (non-`e2e_` usernames, pids != 30, years outside 1900-2200).

## Adjustments vs the plan

1. **`tests/api/*.spec.ts` → `tests/api-e2e/*.test.ts`.** The plan named these files under `tests/api/` with `.spec.ts`, but `vitest.api.config.ts` only globs `tests/api-e2e/**/*.test.ts` — files at the plan's path would silently not run.
2. **Default password kept ≤20 chars.** Verified empirically that the login form's `<input maxlength="20">` truncates Playwright's `fill()`, breaking login. The plan's default `ci-e2e-regular-pass-not-secret` (30 chars) would fail in CI before the repo owner sets the secret. Changed to `e2e-regular-pass` (16 chars). The admin default `ci-e2e-pass-not-secret` (22 chars) has the same latent bug but is out of scope for this PR — its corresponding secret is presumed configured today.
3. **`auth-regular.setup.ts` `setup.skip()` instead of `throw`.** Project-level dependency on the `setup` project means a hard failure in the regular setup would skip every chromium test for devs who haven't configured the env vars.

## Manual external step

Repo owner needs to add `IBL_TEST_USER_REGULAR` and `IBL_TEST_PASS_REGULAR` GitHub secrets. CI falls back to literal defaults (`ci-e2e-regular` / `e2e-regular-pass`) when the secrets are unset — fine for the fresh-DB CI pattern but not useful for local dev.

## Manual Testing

No manual testing needed — all changes are covered by automated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)