### PR TITLE
ops: harden IBL6 PM2 restart policy

### DIFF
--- a/IBL6/ecosystem.config.cjs
+++ b/IBL6/ecosystem.config.cjs
@@ -9,6 +9,9 @@ module.exports = {
         PORT: 3001,
         UV_THREADPOOL_SIZE: 2
       },
+      max_memory_restart: '200M',
+      min_uptime: '10s',
+      max_restarts: 10,
       log_date_format: 'YYYY-MM-DD HH:mm:ss',
       out_file: 'logs/ibl6-out.log',
       error_file: 'logs/ibl6-error.log',


### PR DESCRIPTION
## Why

IBL6 went down on prod on 2026-05-07 and stayed down ~6 days. Two compounding causes:

1. The existing self-healing cron was a no-op since the day it was added — `pm2` shebang is `#!/usr/bin/env node` and cron's `PATH` doesn't include the nvm `node` binary. `~/.pm2/resurrect.log` had 5761 lines of `/usr/bin/env: 'node': No such file or directory`. Even if it had worked, `pm2 ping` always succeeds (it bootstraps an empty daemon), so the `|| pm2 resurrect` branch never fires.
2. PM2 had no automatic-restart guardrails: `--max-old-space-size=128` leaves Node prone to OOM-kill, with no `max_memory_restart`, `min_uptime`, or `max_restarts` to manage the failure.

## What this PR does

Adds three PM2 keys to `IBL6/ecosystem.config.cjs`:

- `max_memory_restart: '200M'` — proactive restart before kernel OOM-kill
- `min_uptime: '10s'` — restarts within 10s don't count as healthy
- `max_restarts: 10` — circuit breaker so PM2 marks the app `errored` instead of crash-looping

## What this PR does NOT do (already applied directly on prod)

The crontab fix (PATH + curl-based healthcheck on port 3001 every 2 min) was applied directly to prod since the crontab isn't tracked in git. Original crontab backed up at `/tmp/crontab.bak.1778713241` on iblhoops.net.

## Verification

- `pm2 jlist` on prod confirms `max_memory_restart=209715200`, `min_uptime=10000`, `max_restarts=10`
- Both `https://ibl6.iblhoops.net/` and `https://iblhoops.net/IBL6/` returning HTTP 200
- Cron healthcheck tested in clean env (cron-like): healthy path exits 0 with no action; simulated failure (curl wrong port) successfully triggers `pm2 start`

## Deployment note

Prod's `ecosystem.config.cjs` was edited in place and PM2 was reloaded, so the change is live now. This PR makes the change durable so the next `production`-branch deploy doesn't clobber it.