### PR TITLE
fix: rebuild ibl_schedule atomically in ScheduleUpdater::update()

### DIFF
--- a/ibl5/classes/Updater/ScheduleUpdater.php
+++ b/ibl5/classes/Updater/ScheduleUpdater.php
@@ -215,116 +215,124 @@ class ScheduleUpdater extends \BaseMysqliRepository {
 
         $log = '';
 
-        $this->execute("DELETE FROM {$scheduleTable}", '');
-        $log .= "DELETE FROM {$scheduleTable}<p>";
+        // Rebuild the schedule atomically: a DELETE followed by row-by-row
+        // INSERTs is not safe to expose to concurrent readers. Without a
+        // transaction, a page load mid-import (or an import that throws partway)
+        // sees only the games inserted so far — the early season, since inserts
+        // run in date order. Wrapping it commits the new schedule all at once
+        // and rolls the DELETE back if any insert fails.
+        $this->transactional(function () use (&$log, $scheduleTable): void {
+            $this->execute("DELETE FROM {$scheduleTable}", '');
+            $log .= "DELETE FROM {$scheduleTable}<p>";
 
-        $this->preloadTeamNameMap();
+            $this->preloadTeamNameMap();
 
-        if ($this->sourceResolver !== null) {
-            $schData = $this->sourceResolver->getContents('sch');
-            if ($schData === null) {
-                throw new \RuntimeException('Schedule file not found via resolver');
+            if ($this->sourceResolver !== null) {
+                $schData = $this->sourceResolver->getContents('sch');
+                if ($schData === null) {
+                    throw new \RuntimeException('Schedule file not found via resolver');
+                }
+                $games = SchFileParser::parse($schData);
+            } else {
+                $ibl5Root = \Bootstrap\AppPaths::root();
+                $filePrefix = $this->leagueContext !== null ? $this->leagueContext->getFilePrefix() : 'IBL5';
+                $schFilePath = $ibl5Root . '/' . $filePrefix . '.sch';
+                $games = SchFileParser::parseFile($schFilePath);
             }
-            $games = SchFileParser::parse($schData);
-        } else {
-            $ibl5Root = \Bootstrap\AppPaths::root();
-            $filePrefix = $this->leagueContext !== null ? $this->leagueContext->getFilePrefix() : 'IBL5';
-            $schFilePath = $ibl5Root . '/' . $filePrefix . '.sch';
-            $games = SchFileParser::parseFile($schFilePath);
-        }
 
-        $currentDateSlot = -1;
-        $date = null;
-        $year = null;
-        /** @var int|null $month */
-        $month = null;
+            $currentDateSlot = -1;
+            $date = null;
+            $year = null;
+            /** @var int|null $month */
+            $month = null;
 
-        foreach ($games as $game) {
-            // Compute date when we move to a new date slot
-            if ($game['date_slot'] !== $currentDateSlot) {
-                $currentDateSlot = $game['date_slot'];
-                $monthDay = SchFileParser::dateSlotToMonthDay($game['date_slot']);
+            foreach ($games as $game) {
+                // Compute date when we move to a new date slot
+                if ($game['date_slot'] !== $currentDateSlot) {
+                    $currentDateSlot = $game['date_slot'];
+                    $monthDay = SchFileParser::dateSlotToMonthDay($game['date_slot']);
 
-                if ($monthDay !== null) {
-                    $dateString = $this->buildDateString($monthDay['month'], $monthDay['day']);
-                    $fullDate = $this->extractDate($dateString);
-                    $date = $fullDate['date'] ?? null;
-                    $year = $fullDate['year'] ?? null;
-                    $month = $fullDate['month'] ?? null;
+                    if ($monthDay !== null) {
+                        $dateString = $this->buildDateString($monthDay['month'], $monthDay['day']);
+                        $fullDate = $this->extractDate($dateString);
+                        $date = $fullDate['date'] ?? null;
+                        $year = $fullDate['year'] ?? null;
+                        $month = $fullDate['month'] ?? null;
+                    } else {
+                        $date = null;
+                        $year = null;
+                        $month = null;
+                    }
+                }
+
+                if ($date === null || $year === null) {
+                    continue;
+                }
+
+                // HEAT phase: only include games from the HEAT month
+                if ($this->season->phase === "HEAT" && $month !== Season::IBL_HEAT_MONTH) {
+                    continue;
+                }
+                if ($this->season->phase === "Preseason" && $month !== null
+                    && $month !== Season::IBL_PRESEASON_MONTH && $month !== Season::IBL_HEAT_MONTH) {
+                    continue;
+                }
+
+                // Compute BoxID: real for played games, placeholder for unplayed
+                if ($game['played']) {
+                    $boxID = SchFileParser::computeBoxId($game['date_slot'], $game['game_index']);
                 } else {
-                    $date = null;
-                    $year = null;
-                    $month = null;
+                    $boxID = self::UNPLAYED_BOX_ID;
+                }
+
+                $visitor_teamid = $game['visitor'];
+                $home_teamid = $game['home'];
+
+                if (!$this->isRealTeamGame($visitor_teamid, $home_teamid)) {
+                    continue;
+                }
+
+                $vScore = $game['visitor_score'];
+                $hScore = $game['home_score'];
+
+                $uuid = UuidGenerator::generateUuid();
+
+                $visitorName = $this->getTeamNameById($visitor_teamid);
+                $homeName = $this->getTeamNameById($home_teamid);
+
+                try {
+                    $this->execute(
+                        "INSERT INTO {$scheduleTable} (
+                            season_year,
+                            box_id,
+                            game_date,
+                            visitor_teamid,
+                            visitor_score,
+                            home_teamid,
+                            home_score,
+                            uuid
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        "iisiiiis",
+                        $this->season->endingYear,
+                        $boxID,
+                        $date,
+                        $visitor_teamid,
+                        $vScore,
+                        $home_teamid,
+                        $hScore,
+                        $uuid
+                    );
+                    $log .= "Inserted game: {$visitorName} @ {$homeName} on {$date}<br>";
+                } catch (\Exception $e) {
+                    $errorMessage = "Failed to insert schedule data for game between {$visitorName} and {$homeName}: " . $e->getMessage();
+                    \Logging\LoggerFactory::getChannel('db')->error('ScheduleUpdater database insert error', ['error' => $errorMessage]);
+                    echo '<strong class="ibl-form-error">Script Error: Failed to insert schedule data for game between ' . HtmlSanitizer::e($visitorName) . ' and ' . HtmlSanitizer::e($homeName) . '.</strong>';
+                    throw new \RuntimeException($errorMessage, 1002);
                 }
             }
 
-            if ($date === null || $year === null) {
-                continue;
-            }
-
-            // HEAT phase: only include games from the HEAT month
-            if ($this->season->phase === "HEAT" && $month !== Season::IBL_HEAT_MONTH) {
-                continue;
-            }
-            if ($this->season->phase === "Preseason" && $month !== null
-                && $month !== Season::IBL_PRESEASON_MONTH && $month !== Season::IBL_HEAT_MONTH) {
-                continue;
-            }
-
-            // Compute BoxID: real for played games, placeholder for unplayed
-            if ($game['played']) {
-                $boxID = SchFileParser::computeBoxId($game['date_slot'], $game['game_index']);
-            } else {
-                $boxID = self::UNPLAYED_BOX_ID;
-            }
-
-            $visitor_teamid = $game['visitor'];
-            $home_teamid = $game['home'];
-
-            if (!$this->isRealTeamGame($visitor_teamid, $home_teamid)) {
-                continue;
-            }
-
-            $vScore = $game['visitor_score'];
-            $hScore = $game['home_score'];
-
-            $uuid = UuidGenerator::generateUuid();
-
-            $visitorName = $this->getTeamNameById($visitor_teamid);
-            $homeName = $this->getTeamNameById($home_teamid);
-
-            try {
-                $this->execute(
-                    "INSERT INTO {$scheduleTable} (
-                        season_year,
-                        box_id,
-                        game_date,
-                        visitor_teamid,
-                        visitor_score,
-                        home_teamid,
-                        home_score,
-                        uuid
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    "iisiiiis",
-                    $this->season->endingYear,
-                    $boxID,
-                    $date,
-                    $visitor_teamid,
-                    $vScore,
-                    $home_teamid,
-                    $hScore,
-                    $uuid
-                );
-                $log .= "Inserted game: {$visitorName} @ {$homeName} on {$date}<br>";
-            } catch (\Exception $e) {
-                $errorMessage = "Failed to insert schedule data for game between {$visitorName} and {$homeName}: " . $e->getMessage();
-                \Logging\LoggerFactory::getChannel('db')->error('ScheduleUpdater database insert error', ['error' => $errorMessage]);
-                echo '<strong class="ibl-form-error">Script Error: Failed to insert schedule data for game between ' . HtmlSanitizer::e($visitorName) . ' and ' . HtmlSanitizer::e($homeName) . '.</strong>';
-                throw new \RuntimeException($errorMessage, 1002);
-            }
-        }
-
-        $log .= $this->insertPlayoffGamesFromScheduleHtm($scheduleTable);
+            $log .= $this->insertPlayoffGamesFromScheduleHtm($scheduleTable);
+        });
 
         \UI\DebugOutput::display($log, "{$scheduleTable} SQL Queries");
 

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/ScheduleAtomicityTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/ScheduleAtomicityTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\UpdateAllTheThings;
+
+use PHPUnit\Framework\Attributes\Group;
+use Season\Season;
+use Updater\Contracts\JsbSourceResolverInterface;
+
+/**
+ * Verifies that ScheduleUpdater::update() rebuilds ibl_schedule atomically:
+ * a mid-rebuild failure must leave the prior schedule intact rather than the
+ * DELETE'd / partially re-inserted state that produced the prod truncation bug.
+ */
+#[Group('database')]
+class ScheduleAtomicityTest extends PipelineIntegrationTestCase
+{
+    public function testFailedRebuildLeavesPriorScheduleIntact(): void
+    {
+        $this->updateSetting('Current Season Phase', 'Regular Season');
+        $this->updateSetting('Current Season Ending Year', '2026');
+        $this->seedSimDates(4, '2026-01-05', '2026-01-09');
+        $this->seedSimDates(5, '2026-01-10', '2026-01-15');
+        $this->seedLeagueConfig(2026);
+        $season = $this->buildSeason('Regular Season', 2026);
+
+        // Establish a known baseline schedule of exactly 3 rows.
+        $this->db->query("DELETE FROM ibl_schedule");
+        $this->seedScheduleRow('2026-02-01', 1, 2);
+        $this->seedScheduleRow('2026-02-02', 3, 4);
+        $this->seedScheduleRow('2026-02-03', 5, 6);
+        self::assertSame(3, $this->countRows('ibl_schedule'), 'baseline should be 3 rows');
+
+        // Second game's visitor_score = 201 violates chk_schedule_vscore (0..200),
+        // forcing a failure AFTER the DELETE and after one good insert.
+        $schPath = $this->buildSchFile([
+            ['date_slot' => 103, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 100, 'home_score' => 95],
+            ['date_slot' => 104, 'game_index' => 0, 'visitor' => 3, 'home' => 4, 'visitor_score' => 201, 'home_score' => 98],
+        ]);
+        $updater = $this->makeScheduleUpdater($season, $schPath);
+
+        $threw = false;
+        $level = ob_get_level();
+        ob_start();
+        try {
+            $updater->update();
+        } catch (\RuntimeException) {
+            $threw = true;
+        } finally {
+            while (ob_get_level() > $level) {
+                ob_end_clean();
+            }
+        }
+
+        self::assertTrue($threw, 'update() must throw when an insert violates a constraint');
+        self::assertSame(
+            3,
+            $this->countRows('ibl_schedule'),
+            'the DELETE must roll back — the prior 3-row schedule should be intact, not empty or partial',
+        );
+    }
+
+    public function testSuccessfulRebuildCommitsFullSchedule(): void
+    {
+        $this->updateSetting('Current Season Phase', 'Regular Season');
+        $this->updateSetting('Current Season Ending Year', '2026');
+        $this->seedSimDates(4, '2026-01-05', '2026-01-09');
+        $this->seedSimDates(5, '2026-01-10', '2026-01-15');
+        $this->seedLeagueConfig(2026);
+        $season = $this->buildSeason('Regular Season', 2026);
+
+        // Jan 11 → date_slot 103, Jan 12 → date_slot 104.
+        $schPath = $this->buildSchFile([
+            ['date_slot' => 103, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 105, 'home_score' => 98],
+            ['date_slot' => 103, 'game_index' => 1, 'visitor' => 3, 'home' => 4, 'visitor_score' => 110, 'home_score' => 102],
+            ['date_slot' => 104, 'game_index' => 0, 'visitor' => 5, 'home' => 6, 'visitor_score' => 99, 'home_score' => 101],
+        ]);
+        $updater = $this->makeScheduleUpdater($season, $schPath);
+
+        $level = ob_get_level();
+        ob_start();
+        try {
+            $updater->update();
+        } finally {
+            while (ob_get_level() > $level) {
+                ob_end_clean();
+            }
+        }
+
+        self::assertSame(
+            3,
+            $this->countRows('ibl_schedule', "game_date LIKE '2026-01-%'"),
+            'a successful rebuild should commit all parsed games',
+        );
+    }
+
+    private function makeScheduleUpdater(Season $season, string $schPath): \Updater\ScheduleUpdater
+    {
+        $schResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $schResolver->method('getContents')->willReturnCallback(
+            static function (string $ext) use ($schPath): ?string {
+                if ($ext === 'sch' && is_file($schPath)) {
+                    $data = file_get_contents($schPath);
+                    return $data !== false ? $data : null;
+                }
+                return null;
+            },
+        );
+
+        return new \Updater\ScheduleUpdater($this->db, $season, null, $schResolver);
+    }
+
+    private function seedScheduleRow(string $gameDate, int $visitor, int $home): void
+    {
+        $stmt = $this->db->prepare(
+            "INSERT INTO ibl_schedule
+                (season_year, box_id, game_date, visitor_teamid, visitor_score, home_teamid, home_score, uuid)
+             VALUES (2026, 100000, ?, ?, 0, ?, 0, ?)"
+        );
+        self::assertNotFalse($stmt);
+        $uuid = bin2hex(random_bytes(8));
+        $stmt->bind_param('siis', $gameDate, $visitor, $home, $uuid);
+        $stmt->execute();
+        $stmt->close();
+    }
+}

--- a/ibl5/tests/Updater/ScheduleUpdaterTest.php
+++ b/ibl5/tests/Updater/ScheduleUpdaterTest.php
@@ -8,6 +8,8 @@ use League\LeagueContext;
 use PHPUnit\Framework\TestCase;
 use Tests\WideUnit\Mocks\MockDatabase;
 use Season\Season;
+use Updater\Contracts\JsbSourceResolverInterface;
+use JsbParser\SchFileParser;
 
 /**
  * @covers \Updater\ScheduleUpdater
@@ -21,8 +23,12 @@ class ScheduleUpdaterTest extends TestCase
         $this->mockDb = new MockDatabase();
     }
 
-    private function createUpdater(string $phase = 'Regular Season', int $endingYear = 2025, bool $olympics = false): TestableScheduleUpdater
-    {
+    private function createUpdater(
+        string $phase = 'Regular Season',
+        int $endingYear = 2025,
+        bool $olympics = false,
+        ?JsbSourceResolverInterface $sourceResolver = null,
+    ): TestableScheduleUpdater {
         $season = $this->createStub(Season::class);
         $season->endingYear = $endingYear;
         $season->beginningYear = $endingYear - 1;
@@ -37,7 +43,135 @@ class ScheduleUpdaterTest extends TestCase
                 : $table,
         );
 
-        return new TestableScheduleUpdater($this->mockDb, $season, $leagueContext);
+        return new TestableScheduleUpdater($this->mockDb, $season, $leagueContext, $sourceResolver);
+    }
+
+    /**
+     * Build raw .sch bytes (80,000 bytes) containing the given games, for driving
+     * the full update() path through a stubbed resolver without touching disk.
+     *
+     * @param list<array{date_slot: int, game_index: int, visitor: int, home: int, visitor_score: int, home_score: int}> $games
+     */
+    private function buildSchBytes(array $games): string
+    {
+        $empty = str_repeat('0   0     ', SchFileParser::SLOTS_PER_DATE);
+        $data = str_repeat($empty, (int) (SchFileParser::FILE_SIZE / (SchFileParser::SLOTS_PER_DATE * SchFileParser::RECORD_SIZE)));
+
+        foreach ($games as $game) {
+            $offset = ($game['date_slot'] * SchFileParser::SLOTS_PER_DATE + $game['game_index']) * SchFileParser::RECORD_SIZE;
+
+            $home = str_pad((string) $game['home'], 2, '0', STR_PAD_LEFT);
+            $teamsField = str_pad((string) $game['visitor'] . $home, SchFileParser::TEAMS_FIELD_SIZE);
+
+            if ($game['visitor_score'] === 0 && $game['home_score'] === 0) {
+                $scoresField = str_pad('0', SchFileParser::SCORES_FIELD_SIZE);
+            } else {
+                $homeScore = str_pad((string) $game['home_score'], 3, '0', STR_PAD_LEFT);
+                $scoresField = str_pad((string) $game['visitor_score'] . $homeScore, SchFileParser::SCORES_FIELD_SIZE);
+            }
+
+            $data = substr_replace($data, $teamsField . $scoresField, $offset, SchFileParser::RECORD_SIZE);
+        }
+
+        return $data;
+    }
+
+    /** @param list<string> $queries */
+    private function firstIndexContaining(array $queries, string $needle): ?int
+    {
+        foreach ($queries as $i => $q) {
+            if (str_contains($q, $needle)) {
+                return $i;
+            }
+        }
+        return null;
+    }
+
+    /** @param list<string> $queries */
+    private function lastIndexContaining(array $queries, string $needle): ?int
+    {
+        $found = null;
+        foreach ($queries as $i => $q) {
+            if (str_contains($q, $needle)) {
+                $found = $i;
+            }
+        }
+        return $found;
+    }
+
+    /**
+     * @param list<array{team_name: string, teamid: int}> $teams
+     * @param list<array{date_slot: int, game_index: int, visitor: int, home: int, visitor_score: int, home_score: int}> $games
+     */
+    private function createUpdaterForFullRun(array $teams, array $games): TestableScheduleUpdater
+    {
+        $this->mockDb->setMockData($teams);
+        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver->method('getContents')->willReturn($this->buildSchBytes($games));
+
+        return $this->createUpdater(sourceResolver: $resolver);
+    }
+
+    public function testUpdateWrapsRebuildInCommittedTransaction(): void
+    {
+        $updater = $this->createUpdaterForFullRun(
+            [
+                ['team_name' => 'Alpha', 'teamid' => 1],
+                ['team_name' => 'Beta', 'teamid' => 2],
+            ],
+            [
+                ['date_slot' => 103, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 100, 'home_score' => 95],
+                ['date_slot' => 103, 'game_index' => 1, 'visitor' => 2, 'home' => 1, 'visitor_score' => 88, 'home_score' => 90],
+            ],
+        );
+
+        ob_start();
+        $updater->update();
+        ob_end_clean();
+
+        $log = $this->mockDb->getOperationLog();
+        $beginIdx = array_search('BEGIN', $log, true);
+        $commitIdx = array_search('COMMIT', $log, true);
+        $deleteIdx = $this->firstIndexContaining($log, 'DELETE FROM ibl_schedule');
+        $lastInsertIdx = $this->lastIndexContaining($log, 'INSERT INTO ibl_schedule');
+
+        $this->assertNotFalse($beginIdx, 'expected a BEGIN');
+        $this->assertNotFalse($commitIdx, 'expected a COMMIT');
+        $this->assertNotContains('ROLLBACK', $log, 'a committed run must not roll back');
+        $this->assertNotNull($deleteIdx);
+        $this->assertNotNull($lastInsertIdx);
+        $this->assertLessThan($deleteIdx, $beginIdx, 'BEGIN must precede the DELETE');
+        $this->assertGreaterThan($lastInsertIdx, $commitIdx, 'COMMIT must follow the last INSERT');
+    }
+
+    public function testUpdateRollsBackWhenAnInsertFails(): void
+    {
+        $updater = $this->createUpdaterForFullRun(
+            [
+                ['team_name' => 'Alpha', 'teamid' => 1],
+                ['team_name' => 'Beta', 'teamid' => 2],
+            ],
+            [
+                ['date_slot' => 103, 'game_index' => 0, 'visitor' => 1, 'home' => 2, 'visitor_score' => 100, 'home_score' => 95],
+                ['date_slot' => 103, 'game_index' => 1, 'visitor' => 2, 'home' => 1, 'visitor_score' => 88, 'home_score' => 90],
+            ],
+        );
+        $this->mockDb->failOnNthInsert(2);
+
+        ob_start();
+        try {
+            $updater->update();
+            $threw = false;
+        } catch (\RuntimeException) {
+            $threw = true;
+        } finally {
+            ob_end_clean();
+        }
+
+        $log = $this->mockDb->getOperationLog();
+        $this->assertTrue($threw, 'update() must rethrow when an insert fails');
+        $this->assertContains('ROLLBACK', $log, 'a failed run must roll back');
+        $this->assertNotContains('COMMIT', $log, 'a failed run must not commit');
     }
 
     public function testExtractDateReturnsNullForEmptyString(): void

--- a/ibl5/tests/WideUnit/Mocks/MockDatabase.php
+++ b/ibl5/tests/WideUnit/Mocks/MockDatabase.php
@@ -27,7 +27,16 @@ class MockDatabase extends \mysqli
     private ?int $numRows = null;
     private bool $returnTrue = true;
     private array $executedQueries = [];
+    /**
+     * Ordered log of SQL queries AND transaction lifecycle markers
+     * (BEGIN/COMMIT/ROLLBACK), kept separate from $executedQueries so callers
+     * that assert on the SQL-only log are unaffected by transaction recording.
+     * @var list<string>
+     */
+    private array $operationLog = [];
     private int $affectedRows = 0;
+    private ?int $failOnNthInsert = null;
+    private int $insertCount = 0;
 
     /**
      * Pattern-based query routing: maps SQL regex patterns to specific result sets.
@@ -60,6 +69,7 @@ class MockDatabase extends \mysqli
     {
         // Track all executed queries for verification
         $this->executedQueries[] = $query;
+        $this->operationLog[] = $query;
 
         // Strip backticks for pattern matching (SQL table names may be backtick-quoted)
         $normalized = str_replace('`', '', $query);
@@ -68,6 +78,14 @@ class MockDatabase extends \mysqli
         if (stripos($normalized, 'INSERT') === 0 ||
             stripos($normalized, 'UPDATE') === 0 ||
             stripos($normalized, 'DELETE') === 0) {
+            // Optional failure injection: make the Nth INSERT fail, simulating a
+            // constraint violation mid-import so tests can exercise rollback.
+            if (stripos($normalized, 'INSERT') === 0) {
+                $this->insertCount++;
+                if ($this->failOnNthInsert !== null && $this->insertCount === $this->failOnNthInsert) {
+                    return false;
+                }
+            }
             // Set affected rows for UPDATE/DELETE operations (default to 1 for successful operations)
             if ($this->returnTrue) {
                 $this->affectedRows = 1;
@@ -293,6 +311,15 @@ class MockDatabase extends \mysqli
     {
         $this->returnTrue = $returnTrue;
     }
+
+    /**
+     * Configure the mock so the Nth INSERT (1-based, counting only INSERTs)
+     * returns false, mimicking a constraint violation mid-import.
+     */
+    public function failOnNthInsert(int $n): void
+    {
+        $this->failOnNthInsert = $n;
+    }
     
     public function getExecutedQueries(): array
     {
@@ -301,10 +328,25 @@ class MockDatabase extends \mysqli
             $this->executedQueries
         );
     }
-    
+
+    /**
+     * SQL queries interleaved with transaction markers (BEGIN/COMMIT/ROLLBACK),
+     * in execution order. Use this to assert transactional wrapping/ordering.
+     *
+     * @return list<string>
+     */
+    public function getOperationLog(): array
+    {
+        return array_map(
+            static fn (string $q): string => str_replace('`', '', $q),
+            $this->operationLog
+        );
+    }
+
     public function clearQueries(): void
     {
         $this->executedQueries = [];
+        $this->operationLog = [];
     }
     
     public function sql_escape_string(string $string): string
@@ -323,20 +365,25 @@ class MockDatabase extends \mysqli
     }
 
     /**
-     * Mock transaction support - no-op stubs to prevent "object is already closed" errors
+     * Mock transaction support — record lifecycle into the operation log (not the
+     * SQL-only executed-query log) so tests can assert the BEGIN/COMMIT/ROLLBACK
+     * ordering around a unit of work without perturbing getExecutedQueries().
      */
     public function begin_transaction(int $flags = 0, ?string $name = null): bool
     {
+        $this->operationLog[] = 'BEGIN';
         return true;
     }
 
     public function commit(int $flags = 0, ?string $name = null): bool
     {
+        $this->operationLog[] = 'COMMIT';
         return true;
     }
 
     public function rollback(int $flags = 0, ?string $name = null): bool
     {
+        $this->operationLog[] = 'ROLLBACK';
         return true;
     }
 

--- a/ibl5/tests/WideUnit/Mocks/MockDatabase.php
+++ b/ibl5/tests/WideUnit/Mocks/MockDatabase.php
@@ -347,6 +347,7 @@ class MockDatabase extends \mysqli
     {
         $this->executedQueries = [];
         $this->operationLog = [];
+        $this->insertCount = 0;
     }
     
     public function sql_escape_string(string $string): string


### PR DESCRIPTION
## What

Wrap the schedule rebuild in `ScheduleUpdater::update()` (`DELETE FROM ibl_schedule` + the regular-season insert loop + the playoff insert) in `BaseMysqliRepository::transactional()`.

## Why

The rebuild was **not** transactional: it `DELETE`d the whole table, then re-`INSERT`ed games one at a time in date order. During every sim's import there is a window where `ibl_schedule` is empty or partial — and because inserts run in date order, a mid-import read returns only the early season. This surfaced on prod as a team schedule showing only the upcoming-sim window (e.g. through mid-December) with the rest of the season (Jan–May) missing. An import that throws partway (the per-game `try/catch` rethrows) leaves the same partial state persisted.

The `season_year` filter from #873 was **not** the cause — prod data is uniformly `season_year=2008` and the filter passes every row. The `DELETE`+reINSERT pattern predates this change; this PR only makes it atomic.

## How

`transactional()` begins/commits a transaction around the rebuild (and uses a savepoint when already nested, e.g. inside the sim pipeline). Readers now see the old complete schedule until commit, the new one after — never a gap. A failed insert rolls the `DELETE` back. `DELETE` (not `TRUNCATE`) is retained — `TRUNCATE` would implicitly commit and defeat atomicity.

## Tests

- **Unit** (`ScheduleUpdaterTest`): rebuild is wrapped (`BEGIN` before the `DELETE`, `COMMIT` after the last `INSERT`); an insert failure produces `ROLLBACK` and no `COMMIT`. `MockDatabase` gained a separate operation log (`getOperationLog`) so `getExecutedQueries` is unchanged for existing tests, plus a `failOnNthInsert` hook.
- **DB integration** (`ScheduleAtomicityTest`): a mid-rebuild CHECK violation makes `update()` throw and leaves the prior schedule fully intact (no empty/partial state); a successful rebuild commits the full schedule.

## Manual Testing

No manual testing needed — all changes are covered by unit and DB-integration tests.

## Out of scope (noted during investigation)

`bin/db-sync-prod` checks a `schema_migrations` table while prod tracks migrations in a table named `migrations`. This mismatch made it look like migration 133 wasn't applied on prod when it was. Left for a dedicated change.