### PR TITLE
feat: add EOY award generation prompts to updater pipeline

### DIFF
--- a/ibl5/classes/LeagueControlPanel/Contracts/LeagueControlPanelRepositoryInterface.php
+++ b/ibl5/classes/LeagueControlPanel/Contracts/LeagueControlPanelRepositoryInterface.php
@@ -197,4 +197,21 @@ interface LeagueControlPanelRepositoryInterface
      * @return int Number of deleted rows
      */
     public function deleteOutdatedBuyoutsAndCash(): int;
+
+    /**
+     * Check if season awards have been generated for the given year.
+     *
+     * Uses "Most Valuable Player (1st)" as the sentinel award.
+     *
+     * @param int $year Season ending year
+     * @return bool True if awards exist
+     */
+    public function hasGeneratedAwardsForYear(int $year): bool;
+
+    /**
+     * Count how many teams have cast their EOY vote.
+     *
+     * @return int Number of votes cast (eoy_vote != 'No Vote')
+     */
+    public function getEoyVotesCastCount(): int;
 }

--- a/ibl5/classes/LeagueControlPanel/LeagueControlPanelRepository.php
+++ b/ibl5/classes/LeagueControlPanel/LeagueControlPanelRepository.php
@@ -335,4 +335,30 @@ class LeagueControlPanelRepository extends \BaseMysqliRepository implements Leag
 
         return $row !== null;
     }
+
+    /**
+     * @see LeagueControlPanelRepositoryInterface::hasGeneratedAwardsForYear()
+     */
+    public function hasGeneratedAwardsForYear(int $year): bool
+    {
+        $row = $this->fetchOne(
+            "SELECT table_id FROM ibl_awards WHERE year = ? AND award = 'Most Valuable Player (1st)' LIMIT 1",
+            'i',
+            $year
+        );
+        return $row !== null;
+    }
+
+    /**
+     * @see LeagueControlPanelRepositoryInterface::getEoyVotesCastCount()
+     */
+    public function getEoyVotesCastCount(): int
+    {
+        /** @var array{cnt: int}|null $row */
+        $row = $this->fetchOne(
+            "SELECT COUNT(*) AS cnt FROM ibl_team_info WHERE eoy_vote != 'No Vote' AND teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID,
+            ""
+        );
+        return $row !== null ? $row['cnt'] : 0;
+    }
 }

--- a/ibl5/classes/Updater/Steps/EndOfSeasonImportStep.php
+++ b/ibl5/classes/Updater/Steps/EndOfSeasonImportStep.php
@@ -29,6 +29,7 @@ final class EndOfSeasonImportStep implements PipelineStepInterface
         private readonly JsbImportService $jsbService,
         private readonly int $seasonEndingYear,
         private readonly JsbSourceResolverInterface $sourceResolver,
+        private readonly bool $hasFinalsMvp = true,
     ) {
     }
 
@@ -52,9 +53,12 @@ final class EndOfSeasonImportStep implements PipelineStepInterface
         $this->importHof($result, $messages);
         $this->importAwa($result, $messages);
 
+        $inlineHtml = $this->renderFinalsMvpCard();
+
         return StepResult::success(
             $this->getLabel(),
             $result->summary(),
+            inlineHtml: $inlineHtml,
             messages: $messages,
             messageErrorCount: $result->errors,
         );
@@ -119,5 +123,39 @@ final class EndOfSeasonImportStep implements PipelineStepInterface
         $awaResult = $this->jsbService->processAwaData($awaData, $carData, $this->seasonEndingYear);
         $result->merge($awaResult);
         $messages[] = 'AWA: ' . $awaResult->summary();
+    }
+
+    private function renderFinalsMvpCard(): string
+    {
+        if ($this->hasFinalsMvp) {
+            ob_start();
+            ?>
+<div class="ibl-card sco-parse-result">
+    <div class="ibl-card__header">
+        <h2 class="ibl-card__title">IBL Finals MVP</h2>
+    </div>
+    <div class="ibl-card__body">
+        <span class="step-result__icon step-result__icon--ok">✔</span> Finals MVP already recorded
+    </div>
+</div>
+            <?php
+            return (string) ob_get_clean();
+        }
+
+        ob_start();
+        ?>
+<div class="ibl-card sco-parse-result">
+    <div class="ibl-card__header">
+        <h2 class="ibl-card__title">IBL Finals MVP</h2>
+    </div>
+    <div class="ibl-card__body">
+        <form method="POST" action="/ibl5/leagueControlPanel.php">
+            <input type="text" name="finals_mvp_name" maxlength="32" placeholder="Finals MVP name" class="ibl-input ibl-input--sm">
+            <button type="submit" name="action" value="set_finals_mvp" class="ibl-btn ibl-btn--primary">Set Finals MVP</button>
+        </form>
+    </div>
+</div>
+        <?php
+        return (string) ob_get_clean();
     }
 }

--- a/ibl5/classes/Updater/Steps/GenerateSeasonAwardsStep.php
+++ b/ibl5/classes/Updater/Steps/GenerateSeasonAwardsStep.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Updater\Steps;
+
+use Updater\Contracts\PipelineStepInterface;
+use Updater\StepResult;
+
+final class GenerateSeasonAwardsStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly string $seasonPhase,
+        private readonly int $seasonEndingYear,
+        private readonly int $eoyVotesCast,
+        private readonly int $totalRealTeams,
+        private readonly bool $awardsAlreadyGenerated,
+        private readonly bool $leadersHtmExists,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Season awards';
+    }
+
+    public function execute(): StepResult
+    {
+        if ($this->awardsAlreadyGenerated) {
+            return StepResult::success(
+                $this->getLabel(),
+                'Season awards already generated for ' . $this->seasonEndingYear,
+            );
+        }
+
+        if ($this->seasonPhase !== 'Playoffs') {
+            return StepResult::skipped($this->getLabel(), 'Only available during Playoffs phase');
+        }
+
+        $threshold = (int) ceil($this->totalRealTeams * 0.75);
+        if ($this->eoyVotesCast < $threshold) {
+            return StepResult::skipped(
+                $this->getLabel(),
+                'Voting not yet complete (' . $this->eoyVotesCast . '/' . $this->totalRealTeams . ' votes submitted)',
+            );
+        }
+
+        if (!$this->leadersHtmExists) {
+            return StepResult::skipped(
+                $this->getLabel(),
+                'Leaders.htm not found — upload sim backup before generating awards',
+            );
+        }
+
+        return StepResult::success($this->getLabel(), inlineHtml: $this->renderForm());
+    }
+
+    private function renderForm(): string
+    {
+        ob_start();
+        ?>
+<div class="ibl-card sco-parse-result">
+    <div class="ibl-card__header">
+        <h2 class="ibl-card__title">Season Awards</h2>
+        <div class="ibl-card__subtitle"><?= $this->eoyVotesCast ?>/<?= $this->totalRealTeams ?> EOY votes submitted</div>
+    </div>
+    <div class="ibl-card__body">
+        <form method="POST" action="/ibl5/leagueControlPanel.php">
+            <button type="submit" name="action" value="generate_awards" class="ibl-btn ibl-btn--primary">Generate Season Awards</button>
+        </form>
+    </div>
+</div>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -217,10 +217,26 @@ try {
 
     $updaterService->addStep(new Updater\Steps\ParseJsbFilesStep($jsbService, $sourceResolver, $season->endingYear));
 
-    // IBL-only: End-of-season imports when champion exists
+    // IBL-only: Season awards + end-of-season imports when champion exists
     if (!$isOlympics) {
+        $lcpRepo = new LeagueControlPanel\LeagueControlPanelRepository($mysqli_db);
+        $seasonPhase = $lcpRepo->getSetting('Current Season Phase') ?? '';
+        $eoyVotesCast = $lcpRepo->getEoyVotesCastCount();
+        $awardsAlreadyGenerated = $lcpRepo->hasGeneratedAwardsForYear($season->endingYear);
+        $leadersHtmExists = file_exists($basePath . '/Leaders.htm');
+        $hasFinalsMvp = $lcpRepo->hasFinalsMvp($season->endingYear);
+
+        $updaterService->addStep(new Updater\Steps\GenerateSeasonAwardsStep(
+            $seasonPhase,
+            $season->endingYear,
+            $eoyVotesCast,
+            League\League::MAX_REAL_TEAMID,
+            $awardsAlreadyGenerated,
+            $leadersHtmExists,
+        ));
+
         $updaterService->addStep(new Updater\Steps\EndOfSeasonImportStep(
-            $jsbRepo, $jsbService, $season->endingYear, $sourceResolver,
+            $jsbRepo, $jsbService, $season->endingYear, $sourceResolver, $hasFinalsMvp,
         ));
     }
 

--- a/ibl5/test-state.php
+++ b/ibl5/test-state.php
@@ -159,6 +159,29 @@ if ($method === 'DELETE' && $action === 'delete-test-user') {
     exit;
 }
 
+// DELETE ?action=set-eoy-votes&count=N — set N teams as having voted for E2E
+// testing of the updater awards step. Teams 1..count get a non-default vote,
+// teams (count+1)..28 get reset to 'No Vote'.
+if ($method === 'DELETE' && $action === 'set-eoy-votes') {
+    $count = (int)($_GET['count'] ?? -1);
+    if ($count < 0 || $count > 28) {
+        http_response_code(400);
+        echo json_encode(['error' => 'set-eoy-votes count must be 0-28']);
+        $db->close();
+        exit;
+    }
+    if ($count > 0) {
+        $db->query("UPDATE ibl_team_info SET eoy_vote = NOW() WHERE teamid BETWEEN 1 AND $count");
+    }
+    if ($count < 28) {
+        $next = $count + 1;
+        $db->query("UPDATE ibl_team_info SET eoy_vote = 'No Vote' WHERE teamid BETWEEN $next AND 28");
+    }
+    echo json_encode(['set' => $count]);
+    $db->close();
+    exit;
+}
+
 if ($method === 'GET') {
     $result = $db->query('SELECT name, value FROM ibl_settings');
     $settings = [];

--- a/ibl5/tests/DatabaseIntegration/LeagueControlPanelRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/LeagueControlPanelRepositoryTest.php
@@ -326,6 +326,37 @@ class LeagueControlPanelRepositoryTest extends DatabaseTestCase
         return is_array($row) ? $row : null;
     }
 
+    // ── hasGeneratedAwardsForYear ──────────────────────────────────
+
+    public function testHasGeneratedAwardsForYearReturnsTrueWhenMvpExists(): void
+    {
+        $this->insertRow('ibl_awards', [
+            'year' => 2099,
+            'award' => 'Most Valuable Player (1st)',
+            'name' => 'Test Player',
+        ]);
+
+        self::assertTrue($this->repo->hasGeneratedAwardsForYear(2099));
+    }
+
+    public function testHasGeneratedAwardsForYearReturnsFalseWhenNoMvp(): void
+    {
+        self::assertFalse($this->repo->hasGeneratedAwardsForYear(2099));
+    }
+
+    // ── getEoyVotesCastCount ───────────────────────────────────────
+
+    public function testGetEoyVotesCastCountReturnsCorrectCount(): void
+    {
+        // CI seed has all 28 teams with eoy_vote = 'No Vote' by default
+        // Set some votes to a non-default value
+        $this->db->query("UPDATE ibl_team_info SET eoy_vote = '2026-01-15' WHERE teamid IN (1, 2, 3)");
+
+        $count = $this->repo->getEoyVotesCastCount();
+
+        self::assertSame(3, $count);
+    }
+
     // ── setFreeAgencyFactorsForPfw ──────────────────────────────
 
     public function testSetFreeAgencyFactorsForPfwUpdatesTeamInfo(): void

--- a/ibl5/tests/UpdateAllTheThings/Steps/EndOfSeasonImportStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/EndOfSeasonImportStepTest.php
@@ -136,4 +136,62 @@ class EndOfSeasonImportStepTest extends TestCase
         $this->assertTrue($result->success);
         $this->assertSame([], $result->messages);
     }
+
+    public function testRendersFinalsMvpFormWhenChampionExistsAndNoMvp(): void
+    {
+        $this->stubRepo->method('hasChampionForSeason')->willReturn(true);
+        $this->stubResolver->method('getContents')->willReturn(null);
+
+        $step = new EndOfSeasonImportStep(
+            $this->stubRepo,
+            $this->stubService,
+            2026,
+            $this->stubResolver,
+            false,
+        );
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('set_finals_mvp', $result->inlineHtml);
+        $this->assertStringContainsString('Finals MVP name', $result->inlineHtml);
+        $this->assertStringContainsString('ibl-btn--primary', $result->inlineHtml);
+    }
+
+    public function testShowsFinalsMvpCheckmarkWhenAlreadyRecorded(): void
+    {
+        $this->stubRepo->method('hasChampionForSeason')->willReturn(true);
+        $this->stubResolver->method('getContents')->willReturn(null);
+
+        $step = new EndOfSeasonImportStep(
+            $this->stubRepo,
+            $this->stubService,
+            2026,
+            $this->stubResolver,
+            true,
+        );
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('Finals MVP already recorded', $result->inlineHtml);
+    }
+
+    public function testNoFinalsMvpPromptWhenNoChampion(): void
+    {
+        $this->stubRepo->method('hasChampionForSeason')->willReturn(false);
+
+        $step = new EndOfSeasonImportStep(
+            $this->stubRepo,
+            $this->stubService,
+            2026,
+            $this->stubResolver,
+            false,
+        );
+
+        $result = $step->execute();
+
+        $this->assertStringContainsString('No champion', $result->detail);
+        $this->assertSame('', $result->inlineHtml);
+    }
 }

--- a/ibl5/tests/UpdateAllTheThings/Steps/GenerateSeasonAwardsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/GenerateSeasonAwardsStepTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UpdateAllTheThings\Steps;
+
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Steps\GenerateSeasonAwardsStep;
+
+class GenerateSeasonAwardsStepTest extends TestCase
+{
+    private function createStep(
+        string $seasonPhase = 'Playoffs',
+        int $seasonEndingYear = 2026,
+        int $eoyVotesCast = 28,
+        int $totalRealTeams = 28,
+        bool $awardsAlreadyGenerated = false,
+        bool $leadersHtmExists = true,
+    ): GenerateSeasonAwardsStep {
+        return new GenerateSeasonAwardsStep(
+            $seasonPhase,
+            $seasonEndingYear,
+            $eoyVotesCast,
+            $totalRealTeams,
+            $awardsAlreadyGenerated,
+            $leadersHtmExists,
+        );
+    }
+
+    public function testImplementsPipelineStepInterface(): void
+    {
+        $this->assertInstanceOf(PipelineStepInterface::class, $this->createStep());
+    }
+
+    public function testGetLabelReturnsExpectedLabel(): void
+    {
+        $this->assertSame('Season awards', $this->createStep()->getLabel());
+    }
+
+    public function testShowsSuccessWhenAwardsAlreadyGenerated(): void
+    {
+        $step = $this->createStep(awardsAlreadyGenerated: true);
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('already generated', $result->detail);
+        $this->assertStringContainsString('2026', $result->detail);
+        $this->assertSame('', $result->inlineHtml);
+    }
+
+    public function testSkipsWhenPhaseIsNotPlayoffs(): void
+    {
+        $step = $this->createStep(seasonPhase: 'Regular Season');
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('Only available during Playoffs', $result->detail);
+    }
+
+    public function testSkipsWhenVotingBelowThreshold(): void
+    {
+        $step = $this->createStep(eoyVotesCast: 20, totalRealTeams: 28);
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('Voting not yet complete', $result->detail);
+        $this->assertStringContainsString('20/28', $result->detail);
+    }
+
+    public function testSkipsWhenLeadersHtmMissing(): void
+    {
+        $step = $this->createStep(leadersHtmExists: false);
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('Leaders.htm not found', $result->detail);
+    }
+
+    public function testRendersFormWhenAllPrerequisitesMet(): void
+    {
+        $step = $this->createStep();
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('generate_awards', $result->inlineHtml);
+        $this->assertStringContainsString('Generate Season Awards', $result->inlineHtml);
+        $this->assertStringContainsString('ibl-card', $result->inlineHtml);
+        $this->assertStringContainsString('28/28 EOY votes', $result->inlineHtml);
+    }
+
+    public function testThresholdBoundary21Of28Passes(): void
+    {
+        $step = $this->createStep(eoyVotesCast: 21, totalRealTeams: 28);
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('generate_awards', $result->inlineHtml);
+    }
+
+    public function testThresholdBoundary20Of28Fails(): void
+    {
+        $step = $this->createStep(eoyVotesCast: 20, totalRealTeams: 28);
+
+        $result = $step->execute();
+
+        $this->assertTrue($result->success);
+        $this->assertStringContainsString('Voting not yet complete', $result->detail);
+        $this->assertSame('', $result->inlineHtml);
+    }
+}

--- a/ibl5/tests/e2e/helpers/test-state.ts
+++ b/ibl5/tests/e2e/helpers/test-state.ts
@@ -41,6 +41,20 @@ export async function setState(
   return (await response.json()) as SetStateResult;
 }
 
+export async function setEoyVotes(
+  request: APIRequestContext,
+  count: number,
+): Promise<void> {
+  const response = await request.delete(
+    `test-state.php?action=set-eoy-votes&count=${count}`,
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `test-state.php set-eoy-votes failed: ${response.status()} ${await response.text()}`,
+    );
+  }
+}
+
 export type SetStateFn = (settings: Settings) => Promise<SetStateResult>;
 
 /**

--- a/ibl5/tests/e2e/smoke/updater-awards.spec.ts
+++ b/ibl5/tests/e2e/smoke/updater-awards.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '../fixtures/auth';
+import { setEoyVotes } from '../helpers/test-state';
+
+// E2E tests for the updater awards steps:
+//   - GenerateSeasonAwardsStep (Season awards card)
+//   - EndOfSeasonImportStep Finals MVP card
+//
+// The CI seed has:
+//   - No ibl_jsb_history rows with won_championship=1 for year 2026,
+//     so EndOfSeasonImportStep is skipped ("No champion determined yet")
+//   - No Leaders.htm at $basePath/Leaders.htm, so the Generate button
+//     is gated behind "Leaders.htm not found" even when votes ≥ 75%
+//   - No 'Most Valuable Player (1st)' award for 2026, so
+//     awardsAlreadyGenerated = false (no short-circuit)
+//
+// Tests are serial because they mutate shared ibl_team_info.eoy_vote rows
+// via setEoyVotes, and the updater page is slow (~60s timeout).
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
+  test.afterEach(async ({ request }) => {
+    // Reset eoy_vote back to 0 to avoid leaking state across tests
+    await setEoyVotes(request, 0);
+  });
+
+  test('phase not Playoffs: shows "Only available during Playoffs phase"', async ({
+    appState,
+    page,
+  }) => {
+    await appState({ 'Current Season Phase': 'Regular Season' });
+    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+
+    await expect(
+      page.getByText('Only available during Playoffs phase'),
+    ).toBeVisible({ timeout: 60_000 });
+  });
+
+  test('Playoffs + votes < 75%: shows "Voting not yet complete"', async ({
+    appState,
+    page,
+    request,
+  }) => {
+    await appState({ 'Current Season Phase': 'Playoffs' });
+    await setEoyVotes(request, 15);
+    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+
+    await expect(
+      page.getByText(/Voting not yet complete/),
+    ).toBeVisible({ timeout: 60_000 });
+  });
+
+  test('Playoffs + votes ≥ 75% + no Leaders.htm: shows upload prompt', async ({
+    appState,
+    page,
+    request,
+  }) => {
+    // 21/28 = 75% threshold met, but Leaders.htm is not present in the
+    // test environment — the step shows the missing-file message instead
+    // of the Generate button.
+    await appState({ 'Current Season Phase': 'Playoffs' });
+    await setEoyVotes(request, 21);
+    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+
+    await expect(
+      page.getByText('Leaders.htm not found'),
+    ).toBeVisible({ timeout: 60_000 });
+  });
+});
+
+test.describe('Updater awards — EndOfSeasonImportStep (no champion in seed)', () => {
+  test('no champion: Finals MVP UI is not shown', async ({ appState, page }) => {
+    // CI seed has no won_championship=1 row for season year 2026, so
+    // EndOfSeasonImportStep returns skipped and "IBL Finals MVP" is never rendered.
+    await appState({ 'Current Season Phase': 'Playoffs' });
+    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+
+    // Anchor: confirm the pipeline ran to completion before checking negative
+    await expect(
+      page.getByText(/\d+\s+(steps?\s+completed|succeeded)/i),
+    ).toBeVisible({ timeout: 60_000 });
+
+    await expect(page.getByText('IBL Finals MVP')).not.toBeVisible();
+  });
+});

--- a/ibl5/tests/e2e/smoke/updater-awards.spec.ts
+++ b/ibl5/tests/e2e/smoke/updater-awards.spec.ts
@@ -1,11 +1,16 @@
 import { test, expect } from '../fixtures/auth';
-import { setEoyVotes } from '../helpers/test-state';
+import { setState, setEoyVotes } from '../helpers/test-state';
 
 // E2E tests for the updater awards steps:
 //   - GenerateSeasonAwardsStep (Season awards card)
 //   - EndOfSeasonImportStep Finals MVP card
 //
+// The updater script queries ibl_settings via $lcpRepo->getSetting()
+// (direct DB read), so cookie-based appState overrides don't work here.
+// All state mutations use setState() (DB-level) with afterEach cleanup.
+//
 // The CI seed has:
+//   - Phase = 'Regular Season', so non-Playoffs skip is the default
 //   - No ibl_jsb_history rows with won_championship=1 for year 2026,
 //     so EndOfSeasonImportStep is skipped ("No champion determined yet")
 //   - No Leaders.htm at $basePath/Leaders.htm, so the Generate button
@@ -13,21 +18,19 @@ import { setEoyVotes } from '../helpers/test-state';
 //   - No 'Most Valuable Player (1st)' award for 2026, so
 //     awardsAlreadyGenerated = false (no short-circuit)
 //
-// Tests are serial because they mutate shared ibl_team_info.eoy_vote rows
-// via setEoyVotes, and the updater page is slow (~60s timeout).
+// Tests are serial because they mutate shared DB rows.
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
   test.afterEach(async ({ request }) => {
-    // Reset eoy_vote back to 0 to avoid leaking state across tests
     await setEoyVotes(request, 0);
+    await setState(request, { 'Current Season Phase': 'Regular Season' });
   });
 
   test('phase not Playoffs: shows "Only available during Playoffs phase"', async ({
-    appState,
     page,
   }) => {
-    await appState({ 'Current Season Phase': 'Regular Season' });
+    // Seed default is 'Regular Season' — no setup needed
     await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
 
     await expect(
@@ -36,11 +39,10 @@ test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
   });
 
   test('Playoffs + votes < 75%: shows "Voting not yet complete"', async ({
-    appState,
     page,
     request,
   }) => {
-    await appState({ 'Current Season Phase': 'Playoffs' });
+    await setState(request, { 'Current Season Phase': 'Playoffs' });
     await setEoyVotes(request, 15);
     await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
 
@@ -50,14 +52,13 @@ test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
   });
 
   test('Playoffs + votes ≥ 75% + no Leaders.htm: shows upload prompt', async ({
-    appState,
     page,
     request,
   }) => {
     // 21/28 = 75% threshold met, but Leaders.htm is not present in the
     // test environment — the step shows the missing-file message instead
     // of the Generate button.
-    await appState({ 'Current Season Phase': 'Playoffs' });
+    await setState(request, { 'Current Season Phase': 'Playoffs' });
     await setEoyVotes(request, 21);
     await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
 
@@ -68,10 +69,14 @@ test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
 });
 
 test.describe('Updater awards — EndOfSeasonImportStep (no champion in seed)', () => {
-  test('no champion: Finals MVP UI is not shown', async ({ appState, page }) => {
+  test.afterEach(async ({ request }) => {
+    await setState(request, { 'Current Season Phase': 'Regular Season' });
+  });
+
+  test('no champion: Finals MVP UI is not shown', async ({ page, request }) => {
     // CI seed has no won_championship=1 row for season year 2026, so
     // EndOfSeasonImportStep returns skipped and "IBL Finals MVP" is never rendered.
-    await appState({ 'Current Season Phase': 'Playoffs' });
+    await setState(request, { 'Current Season Phase': 'Playoffs' });
     await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
 
     // Anchor: confirm the pipeline ran to completion before checking negative


### PR DESCRIPTION
## Summary

Add two new interactive prompts to the updater pipeline so the commissioner no longer needs to visit the LCP to generate awards manually:

1. **GenerateSeasonAwardsStep** — Surfaces during Playoffs when EOY voting is ≥75% complete, offering a one-click "Generate Season Awards" button.
2. **Finals MVP prompt** — Appended to EndOfSeasonImportStep when a champion exists but no Finals MVP is recorded.

Both prompts POST to existing LCP actions (`generate_awards`, `set_finals_mvp`), which use PRG redirects back to the LCP page.

## Architecture

- Scalar injection pattern: `updateAllTheThings.php` queries LCP data and injects pre-computed scalars into steps — no cross-module dependency between Updater and LeagueControlPanel modules.
- Two new repository methods: `hasGeneratedAwardsForYear()` and `getEoyVotesCastCount()`.
- `hasFinalsMvp()` was already on the interface.

## Testing

- 12 new PHPUnit tests (9 for GenerateSeasonAwardsStep, 3 for EndOfSeasonImportStep Finals MVP)
- 3 new DB integration tests for repository methods
- 4 E2E tests covering step visibility states on the updater page
- E2E fixture: `set-eoy-votes` action in test-state.php

## Manual Testing

- [x] Visual inspection of both inline form cards in the updater page (card layout, button styling, input sizing) — requires Playoffs phase + ≥75% EOY votes + Leaders.htm present for the awards card, and a champion for the Finals MVP card