### PR TITLE
Unlock Handlers and Repositories from Mutation Testing Exclusion

### DIFF
--- a/ibl5/classes/NextSim/NextSimTabApiHandler.php
+++ b/ibl5/classes/NextSim/NextSimTabApiHandler.php
@@ -27,15 +27,8 @@ class NextSimTabApiHandler
     {
         header('Content-Type: text/html; charset=utf-8');
 
-        $teamid = isset($_GET['teamid']) && is_string($_GET['teamid']) ? (int) $_GET['teamid'] : 0;
-
-        $position = 'PG';
-        if (isset($_GET['position']) && is_string($_GET['position'])) {
-            $rawPosition = $_GET['position'];
-            if (in_array($rawPosition, \JSB::PLAYER_POSITIONS, true)) {
-                $position = $rawPosition;
-            }
-        }
+        $teamid = self::extractValidatedTeamid($_GET);
+        $position = self::extractValidatedPosition($_GET);
 
         $season = new Season($this->db);
         $team = Team::initialize($this->db, $teamid);
@@ -58,5 +51,24 @@ class NextSimTabApiHandler
 
         $responder = new \Api\Response\HtmlResponder();
         $responder->html($view->renderTabbedPositionTable($games, $position, $team, $userStarters));
+    }
+
+    /** @param array<string, mixed> $params */
+    public static function extractValidatedTeamid(array $params): int
+    {
+        return isset($params['teamid']) && is_string($params['teamid']) ? (int) $params['teamid'] : 0;
+    }
+
+    /** @param array<string, mixed> $params */
+    public static function extractValidatedPosition(array $params): string
+    {
+        if (isset($params['position']) && is_string($params['position'])) {
+            $rawPosition = $params['position'];
+            if (in_array($rawPosition, \JSB::PLAYER_POSITIONS, true)) {
+                return $rawPosition;
+            }
+        }
+
+        return 'PG';
     }
 }

--- a/ibl5/classes/NextSim/NextSimTabApiHandler.php
+++ b/ibl5/classes/NextSim/NextSimTabApiHandler.php
@@ -53,13 +53,13 @@ class NextSimTabApiHandler
         $responder->html($view->renderTabbedPositionTable($games, $position, $team, $userStarters));
     }
 
-    /** @param array<string, mixed> $params */
+    /** @param array<mixed> $params */
     public static function extractValidatedTeamid(array $params): int
     {
         return isset($params['teamid']) && is_string($params['teamid']) ? (int) $params['teamid'] : 0;
     }
 
-    /** @param array<string, mixed> $params */
+    /** @param array<mixed> $params */
     public static function extractValidatedPosition(array $params): string
     {
         if (isset($params['position']) && is_string($params['position'])) {

--- a/ibl5/classes/Team/TeamApiHandler.php
+++ b/ibl5/classes/Team/TeamApiHandler.php
@@ -39,23 +39,9 @@ class TeamApiHandler
 
         $teamid = isset($_GET['teamid']) && is_string($_GET['teamid']) ? (int) $_GET['teamid'] : 0;
 
-        $display = 'ratings';
-        if (isset($_GET['display']) && is_string($_GET['display'])) {
-            $rawDisplay = $_GET['display'];
-            if (in_array($rawDisplay, self::VALID_DISPLAY_MODES, true)) {
-                $display = $rawDisplay;
-            }
-        }
+        $display = self::extractValidatedDisplay($_GET);
+        $yr = self::extractValidatedYr($_GET);
 
-        $yr = null;
-        if (isset($_GET['yr']) && is_string($_GET['yr']) && $_GET['yr'] !== '') {
-            $rawYr = $_GET['yr'];
-            if (preg_match('/^\d{4}(-\d{2})?$/', $rawYr) === 1) {
-                $yr = $rawYr;
-            }
-        }
-
-        // Validate split parameter when display=split
         $split = null;
         if ($display === 'split' && isset($_GET['split']) && is_string($_GET['split'])) {
             $splitRepo = new SplitStatsRepository($this->db);
@@ -69,17 +55,47 @@ class TeamApiHandler
             $display = 'ratings';
         }
 
-        // Emit HX-Push-Url so HTMX pushes the user-friendly URL
-        $pushUrl = 'modules.php?name=Team&op=team&teamid=' . $teamid . '&display=' . $display;
-        if ($split !== null) {
-            $pushUrl .= '&split=' . $split;
-        }
-        if ($yr !== null) {
-            $pushUrl .= '&yr=' . $yr;
-        }
-        header('HX-Push-Url: ' . $pushUrl);
+        header('HX-Push-Url: ' . self::buildPushUrl($teamid, $display, $split, $yr));
 
         $responder = new \Api\Response\HtmlResponder();
         $responder->html($this->tableService->getTableOutput($teamid, $yr, $display, $split));
+    }
+
+    /** @param array<string, mixed> $params */
+    public static function extractValidatedDisplay(array $params): string
+    {
+        if (isset($params['display']) && is_string($params['display'])) {
+            $raw = $params['display'];
+            if (in_array($raw, self::VALID_DISPLAY_MODES, true)) {
+                return $raw;
+            }
+        }
+
+        return 'ratings';
+    }
+
+    /** @param array<string, mixed> $params */
+    public static function extractValidatedYr(array $params): ?string
+    {
+        if (isset($params['yr']) && is_string($params['yr']) && $params['yr'] !== '') {
+            $raw = $params['yr'];
+            if (preg_match('/^\d{4}(-\d{2})?$/', $raw) === 1) {
+                return $raw;
+            }
+        }
+
+        return null;
+    }
+
+    public static function buildPushUrl(int $teamid, string $display, ?string $split, ?string $yr): string
+    {
+        $url = 'modules.php?name=Team&op=team&teamid=' . $teamid . '&display=' . $display;
+        if ($split !== null) {
+            $url .= '&split=' . $split;
+        }
+        if ($yr !== null) {
+            $url .= '&yr=' . $yr;
+        }
+        return $url;
     }
 }

--- a/ibl5/classes/Team/TeamApiHandler.php
+++ b/ibl5/classes/Team/TeamApiHandler.php
@@ -61,7 +61,7 @@ class TeamApiHandler
         $responder->html($this->tableService->getTableOutput($teamid, $yr, $display, $split));
     }
 
-    /** @param array<string, mixed> $params */
+    /** @param array<mixed> $params */
     public static function extractValidatedDisplay(array $params): string
     {
         if (isset($params['display']) && is_string($params['display'])) {
@@ -74,7 +74,7 @@ class TeamApiHandler
         return 'ratings';
     }
 
-    /** @param array<string, mixed> $params */
+    /** @param array<mixed> $params */
     public static function extractValidatedYr(array $params): ?string
     {
         if (isset($params['yr']) && is_string($params['yr']) && $params['yr'] !== '') {

--- a/ibl5/infection.json5
+++ b/ibl5/infection.json5
@@ -6,11 +6,6 @@
             "*/Contracts/*",
             "Bootstrap", "Database",
             "OneOnOneGame",
-            // Repositories without direct test coverage (Pass 2 — deferred)
-            "ApiKeys/ApiKeysRepository.php",
-            "BaseMysqliRepository.php",
-            "PlrParser/PlrBoxScoreRepository.php",
-            "Voting/VotingRepository.php",
             // Views without companion tests (Pass 2 — deferred)
             "Boxscore/BoxscoreView.php",
             "FreeAgency/FreeAgencyOfferView.php",
@@ -41,10 +36,7 @@
             "Player/Stats/Views/PlayerSimStatsView.php",
             "Player/Views/PlayerTradingCardBackView.php",
             "Player/Views/PlayerTradingCardFlipView.php",
-            "Player/Views/PlayerTradingCardFrontView.php",
-            // Handlers without direct test coverage (Pass 2 — deferred)
-            "NextSim/NextSimTabApiHandler.php",
-            "Team/TeamApiHandler.php"
+            "Player/Views/PlayerTradingCardFrontView.php"
         ]
     },
     "phpUnit": {

--- a/ibl5/tests/DatabaseIntegration/ApiKeysManagementRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/ApiKeysManagementRepositoryTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use ApiKeys\ApiKeysRepository;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('database')]
+class ApiKeysManagementRepositoryTest extends DatabaseTestCase
+{
+    private ApiKeysRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new ApiKeysRepository($this->db);
+    }
+
+    public function testFindByUserIdReturnsNullWhenNoKey(): void
+    {
+        $result = $this->repo->findByUserId(1);
+        self::assertNull($result);
+    }
+
+    public function testFindByUserIdReturnsKeyWhenExists(): void
+    {
+        $this->insertRow('ibl_api_keys', [
+            'user_id' => 1,
+            'key_hash' => str_repeat('a', 64),
+            'key_prefix' => 'ibl_test',
+            'owner_name' => 'testowner',
+            'permission_level' => 'public',
+            'rate_limit_tier' => 'standard',
+            'is_active' => 1,
+        ]);
+
+        $result = $this->repo->findByUserId(1);
+
+        self::assertNotNull($result);
+        self::assertSame('ibl_test', $result['key_prefix']);
+        self::assertSame('public', $result['permission_level']);
+        self::assertSame('standard', $result['rate_limit_tier']);
+        self::assertSame(1, $result['is_active']);
+        self::assertArrayHasKey('created_at', $result);
+        self::assertNull($result['last_used_at']);
+    }
+
+    public function testFindByUserIdReturnsLatestByCreatedAt(): void
+    {
+        $this->insertRow('ibl_api_keys', [
+            'user_id' => 1,
+            'key_hash' => str_repeat('a', 64),
+            'key_prefix' => 'ibl_old_',
+            'owner_name' => 'testowner',
+            'permission_level' => 'public',
+            'rate_limit_tier' => 'standard',
+            'is_active' => 0,
+            'created_at' => '2025-01-01 00:00:00',
+        ]);
+
+        $this->insertRow('ibl_api_keys', [
+            'user_id' => 1,
+            'key_hash' => str_repeat('b', 64),
+            'key_prefix' => 'ibl_new_',
+            'owner_name' => 'testowner',
+            'permission_level' => 'public',
+            'rate_limit_tier' => 'standard',
+            'is_active' => 1,
+            'created_at' => '2025-06-01 00:00:00',
+        ]);
+
+        $result = $this->repo->findByUserId(1);
+
+        self::assertNotNull($result);
+        self::assertSame('ibl_new_', $result['key_prefix']);
+    }
+
+    public function testCreateKeyInsertsRow(): void
+    {
+        $this->repo->createKey(1, str_repeat('c', 64), 'ibl_crea', 'creator');
+
+        $result = $this->repo->findByUserId(1);
+
+        self::assertNotNull($result);
+        self::assertSame('ibl_crea', $result['key_prefix']);
+        self::assertSame('public', $result['permission_level']);
+        self::assertSame('standard', $result['rate_limit_tier']);
+        self::assertSame(1, $result['is_active']);
+    }
+
+    public function testRevokeByUserIdDeactivatesActiveKey(): void
+    {
+        $this->insertRow('ibl_api_keys', [
+            'user_id' => 2,
+            'key_hash' => str_repeat('d', 64),
+            'key_prefix' => 'ibl_rev_',
+            'owner_name' => 'revoketest',
+            'permission_level' => 'public',
+            'rate_limit_tier' => 'standard',
+            'is_active' => 1,
+        ]);
+
+        $this->repo->revokeByUserId(2);
+
+        $result = $this->repo->findByUserId(2);
+        self::assertNotNull($result);
+        self::assertSame(0, $result['is_active']);
+    }
+
+    public function testRevokeByUserIdDoesNotAffectAlreadyInactiveKey(): void
+    {
+        $this->insertRow('ibl_api_keys', [
+            'user_id' => 1,
+            'key_hash' => str_repeat('e', 64),
+            'key_prefix' => 'ibl_ina_',
+            'owner_name' => 'inactivetest',
+            'permission_level' => 'public',
+            'rate_limit_tier' => 'standard',
+            'is_active' => 0,
+        ]);
+
+        $this->repo->revokeByUserId(1);
+
+        $result = $this->repo->findByUserId(1);
+        self::assertNotNull($result);
+        self::assertSame(0, $result['is_active']);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
@@ -1,0 +1,369 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use League\LeagueContext;
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Log\LoggerInterface;
+
+#[Group('database')]
+class BaseMysqliRepositoryTest extends DatabaseTestCase
+{
+    private TestableBaseMysqliRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new TestableBaseMysqliRepository($this->db);
+    }
+
+    // ==================== Constructor ====================
+
+    public function testConstructorThrowsOnInvalidConnection(): void
+    {
+        $badDb = new \mysqli();
+        try {
+            $badDb->real_connect('db', 'nonexistent_user_xyz', 'wrong', 'x');
+        } catch (\mysqli_sql_exception) {
+            // connect_errno is now set
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1002);
+
+        new TestableBaseMysqliRepository($badDb);
+    }
+
+    // ==================== resolveTable ====================
+
+    public function testResolveTableWithoutLeagueContext(): void
+    {
+        self::assertSame('ibl_standings', $this->repo->callResolveTable('ibl_standings'));
+    }
+
+    public function testResolveTableWithLeagueContext(): void
+    {
+        $context = $this->createStub(LeagueContext::class);
+        $context->method('getTableName')
+            ->willReturnCallback(static fn (string $table): string => str_replace('ibl_', 'ibl_olympics_', $table));
+
+        $repo = new TestableBaseMysqliRepository($this->db, $context);
+        self::assertSame('ibl_olympics_standings', $repo->callResolveTable('ibl_standings'));
+    }
+
+    // ==================== executeQuery errors ====================
+
+    public function testExecuteQueryThrowsOnTypeMismatch(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1001);
+
+        $this->repo->callExecuteQuery('SELECT 1', 'ii', 1);
+    }
+
+    public function testExecuteQueryThrowsOnPrepareFail(): void
+    {
+        $this->expectException(\Throwable::class);
+
+        $this->repo->callExecuteQuery('SELECT * FROM nonexistent_table_xyz', '');
+    }
+
+    public function testExecuteQueryThrowsOnExecuteFail(): void
+    {
+        $this->insertRow('ibl_team_info', [
+            'teamid' => 999,
+            'team_city' => 'Test',
+            'team_name' => 'Testers',
+        ]);
+
+        $this->expectException(\Throwable::class);
+
+        $this->repo->callExecute(
+            "INSERT INTO `ibl_team_info` (teamid, team_city, team_name) VALUES (?, ?, ?)",
+            'iss',
+            999,
+            'Dupe',
+            'Dupers'
+        );
+    }
+
+    // ==================== fetchOne / fetchAll / execute ====================
+
+    public function testFetchOneReturnsRowWhenFound(): void
+    {
+        $row = $this->repo->callFetchOne(
+            "SELECT team_name FROM `ibl_team_info` WHERE teamid = ?",
+            'i',
+            1
+        );
+
+        self::assertNotNull($row);
+        self::assertSame('Metros', $row['team_name']);
+    }
+
+    public function testFetchOneReturnsNullWhenNotFound(): void
+    {
+        $row = $this->repo->callFetchOne(
+            "SELECT team_name FROM `ibl_team_info` WHERE teamid = ?",
+            'i',
+            999999
+        );
+
+        self::assertNull($row);
+    }
+
+    public function testFetchAllReturnsMultipleRows(): void
+    {
+        $rows = $this->repo->callFetchAll(
+            "SELECT teamid FROM `ibl_team_info` WHERE teamid IN (1, 2) ORDER BY teamid"
+        );
+
+        self::assertCount(2, $rows);
+        self::assertSame(1, $rows[0]['teamid']);
+        self::assertSame(2, $rows[1]['teamid']);
+    }
+
+    public function testFetchAllReturnsEmptyArray(): void
+    {
+        $rows = $this->repo->callFetchAll(
+            "SELECT teamid FROM `ibl_team_info` WHERE teamid = ?",
+            'i',
+            999999
+        );
+
+        self::assertSame([], $rows);
+    }
+
+    public function testExecuteReturnsAffectedRowCount(): void
+    {
+        $affected = $this->repo->callExecute(
+            "UPDATE `ibl_team_info` SET team_city = 'TestCity' WHERE teamid = ?",
+            'i',
+            1
+        );
+
+        self::assertSame(1, $affected);
+    }
+
+    public function testExecuteReturnsZeroWhenNoRowsAffected(): void
+    {
+        $affected = $this->repo->callExecute(
+            "UPDATE `ibl_team_info` SET team_city = 'TestCity' WHERE teamid = ?",
+            'i',
+            999999
+        );
+
+        self::assertSame(0, $affected);
+    }
+
+    // ==================== fetchAllRealTeams ====================
+
+    public function testFetchAllRealTeamsDefaultOrder(): void
+    {
+        $teams = $this->repo->callFetchAllRealTeams();
+        self::assertNotEmpty($teams);
+
+        $names = array_column($teams, 'team_name');
+        $sorted = $names;
+        sort($sorted);
+        self::assertSame($sorted, $names);
+    }
+
+    public function testFetchAllRealTeamsOrderByTeamid(): void
+    {
+        $teams = $this->repo->callFetchAllRealTeams('teamid ASC');
+        self::assertNotEmpty($teams);
+
+        $ids = array_column($teams, 'teamid');
+        $sorted = $ids;
+        sort($sorted, SORT_NUMERIC);
+        self::assertSame($sorted, $ids);
+    }
+
+    public function testFetchAllRealTeamsInvalidOrderFallsBackToDefault(): void
+    {
+        $teams = $this->repo->callFetchAllRealTeams('DROP TABLE');
+        self::assertNotEmpty($teams);
+
+        $names = array_column($teams, 'team_name');
+        $sorted = $names;
+        sort($sorted);
+        self::assertSame($sorted, $names);
+    }
+
+    // ==================== getLastInsertId ====================
+
+    public function testGetLastInsertIdAfterInsert(): void
+    {
+        $this->repo->callExecute(
+            "INSERT INTO `ibl_sim_dates` (start_date, end_date) VALUES (?, ?)",
+            'ss',
+            '2025-03-01',
+            '2025-03-10'
+        );
+
+        $id = $this->repo->callGetLastInsertId();
+        self::assertGreaterThan(0, $id);
+    }
+
+    // ==================== transactional ====================
+
+    public function testTransactionalCommitsOnSuccess(): void
+    {
+        // DatabaseTestCase starts a transaction, so this will use savepoints
+        $result = $this->repo->callTransactional(function () {
+            $this->repo->callExecute(
+                "UPDATE `ibl_team_info` SET team_city = 'TxCity' WHERE teamid = ?",
+                'i',
+                1
+            );
+            return 'done';
+        });
+
+        self::assertSame('done', $result);
+
+        $row = $this->repo->callFetchOne(
+            "SELECT team_city FROM `ibl_team_info` WHERE teamid = ?",
+            'i',
+            1
+        );
+        self::assertNotNull($row);
+        self::assertSame('TxCity', $row['team_city']);
+    }
+
+    public function testTransactionalRollsBackOnException(): void
+    {
+        $originalRow = $this->repo->callFetchOne(
+            "SELECT team_city FROM `ibl_team_info` WHERE teamid = ?",
+            'i',
+            1
+        );
+
+        try {
+            $this->repo->callTransactional(function (): void {
+                $this->repo->callExecute(
+                    "UPDATE `ibl_team_info` SET team_city = 'RolledBack' WHERE teamid = ?",
+                    'i',
+                    1
+                );
+                throw new \RuntimeException('Intentional rollback');
+            });
+        } catch (\RuntimeException $e) {
+            self::assertSame('Intentional rollback', $e->getMessage());
+        }
+
+        $row = $this->repo->callFetchOne(
+            "SELECT team_city FROM `ibl_team_info` WHERE teamid = ?",
+            'i',
+            1
+        );
+        self::assertNotNull($row);
+        self::assertNotNull($originalRow);
+        self::assertSame($originalRow['team_city'], $row['team_city']);
+    }
+
+    public function testTransactionalUsesSavepointWhenAlreadyInTransaction(): void
+    {
+        // DatabaseTestCase::setUp() starts a transaction, so we're already in one.
+        // This verifies that transactional() doesn't throw when called inside a transaction.
+        $result = $this->repo->callTransactional(static fn (): string => 'savepoint_ok');
+        self::assertSame('savepoint_ok', $result);
+    }
+
+    public function testTransactionalSavepointRollsBackOnException(): void
+    {
+        $this->repo->callExecute(
+            "UPDATE `ibl_team_info` SET team_city = 'Before' WHERE teamid = ?",
+            'i',
+            1
+        );
+
+        try {
+            $this->repo->callTransactional(function (): void {
+                $this->repo->callExecute(
+                    "UPDATE `ibl_team_info` SET team_city = 'Inside' WHERE teamid = ?",
+                    'i',
+                    1
+                );
+                throw new \RuntimeException('savepoint rollback');
+            });
+        } catch (\RuntimeException) {
+            // expected
+        }
+
+        $row = $this->repo->callFetchOne(
+            "SELECT team_city FROM `ibl_team_info` WHERE teamid = ?",
+            'i',
+            1
+        );
+        self::assertNotNull($row);
+        self::assertSame('Before', $row['team_city']);
+    }
+
+    // ==================== setLogger ====================
+
+    public function testSetLoggerOverridesDefaultChannel(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())->method('error');
+
+        $this->repo->setLogger($logger);
+
+        try {
+            $this->repo->callExecuteQuery('SELECT 1', 'ii', 1);
+        } catch (\RuntimeException) {
+            // expected — type mismatch
+        }
+    }
+}
+
+/**
+ * @internal Test double exposing protected BaseMysqliRepository methods.
+ */
+class TestableBaseMysqliRepository extends \BaseMysqliRepository
+{
+    public function callResolveTable(string $table): string
+    {
+        return $this->resolveTable($table);
+    }
+
+    public function callExecuteQuery(string $query, string $types = '', mixed ...$params): object
+    {
+        return $this->executeQuery($query, $types, ...$params);
+    }
+
+    public function callFetchOne(string $query, string $types = '', mixed ...$params): ?array
+    {
+        return $this->fetchOne($query, $types, ...$params);
+    }
+
+    public function callFetchAll(string $query, string $types = '', mixed ...$params): array
+    {
+        return $this->fetchAll($query, $types, ...$params);
+    }
+
+    public function callExecute(string $query, string $types = '', mixed ...$params): int
+    {
+        return $this->execute($query, $types, ...$params);
+    }
+
+    public function callFetchAllRealTeams(string $orderBy = 'team_name ASC'): array
+    {
+        return $this->fetchAllRealTeams($orderBy);
+    }
+
+    public function callGetLastInsertId(): int
+    {
+        return $this->getLastInsertId();
+    }
+
+    /** @template T
+     * @param callable(): T $fn
+     * @return T */
+    public function callTransactional(callable $fn): mixed
+    {
+        return $this->transactional($fn);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/PlrBoxScoreRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/PlrBoxScoreRepositoryTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use PHPUnit\Framework\Attributes\Group;
+use PlrParser\PlrBoxScoreRepository;
+
+#[Group('database')]
+class PlrBoxScoreRepositoryTest extends DatabaseTestCase
+{
+    private PlrBoxScoreRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new PlrBoxScoreRepository($this->db);
+    }
+
+    public function testSumStatsByGameTypeThroughDateReturnsAggregatesPerPid(): void
+    {
+        $this->insertPlayerBoxscoreRow('2025-01-15', 1, 'P1', 'PG', 2, 1, 1, minutes: 30, points2m: 5, points2a: 10, ftm: 3, fta: 4, points3m: 2, points3a: 5, orb: 2, drb: 4, ast: 6, stl: 1, tov: 2, blk: 1, pf: 2);
+        $this->insertPlayerBoxscoreRow('2025-01-20', 1, 'P1', 'PG', 1, 3, 1, minutes: 28, points2m: 4, points2a: 8, ftm: 2, fta: 3, points3m: 1, points3a: 4, orb: 1, drb: 3, ast: 4, stl: 2, tov: 1, blk: 0, pf: 3);
+
+        $result = $this->repo->sumStatsByGameTypeThroughDate(2025, 1, '2025-01-31');
+
+        self::assertArrayHasKey(1, $result);
+        self::assertSame(2, $result[1]['gp']);
+        self::assertSame(58, $result[1]['min']);
+        self::assertSame(9, $result[1]['two_gm']);
+        self::assertSame(18, $result[1]['two_ga']);
+        self::assertSame(5, $result[1]['ftm']);
+        self::assertSame(7, $result[1]['fta']);
+        self::assertSame(3, $result[1]['three_gm']);
+        self::assertSame(9, $result[1]['three_ga']);
+        self::assertSame(3, $result[1]['orb']);
+        self::assertSame(7, $result[1]['drb']);
+        self::assertSame(10, $result[1]['ast']);
+        self::assertSame(3, $result[1]['stl']);
+        self::assertSame(3, $result[1]['tov']);
+        self::assertSame(1, $result[1]['blk']);
+        self::assertSame(5, $result[1]['pf']);
+    }
+
+    public function testSumStatsByGameTypeThroughDateExcludesRowsAfterEndDate(): void
+    {
+        $this->insertPlayerBoxscoreRow('2025-01-15', 1, 'P1', 'PG', 2, 1, 1);
+        $this->insertPlayerBoxscoreRow('2025-02-15', 1, 'P1', 'PG', 2, 1, 1);
+
+        $result = $this->repo->sumStatsByGameTypeThroughDate(2025, 1, '2025-01-31');
+
+        self::assertArrayHasKey(1, $result);
+        self::assertSame(1, $result[1]['gp']);
+    }
+
+    public function testSumStatsByGameTypeThroughDateCountsGpOnlyForNonZeroMinutes(): void
+    {
+        $this->insertPlayerBoxscoreRow('2025-01-15', 1, 'P1', 'PG', 2, 1, 1, minutes: 30);
+        $this->insertPlayerBoxscoreRow('2025-01-20', 1, 'P1', 'PG', 1, 3, 1, minutes: 0, points2m: 0, points2a: 0, ftm: 0, fta: 0, points3m: 0, points3a: 0, orb: 0, drb: 0, ast: 0, stl: 0, tov: 0, blk: 0, pf: 0);
+
+        $result = $this->repo->sumStatsByGameTypeThroughDate(2025, 1, '2025-01-31');
+
+        self::assertArrayHasKey(1, $result);
+        self::assertSame(1, $result[1]['gp']);
+    }
+
+    public function testSumStatsByGameTypeThroughDateReturnsEmptyForNoData(): void
+    {
+        $result = $this->repo->sumStatsByGameTypeThroughDate(2025, 1, '2025-01-31');
+        self::assertSame([], $result);
+    }
+
+    public function testGetSingleGameMaximumsThroughDateReturnsMaxima(): void
+    {
+        $this->insertPlayerBoxscoreRow('2025-01-15', 1, 'P1', 'PG', 2, 1, 1, minutes: 30, points2m: 8, points2a: 12, ftm: 5, fta: 6, points3m: 3, points3a: 7, orb: 3, drb: 7, ast: 8, stl: 3, tov: 2, blk: 2, pf: 2);
+        $this->insertPlayerBoxscoreRow('2025-01-20', 1, 'P1', 'PG', 1, 3, 1, minutes: 35, points2m: 10, points2a: 15, ftm: 8, fta: 10, points3m: 5, points3a: 10, orb: 5, drb: 9, ast: 12, stl: 5, tov: 3, blk: 4, pf: 4);
+
+        $result = $this->repo->getSingleGameMaximumsThroughDate(2025, 1, '2025-01-31');
+
+        self::assertArrayHasKey(1, $result);
+        // Game 2: 10*2 + 8 + 5*3 = 43 points
+        self::assertSame(43, $result[1]['high_pts']);
+        // Game 2: orb 5 + drb 9 = 14 rebounds
+        self::assertSame(14, $result[1]['high_reb']);
+        self::assertSame(12, $result[1]['high_ast']);
+        self::assertSame(5, $result[1]['high_stl']);
+        self::assertSame(4, $result[1]['high_blk']);
+    }
+
+    public function testGetSingleGameMaximumsThroughDateCountsDoubleDoubles(): void
+    {
+        // 10pts (5*2=10), 10reb (3orb+7drb), 5ast — that's a double-double
+        $this->insertPlayerBoxscoreRow('2025-01-15', 1, 'P1', 'PG', 2, 1, 1, minutes: 30, points2m: 5, points2a: 10, ftm: 0, fta: 0, points3m: 0, points3a: 0, orb: 3, drb: 7, ast: 5, stl: 1, tov: 2, blk: 0, pf: 2);
+
+        $result = $this->repo->getSingleGameMaximumsThroughDate(2025, 1, '2025-01-31');
+
+        self::assertSame(1, $result[1]['doubles']);
+        self::assertSame(0, $result[1]['triples']);
+    }
+
+    public function testGetSingleGameMaximumsThroughDateCountsTripleDoubles(): void
+    {
+        // 10pts (5*2=10), 10reb (3orb+7drb), 10ast — triple-double
+        $this->insertPlayerBoxscoreRow('2025-01-15', 1, 'P1', 'PG', 2, 1, 1, minutes: 35, points2m: 5, points2a: 12, ftm: 0, fta: 0, points3m: 0, points3a: 0, orb: 3, drb: 7, ast: 10, stl: 1, tov: 2, blk: 0, pf: 2);
+
+        $result = $this->repo->getSingleGameMaximumsThroughDate(2025, 1, '2025-01-31');
+
+        self::assertSame(0, $result[1]['doubles']);
+        self::assertSame(1, $result[1]['triples']);
+    }
+
+    public function testLatestGameDateReturnsMaxDate(): void
+    {
+        $this->insertPlayerBoxscoreRow('2025-01-15', 1, 'P1', 'PG', 2, 1, 1);
+        $this->insertPlayerBoxscoreRow('2025-01-20', 1, 'P1', 'PG', 1, 3, 1);
+
+        $result = $this->repo->latestGameDate(2025, 1);
+        self::assertSame('2025-01-20', $result);
+    }
+
+    public function testLatestGameDateReturnsNullWhenEmpty(): void
+    {
+        $result = $this->repo->latestGameDate(2025, 1);
+        self::assertNull($result);
+    }
+
+    public function testCumulativeRegularSeasonStatsByDateReturnsCumulativeRunningTotals(): void
+    {
+        $this->insertPlayerBoxscoreRow('2025-01-15', 1, 'P1', 'PG', 2, 1, 1, minutes: 30, points2m: 5, points2a: 10, ftm: 3, fta: 4, points3m: 2, points3a: 5, orb: 2, drb: 4, ast: 6, stl: 1, tov: 2, blk: 1, pf: 2);
+        $this->insertPlayerBoxscoreRow('2025-01-20', 1, 'P1', 'PG', 1, 3, 1, minutes: 28, points2m: 4, points2a: 8, ftm: 2, fta: 3, points3m: 1, points3a: 4, orb: 1, drb: 3, ast: 4, stl: 2, tov: 1, blk: 0, pf: 3);
+
+        $result = $this->repo->cumulativeRegularSeasonStatsByDate(1, 2025);
+
+        self::assertCount(2, $result);
+
+        self::assertSame('2025-01-15', $result[0]['date']);
+        self::assertSame(1, $result[0]['gp']);
+        self::assertSame(30, $result[0]['min']);
+        self::assertSame(5, $result[0]['two_gm']);
+
+        self::assertSame('2025-01-20', $result[1]['date']);
+        self::assertSame(2, $result[1]['gp']);
+        self::assertSame(58, $result[1]['min']);
+        self::assertSame(9, $result[1]['two_gm']);
+    }
+
+    public function testSumTeamRegularSeasonStatsThroughDateAggregatesTeamStats(): void
+    {
+        // Insert two team boxscore rows per game (visitor row 1, home row 2)
+        $this->insertTeamBoxscoreRow('2025-01-15', 'Stars', 1, 2, 1);
+        $this->insertTeamBoxscoreRow('2025-01-15', 'Metros', 1, 2, 1);
+
+        $result = $this->repo->sumTeamRegularSeasonStatsThroughDate(2025, '2025-01-31');
+
+        // visitor_teamid=2 (Stars) gets rn=1, home_teamid=1 (Metros) gets rn=2
+        self::assertArrayHasKey(2, $result);
+        self::assertArrayHasKey(1, $result);
+        self::assertSame(1, $result[2]['gp']);
+        self::assertSame(1, $result[1]['gp']);
+    }
+
+    public function testSumTeamPlayoffStatsThroughDateUsesGameType2(): void
+    {
+        // June dates = game_type 2 (playoffs)
+        $this->insertTeamBoxscoreRow('2025-06-10', 'Stars', 1, 2, 1);
+        $this->insertTeamBoxscoreRow('2025-06-10', 'Metros', 1, 2, 1);
+
+        $result = $this->repo->sumTeamPlayoffStatsThroughDate(2025, '2025-06-30');
+
+        self::assertArrayHasKey(2, $result);
+        self::assertArrayHasKey(1, $result);
+        self::assertSame(1, $result[2]['gp']);
+
+        $regularSeason = $this->repo->sumTeamRegularSeasonStatsThroughDate(2025, '2025-06-30');
+        self::assertSame([], $regularSeason);
+    }
+
+    public function testSimEndDatesForSeasonReturnsOrderedDates(): void
+    {
+        // Seed has sim 1: start=2025-01-10, end=2025-01-20
+        // Add another sim within the 2025 season window
+        $this->insertRow('ibl_sim_dates', [
+            'start_date' => '2025-02-01',
+            'end_date' => '2025-02-10',
+        ]);
+
+        $result = $this->repo->simEndDatesForSeason(2025);
+
+        self::assertCount(2, $result);
+        self::assertSame('2025-01-20', $result[0]);
+        self::assertSame('2025-02-10', $result[1]);
+    }
+
+    public function testSimEndDatesForSeasonExcludesOutOfWindowDates(): void
+    {
+        // Insert a sim outside the 2025 season window (before Oct 2024)
+        $this->insertRow('ibl_sim_dates', [
+            'start_date' => '2024-08-01',
+            'end_date' => '2024-08-10',
+        ]);
+
+        $result = $this->repo->simEndDatesForSeason(2025);
+
+        // Only the seed sim (2025-01-20) should be returned
+        self::assertCount(1, $result);
+        self::assertSame('2025-01-20', $result[0]);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/VotingRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/VotingRepositoryTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use PHPUnit\Framework\Attributes\Group;
+use Voting\VotingRepository;
+
+#[Group('database')]
+class VotingRepositoryTest extends DatabaseTestCase
+{
+    private VotingRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new VotingRepository($this->db);
+    }
+
+    public function testSaveEoyVoteUpdatesRow(): void
+    {
+        $ballot = [
+            'mvp_1' => 'Test Player One, Metros',
+            'mvp_2' => 'Test Player Two, Stars',
+            'mvp_3' => 'Test Player Three, Stars',
+            'six_1' => 'Test Player Four, Stars',
+            'six_2' => '', 'six_3' => '',
+            'roy_1' => '', 'roy_2' => '', 'roy_3' => '',
+            'gm_1' => '', 'gm_2' => '', 'gm_3' => '',
+        ];
+
+        $this->repo->saveEoyVote('Metros', $ballot);
+
+        $row = $this->fetchRow('ibl_votes_EOY', 'team_name', 'Metros');
+        self::assertSame('Test Player One, Metros', $row['mvp_1']);
+        self::assertSame('Test Player Two, Stars', $row['mvp_2']);
+        self::assertSame('Test Player Three, Stars', $row['mvp_3']);
+        self::assertSame('Test Player Four, Stars', $row['six_1']);
+    }
+
+    public function testSaveAsgVoteUpdatesRow(): void
+    {
+        $ballot = [
+            'east_f1' => 'Test Player One, Metros',
+            'east_f2' => 'Test Player Three, Stars',
+            'east_f3' => '', 'east_f4' => '',
+            'east_b1' => '', 'east_b2' => '', 'east_b3' => '', 'east_b4' => '',
+            'west_f1' => 'Test Player Five, Cougars',
+            'west_f2' => '', 'west_f3' => '', 'west_f4' => '',
+            'west_b1' => '', 'west_b2' => '', 'west_b3' => '', 'west_b4' => '',
+        ];
+
+        $this->repo->saveAsgVote('Stars', $ballot);
+
+        $row = $this->fetchRow('ibl_votes_ASG', 'team_name', 'Stars');
+        self::assertSame('Test Player One, Metros', $row['east_f1']);
+        self::assertSame('Test Player Three, Stars', $row['east_f2']);
+        self::assertSame('Test Player Five, Cougars', $row['west_f1']);
+    }
+
+    public function testMarkEoyVoteCastSetsTimestamp(): void
+    {
+        $this->repo->markEoyVoteCast('Metros');
+
+        $row = $this->fetchRow('ibl_team_info', 'team_name', 'Metros');
+        self::assertNotSame('No Vote', $row['eoy_vote']);
+    }
+
+    public function testMarkAsgVoteCastSetsTimestamp(): void
+    {
+        $this->repo->markAsgVoteCast('Stars');
+
+        $row = $this->fetchRow('ibl_team_info', 'team_name', 'Stars');
+        self::assertNotSame('No Vote', $row['asg_vote']);
+    }
+
+    public function testFetchAllStarTotalsAggregatesVotesAcrossColumns(): void
+    {
+        $this->setAsgVote('Metros', 'east_f1', 'Test Player One, Metros');
+        $this->setAsgVote('Metros', 'east_f2', 'Test Player Three, Stars');
+        $this->setAsgVote('Stars', 'east_f1', 'Test Player One, Metros');
+        $this->setAsgVote('Stars', 'east_f2', 'Test Player One, Metros');
+
+        $results = $this->repo->fetchAllStarTotals(['east_f1', 'east_f2']);
+
+        $byName = $this->indexByName($results);
+        self::assertSame(3, $byName['Test Player One, Metros']['votes']);
+        self::assertSame(1, $byName['Test Player Three, Stars']['votes']);
+    }
+
+    public function testFetchAllStarTotalsExcludesBlankEntries(): void
+    {
+        $this->setAsgVote('Metros', 'east_f1', 'Test Player One, Metros');
+        $this->setAsgVote('Metros', 'east_f2', '');
+        $this->setAsgVote('Stars', 'east_f1', '');
+        $this->setAsgVote('Stars', 'east_f2', '');
+
+        $results = $this->repo->fetchAllStarTotals(['east_f1', 'east_f2']);
+
+        $names = array_column($results, 'name');
+        self::assertNotContains('', $names);
+        self::assertCount(1, array_filter($results, static fn (array $r): bool => $r['name'] !== VotingRepository::BLANK_BALLOT_LABEL));
+    }
+
+    public function testFetchEndOfYearTotalsAppliesWeightedScoring(): void
+    {
+        $this->setEoyVote('Metros', 'mvp_1', 'Test Player One, Metros');
+        $this->setEoyVote('Stars', 'mvp_2', 'Test Player One, Metros');
+        $this->setEoyVote('Metros', 'mvp_2', 'Test Player Three, Stars');
+
+        $results = $this->repo->fetchEndOfYearTotals([
+            'mvp_1' => 5,
+            'mvp_2' => 3,
+        ]);
+
+        $byName = $this->indexByName($results);
+        self::assertSame(8, $byName['Test Player One, Metros']['votes']);
+        self::assertSame(3, $byName['Test Player Three, Stars']['votes']);
+    }
+
+    public function testFetchPlayerIdsByNamesReturnsPidMap(): void
+    {
+        $result = $this->repo->fetchPlayerIdsByNames(['Test Player One', 'Test Player Three']);
+
+        self::assertSame(1, $result['Test Player One']);
+        self::assertSame(3, $result['Test Player Three']);
+    }
+
+    public function testFetchPlayerIdsByNamesReturnsEmptyForNoMatches(): void
+    {
+        $result = $this->repo->fetchPlayerIdsByNames(['Nonexistent Player']);
+        self::assertSame([], $result);
+    }
+
+    public function testValidateColumnsRejectsInvalidColumn(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid vote column: bobby_tables');
+
+        $this->repo->fetchAllStarTotals(['bobby_tables']);
+    }
+
+    public function testFetchAllStarTotalsResolvesPlayerIds(): void
+    {
+        $this->setAsgVote('Metros', 'east_f1', 'Test Player One, Metros');
+
+        $results = $this->repo->fetchAllStarTotals(['east_f1']);
+
+        self::assertCount(1, $results);
+        self::assertSame(1, $results[0]['pid']);
+    }
+
+    // ==================== Helpers ====================
+
+    private function fetchRow(string $table, string $keyColumn, string $keyValue): array
+    {
+        $stmt = $this->db->prepare("SELECT * FROM `{$table}` WHERE `{$keyColumn}` = ?");
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('s', $keyValue);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $row = $result->fetch_assoc();
+        $stmt->close();
+        self::assertIsArray($row);
+
+        return $row;
+    }
+
+    private function setAsgVote(string $teamName, string $column, string $value): void
+    {
+        $stmt = $this->db->prepare("UPDATE `ibl_votes_ASG` SET `{$column}` = ? WHERE team_name = ?");
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('ss', $value, $teamName);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    private function setEoyVote(string $teamName, string $column, string $value): void
+    {
+        $stmt = $this->db->prepare("UPDATE `ibl_votes_EOY` SET `{$column}` = ? WHERE team_name = ?");
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('ss', $value, $teamName);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    /**
+     * @param list<array{name: string, votes: int, pid: int}> $rows
+     * @return array<string, array{name: string, votes: int, pid: int}>
+     */
+    private function indexByName(array $rows): array
+    {
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['name']] = $row;
+        }
+        return $result;
+    }
+}

--- a/ibl5/tests/NextSim/NextSimTabApiHandlerTest.php
+++ b/ibl5/tests/NextSim/NextSimTabApiHandlerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\NextSim;
+
+use NextSim\NextSimTabApiHandler;
+use PHPUnit\Framework\TestCase;
+
+class NextSimTabApiHandlerTest extends TestCase
+{
+    public function testExtractValidatedPositionDefaultsToPg(): void
+    {
+        self::assertSame('PG', NextSimTabApiHandler::extractValidatedPosition([]));
+    }
+
+    public function testExtractValidatedPositionUsesValidParam(): void
+    {
+        self::assertSame('SF', NextSimTabApiHandler::extractValidatedPosition(['position' => 'SF']));
+        self::assertSame('C', NextSimTabApiHandler::extractValidatedPosition(['position' => 'C']));
+        self::assertSame('SG', NextSimTabApiHandler::extractValidatedPosition(['position' => 'SG']));
+        self::assertSame('PF', NextSimTabApiHandler::extractValidatedPosition(['position' => 'PF']));
+    }
+
+    public function testExtractValidatedPositionRejectsInvalidAndFallsToPg(): void
+    {
+        self::assertSame('PG', NextSimTabApiHandler::extractValidatedPosition(['position' => 'ZZ']));
+        self::assertSame('PG', NextSimTabApiHandler::extractValidatedPosition(['position' => 'pg']));
+        self::assertSame('PG', NextSimTabApiHandler::extractValidatedPosition(['position' => '']));
+    }
+
+    public function testExtractValidatedPositionRejectsNonStringAndFallsToPg(): void
+    {
+        self::assertSame('PG', NextSimTabApiHandler::extractValidatedPosition(['position' => ['array']]));
+        self::assertSame('PG', NextSimTabApiHandler::extractValidatedPosition(['position' => 123]));
+    }
+
+    public function testExtractValidatedTeamidDefaultsToZero(): void
+    {
+        self::assertSame(0, NextSimTabApiHandler::extractValidatedTeamid([]));
+    }
+
+    public function testExtractValidatedTeamidParsesStringToInt(): void
+    {
+        self::assertSame(5, NextSimTabApiHandler::extractValidatedTeamid(['teamid' => '5']));
+    }
+
+    public function testExtractValidatedTeamidRejectsNonString(): void
+    {
+        self::assertSame(0, NextSimTabApiHandler::extractValidatedTeamid(['teamid' => ['array']]));
+        self::assertSame(0, NextSimTabApiHandler::extractValidatedTeamid(['teamid' => 42]));
+    }
+}

--- a/ibl5/tests/Team/TeamApiHandlerTest.php
+++ b/ibl5/tests/Team/TeamApiHandlerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Team;
+
+use PHPUnit\Framework\TestCase;
+use Team\TeamApiHandler;
+
+class TeamApiHandlerTest extends TestCase
+{
+    // ==================== Display Validation ====================
+
+    public function testExtractValidatedDisplayDefaultsToRatings(): void
+    {
+        self::assertSame('ratings', TeamApiHandler::extractValidatedDisplay([]));
+    }
+
+    public function testExtractValidatedDisplayUsesValidMode(): void
+    {
+        self::assertSame('total_s', TeamApiHandler::extractValidatedDisplay(['display' => 'total_s']));
+        self::assertSame('avg_s', TeamApiHandler::extractValidatedDisplay(['display' => 'avg_s']));
+        self::assertSame('split', TeamApiHandler::extractValidatedDisplay(['display' => 'split']));
+        self::assertSame('playoffs', TeamApiHandler::extractValidatedDisplay(['display' => 'playoffs']));
+        self::assertSame('contracts', TeamApiHandler::extractValidatedDisplay(['display' => 'contracts']));
+        self::assertSame('per36mins', TeamApiHandler::extractValidatedDisplay(['display' => 'per36mins']));
+        self::assertSame('chunk', TeamApiHandler::extractValidatedDisplay(['display' => 'chunk']));
+    }
+
+    public function testExtractValidatedDisplayRejectsInvalidMode(): void
+    {
+        self::assertSame('ratings', TeamApiHandler::extractValidatedDisplay(['display' => 'bogus']));
+        self::assertSame('ratings', TeamApiHandler::extractValidatedDisplay(['display' => '']));
+    }
+
+    public function testExtractValidatedDisplayRejectsNonString(): void
+    {
+        self::assertSame('ratings', TeamApiHandler::extractValidatedDisplay(['display' => 42]));
+    }
+
+    // ==================== Year Validation ====================
+
+    public function testExtractValidatedYrReturnsNullWhenMissing(): void
+    {
+        self::assertNull(TeamApiHandler::extractValidatedYr([]));
+    }
+
+    public function testExtractValidatedYrAcceptsYearOnly(): void
+    {
+        self::assertSame('2024', TeamApiHandler::extractValidatedYr(['yr' => '2024']));
+    }
+
+    public function testExtractValidatedYrAcceptsYearMonth(): void
+    {
+        self::assertSame('2024-01', TeamApiHandler::extractValidatedYr(['yr' => '2024-01']));
+    }
+
+    public function testExtractValidatedYrRejectsInvalidFormat(): void
+    {
+        self::assertNull(TeamApiHandler::extractValidatedYr(['yr' => 'abc']));
+        self::assertNull(TeamApiHandler::extractValidatedYr(['yr' => '24']));
+        self::assertNull(TeamApiHandler::extractValidatedYr(['yr' => '2024-1']));
+        self::assertNull(TeamApiHandler::extractValidatedYr(['yr' => '2024-123']));
+    }
+
+    public function testExtractValidatedYrRejectsEmpty(): void
+    {
+        self::assertNull(TeamApiHandler::extractValidatedYr(['yr' => '']));
+    }
+
+    public function testExtractValidatedYrRejectsNonString(): void
+    {
+        self::assertNull(TeamApiHandler::extractValidatedYr(['yr' => 2024]));
+    }
+
+    // ==================== Push URL Building ====================
+
+    public function testBuildPushUrlIncludesAllParams(): void
+    {
+        $url = TeamApiHandler::buildPushUrl(5, 'split', 'home', '2024');
+        self::assertSame('modules.php?name=Team&op=team&teamid=5&display=split&split=home&yr=2024', $url);
+    }
+
+    public function testBuildPushUrlOmitsSplitWhenNull(): void
+    {
+        $url = TeamApiHandler::buildPushUrl(3, 'total_s', null, '2024');
+        self::assertSame('modules.php?name=Team&op=team&teamid=3&display=total_s&yr=2024', $url);
+    }
+
+    public function testBuildPushUrlOmitsYrWhenNull(): void
+    {
+        $url = TeamApiHandler::buildPushUrl(7, 'ratings', null, null);
+        self::assertSame('modules.php?name=Team&op=team&teamid=7&display=ratings', $url);
+    }
+}


### PR DESCRIPTION
## Summary

Write tests for the 6 remaining Pass 2 deferred handlers and repositories, then remove them from `infection.json5`. After this PR, only directory-level excludes and 22 view files remain.

**Depends on:** `mutation-04-unlock-controllers` (which removes controller excludes first).

## Changes

- **Handler tests:** `NextSimTabApiHandlerTest` (6 test cases) and `TeamApiHandlerTest` (13 test cases), including extraction of `buildPushUrl()` for direct testability
- **Repository DB integration tests:** `ApiKeysManagementRepositoryTest`, `PlrBoxScoreRepositoryTest`, `VotingRepositoryTest`, `BaseMysqliRepositoryTest`
- **Mutation exclusions removed:** 6 files removed from `infection.json5` exclusion list

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.