### PR TITLE
refactor: split JsbImportService into per-format importers + thin facade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,4 @@
----
-description: Worktree-local Claude Code instructions for maint-16-pr1-team-registry-cleanup.
-last_verified: 2026-05-19
----
+# Worktree: jsb-import-service-split
 
-# Worktree: maint-16-pr1-team-registry-cleanup
-
-This worktree's Docker instance is at `maint-16-pr1-team-registry-cleanup.localhost`.
+This worktree's Docker instance is at `jsb-import-service-split.localhost`.
 Use this hostname for all browser checks, curl, and E2E — never `main.localhost`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+description: Worktree-local Claude Code instructions for jsb-import-service-split.
+last_verified: 2026-05-20
+---
+
 # Worktree: jsb-import-service-split
 
 This worktree's Docker instance is at `jsb-import-service-split.localhost`.

--- a/ibl5/classes/JsbParser/Importers/AswImporter.php
+++ b/ibl5/classes/JsbParser/Importers/AswImporter.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\AswFileParser;
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\JsbImportResult;
+
+class AswImporter
+{
+    private JsbImportRepositoryInterface $repository;
+
+    public function __construct(JsbImportRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function import(string $data, int $seasonYear): JsbImportResult
+    {
+        $result = new JsbImportResult();
+
+        try {
+            $parsed = AswFileParser::parse($data);
+        } catch (\RuntimeException $e) {
+            $result->addError('ASW parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        /** @var array<string, list<int>> $rosters */
+        $rosters = $parsed['rosters'];
+        foreach ($rosters as $eventType => $playerIds) {
+            foreach ($playerIds as $slot => $pid) {
+                $playerName = $this->repository->getPlayerName($pid);
+
+                try {
+                    $affected = $this->repository->upsertAllStarRoster([
+                        'season_year' => $seasonYear,
+                        'event_type' => $eventType,
+                        'roster_slot' => $slot + 1,
+                        'pid' => $pid,
+                        'player_name' => $playerName,
+                    ]);
+                    $result->recordUpsert($affected);
+                } catch (\RuntimeException $e) {
+                    $result->addError('All-Star roster upsert failed: ' . $e->getMessage());
+                }
+            }
+        }
+
+        $this->importContestScores($parsed['scores']['dunk_round1'], 'dunk_contest', 1, $seasonYear, $rosters['dunk_contest'], $result);
+        $this->importContestScores($parsed['scores']['dunk_finals'], 'dunk_contest', 3, $seasonYear, $rosters['dunk_contest'], $result);
+        $this->importContestScores($parsed['scores']['three_pt_round1'], 'three_point', 1, $seasonYear, $rosters['three_point'], $result);
+        $this->importContestScores($parsed['scores']['three_pt_semis'], 'three_point', 2, $seasonYear, $rosters['three_point'], $result);
+        $this->importContestScores($parsed['scores']['three_pt_finals'], 'three_point', 3, $seasonYear, $rosters['three_point'], $result);
+
+        return $result;
+    }
+
+    public function importFile(string $filePath, int $seasonYear): JsbImportResult
+    {
+        return FileReader::readOrFail($filePath, 'ASW', fn (string $data) => $this->import($data, $seasonYear));
+    }
+
+    /**
+     * @param list<int> $scores
+     * @param list<int> $participants
+     */
+    private function importContestScores(
+        array $scores,
+        string $contestType,
+        int $round,
+        int $seasonYear,
+        array $participants,
+        JsbImportResult $result,
+    ): void {
+        foreach ($scores as $slot => $score) {
+            $pid = $participants[$slot] ?? null;
+
+            try {
+                $affected = $this->repository->upsertAllStarScore([
+                    'season_year' => $seasonYear,
+                    'contest_type' => $contestType,
+                    'round' => $round,
+                    'participant_slot' => $slot + 1,
+                    'pid' => $pid,
+                    'score' => $score,
+                ]);
+                $result->recordUpsert($affected);
+            } catch (\RuntimeException $e) {
+                $result->addError('All-Star score upsert failed: ' . $e->getMessage());
+            }
+        }
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/AwaImporter.php
+++ b/ibl5/classes/JsbParser/Importers/AwaImporter.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\AwaFileParser;
+use JsbParser\CarFileParser;
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\JsbImportResult;
+
+class AwaImporter
+{
+    /** @var list<string> */
+    private const RANK_SUFFIXES = ['(1st)', '(2nd)', '(3rd)', '(4th)', '(5th)'];
+
+    private JsbImportRepositoryInterface $repository;
+
+    public function __construct(JsbImportRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function import(string $awaData, string $carData, ?int $filterYear = null): JsbImportResult
+    {
+        $result = new JsbImportResult();
+
+        try {
+            $awaParsed = AwaFileParser::parse($awaData);
+        } catch (\RuntimeException $e) {
+            $result->addError('AWA parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        try {
+            $carParsed = CarFileParser::parse($carData);
+        } catch (\RuntimeException $e) {
+            $result->addError('CAR parse failed (for AWA name resolution): ' . $e->getMessage());
+            return $result;
+        }
+
+        /** @var array<int, string> $pidNameMap */
+        $pidNameMap = [];
+        foreach ($carParsed['players'] as $player) {
+            $name = mb_convert_encoding($player['name'], 'UTF-8', 'Windows-1252');
+            $pidNameMap[$player['block_index']] = $name;
+        }
+
+        foreach ($awaParsed['seasons'] as $season) {
+            if ($filterYear !== null && $season['year'] !== $filterYear) {
+                continue;
+            }
+
+            foreach ($season['stat_leaders'] as $category => $leaders) {
+                foreach ($leaders as $leader) {
+                    $playerName = $pidNameMap[$leader['pid']] ?? null;
+                    if ($playerName === null) {
+                        $result->addSkipped();
+                        continue;
+                    }
+
+                    $rankIndex = $leader['rank'] - 1;
+                    if ($rankIndex < 0 || $rankIndex >= 5) {
+                        $result->addSkipped();
+                        continue;
+                    }
+
+                    $awardName = $category . ' ' . self::RANK_SUFFIXES[$rankIndex];
+
+                    try {
+                        $affected = $this->repository->upsertAward($season['year'], $awardName, $playerName);
+                        $result->recordUpsert($affected);
+                    } catch (\RuntimeException $e) {
+                        $result->addError('Award upsert failed for ' . $playerName . ': ' . $e->getMessage());
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    public function importFiles(string $awaPath, string $carPath, ?int $filterYear = null): JsbImportResult
+    {
+        if (!file_exists($awaPath) || !file_exists($carPath)) {
+            $result = new JsbImportResult();
+            $result->addError('AWA or CAR file not found');
+            return $result;
+        }
+
+        $awaData = file_get_contents($awaPath);
+        $carData = file_get_contents($carPath);
+        if ($awaData === false || $carData === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read AWA or CAR file');
+            return $result;
+        }
+
+        return $this->import($awaData, $carData, $filterYear);
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/CarImporter.php
+++ b/ibl5/classes/JsbParser/Importers/CarImporter.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\CarFileParser;
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\JsbImportResult;
+use JsbParser\PlayerIdResolver;
+
+class CarImporter
+{
+    private JsbImportRepositoryInterface $repository;
+    private PlayerIdResolver $resolver;
+
+    public function __construct(JsbImportRepositoryInterface $repository, PlayerIdResolver $resolver)
+    {
+        $this->repository = $repository;
+        $this->resolver = $resolver;
+    }
+
+    public function import(string $data, ?int $filterYear = null): JsbImportResult
+    {
+        $result = new JsbImportResult();
+
+        try {
+            $parsed = CarFileParser::parse($data);
+        } catch (\RuntimeException $e) {
+            $result->addError('CAR parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        foreach ($parsed['players'] as $player) {
+            foreach ($player['seasons'] as $season) {
+                if ($filterYear !== null && $season['year'] !== $filterYear) {
+                    continue;
+                }
+
+                $histData = CarFileParser::convertToHistFormat($season);
+
+                $resolvedTeamId = $this->repository->resolveTeamIdByName($histData['team']);
+
+                $pid = $this->resolver->resolve($histData['name'], $histData['team'], $histData['year'], $resolvedTeamId);
+                if ($pid === null) {
+                    $result->addSkipped();
+                    continue;
+                }
+
+                $result->addInserted();
+            }
+        }
+
+        return $result;
+    }
+
+    public function importFile(string $filePath, ?int $filterYear = null): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('CAR file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read CAR file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->import($data, $filterYear);
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/CarImporter.php
+++ b/ibl5/classes/JsbParser/Importers/CarImporter.php
@@ -56,19 +56,6 @@ class CarImporter
 
     public function importFile(string $filePath, ?int $filterYear = null): JsbImportResult
     {
-        if (!file_exists($filePath)) {
-            $result = new JsbImportResult();
-            $result->addError('CAR file not found: ' . $filePath);
-            return $result;
-        }
-
-        $data = file_get_contents($filePath);
-        if ($data === false) {
-            $result = new JsbImportResult();
-            $result->addError('Failed to read CAR file: ' . $filePath);
-            return $result;
-        }
-
-        return $this->import($data, $filterYear);
+        return FileReader::readOrFail($filePath, 'CAR', fn (string $data) => $this->import($data, $filterYear));
     }
 }

--- a/ibl5/classes/JsbParser/Importers/DraImporter.php
+++ b/ibl5/classes/JsbParser/Importers/DraImporter.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\DraFileParser;
+use JsbParser\JsbImportResult;
+
+class DraImporter
+{
+    private JsbImportRepositoryInterface $repository;
+
+    public function __construct(JsbImportRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function import(string $data): JsbImportResult
+    {
+        $result = new JsbImportResult();
+
+        try {
+            $parsed = DraFileParser::parse($data);
+        } catch (\RuntimeException $e) {
+            $result->addError('DRA parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        foreach ($parsed as $draft) {
+            foreach ($draft['picks'] as $pick) {
+                try {
+                    $affected = $this->repository->upsertDraftResult([
+                        'draft_year' => $draft['draft_year'],
+                        'round' => $pick['round'],
+                        'pick' => $pick['pick'],
+                        'team_name' => $pick['team_name'],
+                        'pos' => $pick['pos'],
+                        'player_name' => $pick['player_name'],
+                        'pid' => null,
+                    ]);
+                    $result->recordUpsert($affected);
+                } catch (\RuntimeException $e) {
+                    $result->addError('Draft upsert failed for ' . $pick['player_name'] . ': ' . $e->getMessage());
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    public function importFile(string $filePath): JsbImportResult
+    {
+        return FileReader::readOrFail($filePath, 'DRA', fn (string $data) => $this->import($data));
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/FileReader.php
+++ b/ibl5/classes/JsbParser/Importers/FileReader.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\JsbImportResult;
+
+class FileReader
+{
+    /**
+     * @param callable(string): JsbImportResult $processor
+     */
+    public static function readOrFail(string $filePath, string $label, callable $processor): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError($label . ' file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read ' . $label . ' file: ' . $filePath);
+            return $result;
+        }
+
+        return $processor($data);
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/HisImporter.php
+++ b/ibl5/classes/JsbParser/Importers/HisImporter.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\HisFileParser;
+use JsbParser\JsbImportResult;
+
+class HisImporter
+{
+    private JsbImportRepositoryInterface $repository;
+
+    public function __construct(JsbImportRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function import(string $data, ?string $sourceLabel = null): JsbImportResult
+    {
+        $result = new JsbImportResult();
+
+        try {
+            $parsed = HisFileParser::parse($data);
+        } catch (\RuntimeException $e) {
+            $result->addError('HIS parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        foreach ($parsed as $season) {
+            foreach ($season['teams'] as $team) {
+                $teamId = $this->repository->resolveTeamIdByName($team['name']);
+
+                try {
+                    $affected = $this->repository->upsertHistoryRecord([
+                        'season_year' => $season['year'],
+                        'team_name' => $team['name'],
+                        'teamid' => $teamId,
+                        'wins' => $team['wins'],
+                        'losses' => $team['losses'],
+                        'made_playoffs' => $team['made_playoffs'],
+                        'playoff_result' => $team['playoff_result'] !== '' ? $team['playoff_result'] : null,
+                        'playoff_round_reached' => $team['playoff_round_reached'] !== '' ? $team['playoff_round_reached'] : null,
+                        'won_championship' => $team['won_championship'],
+                        'source_file' => $sourceLabel,
+                    ]);
+                    $result->recordUpsert($affected);
+                } catch (\RuntimeException $e) {
+                    $result->addError('History upsert failed for ' . $team['name'] . ' (' . $season['year'] . '): ' . $e->getMessage());
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    public function importFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('HIS file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read HIS file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->import($data, $sourceLabel);
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/HisImporter.php
+++ b/ibl5/classes/JsbParser/Importers/HisImporter.php
@@ -57,19 +57,6 @@ class HisImporter
 
     public function importFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
     {
-        if (!file_exists($filePath)) {
-            $result = new JsbImportResult();
-            $result->addError('HIS file not found: ' . $filePath);
-            return $result;
-        }
-
-        $data = file_get_contents($filePath);
-        if ($data === false) {
-            $result = new JsbImportResult();
-            $result->addError('Failed to read HIS file: ' . $filePath);
-            return $result;
-        }
-
-        return $this->import($data, $sourceLabel);
+        return FileReader::readOrFail($filePath, 'HIS', fn (string $data) => $this->import($data, $sourceLabel));
     }
 }

--- a/ibl5/classes/JsbParser/Importers/HofImporter.php
+++ b/ibl5/classes/JsbParser/Importers/HofImporter.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\HofFileParser;
+use JsbParser\JsbImportResult;
+
+class HofImporter
+{
+    private JsbImportRepositoryInterface $repository;
+
+    public function __construct(JsbImportRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function import(string $data): JsbImportResult
+    {
+        $result = new JsbImportResult();
+
+        try {
+            $parsed = HofFileParser::parse($data);
+        } catch (\RuntimeException $e) {
+            $result->addError('HOF parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        foreach ($parsed as $entry) {
+            $pid = $this->repository->getPlayerName($entry['jsb_pid']) !== null
+                ? $entry['jsb_pid']
+                : null;
+
+            try {
+                $affected = $this->repository->upsertHofInductee([
+                    'jsb_pid' => $entry['jsb_pid'],
+                    'player_name' => $entry['player_name'],
+                    'pos' => $entry['pos'],
+                    'induction_year' => $entry['induction_year'],
+                    'pid' => $pid,
+                ]);
+                $result->recordUpsert($affected);
+            } catch (\RuntimeException $e) {
+                $result->addError('HoF upsert failed for ' . $entry['player_name'] . ': ' . $e->getMessage());
+            }
+        }
+
+        return $result;
+    }
+
+    public function importFile(string $filePath): JsbImportResult
+    {
+        return FileReader::readOrFail($filePath, 'HOF', fn (string $data) => $this->import($data));
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/PlbImporter.php
+++ b/ibl5/classes/JsbParser/Importers/PlbImporter.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\JsbImportResult;
+use JsbParser\PlbFileParser;
+use PlrParser\PlrOrdinalMap;
+
+class PlbImporter
+{
+    private JsbImportRepositoryInterface $repository;
+
+    public function __construct(JsbImportRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function import(
+        string $data,
+        PlrOrdinalMap $map,
+        int $seasonYear,
+        int $simNumber,
+        string $sourceArchive,
+    ): JsbImportResult {
+        $result = new JsbImportResult();
+
+        try {
+            $parsed = PlbFileParser::parse($data);
+        } catch (\RuntimeException $e) {
+            $result->addError('PLB parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        foreach ($parsed as $lineIndex => $slots) {
+            $teamid = $lineIndex + 1;
+
+            if ($teamid > 28) {
+                continue;
+            }
+
+            foreach ($slots as $slot) {
+                if ($slot['dc_minutes'] === 0) {
+                    $result->addSkipped();
+                    continue;
+                }
+
+                $player = $map->getSlotPlayer($teamid, $slot['slot_index']);
+                $pid = $player !== null ? $player['pid'] : null;
+                $playerName = $player !== null ? $player['name'] : null;
+
+                try {
+                    $affected = $this->repository->upsertPlbSnapshot([
+                        'season_year' => $seasonYear,
+                        'sim_number' => $simNumber,
+                        'source_archive' => $sourceArchive,
+                        'teamid' => $teamid,
+                        'slot_index' => $slot['slot_index'],
+                        'pid' => $pid,
+                        'player_name' => $playerName,
+                        'dc_minutes' => $slot['dc_minutes'],
+                        'dc_of' => $slot['dc_of'],
+                        'dc_df' => $slot['dc_df'],
+                        'dc_oi' => $slot['dc_oi'],
+                        'dc_di' => $slot['dc_di'],
+                        'dc_bh' => $slot['dc_bh'],
+                    ]);
+                    $result->recordUpsert($affected);
+                } catch (\RuntimeException $e) {
+                    $result->addError('PLB upsert failed for teamid=' . $teamid . ' slot=' . $slot['slot_index'] . ': ' . $e->getMessage());
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    public function importFile(
+        string $filePath,
+        PlrOrdinalMap $map,
+        int $seasonYear,
+        int $simNumber,
+        string $sourceArchive,
+    ): JsbImportResult {
+        return FileReader::readOrFail($filePath, 'PLB', fn (string $data) => $this->import($data, $map, $seasonYear, $simNumber, $sourceArchive));
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/RcbImporter.php
+++ b/ibl5/classes/JsbParser/Importers/RcbImporter.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\JsbImportResult;
+use JsbParser\RcbFileParser;
+
+class RcbImporter
+{
+    private JsbImportRepositoryInterface $repository;
+
+    public function __construct(JsbImportRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function import(string $data, int $seasonYear, ?string $sourceLabel = null, bool $includeAlltime = true): JsbImportResult
+    {
+        $result = new JsbImportResult();
+
+        try {
+            $parsed = RcbFileParser::parse($data);
+        } catch (\RuntimeException $e) {
+            $result->addError('RCB parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        if ($includeAlltime) {
+            if ($parsed['alltime'] === []) {
+                $result->addMessage('RCB alltime section empty — skipping replace to avoid wiping authoritative state');
+            } else {
+                $alltimeRecords = array_map(
+                    static fn (array $record): array => [
+                        'scope' => $record['scope'],
+                        'teamid' => $record['teamid'],
+                        'record_type' => $record['record_type'],
+                        'stat_category' => $record['stat_category'],
+                        'ranking' => $record['ranking'],
+                        'player_name' => $record['player_name'],
+                        'car_block_id' => $record['car_block_id'],
+                        'pid' => null,
+                        'stat_value' => $record['stat_value'],
+                        'stat_raw' => $record['stat_raw'],
+                        'team_of_record' => $record['team_of_record'],
+                        'season_year' => $record['season_year'],
+                        'career_total' => $record['career_total'],
+                        'source_file' => $sourceLabel,
+                    ],
+                    $parsed['alltime']
+                );
+                try {
+                    $inserted = $this->repository->replaceRcbAlltimeRecords($alltimeRecords);
+                    $result->addInserted($inserted);
+                } catch (\RuntimeException $e) {
+                    $result->addError('RCB alltime replace failed: ' . $e->getMessage());
+                }
+            }
+        }
+
+        if ($parsed['currentSeason'] === []) {
+            $result->addMessage('RCB season section empty — skipping replace');
+        } else {
+            $seasonRecords = array_map(
+                static fn (array $record): array => [
+                    'season_year' => $seasonYear,
+                    'scope' => $record['scope'],
+                    'teamid' => $record['teamid'],
+                    'context' => $record['context'],
+                    'stat_category' => $record['stat_category'],
+                    'ranking' => $record['ranking'],
+                    'player_name' => $record['player_name'],
+                    'player_position' => $record['player_position'],
+                    'car_block_id' => $record['car_block_id'],
+                    'pid' => null,
+                    'stat_value' => $record['stat_value'],
+                    'record_season_year' => $record['season_year'],
+                    'source_file' => $sourceLabel,
+                ],
+                $parsed['currentSeason']
+            );
+            try {
+                $inserted = $this->repository->replaceRcbSeasonRecords($seasonYear, $seasonRecords);
+                $result->addInserted($inserted);
+            } catch (\RuntimeException $e) {
+                $result->addError('RCB season replace failed: ' . $e->getMessage());
+            }
+        }
+
+        return $result;
+    }
+
+    public function importFile(string $filePath, int $seasonYear, ?string $sourceLabel = null, bool $includeAlltime = true): JsbImportResult
+    {
+        return FileReader::readOrFail($filePath, 'RCB', fn (string $data) => $this->import($data, $seasonYear, $sourceLabel, $includeAlltime));
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/RetImporter.php
+++ b/ibl5/classes/JsbParser/Importers/RetImporter.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\JsbImportResult;
+use JsbParser\RetFileParser;
+
+class RetImporter
+{
+    private JsbImportRepositoryInterface $repository;
+
+    public function __construct(JsbImportRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function import(string $data, int $retirementYear): JsbImportResult
+    {
+        $result = new JsbImportResult();
+
+        try {
+            $parsed = RetFileParser::parse($data);
+        } catch (\RuntimeException $e) {
+            $result->addError('RET parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        foreach ($parsed as $entry) {
+            $pid = $this->repository->getPlayerName($entry['jsb_pid']) !== null
+                ? $entry['jsb_pid']
+                : null;
+
+            try {
+                $affected = $this->repository->upsertRetiredPlayer([
+                    'jsb_pid' => $entry['jsb_pid'],
+                    'retirement_year' => $retirementYear,
+                    'player_name' => $entry['player_name'],
+                    'pid' => $pid,
+                ]);
+                $result->recordUpsert($affected);
+            } catch (\RuntimeException $e) {
+                $result->addError('Retired player upsert failed for ' . $entry['player_name'] . ': ' . $e->getMessage());
+            }
+        }
+
+        return $result;
+    }
+
+    public function importFile(string $filePath, int $retirementYear): JsbImportResult
+    {
+        return FileReader::readOrFail($filePath, 'RET', fn (string $data) => $this->import($data, $retirementYear));
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/TrnImporter.php
+++ b/ibl5/classes/JsbParser/Importers/TrnImporter.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Importers;
+
+use JsbParser\Contracts\JsbImportRepositoryInterface;
+use JsbParser\JsbImportResult;
+use JsbParser\TrnFileParser;
+
+class TrnImporter
+{
+    private JsbImportRepositoryInterface $repository;
+
+    /** @var int Auto-incrementing trade group ID for grouping trade items */
+    private int $nextTradeGroupId = 1;
+
+    public function __construct(JsbImportRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function import(string $data, ?string $sourceLabel = null): JsbImportResult
+    {
+        $result = new JsbImportResult();
+
+        try {
+            $parsed = TrnFileParser::parse($data);
+        } catch (\RuntimeException $e) {
+            $result->addError('TRN parse failed: ' . $e->getMessage());
+            return $result;
+        }
+
+        $this->initTradeGroupId();
+
+        foreach ($parsed['transactions'] as $transaction) {
+            $type = $transaction['type'];
+
+            switch ($type) {
+                case TrnFileParser::TYPE_INJURY:
+                    $this->importInjuryTransaction($transaction, $sourceLabel, $result);
+                    break;
+
+                case TrnFileParser::TYPE_TRADE:
+                    $this->importTradeTransaction($transaction, $sourceLabel, $result);
+                    break;
+
+                case TrnFileParser::TYPE_WAIVER_CLAIM:
+                case TrnFileParser::TYPE_WAIVER_RELEASE:
+                    $this->importWaiverTransaction($transaction, $sourceLabel, $result);
+                    break;
+            }
+        }
+
+        return $result;
+    }
+
+    public function importFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
+    {
+        if (!file_exists($filePath)) {
+            $result = new JsbImportResult();
+            $result->addError('TRN file not found: ' . $filePath);
+            return $result;
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            $result = new JsbImportResult();
+            $result->addError('Failed to read TRN file: ' . $filePath);
+            return $result;
+        }
+
+        return $this->import($data, $sourceLabel);
+    }
+
+    private function initTradeGroupId(): void
+    {
+        try {
+            $row = $this->repository->fetchMaxTradeGroupId();
+            $this->nextTradeGroupId = $row + 1;
+        } catch (\RuntimeException) {
+            $this->nextTradeGroupId = 1;
+        }
+    }
+
+    /**
+     * @param array{index: int, month: int, day: int, year: int, type: int, pid: int|null, team_id: int|null, games_missed: int|null, injury_description: string|null, trade_items: list<array{marker: int, from_team: int, to_team: int, player_id: int|null, draft_year: int|null}>|null} $transaction
+     */
+    private function importInjuryTransaction(array $transaction, ?string $sourceLabel, JsbImportResult $result): void
+    {
+        $pid = $transaction['pid'];
+        $playerName = null;
+        if ($pid !== null) {
+            $playerName = $this->repository->getPlayerName($pid);
+        }
+
+        try {
+            $affected = $this->repository->upsertTransaction([
+                'season_year' => $transaction['year'],
+                'transaction_month' => $transaction['month'],
+                'transaction_day' => $transaction['day'],
+                'transaction_type' => TrnFileParser::TYPE_INJURY,
+                'pid' => $pid ?? 0,
+                'player_name' => $playerName,
+                'from_teamid' => $transaction['team_id'] ?? 0,
+                'to_teamid' => 0,
+                'injury_games_missed' => $transaction['games_missed'],
+                'injury_description' => $transaction['injury_description'],
+                'trade_group_id' => null,
+                'is_draft_pick' => 0,
+                'draft_pick_year' => null,
+                'source_file' => $sourceLabel,
+            ]);
+            $result->recordUpsert($affected);
+        } catch (\RuntimeException $e) {
+            $result->addError('Injury transaction upsert failed: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * @param array{index: int, month: int, day: int, year: int, type: int, pid: int|null, team_id: int|null, games_missed: int|null, injury_description: string|null, trade_items: list<array{marker: int, from_team: int, to_team: int, player_id: int|null, draft_year: int|null}>|null} $transaction
+     */
+    private function importTradeTransaction(array $transaction, ?string $sourceLabel, JsbImportResult $result): void
+    {
+        $items = $transaction['trade_items'];
+        if ($items === null || $items === []) {
+            return;
+        }
+
+        $tradeGroupId = $this->nextTradeGroupId++;
+
+        foreach ($items as $item) {
+            $pid = $item['player_id'];
+            $playerName = null;
+            if ($pid !== null) {
+                $playerName = $this->repository->getPlayerName($pid);
+            }
+
+            $isDraftPick = $item['marker'] === TrnFileParser::TRADE_MARKER_DRAFT_PICK ? 1 : 0;
+
+            try {
+                $affected = $this->repository->upsertTransaction([
+                    'season_year' => $transaction['year'],
+                    'transaction_month' => $transaction['month'],
+                    'transaction_day' => $transaction['day'],
+                    'transaction_type' => TrnFileParser::TYPE_TRADE,
+                    'pid' => $pid ?? 0,
+                    'player_name' => $playerName,
+                    'from_teamid' => $item['from_team'],
+                    'to_teamid' => $item['to_team'],
+                    'injury_games_missed' => null,
+                    'injury_description' => null,
+                    'trade_group_id' => $tradeGroupId,
+                    'is_draft_pick' => $isDraftPick,
+                    'draft_pick_year' => $item['draft_year'],
+                    'source_file' => $sourceLabel,
+                ]);
+                $result->recordUpsert($affected);
+            } catch (\RuntimeException $e) {
+                $result->addError('Trade transaction upsert failed: ' . $e->getMessage());
+            }
+        }
+    }
+
+    /**
+     * @param array{index: int, month: int, day: int, year: int, type: int, pid: int|null, team_id: int|null, games_missed: int|null, injury_description: string|null, trade_items: list<array{marker: int, from_team: int, to_team: int, player_id: int|null, draft_year: int|null}>|null} $transaction
+     */
+    private function importWaiverTransaction(array $transaction, ?string $sourceLabel, JsbImportResult $result): void
+    {
+        $pid = $transaction['pid'];
+        $playerName = null;
+        if ($pid !== null) {
+            $playerName = $this->repository->getPlayerName($pid);
+        }
+
+        $isRelease = $transaction['type'] === TrnFileParser::TYPE_WAIVER_RELEASE;
+
+        try {
+            $affected = $this->repository->upsertTransaction([
+                'season_year' => $transaction['year'],
+                'transaction_month' => $transaction['month'],
+                'transaction_day' => $transaction['day'],
+                'transaction_type' => $transaction['type'],
+                'pid' => $pid ?? 0,
+                'player_name' => $playerName,
+                'from_teamid' => $isRelease ? ($transaction['team_id'] ?? 0) : 0,
+                'to_teamid' => $isRelease ? 0 : ($transaction['team_id'] ?? 0),
+                'injury_games_missed' => null,
+                'injury_description' => null,
+                'trade_group_id' => null,
+                'is_draft_pick' => 0,
+                'draft_pick_year' => null,
+                'source_file' => $sourceLabel,
+            ]);
+            $result->recordUpsert($affected);
+        } catch (\RuntimeException $e) {
+            $result->addError('Waiver transaction upsert failed: ' . $e->getMessage());
+        }
+    }
+}

--- a/ibl5/classes/JsbParser/Importers/TrnImporter.php
+++ b/ibl5/classes/JsbParser/Importers/TrnImporter.php
@@ -57,20 +57,7 @@ class TrnImporter
 
     public function importFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
     {
-        if (!file_exists($filePath)) {
-            $result = new JsbImportResult();
-            $result->addError('TRN file not found: ' . $filePath);
-            return $result;
-        }
-
-        $data = file_get_contents($filePath);
-        if ($data === false) {
-            $result = new JsbImportResult();
-            $result->addError('Failed to read TRN file: ' . $filePath);
-            return $result;
-        }
-
-        return $this->import($data, $sourceLabel);
+        return FileReader::readOrFail($filePath, 'TRN', fn (string $data) => $this->import($data, $sourceLabel));
     }
 
     private function initTradeGroupId(): void

--- a/ibl5/classes/JsbParser/JsbImportResult.php
+++ b/ibl5/classes/JsbParser/JsbImportResult.php
@@ -43,6 +43,17 @@ class JsbImportResult
         $this->messages[] = $message;
     }
 
+    public const AFFECTED_ROWS_INSERTED = 1;
+
+    public function recordUpsert(int $affectedRows): void
+    {
+        if ($affectedRows === self::AFFECTED_ROWS_INSERTED) {
+            $this->addInserted();
+        } else {
+            $this->addUpdated();
+        }
+    }
+
     /**
      * Create a JsbImportResult from a BoxscoreProcessor::processScoFile() result array.
      *

--- a/ibl5/classes/JsbParser/JsbImportService.php
+++ b/ibl5/classes/JsbParser/JsbImportService.php
@@ -6,6 +6,7 @@ namespace JsbParser;
 
 use JsbParser\Contracts\JsbImportRepositoryInterface;
 use JsbParser\Contracts\JsbImportServiceInterface;
+use JsbParser\Importers\AwaImporter;
 use PlrParser\PlrOrdinalMap;
 
 /**
@@ -18,14 +19,16 @@ class JsbImportService implements JsbImportServiceInterface
 {
     private JsbImportRepositoryInterface $repository;
     private PlayerIdResolver $resolver;
+    private AwaImporter $awa;
 
     /** @var int Auto-incrementing trade group ID for grouping trade items */
     private int $nextTradeGroupId = 1;
 
-public function __construct(JsbImportRepositoryInterface $repository, PlayerIdResolver $resolver)
+    public function __construct(JsbImportRepositoryInterface $repository, PlayerIdResolver $resolver)
     {
         $this->repository = $repository;
         $this->resolver = $resolver;
+        $this->awa = new AwaImporter($repository);
     }
 
     /**
@@ -265,71 +268,12 @@ public function __construct(JsbImportRepositoryInterface $repository, PlayerIdRe
         return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processAswData($c, $seasonYear), 'ASW');
     }
 
-    /** @var list<string> Rank suffixes for award names */
-    private const RANK_SUFFIXES = ['(1st)', '(2nd)', '(3rd)', '(4th)', '(5th)'];
-
     /**
      * @see JsbImportServiceInterface::processAwaData()
      */
     public function processAwaData(string $awaData, string $carData, ?int $filterYear = null): JsbImportResult
     {
-        $result = new JsbImportResult();
-
-        try {
-            $awaParsed = AwaFileParser::parse($awaData);
-        } catch (\RuntimeException $e) {
-            $result->addError('AWA parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        // Build PID → name map from .car data
-        try {
-            $carParsed = CarFileParser::parse($carData);
-        } catch (\RuntimeException $e) {
-            $result->addError('CAR parse failed (for AWA name resolution): ' . $e->getMessage());
-            return $result;
-        }
-
-        /** @var array<int, string> $pidNameMap */
-        $pidNameMap = [];
-        foreach ($carParsed['players'] as $player) {
-            // .car stores names in CP1252; convert to UTF-8 for DB storage
-            $name = mb_convert_encoding($player['name'], 'UTF-8', 'Windows-1252');
-            $pidNameMap[$player['block_index']] = $name;
-        }
-
-        foreach ($awaParsed['seasons'] as $season) {
-            if ($filterYear !== null && $season['year'] !== $filterYear) {
-                continue;
-            }
-
-            foreach ($season['stat_leaders'] as $category => $leaders) {
-                foreach ($leaders as $leader) {
-                    $playerName = $pidNameMap[$leader['pid']] ?? null;
-                    if ($playerName === null) {
-                        $result->addSkipped();
-                        continue;
-                    }
-
-                    $rankIndex = $leader['rank'] - 1;
-                    if ($rankIndex < 0 || $rankIndex >= 5) {
-                        $result->addSkipped();
-                        continue;
-                    }
-
-                    $awardName = $category . ' ' . self::RANK_SUFFIXES[$rankIndex];
-
-                    try {
-                        $affected = $this->repository->upsertAward($season['year'], $awardName, $playerName);
-                        $result->recordUpsert($affected);
-                    } catch (\RuntimeException $e) {
-                        $result->addError('Award upsert failed for ' . $playerName . ': ' . $e->getMessage());
-                    }
-                }
-            }
-        }
-
-        return $result;
+        return $this->awa->import($awaData, $carData, $filterYear);
     }
 
     /**
@@ -337,21 +281,7 @@ public function __construct(JsbImportRepositoryInterface $repository, PlayerIdRe
      */
     public function processAwaFile(string $awaPath, string $carPath, ?int $filterYear = null): JsbImportResult
     {
-        if (!file_exists($awaPath) || !file_exists($carPath)) {
-            $result = new JsbImportResult();
-            $result->addError('AWA or CAR file not found');
-            return $result;
-        }
-
-        $awaData = file_get_contents($awaPath);
-        $carData = file_get_contents($carPath);
-        if ($awaData === false || $carData === false) {
-            $result = new JsbImportResult();
-            $result->addError('Failed to read AWA or CAR file');
-            return $result;
-        }
-
-        return $this->processAwaData($awaData, $carData, $filterYear);
+        return $this->awa->importFiles($awaPath, $carPath, $filterYear);
     }
 
     /**

--- a/ibl5/classes/JsbParser/JsbImportService.php
+++ b/ibl5/classes/JsbParser/JsbImportService.php
@@ -6,316 +6,118 @@ namespace JsbParser;
 
 use JsbParser\Contracts\JsbImportRepositoryInterface;
 use JsbParser\Contracts\JsbImportServiceInterface;
+use JsbParser\Importers\AswImporter;
 use JsbParser\Importers\AwaImporter;
 use JsbParser\Importers\CarImporter;
+use JsbParser\Importers\DraImporter;
 use JsbParser\Importers\HisImporter;
+use JsbParser\Importers\HofImporter;
+use JsbParser\Importers\PlbImporter;
+use JsbParser\Importers\RcbImporter;
+use JsbParser\Importers\RetImporter;
 use JsbParser\Importers\TrnImporter;
 use PlrParser\PlrOrdinalMap;
 
-/**
- * Orchestrator service for JSB file parsing and database import.
- *
- * Coordinates parsing of .car, .trn, .his, and .asw files, resolves player/team IDs,
- * and stores results in the database. Season stats flow from `ibl_box_scores` via the ibl_hist VIEW.
- */
 class JsbImportService implements JsbImportServiceInterface
 {
-    private JsbImportRepositoryInterface $repository;
-    private AwaImporter $awa;
     private CarImporter $car;
     private TrnImporter $trn;
     private HisImporter $his;
+    private AswImporter $asw;
+    private AwaImporter $awa;
+    private RcbImporter $rcb;
+    private PlbImporter $plb;
+    private DraImporter $dra;
+    private RetImporter $ret;
+    private HofImporter $hof;
 
     public function __construct(JsbImportRepositoryInterface $repository, PlayerIdResolver $resolver)
     {
-        $this->repository = $repository;
-        $this->awa = new AwaImporter($repository);
         $this->car = new CarImporter($repository, $resolver);
         $this->trn = new TrnImporter($repository);
         $this->his = new HisImporter($repository);
+        $this->asw = new AswImporter($repository);
+        $this->awa = new AwaImporter($repository);
+        $this->rcb = new RcbImporter($repository);
+        $this->plb = new PlbImporter($repository);
+        $this->dra = new DraImporter($repository);
+        $this->ret = new RetImporter($repository);
+        $this->hof = new HofImporter($repository);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processCarData()
-     */
+    /** @see JsbImportServiceInterface::processCarData() */
     public function processCarData(string $data, ?int $filterYear = null): JsbImportResult
     {
         return $this->car->import($data, $filterYear);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processCarFile()
-     */
+    /** @see JsbImportServiceInterface::processCarFile() */
     public function processCarFile(string $filePath, ?int $filterYear = null): JsbImportResult
     {
         return $this->car->importFile($filePath, $filterYear);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processTrnData()
-     */
+    /** @see JsbImportServiceInterface::processTrnData() */
     public function processTrnData(string $data, ?string $sourceLabel = null): JsbImportResult
     {
         return $this->trn->import($data, $sourceLabel);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processTrnFile()
-     */
+    /** @see JsbImportServiceInterface::processTrnFile() */
     public function processTrnFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
     {
         return $this->trn->importFile($filePath, $sourceLabel);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processHisData()
-     */
+    /** @see JsbImportServiceInterface::processHisData() */
     public function processHisData(string $data, ?string $sourceLabel = null): JsbImportResult
     {
         return $this->his->import($data, $sourceLabel);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processHisFile()
-     */
+    /** @see JsbImportServiceInterface::processHisFile() */
     public function processHisFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
     {
         return $this->his->importFile($filePath, $sourceLabel);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processAswData()
-     */
+    /** @see JsbImportServiceInterface::processAswData() */
     public function processAswData(string $data, int $seasonYear): JsbImportResult
     {
-        $result = new JsbImportResult();
-
-        try {
-            $parsed = AswFileParser::parse($data);
-        } catch (\RuntimeException $e) {
-            $result->addError('ASW parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        // Import rosters
-        /** @var array<string, list<int>> $rosters */
-        $rosters = $parsed['rosters'];
-        foreach ($rosters as $eventType => $playerIds) {
-            foreach ($playerIds as $slot => $pid) {
-                $playerName = $this->repository->getPlayerName($pid);
-
-                try {
-                    $affected = $this->repository->upsertAllStarRoster([
-                        'season_year' => $seasonYear,
-                        'event_type' => $eventType,
-                        'roster_slot' => $slot + 1,
-                        'pid' => $pid,
-                        'player_name' => $playerName,
-                    ]);
-                    $result->recordUpsert($affected);
-                } catch (\RuntimeException $e) {
-                    $result->addError('All-Star roster upsert failed: ' . $e->getMessage());
-                }
-            }
-        }
-
-        // Import dunk contest scores
-        $this->importContestScores(
-            $parsed['scores']['dunk_round1'],
-            'dunk_contest',
-            1,
-            $seasonYear,
-            $rosters['dunk_contest'],
-            $result
-        );
-        $this->importContestScores(
-            $parsed['scores']['dunk_finals'],
-            'dunk_contest',
-            3, // finals
-            $seasonYear,
-            $rosters['dunk_contest'],
-            $result
-        );
-
-        // Import 3-point shootout scores
-        $this->importContestScores(
-            $parsed['scores']['three_pt_round1'],
-            'three_point',
-            1,
-            $seasonYear,
-            $rosters['three_point'],
-            $result
-        );
-        $this->importContestScores(
-            $parsed['scores']['three_pt_semis'],
-            'three_point',
-            2, // semifinals
-            $seasonYear,
-            $rosters['three_point'],
-            $result
-        );
-        $this->importContestScores(
-            $parsed['scores']['three_pt_finals'],
-            'three_point',
-            3, // finals
-            $seasonYear,
-            $rosters['three_point'],
-            $result
-        );
-
-        return $result;
+        return $this->asw->import($data, $seasonYear);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processAswFile()
-     */
+    /** @see JsbImportServiceInterface::processAswFile() */
     public function processAswFile(string $filePath, int $seasonYear): JsbImportResult
     {
-        return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processAswData($c, $seasonYear), 'ASW');
+        return $this->asw->importFile($filePath, $seasonYear);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processAwaData()
-     */
+    /** @see JsbImportServiceInterface::processAwaData() */
     public function processAwaData(string $awaData, string $carData, ?int $filterYear = null): JsbImportResult
     {
         return $this->awa->import($awaData, $carData, $filterYear);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processAwaFile()
-     */
+    /** @see JsbImportServiceInterface::processAwaFile() */
     public function processAwaFile(string $awaPath, string $carPath, ?int $filterYear = null): JsbImportResult
     {
         return $this->awa->importFiles($awaPath, $carPath, $filterYear);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processRcbData()
-     */
+    /** @see JsbImportServiceInterface::processRcbData() */
     public function processRcbData(string $data, int $seasonYear, ?string $sourceLabel = null, bool $includeAlltime = true): JsbImportResult
     {
-        $result = new JsbImportResult();
-
-        try {
-            $parsed = RcbFileParser::parse($data);
-        } catch (\RuntimeException $e) {
-            $result->addError('RCB parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        if ($includeAlltime) {
-            if ($parsed['alltime'] === []) {
-                $result->addMessage('RCB alltime section empty — skipping replace to avoid wiping authoritative state');
-            } else {
-                $alltimeRecords = array_map(
-                    static fn (array $record): array => [
-                        'scope' => $record['scope'],
-                        'teamid' => $record['teamid'],
-                        'record_type' => $record['record_type'],
-                        'stat_category' => $record['stat_category'],
-                        'ranking' => $record['ranking'],
-                        'player_name' => $record['player_name'],
-                        'car_block_id' => $record['car_block_id'],
-                        'pid' => null,
-                        'stat_value' => $record['stat_value'],
-                        'stat_raw' => $record['stat_raw'],
-                        'team_of_record' => $record['team_of_record'],
-                        'season_year' => $record['season_year'],
-                        'career_total' => $record['career_total'],
-                        'source_file' => $sourceLabel,
-                    ],
-                    $parsed['alltime']
-                );
-                try {
-                    $inserted = $this->repository->replaceRcbAlltimeRecords($alltimeRecords);
-                    $result->addInserted($inserted);
-                } catch (\RuntimeException $e) {
-                    $result->addError('RCB alltime replace failed: ' . $e->getMessage());
-                }
-            }
-        }
-
-        if ($parsed['currentSeason'] === []) {
-            $result->addMessage('RCB season section empty — skipping replace');
-        } else {
-            $seasonRecords = array_map(
-                static fn (array $record): array => [
-                    'season_year' => $seasonYear,
-                    'scope' => $record['scope'],
-                    'teamid' => $record['teamid'],
-                    'context' => $record['context'],
-                    'stat_category' => $record['stat_category'],
-                    'ranking' => $record['ranking'],
-                    'player_name' => $record['player_name'],
-                    'player_position' => $record['player_position'],
-                    'car_block_id' => $record['car_block_id'],
-                    'pid' => null,
-                    'stat_value' => $record['stat_value'],
-                    'record_season_year' => $record['season_year'],
-                    'source_file' => $sourceLabel,
-                ],
-                $parsed['currentSeason']
-            );
-            try {
-                $inserted = $this->repository->replaceRcbSeasonRecords($seasonYear, $seasonRecords);
-                $result->addInserted($inserted);
-            } catch (\RuntimeException $e) {
-                $result->addError('RCB season replace failed: ' . $e->getMessage());
-            }
-        }
-
-        return $result;
+        return $this->rcb->import($data, $seasonYear, $sourceLabel, $includeAlltime);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processRcbFile()
-     */
+    /** @see JsbImportServiceInterface::processRcbFile() */
     public function processRcbFile(string $filePath, int $seasonYear, ?string $sourceLabel = null, bool $includeAlltime = true): JsbImportResult
     {
-        return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processRcbData($c, $seasonYear, $sourceLabel, $includeAlltime), 'RCB');
+        return $this->rcb->importFile($filePath, $seasonYear, $sourceLabel, $includeAlltime);
     }
 
-    /**
-     * Import contest scores for a specific round.
-     *
-     * @param list<int> $scores Score values
-     * @param string $contestType 'dunk_contest' or 'three_point'
-     * @param int $round Round number (1=round1, 2=semis, 3=finals)
-     * @param int $seasonYear Season year
-     * @param list<int> $participants Participant PIDs from roster section
-     */
-    private function importContestScores(
-        array $scores,
-        string $contestType,
-        int $round,
-        int $seasonYear,
-        array $participants,
-        JsbImportResult $result,
-    ): void {
-        foreach ($scores as $slot => $score) {
-            // Try to match score slot to participant
-            $pid = $participants[$slot] ?? null;
-
-            try {
-                $affected = $this->repository->upsertAllStarScore([
-                    'season_year' => $seasonYear,
-                    'contest_type' => $contestType,
-                    'round' => $round,
-                    'participant_slot' => $slot + 1,
-                    'pid' => $pid,
-                    'score' => $score,
-                ]);
-                $result->recordUpsert($affected);
-            } catch (\RuntimeException $e) {
-                $result->addError('All-Star score upsert failed: ' . $e->getMessage());
-            }
-        }
-    }
-
-    /**
-     * @see JsbImportServiceInterface::processPlbData()
-     */
+    /** @see JsbImportServiceInterface::processPlbData() */
     public function processPlbData(
         string $data,
         PlrOrdinalMap $map,
@@ -323,65 +125,10 @@ class JsbImportService implements JsbImportServiceInterface
         int $simNumber,
         string $sourceArchive,
     ): JsbImportResult {
-        $result = new JsbImportResult();
-
-        try {
-            $parsed = PlbFileParser::parse($data);
-        } catch (\RuntimeException $e) {
-            $result->addError('PLB parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        foreach ($parsed as $lineIndex => $slots) {
-            // .plb line index is 0-based; teamid = lineIndex + 1 (1-based team ID)
-            $teamid = $lineIndex + 1;
-
-            // Skip special teams (teamid > 28 = rookies, all-stars, etc.)
-            if ($teamid > 28) {
-                continue;
-            }
-
-            foreach ($slots as $slot) {
-                // Skip empty slots (zero minutes)
-                if ($slot['dc_minutes'] === 0) {
-                    $result->addSkipped();
-                    continue;
-                }
-
-                // Resolve player identity from ordinal map
-                $player = $map->getSlotPlayer($teamid, $slot['slot_index']);
-                $pid = $player !== null ? $player['pid'] : null;
-                $playerName = $player !== null ? $player['name'] : null;
-
-                try {
-                    $affected = $this->repository->upsertPlbSnapshot([
-                        'season_year' => $seasonYear,
-                        'sim_number' => $simNumber,
-                        'source_archive' => $sourceArchive,
-                        'teamid' => $teamid,
-                        'slot_index' => $slot['slot_index'],
-                        'pid' => $pid,
-                        'player_name' => $playerName,
-                        'dc_minutes' => $slot['dc_minutes'],
-                        'dc_of' => $slot['dc_of'],
-                        'dc_df' => $slot['dc_df'],
-                        'dc_oi' => $slot['dc_oi'],
-                        'dc_di' => $slot['dc_di'],
-                        'dc_bh' => $slot['dc_bh'],
-                    ]);
-                    $result->recordUpsert($affected);
-                } catch (\RuntimeException $e) {
-                    $result->addError('PLB upsert failed for teamid=' . $teamid . ' slot=' . $slot['slot_index'] . ': ' . $e->getMessage());
-                }
-            }
-        }
-
-        return $result;
+        return $this->plb->import($data, $map, $seasonYear, $simNumber, $sourceArchive);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processPlbFile()
-     */
+    /** @see JsbImportServiceInterface::processPlbFile() */
     public function processPlbFile(
         string $filePath,
         PlrOrdinalMap $map,
@@ -389,158 +136,42 @@ class JsbImportService implements JsbImportServiceInterface
         int $simNumber,
         string $sourceArchive,
     ): JsbImportResult {
-        return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processPlbData($c, $map, $seasonYear, $simNumber, $sourceArchive), 'PLB');
+        return $this->plb->importFile($filePath, $map, $seasonYear, $simNumber, $sourceArchive);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processDraData()
-     */
+    /** @see JsbImportServiceInterface::processDraData() */
     public function processDraData(string $data): JsbImportResult
     {
-        $result = new JsbImportResult();
-
-        try {
-            $parsed = DraFileParser::parse($data);
-        } catch (\RuntimeException $e) {
-            $result->addError('DRA parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        foreach ($parsed as $draft) {
-            foreach ($draft['picks'] as $pick) {
-                try {
-                    $affected = $this->repository->upsertDraftResult([
-                        'draft_year' => $draft['draft_year'],
-                        'round' => $pick['round'],
-                        'pick' => $pick['pick'],
-                        'team_name' => $pick['team_name'],
-                        'pos' => $pick['pos'],
-                        'player_name' => $pick['player_name'],
-                        'pid' => null,
-                    ]);
-                    $result->recordUpsert($affected);
-                } catch (\RuntimeException $e) {
-                    $result->addError('Draft upsert failed for ' . $pick['player_name'] . ': ' . $e->getMessage());
-                }
-            }
-        }
-
-        return $result;
+        return $this->dra->import($data);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processDraFile()
-     */
+    /** @see JsbImportServiceInterface::processDraFile() */
     public function processDraFile(string $filePath): JsbImportResult
     {
-        return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processDraData($c), 'DRA');
+        return $this->dra->importFile($filePath);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processRetData()
-     */
+    /** @see JsbImportServiceInterface::processRetData() */
     public function processRetData(string $data, int $retirementYear): JsbImportResult
     {
-        $result = new JsbImportResult();
-
-        try {
-            $parsed = RetFileParser::parse($data);
-        } catch (\RuntimeException $e) {
-            $result->addError('RET parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        foreach ($parsed as $entry) {
-            $pid = $this->repository->getPlayerName($entry['jsb_pid']) !== null
-                ? $entry['jsb_pid']
-                : null;
-
-            try {
-                $affected = $this->repository->upsertRetiredPlayer([
-                    'jsb_pid' => $entry['jsb_pid'],
-                    'retirement_year' => $retirementYear,
-                    'player_name' => $entry['player_name'],
-                    'pid' => $pid,
-                ]);
-                $result->recordUpsert($affected);
-            } catch (\RuntimeException $e) {
-                $result->addError('Retired player upsert failed for ' . $entry['player_name'] . ': ' . $e->getMessage());
-            }
-        }
-
-        return $result;
+        return $this->ret->import($data, $retirementYear);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processRetFile()
-     */
+    /** @see JsbImportServiceInterface::processRetFile() */
     public function processRetFile(string $filePath, int $retirementYear): JsbImportResult
     {
-        return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processRetData($c, $retirementYear), 'RET');
+        return $this->ret->importFile($filePath, $retirementYear);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processHofData()
-     */
+    /** @see JsbImportServiceInterface::processHofData() */
     public function processHofData(string $data): JsbImportResult
     {
-        $result = new JsbImportResult();
-
-        try {
-            $parsed = HofFileParser::parse($data);
-        } catch (\RuntimeException $e) {
-            $result->addError('HOF parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        foreach ($parsed as $entry) {
-            $pid = $this->repository->getPlayerName($entry['jsb_pid']) !== null
-                ? $entry['jsb_pid']
-                : null;
-
-            try {
-                $affected = $this->repository->upsertHofInductee([
-                    'jsb_pid' => $entry['jsb_pid'],
-                    'player_name' => $entry['player_name'],
-                    'pos' => $entry['pos'],
-                    'induction_year' => $entry['induction_year'],
-                    'pid' => $pid,
-                ]);
-                $result->recordUpsert($affected);
-            } catch (\RuntimeException $e) {
-                $result->addError('HoF upsert failed for ' . $entry['player_name'] . ': ' . $e->getMessage());
-            }
-        }
-
-        return $result;
+        return $this->hof->import($data);
     }
 
-    /**
-     * @see JsbImportServiceInterface::processHofFile()
-     */
+    /** @see JsbImportServiceInterface::processHofFile() */
     public function processHofFile(string $filePath): JsbImportResult
     {
-        return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processHofData($c), 'HOF');
-    }
-
-    /**
-     * @param callable(string): JsbImportResult $processor
-     */
-    private function loadFileAndProcess(string $filePath, callable $processor, string $label): JsbImportResult
-    {
-        if (!file_exists($filePath)) {
-            $result = new JsbImportResult();
-            $result->addError($label . ' file not found: ' . $filePath);
-            return $result;
-        }
-
-        $data = file_get_contents($filePath);
-        if ($data === false) {
-            $result = new JsbImportResult();
-            $result->addError('Failed to read ' . $label . ' file: ' . $filePath);
-            return $result;
-        }
-
-        return $processor($data);
+        return $this->hof->importFile($filePath);
     }
 }

--- a/ibl5/classes/JsbParser/JsbImportService.php
+++ b/ibl5/classes/JsbParser/JsbImportService.php
@@ -22,13 +22,7 @@ class JsbImportService implements JsbImportServiceInterface
     /** @var int Auto-incrementing trade group ID for grouping trade items */
     private int $nextTradeGroupId = 1;
 
-    /**
-     * MySQL affected_rows for INSERT ... ON DUPLICATE KEY UPDATE:
-     * 1 = new row inserted, 2 = existing row updated, 0 = no change.
-     */
-    private const AFFECTED_ROWS_INSERTED = 1;
-
-    public function __construct(JsbImportRepositoryInterface $repository, PlayerIdResolver $resolver)
+public function __construct(JsbImportRepositoryInterface $repository, PlayerIdResolver $resolver)
     {
         $this->repository = $repository;
         $this->resolver = $resolver;
@@ -162,7 +156,7 @@ class JsbImportService implements JsbImportServiceInterface
                         'won_championship' => $team['won_championship'],
                         'source_file' => $sourceLabel,
                     ]);
-                    $this->recordUpsertResult($affected, $result);
+                    $result->recordUpsert($affected);
                 } catch (\RuntimeException $e) {
                     $result->addError('History upsert failed for ' . $team['name'] . ' (' . $season['year'] . '): ' . $e->getMessage());
                 }
@@ -209,7 +203,7 @@ class JsbImportService implements JsbImportServiceInterface
                         'pid' => $pid,
                         'player_name' => $playerName,
                     ]);
-                    $this->recordUpsertResult($affected, $result);
+                    $result->recordUpsert($affected);
                 } catch (\RuntimeException $e) {
                     $result->addError('All-Star roster upsert failed: ' . $e->getMessage());
                 }
@@ -327,7 +321,7 @@ class JsbImportService implements JsbImportServiceInterface
 
                     try {
                         $affected = $this->repository->upsertAward($season['year'], $awardName, $playerName);
-                        $this->recordUpsertResult($affected, $result);
+                        $result->recordUpsert($affected);
                     } catch (\RuntimeException $e) {
                         $result->addError('Award upsert failed for ' . $playerName . ': ' . $e->getMessage());
                     }
@@ -476,7 +470,7 @@ class JsbImportService implements JsbImportServiceInterface
                     'pid' => $pid,
                     'score' => $score,
                 ]);
-                $this->recordUpsertResult($affected, $result);
+                $result->recordUpsert($affected);
             } catch (\RuntimeException $e) {
                 $result->addError('All-Star score upsert failed: ' . $e->getMessage());
             }
@@ -513,7 +507,7 @@ class JsbImportService implements JsbImportServiceInterface
                 'draft_pick_year' => null,
                 'source_file' => $sourceLabel,
             ]);
-            $this->recordUpsertResult($affected, $result);
+            $result->recordUpsert($affected);
         } catch (\RuntimeException $e) {
             $result->addError('Injury transaction upsert failed: ' . $e->getMessage());
         }
@@ -560,7 +554,7 @@ class JsbImportService implements JsbImportServiceInterface
                     'draft_pick_year' => $item['draft_year'],
                     'source_file' => $sourceLabel,
                 ]);
-                $this->recordUpsertResult($affected, $result);
+                $result->recordUpsert($affected);
             } catch (\RuntimeException $e) {
                 $result->addError('Trade transaction upsert failed: ' . $e->getMessage());
             }
@@ -599,27 +593,13 @@ class JsbImportService implements JsbImportServiceInterface
                 'draft_pick_year' => null,
                 'source_file' => $sourceLabel,
             ]);
-            $this->recordUpsertResult($affected, $result);
+            $result->recordUpsert($affected);
         } catch (\RuntimeException $e) {
             $result->addError('Waiver transaction upsert failed: ' . $e->getMessage());
         }
     }
 
-    /**
-     * Record an upsert result based on MySQL affected_rows.
-     *
-     * @param int $affectedRows 1=inserted, 2=updated, 0=unchanged
-     */
-    private function recordUpsertResult(int $affectedRows, JsbImportResult $result): void
-    {
-        if ($affectedRows === self::AFFECTED_ROWS_INSERTED) {
-            $result->addInserted();
-        } else {
-            $result->addUpdated();
-        }
-    }
-
-    /**
+/**
      * @see JsbImportServiceInterface::processPlbData()
      */
     public function processPlbData(
@@ -675,7 +655,7 @@ class JsbImportService implements JsbImportServiceInterface
                         'dc_di' => $slot['dc_di'],
                         'dc_bh' => $slot['dc_bh'],
                     ]);
-                    $this->recordUpsertResult($affected, $result);
+                    $result->recordUpsert($affected);
                 } catch (\RuntimeException $e) {
                     $result->addError('PLB upsert failed for teamid=' . $teamid . ' slot=' . $slot['slot_index'] . ': ' . $e->getMessage());
                 }
@@ -737,7 +717,7 @@ class JsbImportService implements JsbImportServiceInterface
                         'player_name' => $pick['player_name'],
                         'pid' => null,
                     ]);
-                    $this->recordUpsertResult($affected, $result);
+                    $result->recordUpsert($affected);
                 } catch (\RuntimeException $e) {
                     $result->addError('Draft upsert failed for ' . $pick['player_name'] . ': ' . $e->getMessage());
                 }
@@ -781,7 +761,7 @@ class JsbImportService implements JsbImportServiceInterface
                     'player_name' => $entry['player_name'],
                     'pid' => $pid,
                 ]);
-                $this->recordUpsertResult($affected, $result);
+                $result->recordUpsert($affected);
             } catch (\RuntimeException $e) {
                 $result->addError('Retired player upsert failed for ' . $entry['player_name'] . ': ' . $e->getMessage());
             }
@@ -825,7 +805,7 @@ class JsbImportService implements JsbImportServiceInterface
                     'induction_year' => $entry['induction_year'],
                     'pid' => $pid,
                 ]);
-                $this->recordUpsertResult($affected, $result);
+                $result->recordUpsert($affected);
             } catch (\RuntimeException $e) {
                 $result->addError('HoF upsert failed for ' . $entry['player_name'] . ': ' . $e->getMessage());
             }

--- a/ibl5/classes/JsbParser/JsbImportService.php
+++ b/ibl5/classes/JsbParser/JsbImportService.php
@@ -7,6 +7,9 @@ namespace JsbParser;
 use JsbParser\Contracts\JsbImportRepositoryInterface;
 use JsbParser\Contracts\JsbImportServiceInterface;
 use JsbParser\Importers\AwaImporter;
+use JsbParser\Importers\CarImporter;
+use JsbParser\Importers\HisImporter;
+use JsbParser\Importers\TrnImporter;
 use PlrParser\PlrOrdinalMap;
 
 /**
@@ -18,17 +21,18 @@ use PlrParser\PlrOrdinalMap;
 class JsbImportService implements JsbImportServiceInterface
 {
     private JsbImportRepositoryInterface $repository;
-    private PlayerIdResolver $resolver;
     private AwaImporter $awa;
-
-    /** @var int Auto-incrementing trade group ID for grouping trade items */
-    private int $nextTradeGroupId = 1;
+    private CarImporter $car;
+    private TrnImporter $trn;
+    private HisImporter $his;
 
     public function __construct(JsbImportRepositoryInterface $repository, PlayerIdResolver $resolver)
     {
         $this->repository = $repository;
-        $this->resolver = $resolver;
         $this->awa = new AwaImporter($repository);
+        $this->car = new CarImporter($repository, $resolver);
+        $this->trn = new TrnImporter($repository);
+        $this->his = new HisImporter($repository);
     }
 
     /**
@@ -36,41 +40,7 @@ class JsbImportService implements JsbImportServiceInterface
      */
     public function processCarData(string $data, ?int $filterYear = null): JsbImportResult
     {
-        $result = new JsbImportResult();
-
-        try {
-            $parsed = CarFileParser::parse($data);
-        } catch (\RuntimeException $e) {
-            $result->addError('CAR parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        foreach ($parsed['players'] as $player) {
-            foreach ($player['seasons'] as $season) {
-                if ($filterYear !== null && $season['year'] !== $filterYear) {
-                    continue;
-                }
-
-                $histData = CarFileParser::convertToHistFormat($season);
-
-                // Resolve team ID
-                $resolvedTeamId = $this->repository->resolveTeamIdByName($histData['team']);
-                $teamId = $resolvedTeamId ?? 0;
-
-                // Resolve player ID (pass resolvedTeamId for teamid-based ibl_plr lookup; null skips Strategy 2)
-                $pid = $this->resolver->resolve($histData['name'], $histData['team'], $histData['year'], $resolvedTeamId);
-                if ($pid === null) {
-                    $result->addSkipped();
-                    continue;
-                }
-
-                // ibl_hist is now a VIEW derived from `ibl_box_scores` — no direct writes needed.
-                // Season stats are derived from individual game box scores automatically.
-                $result->addInserted();
-            }
-        }
-
-        return $result;
+        return $this->car->import($data, $filterYear);
     }
 
     /**
@@ -78,7 +48,7 @@ class JsbImportService implements JsbImportServiceInterface
      */
     public function processCarFile(string $filePath, ?int $filterYear = null): JsbImportResult
     {
-        return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processCarData($c, $filterYear), 'CAR');
+        return $this->car->importFile($filePath, $filterYear);
     }
 
     /**
@@ -86,38 +56,7 @@ class JsbImportService implements JsbImportServiceInterface
      */
     public function processTrnData(string $data, ?string $sourceLabel = null): JsbImportResult
     {
-        $result = new JsbImportResult();
-
-        try {
-            $parsed = TrnFileParser::parse($data);
-        } catch (\RuntimeException $e) {
-            $result->addError('TRN parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        // Get the max existing trade_group_id to avoid collisions
-        $this->initTradeGroupId();
-
-        foreach ($parsed['transactions'] as $transaction) {
-            $type = $transaction['type'];
-
-            switch ($type) {
-                case TrnFileParser::TYPE_INJURY:
-                    $this->importInjuryTransaction($transaction, $sourceLabel, $result);
-                    break;
-
-                case TrnFileParser::TYPE_TRADE:
-                    $this->importTradeTransaction($transaction, $sourceLabel, $result);
-                    break;
-
-                case TrnFileParser::TYPE_WAIVER_CLAIM:
-                case TrnFileParser::TYPE_WAIVER_RELEASE:
-                    $this->importWaiverTransaction($transaction, $sourceLabel, $result);
-                    break;
-            }
-        }
-
-        return $result;
+        return $this->trn->import($data, $sourceLabel);
     }
 
     /**
@@ -125,7 +64,7 @@ class JsbImportService implements JsbImportServiceInterface
      */
     public function processTrnFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
     {
-        return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processTrnData($c, $sourceLabel), 'TRN');
+        return $this->trn->importFile($filePath, $sourceLabel);
     }
 
     /**
@@ -133,40 +72,7 @@ class JsbImportService implements JsbImportServiceInterface
      */
     public function processHisData(string $data, ?string $sourceLabel = null): JsbImportResult
     {
-        $result = new JsbImportResult();
-
-        try {
-            $parsed = HisFileParser::parse($data);
-        } catch (\RuntimeException $e) {
-            $result->addError('HIS parse failed: ' . $e->getMessage());
-            return $result;
-        }
-
-        foreach ($parsed as $season) {
-            foreach ($season['teams'] as $team) {
-                $teamId = $this->repository->resolveTeamIdByName($team['name']);
-
-                try {
-                    $affected = $this->repository->upsertHistoryRecord([
-                        'season_year' => $season['year'],
-                        'team_name' => $team['name'],
-                        'teamid' => $teamId,
-                        'wins' => $team['wins'],
-                        'losses' => $team['losses'],
-                        'made_playoffs' => $team['made_playoffs'],
-                        'playoff_result' => $team['playoff_result'] !== '' ? $team['playoff_result'] : null,
-                        'playoff_round_reached' => $team['playoff_round_reached'] !== '' ? $team['playoff_round_reached'] : null,
-                        'won_championship' => $team['won_championship'],
-                        'source_file' => $sourceLabel,
-                    ]);
-                    $result->recordUpsert($affected);
-                } catch (\RuntimeException $e) {
-                    $result->addError('History upsert failed for ' . $team['name'] . ' (' . $season['year'] . '): ' . $e->getMessage());
-                }
-            }
-        }
-
-        return $result;
+        return $this->his->import($data, $sourceLabel);
     }
 
     /**
@@ -174,7 +80,7 @@ class JsbImportService implements JsbImportServiceInterface
      */
     public function processHisFile(string $filePath, ?string $sourceLabel = null): JsbImportResult
     {
-        return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processHisData($c, $sourceLabel), 'HIS');
+        return $this->his->importFile($filePath, $sourceLabel);
     }
 
     /**
@@ -408,128 +314,6 @@ class JsbImportService implements JsbImportServiceInterface
     }
 
     /**
-     * Import an injury transaction.
-     *
-     * @param array{index: int, month: int, day: int, year: int, type: int, pid: int|null, team_id: int|null, games_missed: int|null, injury_description: string|null, trade_items: list<array{marker: int, from_team: int, to_team: int, player_id: int|null, draft_year: int|null}>|null} $transaction
-     */
-    private function importInjuryTransaction(array $transaction, ?string $sourceLabel, JsbImportResult $result): void
-    {
-        $pid = $transaction['pid'];
-        $playerName = null;
-        if ($pid !== null) {
-            $playerName = $this->repository->getPlayerName($pid);
-        }
-
-        try {
-            $affected = $this->repository->upsertTransaction([
-                'season_year' => $transaction['year'],
-                'transaction_month' => $transaction['month'],
-                'transaction_day' => $transaction['day'],
-                'transaction_type' => TrnFileParser::TYPE_INJURY,
-                'pid' => $pid ?? 0,
-                'player_name' => $playerName,
-                'from_teamid' => $transaction['team_id'] ?? 0,
-                'to_teamid' => 0,
-                'injury_games_missed' => $transaction['games_missed'],
-                'injury_description' => $transaction['injury_description'],
-                'trade_group_id' => null,
-                'is_draft_pick' => 0,
-                'draft_pick_year' => null,
-                'source_file' => $sourceLabel,
-            ]);
-            $result->recordUpsert($affected);
-        } catch (\RuntimeException $e) {
-            $result->addError('Injury transaction upsert failed: ' . $e->getMessage());
-        }
-    }
-
-    /**
-     * Import a trade transaction (may contain multiple items).
-     *
-     * @param array{index: int, month: int, day: int, year: int, type: int, pid: int|null, team_id: int|null, games_missed: int|null, injury_description: string|null, trade_items: list<array{marker: int, from_team: int, to_team: int, player_id: int|null, draft_year: int|null}>|null} $transaction
-     */
-    private function importTradeTransaction(array $transaction, ?string $sourceLabel, JsbImportResult $result): void
-    {
-        $items = $transaction['trade_items'];
-        if ($items === null || $items === []) {
-            // Separator record — skip
-            return;
-        }
-
-        $tradeGroupId = $this->nextTradeGroupId++;
-
-        foreach ($items as $item) {
-            $pid = $item['player_id'];
-            $playerName = null;
-            if ($pid !== null) {
-                $playerName = $this->repository->getPlayerName($pid);
-            }
-
-            $isDraftPick = $item['marker'] === TrnFileParser::TRADE_MARKER_DRAFT_PICK ? 1 : 0;
-
-            try {
-                $affected = $this->repository->upsertTransaction([
-                    'season_year' => $transaction['year'],
-                    'transaction_month' => $transaction['month'],
-                    'transaction_day' => $transaction['day'],
-                    'transaction_type' => TrnFileParser::TYPE_TRADE,
-                    'pid' => $pid ?? 0,
-                    'player_name' => $playerName,
-                    'from_teamid' => $item['from_team'],
-                    'to_teamid' => $item['to_team'],
-                    'injury_games_missed' => null,
-                    'injury_description' => null,
-                    'trade_group_id' => $tradeGroupId,
-                    'is_draft_pick' => $isDraftPick,
-                    'draft_pick_year' => $item['draft_year'],
-                    'source_file' => $sourceLabel,
-                ]);
-                $result->recordUpsert($affected);
-            } catch (\RuntimeException $e) {
-                $result->addError('Trade transaction upsert failed: ' . $e->getMessage());
-            }
-        }
-    }
-
-    /**
-     * Import a waiver claim or release transaction.
-     *
-     * @param array{index: int, month: int, day: int, year: int, type: int, pid: int|null, team_id: int|null, games_missed: int|null, injury_description: string|null, trade_items: list<array{marker: int, from_team: int, to_team: int, player_id: int|null, draft_year: int|null}>|null} $transaction
-     */
-    private function importWaiverTransaction(array $transaction, ?string $sourceLabel, JsbImportResult $result): void
-    {
-        $pid = $transaction['pid'];
-        $playerName = null;
-        if ($pid !== null) {
-            $playerName = $this->repository->getPlayerName($pid);
-        }
-
-        $isRelease = $transaction['type'] === TrnFileParser::TYPE_WAIVER_RELEASE;
-
-        try {
-            $affected = $this->repository->upsertTransaction([
-                'season_year' => $transaction['year'],
-                'transaction_month' => $transaction['month'],
-                'transaction_day' => $transaction['day'],
-                'transaction_type' => $transaction['type'],
-                'pid' => $pid ?? 0,
-                'player_name' => $playerName,
-                'from_teamid' => $isRelease ? ($transaction['team_id'] ?? 0) : 0,
-                'to_teamid' => $isRelease ? 0 : ($transaction['team_id'] ?? 0),
-                'injury_games_missed' => null,
-                'injury_description' => null,
-                'trade_group_id' => null,
-                'is_draft_pick' => 0,
-                'draft_pick_year' => null,
-                'source_file' => $sourceLabel,
-            ]);
-            $result->recordUpsert($affected);
-        } catch (\RuntimeException $e) {
-            $result->addError('Waiver transaction upsert failed: ' . $e->getMessage());
-        }
-    }
-
-/**
      * @see JsbImportServiceInterface::processPlbData()
      */
     public function processPlbData(
@@ -606,19 +390,6 @@ class JsbImportService implements JsbImportServiceInterface
         string $sourceArchive,
     ): JsbImportResult {
         return $this->loadFileAndProcess($filePath, fn (string $c) => $this->processPlbData($c, $map, $seasonYear, $simNumber, $sourceArchive), 'PLB');
-    }
-
-    /**
-     * Initialize trade group ID counter from existing data.
-     */
-    private function initTradeGroupId(): void
-    {
-        try {
-            $row = $this->repository->fetchMaxTradeGroupId();
-            $this->nextTradeGroupId = $row + 1;
-        } catch (\RuntimeException) {
-            $this->nextTradeGroupId = 1;
-        }
     }
 
     /**

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -57,6 +57,7 @@ Effort scale:
 **Suggested direction:** Extract per-format importers injected into a thin `JsbImportOrchestrator`.
 **Est. effort:** L
 **Risk if untouched:** Adding/changing one format requires reading 800+ lines; bug in one importer's type handling cascades into adjacent code during reviews.
+**Status:** Completed (2026-05-19) — split into 10 per-format importers under `JsbParser/Importers/`; `JsbImportService` is a 177-LOC thin facade. `JsbImportServiceInterface` unchanged.
 
 ### 1.5 ProjectedDraftOrderService — Sorting + Tiebreaker Logic at 600+ Lines
 **Location:** `ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderService.php` (615 lines)

--- a/ibl5/tests/JsbParser/JsbImportResultTest.php
+++ b/ibl5/tests/JsbParser/JsbImportResultTest.php
@@ -114,6 +114,33 @@ class JsbImportResultTest extends TestCase
         $this->assertSame('No changes', $result->summary());
     }
 
+    public function testRecordUpsertInserted(): void
+    {
+        $result = new JsbImportResult();
+        $result->recordUpsert(JsbImportResult::AFFECTED_ROWS_INSERTED);
+
+        $this->assertSame(1, $result->inserted);
+        $this->assertSame(0, $result->updated);
+    }
+
+    public function testRecordUpsertUpdated(): void
+    {
+        $result = new JsbImportResult();
+        $result->recordUpsert(2);
+
+        $this->assertSame(0, $result->inserted);
+        $this->assertSame(1, $result->updated);
+    }
+
+    public function testRecordUpsertUnchanged(): void
+    {
+        $result = new JsbImportResult();
+        $result->recordUpsert(0);
+
+        $this->assertSame(0, $result->inserted);
+        $this->assertSame(1, $result->updated);
+    }
+
     public function testFromScoResultMapsFields(): void
     {
         $scoResult = [

--- a/ibl5/tests/JsbParser/JsbImportServiceTest.php
+++ b/ibl5/tests/JsbParser/JsbImportServiceTest.php
@@ -255,6 +255,36 @@ class JsbImportServiceTest extends TestCase
         return $record;
     }
 
+    /**
+     * @param list<array{marker: int, from_team: int, to_team: int, player_id: int|null, draft_year: int|null}> $tradeItems
+     */
+    private function buildTradeRecord(int $month, int $day, int $year, array $tradeItems): string
+    {
+        $record = str_repeat(' ', TrnFileParser::RECORD_SIZE);
+        $record = substr_replace($record, str_pad((string) $month, 2, ' ', STR_PAD_LEFT), 17, 2);
+        $record = substr_replace($record, str_pad((string) $day, 2, ' ', STR_PAD_LEFT), 19, 2);
+        $record = substr_replace($record, str_pad((string) ($year - 1), 4, ' ', STR_PAD_LEFT), 21, 4);
+        $record = substr_replace($record, (string) TrnFileParser::TYPE_TRADE, 26, 1);
+
+        $tradeAreaStart = 27;
+        foreach ($tradeItems as $i => $item) {
+            $offset = $tradeAreaStart + $i * TrnFileParser::TRADE_ITEM_SIZE;
+            $itemStr = (string) $item['marker'];
+            if ($item['marker'] === TrnFileParser::TRADE_MARKER_PLAYER) {
+                $itemStr .= str_pad((string) $item['from_team'], 6, ' ', STR_PAD_LEFT);
+                $itemStr .= str_pad((string) $item['to_team'], 6, ' ', STR_PAD_LEFT);
+                $itemStr .= str_pad((string) ($item['player_id'] ?? 0), 6, ' ', STR_PAD_LEFT);
+            } else {
+                $itemStr .= str_pad((string) ($item['draft_year'] ?? 0), 6, ' ', STR_PAD_LEFT);
+                $itemStr .= str_pad((string) $item['from_team'], 6, ' ', STR_PAD_LEFT);
+                $itemStr .= str_pad((string) $item['to_team'], 6, ' ', STR_PAD_LEFT);
+            }
+            $record = substr_replace($record, $itemStr, $offset, TrnFileParser::TRADE_ITEM_SIZE);
+        }
+
+        return $record;
+    }
+
     public function testProcessTrnFileReturnsErrorOnParseFailure(): void
     {
         $tmpFile = $this->writeTmpFile('invalid data');
@@ -548,6 +578,116 @@ class JsbImportServiceTest extends TestCase
     {
         $result = $this->makeService()->processHofData(str_repeat(' ', 7000));
         $this->assertSame(0, $result->errors);
+    }
+
+    // ── processAwaFile — dual-path characterization ────────────
+
+    public function testProcessAwaFileReturnsErrorWhenAwaPathMissing(): void
+    {
+        $carFile = $this->writeTmpFile('dummy car data');
+
+        try {
+            $result = $this->makeService()->processAwaFile('/nonexistent-awa', $carFile);
+            $this->assertSame(1, $result->errors);
+            $this->assertStringContainsString('AWA or CAR file not found', $result->messages[0]);
+        } finally {
+            unlink($carFile);
+        }
+    }
+
+    public function testProcessAwaFileReturnsErrorWhenCarPathMissing(): void
+    {
+        $awaFile = $this->writeTmpFile('dummy awa data');
+
+        try {
+            $result = $this->makeService()->processAwaFile($awaFile, '/nonexistent-car');
+            $this->assertSame(1, $result->errors);
+            $this->assertStringContainsString('AWA or CAR file not found', $result->messages[0]);
+        } finally {
+            unlink($awaFile);
+        }
+    }
+
+    public function testProcessAwaFileDelegatesToProcessAwaDataOnBothReadable(): void
+    {
+        $seasonRecord = $this->buildSeasonRecord(2006);
+        $playerBlock = $this->buildPlayerBlock(1, 100, 'Test Player', $seasonRecord);
+        $carData = $this->buildCarFile(1, $playerBlock);
+        $carFile = $this->writeTmpFile($carData);
+
+        $awaData = str_repeat("\x00", 100);
+        $awaFile = $this->writeTmpFile($awaData);
+
+        try {
+            $result = $this->makeService()->processAwaFile($awaFile, $carFile, 2006);
+            // AWA parse will fail on the binary data, proving delegation happened
+            $this->assertSame(1, $result->errors);
+            $this->assertStringContainsString('AWA parse failed', $result->messages[0]);
+        } finally {
+            unlink($awaFile);
+            unlink($carFile);
+        }
+    }
+
+    // ── processTrnData — trade-group ID characterization ────────
+
+    public function testProcessTrnDataIncrementsTradeGroupIdFromMaxPlusOne(): void
+    {
+        $mockRepo = $this->createMock(JsbImportRepositoryInterface::class);
+        $mockRepo->expects($this->once())->method('fetchMaxTradeGroupId')->willReturn(42);
+        $mockRepo->method('getPlayerName')->willReturn('Traded Player');
+
+        $capturedTradeGroupId = null;
+        $mockRepo->method('upsertTransaction')->willReturnCallback(
+            static function (array $data) use (&$capturedTradeGroupId): int {
+                if ($data['trade_group_id'] !== null) {
+                    $capturedTradeGroupId = $data['trade_group_id'];
+                }
+                return 1;
+            }
+        );
+
+        $this->stubRepo = $mockRepo;
+        $service = $this->makeService();
+
+        $tradeRecord = $this->buildTradeRecord(10, 15, 2006, [
+            ['marker' => TrnFileParser::TRADE_MARKER_PLAYER, 'from_team' => 1, 'to_team' => 5, 'player_id' => 100, 'draft_year' => null],
+        ]);
+        $trnData = $this->buildTrnFile(1, [$tradeRecord]);
+
+        $result = $service->processTrnData($trnData);
+        $this->assertSame(0, $result->errors);
+        $this->assertSame(43, $capturedTradeGroupId);
+    }
+
+    public function testProcessTrnDataTradeGroupIdFallsBackToOneOnRepoException(): void
+    {
+        $mockRepo = $this->createMock(JsbImportRepositoryInterface::class);
+        $mockRepo->expects($this->once())->method('fetchMaxTradeGroupId')
+            ->willThrowException(new \RuntimeException('DB error'));
+        $mockRepo->method('getPlayerName')->willReturn('Traded Player');
+
+        $capturedTradeGroupId = null;
+        $mockRepo->method('upsertTransaction')->willReturnCallback(
+            static function (array $data) use (&$capturedTradeGroupId): int {
+                if ($data['trade_group_id'] !== null) {
+                    $capturedTradeGroupId = $data['trade_group_id'];
+                }
+                return 1;
+            }
+        );
+
+        $this->stubRepo = $mockRepo;
+        $service = $this->makeService();
+
+        $tradeRecord = $this->buildTradeRecord(10, 15, 2006, [
+            ['marker' => TrnFileParser::TRADE_MARKER_PLAYER, 'from_team' => 1, 'to_team' => 5, 'player_id' => 200, 'draft_year' => null],
+        ]);
+        $trnData = $this->buildTrnFile(1, [$tradeRecord]);
+
+        $result = $service->processTrnData($trnData);
+        $this->assertSame(0, $result->errors);
+        $this->assertSame(1, $capturedTradeGroupId);
     }
 
     // ── processXxxFile — file-not-found characterization ────────


### PR DESCRIPTION
## Summary

Splits the 865-LOC `JsbImportService` (10 paired `processXxx` method pairs covering 10 independent JSB binary formats) into per-format importer classes under `JsbParser/Importers/`, leaving `JsbImportService` as a 177-LOC thin facade. All 5 external call sites and `JsbImportServiceInterface` consumers are byte-identical.

This is maintenance-backlog 1.4. Subsumes `classes-audit-21` (file-vs-data boilerplate collapse, shipped 2026-05-18).

## Changes

- **`JsbImportResult::recordUpsert()`** — promotes `recordUpsertResult` from a private helper + constant in `JsbImportService` to a public method on the result VO; eliminates the same 3-line pattern from 8 importers.
- **`JsbParser/Importers/`** — 10 new per-format importer classes (`AwaImporter`, `CarImporter`, `TrnImporter`, `HisImporter`, `AswImporter`, `RcbImporter`, `PlbImporter`, `DraImporter`, `RetImporter`, `HofImporter`) + shared `FileReader` helper.
- **`JsbImportService`** — reduced to constructor + 20 single-line forwarding methods. LOC: 865 → 177.
- **Tests** — characterization tests pre-extraction (Trn trade-group state, AWA dual-path); `JsbImportResultTest` cases for `recordUpsert`; 26 existing `JsbImportServiceTest` facade tests remain green.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-refactor-tests: Existing JsbImportServiceTest.php (26 tests) and new JsbImportResultTest.php cover all extracted behavior; refactor-flag fires on large deletions from JsbImportService but the test suite is the characterization contract. -->

---

Generated with [Claude Code](https://claude.ai/code)