### PR TITLE
refactor: extract interfaces for UI module STAY classes

### DIFF
--- a/ibl5/classes/UI/AlertRenderer.php
+++ b/ibl5/classes/UI/AlertRenderer.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace UI;
 
 use Security\HtmlSanitizer;
+use UI\Contracts\AlertRendererInterface;
 
 /**
  * AlertRenderer - Shared utility for rendering ibl-alert banners
  *
  * Replaces identical private renderResultBanner() methods across multiple view classes.
  */
-class AlertRenderer
+class AlertRenderer implements AlertRendererInterface
 {
     /**
      * Render an alert banner from a result code using a caller-supplied banner map

--- a/ibl5/classes/UI/Components/TableViewDropdown.php
+++ b/ibl5/classes/UI/Components/TableViewDropdown.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UI\Components;
 
 use Security\HtmlSanitizer;
+use UI\Contracts\TableViewDropdownInterface;
 
 /**
  * TableViewDropdown - Dropdown <select> navigation for team page views with split stats
@@ -15,7 +16,7 @@ use Security\HtmlSanitizer;
  * Split values are encoded as "split:{key}" in option values; non-split values
  * are bare strings (e.g. "ratings", "total_s").
  */
-class TableViewDropdown
+class TableViewDropdown implements TableViewDropdownInterface
 {
     /** @var array<string, array<string, string>> Optgroup label => [value => label] */
     private array $groups;

--- a/ibl5/classes/UI/Components/TableViewSwitcher.php
+++ b/ibl5/classes/UI/Components/TableViewSwitcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UI\Components;
 
 use Security\HtmlSanitizer;
+use UI\Contracts\TableViewSwitcherInterface;
 
 /**
  * TableViewSwitcher - Reusable tab navigation for switching table display views
@@ -16,7 +17,7 @@ use Security\HtmlSanitizer;
  * - Single table: $switcher->wrap($tableHtml) — tabs injected as <caption>
  * - Multiple tables: $switcher->renderTabs() — rendered standalone above all tables
  */
-class TableViewSwitcher
+class TableViewSwitcher implements TableViewSwitcherInterface
 {
     /** @var array<string, string> Tab keys mapped to display labels */
     private array $tabs;

--- a/ibl5/classes/UI/Components/TooltipLabel.php
+++ b/ibl5/classes/UI/Components/TooltipLabel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UI\Components;
 
 use Security\HtmlSanitizer;
+use UI\Contracts\TooltipLabelInterface;
 
 /**
  * Renders a value with a CSS-only hover/focus tooltip.
@@ -15,7 +16,7 @@ use Security\HtmlSanitizer;
  * Used for injury return dates, sim number context, and any other
  * value that benefits from a hover/tap tooltip.
  */
-class TooltipLabel
+class TooltipLabel implements TooltipLabelInterface
 {
     /**
      * Render a value with an optional tooltip.

--- a/ibl5/classes/UI/Contracts/AlertRendererInterface.php
+++ b/ibl5/classes/UI/Contracts/AlertRendererInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Contracts;
+
+/**
+ * AlertRendererInterface - Contract for rendering ibl-alert banners
+ */
+interface AlertRendererInterface
+{
+    /**
+     * Render an alert banner from a result code using a caller-supplied banner map
+     *
+     * @param string|null $code Result code from query parameter
+     * @param array<string, array{class: string, message: string}> $banners Map of code → CSS class + message
+     * @param string|null $error Optional error message (takes priority over $code)
+     * @return string HTML alert div or empty string
+     */
+    public static function fromCode(?string $code, array $banners, ?string $error = null): string;
+
+    /**
+     * Render an arbitrary alert message
+     *
+     * @param string $message Alert message (will be HTML-escaped)
+     * @param string $cssModifier CSS modifier class (e.g. 'ibl-alert--success')
+     * @return string HTML alert div
+     */
+    public static function render(string $message, string $cssModifier): string;
+}

--- a/ibl5/classes/UI/Contracts/ContractsTableInterface.php
+++ b/ibl5/classes/UI/Contracts/ContractsTableInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Contracts;
+
+/**
+ * ContractsTableInterface - Contract for displaying team contracts table
+ */
+interface ContractsTableInterface
+{
+    /**
+     * Render the contracts table
+     *
+     * @param \mysqli $db Database connection
+     * @param iterable<int, array<string, mixed>> $result Player result set
+     * @param \Team\Team $team Team object
+     * @param \Season\Season $season Season object
+     * @param list<int> $starterPids Starter player IDs
+     * @param list<int> $excludeFromCapPids PIDs to exclude from cap total sums (e.g. outgoing trade players)
+     * @param bool $showActionLinks When false, Rookie Option / Contract Extension eligibility markers still render but are not clickable links (used when previewing another GM's roster in the Trading module)
+     * @return string HTML table
+     */
+    public static function render(\mysqli $db, iterable $result, \Team\Team $team, \Season\Season $season, array $starterPids = [], array $excludeFromCapPids = [], bool $showActionLinks = true): string;
+}

--- a/ibl5/classes/UI/Contracts/DebugOutputInterface.php
+++ b/ibl5/classes/UI/Contracts/DebugOutputInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Contracts;
+
+/**
+ * DebugOutputInterface - Contract for displaying debug information in a collapsible panel
+ */
+interface DebugOutputInterface
+{
+    /**
+     * Display debug output in a collapsible panel
+     *
+     * SECURITY: Only displays to admin users. Content is HTML-escaped
+     * to prevent XSS attacks.
+     *
+     * @param string $content The content to display
+     * @param string $title The title of the debug panel
+     * @return void
+     */
+    public static function display(string $content, string $title = 'Debug Output'): void;
+}

--- a/ibl5/classes/UI/Contracts/PlayerRowTransformerInterface.php
+++ b/ibl5/classes/UI/Contracts/PlayerRowTransformerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Contracts;
+
+/**
+ * PlayerRowTransformerInterface - Contract for resolving Player and PlayerStats objects from player rows
+ */
+interface PlayerRowTransformerInterface
+{
+    /**
+     * Resolve an iterable of player rows into Player + PlayerStats pairs.
+     * Filters out '|'-prefixed placeholder names.
+     *
+     * @param \mysqli $db Database connection
+     * @param iterable<int, \Player\Player|array<string, mixed>> $result Player result set
+     * @param string $yr Year filter (empty for current season)
+     * @return list<array{player: \Player\Player, playerStats: \Player\Stats\PlayerStats}>
+     */
+    public static function resolveWithStats(\mysqli $db, iterable $result, string $yr): array;
+
+    /**
+     * Resolve an iterable of player rows into Player objects only.
+     * Filters out '|'-prefixed placeholder names.
+     *
+     * @param \mysqli $db Database connection
+     * @param iterable<int, \Player\Player|array<string, mixed>> $result Player result set
+     * @param string $yr Year filter (empty for current season)
+     * @return list<\Player\Player>
+     */
+    public static function resolvePlayers(\mysqli $db, iterable $result, string $yr): array;
+}

--- a/ibl5/classes/UI/Contracts/RatingsInterface.php
+++ b/ibl5/classes/UI/Contracts/RatingsInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Contracts;
+
+/**
+ * RatingsInterface - Contract for displaying player ratings table
+ */
+interface RatingsInterface
+{
+    /**
+     * Render the ratings table
+     *
+     * @param \mysqli $db Database connection
+     * @param iterable<int, \Player\Player|array<string, mixed>> $data Player data
+     * @param \Team\Team $team Team object
+     * @param string $yr Year filter (empty for current season)
+     * @param \Season\Season $season Season object
+     * @param string $moduleName Module name for styling variations
+     * @param list<int> $starterPids Starter player IDs
+     * @return string HTML table
+     */
+    public static function render($db, $data, $team, string $yr, $season, string $moduleName = "", array $starterPids = []): string;
+}

--- a/ibl5/classes/UI/Contracts/TableStylesInterface.php
+++ b/ibl5/classes/UI/Contracts/TableStylesInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Contracts;
+
+/**
+ * TableStylesInterface - Contract for generating inline CSS custom property values for team-colored tables
+ */
+interface TableStylesInterface
+{
+    /**
+     * Generate inline CSS custom property declarations for team colors
+     *
+     * @param string $teamColor Primary team color (hex without #)
+     * @param string $teamColor2 Secondary team color (hex without #)
+     * @return string Inline style value (e.g. "--team-color-primary: #1e3a5f; --team-color-secondary: #D4AF37;")
+     */
+    public static function inlineVars(string $teamColor, string $teamColor2): string;
+
+    /**
+     * Sanitize color value to prevent injection
+     *
+     * @param string $color Hex color value
+     * @return string Sanitized hex color
+     */
+    public static function sanitizeColor(string $color): string;
+}

--- a/ibl5/classes/UI/Contracts/TableViewDropdownInterface.php
+++ b/ibl5/classes/UI/Contracts/TableViewDropdownInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Contracts;
+
+/**
+ * TableViewDropdownInterface - Contract for dropdown select navigation for team page views
+ */
+interface TableViewDropdownInterface
+{
+    /**
+     * Render the dropdown HTML
+     */
+    public function renderDropdown(): string;
+
+    /**
+     * Inject dropdown as a <caption> element inside the first <table> tag
+     *
+     * @param string $tableHtml Pre-rendered table HTML
+     * @return string Table HTML with caption injected after opening <table> tag
+     */
+    public function wrap(string $tableHtml): string;
+}

--- a/ibl5/classes/UI/Contracts/TableViewSwitcherInterface.php
+++ b/ibl5/classes/UI/Contracts/TableViewSwitcherInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Contracts;
+
+/**
+ * TableViewSwitcherInterface - Contract for tab navigation switching table display views
+ */
+interface TableViewSwitcherInterface
+{
+    /**
+     * Inject tabs as a <caption> element inside the first <table> tag
+     *
+     * @param string $tableHtml Pre-rendered table HTML
+     * @return string Table HTML with caption injected after opening <table> tag
+     */
+    public function wrap(string $tableHtml): string;
+
+    /**
+     * Render just the tabs HTML (for standalone placement above multiple tables)
+     *
+     * @return string HTML div containing tab links
+     */
+    public function renderTabs(): string;
+}

--- a/ibl5/classes/UI/Contracts/TooltipLabelInterface.php
+++ b/ibl5/classes/UI/Contracts/TooltipLabelInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Contracts;
+
+/**
+ * TooltipLabelInterface - Contract for rendering a value with a CSS-only hover/focus tooltip
+ */
+interface TooltipLabelInterface
+{
+    /**
+     * Render a value with an optional tooltip.
+     *
+     * @param string $displayValue The visible text (caller is responsible for sanitization)
+     * @param string $tooltipText  Text shown on hover/focus, or empty string for no tooltip
+     * @param string $cssClass     Additional CSS class(es) to add to the span
+     * @return string HTML: tooltip span when tooltipText is provided, plain displayValue otherwise
+     */
+    public static function render(string $displayValue, string $tooltipText, string $cssClass = ''): string;
+}

--- a/ibl5/classes/UI/DebugOutput.php
+++ b/ibl5/classes/UI/DebugOutput.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UI;
 
 use Security\HtmlSanitizer;
+use UI\Contracts\DebugOutputInterface;
 
 /**
  * DebugOutput - Displays debug information in a collapsible panel
@@ -12,7 +13,7 @@ use Security\HtmlSanitizer;
  * SECURITY: Debug output is only shown to admin users to prevent
  * information disclosure to regular users.
  */
-class DebugOutput
+class DebugOutput implements DebugOutputInterface
 {
     private static int $debugId = 0;
 

--- a/ibl5/classes/UI/TableStyles.php
+++ b/ibl5/classes/UI/TableStyles.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace UI;
 
+use UI\Contracts\TableStylesInterface;
+
 /**
  * TableStyles - Generates inline CSS custom property values for team-colored tables
  *
  * Used with the .team-table modifier class in tables.css.
  * Outputs only --team-color-primary and --team-color-secondary as inline style values.
  */
-class TableStyles
+class TableStyles implements TableStylesInterface
 {
     /**
      * Generate inline CSS custom property declarations for team colors

--- a/ibl5/classes/UI/Tables/Contracts.php
+++ b/ibl5/classes/UI/Tables/Contracts.php
@@ -10,13 +10,14 @@ use Player\PlayerImageHelper;
 use Security\HtmlSanitizer;
 use Team\Team;
 use Season\Season;
+use UI\Contracts\ContractsTableInterface;
 
 /**
  * Contracts - Displays team contracts table
  *
  * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
  */
-class Contracts
+class Contracts implements ContractsTableInterface
 {
     /**
      * Render the contracts table

--- a/ibl5/classes/UI/Tables/PlayerRowTransformer.php
+++ b/ibl5/classes/UI/Tables/PlayerRowTransformer.php
@@ -6,6 +6,7 @@ namespace UI\Tables;
 
 use Player\Player;
 use Player\Stats\PlayerStats;
+use UI\Contracts\PlayerRowTransformerInterface;
 
 /**
  * PlayerRowTransformer - Resolves Player (and optionally PlayerStats) objects
@@ -17,7 +18,7 @@ use Player\Stats\PlayerStats;
  * @phpstan-import-type PlayerRow from \Services\CommonMysqliRepository
  * @phpstan-import-type HistoricalPlayerRow from \Player\Contracts\PlayerRepositoryInterface
  */
-class PlayerRowTransformer
+class PlayerRowTransformer implements PlayerRowTransformerInterface
 {
     /**
      * Resolve an iterable of player rows into Player + PlayerStats pairs.

--- a/ibl5/classes/UI/Tables/Ratings.php
+++ b/ibl5/classes/UI/Tables/Ratings.php
@@ -11,11 +11,12 @@ use UI\TeamCellHelper;
 use Security\HtmlSanitizer;
 use Team\Team;
 use Season\Season;
+use UI\Contracts\RatingsInterface;
 
 /**
  * Ratings - Displays player ratings table
  */
-class Ratings
+class Ratings implements RatingsInterface
 {
     /**
      * Render the ratings table

--- a/ibl5/tests/UI/Contracts/InterfaceContractsTest.php
+++ b/ibl5/tests/UI/Contracts/InterfaceContractsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UI\Contracts;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class InterfaceContractsTest extends TestCase
+{
+    /** @return iterable<string, array{class-string, class-string}> */
+    public static function classToInterfaceProvider(): iterable
+    {
+        yield 'AlertRenderer'         => [\UI\AlertRenderer::class,                  \UI\Contracts\AlertRendererInterface::class];
+        yield 'DebugOutput'           => [\UI\DebugOutput::class,                    \UI\Contracts\DebugOutputInterface::class];
+        yield 'TableStyles'           => [\UI\TableStyles::class,                    \UI\Contracts\TableStylesInterface::class];
+        yield 'TeamCellHelper'        => [\UI\TeamCellHelper::class,                 \UI\Contracts\TeamCellHelperInterface::class];
+        yield 'TableViewDropdown'     => [\UI\Components\TableViewDropdown::class,   \UI\Contracts\TableViewDropdownInterface::class];
+        yield 'TableViewSwitcher'     => [\UI\Components\TableViewSwitcher::class,   \UI\Contracts\TableViewSwitcherInterface::class];
+        yield 'TooltipLabel'          => [\UI\Components\TooltipLabel::class,        \UI\Contracts\TooltipLabelInterface::class];
+        yield 'TablesContracts'       => [\UI\Tables\Contracts::class,               \UI\Contracts\ContractsTableInterface::class];
+        yield 'PlayerRowTransformer'  => [\UI\Tables\PlayerRowTransformer::class,    \UI\Contracts\PlayerRowTransformerInterface::class];
+        yield 'Ratings'               => [\UI\Tables\Ratings::class,                 \UI\Contracts\RatingsInterface::class];
+    }
+
+    /**
+     * @param class-string $class
+     * @param class-string $interface
+     */
+    #[DataProvider('classToInterfaceProvider')]
+    public function testClassImplementsInterface(string $class, string $interface): void
+    {
+        $implements = class_implements($class);
+        self::assertNotFalse($implements, "{$class} must be autoloadable");
+        self::assertContains(
+            $interface,
+            $implements,
+            "{$class} must implement {$interface}",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Extract PHP interfaces for the 9 UI module classes marked STAY in the classes-audit. Each class now declares `implements <Interface>`, and a new `InterfaceContractsTest` asserts conformance for all 10 UI classes (9 new + pre-existing `TeamCellHelper`).

### Classes covered
- `UI\AlertRenderer` → `UI\Contracts\AlertRendererInterface`
- `UI\DebugOutput` → `UI\Contracts\DebugOutputInterface`
- `UI\TableStyles` → `UI\Contracts\TableStylesInterface`
- `UI\Components\TableViewDropdown` → `UI\Contracts\TableViewDropdownInterface`
- `UI\Components\TableViewSwitcher` → `UI\Contracts\TableViewSwitcherInterface`
- `UI\Components\TooltipLabel` → `UI\Contracts\TooltipLabelInterface`
- `UI\Tables\Contracts` → `UI\Contracts\ContractsTableInterface`
- `UI\Tables\PlayerRowTransformer` → `UI\Contracts\PlayerRowTransformerInterface`
- `UI\Tables\Ratings` → `UI\Contracts\RatingsInterface`

### No behavior changes
Interface extraction only — no method implementations touched. Call sites continue referencing concrete classes.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

Generated with [Claude Code](https://claude.ai/code)