### PR TITLE
perf: batch ProjectedDraftOrderRepository::saveFinalDraftOrder() INSERTs

### DIFF
--- a/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderRepository.php
+++ b/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderRepository.php
@@ -102,16 +102,22 @@ class ProjectedDraftOrderRepository extends \BaseMysqliRepository implements Pro
                 $year,
             );
 
-            foreach ($picks as $pick) {
+            foreach (array_chunk($picks, 500) as $chunk) {
+                $placeholders = implode(',', array_fill(0, count($chunk), '(?, ?, ?, ?, ?, \'\', UUID())'));
+                $types = str_repeat('iiisi', count($chunk));
+                $params = [];
+                foreach ($chunk as $pick) {
+                    $params[] = $year;
+                    $params[] = $pick['round'];
+                    $params[] = $pick['pick'];
+                    $params[] = $pick['team'];
+                    $params[] = $pick['teamid'];
+                }
                 $this->execute(
-                    "INSERT INTO `ibl_draft` (year, round, pick, team, teamid, player, uuid)
-                     VALUES (?, ?, ?, ?, ?, '', UUID())",
-                    "iiisi",
-                    $year,
-                    $pick['round'],
-                    $pick['pick'],
-                    $pick['team'],
-                    $pick['teamid'],
+                    "INSERT INTO `ibl_draft` (`year`, `round`, `pick`, `team`, `teamid`, `player`, `uuid`)
+                     VALUES $placeholders",
+                    $types,
+                    ...$params,
                 );
             }
 

--- a/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderRepositoryTest.php
+++ b/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderRepositoryTest.php
@@ -94,6 +94,51 @@ class ProjectedDraftOrderRepositoryTest extends TestCase
         $this->assertSame(1, $result[0]['teamid']);
     }
 
+    public function testSaveFinalDraftOrderExecutesInsert(): void
+    {
+        $picks = [
+            ['round' => 1, 'pick' => 1, 'team' => 'Heat', 'teamid' => 1],
+            ['round' => 1, 'pick' => 2, 'team' => 'Celtics', 'teamid' => 2],
+        ];
+
+        $this->repository->saveFinalDraftOrder(2026, $picks);
+
+        $queries = $this->db->getExecutedQueries();
+        $insertQueries = array_filter($queries, static fn (string $q): bool => str_contains($q, 'INSERT INTO ibl_draft'));
+        $this->assertCount(1, $insertQueries);
+    }
+
+    public function testSaveFinalDraftOrderWithEmptyPicksSkipsInsert(): void
+    {
+        $this->repository->saveFinalDraftOrder(2026, []);
+
+        $queries = $this->db->getExecutedQueries();
+        $insertQueries = array_filter($queries, static fn (string $q): bool => str_contains($q, 'INSERT INTO ibl_draft'));
+        $this->assertCount(0, $insertQueries);
+    }
+
+    public function testSaveFinalDraftOrderUpdatesSettings(): void
+    {
+        $picks = [
+            ['round' => 1, 'pick' => 1, 'team' => 'Heat', 'teamid' => 1],
+        ];
+
+        $this->repository->saveFinalDraftOrder(2026, $picks);
+
+        $queries = $this->db->getExecutedQueries();
+        $settingsQueries = array_filter($queries, static fn (string $q): bool => str_contains($q, 'ibl_settings'));
+        $this->assertNotEmpty($settingsQueries);
+    }
+
+    public function testSaveFinalDraftOrderDeletesOldDraftRows(): void
+    {
+        $this->repository->saveFinalDraftOrder(2026, []);
+
+        $queries = $this->db->getExecutedQueries();
+        $deleteQueries = array_filter($queries, static fn (string $q): bool => str_contains($q, 'DELETE FROM ibl_draft'));
+        $this->assertCount(2, $deleteQueries);
+    }
+
     public function testExtendsBaseMysqliRepository(): void
     {
         $this->assertInstanceOf(\BaseMysqliRepository::class, $this->repository);


### PR DESCRIPTION
## Summary

Replaces the per-pick `INSERT` loop in `saveFinalDraftOrder()` with a chunked multi-row `INSERT ... VALUES (...), (...), ...` approach. For a 30-team, 2-round draft this reduces 60 round-trips to 1, shrinking the transaction window and reducing lock duration on `ibl_draft`.

Chunks at 500 picks per INSERT as a conservative guard against `max_allowed_packet` limits.

## Changes

- `ProjectedDraftOrderRepository::saveFinalDraftOrder()`: loop → `array_chunk(500)` + batch INSERT with dynamically built placeholder string and type string
- Tests added: insert executes (batched), empty picks no-op, settings updated, old rows deleted

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.