### PR TITLE
Layer 4: Semantic E2E Spec Reviewer Agent

### DIFF
--- a/.claude/commands/_review-agents.md
+++ b/.claude/commands/_review-agents.md
@@ -1,6 +1,6 @@
 ---
 description: Shared code-review agent definitions used by /pr-review and /post-plan.
-last_verified: 2026-05-21
+last_verified: 2026-05-23
 ---
 
 # Code Review Agents (shared definitions)
@@ -21,7 +21,7 @@ Each agent receives: filtered PR diff, file list, and PR metadata from the paren
 
 **Assume PHPStan `level: max` + `phpstan-strict-rules` + the custom rules listed in `_review-rubric.md` are satisfied.** Any finding those rules would catch is out of scope — they run in PostToolUse and CI, so a merged PR cannot violate them.
 
-**Playwright `.spec.ts` files are lint-enforced by `bun run lint:e2e` (CI job `ESLint (e2e specs)`).** Reviewers should not duplicate `playwright/*` or `@typescript-eslint/*` rule checks — the preset already covers missing `await`, `{ force: true }`, `waitForTimeout`, `networkidle`, web-first assertions, etc.
+**Playwright `.spec.ts` files are lint-enforced by `bun run lint:e2e` (CI job `ESLint (e2e specs)`).** Reviewers should not duplicate `playwright/*` or `@typescript-eslint/*` rule checks — the preset already covers missing `await`, `{ force: true }`, `waitForTimeout`, `networkidle`, web-first assertions, etc. Semantic E2E spec review (POST-effect verification, assertion discrimination, coverage-branch check) is handled by **Agent D**, defined in `.claude/commands/_test-spec-agent.md` and launched from `/post-plan` Phase 4B. Do not duplicate its checks here.
 
 ---
 

--- a/.claude/commands/_review-rubric.md
+++ b/.claude/commands/_review-rubric.md
@@ -1,6 +1,6 @@
 ---
 description: Shared review rubric and false-positive filter used by /pr-review, /security-audit, and /post-plan.
-last_verified: 2026-05-15
+last_verified: 2026-05-23
 ---
 
 # Review Rubric and False-Positive Filter (shared)
@@ -57,6 +57,20 @@ Catches type errors, loose comparisons (`==`/`!=`), unused imports, unreachable 
 
 ---
 
+## E2E spec patterns to flag (Agent D)
+
+When Agent D reports a finding, the scoring agent should anchor on these named anti-patterns:
+
+| Anti-pattern | Detection signal | Section |
+|---|---|---|
+| Same-page-success-only | Happy-path `*-submission.spec.ts` test asserts on `.alert--success`/`.voting-submission-success`/etc. without a cross-page navigation, API read-back, or `submitFormAndAssertEffect` call | 1 |
+| Generic-fallback assertion | `expect(loc).toBeVisible()` on `body`, `.ibl-content`, `#main`, or selectors present on every error template | 2 |
+| Header-text assertion | `toContain('IBL')`, `toHaveTitle(/IBL/i)` as the only discrimination in a non-smoke test | 2 |
+| Uncounted `.first()` | `.first()` used where the test name implies multiple items, with no `toHaveCount` or count check | 2 |
+| New UI branch w/o spec | Production diff adds a new phase-gated state / admin-only module / HTMX-swapped tab / conditional `<details>`/modal, spec diff has no matching `test(...)` block setting that state | 3 |
+
+---
+
 ## IBL5-specific false positives (score 0-25)
 
 Apply after the Automatic Zero list.
@@ -71,3 +85,9 @@ Apply after the Automatic Zero list.
 - Pre-existing issues on lines the PR did not modify
 - Changes in functionality that are likely intentional or directly related to the broader change
 - Issues called out in CLAUDE.md but silenced by explicit opt-out comments (e.g. `// phpcs:ignore`, `@phpstan-ignore-next-line`)
+- `tests/e2e/smoke/**/*.ts` flagged for Section 2 generic-visibility assertions — smoke tests legitimately assert "page loads" via generic selectors; Agent D should already exempt these, but if one slips through it scores 0
+- Error-path tests (`test('...invalid...'/'...too few...'/'...duplicate...')`) flagged for missing POST-effect — they intentionally verify absence of effect
+- Helpers returning null/empty arrays as legitimate sentinels (`getOptional…`, `findIf…`) flagged for "missing assertion" — sentinel returns are by design
+- Section 3 findings when `ibl5/tests/e2e/vr-manifest.ts` does not exist in the repo (Layer 3b not landed)
+- Section 1 findings when `submitFormAndAssertEffect` helper does not exist AND the test uses cross-page navigation + destination assertion (Layer 3a not landed, underlying pattern present)
+- Pre-existing assertion patterns on lines the PR did not modify (restated from above for E2E clarity)

--- a/.claude/commands/_test-spec-agent.md
+++ b/.claude/commands/_test-spec-agent.md
@@ -1,0 +1,90 @@
+---
+description: Shared E2E spec reviewer agent used by /post-plan Phase 4B Agent D.
+last_verified: 2026-05-23
+---
+
+# Agent D: E2E Spec Reviewer (Sonnet)
+
+Semantic reviewer for E2E spec quality. Catches weaknesses that lint cannot — missing POST-effect verification, non-discriminating assertions, and UI branches added without spec coverage.
+
+## Token-efficiency design
+
+Single Sonnet agent covering all three sections. Sonnet is required because Sections 1-2 need synthesis ("does this assertion discriminate?", "does this prove persistence?"). Section 3 is closer to pattern-match but shares the same prompt to avoid doubling the ~5K per-agent spawn overhead.
+
+**Downgrade trigger:** Swap to `model: "haiku"` when the corpus reaches 20+ calibrated examples per category AND the agent's flagged findings track human review with >=80% precision for 4 consecutive weeks.
+
+## Common preamble
+
+Each agent receives: filtered PR diff, file list, and PR metadata from the parent command. **No agent should call `gh pr diff`** — the diff is already fetched by the parent. **Do not forward CLAUDE.md content in the prompt** — agents auto-load CLAUDE.md on init.
+
+Path-conditional loading covers `.claude/rules/playwright-tests.md` when the diff touches `ibl5/tests/e2e/**/*.ts`.
+
+**Mandatory calibration step:** Before judging, read `.claude/commands/_test-spec-corpus.md` to calibrate against known-good and known-bad examples.
+
+**Graceful-degradation clause:** If the `submitFormAndAssertEffect` helper (`tests/e2e/helpers/submit-form-effect.ts` (example)) is absent from the repo (verify with a single `ls`), do not flag absence of that helper — instead check the underlying pattern directly: cross-page navigation (`page.goto(differentUrl)` or `waitForURL(differentUrl)`) followed by a web-first assertion on the destination. Same for `ibl5/tests/e2e/vr-manifest.ts` — if absent, do not flag missing manifest rows; treat the VR-coverage check in Section 3 as informational only.
+
+---
+
+## Section 1 — Submission-spec POST-effect check
+
+**Trigger:** every `*-submission.spec.ts` file in the diff.
+
+Per-test classification:
+- `happy-path` — form submitted with valid data, success expected
+- `error-path` — form submitted with invalid data, validation error expected
+- `render-only` — only renders the form, no submission
+
+For each happy-path test, verify a persisted side effect is asserted via one of:
+1. Cross-page navigation (`waitForURL` to a different URL, or `page.goto` to a different module) followed by a web-first assertion on the destination
+2. API read-back (`request.get(...)` returning the new record)
+3. Use of `submitFormAndAssertEffect` helper (when present)
+
+**Flag pattern:** success detection happens only via same-page selectors (`.alert--success`, `.flash`, `.voting-submission-success`) without any of the above. The success banner alone proves the controller rendered "we got your POST" — not that the POST persisted.
+
+**Do not flag:**
+- Error-path tests (intentional — verifying validation rejection)
+- Render-only tests (different responsibility)
+- Smoke tests under `tests/e2e/smoke/`
+
+---
+
+## Section 2 — Assertion discrimination
+
+**Trigger:** every changed spec (added or modified `.ts`).
+
+For each new or modified assertion, ask: would this still pass on a broken render (PHP error page, 404 template, generic fallback view)?
+
+**Flag patterns:**
+- `expect(loc).toBeVisible()` on `body`, `.ibl-content`, `#main`, or other selectors present on every error template
+- `expect(body).toContain('IBL')` or any string the site-wide header always renders
+- `await expect(page).toHaveTitle(/IBL/i)` as the only assertion in a non-smoke test (title is on every page including 500s)
+- `.first()` chained onto a selector with no count assertion when the test claims to verify multiple items (test passes when only one item rendered, hiding regressions)
+- Generic-fallback selectors: `.box`, `div`, `td` without a stable IBL class
+
+**Do not flag:**
+- Smoke tests whose explicit purpose is "page loads" (legitimately assert generic visibility). Look at the test name/describe block; if it says "loads", "renders", "smoke", it is exempt for Section 2.
+
+---
+
+## Section 3 — Coverage-branch check
+
+**Pre-gate:** skip Section 3 entirely if `HAS_E2E_PROD_OVERLAP=false` (the parent computes this; if no production diff overlaps the modules referenced by spec changes, there is nothing to cross-reference).
+
+The agent receives a focused two-part bundle:
+- (a) the `.ts` portion of the diff for changed specs
+- (b) the production diff lines under `ibl5/modules/<M>/` for every `M` in `E2E_SPEC_MODULES`
+
+For new UI branches in the production diff (new phase-gated states, new admin-only modules, new HTMX-swapped tabs, new conditional `<details>`/modal/toggle sections, new `if ($phase === '...')` rendering branches), confirm the spec PR adds corresponding E2E coverage (a new `test(...)` block with `appState` setting the phase, or a new spec file).
+
+When `ibl5/tests/e2e/vr-manifest.ts` exists, also confirm manifest rows were added for newly-covered pages. When absent, treat the VR check as informational only (see preamble degradation clause).
+
+**Do not flag:**
+- Branches that are pure refactors (logic moved, no new user-visible state)
+- Pre-existing branches that the diff did not introduce
+- Branches gated by configuration the test suite cannot reach
+
+---
+
+## Output format
+
+Return issues with the specific anti-pattern matched (Section/Pattern name). For each section with no issues, return a 1-2 sentence evidence summary citing what was checked (e.g., "Scanned 3 *-submission.spec.ts files; all happy-path tests use cross-page navigation + destination assertion.").

--- a/.claude/commands/_test-spec-corpus.md
+++ b/.claude/commands/_test-spec-corpus.md
@@ -1,0 +1,363 @@
+---
+description: Calibration corpus of known-good and known-bad E2E spec patterns for the Agent D (E2E specs) reviewer.
+last_verified: 2026-05-23
+---
+
+# E2E Spec Reviewer Calibration Corpus
+
+Read this file before judging any spec. Each section matches an Agent D section. Anchor your flag/no-flag decisions against these examples.
+
+---
+
+## Section 1 — POST-effect
+
+### Known-bad (flag)
+
+**1a. Same-page success banner only**
+
+```ts
+test('submit trade proposal', async ({ page }) => {
+  await page.goto('modules.php?name=Trading');
+  await page.fill('#player-name', 'John Smith');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('.alert--success')).toBeVisible();
+});
+```
+
+Why bad: `.alert--success` proves the controller rendered a success message — not that the trade was persisted to the database. The test passes even if the INSERT silently failed.
+
+**1b. Same-page flash message**
+
+```ts
+test('submit waiver claim', async ({ page }) => {
+  await page.goto('modules.php?name=Waivers');
+  await page.selectOption('#player-select', 'Jane Doe');
+  await page.click('#claim-btn');
+  await expect(page.locator('.flash')).toContainText('Claim submitted');
+});
+```
+
+Why bad: `.flash` is a same-page element rendered by the controller's redirect-back. No verification that the claim row exists in the database.
+
+**1c. Voting submission with only class check**
+
+```ts
+test('cast MVP vote', async ({ page }) => {
+  await page.goto('modules.php?name=Voting');
+  await page.selectOption('#mvp-select', 'Player One');
+  await page.click('#submit-vote');
+  await expect(page.locator('.voting-submission-success')).toBeVisible();
+});
+```
+
+Why bad: `.voting-submission-success` is a same-page success indicator. Does not prove the vote was recorded.
+
+**1d. Reload trick (still bad)**
+
+```ts
+test('submit lineup', async ({ page }) => {
+  await page.goto('modules.php?name=Lineup');
+  await page.click('#starter-1');
+  await page.click('#save-lineup');
+  await expect(page.locator('.alert--success')).toBeVisible();
+  await page.reload();
+  await expect(page.locator('.alert--success')).toBeVisible();
+});
+```
+
+Why bad: Reloading the same page re-renders the same view state. The success banner may be flash-session-based and disappear, or it may persist from the query string. Neither proves persistence — the test needs to navigate to a *different* page that reads back the saved lineup.
+
+**1e. Multiple same-page assertions**
+
+```ts
+test('submit free agent signing', async ({ page }) => {
+  await page.goto('modules.php?name=FreeAgents');
+  await page.fill('#offer-amount', '5000000');
+  await page.click('#sign-btn');
+  await expect(page.locator('.alert--success')).toBeVisible();
+  await expect(page.locator('#offer-amount')).toHaveValue('');
+});
+```
+
+Why bad: Form clearing + success banner are both same-page controller behavior. No cross-page read-back proving the signing persisted.
+
+### Known-good (do not flag)
+
+**1f. Cross-page navigation + destination assertion**
+
+```ts
+test('submit trade proposal', async ({ page }) => {
+  await page.goto('modules.php?name=Trading');
+  await page.fill('#player-name', 'John Smith');
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/modules\.php\?name=Transactions/);
+  await expect(page.locator('.ibl-data-table')).toContainText('John Smith');
+});
+```
+
+Why good: Navigates to Transactions page and asserts the trade appears there — proves persistence.
+
+**1g. API read-back**
+
+```ts
+test('submit draft pick', async ({ page, request }) => {
+  await page.goto('modules.php?name=Draft');
+  await page.click('#pick-player');
+  await page.click('button[type="submit"]');
+  const res = await request.get('/api/v1/draft-picks?round=1');
+  const data = await res.json();
+  expect(data.picks).toContainEqual(expect.objectContaining({ player: 'John Smith' }));
+});
+```
+
+Why good: API read-back independently verifies the draft pick was persisted.
+
+**1h. goto different module + assert**
+
+```ts
+test('submit roster move', async ({ page }) => {
+  await page.goto('modules.php?name=Roster');
+  await page.click('#activate-player');
+  await page.click('#confirm');
+  await page.goto('modules.php?name=Transactions');
+  await expect(page.locator('table')).toContainText('Activated');
+});
+```
+
+Why good: Explicit navigation to a different module and assertion on the destination.
+
+**1i. Error-path test (exempt)**
+
+```ts
+test('reject trade with too few players', async ({ page }) => {
+  await page.goto('modules.php?name=Trading');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('.alert--danger')).toContainText('at least');
+});
+```
+
+Why good: Error-path — intentionally verifying validation rejection. No POST effect expected.
+
+**1j. Error-path duplicate submission (exempt)**
+
+```ts
+test('duplicate vote shows error', async ({ page }) => {
+  await page.goto('modules.php?name=Voting');
+  await page.click('#submit-vote');
+  await page.click('#submit-vote');
+  await expect(page.locator('.alert--warning')).toContainText('already voted');
+});
+```
+
+Why good: Error-path — tests duplicate-submission guard. Correct to assert on same-page error.
+
+---
+
+## Section 2 — Assertion discrimination
+
+### Known-bad (flag)
+
+**2a. Body visibility**
+
+```ts
+test('standings page loads data', async ({ page }) => {
+  await page.goto('modules.php?name=Standings');
+  await expect(page.locator('body')).toBeVisible();
+});
+```
+
+Why bad: `body` is visible on every page including 500 error pages. This proves nothing about Standings.
+
+**2b. Title-only assertion in a flow test**
+
+```ts
+test('trade form shows correct teams', async ({ page }) => {
+  await page.goto('modules.php?name=Trading');
+  await expect(page).toHaveTitle(/IBL/i);
+});
+```
+
+Why bad: Every page has "IBL" in the title, including error pages. The test name claims to verify teams but asserts nothing about them.
+
+**2c. Uncounted .first()**
+
+```ts
+test('roster shows all players', async ({ page }) => {
+  await page.goto('modules.php?name=Roster&team=Heat');
+  await expect(page.locator('.player-row').first()).toBeVisible();
+});
+```
+
+Why bad: Test name says "all players" but `.first()` passes with just one row. Needs `toHaveCount(N)` or a minimum count assertion.
+
+**2d. Header text as discrimination**
+
+```ts
+test('stats page renders correctly', async ({ page }) => {
+  await page.goto('modules.php?name=Stats');
+  const body = await page.textContent('body');
+  expect(body).toContain('IBL');
+});
+```
+
+Why bad: "IBL" appears in the site-wide header on every page. This is not discriminating for the Stats page.
+
+**2e. Generic fallback selector**
+
+```ts
+test('schedule displays games', async ({ page }) => {
+  await page.goto('modules.php?name=Schedule');
+  await expect(page.locator('td')).toBeVisible();
+});
+```
+
+Why bad: `td` is too generic — present on error templates, nav tables, etc. Use a module-specific selector.
+
+### Known-good (do not flag)
+
+**2f. Smoke test with generic assertion (exempt)**
+
+```ts
+test('standings page loads', async ({ page }) => {
+  await page.goto('modules.php?name=Standings');
+  await expect(page.locator('.ibl-data-table').first()).toBeVisible();
+});
+```
+
+Why good: Smoke test (name says "loads") — generic visibility is the explicit purpose. Exempt from Section 2.
+
+**2g. Specific count assertion**
+
+```ts
+test('standings shows all teams', async ({ page }) => {
+  await page.goto('modules.php?name=Standings');
+  await expect(page.locator('.standings-row')).toHaveCount(28);
+});
+```
+
+Why good: Discriminating — 28 rows is specific to a valid standings render. Error pages don't produce 28 `.standings-row` elements.
+
+**2h. Validation-specific text**
+
+```ts
+test('trade with too few players shows error', async ({ page }) => {
+  await page.goto('modules.php?name=Trading');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('.alert--danger')).toContainText('less than FOUR');
+});
+```
+
+Why good: "less than FOUR" is a validation message specific to this form — not rendered by the global header or error templates.
+
+**2i. Module-specific class**
+
+```ts
+test('depth chart renders', async ({ page }) => {
+  await page.goto('modules.php?name=DepthChart');
+  await expect(page.locator('.depth-chart-position')).toHaveCount(5);
+});
+```
+
+Why good: `.depth-chart-position` is module-specific, and count of 5 is discriminating.
+
+**2j. Smoke test with explicit "renders" name (exempt)**
+
+```ts
+test('free agents page renders', async ({ page }) => {
+  await page.goto('modules.php?name=FreeAgents');
+  await expect(page.locator('#main')).toBeVisible();
+});
+```
+
+Why good: Test name says "renders" — smoke test, exempt from Section 2.
+
+---
+
+## Section 3 — Coverage-branch
+
+### Known-bad (flag)
+
+**3a. New phase-gated view without spec coverage**
+
+Production diff adds:
+```php
+if ($phase === 'Playoffs') {
+    echo '<div class="playoff-bracket">...</div>';
+}
+```
+
+Spec diff has no new `test(...)` block calling `appState({ 'Current Season Phase': 'Playoffs' })`.
+
+Why bad: New user-visible UI state with no E2E coverage — regressions in the playoff bracket will be invisible.
+
+**3b. New HTMX-swapped admin tab without spec**
+
+Production diff adds:
+```php
+<button hx-get="modules.php?name=Admin&tab=audit" hx-target="#tab-content">Audit Log</button>
+```
+
+No new spec covers clicking the tab and asserting on `#tab-content`.
+
+Why bad: New interactive UI element with no E2E verifying the swap renders correctly.
+
+**3c. New conditional details/modal without spec**
+
+Production diff adds:
+```php
+<details>
+  <summary>Advanced Trade Options</summary>
+  <div class="trade-advanced"><?= $advancedForm ?></div>
+</details>
+```
+
+No new spec verifies the `<details>` opens and shows `.trade-advanced` content.
+
+Why bad: New expandable section — E2E is required per plan-verification forced-E2E triggers.
+
+### Known-good (do not flag)
+
+**3d. Pure refactor — no new user-visible state**
+
+Production diff moves logic from `Trading/index.php` to `Trading/TradeFormRenderer.php`. Same HTML output. No new conditional branches.
+
+Why good: No new user-visible state — refactoring the rendering path doesn't require new specs.
+
+**3e. New phase-gated state WITH matching spec**
+
+Production diff adds:
+```php
+if ($phase === 'Playoffs') {
+    echo '<div class="playoff-bracket">...</div>';
+}
+```
+
+Spec diff adds:
+```ts
+test('renders playoff bracket', async ({ appState, page }) => {
+  await appState({ 'Current Season Phase': 'Playoffs' });
+  await page.goto('modules.php?name=Standings');
+  await expect(page.locator('.playoff-bracket')).toBeVisible();
+});
+```
+
+Why good: New state and matching spec — coverage present.
+
+**3f. Module not covered by any spec (Agent D not launched)**
+
+Production diff touches an admin module but no e2e spec was changed. Agent D was not launched for this PR (no `ibl5/tests/e2e/**/*.ts` in the diff), so there is nothing to cross-reference.
+
+Why good: Outside Agent D's scope — the agent only runs when spec files are in the diff.
+
+**3g. Branch gated by unreachable configuration**
+
+Production diff adds:
+```php
+if ($config->isFeatureFlagEnabled('beta-dashboard')) {
+    echo '<div class="beta-dash">...</div>';
+}
+```
+
+The feature flag is not settable in the test environment.
+
+Why good: Branch gated by configuration the test suite cannot reach. Do not flag.

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: post-plan
 description: Single orchestrator for the post-plan workflow. Runs commit/push/PR, diff classification, code review, security audit, verification, CI monitoring, retrospective, worktree teardown, and background process cleanup as one uninterrupted sequence.
-last_verified: 2026-05-21
+last_verified: 2026-05-23
 ---
 
 # Post-Plan Orchestrator
@@ -77,6 +77,7 @@ COUNT_CSS=$(echo "$FILES" | grep -cE '\.css$|^ibl5/design/' || true)
 COUNT_MD=$(echo "$FILES" | grep -cE '\.md$' || true)
 COUNT_MIGRATION=$(echo "$FILES" | grep -cE '^ibl5/migrations/.*\.sql$' || true)
 COUNT_TEST=$(echo "$FILES" | grep -cE '^ibl5/tests/|\.test\.(ts|js|php)$|\.spec\.(ts|js)$' || true)
+COUNT_E2E_SPECS=$(echo "$FILES" | grep -cE '^ibl5/tests/e2e/.*\.ts$' || true)
 COUNT_LOCK=$(echo "$FILES" | grep -cE '(composer|package|bun)\.lock$' || true)
 COUNT_SNAPSHOT=$(echo "$FILES" | grep -cE '__snapshots__/|\.snap$' || true)
 COUNT_NON_CODE=$(( COUNT_MD + COUNT_LOCK + COUNT_SNAPSHOT ))
@@ -86,6 +87,29 @@ HAS_PHP=$([ "$COUNT_PHP" -gt 0 ] && echo true || echo false)
 HAS_CSS=$([ "$COUNT_CSS" -gt 0 ] && echo true || echo false)
 HAS_MIGRATION=$([ "$COUNT_MIGRATION" -gt 0 ] && echo true || echo false)
 HAS_TEST=$([ "$COUNT_TEST" -gt 0 ] && echo true || echo false)
+HAS_E2E_SPECS=$([ "$COUNT_E2E_SPECS" -gt 0 ] && echo true || echo false)
+
+# E2E spec module extraction (drives Agent D cross-reference)
+E2E_SPEC_MODULES=""
+HAS_E2E_PROD_OVERLAP=false
+if [ "$COUNT_E2E_SPECS" -gt 0 ]; then
+    E2E_SPEC_FILES=$(echo "$FILES" | grep -E '^ibl5/tests/e2e/.*\.ts$')
+    E2E_SPEC_MODULES=$(
+      git diff origin/master...HEAD -- $E2E_SPEC_FILES \
+        | grep -E '^\+' \
+        | grep -oE "(modules\.php\?name=[A-Za-z][A-Za-z0-9_]*|modules/[A-Za-z][A-Za-z0-9_]*/)" \
+        | sed -E 's#modules\.php\?name=##; s#modules/##; s#/##' \
+        | sort -u
+    )
+    if [ -n "$E2E_SPEC_MODULES" ]; then
+        for M in $E2E_SPEC_MODULES; do
+            if echo "$FILES" | grep -qE "^ibl5/modules/$M/"; then
+                HAS_E2E_PROD_OVERLAP=true
+                break
+            fi
+        done
+    fi
+fi
 
 # "X-only" means every file in $FILES matches that category
 DOCS_ONLY=$([ "$COUNT_TOTAL" -gt 0 ] && [ "$COUNT_MD" -eq "$COUNT_TOTAL" ] && echo true || echo false)
@@ -130,6 +154,8 @@ echo "=== Diff classification ==="
 echo "  total=$COUNT_TOTAL php=$COUNT_PHP css=$COUNT_CSS md=$COUNT_MD migration=$COUNT_MIGRATION test=$COUNT_TEST lock=$COUNT_LOCK snapshot=$COUNT_SNAPSHOT"
 echo "  DOCS_ONLY=$DOCS_ONLY CSS_ONLY=$CSS_ONLY MIGRATION_ONLY=$MIGRATION_ONLY TEST_ONLY=$TEST_ONLY NON_CODE_ONLY=$NON_CODE_ONLY"
 echo "  HAS_PHP=$HAS_PHP HAS_CSS=$HAS_CSS HAS_MODIFIED=$HAS_MODIFIED HAS_COMMENTS_IN_DIFF=$HAS_COMMENTS_IN_DIFF LINES_PHP_CHANGED=$LINES_PHP_CHANGED"
+echo "  HAS_E2E_SPECS=$HAS_E2E_SPECS HAS_E2E_PROD_OVERLAP=$HAS_E2E_PROD_OVERLAP"
+echo "  E2E_SPEC_MODULES=$(echo $E2E_SPEC_MODULES | tr '\n' ' ')"
 echo "  DIFF_FILE=$DIFF_FILE ($(wc -c < "$DIFF_FILE") bytes)"
 ```
 
@@ -156,7 +182,7 @@ Capture the `cat` output — that is `$DIFF` for every sub-agent prompt below. N
 
 ### 4B: Code Review — up to 3 parallel agents (merged by tier)
 
-**Read** `.claude/commands/_review-agents.md` — the canonical agent definitions (3 merged agents: A=architecture+bugs+DB, B=git history+code comments, C=previous PRs).
+**Read** `.claude/commands/_review-agents.md` (Agents A/B/C) and `.claude/commands/_test-spec-agent.md` (Agent D — E2E specs). The canonical agent definitions.
 
 Pass each agent: PR metadata, file list, and filtered `$DIFF`. **No agent calls `gh pr diff`.** Do not forward CLAUDE.md content (auto-loaded).
 
@@ -165,12 +191,35 @@ Pass each agent: PR metadata, file list, and filtered `$DIFF`. **No agent calls 
 - Agent A (Architecture + Bug detection + DB performance): **Sonnet**
 - Agent B (Git history + Code comments): **Sonnet**
 - Agent C (Previous PRs): **Haiku**
+- Agent D (E2E specs — POST-effect + assertion discrimination + coverage-branch): **Sonnet**
 
 **Launch gates** (consult Phase 3 variables — skip the launch entirely, don't let the agent exit early):
 
 - Agent A: skip if `$NON_CODE_ONLY`. If `$MIGRATION_ONLY`, instruct agent to skip Section 2 (bug detection). If `! $HAS_PHP`, instruct agent to skip Section 3 (DB performance).
 - Agent B: skip if BOTH sub-gates fail: (`! $HAS_PHP` or `$LINES_PHP_CHANGED <= 50`) AND (`$NON_CODE_ONLY` or `! $HAS_COMMENTS_IN_DIFF`). If only one sub-gate passes, instruct agent to run only that section.
 - Agent C: skip if `$NON_CODE_ONLY` or `! $HAS_MODIFIED` or `$LINES_PHP_CHANGED <= 50`
+- Agent D: skip if `! $HAS_E2E_SPECS`. When launched, pre-slice the diff into two temp files before forwarding to the agent:
+  ```bash
+  # Spec portion of the diff (only .ts under ibl5/tests/e2e/)
+  awk '
+    /^diff --git.*ibl5\/tests\/e2e\/.*\.ts/ {keep=1; print; next}
+    /^diff --git/ {keep=0}
+    keep==1 {print}
+  ' "$DIFF_FILE" > /tmp/post-plan-spec-diff-$PPID
+
+  # Production portion: only files under ibl5/modules/<M>/ for M in E2E_SPEC_MODULES
+  MODULES_REGEX=$(echo "$E2E_SPEC_MODULES" | tr '\n' '|' | sed 's/|$//')
+  if [ -n "$MODULES_REGEX" ]; then
+      awk -v re="ibl5/modules/($MODULES_REGEX)/" '
+        $0 ~ "^diff --git.*"re {keep=1; print; next}
+        /^diff --git/ {keep=0}
+        keep==1 {print}
+      ' "$DIFF_FILE" > /tmp/post-plan-spec-prod-diff-$PPID
+  else
+      : > /tmp/post-plan-spec-prod-diff-$PPID
+  fi
+  ```
+  Pass Agent D: PR metadata, the spec file list, `/tmp/post-plan-spec-diff-$PPID`, `/tmp/post-plan-spec-prod-diff-$PPID`, and `$HAS_E2E_PROD_OVERLAP`. The agent does **not** call `gh pr diff`.
 
 ### 4C: Security Audit — single conditional Haiku agent
 
@@ -439,6 +488,7 @@ Kill known lingering patterns so their tool results deliver immediately (cache w
 pkill -f 'bin/e2e-wt\.sh' 2>/dev/null
 pkill -f 'bunx.*playwright' 2>/dev/null
 pkill -f 'gh pr checks.*--watch' 2>/dev/null
+rm -f /tmp/post-plan-spec-diff-$PPID /tmp/post-plan-spec-prod-diff-$PPID 2>/dev/null
 echo "Background process cleanup complete"
 ```
 


### PR DESCRIPTION
## Summary

Adds Agent D — a semantic E2E spec reviewer — to the post-plan review pipeline. This agent analyzes Playwright test specs for structural quality, selector hygiene, and assertion correctness against a calibration corpus of good/bad examples.

**Changes:**
- : Agent D definition with rubric, calibration patterns, and scoring criteria
- : Calibration corpus of good and bad E2E spec examples
- : Wired Agent D into the review-agents preamble
- : Extended rubric to include E2E spec quality scoring  
- : Agent D launch gate and integration in Phase 4B

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.