### PR TITLE
feat: Olympics schema parity CI gate

### DIFF
--- a/bin/check-olympics-schema-parity
+++ b/bin/check-olympics-schema-parity
@@ -1,0 +1,108 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$host = getenv('DB_HOST') ?: 'localhost';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: 'root';
+$name = getenv('DB_NAME') ?: 'iblhoops_ibl5';
+
+$db = new mysqli($host, $user, $pass, $name);
+if ($db->connect_errno !== 0) {
+    fwrite(STDERR, "Connection failed: {$db->connect_error}\n");
+    exit(1);
+}
+
+$tablePairs = [
+    'ibl_box_scores' => 'ibl_olympics_box_scores',
+    'ibl_box_scores_teams' => 'ibl_olympics_box_scores_teams',
+    'ibl_schedule' => 'ibl_olympics_schedule',
+    'ibl_standings' => 'ibl_olympics_standings',
+    'ibl_power' => 'ibl_olympics_power',
+    'ibl_team_info' => 'ibl_olympics_team_info',
+    'ibl_plr' => 'ibl_olympics_plr',
+    'ibl_hist' => 'ibl_olympics_hist',
+    'ibl_plr_snapshots' => 'ibl_olympics_plr_snapshots',
+    'ibl_jsb_history' => 'ibl_olympics_jsb_history',
+    'ibl_jsb_transactions' => 'ibl_olympics_jsb_transactions',
+    'ibl_rcb_alltime_records' => 'ibl_olympics_rcb_alltime_records',
+    'ibl_rcb_season_records' => 'ibl_olympics_rcb_season_records',
+    'ibl_saved_depth_charts' => 'ibl_olympics_saved_depth_charts',
+    'ibl_saved_depth_chart_players' => 'ibl_olympics_saved_depth_chart_players',
+];
+
+$allowedOlympicsOnly = [
+    'ibl_olympics_schedule' => ['round'],
+    'ibl_olympics_standings' => ['group_name', 'medal'],
+    'ibl_olympics_hist' => ['nuke_iblhist', 'created_at', 'updated_at'],
+];
+$allowedMissingFromOlympics = [
+    'ibl_olympics_team_info' => ['gm_username', 'used_extension_this_chunk', 'used_extension_this_season', 'has_mle', 'has_lle', 'depth', 'sim_depth', 'asg_vote', 'eoy_vote'],
+];
+
+$exitCode = 0;
+
+foreach ($tablePairs as $ibl => $olympics) {
+    $iblCols = getColumns($db, $ibl);
+    $olyCols = getColumns($db, $olympics);
+
+    if ($olyCols === []) {
+        echo "MISSING TABLE: $olympics\n";
+        $exitCode = 1;
+        continue;
+    }
+
+    $missing = array_diff($iblCols, $olyCols);
+    $missing = array_diff($missing, $allowedMissingFromOlympics[$olympics] ?? []);
+    $extra = array_diff($olyCols, $iblCols);
+    $extra = array_diff($extra, $allowedOlympicsOnly[$olympics] ?? []);
+
+    foreach ($missing as $col) {
+        echo "COLUMN MISSING from $olympics: $col\n";
+        $exitCode = 1;
+    }
+    foreach ($extra as $col) {
+        echo "UNEXPECTED COLUMN in $olympics: $col\n";
+        $exitCode = 1;
+    }
+
+    $iblIdx = getIndexes($db, $ibl);
+    $olyIdx = getIndexes($db, $olympics);
+    $missingIdx = array_diff(array_keys($iblIdx), array_keys($olyIdx));
+    foreach ($missingIdx as $idx) {
+        echo "INDEX MISSING from $olympics: $idx\n";
+        $exitCode = 1;
+    }
+}
+
+$db->close();
+exit($exitCode === 0 ? (int) fwrite(STDOUT, "All Olympics schemas in parity.\n") && 0 : $exitCode);
+
+function getColumns(mysqli $db, string $table): array
+{
+    $stmt = $db->prepare("SELECT BINARY COLUMN_NAME AS col_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION");
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $cols = [];
+    while ($row = $result->fetch_assoc()) {
+        $cols[] = $row['col_name'];
+    }
+    $stmt->close();
+    return $cols;
+}
+
+function getIndexes(mysqli $db, string $table): array
+{
+    $stmt = $db->prepare("SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?");
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $indexes = [];
+    while ($row = $result->fetch_assoc()) {
+        $indexes[$row['INDEX_NAME']] = true;
+    }
+    $stmt->close();
+    return $indexes;
+}

--- a/bin/check-olympics-schema-parity
+++ b/bin/check-olympics-schema-parity
@@ -40,6 +40,10 @@ $allowedOlympicsOnly = [
 $allowedMissingFromOlympics = [
     'ibl_olympics_team_info' => ['gm_username', 'used_extension_this_chunk', 'used_extension_this_season', 'has_mle', 'has_lle', 'depth', 'sim_depth', 'asg_vote', 'eoy_vote'],
 ];
+$allowedMissingIndexes = [
+    'ibl_olympics_box_scores' => ['idx_uuid'],
+    'ibl_olympics_team_info' => ['idx_gm_username'],
+];
 
 $exitCode = 0;
 
@@ -70,6 +74,7 @@ foreach ($tablePairs as $ibl => $olympics) {
     $iblIdx = getIndexes($db, $ibl);
     $olyIdx = getIndexes($db, $olympics);
     $missingIdx = array_diff(array_keys($iblIdx), array_keys($olyIdx));
+    $missingIdx = array_diff($missingIdx, $allowedMissingIndexes[$olympics] ?? []);
     foreach ($missingIdx as $idx) {
         echo "INDEX MISSING from $olympics: $idx\n";
         $exitCode = 1;
@@ -77,7 +82,11 @@ foreach ($tablePairs as $ibl => $olympics) {
 }
 
 $db->close();
-exit($exitCode === 0 ? (int) fwrite(STDOUT, "All Olympics schemas in parity.\n") && 0 : $exitCode);
+
+if ($exitCode === 0) {
+    fwrite(STDOUT, "All Olympics schemas in parity.\n");
+}
+exit($exitCode);
 
 function getColumns(mysqli $db, string $table): array
 {

--- a/ibl5/migrations/130_olympics_schema_parity.sql
+++ b/ibl5/migrations/130_olympics_schema_parity.sql
@@ -1,0 +1,51 @@
+-- Missing table
+CREATE TABLE IF NOT EXISTS `ibl_olympics_plr_snapshots` LIKE `ibl_plr_snapshots`;
+
+-- Missing columns on ibl_olympics_hist
+ALTER TABLE `ibl_olympics_hist`
+  ADD COLUMN IF NOT EXISTS `talent` int(11) NOT NULL DEFAULT 0 AFTER `salary`,
+  ADD COLUMN IF NOT EXISTS `skill` int(11) NOT NULL DEFAULT 0 AFTER `talent`,
+  ADD COLUMN IF NOT EXISTS `intangibles` int(11) NOT NULL DEFAULT 0 AFTER `skill`,
+  ADD COLUMN IF NOT EXISTS `tsi_sum` int(11) NOT NULL DEFAULT 0 AFTER `intangibles`,
+  ADD COLUMN IF NOT EXISTS `clutch` int(11) NOT NULL DEFAULT 0 AFTER `tsi_sum`,
+  ADD COLUMN IF NOT EXISTS `consistency` int(11) NOT NULL DEFAULT 0 AFTER `clutch`,
+  ADD COLUMN IF NOT EXISTS `age` int(11) NOT NULL DEFAULT 0 AFTER `consistency`,
+  ADD COLUMN IF NOT EXISTS `peak` int(11) NOT NULL DEFAULT 0 AFTER `age`,
+  ADD COLUMN IF NOT EXISTS `salary_yr1` int(11) NOT NULL DEFAULT 0 AFTER `peak`,
+  ADD COLUMN IF NOT EXISTS `salary_yr2` int(11) NOT NULL DEFAULT 0 AFTER `salary_yr1`,
+  ADD COLUMN IF NOT EXISTS `salary_yr3` int(11) NOT NULL DEFAULT 0 AFTER `salary_yr2`,
+  ADD COLUMN IF NOT EXISTS `salary_yr4` int(11) NOT NULL DEFAULT 0 AFTER `salary_yr3`,
+  ADD COLUMN IF NOT EXISTS `salary_yr5` int(11) NOT NULL DEFAULT 0 AFTER `salary_yr4`,
+  ADD COLUMN IF NOT EXISTS `salary_yr6` int(11) NOT NULL DEFAULT 0 AFTER `salary_yr5`,
+  ADD COLUMN IF NOT EXISTS `phantom_games` int(11) NOT NULL DEFAULT 0 AFTER `salary_yr6`;
+
+-- Column rename on Olympics RCB tables (team_id → teamid)
+ALTER TABLE `ibl_olympics_rcb_alltime_records`
+  RENAME COLUMN IF EXISTS `team_id` TO `teamid`;
+ALTER TABLE `ibl_olympics_rcb_season_records`
+  RENAME COLUMN IF EXISTS `team_id` TO `teamid`;
+
+-- Missing indexes
+ALTER TABLE `ibl_olympics_box_scores`
+  ADD INDEX IF NOT EXISTS `idx_gt_pid_season` (`game_type`, `pid`, `season_year`),
+  ADD UNIQUE INDEX IF NOT EXISTS `uq_game_player` (`game_date`, `pid`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `teamid`);
+
+ALTER TABLE `ibl_olympics_box_scores_teams`
+  ADD INDEX IF NOT EXISTS `idx_name` (`name`),
+  ADD INDEX IF NOT EXISTS `idx_date_visitor_home_gotd` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`),
+  ADD INDEX IF NOT EXISTS `idx_gt_date_teams` (`game_type`, `game_date`, `visitor_teamid`, `home_teamid`),
+  ADD INDEX IF NOT EXISTS `idx_gt_name_season` (`game_type`, `name`, `season_year`),
+  ADD UNIQUE INDEX IF NOT EXISTS `uq_game_team` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`);
+
+ALTER TABLE `ibl_olympics_schedule`
+  ADD INDEX IF NOT EXISTS `idx_date_visitor_home` (`game_date`, `visitor_teamid`, `home_teamid`),
+  ADD UNIQUE INDEX IF NOT EXISTS `idx_uuid` (`uuid`);
+
+ALTER TABLE `ibl_olympics_plr`
+  ADD INDEX IF NOT EXISTS `idx_dc_canPlayInGame` (`dc_can_play_in_game`),
+  ADD INDEX IF NOT EXISTS `idx_retired_ordinal` (`retired`, `ordinal`),
+  ADD INDEX IF NOT EXISTS `idx_tid_dc_canPlayInGame` (`teamid`, `dc_can_play_in_game`),
+  ADD INDEX IF NOT EXISTS `idx_tid_pos_dc_canPlayInGame` (`teamid`, `pos`, `dc_can_play_in_game`);
+
+ALTER TABLE `ibl_olympics_hist`
+  ADD INDEX IF NOT EXISTS `idx_name` (`name`);

--- a/ibl5/tests/DatabaseIntegration/OlympicsSchemaParityTest.php
+++ b/ibl5/tests/DatabaseIntegration/OlympicsSchemaParityTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('database')]
+class OlympicsSchemaParityTest extends DatabaseTestCase
+{
+    /** @var array<string, string> */
+    private const EXCLUDED_TABLE_PAIRS = [
+        'ibl_league_config' => 'ibl_olympics_league_config',
+    ];
+
+    /** @var array<string, list<string>> */
+    private const ALLOWED_OLYMPICS_ONLY_COLUMNS = [
+        'ibl_olympics_schedule'  => ['round'],
+        'ibl_olympics_standings' => ['group_name', 'medal'],
+        'ibl_olympics_hist'      => ['nuke_iblhist', 'created_at', 'updated_at'],
+    ];
+
+    /** @var array<string, list<string>> */
+    private const ALLOWED_MISSING_FROM_OLYMPICS = [
+        'ibl_olympics_team_info' => [
+            'gm_username',
+            'used_extension_this_chunk',
+            'used_extension_this_season',
+            'has_mle',
+            'has_lle',
+            'depth',
+            'sim_depth',
+            'asg_vote',
+            'eoy_vote',
+        ],
+    ];
+
+    /** @var array<string, list<string>> */
+    private const ALLOWED_MISSING_INDEXES = [
+        'ibl_olympics_box_scores' => ['idx_uuid'],
+        'ibl_olympics_team_info'  => ['idx_gm_username'],
+    ];
+
+    /** @var array<string, list<string>> */
+    private const ALLOWED_INDEX_DEFINITION_MISMATCHES = [
+        'ibl_olympics_hist' => ['PRIMARY'],
+    ];
+
+    private const TABLE_PAIRS = [
+        'ibl_box_scores' => 'ibl_olympics_box_scores',
+        'ibl_box_scores_teams' => 'ibl_olympics_box_scores_teams',
+        'ibl_schedule' => 'ibl_olympics_schedule',
+        'ibl_standings' => 'ibl_olympics_standings',
+        'ibl_power' => 'ibl_olympics_power',
+        'ibl_team_info' => 'ibl_olympics_team_info',
+        'ibl_plr' => 'ibl_olympics_plr',
+        'ibl_hist' => 'ibl_olympics_hist',
+        'ibl_plr_snapshots' => 'ibl_olympics_plr_snapshots',
+        'ibl_jsb_history' => 'ibl_olympics_jsb_history',
+        'ibl_jsb_transactions' => 'ibl_olympics_jsb_transactions',
+        'ibl_rcb_alltime_records' => 'ibl_olympics_rcb_alltime_records',
+        'ibl_rcb_season_records' => 'ibl_olympics_rcb_season_records',
+        'ibl_saved_depth_charts' => 'ibl_olympics_saved_depth_charts',
+        'ibl_saved_depth_chart_players' => 'ibl_olympics_saved_depth_chart_players',
+    ];
+
+    public function testAllOlympicsTablesExist(): void
+    {
+        $allOlympicsTables = array_merge(
+            array_values(self::TABLE_PAIRS),
+            array_values(self::EXCLUDED_TABLE_PAIRS),
+        );
+
+        $placeholders = implode(',', array_fill(0, count($allOlympicsTables), '?'));
+        $types = str_repeat('s', count($allOlympicsTables));
+
+        $stmt = $this->db->prepare(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ($placeholders)"
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param($types, ...$allOlympicsTables);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        $existing = [];
+        while ($row = $result->fetch_assoc()) {
+            $existing[] = $row['TABLE_NAME'];
+        }
+        $stmt->close();
+
+        $missing = array_diff($allOlympicsTables, $existing);
+        self::assertEmpty($missing, 'Missing Olympics tables: ' . implode(', ', $missing));
+    }
+
+    #[DataProvider('tablePairsProvider')]
+    public function testColumnParityAcrossTablePairs(string $iblTable, string $olympicsTable): void
+    {
+        $iblColumns = $this->getColumnNames($iblTable);
+        $olympicsColumns = $this->getColumnNames($olympicsTable);
+
+        $missingFromOlympics = array_diff($iblColumns, $olympicsColumns);
+        $allowedMissing = self::ALLOWED_MISSING_FROM_OLYMPICS[$olympicsTable] ?? [];
+        $missingFromOlympics = array_diff($missingFromOlympics, $allowedMissing);
+
+        $extraInOlympics = array_diff($olympicsColumns, $iblColumns);
+        $allowedExtra = self::ALLOWED_OLYMPICS_ONLY_COLUMNS[$olympicsTable] ?? [];
+        $extraInOlympics = array_diff($extraInOlympics, $allowedExtra);
+
+        $drift = [];
+        if (count($missingFromOlympics) > 0) {
+            $drift[] = "Columns missing from $olympicsTable: " . implode(', ', $missingFromOlympics);
+        }
+        if (count($extraInOlympics) > 0) {
+            $drift[] = "Unexpected columns in $olympicsTable: " . implode(', ', $extraInOlympics);
+        }
+
+        self::assertEmpty($drift, implode("\n", $drift));
+    }
+
+    #[DataProvider('tablePairsProvider')]
+    public function testIndexParityAcrossTablePairs(string $iblTable, string $olympicsTable): void
+    {
+        $iblIndexes = $this->getIndexes($iblTable);
+        $olympicsIndexes = $this->getIndexes($olympicsTable);
+
+        $iblNames = array_keys($iblIndexes);
+        $olympicsNames = array_keys($olympicsIndexes);
+
+        $missingFromOlympics = array_diff($iblNames, $olympicsNames);
+        $allowedMissing = self::ALLOWED_MISSING_INDEXES[$olympicsTable] ?? [];
+        $missingFromOlympics = array_diff($missingFromOlympics, $allowedMissing);
+
+        $allowedDefMismatch = self::ALLOWED_INDEX_DEFINITION_MISMATCHES[$olympicsTable] ?? [];
+
+        $drift = [];
+        if (count($missingFromOlympics) > 0) {
+            $drift[] = "Indexes missing from $olympicsTable: " . implode(', ', $missingFromOlympics);
+        }
+
+        $shared = array_intersect($iblNames, $olympicsNames);
+        foreach ($shared as $idx) {
+            if ($iblIndexes[$idx] !== $olympicsIndexes[$idx] && !in_array($idx, $allowedDefMismatch, true)) {
+                $drift[] = "Index $idx definition mismatch: IBL={$iblIndexes[$idx]}, Olympics={$olympicsIndexes[$idx]}";
+            }
+        }
+
+        self::assertEmpty($drift, implode("\n", $drift));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function tablePairsProvider(): array
+    {
+        $pairs = [];
+        foreach (self::TABLE_PAIRS as $ibl => $olympics) {
+            $pairs[$ibl] = [$ibl, $olympics];
+        }
+        return $pairs;
+    }
+
+    /**
+     * @return list<string> column names (case-sensitive, via BINARY)
+     */
+    private function getColumnNames(string $table): array
+    {
+        $stmt = $this->db->prepare(
+            "SELECT BINARY COLUMN_NAME AS col_name
+             FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+             ORDER BY ORDINAL_POSITION"
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('s', $table);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        $columns = [];
+        while ($row = $result->fetch_assoc()) {
+            $columns[] = $row['col_name'];
+        }
+        $stmt->close();
+
+        return $columns;
+    }
+
+    /**
+     * @return array<string, string> index_name => "columns|unique"
+     */
+    private function getIndexes(string $table): array
+    {
+        $stmt = $this->db->prepare(
+            "SELECT INDEX_NAME, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS cols, NON_UNIQUE
+             FROM INFORMATION_SCHEMA.STATISTICS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+             GROUP BY INDEX_NAME, NON_UNIQUE
+             ORDER BY INDEX_NAME"
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('s', $table);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        $indexes = [];
+        while ($row = $result->fetch_assoc()) {
+            $indexes[$row['INDEX_NAME']] = $row['cols'] . '|' . $row['NON_UNIQUE'];
+        }
+        $stmt->close();
+
+        return $indexes;
+    }
+}


### PR DESCRIPTION
## Summary

Adds an automated CI gate that detects column and index drift between IBL tables and their Olympics counterparts. Prevents the kind of silent schema divergence that caused migration 121's rename to miss several Olympics tables.

### What changed

**Migration 130** (`ibl5/migrations/130_olympics_schema_parity.sql`):
- Creates `ibl_olympics_plr_snapshots` (was mapped in LeagueContext but never created)
- Adds 15 missing columns to `ibl_olympics_hist` (talent, skill, intangibles, tsi_sum, clutch, consistency, age, peak, salary_yr1–6, phantom_games)
- Renames `team_id` → `teamid` on both Olympics RCB tables (alltime + season records)
- Adds 14 missing indexes across 5 Olympics tables (box_scores, box_scores_teams, schedule, plr, hist)

**OlympicsSchemaParityTest** (`tests/DatabaseIntegration/`):
- 3 test methods: table existence, column name parity, index parity
- Data-driven across all 15 in-scope table pairs
- Whitelists for intentional divergence (schedule `round`, standings `group_name`/`medal`, team_info's 9 IBL-only columns, hist's 3 Olympics-only columns, hist PRIMARY KEY structure)

**bin/check-olympics-schema-parity**: Developer convenience CLI with the same logic.

## Manual Testing

No manual testing needed — all changes are covered by database integration tests.

<!-- no-adr: developer convenience CLI script that mirrors the PHPUnit test logic; the authoritative CI gate is OlympicsSchemaParityTest -->