### PR TITLE
fix: filter schedule queries by season_year (ending year)

### DIFF
--- a/ibl5/classes/LeagueSchedule/Contracts/LeagueScheduleRepositoryInterface.php
+++ b/ibl5/classes/LeagueSchedule/Contracts/LeagueScheduleRepositoryInterface.php
@@ -23,11 +23,12 @@ namespace LeagueSchedule\Contracts;
 interface LeagueScheduleRepositoryInterface
 {
     /**
-     * Get all scheduled games with box score info
+     * Get all scheduled games with box score info for a given season
      *
+     * @param int $seasonYear Season ending year to filter by
      * @return list<ScheduleRow> Games ordered by date ascending, then id ascending
      */
-    public function getAllGamesWithBoxScoreInfo(): array;
+    public function getAllGamesWithBoxScoreInfo(int $seasonYear): array;
 
     /**
      * Get team records indexed by team ID

--- a/ibl5/classes/LeagueSchedule/LeagueScheduleRepository.php
+++ b/ibl5/classes/LeagueSchedule/LeagueScheduleRepository.php
@@ -31,16 +31,17 @@ class LeagueScheduleRepository extends \BaseMysqliRepository implements LeagueSc
      *
      * @return list<ScheduleRow>
      */
-    public function getAllGamesWithBoxScoreInfo(): array
+    public function getAllGamesWithBoxScoreInfo(int $seasonYear): array
     {
         $query = "SELECT s.id, s.game_date, s.visitor_teamid, s.visitor_score, s.home_teamid, s.home_score, s.box_id,
                   bst.game_of_that_day
                   FROM {$this->scheduleTable} s
                   LEFT JOIN " . $this->gameOfThatDaySubquery() . " bst ON bst.game_date = s.game_date AND bst.visitor_teamid = s.visitor_teamid AND bst.home_teamid = s.home_teamid
+                  WHERE s.season_year = ?
                   ORDER BY s.game_date ASC, s.id ASC";
 
         /** @var list<ScheduleRow> $rows */
-        $rows = $this->fetchAll($query);
+        $rows = $this->fetchAll($query, 'i', $seasonYear);
 
         // Normalize game_of_that_day — the LEFT JOIN can return null
         foreach ($rows as $index => $row) {

--- a/ibl5/classes/LeagueSchedule/LeagueScheduleService.php
+++ b/ibl5/classes/LeagueSchedule/LeagueScheduleService.php
@@ -52,7 +52,7 @@ class LeagueScheduleService implements LeagueScheduleServiceInterface
         $projectedNextSimEndDate = $season->projectedNextSimEndDate;
         $simLengthDays = $league->getSimLengthInDays();
 
-        $rawGames = $this->repository->getAllGamesWithBoxScoreInfo();
+        $rawGames = $this->repository->getAllGamesWithBoxScoreInfo($season->endingYear);
         $teamRecords = $this->repository->getTeamRecords();
 
         /** @var array<string, MonthData> $gamesByMonth */

--- a/ibl5/classes/NextSim/NextSimService.php
+++ b/ibl5/classes/NextSim/NextSimService.php
@@ -58,7 +58,8 @@ class NextSimService implements NextSimServiceInterface
         $projectedGames = $this->teamScheduleRepository->getProjectedGamesNextSimResult(
             $teamId,
             $season->lastSimEndDate,
-            $season->projectedNextSimEndDate->format('Y-m-d')
+            $season->projectedNextSimEndDate->format('Y-m-d'),
+            $season->endingYear
         );
 
         $lastSimEndDateObject = new \DateTime($season->lastSimEndDate);

--- a/ibl5/classes/TeamSchedule/Contracts/TeamScheduleRepositoryInterface.php
+++ b/ibl5/classes/TeamSchedule/Contracts/TeamScheduleRepositoryInterface.php
@@ -23,9 +23,10 @@ interface TeamScheduleRepositoryInterface
      * joined with box score data to include gameOfThatDay.
      *
      * @param int $teamid Team ID to get schedule for
+     * @param int $seasonYear Season ending year to filter by
      * @return list<ScheduleRow> Schedule rows ordered by date ascending
      */
-    public function getSchedule(int $teamid): array;
+    public function getSchedule(int $teamid, int $seasonYear): array;
 
     /**
      * Get projected games for next simulation result
@@ -36,7 +37,8 @@ interface TeamScheduleRepositoryInterface
      * @param int $teamid Team ID to get schedule for
      * @param string $lastSimEndDate Date string (YYYY-MM-DD) of last sim end
      * @param string $projectedNextSimEndDate Date string (YYYY-MM-DD) of projected next sim end (break-aware)
+     * @param int $seasonYear Season ending year to filter by
      * @return list<ProjectedGameRow> Upcoming game rows ordered by date ascending
      */
-    public function getProjectedGamesNextSimResult(int $teamid, string $lastSimEndDate, string $projectedNextSimEndDate): array;
+    public function getProjectedGamesNextSimResult(int $teamid, string $lastSimEndDate, string $projectedNextSimEndDate, int $seasonYear): array;
 }

--- a/ibl5/classes/TeamSchedule/TeamScheduleRepository.php
+++ b/ibl5/classes/TeamSchedule/TeamScheduleRepository.php
@@ -30,16 +30,17 @@ class TeamScheduleRepository extends \BaseMysqliRepository implements TeamSchedu
      *
      * @return list<ScheduleRow>
      */
-    public function getSchedule(int $teamid): array
+    public function getSchedule(int $teamid, int $seasonYear): array
     {
         /** @var list<ScheduleRow> */
         return $this->fetchAll(
             "SELECT s.*, bst.game_of_that_day
             FROM {$this->scheduleTable} s
             LEFT JOIN " . $this->gameOfThatDaySubquery() . " bst ON bst.game_date = s.game_date AND bst.visitor_teamid = s.visitor_teamid AND bst.home_teamid = s.home_teamid
-            WHERE s.visitor_teamid = ? OR s.home_teamid = ?
+            WHERE s.season_year = ? AND (s.visitor_teamid = ? OR s.home_teamid = ?)
             ORDER BY s.game_date ASC",
-            'ii',
+            'iii',
+            $seasonYear,
             $teamid,
             $teamid
         );
@@ -50,15 +51,17 @@ class TeamScheduleRepository extends \BaseMysqliRepository implements TeamSchedu
      *
      * @return list<ProjectedGameRow>
      */
-    public function getProjectedGamesNextSimResult(int $teamid, string $lastSimEndDate, string $projectedNextSimEndDate): array
+    public function getProjectedGamesNextSimResult(int $teamid, string $lastSimEndDate, string $projectedNextSimEndDate, int $seasonYear): array
     {
         /** @var list<ProjectedGameRow> */
         return $this->fetchAll(
             "SELECT * FROM `{$this->scheduleTable}`
-             WHERE (visitor_teamid = ? OR home_teamid = ?)
+             WHERE season_year = ?
+               AND (visitor_teamid = ? OR home_teamid = ?)
                AND game_date BETWEEN ADDDATE(?, 1) AND ?
              ORDER BY game_date ASC",
-            'iiss',
+            'iiiss',
+            $seasonYear,
             $teamid,
             $teamid,
             $lastSimEndDate,

--- a/ibl5/classes/TeamSchedule/TeamScheduleService.php
+++ b/ibl5/classes/TeamSchedule/TeamScheduleService.php
@@ -53,7 +53,7 @@ class TeamScheduleService implements TeamScheduleServiceInterface
      */
     public function getProcessedSchedule(int $teamId, Season $season): array
     {
-        $teamSchedule = $this->repository->getSchedule($teamId);
+        $teamSchedule = $this->repository->getSchedule($teamId, $season->endingYear);
 
         /** @var list<ScheduleGameRow> $rows */
         $rows = [];

--- a/ibl5/classes/Updater/ScheduleUpdater.php
+++ b/ibl5/classes/Updater/ScheduleUpdater.php
@@ -193,7 +193,7 @@ class ScheduleUpdater extends \BaseMysqliRepository {
                     season_year, box_id, game_date, visitor_teamid, visitor_score, home_teamid, home_score, uuid
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 "iisiiiis",
-                $fullDate['year'],
+                $this->season->endingYear,
                 $boxId,
                 $fullDate['date'],
                 $visitor_teamid,
@@ -306,7 +306,7 @@ class ScheduleUpdater extends \BaseMysqliRepository {
                         uuid
                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     "iisiiiis",
-                    $year,
+                    $this->season->endingYear,
                     $boxID,
                     $date,
                     $visitor_teamid,

--- a/ibl5/migrations/133_fix_schedule_season_year.sql
+++ b/ibl5/migrations/133_fix_schedule_season_year.sql
@@ -1,0 +1,9 @@
+-- Fix ibl_schedule.season_year to use ending-year convention.
+--
+-- ScheduleUpdater stored the calendar year for Oct-Dec games (e.g., 2025
+-- for a Nov 2025 game in the 2025-2026 season). Every other table uses
+-- the ending year (2026). Shift affected rows to match.
+
+UPDATE ibl_schedule
+   SET season_year = season_year + 1
+ WHERE MONTH(game_date) >= 10;

--- a/ibl5/tests/DatabaseIntegration/LeagueScheduleRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/LeagueScheduleRepositoryTest.php
@@ -23,7 +23,7 @@ class LeagueScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-01-15', 1, 100, 2, 95);
 
-        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+        $results = $this->repo->getAllGamesWithBoxScoreInfo(2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found);
@@ -36,7 +36,7 @@ class LeagueScheduleRepositoryTest extends DatabaseTestCase
         $schedId = $this->insertScheduleRow(2090, '2090-02-15', 1, 100, 2, 95);
         $this->insertTeamBoxscoreRow('2090-02-15', 'test-game', 3, 1, 2);
 
-        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+        $results = $this->repo->getAllGamesWithBoxScoreInfo(2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found);
@@ -47,7 +47,7 @@ class LeagueScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-03-15', 3, 80, 4, 90);
 
-        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+        $results = $this->repo->getAllGamesWithBoxScoreInfo(2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found);
@@ -60,7 +60,7 @@ class LeagueScheduleRepositoryTest extends DatabaseTestCase
         $this->insertTeamBoxscoreRow('2090-04-15', 'game-a', 5, 1, 2);
         $this->insertTeamBoxscoreRow('2090-04-15', 'game-b', 2, 1, 2);
 
-        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+        $results = $this->repo->getAllGamesWithBoxScoreInfo(2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found);
@@ -71,7 +71,7 @@ class LeagueScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-05-15', 1, 90, 2, 85);
 
-        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+        $results = $this->repo->getAllGamesWithBoxScoreInfo(2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found);
@@ -86,7 +86,7 @@ class LeagueScheduleRepositoryTest extends DatabaseTestCase
         $schedId1 = $this->insertScheduleRow(2090, '2090-06-20', 1, 90, 2, 85);
         $schedId2 = $this->insertScheduleRow(2090, '2090-06-15', 3, 90, 4, 85);
 
-        $results = $this->repo->getAllGamesWithBoxScoreInfo();
+        $results = $this->repo->getAllGamesWithBoxScoreInfo(2090);
 
         $pos1 = null;
         $pos2 = null;
@@ -102,6 +102,19 @@ class LeagueScheduleRepositoryTest extends DatabaseTestCase
         self::assertNotNull($pos2);
         // June 15 before June 20
         self::assertLessThan($pos1, $pos2);
+    }
+
+    public function testGetAllGamesFiltersBySeasonYear(): void
+    {
+        $currentSeason = $this->insertScheduleRow(2090, '2090-01-15', 1, 100, 2, 95);
+        $otherSeason = $this->insertScheduleRow(2089, '2089-06-01', 3, 110, 4, 105);
+
+        $results = $this->repo->getAllGamesWithBoxScoreInfo(2090);
+
+        $foundCurrent = $this->findBySchedId($results, $currentSeason);
+        $foundOther = $this->findBySchedId($results, $otherSeason);
+        self::assertNotNull($foundCurrent, 'Current season game should appear');
+        self::assertNull($foundOther, 'Other season game should be filtered out');
     }
 
     public function testGetTeamRecordsKeyedByIntTid(): void

--- a/ibl5/tests/DatabaseIntegration/TeamScheduleRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamScheduleRepositoryTest.php
@@ -23,7 +23,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-01-10', 5, 100, 6, 95);
 
-        $results = $this->repo->getSchedule(5);
+        $results = $this->repo->getSchedule(5, 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found, 'Team as visitor should appear');
@@ -33,7 +33,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-01-11', 5, 90, 6, 100);
 
-        $results = $this->repo->getSchedule(6);
+        $results = $this->repo->getSchedule(6, 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found, 'Team as home should appear');
@@ -43,7 +43,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-01-12', 5, 90, 6, 100);
 
-        $results = $this->repo->getSchedule(7);
+        $results = $this->repo->getSchedule(7, 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNull($found, 'Unrelated team should not see this game');
@@ -54,7 +54,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
         $schedId = $this->insertScheduleRow(2090, '2090-02-10', 5, 105, 6, 98);
         $this->insertTeamBoxscoreRow('2090-02-10', 'ts-game', 2, 5, 6);
 
-        $results = $this->repo->getSchedule(5);
+        $results = $this->repo->getSchedule(5, 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found);
@@ -65,7 +65,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-03-10', 5, 80, 6, 90);
 
-        $results = $this->repo->getSchedule(5);
+        $results = $this->repo->getSchedule(5, 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found);
@@ -78,7 +78,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
         $schedId1 = $this->insertScheduleRow(2090, '2090-04-20', 5, 100, 6, 90);
         $schedId2 = $this->insertScheduleRow(2090, '2090-04-10', 5, 95, 7, 85);
 
-        $results = $this->repo->getSchedule(5);
+        $results = $this->repo->getSchedule(5, 2090);
 
         $pos1 = null;
         $pos2 = null;
@@ -101,7 +101,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
         $schedIdAway = $this->insertScheduleRow(2090, '2090-05-01', 5, 100, 6, 95);
         $schedIdHome = $this->insertScheduleRow(2090, '2090-05-02', 7, 90, 5, 105);
 
-        $results = $this->repo->getSchedule(5);
+        $results = $this->repo->getSchedule(5, 2090);
 
         $foundAway = $this->findBySchedId($results, $schedIdAway);
         $foundHome = $this->findBySchedId($results, $schedIdHome);
@@ -113,7 +113,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-06-15', 5, 0, 6, 0);
 
-        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-06-10', '2090-06-20');
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-06-10', '2090-06-20', 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found, 'Game in range should be returned');
@@ -124,7 +124,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
         // ADDDATE excludes lastSimEndDate itself — uses day after
         $schedId = $this->insertScheduleRow(2090, '2090-07-10', 5, 0, 6, 0);
 
-        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-07-10', '2090-07-20');
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-07-10', '2090-07-20', 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNull($found, 'Game on lastSimEndDate should be excluded by ADDDATE');
@@ -134,7 +134,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-07-11', 5, 0, 6, 0);
 
-        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-07-10', '2090-07-20');
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-07-10', '2090-07-20', 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNotNull($found, 'Game day after lastSimEndDate should be included');
@@ -144,7 +144,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-08-25', 5, 0, 6, 0);
 
-        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-08-01', '2090-08-20');
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-08-01', '2090-08-20', 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNull($found, 'Game after projected end should be excluded');
@@ -154,7 +154,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
     {
         $schedId = $this->insertScheduleRow(2090, '2090-09-15', 7, 0, 8, 0);
 
-        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-09-10', '2090-09-20');
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-09-10', '2090-09-20', 2090);
 
         $found = $this->findBySchedId($results, $schedId);
         self::assertNull($found, 'Game for different team should be excluded');
@@ -162,12 +162,12 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
 
     public function testGetProjectedGamesEmptyWhenNoGamesInRange(): void
     {
-        $results = $this->repo->getProjectedGamesNextSimResult(5, '2099-01-01', '2099-01-10');
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2099-01-01', '2099-01-10', 2099);
 
         // Filter to only test data
         $testResults = array_filter(
             $results,
-            static fn (array $row): bool => $row['Year'] === 2099,
+            static fn (array $row): bool => $row['season_year'] === 2099,
         );
         self::assertCount(0, $testResults);
     }
@@ -177,7 +177,7 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
         $schedId1 = $this->insertScheduleRow(2090, '2090-10-20', 5, 0, 6, 0);
         $schedId2 = $this->insertScheduleRow(2090, '2090-10-15', 5, 0, 7, 0);
 
-        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-10-10', '2090-10-25');
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-10-10', '2090-10-25', 2090);
 
         $pos1 = null;
         $pos2 = null;
@@ -193,6 +193,32 @@ class TeamScheduleRepositoryTest extends DatabaseTestCase
         self::assertNotNull($pos2);
         // Oct 15 before Oct 20
         self::assertLessThan($pos1, $pos2);
+    }
+
+    public function testGetScheduleFiltersBySeasonYear(): void
+    {
+        $currentSeason = $this->insertScheduleRow(2090, '2090-01-10', 5, 100, 6, 95);
+        $otherSeason = $this->insertScheduleRow(2089, '2089-06-01', 5, 110, 6, 105);
+
+        $results = $this->repo->getSchedule(5, 2090);
+
+        $foundCurrent = $this->findBySchedId($results, $currentSeason);
+        $foundOther = $this->findBySchedId($results, $otherSeason);
+        self::assertNotNull($foundCurrent, 'Current season game should appear');
+        self::assertNull($foundOther, 'Other season game should be filtered out');
+    }
+
+    public function testGetProjectedGamesFiltersBySeasonYear(): void
+    {
+        $currentSeason = $this->insertScheduleRow(2090, '2090-06-15', 5, 0, 6, 0);
+        $otherSeason = $this->insertScheduleRow(2089, '2090-06-15', 5, 0, 7, 0);
+
+        $results = $this->repo->getProjectedGamesNextSimResult(5, '2090-06-10', '2090-06-20', 2090);
+
+        $foundCurrent = $this->findBySchedId($results, $currentSeason);
+        $foundOther = $this->findBySchedId($results, $otherSeason);
+        self::assertNotNull($foundCurrent, 'Current season game should appear');
+        self::assertNull($foundOther, 'Other season game should be filtered out');
     }
 
     /**

--- a/ibl5/tests/LeagueSchedule/LeagueScheduleRepositoryTest.php
+++ b/ibl5/tests/LeagueSchedule/LeagueScheduleRepositoryTest.php
@@ -55,7 +55,7 @@ class LeagueScheduleRepositoryTest extends TestCase
         $this->mockDb->setMockData([]);
         $repository = new LeagueScheduleRepository($this->mockMysqliDb);
 
-        $result = $repository->getAllGamesWithBoxScoreInfo();
+        $result = $repository->getAllGamesWithBoxScoreInfo(2026);
 
         $this->assertSame([], $result);
     }
@@ -76,7 +76,7 @@ class LeagueScheduleRepositoryTest extends TestCase
         ]);
         $repository = new LeagueScheduleRepository($this->mockMysqliDb);
 
-        $result = $repository->getAllGamesWithBoxScoreInfo();
+        $result = $repository->getAllGamesWithBoxScoreInfo(2026);
 
         $this->assertCount(1, $result);
         $this->assertSame('2025-11-01', $result[0]['game_date']);
@@ -100,7 +100,7 @@ class LeagueScheduleRepositoryTest extends TestCase
         ]);
         $repository = new LeagueScheduleRepository($this->mockMysqliDb);
 
-        $result = $repository->getAllGamesWithBoxScoreInfo();
+        $result = $repository->getAllGamesWithBoxScoreInfo(2026);
 
         $this->assertSame(0, $result[0]['game_of_that_day']);
     }

--- a/ibl5/tests/LeagueSchedule/LeagueScheduleServiceTest.php
+++ b/ibl5/tests/LeagueSchedule/LeagueScheduleServiceTest.php
@@ -227,6 +227,29 @@ class LeagueScheduleServiceTest extends TestCase
         $this->assertFalse($game['homeWon']);
     }
 
+    public function testGetSchedulePageDataPassesSeasonEndingYearToRepository(): void
+    {
+        $mockRepo = $this->createMock(LeagueScheduleRepositoryInterface::class);
+        $mockRepo->expects($this->once())
+            ->method('getAllGamesWithBoxScoreInfo')
+            ->with(2026)
+            ->willReturn([]);
+        $mockRepo->method('getTeamRecords')->willReturn([]);
+
+        $season = $this->createStub(Season::class);
+        $season->endingYear = 2026;
+        $season->projectedNextSimEndDate = new \DateTime('2025-11-15');
+        $season->phase = 'Regular Season';
+
+        $league = $this->createStub(League::class);
+        $league->method('getSimLengthInDays')->willReturn(7);
+
+        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+
+        $service = new LeagueScheduleService($mockRepo);
+        $service->getSchedulePageData($season, $league, $commonRepo);
+    }
+
     public function testRegularSeasonIsNotPlayoffPhase(): void
     {
         $mockRepo = $this->createStub(LeagueScheduleRepositoryInterface::class);

--- a/ibl5/tests/NextSim/NextSimServiceTest.php
+++ b/ibl5/tests/NextSim/NextSimServiceTest.php
@@ -100,4 +100,52 @@ class NextSimServiceTest extends TestCase
 
         $this->assertNotSame($service1, $service2);
     }
+
+    // ============================================
+    // SEASON YEAR FILTERING
+    // ============================================
+
+    public function testGetNextSimGamesPassesSeasonEndingYearToRepository(): void
+    {
+        $this->setupTeamMockData();
+        $season = new \Season\Season($this->mockDb);
+
+        $mockRepository = $this->createMock(TeamScheduleRepositoryInterface::class);
+        $mockRepository->expects($this->once())
+            ->method('getProjectedGamesNextSimResult')
+            ->with(
+                1,
+                $season->lastSimEndDate,
+                $season->projectedNextSimEndDate->format('Y-m-d'),
+                $season->endingYear
+            )
+            ->willReturn([]);
+
+        $service = new NextSimService($this->mockMysqliDb, $mockRepository);
+
+        $service->getNextSimGames(1, $season);
+    }
+
+    private function setupTeamMockData(): void
+    {
+        $this->mockDb->setMockData([
+            [
+                'teamid' => 1,
+                'team_city' => 'Test City',
+                'team_name' => 'TestTeam',
+                'color1' => 'FF0000',
+                'color2' => '0000FF',
+                'arena' => 'Test Arena',
+                'capacity' => 20000,
+                'owner_name' => 'Test Owner',
+                'owner_email' => 'test@test.com',
+                'discord_id' => null,
+                'used_extension_this_chunk' => 0,
+                'used_extension_this_season' => 0,
+                'has_mle' => 0,
+                'has_lle' => 0,
+                'league_record' => '30-10',
+            ],
+        ]);
+    }
 }

--- a/ibl5/tests/TeamSchedule/TeamScheduleServiceTest.php
+++ b/ibl5/tests/TeamSchedule/TeamScheduleServiceTest.php
@@ -223,6 +223,25 @@ class TeamScheduleServiceTest extends TestCase
     }
 
     // ============================================
+    // SEASON YEAR FILTERING
+    // ============================================
+
+    public function testGetProcessedSchedulePassesSeasonEndingYearToRepository(): void
+    {
+        $mockRepository = $this->createMock(TeamScheduleRepositoryInterface::class);
+        $season = new Season($this->mockDb);
+
+        $mockRepository->expects($this->once())
+            ->method('getSchedule')
+            ->with(1, $season->endingYear)
+            ->willReturn([]);
+
+        $service = new TeamScheduleService($this->mockMysqliDb, $mockRepository);
+
+        $service->getProcessedSchedule(1, $season);
+    }
+
+    // ============================================
     // HELPERS
     // ============================================
 

--- a/ibl5/tests/WideUnit/Schedule/ScheduleWideUnitTest.php
+++ b/ibl5/tests/WideUnit/Schedule/ScheduleWideUnitTest.php
@@ -108,7 +108,7 @@ class ScheduleWideUnitTest extends WideUnitTestCase
         $this->mockDb->setMockData([]);
 
         // Act
-        $this->repository->getSchedule($teamId);
+        $this->repository->getSchedule($teamId, 2025);
 
         // Assert
         $this->assertQueryExecuted('ibl_schedule');
@@ -132,7 +132,7 @@ class ScheduleWideUnitTest extends WideUnitTestCase
         $this->mockDb->setMockData($scheduleData);
 
         // Act
-        $result = $this->repository->getSchedule($teamId);
+        $result = $this->repository->getSchedule($teamId, 2025);
 
         // Assert - Result should be an array
         $this->assertIsArray($result);
@@ -151,7 +151,7 @@ class ScheduleWideUnitTest extends WideUnitTestCase
         $this->mockDb->setMockData([]);
 
         // Act
-        $this->repository->getSchedule($teamId);
+        $this->repository->getSchedule($teamId, 2025);
 
         // Assert
         $this->assertQueryExecuted('ORDER BY s.game_date ASC');
@@ -169,7 +169,7 @@ class ScheduleWideUnitTest extends WideUnitTestCase
         $this->mockDb->setMockData([]);
 
         // Act
-        $result = $this->repository->getSchedule($teamId);
+        $result = $this->repository->getSchedule($teamId, 2025);
 
         // Assert
         $this->assertSame([], $result);
@@ -189,7 +189,7 @@ class ScheduleWideUnitTest extends WideUnitTestCase
         $this->mockDb->setMockData([]);
 
         // Act
-        $this->repository->getProjectedGamesNextSimResult($teamId, $lastSimEndDate, $projectedNextSimEndDate);
+        $this->repository->getProjectedGamesNextSimResult($teamId, $lastSimEndDate, $projectedNextSimEndDate, 2025);
 
         // Assert - Verify query was executed against ibl_schedule
         $this->assertQueryExecuted('ibl_schedule');


### PR DESCRIPTION
## Summary

Fix two related defects:

1. **`ScheduleUpdater` wrote calendar year for Oct-Dec games** — `ibl_schedule.season_year` should be the season ending year (matching every other table), but `DateParser::extractDate()` returns the calendar year which was used directly. A Nov 2025 game in the 2025-26 season got `season_year = 2025` instead of `2026`.

2. **Schedule repository queries had no `season_year` filter** — `TeamScheduleRepository::getSchedule()`, `LeagueScheduleRepository::getAllGamesWithBoxScoreInfo()`, and `getProjectedGamesNextSimResult()` returned all games across all seasons. This caused last season's playoff games to appear on the current schedule, and tainted W-L record/streak calculations.

## Changes

- `ScheduleUpdater`: use `$this->season->endingYear` for `season_year` INSERT values
- `TeamScheduleRepository`: add `WHERE season_year = ?` to both query methods
- `LeagueScheduleRepository`: add `WHERE season_year = ?` to `getAllGamesWithBoxScoreInfo()`
- Thread `$season->endingYear` through service layers (TeamSchedule, LeagueSchedule, NextSim)
- Migration 133: shift existing Oct-Dec rows (`+1`) to ending-year convention
- Update all tests for new repository signatures + new filtering tests

## Collateral fix

`ProjectedDraftOrderRepository` already filters `WHERE season_year = ?` with `$season->endingYear`, but was silently missing Nov-Dec game results due to the incorrect `season_year` values. The migration corrects the data; no code change needed there.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.