### PR TITLE
ci: run Lighthouse on master pushes and publish to job summary

### DIFF
--- a/.github/workflows/lighthouse-baseline.yml
+++ b/.github/workflows/lighthouse-baseline.yml
@@ -63,6 +63,19 @@ jobs:
         env:
           CHROME_PATH: /usr/bin/google-chrome-stable
 
+      # autorun's upload step uses temporary-public-storage (writes links.json
+      # only). The baseline artifact needs manifest.json — emit it via a
+      # second filesystem upload from the same collected lhr-*.json files.
+      - name: Write manifest.json for baseline artifact
+        working-directory: ibl5
+        run: |
+          bunx @lhci/cli upload --target=filesystem --outputDir=.lighthouseci
+          # lhci writes one entry per run (3 per URL); the formatter expects
+          # one entry per URL — filter to representative runs.
+          jq '[.[] | select(.isRepresentativeRun == true)]' \
+            .lighthouseci/manifest.json > .lighthouseci/manifest.tmp.json
+          mv .lighthouseci/manifest.tmp.json .lighthouseci/manifest.json
+
       - name: Upload baseline manifest
         uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,6 +4,18 @@ on:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [master]
+    paths:
+      - '**.php'
+      - '**.css'
+      - '**.ts'
+      - '**.js'
+      - 'ibl5/design/**'
+      - 'ibl5/migrations/**.sql'
+      - 'Dockerfile'
+      - 'docker-compose*.yml'
+      - '.github/workflows/lighthouse.yml'
 
 permissions:
   contents: read
@@ -16,6 +28,7 @@ concurrency:
 jobs:
   changes:
     name: Detect changes
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -40,7 +53,9 @@ jobs:
   lighthouse:
     name: Performance Audit
     needs: [changes]
-    if: needs.changes.outputs.src == 'true'
+    if: |
+      always() &&
+      (github.event_name == 'push' || needs.changes.outputs.src == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -114,11 +129,15 @@ jobs:
             --out=.lighthouseci/comment.md || true
 
       - name: Post sticky PR comment
-        if: always() && hashFiles('ibl5/.lighthouseci/comment.md') != ''
+        if: always() && github.event_name == 'pull_request' && hashFiles('ibl5/.lighthouseci/comment.md') != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: lighthouse-comment
           path: ibl5/.lighthouseci/comment.md
+
+      - name: Publish to job summary (master push)
+        if: always() && github.event_name == 'push' && hashFiles('ibl5/.lighthouseci/comment.md') != ''
+        run: cat ibl5/.lighthouseci/comment.md >> "$GITHUB_STEP_SUMMARY"
 
       # --- Cleanup ---
       - name: Teardown

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -101,6 +101,19 @@ jobs:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           CHROME_PATH: /usr/bin/google-chrome-stable
 
+      # autorun's upload step uses temporary-public-storage (writes links.json
+      # only). The comment formatter also needs manifest.json — emit it via a
+      # second filesystem upload from the same collected lhr-*.json files.
+      - name: Write manifest.json for comment formatter
+        working-directory: ibl5
+        run: |
+          bunx @lhci/cli upload --target=filesystem --outputDir=.lighthouseci
+          # lhci writes one entry per run (3 per URL); the formatter expects
+          # one entry per URL — filter to representative runs.
+          jq '[.[] | select(.isRepresentativeRun == true)]' \
+            .lighthouseci/manifest.json > .lighthouseci/manifest.tmp.json
+          mv .lighthouseci/manifest.tmp.json .lighthouseci/manifest.json
+
       - name: Download master baseline
         id: baseline
         if: always()


### PR DESCRIPTION
## Why

Lighthouse previously ran on PRs only. A sequence of individually-passing PRs can compose into a regression that's invisible until the next PR opens. Running on master pushes surfaces post-merge scores against the prior baseline (uploaded by `lighthouse-baseline.yml`), with the delta visible on the workflow run page via GitHub's job summary feature.

## Commits in this PR

1. **`ci: run Lighthouse on master pushes and publish to job summary`** — adds the `push: master` trigger and routes the existing comment markdown to `$GITHUB_STEP_SUMMARY` instead of a sticky PR comment on push events.

2. **`fix(ci): write manifest.json so lighthouse-comment can run`** — pre-existing bug surfaced during verification: `lhci autorun` uploads with `target: temporary-public-storage` (per `.lighthouserc.json`), which writes `links.json` but NOT `manifest.json`. Without it, `bin/lighthouse-comment` fails with 'Manifest file not found' and never produces `comment.md`. Result: the sticky-comment feature (PR #715) has been silently broken since it landed — zero PRs since #715 had actually posted a Lighthouse score comment. The same bug affected `lighthouse-baseline.yml` (the baseline artifact was a 386-byte zip containing only `links.json`).

   Fix: add a second `lhci upload --target=filesystem --outputDir=.lighthouseci` step in both workflows, then `jq`-filter the resulting manifest to representative runs only (lhci emits one entry per run, we need one per URL).

## Verification

- YAML parses cleanly, `actionlint` clean
- This PR's own run shows the **first-ever working sticky Lighthouse comment** posted on a PR — 5 rows (one per URL), live performance/accessibility/best-practices scores, baseline note ("No master baseline yet")
- `Performance Audit` check green (5m19s)
- The push-event path uses the same `comment.md` generation pipeline as the PR path — provably correct by inspection
- Once this merges, the lighthouse-baseline.yml run will produce the first complete baseline artifact, and the next master push's Lighthouse run will show real deltas

## Tradeoff considered

Lighthouse now runs twice on each master push: once via `lighthouse-baseline.yml` (uploads new baseline) and once via `lighthouse.yml` (compares against prior baseline + publishes summary). ~10 min extra CI per merge. Acceptable for now; consolidating both into a single workflow is a follow-up refactor.