### PR TITLE
fix(phpstan): burn down ibl.cookieBeforeHeader baseline; add zero-floor ratchet

### DIFF
--- a/ibl5/classes/SeriesRecords/SeriesRecordsController.php
+++ b/ibl5/classes/SeriesRecords/SeriesRecordsController.php
@@ -76,8 +76,8 @@ class SeriesRecordsController implements SeriesRecordsControllerInterface
     public function main(mixed $user): void
     {
         if ($this->nukeCompat->isUser($user)) {
-            $cookie = $this->nukeCompat->cookieDecode($user);
-            $username = $cookie[1] ?? '';
+            $decoded = $this->nukeCompat->cookieDecode($user);
+            $username = $decoded[1] ?? '';
 
             if ($username !== '') {
                 $this->displayForUser($username);

--- a/ibl5/docs/decisions/0032-cookie-before-header-zero-floor.md
+++ b/ibl5/docs/decisions/0032-cookie-before-header-zero-floor.md
@@ -1,0 +1,32 @@
+---
+description: Zero-floor ratchet for ibl.cookieBeforeHeader PHPStan rule, preventing baseline regression in cleaned controllers
+last_verified: 2026-05-17
+---
+
+# ADR-0032: Zero-Floor Ratchet for `ibl.cookieBeforeHeader`
+
+## Status
+
+Accepted
+
+## Context
+
+The `PageLayoutHeaderBeforeCookieRule` (identifier `ibl.cookieBeforeHeader`) flags `$cookie[...]` reads that appear before `PageLayout::header()` in the same method body. Four controllers carried baseline suppressions masking violations that were either stale (code already fixed) or false positives (local `$cookie` from `cookieDecode()` unrelated to the global).
+
+After fixing the rule's namespace detection (it wasn't matching `\PageLayout\PageLayout::header()`, only the bare `PageLayout::header()`) and resolving the one genuine false positive (renaming a local `$cookie` variable in SeriesRecordsController), all four baseline entries were removed.
+
+Without a ratchet, future baseline regeneration could silently re-suppress a new violation in these files.
+
+## Decision
+
+Apply the zero-floor pattern established in [ADR-0031](0031-xss-zero-floor-ratchet.md) to `PageLayoutHeaderBeforeCookieRule`:
+
+- A `ZERO_FLOOR_FILES` constant lists the four cleaned controllers.
+- Errors in zero-floor files are emitted with `->nonIgnorable()`, bypassing baseline suppression.
+- A tip message identifies the file as zero-floored.
+
+## Consequences
+
+- New `$cookie[...]` reads before `PageLayout::header()` in these four files will fail PHPStan unconditionally.
+- Other files not in the zero-floor list remain baseline-suppressible (backwards-compatible).
+- Future controller cleanups can add files to the list incrementally.

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -872,6 +872,7 @@ Effort scale:
 **Suggested direction:** Investigate the three controllers; fix ordering or add explicit `@phpstan-ignore` with reason.
 **Est. effort:** S
 **Risk if untouched:** Reading stale/missing CSRF or session state — security-relevant.
+**Status:** Completed (2026-05-17) — 4 baselines cleared, 4 files added to zero-floor. Rule namespace detection fixed. See [ADR-0032](decisions/0032-cookie-before-header-zero-floor.md).
 
 ### 5.18 ConfigBootstrap — 6 Baseline Entries Block Deprecated `Database\MySQL` Removal
 **Location:** `ibl5/classes/Bootstrap/ConfigBootstrap.php`
@@ -1613,6 +1614,7 @@ Effort scale:
 **Suggested direction:** Burn down in one PR (one-line reorder each); add to zero-floor.
 **Est. effort:** S
 **Risk if untouched:** Stale CSRF/auth read in 4 controllers.
+**Status:** Completed (2026-05-17) — 4 baselines cleared, 4 files added to zero-floor. See [ADR-0032](decisions/0032-cookie-before-header-zero-floor.md).
 
 ### 10.18 ADR-0001: No Rule Blocks `Service extends BaseMysqliRepository`
 **Location:** No existing rule
@@ -1664,7 +1666,7 @@ Effort scale:
 **Risk if untouched:** Rule files self-exempt; coercion bugs in rules.
 
 ### 10.25 Baseline Burn-Down Targets (no new rule)
-**Location:** `phpstan-baseline.neon` — `ibl.unescapedOutput` (17), `ibl.cookieBeforeHeader` (4), `ibl.inlineCss` (6), `ibl.deprecatedHtmlTag` (3)
+**Location:** `phpstan-baseline.neon` — `ibl.unescapedOutput` (17), `ibl.cookieBeforeHeader` (0 — zero-floored), `ibl.inlineCss` (6), `ibl.deprecatedHtmlTag` (3)
 **Problem:** Existing rules have actionable backlogs; staleness of `rawSuperglobal` (10.1) shows snapshot drift.
 **Suggested direction:** Sprint focus + `ibl5/bin/check-baseline-drift --update`.
 **Est. effort:** M (cumulative burn-down)

--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -1,6 +1,5 @@
 {
     "phpstan-baseline.neon": {
-        "ibl.cookieBeforeHeader": 4,
         "ibl.deprecatedHtmlTag": 3,
         "ibl.inlineCss": 6,
         "ibl.unescapedOutput": 12,

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -130,12 +130,6 @@ parameters:
 			path: classes/FranchiseRecordBook/FranchiseRecordBookView.php
 
 		-
-			rawMessage: '$cookie[...] is read before PageLayout::header() in the same method. PageLayout::header() populates $cookie with auth and CSRF state — call it first, otherwise you will read stale or missing values (see CsrfGuard MAX_TOKENS incident).'
-			identifier: ibl.cookieBeforeHeader
-			count: 2
-			path: classes/FreeAgency/FreeAgencyController.php
-
-		-
 			rawMessage: 'Unescaped output in View. Wrap the expression in HtmlSanitizer::e() (or another whitelisted safe helper), or cast it to (int)/(float)/(bool) if it is numeric.'
 			identifier: ibl.unescapedOutput
 			count: 16
@@ -184,22 +178,10 @@ parameters:
 			path: classes/RookieOption/RookieOptionFormView.php
 
 		-
-			rawMessage: '$cookie[...] is read before PageLayout::header() in the same method. PageLayout::header() populates $cookie with auth and CSRF state — call it first, otherwise you will read stale or missing values (see CsrfGuard MAX_TOKENS incident).'
-			identifier: ibl.cookieBeforeHeader
-			count: 1
-			path: classes/SeriesRecords/SeriesRecordsController.php
-
-		-
 			rawMessage: 'Unescaped output in View. Wrap the expression in HtmlSanitizer::e() (or another whitelisted safe helper), or cast it to (int)/(float)/(bool) if it is numeric.'
 			identifier: ibl.unescapedOutput
 			count: 20
 			path: classes/Standings/StandingsView.php
-
-		-
-			rawMessage: '$cookie[...] is read before PageLayout::header() in the same method. PageLayout::header() populates $cookie with auth and CSRF state — call it first, otherwise you will read stale or missing values (see CsrfGuard MAX_TOKENS incident).'
-			identifier: ibl.cookieBeforeHeader
-			count: 1
-			path: classes/Team/TeamController.php
 
 		-
 			rawMessage: 'Unescaped output in View. Wrap the expression in HtmlSanitizer::e() (or another whitelisted safe helper), or cast it to (int)/(float)/(bool) if it is numeric.'
@@ -224,12 +206,6 @@ parameters:
 			identifier: ibl.unescapedOutput
 			count: 10
 			path: classes/TransactionHistory/TransactionHistoryView.php
-
-		-
-			rawMessage: '$cookie[...] is read before PageLayout::header() in the same method. PageLayout::header() populates $cookie with auth and CSRF state — call it first, otherwise you will read stale or missing values (see CsrfGuard MAX_TOKENS incident).'
-			identifier: ibl.cookieBeforeHeader
-			count: 2
-			path: classes/Waivers/WaiversController.php
 
 		-
 			rawMessage: 'Unescaped output in View. Wrap the expression in HtmlSanitizer::e() (or another whitelisted safe helper), or cast it to (int)/(float)/(bool) if it is numeric.'

--- a/ibl5/phpstan-rules/PageLayoutHeaderBeforeCookieRule.php
+++ b/ibl5/phpstan-rules/PageLayoutHeaderBeforeCookieRule.php
@@ -34,6 +34,14 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 final class PageLayoutHeaderBeforeCookieRule implements Rule
 {
+    /** @var list<string> */
+    private const ZERO_FLOOR_FILES = [
+        'classes/FreeAgency/FreeAgencyController.php',
+        'classes/SeriesRecords/SeriesRecordsController.php',
+        'classes/Team/TeamController.php',
+        'classes/Waivers/WaiversController.php',
+    ];
+
     public function getNodeType(): string
     {
         return ClassMethod::class;
@@ -73,7 +81,8 @@ final class PageLayoutHeaderBeforeCookieRule implements Rule
                     if (!$inner->name instanceof Identifier) {
                         return false;
                     }
-                    return $inner->class->toString() === 'PageLayout'
+                    $className = $inner->class->toString();
+                    return ($className === 'PageLayout' || $className === 'PageLayout\PageLayout')
                         && $inner->name->name === 'header';
                 });
                 if (count($headerCalls) > 0) {
@@ -120,19 +129,36 @@ final class PageLayoutHeaderBeforeCookieRule implements Rule
                     if (in_array($cookieRead, $writeTargets, true)) {
                         continue;
                     }
-                    $errors[] = RuleErrorBuilder::message(
+                    $builder = RuleErrorBuilder::message(
                         '$cookie[...] is read before PageLayout::header() in the same '
                         . 'method. PageLayout::header() populates $cookie with auth and '
                         . 'CSRF state — call it first, otherwise you will read stale or '
                         . 'missing values (see CsrfGuard MAX_TOKENS incident).'
                     )
                         ->identifier('ibl.cookieBeforeHeader')
-                        ->line($cookieRead->getStartLine())
-                        ->build();
+                        ->line($cookieRead->getStartLine());
+
+                    if ($this->isZeroFloorFile($file)) {
+                        $builder->nonIgnorable();
+                        $builder->tip('Zero-floor file — baseline suppression is disabled.');
+                    }
+
+                    $errors[] = $builder->build();
                 }
             }
         }
 
         return $errors;
+    }
+
+    private function isZeroFloorFile(string $file): bool
+    {
+        $normalized = str_replace('\\', '/', $file);
+        foreach (self::ZERO_FLOOR_FILES as $suffix) {
+            if (str_ends_with($normalized, $suffix)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/ibl5/tests/PHPStanRules/Fixtures/bootstrap.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/bootstrap.php
@@ -20,3 +20,4 @@ require_once __DIR__ . '/classes/CookieBeforeHeader.php';
 require_once __DIR__ . '/classes/CookieAfterHeader.php';
 require_once __DIR__ . '/classes/CookieWithoutHeader.php';
 require_once __DIR__ . '/classes/CookieWriteBeforeHeader.php';
+require_once __DIR__ . '/classes/FreeAgency/FreeAgencyController.php';

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/FreeAgency/FreeAgencyController.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/FreeAgency/FreeAgencyController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+final class FreeAgencyController
+{
+    public function handle(): void
+    {
+        global $cookie;
+        $token = $cookie['_csrf_token'] ?? '';
+        \PageLayout::header('Title');
+    }
+}

--- a/ibl5/tests/PHPStanRules/PageLayoutHeaderBeforeCookieRuleTest.php
+++ b/ibl5/tests/PHPStanRules/PageLayoutHeaderBeforeCookieRuleTest.php
@@ -75,4 +75,37 @@ final class PageLayoutHeaderBeforeCookieRuleTest extends RuleTestCase
             [],
         );
     }
+
+    public function testZeroFloorFileEmitsNonIgnorableError(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/FreeAgency/FreeAgencyController.php'],
+            [
+                [
+                    '$cookie[...] is read before PageLayout::header() in the same '
+                    . 'method. PageLayout::header() populates $cookie with auth and '
+                    . 'CSRF state — call it first, otherwise you will read stale or '
+                    . 'missing values (see CsrfGuard MAX_TOKENS incident).',
+                    10,
+                    'Zero-floor file — baseline suppression is disabled.',
+                ],
+            ],
+        );
+    }
+
+    public function testNonZeroFloorFileEmitsIgnorableError(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/CookieBeforeHeader.php'],
+            [
+                [
+                    '$cookie[...] is read before PageLayout::header() in the same '
+                    . 'method. PageLayout::header() populates $cookie with auth and '
+                    . 'CSRF state — call it first, otherwise you will read stale or '
+                    . 'missing values (see CsrfGuard MAX_TOKENS incident).',
+                    10,
+                ],
+            ],
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a namespace detection bug in `PageLayoutHeaderBeforeCookieRule` that caused it to miss `\PageLayout\PageLayout::header()` calls (only matched bare `PageLayout::header()`). All 4 baseline entries were stale due to this bug — removed.

Adds a zero-floor ratchet (ADR-0032) following the ADR-0031 pattern: the 4 cleaned controllers now emit `nonIgnorable()` errors, preventing baseline re-suppression.

## Changes

- **Rule fix:** Match both `PageLayout` and `PageLayout\PageLayout` in static call detection
- **Zero-floor:** `ZERO_FLOOR_FILES` constant + `isZeroFloorFile()` method + `nonIgnorable()` + tip
- **False positive fix:** Renamed local `$cookie` → `$decoded` in `SeriesRecordsController::main()`
- **Baseline cleanup:** Removed all 4 `ibl.cookieBeforeHeader` entries from baseline
- **ADR-0032:** Documents the zero-floor decision
- **Tests:** 2 new test methods covering zero-floor and non-zero-floor behavior

## Manual Testing

No manual testing needed — all changes are covered by unit tests and PHPStan verification.