### PR TITLE
feat: add decision-trigger pre-classification to plan verification

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -4,6 +4,7 @@ disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
 last_verified: 2026-05-28
+
 ---
 
 # /plan — Implementation Planning with Verification Matrix
@@ -66,6 +67,7 @@ After receiving the Plan agent's output, check these gates yourself — do NOT d
    - `subject to validation`
    - `subject to review`
    If any match is found, resolve the decision in-place before saving the plan. The nightly agent cannot make judgment calls — every table cell must contain a concrete action, not a deferred question.
+8. **Decision-trigger pre-classified** — scan implementation phases for file additions matching `bin/adr-check` trigger patterns (listed in `plan-verification.md` § Decision-trigger pre-classification). If any trigger fires, verify the plan includes a resolution step (ADR or bypass marker). If missing, add the appropriate resolution step and update the verification matrix.
 
 If validation fails on any gate, fix the matrix yourself rather than re-running the Plan agent.
 

--- a/.claude/rules/plan-verification.md
+++ b/.claude/rules/plan-verification.md
@@ -1,6 +1,6 @@
 ---
 description: Requires plans to classify every verification step into the test-type taxonomy at plan-write time, preventing manual-testing items from deferring to post-plan cleanup.
-last_verified: 2026-05-16
+last_verified: 2026-05-28
 ---
 
 # Plan Verification Matrix
@@ -81,6 +81,26 @@ flags the PR (advisory comment, non-blocking).
 This rule is advisory — gated growth is acceptable when justified. The goal is
 to force a structural conversation at plan-write time, not to enforce a hard
 ceiling.
+
+## Decision-trigger pre-classification
+
+`bin/adr-check` fires on PRs that add files matching specific trigger patterns. When a plan phase adds any of these, the plan must pre-decide the resolution:
+
+| Trigger | File pattern |
+|---------|-------------|
+| PHPStan rule | `ibl5/phpstan-rules/*.php` |
+| Agent rule | `.claude/rules/*.md` |
+| CI workflow | `.github/workflows/*.yml` |
+| Destructive migration | Migration SQL containing `DROP TABLE`, `DROP COLUMN`, or `DROP INDEX` |
+| Tool script | `bin/*` (new file, ≥50 lines) |
+| New dependency | New entry in `ibl5/composer.json` `require` or `require-dev` |
+
+**Resolution — exactly one of:**
+
+- **ADR:** Add an implementation step to write an ADR under `ibl5/docs/decisions/`. Use when the change introduces a genuinely new architectural constraint not covered by an existing ADR.
+- **Bypass:** Add an implementation step to include `<!-- no-adr: reason at least 15 characters -->` in the PR body. Use when the decision is already captured in an existing ADR (e.g., new PHPStan rules enforcing ADR-0001's architecture split).
+
+If the plan has no phases adding trigger-pattern files, no action is needed.
 
 ## What the plan must NOT do
 


### PR DESCRIPTION
## Summary

Add `bin/adr-check` decision-trigger pre-classification to the plan verification matrix rule and the `/plan` validation gates, so plans that add trigger files must pre-decide ADR vs bypass at plan-write time.

This prevents the reactive CI failure pattern where the nightly agent discovers the `bin/adr-check` gate failure after commit, requiring a fix commit and full CI re-run.

## Changes

- `.claude/rules/plan-verification.md`: Added "Decision-trigger pre-classification" section listing all 6 trigger patterns and requiring plans to include a resolution step (ADR or bypass) at plan-write time.
- `.claude/commands/plan.md`: Added gate 8 to Step 4 validation — scan implementation phases for trigger-pattern file additions and verify a resolution step is present.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.