### PR TITLE
Fix DraftViewInterface docblock: == 0 → === 0 (strict comparison)

### DIFF
--- a/ibl5/classes/Draft/Contracts/DraftViewInterface.php
+++ b/ibl5/classes/Draft/Contracts/DraftViewInterface.php
@@ -190,12 +190,12 @@ interface DraftViewInterface
      *  - Iterates through all players checking 'drafted' field
      *  - Returns true as soon as first undrafted player found (early exit)
      *  - Returns false if $players is empty or all players drafted
-     *  - Compares drafted field with == 0 (loose comparison with integer 0)
+     *  - Compares drafted field with === 0 (strict comparison with integer 0)
      *  - NEVER throws exceptions
      *
      * Examples:
      *  $hasPlayers = $view->hasUndraftedPlayers($players);
-     *  // Returns true if any player has drafted == 0
+     *  // Returns true if any player has drafted === 0
      *  // Returns false if all have drafted == 1 or array is empty
      */
     public function hasUndraftedPlayers(array $players): bool;


### PR DESCRIPTION
## Summary

Fix a docblock in `DraftViewInterface::hasUndraftedPlayers()` that incorrectly claimed loose comparison (`== 0`) when the implementation uses strict comparison (`=== 0`). The misleading docblock could invite future contributors to copy-paste loose-comparison style, conflicting with the strict-equality rule in CLAUDE.md.

## Changes

- `ibl5/classes/Draft/Contracts/DraftViewInterface.php`: Updated two docblock lines to cite `=== 0` instead of `== 0`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.