### PR TITLE
fix(Player): render notice for bare module URL (Lighthouse NO_FCP)

### DIFF
--- a/ibl5/modules/Player/index.php
+++ b/ibl5/modules/Player/index.php
@@ -195,4 +195,14 @@ switch ($pa) {
     case "showpage":
         showpage($pid, $pageView);
         break;
+
+    default:
+        // No (or unrecognized) action: the Player module has no landing view, but
+        // a bare `?name=Player` request must still paint content — a blank 200
+        // body fails Lighthouse with NO_FCP. Render page chrome with a notice.
+        PageLayout\PageLayout::header();
+        echo '<div class="ibl-alert ibl-alert--info">No player selected. Choose a player from a roster, leaderboard, or search to view their archives.</div>';
+        echo '<a href="index.php" class="ibl-btn ibl-btn--primary" style="margin-top: 0.5rem; display: inline-block;">Return to Home</a>';
+        PageLayout\PageLayout::footer();
+        break;
 }

--- a/ibl5/tests/Module/EntryPoints/PlayerEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/PlayerEntryPointTest.php
@@ -17,20 +17,22 @@ use Tests\WideUnit\Mocks\TestDataFactory;
 #[PreserveGlobalState(false)]
 class PlayerEntryPointTest extends ModuleEntryPointTestCase
 {
-    public function testMissingPaShowsNothing(): void
+    public function testMissingPaRendersNoPlayerSelectedNotice(): void
     {
         $this->mockDb->setMockData([]);
         $output = $this->runModule('Player');
 
-        $this->assertSame('', $output);
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('No player selected', $output);
     }
 
-    public function testInvalidPaShowsNothing(): void
+    public function testInvalidPaRendersNoPlayerSelectedNotice(): void
     {
         $this->mockDb->setMockData([]);
         $output = $this->runModule('Player', ['pa' => 'bogus']);
 
-        $this->assertSame('', $output);
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('No player selected', $output);
     }
 
     private function seedShowpageMocks(array $playerOverrides = []): void


### PR DESCRIPTION
## Summary

The Weekly Lighthouse Audit failed on `modules.php?name=Player` with `NO_FCP` ("The page did not paint any content"), aborting the entire audit run.

**Root cause:** A bare `?name=Player` request returned **HTTP 200 with a 0-byte body**. The Player module dispatches on `switch ($pa)` with cases only for `negotiate`, `rookieoption`, `processrookieoption`, and `showpage` — and **no `default`**. With no `pa`, the switch fell through and echoed nothing. Lighthouse can't get a First Contentful Paint on an empty body.

Player was the **only** at-risk module. A full sweep of every audited URL found two other 0-byte bodies (DebugMenu, YourAccount), but both return `302` redirects that resolve to painting pages — false positives. Player alone returns a dead `200`.

## Fix

Add a `default:` case to the dispatch that renders page chrome + a visible "No player selected" info notice + a home link, so the bare/unknown-action URL always paints content.

## Testing

- Updated the two characterization tests (`testMissingPaShowsNothing` / `testInvalidPaShowsNothing`) that asserted the old empty-body contract — they now assert the notice renders.
- Verified live in the worktree Docker stack: bare `?name=Player` now returns HTTP 200 with 60 KB including the notice.

## Manual Testing

No manual testing needed — all changes are covered by automated tests.