### PR TITLE
ci(mutation): fix per-PR Infection comment

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -213,10 +213,11 @@ jobs:
 
     - name: Run Infection on diff
       if: steps.changes.outputs.skip == 'false'
+      working-directory: ibl5
       run: |
-        ibl5/vendor/bin/infection \
-          --configuration=ibl5/infection.json5 \
-          --coverage=ibl5/coverage \
+        vendor/bin/infection \
+          --configuration=infection.json5 \
+          --coverage=coverage \
           --git-diff-base=origin/${{ github.base_ref }} \
           --git-diff-lines \
           --map-source-class-to-test \
@@ -226,26 +227,31 @@ jobs:
           --no-progress \
           --min-msi=100
 
-    - name: Post PR comment with summary
-      if: always() && steps.changes.outputs.skip == 'false'
-      uses: actions/github-script@v9
+    - name: Build mutation comment body
+      if: always() && steps.changes.outputs.skip == 'false' && hashFiles('ibl5/infection-summary.log') != ''
+      working-directory: ibl5
+      run: |
+        {
+          echo "## Mutation Testing (Diff)"
+          echo ""
+          echo '```'
+          cat infection-summary.log
+          echo '```'
+        } > /tmp/mutation-comment.md
+
+    - name: Post sticky mutation comment
+      if: always() && steps.changes.outputs.skip == 'false' && hashFiles('ibl5/infection-summary.log') != ''
+      uses: marocchino/sticky-pull-request-comment@v3
       with:
-        script: |
-          const fs = require('fs');
-          const path = 'ibl5/infection-summary.log';
-          let body;
-          if (fs.existsSync(path)) {
-            const summary = fs.readFileSync(path, 'utf8');
-            body = `## Mutation Testing (Diff)\n\`\`\`\n${summary}\n\`\`\``;
-          } else {
-            body = `## Mutation Testing (Diff)\n\nInfection did not produce a summary log. Check the workflow run for details.`;
-          }
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body
-          });
+        header: mutation-comment
+        path: /tmp/mutation-comment.md
+
+    - name: Remove stale mutation comment
+      if: always() && hashFiles('ibl5/infection-summary.log') == ''
+      uses: marocchino/sticky-pull-request-comment@v3
+      with:
+        header: mutation-comment
+        delete: true
 
     - name: Post summary
       if: always() && steps.changes.outputs.skip == 'false'


### PR DESCRIPTION
## Summary

The per-PR mutation testing flow was broken in three ways. Every previous PR comment was the worthless fallback message because Infection never actually ran:

1. **Path mismatch.** The 'Run Infection on diff' step executed from the repo root while passing 'classes' as the source pathspec. From repo root, './classes/' doesn't exist — git diff returned empty — Infection exited cleanly with 'Could not find any modified files'. **Verified on PR #819**: it modified `ibl5/classes/ContractList/Contracts/ContractListServiceInterface.php` and still got the fallback comment.
2. **Comment duplication.** `github.rest.issues.createComment` always appends. PR #805 accumulated 10 identical fallback comments.
3. **Worthless fallback noise.** When Infection produced no summary, the comment posted 'Infection did not produce a summary log' instead of staying silent.

## Changes

- Add `working-directory: ibl5` to 'Run Infection on diff' and switch to relative paths — Infection's git diff now resolves correctly.
- Replace `actions/github-script@v9` with `marocchino/sticky-pull-request-comment@v3` (header: `mutation-comment`). One sticky comment per PR, edited in place — matches the lighthouse.yml pattern.
- Guard the post step on `hashFiles('ibl5/infection-summary.log') != ''` so we only comment when Infection produced output.
- Add a delete-stale step that removes the sticky comment when no summary exists (covers Infection crashes, PRs that previously had PHP but no longer do, etc).

## Manual Testing

No manual testing needed — this is a CI workflow change. Empirical validation happens on the next PR that touches `ibl5/classes/` files; this PR's own CI will set `skip=true` and won't exercise the new code path (a no-op classes/ change just to self-test was considered but rejected as scope creep — the fix is structurally simple and the next real PHP-touching PR will validate it.).

If validation reveals the fix is wrong, the symptom will be the same as today (worthless fallback or no comment), and we can iterate.

Generated with [Claude Code](https://claude.ai/code)