### PR TITLE
harden Olympics table rewrite + session-isolation regression guards

### DIFF
--- a/.claude/rules/database-access.md
+++ b/.claude/rules/database-access.md
@@ -1,5 +1,6 @@
 ---
 description: Docker MariaDB connection details, query patterns, and schema verification rules.
+last_verified: 2026-05-28
 paths:
   - "**/*Repository.php"
   - "**/migrations/000_baseline_schema.sql"
@@ -66,6 +67,8 @@ bin/db-test-up [worktree-name] [--no-run]
 ```
 
 Bootstraps a sibling `ibl5_test` database for `phpunit --group database` runs. Drops and recreates `ibl5_test` each run; never touches `iblhoops_ibl5`. Without arguments, uses the main checkout Docker environment. With a worktree name, uses the worktree's Docker stack. `--no-run` bootstraps the database only.
+
+**In a worktree, ALWAYS run DB-integration tests via `bin/db-test-up <slug>` — never hand-run `DB_HOST=127.0.0.1 vendor/bin/phpunit --group database` from the host.** Only the main stack's `ibl5-mariadb` publishes host port 3306; worktree DB containers (`ibl5-db-<slug>`) are reachable on the Docker network only. So a host-side `127.0.0.1` connection silently targets the **main** stack's `ibl5_test` — typically a stale DB from an earlier run — producing phantom failures (wrong counts, duplicate-key errors) that don't reproduce in CI. `bin/db-test-up <slug>` runs phpunit inside the worktree php container against `DB_HOST=db`, hitting the freshly-built worktree DB. Verify port ownership with `docker ps --format '{{.Names}} {{.Ports}}' | grep 3306`.
 
 ## MariaDB Strict Mode & Triggers
 

--- a/.claude/rules/playwright-tests.md
+++ b/.claude/rules/playwright-tests.md
@@ -1,7 +1,7 @@
 ---
 description: Playwright E2E testing rules, Docker requirements, and actionability pitfalls.
 paths: ibl5/tests/e2e/**/*.ts
-last_verified: 2026-05-23
+last_verified: 2026-05-28
 ---
 
 # Playwright E2E Testing Rules
@@ -141,6 +141,28 @@ test.describe('Public module flow', () => {
 | Authenticated page | `../fixtures/auth` | None (uses stored auth state + cookie-based appState) |
 
 **Never** call the login flow inside a test — always use the auth fixture. The `auth.setup.ts` project runs first and saves browser state to `playwright/.auth/user.json`.
+
+### Shared server session — never mutate it; test the isolation invariant
+
+All authenticated workers share ONE server-side PHP session (the single pinned
+PHPSESSID in `playwright/.auth/user.json`). Per-browser-context cookie jars are
+isolated; the server session is not. So **anything an authenticated test writes
+into `$_SESSION` leaks into every other concurrent authenticated test.** This is
+why the auth fixture forbids logout tests, and it is what broke PR #878: an
+authenticated test switching `?league=olympics` wrote `$_SESSION['current_league']`,
+flipping every parallel test into Olympics context.
+
+Two consequences for any **global mode/context switch** (league, impersonation,
+admin-mode, feature flag) that is read by shared infrastructure:
+
+1. **Production code** must persist the switch per-request (cookie + in-memory),
+   never in `$_SESSION`. See `League\LeagueContext::setLeague()`.
+2. **Tests** must cover the *negative invariant*, not just that the switch works:
+   open a second context sharing the same storageState (= same session) and assert
+   the switch in context A does NOT change what context B resolves. See
+   `tests/e2e/flows/league-context-isolation.spec.ts` as the canonical example.
+   Assert against the RAW server response (`context.request.get(...)`) when the
+   signal lives in markup that Alpine/HTMX removes from the live DOM.
 
 ## PHP Error Detection (Mandatory)
 

--- a/ibl5/classes/BaseMysqliRepository.php
+++ b/ibl5/classes/BaseMysqliRepository.php
@@ -153,6 +153,29 @@ abstract class BaseMysqliRepository
             : $iblTableName;
     }
 
+    /**
+     * Rewrite IBL table names to their Olympics equivalents when the active
+     * league context is Olympics.
+     *
+     * Opt-in is signalled by BACKTICK-QUOTING the table name (`` `ibl_plr` ``):
+     * a query that quotes a mapped table is rewritten; a query that references
+     * it bare (e.g. `FROM ibl_team_info`) is left on IBL. This is deliberate —
+     * identity/GM lookups (e.g. NavigationRepository::resolveTeamId, which reads
+     * the IBL-only `gm_username` column) write the table name bare precisely so
+     * they stay on IBL even in Olympics context. Rewriting bare names would
+     * route them to Olympics tables that lack those columns and fatal.
+     *
+     * When a table opts in, ALL of its references in that query are rewritten —
+     * the backtick FROM, column-qualified refs (`ibl_plr.pid`), and any bare
+     * mention. A naive backtick-only str_replace rewrote the FROM but left
+     * `table.column` references dangling, producing "Unknown table" fatals
+     * (e.g. Team::load() in Olympics context). Word boundaries ensure `ibl_plr`
+     * never matches inside `ibl_plr_snapshots` or the already-rewritten
+     * `ibl_olympics_plr`, so the transform is idempotent.
+     *
+     * The IBL→Olympics mapping is owned by {@see \League\LeagueContext::TABLE_MAP}
+     * — the single source of truth shared with getTableName().
+     */
     protected function rewriteTableNames(string $query): string
     {
         $ctx = $this->leagueContext ?? self::$sharedLeagueContext;
@@ -160,45 +183,24 @@ abstract class BaseMysqliRepository
             return $query;
         }
 
-        return str_replace(
-            [
-                '`ibl_saved_depth_chart_players`',
-                '`ibl_saved_depth_charts`',
-                '`ibl_box_scores_teams`',
-                '`ibl_box_scores`',
-                '`ibl_rcb_alltime_records`',
-                '`ibl_rcb_season_records`',
-                '`ibl_jsb_transactions`',
-                '`ibl_jsb_history`',
-                '`ibl_plr_snapshots`',
-                '`ibl_league_config`',
-                '`ibl_team_info`',
-                '`ibl_standings`',
-                '`ibl_schedule`',
-                '`ibl_power`',
-                '`ibl_hist`',
-                '`ibl_plr`',
-            ],
-            [
-                '`ibl_olympics_saved_depth_chart_players`',
-                '`ibl_olympics_saved_depth_charts`',
-                '`ibl_olympics_box_scores_teams`',
-                '`ibl_olympics_box_scores`',
-                '`ibl_olympics_rcb_alltime_records`',
-                '`ibl_olympics_rcb_season_records`',
-                '`ibl_olympics_jsb_transactions`',
-                '`ibl_olympics_jsb_history`',
-                '`ibl_olympics_plr_snapshots`',
-                '`ibl_olympics_league_config`',
-                '`ibl_olympics_team_info`',
-                '`ibl_olympics_standings`',
-                '`ibl_olympics_schedule`',
-                '`ibl_olympics_power`',
-                '`ibl_olympics_hist`',
-                '`ibl_olympics_plr`',
-            ],
-            $query
-        );
+        foreach (\League\LeagueContext::TABLE_MAP as $iblTable => $olympicsTable) {
+            // Only rewrite tables that opt in via a backtick-quoted reference.
+            if (strpos($query, '`' . $iblTable . '`') === false) {
+                continue;
+            }
+
+            $rewritten = preg_replace(
+                '/(?<![A-Za-z0-9_])' . preg_quote($iblTable, '/') . '(?![A-Za-z0-9_])/',
+                $olympicsTable,
+                $query
+            );
+
+            // preg_replace returns null only on regex engine failure; keep the
+            // current query rather than passing null downstream.
+            $query = $rewritten ?? $query;
+        }
+
+        return $query;
     }
 
     /**

--- a/ibl5/classes/League/LeagueContext.php
+++ b/ibl5/classes/League/LeagueContext.php
@@ -17,6 +17,33 @@ class LeagueContext
     const COOKIE_NAME = 'ibl_league';
 
     /**
+     * Single source of truth mapping IBL table names to their Olympics
+     * equivalents. Consumed by both getTableName() (explicit per-name
+     * resolution) and BaseMysqliRepository::rewriteTableNames() (query-string
+     * rewrite). Add a new Olympics-backed table here in ONE place.
+     *
+     * @var array<string, string>
+     */
+    const TABLE_MAP = [
+        'ibl_box_scores' => 'ibl_olympics_box_scores',
+        'ibl_box_scores_teams' => 'ibl_olympics_box_scores_teams',
+        'ibl_schedule' => 'ibl_olympics_schedule',
+        'ibl_standings' => 'ibl_olympics_standings',
+        'ibl_power' => 'ibl_olympics_power',
+        'ibl_team_info' => 'ibl_olympics_team_info',
+        'ibl_league_config' => 'ibl_olympics_league_config',
+        'ibl_plr' => 'ibl_olympics_plr',
+        'ibl_hist' => 'ibl_olympics_hist',
+        'ibl_plr_snapshots' => 'ibl_olympics_plr_snapshots',
+        'ibl_jsb_history' => 'ibl_olympics_jsb_history',
+        'ibl_jsb_transactions' => 'ibl_olympics_jsb_transactions',
+        'ibl_rcb_alltime_records' => 'ibl_olympics_rcb_alltime_records',
+        'ibl_rcb_season_records' => 'ibl_olympics_rcb_season_records',
+        'ibl_saved_depth_charts' => 'ibl_olympics_saved_depth_charts',
+        'ibl_saved_depth_chart_players' => 'ibl_olympics_saved_depth_chart_players',
+    ];
+
+    /**
      * Request-scoped league selection set via setLeague().
      *
      * Holds the value for the remainder of the current request so that an
@@ -216,25 +243,7 @@ class LeagueContext
             return $iblTableName;
         }
 
-        return match ($iblTableName) {
-            'ibl_box_scores' => 'ibl_olympics_box_scores',
-            'ibl_box_scores_teams' => 'ibl_olympics_box_scores_teams',
-            'ibl_schedule' => 'ibl_olympics_schedule',
-            'ibl_standings' => 'ibl_olympics_standings',
-            'ibl_power' => 'ibl_olympics_power',
-            'ibl_team_info' => 'ibl_olympics_team_info',
-            'ibl_league_config' => 'ibl_olympics_league_config',
-            'ibl_plr' => 'ibl_olympics_plr',
-            'ibl_hist' => 'ibl_olympics_hist',
-            'ibl_plr_snapshots' => 'ibl_olympics_plr_snapshots',
-            'ibl_jsb_history' => 'ibl_olympics_jsb_history',
-            'ibl_jsb_transactions' => 'ibl_olympics_jsb_transactions',
-            'ibl_rcb_alltime_records' => 'ibl_olympics_rcb_alltime_records',
-            'ibl_rcb_season_records' => 'ibl_olympics_rcb_season_records',
-            'ibl_saved_depth_charts' => 'ibl_olympics_saved_depth_charts',
-            'ibl_saved_depth_chart_players' => 'ibl_olympics_saved_depth_chart_players',
-            default => $iblTableName,
-        };
+        return self::TABLE_MAP[$iblTableName] ?? $iblTableName;
     }
 
     /**

--- a/ibl5/classes/Team/Team.php
+++ b/ibl5/classes/Team/Team.php
@@ -15,7 +15,7 @@ use League\League;
  * @see BaseMysqliRepository For base class documentation and error codes
  *
  *
- * @phpstan-type TeamWithStandingsRow array{teamid: int, team_city: string, team_name: string, color1: string, color2: string, arena: string, capacity: int, owner_name: string, owner_email: string, discord_id: ?int, used_extension_this_chunk: int, used_extension_this_season: ?int, has_mle: int, has_lle: int, league_record: ?string, ...}
+ * @phpstan-type TeamWithStandingsRow array{teamid: int, team_city: string, team_name: string, color1: string, color2: string, arena: string, capacity: int, owner_name: string, owner_email: string, discord_id: ?int, used_extension_this_chunk?: int, used_extension_this_season?: ?int, has_mle?: int, has_lle?: int, league_record: ?string, ...}
  */
 class Team extends \BaseMysqliRepository
 {
@@ -144,10 +144,13 @@ class Team extends \BaseMysqliRepository
         $discordId = $teamRow['discord_id'] ?? null;
         $this->discord_id = $discordId;
 
-        $this->hasUsedExtensionThisSim = $teamRow['used_extension_this_chunk'];
+        // Extension / MLE / LLE are IBL salary-cap concepts; the Olympics
+        // team_info table omits these columns, so SELECT * yields a row without
+        // these keys. Default to 0 rather than fataling on the typed int props.
+        $this->hasUsedExtensionThisSim = $teamRow['used_extension_this_chunk'] ?? 0;
         $this->hasUsedExtensionThisSeason = $teamRow['used_extension_this_season'] ?? 0;
-        $this->has_mle = $teamRow['has_mle'];
-        $this->has_lle = $teamRow['has_lle'];
+        $this->has_mle = $teamRow['has_mle'] ?? 0;
+        $this->has_lle = $teamRow['has_lle'] ?? 0;
 
         /** @var string|null $leagueRecord */
         $leagueRecord = $teamRow['league_record'] ?? null;

--- a/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
@@ -378,8 +378,12 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
         self::assertStringContainsString('`ibl_olympics_saved_depth_charts`', $result);
     }
 
-    public function testRewriteTableNamesLeavesBareNamesAlone(): void
+    public function testRewriteTableNamesRewritesColumnQualifiedReferences(): void
     {
+        // Regression: a table-qualified column reference (ibl_plr.name) MUST be
+        // rewritten alongside its FROM clause. The previous backtick-only
+        // str_replace left it dangling, so rewriting `FROM `ibl_plr`` while
+        // leaving `ibl_plr.name` produced "Unknown table 'ibl_plr'".
         $context = $this->createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
 
@@ -389,7 +393,92 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
         $result = $repo->callRewriteTableNames($query);
 
         self::assertStringContainsString('`ibl_olympics_plr`', $result);
-        self::assertStringContainsString('ibl_plr.name AS ibl_plr_name', $result);
+        self::assertStringContainsString('ibl_olympics_plr.name', $result);
+        // The qualified column ref is rewritten; the column alias, which merely
+        // contains the table name as a substring, is left untouched.
+        self::assertStringContainsString('AS ibl_plr_name', $result);
+        self::assertDoesNotMatchRegularExpression('/(?<![A-Za-z0-9_])ibl_plr\./', $result);
+    }
+
+    public function testRewriteTableNamesLeavesBareReferencesOnIbl(): void
+    {
+        // Regression guard for the NavigationRepository::resolveTeamId fatal:
+        // identity/GM lookups reference the table BARE (no backticks) precisely
+        // so they stay on IBL even in Olympics context — the IBL-only
+        // `gm_username` column does not exist on ibl_olympics_team_info.
+        // Backtick-quoting is the opt-in signal; bare references must NOT be
+        // rewritten.
+        $context = $this->createStub(LeagueContext::class);
+        $context->method('isOlympics')->willReturn(true);
+
+        $repo = new TestableBaseMysqliRepository($this->db, $context);
+
+        $query = "SELECT teamid FROM ibl_team_info WHERE gm_username = ?";
+        $result = $repo->callRewriteTableNames($query);
+
+        self::assertSame($query, $result, 'bare (non-backticked) table refs must stay on IBL');
+
+        // This bare query must remain executable against the live IBL schema.
+        $stmt = $this->db->prepare($result);
+        self::assertNotFalse($stmt, 'bare IBL query failed to prepare: ' . $result);
+        $stmt->close();
+    }
+
+    public function testRewriteTableNamesIsIdempotent(): void
+    {
+        $context = $this->createStub(LeagueContext::class);
+        $context->method('isOlympics')->willReturn(true);
+
+        $repo = new TestableBaseMysqliRepository($this->db, $context);
+
+        $query = "SELECT ibl_team_info.* FROM `ibl_team_info` "
+            . "LEFT JOIN `ibl_standings` ON ibl_team_info.teamid = ibl_standings.teamid";
+        $once = $repo->callRewriteTableNames($query);
+        $twice = $repo->callRewriteTableNames($once);
+
+        self::assertSame($once, $twice, 'rewriteTableNames must be idempotent');
+        self::assertNoUnprefixedIblTable($once);
+    }
+
+    public function testRewriteTableNamesProducesExecutableQueryForColumnQualifiedJoin(): void
+    {
+        // Gold-standard regression: the exact Team::load() shape that fataled in
+        // CI ("Unknown table 'ibl5.ibl_team_info'"). After rewriting it must run.
+        $context = $this->createStub(LeagueContext::class);
+        $context->method('isOlympics')->willReturn(true);
+
+        $repo = new TestableBaseMysqliRepository($this->db, $context);
+
+        $query = "SELECT ibl_team_info.*, ibl_standings.league_record "
+            . "FROM `ibl_team_info` "
+            . "LEFT JOIN `ibl_standings` ON ibl_team_info.teamid = ibl_standings.teamid "
+            . "WHERE ibl_team_info.teamid = ? LIMIT 1";
+        $rewritten = $repo->callRewriteTableNames($query);
+
+        self::assertNoUnprefixedIblTable($rewritten);
+
+        // Executing the rewritten query against the live schema must not throw.
+        $stmt = $this->db->prepare($rewritten);
+        self::assertNotFalse($stmt, 'rewritten query failed to prepare: ' . $rewritten);
+        $teamid = 1;
+        $stmt->bind_param('i', $teamid);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    /**
+     * Assert no mapped IBL table name survives as a standalone identifier token.
+     */
+    private static function assertNoUnprefixedIblTable(string $query): void
+    {
+        foreach (array_keys(LeagueContext::TABLE_MAP) as $iblTable) {
+            $pattern = '/(?<![A-Za-z0-9_])' . preg_quote($iblTable, '/') . '(?![A-Za-z0-9_])/';
+            self::assertDoesNotMatchRegularExpression(
+                $pattern,
+                $query,
+                "Un-rewritten IBL table '$iblTable' survived: $query"
+            );
+        }
     }
 
     public function testRewriteTableNamesUsesSharedContextFallback(): void

--- a/ibl5/tests/DatabaseIntegration/TeamOlympicsLoadTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamOlympicsLoadTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use League\LeagueContext;
+use PHPUnit\Framework\Attributes\Group;
+use Team\Team;
+
+#[Group('database')]
+class TeamOlympicsLoadTest extends DatabaseTestCase
+{
+    protected function tearDown(): void
+    {
+        \BaseMysqliRepository::clearSharedLeagueContext();
+        parent::tearDown();
+    }
+
+    /**
+     * Regression: the Olympics team_info table omits IBL-only salary-cap columns
+     * (used_extension_this_chunk, has_mle, has_lle). Once the table-name rewrite
+     * was fixed so Team::load() actually resolves the Olympics table, SELECT *
+     * returns a row WITHOUT those keys — and Team::fill() fataled with
+     * "Cannot assign null to property ...::$hasUsedExtensionThisSim of type int".
+     * Loading an Olympics team must default the missing IBL-only fields to 0.
+     */
+    public function testLoadsOlympicsTeamThatOmitsIblOnlyColumns(): void
+    {
+        $this->insertRow('ibl_olympics_team_info', [
+            'teamid' => 99,
+            'team_city' => 'Test City',
+            'team_name' => 'Test Oly',
+            'color1' => '000000',
+            'color2' => 'FFFFFF',
+            'arena' => 'Test Arena',
+            'capacity' => 0,
+            'owner_name' => 'GM Test',
+            'owner_email' => 'gm@test',
+        ]);
+
+        $context = $this->createStub(LeagueContext::class);
+        $context->method('isOlympics')->willReturn(true);
+        \BaseMysqliRepository::setSharedLeagueContext($context);
+
+        // Must not throw — this is the exact path that fataled in CI.
+        $team = Team::initialize($this->db, 99);
+
+        self::assertSame(99, $team->teamid);
+        self::assertSame('Test Oly', $team->name);
+        self::assertSame(0, $team->hasUsedExtensionThisSim);
+        self::assertSame(0, $team->hasUsedExtensionThisSeason);
+        self::assertSame(0, $team->has_mle);
+        self::assertSame(0, $team->has_lle);
+    }
+}

--- a/ibl5/tests/League/LeagueContextTest.php
+++ b/ibl5/tests/League/LeagueContextTest.php
@@ -349,6 +349,30 @@ class LeagueContextTest extends TestCase
         $this->assertSame('some_other_table', $this->leagueContext->getTableName('some_other_table'));
     }
 
+    public function testTableMapIsTheSingleSourceOfTruthForGetTableName(): void
+    {
+        $_SESSION['current_league'] = 'olympics';
+
+        // getTableName() must be a thin lookup over TABLE_MAP (the shared map
+        // also consumed by BaseMysqliRepository::rewriteTableNames). Guards
+        // against the two diverging, which is how Olympics tables silently
+        // stopped being rewritten.
+        foreach (LeagueContext::TABLE_MAP as $iblTable => $olympicsTable) {
+            $this->assertSame($olympicsTable, $this->leagueContext->getTableName($iblTable));
+        }
+    }
+
+    public function testTableMapEntriesAreWellFormed(): void
+    {
+        foreach (LeagueContext::TABLE_MAP as $iblTable => $olympicsTable) {
+            $this->assertStringStartsWith('ibl_', $iblTable, "Key '$iblTable' must be an IBL table");
+            $this->assertStringStartsWith('ibl_olympics_', $olympicsTable, "Value '$olympicsTable' must be Olympics-prefixed");
+            $this->assertNotSame($iblTable, $olympicsTable, "'$iblTable' must map to a distinct Olympics table");
+            // The Olympics name is the IBL name with the olympics_ infix.
+            $this->assertSame('ibl_olympics_' . substr($iblTable, strlen('ibl_')), $olympicsTable);
+        }
+    }
+
     public function testGetTableNameReturnsIblTableNamesByDefault(): void
     {
         // No league set — defaults to IBL

--- a/ibl5/tests/e2e/flows/league-context-isolation.spec.ts
+++ b/ibl5/tests/e2e/flows/league-context-isolation.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '../fixtures/auth';
+
+/**
+ * Regression guard for the Olympics league-switch session leak (PR #878).
+ *
+ * All authenticated E2E workers share ONE server-side PHP session (the pinned
+ * PHPSESSID in playwright/.auth/user.json). The league switch must therefore
+ * persist via the per-browser-context cookie + an in-memory request value —
+ * never `$_SESSION`. If it writes the shared session, one test switching to
+ * Olympics flips every other concurrent authenticated test into Olympics
+ * context, which silently rewrites their queries to ibl_olympics_* tables.
+ *
+ * Assertions inspect the RAW server response (via `request`) rather than the
+ * rendered DOM: the league `<select>` lives inside an Alpine dropdown template
+ * that is absent from the live DOM until opened, and the raw HTML is the
+ * truest signal of which league the server resolved for the request.
+ */
+const STORAGE_STATE = 'playwright/.auth/user.json';
+// The resolved league's <option> carries `selected` in the nav switcher markup.
+const OLYMPICS_SELECTED = /league=olympics"\s+selected/;
+const IBL_SELECTED = /league=ibl"\s+selected/;
+
+test('switching league in one context does not leak via the shared session', async ({
+  page,
+  browser,
+}) => {
+  // Context A (default authenticated context) switches to Olympics.
+  const switchResp = await page.request.get('index.php?league=olympics');
+  expect(await switchResp.text()).toMatch(OLYMPICS_SELECTED);
+
+  // Context B shares the same auth storageState — the same server-side session
+  // (PHPSESSID) — but has its own cookie jar with no ibl_league cookie.
+  const contextB = await browser.newContext({ storageState: STORAGE_STATE });
+  try {
+    const respB = await contextB.request.get('index.php');
+    const bodyB = await respB.text();
+    // Must still resolve to IBL: A's switch lives in A's cookie + request,
+    // not in the session both contexts share.
+    expect(bodyB).toMatch(IBL_SELECTED);
+    expect(bodyB).not.toMatch(OLYMPICS_SELECTED);
+  } finally {
+    await contextB.close();
+  }
+});
+
+test('league switch persists within the same context via cookie', async ({ page }) => {
+  // Positive half of the invariant: persistence still works for the switcher.
+  const switchResp = await page.request.get('index.php?league=olympics');
+  expect(await switchResp.text()).toMatch(OLYMPICS_SELECTED);
+
+  // A later request in the SAME context (no league param) stays Olympics,
+  // carried by the per-context ibl_league cookie.
+  const followUp = await page.request.get('index.php');
+  expect(await followUp.text()).toMatch(OLYMPICS_SELECTED);
+});


### PR DESCRIPTION
Follow-up resilience for the PR #878 league-switch session leak.

## Why
PR #878's session leak was a *negative-space* gap: the Olympics tests verified the switch works, but nothing verified it doesn't leak into other (parallel, session-sharing) tests. While adding that guard I audited the table-rewrite and found two latent bugs.

## What
**`LeagueContext`** — extract the IBL→Olympics map to a `TABLE_MAP` constant (single source of truth); `getTableName()` is now a thin lookup. Previously the map was duplicated between `getTableName()` and `rewriteTableNames()` (drift risk).

**`BaseMysqliRepository::rewriteTableNames()`** — the backtick-only `str_replace` rewrote a backtick FROM but left column-qualified refs (`ibl_team_info.teamid`) dangling, fataling `Team::load()` in Olympics context (`Unknown table 'ibl_team_info'`) and silently rendering the Olympics Team page as "not found". Now, when a table opts in via a backtick-quoted reference, **all** its references in that query are rewritten (word-boundary regex, idempotent). Bare references are still left on IBL **by design** — that opt-out is what keeps identity/GM lookups (`NavigationRepository::resolveTeamId`, which reads the IBL-only `gm_username` column) from being routed to Olympics tables that lack those columns.

## Tests
- `BaseMysqliRepositoryTest`: column-qualified rewrite, bare-refs-stay-on-IBL (the `resolveTeamId` fatal), idempotency, and an **executable-query** check of the exact `Team::load()` shape that fataled in CI.
- `LeagueContextTest`: `TABLE_MAP` is the single source for `getTableName`; entries well-formed.
- `league-context-isolation.spec.ts` (new E2E): proves the **negative invariant** — switching league in one context does not leak via the shared server session, while same-context cookie persistence still works.

## Rule
`playwright-tests.md` now documents the shared-session hazard and the negative-invariant test requirement for global mode switches.

## Verification
- `composer test` — 5754 pass.
- `--group database` BaseMysqliRepository + LeagueContext suites — pass; PHPStan clean.
- Olympics E2E specs + new isolation spec — pass locally.