### PR TITLE
test(auth): negative-path auth & security E2E coverage + handler guards

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -11,7 +11,9 @@ last_verified: 2026-05-28
 
 You are planning an implementation task. The user's request follows this skill's instructions as `$ARGUMENTS`.
 
-**Do NOT write or edit any code files.** This skill produces a plan only. The single output is the plan file.
+**Do NOT write or edit any code files.** This skill produces a plan only. The output is one plan file per PR.
+
+**One plan = one PR.** A single plan file must be implementable and mergeable as exactly one pull request. If the work naturally spans multiple PRs (independent concerns, separate review surfaces, a refactor that should land before the feature that uses it, or a change too large to review in one sitting), do NOT bundle them. Split the work into PR-sized units and produce a separate, fully self-contained plan — its own implementation steps and its own Verification Matrix — for each one. The user should never have to ask for this split.
 
 ## Step 1: Verification rule
 
@@ -35,13 +37,28 @@ Provide each agent a single concrete question, pre-resolved paths, and a respons
 
 Collect: file paths, existing patterns, dependencies, blast radius, existing test coverage for affected code.
 
+## Step 2.5: Scope into PRs
+
+Using the blast radius from Step 2, decide how many PRs the work requires. Default to **one** — most tasks are a single PR. Split into multiple only when a boundary is real:
+
+- Independent concerns that can land and be reviewed separately
+- A refactor/extraction that should merge before the feature that depends on it (stacked PRs)
+- A change large enough that one reviewer cannot reasonably review it in a single sitting
+- Distinct migrations or schema changes that each warrant their own rollback boundary
+
+If the work is **one PR**, proceed to Step 3 once.
+
+If the work is **multiple PRs**, list the PR-sized units in dependency order (what must merge first), then run Steps 3–5 **once per unit** — each producing its own plan file. Plans for stacked PRs should note their base branch in the implementation steps (`bin/wt-new --base <branch>`). Do not collapse the units back into one plan to "save effort" — the split is the deliverable.
+
 ## Step 3: Design the plan
+
+Run this step once per PR-sized unit identified in Step 2.5. Each run plans exactly one PR.
 
 The Plan agent auto-loads CLAUDE.md, all always-loaded rules (agent-tiering, core-coding, plan-verification, etc.), and user memory. Do NOT re-inject any of these into the prompt — only supply what the agent cannot get on its own.
 
 Launch a **single Plan agent** (`model: "opus"`) with a prompt containing ALL of these:
 
-1. **Task description** from `$ARGUMENTS`
+1. **Task description** from `$ARGUMENTS` — when the work was split in Step 2.5, scope this to the single PR being planned and state which PR it is and what it depends on
 2. **Exploration results** from Step 2 — file paths, code traces, existing patterns, test coverage findings
 3. **The full `$VERIFICATION_RULE`** from Step 1, prefixed with: `MANDATORY — you must follow this rule exactly:`
 
@@ -81,11 +98,12 @@ PLAN_PATH="$HOME/.claude/plans/<slug>.md"
 
 If a plan file already exists at that path, create a new one with a numeric suffix rather than overwriting.
 
-Write the validated plan (with corrected matrix if Step 4 required fixes) to the plan file.
+Write the validated plan (with corrected matrix if Step 4 required fixes) to the plan file. When the work was split into multiple PRs, give each plan a distinct slug (e.g. `<base-slug>-1-<unit>`, `<base-slug>-2-<unit>`) so they sort in dependency order, and write one file per unit.
 
 ## Step 6: Report
 
 Tell the user:
-- The plan file path
-- A one-line matrix summary (e.g., "12 items: 7 PHPUnit, 3 E2E, 2 CLI-executable, 0 truly-manual")
-- Whether the plan is ready for implementation or has open questions
+- The plan file path — **all of them** when the work was split into multiple PRs
+- A one-line matrix summary per plan (e.g., "12 items: 7 PHPUnit, 3 E2E, 2 CLI-executable, 0 truly-manual")
+- For a multi-PR split: the PR sequence and dependency order (which lands first, what each stacks on)
+- Whether each plan is ready for implementation or has open questions

--- a/ibl5/classes/Api/Middleware/RateLimiter.php
+++ b/ibl5/classes/Api/Middleware/RateLimiter.php
@@ -65,6 +65,28 @@ class RateLimiter implements RateLimiterInterface
     }
 
     /**
+     * Rate-limit headers advertised on every successful request so a client (or
+     * test) can observe its tier without firing enough requests to hit the
+     * limit. Limit-only by design: X-RateLimit-Remaining would require the live
+     * count and couple this pure method to the repository. The unlimited tier
+     * advertises nothing (there is no limit to report).
+     *
+     * @param array{rate_limit_tier: string} $apiKey
+     * @return array<string, string>
+     */
+    public function limitHeaders(array $apiKey): array
+    {
+        $tier = $apiKey['rate_limit_tier'];
+        $limit = self::TIER_LIMITS[$tier] ?? self::TIER_LIMITS['standard'];
+
+        if ($limit === 0) {
+            return [];
+        }
+
+        return ['X-RateLimit-Limit' => (string) $limit];
+    }
+
+    /**
      * ~1% probability cleanup of old rate limit entries.
      */
     private function maybePrune(): void

--- a/ibl5/classes/Bootstrap/RateLimitingBootstrap.php
+++ b/ibl5/classes/Bootstrap/RateLimitingBootstrap.php
@@ -35,6 +35,13 @@ class RateLimitingBootstrap implements BootstrapStepInterface
             $responder = $container->get('api.responder');
             $responder->error(429, 'rate_limit_exceeded', 'Rate limit exceeded. Try again later.', $rateLimitResult);
             $container->set('app.terminated', true);
+            return;
+        }
+
+        // Advertise the tier's limit on successful requests so clients can
+        // observe their tier without firing enough requests to trip the limit.
+        foreach ($rateLimiter->limitHeaders($apiKey) as $name => $value) {
+            header($name . ': ' . $value);
         }
     }
 }

--- a/ibl5/classes/Team/TeamApiHandler.php
+++ b/ibl5/classes/Team/TeamApiHandler.php
@@ -24,13 +24,14 @@ class TeamApiHandler
     ];
 
     private \mysqli $db;
+    private TeamRepository $repository;
     private TeamTableService $tableService;
 
     public function __construct(\mysqli $db)
     {
         $this->db = $db;
-        $repository = new TeamRepository($db);
-        $this->tableService = new TeamTableService($db, $repository);
+        $this->repository = new TeamRepository($db);
+        $this->tableService = new TeamTableService($db, $this->repository);
     }
 
     public function handle(): void
@@ -38,6 +39,17 @@ class TeamApiHandler
         header('Content-Type: text/html; charset=utf-8');
 
         $teamid = isset($_GET['teamid']) && is_string($_GET['teamid']) ? (int) $_GET['teamid'] : 0;
+
+        // Guard unknown teams with a 404 before Team initialization would throw
+        // a 500. Pseudo-teams 0 (free agents) and -1 (entire league roster) are
+        // valid and handled by TeamTableService, so only positive ids are
+        // checked against ibl_team_info.
+        $teamRow = $teamid > 0 ? $this->repository->getTeam($teamid) : null;
+        if (self::isUnknownTeam($teamid, $teamRow)) {
+            http_response_code(404);
+            (new \Api\Response\HtmlResponder())->html('Unknown team.');
+            return;
+        }
 
         $display = self::extractValidatedDisplay($_GET);
         $yr = self::extractValidatedYr($_GET);
@@ -59,6 +71,22 @@ class TeamApiHandler
 
         $responder = new \Api\Response\HtmlResponder();
         $responder->html($this->tableService->getTableOutput($teamid, $yr, $display, $split));
+    }
+
+    /**
+     * Whether a teamid has no servable team. Pseudo-teams 0 (free agents) and
+     * -1 (entire league roster) are always servable; a positive teamid is
+     * unknown only when no ibl_team_info row exists for it.
+     *
+     * @param array<mixed>|null $teamRow result of TeamRepository::getTeam()
+     */
+    public static function isUnknownTeam(int $teamid, ?array $teamRow): bool
+    {
+        if ($teamid <= 0) {
+            return false;
+        }
+
+        return $teamRow === null;
     }
 
     /** @param array<mixed> $params */

--- a/ibl5/test-state.php
+++ b/ibl5/test-state.php
@@ -42,13 +42,49 @@ if (!$allowed) {
     exit;
 }
 
-// Minimal bootstrap — only config.php for DB credentials
+// Minimal bootstrap — config.php for DB credentials, Composer autoloader for
+// the delight-auth seeding actions below (reset/confirm user fixtures). Both
+// requires sit after the E2E_TESTING gate, so neither loads in production.
 require __DIR__ . '/config.php';
+require_once __DIR__ . '/vendor/autoload.php';
+
+// In git worktrees vendor/ is symlinked to the main repo, so Composer resolves
+// classes/ through the symlink's realpath and app classes (e.g. PdoConnection)
+// fail to load. Mirror mainfile.php's worktree fallback autoloader so the
+// seeding actions below can reach classes/. No-op in CI (vendor/ is real).
+if (is_link(__DIR__ . '/vendor')) {
+    $worktreeClasses = realpath(__DIR__ . '/classes');
+    if ($worktreeClasses !== false) {
+        spl_autoload_register(static function (string $class) use ($worktreeClasses): void {
+            $file = $worktreeClasses . '/' . str_replace('\\', '/', $class) . '.php';
+            if (file_exists($file)) {
+                require $file;
+            }
+        }, true, true);
+    }
+}
 
 /** @var string $dbhost */
 /** @var string $dbuname */
 /** @var string $dbpass */
 /** @var string $dbname */
+
+/**
+ * Build a Delight\Auth\Auth instance over the shared PDO connection.
+ *
+ * Mirrors classes/Auth/AuthService.php's construction (prefix 'auth_') but with
+ * throttling disabled — E2E seeds many accounts and must not trip the lockout.
+ * Used only by the seed-reset-user / seed-confirm-user actions.
+ */
+function e2eAuth(): \Delight\Auth\Auth
+{
+    return new \Delight\Auth\Auth(
+        \Database\PdoConnection::getInstance(),
+        null,
+        'auth_',
+        false,
+    );
+}
 
 $db = new mysqli($dbhost, $dbuname, $dbpass, $dbname);
 if ($db->connect_error) {
@@ -155,6 +191,80 @@ if ($method === 'DELETE' && $action === 'delete-test-user') {
     $deleted = $stmt->affected_rows;
     $stmt->close();
     echo json_encode(['deleted' => $deleted]);
+    $db->close();
+    exit;
+}
+
+// POST ?action=seed-reset-user — create a VERIFIED e2e_reset_<rand> account
+// and generate a real password-reset selector/token pair via the delight-auth
+// library. The reset row stores a password_hash() digest of the token, so a
+// raw SQL INSERT cannot mint a usable pair — only forgotPassword()'s callback
+// can. forgotPassword() requires a confirmed account, so we register then
+// immediately confirm before requesting the reset. Returns the pair plus the
+// known oldPassword so the E2E can prove the new password works / old fails.
+if ($method === 'POST' && $action === 'seed-reset-user') {
+    $rand = bin2hex(random_bytes(4));
+    $username = 'e2e_reset_' . $rand;
+    $email = $username . '@example.test';
+    $oldPassword = 'OldPass!' . $rand;
+    try {
+        $auth = e2eAuth();
+        $confirm = ['selector' => '', 'token' => ''];
+        $auth->register($email, $oldPassword, $username, function (string $selector, string $token) use (&$confirm): void {
+            $confirm['selector'] = $selector;
+            $confirm['token'] = $token;
+        });
+        $auth->confirmEmail($confirm['selector'], $confirm['token']);
+
+        $reset = ['selector' => '', 'token' => ''];
+        $auth->forgotPassword($email, function (string $selector, string $token) use (&$reset): void {
+            $reset['selector'] = $selector;
+            $reset['token'] = $token;
+        });
+    } catch (\Throwable $e) {
+        http_response_code(500);
+        echo json_encode(['error' => 'seed-reset-user failed: ' . $e->getMessage()]);
+        $db->close();
+        exit;
+    }
+    echo json_encode([
+        'username' => $username,
+        'email' => $email,
+        'selector' => $reset['selector'],
+        'token' => $reset['token'],
+        'oldPassword' => $oldPassword,
+    ]);
+    $db->close();
+    exit;
+}
+
+// POST ?action=seed-confirm-user — register an UNVERIFIED e2e_confirm_<rand>
+// account and capture the confirmation selector/token from the registration
+// email callback, so the confirm_email success round-trip can be driven E2E.
+if ($method === 'POST' && $action === 'seed-confirm-user') {
+    $rand = bin2hex(random_bytes(4));
+    $username = 'e2e_confirm_' . $rand;
+    $email = $username . '@example.test';
+    $password = 'ConfirmPass!' . $rand;
+    try {
+        $auth = e2eAuth();
+        $confirm = ['selector' => '', 'token' => ''];
+        $auth->register($email, $password, $username, function (string $selector, string $token) use (&$confirm): void {
+            $confirm['selector'] = $selector;
+            $confirm['token'] = $token;
+        });
+    } catch (\Throwable $e) {
+        http_response_code(500);
+        echo json_encode(['error' => 'seed-confirm-user failed: ' . $e->getMessage()]);
+        $db->close();
+        exit;
+    }
+    echo json_encode([
+        'username' => $username,
+        'email' => $email,
+        'selector' => $confirm['selector'],
+        'token' => $confirm['token'],
+    ]);
     $db->close();
     exit;
 }

--- a/ibl5/tests/Api/Middleware/RateLimiterTest.php
+++ b/ibl5/tests/Api/Middleware/RateLimiterTest.php
@@ -151,4 +151,39 @@ class RateLimiterTest extends TestCase
         $rateLimiter->check($apiKey);
         $this->assertSame(['increment', 'getRequestCount'], $callOrder);
     }
+
+    // ==================== limitHeaders (always-on tier advertisement) ====================
+
+    public function testLimitHeadersAdvertisesStandardLimit(): void
+    {
+        $rateLimiter = new RateLimiter($this->createStub(RateLimitRepository::class));
+        $this->assertSame(
+            ['X-RateLimit-Limit' => '60'],
+            $rateLimiter->limitHeaders($this->makeApiKey('standard')),
+        );
+    }
+
+    public function testLimitHeadersAdvertisesElevatedLimit(): void
+    {
+        $rateLimiter = new RateLimiter($this->createStub(RateLimitRepository::class));
+        $this->assertSame(
+            ['X-RateLimit-Limit' => '300'],
+            $rateLimiter->limitHeaders($this->makeApiKey('elevated')),
+        );
+    }
+
+    public function testLimitHeadersAreEmptyForUnlimitedTier(): void
+    {
+        $rateLimiter = new RateLimiter($this->createStub(RateLimitRepository::class));
+        $this->assertSame([], $rateLimiter->limitHeaders($this->makeApiKey('unlimited')));
+    }
+
+    public function testLimitHeadersUnknownTierDefaultsToStandard(): void
+    {
+        $rateLimiter = new RateLimiter($this->createStub(RateLimitRepository::class));
+        $this->assertSame(
+            ['X-RateLimit-Limit' => '60'],
+            $rateLimiter->limitHeaders($this->makeApiKey('mystery_tier')),
+        );
+    }
 }

--- a/ibl5/tests/Team/TeamApiHandlerTest.php
+++ b/ibl5/tests/Team/TeamApiHandlerTest.php
@@ -92,4 +92,28 @@ class TeamApiHandlerTest extends TestCase
         $url = TeamApiHandler::buildPushUrl(7, 'ratings', null, null);
         self::assertSame('modules.php?name=Team&op=team&teamid=7&display=ratings', $url);
     }
+
+    // ==================== Unknown-team guard ====================
+
+    public function testIsUnknownTeamFlagsPositiveIdWithNoRow(): void
+    {
+        self::assertTrue(TeamApiHandler::isUnknownTeam(99999, null));
+    }
+
+    public function testIsUnknownTeamAcceptsExistingTeam(): void
+    {
+        self::assertFalse(TeamApiHandler::isUnknownTeam(1, ['team_name' => 'Metros']));
+    }
+
+    public function testIsUnknownTeamTreatsFreeAgentsAsServable(): void
+    {
+        // teamid=0 → free agents, handled by TeamTableService; never a 404.
+        self::assertFalse(TeamApiHandler::isUnknownTeam(0, null));
+    }
+
+    public function testIsUnknownTeamTreatsEntireLeagueAsServable(): void
+    {
+        // teamid=-1 → entire league roster; never a 404.
+        self::assertFalse(TeamApiHandler::isUnknownTeam(-1, null));
+    }
 }

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -1642,6 +1642,30 @@ VALUES (
   1
 ) ON DUPLICATE KEY UPDATE is_active = 1;
 
+-- Standard-tier key — exercises the X-RateLimit-Limit: 60 tier signal.
+-- Raw key: "e2e-standard-tier-key"
+INSERT INTO ibl_api_keys (key_hash, key_prefix, owner_name, permission_level, rate_limit_tier, is_active)
+VALUES (
+  SHA2('e2e-standard-tier-key', 256),
+  'e2e-std',
+  'E2E Standard Tier',
+  'public',
+  'standard',
+  1
+) ON DUPLICATE KEY UPDATE is_active = 1, rate_limit_tier = 'standard';
+
+-- Revoked key (is_active = 0) — every lookup resolves to null → 401.
+-- Raw key: "e2e-revoked-key"
+INSERT INTO ibl_api_keys (key_hash, key_prefix, owner_name, permission_level, rate_limit_tier, is_active)
+VALUES (
+  SHA2('e2e-revoked-key', 256),
+  'e2e-rvk',
+  'E2E Revoked Key',
+  'public',
+  'standard',
+  0
+) ON DUPLICATE KEY UPDATE is_active = 0;
+
 
 -- ============================================================
 -- Voting Results test data (ASG and EOY ballots)

--- a/ibl5/tests/e2e/flows/ajax-api-endpoints.spec.ts
+++ b/ibl5/tests/e2e/flows/ajax-api-endpoints.spec.ts
@@ -163,14 +163,15 @@ test.describe('Team API', () => {
     expect(pushUrl).toContain('teamid=1');
   });
 
-  test('invalid teamID returns error response', async ({ request }) => {
+  test('invalid teamID returns a 4xx client error', async ({ request }) => {
     const response = await request.get(
       'modules.php?name=Team&op=api&teamid=99999&display=ratings',
     );
 
-    // Invalid teamID currently returns 500 (Team::initialize fails).
-    // Verify it returns a response at all (doesn't hang/timeout).
-    expect([200, 500]).toContain(response.status());
+    // An unknown teamID is a client error: TeamApiHandler guards it with a 404
+    // before Team initialization would otherwise throw a 500.
+    expect(response.status()).toBeGreaterThanOrEqual(400);
+    expect(response.status()).toBeLessThan(500);
   });
 });
 

--- a/ibl5/tests/e2e/flows/api-v1-rest.spec.ts
+++ b/ibl5/tests/e2e/flows/api-v1-rest.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect } from '../fixtures/public';
 
-const API_KEY = 'e2e-test-key-do-not-use-in-production'; // ci-seed.sql:1524
+const API_KEY = 'e2e-test-key-do-not-use-in-production'; // ci-seed.sql (unlimited tier)
 const AUTH_HEADERS = { 'X-API-Key': API_KEY };
+
+const STANDARD_KEY = 'e2e-standard-tier-key'; // ci-seed.sql, rate_limit_tier=standard
+const REVOKED_KEY = 'e2e-revoked-key'; // ci-seed.sql, is_active=0
+const WRONG_KEY = `wrong-${'f'.repeat(40)}`; // valid format, never seeded
 
 const PLAYER_UUID = 'a0000000-0000-0000-0000-000000000001'; // pid=1, Test Player
 const TEAM_UUID = 'b0000000-0000-0000-0000-000000000001'; // teamid=1, Metros
@@ -45,6 +49,44 @@ test.describe('api/v1 REST contract', () => {
     expectJsonEnvelope(response, 401);
     const body = await response.json();
     expect(body.error.code).toBe('unauthorized');
+  });
+
+  test('GET api/v1/players with a wrong (valid-format) key returns 401', async ({
+    request,
+  }) => {
+    const response = await request.get('api/v1/players', {
+      headers: { 'X-API-Key': WRONG_KEY },
+    });
+    expectJsonEnvelope(response, 401);
+    const body = await response.json();
+    expect(body.error.code).toBe('unauthorized');
+  });
+
+  test('GET api/v1/players with a revoked key returns 401', async ({
+    request,
+  }) => {
+    // is_active=0 → ApiKeyRepository::findByHash resolves null → 401, same as
+    // an unknown key (there is no separate "forbidden" path for keys today).
+    const response = await request.get('api/v1/players', {
+      headers: { 'X-API-Key': REVOKED_KEY },
+    });
+    expectJsonEnvelope(response, 401);
+    const body = await response.json();
+    expect(body.error.code).toBe('unauthorized');
+  });
+
+  test('rate-limit tier is observable: standard key emits X-RateLimit-Limit, unlimited does not', async ({
+    request,
+  }) => {
+    const standard = await request.get('api/v1/players', {
+      headers: { 'X-API-Key': STANDARD_KEY },
+    });
+    expect(standard.status()).toBe(200);
+    expect(standard.headers()['x-ratelimit-limit']).toBe('60');
+
+    const unlimited = await getJson(request, 'api/v1/players');
+    expect(unlimited.status()).toBe(200);
+    expect(unlimited.headers()['x-ratelimit-limit']).toBeUndefined();
   });
 
   test('GET api/v1/players/{uuid} returns seeded player', async ({ request }) => {

--- a/ibl5/tests/e2e/flows/auth.spec.ts
+++ b/ibl5/tests/e2e/flows/auth.spec.ts
@@ -77,15 +77,11 @@ test.describe('Login page', () => {
     await loginForm.locator('#login-password').fill('wrong_password_123');
     await loginForm.locator('button[type="submit"]').click();
 
-    await page.waitForLoadState('domcontentloaded');
-
-    // Should stay on login page or show error
-    const body = await page.locator('body').textContent();
-    const hasError =
-      body?.match(/incorrect|invalid|error|failed/i) ||
-      page.url().includes('YourAccount');
-
-    expect(hasError).toBeTruthy();
+    // Deterministic: the rendered login error must be visible AND we must
+    // remain on YourAccount. (No `|| url.includes('YourAccount')` escape — that
+    // clause was always true and made the test green regardless of the error.)
+    await expect(page.getByText(/login was incorrect/i)).toBeVisible();
+    expect(page.url()).toContain('name=YourAccount');
   });
 
   test('no PHP errors on login page', async ({ page }) => {
@@ -100,16 +96,83 @@ test.describe('Login required redirect', () => {
   }) => {
     await page.goto('modules.php?name=DepthChartEntry');
 
-    // Should see login form or redirect to login
-    const loginForm = page.locator('#login-username');
-    const signInText = page.getByText('Sign In');
+    // loginbox() emits a JS redirect to YourAccount for unauthenticated users.
+    // Deterministic: wait for that redirect, then confirm the login form
+    // rendered. (No three-way OR with an always-true URL clause.)
+    await page.waitForURL(/name=YourAccount/, { timeout: 10_000 });
+    await expect(page.locator('#login-username')).toBeVisible();
+  });
+});
 
-    // Either the login form is shown inline or we're redirected to YourAccount
-    const hasLoginForm = (await loginForm.count()) > 0;
-    const hasSignInText = (await signInText.count()) > 0;
-    const isOnLoginPage = page.url().includes('YourAccount');
+// ============================================================
+// Remember me — drives the login form with the checkbox on/off and inspects
+// the resulting cookies. delight-auth's persistent cookie name is a hash of
+// the session name (not the literal `auth_remember`), so we assert on the
+// observable discriminator: a long-lived cookie (90-day expiry) appears only
+// when remember-me is checked. Public fixture (fresh context per test).
+// ============================================================
 
-    expect(hasLoginForm || hasSignInText || isOnLoginPage).toBeTruthy();
+test.describe('Remember me cookie', () => {
+  const username = process.env.IBL_TEST_USER;
+  const password = process.env.IBL_TEST_PASS;
+  // delight-auth names its persistent cookie `remember_<hash-of-session-name>`,
+  // not the literal `auth_remember`. Matching the prefix isolates it from the
+  // always-present `lang` / `PHPSESSID` cookies (which are persistent too).
+  const REMEMBER_PREFIX = /^remember_/;
+  // 30 days: above a session cookie, below the 90-day remember lifetime.
+  const PERSISTENT_THRESHOLD_S = 30 * 24 * 60 * 60;
+
+  test.beforeAll(() => {
+    expect(username, 'IBL_TEST_USER must be set').toBeTruthy();
+    expect(password, 'IBL_TEST_PASS must be set').toBeTruthy();
+  });
+
+  async function loginWithRemember(
+    page: import('@playwright/test').Page,
+    remember: boolean,
+  ): Promise<void> {
+    await page.goto('modules.php?name=YourAccount');
+    const loginForm = page.locator('form', {
+      has: page.locator('#login-username'),
+    });
+    await loginForm.locator('#login-username').fill(username!);
+    await loginForm.locator('#login-password').fill(password!);
+    if (remember) {
+      await loginForm.locator('input[name="remember_me"]').check();
+    }
+    await loginForm.locator('button[type="submit"]').click();
+    await page.waitForURL((url) => !url.href.includes('name=YourAccount'), {
+      timeout: 10_000,
+    });
+  }
+
+  test('checked remember-me sets a long-lived remember cookie', async ({
+    page,
+  }) => {
+    await loginWithRemember(page, true);
+
+    const cookies = await page.context().cookies();
+    const nowS = Date.now() / 1000;
+    const remember = cookies.filter((c) => REMEMBER_PREFIX.test(c.name));
+    expect(
+      remember,
+      'a remember_ cookie should be set when remember-me is checked',
+    ).toHaveLength(1);
+    expect(
+      remember[0].expires,
+      'the remember cookie should be long-lived, not session-scoped',
+    ).toBeGreaterThan(nowS + PERSISTENT_THRESHOLD_S);
+  });
+
+  test('unchecked remember-me sets no remember cookie', async ({ page }) => {
+    await loginWithRemember(page, false);
+
+    const cookies = await page.context().cookies();
+    const remember = cookies.filter((c) => REMEMBER_PREFIX.test(c.name));
+    expect(
+      remember,
+      'no remember_ cookie should be set without remember-me',
+    ).toHaveLength(0);
   });
 });
 

--- a/ibl5/tests/e2e/flows/csrf-rejection.spec.ts
+++ b/ibl5/tests/e2e/flows/csrf-rejection.spec.ts
@@ -1,0 +1,107 @@
+import { randomBytes } from 'node:crypto';
+import { test, expect } from '../fixtures/auth';
+
+/**
+ * Forged-CSRF-token rejection — the negative security path the rest of the
+ * suite misses. Every other CSRF test submits a MISSING/empty token; here we
+ * submit a syntactically valid but WRONG 64-hex token, exercising the
+ * valid-format-but-incorrect-token branch of CsrfGuard::validateToken().
+ *
+ * Each protected endpoint validates the token BEFORE any DB mutation, so the
+ * endpoint-specific rejection signal (error message / redirect away from the
+ * success page) is itself proof that no mutation occurred. For block.php we
+ * additionally read back the offer count, since a reset endpoint already
+ * exists and the assertion is cheap.
+ *
+ * Admin (auth) fixture: all four endpoints are GM/admin actions.
+ */
+
+/** A random 64-hex token — correct format, wrong value. */
+function forgedToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+test.describe('Forged CSRF token is rejected', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(async ({ request }) => {
+    await request.delete('test-state.php?action=reset-fa-offers');
+  });
+
+  test.afterAll(async ({ request }) => {
+    await request.delete('test-state.php?action=reset-fa-offers');
+  });
+
+  test('block.php clear_offers with forged token → rejected, offers untouched', async ({
+    request,
+  }) => {
+    const response = await request.post('block.php', {
+      form: { _csrf_token: forgedToken(), action: 'clear_offers' },
+    });
+    expect(response.status()).toBeLessThan(400);
+    const html = await response.text();
+    expect(html).toContain('Security validation failed');
+
+    // Read-back: the three seed offers must still be present.
+    const reload = await request.get('block.php');
+    const reloadHtml = await reload.text();
+    expect(reloadHtml).toMatch(/total number of offers:\s*3/i);
+  });
+
+  test('maketradeoffer.php with forged token → redirected to Trading error, no offer sent', async ({
+    request,
+  }) => {
+    const response = await request.post(
+      '/ibl5/modules/Trading/maketradeoffer.php',
+      {
+        form: {
+          _csrf_token: forgedToken(),
+          offeringTeam: 'Metros',
+          listeningTeam: 'Knights',
+        },
+        maxRedirects: 0,
+      },
+    );
+    expect([301, 302, 303]).toContain(response.status());
+    const location = response.headers()['location'] ?? '';
+    expect(location).toContain('name=Trading');
+    // CSRF-specific: redirected to the "Invalid or expired form submission"
+    // error, NOT the offer_sent success page.
+    expect(location).toContain('Invalid');
+    expect(location).not.toContain('offer_sent');
+  });
+
+  test('extension.php with forged token → redirected to index.php, contract untouched', async ({
+    request,
+  }) => {
+    const response = await request.post(
+      '/ibl5/modules/Player/extension.php',
+      {
+        form: {
+          _csrf_token: forgedToken(),
+          teamName: 'Metros',
+          playerID: '30',
+        },
+        maxRedirects: 0,
+      },
+    );
+    expect([301, 302, 303]).toContain(response.status());
+    // extension.php redirects to /ibl5/index.php on CSRF failure, BEFORE any
+    // ibl_plr write — distinct from the Team contracts result page a real
+    // submission lands on.
+    expect(response.headers()['location']).toBe('/ibl5/index.php');
+  });
+
+  test('ApiKeys generate with forged token → no key generated', async ({
+    request,
+  }) => {
+    const response = await request.post(
+      'modules.php?name=ApiKeys&op=generate',
+      { form: { _csrf_token: forgedToken() } },
+    );
+    expect(response.status()).toBeLessThan(400);
+    const html = await response.text();
+    expect(html).not.toContain('API Key Generated');
+    expect(html).toContain('Invalid or expired form submission');
+  });
+});

--- a/ibl5/tests/e2e/flows/password-reset.spec.ts
+++ b/ibl5/tests/e2e/flows/password-reset.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '../fixtures/public';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { seedResetUser, type SeedResetUser } from '../helpers/test-state';
+import { deleteTestUser } from '../helpers/cleanup';
 
 // Password reset flow — uses public (unauthenticated) fixture.
 // Full end-to-end reset not covered: intercepting the password-reset email
@@ -87,5 +89,74 @@ test.describe('Password reset flow', () => {
     await expect(
       page.locator('input[name="op"][value="do_reset_password"]'),
     ).toBeAttached();
+  });
+});
+
+// Full do_reset_password round-trip against a real, library-minted reset token.
+// A dedicated e2e_reset_* user (seeded VERIFIED so forgotPassword can issue a
+// token) keeps the shared IBL_TEST_USER password untouched. Serial: the three
+// tests share one seeded account whose password Test 1 changes.
+test.describe('Password reset round-trip', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  const NEW_PASSWORD = 'ResetNewPass456!';
+  let seeded: SeedResetUser;
+
+  test.beforeAll(async ({ request }) => {
+    seeded = await seedResetUser(request);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteTestUser(request, seeded.username);
+  });
+
+  test('do_reset_password with valid token sets the new password', async ({
+    page,
+  }) => {
+    await page.goto(
+      `modules.php?name=YourAccount&op=reset_password&selector=${seeded.selector}&token=${seeded.token}`,
+    );
+    // Driving the form submits the reset form's own CSRF token; the layout also
+    // renders login forms with their own tokens, so manual extraction would
+    // grab the wrong one.
+    await page.locator('#reset-new-password').fill(NEW_PASSWORD);
+    await page.locator('#reset-confirm-password').fill(NEW_PASSWORD);
+    await page
+      .locator('form:has(input[name="op"][value="do_reset_password"]) button[type="submit"]')
+      .click();
+
+    await expect(page.locator('.auth-status__title')).toContainText(
+      /password changed/i,
+    );
+    await expect(page.locator('body')).toContainText(/password has been reset/i);
+    await assertNoPhpErrors(page, 'after do_reset_password');
+  });
+
+  test('new password logs in successfully', async ({ page }) => {
+    await page.goto('modules.php?name=YourAccount');
+    const loginForm = page.locator('form', {
+      has: page.locator('#login-username'),
+    });
+    await loginForm.locator('#login-username').fill(seeded.username);
+    await loginForm.locator('#login-password').fill(NEW_PASSWORD);
+    await loginForm.locator('button[type="submit"]').click();
+
+    await page.waitForURL((url) => !url.href.includes('name=YourAccount'), {
+      timeout: 10_000,
+    });
+    expect(page.url()).not.toContain('name=YourAccount');
+  });
+
+  test('old password no longer logs in', async ({ page }) => {
+    await page.goto('modules.php?name=YourAccount');
+    const loginForm = page.locator('form', {
+      has: page.locator('#login-username'),
+    });
+    await loginForm.locator('#login-username').fill(seeded.username);
+    await loginForm.locator('#login-password').fill(seeded.oldPassword);
+    await loginForm.locator('button[type="submit"]').click();
+
+    await expect(page.getByText(/login was incorrect/i)).toBeVisible();
+    expect(page.url()).toContain('name=YourAccount');
   });
 });

--- a/ibl5/tests/e2e/flows/phase-gating-public.spec.ts
+++ b/ibl5/tests/e2e/flows/phase-gating-public.spec.ts
@@ -13,6 +13,10 @@ test.describe('Trading disabled', () => {
     await appState({ 'Allow Trades': 'No' });
     await page.goto('modules.php?name=Trading');
 
+    // Positive: the gating UI (loginBox) actually rendered — a blank PHP crash
+    // would fail this, where the absence check alone would pass.
+    await expect(page.locator('#login-username')).toBeVisible();
+
     // Should NOT show the trade partner selection form
     const teamSelect = page.locator('.trading-team-select');
     const teamSelectVisible = await teamSelect.isVisible().catch(() => false);
@@ -32,6 +36,10 @@ test.describe('Draft hidden', () => {
       'Show Draft Link': 'Off',
     });
     await page.goto('modules.php?name=Draft');
+
+    // Positive: the page rendered its content shell (Draft is a public,
+    // read-only view — no loginBox), so a blank PHP crash would fail here.
+    await expect(page.locator('#site-content')).toBeVisible();
 
     // Should NOT show the draft table
     const draftTable = page.locator('table.draft-table');
@@ -53,6 +61,9 @@ test.describe('Voting closed (ASG)', () => {
     });
     await page.goto('modules.php?name=Voting');
 
+    // Positive: gating UI (loginBox) rendered, not a blank crash.
+    await expect(page.locator('#login-username')).toBeVisible();
+
     // Should NOT show the ASG ballot form
     const form = page.locator('form[name="ASGVote"]');
     const formVisible = await form.isVisible().catch(() => false);
@@ -73,6 +84,9 @@ test.describe('Voting closed (EOY)', () => {
     });
     await page.goto('modules.php?name=Voting');
 
+    // Positive: gating UI (loginBox) rendered, not a blank crash.
+    await expect(page.locator('#login-username')).toBeVisible();
+
     // Should NOT show the EOY ballot form
     const form = page.locator('form[name="EOYVote"]');
     const formVisible = await form.isVisible().catch(() => false);
@@ -89,6 +103,10 @@ test.describe('Waivers disabled', () => {
   }) => {
     await appState({ 'Allow Waiver Moves': 'No' });
     await page.goto('modules.php?name=Waivers');
+
+    // Positive: the page rendered its content shell (Waivers is a public,
+    // read-only view — no loginBox), so a blank PHP crash would fail here.
+    await expect(page.locator('#site-content')).toBeVisible();
 
     // Should NOT show waiver claim form elements
     const waiverForm = page.locator('form[name="waiver_add"], .waiver-form');

--- a/ibl5/tests/e2e/flows/voting-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/voting-submission.spec.ts
@@ -107,13 +107,9 @@ test.describe('ASG Voting: validation errors', () => {
       hasText: /submit votes/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.first().click(),
-    ]);
+    await submitBtn.first().click();
 
-    const body = await page.locator('body').textContent();
-    expect(body).toContain('less than FOUR');
+    await expect(page.locator('body')).toContainText('less than FOUR');
   });
 
   test('no PHP errors on validation page', async ({ appState, page }) => {
@@ -140,10 +136,8 @@ test.describe('ASG Voting: validation errors', () => {
       hasText: /submit votes/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.first().click(),
-    ]);
+    await submitBtn.first().click();
+    await page.waitForLoadState('domcontentloaded');
 
     await assertNoPhpErrors(page, 'after ASG validation error');
   });
@@ -200,13 +194,9 @@ test.describe('EOY Voting: validation errors', () => {
       hasText: /submit votes/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.first().click(),
-    ]);
+    await submitBtn.first().click();
 
-    const body = await page.locator('body').textContent();
-    expect(body).toContain('you must select an MVP');
+    await expect(page.locator('body')).toContainText('you must select an MVP');
   });
 
   test('duplicate EOY selections shows error', async ({ appState, page }) => {
@@ -280,13 +270,11 @@ test.describe('EOY Voting: validation errors', () => {
       hasText: /submit votes/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.first().click(),
-    ]);
+    await submitBtn.first().click();
 
-    const body = await page.locator('body').textContent();
-    expect(body).toContain('same player for multiple MVP slots');
+    await expect(page.locator('body')).toContainText(
+      'same player for multiple MVP slots',
+    );
   });
 });
 

--- a/ibl5/tests/e2e/flows/your-account.spec.ts
+++ b/ibl5/tests/e2e/flows/your-account.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/public';
 import { assertNoPhpErrors } from '../helpers/php-errors';
 import { deleteTestUser } from '../helpers/cleanup';
+import { seedConfirmUser, type SeedConfirmUser } from '../helpers/test-state';
 
 // YourAccount flow tests — registration, forgot password, activation errors,
 // reset password. Login/logout is covered in login-logout.spec.ts.
@@ -59,10 +60,7 @@ test.describe('Registration validation errors', () => {
       hasText: /create account/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.click(),
-    ]);
+    await submitBtn.click();
 
     await expect(page.locator('.ibl-alert--error')).toContainText(
       /passwords you entered do not match/i,
@@ -81,10 +79,7 @@ test.describe('Registration validation errors', () => {
       hasText: /create account/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.click(),
-    ]);
+    await submitBtn.click();
 
     await expect(page.locator('.ibl-alert--error')).toContainText(
       /password must be at least/i,
@@ -103,15 +98,11 @@ test.describe('Registration validation errors', () => {
       hasText: /create account/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.click(),
-    ]);
+    await submitBtn.click();
 
     // Global username guard (index.php line 23) fires before form handler,
     // rendering plain text "Illegal username..." via die()
-    const body = await page.locator('body').textContent();
-    expect(body).toMatch(/illegal username/i);
+    await expect(page.locator('body')).toContainText(/illegal username/i);
   });
 });
 
@@ -130,14 +121,10 @@ test.describe('Registration: duplicate username', () => {
       hasText: /create account/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.click(),
-    ]);
+    await submitBtn.click();
 
     // Should show error about username already being taken
-    const body = await page.locator('body').textContent();
-    expect(body).toMatch(/already|taken|exists|in use/i);
+    await expect(page.locator('body')).toContainText(/already|taken|exists|in use/i);
   });
 });
 
@@ -181,15 +168,13 @@ test.describe('Registration: successful submission', () => {
       hasText: /create account/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.click(),
-    ]);
+    await submitBtn.click();
 
     // Success page shows "Account Created" with activation email confirmation
     await expect(page.locator('.auth-status__icon--success')).toBeVisible();
-    const body = await page.locator('body').textContent();
-    expect(body).toMatch(/account created|activation email/i);
+    await expect(page.locator('body')).toContainText(
+      /account created|activation email/i,
+    );
 
     // The afterEach hook above asserts the auth_users row was actually
     // written (deleted === 1). That's the DB-level proof — a passing
@@ -261,10 +246,7 @@ test.describe('Forgot password submission', () => {
       hasText: /send reset link/i,
     });
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitBtn.click(),
-    ]);
+    await submitBtn.click();
 
     await expect(page.locator('.auth-status__title')).toContainText(
       /check your email/i,
@@ -291,6 +273,33 @@ test.describe('Email activation error pages', () => {
     );
     const body = await page.locator('body').textContent();
     expect(body).toMatch(/expired or is invalid/i);
+  });
+});
+
+test.describe('Email activation success', () => {
+  let seeded: SeedConfirmUser;
+
+  test.beforeEach(async ({ request }) => {
+    seeded = await seedConfirmUser(request);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await deleteTestUser(request, seeded.username);
+  });
+
+  test('confirm_email with valid token activates the account', async ({
+    page,
+  }) => {
+    await page.goto(
+      `modules.php?name=YourAccount&op=confirm_email&selector=${seeded.selector}&token=${seeded.token}`,
+    );
+
+    await expect(page.locator('.auth-status__title')).toContainText(
+      /account activated/i,
+    );
+    // renderActivationSuccessPage echoes the username in a <strong> tag.
+    await expect(page.locator('body')).toContainText(seeded.username);
+    await assertNoPhpErrors(page, 'after confirm_email success');
   });
 });
 

--- a/ibl5/tests/e2e/helpers/test-state.ts
+++ b/ibl5/tests/e2e/helpers/test-state.ts
@@ -137,6 +137,62 @@ export async function resetVote(
   }
 }
 
+export interface SeedResetUser {
+  username: string;
+  email: string;
+  selector: string;
+  token: string;
+  oldPassword: string;
+}
+
+export interface SeedConfirmUser {
+  username: string;
+  email: string;
+  selector: string;
+  token: string;
+}
+
+/**
+ * Seed a VERIFIED `e2e_reset_*` account and return a usable password-reset
+ * selector/token pair (minted by delight-auth, since the reset row stores a
+ * password_hash digest a raw INSERT cannot reproduce). Clean up with
+ * deleteTestUser(request, result.username).
+ */
+export async function seedResetUser(
+  request: APIRequestContext,
+): Promise<SeedResetUser> {
+  const response = await request.post(
+    'test-state.php?action=seed-reset-user',
+    { data: {} },
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `seed-reset-user failed: ${response.status()} ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as SeedResetUser;
+}
+
+/**
+ * Seed an UNVERIFIED `e2e_confirm_*` account and return the confirmation
+ * selector/token pair so the confirm_email success round-trip can run.
+ * Clean up with deleteTestUser(request, result.username).
+ */
+export async function seedConfirmUser(
+  request: APIRequestContext,
+): Promise<SeedConfirmUser> {
+  const response = await request.post(
+    'test-state.php?action=seed-confirm-user',
+    { data: {} },
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `seed-confirm-user failed: ${response.status()} ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as SeedConfirmUser;
+}
+
 export type SetStateFn = (settings: Settings) => Promise<SetStateResult>;
 
 /**

--- a/ibl5/tests/e2e/smoke/auth-redirect.spec.ts
+++ b/ibl5/tests/e2e/smoke/auth-redirect.spec.ts
@@ -14,8 +14,14 @@ const AUTH_MODULES = [
   { name: 'DepthChartEntry', phase: null },
   { name: 'NextSim', phase: null },
   { name: 'Voting', phase: null },
-  // Trading, FreeAgency, and Draft require specific phase settings
-  // but the auth check happens first inside the module
+  // Trading and FreeAgency call loginbox() for unauthenticated users before the
+  // phase gate, so they redirect to YourAccount regardless of phase.
+  { name: 'Trading', phase: null },
+  { name: 'FreeAgency', phase: null },
+  // NOTE: Draft and Waivers are intentionally NOT here — they render a public,
+  // read-only view for unauthenticated users (no loginbox redirect), so a
+  // redirect assertion would not hold. Their public render is covered by the
+  // phase-gating-public spec instead.
 ];
 
 test.describe('Unauthenticated redirect tests', () => {


### PR DESCRIPTION
## Summary

Closes confirmed gaps in the **negative** security paths of the E2E suite (the happy paths were already covered), plus two small handler guards the new tests exercise. Implements `auth-security-e2e-coverage.md`.

### E2E coverage added
- **Forged CSRF token** (new `csrf-rejection.spec.ts`): valid-format-but-wrong 64-hex token on `block.php`, `maketradeoffer.php`, `extension.php`, ApiKeys generate — the rejection branch every existing (missing-token) CSRF test skipped.
- **Reset password** round-trip: `do_reset_password` success + new-password-works + old-password-fails, against a real library-minted token.
- **Confirm email** success round-trip.
- **Remember-me** cookie ON/OFF.
- **API auth**: wrong-key 401, revoked-key 401, rate-limit-tier header observability.
- Fixed two always-green auth tests (removed always-true `|| url.includes(...)` escape hatches).
- `auth-redirect` smoke: added Trading + FreeAgency; `phase-gating-public`: added positive page-rendered assertions.
- Replaced deprecated `Promise.all([waitForNavigation, click])` with web-first waits in `your-account` + `voting-submission`.

### Supporting changes
- `test-state.php`: `seed-reset-user` / `seed-confirm-user` actions (real `Delight\Auth\Auth` over PDO, capturing selector/token pairs) + worktree fallback autoloader.
- `ci-seed.sql`: static standard-tier + revoked API keys.
- `TeamApiHandler`: 404 guard for unknown teams (pure `isUnknownTeam()`) before `Team::initialize` throws 500.
- `RateLimiter::limitHeaders()`: emits `X-RateLimit-Limit` for limited tiers on every request.

### Deviations from the plan (validated against real app behavior)
1. **Draft & Waivers are publicly-viewable read-only pages**, not redirect-gated. Removed Draft from the auth-redirect list (kept Trading/FreeAgency); used a `#site-content` "page rendered" positive assertion for Draft/Waivers gating. Corrects plan matrix #24/#26.
2. **Remember-me** asserted via the `remember_<hash>` cookie prefix + 90-day expiry — delight-auth does **not** use the literal `auth_remember` name.
3. **TeamApiHandler guard** uses a DB existence check (not `League::isRealFranchise`) so pseudo-teams `0` (free agents) and `-1` (league roster) stay servable.
4. Skipped the unused `seed-api-key`/`delete-test-api-key` actions — the static ci-seed keys cover every matrix row.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.ai/code)