### PR TITLE
refactor: unify RecordHoldersService team maps into TEAM_REGISTRY

### DIFF
--- a/ibl5/classes/RecordHolders/RecordHoldersService.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersService.php
@@ -27,41 +27,42 @@ class RecordHoldersService implements RecordHoldersServiceInterface
     private RecordHoldersRepositoryInterface $repository;
 
     /**
-     * Team ID to logo abbreviation mapping.
+     * Single source of truth for team ID → abbreviation + name.
      *
-     * These abbreviations correspond to image files in images/topics/{abbr}.png
+     * Abbreviations correspond to image files in images/topics/{abbr}.png.
+     * Derive all team lookups from this registry so a rebrand is a one-line edit.
      *
-     * @var array<int, string>
+     * @var array<int, array{abbr: string, name: string}>
      */
-    private const TEAM_ABBREVIATIONS = [
-        1 => 'bos',
-        2 => 'mia',
-        3 => 'nyk',
-        4 => 'bkn',
-        5 => 'orl',
-        6 => 'mil',
-        7 => 'chi',
-        8 => 'nor',
-        9 => 'atl',
-        10 => 'cha',
-        11 => 'ind',
-        12 => 'tor',
-        13 => 'uta',
-        14 => 'min',
-        15 => 'den',
-        16 => 'lva',
-        17 => 'hou',
-        18 => 'por',
-        19 => 'lac',
-        20 => 'van',
-        21 => 'lal',
-        22 => 'braves',
-        23 => 'phx',
-        24 => 'gsw',
-        25 => 'det',
-        26 => 'sac',
-        27 => 'was',
-        28 => 'dal',
+    private const TEAM_REGISTRY = [
+        1  => ['abbr' => 'bos', 'name' => 'Celtics'],
+        2  => ['abbr' => 'mia', 'name' => 'Heat'],
+        3  => ['abbr' => 'nyk', 'name' => 'Knicks'],
+        4  => ['abbr' => 'bkn', 'name' => 'Nets'],
+        5  => ['abbr' => 'orl', 'name' => 'Magic'],
+        6  => ['abbr' => 'mil', 'name' => 'Bucks'],
+        7  => ['abbr' => 'chi', 'name' => 'Bulls'],
+        8  => ['abbr' => 'nor', 'name' => 'Pelicans'],
+        9  => ['abbr' => 'atl', 'name' => 'Hawks'],
+        10 => ['abbr' => 'cha', 'name' => 'Sting'],
+        11 => ['abbr' => 'ind', 'name' => 'Pacers'],
+        12 => ['abbr' => 'tor', 'name' => 'Raptors'],
+        13 => ['abbr' => 'uta', 'name' => 'Jazz'],
+        14 => ['abbr' => 'min', 'name' => 'Timberwolves'],
+        15 => ['abbr' => 'den', 'name' => 'Nuggets'],
+        16 => ['abbr' => 'lva', 'name' => 'Aces'],
+        17 => ['abbr' => 'hou', 'name' => 'Rockets'],
+        18 => ['abbr' => 'por', 'name' => 'Trailblazers'],
+        19 => ['abbr' => 'lac', 'name' => 'Clippers'],
+        20 => ['abbr' => 'van', 'name' => 'Grizzlies'],
+        21 => ['abbr' => 'lal', 'name' => 'Lakers'],
+        22 => ['abbr' => 'braves', 'name' => 'Braves'],
+        23 => ['abbr' => 'phx', 'name' => 'Suns'],
+        24 => ['abbr' => 'gsw', 'name' => 'Warriors'],
+        25 => ['abbr' => 'det', 'name' => 'Pistons'],
+        26 => ['abbr' => 'sac', 'name' => 'Kings'],
+        27 => ['abbr' => 'was', 'name' => 'Bullets'],
+        28 => ['abbr' => 'dal', 'name' => 'Mavericks'],
     ];
 
     /**
@@ -620,7 +621,7 @@ class RecordHoldersService implements RecordHoldersServiceInterface
      */
     private function getTeamAbbreviation(int $teamId): string
     {
-        return self::TEAM_ABBREVIATIONS[$teamId] ?? '';
+        return self::TEAM_REGISTRY[$teamId]['abbr'] ?? '';
     }
 
     /** @var array<string, int>|null */
@@ -629,16 +630,10 @@ class RecordHoldersService implements RecordHoldersServiceInterface
     private function getTeamAbbreviationByName(string $teamName): string
     {
         if ($this->nameToIdCache === null) {
-            $this->nameToIdCache = [
-                'Celtics' => 1, 'Heat' => 2, 'Knicks' => 3, 'Nets' => 4,
-                'Magic' => 5, 'Bucks' => 6, 'Bulls' => 7, 'Pelicans' => 8,
-                'Hawks' => 9, 'Sting' => 10, 'Pacers' => 11, 'Raptors' => 12,
-                'Jazz' => 13, 'Timberwolves' => 14, 'Nuggets' => 15, 'Aces' => 16,
-                'Rockets' => 17, 'Trailblazers' => 18, 'Clippers' => 19,
-                'Grizzlies' => 20, 'Lakers' => 21, 'Braves' => 22,
-                'Suns' => 23, 'Warriors' => 24, 'Pistons' => 25,
-                'Kings' => 26, 'Bullets' => 27, 'Mavericks' => 28,
-            ];
+            $this->nameToIdCache = [];
+            foreach (self::TEAM_REGISTRY as $id => $info) {
+                $this->nameToIdCache[$info['name']] = $id;
+            }
         }
 
         $teamId = $this->nameToIdCache[$teamName] ?? 0;

--- a/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
+++ b/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\RecordHolders;
 
+use League\League;
 use PHPUnit\Framework\TestCase;
 use RecordHolders\RecordHoldersService;
 use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
@@ -437,6 +438,91 @@ final class RecordHoldersServiceTest extends TestCase
         $this->assertArrayHasKey('Most Division Championships', $franchise);
         $this->assertArrayHasKey('Most IBL Finals Appearances', $franchise);
         $this->assertArrayHasKey('Most IBL Championships', $franchise);
+    }
+
+    public function testTeamRegistryContainsExactlyMaxRealTeamidEntries(): void
+    {
+        $reflection = new \ReflectionClass(RecordHoldersService::class);
+        $registry = $reflection->getConstant('TEAM_REGISTRY');
+        $this->assertIsArray($registry);
+        $this->assertCount(League::MAX_REAL_TEAMID, $registry);
+    }
+
+    public function testTeamRegistryEachEntryHasAbbrAndName(): void
+    {
+        $reflection = new \ReflectionClass(RecordHoldersService::class);
+        /** @var array<int, array{abbr: string, name: string}> $registry */
+        $registry = $reflection->getConstant('TEAM_REGISTRY');
+        $this->assertIsArray($registry);
+
+        foreach ($registry as $id => $info) {
+            $this->assertArrayHasKey('abbr', $info, "Team {$id} missing 'abbr'");
+            $this->assertArrayHasKey('name', $info, "Team {$id} missing 'name'");
+            $this->assertNotEmpty($info['abbr'], "Team {$id} has empty abbreviation");
+            $this->assertNotEmpty($info['name'], "Team {$id} has empty name");
+        }
+    }
+
+    public function testUnknownTeamIdReturnsEmptyAbbreviation(): void
+    {
+        $record = $this->createPlayerRecord(1, 'Unknown', 50, 999);
+
+        $batchResult = $this->buildBatchPlayerResult([$record]);
+        $this->mockRepository->method('getTopPlayerSingleGameBatch')
+            ->willReturn($batchResult);
+        $this->configureOtherMocksEmpty();
+
+        $result = $this->service->getAllRecords();
+
+        $regSeason = $result['playerSingleGame']['regularSeason'];
+        $firstCategory = array_values($regSeason)[0];
+        $this->assertSame('', $firstCategory[0]['teamAbbr']);
+    }
+
+    public function testNameToIdDerivedFromRegistryMatchesTeamSeasonRecords(): void
+    {
+        $seasonRecord = [
+            'team_name' => 'Lakers',
+            'year' => 2001,
+            'wins' => 65,
+            'losses' => 17,
+        ];
+
+        $this->mockRepository->method('getBestWorstSeasonRecord')
+            ->willReturn([$seasonRecord]);
+        $this->mockRepository->method('getBestWorstSeasonStart')->willReturn([]);
+        $this->mockRepository->method('getLongestStreak')->willReturn([]);
+        $this->configureNonSeasonMocksEmpty();
+
+        $result = $this->service->getAllRecords();
+
+        $bestRecord = $result['teamSeasonRecords']['Best Season Record'];
+        $this->assertCount(1, $bestRecord);
+        $this->assertSame(21, $bestRecord[0]['teamTid']);
+        $this->assertSame('lal', $bestRecord[0]['teamAbbr']);
+    }
+
+    public function testUnknownTeamNameReturnsZeroTidAndEmptyAbbr(): void
+    {
+        $seasonRecord = [
+            'team_name' => 'NonexistentTeam',
+            'year' => 2001,
+            'wins' => 50,
+            'losses' => 32,
+        ];
+
+        $this->mockRepository->method('getBestWorstSeasonRecord')
+            ->willReturn([$seasonRecord]);
+        $this->mockRepository->method('getBestWorstSeasonStart')->willReturn([]);
+        $this->mockRepository->method('getLongestStreak')->willReturn([]);
+        $this->configureNonSeasonMocksEmpty();
+
+        $result = $this->service->getAllRecords();
+
+        $bestRecord = $result['teamSeasonRecords']['Best Season Record'];
+        $this->assertCount(1, $bestRecord);
+        $this->assertSame(0, $bestRecord[0]['teamTid']);
+        $this->assertSame('', $bestRecord[0]['teamAbbr']);
     }
 
     /**


### PR DESCRIPTION
## Summary

Collapses two parallel 28-entry team mappings in `RecordHoldersService` into a single `TEAM_REGISTRY` constant:

- Removed `TEAM_ABBREVIATIONS` const (teamId → abbr)
- Kept `$nameToIdCache` as a lazy runtime cache **derived from** `TEAM_REGISTRY` (no longer a second source of truth)
- All abbreviation and name→ID lookups now flow through `getTeamAbbreviation()` and `getTeamAbbreviationByName()`/`getTeamIdByName()` which read `TEAM_REGISTRY`

A team rebrand is now a one-line edit in `TEAM_REGISTRY` instead of two separate structures.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.