### PR TITLE
refactor: extract IN-clause query from TradeRosterPreviewApiHandler into TradeAssetRepository

### DIFF
--- a/ibl5/classes/Trading/TradeRosterPreviewApiHandler.php
+++ b/ibl5/classes/Trading/TradeRosterPreviewApiHandler.php
@@ -6,6 +6,7 @@ namespace Trading;
 
 use Team\TeamRepository;
 use Team\TeamTableService;
+use Trading\Contracts\TradeAssetRepositoryInterface;
 use UI\Components\TableViewDropdown;
 use Team\Team;
 use Season\Season;
@@ -33,6 +34,7 @@ class TradeRosterPreviewApiHandler
     private const MAX_PIDS = 20;
 
     private \mysqli $db;
+    private TradeAssetRepositoryInterface $tradeAssetRepository;
 
     /**
      * The logged-in user's team ID, used to decide whether eligibility action
@@ -41,9 +43,10 @@ class TradeRosterPreviewApiHandler
      */
     private int $loggedInTeamID;
 
-    public function __construct(\mysqli $db, int $loggedInTeamID = 0)
+    public function __construct(\mysqli $db, TradeAssetRepositoryInterface $tradeAssetRepository, int $loggedInTeamID = 0)
     {
         $this->db = $db;
+        $this->tradeAssetRepository = $tradeAssetRepository;
         $this->loggedInTeamID = $loggedInTeamID;
     }
 
@@ -104,7 +107,7 @@ class TradeRosterPreviewApiHandler
 
             // Fetch and append incoming players
             if ($addPids !== []) {
-                $incomingPlayers = $this->fetchPlayersByPids($addPids);
+                $incomingPlayers = $this->tradeAssetRepository->getPlayersByIds($addPids);
                 foreach ($incomingPlayers as $incoming) {
                     $roster[] = $incoming;
                 }
@@ -233,42 +236,6 @@ class TradeRosterPreviewApiHandler
         }
 
         return 'ratings';
-    }
-
-    /**
-     * Fetch player rows by PIDs using prepared statement with IN clause
-     *
-     * @param list<int> $pids Player IDs
-     * @return list<array<string, mixed>> Player rows from `ibl_plr`
-     */
-    private function fetchPlayersByPids(array $pids): array
-    {
-        if ($pids === []) {
-            return [];
-        }
-
-        $placeholders = implode(',', array_fill(0, count($pids), '?'));
-        $types = str_repeat('i', count($pids));
-
-        $stmt = $this->db->prepare("SELECT * FROM `ibl_plr` WHERE pid IN ({$placeholders})");
-        if ($stmt === false) {
-            return [];
-        }
-
-        $stmt->bind_param($types, ...$pids);
-        $stmt->execute();
-        $result = $stmt->get_result();
-
-        if ($result === false) {
-            $stmt->close();
-            return [];
-        }
-
-        /** @var list<array<string, mixed>> $rows */
-        $rows = $result->fetch_all(MYSQLI_ASSOC);
-        $stmt->close();
-
-        return $rows;
     }
 
     /**

--- a/ibl5/modules/Trading/index.php
+++ b/ibl5/modules/Trading/index.php
@@ -118,7 +118,8 @@ switch ($op) {
                     $loggedInTeamID = $commonRepo->getTidFromTeamname($loggedInTeamName) ?? 0;
                 }
             }
-            $handler = new Trading\TradeRosterPreviewApiHandler($mysqli_db, $loggedInTeamID);
+            $tradeAssetRepo = new Trading\TradeAssetRepository($mysqli_db);
+            $handler = new Trading\TradeRosterPreviewApiHandler($mysqli_db, $tradeAssetRepo, $loggedInTeamID);
             $handler->handle();
         }
         break;

--- a/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
+++ b/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Tests\Trading;
 
 use PHPUnit\Framework\TestCase;
+use Trading\Contracts\TradeAssetRepositoryInterface;
 use Trading\TradeRosterPreviewApiHandler;
 
 class TradeRosterPreviewApiHandlerTest extends TestCase
 {
     private \mysqli $mockDb;
+    private TradeAssetRepositoryInterface $stubTradeAssetRepo;
 
     protected function setUp(): void
     {
@@ -34,6 +36,8 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
                 return false;
             }
         };
+
+        $this->stubTradeAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
     }
 
     protected function tearDown(): void
@@ -57,7 +61,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = [];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -72,7 +76,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '0'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -87,7 +91,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'addPids' => '1,abc,3'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -102,7 +106,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'removePids' => 'x,y'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -118,7 +122,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
         $pids = implode(',', range(1, 21));
         $_GET = ['teamid' => '1', 'addPids' => $pids];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -134,7 +138,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
         $pids = implode(',', range(1, 21));
         $_GET = ['teamid' => '1', 'removePids' => $pids];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -149,7 +153,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -164,7 +168,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'display' => 'split'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -179,7 +183,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'display' => 'split', 'split' => 'invalid_key'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -194,7 +198,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = [];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $this->captureOutput(fn () => $handler->handle());
 
@@ -206,7 +210,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'addPids' => '', 'removePids' => '1,2'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -221,7 +225,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'addPids' => '1,2', 'removePids' => ''];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -245,7 +249,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'userCash1' => '500',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -263,7 +267,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'display' => 'contracts',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -288,7 +292,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'partnerCash1' => '0',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -313,7 +317,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'partnerCash1' => '0',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -338,7 +342,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'partnerCash1' => '0',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb);
+        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 


### PR DESCRIPTION
## Summary

Removes the private `fetchPlayersByPids()` method from `TradeRosterPreviewApiHandler` and replaces it with a call to the pre-existing `TradeAssetRepository::getPlayersByIds()` via constructor-injected `TradeAssetRepositoryInterface`.

### Problem
Handler-level raw `prepare()` bypassed `BaseMysqliRepository`'s slow-query log and prepare-failure logging. The IN-clause pattern (placeholder generation, dynamic type-string) was duplicated — `TradeAssetRepository::getPlayersByIds()` already existed with identical logic.

### Changes
- Inject `TradeAssetRepositoryInterface` into `TradeRosterPreviewApiHandler` constructor
- Remove private `fetchPlayersByPids()` (42 lines) and delegate to `tradeAssetRepository->getPlayersByIds()`
- Update `modules/Trading/index.php` DI wiring
- Update test file to provide `TradeAssetRepositoryInterface` stub

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.