### PR TITLE
Unlock Controllers from Mutation Testing Exclusion

### DIFF
--- a/ibl5/bun.lock
+++ b/ibl5/bun.lock
@@ -19,10 +19,14 @@
     },
   },
   "overrides": {
+    "chrome-launcher": "1.2.1",
+    "engine.io": "6.6.8",
+    "engine.io-client": "6.6.5",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "tmp": "0.2.5",
-    "uuid": ">=11.1.1",
+    "socket.io-adapter": "2.5.7",
+    "tmp": "0.2.6",
+    "uuid": "14.0.0",
   },
   "packages": {
     "@axe-core/playwright": ["@axe-core/playwright@4.11.3", "", { "dependencies": { "axe-core": "~4.11.4" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w=="],
@@ -341,7 +345,7 @@
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
-    "chrome-launcher": ["chrome-launcher@0.13.4", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^1.0.5", "is-wsl": "^2.2.0", "lighthouse-logger": "^1.0.0", "mkdirp": "^0.5.3", "rimraf": "^3.0.2" } }, "sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A=="],
+    "chrome-launcher": ["chrome-launcher@1.2.1", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A=="],
 
     "chromium-bidi": ["chromium-bidi@14.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw=="],
 
@@ -427,9 +431,9 @@
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
-    "engine.io": ["engine.io@6.6.6", "", { "dependencies": { "@types/cors": "^2.8.12", "@types/node": ">=10.0.0", "@types/ws": "^8.5.12", "accepts": "~1.3.4", "base64id": "2.0.0", "cookie": "~0.7.2", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.18.3" } }, "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA=="],
+    "engine.io": ["engine.io@6.6.8", "", { "dependencies": { "@types/cors": "^2.8.12", "@types/node": ">=10.0.0", "@types/ws": "^8.5.12", "accepts": "~1.3.4", "base64id": "2.0.0", "cookie": "~0.7.2", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.20.1" } }, "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g=="],
 
-    "engine.io-client": ["engine.io-client@6.6.4", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.18.3", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw=="],
+    "engine.io-client": ["engine.io-client@6.6.5", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.20.1", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg=="],
 
     "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
 
@@ -523,8 +527,6 @@
 
     "fs-extra": ["fs-extra@3.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^3.0.0", "universalify": "^0.1.0" } }, "sha512-V3Z3WZWVUYd8hoCL5xfXJCaHWYzmtwW5XWYSlLgERi8PWd8bx1kUHUk8L1BT57e49oKnDDD180mjfrHc1yA9rg=="],
 
-    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
-
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
@@ -538,8 +540,6 @@
     "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
-
-    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -576,8 +576,6 @@
     "immutable": ["immutable@3.8.3", "", {}, "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
-
-    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -711,11 +709,7 @@
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
     "mitt": ["mitt@1.2.0", "", {}, "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="],
-
-    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -773,8 +767,6 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
-    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
-
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
@@ -829,8 +821,6 @@
 
     "restore-cursor": ["restore-cursor@2.0.0", "", { "dependencies": { "onetime": "^2.0.0", "signal-exit": "^3.0.2" } }, "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q=="],
 
-    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
-
     "robots-parser": ["robots-parser@3.0.1", "", {}, "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ=="],
 
     "rolldown": ["rolldown@1.0.0-rc.10", "", { "dependencies": { "@oxc-project/types": "=0.120.0", "@rolldown/pluginutils": "1.0.0-rc.10" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.10", "@rolldown/binding-darwin-arm64": "1.0.0-rc.10", "@rolldown/binding-darwin-x64": "1.0.0-rc.10", "@rolldown/binding-freebsd-x64": "1.0.0-rc.10", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA=="],
@@ -879,7 +869,7 @@
 
     "socket.io": ["socket.io@4.8.3", "", { "dependencies": { "accepts": "~1.3.4", "base64id": "~2.0.0", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io": "~6.6.0", "socket.io-adapter": "~2.5.2", "socket.io-parser": "~4.2.4" } }, "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A=="],
 
-    "socket.io-adapter": ["socket.io-adapter@2.5.6", "", { "dependencies": { "debug": "~4.4.1", "ws": "~8.18.3" } }, "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ=="],
+    "socket.io-adapter": ["socket.io-adapter@2.5.7", "", { "dependencies": { "debug": "~4.4.1", "ws": "~8.20.1" } }, "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg=="],
 
     "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
 
@@ -941,7 +931,7 @@
 
     "tldts-icann": ["tldts-icann@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" } }, "sha512-NFxmRT2lAEMcCOBgeZ0NuM0zsK/xgmNajnY6n4S1mwAKocft2s2ise1O3nQxrH3c+uY6hgHUV9GGNVp7tUE4Sg=="],
 
-    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
+    "tmp": ["tmp@0.2.6", "", {}, "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1085,7 +1075,7 @@
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "chrome-launcher/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+    "chrome-launcher/lighthouse-logger": ["lighthouse-logger@2.0.2", "", { "dependencies": { "debug": "^4.4.1", "marky": "^1.2.2" } }, "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg=="],
 
     "chromium-bidi/mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
@@ -1099,9 +1089,9 @@
 
     "connect/finalhandler": ["finalhandler@1.1.0", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.1", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.2", "statuses": "~1.3.1", "unpipe": "~1.0.0" } }, "sha512-ejnvM9ZXYzp6PUPUyQBMBf0Co5VX2gr5H2VQe2Ui2jWXNlxv+PYZo8wpAymJNJdLsG1R4p+M4aynF8KuoUEwRw=="],
 
-    "engine.io/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+    "engine.io/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
-    "engine.io-client/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+    "engine.io-client/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1111,15 +1101,11 @@
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
     "inquirer/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "intl-messageformat/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "lighthouse/axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
-
-    "lighthouse/chrome-launcher": ["chrome-launcher@1.2.1", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A=="],
 
     "lighthouse/lighthouse-logger": ["lighthouse-logger@2.0.2", "", { "dependencies": { "debug": "^4.4.1", "marky": "^1.2.2" } }, "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg=="],
 
@@ -1157,7 +1143,7 @@
 
     "serve-index/http-errors": ["http-errors@1.8.1", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
 
-    "socket.io-adapter/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+    "socket.io-adapter/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "string-width/strip-ansi": ["strip-ansi@4.0.0", "", { "dependencies": { "ansi-regex": "^3.0.0" } }, "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow=="],
 
@@ -1210,8 +1196,6 @@
     "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "inquirer/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
@@ -1266,8 +1250,6 @@
     "browser-sync/yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "browser-sync/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "inquirer/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 

--- a/ibl5/docs/decisions/0007-nightly-autonomous-workflow.md
+++ b/ibl5/docs/decisions/0007-nightly-autonomous-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: ADR for the nightly autonomous workflow — headless Claude executes queued plans via launchd at midnight.
-last_verified: 2026-05-01
+last_verified: 2026-05-26
 ---
 
 # ADR-0007: Nightly Autonomous Workflow
@@ -29,7 +29,7 @@ Enforcement: `launchd` plist at `~/Library/LaunchAgents/com.ibl5.nightly-claude.
 - Positive: Plans execute overnight without human presence, producing review-ready PRs by morning.
 - Positive: Symlink-based queue preserves original plans in `~/.claude/plans/` while tracking execution state.
 - Positive: `CLAUDE_HEADLESS` env var is a clean, extensible gate for headless-specific behavior in any skill.
-- Negative: Mac must remain powered on overnight.
+- Negative: Mac must remain awake overnight (clamshell mode with external monitor and power connected, or display-sleep-only with lid open). System sleep prevents `launchd` from firing; clamshell mode avoids this.
 - Negative: `--dangerously-skip-permissions` grants full tool access to the headless agent — mitigated by plan validation and skip-on-ambiguity behavior.
 
 ## References

--- a/ibl5/infection.json5
+++ b/ibl5/infection.json5
@@ -42,19 +42,6 @@
             "Player/Views/PlayerTradingCardBackView.php",
             "Player/Views/PlayerTradingCardFlipView.php",
             "Player/Views/PlayerTradingCardFrontView.php",
-            // Controllers without direct test coverage (Pass 2 — deferred)
-            "Player/PlayerPageController.php",
-            "Updater/UpdaterController.php",
-            "Api/Controller/PlayerExportController.php",
-            "Api/Controller/TeamDetailController.php",
-            "Api/Controller/GameDetailController.php",
-            "Api/Controller/PlayerDetailController.php",
-            "Api/Controller/TeamListController.php",
-            "Api/Controller/PlayerHistoryController.php",
-            "Api/Controller/SeasonController.php",
-            "Api/Controller/TeamRosterController.php",
-            "Api/Controller/PlayerListController.php",
-            "Api/Controller/GameBoxscoreController.php",
             // Handlers without direct test coverage (Pass 2 — deferred)
             "NextSim/NextSimTabApiHandler.php",
             "Team/TeamApiHandler.php"

--- a/ibl5/package-lock.json
+++ b/ibl5/package-lock.json
@@ -6714,7 +6714,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ibl5/package.json
+++ b/ibl5/package.json
@@ -29,7 +29,7 @@
   "overrides": {
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "tmp": "0.2.5",
+    "tmp": "0.2.6",
     "chrome-launcher": "1.2.1",
     "engine.io": "6.6.8",
     "engine.io-client": "6.6.5",

--- a/ibl5/tests/Api/Controller/GameBoxscoreControllerTest.php
+++ b/ibl5/tests/Api/Controller/GameBoxscoreControllerTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\GameBoxscoreController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+class GameBoxscoreControllerTest extends WideUnitTestCase
+{
+    private const GAME_UUID = 'game-boxscore-uuid-abc';
+    private const UPDATED_AT = '2026-03-20 08:00:00';
+    private const VISITOR_TEAM_ID = 1;
+    private const HOME_TEAM_ID = 14;
+    private const GAME_DATE = '2026-03-20';
+
+    private function gameRow(string $status = 'completed'): array
+    {
+        return [
+            'game_uuid' => self::GAME_UUID,
+            'season_year' => 2026,
+            'game_date' => self::GAME_DATE,
+            'game_status' => $status,
+            'box_score_id' => 555,
+            'game_of_that_day' => 1,
+            'visitor_uuid' => 'visitor-team-uuid',
+            'visitor_city' => 'Boston',
+            'visitor_name' => 'Celtics',
+            'visitor_full_name' => 'Boston Celtics',
+            'visitor_score' => 112,
+            'visitor_team_id' => self::VISITOR_TEAM_ID,
+            'home_uuid' => 'home-team-uuid',
+            'home_city' => 'Miami',
+            'home_name' => 'Heat',
+            'home_full_name' => 'Miami Heat',
+            'home_score' => 108,
+            'home_team_id' => self::HOME_TEAM_ID,
+            'updated_at' => self::UPDATED_AT,
+            'created_at' => '2026-01-01 00:00:00',
+        ];
+    }
+
+    private function teamBoxscoreRow(string $name): array
+    {
+        return [
+            'name' => $name,
+            'visitor_q1_points' => 28,
+            'visitor_q2_points' => 30,
+            'visitor_q3_points' => 27,
+            'visitor_q4_points' => 27,
+            'visitor_ot_points' => 0,
+            'home_q1_points' => 25,
+            'home_q2_points' => 28,
+            'home_q3_points' => 29,
+            'home_q4_points' => 26,
+            'home_ot_points' => 0,
+            'game_min' => 240,
+            'game_2gm' => 35,
+            'game_2ga' => 72,
+            'game_ftm' => 18,
+            'game_fta' => 22,
+            'game_3gm' => 14,
+            'game_3ga' => 35,
+            'game_orb' => 10,
+            'game_drb' => 30,
+            'game_ast' => 24,
+            'game_stl' => 8,
+            'game_tov' => 12,
+            'game_blk' => 5,
+            'game_pf' => 20,
+            'attendance' => 19600,
+            'capacity' => 20000,
+            'visitor_wins' => 38,
+            'visitor_losses' => 20,
+            'home_wins' => 36,
+            'home_losses' => 22,
+            'calc_points' => 112,
+            'calc_rebounds' => 40,
+            'calc_fg_made' => 49,
+        ];
+    }
+
+    private function playerBoxscoreRow(
+        string $uuid,
+        string $name,
+        string $pos,
+        int $teamId,
+        int $points = 20
+    ): array {
+        return [
+            'player_uuid' => $uuid,
+            'name' => $name,
+            'pos' => $pos,
+            'game_min' => 36,
+            'game_2gm' => 7,
+            'game_2ga' => 14,
+            'game_ftm' => 4,
+            'game_fta' => 5,
+            'game_3gm' => 2,
+            'game_3ga' => 6,
+            'game_orb' => 2,
+            'game_drb' => 5,
+            'game_ast' => 4,
+            'game_stl' => 2,
+            'game_tov' => 3,
+            'game_blk' => 1,
+            'game_pf' => 3,
+            'calc_points' => $points,
+            'calc_rebounds' => 7,
+            'calc_fg_made' => 9,
+            'player_tid' => $teamId,
+        ];
+    }
+
+    private function seedSuccessMocks(): void
+    {
+        // getGameByUuid uses vw_schedule_upcoming
+        $this->mockDb->onQuery('vw_schedule_upcoming', [$this->gameRow()]);
+
+        // getBoxscoreTeams uses ibl_box_scores_teams
+        $this->mockDb->onQuery('ibl_box_scores_teams', [
+            $this->teamBoxscoreRow('Celtics'),
+            $this->teamBoxscoreRow('Heat'),
+        ]);
+
+        // getBoxscorePlayers uses ibl_box_scores (without _teams)
+        // The query is: FROM ibl_box_scores b LEFT JOIN ibl_plr ...
+        $this->mockDb->onQuery('ibl_box_scores b', [
+            $this->playerBoxscoreRow('visitor-p1-uuid', 'Visitor Player One', 'PG', self::VISITOR_TEAM_ID, 28),
+            $this->playerBoxscoreRow('visitor-p2-uuid', 'Visitor Player Two', 'SG', self::VISITOR_TEAM_ID, 18),
+            $this->playerBoxscoreRow('home-p1-uuid', 'Home Player One', 'C', self::HOME_TEAM_ID, 22),
+            $this->playerBoxscoreRow('home-p2-uuid', 'Home Player Two', 'PF', self::HOME_TEAM_ID, 15),
+        ]);
+    }
+
+    public function testHandleReturnsBoxscoreForCompletedGame(): void
+    {
+        $this->seedSuccessMocks();
+
+        $controller = new GameBoxscoreController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    return isset($data['game'], $data['visitor'], $data['home'])
+                        && $data['game']['uuid'] === self::GAME_UUID
+                        && $data['game']['status'] === 'completed'
+                        && isset($data['visitor']['team_stats'], $data['visitor']['players'])
+                        && isset($data['home']['team_stats'], $data['home']['players'])
+                        && count($data['visitor']['players']) === 2
+                        && count($data['home']['players']) === 2;
+                }),
+                $this->isArray(),
+                200,
+                $this->callback(function (array $headers): bool {
+                    return isset($headers['ETag'])
+                        && $headers['Cache-Control'] === 'public, max-age=60';
+                })
+            );
+
+        $controller->handle(['uuid' => self::GAME_UUID], [], $responder);
+    }
+
+    public function testHandleReturns404ForUnknownGame(): void
+    {
+        $this->mockDb->onQuery('vw_schedule_upcoming', []);
+
+        $controller = new GameBoxscoreController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(404, 'not_found', 'Game not found.');
+
+        $responder->expects($this->never())
+            ->method('success');
+
+        $controller->handle(['uuid' => 'nonexistent-uuid'], [], $responder);
+    }
+
+    public function testHandleReturns404ForScheduledGame(): void
+    {
+        $this->mockDb->onQuery('vw_schedule_upcoming', [$this->gameRow('scheduled')]);
+
+        $controller = new GameBoxscoreController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(404, 'no_boxscore', 'Box score is not available for scheduled games.');
+
+        $responder->expects($this->never())
+            ->method('success');
+
+        $controller->handle(['uuid' => self::GAME_UUID], [], $responder);
+    }
+
+    public function testHandleReturns304WhenETagMatches(): void
+    {
+        $this->seedSuccessMocks();
+
+        $expectedTag = '"' . md5(self::UPDATED_AT) . '"';
+        $_SERVER['HTTP_IF_NONE_MATCH'] = $expectedTag;
+
+        $controller = new GameBoxscoreController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('notModified');
+
+        $responder->expects($this->never())
+            ->method('success');
+
+        $controller->handle(['uuid' => self::GAME_UUID], [], $responder);
+    }
+
+    public function testHandleCorrectlyPartitionsPlayersByTeam(): void
+    {
+        $this->seedSuccessMocks();
+
+        $controller = new GameBoxscoreController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    $visitorPlayers = $data['visitor']['players'] ?? [];
+                    $homePlayers = $data['home']['players'] ?? [];
+
+                    if (count($visitorPlayers) !== 2 || count($homePlayers) !== 2) {
+                        return false;
+                    }
+
+                    // Verify visitor players are correctly identified by name
+                    $visitorNames = array_column($visitorPlayers, 'name');
+                    $homeNames = array_column($homePlayers, 'name');
+
+                    return in_array('Visitor Player One', $visitorNames, true)
+                        && in_array('Visitor Player Two', $visitorNames, true)
+                        && in_array('Home Player One', $homeNames, true)
+                        && in_array('Home Player Two', $homeNames, true);
+                }),
+                $this->isArray(),
+                200,
+                $this->isArray()
+            );
+
+        $controller->handle(['uuid' => self::GAME_UUID], [], $responder);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+        parent::tearDown();
+    }
+}

--- a/ibl5/tests/Api/Controller/GameDetailControllerTest.php
+++ b/ibl5/tests/Api/Controller/GameDetailControllerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\GameDetailController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+class GameDetailControllerTest extends WideUnitTestCase
+{
+    private const GAME_UUID = 'game-uuid-abc123';
+    private const UPDATED_AT = '2026-03-15 10:00:00';
+
+    private function gameRow(): array
+    {
+        return [
+            'game_uuid' => self::GAME_UUID,
+            'season_year' => 2026,
+            'game_date' => '2026-03-15',
+            'game_status' => 'completed',
+            'box_score_id' => 789,
+            'game_of_that_day' => 2,
+            'visitor_uuid' => 'visitor-team-uuid',
+            'visitor_city' => 'Boston',
+            'visitor_name' => 'Celtics',
+            'visitor_full_name' => 'Boston Celtics',
+            'visitor_score' => 108,
+            'visitor_team_id' => 1,
+            'home_uuid' => 'home-team-uuid',
+            'home_city' => 'Miami',
+            'home_name' => 'Heat',
+            'home_full_name' => 'Miami Heat',
+            'home_score' => 115,
+            'home_team_id' => 14,
+            'updated_at' => self::UPDATED_AT,
+            'created_at' => '2026-01-01 00:00:00',
+        ];
+    }
+
+    public function testHandleReturnsGameDataForValidUuid(): void
+    {
+        $this->mockDb->setMockData([$this->gameRow()]);
+
+        $controller = new GameDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    return $data['uuid'] === self::GAME_UUID
+                        && $data['season'] === 2026
+                        && $data['date'] === '2026-03-15'
+                        && $data['status'] === 'completed'
+                        && $data['box_score_id'] === 789
+                        && $data['game_of_that_day'] === 2
+                        && $data['visitor']['uuid'] === 'visitor-team-uuid'
+                        && $data['visitor']['city'] === 'Boston'
+                        && $data['visitor']['name'] === 'Celtics'
+                        && $data['visitor']['full_name'] === 'Boston Celtics'
+                        && $data['visitor']['score'] === 108
+                        && $data['visitor']['team_id'] === 1
+                        && $data['home']['uuid'] === 'home-team-uuid'
+                        && $data['home']['city'] === 'Miami'
+                        && $data['home']['name'] === 'Heat'
+                        && $data['home']['full_name'] === 'Miami Heat'
+                        && $data['home']['score'] === 115
+                        && $data['home']['team_id'] === 14;
+                }),
+                $this->isArray(),
+                200,
+                $this->callback(function (array $headers): bool {
+                    return isset($headers['ETag'])
+                        && $headers['Cache-Control'] === 'public, max-age=60';
+                })
+            );
+
+        $controller->handle(['uuid' => self::GAME_UUID], [], $responder);
+    }
+
+    public function testHandleReturns404ForUnknownUuid(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $controller = new GameDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(404, 'not_found', 'Game not found.');
+
+        $controller->handle(['uuid' => 'nonexistent-uuid'], [], $responder);
+    }
+
+    public function testHandleReturns304WhenETagMatches(): void
+    {
+        $this->mockDb->setMockData([$this->gameRow()]);
+
+        $expectedTag = '"' . md5(self::UPDATED_AT) . '"';
+        $_SERVER['HTTP_IF_NONE_MATCH'] = $expectedTag;
+
+        $controller = new GameDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('notModified');
+
+        $controller->handle(['uuid' => self::GAME_UUID], [], $responder);
+    }
+
+    public function testHandlePassesCorrectETagInHeaders(): void
+    {
+        $this->mockDb->setMockData([$this->gameRow()]);
+
+        $expectedTag = '"' . md5(self::UPDATED_AT) . '"';
+
+        $controller = new GameDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->isArray(),
+                $this->isArray(),
+                200,
+                $this->callback(function (array $headers) use ($expectedTag): bool {
+                    return $headers['ETag'] === $expectedTag;
+                })
+            );
+
+        $controller->handle(['uuid' => self::GAME_UUID], [], $responder);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+        parent::tearDown();
+    }
+}

--- a/ibl5/tests/Api/Controller/PlayerDetailControllerTest.php
+++ b/ibl5/tests/Api/Controller/PlayerDetailControllerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\PlayerDetailController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+class PlayerDetailControllerTest extends WideUnitTestCase
+{
+    private const PLAYER_UUID = 'player-uuid-def456';
+    private const UPDATED_AT = '2026-04-10 08:30:00';
+
+    private function playerRow(): array
+    {
+        return [
+            'player_uuid' => self::PLAYER_UUID,
+            'pid' => 42,
+            'name' => 'John Smith',
+            'nickname' => null,
+            'position' => 'PG',
+            'age' => 28,
+            'htft' => 6,
+            'htin' => 6,
+            'dc_can_play_in_game' => 1,
+            'retired' => 0,
+            'experience' => 5,
+            'bird_rights' => 1,
+            'teamid' => 3,
+            'team_uuid' => 'team-uuid-xyz',
+            'team_city' => 'Chicago',
+            'team_name' => 'Bulls',
+            'full_team_name' => 'Chicago Bulls',
+            'owner_name' => 'TestOwner',
+            'contract_year' => 2,
+            'current_salary' => 5000000,
+            'year1_salary' => 5000000,
+            'year2_salary' => 5500000,
+            'year3_salary' => 0,
+            'year4_salary' => 0,
+            'year5_salary' => 0,
+            'year6_salary' => 0,
+            'games_played' => 60,
+            'minutes_played' => 1800,
+            'field_goals_made' => 400,
+            'field_goals_attempted' => 850,
+            'free_throws_made' => 150,
+            'free_throws_attempted' => 180,
+            'three_pointers_made' => 80,
+            'three_pointers_attempted' => 200,
+            'offensive_rebounds' => 30,
+            'defensive_rebounds' => 120,
+            'assists' => 350,
+            'steals' => 90,
+            'turnovers' => 110,
+            'blocks' => 20,
+            'personal_fouls' => 140,
+            'points_per_game' => 18.5,
+            'fg_percentage' => 0.471,
+            'ft_percentage' => 0.833,
+            'three_pt_percentage' => 0.400,
+            'updated_at' => self::UPDATED_AT,
+        ];
+    }
+
+    public function testHandleReturnsPlayerDataForValidUuid(): void
+    {
+        $this->mockDb->setMockData([$this->playerRow()]);
+
+        $controller = new PlayerDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    return $data['uuid'] === self::PLAYER_UUID
+                        && $data['pid'] === 42
+                        && $data['name'] === 'John Smith'
+                        && $data['position'] === 'PG'
+                        && $data['age'] === 28
+                        && $data['height'] === '6-6'
+                        && $data['experience'] === 5
+                        && $data['bird_rights'] === 1
+                        && $data['team']['uuid'] === 'team-uuid-xyz'
+                        && $data['team']['city'] === 'Chicago'
+                        && $data['team']['name'] === 'Bulls'
+                        && $data['team']['full_name'] === 'Chicago Bulls'
+                        && $data['team']['team_id'] === 3
+                        && $data['contract']['current_salary'] === 5000000
+                        && $data['contract']['year1'] === 5000000
+                        && $data['contract']['year2'] === 5500000
+                        && $data['stats']['games_played'] === 60
+                        && $data['stats']['minutes_played'] === 1800
+                        && $data['stats']['field_goals_made'] === 400
+                        && $data['stats']['field_goals_attempted'] === 850
+                        && $data['stats']['free_throws_made'] === 150
+                        && $data['stats']['free_throws_attempted'] === 180
+                        && $data['stats']['three_pointers_made'] === 80
+                        && $data['stats']['three_pointers_attempted'] === 200
+                        && $data['stats']['offensive_rebounds'] === 30
+                        && $data['stats']['defensive_rebounds'] === 120
+                        && $data['stats']['assists'] === 350
+                        && $data['stats']['steals'] === 90
+                        && $data['stats']['turnovers'] === 110
+                        && $data['stats']['blocks'] === 20
+                        && $data['stats']['personal_fouls'] === 140
+                        && $data['stats']['points_per_game'] === 18.5
+                        && $data['stats']['fg_percentage'] === 0.471
+                        && $data['stats']['ft_percentage'] === 0.833
+                        && $data['stats']['three_pt_percentage'] === 0.400;
+                }),
+                $this->isArray(),
+                200,
+                $this->callback(function (array $headers): bool {
+                    return isset($headers['ETag'])
+                        && $headers['Cache-Control'] === 'public, max-age=60';
+                })
+            );
+
+        $controller->handle(['uuid' => self::PLAYER_UUID], [], $responder);
+    }
+
+    public function testHandleReturns404ForUnknownUuid(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $controller = new PlayerDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(404, 'not_found', 'Player not found.');
+
+        $controller->handle(['uuid' => 'nonexistent-uuid'], [], $responder);
+    }
+
+    public function testHandleReturns304WhenETagMatches(): void
+    {
+        $this->mockDb->setMockData([$this->playerRow()]);
+
+        $expectedTag = '"' . md5(self::UPDATED_AT) . '"';
+        $_SERVER['HTTP_IF_NONE_MATCH'] = $expectedTag;
+
+        $controller = new PlayerDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('notModified');
+
+        $controller->handle(['uuid' => self::PLAYER_UUID], [], $responder);
+    }
+
+    public function testHandlePassesCorrectETagInHeaders(): void
+    {
+        $this->mockDb->setMockData([$this->playerRow()]);
+
+        $expectedTag = '"' . md5(self::UPDATED_AT) . '"';
+
+        $controller = new PlayerDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->isArray(),
+                $this->isArray(),
+                200,
+                $this->callback(function (array $headers) use ($expectedTag): bool {
+                    return $headers['ETag'] === $expectedTag;
+                })
+            );
+
+        $controller->handle(['uuid' => self::PLAYER_UUID], [], $responder);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+        parent::tearDown();
+    }
+}

--- a/ibl5/tests/Api/Controller/PlayerExportControllerTest.php
+++ b/ibl5/tests/Api/Controller/PlayerExportControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\PlayerExportController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+class PlayerExportControllerTest extends WideUnitTestCase
+{
+    private function playerRow(int $pid, string $name, string $position): array
+    {
+        return [
+            'player_uuid' => 'uuid-' . $pid,
+            'pid' => $pid,
+            'name' => $name,
+            'nickname' => null,
+            'position' => $position,
+            'age' => 25,
+            'htft' => 6,
+            'htin' => 2,
+            'dc_can_play_in_game' => 1,
+            'retired' => 0,
+            'experience' => 5,
+            'bird_rights' => 1,
+            'teamid' => 14,
+            'team_uuid' => 'team-uuid-14',
+            'team_city' => 'Miami',
+            'team_name' => 'Heat',
+            'full_team_name' => 'Miami Heat',
+            'owner_name' => 'TestOwner',
+            'contract_year' => 2,
+            'current_salary' => 5000000,
+            'year1_salary' => 5000000,
+            'year2_salary' => 5500000,
+            'year3_salary' => 0,
+            'year4_salary' => 0,
+            'year5_salary' => 0,
+            'year6_salary' => 0,
+            'games_played' => 60,
+            'minutes_played' => 2100,
+            'field_goals_made' => 480,
+            'field_goals_attempted' => 1000,
+            'free_throws_made' => 150,
+            'free_throws_attempted' => 180,
+            'three_pointers_made' => 80,
+            'three_pointers_attempted' => 220,
+            'offensive_rebounds' => 50,
+            'defensive_rebounds' => 200,
+            'assists' => 300,
+            'steals' => 90,
+            'turnovers' => 110,
+            'blocks' => 30,
+            'personal_fouls' => 120,
+            'points_per_game' => 18.5,
+            'fg_percentage' => 0.480,
+            'ft_percentage' => 0.833,
+            'three_pt_percentage' => 0.364,
+            'updated_at' => '2026-03-01 00:00:00',
+        ];
+    }
+
+    public function testHandleProducesCSVOutput(): void
+    {
+        $this->mockDb->setMockData([
+            $this->playerRow(101, 'Alpha Player', 'PG'),
+        ]);
+
+        $controller = new PlayerExportController($this->mockDb);
+        $responder = $this->createStub(JsonResponder::class);
+
+        $output = $this->captureOutput(function () use ($controller, $responder): void {
+            $controller->handle([], [], $responder);
+        });
+
+        // Strip UTF-8 BOM if present
+        $output = ltrim($output, "\xEF\xBB\xBF");
+
+        $this->assertNotEmpty($output, 'CSV output should not be empty');
+        $this->assertStringContainsString(',', $output);
+    }
+
+    public function testHandleIncludesHeaderRow(): void
+    {
+        $this->mockDb->setMockData([
+            $this->playerRow(101, 'Alpha Player', 'PG'),
+        ]);
+
+        $controller = new PlayerExportController($this->mockDb);
+        $responder = $this->createStub(JsonResponder::class);
+
+        $output = $this->captureOutput(function () use ($controller, $responder): void {
+            $controller->handle([], [], $responder);
+        });
+
+        $output = ltrim($output, "\xEF\xBB\xBF");
+        $firstLine = strtok($output, "\n") ?: '';
+
+        // Verify key column headers from PlayerExportTransformer::HEADERS
+        $this->assertStringContainsString('PID', $firstLine);
+        $this->assertStringContainsString('Name', $firstLine);
+        $this->assertStringContainsString('Nickname', $firstLine);
+        $this->assertStringContainsString('Position', $firstLine);
+        $this->assertStringContainsString('GP', $firstLine);
+        $this->assertStringContainsString('PPG', $firstLine);
+    }
+
+    public function testHandleTransformsPlayerData(): void
+    {
+        $this->mockDb->setMockData([
+            $this->playerRow(201, 'Bravo Player', 'SG'),
+            $this->playerRow(202, 'Charlie Player', 'SF'),
+        ]);
+
+        $controller = new PlayerExportController($this->mockDb);
+        $responder = $this->createStub(JsonResponder::class);
+
+        $output = $this->captureOutput(function () use ($controller, $responder): void {
+            $controller->handle([], [], $responder);
+        });
+
+        $output = ltrim($output, "\xEF\xBB\xBF");
+
+        // Both players' names must appear
+        $this->assertStringContainsString('Bravo Player', $output);
+        $this->assertStringContainsString('Charlie Player', $output);
+
+        // PIDs must appear
+        $this->assertStringContainsString('201', $output);
+        $this->assertStringContainsString('202', $output);
+
+        // Positions must appear
+        $this->assertStringContainsString('SG', $output);
+        $this->assertStringContainsString('SF', $output);
+
+        // Output must have at least 3 lines: header + 2 player rows
+        $lines = array_filter(explode("\n", trim($output)));
+        $this->assertGreaterThanOrEqual(3, count($lines));
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}

--- a/ibl5/tests/Api/Controller/PlayerHistoryControllerTest.php
+++ b/ibl5/tests/Api/Controller/PlayerHistoryControllerTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\PlayerHistoryController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+class PlayerHistoryControllerTest extends WideUnitTestCase
+{
+    private const PLAYER_UUID = 'player-uuid-hist789';
+    private const UPDATED_AT_1 = '2026-05-01 12:00:00';
+    private const UPDATED_AT_2 = '2025-05-01 12:00:00';
+
+    private function historyRow(int $year, string $updatedAt): array
+    {
+        return [
+            'player_uuid' => self::PLAYER_UUID,
+            'pid' => 77,
+            'name' => 'Jane Doe',
+            'year' => $year,
+            'teamid' => 5,
+            'team' => 'Cavaliers',
+            'team_uuid' => 'team-uuid-cavs',
+            'team_city' => 'Cleveland',
+            'team_name' => 'Cavaliers',
+            'games' => 70,
+            'minutes' => 2100,
+            'fgm' => 450,
+            'fga' => 900,
+            'ftm' => 160,
+            'fta' => 190,
+            'tgm' => 100,
+            'tga' => 250,
+            'orb' => 40,
+            'reb' => 200,
+            'ast' => 120,
+            'stl' => 80,
+            'blk' => 30,
+            'tvr' => 90,
+            'pf' => 170,
+            'pts' => 1260,
+            'salary' => 4500000,
+            'updated_at' => $updatedAt,
+        ];
+    }
+
+    private function twoHistoryRows(): array
+    {
+        return [
+            $this->historyRow(2026, self::UPDATED_AT_1),
+            $this->historyRow(2025, self::UPDATED_AT_2),
+        ];
+    }
+
+    public function testHandleReturnsSeasonHistoryForValidUuid(): void
+    {
+        $this->mockDb->setMockData($this->twoHistoryRows());
+
+        $controller = new PlayerHistoryController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    if (count($data) !== 2) {
+                        return false;
+                    }
+                    $first = $data[0];
+                    return $first['year'] === 2026
+                        && $first['pid'] === 77
+                        && $first['player_name'] === 'Jane Doe'
+                        && $first['team']['uuid'] === 'team-uuid-cavs'
+                        && $first['team']['city'] === 'Cleveland'
+                        && $first['team']['name'] === 'Cavaliers'
+                        && $first['team']['team_id'] === 5
+                        && $first['games'] === 70
+                        && $first['minutes'] === 2100
+                        && isset($first['stats'])
+                        && $first['stats']['fg_made'] === 450
+                        && $first['stats']['fg_attempted'] === 900
+                        && $first['stats']['ft_made'] === 160
+                        && $first['stats']['ft_attempted'] === 190
+                        && $first['stats']['three_pt_made'] === 100
+                        && $first['stats']['three_pt_attempted'] === 250
+                        && $first['stats']['offensive_rebounds'] === 40
+                        && $first['stats']['rebounds'] === 200
+                        && $first['stats']['assists'] === 120
+                        && $first['stats']['steals'] === 80
+                        && $first['stats']['blocks'] === 30
+                        && $first['stats']['turnovers'] === 90
+                        && $first['stats']['personal_fouls'] === 170
+                        && $first['salary'] === 4500000;
+                }),
+                $this->callback(function (array $meta): bool {
+                    return $meta['total'] === 2;
+                }),
+                200,
+                $this->callback(function (array $headers): bool {
+                    return isset($headers['ETag'])
+                        && $headers['Cache-Control'] === 'public, max-age=60';
+                })
+            );
+
+        $controller->handle(['uuid' => self::PLAYER_UUID], [], $responder);
+    }
+
+    public function testHandleReturns404WhenNoHistory(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $controller = new PlayerHistoryController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(404, 'not_found', 'Player not found or has no history.');
+
+        $controller->handle(['uuid' => 'nonexistent-uuid'], [], $responder);
+    }
+
+    public function testHandleReturns304WhenETagMatches(): void
+    {
+        $rows = $this->twoHistoryRows();
+        $this->mockDb->setMockData($rows);
+
+        $concatenated = self::UPDATED_AT_1 . self::UPDATED_AT_2;
+        $expectedTag = '"' . md5($concatenated) . '"';
+        $_SERVER['HTTP_IF_NONE_MATCH'] = $expectedTag;
+
+        $controller = new PlayerHistoryController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('notModified');
+
+        $controller->handle(['uuid' => self::PLAYER_UUID], [], $responder);
+    }
+
+    public function testHandlePassesCorrectTotalInMeta(): void
+    {
+        $this->mockDb->setMockData($this->twoHistoryRows());
+
+        $controller = new PlayerHistoryController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->isArray(),
+                $this->callback(function (array $meta): bool {
+                    return $meta['total'] === 2;
+                }),
+                200,
+                $this->isArray()
+            );
+
+        $controller->handle(['uuid' => self::PLAYER_UUID], [], $responder);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+        parent::tearDown();
+    }
+}

--- a/ibl5/tests/Api/Controller/PlayerListControllerTest.php
+++ b/ibl5/tests/Api/Controller/PlayerListControllerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\PlayerListController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+class PlayerListControllerTest extends WideUnitTestCase
+{
+    private const PLAYER_UUID = 'player-uuid-001';
+    private const TEAM_UUID = 'team-uuid-001';
+    private const UPDATED_AT = '2026-01-15 12:00:00';
+
+    private function playerRow(): array
+    {
+        return [
+            'player_uuid' => self::PLAYER_UUID,
+            'pid' => 1001,
+            'name' => 'LeBron James',
+            'nickname' => null,
+            'position' => 'SF',
+            'age' => 38,
+            'htft' => 6,
+            'htin' => 9,
+            'dc_can_play_in_game' => 1,
+            'retired' => 0,
+            'experience' => 20,
+            'bird_rights' => 1,
+            'teamid' => 5,
+            'team_uuid' => self::TEAM_UUID,
+            'team_city' => 'Los Angeles',
+            'team_name' => 'Lakers',
+            'full_team_name' => 'Los Angeles Lakers',
+            'owner_name' => 'TestOwner',
+            'contract_year' => 1,
+            'current_salary' => 45000000,
+            'year1_salary' => 45000000,
+            'year2_salary' => 47000000,
+            'year3_salary' => 0,
+            'year4_salary' => 0,
+            'year5_salary' => 0,
+            'year6_salary' => 0,
+            'games_played' => 55,
+            'minutes_played' => 1800,
+            'field_goals_made' => 400,
+            'field_goals_attempted' => 800,
+            'free_throws_made' => 200,
+            'free_throws_attempted' => 250,
+            'three_pointers_made' => 80,
+            'three_pointers_attempted' => 200,
+            'offensive_rebounds' => 60,
+            'defensive_rebounds' => 400,
+            'assists' => 600,
+            'steals' => 90,
+            'turnovers' => 150,
+            'blocks' => 30,
+            'personal_fouls' => 100,
+            'points_per_game' => 27.5,
+            'fg_percentage' => 0.5,
+            'ft_percentage' => 0.8,
+            'three_pt_percentage' => 0.4,
+            'updated_at' => self::UPDATED_AT,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+        parent::tearDown();
+    }
+
+    public function testHandleReturnsPlayerList(): void
+    {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 1]]);
+        $this->mockDb->setMockData([$this->playerRow()]);
+
+        $controller = new PlayerListController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    if (count($data) !== 1) {
+                        return false;
+                    }
+                    $first = $data[0];
+                    return $first['uuid'] === self::PLAYER_UUID
+                        && $first['pid'] === 1001
+                        && $first['name'] === 'LeBron James'
+                        && $first['position'] === 'SF'
+                        && $first['age'] === 38
+                        && $first['height'] === '6-9'
+                        && $first['experience'] === 20
+                        && $first['team']['uuid'] === self::TEAM_UUID
+                        && $first['team']['city'] === 'Los Angeles'
+                        && $first['team']['name'] === 'Lakers'
+                        && $first['contract']['current_salary'] === 45000000
+                        && $first['stats']['games_played'] === 55
+                        && $first['stats']['points_per_game'] === 27.5;
+                }),
+                $this->isArray(),
+                200,
+                $this->isArray()
+            );
+
+        $controller->handle([], [], $responder);
+    }
+
+    public function testHandleAppliesPositionFilter(): void
+    {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 0]]);
+        $this->mockDb->setMockData([]);
+
+        $controller = new PlayerListController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success');
+
+        $controller->handle([], ['position' => 'SF'], $responder);
+
+        $this->assertQueryExecuted('position =');
+    }
+
+    public function testHandleAppliesTeamFilter(): void
+    {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 0]]);
+        $this->mockDb->setMockData([]);
+
+        $controller = new PlayerListController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success');
+
+        $controller->handle([], ['team' => self::TEAM_UUID], $responder);
+
+        $this->assertQueryExecuted('team_uuid =');
+    }
+
+    public function testHandleAppliesSearchFilter(): void
+    {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 0]]);
+        $this->mockDb->setMockData([]);
+
+        $controller = new PlayerListController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success');
+
+        $controller->handle([], ['search' => 'LeBron'], $responder);
+
+        $this->assertQueryExecuted('LIKE');
+    }
+
+    public function testHandleReturns304WhenETagMatches(): void
+    {
+        $row = $this->playerRow();
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 1]]);
+        $this->mockDb->setMockData([$row]);
+
+        $expectedTag = '"' . md5($row['updated_at']) . '"';
+        $_SERVER['HTTP_IF_NONE_MATCH'] = $expectedTag;
+
+        $controller = new PlayerListController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('notModified');
+
+        $controller->handle([], [], $responder);
+    }
+}

--- a/ibl5/tests/Api/Controller/SeasonControllerTest.php
+++ b/ibl5/tests/Api/Controller/SeasonControllerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\SeasonController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+/**
+ * Tests for SeasonController.
+ *
+ * NOTE: The test environment aliases Season\Season → Tests\WideUnit\Mocks\Season,
+ * so the controller uses the mock Season with fixed properties:
+ *   - phase = 'Regular Season'
+ *   - lastSimNumber = 1
+ *   - lastSimStartDate = '2024-01-01'
+ *   - lastSimEndDate = '2024-01-02'
+ *   - projectedNextSimEndDate = '2024-01-10'
+ *   - getPhaseSpecificSimNumber() returns lastSimNumber (= 1)
+ */
+class SeasonControllerTest extends WideUnitTestCase
+{
+    // These constants mirror the mock Season's fixed properties
+    private const PHASE = 'Regular Season';
+    private const SIM_NUMBER = 1;
+    private const PHASE_SIM_NUMBER = 1;  // mock returns lastSimNumber
+    private const SIM_START_DATE = '2024-01-01';
+    private const SIM_END_DATE = '2024-01-02';
+    private const PROJECTED_NEXT_SIM_END_DATE = '2024-01-10';
+
+    /**
+     * Compute the expected ETag from the concatenated cache key.
+     *
+     * Mirrors SeasonController::handle():
+     * $cacheKey = $season->phase . $season->lastSimNumber . $phaseSimNumber
+     *           . $season->lastSimStartDate . $season->lastSimEndDate . $projectedNextSimEndDate;
+     */
+    private function expectedETag(): string
+    {
+        $cacheKey = self::PHASE
+            . self::SIM_NUMBER
+            . self::PHASE_SIM_NUMBER
+            . self::SIM_START_DATE
+            . self::SIM_END_DATE
+            . self::PROJECTED_NEXT_SIM_END_DATE;
+
+        return '"' . md5($cacheKey) . '"';
+    }
+
+    public function testHandleReturnsSeasonData(): void
+    {
+        $controller = new SeasonController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    return $data['phase'] === self::PHASE
+                        && $data['last_sim']['number'] === self::SIM_NUMBER
+                        && $data['last_sim']['phase_sim_number'] === self::PHASE_SIM_NUMBER
+                        && $data['last_sim']['start_date'] === self::SIM_START_DATE
+                        && $data['last_sim']['end_date'] === self::SIM_END_DATE
+                        && $data['projected_next_sim_end_date'] === self::PROJECTED_NEXT_SIM_END_DATE;
+                }),
+                $this->isArray(),
+                200,
+                $this->isArray()
+            );
+
+        $controller->handle([], [], $responder);
+    }
+
+    public function testHandleReturns304WhenETagMatches(): void
+    {
+        $_SERVER['HTTP_IF_NONE_MATCH'] = $this->expectedETag();
+
+        $controller = new SeasonController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('notModified');
+
+        $responder->expects($this->never())
+            ->method('success');
+
+        $controller->handle([], [], $responder);
+    }
+
+    public function testHandlePassesCorrectETagInHeaders(): void
+    {
+        $expectedTag = $this->expectedETag();
+
+        $controller = new SeasonController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->isArray(),
+                $this->isArray(),
+                200,
+                $this->callback(function (array $headers) use ($expectedTag): bool {
+                    return isset($headers['ETag'])
+                        && $headers['ETag'] === $expectedTag
+                        && $headers['Cache-Control'] === 'public, max-age=60';
+                })
+            );
+
+        $controller->handle([], [], $responder);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+        parent::tearDown();
+    }
+}

--- a/ibl5/tests/Api/Controller/TeamDetailControllerTest.php
+++ b/ibl5/tests/Api/Controller/TeamDetailControllerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\TeamDetailController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+class TeamDetailControllerTest extends WideUnitTestCase
+{
+    private const TEAM_UUID = 'team-uuid-abc';
+
+    private function teamRow(): array
+    {
+        return [
+            'teamid' => 1,
+            'uuid' => self::TEAM_UUID,
+            'team_city' => 'Boston',
+            'team_name' => 'Celtics',
+            'owner_name' => 'TestOwner',
+            'arena' => 'Test Arena',
+            'conference' => 'Eastern',
+            'division' => 'Atlantic',
+            'discord_id' => 12345,
+            'league_record' => '50-32',
+            'conference_record' => '30-20',
+            'division_record' => '12-4',
+            'home_wins' => 30,
+            'home_losses' => 11,
+            'away_wins' => 20,
+            'away_losses' => 21,
+            'win_percentage' => 0.61,
+            'conference_games_back' => '5.0',
+            'division_games_back' => '2.0',
+            'games_remaining' => 0,
+        ];
+    }
+
+    public function testHandleReturnsTeamDataForValidUuid(): void
+    {
+        $this->mockDb->setMockData([$this->teamRow()]);
+
+        $controller = new TeamDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    return $data['uuid'] === self::TEAM_UUID
+                        && $data['city'] === 'Boston'
+                        && $data['name'] === 'Celtics'
+                        && $data['full_name'] === 'Boston Celtics'
+                        && $data['owner'] === 'TestOwner'
+                        && $data['record']['league'] === '50-32'
+                        && $data['record']['home'] === '30-11'
+                        && $data['standings']['win_percentage'] === 0.61;
+                }),
+                $this->isArray(),
+                200,
+                $this->callback(function (array $headers): bool {
+                    return isset($headers['ETag'])
+                        && $headers['Cache-Control'] === 'public, max-age=60';
+                })
+            );
+
+        $controller->handle(['uuid' => self::TEAM_UUID], [], $responder);
+    }
+
+    public function testHandleReturns404ForUnknownUuid(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $controller = new TeamDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(404, 'not_found', 'Team not found.');
+
+        $controller->handle(['uuid' => 'nonexistent'], [], $responder);
+    }
+
+    public function testHandleReturns304WhenETagMatches(): void
+    {
+        $this->mockDb->setMockData([$this->teamRow()]);
+
+        $expectedTag = '"' . md5('team-' . self::TEAM_UUID) . '"';
+        $_SERVER['HTTP_IF_NONE_MATCH'] = $expectedTag;
+
+        $controller = new TeamDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('notModified');
+
+        $controller->handle(['uuid' => self::TEAM_UUID], [], $responder);
+    }
+
+    public function testHandlePassesCorrectETagInHeaders(): void
+    {
+        $this->mockDb->setMockData([$this->teamRow()]);
+
+        $expectedTag = '"' . md5('team-' . self::TEAM_UUID) . '"';
+
+        $controller = new TeamDetailController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->isArray(),
+                $this->isArray(),
+                200,
+                $this->callback(function (array $headers) use ($expectedTag): bool {
+                    return $headers['ETag'] === $expectedTag;
+                })
+            );
+
+        $controller->handle(['uuid' => self::TEAM_UUID], [], $responder);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+        parent::tearDown();
+    }
+}

--- a/ibl5/tests/Api/Controller/TeamListControllerTest.php
+++ b/ibl5/tests/Api/Controller/TeamListControllerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\TeamListController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+class TeamListControllerTest extends WideUnitTestCase
+{
+    private const UPDATED_AT = '2026-01-15 12:00:00';
+    private const TEAM_UUID = 'team-uuid-001';
+
+    private function teamRow(): array
+    {
+        return [
+            'teamid' => 1,
+            'uuid' => self::TEAM_UUID,
+            'team_city' => 'Boston',
+            'team_name' => 'Celtics',
+            'owner_name' => 'TestOwner',
+            'arena' => 'TD Garden',
+            'conference' => 'Eastern',
+            'division' => 'Atlantic',
+            'discord_id' => 12345,
+            'updated_at' => self::UPDATED_AT,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+        parent::tearDown();
+    }
+
+    public function testHandleReturnsTeamList(): void
+    {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 1]]);
+        $this->mockDb->setMockData([$this->teamRow()]);
+
+        $controller = new TeamListController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    if (count($data) !== 1) {
+                        return false;
+                    }
+                    $first = $data[0];
+                    return $first['uuid'] === self::TEAM_UUID
+                        && $first['city'] === 'Boston'
+                        && $first['name'] === 'Celtics'
+                        && $first['full_name'] === 'Boston Celtics'
+                        && $first['owner'] === 'TestOwner'
+                        && $first['arena'] === 'TD Garden'
+                        && $first['conference'] === 'Eastern'
+                        && $first['division'] === 'Atlantic';
+                }),
+                $this->isArray(),
+                200,
+                $this->isArray()
+            );
+
+        $controller->handle([], [], $responder);
+    }
+
+    public function testHandleReturns304WhenETagMatches(): void
+    {
+        $row = $this->teamRow();
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 1]]);
+        $this->mockDb->setMockData([$row]);
+
+        $expectedTag = '"' . md5($row['updated_at']) . '"';
+        $_SERVER['HTTP_IF_NONE_MATCH'] = $expectedTag;
+
+        $controller = new TeamListController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('notModified');
+
+        $controller->handle([], [], $responder);
+    }
+
+    public function testHandleDefaultSortIsTeamName(): void
+    {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 0]]);
+        $this->mockDb->setMockData([]);
+
+        $controller = new TeamListController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->isArray(),
+                $this->callback(function (array $meta): bool {
+                    return ($meta['sort'] ?? '') === 'team_name'
+                        && ($meta['order'] ?? '') === 'asc';
+                }),
+                200,
+                $this->isArray()
+            );
+
+        $controller->handle([], [], $responder);
+    }
+}

--- a/ibl5/tests/Api/Controller/TeamRosterControllerTest.php
+++ b/ibl5/tests/Api/Controller/TeamRosterControllerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\TeamRosterController;
+use Api\Response\JsonResponder;
+use Tests\WideUnit\WideUnitTestCase;
+
+class TeamRosterControllerTest extends WideUnitTestCase
+{
+    private const TEAM_UUID = 'team-uuid-abc';
+    private const PLAYER_UUID = 'player-uuid-001';
+    private const UPDATED_AT = '2026-01-15 12:00:00';
+
+    private function playerRow(): array
+    {
+        return [
+            'player_uuid' => self::PLAYER_UUID,
+            'pid' => 2001,
+            'name' => 'Stephen Curry',
+            'nickname' => null,
+            'position' => 'PG',
+            'age' => 35,
+            'htft' => 6,
+            'htin' => 2,
+            'dc_can_play_in_game' => 1,
+            'retired' => 0,
+            'experience' => 14,
+            'bird_rights' => 1,
+            'teamid' => 10,
+            'team_uuid' => self::TEAM_UUID,
+            'team_city' => 'Golden State',
+            'team_name' => 'Warriors',
+            'full_team_name' => 'Golden State Warriors',
+            'owner_name' => 'TestOwner2',
+            'contract_year' => 1,
+            'current_salary' => 50000000,
+            'year1_salary' => 50000000,
+            'year2_salary' => 52000000,
+            'year3_salary' => 0,
+            'year4_salary' => 0,
+            'year5_salary' => 0,
+            'year6_salary' => 0,
+            'games_played' => 60,
+            'minutes_played' => 2000,
+            'field_goals_made' => 430,
+            'field_goals_attempted' => 900,
+            'free_throws_made' => 180,
+            'free_throws_attempted' => 200,
+            'three_pointers_made' => 200,
+            'three_pointers_attempted' => 500,
+            'offensive_rebounds' => 30,
+            'defensive_rebounds' => 250,
+            'assists' => 450,
+            'steals' => 95,
+            'turnovers' => 200,
+            'blocks' => 10,
+            'personal_fouls' => 90,
+            'points_per_game' => 29.4,
+            'fg_percentage' => 0.478,
+            'ft_percentage' => 0.9,
+            'three_pt_percentage' => 0.4,
+            'updated_at' => self::UPDATED_AT,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_IF_NONE_MATCH']);
+        parent::tearDown();
+    }
+
+    public function testHandleReturnsRosterForValidTeam(): void
+    {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 1]]);
+        $this->mockDb->setMockData([$this->playerRow()]);
+
+        $controller = new TeamRosterController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(
+                $this->callback(function (array $data): bool {
+                    if (count($data) !== 1) {
+                        return false;
+                    }
+                    $first = $data[0];
+                    return $first['uuid'] === self::PLAYER_UUID
+                        && $first['pid'] === 2001
+                        && $first['name'] === 'Stephen Curry'
+                        && $first['position'] === 'PG'
+                        && $first['height'] === '6-2'
+                        && $first['team']['uuid'] === self::TEAM_UUID
+                        && $first['team']['name'] === 'Warriors'
+                        && $first['contract']['current_salary'] === 50000000
+                        && $first['stats']['games_played'] === 60
+                        && $first['stats']['points_per_game'] === 29.4;
+                }),
+                $this->isArray(),
+                200,
+                $this->isArray()
+            );
+
+        $controller->handle(['uuid' => self::TEAM_UUID], [], $responder);
+    }
+
+    public function testHandleReturns404WhenTeamHasNoPlayers(): void
+    {
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 0]]);
+
+        $controller = new TeamRosterController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(404, 'not_found', 'Team not found or has no players.');
+
+        $controller->handle(['uuid' => self::TEAM_UUID], [], $responder);
+    }
+
+    public function testHandleReturns304WhenETagMatches(): void
+    {
+        $row = $this->playerRow();
+        $this->mockDb->onQuery('SELECT COUNT', [['total' => 1]]);
+        $this->mockDb->setMockData([$row]);
+
+        $expectedTag = '"' . md5($row['updated_at']) . '"';
+        $_SERVER['HTTP_IF_NONE_MATCH'] = $expectedTag;
+
+        $controller = new TeamRosterController($this->mockDb);
+        $responder = $this->createMock(JsonResponder::class);
+
+        $responder->expects($this->once())
+            ->method('notModified');
+
+        $controller->handle(['uuid' => self::TEAM_UUID], [], $responder);
+    }
+}

--- a/ibl5/tests/Player/PlayerPageControllerTest.php
+++ b/ibl5/tests/Player/PlayerPageControllerTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Player;
+
+use Player\PlayerPageController;
+use Player\PlayerPageType;
+use Repositories\Contracts\TeamIdentityRepositoryInterface;
+use Tests\WideUnit\WideUnitTestCase;
+
+class PlayerPageControllerTest extends WideUnitTestCase
+{
+    private TeamIdentityRepositoryInterface $stubRepo;
+    private PlayerPageController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stubRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->stubRepo->method('getTeamnameFromUsername')->willReturn('Heat');
+        $this->stubRepo->method('getTeamnameFromTeamID')->willReturn('Heat');
+
+        $this->seedInvariantQueries();
+        $this->controller = new PlayerPageController($this->mockDb, $this->stubRepo);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_GET['result']);
+        parent::tearDown();
+    }
+
+    private function seedInvariantQueries(): void
+    {
+        $playerRow = [
+            'pid' => 1, 'ordinal' => 1, 'name' => 'Test Player', 'nickname' => null,
+            'age' => 25, 'teamid' => 5, 'pos' => 'PG',
+            'r_fga' => 70, 'r_fgp' => 50, 'r_fta' => 60, 'r_ftp' => 80,
+            'r_3ga' => 40, 'r_3gp' => 35, 'r_orb' => 30, 'r_drb' => 50,
+            'r_ast' => 60, 'r_stl' => 50, 'r_tvr' => 40, 'r_blk' => 30,
+            'r_foul' => 40, 'oo' => 70, 'od' => 60, 'r_drive_off' => 65,
+            'dd' => 55, 'po' => 50, 'pd' => 45, 'r_trans_off' => 70,
+            'td' => 60, 'clutch' => 75, 'consistency' => 80,
+            'talent' => 85, 'skill' => 80, 'intangibles' => 70,
+            'loyalty' => 50, 'playing_time' => 60, 'winner' => 40,
+            'tradition' => 30, 'security' => 55,
+            'exp' => 3, 'bird' => 3, 'cy' => 2, 'cyt' => 4,
+            'salary_yr1' => 1000, 'salary_yr2' => 1100, 'salary_yr3' => 1200,
+            'salary_yr4' => 0, 'salary_yr5' => 0, 'salary_yr6' => 0,
+            'draftyear' => 2021, 'draftround' => 1, 'draftpickno' => 5,
+            'draftedby' => 'Heat', 'draftedbycurrentname' => 'Heat',
+            'college' => 'State U',
+            'htft' => 6, 'htin' => 3, 'wt' => 195,
+            'injured' => 0, 'retired' => 0, 'droptime' => 0,
+            'teamname' => 'Heat', 'color1' => 'CE1141', 'color2' => '000000',
+            'rookie_option_used' => 0, 'uuid' => 'test-uuid-123',
+            'gm_username' => 'testgm',
+        ];
+
+        $teamRow = [
+            'teamid' => 5, 'team_city' => 'Miami', 'team_name' => 'Heat',
+            'color1' => 'CE1141', 'color2' => '000000',
+            'arena' => 'Test Arena', 'capacity' => 19600,
+            'owner_name' => 'Owner', 'owner_email' => 'owner@test.com',
+            'discord_id' => null, 'used_extension_this_chunk' => 0,
+            'used_extension_this_season' => 0, 'has_mle' => 0, 'has_lle' => 0,
+            'league_record' => '30-20', 'uuid' => 'team-uuid-5',
+            'gm_username' => 'testgm',
+        ];
+
+        // Player::withPlayerID — matches the LEFT JOIN pattern
+        $this->mockDb->onQuery('team_name AS teamname', [$playerRow]);
+
+        // TeamColorHelper::getTeamColors — matches the color SELECT pattern
+        $this->mockDb->onQuery('SELECT color1, color2', [['color1' => 'CE1141', 'color2' => '000000']]);
+
+        // PlayerRepository::getAllStarWeekendCounts (SUM(CASE) query)
+        $this->mockDb->onQuery('SUM.*CASE.*ibl_awards', [['allStar' => 2, 'threePoint' => 1, 'dunkContest' => 0, 'rookieSoph' => 1]]);
+
+        // PlayerRepository::getAwards (individual award rows) — return empty for most tests
+        $this->mockDb->onQuery('ibl_awards.*WHERE name', []);
+
+        // Team::initialize — matches standings join pattern
+        $this->mockDb->onQuery('ibl_standings', [$teamRow]);
+
+        // PlayerStats::withPlayerID — matches the plain ibl_plr SELECT without JOIN
+        $this->mockDb->onQuery('SELECT \* FROM.*ibl_plr.*WHERE pid', [$this->playerStatsRow()]);
+
+        // Fallback: empty results for all other queries (box scores, hist, etc.)
+        $this->mockDb->setMockData([]);
+    }
+
+    private function playerStatsRow(): array
+    {
+        return [
+            'pid' => 1, 'name' => 'Test Player', 'pos' => 'PG', 'retired' => 0,
+            'stats_gs' => 50, 'stats_gm' => 55, 'stats_min' => 1500,
+            'stats_fgm' => 400, 'stats_fga' => 800,
+            'stats_ftm' => 200, 'stats_fta' => 250,
+            'stats_3gm' => 100, 'stats_3ga' => 280,
+            'stats_orb' => 50, 'stats_drb' => 150,
+            'stats_ast' => 300, 'stats_stl' => 80,
+            'stats_tvr' => 120, 'stats_blk' => 40, 'stats_pf' => 130,
+            'sh_pts' => 42, 'sh_reb' => 15, 'sh_ast' => 18,
+            'sh_stl' => 6, 'sh_blk' => 5,
+            's_dd' => 20, 's_td' => 5,
+            'sp_pts' => 38, 'sp_reb' => 12, 'sp_ast' => 14,
+            'sp_stl' => 4, 'sp_blk' => 3,
+            'ch_pts' => 50, 'ch_reb' => 18, 'ch_ast' => 20,
+            'ch_stl' => 8, 'ch_blk' => 7,
+            'c_dd' => 80, 'c_td' => 18,
+            'cp_pts' => 45, 'cp_reb' => 16, 'cp_ast' => 18,
+            'cp_stl' => 6, 'cp_blk' => 5,
+            'car_gm' => 300, 'car_min' => 9000,
+            'car_fgm' => 2000, 'car_fga' => 4200,
+            'car_ftm' => 1000, 'car_fta' => 1250,
+            'car_3gm' => 500, 'car_3ga' => 1400,
+            'car_orb' => 300, 'car_drb' => 700, 'car_reb' => 1000,
+            'car_ast' => 1800, 'car_stl' => 400,
+            'car_tvr' => 600, 'car_blk' => 200, 'car_pf' => 600,
+        ];
+    }
+
+    public function testRenderPageReturnsHtmlForActivePlayer(): void
+    {
+        $html = $this->controller->renderPage(1, null, 'testuser');
+
+        $this->assertStringContainsString('Test Player', $html);
+        $this->assertStringContainsString('card-flip-container', $html);
+    }
+
+    public function testRenderPageOverviewForRetiredPlayer(): void
+    {
+        $retiredRow = array_merge($this->playerStatsRow(), ['retired' => 1]);
+        $playerWithRetired = [
+            'pid' => 1, 'ordinal' => 1, 'name' => 'Retired Player', 'nickname' => null,
+            'age' => 40, 'teamid' => 0, 'pos' => 'SG',
+            'r_fga' => 70, 'r_fgp' => 50, 'r_fta' => 60, 'r_ftp' => 80,
+            'r_3ga' => 40, 'r_3gp' => 35, 'r_orb' => 30, 'r_drb' => 50,
+            'r_ast' => 60, 'r_stl' => 50, 'r_tvr' => 40, 'r_blk' => 30,
+            'r_foul' => 40, 'oo' => 70, 'od' => 60, 'r_drive_off' => 65,
+            'dd' => 55, 'po' => 50, 'pd' => 45, 'r_trans_off' => 70,
+            'td' => 60, 'clutch' => 75, 'consistency' => 80,
+            'talent' => 85, 'skill' => 80, 'intangibles' => 70,
+            'loyalty' => 50, 'playing_time' => 60, 'winner' => 40,
+            'tradition' => 30, 'security' => 55,
+            'exp' => 15, 'bird' => 0, 'cy' => 0, 'cyt' => 0,
+            'salary_yr1' => 0, 'salary_yr2' => 0, 'salary_yr3' => 0,
+            'salary_yr4' => 0, 'salary_yr5' => 0, 'salary_yr6' => 0,
+            'draftyear' => 2010, 'draftround' => 1, 'draftpickno' => 3,
+            'draftedby' => 'Heat', 'draftedbycurrentname' => 'Heat',
+            'college' => 'U of Test',
+            'htft' => 6, 'htin' => 5, 'wt' => 210,
+            'injured' => 0, 'retired' => 1, 'droptime' => 0,
+            'teamname' => 'Free Agents', 'color1' => 'D4AF37', 'color2' => '1e3a5f',
+            'rookie_option_used' => 0, 'uuid' => 'retired-uuid',
+            'gm_username' => '',
+        ];
+
+        $histRow = [
+            'pid' => 1, 'year' => 2020, 'teamid' => 5, 'team' => 'Heat',
+            'games' => 55, 'minutes' => 1500,
+            'fgm' => 400, 'fga' => 800, 'ftm' => 200, 'fta' => 250,
+            'tgm' => 100, 'tga' => 280,
+            'orb' => 50, 'reb' => 200, 'ast' => 300, 'stl' => 80,
+            'tvr' => 120, 'blk' => 40, 'pf' => 130, 'pts' => 1100,
+            'salary' => 1000,
+        ];
+
+        // Reset mock and re-seed with retired player
+        $this->mockDb = new \Tests\WideUnit\Mocks\MockDatabase();
+        $this->injectGlobalMockDb();
+        $this->mockDb->onQuery('team_name AS teamname', [$playerWithRetired]);
+        $this->mockDb->onQuery('SELECT color1, color2', [['color1' => 'D4AF37', 'color2' => '1e3a5f']]);
+        $this->mockDb->onQuery('SUM.*CASE.*ibl_awards', [['allStar' => 0, 'threePoint' => 0, 'dunkContest' => 0, 'rookieSoph' => 0]]);
+        $this->mockDb->onQuery('ibl_awards.*WHERE name', []);
+        $this->mockDb->onQuery('ibl_standings', [[
+            'teamid' => 0, 'team_city' => '', 'team_name' => 'Free Agents',
+            'color1' => 'D4AF37', 'color2' => '1e3a5f',
+            'arena' => '', 'capacity' => 0,
+            'owner_name' => '', 'owner_email' => '',
+            'discord_id' => null, 'used_extension_this_chunk' => 0,
+            'used_extension_this_season' => 0, 'has_mle' => 0, 'has_lle' => 0,
+            'league_record' => '0-0', 'uuid' => 'fa-uuid',
+            'gm_username' => '',
+        ]]);
+        $this->mockDb->onQuery('ibl_hist', [$histRow]);
+        $this->mockDb->setMockData([$retiredRow]);
+
+        $this->stubRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->stubRepo->method('getTeamnameFromUsername')->willReturn('Free Agents');
+
+        $controller = new PlayerPageController($this->mockDb, $this->stubRepo);
+        $html = $controller->renderPage(1, null, 'nobody');
+
+        $this->assertStringContainsString('Retired Player', $html);
+        $this->assertStringContainsString('card-flip-container', $html);
+    }
+
+    public function testRenderPageSimStats(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::SIM_STATS, 'testuser');
+
+        $this->assertStringContainsString('Test Player', $html);
+    }
+
+    public function testRenderPageRegularSeasonAverages(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::REGULAR_SEASON_AVERAGES, 'testuser');
+
+        $this->assertStringContainsString('card-flip-container', $html);
+        $this->assertStringContainsString('Regular Season', $html);
+    }
+
+    public function testRenderPageRegularSeasonTotals(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::REGULAR_SEASON_TOTALS, 'testuser');
+
+        $this->assertStringContainsString('Regular Season', $html);
+    }
+
+    public function testRenderPagePlayoffAverages(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::PLAYOFF_AVERAGES, 'testuser');
+
+        $this->assertStringContainsString('Playoffs', $html);
+    }
+
+    public function testRenderPagePlayoffTotals(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::PLAYOFF_TOTALS, 'testuser');
+
+        $this->assertStringContainsString('Playoffs', $html);
+    }
+
+    public function testRenderPageHeatAverages(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::HEAT_AVERAGES, 'testuser');
+
+        $this->assertStringContainsString('H.E.A.T.', $html);
+    }
+
+    public function testRenderPageHeatTotals(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::HEAT_TOTALS, 'testuser');
+
+        $this->assertStringContainsString('H.E.A.T.', $html);
+    }
+
+    public function testRenderPageOlympicAverages(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::OLYMPIC_AVERAGES, 'testuser');
+
+        $this->assertStringContainsString('Olympics', $html);
+    }
+
+    public function testRenderPageOlympicTotals(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::OLYMPIC_TOTALS, 'testuser');
+
+        $this->assertStringContainsString('Olympics', $html);
+    }
+
+    public function testRenderPageRatingsAndSalary(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::RATINGS_AND_SALARY, 'testuser');
+
+        $this->assertStringContainsString('Test Player', $html);
+    }
+
+    public function testRenderPageAwardsAndNews(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::AWARDS_AND_NEWS, 'testuser');
+
+        $this->assertStringContainsString('Test Player', $html);
+    }
+
+    public function testRenderPageOneOnOne(): void
+    {
+        $html = $this->controller->renderPage(1, PlayerPageType::ONE_ON_ONE, 'testuser');
+
+        $this->assertStringContainsString('Test Player', $html);
+    }
+
+    public function testRenderPageDefaultFallback(): void
+    {
+        // Using PlayerPageType::OVERVIEW (null) explicitly
+        $html = $this->controller->renderPage(1, PlayerPageType::OVERVIEW, 'testuser');
+
+        $this->assertStringContainsString('Test Player', $html);
+        $this->assertStringContainsString('Game Log', $html);
+    }
+
+    public function testRenderPageShowsResultBanner(): void
+    {
+        $_GET['result'] = 'rookie_option_success';
+        $html = $this->controller->renderPage(1, null, 'testuser');
+
+        $this->assertStringContainsString('Rookie option has been exercised successfully', $html);
+    }
+}

--- a/ibl5/tests/Updater/UpdaterControllerTest.php
+++ b/ibl5/tests/Updater/UpdaterControllerTest.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Updater;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\PipelineStepInterface;
+use Updater\Contracts\UpdaterViewInterface;
+use Updater\StepResult;
+use Updater\UpdaterController;
+use Updater\UpdaterService;
+
+class UpdaterControllerTest extends TestCase
+{
+    private UpdaterService $stubService;
+    private UpdaterViewInterface $stubView;
+
+    protected function setUp(): void
+    {
+        $this->stubService = $this->createStub(UpdaterService::class);
+        $this->stubView = $this->createStub(UpdaterViewInterface::class);
+
+        $this->stubService->method('getSuccessCount')->willReturn(0);
+        $this->stubService->method('getErrorCount')->willReturn(0);
+
+        $this->stubView->method('renderSectionOpen')->willReturn('<section>');
+        $this->stubView->method('renderSectionClose')->willReturn('</section>');
+        $this->stubView->method('renderSummary')->willReturn('<summary>');
+        $this->stubView->method('renderStepStart')->willReturn('<start>');
+        $this->stubView->method('renderStepComplete')->willReturn('<complete>');
+        $this->stubView->method('renderStepError')->willReturn('<error>');
+    }
+
+    public function testRunOutputsSectionOpenAndClose(): void
+    {
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->expects($this->once())->method('renderSectionOpen')->with('Pipeline')->willReturn('<section>');
+        $mockView->expects($this->once())->method('renderSectionClose')->willReturn('</section>');
+        $mockView->method('renderSummary')->willReturn('<summary>');
+
+        $controller = new UpdaterController($this->stubService, $mockView);
+
+        $output = $this->captureOutput(fn () => $controller->run());
+
+        $this->assertStringContainsString('<section>', $output);
+        $this->assertStringContainsString('</section>', $output);
+    }
+
+    public function testRunOutputsSummary(): void
+    {
+        $mockService = $this->createStub(UpdaterService::class);
+        $mockService->method('getSuccessCount')->willReturn(5);
+        $mockService->method('getErrorCount')->willReturn(2);
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->expects($this->once())
+            ->method('renderSummary')
+            ->with(5, 2)
+            ->willReturn('<summary:5:2>');
+
+        $controller = new UpdaterController($mockService, $mockView);
+
+        $output = $this->captureOutput(fn () => $controller->run());
+
+        $this->assertStringContainsString('<summary:5:2>', $output);
+    }
+
+    #[DataProvider('stepProgressLabelProvider')]
+    public function testGetStepProgressLabelMapsKnownLabels(string $stepLabel, string $expectedProgress): void
+    {
+        $step = $this->createStub(PipelineStepInterface::class);
+        $step->method('getLabel')->willReturn($stepLabel);
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->method('renderSummary')->willReturn('');
+        $mockView->method('renderStepComplete')->willReturn('');
+
+        $mockView->expects($this->once())
+            ->method('renderStepStart')
+            ->with($expectedProgress)
+            ->willReturn('<start>');
+
+        $mockService = $this->createStub(UpdaterService::class);
+        $mockService->method('getSuccessCount')->willReturn(0);
+        $mockService->method('getErrorCount')->willReturn(0);
+        $mockService->method('run')->willReturnCallback(
+            function (callable $onStart, callable $onComplete) use ($step): array {
+                $onStart($step);
+                $onComplete(StepResult::success($step->getLabel()));
+                return [];
+            }
+        );
+
+        $controller = new UpdaterController($mockService, $mockView);
+        $this->captureOutput(fn () => $controller->run());
+    }
+
+    public static function stepProgressLabelProvider(): array
+    {
+        return [
+            'backup' => ['Backup extracted', 'Extracting files from backup archive...'],
+            'league config' => ['League config', 'Importing league config (.lge)...'],
+            'player file' => ['Player file', 'Parsing player file (.plr)...'],
+            'preseason' => ['Preseason data cleaned', 'Cleaning preseason data...'],
+            'schedule' => ['Schedule updated', 'Updating schedule...'],
+            'standings' => ['Standings updated', 'Updating standings...'],
+            'power rankings' => ['Power rankings updated', 'Updating power rankings...'],
+            'extensions' => ['Extension attempts reset', 'Resetting extension attempts...'],
+            'depth charts' => ['Saved depth charts updated', 'Updating saved depth charts...'],
+            'boxscores' => ['Boxscores processed', 'Processing boxscores (.sco)...'],
+            'all-star' => ['All-Star games processed', 'Processing All-Star games...'],
+            'jsb' => ['JSB files parsed', 'Parsing JSB engine files...'],
+            'end-of-season' => ['End-of-season imports', 'Running end-of-season imports (.dra, .ret, .hof, .awa)...'],
+            'snapshot' => ['Player snapshot', 'Snapshotting player stats...'],
+            'hist' => ['ibl_hist refreshed', 'Refreshing historical stats table...'],
+            'default fallback' => ['Unknown step', 'Unknown step...'],
+        ];
+    }
+
+    public function testRenderStepResultSuccess(): void
+    {
+        $result = StepResult::success('Test step', 'detail text');
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->method('renderSummary')->willReturn('');
+        $mockView->method('renderStepStart')->willReturn('');
+        $mockView->expects($this->once())
+            ->method('renderStepComplete')
+            ->with('Test step', 'detail text')
+            ->willReturn('<done>');
+
+        $service = $this->createStub(UpdaterService::class);
+        $service->method('getSuccessCount')->willReturn(0);
+        $service->method('getErrorCount')->willReturn(0);
+        $service->method('run')->willReturnCallback(
+            function (callable $onStart, callable $onComplete) use ($result): array {
+                $step = $this->createStub(PipelineStepInterface::class);
+                $step->method('getLabel')->willReturn('Test step');
+                $onStart($step);
+                $onComplete($result);
+                return [];
+            }
+        );
+
+        $controller = new UpdaterController($service, $mockView);
+        $output = $this->captureOutput(fn () => $controller->run());
+        $this->assertStringContainsString('<done>', $output);
+    }
+
+    public function testRenderStepResultFailure(): void
+    {
+        $result = StepResult::failure('Failed step', 'Something broke');
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->method('renderSummary')->willReturn('');
+        $mockView->method('renderStepStart')->willReturn('');
+        $mockView->expects($this->once())
+            ->method('renderStepError')
+            ->with('Failed step', 'Something broke')
+            ->willReturn('<error>');
+
+        $service = $this->createStub(UpdaterService::class);
+        $service->method('getSuccessCount')->willReturn(0);
+        $service->method('getErrorCount')->willReturn(0);
+        $service->method('run')->willReturnCallback(
+            function (callable $onStart, callable $onComplete) use ($result): array {
+                $step = $this->createStub(PipelineStepInterface::class);
+                $step->method('getLabel')->willReturn('Failed step');
+                $onStart($step);
+                $onComplete($result);
+                return [];
+            }
+        );
+
+        $controller = new UpdaterController($service, $mockView);
+        $output = $this->captureOutput(fn () => $controller->run());
+        $this->assertStringContainsString('<error>', $output);
+    }
+
+    public function testRenderStepResultWithInlineHtml(): void
+    {
+        $result = StepResult::success('Step', inlineHtml: '<div>inline</div>');
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->method('renderSummary')->willReturn('');
+        $mockView->method('renderStepStart')->willReturn('');
+        $mockView->method('renderStepComplete')->willReturn('');
+        $mockView->expects($this->once())
+            ->method('renderInlineHtml')
+            ->with('<div>inline</div>')
+            ->willReturn('<inline>');
+        $mockView->expects($this->never())->method('renderCollapsibleLog');
+
+        $service = $this->stubServiceWithResult($result);
+
+        $controller = new UpdaterController($service, $mockView);
+        $output = $this->captureOutput(fn () => $controller->run());
+        $this->assertStringContainsString('<inline>', $output);
+    }
+
+    public function testRenderStepResultWithCollapsibleLog(): void
+    {
+        $result = StepResult::success('Step', inlineHtml: '<div>log</div>', collapsibleLog: true);
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->method('renderSummary')->willReturn('');
+        $mockView->method('renderStepStart')->willReturn('');
+        $mockView->method('renderStepComplete')->willReturn('');
+        $mockView->expects($this->once())
+            ->method('renderCollapsibleLog')
+            ->with('<div>log</div>')
+            ->willReturn('<collapsible>');
+        $mockView->expects($this->never())->method('renderInlineHtml');
+
+        $service = $this->stubServiceWithResult($result);
+
+        $controller = new UpdaterController($service, $mockView);
+        $output = $this->captureOutput(fn () => $controller->run());
+        $this->assertStringContainsString('<collapsible>', $output);
+    }
+
+    public function testRenderStepResultWithCapturedLog(): void
+    {
+        $result = StepResult::success('Step', capturedLog: 'log output');
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->method('renderSummary')->willReturn('');
+        $mockView->method('renderStepStart')->willReturn('');
+        $mockView->method('renderStepComplete')->willReturn('');
+        $mockView->expects($this->once())
+            ->method('renderLog')
+            ->with('log output')
+            ->willReturn('<log>');
+
+        $service = $this->stubServiceWithResult($result);
+
+        $controller = new UpdaterController($service, $mockView);
+        $output = $this->captureOutput(fn () => $controller->run());
+        $this->assertStringContainsString('<log>', $output);
+    }
+
+    public function testRenderStepResultWithCapturedLogCollapsible(): void
+    {
+        $result = StepResult::success('Step', capturedLog: 'log output', collapsibleLog: true);
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->method('renderSummary')->willReturn('');
+        $mockView->method('renderStepStart')->willReturn('');
+        $mockView->method('renderStepComplete')->willReturn('');
+        $mockView->expects($this->once())
+            ->method('renderCollapsibleLog')
+            ->with('log output')
+            ->willReturn('<collapsible-log>');
+        $mockView->expects($this->never())->method('renderLog');
+
+        $service = $this->stubServiceWithResult($result);
+
+        $controller = new UpdaterController($service, $mockView);
+        $output = $this->captureOutput(fn () => $controller->run());
+        $this->assertStringContainsString('<collapsible-log>', $output);
+    }
+
+    public function testRenderStepResultWithMessages(): void
+    {
+        $result = StepResult::success('Step', messages: ['msg1', 'msg2'], messageErrorCount: 1);
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->method('renderSummary')->willReturn('');
+        $mockView->method('renderStepStart')->willReturn('');
+        $mockView->method('renderStepComplete')->willReturn('');
+        $mockView->expects($this->once())
+            ->method('renderMessageLog')
+            ->with(['msg1', 'msg2'], 1)
+            ->willReturn('<messages>');
+
+        $service = $this->stubServiceWithResult($result);
+
+        $controller = new UpdaterController($service, $mockView);
+        $output = $this->captureOutput(fn () => $controller->run());
+        $this->assertStringContainsString('<messages>', $output);
+    }
+
+    public function testRenderStepResultWithMessageErrorCountOnly(): void
+    {
+        $result = StepResult::success('Step', messages: [], messageErrorCount: 3);
+
+        $mockView = $this->createMock(UpdaterViewInterface::class);
+        $mockView->method('renderSectionOpen')->willReturn('');
+        $mockView->method('renderSectionClose')->willReturn('');
+        $mockView->method('renderSummary')->willReturn('');
+        $mockView->method('renderStepStart')->willReturn('');
+        $mockView->method('renderStepComplete')->willReturn('');
+        $mockView->expects($this->once())
+            ->method('renderMessageLog')
+            ->with([], 3)
+            ->willReturn('<error-messages>');
+
+        $service = $this->stubServiceWithResult($result);
+
+        $controller = new UpdaterController($service, $mockView);
+        $output = $this->captureOutput(fn () => $controller->run());
+        $this->assertStringContainsString('<error-messages>', $output);
+    }
+
+    private function stubServiceWithResult(StepResult $result): UpdaterService
+    {
+        $service = $this->createStub(UpdaterService::class);
+        $service->method('getSuccessCount')->willReturn(0);
+        $service->method('getErrorCount')->willReturn(0);
+        $service->method('run')->willReturnCallback(
+            function (callable $onStart, callable $onComplete) use ($result): array {
+                $step = $this->createStub(PipelineStepInterface::class);
+                $step->method('getLabel')->willReturn($result->label);
+                $onStart($step);
+                $onComplete($result);
+                return [];
+            }
+        );
+        return $service;
+    }
+
+    private function captureOutput(callable $fn): string
+    {
+        ob_start();
+        try {
+            $fn();
+            return (string) ob_get_clean();
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Write tests for 12 controllers currently excluded from mutation testing, then remove them from `infection.json5`. After this PR, no controllers remain in the Pass 2 deferred list.

## Changes

- Added PHPUnit tests for all 12 previously-excluded controllers:
  - API detail controllers: TeamDetail, GameDetail, PlayerDetail, PlayerHistory
  - API list controllers: TeamList, PlayerList, TeamRoster
  - API special controllers: PlayerExport, Season, GameBoxscore
  - UpdaterController (26 tests covering all branches and 15 progress labels)
  - PlayerPageController (covers all 10+ page-view branches, active/retired paths)
- Removed all 12 controllers from `infection.json5` exclusion list
- Clarified ADR-0007 sleep requirement note

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.