### PR TITLE
fix: remove redundant === 0 sentinel from validatePlayerSelection

### DIFF
--- a/ibl5/classes/OneOnOneGame/OneOnOneGameService.php
+++ b/ibl5/classes/OneOnOneGame/OneOnOneGameService.php
@@ -83,11 +83,11 @@ class OneOnOneGameService implements OneOnOneGameServiceInterface
     {
         $errors = [];
 
-        if ($player1Id === null || $player1Id === 0) {
+        if ($player1Id === null) {
             $errors[] = "Please select a Player from the Player 1 Category.";
         }
 
-        if ($player2Id === null || $player2Id === 0) {
+        if ($player2Id === null) {
             $errors[] = "Please select a Player from the Player 2 Category.";
         }
 

--- a/ibl5/tests/OneOnOneGame/OneOnOneGameServiceTest.php
+++ b/ibl5/tests/OneOnOneGame/OneOnOneGameServiceTest.php
@@ -64,20 +64,18 @@ final class OneOnOneGameServiceTest extends TestCase
         $this->assertStringContainsString('Player 2', $errors[0]);
     }
 
-    public function testValidatePlayerSelectionReturnsErrorWhenPlayer1IsZero(): void
+    public function testValidatePlayerSelectionAcceptsZeroForPlayer1(): void
     {
         $errors = $this->service->validatePlayerSelection(0, 2);
 
-        $this->assertNotEmpty($errors);
-        $this->assertStringContainsString('Player 1', $errors[0]);
+        $this->assertEmpty($errors);
     }
 
-    public function testValidatePlayerSelectionReturnsErrorWhenPlayer2IsZero(): void
+    public function testValidatePlayerSelectionAcceptsZeroForPlayer2(): void
     {
         $errors = $this->service->validatePlayerSelection(1, 0);
 
-        $this->assertNotEmpty($errors);
-        $this->assertStringContainsString('Player 2', $errors[0]);
+        $this->assertEmpty($errors);
     }
 
     public function testValidatePlayerSelectionReturnsErrorWhenBothPlayersAreSame(): void


### PR DESCRIPTION
## Summary

Remove the redundant `=== 0` sentinel from `OneOnOneGameService::validatePlayerSelection`. The method signature accepts `?int` — `null` already covers the "unselected" case. The `=== 0` check was a leftover from a previous refactor and would silently reject any hypothetical player with `pid=0`.

Callers already pass `null` for empty form fields (confirmed by grep), so no caller-side changes were needed.

## Changes

- `OneOnOneGameService::validatePlayerSelection`: drop `|| $player1Id === 0` and `|| $player2Id === 0` conditions
- `OneOnOneGameServiceTest`: update two tests — zero is now accepted (not an error)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

## Verification Matrix

| # | What | Test type | Status |
|---|------|-----------|--------|
| 1 | `null` → "not selected" error | PHPUnit | covered by existing tests |
| 2 | `=== 0` check removed | CLI | confirmed |
| 3 | `0` input no longer rejected | PHPUnit | `testValidatePlayerSelectionAcceptsZeroForPlayer1/2` |
| 4 | PHPStan passes | CLI | auto-run on commit |
| 5 | Full PHPUnit suite | CLI | auto-run on commit |