### PR TITLE
ci: add push-to-master trigger for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,6 +4,21 @@ on:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
+  push:
+    branches: [master]
+    paths:
+      - '**.php'
+      - '**.ts'
+      - '**.js'
+      - '**.css'
+      - 'ibl5/design/**'
+      - 'ibl5/migrations/**.sql'
+      - 'Dockerfile'
+      - 'docker-compose*.yml'
+      - 'docker/**'
+      - 'ibl5/tests/e2e/**'
+      - '.github/workflows/e2e-tests.yml'
+      - '.github/scripts/**'
 
 permissions:
   contents: read
@@ -19,11 +34,11 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      src: ${{ github.event.action == 'labeled' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
+      src: ${{ github.event_name == 'push' || github.event.action == 'labeled' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
     steps:
       - uses: dorny/paths-filter@v4
         id: filter
-        if: github.event.action != 'labeled'
+        if: github.event_name == 'pull_request' && github.event.action != 'labeled'
         with:
           filters: |
             src:
@@ -77,7 +92,7 @@ jobs:
           # PAT is needed when update-baselines label is present so the push triggers a new CI run.
           # Default GITHUB_TOKEN pushes don't trigger workflows (GitHub's anti-loop protection).
           token: ${{ contains(github.event.pull_request.labels.*.name, 'update-baselines') && secrets.CI_PAT || github.token }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -145,7 +160,7 @@ jobs:
 
       # --- Auto-update baselines when label is present ---
       - name: Regenerate visual regression baselines
-        if: steps.visual-regression.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'update-baselines')
+        if: github.event_name == 'pull_request' && steps.visual-regression.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'update-baselines')
         env:
           IBL_TEST_USER: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
           IBL_TEST_PASS: ${{ secrets.IBL_TEST_PASS || 'ci-e2e-pass-not-secret' }}
@@ -167,7 +182,7 @@ jobs:
             npx playwright test --config=playwright.visual.config.ts --update-snapshots
 
       - name: Commit and push updated baselines
-        if: steps.visual-regression.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'update-baselines')
+        if: github.event_name == 'pull_request' && steps.visual-regression.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'update-baselines')
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -180,7 +195,7 @@ jobs:
           fi
 
       - name: Remove update-baselines label
-        if: always() && contains(github.event.pull_request.labels.*.name, 'update-baselines')
+        if: always() && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'update-baselines')
         env:
           GH_TOKEN: ${{ secrets.CI_PAT }}
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label update-baselines


### PR DESCRIPTION
## Summary

Closes gap #2 from the testing-apparatus audit: E2E tests only ran on `pull_request`, so after PRs merged, the combined master-tip state was never E2E-gated before master→production merges.

## Changes

- **New `push` trigger** on `e2e-tests.yml` with a `paths:` filter matching the existing `dorny/paths-filter` config (PHP, TS, JS, CSS, design assets, migrations, Docker files, E2E specs, workflow file, scripts). Non-source pushes (docs, lockfiles) skip the workflow entirely.
- **`changes` job flow-through** on push events: `src` output is `true` unconditionally (the trigger-level paths filter already screened), and the `dorny/paths-filter` step is skipped (it requires PR context).
- **Belt-and-suspenders `github.event_name == 'pull_request'`** guards on baseline regeneration, commit/push updated baselines, and label removal steps — these were already effectively gated by label checks, but explicit event guards prevent any edge case on push events.
- **Defensive `ref: github.head_ref || github.sha`** so the checkout step works on push events where `head_ref` is empty.

## Paths drift vs tests.yml

E2E paths include frontend-specific entries (`**.css`, `**.js`, `**.ts`, `Dockerfile`, `docker/**`, `docker-compose*.yml`, `ibl5/design/**`, `ibl5/tests/e2e/**`, `.github/scripts/**`) that `tests.yml` doesn't need. `tests.yml` includes shell-specific entries (`bin/**`, `ibl5/bin/**`) that E2E doesn't need. Both share `**.php` and `ibl5/migrations/**.sql`.

## Out of scope

The policy of blocking `bin/merge-master-to-prod` when the master-tip E2E is red is enforced by humans — a future PR could add a status-check precondition to the merge script.

## Manual Testing

No manual testing needed — all changes are covered by CI workflow validation.

## Verification

- `actionlint .github/workflows/e2e-tests.yml` — only pre-existing SC2086 info-level warning (unchanged)
- Push-trigger paths list compared against `tests.yml` — drift is expected and documented above
- 8 `github.event_name == 'pull_request'` guards confirmed (4 pre-existing in `merge-reports`, 4 new)