### PR TITLE
ci: deploy rehearsal pre-flight gate for production deploys

### DIFF
--- a/.github/workflows/deploy-rehearsal.yml
+++ b/.github/workflows/deploy-rehearsal.yml
@@ -1,0 +1,104 @@
+name: Deploy Rehearsal
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'ibl5/migrations/**.sql'
+      - 'ibl5/composer.json'
+      - 'ibl5/composer.lock'
+      - 'ibl5/bin/migrate'
+      - 'ibl5/bin/validate-schema'
+      - 'ibl5/config/schema-assertions.php'
+      - 'ibl5/classes/Migration/**'
+      - '.github/workflows/deploy-rehearsal.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'ibl5/migrations/**.sql'
+      - 'ibl5/composer.json'
+      - 'ibl5/composer.lock'
+      - 'ibl5/bin/migrate'
+      - 'ibl5/bin/validate-schema'
+      - 'ibl5/config/schema-assertions.php'
+      - 'ibl5/classes/Migration/**'
+      - '.github/workflows/deploy-rehearsal.yml'
+  workflow_call: {}
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rehearse:
+    name: Deploy Rehearsal (composer --no-dev + migrate + validate-schema)
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: iblhoops_ibl5
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mariadb-admin ping -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: mbstring, intl, mysqli
+          coverage: none
+
+      # Mirror main.yml "Install PHP dependencies" exactly (--no-dev catches
+      # dev-dependency leaks that tests.yml's full install would miss)
+      - name: composer install --no-dev (mirrors main.yml)
+        working-directory: ibl5
+        run: composer install --no-dev --no-interaction --optimize-autoloader
+
+      - name: Configure ibl5 to point at CI MariaDB
+        working-directory: ibl5
+        run: |
+          cp config.php.example config.php
+          sed -i "s/\$dbhost = getenv('DB_HOST') ?: 'localhost';/\$dbhost = '127.0.0.1';/" config.php
+          sed -i "s/\$dbuname = \"iblhoops_\";/\$dbuname = \"root\";/" config.php
+          sed -i "s/\$dbpass = \"password\";/\$dbpass = \"root\";/" config.php
+          sed -i "s/\$dbname = \"iblhoops_\";/\$dbname = \"iblhoops_ibl5\";/" config.php
+
+      - name: Apply baseline schema
+        working-directory: ibl5
+        run: |
+          sed 's/DEFINER=`[^`]*`@`[^`]*`//g' migrations/000_baseline_schema.sql \
+            | mysql -h 127.0.0.1 -u root -proot iblhoops_ibl5
+
+      - name: Mark baseline as applied in migration tracker
+        run: |
+          mysql -h 127.0.0.1 -u root -proot iblhoops_ibl5 -e "
+            CREATE TABLE IF NOT EXISTS migrations (
+              id INT AUTO_INCREMENT PRIMARY KEY,
+              migration VARCHAR(255) NOT NULL,
+              batch INT NOT NULL
+            );
+            INSERT INTO migrations (migration, batch) VALUES ('000_baseline_schema.sql', 0);
+          "
+
+      # Mirror main.yml "Run database migrations" exactly
+      - name: php bin/migrate (mirrors main.yml)
+        run: php ibl5/bin/migrate
+
+      # Mirror main.yml "Validate database schema" exactly — this is the gate
+      - name: php bin/validate-schema (mirrors main.yml; pre-flight gate)
+        run: php ibl5/bin/validate-schema

--- a/.github/workflows/deploy-rehearsal.yml
+++ b/.github/workflows/deploy-rehearsal.yml
@@ -12,6 +12,7 @@ on:
       - 'ibl5/config/schema-assertions.php'
       - 'ibl5/classes/Migration/**'
       - '.github/workflows/deploy-rehearsal.yml'
+      - '.github/workflows/main.yml'
   push:
     branches: [master]
     paths:
@@ -23,6 +24,7 @@ on:
       - 'ibl5/config/schema-assertions.php'
       - 'ibl5/classes/Migration/**'
       - '.github/workflows/deploy-rehearsal.yml'
+      - '.github/workflows/main.yml'
   workflow_call: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  pre-flight:
+    name: Pre-flight (composer --no-dev + migrate + validate-schema dry-run)
+    uses: ./.github/workflows/deploy-rehearsal.yml
+
   build-and-deploy:
     name: Build and Deploy
+    needs: pre-flight
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -195,8 +200,9 @@ jobs:
   notify-deploy-failure:
     name: Notify Deploy Failure
     runs-on: ubuntu-latest
-    needs: build-and-deploy
-    if: ${{ always() && needs.build-and-deploy.result == 'failure' }}
+    # pre-flight failure → build-and-deploy is 'skipped', not 'failure'
+    needs: [pre-flight, build-and-deploy]
+    if: ${{ always() && (needs.build-and-deploy.result == 'failure' || needs.pre-flight.result == 'failure') }}
     timeout-minutes: 5
 
     steps:
@@ -212,11 +218,16 @@ jobs:
       - name: Send Discord DM
         env:
           OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
+          PREFLIGHT_RESULT: ${{ needs.pre-flight.result }}
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SHORT_SHA="${{ github.sha }}"
           SHORT_SHA="${SHORT_SHA:0:7}"
-          MSG=$(printf 'Production deploy FAILED for commit %s.\n\nCheck the run for details: %s' "$SHORT_SHA" "$RUN_URL")
+          if [ "$PREFLIGHT_RESULT" = "failure" ]; then
+            MSG=$(printf 'Production deploy BLOCKED — pre-flight rehearsal FAILED for commit %s. Deploy did not start.\n\nCheck the run for details: %s' "$SHORT_SHA" "$RUN_URL")
+          else
+            MSG=$(printf 'Production deploy FAILED for commit %s.\n\nCheck the run for details: %s' "$SHORT_SHA" "$RUN_URL")
+          fi
 
           PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
             '{content: {receivingUserDiscordID: $id, message: $msg}}')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     # pre-flight failure → build-and-deploy is 'skipped', not 'failure'
     needs: [pre-flight, build-and-deploy]
-    if: ${{ always() && (needs.build-and-deploy.result == 'failure' || needs.pre-flight.result == 'failure') }}
+    if: ${{ always() && (needs.build-and-deploy.result == 'failure' || needs.pre-flight.result == 'failure' || needs.pre-flight.result == 'cancelled') }}
     timeout-minutes: 5
 
     steps:
@@ -223,8 +223,8 @@ jobs:
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SHORT_SHA="${{ github.sha }}"
           SHORT_SHA="${SHORT_SHA:0:7}"
-          if [ "$PREFLIGHT_RESULT" = "failure" ]; then
-            MSG=$(printf 'Production deploy BLOCKED — pre-flight rehearsal FAILED for commit %s. Deploy did not start.\n\nCheck the run for details: %s' "$SHORT_SHA" "$RUN_URL")
+          if [ "$PREFLIGHT_RESULT" = "failure" ] || [ "$PREFLIGHT_RESULT" = "cancelled" ]; then
+            MSG=$(printf 'Production deploy BLOCKED — pre-flight rehearsal %s for commit %s. Deploy did not start.\n\nCheck the run for details: %s' "${PREFLIGHT_RESULT^^}" "$SHORT_SHA" "$RUN_URL")
           else
             MSG=$(printf 'Production deploy FAILED for commit %s.\n\nCheck the run for details: %s' "$SHORT_SHA" "$RUN_URL")
           fi

--- a/ibl5/docs/decisions/0023-deploy-rehearsal-pre-flight-gate.md
+++ b/ibl5/docs/decisions/0023-deploy-rehearsal-pre-flight-gate.md
@@ -1,0 +1,37 @@
+---
+description: Deploy rehearsal workflow gates production deploys by dry-running composer --no-dev, migrations, and schema validation against a disposable MariaDB before SSH steps touch prod.
+last_verified: 2026-05-13
+---
+
+# ADR-0023: Deploy Rehearsal Pre-Flight Gate
+
+**Status:** Accepted
+**Date:** 2026-05-13
+
+## Context
+
+`main.yml` SSHes into the production server and runs `composer install --no-dev`, `php bin/migrate`, and `php bin/validate-schema` directly against the production database. If any of these steps fail, production is left in a partially-deployed state. There was no CI gate that exercised the exact production install sequence (no-dev deps, migration application, schema validation) against a disposable database before the deploy touched prod. The existing `tests.yml` uses `composer install` with dev dependencies and `migration-safety.yml` checks migration idempotency but not the validate-schema assertion set.
+
+## Decision
+
+A reusable workflow `.github/workflows/deploy-rehearsal.yml` mirrors the exact `main.yml` production sequence (`composer install --no-dev`, `php bin/migrate`, `php bin/validate-schema`) against a fresh MariaDB 10.11 service container. It runs on `pull_request` and `push` to `master` for early signal, and is called from `main.yml` as a `pre-flight` job that gates `build-and-deploy` via `needs:`. The on-box `Validate database schema` step in `build-and-deploy` is kept as defense in depth (catches prod-DB mutations outside the migration path).
+
+## Alternatives Considered
+
+- **Run validate-schema only on the prod box (status quo)** — no CI signal; failures discovered after SSH has already mutated prod. Rejected because the whole point is pre-flight gating.
+- **Add migration + validate-schema steps inline to `main.yml`** — duplicates the MariaDB service setup and makes `main.yml` longer. Rejected because a reusable workflow is callable from both `main.yml` and independently for PR/push signal.
+- **Remove the on-box validate-schema after adding the pre-flight** — removes defense in depth against out-of-band prod-DB changes. Rejected because the two steps catch different failure modes.
+
+## Consequences
+
+- Positive: production deploys are blocked before SSH if migrations or schema assertions are inconsistent.
+- Positive: PR authors get early signal on migration/schema issues without waiting for a production push.
+- Negative: adds ~2-3 minutes to the production deploy pipeline (MariaDB boot + migration apply + validation).
+
+## References
+
+- `.github/workflows/deploy-rehearsal.yml` — the reusable workflow
+- `.github/workflows/main.yml` — `pre-flight` job + `notify-deploy-failure` adjustment
+- `.github/workflows/migration-safety.yml` — template for MariaDB service + tracker-seed pattern
+- `ibl5/bin/validate-schema` — schema assertion runner
+- `ibl5/config/schema-assertions.php` — assertion definitions

--- a/ibl5/docs/decisions/README.md
+++ b/ibl5/docs/decisions/README.md
@@ -1,6 +1,6 @@
 ---
 description: Index of IBL5 Architecture Decision Records (ADRs). Source of truth for every load-bearing decision and its rationale.
-last_verified: 2026-05-01
+last_verified: 2026-05-13
 ---
 
 # IBL5 Architecture Decision Records
@@ -25,6 +25,7 @@ Every load-bearing decision in IBL5 is captured here as a numbered ADR so that f
 | [0012](0012-archive-first-jsb-reading.md) | Archive-first JSB file reading | Accepted | `.lge`/`.sch` read directly from backup archive via `JsbSourceResolver`; disk-fallback for manual uploads. |
 | [0016](0016-remove-duckdb-analytics.md) | Remove DuckDB analytics layer | Accepted | JSB source decompiled; DuckDB OLAP layer and write-back tables removed. |
 | [0017](0017-dependabot-full-ci-and-auto-merge.md) | Dependabot full CI and auto-merge | Accepted | Force all CI checks on Dependabot PRs; auto-squash-merge on pass. |
+| [0023](0023-deploy-rehearsal-pre-flight-gate.md) | Deploy rehearsal pre-flight gate | Accepted | Reusable workflow dry-runs `composer --no-dev` + migrate + validate-schema against disposable MariaDB before prod deploy. |
 
 ## When an ADR is Required
 


### PR DESCRIPTION
## Summary

Adds a deploy rehearsal workflow that mirrors the exact `main.yml` production sequence (`composer install --no-dev`, `php bin/migrate`, `php bin/validate-schema`) against a disposable MariaDB 10.11 container. This gates production deploys: if migrations or schema assertions are inconsistent, the deploy never starts and the production database is never mutated.

Closes gaps #3 (deploy dry-run) and #4 (pre-flight schema validation) from the testing apparatus plan.

## Changes

### New: `.github/workflows/deploy-rehearsal.yml`

Reusable workflow triggered three ways:
- `pull_request` on master (PR-time signal)
- `push` on master (master-tip signal)  
- `workflow_call` (called from `main.yml` as pre-flight gate)
- `workflow_dispatch` (ad-hoc rehearsal runs)

Path-filtered to: migrations, composer files, validate-schema, Migration classes, and the workflow itself.

Steps mirror `migration-safety.yml`'s MariaDB service + tracker-seed pattern:
1. Stand up MariaDB 10.11
2. Apply baseline schema
3. Mark baseline in migration tracker
4. `composer install --no-dev` (matches `main.yml` exactly — catches dev-dependency leaks)
5. `php bin/migrate`
6. `php bin/validate-schema`

### Modified: `.github/workflows/main.yml`

- New `pre-flight` job calls `deploy-rehearsal.yml`
- `build-and-deploy` now `needs: pre-flight` — blocked until rehearsal passes
- `notify-deploy-failure` expanded: `needs: [pre-flight, build-and-deploy]` with `if:` covering both failure paths
- Discord message distinguishes "pre-flight failed (deploy blocked)" from "deploy failed"
- On-box `Validate database schema` step kept as defense in depth (catches out-of-band prod-DB mutations)

### Design decisions

- **Keep on-box validate-schema:** pre-flight catches "code + migrations disagree at this commit"; on-box catches "prod DB was mutated outside migrations." Different failure modes.
- **`cancel-in-progress: true` on the reusable workflow:** when called via `workflow_call` from `main.yml`, the parent's `cancel-in-progress: false` governs overall deploy serialization. The reusable workflow's concurrency only affects its own PR/push runs.
- **`notify-deploy-failure` needs both jobs:** when `pre-flight` fails, `build-and-deploy.result` is `skipped` (not `failure`), so the `OR needs.pre-flight.result == 'failure'` is load-bearing.

### ADR-0023

Documents the deploy rehearsal pre-flight gate decision per the ADR requirement for new CI workflows.

## Manual Testing

No manual testing needed — all changes are covered by automated CI validation.

## Verification notes

- `actionlint` passes on both `deploy-rehearsal.yml` and `main.yml`
- `bin/adr-check --staged` confirms ADR requirement satisfied
- `bin/check-docs` passes (70 docs verified)
- PHPUnit suite green (5224 tests)
- Composer `--no-dev` flags match exactly between `main.yml` and `deploy-rehearsal.yml`
- On-box `Validate database schema` step confirmed present in `main.yml`
- Verification matrix item 8 (simulate pre-flight failure triggering notify-deploy-failure) cannot be dispatched locally since `main.yml` only triggers on `push: production` — verified by `if:` condition inspection