### PR TITLE
refactor: replace collectPlayerNames with source-accumulator pattern

### DIFF
--- a/ibl5/classes/SeasonArchive/SeasonArchiveService.php
+++ b/ibl5/classes/SeasonArchive/SeasonArchiveService.php
@@ -31,6 +31,9 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
 
     private SeasonArchiveRepositoryInterface $repository;
 
+    /** @var array<string, true> Player names accumulated during getSeasonDetail() assembly */
+    private array $collectedPlayerNames = [];
+
     public function __construct(SeasonArchiveRepositoryInterface $repository)
     {
         $this->repository = $repository;
@@ -129,7 +132,9 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
             $teamIds[$teamName] = $colorData['teamid'];
         }
 
-        // Assemble the season data first, then collect all player names
+        // Reset accumulator — extractAward/extractAwardList populate it during assembly
+        $this->collectedPlayerNames = [];
+
         $seasonData = [
             'year' => $year,
             'label' => $this->buildSeasonLabel($year),
@@ -204,9 +209,7 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
             'teamIds' => $teamIds,
         ];
 
-        // Collect all unique player names from the assembled data
-        $playerNames = $this->collectPlayerNames($seasonData);
-        $seasonData['playerIds'] = $this->repository->getPlayerIdsByNames($playerNames);
+        $seasonData['playerIds'] = $this->repository->getPlayerIdsByNames(array_keys($this->collectedPlayerNames));
 
         return $seasonData;
     }
@@ -255,7 +258,12 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
     {
         foreach ($awards as $award) {
             if (trim($award['award']) === $awardName) {
-                return trim($award['name']);
+                $name = trim($award['name']);
+                if ($name !== '') {
+                    $this->collectedPlayerNames[$name] = true;
+                }
+
+                return $name;
             }
         }
 
@@ -276,7 +284,11 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
         $names = [];
         foreach ($awards as $award) {
             if (trim($award['award']) === $awardName) {
-                $names[] = trim($award['name']);
+                $name = trim($award['name']);
+                $names[] = $name;
+                if ($name !== '') {
+                    $this->collectedPlayerNames[$name] = true;
+                }
             }
         }
 
@@ -410,92 +422,6 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
         }
 
         return $awards;
-    }
-
-    /**
-     * Collect all unique player names from assembled season data for batch ID lookup
-     *
-     * @param array<string, mixed> $data Assembled season data
-     * @return list<string> Unique non-empty player names
-     */
-    private function collectPlayerNames(array $data): array
-    {
-        /** @var array<string, true> $names */
-        $names = [];
-
-        // Major Awards (single player names)
-        /** @var array{mvp: string, dpoy: string, roy: string, sixthMan: string, gmOfYear: array{name: string, team: string}, finalsMvp: string} $awards */
-        $awards = $data['majorAwards'];
-        foreach ([$awards['mvp'], $awards['dpoy'], $awards['roy'], $awards['sixthMan'], $awards['finalsMvp']] as $name) {
-            if ($name !== '') {
-                $names[$name] = true;
-            }
-        }
-
-        // Statistical Leaders
-        /** @var array{scoring: string, rebounds: string, assists: string, steals: string, blocks: string} $leaders */
-        $leaders = $data['statisticalLeaders'];
-        foreach ([$leaders['scoring'], $leaders['rebounds'], $leaders['assists'], $leaders['steals'], $leaders['blocks']] as $name) {
-            if ($name !== '') {
-                $names[$name] = true;
-            }
-        }
-
-        // All-Star Weekend winners
-        /** @var array{gameMvps: list<string>, slamDunkWinner: string, threePointWinner: string, rookieSophomoreMvp: string, slamDunkParticipants: list<string>, threePointParticipants: list<string>, rookieSophomoreParticipants: list<string>} $asw */
-        $asw = $data['allStarWeekend'];
-        foreach ($asw['gameMvps'] as $name) {
-            if ($name !== '') {
-                $names[$name] = true;
-            }
-        }
-        foreach ([$asw['slamDunkWinner'], $asw['threePointWinner'], $asw['rookieSophomoreMvp']] as $name) {
-            if ($name !== '') {
-                $names[$name] = true;
-            }
-        }
-
-        // Tournament player winners
-        /** @var array{heatChampion: string, heatUrl: string, oneOnOneChampion: string, rookieOneOnOneChampion: string, oneOnOneUrl: string, iblFinalsWinner: string, iblFinalsLoser: string, iblFinalsLoserGames: int, playoffsUrl: string} $tournaments */
-        $tournaments = $data['tournaments'];
-        foreach ([$tournaments['oneOnOneChampion'], $tournaments['rookieOneOnOneChampion']] as $name) {
-            if ($name !== '') {
-                $names[$name] = true;
-            }
-        }
-
-        // All-League/Defensive/Rookie teams (lists of player names)
-        foreach (['allLeagueTeams', 'allDefensiveTeams', 'allRookieTeams'] as $teamKey) {
-            /** @var array{first: list<string>, second: list<string>, third: list<string>} $teamSet */
-            $teamSet = $data[$teamKey];
-            foreach (['first', 'second', 'third'] as $tier) {
-                foreach ($teamSet[$tier] as $name) {
-                    if ($name !== '') {
-                        $names[$name] = true;
-                    }
-                }
-            }
-        }
-
-        // Championship Rosters
-        /** @var array{ibl: list<string>, heat: list<string>} $championRosters */
-        $championRosters = $data['championRosters'];
-        foreach (array_merge($championRosters['ibl'], $championRosters['heat']) as $name) {
-            if ($name !== '') {
-                $names[$name] = true;
-            }
-        }
-
-        // All-Star Rosters
-        /** @var array{east: list<string>, west: list<string>} $allStarRosters */
-        $allStarRosters = $data['allStarRosters'];
-        foreach (array_merge($allStarRosters['east'], $allStarRosters['west']) as $name) {
-            if ($name !== '') {
-                $names[$name] = true;
-            }
-        }
-
-        return array_keys($names);
     }
 
     /**

--- a/ibl5/tests/SeasonArchive/SeasonArchiveServiceTest.php
+++ b/ibl5/tests/SeasonArchive/SeasonArchiveServiceTest.php
@@ -414,6 +414,97 @@ class SeasonArchiveServiceTest extends TestCase
         $this->assertSame(1, $result['playerIds']['MVP Player']);
     }
 
+    public function testPlayerNamesAutoCollectedFromAllExtractAwardCalls(): void
+    {
+        $this->mockRepository->method('getAwardsByYear')->willReturn([
+            ['year' => 1989, 'award' => 'Most Valuable Player (1st)', 'name' => 'MVP Player', 'table_id' => 1],
+            ['year' => 1989, 'award' => 'Scoring Leader (1st)', 'name' => 'Scorer', 'table_id' => 2],
+            ['year' => 1989, 'award' => 'All-Star Game MVP', 'name' => 'ASG MVP', 'table_id' => 3],
+            ['year' => 1989, 'award' => 'One-on-One Tournament Champion', 'name' => '1v1 Champ', 'table_id' => 4],
+            ['year' => 1989, 'award' => 'All-League First Team', 'name' => 'First Teamer', 'table_id' => 5],
+            ['year' => 1989, 'award' => 'All-Defensive Team (1st)', 'name' => 'Defender', 'table_id' => 6],
+            ['year' => 1989, 'award' => 'All-Rookie Team (1st)', 'name' => 'Rookie', 'table_id' => 7],
+            ['year' => 1989, 'award' => 'IBL Champion', 'name' => 'Champ Player', 'table_id' => 8],
+            ['year' => 1989, 'award' => 'Eastern Conference All-Star', 'name' => 'East Star', 'table_id' => 9],
+            ['year' => 1989, 'award' => 'Slam Dunk Competition - Winner', 'name' => 'Dunker', 'table_id' => 10],
+            ['year' => 1989, 'award' => 'Three-Point Contest', 'name' => 'Shooter', 'table_id' => 11],
+        ]);
+        $this->mockRepository->method('getPlayoffResultsByYear')->willReturn([]);
+        $this->mockRepository->method('getTeamAwardsByYear')->willReturn([]);
+        $this->mockRepository->method('getAllGmAwardsWithTeams')->willReturn([]);
+        $this->mockRepository->method('getAllGmTenuresWithTeams')->willReturn([]);
+        $this->mockRepository->method('getHeatWinLossByYear')->willReturn([]);
+        $this->mockRepository->method('getTeamColors')->willReturn([]);
+
+        $expectedNames = [
+            'MVP Player', 'Scorer', 'ASG MVP', '1v1 Champ',
+            'First Teamer', 'Defender', 'Rookie', 'Champ Player',
+            'East Star', 'Dunker', 'Shooter',
+        ];
+
+        $this->mockRepository->expects($this->once())
+            ->method('getPlayerIdsByNames')
+            ->with($this->callback(static function (array $names) use ($expectedNames): bool {
+                foreach ($expectedNames as $expected) {
+                    if (!in_array($expected, $names, true)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }))
+            ->willReturn([]);
+
+        $this->service->getSeasonDetail(1989);
+    }
+
+    public function testAccumulatorResetsBetweenCalls(): void
+    {
+        $stubRepo = $this->createStub(SeasonArchiveRepositoryInterface::class);
+        $stubRepo->method('getTeamConferences')->willReturn([]);
+        $stubRepo->method('getPlayoffResultsByYear')->willReturn([]);
+        $stubRepo->method('getTeamAwardsByYear')->willReturn([]);
+        $stubRepo->method('getAllGmAwardsWithTeams')->willReturn([]);
+        $stubRepo->method('getAllGmTenuresWithTeams')->willReturn([]);
+        $stubRepo->method('getHeatWinLossByYear')->willReturn([]);
+        $stubRepo->method('getTeamColors')->willReturn([]);
+
+        $callCount = 0;
+        $stubRepo->method('getAwardsByYear')->willReturnCallback(
+            static function (int $year) use (&$callCount): array {
+                $callCount++;
+                if ($callCount === 1) {
+                    return [
+                        ['year' => 1989, 'award' => 'Most Valuable Player (1st)', 'name' => 'Season1 MVP', 'table_id' => 1],
+                    ];
+                }
+
+                return [
+                    ['year' => 1990, 'award' => 'Most Valuable Player (1st)', 'name' => 'Season2 MVP', 'table_id' => 2],
+                ];
+            },
+        );
+
+        $capturedNames = [];
+        $stubRepo->method('getPlayerIdsByNames')->willReturnCallback(
+            static function (array $names) use (&$capturedNames): array {
+                $capturedNames[] = $names;
+
+                return [];
+            },
+        );
+
+        $service = new SeasonArchiveService($stubRepo);
+        $service->getSeasonDetail(1989);
+        $service->getSeasonDetail(1990);
+
+        $this->assertCount(2, $capturedNames);
+        $this->assertContains('Season1 MVP', $capturedNames[0]);
+        $this->assertNotContains('Season2 MVP', $capturedNames[0]);
+        $this->assertContains('Season2 MVP', $capturedNames[1]);
+        $this->assertNotContains('Season1 MVP', $capturedNames[1]);
+    }
+
     public function testAllStarCoachesIncludedInSeasonDetail(): void
     {
         $mockRepo = $this->createMock(SeasonArchiveRepositoryInterface::class);


### PR DESCRIPTION
## Summary

Replaces the 92-line post-assembly `collectPlayerNames()` traversal with a lightweight source-accumulator pattern. Player names are now collected inside `extractAward()` and `extractAwardList()` as each award is fetched during assembly — eliminating a redundant full-pass over the already-assembled data structure.

## Changes

- **Removed** `collectPlayerNames()` (92 lines) — the post-assembly recursive traversal
- **Added** `$collectedPlayerNames` property as a per-call accumulator (reset at the start of each `getSeasonDetail()` invocation)
- **Modified** `extractAward()` and `extractAwardList()` to populate the accumulator as a side-effect
- **Added** two new tests:
  - `testPlayerNamesAutoCollectedFromAllExtractAwardCalls` — asserts all award types flow through the accumulator
  - `testAccumulatorResetsBetweenCalls` — asserts fresh accumulator per `getSeasonDetail()` call

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.