### PR TITLE
test(e2e): add content-specific assertions to auth-pages-extended smoke tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,4 @@
----
-description: Worktree instructions for the e2e-vr-anchors-specific-selectors branch.
-last_verified: 2026-05-20
----
+# Worktree: e2e-auth-pages-extended-content-selectors
 
-# Worktree: e2e-vr-anchors-specific-selectors
-
-This worktree's Docker instance is at `e2e-vr-anchors-specific-selectors.localhost`.
+This worktree's Docker instance is at `e2e-auth-pages-extended-content-selectors.localhost`.
 Use this hostname for all browser checks, curl, and E2E — never `main.localhost`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+description: Worktree instructions for the e2e-auth-pages-extended-content-selectors branch.
+last_verified: 2026-05-20
+---
+
 # Worktree: e2e-auth-pages-extended-content-selectors
 
 This worktree's Docker instance is at `e2e-auth-pages-extended-content-selectors.localhost`.

--- a/ibl5/tests/e2e/smoke/auth-pages-extended.spec.ts
+++ b/ibl5/tests/e2e/smoke/auth-pages-extended.spec.ts
@@ -9,6 +9,7 @@ test.describe('Extended authenticated page smoke tests', () => {
     await page.goto('modules.php?name=FreeAgency');
     await assertNoPhpErrors(page, 'on modules.php?name=FreeAgency');
     await expect(page.getByText('Sign In')).not.toBeVisible();
+    await expect(page.locator('table.fa-table').first()).toBeVisible();
   });
 
   test('draft page loads', async ({ appState, page }) => {
@@ -19,12 +20,14 @@ test.describe('Extended authenticated page smoke tests', () => {
     await page.goto('modules.php?name=Draft');
     await assertNoPhpErrors(page, 'on modules.php?name=Draft');
     await expect(page.getByText('Sign In')).not.toBeVisible();
+    await expect(page.locator('div.draft-container')).toBeVisible();
   });
 
   test('waivers page loads', async ({ page }) => {
     await page.goto('modules.php?name=Waivers');
     await assertNoPhpErrors(page, 'on modules.php?name=Waivers');
     await expect(page.getByText('Sign In')).not.toBeVisible();
+    await expect(page.locator('div.waivers-page')).toBeVisible();
   });
 
   test('voting page loads', async ({ appState, page }) => {
@@ -32,6 +35,7 @@ test.describe('Extended authenticated page smoke tests', () => {
     await page.goto('modules.php?name=Voting');
     await assertNoPhpErrors(page, 'on modules.php?name=Voting');
     await expect(page.getByText('Sign In')).not.toBeVisible();
+    await expect(page.locator('div.voting-form-container')).toBeVisible();
   });
 
   test('next sim page loads', async ({ page }) => {


### PR DESCRIPTION
## Summary

Adds content-bearing visibility assertions to the FreeAgency, Draft, Waivers, and Voting per-page smoke tests in `auth-pages-extended.spec.ts`. Previously these tests only verified no sign-in redirect occurred — a page could render an empty content area and still pass. Each test now asserts the primary content element is visible.

**Changed pages:**
- **FreeAgency** → `table.fa-table`
- **Draft** → `div.draft-container`
- **Waivers** → `div.waivers-page`
- **Voting** → `div.voting-form-container`

NextSim and GMContactList already had content selectors — left untouched.

## Verification Matrix

| # | What to verify | Test type | Test file |
|---|---------------|-----------|-----------|
| 2-5 | Each page asserts a visible content selector | E2E (post-impl) | `ibl5/tests/e2e/smoke/auth-pages-extended.spec.ts` |
| 8 | NextSim and GMContactList retain existing assertions (no regression) | E2E (post-impl) | `ibl5/tests/e2e/smoke/auth-pages-extended.spec.ts` |

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.