### PR TITLE
ops: scope smoke-prod by IBL5/IBL6 to prevent cross-site rollback

### DIFF
--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -20,6 +20,9 @@ on:
 permissions:
   contents: read
 
+env:
+  BASE_URL: ${{ github.event.inputs.base_url || 'https://www.iblhoops.net' }}
+
 concurrency:
   # Shared with main.yml so a new deploy can't race an in-flight smoke run.
   group: production-deploy
@@ -34,6 +37,9 @@ jobs:
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 5
+    outputs:
+      # 'false' on skip paths (stale guard) because skipped != failure
+      ibl6_failed: ${{ steps.ibl6.outcome == 'failure' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -66,11 +72,17 @@ jobs:
         if: github.event_name == 'workflow_run' && steps.guard.outputs.stale != 'true'
         run: sleep 15
 
-      - name: Run smoke tests
+      - name: Run IBL5 smoke checks (gates auto-rollback)
         if: steps.guard.outputs.stale != 'true'
         run: |
           chmod +x bin/smoke-prod
-          bin/smoke-prod "${{ github.event.inputs.base_url || 'https://www.iblhoops.net' }}"
+          bin/smoke-prod --scope=ibl5 "$BASE_URL"
+
+      - name: Run IBL6 smoke checks (notify-only)
+        id: ibl6
+        if: steps.guard.outputs.stale != 'true'
+        continue-on-error: true
+        run: bin/smoke-prod --scope=ibl6 "$BASE_URL"
 
   rollback-and-notify:
     name: Auto-Rollback and Notify
@@ -184,6 +196,40 @@ jobs:
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           TRIGGER="${{ github.event_name }}"
           MSG=$(printf 'Production smoke test FAILED (%s trigger — no auto-rollback).\n\nThis may be a transient issue. Check the run for details: %s' "$TRIGGER" "$RUN_URL")
+
+          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
+            '{content: {receivingUserDiscordID: $id, message: $msg}}')
+
+          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
+            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
+            || echo "IBLbot notification failed (bot may be down)"
+
+  notify-ibl6-degradation:
+    name: Notify IBL6 Degradation
+    runs-on: ubuntu-latest
+    needs: smoke
+    if: >-
+      always() &&
+      needs.smoke.outputs.ibl6_failed == 'true' &&
+      needs.smoke.result == 'success'
+    timeout-minutes: 5
+
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+        env:
+          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Send Discord DM
+        env:
+          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
+        run: |
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG=$(printf 'IBL6 smoke FAILED; IBL5 unaffected. No rollback.\n\nRun: %s' "$RUN_URL")
 
           PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
             '{content: {receivingUserDiscordID: $id, message: $msg}}')

--- a/bin/smoke-prod
+++ b/bin/smoke-prod
@@ -1,22 +1,77 @@
 #!/usr/bin/env bash
 # Production smoke test — lightweight HTTP checks against the live site.
 #
-# Usage: bin/smoke-prod [base_url]
-# Default: https://www.iblhoops.net
+# Usage: bin/smoke-prod [--scope=ibl5|ibl6|all] [base_url]
+# Default scope: all
+# Default base_url: https://www.iblhoops.net
 #
-# Checks 8 public URLs for:
-#   - HTTP 200 status (retries once on any unexpected status after 10s)
+# Checks public URLs for:
+#   - HTTP 200 status (retries once on any unexpected status)
 #   - Expected content in response body
 #   - Absence of PHP error messages
 #
-# Exit code: 0 if all pass, 1 if any fail.
+# Exit code:
+#   0 — all in-scope checks passed
+#   1 — one or more in-scope checks failed
+#   2 — usage error (bad arguments)
+#
+# Environment variables:
+#   SMOKE_IBL6_URL          Override the IBL6 probe URL (default: https://ibl6.iblhoops.net/)
+#   SMOKE_INTERCHECK_DELAY  Seconds between checks (default: 1)
+#   SMOKE_RETRY_DELAY       Seconds to wait before retry on unexpected status (default: 10)
 
 set -euo pipefail
 
-BASE="${1:-https://www.iblhoops.net}"
-PASS=0
-FAIL=0
-ERRORS=""
+# --- Argument parsing -----------------------------------------------------------
+
+SCOPE="all"
+BASE=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --scope=*)
+            SCOPE="${arg#--scope=}"
+            ;;
+        --help)
+            echo "Usage: bin/smoke-prod [--scope=ibl5|ibl6|all] [base_url]"
+            echo ""
+            echo "Options:"
+            echo "  --scope=ibl5   Run IBL5 checks only"
+            echo "  --scope=ibl6   Run IBL6 checks only"
+            echo "  --scope=all    Run all checks (default)"
+            echo "  --help         Show this help"
+            echo ""
+            echo "Environment:"
+            echo "  SMOKE_IBL6_URL          Override IBL6 probe URL"
+            echo "  SMOKE_INTERCHECK_DELAY  Seconds between checks (default: 1)"
+            echo "  SMOKE_RETRY_DELAY       Seconds before retry (default: 10)"
+            exit 0
+            ;;
+        --*)
+            echo "error: unknown flag: $arg" >&2
+            echo "Usage: bin/smoke-prod [--scope=ibl5|ibl6|all] [base_url]" >&2
+            exit 2
+            ;;
+        *)
+            BASE="$arg"
+            ;;
+    esac
+done
+
+case "$SCOPE" in
+    ibl5|ibl6|all) ;;
+    *)
+        echo "error: unknown scope: $SCOPE (expected ibl5, ibl6, or all)" >&2
+        echo "Usage: bin/smoke-prod [--scope=ibl5|ibl6|all] [base_url]" >&2
+        exit 2
+        ;;
+esac
+
+BASE="${BASE:-https://www.iblhoops.net}"
+
+# --- Configuration --------------------------------------------------------------
+
+IBL6_URL="${SMOKE_IBL6_URL:-https://ibl6.iblhoops.net/}"
 
 # Identify ourselves — the default curl UA can get classified as a bot by
 # LiteSpeed mod_security and produce a blanket 415 ban on the runner IP.
@@ -24,81 +79,115 @@ USER_AGENT="IBL5-smoke/1.0 (+https://github.com/a-jay85/IBL5)"
 
 # Space requests apart so we stay under the LiteSpeed per-IP WAF threshold.
 INTERCHECK_DELAY="${SMOKE_INTERCHECK_DELAY:-1}"
+RETRY_DELAY="${SMOKE_RETRY_DELAY:-10}"
+
+# Per-scope counters
+IBL5_PASS=0
+IBL5_FAIL=0
+IBL6_PASS=0
+IBL6_FAIL=0
+ERRORS=""
 
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
 
-check() {
-    local name="$1" url="$2" expect="${3:-}" accept="${4:-200}"
+# --- Check function --------------------------------------------------------------
 
-    # Single request: capture body to temp file + status code
+check() {
+    local category="$1" name="$2" url="$3" expect="${4:-}" accept="${5:-200}"
+
     local status
     status=$(curl -sS -w "%{http_code}" --max-time 30 -A "$USER_AGENT" -o "$TMPFILE" "$url" 2>/dev/null) || true
-    # Extract just the HTTP code (last 3 chars of output)
     status="${status: -3}"
     [[ "$status" =~ ^[0-9]+$ ]] || status="000"
 
-    # Retry once on any unexpected status — transient during deploys,
-    # LSCache purge windows, or brief LiteSpeed WAF blips.
+    # Retry once on unexpected status
     if ! echo "$accept" | grep -qw "$status"; then
-        echo "  RETRY: $name — HTTP $status, waiting 10s..."
-        sleep 10
+        echo "  RETRY: $name — HTTP $status, waiting ${RETRY_DELAY}s..."
+        sleep "$RETRY_DELAY"
         status=$(curl -sS -w "%{http_code}" --max-time 30 -A "$USER_AGENT" -o "$TMPFILE" "$url" 2>/dev/null) || true
         status="${status: -3}"
         [[ "$status" =~ ^[0-9]+$ ]] || status="000"
     fi
 
-    # Check if status is in the accepted list (pipe-separated, e.g., "200|401")
     if ! echo "$accept" | grep -qw "$status"; then
-        FAIL=$((FAIL + 1))
+        eval "${category}_FAIL=\$(( ${category}_FAIL + 1 ))"
         ERRORS="${ERRORS}\n  FAIL: $name — HTTP $status (expected $accept)"
         return
     fi
 
-    # Check content (only if expect is non-empty)
     if [ -n "$expect" ]; then
-        # Check for PHP errors
         if grep -qiE "Fatal error|Parse error|Warning:|Uncaught|Stack trace:" "$TMPFILE"; then
-            FAIL=$((FAIL + 1))
+            eval "${category}_FAIL=\$(( ${category}_FAIL + 1 ))"
             ERRORS="${ERRORS}\n  FAIL: $name — PHP error detected"
             return
         fi
 
-        # Check for expected content
         if ! grep -qi "$expect" "$TMPFILE"; then
-            FAIL=$((FAIL + 1))
+            eval "${category}_FAIL=\$(( ${category}_FAIL + 1 ))"
             ERRORS="${ERRORS}\n  FAIL: $name — missing expected content: $expect"
             return
         fi
     fi
 
-    PASS=$((PASS + 1))
+    eval "${category}_PASS=\$(( ${category}_PASS + 1 ))"
     echo "  OK: $name"
 }
 
-echo "Smoke testing $BASE ..."
+# --- Run checks ------------------------------------------------------------------
+
+echo "Smoke testing $BASE (scope: $SCOPE) ..."
 echo ""
 
-check "Homepage"     "$BASE/ibl5/index.php"                                 "IBL"
-sleep "$INTERCHECK_DELAY"
-check "Standings"    "$BASE/ibl5/modules.php?name=Standings"                "Standings"
-sleep "$INTERCHECK_DELAY"
-check "Team page"    "$BASE/ibl5/modules.php?name=Team&op=team&teamID=1"    "team"
-sleep "$INTERCHECK_DELAY"
-check "Player page"  "$BASE/ibl5/modules.php?name=Player&pa=showpage&pid=1" "player"
-sleep "$INTERCHECK_DELAY"
-check "Login page"   "$BASE/ibl5/modules.php?name=YourAccount"              "Sign In"
-sleep "$INTERCHECK_DELAY"
-check "API routing"  "$BASE/ibl5/api/v1/season"                             "" "200|401"
-sleep "$INTERCHECK_DELAY"
-check "CSS asset"    "$BASE/ibl5/themes/IBL/style/style.css"                ""
-sleep "$INTERCHECK_DELAY"
-check "IBL6 app"     "https://ibl6.iblhoops.net/"                           ""
+if [ "$SCOPE" = "ibl5" ] || [ "$SCOPE" = "all" ]; then
+    echo "=== IBL5 checks ==="
+    check IBL5 "Homepage"     "$BASE/ibl5/index.php"                                 "IBL"
+    sleep "$INTERCHECK_DELAY"
+    check IBL5 "Standings"    "$BASE/ibl5/modules.php?name=Standings"                "Standings"
+    sleep "$INTERCHECK_DELAY"
+    check IBL5 "Team page"    "$BASE/ibl5/modules.php?name=Team&op=team&teamID=1"    "team"
+    sleep "$INTERCHECK_DELAY"
+    check IBL5 "Player page"  "$BASE/ibl5/modules.php?name=Player&pa=showpage&pid=1" "player"
+    sleep "$INTERCHECK_DELAY"
+    check IBL5 "Login page"   "$BASE/ibl5/modules.php?name=YourAccount"              "Sign In"
+    sleep "$INTERCHECK_DELAY"
+    check IBL5 "API routing"  "$BASE/ibl5/api/v1/season"                             "" "200|401"
+    sleep "$INTERCHECK_DELAY"
+    check IBL5 "CSS asset"    "$BASE/ibl5/themes/IBL/style/style.css"                ""
+    sleep "$INTERCHECK_DELAY"
+    echo ""
+fi
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
+if [ "$SCOPE" = "ibl6" ] || [ "$SCOPE" = "all" ]; then
+    echo "=== IBL6 checks ==="
+    check IBL6 "IBL6 app"    "$IBL6_URL"                                             ""
+    echo ""
+fi
 
-if [ "$FAIL" -gt 0 ]; then
+# --- Results ---------------------------------------------------------------------
+
+TOTAL_PASS=$((IBL5_PASS + IBL6_PASS))
+TOTAL_FAIL=$((IBL5_FAIL + IBL6_FAIL))
+
+if [ "$SCOPE" = "ibl5" ]; then
+    echo "Results: $IBL5_PASS passed, $IBL5_FAIL failed (IBL5 scope)"
+elif [ "$SCOPE" = "ibl6" ]; then
+    echo "Results: $IBL6_PASS passed, $IBL6_FAIL failed (IBL6 scope)"
+else
+    echo "Results: $TOTAL_PASS passed, $TOTAL_FAIL failed"
+    if [ "$IBL5_FAIL" -gt 0 ] || [ "$IBL6_FAIL" -gt 0 ]; then
+        echo "  IBL5: $IBL5_PASS passed, $IBL5_FAIL failed"
+        echo "  IBL6: $IBL6_PASS passed, $IBL6_FAIL failed"
+    fi
+fi
+
+if [ "$SCOPE" = "ibl5" ] && [ "$IBL5_FAIL" -gt 0 ]; then
+    echo -e "\nFailures:$ERRORS"
+    exit 1
+elif [ "$SCOPE" = "ibl6" ] && [ "$IBL6_FAIL" -gt 0 ]; then
+    echo -e "\nFailures:$ERRORS"
+    exit 1
+elif [ "$SCOPE" = "all" ] && [ "$TOTAL_FAIL" -gt 0 ]; then
     echo -e "\nFailures:$ERRORS"
     exit 1
 fi

--- a/ibl5/tests/Cli/SmokeProdCliTest.php
+++ b/ibl5/tests/Cli/SmokeProdCliTest.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class SmokeProdCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $fixtureDir;
+
+    /** @var array<string, resource|null> */
+    private array $servers = [];
+
+    /** @var array<string, int> */
+    private array $ports = [];
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/smoke-prod');
+        self::assertNotFalse($resolved, 'bin/smoke-prod must exist');
+        $this->scriptPath = $resolved;
+
+        $this->fixtureDir = sys_get_temp_dir() . '/smoke-prod-test-' . bin2hex(random_bytes(4));
+        mkdir($this->fixtureDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->servers as $name => $proc) {
+            if (is_resource($proc)) {
+                $status = proc_get_status($proc);
+                if ($status['running']) {
+                    posix_kill($status['pid'], SIGTERM);
+                    usleep(100_000);
+                    // kill the child php process tree
+                    exec('kill ' . $status['pid'] . ' 2>/dev/null');
+                }
+                proc_close($proc);
+            }
+        }
+
+        if (is_dir($this->fixtureDir)) {
+            $this->recursiveRm($this->fixtureDir);
+        }
+    }
+
+    // =========================================================================
+    // Characterization tests (pre-impl behavior, now exercised via --scope=all)
+    // =========================================================================
+
+    public function testAllEndpointsHealthyExitsZero(): void
+    {
+        $this->startServer('ibl5', healthy: true);
+        $this->startServer('ibl6', healthy: true);
+
+        $result = $this->runSmoke(scope: 'all');
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('OK: Homepage', $result['output']);
+        self::assertStringContainsString('OK: IBL6 app', $result['output']);
+    }
+
+    public function testIbl5EndpointReturns500ExitsOne(): void
+    {
+        $this->startServer('ibl5', healthy: false);
+        $this->startServer('ibl6', healthy: true);
+
+        $result = $this->runSmoke(scope: 'all');
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL: Homepage', $result['output']);
+    }
+
+    public function testIbl6UnreachableExitsOne(): void
+    {
+        $this->startServer('ibl5', healthy: true);
+        // no IBL6 server → connection refused
+
+        $result = $this->runSmoke(scope: 'all', ibl6Url: 'http://127.0.0.1:1/');
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL: IBL6 app', $result['output']);
+    }
+
+    // =========================================================================
+    // Post-impl: --scope=ibl5
+    // =========================================================================
+
+    public function testScopeIbl5IgnoresIbl6Failures(): void
+    {
+        $this->startServer('ibl5', healthy: true);
+        // IBL6 deliberately broken (no server)
+
+        $result = $this->runSmoke(scope: 'ibl5');
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('IBL5 checks', $result['output']);
+        self::assertStringNotContainsString('IBL6 checks', $result['output']);
+    }
+
+    public function testScopeIbl5FailsWhenIbl5Broken(): void
+    {
+        $this->startServer('ibl5', healthy: false);
+        $this->startServer('ibl6', healthy: true);
+
+        $result = $this->runSmoke(scope: 'ibl5');
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL: Homepage', $result['output']);
+    }
+
+    // =========================================================================
+    // Post-impl: --scope=ibl6
+    // =========================================================================
+
+    public function testScopeIbl6IgnoresIbl5Failures(): void
+    {
+        // IBL5 deliberately broken
+        $this->startServer('ibl6', healthy: true);
+
+        $result = $this->runSmoke(scope: 'ibl6');
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('IBL6 checks', $result['output']);
+        self::assertStringNotContainsString('IBL5 checks', $result['output']);
+    }
+
+    public function testScopeIbl6FailsWhenIbl6Broken(): void
+    {
+        $this->startServer('ibl5', healthy: true);
+
+        $result = $this->runSmoke(scope: 'ibl6', ibl6Url: 'http://127.0.0.1:1/');
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL: IBL6 app', $result['output']);
+    }
+
+    // =========================================================================
+    // Post-impl: --scope=all (default) preserves prior behavior
+    // =========================================================================
+
+    public function testScopeAllFailsWhenEitherBroken(): void
+    {
+        $this->startServer('ibl5', healthy: true);
+        // IBL6 broken
+
+        $result = $this->runSmoke(scope: 'all', ibl6Url: 'http://127.0.0.1:1/');
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('FAIL: IBL6 app', $result['output']);
+    }
+
+    // =========================================================================
+    // Post-impl: --help
+    // =========================================================================
+
+    public function testHelpExitsZeroWithScopeInfo(): void
+    {
+        $result = $this->runRaw('--help');
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('--scope', $result['output']);
+    }
+
+    // =========================================================================
+    // Post-impl: unknown --scope
+    // =========================================================================
+
+    public function testUnknownScopeExitsTwo(): void
+    {
+        $result = $this->runRaw('--scope=garbage');
+
+        self::assertSame(2, $result['exit']);
+        self::assertStringContainsString('unknown scope', $result['output']);
+    }
+
+    // =========================================================================
+    // Post-impl: SMOKE_IBL6_URL env var
+    // =========================================================================
+
+    public function testIbl6UrlEnvVarOverridesDefault(): void
+    {
+        $this->startServer('ibl6', healthy: true);
+
+        $result = $this->runSmoke(
+            scope: 'ibl6',
+            ibl6Url: 'http://127.0.0.1:' . $this->ports['ibl6'] . '/',
+        );
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('OK: IBL6 app', $result['output']);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function startServer(string $name, bool $healthy): void
+    {
+        $port = $this->findFreePort();
+        $this->ports[$name] = $port;
+
+        $routerContent = $healthy
+            ? '<?php http_response_code(200); echo "IBL Standings team player Sign In";'
+            : '<?php http_response_code(500); echo "Server Error";';
+
+        $routerFile = $this->fixtureDir . "/router-{$name}.php";
+        file_put_contents($routerFile, $routerContent);
+
+        $cmd = sprintf(
+            'exec php -S 127.0.0.1:%d -t %s %s',
+            $port,
+            escapeshellarg($this->fixtureDir),
+            escapeshellarg($routerFile),
+        );
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $proc = proc_open($cmd, $descriptors, $pipes);
+        self::assertIsResource($proc, "Failed to start {$name} fixture server");
+        $this->servers[$name] = $proc;
+
+        // Wait for server to be accepting connections
+        $deadline = microtime(true) + 5.0;
+        while (microtime(true) < $deadline) {
+            $sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.1);
+            if ($sock !== false) {
+                fclose($sock);
+                return;
+            }
+            usleep(50_000);
+        }
+
+        self::fail("Fixture server {$name} did not start on port {$port} within 5s");
+    }
+
+    private function findFreePort(): int
+    {
+        $sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        self::assertNotFalse($sock, 'Could not create socket');
+        socket_bind($sock, '127.0.0.1', 0);
+        socket_getsockname($sock, $addr, $port);
+        socket_close($sock);
+
+        return $port;
+    }
+
+    /**
+     * Run bin/smoke-prod with --scope and env overrides.
+     * @return array{output: string, exit: int}
+     */
+    private function runSmoke(string $scope, ?string $ibl6Url = null): array
+    {
+        $baseUrl = isset($this->ports['ibl5'])
+            ? 'http://127.0.0.1:' . $this->ports['ibl5']
+            : 'http://127.0.0.1:1';
+
+        $env = 'SMOKE_INTERCHECK_DELAY=0 SMOKE_RETRY_DELAY=0';
+
+        if ($ibl6Url !== null) {
+            $env .= ' SMOKE_IBL6_URL=' . escapeshellarg($ibl6Url);
+        } elseif (isset($this->ports['ibl6'])) {
+            $env .= ' SMOKE_IBL6_URL=' . escapeshellarg(
+                'http://127.0.0.1:' . $this->ports['ibl6'] . '/',
+            );
+        }
+
+        $cmd = sprintf(
+            '%s %s --scope=%s %s 2>&1',
+            $env,
+            escapeshellcmd($this->scriptPath),
+            escapeshellarg($scope),
+            escapeshellarg($baseUrl),
+        );
+
+        $output = [];
+        $exit = 0;
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    /**
+     * Run bin/smoke-prod with raw arguments (for --help, unknown flags).
+     * @return array{output: string, exit: int}
+     */
+    private function runRaw(string $args): array
+    {
+        $cmd = escapeshellcmd($this->scriptPath) . ' ' . $args . ' 2>&1';
+        $output = [];
+        $exit = 0;
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Problem

An IBL6 outage triggers the IBL5 auto-rollback because `bin/smoke-prod` treats all 8 checks as a single pass/fail. The `rollback-and-notify` job in `smoke-prod.yml` reverts the IBL5 production commit even when IBL5 is healthy — the failure came from the unrelated IBL6 probe.

## Solution

### Script: `bin/smoke-prod`

Added `--scope=ibl5|ibl6|all` flag (default: `all` preserves backward compat). Each scope tracks its own pass/fail counters. Exit code reflects only in-scope failures.

New env vars:
- `SMOKE_IBL6_URL` — override the IBL6 probe URL
- `SMOKE_RETRY_DELAY` — seconds before retry (tests set to 0)

### Workflow: `smoke-prod.yml`

Split the single `Run smoke tests` step into two:
1. **IBL5 scope** (gates auto-rollback) — if this fails, the `smoke` job fails, and `rollback-and-notify` fires as before
2. **IBL6 scope** (`continue-on-error: true`) — failure does NOT fail the `smoke` job

New `notify-ibl6-degradation` job: fires when IBL6 fails but IBL5 passes. Sends a Discord notification without triggering rollback.

### Non-changes

- `main.yml`'s inline `Smoke test IBL6` step (~line 181) is unchanged — it's a deploy-time health probe, not the post-deploy smoke suite
- `rollback-and-notify` job predicate unchanged (`needs.smoke.result == 'failure'`)

## Testing

11 PHPUnit tests in `SmokeProdCliTest.php` using `php -S` fixture servers:
- Characterization: all-healthy exits 0, IBL5 broken exits 1, IBL6 unreachable exits 1
- Scope isolation: `--scope=ibl5` ignores IBL6 failures and vice versa
- Default: `--scope=all` preserves prior behavior
- Edge cases: `--help`, unknown scope, `SMOKE_IBL6_URL` override

## Manual Testing

No manual testing needed — all changes are covered by unit tests.

## Verification deferred to post-merge

- Workflow round-trip with deliberately broken IBL6 URL (matrix row #12): `gh workflow run smoke-prod.yml -f base_url=https://www.iblhoops.net` with `SMOKE_IBL6_URL` override
- Workflow round-trip with broken IBL5 URL (matrix row #13): `gh workflow run smoke-prod.yml -f base_url=https://httpstat.us/500`

## Plan

PR-1 of `~/.claude/plans/fill-testing-apparatus-gaps.md`