### PR TITLE
refactor: unify PlayerRepository stat methods with PlayerStatsRepository

### DIFF
--- a/ibl5/classes/Player/Contracts/PlayerRepositoryInterface.php
+++ b/ibl5/classes/Player/Contracts/PlayerRepositoryInterface.php
@@ -75,17 +75,6 @@ interface PlayerRepositoryInterface
     public function getFreeAgencyDemands(int $playerID): array;
 
     /**
-     * Get player statistics by player ID
-     *
-     * Queries ibl_plr table for all player data by ID.
-     * Returns raw database row with all statistics columns.
-     *
-     * @param int $playerID Player ID
-     * @return PlayerRow|null Player statistics row or null if not found
-     */
-    public function getPlayerStats(int $playerID): ?array;
-
-    /**
      * Get All-Star Game appearances count for a player
      * 
      * Counts awards where awardcontains 'Conference All-Star'.
@@ -132,38 +121,6 @@ interface PlayerRepositoryInterface
      * @return list<AwardRow> Award records ordered by year ASC
      */
     public function getAwards(string $playerName): array;
-
-    /**
-     * Get historical stats for a player ordered by year
-     * 
-     * @param int $playerID Player ID
-     * @return array<array<string, mixed>> Array of historical stat records ordered by year ASC
-     */
-    public function getHistoricalStats(int $playerID): array;
-
-    /**
-     * Get playoff stats for a player ordered by year
-     *
-     * @param string $playerName Player name (exact match)
-     * @return list<array{year: int, pos: string, pid: int, name: string, team: string, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int}> Array of playoff stat records ordered by year ASC
-     */
-    public function getPlayoffStats(string $playerName): array;
-
-    /**
-     * Get HEAT stats for a player ordered by year
-     *
-     * @param string $playerName Player name (exact match)
-     * @return list<array{year: int, pos: string, pid: int, name: string, team: string, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int}> Array of HEAT stat records ordered by year ASC
-     */
-    public function getHeatStats(string $playerName): array;
-
-    /**
-     * Get Olympics stats for a player ordered by year
-     * 
-     * @param int $playerID Player ID
-     * @return array<array<string, mixed>> Array of Olympics stat records ordered by year ASC
-     */
-    public function getOlympicsStats(int $playerID): array;
 
     /**
      * Get news articles mentioning a player

--- a/ibl5/classes/Player/PlayerRepository.php
+++ b/ibl5/classes/Player/PlayerRepository.php
@@ -523,107 +523,6 @@ class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryI
     }
 
     /**
-     * Get all sim dates ordered by sim number
-     *
-     * @return array<int, array<string, mixed>> Array of sim date records (keys: sim, start_date, end_date)
-     */
-    public function getAllSimDates(): array
-    {
-        return $this->fetchAll(
-            "SELECT sim, start_date, end_date FROM `ibl_sim_dates` ORDER BY sim ASC",
-            ""
-        );
-    }
-
-    /**
-     * @see PlayerRepositoryInterface::getHistoricalStats()
-     * @return array<int, array<string, mixed>>
-     */
-    public function getHistoricalStats(int $playerID): array
-    {
-        return $this->fetchAll(
-            "SELECT * FROM `ibl_hist` WHERE pid = ? ORDER BY year ASC",
-            "i",
-            $playerID
-        );
-    }
-
-    /**
-     * @see PlayerRepositoryInterface::getPlayoffStats()
-     * @return list<array{year: int, pos: string, pid: int, name: string, team: string, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int}>
-     */
-    public function getPlayoffStats(string $playerName): array
-    {
-        /** @var list<array{year: int, pos: string, pid: int, name: string, team: string, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int}> */
-        return $this->fetchAll(
-            self::buildPerSeasonStatsQuery(2),
-            "s",
-            $playerName
-        );
-    }
-
-    /**
-     * @see PlayerRepositoryInterface::getHeatStats()
-     * @return list<array{year: int, pos: string, pid: int, name: string, team: string, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int}>
-     */
-    public function getHeatStats(string $playerName): array
-    {
-        /** @var list<array{year: int, pos: string, pid: int, name: string, team: string, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int}> */
-        return $this->fetchAll(
-            self::buildPerSeasonStatsQuery(3),
-            "s",
-            $playerName
-        );
-    }
-
-    /**
-     * Build inlined per-season stats query with predicate pushed before GROUP BY.
-     *
-     * Replaces SELECT from `ibl_playoff_stats` / ibl_heat_stats views.
-     */
-    private static function buildPerSeasonStatsQuery(int $gameType): string
-    {
-        return "SELECT bs.season_year AS year, MIN(bs.pos) AS pos, bs.pid, p.name,
-            fs.team_name AS team,
-            CAST(COUNT(*) AS SIGNED) AS games,
-            CAST(SUM(bs.game_min) AS SIGNED) AS minutes,
-            CAST(SUM(bs.calc_fg_made) AS SIGNED) AS fgm,
-            CAST(SUM(bs.game_2ga + bs.game_3ga) AS SIGNED) AS fga,
-            CAST(SUM(bs.game_ftm) AS SIGNED) AS ftm,
-            CAST(SUM(bs.game_fta) AS SIGNED) AS fta,
-            CAST(SUM(bs.game_3gm) AS SIGNED) AS tgm,
-            CAST(SUM(bs.game_3ga) AS SIGNED) AS tga,
-            CAST(SUM(bs.game_orb) AS SIGNED) AS orb,
-            CAST(SUM(bs.calc_rebounds) AS SIGNED) AS reb,
-            CAST(SUM(bs.game_ast) AS SIGNED) AS ast,
-            CAST(SUM(bs.game_stl) AS SIGNED) AS stl,
-            CAST(SUM(bs.game_tov) AS SIGNED) AS tvr,
-            CAST(SUM(bs.game_blk) AS SIGNED) AS blk,
-            CAST(SUM(bs.game_pf) AS SIGNED) AS pf,
-            CAST(SUM(bs.calc_points) AS SIGNED) AS pts
-        FROM `ibl_box_scores` bs
-        JOIN `ibl_plr` p ON bs.pid = p.pid
-        JOIN `ibl_franchise_seasons` fs ON bs.teamid = fs.franchise_id
-            AND bs.season_year = fs.season_ending_year
-        WHERE bs.game_type = {$gameType} AND p.name = ?
-        GROUP BY bs.pid, p.name, bs.season_year, fs.team_name
-        ORDER BY year ASC";
-    }
-
-    /**
-     * @see PlayerRepositoryInterface::getOlympicsStats()
-     * @return array<int, array<string, mixed>>
-     */
-    public function getOlympicsStats(int $playerID): array
-    {
-        return $this->fetchAll(
-            "SELECT * FROM `ibl_olympics_stats` WHERE pid = ? ORDER BY year ASC",
-            "i",
-            $playerID
-        );
-    }
-
-    /**
      * @see PlayerRepositoryInterface::getAwards()
      *
      * @return list<AwardRow>
@@ -635,20 +534,6 @@ class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryI
             "SELECT * FROM `ibl_awards` WHERE name = ? ORDER BY year ASC",
             "s",
             $playerName
-        );
-    }
-
-    /**
-     * @see PlayerRepositoryInterface::getPlayerStats()
-     * @return PlayerRow|null
-     */
-    public function getPlayerStats(int $playerID): ?array
-    {
-        /** @var PlayerRow|null */
-        return $this->fetchOne(
-            "SELECT * FROM `ibl_plr` WHERE pid = ? LIMIT 1",
-            "i",
-            $playerID
         );
     }
 

--- a/ibl5/classes/Player/Views/PlayerHeatAveragesView.php
+++ b/ibl5/classes/Player/Views/PlayerHeatAveragesView.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
 use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerHeatAveragesViewInterface;
 use BasketballStats\StatsFormatter;
@@ -14,19 +13,17 @@ use Security\HtmlSanitizer;
  * PlayerHeatAveragesView - Renders H.E.A.T. averages table
  *
  * Shows year-by-year H.E.A.T. statistics averages with career averages row.
- * Uses PlayerRepository and PlayerStatsRepository for all database access.
+ * Uses PlayerStatsRepository for all database access.
  *
  * @see PlayerHeatAveragesViewInterface
  */
 class PlayerHeatAveragesView implements PlayerHeatAveragesViewInterface
 {
-    private PlayerRepository $repository;
-    private PlayerStatsRepository $statsRepository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository, PlayerStatsRepository $statsRepository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
-        $this->statsRepository = $statsRepository;
     }
 
     /**
@@ -43,7 +40,7 @@ class PlayerHeatAveragesView implements PlayerHeatAveragesViewInterface
     public function renderAverages(string $playerName): string
     {
         $heatStats = $this->repository->getHeatStats($playerName);
-        $careerAverages = $this->statsRepository->getHeatCareerAverages($playerName);
+        $careerAverages = $this->repository->getHeatCareerAverages($playerName);
 
         ob_start();
         ?>

--- a/ibl5/classes/Player/Views/PlayerHeatStatsView.php
+++ b/ibl5/classes/Player/Views/PlayerHeatStatsView.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
+use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerHeatStatsViewInterface;
 use BasketballStats\StatsFormatter;
 use Security\HtmlSanitizer;
@@ -12,15 +12,15 @@ use Security\HtmlSanitizer;
 /**
  * PlayerHeatStatsView - Renders Heat tournament statistics
  *
- * Pure rendering with no database logic - all data fetched via PlayerRepository
+ * Pure rendering with no database logic - all data fetched via PlayerStatsRepository
  *
  * @see PlayerHeatStatsViewInterface
  */
 class PlayerHeatStatsView implements PlayerHeatStatsViewInterface
 {
-    private PlayerRepository $repository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
     }

--- a/ibl5/classes/Player/Views/PlayerHeatTotalsView.php
+++ b/ibl5/classes/Player/Views/PlayerHeatTotalsView.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
+use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerHeatTotalsViewInterface;
 use Security\HtmlSanitizer;
 
@@ -12,15 +12,15 @@ use Security\HtmlSanitizer;
  * PlayerHeatTotalsView - Renders H.E.A.T. totals table
  *
  * Shows year-by-year H.E.A.T. statistics totals with career totals row.
- * Uses PlayerRepository for all database access.
+ * Uses PlayerStatsRepository for all database access.
  *
  * @see PlayerHeatTotalsViewInterface
  */
 class PlayerHeatTotalsView implements PlayerHeatTotalsViewInterface
 {
-    private PlayerRepository $repository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
     }

--- a/ibl5/classes/Player/Views/PlayerOlympicAveragesView.php
+++ b/ibl5/classes/Player/Views/PlayerOlympicAveragesView.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
 use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerOlympicAveragesViewInterface;
 use BasketballStats\StatsFormatter;
@@ -14,19 +13,17 @@ use Security\HtmlSanitizer;
  * PlayerOlympicAveragesView - Renders Olympics averages table
  *
  * Shows year-by-year Olympics statistics averages with career averages row.
- * Uses PlayerRepository and PlayerStatsRepository for all database access.
+ * Uses PlayerStatsRepository for all database access.
  *
  * @see PlayerOlympicAveragesViewInterface
  */
 class PlayerOlympicAveragesView implements PlayerOlympicAveragesViewInterface
 {
-    private PlayerRepository $repository;
-    private PlayerStatsRepository $statsRepository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository, PlayerStatsRepository $statsRepository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
-        $this->statsRepository = $statsRepository;
     }
 
     /**
@@ -43,7 +40,7 @@ class PlayerOlympicAveragesView implements PlayerOlympicAveragesViewInterface
     public function renderAverages(int $playerID): string
     {
         $olympicsStats = $this->repository->getOlympicsStats($playerID);
-        $careerAverages = $this->statsRepository->getOlympicsCareerAverages($playerID);
+        $careerAverages = $this->repository->getOlympicsCareerAverages($playerID);
 
         ob_start();
         ?>

--- a/ibl5/classes/Player/Views/PlayerOlympicTotalsView.php
+++ b/ibl5/classes/Player/Views/PlayerOlympicTotalsView.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
+use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerOlympicTotalsViewInterface;
 use Security\HtmlSanitizer;
 
@@ -12,15 +12,15 @@ use Security\HtmlSanitizer;
  * PlayerOlympicTotalsView - Renders Olympics totals table
  *
  * Shows year-by-year Olympics statistics totals with career totals row.
- * Uses PlayerRepository for all database access.
+ * Uses PlayerStatsRepository for all database access.
  *
  * @see PlayerOlympicTotalsViewInterface
  */
 class PlayerOlympicTotalsView implements PlayerOlympicTotalsViewInterface
 {
-    private PlayerRepository $repository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
     }

--- a/ibl5/classes/Player/Views/PlayerOlympicsStatsView.php
+++ b/ibl5/classes/Player/Views/PlayerOlympicsStatsView.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
+use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerOlympicsStatsViewInterface;
 use BasketballStats\StatsFormatter;
 use Security\HtmlSanitizer;
@@ -12,15 +12,15 @@ use Security\HtmlSanitizer;
 /**
  * PlayerOlympicsStatsView - Renders Olympics tournament statistics
  *
- * Pure rendering with no database logic - all data fetched via PlayerRepository
+ * Pure rendering with no database logic - all data fetched via PlayerStatsRepository
  *
  * @see PlayerOlympicsStatsViewInterface
  */
 class PlayerOlympicsStatsView implements PlayerOlympicsStatsViewInterface
 {
-    private PlayerRepository $repository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
     }

--- a/ibl5/classes/Player/Views/PlayerPlayoffAveragesView.php
+++ b/ibl5/classes/Player/Views/PlayerPlayoffAveragesView.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
 use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerPlayoffAveragesViewInterface;
 use BasketballStats\StatsFormatter;
@@ -14,19 +13,17 @@ use Security\HtmlSanitizer;
  * PlayerPlayoffAveragesView - Renders playoff averages table
  *
  * Shows year-by-year playoff statistics averages with career averages row.
- * Uses PlayerRepository and PlayerStatsRepository for all database access.
+ * Uses PlayerStatsRepository for all database access.
  *
  * @see PlayerPlayoffAveragesViewInterface
  */
 class PlayerPlayoffAveragesView implements PlayerPlayoffAveragesViewInterface
 {
-    private PlayerRepository $repository;
-    private PlayerStatsRepository $statsRepository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository, PlayerStatsRepository $statsRepository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
-        $this->statsRepository = $statsRepository;
     }
 
     /**
@@ -43,7 +40,7 @@ class PlayerPlayoffAveragesView implements PlayerPlayoffAveragesViewInterface
     public function renderAverages(string $playerName): string
     {
         $playoffStats = $this->repository->getPlayoffStats($playerName);
-        $careerAverages = $this->statsRepository->getPlayoffCareerAverages($playerName);
+        $careerAverages = $this->repository->getPlayoffCareerAverages($playerName);
 
         ob_start();
         ?>

--- a/ibl5/classes/Player/Views/PlayerPlayoffStatsView.php
+++ b/ibl5/classes/Player/Views/PlayerPlayoffStatsView.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
+use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerPlayoffStatsViewInterface;
 use BasketballStats\StatsFormatter;
 use Security\HtmlSanitizer;
@@ -12,15 +12,15 @@ use Security\HtmlSanitizer;
 /**
  * PlayerPlayoffStatsView - Renders playoff statistics (totals/averages)
  *
- * Pure rendering with no database logic - all data fetched via PlayerRepository
+ * Pure rendering with no database logic - all data fetched via PlayerStatsRepository
  *
  * @see PlayerPlayoffStatsViewInterface
  */
 class PlayerPlayoffStatsView implements PlayerPlayoffStatsViewInterface
 {
-    private PlayerRepository $repository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
     }

--- a/ibl5/classes/Player/Views/PlayerPlayoffTotalsView.php
+++ b/ibl5/classes/Player/Views/PlayerPlayoffTotalsView.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
+use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerPlayoffTotalsViewInterface;
 use Security\HtmlSanitizer;
 
@@ -12,15 +12,15 @@ use Security\HtmlSanitizer;
  * PlayerPlayoffTotalsView - Renders playoff totals table
  *
  * Shows year-by-year playoff statistics totals with career totals row.
- * Uses PlayerRepository for all database access.
+ * Uses PlayerStatsRepository for all database access.
  *
  * @see PlayerPlayoffTotalsViewInterface
  */
 class PlayerPlayoffTotalsView implements PlayerPlayoffTotalsViewInterface
 {
-    private PlayerRepository $repository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
     }

--- a/ibl5/classes/Player/Views/PlayerSeasonStatsView.php
+++ b/ibl5/classes/Player/Views/PlayerSeasonStatsView.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace Player\Views;
 
-use Player\PlayerRepository;
+use Player\PlayerStatsRepository;
 use Player\Contracts\PlayerSeasonStatsViewInterface;
 use BasketballStats\StatsFormatter;
 use Security\HtmlSanitizer;
 
 /**
  * PlayerSeasonStatsView - Renders regular season statistics (totals/averages)
- * 
- * Pure rendering with no database logic - all data fetched via PlayerRepository
- * 
+ *
+ * Pure rendering with no database logic - all data fetched via PlayerStatsRepository
+ *
  * @see PlayerSeasonStatsViewInterface
  */
 class PlayerSeasonStatsView implements PlayerSeasonStatsViewInterface
 {
-    private PlayerRepository $repository;
+    private PlayerStatsRepository $repository;
 
-    public function __construct(PlayerRepository $repository)
+    public function __construct(PlayerStatsRepository $repository)
     {
         $this->repository = $repository;
     }
@@ -61,7 +61,7 @@ class PlayerSeasonStatsView implements PlayerSeasonStatsViewInterface
     <tbody>
         <?php
         foreach ($historicalStats as $stats) {
-            /** @var array{team: string, year: int, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int} $stats */
+            /** @var array{pid: int, name: string, year: int, team: string, teamid: int, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, blk: int, tvr: int, pf: int, pts: int, ...} $stats */
             $drb = $stats['reb'] - $stats['orb'];
             ?>
     <tr>
@@ -127,7 +127,7 @@ class PlayerSeasonStatsView implements PlayerSeasonStatsViewInterface
     <tbody>
         <?php
         foreach ($historicalStats as $stats) {
-            /** @var array{team: string, year: int, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int} $stats */
+            /** @var array{pid: int, name: string, year: int, team: string, teamid: int, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, blk: int, tvr: int, pf: int, pts: int, ...} $stats */
             $games = $stats['games'];
             if ($games === 0) {
                 continue;

--- a/ibl5/classes/Player/Views/PlayerViewFactory.php
+++ b/ibl5/classes/Player/Views/PlayerViewFactory.php
@@ -105,7 +105,7 @@ class PlayerViewFactory
      */
     public function createPlayoffTotalsView(): PlayerPlayoffTotalsView
     {
-        return new PlayerPlayoffTotalsView($this->repository);
+        return new PlayerPlayoffTotalsView($this->statsRepository);
     }
 
     /**
@@ -113,7 +113,7 @@ class PlayerViewFactory
      */
     public function createPlayoffAveragesView(): PlayerPlayoffAveragesView
     {
-        return new PlayerPlayoffAveragesView($this->repository, $this->statsRepository);
+        return new PlayerPlayoffAveragesView($this->statsRepository);
     }
 
     /**
@@ -121,7 +121,7 @@ class PlayerViewFactory
      */
     public function createHeatTotalsView(): PlayerHeatTotalsView
     {
-        return new PlayerHeatTotalsView($this->repository);
+        return new PlayerHeatTotalsView($this->statsRepository);
     }
 
     /**
@@ -129,7 +129,7 @@ class PlayerViewFactory
      */
     public function createHeatAveragesView(): PlayerHeatAveragesView
     {
-        return new PlayerHeatAveragesView($this->repository, $this->statsRepository);
+        return new PlayerHeatAveragesView($this->statsRepository);
     }
 
     /**
@@ -137,7 +137,7 @@ class PlayerViewFactory
      */
     public function createOlympicTotalsView(): PlayerOlympicTotalsView
     {
-        return new PlayerOlympicTotalsView($this->repository);
+        return new PlayerOlympicTotalsView($this->statsRepository);
     }
 
     /**
@@ -145,7 +145,7 @@ class PlayerViewFactory
      */
     public function createOlympicAveragesView(): PlayerOlympicAveragesView
     {
-        return new PlayerOlympicAveragesView($this->repository, $this->statsRepository);
+        return new PlayerOlympicAveragesView($this->statsRepository);
     }
 
     /**

--- a/ibl5/tests/DatabaseIntegration/PlayerRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/PlayerRepositoryTest.php
@@ -48,28 +48,6 @@ class PlayerRepositoryTest extends DatabaseTestCase
         $this->repo->loadByID(99999);
     }
 
-    public function testGetPlayerStatsReturnsRowWithNativeTypes(): void
-    {
-        $this->insertTestPlayer(200010003, 'PLR StatsTest', [
-            'teamid' => 2,
-            'pos' => 'SG',
-        ]);
-
-        $row = $this->repo->getPlayerStats(200010003);
-
-        self::assertNotNull($row);
-        self::assertSame(200010003, $row['pid']);
-        self::assertSame(2, $row['teamid']);
-        self::assertSame('SG', $row['pos']);
-    }
-
-    public function testGetPlayerStatsReturnsNullForUnknownPlayer(): void
-    {
-        $row = $this->repo->getPlayerStats(99999);
-
-        self::assertNull($row);
-    }
-
     public function testGetFreeAgencyDemandsReturnsZeroesWhenNoDemandRow(): void
     {
         $this->insertTestPlayer(200010004, 'PLR DemandTst');
@@ -154,57 +132,6 @@ class PlayerRepositoryTest extends DatabaseTestCase
 
         self::assertSame(1, $this->repo->getAllStarGameCount('PLR CacheTest'));
         self::assertSame(1, $this->repo->getThreePointContestCount('PLR CacheTest'));
-    }
-
-    // ── Historical stats ────────────────────────────────────────
-
-    public function testGetHistoricalStatsReturnsOrderedByYear(): void
-    {
-        $this->insertTestPlayer(200010010, 'PLR HistStats');
-        $this->insertHistRow(200010010, 'PLR HistStats', 2025, ['teamid' => 1]);
-        $this->insertHistRow(200010010, 'PLR HistStats', 2023, ['teamid' => 1]);
-        $this->insertHistRow(200010010, 'PLR HistStats', 2024, ['teamid' => 1]);
-
-        $stats = $this->repo->getHistoricalStats(200010010);
-
-        self::assertCount(3, $stats);
-        self::assertSame(2023, $stats[0]['year']);
-        self::assertSame(2024, $stats[1]['year']);
-        self::assertSame(2025, $stats[2]['year']);
-    }
-
-    public function testGetHistoricalStatsReturnsEmptyForNoHistory(): void
-    {
-        self::assertSame([], $this->repo->getHistoricalStats(999999999));
-    }
-
-    // ── Playoff / Heat / Olympics stats ─────────────────────────
-
-    public function testGetPlayoffStatsReturnsEmptyForNoData(): void
-    {
-        self::assertSame([], $this->repo->getPlayoffStats('PLR NoPlayoffs'));
-    }
-
-    public function testGetHeatStatsReturnsEmptyForNoData(): void
-    {
-        self::assertSame([], $this->repo->getHeatStats('PLR NoHeat'));
-    }
-
-    public function testGetOlympicsStatsReturnsEmptyForNoData(): void
-    {
-        self::assertSame([], $this->repo->getOlympicsStats(999999999));
-    }
-
-    // ── getAllSimDates ───────────────────────────────────────────
-
-    public function testGetAllSimDatesReturnsArray(): void
-    {
-        $dates = $this->repo->getAllSimDates();
-
-        self::assertIsArray($dates);
-        if ($dates !== []) {
-            self::assertArrayHasKey('sim', $dates[0]);
-        }
     }
 
     // ── One-on-One wins/losses ──────────────────────────────────


### PR DESCRIPTION
## Summary

Removes 6 duplicated stat methods from `PlayerRepository` that were already present in `PlayerStatsRepository` (getHistoricalStats, getPlayoffStats, getHeatStats, getOlympicsStats, getPlayerStats, buildPerSeasonStatsQuery) plus the unused `getAllSimDates`. Rewires 7 View classes and updates `PlayerViewFactory` to use `PlayerStatsRepository` exclusively.

## Changes
- Removed 6 duplicated stat methods from PlayerRepository plus unused getAllSimDates
- Rewired 7 Views from PlayerRepository → PlayerStatsRepository for stat queries
- Simplified 3 dual-repo averages Views (Playoff, Heat, Olympic) to single PlayerStatsRepository dependency
- Updated PlayerViewFactory wiring to pass statsRepository to stat Views
- Removed corresponding interface methods from PlayerRepositoryInterface
- Removed DB integration tests for deleted methods (covered by PlayerStatsRepositoryTest)
- Fixed @var annotations in PlayerSeasonStatsView for StatsRow type compatibility

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.