### PR TITLE
feat(e2e): add HTTP status-code check to gotoWithRetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,4 @@
----
-description: Worktree instructions for the css-architecture-cleanup branch.
-last_verified: 2026-05-20
----
+# Worktree: e2e-status-check-in-goto-retry
 
-# Worktree: css-architecture-cleanup
-
-This worktree's Docker instance is at `css-architecture-cleanup.localhost`.
+This worktree's Docker instance is at `e2e-status-check-in-goto-retry.localhost`.
 Use this hostname for all browser checks, curl, and E2E — never `main.localhost`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+description: Worktree instructions for the e2e-status-check-in-goto-retry branch.
+last_verified: 2026-05-20
+---
+
 # Worktree: e2e-status-check-in-goto-retry
 
 This worktree's Docker instance is at `e2e-status-check-in-goto-retry.localhost`.

--- a/ibl5/tests/e2e/helpers/navigation.ts
+++ b/ibl5/tests/e2e/helpers/navigation.ts
@@ -17,13 +17,18 @@ export async function openMobileMenu(page: Page): Promise<Locator> {
 export async function gotoWithRetry(page: Page, url: string): Promise<void> {
   for (let attempt = 0; attempt < 5; attempt++) {
     if (attempt > 0) await page.waitForTimeout(attempt * 1000);
+    let response: Awaited<ReturnType<Page['goto']>>;
     try {
-      await page.goto(url, { timeout: 15_000 });
+      response = await page.goto(url, { timeout: 15_000 });
     } catch {
       continue;
     }
     const body = await page.locator('body').innerText();
-    if (body.trim().length >= 20) return;
+    if (body.trim().length < 20) continue;
+    if (response && response.status() >= 400) {
+      throw new Error(`Page returned HTTP ${response.status()} for ${url}`);
+    }
+    return;
   }
   throw new Error(`Page returned blank content after 5 attempts: ${url}`);
 }

--- a/ibl5/tests/e2e/smoke/navigation-helper.spec.ts
+++ b/ibl5/tests/e2e/smoke/navigation-helper.spec.ts
@@ -1,8 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures/public';
 import { gotoWithRetry } from '../helpers/navigation';
-import { publicStorageState } from '../helpers/public-storage-state';
-
-test.use({ storageState: publicStorageState() });
 
 test.describe('gotoWithRetry helper', () => {
   test('throws on HTTP 500 with non-blank body', async ({ page }) => {

--- a/ibl5/tests/e2e/smoke/navigation-helper.spec.ts
+++ b/ibl5/tests/e2e/smoke/navigation-helper.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { gotoWithRetry } from '../helpers/navigation';
+import { publicStorageState } from '../helpers/public-storage-state';
+
+test.use({ storageState: publicStorageState() });
+
+test.describe('gotoWithRetry helper', () => {
+  test('throws on HTTP 500 with non-blank body', async ({ page }) => {
+    await page.route('**/status-500-fixture', (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: 'text/html',
+        body: '<html><body>Internal Server Error - long enough body to pass the 20-char gate</body></html>',
+      });
+    });
+
+    const url = 'http://localhost/status-500-fixture';
+    await expect(gotoWithRetry(page, url)).rejects.toThrow(/HTTP 500/);
+  });
+
+  test('throws on HTTP 404 with non-blank body', async ({ page }) => {
+    await page.route('**/status-404-fixture', (route) => {
+      route.fulfill({
+        status: 404,
+        contentType: 'text/html',
+        body: '<html><body>Not Found page with long enough content to pass the gate</body></html>',
+      });
+    });
+
+    const url = 'http://localhost/status-404-fixture';
+    await expect(gotoWithRetry(page, url)).rejects.toThrow(/HTTP 404/);
+  });
+
+  test('does not retry on 4xx status', async ({ page }) => {
+    let hitCount = 0;
+    await page.route('**/status-404-no-retry', (route) => {
+      hitCount++;
+      route.fulfill({
+        status: 404,
+        contentType: 'text/html',
+        body: '<html><body>Not Found page with long enough content to pass the gate</body></html>',
+      });
+    });
+
+    const url = 'http://localhost/status-404-no-retry';
+    await expect(gotoWithRetry(page, url)).rejects.toThrow(/HTTP 404/);
+    expect(hitCount).toBe(1);
+  });
+
+  test('throws on persistently blank body', async ({ page }) => {
+    await page.route('**/blank-body-fixture', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '',
+      });
+    });
+
+    const url = 'http://localhost/blank-body-fixture';
+    await expect(gotoWithRetry(page, url)).rejects.toThrow(/blank content/);
+  });
+
+  test('succeeds on HTTP 200 with non-blank body', async ({ page }) => {
+    await page.route('**/status-200-fixture', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>This is a valid page with enough content to pass the body check</body></html>',
+      });
+    });
+
+    const url = 'http://localhost/status-200-fixture';
+    await expect(gotoWithRetry(page, url)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`gotoWithRetry()` previously accepted any HTTP status as long as the page body was ≥ 20 characters. A 500 page rendering a full error template would silently pass the retry loop, causing downstream assertions to report misleading failures (e.g., "expected to see standings table").

**Change:** After the blank-body gate passes, a `response.status() >= 400` check now throws immediately with the URL + status code. Blank-body behavior (up to 5 retries) is unchanged — only deterministic error responses fail fast.

## Files Changed

- `ibl5/tests/e2e/helpers/navigation.ts` — add status check after body-length gate
- `ibl5/tests/e2e/smoke/navigation-helper.spec.ts` — new spec covering all 5 branches (500 throws, 404 throws, no retry on 4xx, blank-body still retries, 200 succeeds)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.