### PR TITLE
refactor: move ranking compute from CachedSeasonLeaderboardsRepository to Service

### DIFF
--- a/ibl5/classes/SeasonLeaderboards/CachedSeasonLeaderboardsRepository.php
+++ b/ibl5/classes/SeasonLeaderboards/CachedSeasonLeaderboardsRepository.php
@@ -10,10 +10,8 @@ use SeasonLeaderboards\Contracts\SeasonLeaderboardsRepositoryInterface;
 /**
  * CachedSeasonLeaderboardsRepository - Caching decorator for SeasonLeaderboardsRepositoryInterface.
  *
- * Caches the full unsorted leaders result set, years list, and teams list.
- * On cache hit, filters by year/team, sorts by the requested stat, and
- * slices for limit — all in PHP. This avoids materializing the expensive
- * ibl_hist VIEW on every sort/filter change.
+ * Pure cache pass-through: caches the full result set from the inner repository.
+ * Filtering, sorting, and limiting are handled by SeasonLeaderboardsService.
  *
  * @phpstan-import-type HistRow from SeasonLeaderboardsRepositoryInterface
  * @phpstan-import-type LeaderboardFilters from SeasonLeaderboardsRepositoryInterface
@@ -51,42 +49,6 @@ class CachedSeasonLeaderboardsRepository implements SeasonLeaderboardsRepository
             $innerResult = $this->inner->getSeasonLeaders([], 0);
             $rows = $innerResult['results'];
             $this->cache->set(self::CACHE_KEY_LEADERS, $rows, self::TTL_SECONDS);
-        }
-
-        // Filter by year
-        $yearFilter = (string) ($filters['year'] ?? '');
-        if ($yearFilter !== '') {
-            $yearInt = (int) $yearFilter;
-            $rows = array_values(array_filter(
-                $rows,
-                static fn (array $row): bool => $row['year'] === $yearInt
-            ));
-        }
-
-        // Filter by team
-        $teamId = (int) ($filters['team'] ?? 0);
-        if ($teamId !== 0) {
-            $rows = array_values(array_filter(
-                $rows,
-                static fn (array $row): bool => $row['teamid'] === $teamId
-            ));
-        }
-
-        // Sort by the requested stat DESC
-        $sortBy = (string) ($filters['sortby'] ?? 'PPG');
-        usort($rows, static function (array $a, array $b) use ($sortBy): int {
-            $aVal = self::getSortValue($a, $sortBy);
-            $bVal = self::getSortValue($b, $sortBy);
-            $cmp = $bVal <=> $aVal;
-            if ($cmp !== 0) {
-                return $cmp;
-            }
-            return $a['pid'] <=> $b['pid'];
-        });
-
-        // Apply limit
-        if ($limit > 0) {
-            $rows = array_slice($rows, 0, $limit);
         }
 
         return [
@@ -153,72 +115,5 @@ class CachedSeasonLeaderboardsRepository implements SeasonLeaderboardsRepository
         $this->cache->delete(self::CACHE_KEY_LEADERS);
         $this->cache->delete(self::CACHE_KEY_YEARS);
         $this->cache->delete(self::CACHE_KEY_TEAMS);
-    }
-
-    /**
-     * Compute the sort value for a row, matching the SQL expressions in
-     * SeasonLeaderboardsRepository::getSortColumn().
-     *
-     * @param HistRow $row
-     */
-    private static function getSortValue(array $row, string $sortBy): float
-    {
-        $games = $row['games'];
-        if ($games === 0 && $sortBy !== 'GAMES') {
-            return 0.0;
-        }
-
-        $fgm = $row['fgm'];
-        $fga = $row['fga'];
-        $ftm = $row['ftm'];
-        $fta = $row['fta'];
-        $tgm = $row['tgm'];
-        $tga = $row['tga'];
-
-        return match ($sortBy) {
-            'PPG' => (2 * $fgm + $ftm + $tgm) / $games,
-            'REB' => $row['reb'] / $games,
-            'OREB' => $row['orb'] / $games,
-            'DREB' => ($row['reb'] - $row['orb']) / $games,
-            'AST' => $row['ast'] / $games,
-            'STL' => $row['stl'] / $games,
-            'BLK' => $row['blk'] / $games,
-            'TO' => $row['tvr'] / $games,
-            'FOUL' => $row['pf'] / $games,
-            'QA' => self::computeQaPerGame($row, $games),
-            'FGM' => $fgm / $games,
-            'FGA' => $fga / $games,
-            'FGP' => $fga > 0 ? $fgm / $fga : 0.0,
-            'FTM' => $ftm / $games,
-            'FTA' => $fta / $games,
-            'FTP' => $fta > 0 ? $ftm / $fta : 0.0,
-            'TGM' => $tgm / $games,
-            'TGA' => $tga / $games,
-            'TGP' => $tga > 0 ? $tgm / $tga : 0.0,
-            'GAMES' => (float) $games,
-            'MIN' => $row['minutes'] / $games,
-            default => (2 * $fgm + $ftm + $tgm) / $games,
-        };
-    }
-
-    /**
-     * QA per game — matches SQL expression:
-     * ((2*fgm+ftm+tgm)+reb+(2*ast)+(2*stl)+(2*blk))-((fga-fgm)+(fta-ftm)+tvr+pf)) / games
-     *
-     * @param HistRow $row
-     */
-    private static function computeQaPerGame(array $row, int $games): float
-    {
-        $fgm = $row['fgm'];
-        $fga = $row['fga'];
-        $ftm = $row['ftm'];
-        $fta = $row['fta'];
-        $tgm = $row['tgm'];
-
-        $pts = 2 * $fgm + $ftm + $tgm;
-        $positive = $pts + $row['reb'] + (2 * $row['ast']) + (2 * $row['stl']) + (2 * $row['blk']);
-        $negative = ($fga - $fgm) + ($fta - $ftm) + $row['tvr'] + $row['pf'];
-
-        return ($positive - $negative) / $games;
     }
 }

--- a/ibl5/classes/SeasonLeaderboards/Contracts/SeasonLeaderboardsServiceInterface.php
+++ b/ibl5/classes/SeasonLeaderboards/Contracts/SeasonLeaderboardsServiceInterface.php
@@ -7,13 +7,27 @@ namespace SeasonLeaderboards\Contracts;
 /**
  * SeasonLeaderboardsServiceInterface - Season leaders business logic
  *
- * Handles data transformation and calculations for season statistics.
+ * Handles data transformation, filtering, sorting, and calculations for season statistics.
  *
  * @phpstan-import-type HistRow from SeasonLeaderboardsRepositoryInterface
+ * @phpstan-import-type LeaderboardFilters from SeasonLeaderboardsRepositoryInterface
+ * @phpstan-import-type LeaderboardResult from SeasonLeaderboardsRepositoryInterface
  * @phpstan-type ProcessedStats array{pid: int, name: string, year: int, teamname: string, teamid: int, team_city: string, color1: string, color2: string, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, points: int, fgp: string, ftp: string, tgp: string, mpg: string, fgmpg: string, fgapg: string, ftmpg: string, ftapg: string, tgmpg: string, tgapg: string, orbpg: string, drebpg: string, rpg: string, apg: string, spg: string, tpg: string, bpg: string, fpg: string, ppg: string, qa: string}
  */
 interface SeasonLeaderboardsServiceInterface
 {
+    /**
+     * Get filtered, sorted, and limited leaderboard results.
+     *
+     * Fetches all leaders from the repository, then applies year/team
+     * filtering, stat-based sorting, and limit in PHP.
+     *
+     * @param LeaderboardFilters $filters Filter parameters
+     * @param int $limit Maximum number of records to return (0 for unlimited)
+     * @return LeaderboardResult Result with rows and count
+     */
+    public function getFilteredLeaderboard(array $filters, int $limit = 0): array;
+
     /**
      * Process a player row from database into formatted statistics
      *

--- a/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsService.php
+++ b/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsService.php
@@ -12,10 +12,73 @@ use SeasonLeaderboards\Contracts\SeasonLeaderboardsServiceInterface;
  * @see SeasonLeaderboardsServiceInterface
  *
  * @phpstan-import-type HistRow from SeasonLeaderboardsRepositoryInterface
+ * @phpstan-import-type LeaderboardFilters from SeasonLeaderboardsRepositoryInterface
+ * @phpstan-import-type LeaderboardResult from SeasonLeaderboardsRepositoryInterface
  * @phpstan-import-type ProcessedStats from SeasonLeaderboardsServiceInterface
  */
 class SeasonLeaderboardsService implements SeasonLeaderboardsServiceInterface
 {
+    private SeasonLeaderboardsRepositoryInterface $repository;
+
+    public function __construct(SeasonLeaderboardsRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @see SeasonLeaderboardsServiceInterface::getFilteredLeaderboard()
+     *
+     * @param LeaderboardFilters $filters
+     * @return LeaderboardResult
+     */
+    public function getFilteredLeaderboard(array $filters, int $limit = 0): array
+    {
+        $result = $this->repository->getSeasonLeaders([], 0);
+        /** @var list<HistRow> $rows */
+        $rows = $result['results'];
+
+        // Filter by year
+        $yearFilter = (string) ($filters['year'] ?? '');
+        if ($yearFilter !== '') {
+            $yearInt = (int) $yearFilter;
+            $rows = array_values(array_filter(
+                $rows,
+                static fn (array $row): bool => $row['year'] === $yearInt
+            ));
+        }
+
+        // Filter by team
+        $teamId = (int) ($filters['team'] ?? 0);
+        if ($teamId !== 0) {
+            $rows = array_values(array_filter(
+                $rows,
+                static fn (array $row): bool => $row['teamid'] === $teamId
+            ));
+        }
+
+        // Sort by the requested stat DESC
+        $sortBy = (string) ($filters['sortby'] ?? 'PPG');
+        usort($rows, static function (array $a, array $b) use ($sortBy): int {
+            $aVal = self::getSortValue($a, $sortBy);
+            $bVal = self::getSortValue($b, $sortBy);
+            $cmp = $bVal <=> $aVal;
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+            return $a['pid'] <=> $b['pid'];
+        });
+
+        // Apply limit
+        if ($limit > 0) {
+            $rows = array_slice($rows, 0, $limit);
+        }
+
+        return [
+            'results' => $rows,
+            'count' => count($rows),
+        ];
+    }
+
     /**
      * @see SeasonLeaderboardsServiceInterface::processPlayerRow()
      *
@@ -171,5 +234,66 @@ class SeasonLeaderboardsService implements SeasonLeaderboardsServiceInterface
             'TGM' => 'TGM', 'TGA' => 'TGA', 'TGP' => 'TG%', 'GAMES' => 'GAMES',
             'MIN' => 'MIN',
         ];
+    }
+
+    /**
+     * @param HistRow $row
+     */
+    private static function getSortValue(array $row, string $sortBy): float
+    {
+        $games = $row['games'];
+        if ($games === 0 && $sortBy !== 'GAMES') {
+            return 0.0;
+        }
+
+        $fgm = $row['fgm'];
+        $fga = $row['fga'];
+        $ftm = $row['ftm'];
+        $fta = $row['fta'];
+        $tgm = $row['tgm'];
+        $tga = $row['tga'];
+
+        return match ($sortBy) {
+            'PPG' => (2 * $fgm + $ftm + $tgm) / $games,
+            'REB' => $row['reb'] / $games,
+            'OREB' => $row['orb'] / $games,
+            'DREB' => ($row['reb'] - $row['orb']) / $games,
+            'AST' => $row['ast'] / $games,
+            'STL' => $row['stl'] / $games,
+            'BLK' => $row['blk'] / $games,
+            'TO' => $row['tvr'] / $games,
+            'FOUL' => $row['pf'] / $games,
+            'QA' => self::computeQaPerGame($row, $games),
+            'FGM' => $fgm / $games,
+            'FGA' => $fga / $games,
+            'FGP' => $fga > 0 ? $fgm / $fga : 0.0,
+            'FTM' => $ftm / $games,
+            'FTA' => $fta / $games,
+            'FTP' => $fta > 0 ? $ftm / $fta : 0.0,
+            'TGM' => $tgm / $games,
+            'TGA' => $tga / $games,
+            'TGP' => $tga > 0 ? $tgm / $tga : 0.0,
+            'GAMES' => (float) $games,
+            'MIN' => $row['minutes'] / $games,
+            default => (2 * $fgm + $ftm + $tgm) / $games,
+        };
+    }
+
+    /**
+     * @param HistRow $row
+     */
+    private static function computeQaPerGame(array $row, int $games): float
+    {
+        $fgm = $row['fgm'];
+        $fga = $row['fga'];
+        $ftm = $row['ftm'];
+        $fta = $row['fta'];
+        $tgm = $row['tgm'];
+
+        $pts = 2 * $fgm + $ftm + $tgm;
+        $positive = $pts + $row['reb'] + (2 * $row['ast']) + (2 * $row['stl']) + (2 * $row['blk']);
+        $negative = ($fga - $fgm) + ($fta - $ftm) + $row['tvr'] + $row['pf'];
+
+        return ($positive - $negative) / $games;
     }
 }

--- a/ibl5/modules/SeasonLeaderboards/index.php
+++ b/ibl5/modules/SeasonLeaderboards/index.php
@@ -20,7 +20,7 @@ $pagetitle = "Season Stats";
 $dbCache = new \Cache\DatabaseCache($mysqli_db);
 $innerRepository = new SeasonLeaderboardsRepository($mysqli_db);
 $repository = new CachedSeasonLeaderboardsRepository($innerRepository, $dbCache);
-$service = new SeasonLeaderboardsService();
+$service = new SeasonLeaderboardsService($repository);
 $view = new SeasonLeaderboardsView($service);
 
 // Get filter parameters from POST
@@ -53,7 +53,7 @@ $years = $repository->getYears();
 echo $view->renderFilterForm($teams, $years, $filters);
 
 // Get and render season leaders
-$leadersData = $repository->getSeasonLeaders($filters, $limit);
+$leadersData = $service->getFilteredLeaderboard($filters, $limit);
 $rows = $leadersData['results'];
 $numRows = $leadersData['count'];
 

--- a/ibl5/tests/SeasonLeaderboards/CachedSeasonLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/SeasonLeaderboards/CachedSeasonLeaderboardsRepositoryTest.php
@@ -23,13 +23,17 @@ final class CachedSeasonLeaderboardsRepositoryTest extends TestCase
         $mockInner = $this->createMock(SeasonLeaderboardsRepositoryInterface::class);
         $repository = new CachedSeasonLeaderboardsRepository($mockInner, $this->cache);
 
-        $this->cache->set('season_leaderboards:leaders', $this->createSampleRows(), 86400);
+        $rows = [
+            ['pid' => 1, 'name' => 'P1', 'year' => 2024, 'team' => 'T1', 'teamid' => 1, 'games' => 80, 'minutes' => 1200, 'fgm' => 400, 'fga' => 800, 'ftm' => 150, 'fta' => 200, 'tgm' => 75, 'tga' => 200, 'orb' => 50, 'reb' => 200, 'ast' => 100, 'stl' => 30, 'blk' => 20, 'tvr' => 50, 'pf' => 60, 'team_city' => null, 'color1' => null, 'color2' => null],
+        ];
+        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
 
         $mockInner->expects($this->never())->method('getSeasonLeaders');
 
-        $result = $repository->getSeasonLeaders(['sortby' => 'PPG'], 0);
+        $result = $repository->getSeasonLeaders([], 0);
 
-        $this->assertSame(3, $result['count']);
+        $this->assertSame(1, $result['count']);
+        $this->assertSame(1, $result['results'][0]['pid']);
     }
 
     public function testCacheMissDelegatesToInnerAndCaches(): void
@@ -37,214 +41,37 @@ final class CachedSeasonLeaderboardsRepositoryTest extends TestCase
         $mockInner = $this->createMock(SeasonLeaderboardsRepositoryInterface::class);
         $repository = new CachedSeasonLeaderboardsRepository($mockInner, $this->cache);
 
-        $rows = $this->createSampleRows();
+        $rows = [
+            ['pid' => 1, 'name' => 'P1', 'year' => 2024, 'team' => 'T1', 'teamid' => 1, 'games' => 80, 'minutes' => 1200, 'fgm' => 400, 'fga' => 800, 'ftm' => 150, 'fta' => 200, 'tgm' => 75, 'tga' => 200, 'orb' => 50, 'reb' => 200, 'ast' => 100, 'stl' => 30, 'blk' => 20, 'tvr' => 50, 'pf' => 60, 'team_city' => null, 'color1' => null, 'color2' => null],
+        ];
 
         $mockInner->expects($this->once())
             ->method('getSeasonLeaders')
             ->with([], 0)
-            ->willReturn(['results' => $rows, 'count' => 3]);
+            ->willReturn(['results' => $rows, 'count' => 1]);
 
-        $result = $repository->getSeasonLeaders(['sortby' => 'PPG'], 0);
+        $result = $repository->getSeasonLeaders([], 0);
 
-        $this->assertSame(3, $result['count']);
+        $this->assertSame(1, $result['count']);
         $this->assertNotNull($this->cache->get('season_leaderboards:leaders'));
     }
 
-    public function testFiltersByYear(): void
+    public function testReturnsAllRowsWithoutFilteringOrSorting(): void
     {
         $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
         $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
 
         $rows = [
-            $this->createRow(1, 'Player A', 2024, 1, 80, 1200),
-            $this->createRow(2, 'Player B', 2025, 2, 70, 1000),
-            $this->createRow(3, 'Player C', 2024, 3, 60, 900),
+            ['pid' => 3, 'name' => 'P3', 'year' => 2025, 'team' => 'T3', 'teamid' => 3, 'games' => 60, 'minutes' => 900, 'fgm' => 250, 'fga' => 500, 'ftm' => 100, 'fta' => 150, 'tgm' => 50, 'tga' => 100, 'orb' => 30, 'reb' => 120, 'ast' => 50, 'stl' => 20, 'blk' => 10, 'tvr' => 30, 'pf' => 40, 'team_city' => null, 'color1' => null, 'color2' => null],
+            ['pid' => 1, 'name' => 'P1', 'year' => 2024, 'team' => 'T1', 'teamid' => 1, 'games' => 80, 'minutes' => 1200, 'fgm' => 400, 'fga' => 800, 'ftm' => 150, 'fta' => 200, 'tgm' => 75, 'tga' => 200, 'orb' => 50, 'reb' => 200, 'ast' => 100, 'stl' => 30, 'blk' => 20, 'tvr' => 50, 'pf' => 60, 'team_city' => null, 'color1' => null, 'color2' => null],
         ];
         $this->cache->set('season_leaderboards:leaders', $rows, 86400);
 
-        $result = $repository->getSeasonLeaders(['year' => '2024', 'sortby' => 'PPG']);
+        $result = $repository->getSeasonLeaders(['year' => '2024', 'sortby' => 'PPG'], 1);
 
         $this->assertSame(2, $result['count']);
-        $pids = array_column($result['results'], 'pid');
-        $this->assertContains(1, $pids);
-        $this->assertContains(3, $pids);
-    }
-
-    public function testFiltersByTeam(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(1, 'Player A', 2024, 5, 80, 1200),
-            $this->createRow(2, 'Player B', 2024, 10, 70, 1000),
-            $this->createRow(3, 'Player C', 2024, 5, 60, 900),
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        $result = $repository->getSeasonLeaders(['team' => 5, 'sortby' => 'PPG']);
-
-        $this->assertSame(2, $result['count']);
-        $pids = array_column($result['results'], 'pid');
-        $this->assertContains(1, $pids);
-        $this->assertContains(3, $pids);
-    }
-
-    public function testSortsByPpgDesc(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(1, 'Low Scorer', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
-            $this->createRow(2, 'High Scorer', 2024, 2, 80, 1600, fgm: 500, ftm: 200, tgm: 100),
-            $this->createRow(3, 'Mid Scorer', 2024, 3, 80, 1200, fgm: 350, ftm: 150, tgm: 75),
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        $result = $repository->getSeasonLeaders(['sortby' => 'PPG']);
-
-        $this->assertSame(2, $result['results'][0]['pid']); // High Scorer: (2*500+200+100)/80 = 16.25
-        $this->assertSame(3, $result['results'][1]['pid']); // Mid Scorer: (2*350+150+75)/80 = 11.5625
-        $this->assertSame(1, $result['results'][2]['pid']); // Low Scorer: (2*200+100+50)/80 = 6.875
-    }
-
-    public function testSortsByReboundsPerGame(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(1, 'Few Boards', 2024, 1, 80, 800, reb: 200),
-            $this->createRow(2, 'Many Boards', 2024, 2, 80, 800, reb: 600),
-            $this->createRow(3, 'Mid Boards', 2024, 3, 80, 800, reb: 400),
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        $result = $repository->getSeasonLeaders(['sortby' => 'REB']);
-
-        $this->assertSame(2, $result['results'][0]['pid']); // 600/80 = 7.5
-        $this->assertSame(3, $result['results'][1]['pid']); // 400/80 = 5.0
-        $this->assertSame(1, $result['results'][2]['pid']); // 200/80 = 2.5
-    }
-
-    public function testSortsByDefensiveReboundsPerGame(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(1, 'Low DREB', 2024, 1, 80, 800, orb: 50, reb: 200),  // dreb=150, /80=1.875
-            $this->createRow(2, 'High DREB', 2024, 2, 80, 800, orb: 50, reb: 600), // dreb=550, /80=6.875
-            $this->createRow(3, 'Mid DREB', 2024, 3, 80, 800, orb: 100, reb: 500), // dreb=400, /80=5.0
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        $result = $repository->getSeasonLeaders(['sortby' => 'DREB']);
-
-        $this->assertSame(2, $result['results'][0]['pid']); // 6.875
-        $this->assertSame(3, $result['results'][1]['pid']); // 5.0
-        $this->assertSame(1, $result['results'][2]['pid']); // 1.875
-    }
-
-    public function testSortsByFgPct(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(1, 'Bad Shooter', 2024, 1, 80, 800, fgm: 200, fga: 600),
-            $this->createRow(2, 'Good Shooter', 2024, 2, 80, 800, fgm: 400, fga: 600),
-            $this->createRow(3, 'Ok Shooter', 2024, 3, 80, 800, fgm: 300, fga: 600),
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        $result = $repository->getSeasonLeaders(['sortby' => 'FGP']);
-
-        $this->assertSame(2, $result['results'][0]['pid']); // 400/600 = .667
-        $this->assertSame(3, $result['results'][1]['pid']); // 300/600 = .500
-        $this->assertSame(1, $result['results'][2]['pid']); // 200/600 = .333
-    }
-
-    public function testSortsByGamesPlayed(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(1, 'Few Games', 2024, 1, 40, 400),
-            $this->createRow(2, 'Many Games', 2024, 2, 82, 800),
-            $this->createRow(3, 'Mid Games', 2024, 3, 60, 600),
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        $result = $repository->getSeasonLeaders(['sortby' => 'GAMES']);
-
-        $this->assertSame(2, $result['results'][0]['pid']); // 82 games
-        $this->assertSame(3, $result['results'][1]['pid']); // 60 games
-        $this->assertSame(1, $result['results'][2]['pid']); // 40 games
-    }
-
-    public function testDefaultSortIsPpg(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(1, 'Low', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
-            $this->createRow(2, 'High', 2024, 2, 80, 1600, fgm: 500, ftm: 200, tgm: 100),
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        // No sortby in filters — should default to PPG
-        $result = $repository->getSeasonLeaders([]);
-
-        $this->assertSame(2, $result['results'][0]['pid']);
-    }
-
-    public function testLimitRestrictsResultCount(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $this->cache->set('season_leaderboards:leaders', $this->createSampleRows(), 86400);
-
-        $result = $repository->getSeasonLeaders(['sortby' => 'PPG'], 2);
-
-        $this->assertSame(2, $result['count']);
-    }
-
-    public function testZeroLimitReturnsAllRows(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $this->cache->set('season_leaderboards:leaders', $this->createSampleRows(), 86400);
-
-        $result = $repository->getSeasonLeaders(['sortby' => 'PPG'], 0);
-
-        $this->assertSame(3, $result['count']);
-    }
-
-    public function testCombinesYearFilterSortAndLimit(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(1, 'P1 2024', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
-            $this->createRow(2, 'P2 2024', 2024, 2, 80, 1600, fgm: 500, ftm: 200, tgm: 100),
-            $this->createRow(3, 'P3 2025', 2025, 3, 80, 1200, fgm: 400, ftm: 180, tgm: 90),
-            $this->createRow(4, 'P4 2024', 2024, 1, 80, 1400, fgm: 450, ftm: 190, tgm: 95),
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        // Year 2024, sorted by PPG, limit 2
-        $result = $repository->getSeasonLeaders(['year' => '2024', 'sortby' => 'PPG'], 2);
-
-        $this->assertSame(2, $result['count']);
-        $this->assertSame(2, $result['results'][0]['pid']); // Highest PPG in 2024
-        $this->assertSame(4, $result['results'][1]['pid']); // Second highest
+        $this->assertSame(3, $result['results'][0]['pid']);
+        $this->assertSame(1, $result['results'][1]['pid']);
     }
 
     public function testGetYearsCachesResult(): void
@@ -256,9 +83,7 @@ final class CachedSeasonLeaderboardsRepositoryTest extends TestCase
             ->method('getYears')
             ->willReturn([2025, 2024, 2023]);
 
-        // First call — cache miss
         $years1 = $repository->getYears();
-        // Second call — cache hit
         $years2 = $repository->getYears();
 
         $this->assertSame([2025, 2024, 2023], $years1);
@@ -276,9 +101,7 @@ final class CachedSeasonLeaderboardsRepositoryTest extends TestCase
             ->method('getTeams')
             ->willReturn($teams);
 
-        // First call — cache miss
         $teams1 = $repository->getTeams();
-        // Second call — cache hit
         $teams2 = $repository->getTeams();
 
         $this->assertSame($teams, $teams1);
@@ -324,105 +147,6 @@ final class CachedSeasonLeaderboardsRepositoryTest extends TestCase
         $this->assertNull($this->cache->get('season_leaderboards:leaders'));
         $this->assertNull($this->cache->get('season_leaderboards:years'));
         $this->assertNull($this->cache->get('season_leaderboards:teams'));
-    }
-
-    public function testTiesResolveByPidAsc(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(30, 'Player C', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
-            $this->createRow(10, 'Player A', 2024, 2, 80, 800, fgm: 200, ftm: 100, tgm: 50),
-            $this->createRow(20, 'Player B', 2024, 3, 80, 800, fgm: 200, ftm: 100, tgm: 50),
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        $result = $repository->getSeasonLeaders(['sortby' => 'PPG']);
-
-        $this->assertSame(10, $result['results'][0]['pid']);
-        $this->assertSame(20, $result['results'][1]['pid']);
-        $this->assertSame(30, $result['results'][2]['pid']);
-    }
-
-    public function testZeroGamesPlayerDoesNotCauseDivisionByZero(): void
-    {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
-        $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
-
-        $rows = [
-            $this->createRow(1, 'No Games', 2024, 1, 0, 0),
-            $this->createRow(2, 'Has Games', 2024, 2, 80, 1600, fgm: 500, ftm: 200, tgm: 100),
-        ];
-        $this->cache->set('season_leaderboards:leaders', $rows, 86400);
-
-        $result = $repository->getSeasonLeaders(['sortby' => 'PPG']);
-
-        $this->assertSame(2, $result['results'][0]['pid']); // Has games sorts first
-        $this->assertSame(1, $result['results'][1]['pid']); // Zero games gets 0.0
-    }
-
-    /**
-     * @return list<array<string, mixed>>
-     */
-    private function createSampleRows(): array
-    {
-        return [
-            $this->createRow(1, 'Player 1', 2024, 1, 80, 1200, fgm: 400, ftm: 150, tgm: 75),
-            $this->createRow(2, 'Player 2', 2024, 2, 70, 1000, fgm: 300, ftm: 120, tgm: 60),
-            $this->createRow(3, 'Player 3', 2025, 3, 60, 900, fgm: 250, ftm: 100, tgm: 50),
-        ];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function createRow(
-        int $pid,
-        string $name,
-        int $year,
-        int $teamid,
-        int $games,
-        int $minutes,
-        int $fgm = 0,
-        int $fga = 0,
-        int $ftm = 0,
-        int $fta = 0,
-        int $tgm = 0,
-        int $tga = 0,
-        int $orb = 0,
-        int $reb = 0,
-        int $ast = 0,
-        int $stl = 0,
-        int $blk = 0,
-        int $tvr = 0,
-        int $pf = 0,
-    ): array {
-        return [
-            'pid' => $pid,
-            'name' => $name,
-            'year' => $year,
-            'team' => "Team $teamid",
-            'teamid' => $teamid,
-            'games' => $games,
-            'minutes' => $minutes,
-            'fgm' => $fgm,
-            'fga' => $fga,
-            'ftm' => $ftm,
-            'fta' => $fta,
-            'tgm' => $tgm,
-            'tga' => $tga,
-            'orb' => $orb,
-            'reb' => $reb,
-            'ast' => $ast,
-            'stl' => $stl,
-            'blk' => $blk,
-            'tvr' => $tvr,
-            'pf' => $pf,
-            'team_city' => null,
-            'color1' => null,
-            'color2' => null,
-        ];
     }
 }
 

--- a/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsServiceTest.php
+++ b/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsServiceTest.php
@@ -5,16 +5,220 @@ declare(strict_types=1);
 namespace Tests\SeasonLeaderboards;
 
 use PHPUnit\Framework\TestCase;
+use SeasonLeaderboards\Contracts\SeasonLeaderboardsRepositoryInterface;
 use SeasonLeaderboards\SeasonLeaderboardsService;
 
 final class SeasonLeaderboardsServiceTest extends TestCase
 {
+    private SeasonLeaderboardsRepositoryInterface $stubRepo;
     private SeasonLeaderboardsService $service;
 
     protected function setUp(): void
     {
-        $this->service = new SeasonLeaderboardsService();
+        $this->stubRepo = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
+        $this->stubRepo->method('getSeasonLeaders')
+            ->willReturn(['results' => [], 'count' => 0]);
+        $this->service = new SeasonLeaderboardsService($this->stubRepo);
     }
+
+    private function buildServiceWithRows(array $rows): SeasonLeaderboardsService
+    {
+        $stub = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
+        $stub->method('getSeasonLeaders')
+            ->willReturn(['results' => $rows, 'count' => count($rows)]);
+        return new SeasonLeaderboardsService($stub);
+    }
+
+    // --- getFilteredLeaderboard: filter tests ---
+
+    public function testFiltersByYear(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Player A', 2024, 1, 80, 1200),
+            $this->createRow(2, 'Player B', 2025, 2, 70, 1000),
+            $this->createRow(3, 'Player C', 2024, 3, 60, 900),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['year' => '2024', 'sortby' => 'PPG']);
+
+        $this->assertSame(2, $result['count']);
+        $pids = array_column($result['results'], 'pid');
+        $this->assertContains(1, $pids);
+        $this->assertContains(3, $pids);
+    }
+
+    public function testFiltersByTeam(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Player A', 2024, 5, 80, 1200),
+            $this->createRow(2, 'Player B', 2024, 10, 70, 1000),
+            $this->createRow(3, 'Player C', 2024, 5, 60, 900),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['team' => 5, 'sortby' => 'PPG']);
+
+        $this->assertSame(2, $result['count']);
+        $pids = array_column($result['results'], 'pid');
+        $this->assertContains(1, $pids);
+        $this->assertContains(3, $pids);
+    }
+
+    // --- getFilteredLeaderboard: sort tests ---
+
+    public function testSortsByPpgDesc(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Low Scorer', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
+            $this->createRow(2, 'High Scorer', 2024, 2, 80, 1600, fgm: 500, ftm: 200, tgm: 100),
+            $this->createRow(3, 'Mid Scorer', 2024, 3, 80, 1200, fgm: 350, ftm: 150, tgm: 75),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'PPG']);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(3, $result['results'][1]['pid']);
+        $this->assertSame(1, $result['results'][2]['pid']);
+    }
+
+    public function testSortsByReboundsPerGame(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Few Boards', 2024, 1, 80, 800, reb: 200),
+            $this->createRow(2, 'Many Boards', 2024, 2, 80, 800, reb: 600),
+            $this->createRow(3, 'Mid Boards', 2024, 3, 80, 800, reb: 400),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'REB']);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(3, $result['results'][1]['pid']);
+        $this->assertSame(1, $result['results'][2]['pid']);
+    }
+
+    public function testSortsByDefensiveReboundsPerGame(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Low DREB', 2024, 1, 80, 800, orb: 50, reb: 200),
+            $this->createRow(2, 'High DREB', 2024, 2, 80, 800, orb: 50, reb: 600),
+            $this->createRow(3, 'Mid DREB', 2024, 3, 80, 800, orb: 100, reb: 500),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'DREB']);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(3, $result['results'][1]['pid']);
+        $this->assertSame(1, $result['results'][2]['pid']);
+    }
+
+    public function testSortsByFgPct(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Bad Shooter', 2024, 1, 80, 800, fgm: 200, fga: 600),
+            $this->createRow(2, 'Good Shooter', 2024, 2, 80, 800, fgm: 400, fga: 600),
+            $this->createRow(3, 'Ok Shooter', 2024, 3, 80, 800, fgm: 300, fga: 600),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'FGP']);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(3, $result['results'][1]['pid']);
+        $this->assertSame(1, $result['results'][2]['pid']);
+    }
+
+    public function testSortsByGamesPlayed(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Few Games', 2024, 1, 40, 400),
+            $this->createRow(2, 'Many Games', 2024, 2, 82, 800),
+            $this->createRow(3, 'Mid Games', 2024, 3, 60, 600),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'GAMES']);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(3, $result['results'][1]['pid']);
+        $this->assertSame(1, $result['results'][2]['pid']);
+    }
+
+    public function testDefaultSortIsPpg(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Low', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
+            $this->createRow(2, 'High', 2024, 2, 80, 1600, fgm: 500, ftm: 200, tgm: 100),
+        ]);
+
+        $result = $service->getFilteredLeaderboard([]);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+    }
+
+    // --- getFilteredLeaderboard: limit tests ---
+
+    public function testLimitRestrictsResultCount(): void
+    {
+        $service = $this->buildServiceWithRows($this->createSampleRows());
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'PPG'], 2);
+
+        $this->assertSame(2, $result['count']);
+    }
+
+    public function testZeroLimitReturnsAllRows(): void
+    {
+        $service = $this->buildServiceWithRows($this->createSampleRows());
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'PPG'], 0);
+
+        $this->assertSame(3, $result['count']);
+    }
+
+    public function testCombinesYearFilterSortAndLimit(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'P1 2024', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
+            $this->createRow(2, 'P2 2024', 2024, 2, 80, 1600, fgm: 500, ftm: 200, tgm: 100),
+            $this->createRow(3, 'P3 2025', 2025, 3, 80, 1200, fgm: 400, ftm: 180, tgm: 90),
+            $this->createRow(4, 'P4 2024', 2024, 1, 80, 1400, fgm: 450, ftm: 190, tgm: 95),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['year' => '2024', 'sortby' => 'PPG'], 2);
+
+        $this->assertSame(2, $result['count']);
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(4, $result['results'][1]['pid']);
+    }
+
+    // --- getFilteredLeaderboard: edge cases ---
+
+    public function testTiesResolveByPidAsc(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(30, 'Player C', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
+            $this->createRow(10, 'Player A', 2024, 2, 80, 800, fgm: 200, ftm: 100, tgm: 50),
+            $this->createRow(20, 'Player B', 2024, 3, 80, 800, fgm: 200, ftm: 100, tgm: 50),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'PPG']);
+
+        $this->assertSame(10, $result['results'][0]['pid']);
+        $this->assertSame(20, $result['results'][1]['pid']);
+        $this->assertSame(30, $result['results'][2]['pid']);
+    }
+
+    public function testZeroGamesPlayerDoesNotCauseDivisionByZero(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'No Games', 2024, 1, 0, 0),
+            $this->createRow(2, 'Has Games', 2024, 2, 80, 1600, fgm: 500, ftm: 200, tgm: 100),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'PPG']);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(1, $result['results'][1]['pid']);
+    }
+
+    // --- processPlayerRow tests ---
 
     public function testProcessPlayerRowCalculatesCorrectly(): void
     {
@@ -43,26 +247,17 @@ final class SeasonLeaderboardsServiceTest extends TestCase
 
         $stats = $this->service->processPlayerRow($row);
 
-        // Check basic info
         $this->assertEquals(123, $stats['pid']);
         $this->assertEquals('Test Player', $stats['name']);
         $this->assertEquals(2024, $stats['year']);
-
-        // Check points calculation: 2*50 + 20 + 15 = 135
         $this->assertEquals(135, $stats['points']);
-
-        // Check per-game averages
-        $this->assertEquals('30.0', $stats['mpg']); // 300/10
-        $this->assertEquals('5.0', $stats['fgmpg']); // 50/10
-        $this->assertEquals('13.5', $stats['ppg']); // 135/10
-
-        // Check defensive rebounds per game: (80-30)/10 = 5.0
+        $this->assertEquals('30.0', $stats['mpg']);
+        $this->assertEquals('5.0', $stats['fgmpg']);
+        $this->assertEquals('13.5', $stats['ppg']);
         $this->assertEquals('5.0', $stats['drebpg']);
-
-        // Check percentages (0-1 range with 3 decimals)
-        $this->assertEquals('0.500', $stats['fgp']); // 50/100
-        $this->assertEquals('0.800', $stats['ftp']); // 20/25
-        $this->assertEquals('0.375', $stats['tgp']); // 15/40
+        $this->assertEquals('0.500', $stats['fgp']);
+        $this->assertEquals('0.800', $stats['ftp']);
+        $this->assertEquals('0.375', $stats['tgp']);
     }
 
     public function testProcessPlayerRowHandlesZeroGames(): void
@@ -92,7 +287,6 @@ final class SeasonLeaderboardsServiceTest extends TestCase
 
         $stats = $this->service->processPlayerRow($row);
 
-        // Check that per-game stats default to 0.0
         $this->assertEquals('0.0', $stats['mpg']);
         $this->assertEquals('0.0', $stats['ppg']);
         $this->assertEquals('0.0', $stats['qa']);
@@ -109,7 +303,7 @@ final class SeasonLeaderboardsServiceTest extends TestCase
             'games' => 10,
             'minutes' => 300,
             'fgm' => 0,
-            'fga' => 0, // Zero attempts
+            'fga' => 0,
             'ftm' => 0,
             'fta' => 0,
             'tgm' => 0,
@@ -125,7 +319,6 @@ final class SeasonLeaderboardsServiceTest extends TestCase
 
         $stats = $this->service->processPlayerRow($row);
 
-        // Check that percentages default to 0.000
         $this->assertEquals('0.000', $stats['fgp']);
         $this->assertEquals('0.000', $stats['ftp']);
         $this->assertEquals('0.000', $stats['tgp']);
@@ -133,7 +326,6 @@ final class SeasonLeaderboardsServiceTest extends TestCase
 
     public function testQualityAssessmentCalculation(): void
     {
-        // QA = (pts + reb + 2*ast + 2*stl + 2*blk - (fga-fgm) - (fta-ftm) - tvr - pf) / games
         $row = [
             'pid' => 123,
             'name' => 'Test Player',
@@ -142,27 +334,23 @@ final class SeasonLeaderboardsServiceTest extends TestCase
             'teamid' => 1,
             'games' => 10,
             'minutes' => 300,
-            'fgm' => 50, // 50 misses (100-50)
+            'fgm' => 50,
             'fga' => 100,
-            'ftm' => 20, // 5 misses (25-20)
+            'ftm' => 20,
             'fta' => 25,
             'tgm' => 15,
             'tga' => 40,
             'orb' => 30,
             'reb' => 80,
-            'ast' => 40, // *2 = 80
-            'stl' => 10, // *2 = 20
-            'tvr' => 15, // -15
-            'blk' => 5,  // *2 = 10
-            'pf' => 20   // -20
+            'ast' => 40,
+            'stl' => 10,
+            'tvr' => 15,
+            'blk' => 5,
+            'pf' => 20
         ];
 
         $stats = $this->service->processPlayerRow($row);
 
-        // Points = 2*50 + 20 + 15 = 135
-        // Positives = 135 + 80 + 80 + 20 + 10 = 325
-        // Negatives = 50 + 5 + 15 + 20 = 90
-        // QA = (325 - 90) / 10 = 23.5
         $this->assertEquals('23.5', $stats['qa']);
     }
 
@@ -176,5 +364,70 @@ final class SeasonLeaderboardsServiceTest extends TestCase
         $this->assertArrayHasKey('MIN', $options);
         $this->assertSame('PPG', $options['PPG']);
         $this->assertSame('FG%', $options['FGP']);
+    }
+
+    // --- Test helpers ---
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function createSampleRows(): array
+    {
+        return [
+            $this->createRow(1, 'Player 1', 2024, 1, 80, 1200, fgm: 400, ftm: 150, tgm: 75),
+            $this->createRow(2, 'Player 2', 2024, 2, 70, 1000, fgm: 300, ftm: 120, tgm: 60),
+            $this->createRow(3, 'Player 3', 2025, 3, 60, 900, fgm: 250, ftm: 100, tgm: 50),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function createRow(
+        int $pid,
+        string $name,
+        int $year,
+        int $teamid,
+        int $games,
+        int $minutes,
+        int $fgm = 0,
+        int $fga = 0,
+        int $ftm = 0,
+        int $fta = 0,
+        int $tgm = 0,
+        int $tga = 0,
+        int $orb = 0,
+        int $reb = 0,
+        int $ast = 0,
+        int $stl = 0,
+        int $blk = 0,
+        int $tvr = 0,
+        int $pf = 0,
+    ): array {
+        return [
+            'pid' => $pid,
+            'name' => $name,
+            'year' => $year,
+            'team' => "Team $teamid",
+            'teamid' => $teamid,
+            'games' => $games,
+            'minutes' => $minutes,
+            'fgm' => $fgm,
+            'fga' => $fga,
+            'ftm' => $ftm,
+            'fta' => $fta,
+            'tgm' => $tgm,
+            'tga' => $tga,
+            'orb' => $orb,
+            'reb' => $reb,
+            'ast' => $ast,
+            'stl' => $stl,
+            'blk' => $blk,
+            'tvr' => $tvr,
+            'pf' => $pf,
+            'team_city' => null,
+            'color1' => null,
+            'color2' => null,
+        ];
     }
 }

--- a/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsViewTest.php
+++ b/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsViewTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\SeasonLeaderboards;
 
 use PHPUnit\Framework\TestCase;
+use SeasonLeaderboards\Contracts\SeasonLeaderboardsRepositoryInterface;
 use SeasonLeaderboards\SeasonLeaderboardsView;
 use SeasonLeaderboards\SeasonLeaderboardsService;
 
@@ -15,8 +16,9 @@ final class SeasonLeaderboardsViewTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->service = new SeasonLeaderboardsService();
-        
+        $stubRepo = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
+        $this->service = new SeasonLeaderboardsService($stubRepo);
+
         $this->view = new SeasonLeaderboardsView($this->service);
     }
 


### PR DESCRIPTION
## Summary

Moves `getSortValue()` and `computeQaPerGame()` (ranking/sort business logic) from `CachedSeasonLeaderboardsRepository` to `SeasonLeaderboardsService`. The cached repo is now a pure cache pass-through; all filter/sort/limit logic lives in the Service layer where it belongs.

### Changes

- **CachedSeasonLeaderboardsRepository**: removed `getSortValue()`, `computeQaPerGame()`, filter/sort/limit loop — now purely wraps the inner repo with cache
- **SeasonLeaderboardsService**: added `getFilteredLeaderboard()` (filters, sorts, limits raw repo results); constructor now takes `SeasonLeaderboardsRepositoryInterface`
- **SeasonLeaderboardsServiceInterface**: added `getFilteredLeaderboard()` to the contract
- **modules/SeasonLeaderboards/index.php**: calls `$service->getFilteredLeaderboard()` instead of reaching into the repo
- **Tests**: migrated filter/sort/limit tests from `CachedSeasonLeaderboardsRepositoryTest` to `SeasonLeaderboardsServiceTest`

### Verification

5315 PHPUnit tests, 28898 assertions — all pass. PHPStan: 0 errors.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.