### PR TITLE
Olympics Updater PR 2: Real-Team Filtering and Standings Display

### DIFF
--- a/ibl5/classes/League/Contracts/OlympicsTeamFilterInterface.php
+++ b/ibl5/classes/League/Contracts/OlympicsTeamFilterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Contracts;
+
+interface OlympicsTeamFilterInterface
+{
+    /**
+     * @return list<int> Team IDs where is_real_team = 1
+     */
+    public static function getRealTeamIds(\mysqli $db): array;
+
+    public static function isRealOlympicsTeam(\mysqli $db, int $teamId): bool;
+
+    public static function resetCache(): void;
+}

--- a/ibl5/classes/League/OlympicsTeamFilter.php
+++ b/ibl5/classes/League/OlympicsTeamFilter.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League;
+
+use League\Contracts\OlympicsTeamFilterInterface;
+
+class OlympicsTeamFilter implements OlympicsTeamFilterInterface
+{
+    /** @var array<int, true>|null */
+    private static ?array $cache = null;
+
+    /**
+     * @see OlympicsTeamFilterInterface::getRealTeamIds()
+     */
+    public static function getRealTeamIds(\mysqli $db): array
+    {
+        self::hydrateCache($db);
+
+        /** @var array<int, true> $cache */
+        $cache = self::$cache;
+
+        return array_keys($cache);
+    }
+
+    /**
+     * @see OlympicsTeamFilterInterface::isRealOlympicsTeam()
+     */
+    public static function isRealOlympicsTeam(\mysqli $db, int $teamId): bool
+    {
+        self::hydrateCache($db);
+
+        return isset(self::$cache[$teamId]);
+    }
+
+    /**
+     * @see OlympicsTeamFilterInterface::resetCache()
+     */
+    public static function resetCache(): void
+    {
+        self::$cache = null;
+    }
+
+    private static function hydrateCache(\mysqli $db): void
+    {
+        if (self::$cache !== null) {
+            return;
+        }
+
+        $stmt = $db->prepare('SELECT teamid FROM `ibl_olympics_team_info` WHERE is_real_team = 1');
+        if ($stmt === false) {
+            self::$cache = [];
+            return;
+        }
+
+        $stmt->execute();
+        $result = $stmt->get_result();
+        if ($result === false) {
+            $stmt->close();
+            self::$cache = [];
+            return;
+        }
+
+        self::$cache = [];
+        while (is_array($row = $result->fetch_assoc())) {
+            $teamId = (int) $row['teamid'];
+            self::$cache[$teamId] = true;
+        }
+
+        $stmt->close();
+    }
+}

--- a/ibl5/classes/Standings/Contracts/OlympicsStandingsViewInterface.php
+++ b/ibl5/classes/Standings/Contracts/OlympicsStandingsViewInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Standings\Contracts;
+
+interface OlympicsStandingsViewInterface
+{
+    public function render(): string;
+}

--- a/ibl5/classes/Standings/OlympicsStandingsView.php
+++ b/ibl5/classes/Standings/OlympicsStandingsView.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Standings;
+
+use Security\HtmlSanitizer;
+use Standings\Contracts\OlympicsStandingsViewInterface;
+use Standings\Contracts\StandingsRepositoryInterface;
+
+class OlympicsStandingsView implements OlympicsStandingsViewInterface
+{
+    private StandingsRepositoryInterface $repository;
+    private int $seasonYear;
+
+    /** @var list<int> */
+    private array $realTeamIds;
+
+    /**
+     * @param list<int> $realTeamIds
+     */
+    public function __construct(
+        StandingsRepositoryInterface $repository,
+        int $seasonYear,
+        array $realTeamIds,
+    ) {
+        $this->repository = $repository;
+        $this->seasonYear = $seasonYear;
+        $this->realTeamIds = $realTeamIds;
+    }
+
+    /**
+     * @see OlympicsStandingsViewInterface::render()
+     */
+    public function render(): string
+    {
+        $allStandings = $this->repository->getAllStandings();
+        $realTeamIdMap = array_flip($this->realTeamIds);
+
+        $filtered = array_filter(
+            $allStandings,
+            static fn (array $row): bool => isset($realTeamIdMap[$row['teamid']]),
+        );
+
+        usort($filtered, static function (array $a, array $b): int {
+            $pctCmp = (float) $b['pct'] <=> (float) $a['pct'];
+            if ($pctCmp !== 0) {
+                return $pctCmp;
+            }
+            return $b['wins'] <=> $a['wins'];
+        });
+
+        ob_start();
+        ?>
+        <h2 class="ibl-title"><?= HtmlSanitizer::e($this->seasonYear . ' Olympics Standings') ?></h2>
+        <table class="ibl-data-table">
+            <thead>
+                <tr>
+                    <th>Rank</th>
+                    <th>Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Games Left</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php
+                $rank = 0;
+        foreach ($filtered as $team) {
+            $rank++;
+            ?>
+                    <tr>
+                        <td><?= HtmlSanitizer::e($rank) ?></td>
+                        <td><?= HtmlSanitizer::e($team['team_name']) ?></td>
+                        <td><?= HtmlSanitizer::e($team['league_record']) ?></td>
+                        <td><?= HtmlSanitizer::e($team['pct']) ?></td>
+                        <td><?= HtmlSanitizer::e($team['home_record']) ?></td>
+                        <td><?= HtmlSanitizer::e($team['away_record']) ?></td>
+                        <td><?= (int) $team['games_unplayed'] ?></td>
+                    </tr>
+                    <?php
+        }
+        ?>
+            </tbody>
+        </table>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/ibl5/classes/Updater/ScheduleUpdater.php
+++ b/ibl5/classes/Updater/ScheduleUpdater.php
@@ -74,13 +74,22 @@ class ScheduleUpdater extends \BaseMysqliRepository {
     private function preloadTeamNameMap(): void
     {
         $teamInfoTable = $this->resolveTable('ibl_team_info');
+        $isOlympics = $this->leagueContext !== null && $this->leagueContext->isOlympics();
 
-        /** @var list<array{team_name: string, teamid: int}> $rows */
-        $rows = $this->fetchAll(
-            "SELECT team_name, teamid FROM {$teamInfoTable} WHERE teamid BETWEEN 1 AND ?",
-            "i",
-            League::MAX_REAL_TEAMID
-        );
+        if ($isOlympics) {
+            /** @var list<array{team_name: string, teamid: int}> $rows */
+            $rows = $this->fetchAll(
+                "SELECT team_name, teamid FROM {$teamInfoTable}",
+                "",
+            );
+        } else {
+            /** @var list<array{team_name: string, teamid: int}> $rows */
+            $rows = $this->fetchAll(
+                "SELECT team_name, teamid FROM {$teamInfoTable} WHERE teamid BETWEEN 1 AND ?",
+                "i",
+                League::MAX_REAL_TEAMID,
+            );
+        }
 
         foreach ($rows as $row) {
             $this->teamIdToNameMap[$row['teamid']] = $row['team_name'];

--- a/ibl5/modules/Standings/index.php
+++ b/ibl5/modules/Standings/index.php
@@ -28,8 +28,14 @@ if (!isset($mysqli_db) || !$mysqli_db) {
 // Create repository and view instances
 $repository = new Standings\StandingsRepository($mysqli_db, $leagueContext);
 $season = new \Season\Season($mysqli_db, $leagueContext);
-$seriesRecordsService = new SeriesRecords\SeriesRecordsService();
-$view = new Standings\StandingsView($repository, $season->endingYear, $seriesRecordsService);
+
+if ($leagueContext !== null && $leagueContext->isOlympics()) {
+    $realTeamIds = \League\OlympicsTeamFilter::getRealTeamIds($mysqli_db);
+    $view = new Standings\OlympicsStandingsView($repository, $season->endingYear, $realTeamIds);
+} else {
+    $seriesRecordsService = new SeriesRecords\SeriesRecordsService();
+    $view = new Standings\StandingsView($repository, $season->endingYear, $seriesRecordsService);
+}
 
 // Render and output the standings
     PageLayout\PageLayout::header();

--- a/ibl5/tests/League/OlympicsTeamFilterTest.php
+++ b/ibl5/tests/League/OlympicsTeamFilterTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\League;
+
+use League\OlympicsTeamFilter;
+use PHPUnit\Framework\TestCase;
+use Tests\WideUnit\Mocks\MockDatabase;
+
+/**
+ * @covers \League\OlympicsTeamFilter
+ */
+class OlympicsTeamFilterTest extends TestCase
+{
+    private MockDatabase $mockDb;
+
+    protected function setUp(): void
+    {
+        OlympicsTeamFilter::resetCache();
+        $this->mockDb = new MockDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        OlympicsTeamFilter::resetCache();
+    }
+
+    public function testGetRealTeamIdsReturnsOnlyRealTeams(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1],
+            ['teamid' => 2],
+            ['teamid' => 5],
+        ]);
+
+        $ids = OlympicsTeamFilter::getRealTeamIds($this->mockDb);
+
+        $this->assertSame([1, 2, 5], $ids);
+    }
+
+    public function testIsRealOlympicsTeamReturnsTrueForRealTeam(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1],
+            ['teamid' => 3],
+        ]);
+
+        $this->assertTrue(OlympicsTeamFilter::isRealOlympicsTeam($this->mockDb, 1));
+        $this->assertTrue(OlympicsTeamFilter::isRealOlympicsTeam($this->mockDb, 3));
+    }
+
+    public function testIsRealOlympicsTeamReturnsFalseForFillerTeam(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1],
+        ]);
+
+        $this->assertFalse(OlympicsTeamFilter::isRealOlympicsTeam($this->mockDb, 99));
+    }
+
+    public function testCachePreventsMultipleQueries(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1],
+        ]);
+
+        OlympicsTeamFilter::getRealTeamIds($this->mockDb);
+        OlympicsTeamFilter::getRealTeamIds($this->mockDb);
+
+        $queries = $this->mockDb->getExecutedQueries();
+        $olympicsQueries = array_filter(
+            $queries,
+            static fn (string $q): bool => str_contains($q, 'ibl_olympics_team_info'),
+        );
+        $this->assertCount(1, $olympicsQueries);
+    }
+
+    public function testResetCacheClearsState(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1],
+        ]);
+
+        OlympicsTeamFilter::getRealTeamIds($this->mockDb);
+        OlympicsTeamFilter::resetCache();
+
+        $this->mockDb->setMockData([
+            ['teamid' => 1],
+            ['teamid' => 2],
+        ]);
+
+        $ids = OlympicsTeamFilter::getRealTeamIds($this->mockDb);
+
+        $this->assertSame([1, 2], $ids);
+    }
+
+    public function testGetRealTeamIdsReturnsEmptyArrayWhenNoRealTeams(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $ids = OlympicsTeamFilter::getRealTeamIds($this->mockDb);
+
+        $this->assertSame([], $ids);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/StandingsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/StandingsEntryPointTest.php
@@ -30,4 +30,59 @@ class StandingsEntryPointTest extends ModuleEntryPointTestCase
         $this->assertNotEmpty($output);
         $this->assertQueryExecuted('ibl_power');
     }
+
+    public function testDispatchesToOlympicsViewWhenOlympics(): void
+    {
+        \League\OlympicsTeamFilter::resetCache();
+
+        $lcStub = $this->createStub(\League\LeagueContext::class);
+        $lcStub->method('isOlympics')->willReturn(true);
+        $lcStub->method('getCurrentLeague')->willReturn('olympics');
+        $lcStub->method('getConfig')->willReturn([
+            'title' => 'IBL Olympics',
+            'short_name' => 'Olympics',
+            'primary_color' => '#c53030',
+            'logo_path' => 'images/olympics/logo.png',
+            'images_path' => 'images/olympics/',
+        ]);
+        $lcStub->method('getTableName')->willReturnCallback(
+            static fn (string $table): string => str_replace('ibl_', 'ibl_olympics_', $table),
+        );
+        $GLOBALS['leagueContext'] = $lcStub;
+
+        $this->mockDb->onQuery('is_real_team', [['teamid' => 1]]);
+        $this->mockDb->onQuery('FROM.*ibl_olympics_standings', [[
+            'teamid' => 1,
+            'team_name' => 'Eagles',
+            'league_record' => '3-1',
+            'pct' => '0.750',
+            'conf_gb' => '0.0',
+            'div_gb' => '0.0',
+            'conf_record' => '0-0',
+            'div_record' => '0-0',
+            'home_record' => '2-0',
+            'away_record' => '1-1',
+            'games_unplayed' => 4,
+            'conf_magic_number' => 0,
+            'div_magic_number' => 0,
+            'clinched_conference' => 0,
+            'clinched_division' => 0,
+            'clinched_playoffs' => 0,
+            'clinched_league' => 0,
+            'wins' => 3,
+            'homeGames' => 2,
+            'awayGames' => 2,
+            'conference' => 'Group A',
+            'division' => '',
+            'color1' => '002868',
+            'color2' => 'BF0A30',
+        ]]);
+
+        $output = $this->runModule('Standings');
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Olympics Standings', $output);
+
+        \League\OlympicsTeamFilter::resetCache();
+    }
 }

--- a/ibl5/tests/Standings/OlympicsStandingsViewTest.php
+++ b/ibl5/tests/Standings/OlympicsStandingsViewTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Standings;
+
+use PHPUnit\Framework\TestCase;
+use Standings\Contracts\StandingsRepositoryInterface;
+use Standings\OlympicsStandingsView;
+
+/**
+ * @covers \Standings\OlympicsStandingsView
+ */
+class OlympicsStandingsViewTest extends TestCase
+{
+    /** @var StandingsRepositoryInterface&\PHPUnit\Framework\MockObject\Stub */
+    private StandingsRepositoryInterface $stubRepository;
+
+    protected function setUp(): void
+    {
+        $this->stubRepository = $this->createStub(StandingsRepositoryInterface::class);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function makeBulkRow(array $overrides = []): array
+    {
+        return array_merge([
+            'teamid' => 1,
+            'team_name' => 'Eagles',
+            'league_record' => '3-1',
+            'pct' => '0.750',
+            'conf_gb' => '0.0',
+            'div_gb' => '0.0',
+            'conf_record' => '0-0',
+            'div_record' => '0-0',
+            'home_record' => '2-0',
+            'away_record' => '1-1',
+            'games_unplayed' => 4,
+            'conf_magic_number' => 0,
+            'div_magic_number' => 0,
+            'clinched_conference' => 0,
+            'clinched_division' => 0,
+            'clinched_playoffs' => 0,
+            'clinched_league' => 0,
+            'wins' => 3,
+            'homeGames' => 2,
+            'awayGames' => 2,
+            'conference' => 'Group A',
+            'division' => '',
+            'color1' => '002868',
+            'color2' => 'BF0A30',
+        ], $overrides);
+    }
+
+    public function testRendersTableWithCorrectColumns(): void
+    {
+        $this->stubRepository->method('getAllStandings')->willReturn([
+            $this->makeBulkRow(),
+        ]);
+
+        $view = new OlympicsStandingsView($this->stubRepository, 2025, [1]);
+        $html = $view->render();
+
+        $this->assertStringContainsString('Rank', $html);
+        $this->assertStringContainsString('Team', $html);
+        $this->assertStringContainsString('W-L', $html);
+        $this->assertStringContainsString('Win%', $html);
+        $this->assertStringContainsString('Home', $html);
+        $this->assertStringContainsString('Away', $html);
+        $this->assertStringContainsString('Games Left', $html);
+    }
+
+    public function testFiltersOutFillerTeams(): void
+    {
+        $this->stubRepository->method('getAllStandings')->willReturn([
+            $this->makeBulkRow(['teamid' => 1, 'team_name' => 'Eagles']),
+            $this->makeBulkRow(['teamid' => 99, 'team_name' => 'Filler']),
+        ]);
+
+        $view = new OlympicsStandingsView($this->stubRepository, 2025, [1]);
+        $html = $view->render();
+
+        $this->assertStringContainsString('Eagles', $html);
+        $this->assertStringNotContainsString('Filler', $html);
+    }
+
+    public function testSortsByWinPercentageDescending(): void
+    {
+        $this->stubRepository->method('getAllStandings')->willReturn([
+            $this->makeBulkRow(['teamid' => 1, 'team_name' => 'Low', 'pct' => '0.250', 'wins' => 1]),
+            $this->makeBulkRow(['teamid' => 2, 'team_name' => 'High', 'pct' => '0.750', 'wins' => 3]),
+            $this->makeBulkRow(['teamid' => 3, 'team_name' => 'Mid', 'pct' => '0.500', 'wins' => 2]),
+        ]);
+
+        $view = new OlympicsStandingsView($this->stubRepository, 2025, [1, 2, 3]);
+        $html = $view->render();
+
+        $highPos = strpos($html, 'High');
+        $midPos = strpos($html, 'Mid');
+        $lowPos = strpos($html, 'Low');
+
+        $this->assertNotFalse($highPos);
+        $this->assertNotFalse($midPos);
+        $this->assertNotFalse($lowPos);
+        $this->assertLessThan($midPos, $highPos);
+        $this->assertLessThan($lowPos, $midPos);
+    }
+
+    public function testNoConferenceDivisionMagicOrClinchContent(): void
+    {
+        $this->stubRepository->method('getAllStandings')->willReturn([
+            $this->makeBulkRow(),
+        ]);
+
+        $view = new OlympicsStandingsView($this->stubRepository, 2025, [1]);
+        $html = $view->render();
+
+        $this->assertStringNotContainsString('Eastern Conference', $html);
+        $this->assertStringNotContainsString('Western Conference', $html);
+        $this->assertStringNotContainsString('Atlantic', $html);
+        $this->assertStringNotContainsString('clinch', strtolower($html));
+        $this->assertStringNotContainsString('magic', strtolower($html));
+    }
+
+    public function testXssEscapesTeamNames(): void
+    {
+        $this->stubRepository->method('getAllStandings')->willReturn([
+            $this->makeBulkRow(['teamid' => 1, 'team_name' => '<script>alert(1)</script>']),
+        ]);
+
+        $view = new OlympicsStandingsView($this->stubRepository, 2025, [1]);
+        $html = $view->render();
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testRendersOlympicsStandingsTitle(): void
+    {
+        $this->stubRepository->method('getAllStandings')->willReturn([]);
+
+        $view = new OlympicsStandingsView($this->stubRepository, 2025, []);
+        $html = $view->render();
+
+        $this->assertStringContainsString('2025 Olympics Standings', $html);
+        $this->assertStringContainsString('ibl-title', $html);
+    }
+
+    public function testWinsTiebreakerWhenPercentageEqual(): void
+    {
+        $this->stubRepository->method('getAllStandings')->willReturn([
+            $this->makeBulkRow(['teamid' => 1, 'team_name' => 'FewerWins', 'pct' => '0.500', 'wins' => 2]),
+            $this->makeBulkRow(['teamid' => 2, 'team_name' => 'MoreWins', 'pct' => '0.500', 'wins' => 5]),
+        ]);
+
+        $view = new OlympicsStandingsView($this->stubRepository, 2025, [1, 2]);
+        $html = $view->render();
+
+        $morePos = strpos($html, 'MoreWins');
+        $fewerPos = strpos($html, 'FewerWins');
+
+        $this->assertNotFalse($morePos);
+        $this->assertNotFalse($fewerPos);
+        $this->assertLessThan($fewerPos, $morePos);
+    }
+}

--- a/ibl5/tests/Updater/ScheduleUpdaterTest.php
+++ b/ibl5/tests/Updater/ScheduleUpdaterTest.php
@@ -21,7 +21,7 @@ class ScheduleUpdaterTest extends TestCase
         $this->mockDb = new MockDatabase();
     }
 
-    private function createUpdater(string $phase = 'Regular Season', int $endingYear = 2025): TestableScheduleUpdater
+    private function createUpdater(string $phase = 'Regular Season', int $endingYear = 2025, bool $olympics = false): TestableScheduleUpdater
     {
         $season = $this->createStub(Season::class);
         $season->endingYear = $endingYear;
@@ -29,7 +29,13 @@ class ScheduleUpdaterTest extends TestCase
         $season->phase = $phase;
 
         $leagueContext = $this->createStub(LeagueContext::class);
-        $leagueContext->method('getCurrentLeague')->willReturn('IBL');
+        $leagueContext->method('getCurrentLeague')->willReturn($olympics ? 'olympics' : 'IBL');
+        $leagueContext->method('isOlympics')->willReturn($olympics);
+        $leagueContext->method('getTableName')->willReturnCallback(
+            static fn (string $table): string => $olympics
+                ? str_replace('ibl_', 'ibl_olympics_', $table)
+                : $table,
+        );
 
         return new TestableScheduleUpdater($this->mockDb, $season, $leagueContext);
     }
@@ -76,6 +82,37 @@ class ScheduleUpdaterTest extends TestCase
         $this->assertSame(15, $result['day']);
         $this->assertSame(2025, $result['year']);
     }
+
+    public function testOlympicsPreloadLoadsAllTeamsWithoutFilter(): void
+    {
+        $this->mockDb->setMockData([
+            ['team_name' => 'Eagles', 'teamid' => 1],
+            ['team_name' => 'Maple', 'teamid' => 2],
+            ['team_name' => 'Filler29', 'teamid' => 29],
+        ]);
+
+        $updater = $this->createUpdater(olympics: true);
+        $updater->exposedPreloadTeamNameMap();
+
+        $map = $updater->getTeamNameToIdMap();
+        $this->assertCount(3, $map);
+        $this->assertSame(29, $map['Filler29']);
+    }
+
+    public function testIblPreloadFiltersToMaxRealTeamId(): void
+    {
+        $this->mockDb->setMockData([
+            ['team_name' => 'Celtics', 'teamid' => 1],
+            ['team_name' => 'Lakers', 'teamid' => 2],
+        ]);
+
+        $updater = $this->createUpdater(olympics: false);
+        $updater->exposedPreloadTeamNameMap();
+
+        $queries = $this->mockDb->getExecutedQueries();
+        $matched = array_filter($queries, static fn (string $q): bool => str_contains($q, 'BETWEEN 1 AND'));
+        $this->assertNotEmpty($matched);
+    }
 }
 
 /**
@@ -89,5 +126,19 @@ class TestableScheduleUpdater extends \Updater\ScheduleUpdater
     public function exposedExtractDate(string $rawDate): ?array
     {
         return $this->extractDate($rawDate);
+    }
+
+    public function exposedPreloadTeamNameMap(): void
+    {
+        $reflection = new \ReflectionMethod(parent::class, 'preloadTeamNameMap');
+        $reflection->invoke($this);
+    }
+
+    /** @return array<string, int> */
+    public function getTeamNameToIdMap(): array
+    {
+        $prop = new \ReflectionProperty(parent::class, 'teamNameToIdMap');
+        /** @var array<string, int> */
+        return $prop->getValue($this);
     }
 }

--- a/ibl5/tests/e2e/smoke/olympics-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/olympics-pages.spec.ts
@@ -11,8 +11,10 @@ test.describe('Olympics page smoke tests', () => {
   test('standings page loads in Olympics context', async ({ page }) => {
     await page.goto('modules.php?name=Standings&league=olympics');
     await assertNoPhpErrors(page, 'on modules.php?name=Standings&league=olympics');
+    await expect(page.locator('.ibl-title')).toContainText(/Olympics Standings/i);
     const body = await page.locator('body').textContent();
-    expect(body?.length).toBeGreaterThan(100);
+    expect(body ?? '').not.toContain('Eastern Conference');
+    expect(body ?? '').not.toContain('Western Conference');
   });
 
   test('team page loads in Olympics context', async ({ page }) => {

--- a/ibl5/tests/e2e/smoke/olympics-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/olympics-pages.spec.ts
@@ -12,9 +12,10 @@ test.describe('Olympics page smoke tests', () => {
     await page.goto('modules.php?name=Standings&league=olympics');
     await assertNoPhpErrors(page, 'on modules.php?name=Standings&league=olympics');
     await expect(page.locator('.ibl-title')).toContainText(/Olympics Standings/i);
-    const body = await page.locator('body').textContent();
-    expect(body ?? '').not.toContain('Eastern Conference');
-    expect(body ?? '').not.toContain('Western Conference');
+    await expect(page.locator('.ibl-data-table')).toBeVisible();
+    const tableText = await page.locator('.ibl-data-table').textContent();
+    expect(tableText ?? '').not.toContain('Eastern Conference');
+    expect(tableText ?? '').not.toContain('Western Conference');
   });
 
   test('team page loads in Olympics context', async ({ page }) => {


### PR DESCRIPTION
## Summary

Adds Olympics-specific real-team filtering, a flat standings display page, and fixes `ScheduleUpdater` to load all Olympic team rows (including filler teams) without the IBL `MAX_REAL_TEAMID` filter.

Depends on PR 1 (`olympics-updater-pr1-unblock-dry-run`) — mergeable after that PR lands.

## Changes

- **`OlympicsTeamFilter`** — static utility with cache; queries `ibl_olympics_team_info` where `is_real_team = 1`
- **`OlympicsStandingsView`** — flat standings table (Rank, Team, W-L, Win%, Home, Away, Games Left); no conferences, divisions, clinch indicators, or magic numbers
- **`Standings/index.php`** — dispatches to `OlympicsStandingsView` when league context is Olympics, preserves IBL path unchanged
- **`ScheduleUpdater::preloadTeamNameMap()`** — Olympics loads all team rows (filler teams appear in .sch files); IBL keeps BETWEEN filter

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)