### PR TITLE
refactor: add declarative FIELD_MAP const to PlayerRepository

### DIFF
--- a/ibl5/classes/Player/PlayerRepository.php
+++ b/ibl5/classes/Player/PlayerRepository.php
@@ -24,6 +24,124 @@ use Player\Contracts\PlayerRepositoryInterface;
  */
 class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryInterface
 {
+    /**
+     * Declarative field map: PlayerData property → DB column for each mapping category.
+     * Used by tests to verify every PlayerData property is accounted for.
+     *
+     * @var array<string, list<array{target: string, source: string}>>
+     */
+    public const FIELD_MAP = [
+        'basic' => [
+            ['target' => 'playerID', 'source' => 'pid'],
+            ['target' => 'ordinal', 'source' => 'ordinal'],
+            ['target' => 'name', 'source' => 'name'],
+            ['target' => 'nickname', 'source' => 'nickname'],
+            ['target' => 'age', 'source' => 'age'],
+            ['target' => 'teamid', 'source' => 'teamid'],
+            ['target' => 'teamName', 'source' => 'teamname'],
+            ['target' => 'teamColor1', 'source' => 'color1'],
+            ['target' => 'teamColor2', 'source' => 'color2'],
+            ['target' => 'position', 'source' => 'pos'],
+        ],
+        'ratings_current' => [
+            ['target' => 'ratingFieldGoalAttempts', 'source' => 'r_fga'],
+            ['target' => 'ratingFieldGoalPercentage', 'source' => 'r_fgp'],
+            ['target' => 'ratingFreeThrowAttempts', 'source' => 'r_fta'],
+            ['target' => 'ratingFreeThrowPercentage', 'source' => 'r_ftp'],
+            ['target' => 'ratingThreePointAttempts', 'source' => 'r_3ga'],
+            ['target' => 'ratingThreePointPercentage', 'source' => 'r_3gp'],
+            ['target' => 'ratingOffensiveRebounds', 'source' => 'r_orb'],
+            ['target' => 'ratingDefensiveRebounds', 'source' => 'r_drb'],
+            ['target' => 'ratingAssists', 'source' => 'r_ast'],
+            ['target' => 'ratingSteals', 'source' => 'r_stl'],
+            ['target' => 'ratingTurnovers', 'source' => 'r_tvr'],
+            ['target' => 'ratingBlocks', 'source' => 'r_blk'],
+            ['target' => 'ratingFouls', 'source' => 'r_foul'],
+            ['target' => 'ratingOutsideOffense', 'source' => 'oo'],
+            ['target' => 'ratingOutsideDefense', 'source' => 'od'],
+            ['target' => 'ratingDriveOffense', 'source' => 'r_drive_off'],
+            ['target' => 'ratingDriveDefense', 'source' => 'dd'],
+            ['target' => 'ratingPostOffense', 'source' => 'po'],
+            ['target' => 'ratingPostDefense', 'source' => 'pd'],
+            ['target' => 'ratingTransitionOffense', 'source' => 'r_trans_off'],
+            ['target' => 'ratingTransitionDefense', 'source' => 'td'],
+            ['target' => 'ratingClutch', 'source' => 'clutch'],
+            ['target' => 'ratingConsistency', 'source' => 'consistency'],
+            ['target' => 'ratingTalent', 'source' => 'talent'],
+            ['target' => 'ratingSkill', 'source' => 'skill'],
+            ['target' => 'ratingIntangibles', 'source' => 'intangibles'],
+        ],
+        'ratings_historical' => [
+            ['target' => 'ratingFieldGoalAttempts', 'source' => 'r_2ga'],
+            ['target' => 'ratingFieldGoalPercentage', 'source' => 'r_2gp'],
+            ['target' => 'ratingFreeThrowAttempts', 'source' => 'r_fta'],
+            ['target' => 'ratingFreeThrowPercentage', 'source' => 'r_ftp'],
+            ['target' => 'ratingThreePointAttempts', 'source' => 'r_3ga'],
+            ['target' => 'ratingThreePointPercentage', 'source' => 'r_3gp'],
+            ['target' => 'ratingOffensiveRebounds', 'source' => 'r_orb'],
+            ['target' => 'ratingDefensiveRebounds', 'source' => 'r_drb'],
+            ['target' => 'ratingAssists', 'source' => 'r_ast'],
+            ['target' => 'ratingSteals', 'source' => 'r_stl'],
+            ['target' => 'ratingBlocks', 'source' => 'r_blk'],
+            ['target' => 'ratingTurnovers', 'source' => 'r_tvr'],
+            ['target' => 'ratingOutsideOffense', 'source' => 'r_oo'],
+            ['target' => 'ratingOutsideDefense', 'source' => 'r_od'],
+            ['target' => 'ratingDriveOffense', 'source' => 'r_drive_off'],
+            ['target' => 'ratingDriveDefense', 'source' => 'r_dd'],
+            ['target' => 'ratingPostOffense', 'source' => 'r_po'],
+            ['target' => 'ratingPostDefense', 'source' => 'r_pd'],
+            ['target' => 'ratingTransitionOffense', 'source' => 'r_trans_off'],
+            ['target' => 'ratingTransitionDefense', 'source' => 'r_td'],
+        ],
+        'free_agency' => [
+            ['target' => 'freeAgencyLoyalty', 'source' => 'loyalty'],
+            ['target' => 'freeAgencyPlayingTime', 'source' => 'playing_time'],
+            ['target' => 'freeAgencyPlayForWinner', 'source' => 'winner'],
+            ['target' => 'freeAgencyTradition', 'source' => 'tradition'],
+            ['target' => 'freeAgencySecurity', 'source' => 'security'],
+        ],
+        'contract' => [
+            ['target' => 'yearsOfExperience', 'source' => 'exp'],
+            ['target' => 'birdYears', 'source' => 'bird'],
+            ['target' => 'contractCurrentYear', 'source' => 'cy'],
+            ['target' => 'contractTotalYears', 'source' => 'cyt'],
+            ['target' => 'contractYear1Salary', 'source' => 'salary_yr1'],
+            ['target' => 'contractYear2Salary', 'source' => 'salary_yr2'],
+            ['target' => 'contractYear3Salary', 'source' => 'salary_yr3'],
+            ['target' => 'contractYear4Salary', 'source' => 'salary_yr4'],
+            ['target' => 'contractYear5Salary', 'source' => 'salary_yr5'],
+            ['target' => 'contractYear6Salary', 'source' => 'salary_yr6'],
+        ],
+        'draft' => [
+            ['target' => 'draftYear', 'source' => 'draftyear'],
+            ['target' => 'draftRound', 'source' => 'draftround'],
+            ['target' => 'draftPickNumber', 'source' => 'draftpickno'],
+            ['target' => 'draftTeamOriginalName', 'source' => 'draftedby'],
+            ['target' => 'draftTeamCurrentName', 'source' => 'draftedbycurrentname'],
+            ['target' => 'collegeName', 'source' => 'college'],
+        ],
+        'physical' => [
+            ['target' => 'heightFeet', 'source' => 'htft'],
+            ['target' => 'heightInches', 'source' => 'htin'],
+            ['target' => 'weightPounds', 'source' => 'wt'],
+        ],
+        'status' => [
+            ['target' => 'daysRemainingForInjury', 'source' => 'injured'],
+            ['target' => 'isRetired', 'source' => 'retired'],
+            ['target' => 'timeDroppedOnWaivers', 'source' => 'droptime'],
+        ],
+    ];
+
+    /** @var list<string> Properties set by non-repository logic or only in specific code paths */
+    public const EXCLUDED_FROM_FIELD_MAP = [
+        'plr',
+        'historicalYear',
+        'currentSeasonSalary',
+        'salaryJSB',
+        'decoratedName',
+        'nameStatusClass',
+    ];
+
     /** @var array{allStar: int, threePoint: int, dunkContest: int, rookieSoph: int}|null */
     private ?array $cachedAllStarWeekendCounts = null;
     private ?string $cachedAllStarWeekendPlayerName = null;
@@ -120,8 +238,6 @@ class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryI
     }
 
     /**
-     * Map rating fields from current player row
-     *
      * @param PlayerRow $plrRow Database row from `ibl_plr`
      */
     private function mapRatingsFromCurrentRow(PlayerData $playerData, array $plrRow): void
@@ -155,8 +271,6 @@ class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryI
     }
 
     /**
-     * Map free agency preference fields
-     *
      * @param PlayerRow $plrRow Database row from `ibl_plr`
      */
     private function mapFreeAgencyFields(PlayerData $playerData, array $plrRow): void
@@ -169,8 +283,6 @@ class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryI
     }
 
     /**
-     * Map contract fields
-     *
      * @param PlayerRow $plrRow Database row from `ibl_plr`
      */
     private function mapContractFields(PlayerData $playerData, array $plrRow): void
@@ -281,9 +393,7 @@ class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryI
     }
 
     /**
-     * Map rating fields from historical player row (different column names than current)
-     *
-     * @param array{r_2ga: ?int, r_2gp: ?int, r_fta: ?int, r_ftp: ?int, r_3ga: ?int, r_3gp: ?int, r_orb: ?int, r_drb: ?int, r_ast: ?int, r_stl: ?int, r_blk: ?int, r_tvr: ?int, r_oo: ?int, r_od: ?int, r_drive_off: ?int, r_dd: ?int, r_po: ?int, r_pd: ?int, r_trans_off: ?int, r_td: ?int, ...} $plrRow
+     * @param HistoricalPlayerRow $plrRow
      */
     private function mapRatingsFromHistoricalRow(PlayerData $playerData, array $plrRow): void
     {

--- a/ibl5/tests/Player/PlayerRepositoryFieldMapTest.php
+++ b/ibl5/tests/Player/PlayerRepositoryFieldMapTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Player;
+
+use PHPUnit\Framework\TestCase;
+use Player\PlayerData;
+use Player\PlayerRepository;
+
+class PlayerRepositoryFieldMapTest extends TestCase
+{
+    private PlayerRepository $repository;
+
+    protected function setUp(): void
+    {
+        $db = $this->createMock(\mysqli::class);
+        $this->repository = new PlayerRepository($db);
+    }
+
+    public function testFillFromCurrentRowMapsAllExpectedFields(): void
+    {
+        $row = $this->buildFullCurrentRow();
+        $player = $this->repository->fillFromCurrentRow($row);
+
+        self::assertSame(100, $player->playerID);
+        self::assertSame(5, $player->ordinal);
+        self::assertSame('Test Player', $player->name);
+        self::assertSame('TP', $player->nickname);
+        self::assertSame(25, $player->age);
+        self::assertSame(1, $player->teamid);
+        self::assertSame('Test Team', $player->teamName);
+        self::assertSame('FF0000', $player->teamColor1);
+        self::assertSame('0000FF', $player->teamColor2);
+        self::assertSame('PG', $player->position);
+
+        // Ratings
+        self::assertSame(3, $player->ratingFieldGoalAttempts);
+        self::assertSame(4, $player->ratingFieldGoalPercentage);
+        self::assertSame(2, $player->ratingFreeThrowAttempts);
+        self::assertSame(5, $player->ratingFreeThrowPercentage);
+        self::assertSame(3, $player->ratingThreePointAttempts);
+        self::assertSame(4, $player->ratingThreePointPercentage);
+        self::assertSame(2, $player->ratingOffensiveRebounds);
+        self::assertSame(3, $player->ratingDefensiveRebounds);
+        self::assertSame(4, $player->ratingAssists);
+        self::assertSame(3, $player->ratingSteals);
+        self::assertSame(2, $player->ratingTurnovers);
+        self::assertSame(3, $player->ratingBlocks);
+        self::assertSame(2, $player->ratingFouls);
+        self::assertSame(4, $player->ratingOutsideOffense);
+        self::assertSame(3, $player->ratingOutsideDefense);
+        self::assertSame(4, $player->ratingDriveOffense);
+        self::assertSame(3, $player->ratingDriveDefense);
+        self::assertSame(4, $player->ratingPostOffense);
+        self::assertSame(3, $player->ratingPostDefense);
+        self::assertSame(4, $player->ratingTransitionOffense);
+        self::assertSame(3, $player->ratingTransitionDefense);
+        self::assertSame(5, $player->ratingClutch);
+        self::assertSame(4, $player->ratingConsistency);
+        self::assertSame(5, $player->ratingTalent);
+        self::assertSame(4, $player->ratingSkill);
+        self::assertSame(3, $player->ratingIntangibles);
+
+        // Free agency
+        self::assertSame(3, $player->freeAgencyLoyalty);
+        self::assertSame(4, $player->freeAgencyPlayingTime);
+        self::assertSame(2, $player->freeAgencyPlayForWinner);
+        self::assertSame(3, $player->freeAgencyTradition);
+        self::assertSame(4, $player->freeAgencySecurity);
+
+        // Contract
+        self::assertSame(5, $player->yearsOfExperience);
+        self::assertSame(3, $player->birdYears);
+        self::assertSame(2, $player->contractCurrentYear);
+        self::assertSame(4, $player->contractTotalYears);
+        self::assertSame(5000, $player->contractYear1Salary);
+        self::assertSame(5500, $player->contractYear2Salary);
+        self::assertSame(6000, $player->contractYear3Salary);
+        self::assertSame(6500, $player->contractYear4Salary);
+        self::assertSame(0, $player->contractYear5Salary);
+        self::assertSame(0, $player->contractYear6Salary);
+
+        // Draft
+        self::assertSame(2020, $player->draftYear);
+        self::assertSame(1, $player->draftRound);
+        self::assertSame(5, $player->draftPickNumber);
+        self::assertSame('Original Team', $player->draftTeamOriginalName);
+        self::assertSame('Current Team', $player->draftTeamCurrentName);
+        self::assertSame('Test University', $player->collegeName);
+
+        // Physical
+        self::assertSame(6, $player->heightFeet);
+        self::assertSame(3, $player->heightInches);
+        self::assertSame(195, $player->weightPounds);
+
+        // Status
+        self::assertSame(0, $player->daysRemainingForInjury);
+        self::assertSame(0, $player->isRetired);
+        self::assertSame(0, $player->timeDroppedOnWaivers);
+    }
+
+    public function testFillFromHistoricalRowMapsAllExpectedFields(): void
+    {
+        $row = $this->buildFullHistoricalRow();
+        $player = $this->repository->fillFromHistoricalRow($row);
+
+        self::assertSame(200, $player->playerID);
+        self::assertSame(2015, $player->historicalYear);
+        self::assertSame('Historical Player', $player->name);
+        self::assertSame('Old Team', $player->teamName);
+        self::assertSame(5, $player->teamid);
+
+        // Ratings (historical uses different column names)
+        self::assertSame(3, $player->ratingFieldGoalAttempts);
+        self::assertSame(4, $player->ratingFieldGoalPercentage);
+        self::assertSame(2, $player->ratingFreeThrowAttempts);
+        self::assertSame(5, $player->ratingFreeThrowPercentage);
+        self::assertSame(3, $player->ratingThreePointAttempts);
+        self::assertSame(4, $player->ratingThreePointPercentage);
+        self::assertSame(2, $player->ratingOffensiveRebounds);
+        self::assertSame(3, $player->ratingDefensiveRebounds);
+        self::assertSame(4, $player->ratingAssists);
+        self::assertSame(3, $player->ratingSteals);
+        self::assertSame(3, $player->ratingBlocks);
+        self::assertSame(2, $player->ratingTurnovers);
+        self::assertSame(4, $player->ratingOutsideOffense);
+        self::assertSame(3, $player->ratingOutsideDefense);
+        self::assertSame(4, $player->ratingDriveOffense);
+        self::assertSame(3, $player->ratingDriveDefense);
+        self::assertSame(4, $player->ratingPostOffense);
+        self::assertSame(3, $player->ratingPostDefense);
+        self::assertSame(4, $player->ratingTransitionOffense);
+        self::assertSame(3, $player->ratingTransitionDefense);
+
+        // Salary
+        self::assertSame(8000, $player->salaryJSB);
+
+        // Contract fields initialized to 0 for historical
+        self::assertSame(0, $player->contractCurrentYear);
+        self::assertSame(0, $player->contractTotalYears);
+        self::assertSame(0, $player->contractYear1Salary);
+        self::assertSame(0, $player->contractYear2Salary);
+        self::assertSame(0, $player->contractYear3Salary);
+        self::assertSame(0, $player->contractYear4Salary);
+        self::assertSame(0, $player->contractYear5Salary);
+        self::assertSame(0, $player->contractYear6Salary);
+    }
+
+    public function testFillFromCurrentRowHandlesNullOptionalFields(): void
+    {
+        $row = $this->buildFullCurrentRow();
+        $row['nickname'] = null;
+        $row['teamname'] = null;
+        $row['color1'] = null;
+        $row['color2'] = null;
+        $row['draftedby'] = null;
+        $row['draftedbycurrentname'] = null;
+        $row['college'] = null;
+        $row['htft'] = null;
+        $row['htin'] = null;
+        $row['wt'] = null;
+        $row['retired'] = null;
+
+        $player = $this->repository->fillFromCurrentRow($row);
+
+        self::assertNull($player->nickname);
+        self::assertNull($player->teamName);
+        self::assertNull($player->teamColor1);
+        self::assertNull($player->teamColor2);
+        self::assertNull($player->draftTeamOriginalName);
+        self::assertNull($player->draftTeamCurrentName);
+        self::assertNull($player->collegeName);
+        self::assertNull($player->heightFeet);
+        self::assertNull($player->heightInches);
+        self::assertNull($player->weightPounds);
+        self::assertNull($player->isRetired);
+    }
+
+    public function testFillFromCurrentRowStripsSlashesFromName(): void
+    {
+        $row = $this->buildFullCurrentRow();
+        $row['name'] = "O\\'Brien";
+
+        $player = $this->repository->fillFromCurrentRow($row);
+        self::assertSame("O'Brien", $player->name);
+    }
+
+    public function testFieldMapCoversAllPlayerDataProperties(): void
+    {
+        $reflection = new \ReflectionClass(PlayerData::class);
+        $allProperties = array_map(
+            static fn (\ReflectionProperty $p): string => $p->getName(),
+            $reflection->getProperties()
+        );
+
+        $mappedTargets = [];
+        foreach (PlayerRepository::FIELD_MAP as $entries) {
+            foreach ($entries as $entry) {
+                $mappedTargets[] = $entry['target'];
+            }
+        }
+        $mappedTargets = array_unique($mappedTargets);
+
+        $accountedFor = array_merge($mappedTargets, PlayerRepository::EXCLUDED_FROM_FIELD_MAP);
+
+        $unmapped = array_diff($allProperties, $accountedFor);
+
+        self::assertSame(
+            [],
+            array_values($unmapped),
+            'PlayerData properties not covered by FIELD_MAP or EXCLUDED_FROM_FIELD_MAP: ' . implode(', ', $unmapped)
+        );
+    }
+
+    public function testFieldMapTargetsAreValidPlayerDataProperties(): void
+    {
+        $reflection = new \ReflectionClass(PlayerData::class);
+        $validProperties = array_map(
+            static fn (\ReflectionProperty $p): string => $p->getName(),
+            $reflection->getProperties()
+        );
+
+        foreach (PlayerRepository::FIELD_MAP as $category => $entries) {
+            foreach ($entries as $entry) {
+                self::assertContains(
+                    $entry['target'],
+                    $validProperties,
+                    "FIELD_MAP[{$category}] target '{$entry['target']}' is not a valid PlayerData property"
+                );
+            }
+        }
+    }
+
+    public function testExcludedPropertiesAreValidPlayerDataProperties(): void
+    {
+        $reflection = new \ReflectionClass(PlayerData::class);
+        $validProperties = array_map(
+            static fn (\ReflectionProperty $p): string => $p->getName(),
+            $reflection->getProperties()
+        );
+
+        foreach (PlayerRepository::EXCLUDED_FROM_FIELD_MAP as $prop) {
+            self::assertContains(
+                $prop,
+                $validProperties,
+                "EXCLUDED_FROM_FIELD_MAP entry '{$prop}' is not a valid PlayerData property"
+            );
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildFullCurrentRow(): array
+    {
+        return [
+            'pid' => 100,
+            'ordinal' => 5,
+            'name' => 'Test Player',
+            'nickname' => 'TP',
+            'age' => 25,
+            'teamid' => 1,
+            'teamname' => 'Test Team',
+            'color1' => 'FF0000',
+            'color2' => '0000FF',
+            'pos' => 'PG',
+            'r_fga' => 3,
+            'r_fgp' => 4,
+            'r_fta' => 2,
+            'r_ftp' => 5,
+            'r_3ga' => 3,
+            'r_3gp' => 4,
+            'r_orb' => 2,
+            'r_drb' => 3,
+            'r_ast' => 4,
+            'r_stl' => 3,
+            'r_tvr' => 2,
+            'r_blk' => 3,
+            'r_foul' => 2,
+            'oo' => 4,
+            'od' => 3,
+            'r_drive_off' => 4,
+            'dd' => 3,
+            'po' => 4,
+            'pd' => 3,
+            'r_trans_off' => 4,
+            'td' => 3,
+            'clutch' => 5,
+            'consistency' => 4,
+            'talent' => 5,
+            'skill' => 4,
+            'intangibles' => 3,
+            'loyalty' => 3,
+            'playing_time' => 4,
+            'winner' => 2,
+            'tradition' => 3,
+            'security' => 4,
+            'exp' => 5,
+            'bird' => 3,
+            'cy' => 2,
+            'cyt' => 4,
+            'salary_yr1' => 5000,
+            'salary_yr2' => 5500,
+            'salary_yr3' => 6000,
+            'salary_yr4' => 6500,
+            'salary_yr5' => 0,
+            'salary_yr6' => 0,
+            'draftyear' => 2020,
+            'draftround' => 1,
+            'draftpickno' => 5,
+            'draftedby' => 'Original Team',
+            'draftedbycurrentname' => 'Current Team',
+            'college' => 'Test University',
+            'htft' => 6,
+            'htin' => 3,
+            'wt' => 195,
+            'injured' => 0,
+            'retired' => 0,
+            'droptime' => 0,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildFullHistoricalRow(): array
+    {
+        return [
+            'pid' => 200,
+            'year' => 2015,
+            'name' => 'Historical Player',
+            'team' => 'Old Team',
+            'teamid' => 5,
+            'r_2ga' => 3,
+            'r_2gp' => 4,
+            'r_fta' => 2,
+            'r_ftp' => 5,
+            'r_3ga' => 3,
+            'r_3gp' => 4,
+            'r_orb' => 2,
+            'r_drb' => 3,
+            'r_ast' => 4,
+            'r_stl' => 3,
+            'r_blk' => 3,
+            'r_tvr' => 2,
+            'r_oo' => 4,
+            'r_od' => 3,
+            'r_drive_off' => 4,
+            'r_dd' => 3,
+            'r_po' => 4,
+            'r_pd' => 3,
+            'r_trans_off' => 4,
+            'r_td' => 3,
+            'salary' => 8000,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Adds a declarative `FIELD_MAP` public constant and `EXCLUDED_FROM_FIELD_MAP` list to `PlayerRepository`, encoding the complete PlayerData-property → DB-column mapping in one place. Existing `mapXxx` methods are unchanged — the constant serves as a machine-readable specification that tests validate against.

**Why this matters:** Without this, adding a new DB column to `PlayerRow` gives no static-analysis signal when the corresponding `PlayerData` property is forgotten in a `mapXxx` method. `testFieldMapCoversAllPlayerDataProperties` now enforces coverage via reflection — a new `PlayerData` property that is neither in `FIELD_MAP` nor `EXCLUDED_FROM_FIELD_MAP` fails the test suite.

## Changes

- `PlayerRepository`: Added `public const FIELD_MAP` (8 categories: basic, ratings_current, ratings_historical, free_agency, contract, draft, physical, status) and `public const EXCLUDED_FROM_FIELD_MAP` (6 properties set by non-repository logic).
- Removed redundant prose from `mapXxx` docblocks; condensed historical-row `@param` to use the existing `HistoricalPlayerRow` type alias.
- `PlayerRepositoryFieldMapTest`: 6 tests — full field coverage for current/historical rows, null handling, stripslashes, reflection-based coverage assertion, and validity guards for FIELD_MAP targets and EXCLUDED entries.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---

Generated with [Claude Code](https://claude.ai/code)
<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>