### PR TITLE
test(e2e): E2E Coverage for Phase-Gated Admin ALLOW Paths

### DIFF
--- a/ibl5/tests/e2e/flows/phase-gating-admin.spec.ts
+++ b/ibl5/tests/e2e/flows/phase-gating-admin.spec.ts
@@ -2,6 +2,27 @@ import { test, expect } from '../fixtures/auth';
 import { gotoWithRetry } from '../helpers/navigation';
 import { assertNoPhpErrors } from '../helpers/php-errors';
 
+// COVERAGE SCOPE — admin phase-gate ALLOW paths
+//
+// Modules whose admin-bypass is enforced ONLY at modules.php
+// (ModuleAccessControl::isModuleAccessible + !is_admin() check):
+//   - Draft         (covered: "shows admin-mode warning on gated module")
+//   - FreeAgency    (covered: "admin sees FreeAgency tables outside Free Agency phase")
+//
+// Modules with a defense-in-depth INNER controller re-gate that blocks
+// admin too — so there is NO admin bypass to test:
+//   - Trading       (TradingController::handleTradeReview line 60 re-checks
+//                    Season::areTradesAllowed(); see flows/trading.spec.ts
+//                    "Trading: trades-closed state" for the admin-also-blocked
+//                    characterization.)
+//   - Waivers       (WaiversController::handleWaiverRequest line 64 re-checks
+//                    Season::areWaiversAllowed(); see flows/waivers.spec.ts
+//                    "Waivers flow: closed" for the admin-also-blocked
+//                    characterization.)
+//
+// Voting (ASG/EOY): non-admin DENY paths are covered in phase-gating-public.spec.ts.
+// Admin-ALLOW path for Voting is out of scope for this PR (Plan 8 candidate).
+
 // Admin phase-gate notice: admin sees a warning banner on gated modules.
 test.describe('Admin phase-gate notice', () => {
   test('shows admin-mode warning on gated module', async ({
@@ -36,5 +57,28 @@ test.describe('Admin phase-gate notice', () => {
     ).not.toBeVisible();
 
     await assertNoPhpErrors(page, 'on Standings without admin notice');
+  });
+
+  test('admin sees FreeAgency tables outside Free Agency phase', async ({
+    appState,
+    page,
+  }) => {
+    await appState({
+      'Current Season Phase': 'Regular Season',
+      'Current Season Ending Year': '2026',
+    });
+    await gotoWithRetry(page, 'modules.php?name=FreeAgency');
+
+    await expect(page.getByText('Players Under Contract').first()).toBeVisible();
+    await expect(page.getByText('Unsigned Free Agents').first()).toBeVisible();
+    await expect(page.getByText('All Other Free Agents').first()).toBeVisible();
+
+    const notice = page.locator('.ibl-alert--warning');
+    await expect(notice).toBeVisible();
+    await expect(notice).toContainText(
+      'Admin mode: You can view this module, but it is currently closed to non-admin GMs.',
+    );
+
+    await assertNoPhpErrors(page, 'on FreeAgency with admin phase-gate bypass');
   });
 });


### PR DESCRIPTION
## Summary

Adds the missing admin-bypass E2E test for FreeAgency and documents the scope correction: Trading and Waivers controllers internally re-gate after `modules.php` admin bypass, so those modules have no admin bypass path to cover.

**New coverage:**
- Admin sees FreeAgency tables (`Players Under Contract`, `Unsigned Free Agents`, `All Other Free Agents`) when `Current Season Phase=Regular Season`
- Admin-mode warning banner (`.ibl-alert--warning`) renders, confirming the `ADMIN_PHASE_GATE_NOTICE` branch in `modules.php`
- `assertNoPhpErrors` on the bypassed route

**Scope correction documented in file header:** Trading and Waivers both re-check the phase gate inside their controllers (`TradingController::handleTradeReview` line 60, `WaiversController::handleWaiverRequest` line 64) — admin is blocked at the controller level even after passing `modules.php`. Existing tests in `flows/trading.spec.ts:626-647` and `flows/waivers.spec.ts:6-22` characterize that behavior.

## Changed Files

- `ibl5/tests/e2e/flows/phase-gating-admin.spec.ts` — new test + header comment documenting coverage scope

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.