### PR TITLE
refactor(RecordHolders): collapse nameToIdCache into static lookup, delete all-star stubs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
 ---
-description: Worktree-local Claude Code instructions for view-layer-db-access-elimination.
+description: Worktree-local Claude Code instructions for maint-16-pr1-team-registry-cleanup.
 last_verified: 2026-05-19
 ---
 
-# Worktree: view-layer-db-access-elimination
+# Worktree: maint-16-pr1-team-registry-cleanup
 
-This worktree's Docker instance is at `view-layer-db-access-elimination.localhost`.
+This worktree's Docker instance is at `maint-16-pr1-team-registry-cleanup.localhost`.
 Use this hostname for all browser checks, curl, and E2E — never `main.localhost`.

--- a/ibl5/classes/RecordHolders/RecordHoldersService.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersService.php
@@ -189,7 +189,7 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         /** @var list<FormattedPlayerRecord> $formatted */
         $formatted = [];
         foreach ($dbRecords as $record) {
-            $teamAbbr = $this->getTeamAbbreviation($record['teamid']);
+            $teamAbbr = self::teamAbbreviation($record['teamid']);
             $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
             $formatted[] = [
                 'pid' => $record['pid'],
@@ -199,7 +199,7 @@ class RecordHoldersService implements RecordHoldersServiceInterface
                 'teamYr' => (string) $seasonYear,
                 'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
                 'dateDisplay' => $this->formatDateDisplay($record['date'], $gameType),
-                'oppAbbr' => $this->getTeamAbbreviation($record['oppTid']),
+                'oppAbbr' => self::teamAbbreviation($record['oppTid']),
                 'oppTid' => $record['oppTid'],
                 'oppYr' => (string) $seasonYear,
                 'amount' => (string) $record['value'],
@@ -222,7 +222,7 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         foreach ($dbRecords as $record) {
             $gameType = IblSeasonDateHelper::getGameTypeFromDate($record['date']);
             $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
-            $teamAbbr = $this->getTeamAbbreviation($record['teamid']);
+            $teamAbbr = self::teamAbbreviation($record['teamid']);
 
             // Build multi-line amount string
             $amount = $record['points'] . "pts\n"
@@ -241,7 +241,7 @@ class RecordHoldersService implements RecordHoldersServiceInterface
                 'teamYr' => (string) $seasonYear,
                 'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
                 'dateDisplay' => $this->formatDateDisplay($record['date'], $gameType),
-                'oppAbbr' => $this->getTeamAbbreviation($record['oppTid']),
+                'oppAbbr' => self::teamAbbreviation($record['oppTid']),
                 'oppTid' => $record['oppTid'],
                 'oppYr' => (string) $seasonYear,
                 'amount' => $amount,
@@ -266,41 +266,14 @@ class RecordHoldersService implements RecordHoldersServiceInterface
 
         $topRecord = $dbRecords[0];
 
-        // Get the years for this player's all-star appearances
-        $years = $this->getAllStarYears($topRecord['name']);
-
-        // Get teams from `ibl_hist` for this player
-        $teams = $this->getAllStarTeams($topRecord['name']);
-
         return [
             'name' => $topRecord['name'],
             'pid' => $topRecord['pid'],
-            'teams' => $teams['abbrs'],
-            'teamTids' => $teams['tids'],
+            'teams' => '',
+            'teamTids' => '',
             'amount' => $topRecord['appearances'],
-            'years' => $years,
+            'years' => '',
         ];
-    }
-
-    /**
-     * Get all-star years for a player.
-     */
-    private function getAllStarYears(string $playerName): string
-    {
-        // The repository returns the count; for years, we'd need another query.
-        // For now, return empty — the view can handle displaying just the count.
-        return '';
-    }
-
-    /**
-     * Get teams a player was an all-star for.
-     *
-     * @return array{abbrs: string, tids: string}
-     */
-    private function getAllStarTeams(string $playerName): array
-    {
-        // Would need additional repository query for team info during all-star years
-        return ['abbrs' => '', 'tids' => ''];
     }
 
     /**
@@ -320,7 +293,7 @@ class RecordHoldersService implements RecordHoldersServiceInterface
                 $formatted[] = [
                     'pid' => $record['pid'],
                     'name' => $record['name'],
-                    'teamAbbr' => $this->getTeamAbbreviation($record['teamid']),
+                    'teamAbbr' => self::teamAbbreviation($record['teamid']),
                     'teamTid' => $record['teamid'],
                     'teamYr' => (string) $record['year'],
                     'season' => $this->formatSeasonYearRange($record['year']),
@@ -406,12 +379,12 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         foreach ($dbRecords as $record) {
             $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
             $formatted[] = [
-                'teamAbbr' => $this->getTeamAbbreviation($record['teamid']),
+                'teamAbbr' => self::teamAbbreviation($record['teamid']),
                 'teamTid' => $record['teamid'],
                 'teamYr' => (string) $seasonYear,
                 'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
                 'dateDisplay' => $this->formatDateDisplay($record['date'], 'regularSeason'),
-                'oppAbbr' => $this->getTeamAbbreviation($record['oppTid']),
+                'oppAbbr' => self::teamAbbreviation($record['oppTid']),
                 'oppTid' => $record['oppTid'],
                 'oppYr' => (string) $seasonYear,
                 'amount' => (string) $record['value'],
@@ -433,12 +406,12 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         foreach ($dbRecords as $record) {
             $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
             $formatted[] = [
-                'teamAbbr' => $this->getTeamAbbreviation($record['winner_tid']),
+                'teamAbbr' => self::teamAbbreviation($record['winner_tid']),
                 'teamTid' => $record['winner_tid'],
                 'teamYr' => (string) $seasonYear,
                 'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
                 'dateDisplay' => $this->formatDateDisplay($record['date'], 'regularSeason'),
-                'oppAbbr' => $this->getTeamAbbreviation($record['loser_tid']),
+                'oppAbbr' => self::teamAbbreviation($record['loser_tid']),
                 'oppTid' => $record['loser_tid'],
                 'oppYr' => (string) $seasonYear,
                 'amount' => (string) $record['margin'],
@@ -493,8 +466,8 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         foreach ($dbRecords as $record) {
             $endingYear = $record['year'];
             $formatted[] = [
-                'teamAbbr' => $this->getTeamAbbreviationByName($record['team_name']),
-                'teamTid' => $this->getTeamIdByName($record['team_name']),
+                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
+                'teamTid' => self::teamIdByName($record['team_name']),
                 'teamYr' => (string) $endingYear,
                 'season' => $this->formatSeasonYearRange($endingYear),
                 'amount' => $record['wins'] . '-' . $record['losses'],
@@ -518,8 +491,8 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         $formatted = [];
         foreach ($dbRecords as $record) {
             $formatted[] = [
-                'teamAbbr' => $this->getTeamAbbreviationByName($record['team_name']),
-                'teamTid' => $this->getTeamIdByName($record['team_name']),
+                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
+                'teamTid' => self::teamIdByName($record['team_name']),
                 'teamYr' => (string) $record['year'],
                 'season' => $this->formatSeasonYearRange($record['year']),
                 'amount' => $record['wins'] . '-' . $record['losses'],
@@ -546,8 +519,8 @@ class RecordHoldersService implements RecordHoldersServiceInterface
                 $season .= ', ' . $this->formatSeasonYearRange($record['end_year']);
             }
             $formatted[] = [
-                'teamAbbr' => $this->getTeamAbbreviationByName($record['team_name']),
-                'teamTid' => $this->getTeamIdByName($record['team_name']),
+                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
+                'teamTid' => self::teamIdByName($record['team_name']),
                 'teamYr' => (string) $record['start_year'],
                 'season' => $season,
                 'amount' => (string) $record['streak'],
@@ -607,8 +580,8 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         $formatted = [];
         foreach ($dbRecords as $record) {
             $formatted[] = [
-                'teamAbbr' => $this->getTeamAbbreviationByName($record['team_name']),
-                'teamTid' => $this->getTeamIdByName($record['team_name']),
+                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
+                'teamTid' => self::teamIdByName($record['team_name']),
                 'amount' => (string) $record['count'],
                 'years' => strip_tags($record['years']),
             ];
@@ -616,39 +589,27 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         return $formatted;
     }
 
-    /**
-     * Get team abbreviation from team ID.
-     */
-    private function getTeamAbbreviation(int $teamId): string
+    private static function teamAbbreviation(int $teamId): string
     {
         return self::TEAM_REGISTRY[$teamId]['abbr'] ?? '';
     }
 
-    /** @var array<string, int>|null */
-    private ?array $nameToIdCache = null;
-
-    private function getTeamAbbreviationByName(string $teamName): string
+    private static function teamIdByName(string $teamName): int
     {
-        if ($this->nameToIdCache === null) {
-            $this->nameToIdCache = [];
+        /** @var array<string, int>|null $byName */
+        static $byName = null;
+        if ($byName === null) {
+            $byName = [];
             foreach (self::TEAM_REGISTRY as $id => $info) {
-                $this->nameToIdCache[$info['name']] = $id;
+                $byName[$info['name']] = $id;
             }
         }
-
-        $teamId = $this->nameToIdCache[$teamName] ?? 0;
-        return $this->getTeamAbbreviation($teamId);
+        return $byName[$teamName] ?? 0;
     }
 
-    /**
-     * Get team ID from team name, using the same cache as getTeamAbbreviationByName().
-     */
-    private function getTeamIdByName(string $teamName): int
+    private static function teamAbbreviationByName(string $teamName): string
     {
-        // Ensure cache is populated
-        $this->getTeamAbbreviationByName($teamName);
-
-        return $this->nameToIdCache[$teamName] ?? 0;
+        return self::teamAbbreviation(self::teamIdByName($teamName));
     }
 
     /**

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -35,6 +35,7 @@ Effort scale:
 **Suggested direction:** Extract `TeamRegistry` (or reuse `League`/`TeamQueryRepository`); implement or delete the two silent stubs.
 **Est. effort:** M
 **Risk if untouched:** Team rename requires DB and constant update; silent stubs create invisible display gaps.
+**Status:** Completed (2026-05-19) — collapsed `nameToIdCache` into static lookup; deleted `getAllStarYears`/`getAllStarTeams` stubs (data not trivially queryable against seed); net −39 LOC.
 
 ### 1.2 RecordHoldersRepository — Streak/Season-Start Logic in Repository Layer
 **Location:** `ibl5/classes/RecordHolders/RecordHoldersRepository.php` lines 401-566

--- a/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
+++ b/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
@@ -227,6 +227,9 @@ final class RecordHoldersServiceTest extends TestCase
         $this->assertSame('Mitch Richmond', $allStar['name']);
         $this->assertSame(304, $allStar['pid']);
         $this->assertSame(10, $allStar['amount']);
+        $this->assertSame('', $allStar['teams']);
+        $this->assertSame('', $allStar['teamTids']);
+        $this->assertSame('', $allStar['years']);
     }
 
     public function testEmptyAllStarRecordHandledGracefully(): void
@@ -241,6 +244,9 @@ final class RecordHoldersServiceTest extends TestCase
         $this->assertSame('', $allStar['name']);
         $this->assertNull($allStar['pid']);
         $this->assertSame(0, $allStar['amount']);
+        $this->assertSame('', $allStar['teams']);
+        $this->assertSame('', $allStar['teamTids']);
+        $this->assertSame('', $allStar['years']);
     }
 
     public function testTeamAbbreviationMapping(): void


### PR DESCRIPTION
## Summary

Finishes backlog item 1.1 from `maintenance-backlog.md`: collapses the `$nameToIdCache` instance field and three private instance helpers into two `private static` methods and one lazy-initialised static local. Deletes the silent stub methods `getAllStarYears()` and `getAllStarTeams()` that unconditionally returned empty strings.

### Changes

- **`RecordHoldersService.php`:** Replace `getTeamAbbreviation()`, `getTeamAbbreviationByName()`, `getTeamIdByName()` (instance methods + `$nameToIdCache` field) with `teamAbbreviation()`, `teamIdByName()`, `teamAbbreviationByName()` (static methods, lazy `static $byName` local). Remove dead `getAllStarYears()` / `getAllStarTeams()` stubs. Update 10 internal call sites.
- **`RecordHoldersServiceTest.php`:** Add assertions for `teams`, `teamTids`, `years` returning `''` on `formatAllStarRecord()` output (locks deletion).

### Why static?

`$nameToIdCache` was a non-static field but the data it holds is derived entirely from `TEAM_REGISTRY` (a class constant) — it never varied between instances. Converting to a static local eliminates per-instance state with identical runtime cost.

### Stub deletion rationale

Both stubs returned `''` / `['abbrs' => '', 'tids' => '']` unconditionally with TODO comments. The view handles empty strings correctly. Deleting removes the illusion of functionality and the maintenance surface.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
*Part of the Maintenance 16 — RecordHolders module cleanup (4-PR cluster). PR1 of 4, based on master.*