### PR TITLE
test: add E2E coverage for uncovered POST and AJAX endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,4 @@
----
-description: Worktree-local Claude Code instructions for e2e-strengthen-public-smoke.
-last_verified: 2026-05-21
----
+# Worktree: e2e-uncovered-post-and-ajax
 
-# Worktree: e2e-strengthen-public-smoke
-
-This worktree's Docker instance is at `e2e-strengthen-public-smoke.localhost`.
+This worktree's Docker instance is at `e2e-uncovered-post-and-ajax.localhost`.
 Use this hostname for all browser checks, curl, and E2E — never `main.localhost`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+description: Worktree-local Claude Code instructions for e2e-uncovered-post-and-ajax.
+last_verified: 2026-05-22
+---
+
 # Worktree: e2e-uncovered-post-and-ajax
 
 This worktree's Docker instance is at `e2e-uncovered-post-and-ajax.localhost`.

--- a/ibl5/tests/e2e/flows/ajax-api-endpoints.spec.ts
+++ b/ibl5/tests/e2e/flows/ajax-api-endpoints.spec.ts
@@ -378,3 +378,83 @@ test.describe('FranchiseRecordBook API', () => {
     expect(pushUrl).toContain('FranchiseRecordBook');
   });
 });
+
+// ============================================================
+// Saved Depth Chart API: load and rename
+// Validation-failure tests for load, rename, and rename-active actions.
+// No successful rename — that would require a cleanup endpoint.
+// ============================================================
+
+test.describe('Saved Depth Chart API: load and rename', () => {
+  test('action=load with invalid id returns 400 JSON error', async ({
+    request,
+  }) => {
+    const { status, body, contentType } = await fetchJson(
+      request,
+      'modules.php?name=DepthChartEntry&op=api&action=load&id=0',
+    );
+    expect(contentType).toContain('json');
+    expect(status).toBe(400);
+    expect(body).toHaveProperty('error', 'Invalid depth chart ID');
+  });
+
+  test('action=load with nonexistent id returns 404 JSON', async ({
+    request,
+  }) => {
+    const { status, body, contentType } = await fetchJson(
+      request,
+      'modules.php?name=DepthChartEntry&op=api&action=load&id=999999',
+    );
+    expect(contentType).toContain('json');
+    expect(status).toBe(404);
+    expect(body).toHaveProperty('error', 'Depth chart not found');
+  });
+
+  test('action=rename with empty name returns 400 JSON', async ({
+    request,
+  }) => {
+    const response = await request.post(
+      'modules.php?name=DepthChartEntry&op=api&action=rename',
+      { data: { id: 1, name: '' } },
+    );
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body).toHaveProperty('error', 'Name cannot be empty');
+  });
+
+  test('action=rename with invalid id returns 400 JSON', async ({
+    request,
+  }) => {
+    const response = await request.post(
+      'modules.php?name=DepthChartEntry&op=api&action=rename',
+      { data: { id: 0, name: 'x' } },
+    );
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body).toHaveProperty('error', 'Invalid depth chart ID');
+  });
+
+  test('action=rename-active with empty name returns 400 JSON', async ({
+    request,
+  }) => {
+    const response = await request.post(
+      'modules.php?name=DepthChartEntry&op=api&action=rename-active',
+      { data: { name: '   ' } },
+    );
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body).toHaveProperty('error', 'Name cannot be empty');
+  });
+
+  test('unauthenticated load returns 401 JSON', async ({ request }) => {
+    const response = await request.get(
+      'modules.php?name=DepthChartEntry&op=api&action=load&id=1',
+      { headers: { Cookie: '_no_auto_login=1' } },
+    );
+    expect(response.status()).toBe(401);
+    const contentType = response.headers()['content-type'] ?? '';
+    expect(contentType).toContain('json');
+    const body = await response.json();
+    expect(body).toHaveProperty('error');
+  });
+});

--- a/ibl5/tests/e2e/flows/password-reset.spec.ts
+++ b/ibl5/tests/e2e/flows/password-reset.spec.ts
@@ -16,7 +16,9 @@ test.describe('Password reset flow', () => {
     await expect(
       page.locator('input[name="op"][value="mailpasswd"]'),
     ).toBeAttached();
-    await expect(page.locator('input[name="_csrf_token"]')).toBeAttached();
+    await expect(
+      page.locator('form:has(input[name="user_email"]) input[name="_csrf_token"]'),
+    ).toBeAttached();
   });
 
   test('POST mailpasswd with valid email returns generic status page', async ({

--- a/ibl5/tests/e2e/flows/password-reset.spec.ts
+++ b/ibl5/tests/e2e/flows/password-reset.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '../fixtures/public';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+
+// Password reset flow — uses public (unauthenticated) fixture.
+// Full end-to-end reset not covered: intercepting the password-reset email
+// is not possible in CI.
+
+test.describe('Password reset flow', () => {
+  test('forgot password page renders form and CSRF token', async ({
+    page,
+  }) => {
+    await page.goto('modules.php?name=YourAccount&op=pass_lost');
+    await assertNoPhpErrors(page, 'on forgot password page');
+
+    await expect(page.locator('input[name="user_email"]')).toBeAttached();
+    await expect(
+      page.locator('input[name="op"][value="mailpasswd"]'),
+    ).toBeAttached();
+    await expect(page.locator('input[name="_csrf_token"]')).toBeAttached();
+  });
+
+  test('POST mailpasswd with valid email returns generic status page', async ({
+    page,
+  }) => {
+    await page.goto('modules.php?name=YourAccount&op=pass_lost');
+    await page.locator('input[name="user_email"]').fill('ci-test@example.com');
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.locator('body')).toContainText('Check Your Email');
+    await assertNoPhpErrors(page, 'after valid email submission');
+  });
+
+  test('POST mailpasswd with nonexistent email returns same generic status page', async ({
+    page,
+  }) => {
+    await page.goto('modules.php?name=YourAccount&op=pass_lost');
+    await page
+      .locator('input[name="user_email"]')
+      .fill('no-such-user-99999@example.com');
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.locator('body')).toContainText('Check Your Email');
+    await assertNoPhpErrors(page, 'after nonexistent email submission');
+  });
+
+  test('POST mailpasswd with empty email returns validation error', async ({
+    page,
+  }) => {
+    await page.goto('modules.php?name=YourAccount&op=pass_lost');
+    await page
+      .locator('input[name="user_email"]')
+      .evaluate((el) => el.removeAttribute('required'));
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.locator('body')).toContainText(
+      'Please enter your email address.',
+    );
+    await assertNoPhpErrors(page, 'after empty email submission');
+  });
+
+  test('GET reset_password without selector/token redirects to pass_lost', async ({
+    page,
+  }) => {
+    await page.goto('modules.php?name=YourAccount&op=reset_password');
+    await expect(page).toHaveURL(/op=pass_lost/);
+    await assertNoPhpErrors(page, 'after redirect to pass_lost');
+  });
+
+  test('GET reset_password with garbage selector/token renders reset form', async ({
+    page,
+  }) => {
+    await page.goto(
+      'modules.php?name=YourAccount&op=reset_password&selector=garbage123&token=invalid456',
+    );
+    await assertNoPhpErrors(page, 'on reset password form with garbage tokens');
+
+    await expect(page.locator('input[name="new_password"]')).toBeAttached();
+    await expect(page.locator('input[name="new_password2"]')).toBeAttached();
+    await expect(
+      page.locator('input[name="op"][value="do_reset_password"]'),
+    ).toBeAttached();
+  });
+});

--- a/ibl5/tests/e2e/flows/password-reset.spec.ts
+++ b/ibl5/tests/e2e/flows/password-reset.spec.ts
@@ -24,7 +24,9 @@ test.describe('Password reset flow', () => {
   }) => {
     await page.goto('modules.php?name=YourAccount&op=pass_lost');
     await page.locator('input[name="user_email"]').fill('ci-test@example.com');
-    await page.locator('button[type="submit"]').click();
+    await page
+      .locator('form:has(input[name="user_email"]) button[type="submit"]')
+      .click();
 
     await expect(page.locator('body')).toContainText('Check Your Email');
     await assertNoPhpErrors(page, 'after valid email submission');
@@ -37,7 +39,9 @@ test.describe('Password reset flow', () => {
     await page
       .locator('input[name="user_email"]')
       .fill('no-such-user-99999@example.com');
-    await page.locator('button[type="submit"]').click();
+    await page
+      .locator('form:has(input[name="user_email"]) button[type="submit"]')
+      .click();
 
     await expect(page.locator('body')).toContainText('Check Your Email');
     await assertNoPhpErrors(page, 'after nonexistent email submission');
@@ -50,7 +54,9 @@ test.describe('Password reset flow', () => {
     await page
       .locator('input[name="user_email"]')
       .evaluate((el) => el.removeAttribute('required'));
-    await page.locator('button[type="submit"]').click();
+    await page
+      .locator('form:has(input[name="user_email"]) button[type="submit"]')
+      .click();
 
     await expect(page.locator('body')).toContainText(
       'Please enter your email address.',

--- a/ibl5/tests/e2e/flows/player-subpages.spec.ts
+++ b/ibl5/tests/e2e/flows/player-subpages.spec.ts
@@ -90,6 +90,33 @@ test.describe('Player rookie option sub-page', () => {
     await page.goto('modules.php?name=Player&pa=rookieoption&pid=99999');
     await assertNoPhpErrors(page, 'on rookie option with invalid PID');
   });
+
+  // Success path not covered — would mutate pid=25's contract; no reset endpoint exists.
+  test('POST to processrookieoption with ineligible player returns error redirect', async ({
+    appState,
+    request,
+  }) => {
+    await appState({
+      'Current Season Phase': 'Regular Season',
+      'Current Season Ending Year': '2026',
+    });
+
+    const response = await request.post(
+      '/ibl5/modules.php?name=Player&pa=processrookieoption',
+      {
+        form: {
+          teamname: 'Metros',
+          playerID: '25',
+          rookieOptionValue: '1000',
+          from: '',
+        },
+        maxRedirects: 0,
+      },
+    );
+    const location = response.headers()['location'] ?? '';
+    expect(location).toContain('error=');
+    expect(location).toContain('pa=rookieoption');
+  });
 });
 
 test.describe('Player extension sub-page (POST handler)', () => {

--- a/ibl5/tests/e2e/flows/trading-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/trading-submission.spec.ts
@@ -175,6 +175,19 @@ async function getCsrfToken(page: Page): Promise<string> {
 }
 
 /**
+ * Extract a valid trade_accept CSRF token from the review page.
+ * The trade_accept token is generated per accept form, not the offer form.
+ */
+async function getAcceptCsrfToken(page: Page): Promise<string> {
+  await gotoWithRetry(page, 'modules.php?name=Trading&op=reviewtrade');
+  const tokenInput = page.locator(
+    '.trade-offer-card form[action*="accepttradeoffer"] input[name="_csrf_token"]',
+  );
+  if ((await tokenInput.count()) === 0) return '';
+  return (await tokenInput.first().getAttribute('value')) ?? '';
+}
+
+/**
  * Build the POST form body from extracted form data, checking specified indices.
  */
 function buildFormBody(
@@ -694,5 +707,81 @@ test.describe('Trade review page: no PHP errors after mutations', () => {
     await appState({ 'Allow Trades': 'Yes', 'Current Season Ending Year': '2026' });
     await gotoWithRetry(page, 'modules.php?name=Trading&op=reviewtrade');
     await assertNoPhpErrors(page, 'on review page after mutations');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block 8: Trade accept: error branches (API)
+// ---------------------------------------------------------------------------
+
+test.describe('Trade accept: error branches (API)', () => {
+  test('accept with stale offer ID returns already_processed', async ({
+    appState,
+    page,
+    request,
+  }) => {
+    await appState({
+      'Allow Trades': 'Yes',
+      'Current Season Ending Year': '2026',
+    });
+    const token = await getAcceptCsrfToken(page);
+    expect(
+      token,
+      'CI seed must provide offers with accept forms on review page',
+    ).toBeTruthy();
+
+    const response = await request.post(
+      '/ibl5/modules/Trading/accepttradeoffer.php',
+      {
+        form: { offer: '999999', _csrf_token: token },
+        maxRedirects: 0,
+      },
+    );
+    const location = response.headers()['location'] ?? '';
+    expect(location).toContain('result=already_processed');
+  });
+
+  test('accept with non-numeric offer redirects to reviewtrade', async ({
+    appState,
+    page,
+    request,
+  }) => {
+    await appState({
+      'Allow Trades': 'Yes',
+      'Current Season Ending Year': '2026',
+    });
+    const token = await getAcceptCsrfToken(page);
+    expect(token).toBeTruthy();
+
+    const response = await request.post(
+      '/ibl5/modules/Trading/accepttradeoffer.php',
+      {
+        form: { offer: 'not-a-number', _csrf_token: token },
+        maxRedirects: 0,
+      },
+    );
+    const location = response.headers()['location'] ?? '';
+    expect(location).toContain('op=reviewtrade');
+    expect(location).not.toContain('result=');
+  });
+
+  test('accept without CSRF token returns error', async ({
+    appState,
+    request,
+  }) => {
+    await appState({
+      'Allow Trades': 'Yes',
+      'Current Season Ending Year': '2026',
+    });
+
+    const response = await request.post(
+      '/ibl5/modules/Trading/accepttradeoffer.php',
+      {
+        form: { offer: '1' },
+        maxRedirects: 0,
+      },
+    );
+    const location = response.headers()['location'] ?? '';
+    expect(location).toContain('error=');
   });
 });


### PR DESCRIPTION
## Summary

Adds E2E coverage for POST handlers and AJAX/HTMX endpoints that lacked any test invocation. This PR adds tests only — no production handler changes.

### Changes

- **`flows/trading-submission.spec.ts`** — new "Trade accept: error branches (API)" block: CSRF rejection, stale offer ID (`already_processed`), non-numeric offer fallback (`reviewtrade`)
- **`flows/player-subpages.spec.ts`** — rookie option POST validation-failure path (ineligible player → error redirect without mutating the DB)
- **`flows/password-reset.spec.ts`** — new spec: forgot-password page, mailpasswd POST (valid/nonexistent/empty email), reset_password redirect, reset form rendering
- **`flows/ajax-api-endpoints.spec.ts`** — new "Saved Depth Chart API: load and rename" block: load (invalid/nonexistent id, unauthenticated), rename (empty name, invalid id), rename-active (whitespace name) validation paths

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.