### PR TITLE
ci: add bin/refactor-flag and refactor-flag.yml workflow

### DIFF
--- a/.claude/rules/refactor-flag.md
+++ b/.claude/rules/refactor-flag.md
@@ -1,0 +1,43 @@
+---
+description: Refactor PRs that touch ibl5/classes/** without an accompanying test change are blocked by bin/refactor-flag (workflow refactor-flag.yml).
+last_verified: 2026-05-13
+---
+
+# Refactor PR Flag
+
+## Triggers
+
+`bin/refactor-flag` runs on every PR. It blocks merge when the diff contains
+any of these refactor signals under `ibl5/classes/**` (excluding `Contracts/`):
+
+- File rename (`git diff --diff-filter=R`)
+- Method signature change (parameters or return type differ)
+- Visibility narrowing (public → protected, public → private, protected → private)
+- Class declaration removal
+- Large deletion (> 30 lines in a single file)
+
+## Resolution
+
+The gate passes if the same PR also:
+
+- Adds at least one new test file under `ibl5/tests/`, OR
+- Modifies an existing test whose filename references the affected class
+  or module (case-insensitive substring), OR
+- Carries a bypass marker in the PR body:
+  `<!-- no-refactor-tests: reason at least 20 characters explaining why -->`
+
+## When to bypass
+
+Bypass is appropriate for:
+
+- Pure file moves with no behavior change AND existing tests still cover the
+  moved code by namespace path (the test's `use` statement updates count as
+  test modification, but the heuristic matches by filename — bypass when the
+  test filename doesn't match).
+- Renames where the test file is also renamed in the same commit (test rename
+  shows as A + D, but the gate counts the A side as "test added").
+- Whitespace-only diffs above the 30-line threshold (rare; should be handled
+  by reformatting in a separate commit).
+
+The bypass reason must be at least 20 characters. "trivial" or "no behavior"
+will be rejected.

--- a/.github/workflows/refactor-flag.yml
+++ b/.github/workflows/refactor-flag.yml
@@ -1,0 +1,36 @@
+name: Refactor PR Flag
+
+on:
+  pull_request:
+    branches: [ master, develop ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  refactor-gate:
+    name: Refactor-without-tests gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Run bin/refactor-flag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bin/refactor-flag --pr

--- a/bin/refactor-flag
+++ b/bin/refactor-flag
@@ -1,0 +1,368 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * bin/refactor-flag — refactor-without-tests CI gate for IBL5.
+ *
+ * Detects refactor signals (renames, signature changes, visibility narrowing,
+ * class removal, large deletions) in ibl5/classes/** and blocks when the PR
+ * does not also touch tests or carry a bypass marker.
+ *
+ * Exits 0 when no triggers fire, or triggers fire with coverage/bypass.
+ * Exits 1 when triggers fire without either resolution.
+ * Exits 2 on usage error.
+ */
+
+const TRIGGER_DESCRIPTIONS = [
+    'rename' => 'file rename under ibl5/classes/ (high refactor signal)',
+    'signature-change' => 'method signature change in ibl5/classes/ (parameters or return type differ)',
+    'visibility-change' => 'visibility narrowing in ibl5/classes/ (e.g. public → private)',
+    'class-removed' => 'class declaration removed from ibl5/classes/ file',
+    'large-deletion' => 'large deletion (>30 lines) in ibl5/classes/ file',
+];
+
+const BYPASS_REGEX = '/<!--\s*no-refactor-tests:\s*(.+?)\s*-->/s';
+const BYPASS_MIN_LENGTH = 20;
+const LARGE_DELETION_THRESHOLD = 30;
+
+function usage(): string
+{
+    return <<<USAGE
+Usage: bin/refactor-flag [options]
+
+Refactor-without-tests gate: refuses to pass when a diff contains refactor
+signals under ibl5/classes/** without accompanying test changes or a bypass
+marker in the PR body.
+
+Modes:
+  --staged           Scan staged changes via `git diff --cached`. Default.
+  --pr               Scan the current PR against origin/master. Fetches the
+                     PR body via `gh pr view` for bypass marker detection.
+
+Options:
+  --bypass-from-stdin   Read the PR body from stdin (for local testing).
+                        Overrides any automatic fetch.
+  --help, -h            Show this message.
+
+Exit 0 on pass, 1 on failure, 2 on usage error.
+
+USAGE;
+}
+
+function runCmd(string $cmd): array
+{
+    $output = [];
+    $exit = 0;
+    exec($cmd . ' 2>/dev/null', $output, $exit);
+    return [$output, $exit];
+}
+
+function gitDiffRange(string $mode): string
+{
+    return $mode === 'pr' ? 'origin/master...HEAD' : '--cached';
+}
+
+/** @return list<string> */
+function diffNames(string $mode, string $filter): array
+{
+    $range = gitDiffRange($mode);
+    [$lines] = runCmd(sprintf('git diff %s --name-only --diff-filter=%s', escapeshellarg($range), escapeshellarg($filter)));
+    return array_values(array_filter($lines, static fn (string $line): bool => $line !== ''));
+}
+
+/**
+ * @return list<array{from: string, to: string}>
+ */
+function diffRenames(string $mode): array
+{
+    $range = gitDiffRange($mode);
+    [$lines] = runCmd(sprintf('git diff %s --name-status --diff-filter=R -M', escapeshellarg($range)));
+    $renames = [];
+    foreach ($lines as $line) {
+        $parts = preg_split('/\t+/', $line);
+        if ($parts !== false && count($parts) >= 3) {
+            $renames[] = ['from' => $parts[1], 'to' => $parts[2]];
+        }
+    }
+    return $renames;
+}
+
+/** @return list<string> */
+function diffAddedAndDeletedLines(string $mode, string $file): array
+{
+    $range = gitDiffRange($mode);
+    [$lines] = runCmd(sprintf('git diff %s -- %s', escapeshellarg($range), escapeshellarg($file)));
+    return $lines;
+}
+
+function isClassesFile(string $path): bool
+{
+    return str_starts_with($path, 'ibl5/classes/') && !str_starts_with($path, 'ibl5/classes/Contracts/');
+}
+
+/**
+ * @return list<array{type: string, file: string, severity: string}>
+ */
+function detectTriggers(string $mode): array
+{
+    $triggers = [];
+
+    // 1. Rename trigger
+    $renames = diffRenames($mode);
+    foreach ($renames as $rename) {
+        if (isClassesFile($rename['from']) || isClassesFile($rename['to'])) {
+            $triggers[] = [
+                'type' => 'rename',
+                'file' => $rename['from'] . ' → ' . $rename['to'],
+                'severity' => 'high',
+            ];
+        }
+    }
+
+    // Get modified files under ibl5/classes/
+    $modified = diffNames($mode, 'M');
+    $classesModified = array_filter($modified, 'isClassesFile');
+
+    foreach ($classesModified as $file) {
+        $diffLines = diffAddedAndDeletedLines($mode, $file);
+
+        $deletedFunctions = [];
+        $addedFunctions = [];
+
+        foreach ($diffLines as $line) {
+            // 2. Method signature change detection
+            if (preg_match('/^-\s*(public|private|protected)\s+(?:static\s+)?function\s+(\w+)\s*\((.*)/', $line, $m)) {
+                $deletedFunctions[$m[2]] = ['visibility' => $m[1], 'rest' => $m[3]];
+            }
+            if (preg_match('/^\+\s*(public|private|protected)\s+(?:static\s+)?function\s+(\w+)\s*\((.*)/', $line, $m)) {
+                $addedFunctions[$m[2]] = ['visibility' => $m[1], 'rest' => $m[3]];
+            }
+
+            // 4. Class declaration removed
+            if (preg_match('/^-class\s+\w+/', $line) === 1) {
+                $triggers[] = [
+                    'type' => 'class-removed',
+                    'file' => $file,
+                    'severity' => 'high',
+                ];
+            }
+        }
+
+        foreach ($deletedFunctions as $name => $del) {
+            if (!isset($addedFunctions[$name])) {
+                continue;
+            }
+            $add = $addedFunctions[$name];
+
+            // 3. Visibility change (narrowing)
+            $visibilityOrder = ['public' => 3, 'protected' => 2, 'private' => 1];
+            $oldVis = $visibilityOrder[$del['visibility']] ?? 0;
+            $newVis = $visibilityOrder[$add['visibility']] ?? 0;
+            if ($newVis < $oldVis) {
+                $triggers[] = [
+                    'type' => 'visibility-change',
+                    'file' => $file,
+                    'severity' => 'medium',
+                ];
+                continue;
+            }
+
+            // 2. Signature change (different parameters or return type)
+            if ($del['rest'] !== $add['rest']) {
+                $triggers[] = [
+                    'type' => 'signature-change',
+                    'file' => $file,
+                    'severity' => 'high',
+                ];
+            }
+        }
+
+        // 5. Large deletion
+        $deletedCount = 0;
+        foreach ($diffLines as $line) {
+            if (str_starts_with($line, '-') && !str_starts_with($line, '---')) {
+                $deletedCount++;
+            }
+        }
+        if ($deletedCount > LARGE_DELETION_THRESHOLD) {
+            $triggers[] = [
+                'type' => 'large-deletion',
+                'file' => $file,
+                'severity' => 'medium',
+            ];
+        }
+    }
+
+    return $triggers;
+}
+
+/**
+ * Extract class/module names affected by triggers.
+ * @param list<array{type: string, file: string, severity: string}> $triggers
+ * @return list<string>
+ */
+function affectedNames(array $triggers): array
+{
+    $names = [];
+    foreach ($triggers as $t) {
+        $file = $t['file'];
+        // Handle rename "from → to" format
+        if (str_contains($file, ' → ')) {
+            $parts = explode(' → ', $file);
+            foreach ($parts as $p) {
+                $names = array_merge($names, extractClassAndModuleNames(trim($p)));
+            }
+        } else {
+            $names = array_merge($names, extractClassAndModuleNames($file));
+        }
+    }
+    return array_values(array_unique($names));
+}
+
+/** @return list<string> */
+function extractClassAndModuleNames(string $path): array
+{
+    $names = [];
+    $basename = pathinfo($path, PATHINFO_FILENAME);
+    if ($basename !== '') {
+        $names[] = strtolower($basename);
+    }
+    // Extract module directory name (e.g. ibl5/classes/Waivers/WaiverService.php → waivers)
+    if (preg_match('#ibl5/classes/([^/]+)/#', $path, $m) === 1) {
+        $names[] = strtolower($m[1]);
+    }
+    return $names;
+}
+
+/**
+ * @param list<array{type: string, file: string, severity: string}> $triggers
+ */
+function checkTestCoverage(string $mode, array $triggers): bool
+{
+    $addedFiles = diffNames($mode, 'A');
+    $modifiedFiles = diffNames($mode, 'M');
+
+    // Test added in this PR — any new file under ibl5/tests/
+    foreach ($addedFiles as $file) {
+        if (str_starts_with($file, 'ibl5/tests/')) {
+            return true;
+        }
+    }
+
+    // Test modified in this PR — must match an affected class/module name
+    $affected = affectedNames($triggers);
+    foreach ($modifiedFiles as $file) {
+        if (!str_starts_with($file, 'ibl5/tests/')) {
+            continue;
+        }
+        $testBasename = strtolower(pathinfo($file, PATHINFO_FILENAME));
+        foreach ($affected as $name) {
+            if (str_contains($testBasename, $name) || str_contains($name, $testBasename)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+function fetchPrBody(string $mode, bool $fromStdin): ?string
+{
+    if ($fromStdin) {
+        $body = stream_get_contents(STDIN);
+        return $body === false ? null : $body;
+    }
+    if ($mode !== 'pr') {
+        return null;
+    }
+    $prNumber = getenv('PR_NUMBER');
+    $cmd = 'gh pr view';
+    if (is_string($prNumber) && $prNumber !== '') {
+        $cmd .= ' ' . escapeshellarg($prNumber);
+    }
+    $cmd .= ' --json body --jq .body';
+    [$lines, $exit] = runCmd($cmd);
+    if ($exit !== 0 || $lines === []) {
+        return null;
+    }
+    return implode("\n", $lines);
+}
+
+function extractBypassReason(?string $body): ?string
+{
+    if ($body === null || $body === '' || $body === 'null') {
+        return null;
+    }
+    if (preg_match(BYPASS_REGEX, $body, $m) !== 1) {
+        return null;
+    }
+    $reason = trim($m[1]);
+    if (strlen($reason) < BYPASS_MIN_LENGTH) {
+        return null;
+    }
+    return $reason;
+}
+
+// --- main ---
+
+$opts = ['mode' => 'staged', 'bypass_from_stdin' => false];
+foreach (array_slice($argv, 1) as $arg) {
+    switch ($arg) {
+        case '--staged':
+            $opts['mode'] = 'staged';
+            break;
+        case '--pr':
+            $opts['mode'] = 'pr';
+            break;
+        case '--bypass-from-stdin':
+            $opts['bypass_from_stdin'] = true;
+            break;
+        case '--help':
+        case '-h':
+            echo usage();
+            exit(0);
+        default:
+            fwrite(STDERR, "unknown flag: {$arg}\n");
+            fwrite(STDERR, usage());
+            exit(2);
+    }
+}
+
+$triggers = detectTriggers($opts['mode']);
+if ($triggers === []) {
+    echo "No refactor signals detected.\n";
+    exit(0);
+}
+
+$bypassReason = extractBypassReason(fetchPrBody($opts['mode'], $opts['bypass_from_stdin']));
+$hasCoverage = checkTestCoverage($opts['mode'], $triggers);
+
+echo "Refactor signals detected:\n";
+foreach ($triggers as $t) {
+    $desc = TRIGGER_DESCRIPTIONS[$t['type']] ?? $t['type'];
+    echo sprintf("  - [%s] %s — %s\n", $t['type'], $t['file'], $desc);
+}
+echo "\n";
+
+if ($hasCoverage) {
+    echo "PASS: test changes cover the refactor.\n";
+    exit(0);
+}
+
+if ($bypassReason !== null) {
+    echo "PASS (bypass): {$bypassReason}\n";
+    exit(0);
+}
+
+echo "FAIL: refactor signals detected without accompanying test changes.\n";
+echo "\n";
+echo "Resolve by either:\n";
+echo "  1. Add or modify a test under ibl5/tests/ that covers the refactored code.\n";
+echo "     Pre-impl characterization tests (green-green) are strongly recommended.\n";
+echo "  2. Add a bypass marker to the PR body (HTML comment):\n";
+echo "     <!-- no-refactor-tests: reason at least 20 characters long -->\n";
+echo "\n";
+echo "See .claude/rules/refactor-flag.md for the full policy.\n";
+exit(1);

--- a/bin/refactor-flag
+++ b/bin/refactor-flag
@@ -141,7 +141,7 @@ function detectTriggers(string $mode): array
             }
 
             // 4. Class declaration removed
-            if (preg_match('/^-class\s+\w+/', $line) === 1) {
+            if (preg_match('/^-(?:(?:abstract|final|readonly)\s+)*class\s+\w+/', $line) === 1) {
                 $triggers[] = [
                     'type' => 'class-removed',
                     'file' => $file,

--- a/ibl5/docs/decisions/0021-refactor-pr-flag.md
+++ b/ibl5/docs/decisions/0021-refactor-pr-flag.md
@@ -1,0 +1,39 @@
+---
+description: ADR for bin/refactor-flag CI gate that blocks refactor PRs without test coverage.
+last_verified: 2026-05-13
+---
+
+# ADR-0021: Refactor PR Flag
+
+**Status:** Accepted
+**Date:** 2026-05-13
+
+## Context
+
+Refactor PRs without pre-implementation characterization tests are the dominant source of behavior-regression incidents in this codebase. The FA formula regression incident and the view materialization incident both landed green because the refactor moved code without locking down current behavior in a test first — existing tests asserted the new shape, not the old. The TDD-selectivity rule ("green-green for refactors") was enforced by author discipline only; CI let renames-only PRs with zero test changes through.
+
+## Decision
+
+Add a CI gate (`bin/refactor-flag`, wired to `.github/workflows/refactor-flag.yml`) that detects refactor signals under `ibl5/classes/**` (file renames, method signature changes, visibility narrowing, class declaration removal, large deletions > 30 lines) and blocks merge when the same PR does not also add or modify a test file under `ibl5/tests/`. A bypass marker (`<!-- no-refactor-tests: reason ≥ 20 chars -->`) in the PR body overrides the gate for documented exceptions. An agent rule (`.claude/rules/refactor-flag.md`) documents the policy for agents.
+
+## Alternatives Considered
+
+- **Require explicit `[refactor]` tag on PR title** — manual, easily forgotten, no enforcement surface.
+- **Measure pre-impl test coverage delta** — requires baseline coverage cache infrastructure, significantly more complex for marginal precision gain.
+- **Require ADR on every refactor** — overweight; ADRs are for architectural decisions, not safety nets. The existing ADR gate already covers new enforcement surfaces.
+
+## Consequences
+
+- Positive: makes the "green-green" TDD rule mechanical rather than voluntary, preventing the class of incidents that led to this decision.
+- Positive: mirrors the existing `bin/adr-check` structure, keeping CI gate patterns consistent and maintainable.
+- Negative: false positives on pure file moves where the test filename doesn't substring-match the class name; mitigated by the bypass marker.
+- Negative: false negatives on subtle behavior changes that don't match any of the five trigger patterns; mitigated by mutation testing (ADR for Plan 05) as second-line defense.
+
+## References
+
+- `bin/refactor-flag` — the CI gate script
+- `.github/workflows/refactor-flag.yml` — the GitHub Actions workflow
+- `.claude/rules/refactor-flag.md` — agent rule documenting the policy
+- `bin/adr-check` — the existing decision-trigger gate this mirrors
+- `ibl5/tests/Cli/RefactorFlagCliTest.php` — test coverage for the gate
+- `ibl5/tests/Cli/AdrCheckCliTest.php` — characterization test for the existing gate

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -262,6 +262,9 @@
         <testsuite name="Database Integration Tests">
             <directory>tests/DatabaseIntegration</directory>
         </testsuite>
+        <testsuite name="Cli Tests">
+            <directory>tests/Cli</directory>
+        </testsuite>
     </testsuites>
     <groups>
         <exclude>

--- a/ibl5/tests/Cli/AdrCheckCliTest.php
+++ b/ibl5/tests/Cli/AdrCheckCliTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class AdrCheckCliTest extends TestCase
+{
+    public function testHelpFlagPrintsUsageAndExitsZero(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd(realpath(__DIR__ . '/../../../bin/adr-check')) . ' --help 2>&1', $output, $exit);
+        self::assertSame(0, $exit);
+        self::assertStringContainsString('Decision-trigger gate', implode("\n", $output));
+    }
+
+    public function testUnknownFlagExitsTwo(): void
+    {
+        exec(escapeshellcmd(realpath(__DIR__ . '/../../../bin/adr-check')) . ' --bogus 2>&1', $unused, $exit);
+        self::assertSame(2, $exit);
+    }
+}

--- a/ibl5/tests/Cli/RefactorFlagCliTest.php
+++ b/ibl5/tests/Cli/RefactorFlagCliTest.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class RefactorFlagCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/refactor-flag');
+        self::assertNotFalse($resolved, 'bin/refactor-flag must exist');
+        $this->scriptPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/refactor-flag-test-' . bin2hex(random_bytes(8));
+        mkdir($this->tmpDir, 0755, true);
+
+        $this->runInDir('git init -b main');
+        $this->runInDir('git config user.email "test@test.com"');
+        $this->runInDir('git config user.name "Test"');
+
+        mkdir($this->tmpDir . '/ibl5/classes/Example', 0755, true);
+        mkdir($this->tmpDir . '/ibl5/tests/Example', 0755, true);
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', "<?php\nclass Foo {}\n");
+        file_put_contents($this->tmpDir . '/ibl5/tests/Example/FooTest.php', "<?php\nclass FooTest {}\n");
+        $this->runInDir('git add -A');
+        $this->runInDir('git commit -m "initial"');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    /** Case 1: No classes/ changes → exit 0 */
+    public function testNoClassesChangesExitsZero(): void
+    {
+        file_put_contents($this->tmpDir . '/README.md', 'hello');
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('No refactor signals detected', $result['output']);
+    }
+
+    /** Case 2: Rename under classes/ + new test in PR → exit 0 */
+    public function testRenameWithNewTestExitsZero(): void
+    {
+        $this->runInDir('git mv ibl5/classes/Example/Foo.php ibl5/classes/Example/Bar.php');
+        file_put_contents($this->tmpDir . '/ibl5/tests/Example/BarTest.php', "<?php\nclass BarTest {}\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('PASS', $result['output']);
+    }
+
+    /** Case 3: Rename under classes/ + no test → exit 1 */
+    public function testRenameWithNoTestExitsOne(): void
+    {
+        $this->runInDir('git mv ibl5/classes/Example/Foo.php ibl5/classes/Example/Bar.php');
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL', $result['output']);
+        self::assertStringContainsString('rename', $result['output']);
+    }
+
+    /** Case 4: Rename + bypass marker (≥20 chars) → exit 0 */
+    public function testRenameWithValidBypassExitsZero(): void
+    {
+        $this->runInDir('git mv ibl5/classes/Example/Foo.php ibl5/classes/Example/Bar.php');
+        $this->runInDir('git add -A');
+
+        $bypass = '<!-- no-refactor-tests: pure namespace move with existing coverage intact -->';
+        $result = $this->runScript($bypass);
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('PASS (bypass)', $result['output']);
+    }
+
+    /** Case 5: Rename + bypass marker too short (10 chars) → exit 1 */
+    public function testRenameWithShortBypassExitsOne(): void
+    {
+        $this->runInDir('git mv ibl5/classes/Example/Foo.php ibl5/classes/Example/Bar.php');
+        $this->runInDir('git add -A');
+
+        $bypass = '<!-- no-refactor-tests: too short -->';
+        $result = $this->runScript($bypass);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL', $result['output']);
+    }
+
+    /** Case 6: Method signature change + matching test modified → exit 0 */
+    public function testSignatureChangeWithMatchingTestExitsZero(): void
+    {
+        $original = <<<'PHP'
+<?php
+class Foo {
+    public function doStuff(int $a): string
+    {
+        return (string) $a;
+    }
+}
+PHP;
+        $changed = <<<'PHP'
+<?php
+class Foo {
+    public function doStuff(int $a, string $b): string
+    {
+        return $b . $a;
+    }
+}
+PHP;
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $original);
+        $this->runInDir('git add -A');
+        $this->runInDir('git commit -m "add method"');
+
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $changed);
+        file_put_contents($this->tmpDir . '/ibl5/tests/Example/FooTest.php', "<?php\nclass FooTest { /* updated */ }\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('PASS', $result['output']);
+    }
+
+    /** Case 7: Method signature change + unrelated test modified → exit 1 */
+    public function testSignatureChangeWithUnrelatedTestExitsOne(): void
+    {
+        $original = <<<'PHP'
+<?php
+class Foo {
+    public function doStuff(int $a): string
+    {
+        return (string) $a;
+    }
+}
+PHP;
+        $changed = <<<'PHP'
+<?php
+class Foo {
+    public function doStuff(int $a, string $b): string
+    {
+        return $b . $a;
+    }
+}
+PHP;
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $original);
+        mkdir($this->tmpDir . '/ibl5/tests/Other', 0755, true);
+        file_put_contents($this->tmpDir . '/ibl5/tests/Other/UnrelatedTest.php', "<?php\nclass UnrelatedTest {}\n");
+        $this->runInDir('git add -A');
+        $this->runInDir('git commit -m "add method"');
+
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $changed);
+        file_put_contents($this->tmpDir . '/ibl5/tests/Other/UnrelatedTest.php', "<?php\nclass UnrelatedTest { /* modified */ }\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL', $result['output']);
+    }
+
+    /** Case 8: Class declaration removed + new test added → exit 0 */
+    public function testClassRemovedWithNewTestExitsZero(): void
+    {
+        $withClass = <<<'PHP'
+<?php
+class Foo {
+    public function hello(): void {}
+}
+PHP;
+        $withoutClass = "<?php\n// removed\n";
+
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $withClass);
+        $this->runInDir('git add -A');
+        $this->runInDir('git commit -m "add class"');
+
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $withoutClass);
+        file_put_contents($this->tmpDir . '/ibl5/tests/Example/FooRemovalTest.php', "<?php\nclass FooRemovalTest {}\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('PASS', $result['output']);
+    }
+
+    /** Case 9: Visibility change (public → private) + no test → exit 1 */
+    public function testVisibilityChangeWithNoTestExitsOne(): void
+    {
+        $original = <<<'PHP'
+<?php
+class Foo {
+    public function secret(): void {}
+}
+PHP;
+        $changed = <<<'PHP'
+<?php
+class Foo {
+    private function secret(): void {}
+}
+PHP;
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $original);
+        $this->runInDir('git add -A');
+        $this->runInDir('git commit -m "add method"');
+
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $changed);
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL', $result['output']);
+        self::assertStringContainsString('visibility', $result['output']);
+    }
+
+    /** Case 10: Large deletion (>30 lines) + no test → exit 1 */
+    public function testLargeDeletionWithNoTestExitsOne(): void
+    {
+        $lines = "<?php\nclass Foo {\n";
+        for ($i = 0; $i < 40; $i++) {
+            $lines .= "    public function method{$i}(): void {}\n";
+        }
+        $lines .= "}\n";
+
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $lines);
+        $this->runInDir('git add -A');
+        $this->runInDir('git commit -m "big class"');
+
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', "<?php\nclass Foo {}\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL', $result['output']);
+        self::assertStringContainsString('large-deletion', $result['output']);
+    }
+
+    /** Case 11: --help flag → exit 0 with "Usage:" */
+    public function testHelpFlagExitsZero(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --help 2>&1', $output, $exit);
+
+        self::assertSame(0, $exit);
+        self::assertStringContainsString('Usage:', implode("\n", $output));
+    }
+
+    /** Case 12: --bogus flag → exit 2 with "unknown flag" */
+    public function testBogusArgExitsTwo(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --bogus 2>&1', $output, $exit);
+
+        self::assertSame(2, $exit);
+        self::assertStringContainsString('unknown flag', implode("\n", $output));
+    }
+
+    /**
+     * Run bin/refactor-flag --staged inside the temporary git repo.
+     * @return array{output: string, exit: int}
+     */
+    private function runScript(?string $prBody = null): array
+    {
+        $output = [];
+        $exit = 0;
+
+        $cmd = 'cd ' . escapeshellarg($this->tmpDir) . ' && ';
+
+        if ($prBody !== null) {
+            $cmd .= 'echo ' . escapeshellarg($prBody) . ' | ';
+            $cmd .= escapeshellcmd($this->scriptPath) . ' --staged --bypass-from-stdin';
+        } else {
+            $cmd .= escapeshellcmd($this->scriptPath) . ' --staged';
+        }
+
+        $cmd .= ' 2>&1';
+
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function runInDir(string $cmd): void
+    {
+        exec('cd ' . escapeshellarg($this->tmpDir) . ' && ' . $cmd . ' 2>&1');
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/ibl5/tests/Cli/RefactorFlagCliTest.php
+++ b/ibl5/tests/Cli/RefactorFlagCliTest.php
@@ -200,6 +200,25 @@ PHP;
         self::assertStringContainsString('PASS', $result['output']);
     }
 
+    /** Case 8b: final/abstract class declaration removed + no test → exit 1 */
+    public function testFinalClassRemovedWithNoTestExitsOne(): void
+    {
+        $withClass = "<?php\nfinal class Foo {}\n";
+
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', $withClass);
+        $this->runInDir('git add -A');
+        $this->runInDir('git commit -m "add final class"');
+
+        file_put_contents($this->tmpDir . '/ibl5/classes/Example/Foo.php', "<?php\n// removed\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL', $result['output']);
+        self::assertStringContainsString('class-removed', $result['output']);
+    }
+
     /** Case 9: Visibility change (public → private) + no test → exit 1 */
     public function testVisibilityChangeWithNoTestExitsOne(): void
     {


### PR DESCRIPTION
## Summary

Adds a CI gate that detects refactor signals under `ibl5/classes/**` (file renames, method signature changes, visibility narrowing, class declaration removal, large deletions > 30 lines) and blocks merge when the PR does not also add/modify a test file or carry a bypass marker.

Modeled on `bin/adr-check`. Mirrors the same pattern: PHP CLI script + GitHub Actions workflow + agent rule doc + ADR.

### Changes

- `bin/refactor-flag` — PHP CLI script; modes `--staged` (pre-commit) and `--pr` (CI); exit 0 pass, 1 fail, 2 usage error
- `.github/workflows/refactor-flag.yml` — runs on every PR, calls `bin/refactor-flag --pr`
- `.claude/rules/refactor-flag.md` — agent rule documenting the policy and bypass conditions
- `ibl5/docs/decisions/0021-refactor-pr-flag.md` — ADR recording the decision
- `ibl5/phpunit.xml` — adds `Cli Tests` testsuite for the new test directory
- `ibl5/tests/Cli/AdrCheckCliTest.php` — characterization test for the existing `bin/adr-check` CLI (pre-impl lock-in)
- `ibl5/tests/Cli/RefactorFlagCliTest.php` — 12 test cases covering all trigger types, coverage checks, and bypass logic

### Bypass mechanism

Add to PR body: `<!-- no-refactor-tests: reason at least 20 characters -->`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.