### PR TITLE
feat: filter Olympics schedule to real-team games only

### DIFF
--- a/ibl5/classes/Updater/ScheduleUpdater.php
+++ b/ibl5/classes/Updater/ScheduleUpdater.php
@@ -21,6 +21,9 @@ class ScheduleUpdater extends \BaseMysqliRepository {
     /** @var array<string, int> Team name to ID lookup (for Schedule.htm parsing) */
     private array $teamNameToIdMap = [];
 
+    /** @var array<int, true> Olympics real-team IDs (empty for IBL — all teams pass) */
+    private array $realTeamIds = [];
+
     private const UNPLAYED_BOX_ID = 100000;
 
     /** @var array<int, string> Calendar month number to name for date string construction */
@@ -77,9 +80,9 @@ class ScheduleUpdater extends \BaseMysqliRepository {
         $isOlympics = $this->leagueContext !== null && $this->leagueContext->isOlympics();
 
         if ($isOlympics) {
-            /** @var list<array{team_name: string, teamid: int}> $rows */
+            /** @var list<array{team_name: string, teamid: int, is_real_team: int}> $rows */
             $rows = $this->fetchAll(
-                "SELECT team_name, teamid FROM {$teamInfoTable}",
+                "SELECT team_name, teamid, is_real_team FROM {$teamInfoTable}",
                 "",
             );
         } else {
@@ -94,6 +97,14 @@ class ScheduleUpdater extends \BaseMysqliRepository {
         foreach ($rows as $row) {
             $this->teamIdToNameMap[$row['teamid']] = $row['team_name'];
             $this->teamNameToIdMap[$row['team_name']] = $row['teamid'];
+        }
+
+        if ($isOlympics) {
+            foreach ($rows as $row) {
+                if ($row['is_real_team'] === 1) {
+                    $this->realTeamIds[$row['teamid']] = true;
+                }
+            }
         }
     }
 
@@ -115,6 +126,14 @@ class ScheduleUpdater extends \BaseMysqliRepository {
     private function getTeamNameById(int $teamId): string
     {
         return $this->teamIdToNameMap[$teamId] ?? "Team #{$teamId}";
+    }
+
+    private function isRealTeamGame(int $visitorId, int $homeId): bool
+    {
+        if ($this->realTeamIds === []) {
+            return true;
+        }
+        return isset($this->realTeamIds[$visitorId]) && isset($this->realTeamIds[$homeId]);
     }
 
     /**
@@ -156,6 +175,10 @@ class ScheduleUpdater extends \BaseMysqliRepository {
 
             if ($visitor_teamid === null || $home_teamid === null) {
                 $log .= "Unknown team in playoff game: {$game['visitor']} @ {$game['home']}<br>";
+                continue;
+            }
+
+            if (!$this->isRealTeamGame($visitor_teamid, $home_teamid)) {
                 continue;
             }
 
@@ -257,6 +280,11 @@ class ScheduleUpdater extends \BaseMysqliRepository {
 
             $visitor_teamid = $game['visitor'];
             $home_teamid = $game['home'];
+
+            if (!$this->isRealTeamGame($visitor_teamid, $home_teamid)) {
+                continue;
+            }
+
             $vScore = $game['visitor_score'];
             $hScore = $game['home_score'];
 

--- a/ibl5/tests/UpdateAllTheThings/ScheduleUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/ScheduleUpdaterTest.php
@@ -231,6 +231,66 @@ class ScheduleUpdaterTest extends TestCase
      * @group schedule-updater
      * @group league-context
      */
+    public function testIsRealTeamGamePassesAllTeamsForIbl(): void
+    {
+        $updater = new ScheduleUpdater($this->mockDb, $this->mockSeason, null);
+
+        $reflection = new \ReflectionClass($updater);
+        $method = $reflection->getMethod('isRealTeamGame');
+
+        $this->assertTrue($method->invoke($updater, 1, 2));
+        $this->assertTrue($method->invoke($updater, 99, 100));
+    }
+
+    /**
+     * @group schedule-updater
+     * @group league-context
+     */
+    public function testIsRealTeamGameFiltersPlaceholderTeamsForOlympics(): void
+    {
+        $olympicsContext = $this->createStub(LeagueContext::class);
+        $olympicsContext->method('getCurrentLeague')->willReturn(LeagueContext::LEAGUE_OLYMPICS);
+        $olympicsContext->method('isOlympics')->willReturn(true);
+        $olympicsContext->method('getTableName')->willReturnCallback(
+            static function (string $table): string {
+                return match ($table) {
+                    'ibl_schedule' => 'ibl_olympics_schedule',
+                    'ibl_team_info' => 'ibl_olympics_team_info',
+                    default => $table,
+                };
+            }
+        );
+
+        $updater = new ScheduleUpdater($this->mockDb, $this->mockSeason, $olympicsContext);
+
+        // Simulate preloadTeamNameMap loading real + placeholder teams
+        $this->mockDb->setMockData([
+            ['team_name' => 'USA', 'teamid' => 1, 'is_real_team' => 1],
+            ['team_name' => 'Canada', 'teamid' => 2, 'is_real_team' => 1],
+            ['team_name' => 'Placeholder A', 'teamid' => 9, 'is_real_team' => 0],
+            ['team_name' => 'Placeholder B', 'teamid' => 10, 'is_real_team' => 0],
+        ]);
+
+        $reflection = new \ReflectionClass($updater);
+        $preload = $reflection->getMethod('preloadTeamNameMap');
+        $preload->invoke($updater);
+
+        $isReal = $reflection->getMethod('isRealTeamGame');
+
+        // Both real → pass
+        $this->assertTrue($isReal->invoke($updater, 1, 2));
+        // Real vs placeholder → reject
+        $this->assertFalse($isReal->invoke($updater, 1, 9));
+        // Placeholder vs real → reject
+        $this->assertFalse($isReal->invoke($updater, 10, 2));
+        // Both placeholder → reject
+        $this->assertFalse($isReal->invoke($updater, 9, 10));
+    }
+
+    /**
+     * @group schedule-updater
+     * @group league-context
+     */
     public function testOlympicsContextTruncatesOlympicsScheduleTable(): void
     {
         $olympicsContext = $this->createStub(LeagueContext::class);

--- a/ibl5/tests/Updater/ScheduleUpdaterTest.php
+++ b/ibl5/tests/Updater/ScheduleUpdaterTest.php
@@ -86,9 +86,9 @@ class ScheduleUpdaterTest extends TestCase
     public function testOlympicsPreloadLoadsAllTeamsWithoutFilter(): void
     {
         $this->mockDb->setMockData([
-            ['team_name' => 'Eagles', 'teamid' => 1],
-            ['team_name' => 'Maple', 'teamid' => 2],
-            ['team_name' => 'Filler29', 'teamid' => 29],
+            ['team_name' => 'Eagles', 'teamid' => 1, 'is_real_team' => 1],
+            ['team_name' => 'Maple', 'teamid' => 2, 'is_real_team' => 1],
+            ['team_name' => 'Filler29', 'teamid' => 29, 'is_real_team' => 0],
         ]);
 
         $updater = $this->createUpdater(olympics: true);


### PR DESCRIPTION
## Summary

ScheduleUpdater now skips schedule entries involving placeholder teams during Olympics imports. Only games where both visitor and home are real teams (`is_real_team = 1` in `ibl_olympics_team_info`) are inserted.

## Changes

- **`ScheduleUpdater::preloadTeamNameMap()`** — now also loads `is_real_team` from `ibl_olympics_team_info` and populates a `$realTeamIds` set for Olympics context
- **`ScheduleUpdater::isRealTeamGame()`** — new private helper; returns `true` for IBL (empty set = all pass), filters for Olympics
- **Main insert loop + playoff insert path** — both skip `INSERT` when either team is a placeholder

## Impact

Olympics 2003 archive dry-run: schedule rows drop from 1121 (all 28 teams) to only real-team matchups. IBL path is completely unaffected (empty `$realTeamIds` set passes all teams through).

## Manual Testing

No manual testing needed — all changes are covered by unit tests.