### PR TITLE
feat: re-enable CastInt/CastFloat/CastString mutators in infection.json5

### DIFF
--- a/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsService.php
+++ b/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsService.php
@@ -273,7 +273,7 @@ class SeasonLeaderboardsService implements SeasonLeaderboardsServiceInterface
             'TGM' => $tgm / $games,
             'TGA' => $tga / $games,
             'TGP' => $tga > 0 ? $tgm / $tga : 0.0,
-            'GAMES' => (float) $games,
+            'GAMES' => $games,
             'MIN' => $row['minutes'] / $games,
             default => (2 * $fgm + $ftm + $tgm) / $games,
         };

--- a/ibl5/infection.json5
+++ b/ibl5/infection.json5
@@ -44,10 +44,7 @@
         "customPath": "vendor/bin/phpunit"
     },
     "mutators": {
-        "@default": true,
-        "CastFloat": false,
-        "CastInt": false,
-        "CastString": false
+        "@default": true
     },
     "testFramework": "phpunit",
     "testFrameworkOptions": "--configuration=phpunit-mutation.xml",


### PR DESCRIPTION
## Summary

Re-enables the three disabled cast mutators (`CastInt`, `CastFloat`, `CastString`) in `infection.json5` and fixes all surviving mutants to maintain MSI at 100%.

### Changes

- `infection.json5`: removed per-mutator exclusions for `CastFloat`, `CastInt`, `CastString`
- `classes/SeasonLeaderboards/SeasonLeaderboardsService.php`: removed redundant `(float)` cast on already-integer `$games` value

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)