### PR TITLE
feat: add token/cost capture to nightly stream filter exit line

### DIFF
--- a/bin/lib/nightly-stream-filter
+++ b/bin/lib/nightly-stream-filter
@@ -42,8 +42,13 @@ while IFS= read -r line; do
             stop_reason=$(printf '%s' "$line" | jq -r '.stop_reason // "unknown"' 2>/dev/null) || true
             num_turns=$(printf '%s' "$line" | jq -r '.num_turns // "?"' 2>/dev/null) || true
             duration_ms=$(printf '%s' "$line" | jq -r '.duration_ms // "?"' 2>/dev/null) || true
-            printf '%s exit: stop_reason=%s turns=%s tools=%d duration=%sms\n' \
-                "$(elapsed_ts)" "$stop_reason" "$num_turns" "$TOOL_COUNT" "$duration_ms"
+            cost_usd=$(printf '%s' "$line" | jq -r '.total_cost_usd // "?"' 2>/dev/null) || true
+            in_tokens=$(printf '%s' "$line" | jq -r '.usage.input_tokens // "?"' 2>/dev/null) || true
+            out_tokens=$(printf '%s' "$line" | jq -r '.usage.output_tokens // "?"' 2>/dev/null) || true
+            cache_tokens=$(printf '%s' "$line" | jq -r '.usage.cache_read_input_tokens // "?"' 2>/dev/null) || true
+            printf '%s exit: stop_reason=%s turns=%s tools=%d duration=%sms cost=$%s in=%s out=%s cache=%s\n' \
+                "$(elapsed_ts)" "$stop_reason" "$num_turns" "$TOOL_COUNT" "$duration_ms" \
+                "$cost_usd" "$in_tokens" "$out_tokens" "$cache_tokens"
             # result is the final stream-json event — terminate claude and exit
             if [ -n "$CMDPID_FILE" ]; then
                 _target_pid=$(cat "$CMDPID_FILE" 2>/dev/null) || true


### PR DESCRIPTION
## Summary

Add token usage and cost data to the nightly stream filter's exit line. The `result` event in `claude -p --output-format stream-json` includes `total_cost_usd` and `usage` (with `input_tokens`, `output_tokens`, `cache_read_input_tokens`) which were being discarded.

**Before:**
```
[HH:MM:SS] exit: stop_reason=end_turn turns=98 tools=117 duration=825787ms
```

**After:**
```
[HH:MM:SS] exit: stop_reason=end_turn turns=98 tools=117 duration=825787ms cost=$1.23 in=45000 out=5000 cache=30000
```

## Changes

- **`bin/lib/nightly-stream-filter`**: Extract `total_cost_usd`, `usage.input_tokens`, `usage.output_tokens`, `usage.cache_read_input_tokens` from the `result` event JSON and include them in the exit line printf.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)