### PR TITLE
test: strengthen 4 weak public smoke specs (continues PR #810)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+description: Worktree-local Claude Code instructions for e2e-strengthen-public-smoke.
+last_verified: 2026-05-21
+---
+
 # Worktree: e2e-strengthen-public-smoke
 
 This worktree's Docker instance is at `e2e-strengthen-public-smoke.localhost`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,4 @@
----
-description: Worktree instructions for the e2e-mobile-public-anchors branch.
-last_verified: 2026-05-21
----
+# Worktree: e2e-strengthen-public-smoke
 
-# Worktree: e2e-mobile-public-anchors
-
-This worktree's Docker instance is at `e2e-mobile-public-anchors.localhost`.
+This worktree's Docker instance is at `e2e-strengthen-public-smoke.localhost`.
 Use this hostname for all browser checks, curl, and E2E — never `main.localhost`.

--- a/ibl5/tests/e2e/flows/homepage.spec.ts
+++ b/ibl5/tests/e2e/flows/homepage.spec.ts
@@ -44,6 +44,6 @@ test.describe('Homepage with state override', () => {
     await assertNoPhpErrors(page, 'on homepage with trivia off');
     await expect(page).toHaveTitle(/IBL/i);
     await expect(page.locator('article').first()).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Standings' })).toBeVisible();
+    await expect(page.locator('a[href*="name=Standings"]').first()).toBeAttached();
   });
 });

--- a/ibl5/tests/e2e/flows/homepage.spec.ts
+++ b/ibl5/tests/e2e/flows/homepage.spec.ts
@@ -43,5 +43,7 @@ test.describe('Homepage with state override', () => {
     await page.goto('index.php');
     await assertNoPhpErrors(page, 'on homepage with trivia off');
     await expect(page).toHaveTitle(/IBL/i);
+    await expect(page.locator('article').first()).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Standings' })).toBeVisible();
   });
 });

--- a/ibl5/tests/e2e/flows/news.spec.ts
+++ b/ibl5/tests/e2e/flows/news.spec.ts
@@ -69,6 +69,14 @@ test.describe('News module flow', () => {
     const href = await link.getAttribute('href');
     await page.goto(href!);
     await assertNoPhpErrors(page, 'on News article view');
+    await expect(page.locator('.news-article')).toBeVisible();
+    await expect(page.locator('.news-article__title').first()).toBeVisible();
+    const body = page.locator('.news-article__body');
+    await expect(body).toBeVisible();
+    const bodyText = await body.textContent();
+    expect((bodyText ?? '').trim().length).toBeGreaterThan(50);
+    await expect(page.locator('.news-article__meta')).toBeVisible();
+    await expect(page.locator('.news-article__meta .news-article__meta-item').first()).toBeVisible();
   });
 
   test('categories page loads', async ({ page }) => {

--- a/ibl5/tests/e2e/smoke/public-pages-extended.spec.ts
+++ b/ibl5/tests/e2e/smoke/public-pages-extended.spec.ts
@@ -7,29 +7,45 @@ import { publicStorageState } from '../helpers/public-storage-state';
 test.use({ storageState: publicStorageState() });
 
 const PAGES = [
-  { name: 'schedule', url: 'modules.php?name=Schedule', selector: '.schedule-container, .ibl-data-table, table' },
-  { name: 'injuries', url: 'modules.php?name=Injuries', selector: '.ibl-title, h2, h3' },
-  { name: 'player database', url: 'modules.php?name=PlayerDatabase', selector: 'form[name="Search"]' },
-  { name: 'projected draft order', url: 'modules.php?name=ProjectedDraftOrder', selector: '.ibl-title, .ibl-data-table, table' },
-  { name: 'draft pick locator', url: 'modules.php?name=DraftPickLocator', selector: '.ibl-title, table' },
-  { name: 'free agency preview', url: 'modules.php?name=FreeAgencyPreview', selector: '.ibl-data-table, table, .ibl-title' },
-  { name: 'contract list', url: 'modules.php?name=ContractList', selector: '.ibl-data-table, table, .ibl-title' },
-  { name: 'player movement', url: 'modules.php?name=PlayerMovement', selector: '.ibl-title, .ibl-data-table, table, h2, h3' },
-  { name: 'league starters', url: 'modules.php?name=LeagueStarters', selector: '.ibl-data-table, table' },
-  { name: 'compare players', url: 'modules.php?name=ComparePlayers', selector: 'input[name="Player1"], input[name="player1"]' },
-  { name: 'season highs', url: 'modules.php?name=SeasonHighs', selector: '.ibl-data-table, table, .ibl-title' },
-  { name: 'series records', url: 'modules.php?name=SeriesRecords', selector: '.ibl-data-table, table, .ibl-title' },
-  { name: 'franchise history', url: 'modules.php?name=FranchiseHistory', selector: '.ibl-data-table, table, .ibl-title' },
-  { name: 'activity tracker', url: 'modules.php?name=ActivityTracker', selector: '.ibl-data-table, table, .ibl-title' },
+  { name: 'schedule', url: 'modules.php?name=Schedule', anchor: '.schedule-header' },
+  { name: 'injuries', url: 'modules.php?name=Injuries', anchor: '.ibl-data-table',
+    rowCount: { selector: '.ibl-data-table tbody tr', minimum: 1 } },
+  { name: 'player database', url: 'modules.php?name=PlayerDatabase', anchor: 'form[action*="PlayerDatabase"]' },
+  { name: 'projected draft order', url: 'modules.php?name=ProjectedDraftOrder', anchor: '.ibl-data-table',
+    rowCount: { selector: '.ibl-data-table tbody tr', minimum: 1 } },
+  { name: 'draft pick locator', url: 'modules.php?name=DraftPickLocator', anchor: '.draft-pick-locator-container' },
+  { name: 'free agency preview', url: 'modules.php?name=FreeAgencyPreview', anchor: 'th.fa-preview-pos-col' },
+  { name: 'contract list', url: 'modules.php?name=ContractList', anchor: '.totals-row' },
+  { name: 'player movement', url: 'modules.php?name=PlayerMovement', anchor: '.ibl-data-table',
+    rowCount: { selector: '.ibl-data-table tbody tr', minimum: 1 } },
+  { name: 'league starters', url: 'modules.php?name=LeagueStarters', anchor: '#league-starters-tables' },
+  { name: 'compare players', url: 'modules.php?name=ComparePlayers', anchor: 'form[action*="ComparePlayers"]' },
+  { name: 'season highs', url: 'modules.php?name=SeasonHighs', anchor: '.ibl-data-table',
+    rowCount: { selector: '.ibl-data-table tbody tr', minimum: 1 } },
+  { name: 'series records', url: 'modules.php?name=SeriesRecords', anchor: '.ibl-data-table',
+    rowCount: { selector: '.ibl-data-table tbody tr', minimum: 1 } },
+  { name: 'franchise history', url: 'modules.php?name=FranchiseHistory', anchor: '.ibl-data-table',
+    rowCount: { selector: 'tr[data-team-id]', minimum: 28 } },
+  { name: 'activity tracker', url: 'modules.php?name=ActivityTracker', anchor: '.ibl-data-table',
+    rowCount: { selector: '.ibl-data-table tbody tr', minimum: 1 } },
 ];
 
 test.describe('Extended public page smoke tests', () => {
-  for (const { name, url, selector } of PAGES) {
+  for (const { name, url, anchor, rowCount } of PAGES) {
     test(`${name} loads`, async ({ page }) => {
       test.setTimeout(60_000);
       await gotoWithRetry(page, url);
       await assertNoPhpErrors(page, `on ${url}`);
-      await expect(page.locator(selector).first()).toBeVisible();
+      await expect(page.locator(anchor).first()).toBeVisible();
+      if (rowCount) {
+        const rows = page.locator(rowCount.selector);
+        if (rowCount.minimum === 1) {
+          await expect(rows.first()).toBeVisible();
+        } else {
+          const count = await rows.count();
+          expect(count, `${name}: expected >= ${rowCount.minimum} rows`).toBeGreaterThanOrEqual(rowCount.minimum);
+        }
+      }
     });
   }
 });

--- a/ibl5/tests/e2e/smoke/public-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/public-pages.spec.ts
@@ -21,24 +21,29 @@ test.describe('Public page smoke tests', () => {
     await assertNoPhpErrors(page, 'on modules.php?name=Standings');
     await expect(page.locator('.ibl-title').first()).toBeVisible();
     await expect(page.locator('.ibl-data-table').first()).toBeVisible();
+    const teamRows = page.locator('tr[data-team-id]');
+    const count = await teamRows.count();
+    expect(count).toBeGreaterThanOrEqual(28);
   });
 
   test('player page loads', async ({ page }) => {
     await page.goto('modules.php?name=Player&pa=showpage&pid=1');
     await assertNoPhpErrors(page, 'on modules.php?name=Player&pa=showpage&pid=1');
-    await expect(page.locator('h2, h3').first()).toBeVisible();
+    await expect(page.locator('.stats-grid').first()).toBeVisible();
   });
 
   test('team page loads', async ({ page }) => {
     await page.goto('modules.php?name=Team&op=team&teamid=1');
     await assertNoPhpErrors(page, 'on modules.php?name=Team&op=team&teamid=1');
-    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
+    await expect(page.locator('.team-page-layout').first()).toBeVisible();
   });
 
   test('season leaderboards loads', async ({ page }) => {
     await page.goto('modules.php?name=SeasonLeaderboards');
     await assertNoPhpErrors(page, 'on modules.php?name=SeasonLeaderboards');
     await expect(page.locator('.ibl-data-table').first()).toBeVisible();
+    const rows = page.locator('.ibl-data-table').first().locator('tbody tr');
+    await expect(rows.first()).toBeVisible();
   });
 
   test('career leaderboards loads', async ({ page }) => {
@@ -51,18 +56,21 @@ test.describe('Public page smoke tests', () => {
     await page.goto('modules.php?name=DraftHistory');
     await assertNoPhpErrors(page, 'on modules.php?name=DraftHistory');
     await expect(page.locator('.ibl-data-table').first()).toBeVisible();
+    const rows = page.locator('.ibl-data-table').first().locator('tbody tr');
+    await expect(rows.first()).toBeVisible();
   });
 
   test('cap space loads', async ({ page }) => {
     await page.goto('modules.php?name=CapSpace');
     await assertNoPhpErrors(page, 'on modules.php?name=CapSpace');
-    const table = page.locator('.ibl-data-table, .sticky-table, table').first();
-    await expect(table).toBeVisible();
+    const teamRows = page.locator('tr[data-team-id]');
+    const count = await teamRows.count();
+    expect(count).toBeGreaterThanOrEqual(28);
   });
 
   test('topics page loads', async ({ page }) => {
     await page.goto('modules.php?name=Topics');
     await assertNoPhpErrors(page, 'on modules.php?name=Topics');
-    await expect(page.locator('.ibl-title, table, a').first()).toBeVisible();
+    await expect(page.locator('.topics-page').first()).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Replace generic fallback selectors with content-specific anchors in 4 smoke spec files, and add per-test row-count assertions so broken modules that render empty wrappers fail instead of passing.

### Changes
- `public-pages.spec.ts`: Replace `h2, h3` and `.ibl-data-table` fallback chains with `.stats-grid`, `.team-page-layout`, `.topics-page` anchors; add `tr[data-team-id]` count checks (`>= 28`)
- `public-pages-extended.spec.ts`: Convert `PAGES` array from `{ selector }` to `{ anchor, rowCount? }`; drop all fallback chains; add row-count assertions
- `news.spec.ts`: Add `.news-article`, `.news-article__title`, body > 50 chars, and `.news-article__meta` assertions to article detail test
- `homepage.spec.ts`: Add `article` first visible and `Standings` nav link assertions to trivia-off test

Continues the selector-hardening pattern from PR #810.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.