### PR TITLE
fix: clear all ibl.requireOnce PHPStan baseline entries

### DIFF
--- a/ibl5/classes/Bootstrap/AuthBootstrap.php
+++ b/ibl5/classes/Bootstrap/AuthBootstrap.php
@@ -47,6 +47,7 @@ class AuthBootstrap implements BootstrapStepInterface
 
         // Custom mainfile extensions
         if (file_exists($this->basePath . '/includes/custom_files/custom_mainfile.php')) {
+            /** @phpstan-ignore ibl.requireOnce (optional user customization hook; not a class) */
             @include_once $this->basePath . '/includes/custom_files/custom_mainfile.php';
         }
     }

--- a/ibl5/classes/Bootstrap/AutoloaderBootstrap.php
+++ b/ibl5/classes/Bootstrap/AutoloaderBootstrap.php
@@ -26,6 +26,7 @@ class AutoloaderBootstrap implements BootstrapStepInterface
      */
     public function boot(ContainerInterface $container): void
     {
+        /** @phpstan-ignore ibl.requireOnce (bootstraps Composer PSR-4 autoloader itself) */
         require_once $this->basePath . '/vendor/autoload.php';
 
         // In git worktrees, vendor/ is symlinked to the main repo. Composer resolves
@@ -38,6 +39,7 @@ class AutoloaderBootstrap implements BootstrapStepInterface
                 spl_autoload_register(static function (string $class) use ($worktreeClasses): void {
                     $file = $worktreeClasses . '/' . str_replace('\\', '/', $class) . '.php';
                     if (file_exists($file)) {
+                        /** @phpstan-ignore ibl.requireOnce (worktree PSR-4 fallback autoloader) */
                         require $file;
                     }
                 }, true, true);

--- a/ibl5/classes/Bootstrap/ConfigBootstrap.php
+++ b/ibl5/classes/Bootstrap/ConfigBootstrap.php
@@ -78,6 +78,7 @@ class ConfigBootstrap implements BootstrapStepInterface
 
     private function loadConfig(): void
     {
+        /** @phpstan-ignore ibl.requireOnce (defines global database/config state; not a class) */
         require_once $this->basePath . '/config.php';
 
         if (!isset($GLOBALS['dbname']) || $GLOBALS['dbname'] === '' || $GLOBALS['dbname'] === false) {
@@ -88,6 +89,7 @@ class ConfigBootstrap implements BootstrapStepInterface
 
     private function loadDatabase(): void
     {
+        /** @phpstan-ignore ibl.requireOnce (initializes $db and $mysqli_db globals; not a class) */
         require_once $this->basePath . '/db/db.php';
     }
 

--- a/ibl5/classes/Bootstrap/SecurityBootstrap.php
+++ b/ibl5/classes/Bootstrap/SecurityBootstrap.php
@@ -100,6 +100,7 @@ class SecurityBootstrap implements BootstrapStepInterface
         }
 
         if (file_exists($safePath)) {
+            /** @phpstan-ignore ibl.requireOnce (dynamic-path safe-include utility) */
             include_once $safePath;
         }
     }

--- a/ibl5/classes/Discord/Discord.php
+++ b/ibl5/classes/Discord/Discord.php
@@ -83,11 +83,10 @@ class Discord
 
         if (file_exists($configPath)) {
             /** @var array{webhooks?: array<string, string>, iblbot_url?: string} $config */
-            $config = require $configPath;
+            $config = require $configPath; /** @phpstan-ignore ibl.requireOnce (config file returns array; not a class) */
         } elseif (file_exists($examplePath)) {
-            // Fallback to example config (e.g., in development without secrets set up)
             /** @var array{webhooks?: array<string, string>, iblbot_url?: string} $config */
-            $config = require $examplePath;
+            $config = require $examplePath; /** @phpstan-ignore ibl.requireOnce (config file returns array; not a class) */
         } else {
             throw new \RuntimeException(
                 'Discord configuration file not found. ' .

--- a/ibl5/classes/Logging/LoggerFactory.php
+++ b/ibl5/classes/Logging/LoggerFactory.php
@@ -62,10 +62,10 @@ class LoggerFactory implements LoggerFactoryInterface
 
         if (file_exists($configPath)) {
             /** @var LoggingConfig $config */
-            $config = require $configPath;
+            $config = require $configPath; /** @phpstan-ignore ibl.requireOnce (config file returns array; not a class) */
         } elseif (file_exists($examplePath)) {
             /** @var LoggingConfig $config */
-            $config = require $examplePath;
+            $config = require $examplePath; /** @phpstan-ignore ibl.requireOnce (config file returns array; not a class) */
         } else {
             $config = self::DEFAULT_CONFIG;
         }

--- a/ibl5/classes/Mail/MailService.php
+++ b/ibl5/classes/Mail/MailService.php
@@ -84,9 +84,9 @@ class MailService implements MailServiceInterface
         $examplePath = self::resolveConfigDir() . '/mail.config.example.php';
 
         if (file_exists($configPath)) {
-            $config = require $configPath;
+            $config = require $configPath; /** @phpstan-ignore ibl.requireOnce (config file returns array; not a class) */
         } elseif (file_exists($examplePath)) {
-            $config = require $examplePath;
+            $config = require $examplePath; /** @phpstan-ignore ibl.requireOnce (config file returns array; not a class) */
         } else {
             $config = self::DEFAULT_CONFIG;
         }

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -13,24 +13,6 @@ parameters:
 			path: classes/ApiKeys/ApiKeysView.php
 
 		-
-			rawMessage: Direct `include_once` is banned in classes/. All classes under ibl5/classes/ autoload via Composer PSR-4. Remove the statement and rely on autoload instead.
-			identifier: ibl.requireOnce
-			count: 1
-			path: classes/Bootstrap/AuthBootstrap.php
-
-		-
-			rawMessage: Direct `require_once` is banned in classes/. All classes under ibl5/classes/ autoload via Composer PSR-4. Remove the statement and rely on autoload instead.
-			identifier: ibl.requireOnce
-			count: 1
-			path: classes/Bootstrap/AutoloaderBootstrap.php
-
-		-
-			rawMessage: Direct `require` is banned in classes/. All classes under ibl5/classes/ autoload via Composer PSR-4. Remove the statement and rely on autoload instead.
-			identifier: ibl.requireOnce
-			count: 1
-			path: classes/Bootstrap/AutoloaderBootstrap.php
-
-		-
 			rawMessage: '''
 				Call to method sql_fetchrow() of deprecated class Database\MySQL:
 				This class is for PHP-Nuke module backward compatibility only.
@@ -107,12 +89,6 @@ parameters:
 			path: classes/Bootstrap/ConfigBootstrap.php
 
 		-
-			rawMessage: Direct `require_once` is banned in classes/. All classes under ibl5/classes/ autoload via Composer PSR-4. Remove the statement and rely on autoload instead.
-			identifier: ibl.requireOnce
-			count: 2
-			path: classes/Bootstrap/ConfigBootstrap.php
-
-		-
 			rawMessage: '''
 				PHPDoc tag @var references deprecated class Database\MySQL:
 				This class is for PHP-Nuke module backward compatibility only.
@@ -154,12 +130,6 @@ parameters:
 			path: classes/Bootstrap/LeagueBootstrap.php
 
 		-
-			rawMessage: Direct `include_once` is banned in classes/. All classes under ibl5/classes/ autoload via Composer PSR-4. Remove the statement and rely on autoload instead.
-			identifier: ibl.requireOnce
-			count: 1
-			path: classes/Bootstrap/SecurityBootstrap.php
-
-		-
 			rawMessage: 'Unescaped output in View. Wrap the expression in HtmlSanitizer::e() (or another whitelisted safe helper), or cast it to (int)/(float)/(bool) if it is numeric.'
 			identifier: ibl.unescapedOutput
 			count: 9
@@ -182,12 +152,6 @@ parameters:
 			identifier: ibl.unescapedOutput
 			count: 25
 			path: classes/DepthChartEntry/DepthChartEntryView.php
-
-		-
-			rawMessage: Direct `require` is banned in classes/. All classes under ibl5/classes/ autoload via Composer PSR-4. Remove the statement and rely on autoload instead.
-			identifier: ibl.requireOnce
-			count: 2
-			path: classes/Discord/Discord.php
 
 		-
 			rawMessage: 'Unescaped output in View. Wrap the expression in HtmlSanitizer::e() (or another whitelisted safe helper), or cast it to (int)/(float)/(bool) if it is numeric.'
@@ -230,18 +194,6 @@ parameters:
 			identifier: ibl.unescapedOutput
 			count: 16
 			path: classes/LeagueControlPanel/LeagueControlPanelView.php
-
-		-
-			rawMessage: Direct `require` is banned in classes/. All classes under ibl5/classes/ autoload via Composer PSR-4. Remove the statement and rely on autoload instead.
-			identifier: ibl.requireOnce
-			count: 2
-			path: classes/Logging/LoggerFactory.php
-
-		-
-			rawMessage: Direct `require` is banned in classes/. All classes under ibl5/classes/ autoload via Composer PSR-4. Remove the statement and rely on autoload instead.
-			identifier: ibl.requireOnce
-			count: 2
-			path: classes/Mail/MailService.php
 
 		-
 			rawMessage: 'Unescaped output in View. Wrap the expression in HtmlSanitizer::e() (or another whitelisted safe helper), or cast it to (int)/(float)/(bool) if it is numeric.'


### PR DESCRIPTION
## Summary

Removes all 8 suppressed `ibl.requireOnce` baseline entries from `phpstan-baseline.neon` by annotating legitimate non-class `require`/`require_once`/`include_once` calls with inline `@phpstan-ignore` comments explaining why each suppression is intentional.

### Files annotated

| File | Statement | Reason |
|------|-----------|--------|
| `Bootstrap/AutoloaderBootstrap.php` | `require_once vendor/autoload.php` | Bootstraps Composer PSR-4 autoloader itself — cannot be autoloaded |
| `Bootstrap/AutoloaderBootstrap.php` | `require $file` (worktree fallback) | Worktree PSR-4 fallback autoloader |
| `Bootstrap/ConfigBootstrap.php` | `require_once config.php` | Defines global database/config state; not a class |
| `Bootstrap/ConfigBootstrap.php` | `require_once db/db.php` | Initializes `$db` and `$mysqli_db` globals; not a class |
| `Bootstrap/AuthBootstrap.php` | `@include_once custom_mainfile.php` | Optional user customization hook; not a class |
| `Bootstrap/SecurityBootstrap.php` | `include_once $safePath` | Dynamic-path safe-include utility |
| `Discord/Discord.php` (×2) | `require $configPath / $examplePath` | Config files return arrays; not classes |
| `Logging/LoggerFactory.php` (×2) | `require $configPath / $examplePath` | Config files return arrays; not classes |
| `Mail/MailService.php` (×2) | `require $configPath / $examplePath` | Config files return arrays; not classes |

These are all legitimate non-class includes that cannot be replaced with PSR-4 autoloading. Annotating with `@phpstan-ignore` is the correct resolution per Step 3 of the plan (side-effect-only / config-return includes).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.