### PR TITLE
refactor(css): delete 11 confirmed-dead CSS classes

### DIFF
--- a/ibl5/design/components/player-cards.css
+++ b/ibl5/design/components/player-cards.css
@@ -629,24 +629,6 @@
 
 @layer components {
 
-/* Card Title Badge */
-.player-stats-card .card-title-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--pc-pad-md);
-}
-
-.player-stats-card .card-title-badge .badge {
-    background: rgba(0, 0, 0, 0.3);
-    color: white;
-    font-size: var(--pc-text-xs);
-    padding: 2px 6px;
-    border-radius: var(--pc-radius-sm);
-    font-weight: 400;
-    text-transform: none;
-    letter-spacing: normal;
-}
-
 /* Stats Type Indicator */
 .player-stats-card .stats-type-indicator {
     position: absolute;

--- a/ibl5/design/components/player-views.css
+++ b/ibl5/design/components/player-views.css
@@ -90,12 +90,6 @@
     text-align: center;
 }
 
-/* Stats table — unique rule */
-.stats-table .header-cell {
-    font-weight: bold;
-    text-align: center;
-}
-
 /* Sortable tables - extends existing .sortable class */
 .sortable.player-table {
     margin: 0 auto;

--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -461,15 +461,6 @@ tr:has(.contract-hint-cell):focus-within .contract-hint-cell {
     border-top-color: color-mix(in srgb, var(--team-color-primary) 30%, var(--gray-200));
 }
 
-/* Ratings highlight rows (team-colored) */
-.team-table tr.ratings-highlight {
-    background-color: var(--team-row-highlight-bg);
-}
-
-.team-table tr.ratings-highlight:hover {
-    background-color: var(--team-row-highlight-hover-bg);
-}
-
 /* Ratings separator row (zero-padding divider) */
 .team-table tr.ratings-separator td {
     padding: 0;
@@ -574,15 +565,6 @@ tr:has(.contract-hint-cell):focus-within .contract-hint-cell {
     /* Drafted row sticky backgrounds - consolidated */
     .responsive-table tbody tr.drafted td[class*="sticky-col"] {
         background-color: var(--gray-100);
-    }
-
-    /* Ratings highlight row sticky backgrounds (team-colored in Next Sim, League Starters) */
-    .responsive-table tbody tr.ratings-highlight td[class*="sticky-col"] {
-        background-color: var(--team-row-highlight-bg);
-    }
-
-    .responsive-table tbody tr.ratings-highlight:hover td[class*="sticky-col"] {
-        background-color: var(--team-row-highlight-hover-bg, var(--gray-100));
     }
 
     /* User team highlight sticky backgrounds */
@@ -790,11 +772,6 @@ tr:has(.contract-hint-cell):focus-within .contract-hint-cell {
 
     .table-scroll-wrapper {
         padding: 0;
-        margin-left: 0;
-        margin-right: 0;
-    }
-
-    .standings-table {
         margin-left: 0;
         margin-right: 0;
     }
@@ -1148,12 +1125,6 @@ tbody tr.user-team-row:nth-child(even):hover {
    Team Name Cell
    ========================================================================== */
 
-.ibl-team-cell {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-}
-
 .ibl-team-cell__logo {
     width: 24px;
     height: 24px;
@@ -1275,19 +1246,6 @@ td.ibl-team-cell--colored {
     gap: 6px;
 }
 
-.ibl-player-cell__img {
-    width: 32px;
-    height: 40px;
-    object-fit: cover;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--gray-200);
-    flex-shrink: 0;
-}
-
-.ibl-player-cell__info {
-    min-width: 0;
-}
-
 .ibl-player-cell__name {
     font-weight: 600;
     color: inherit;
@@ -1309,16 +1267,6 @@ td.ibl-team-cell--colored {
 
 .ibl-player-cell__name.player-expiring::after {
     content: '^';
-}
-
-.ibl-player-cell__team {
-    font-size: 1rem;
-    color: var(--gray-500);
-    text-decoration: none;
-}
-
-.ibl-player-cell__team:hover {
-    color: var(--accent-500);
 }
 
 /* Player Photo (circular thumbnail in name cells) */

--- a/ibl5/design/components/tables/franchise-record-book.css
+++ b/ibl5/design/components/tables/franchise-record-book.css
@@ -32,38 +32,6 @@
     background: white;
 }
 
-.record-book-category {
-    margin-bottom: var(--space-6);
-}
-
-.record-book-category-title {
-    font-family: var(--font-display);
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--gray-700);
-    text-transform: uppercase;
-    letter-spacing: var(--tracking-display);
-    margin: var(--space-3) 0 var(--space-2);
-    padding-left: var(--space-2);
-    border-left: 3px solid var(--accent-500);
-}
-
-.record-book-table {
-    font-size: var(--text-sm);
-}
-
-.record-book-table td:first-child {
-    font-weight: 600;
-    color: var(--gray-500);
-    width: 2rem;
-    text-align: center;
-}
-
-.record-book-table td:nth-child(3) {
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
-}
-
 .record-book-section-title {
     font-size: var(--text-xl);
     margin-top: 1.5rem;

--- a/ibl5/design/components/titles-and-grids.css
+++ b/ibl5/design/components/titles-and-grids.css
@@ -5,9 +5,6 @@
 
    Unified title system for all headings:
    - .ibl-title: Base title (1.5rem, uppercase, orange underline)
-   - .ibl-title--large: Larger variant (2rem)
-   - .ibl-title--centered: Centered text, no underline
-   - .ibl-section-title: Alias for .ibl-title--large with accent line
    ========================================================================== */
 
 .ibl-title {


### PR DESCRIPTION
## What

Deletes 11 CSS classes confirmed dead via a 3-filter coverage check, plus a stale comment listing 3 never-defined classes. **−111 LOC, CSS-only, zero render change.**

## Method

1. Extract every class selector from `ibl5/design/**/*.css` (862 classes).
2. Drop any with a literal reference in source (PHP/JS).
3. Drop any emitted across a 30-route, 9.2 MB crawl of the running app (resolves dynamic composition like `txn-badge--{id}`).

Survivors = absent from source **and** never rendered. Verified on a prod-seeded worktree: Standings & FranchiseRecordBook render identically; deleted classes absent from rendered HTML; live siblings (`ibl-data-table`, `ibl-team-cell__*`, `record-book-section-title`) present; compiled CSS rebuilt cleanly.

## Deleted

- **Orphaned table classes** (views migrated to `.ibl-data-table` + new modifiers): `standings-table`, `ratings-highlight` (+responsive), `record-book-table`, `record-book-category`, `record-book-category-title`
- **Never-adopted design-system** (zero source refs): `ibl-team-cell` (bare container only — `__logo/__name/--colored` kept), `ibl-player-cell__img/__info/__team`, `card-title-badge`, `header-cell`
- **Stale comment** listing 3 never-defined title classes

## Held (NOT deleted — coverage gaps, not dead)

`ibl-textarea` (comma-grouped with live `ibl-input`/`ibl-select`) and `ibl-tabs--accent` (variant of live `ibl-tabs`) are intentional design-system surface. Gated variants (`txn-badge--14`, `sticky-col-3`, etc.) confirmed live by family/stem.

## Follow-ups (separate PRs, planned)

- Token consolidation (Discord/shadow tokens, transition sweep, radius/color unification) + doc-drift fixes to `css-architecture.md` / `CSS_TABLE_MAP.md`.
- `bin/check-orphan-css` advisory CI tool that automates this coverage check.