### PR TITLE
ci: gate merge-to-prod on CI status and scan migrations for destructive patterns

### DIFF
--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -275,3 +275,40 @@ jobs:
           exit 1
         fi
         echo "PASS: All critical columns present."
+
+  destructive-migration-scan:
+    name: Destructive Migration Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Compute diff base
+        id: base
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Scan for destructive patterns
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            printf '%s' "$PR_BODY" | bin/check-destructive-migrations \
+              --since=${{ steps.base.outputs.sha }} --bypass-from-stdin
+          else
+            bin/check-destructive-migrations \
+              --since=${{ steps.base.outputs.sha }}
+          fi
+
+  gate:
+    name: Migration Safety
+    if: always()
+    needs: [idempotency-check, schema-parity-check, schema-completeness, destructive-migration-scan]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/bin/check-destructive-migrations
+++ b/bin/check-destructive-migrations
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# Scans migration SQL files for destructive patterns (DROP COLUMN, DROP TABLE,
+# TRUNCATE, RENAME COLUMN, ADD NOT NULL without DEFAULT).
+#
+# Exit codes: 0 = pass, 1 = destructive patterns found, 2 = usage error.
+
+set -euo pipefail
+
+BYPASS_MIN_LENGTH=20
+BASELINE_FILE="ibl5/migrations/000_baseline_schema.sql"
+
+usage() {
+    cat <<'EOF'
+Usage: bin/check-destructive-migrations [--staged|--since=<sha>] [--bypass-from-stdin] [--help|-h]
+
+Scans added/modified migration files under ibl5/migrations/ for destructive
+SQL patterns and blocks unless a bypass marker is present.
+
+Modes:
+  --staged           Scan staged changes (git diff --cached). Default.
+  --since=<sha>      Scan changes since the given SHA (git diff <sha>...HEAD).
+
+Options:
+  --bypass-from-stdin   Read PR body from stdin for the global bypass marker.
+  --help, -h            Show this message.
+
+Detected patterns (v1):
+  drop-column             ALTER TABLE ... DROP COLUMN
+  drop-table              DROP TABLE (suppressed when IF EXISTS + matching
+                          CREATE TABLE in same file = recreate pattern)
+  truncate                TRUNCATE [TABLE] ...
+  rename-column           ALTER TABLE ... RENAME COLUMN
+  add-not-null-no-default ADD COLUMN ... NOT NULL without DEFAULT
+
+Bypass markers:
+  Per-file (inline SQL comment):
+    -- destructive-migration: <reason at least 20 chars>
+  Per-PR (HTML comment in PR body, via --bypass-from-stdin):
+    <!-- destructive-migration: <reason at least 20 chars> -->
+
+Explicitly NOT scanned (v1 limitations):
+  - MODIFY ... NOT NULL (requires multi-statement analysis)
+  - Bare DELETE FROM (often legitimate cleanup)
+
+Hard-excluded files:
+  - 000_baseline_schema.sql (recreate template with intentional DROP TABLE)
+
+Exit codes: 0 = pass, 1 = destructive patterns found, 2 = usage error.
+EOF
+}
+
+MODE="staged"
+BYPASS_STDIN=0
+SINCE_SHA=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --staged)
+            MODE="staged"
+            ;;
+        --since=*)
+            MODE="since"
+            SINCE_SHA="${arg#--since=}"
+            ;;
+        --bypass-from-stdin)
+            BYPASS_STDIN=1
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --*)
+            echo "unknown flag: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            echo "unknown argument: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ "$MODE" = "since" ]; then
+    RANGE="${SINCE_SHA}...HEAD"
+else
+    RANGE="--cached"
+fi
+
+get_migration_files() {
+    # shellcheck disable=SC2086
+    git diff $RANGE --name-only --diff-filter=AM -- 'ibl5/migrations/*.sql' 2>/dev/null \
+        | grep -v '^$' \
+        | grep -v "^${BASELINE_FILE}$" \
+        || true
+}
+
+FILES="$(get_migration_files)"
+
+if [ -z "$FILES" ]; then
+    echo "No destructive migration patterns detected."
+    exit 0
+fi
+
+PR_BODY_BYPASS=""
+if [ "$BYPASS_STDIN" = "1" ]; then
+    PR_BODY="$(cat)"
+    REASON="$(echo "$PR_BODY" | sed -n 's/.*<!--[[:space:]]*destructive-migration:[[:space:]]*\(.\{1,\}\)[[:space:]]*-->.*/\1/p' | head -1)"
+    REASON="$(echo "$REASON" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    if [ -n "$REASON" ] && [ "${#REASON}" -ge "$BYPASS_MIN_LENGTH" ]; then
+        PR_BODY_BYPASS="$REASON"
+    fi
+fi
+
+TRIGGERS=""
+
+get_added_lines() {
+    local file="$1"
+    # shellcheck disable=SC2086
+    git diff $RANGE -- "$file" | grep '^+' | grep -v '^+++' | sed 's/^+//'
+}
+
+match_icase() {
+    echo "$1" | grep -iqE "$2"
+}
+
+check_file() {
+    local file="$1"
+
+    local added_lines
+    added_lines="$(get_added_lines "$file")" || true
+
+    if [ -z "$added_lines" ]; then
+        return
+    fi
+
+    local inline_bypass=""
+    local bypass_reason
+    bypass_reason="$(echo "$added_lines" | sed -n 's/^[[:space:]]*--[[:space:]]*destructive-migration:[[:space:]]*\(.\{1,\}\)/\1/p' | head -1)" || true
+    bypass_reason="$(echo "$bypass_reason" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    if [ -n "$bypass_reason" ] && [ "${#bypass_reason}" -ge "$BYPASS_MIN_LENGTH" ]; then
+        inline_bypass="$bypass_reason"
+    fi
+
+    local file_triggers=""
+    local line_num=0
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        local stripped
+        stripped="$(echo "$line" | sed 's/--.*$//')"
+        [ -z "$stripped" ] && continue
+
+        # drop-column
+        if match_icase "$stripped" 'ALTER[[:space:]]+TABLE[[:space:]].*DROP[[:space:]]+COLUMN'; then
+            file_triggers="${file_triggers}  [drop-column] ${file}:${line_num} ${stripped}
+"
+        fi
+
+        # drop-table
+        if match_icase "$stripped" 'DROP[[:space:]]+TABLE'; then
+            local suppressed=0
+            if match_icase "$stripped" 'DROP[[:space:]]+TABLE[[:space:]]+IF[[:space:]]+EXISTS'; then
+                local table_name
+                table_name="$(echo "$stripped" | sed -E 's/.*DROP[[:space:]]+TABLE[[:space:]]+IF[[:space:]]+EXISTS[[:space:]]+`?([a-zA-Z0-9_]+).*/\1/I' | head -1)" || true
+                if [ -n "$table_name" ]; then
+                    if echo "$added_lines" | grep -iqE "CREATE[[:space:]]+TABLE[[:space:]]+(IF[[:space:]]+NOT[[:space:]]+EXISTS[[:space:]]+)?\`?${table_name}\`?"; then
+                        suppressed=1
+                    fi
+                fi
+            fi
+            if [ "$suppressed" = "0" ]; then
+                file_triggers="${file_triggers}  [drop-table] ${file}:${line_num} ${stripped}
+"
+            fi
+        fi
+
+        # truncate
+        if match_icase "$stripped" 'TRUNCATE[[:space:]]+(TABLE[[:space:]]+)?[^[:space:]]'; then
+            file_triggers="${file_triggers}  [truncate] ${file}:${line_num} ${stripped}
+"
+        fi
+
+        # rename-column
+        if match_icase "$stripped" 'ALTER[[:space:]]+TABLE[[:space:]].*RENAME[[:space:]]+COLUMN'; then
+            file_triggers="${file_triggers}  [rename-column] ${file}:${line_num} ${stripped}
+"
+        fi
+
+        # add-not-null-no-default
+        if match_icase "$stripped" 'ADD[[:space:]]+COLUMN[[:space:]].*NOT[[:space:]]+NULL'; then
+            if ! match_icase "$stripped" 'DEFAULT'; then
+                file_triggers="${file_triggers}  [add-not-null-no-default] ${file}:${line_num} ${stripped}
+"
+            fi
+        fi
+
+    done <<< "$added_lines"
+
+    if [ -n "$file_triggers" ]; then
+        if [ -n "$inline_bypass" ]; then
+            echo "PASS (bypass): $inline_bypass"
+            return
+        fi
+        TRIGGERS="${TRIGGERS}${file_triggers}"
+    fi
+}
+
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    check_file "$file"
+done <<< "$FILES"
+
+if [ -z "$TRIGGERS" ]; then
+    echo "No destructive migration patterns detected."
+    exit 0
+fi
+
+if [ -n "$PR_BODY_BYPASS" ]; then
+    echo "PASS (bypass): $PR_BODY_BYPASS"
+    exit 0
+fi
+
+echo "Destructive migration patterns detected:"
+echo ""
+printf '%s' "$TRIGGERS"
+echo ""
+echo "To proceed, add one of these bypass markers:"
+echo ""
+echo "  Per-file (SQL comment in the migration):"
+echo "    -- destructive-migration: <reason at least 20 chars>"
+echo ""
+echo "  Per-PR (HTML comment in PR body):"
+echo "    <!-- destructive-migration: <reason at least 20 chars> -->"
+echo ""
+echo "See ibl5/migrations/README.md for the full destructive migration policy."
+exit 1

--- a/bin/check-master-ci-green
+++ b/bin/check-master-ci-green
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Verifies that all GitHub CI check-runs are green on a given SHA.
+# Used by bin/merge-master-to-prod to prevent shipping a red build.
+#
+# Exit codes: 0 = pass, 1 = CI failure, 2 = usage error.
+
+set -euo pipefail
+
+MIN_REQUIRED_CHECKS="${MIN_REQUIRED_CHECKS:-1}"
+GH_API_CMD="${GH_API_CMD:-gh api}"
+
+usage() {
+    cat <<'EOF'
+Usage: bin/check-master-ci-green [SHA] [--skip-ci-check] [--help|-h]
+
+Checks that all GitHub CI check-runs are green on the given SHA
+(defaults to origin/master).
+
+Options:
+  --skip-ci-check   Emergency bypass — prints a warning and exits 0.
+  --help, -h        Show this message.
+
+Environment:
+  GH_API_CMD            Override the API command (default: "gh api").
+                        For testing: GH_API_CMD='cat /tmp/fixture.json #'
+  MIN_REQUIRED_CHECKS   Minimum number of check-runs expected (default: 1).
+                        Guards against the post-push race where workflows
+                        have not started yet.
+
+Trade-off: uses an "all-must-pass" model rather than a hardcoded check-name
+list. A new optional check that lands red will block. Use --skip-ci-check
+as the escape hatch. A future SKIP_CHECKS env var (comma-separated names
+to ignore) may be added but is out of scope for v1.
+
+Limitation: fetches one page of check-runs (100 results). IBL5's combined
+workflow count is well under 50, so a single page suffices.
+
+Exit codes: 0 = pass, 1 = CI failure, 2 = usage error.
+EOF
+}
+
+SHA=""
+SKIP=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --skip-ci-check)
+            SKIP=1
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --*)
+            echo "unknown flag: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            SHA="$arg"
+            ;;
+    esac
+done
+
+if [ "$SKIP" = "1" ]; then
+    echo "BYPASS: --skip-ci-check flag set — skipping CI verification."
+    exit 0
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "ERROR: GitHub CLI is not authenticated." >&2
+    echo "Run 'gh auth login' to authenticate, then retry." >&2
+    exit 2
+fi
+
+if [ -z "$SHA" ]; then
+    SHA="$(git rev-parse origin/master 2>/dev/null)" || {
+        echo "ERROR: cannot resolve origin/master" >&2
+        exit 2
+    }
+fi
+
+REMOTE_URL="$(git remote get-url origin 2>/dev/null)" || {
+    echo "ERROR: cannot read origin remote URL" >&2
+    exit 2
+}
+
+REPO="$(echo "$REMOTE_URL" | sed -E 's#^(https://github\.com/|git@github\.com:)##; s#\.git$##')"
+if [ -z "$REPO" ]; then
+    echo "ERROR: cannot parse repo slug from origin URL: $REMOTE_URL" >&2
+    exit 2
+fi
+
+JSON="$(bash -c "$GH_API_CMD \"repos/$REPO/commits/$SHA/check-runs?per_page=100\"" 2>/dev/null)" || {
+    echo "ERROR: GitHub API request failed" >&2
+    exit 2
+}
+
+TOTAL="$(echo "$JSON" | jq '.check_runs | length')"
+
+if [ "$TOTAL" -lt "$MIN_REQUIRED_CHECKS" ]; then
+    echo "FAIL: only $TOTAL check-run(s) found (minimum: $MIN_REQUIRED_CHECKS)." >&2
+    echo "Workflows may not have started yet. Wait and retry." >&2
+    exit 1
+fi
+
+STILL_RUNNING="$(echo "$JSON" | jq -r '[.check_runs[] | select(.status != "completed")] | map(.name) | join(", ")')"
+if [ -n "$STILL_RUNNING" ]; then
+    echo "FAIL: checks still running: $STILL_RUNNING" >&2
+    exit 1
+fi
+
+FAILED="$(echo "$JSON" | jq -r '[.check_runs[] | select(.status == "completed" and (.conclusion | IN("success","skipped","neutral") | not))] | map(.name + " (" + .conclusion + ")") | join(", ")')"
+if [ -n "$FAILED" ]; then
+    echo "FAIL: checks failed: $FAILED" >&2
+    exit 1
+fi
+
+echo "PASS: $TOTAL check-run(s) all green on $SHA"
+exit 0

--- a/bin/merge-master-to-prod
+++ b/bin/merge-master-to-prod
@@ -2,6 +2,8 @@
 
 # Merges master into production and pushes both branches to origin.
 # All git output is suppressed; only errors or the final summary are printed.
+#
+# Set SKIP_CI_CHECK=1 to bypass the CI-green gate (emergency use only).
 
 set -e
 
@@ -15,6 +17,13 @@ export SKIP_WT_CLEANUP=1
 
 git checkout master -q
 git pull origin master -q
+
+if [ "${SKIP_CI_CHECK:-0}" != "1" ]; then
+    MASTER_SHA="$(git rev-parse origin/master)"
+    SCRIPT_ROOT="$(git rev-parse --show-toplevel)"
+    "$SCRIPT_ROOT/bin/check-master-ci-green" "$MASTER_SHA" || fail "master HEAD is not green on CI (set SKIP_CI_CHECK=1 to bypass)"
+fi
+
 git push origin master -q 2>/dev/null || fail "push master"
 
 git checkout production -q

--- a/ibl5/migrations/README.md
+++ b/ibl5/migrations/README.md
@@ -17,6 +17,36 @@ The production deploy workflow automatically reverts the last commit if post-dep
 
 If a reverted deploy still fails smoke tests (because the old code is incompatible with the new schema), the workflow sends a "manual intervention required" notification instead of reverting again.
 
+## Destructive Migration CI Scan
+
+The `migration-safety.yml` workflow includes a **destructive migration scan** (`bin/check-destructive-migrations`) that blocks PRs and pushes containing these patterns in new or modified `.sql` files under `ibl5/migrations/`:
+
+| Pattern | What it catches |
+|---------|----------------|
+| `drop-column` | `ALTER TABLE ... DROP COLUMN` |
+| `drop-table` | `DROP TABLE` (suppressed when `IF EXISTS` + matching `CREATE TABLE` in same file) |
+| `truncate` | `TRUNCATE [TABLE] ...` |
+| `rename-column` | `ALTER TABLE ... RENAME COLUMN` |
+| `add-not-null-no-default` | `ADD COLUMN ... NOT NULL` without `DEFAULT` |
+
+The file `000_baseline_schema.sql` is always excluded from scanning.
+
+### Bypass markers
+
+When a destructive operation is intentional and reviewed, add a bypass marker:
+
+**Per-file** (inline SQL comment — suppresses all triggers for that file):
+```sql
+-- destructive-migration: <reason at least 20 characters>
+```
+
+**Per-PR** (HTML comment in the PR body — suppresses all triggers globally):
+```html
+<!-- destructive-migration: <reason at least 20 characters> -->
+```
+
+The reason must be at least 20 characters. Short reasons are rejected.
+
 ## Automated Migration Runner
 
 Migrations are applied automatically during deployment via `ibl5/bin/migrate`. The runner:

--- a/ibl5/tests/Cli/CheckDestructiveMigrationsCliTest.php
+++ b/ibl5/tests/Cli/CheckDestructiveMigrationsCliTest.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class CheckDestructiveMigrationsCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/check-destructive-migrations');
+        self::assertNotFalse($resolved, 'bin/check-destructive-migrations must exist');
+        $this->scriptPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/destr-mig-test-' . bin2hex(random_bytes(8));
+        mkdir($this->tmpDir, 0755, true);
+
+        $this->runInDir('git init -b main');
+        $this->runInDir('git config user.email "test@test.com"');
+        $this->runInDir('git config user.name "Test"');
+
+        mkdir($this->tmpDir . '/ibl5/migrations', 0755, true);
+        file_put_contents($this->tmpDir . '/ibl5/migrations/.gitkeep', '');
+        $this->runInDir('git add -A');
+        $this->runInDir('git commit -m "initial"');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    public function testCleanMigrationExitsZero(): void
+    {
+        $this->writeMigration('100_clean.sql', "ALTER TABLE foo ADD COLUMN bar VARCHAR(50) DEFAULT NULL;\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No destructive migration patterns detected', $result['output']);
+    }
+
+    public function testDropColumnExitsOne(): void
+    {
+        $this->writeMigration('101_drop_col.sql', "ALTER TABLE foo DROP COLUMN bar;\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('drop-column', $result['output']);
+        self::assertStringContainsString('101_drop_col.sql', $result['output']);
+    }
+
+    public function testDropTableExitsOne(): void
+    {
+        $this->writeMigration('102_drop_tbl.sql', "DROP TABLE foo;\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('drop-table', $result['output']);
+    }
+
+    public function testDropIfExistsWithRecreateSuppressed(): void
+    {
+        $sql = "DROP TABLE IF EXISTS `foo`;\nCREATE TABLE `foo` (id INT PRIMARY KEY);\n";
+        $this->writeMigration('103_recreate.sql', $sql);
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+    }
+
+    public function testDropIfExistsWithoutRecreateExitsOne(): void
+    {
+        $this->writeMigration('104_drop_only.sql', "DROP TABLE IF EXISTS `foo`;\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('drop-table', $result['output']);
+    }
+
+    public function testTruncateExitsOne(): void
+    {
+        $this->writeMigration('105_truncate.sql', "TRUNCATE TABLE foo;\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('truncate', $result['output']);
+    }
+
+    public function testRenameColumnExitsOne(): void
+    {
+        $this->writeMigration('106_rename.sql', "ALTER TABLE foo RENAME COLUMN a TO b;\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('rename-column', $result['output']);
+    }
+
+    public function testAddNotNullNoDefaultExitsOne(): void
+    {
+        $this->writeMigration('107_notnull.sql', "ALTER TABLE foo ADD COLUMN bar INT NOT NULL;\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('add-not-null-no-default', $result['output']);
+    }
+
+    public function testAddNotNullWithDefaultExitsZero(): void
+    {
+        $this->writeMigration('108_notnull_default.sql', "ALTER TABLE foo ADD COLUMN bar INT NOT NULL DEFAULT 0;\n");
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+    }
+
+    public function testInlineBypassExitsZero(): void
+    {
+        $sql = "-- destructive-migration: dropping unused legacy column after data migration confirmed\n";
+        $sql .= "ALTER TABLE foo DROP COLUMN bar;\n";
+        $this->writeMigration('109_bypassed.sql', $sql);
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('PASS (bypass)', $result['output']);
+    }
+
+    public function testShortInlineBypassExitsOne(): void
+    {
+        $sql = "-- destructive-migration: short\n";
+        $sql .= "ALTER TABLE foo DROP COLUMN bar;\n";
+        $this->writeMigration('110_short_bypass.sql', $sql);
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('drop-column', $result['output']);
+    }
+
+    public function testPrBodyBypassExitsZero(): void
+    {
+        $this->writeMigration('111_pr_bypass.sql', "ALTER TABLE foo DROP COLUMN bar;\n");
+        $this->runInDir('git add -A');
+
+        $prBody = '<!-- destructive-migration: removing deprecated column after successful data migration -->';
+        $result = $this->runScript(['--bypass-from-stdin'], $prBody);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('PASS (bypass)', $result['output']);
+    }
+
+    public function testShortPrBodyBypassExitsOne(): void
+    {
+        $this->writeMigration('112_short_pr.sql', "ALTER TABLE foo DROP COLUMN bar;\n");
+        $this->runInDir('git add -A');
+
+        $prBody = '<!-- destructive-migration: too short -->';
+        $result = $this->runScript(['--bypass-from-stdin'], $prBody);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('drop-column', $result['output']);
+    }
+
+    public function testBaselineFileAlwaysSkipped(): void
+    {
+        file_put_contents(
+            $this->tmpDir . '/ibl5/migrations/000_baseline_schema.sql',
+            "DROP TABLE IF EXISTS foo;\nCREATE TABLE foo (id INT);\n"
+        );
+        $this->runInDir('git add -A');
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+    }
+
+    public function testStagedAndSinceModesAgree(): void
+    {
+        $this->writeMigration('113_staged_since.sql', "ALTER TABLE foo DROP COLUMN bar;\n");
+        $this->runInDir('git add -A');
+
+        $stagedResult = $this->runScript(['--staged']);
+        self::assertSame(1, $stagedResult['exit'], 'staged mode should detect');
+
+        $baseSha = trim(shell_exec(
+            'git -C ' . escapeshellarg($this->tmpDir) . ' rev-parse HEAD'
+        ) ?: '');
+
+        $this->runInDir('git commit -m "add destructive migration"');
+
+        $sinceResult = $this->runScript(['--since=' . $baseSha]);
+        self::assertSame(1, $sinceResult['exit'], 'since mode should detect');
+
+        self::assertStringContainsString('drop-column', $stagedResult['output']);
+        self::assertStringContainsString('drop-column', $sinceResult['output']);
+    }
+
+    public function testHelpFlagExitsZero(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --help 2>&1', $output, $exit);
+
+        self::assertSame(0, $exit);
+        $text = implode("\n", $output);
+        self::assertStringContainsString('Usage:', $text);
+        self::assertStringContainsString('NOT scanned', $text);
+    }
+
+    public function testBogusArgExitsTwo(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --bogus 2>&1', $output, $exit);
+
+        self::assertSame(2, $exit);
+        self::assertStringContainsString('unknown flag', implode("\n", $output));
+    }
+
+    /**
+     * @param list<string> $args
+     * @return array{output: string, exit: int}
+     */
+    private function runScript(array $args = [], ?string $stdin = null): array
+    {
+        $output = [];
+        $exit = 0;
+
+        $argStr = '';
+        if ($args === []) {
+            $argStr = ' --staged';
+        }
+        foreach ($args as $arg) {
+            $argStr .= ' ' . escapeshellarg($arg);
+        }
+
+        $cmd = 'cd ' . escapeshellarg($this->tmpDir) . ' && ';
+
+        if ($stdin !== null) {
+            $cmd .= 'echo ' . escapeshellarg($stdin) . ' | ';
+        }
+
+        $cmd .= 'bash ' . escapeshellarg($this->scriptPath) . $argStr . ' 2>&1';
+
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function writeMigration(string $filename, string $content): void
+    {
+        file_put_contents($this->tmpDir . '/ibl5/migrations/' . $filename, $content);
+    }
+
+    private function runInDir(string $cmd): void
+    {
+        exec('cd ' . escapeshellarg($this->tmpDir) . ' && ' . $cmd . ' 2>&1');
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/ibl5/tests/Cli/CheckMasterCiGreenCliTest.php
+++ b/ibl5/tests/Cli/CheckMasterCiGreenCliTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class CheckMasterCiGreenCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $tmpDir;
+    private string $shimDir;
+    private string $repoDir;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/check-master-ci-green');
+        self::assertNotFalse($resolved, 'bin/check-master-ci-green must exist');
+        $this->scriptPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/ci-green-test-' . bin2hex(random_bytes(8));
+        $this->shimDir = $this->tmpDir . '/shims';
+        $this->repoDir = $this->tmpDir . '/repo';
+
+        mkdir($this->shimDir, 0755, true);
+        mkdir($this->repoDir, 0755, true);
+
+        exec('git init -b master ' . escapeshellarg($this->repoDir) . ' 2>&1');
+        exec('git -C ' . escapeshellarg($this->repoDir) . ' config user.email "test@test.com"');
+        exec('git -C ' . escapeshellarg($this->repoDir) . ' config user.name "Test"');
+        file_put_contents($this->repoDir . '/README.md', 'init');
+        exec('git -C ' . escapeshellarg($this->repoDir) . ' add -A');
+        exec('git -C ' . escapeshellarg($this->repoDir) . ' commit -m "initial" 2>&1');
+        exec('git -C ' . escapeshellarg($this->repoDir) . ' remote add origin https://github.com/test/repo.git 2>&1');
+        exec('git -C ' . escapeshellarg($this->repoDir) . ' update-ref refs/remotes/origin/master HEAD 2>&1');
+
+        $this->createGhShim(0);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    public function testAllGreenExitsZero(): void
+    {
+        $fixture = $this->writeFixture([
+            $this->checkRun('tests', 'completed', 'success'),
+            $this->checkRun('lint', 'completed', 'success'),
+            $this->checkRun('deploy', 'completed', 'success'),
+        ]);
+
+        $result = $this->runScript([], ['GH_API_CMD' => "cat $fixture #"]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('PASS', $result['output']);
+    }
+
+    public function testFailedCheckExitsOne(): void
+    {
+        $fixture = $this->writeFixture([
+            $this->checkRun('tests', 'completed', 'success'),
+            $this->checkRun('deploy', 'completed', 'failure'),
+        ]);
+
+        $result = $this->runScript([], ['GH_API_CMD' => "cat $fixture #"]);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('deploy', $result['output']);
+    }
+
+    public function testInProgressExitsOne(): void
+    {
+        $fixture = $this->writeFixture([
+            $this->checkRun('tests', 'completed', 'success'),
+            $this->checkRun('e2e', 'in_progress', null),
+        ]);
+
+        $result = $this->runScript([], ['GH_API_CMD' => "cat $fixture #"]);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('still running', $result['output']);
+    }
+
+    public function testNoChecksFoundExitsOne(): void
+    {
+        $fixture = $this->writeFixture([]);
+
+        $result = $this->runScript([], ['GH_API_CMD' => "cat $fixture #"]);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('0 check-run', $result['output']);
+    }
+
+    public function testMinRequiredEnvOverride(): void
+    {
+        $fixture = $this->writeFixture([
+            $this->checkRun('tests', 'completed', 'success'),
+            $this->checkRun('lint', 'completed', 'success'),
+        ]);
+
+        $result = $this->runScript([], [
+            'GH_API_CMD' => "cat $fixture #",
+            'MIN_REQUIRED_CHECKS' => '3',
+        ]);
+
+        self::assertSame(1, $result['exit']);
+        self::assertStringContainsString('only 2', $result['output']);
+    }
+
+    public function testSkipCiCheckBypassesFailure(): void
+    {
+        $result = $this->runScript(['--skip-ci-check']);
+
+        self::assertSame(0, $result['exit']);
+        self::assertStringContainsString('BYPASS', $result['output']);
+    }
+
+    public function testHelpFlagExitsZero(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --help 2>&1', $output, $exit);
+
+        self::assertSame(0, $exit);
+        self::assertStringContainsString('Usage:', implode("\n", $output));
+    }
+
+    public function testBogusArgExitsTwo(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --bogus 2>&1', $output, $exit);
+
+        self::assertSame(2, $exit);
+        self::assertStringContainsString('unknown flag', implode("\n", $output));
+    }
+
+    public function testGhUnauthenticatedExitsTwo(): void
+    {
+        $this->createGhShim(1);
+
+        $result = $this->runScript([]);
+
+        self::assertSame(2, $result['exit']);
+        self::assertStringContainsString('gh auth login', $result['output']);
+    }
+
+    /**
+     * @return array{output: string, exit: int}
+     */
+    private function runScript(array $args = [], array $env = []): array
+    {
+        $output = [];
+        $exit = 0;
+
+        $envPrefix = 'PATH=' . escapeshellarg($this->shimDir . ':' . getenv('PATH'));
+        foreach ($env as $key => $value) {
+            $envPrefix .= ' ' . $key . '=' . escapeshellarg($value);
+        }
+
+        $argStr = '';
+        foreach ($args as $arg) {
+            $argStr .= ' ' . escapeshellarg($arg);
+        }
+
+        $cmd = 'cd ' . escapeshellarg($this->repoDir)
+            . ' && ' . $envPrefix
+            . ' bash ' . escapeshellarg($this->scriptPath) . $argStr . ' 2>&1';
+
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function createGhShim(int $authExitCode): void
+    {
+        $script = "#!/bin/bash\n";
+        $script .= "if [[ \"\$1\" == \"auth\" && \"\$2\" == \"status\" ]]; then\n";
+        $script .= "    exit $authExitCode\n";
+        $script .= "fi\n";
+        $script .= "exit 1\n";
+        file_put_contents($this->shimDir . '/gh', $script);
+        chmod($this->shimDir . '/gh', 0755);
+    }
+
+    private function writeFixture(array $checkRuns): string
+    {
+        $path = $this->tmpDir . '/fixture-' . bin2hex(random_bytes(4)) . '.json';
+        $data = json_encode(['check_runs' => $checkRuns], JSON_PRETTY_PRINT);
+        file_put_contents($path, $data);
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function checkRun(string $name, string $status, ?string $conclusion): array
+    {
+        $run = [
+            'name' => $name,
+            'status' => $status,
+        ];
+        if ($conclusion !== null) {
+            $run['conclusion'] = $conclusion;
+        }
+        return $run;
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/ibl5/tests/Cli/MergeMasterToProdCliTest.php
+++ b/ibl5/tests/Cli/MergeMasterToProdCliTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class MergeMasterToProdCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $tmpDir;
+    private string $originDir;
+    private string $cloneDir;
+    private string $shimDir;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/merge-master-to-prod');
+        self::assertNotFalse($resolved, 'bin/merge-master-to-prod must exist');
+        $this->scriptPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/merge-prod-test-' . bin2hex(random_bytes(8));
+        $this->originDir = $this->tmpDir . '/origin.git';
+        $this->cloneDir = $this->tmpDir . '/clone';
+        $this->shimDir = $this->tmpDir . '/shims';
+
+        mkdir($this->tmpDir, 0755, true);
+        mkdir($this->shimDir, 0755, true);
+
+        $this->createBareOrigin();
+        $this->createWorkingClone();
+        $this->createShims();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    public function testHappyPath(): void
+    {
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Expected exit 0, got: {$result['output']}");
+        self::assertStringContainsString('Done. Pushed master and production.', $result['output']);
+
+        $masterSha = trim(shell_exec('git -C ' . escapeshellarg($this->originDir) . ' rev-parse master') ?: '');
+        $prodSha = trim(shell_exec('git -C ' . escapeshellarg($this->originDir) . ' rev-parse production') ?: '');
+        self::assertSame($masterSha, $prodSha, 'production should match master after merge');
+    }
+
+    public function testInvokesCiGreenGate(): void
+    {
+        $sentinel = $this->tmpDir . '/ci-gate-called';
+        $binDir = $this->cloneDir . '/bin';
+        file_put_contents(
+            $binDir . '/check-master-ci-green',
+            "#!/bin/bash\ntouch " . escapeshellarg($sentinel) . "\nexit 0\n"
+        );
+        chmod($binDir . '/check-master-ci-green', 0755);
+
+        $this->runScript();
+
+        self::assertFileExists($sentinel, 'check-master-ci-green should have been called');
+    }
+
+    public function testSkipCiCheckEnvBypassesGate(): void
+    {
+        $binDir = $this->cloneDir . '/bin';
+        file_put_contents($binDir . '/check-master-ci-green', "#!/bin/bash\nexit 1\n");
+        chmod($binDir . '/check-master-ci-green', 0755);
+
+        $result = $this->runScript(['SKIP_CI_CHECK' => '1']);
+
+        self::assertSame(0, $result['exit'], "Expected exit 0 with SKIP_CI_CHECK, got: {$result['output']}");
+        self::assertStringContainsString('Done. Pushed master and production.', $result['output']);
+    }
+
+    public function testRedCiAbortsBeforePush(): void
+    {
+        $binDir = $this->cloneDir . '/bin';
+        file_put_contents($binDir . '/check-master-ci-green', "#!/bin/bash\nexit 1\n");
+        chmod($binDir . '/check-master-ci-green', 0755);
+
+        $prodShaBefore = trim(shell_exec('git -C ' . escapeshellarg($this->originDir) . ' rev-parse production') ?: '');
+
+        $result = $this->runScript();
+
+        self::assertNotSame(0, $result['exit'], 'Should fail when CI is red');
+        self::assertStringContainsString('not green on CI', $result['output']);
+
+        $prodShaAfter = trim(shell_exec('git -C ' . escapeshellarg($this->originDir) . ' rev-parse production') ?: '');
+        self::assertSame($prodShaBefore, $prodShaAfter, 'production should not have changed');
+    }
+
+    public function testDivergedProductionAborts(): void
+    {
+        $prodClone = $this->tmpDir . '/prod-pusher';
+        exec('git clone ' . escapeshellarg($this->originDir) . ' ' . escapeshellarg($prodClone) . ' 2>&1');
+        exec('git -C ' . escapeshellarg($prodClone) . ' checkout production 2>&1');
+        exec('git -C ' . escapeshellarg($prodClone) . ' config user.email "test@test.com"');
+        exec('git -C ' . escapeshellarg($prodClone) . ' config user.name "Test"');
+        file_put_contents($prodClone . '/diverged.txt', 'production-only commit');
+        exec('git -C ' . escapeshellarg($prodClone) . ' add -A');
+        exec('git -C ' . escapeshellarg($prodClone) . ' commit -m "diverge production" 2>&1');
+        exec('git -C ' . escapeshellarg($prodClone) . ' push origin production 2>&1');
+
+        $prodShaBefore = trim(shell_exec('git -C ' . escapeshellarg($this->originDir) . ' rev-parse production') ?: '');
+
+        $result = $this->runScript();
+
+        self::assertNotSame(0, $result['exit'], 'Should fail when production has diverged');
+        self::assertStringContainsString('fast-forward failed', $result['output']);
+
+        $prodShaAfter = trim(shell_exec('git -C ' . escapeshellarg($this->originDir) . ' rev-parse production') ?: '');
+        self::assertSame($prodShaBefore, $prodShaAfter, 'production should not have changed');
+    }
+
+    /**
+     * @return array{output: string, exit: int}
+     */
+    private function runScript(array $env = []): array
+    {
+        $output = [];
+        $exit = 0;
+
+        $envPrefix = 'PATH=' . escapeshellarg($this->shimDir . ':' . getenv('PATH'));
+        $envPrefix .= ' SKIP_WT_CLEANUP=1';
+        foreach ($env as $key => $value) {
+            $envPrefix .= ' ' . $key . '=' . escapeshellarg($value);
+        }
+
+        $cmd = 'cd ' . escapeshellarg($this->cloneDir)
+            . ' && ' . $envPrefix
+            . ' bash ' . escapeshellarg($this->scriptPath) . ' 2>&1';
+
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function createBareOrigin(): void
+    {
+        exec('git init --bare ' . escapeshellarg($this->originDir) . ' 2>&1');
+
+        $setup = $this->tmpDir . '/setup';
+        mkdir($setup, 0755, true);
+        exec('git clone ' . escapeshellarg($this->originDir) . ' ' . escapeshellarg($setup) . ' 2>&1');
+        exec('git -C ' . escapeshellarg($setup) . ' config user.email "test@test.com"');
+        exec('git -C ' . escapeshellarg($setup) . ' config user.name "Test"');
+        exec('git -C ' . escapeshellarg($setup) . ' checkout -b master 2>&1');
+        file_put_contents($setup . '/README.md', 'init');
+        exec('git -C ' . escapeshellarg($setup) . ' add -A');
+        exec('git -C ' . escapeshellarg($setup) . ' commit -m "initial" 2>&1');
+        exec('git -C ' . escapeshellarg($setup) . ' push origin master 2>&1');
+
+        exec('git -C ' . escapeshellarg($setup) . ' checkout -b production 2>&1');
+        exec('git -C ' . escapeshellarg($setup) . ' push origin production 2>&1');
+
+        exec('git -C ' . escapeshellarg($setup) . ' checkout master 2>&1');
+        file_put_contents($setup . '/feature.txt', 'new feature');
+        exec('git -C ' . escapeshellarg($setup) . ' add -A');
+        exec('git -C ' . escapeshellarg($setup) . ' commit -m "add feature" 2>&1');
+        exec('git -C ' . escapeshellarg($setup) . ' push origin master 2>&1');
+
+        $this->recursiveRm($setup);
+    }
+
+    private function createWorkingClone(): void
+    {
+        exec('git clone ' . escapeshellarg($this->originDir) . ' ' . escapeshellarg($this->cloneDir) . ' 2>&1');
+        exec('git -C ' . escapeshellarg($this->cloneDir) . ' config user.email "test@test.com"');
+        exec('git -C ' . escapeshellarg($this->cloneDir) . ' config user.name "Test"');
+        exec('git -C ' . escapeshellarg($this->cloneDir) . ' checkout master 2>&1');
+        exec('git -C ' . escapeshellarg($this->cloneDir) . ' branch production origin/production 2>&1');
+    }
+
+    private function createShims(): void
+    {
+        file_put_contents($this->shimDir . '/gh', "#!/bin/bash\nexit 0\n");
+        chmod($this->shimDir . '/gh', 0755);
+
+        $binDir = $this->cloneDir . '/bin';
+        mkdir($binDir, 0755, true);
+
+        file_put_contents($binDir . '/cleanup', "#!/bin/bash\nexit 0\n");
+        chmod($binDir . '/cleanup', 0755);
+
+        file_put_contents($binDir . '/check-master-ci-green', "#!/bin/bash\nexit 0\n");
+        chmod($binDir . '/check-master-ci-green', 0755);
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

Closes two gaps in the master→production merge harness:

1. **CI-green gate on `bin/merge-master-to-prod`**: The script now calls `bin/check-master-ci-green` to verify all GitHub check-runs pass on master HEAD before fast-forwarding production. Emergency bypass: `SKIP_CI_CHECK=1`.

2. **Destructive migration scan in CI**: New `destructive-migration-scan` job in `migration-safety.yml` runs `bin/check-destructive-migrations` on every PR/push touching `ibl5/migrations/*.sql`. Detects 5 patterns: `DROP COLUMN`, `DROP TABLE`, `TRUNCATE`, `RENAME COLUMN`, `ADD NOT NULL` without `DEFAULT`. Bypass via inline SQL comment or PR-body HTML comment (reason ≥20 chars required).

A `gate:` aggregator job ensures all 4 migration-safety jobs must pass.

## New Scripts

- **`bin/check-master-ci-green`** — queries GitHub check-runs API, supports `GH_API_CMD` for testability
- **`bin/check-destructive-migrations`** — scans migration diffs for destructive SQL patterns, follows `bin/refactor-flag` conventions

## Tests

31 new tests across 3 files:
- `MergeMasterToProdCliTest` (5 tests) — bare-origin temp repo pattern
- `CheckMasterCiGreenCliTest` (9 tests) — fixture JSON + PATH shim pattern
- `CheckDestructiveMigrationsCliTest` (17 tests) — temp git repo + staged diff pattern

## Manual Testing

No manual testing needed — all changes are covered by automated tests.

<!-- no-adr: new bin/ scripts are operational CI gates following established bin/refactor-flag patterns, not architectural decisions -->