### PR TITLE
test(e2e): harden read-only flow specs + extract shared helpers

### DIFF
--- a/ibl5/tests/e2e/flows/activity-tracker.spec.ts
+++ b/ibl5/tests/e2e/flows/activity-tracker.spec.ts
@@ -1,67 +1,22 @@
 import { test, expect } from '../fixtures/base';
-import { assertNoPhpErrors } from '../helpers/php-errors';
 import { publicStorageState } from '../helpers/public-storage-state';
+import { assertSortableTablePage } from '../helpers/sortable-table-page';
 
 // Activity Tracker — public page.
 test.use({ storageState: publicStorageState() });
 
 test.describe('Activity Tracker flow', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('modules.php?name=ActivityTracker');
-  });
-
-  test('page loads with title', async ({ page }) => {
-    await expect(page.locator('.ibl-title')).toContainText(/Activity Tracker/i);
-  });
-
-  test('activity table is visible with expected columns', async ({ page }) => {
-    const table = page.locator('.ibl-data-table').first();
-    await expect(table).toBeVisible();
-
-    const headerText = await table.locator('thead').textContent();
-    expect(headerText).toContain('Team');
-  });
-
-  test('all 5 column headers present', async ({ page }) => {
-    const headers = page.locator('.ibl-data-table thead th');
-    await expect(headers).toHaveCount(5);
-
-    const expectedHeaders = ['Team', 'Sim Depth Chart', 'Last Depth Chart', 'ASG Ballot', 'EOY Ballot'];
-    for (let i = 0; i < expectedHeaders.length; i++) {
-      await expect(headers.nth(i)).toContainText(expectedHeaders[i]);
-    }
-  });
-
-  test('has at least 28 team rows', async ({ page }) => {
-    const teamRows = page.locator('tr[data-team-id]');
-    expect(await teamRows.count()).toBeGreaterThanOrEqual(28);
+  test('page loads with title, table, and 28 team rows', async ({ page }) => {
+    await assertSortableTablePage(page, {
+      url: 'modules.php?name=ActivityTracker',
+      minRows: 28,
+      expectedTitle: /Activity Tracker/i,
+    });
   });
 
   test('team cells link to Team module', async ({ page }) => {
+    await page.goto('modules.php?name=ActivityTracker');
     const firstRowLink = page.locator('tr[data-team-id] a[href*="name=Team"]').first();
     await expect(firstRowLink).toBeVisible();
-  });
-
-  test('ballot columns contain dates, dashes, or No Vote', async ({ page }) => {
-    const firstRow = page.locator('tr[data-team-id]').first();
-    // ASG Ballot is the 4th column (index 3)
-    const asgCell = firstRow.locator('td').nth(3);
-    const text = (await asgCell.textContent())!.trim();
-    expect(text).toMatch(/^\d{4}-\d{2}-\d{2}$|^-$|^No Vote$/);
-  });
-
-  test('team cells have colored backgrounds', async ({ page }) => {
-    const firstTeamCell = page.locator('tr[data-team-id]').first().locator('td').first();
-    const style = await firstTeamCell.getAttribute('style');
-    expect(style).toContain('--team-cell-bg');
-  });
-
-  test('table is sortable', async ({ page }) => {
-    const sortable = page.locator('.sortable');
-    await expect(sortable.first()).toBeVisible();
-  });
-
-  test('no PHP errors', async ({ page }) => {
-    await assertNoPhpErrors(page, 'on Activity Tracker page');
   });
 });

--- a/ibl5/tests/e2e/flows/all-star-appearances.spec.ts
+++ b/ibl5/tests/e2e/flows/all-star-appearances.spec.ts
@@ -1,36 +1,22 @@
 import { test, expect } from '../fixtures/base';
 import { assertNoPhpErrors } from '../helpers/php-errors';
 import { publicStorageState } from '../helpers/public-storage-state';
+import { assertSortableTablePage } from '../helpers/sortable-table-page';
 
 // All-Star Appearances — public page.
 test.use({ storageState: publicStorageState() });
 
 test.describe('All-Star Appearances flow', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('modules.php?name=AllStarAppearances');
-  });
-
-  test('page loads with title', async ({ page }) => {
-    await expect(page.locator('.ibl-title')).toContainText(/All-Star Appearances/i);
-  });
-
-  test('appearances table is visible with correct headers', async ({ page }) => {
-    // CI seed has All-Star awards — table must render
-    const table = page.locator('.ibl-data-table');
-    await expect(table.first()).toBeVisible();
-
-    const headerText = await table.first().locator('thead').textContent();
-    expect(headerText).toContain('Player');
-    expect(headerText).toContain('Appearances');
-  });
-
-  test('table has at least 2 rows with player data', async ({ page }) => {
-    // CI seed: 'Test Player' (3 appearances) + 'Stars Guard' (2 appearances)
-    const rows = page.locator('.ibl-data-table tbody tr');
-    expect(await rows.count()).toBeGreaterThanOrEqual(2);
+  test('page loads with title, table, and player rows', async ({ page }) => {
+    await assertSortableTablePage(page, {
+      url: 'modules.php?name=AllStarAppearances',
+      minRows: 2,
+      expectedTitle: /All-Star Appearances/i,
+    });
   });
 
   test('player links navigate to player page', async ({ page }) => {
+    await page.goto('modules.php?name=AllStarAppearances');
     const playerLinks = page.locator('.ibl-data-table a[href*="pid="]');
     await expect(playerLinks.first()).toBeVisible();
 
@@ -41,30 +27,5 @@ test.describe('All-Star Appearances flow', () => {
     await page.goto(href!);
     await assertNoPhpErrors(page, 'on player page from All-Star Appearances');
     await expect(page.locator('h2, h3').first()).toBeVisible();
-  });
-
-  test('appearances count cells have highlight styling', async ({ page }) => {
-    const highlights = page.locator('.ibl-stat-highlight');
-    await expect(highlights.first()).toBeVisible();
-  });
-
-  test('appearances values are positive integers', async ({ page }) => {
-    const highlights = page.locator('.ibl-stat-highlight');
-    const count = await highlights.count();
-    expect(count).toBeGreaterThanOrEqual(1);
-
-    for (let i = 0; i < count; i++) {
-      const text = await highlights.nth(i).textContent();
-      const value = parseInt(text?.trim() ?? '', 10);
-      expect(value).toBeGreaterThan(0);
-    }
-  });
-
-  test('table is sortable', async ({ page }) => {
-    await expect(page.locator('table.sortable').first()).toBeVisible();
-  });
-
-  test('no PHP errors', async ({ page }) => {
-    await assertNoPhpErrors(page, 'on All-Star Appearances page');
   });
 });

--- a/ibl5/tests/e2e/flows/cap-space.spec.ts
+++ b/ibl5/tests/e2e/flows/cap-space.spec.ts
@@ -15,12 +15,12 @@ test.describe('Cap Space flow', () => {
   });
 
   test('cap space table is visible', async ({ page }) => {
-    const table = page.locator('.ibl-data-table, .sticky-table, table').first();
+    const table = page.locator('.sticky-table').first();
     await expect(table).toBeVisible();
   });
 
   test('table has expected salary columns', async ({ page }) => {
-    const table = page.locator('.ibl-data-table, .sticky-table').first();
+    const table = page.locator('.sticky-table').first();
     await expect(table).toBeVisible();
     const headerText = await table.locator('thead').textContent();
     expect(headerText).toContain('Team');
@@ -33,7 +33,7 @@ test.describe('Cap Space flow', () => {
   });
 
   test('MLE/LLE status indicators are present', async ({ page }) => {
-    const table = page.locator('.ibl-data-table, .sticky-table').first();
+    const table = page.locator('.sticky-table').first();
     await expect(table).toBeVisible();
     const headerText = await table.locator('thead').textContent();
     // Should contain MLE and LLE columns

--- a/ibl5/tests/e2e/flows/draft-pick-locator.spec.ts
+++ b/ibl5/tests/e2e/flows/draft-pick-locator.spec.ts
@@ -10,39 +10,9 @@ test.describe('Draft Pick Locator flow', () => {
     await page.goto('modules.php?name=DraftPickLocator');
   });
 
-  test('page loads with title', async ({ page }) => {
-    await expect(page.locator('.ibl-title')).toContainText(/Draft Pick Locator/i);
-  });
-
-  test('container has .draft-pick-locator-container', async ({ page }) => {
-    await expect(page.locator('.draft-pick-locator-container')).toBeVisible();
-  });
-
-  test('pick locator table is visible', async ({ page }) => {
-    await expect(page.locator('.draft-pick-table').first()).toBeVisible();
-  });
-
-  test('thead has two header rows', async ({ page }) => {
-    await expect(page.locator('.draft-pick-table thead tr')).toHaveCount(2);
-  });
-
   test('has at least 28 team rows', async ({ page }) => {
     const teamRows = page.locator('tr[data-team-id]');
     expect(await teamRows.count()).toBeGreaterThanOrEqual(28);
-  });
-
-  test('year spans in first header row', async ({ page }) => {
-    const yearSpans = page.locator('.draft-pick-table thead tr:first-child th[colspan="2"]');
-    expect(await yearSpans.count()).toBeGreaterThanOrEqual(6);
-
-    const firstYearText = (await yearSpans.first().textContent())!.trim();
-    expect(firstYearText).toMatch(/\d{4}/);
-  });
-
-  test('first column cells have sticky-col class', async ({ page }) => {
-    await expect(
-      page.locator('tbody tr[data-team-id]:first-child td.sticky-col').first()
-    ).toBeVisible();
   });
 
   test('own picks and traded picks are distinguished', async ({ page }) => {

--- a/ibl5/tests/e2e/flows/franchise-history.spec.ts
+++ b/ibl5/tests/e2e/flows/franchise-history.spec.ts
@@ -14,66 +14,14 @@ test.describe('Franchise History flow', () => {
     await expect(page.locator('.ibl-title')).toContainText(/Franchise History/i);
   });
 
-  test('franchise table is visible with expected columns', async ({ page }) => {
-    const table = page.locator('.sticky-table').first();
-    await expect(table).toBeVisible();
-
-    const headerText = await table.locator('thead').textContent();
-    expect(headerText).toContain('Team');
-  });
-
-  test('all 10+ column headers present with key headers', async ({ page }) => {
-    const headers = page.locator('.sticky-table thead th');
-    expect(await headers.count()).toBeGreaterThanOrEqual(10);
-
-    const headerTexts = await headers.allTextContents();
-    const joined = headerTexts.join(' ');
-    expect(joined).toContain('Team');
-    // textContent() strips internal whitespace, so match without spaces
-    expect(joined).toMatch(/All-Time\s*Record/);
-    expect(joined).toMatch(/IBL\s*Titles/);
-  });
-
-  test('sticky corner cell has correct classes', async ({ page }) => {
-    await expect(page.locator('thead th.sticky-col.sticky-corner')).toBeVisible();
-  });
-
   test('has at least 28 team rows', async ({ page }) => {
     const teamRows = page.locator('tr[data-team-id]');
     expect(await teamRows.count()).toBeGreaterThanOrEqual(28);
   });
 
-  test('record cells match wins-losses format', async ({ page }) => {
-    const firstRow = page.locator('tr[data-team-id]').first();
-    // All-Time Record is the 2nd column (index 1)
-    const recordCell = firstRow.locator('td').nth(1);
-    const text = (await recordCell.textContent())!.trim();
-    expect(text).toMatch(/\d+-\d+/);
-  });
-
-  test('championship columns have numeric values', async ({ page }) => {
-    const firstRow = page.locator('tr[data-team-id]').first();
-    // Last 4 columns are championship-related counts
-    const cells = firstRow.locator('td');
-    const count = await cells.count();
-    for (let i = count - 4; i < count; i++) {
-      const text = (await cells.nth(i).textContent())!.trim();
-      expect(text).toMatch(/^\d+$/);
-    }
-  });
-
   test('team cells link to Team module', async ({ page }) => {
     const firstRowLink = page.locator('tr[data-team-id] a[href*="name=Team"]').first();
     await expect(firstRowLink).toBeVisible();
-  });
-
-  test('sticky scroll wrapper is visible', async ({ page }) => {
-    await expect(page.locator('.sticky-scroll-wrapper').first()).toBeVisible();
-  });
-
-  test('table is sortable', async ({ page }) => {
-    const sortable = page.locator('.sortable');
-    await expect(sortable.first()).toBeVisible();
   });
 
   test('no PHP errors', async ({ page }) => {

--- a/ibl5/tests/e2e/flows/gm-contact-list.spec.ts
+++ b/ibl5/tests/e2e/flows/gm-contact-list.spec.ts
@@ -1,59 +1,23 @@
 import { test, expect } from '../fixtures/auth';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { assertSortableTablePage } from '../helpers/sortable-table-page';
 
 test.describe('GM Contact List flow', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('modules.php?name=GMContactList');
-  });
-
-  test('page loads with title', async ({ page }) => {
-    await expect(page.locator('.ibl-title')).toContainText(/GM Contact List/i);
-  });
-
-  test('contact table is visible with expected columns', async ({ page }) => {
-    const table = page.locator('.contact-table, .ibl-data-table').first();
-    await expect(table).toBeVisible();
-
-    const headerText = await table.locator('thead').textContent();
-    expect(headerText).toContain('Team');
-    expect(headerText).toContain('Name');
-  });
-
-  test('table has rows for all 28 teams', async ({ page }) => {
-    const teamRows = page.locator('tr[data-team-id]');
-    // CI seed has 28 real teams
-    expect(await teamRows.count()).toBeGreaterThanOrEqual(28);
-  });
-
-  test('team cells contain team names', async ({ page }) => {
-    const table = page.locator('.contact-table, .ibl-data-table').first();
-    const teamCells = table.locator('.ibl-team-cell--colored, td').first();
-    await expect(teamCells).toBeVisible();
-  });
-
-  test('table is sortable', async ({ page }) => {
-    const sortableTable = page.locator('.sortable');
-    await expect(sortableTable.first()).toBeVisible();
-  });
-
-  test('clicking sort header does not error', async ({ page }) => {
-    const sortHeader = page.locator('.sortable thead th').first();
-    await sortHeader.click();
-    // After clicking, table should still be visible (no JS error broke the page)
-    await expect(page.locator('.sortable').first()).toBeVisible();
-    await assertNoPhpErrors(page, 'after sorting GM Contact List');
+  test('page loads with title, table, and 28 team rows', async ({ page }) => {
+    await assertSortableTablePage(page, {
+      url: 'modules.php?name=GMContactList',
+      minRows: 28,
+      expectedTitle: /GM Contact List/i,
+    });
   });
 
   test('team link navigates to team page', async ({ page }) => {
+    await page.goto('modules.php?name=GMContactList');
     const teamLink = page.locator('.ibl-data-table a[href*="name=Team"], .contact-table a[href*="name=Team"]').first();
     const href = await teamLink.getAttribute('href');
     expect(href).toBeTruthy();
 
     await page.goto(href!);
     await assertNoPhpErrors(page, 'on team page from GM Contact List link');
-  });
-
-  test('no PHP errors', async ({ page }) => {
-    await assertNoPhpErrors(page, 'on GM Contact List');
   });
 });

--- a/ibl5/tests/e2e/flows/injuries.spec.ts
+++ b/ibl5/tests/e2e/flows/injuries.spec.ts
@@ -10,46 +10,10 @@ test.describe('Injuries flow', () => {
     await page.goto('modules.php?name=Injuries');
   });
 
-  test('page loads with title', async ({ page }) => {
-    await expect(page.locator('.ibl-title')).toContainText(/Injured Players/i);
-  });
-
-  test('table has .injuries-table class', async ({ page }) => {
-    await expect(page.locator('table.injuries-table')).toBeVisible();
-  });
-
-  test('4 column headers: Pos, Player, Team, Days', async ({ page }) => {
-    const headers = page.locator('.injuries-table thead th');
-    await expect(headers).toHaveCount(4);
-
-    await expect(headers.nth(0)).toContainText('Pos');
-    await expect(headers.nth(1)).toContainText('Player');
-    await expect(headers.nth(2)).toContainText('Team');
-    await expect(headers.nth(3)).toContainText('Days');
-  });
-
   test('at least 2 injured player rows', async ({ page }) => {
     // CI seed has pid=5 (5 days) and pid=7 (3 days)
     const teamRows = page.locator('.injuries-table tbody tr[data-team-id]');
     expect(await teamRows.count()).toBeGreaterThanOrEqual(2);
-  });
-
-  test('injury rows have data-team-id attribute', async ({ page }) => {
-    const teamRows = page.locator('tr[data-team-id]');
-    const firstTeamId = await teamRows.first().getAttribute('data-team-id');
-    expect(firstTeamId).toBeTruthy();
-  });
-
-  test('days values are positive integers', async ({ page }) => {
-    const daysCells = page.locator('.injuries-table tbody td.ibl-stat-highlight');
-    const count = await daysCells.count();
-    expect(count).toBeGreaterThanOrEqual(2);
-
-    for (let i = 0; i < count; i++) {
-      const text = await daysCells.nth(i).textContent();
-      const value = parseInt(text?.trim() ?? '', 10);
-      expect(value).toBeGreaterThan(0);
-    }
   });
 
   test('days cells have tooltip with return date', async ({ page }) => {

--- a/ibl5/tests/e2e/flows/league-schedule.spec.ts
+++ b/ibl5/tests/e2e/flows/league-schedule.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '../fixtures/auth';
-import { assertNoPhpErrors } from '../helpers/php-errors';
+import {
+  assertScheduleStructure,
+  assertUnplayedGameDash,
+  assertPlayedGameScores,
+  assertPlayoffPhaseLabels,
+} from '../helpers/schedule-page';
 
 const SCHEDULE_URL = 'modules.php?name=Schedule';
 
@@ -13,38 +18,16 @@ test.describe('League Schedule — smoke', () => {
     await page.goto(SCHEDULE_URL);
   });
 
-  test('page loads with title', async ({ page }) => {
-    await expect(page.locator('.ibl-title').first()).toBeVisible();
-  });
-
-  test('no PHP errors', async ({ page }) => {
-    await assertNoPhpErrors(page, 'on League Schedule');
-  });
-
-  test('sim length note visible', async ({ page }) => {
-    await expect(page.locator('.schedule-highlight-note')).toBeVisible();
-  });
-
-  test('SOS legend shows 5 tiers', async ({ page }) => {
-    await expect(page.locator('.sos-legend__item')).toHaveCount(5);
-  });
-
-  test('month nav renders', async ({ page }) => {
-    await expect(page.locator('.schedule-months__link').first()).toBeVisible();
-  });
-
-  test('game rows present', async ({ page }) => {
-    const count = await page.locator('.schedule-game').count();
-    expect(count).toBeGreaterThanOrEqual(3);
+  test('shared schedule structure (title, legend, month nav, game rows, no PHP errors)', async ({ page }) => {
+    await assertScheduleStructure(page, { minGames: 3 });
   });
 
   test('unplayed game shows dash', async ({ page }) => {
-    // Unplayed games render scores as "–" in <span> elements
-    const dashScore = page.locator(
-      '.schedule-game span.schedule-game__score-link',
-      { hasText: '–' },
-    );
-    await expect(dashScore.first()).toBeVisible();
+    await assertUnplayedGameDash(page);
+  });
+
+  test('played games show numeric scores with win class', async ({ page }) => {
+    await assertPlayedGameScores(page);
   });
 
   test('team links point to Team module', async ({ page }) => {
@@ -52,10 +35,6 @@ test.describe('League Schedule — smoke', () => {
     await expect(teamLink).toBeVisible();
     const href = await teamLink.getAttribute('href');
     expect(href).toContain('name=Team');
-  });
-
-  test('team logos present', async ({ page }) => {
-    await expect(page.locator('.schedule-game__logo').first()).toBeAttached();
   });
 });
 
@@ -81,29 +60,13 @@ test.describe('League Schedule — Next Games button', () => {
 });
 
 // ============================================================
-// League Schedule — played games
+// League Schedule — box score links
 // ============================================================
 
-test.describe('League Schedule — played games', () => {
+test.describe('League Schedule — box score links', () => {
   test.beforeEach(async ({ appState, page }) => {
     await appState({ 'Current Season Phase': 'Regular Season', 'Current Season Ending Year': '2026' });
     await page.goto(SCHEDULE_URL);
-  });
-
-  test('played game shows numeric scores', async ({ page }) => {
-    // Feb 20 game: Metros 105 @ Stars 98
-    const scoreLinks = page.locator(
-      '.schedule-game .schedule-game__score-link',
-    );
-    const allTexts = await scoreLinks.allTextContents();
-    const numericScores = allTexts.filter((t) => /\d+/.test(t));
-    expect(numericScores.length).toBeGreaterThanOrEqual(2);
-  });
-
-  test('winning team has win class', async ({ page }) => {
-    await expect(
-      page.locator('.schedule-game__team--win').first(),
-    ).toBeVisible();
   });
 
   test('played game with game_of_that_day has IBL6 link', async ({ page }) => {
@@ -120,14 +83,6 @@ test.describe('League Schedule — played games', () => {
       '.schedule-game a.schedule-game__score-link[href*=".htm"]',
     );
     await expect(legacyLink.first()).toBeVisible();
-  });
-
-  test('unplayed game score is span not link', async ({ page }) => {
-    // March unplayed games should render as spans, not <a> tags
-    const unplayedSpan = page.locator(
-      '.schedule-game span.schedule-game__score-link',
-    );
-    await expect(unplayedSpan.first()).toBeVisible();
   });
 });
 
@@ -172,20 +127,8 @@ test.describe('League Schedule — Playoff phase', () => {
     await page.goto(SCHEDULE_URL);
   });
 
-  test('no PHP errors in playoff phase', async ({ page }) => {
-    await assertNoPhpErrors(page, 'on League Schedule (Playoffs)');
-  });
-
-  test('June relabeled Playoffs', async ({ page }) => {
-    // In playoff phase, the first month header should be "Playoffs" (June moved to front)
-    const firstHeader = page.locator('.schedule-month__header').first();
-    await expect(firstHeader).toContainText('Playoffs');
-  });
-
-  test('Playoffs header has --playoffs class', async ({ page }) => {
-    await expect(
-      page.locator('.schedule-month__header--playoffs').first(),
-    ).toBeVisible();
+  test('playoff phase labels render without PHP errors', async ({ page }) => {
+    await assertPlayoffPhaseLabels(page);
   });
 
   test('June skipped in month nav', async ({ page }) => {

--- a/ibl5/tests/e2e/flows/next-sim.spec.ts
+++ b/ibl5/tests/e2e/flows/next-sim.spec.ts
@@ -14,45 +14,6 @@ test.describe('NextSim flow', () => {
     await assertNoPhpErrors(page, 'on NextSim page');
   });
 
-  test('schedule strip renders', async ({ page }) => {
-    const strip = page.locator('.next-sim-schedule-strip');
-    await expect(strip).toBeVisible();
-  });
-
-  test('schedule strip game cards have dates and logos', async ({
-    page,
-  }) => {
-    const dayRow = page.locator('.next-sim-day-row').first();
-    await expect(dayRow).toBeVisible();
-
-    // Date text
-    const date = dayRow.locator('.next-sim-game-date');
-    await expect(date).toBeVisible();
-
-    // Day label (e.g., "Day N @" or "Day N vs")
-    const dayLabel = dayRow.locator('.next-sim-day-label');
-    await expect(dayLabel).toBeVisible();
-  });
-
-  test('position sections render when games exist', async ({ page }) => {
-    const sections = page.locator('.next-sim-position-section');
-    // 5 positions: PG, SG, SF, PF, C
-    await expect(sections).toHaveCount(5);
-  });
-
-  test('position tables have headers', async ({ page }) => {
-    const firstSection = page.locator('.next-sim-position-section').first();
-    await expect(firstSection).toBeVisible();
-
-    // Should have a title (e.g., "Point Guards")
-    const title = firstSection.locator('.ibl-table-title, h3');
-    await expect(title.first()).toBeVisible();
-
-    // Table with player data
-    const table = firstSection.locator('table.ibl-data-table');
-    await expect(table).toBeVisible();
-  });
-
   test('user starter highlighted with orange styling', async ({ page }) => {
     const userRow = page.locator('.next-sim-row--user');
     await expect(userRow.first()).toBeVisible();

--- a/ibl5/tests/e2e/flows/record-holders.spec.ts
+++ b/ibl5/tests/e2e/flows/record-holders.spec.ts
@@ -13,46 +13,6 @@ test.describe('Record Holders flow', () => {
     await page.goto('modules.php?name=RecordHolders');
   });
 
-  test('page loads with title', async ({ page }) => {
-    const title = page.locator('.ibl-title').first();
-    await expect(title).toBeVisible();
-    const titleText = await title.textContent();
-    expect(titleText?.toLowerCase()).toContain('record');
-  });
-
-  test('multiple record card sections present', async ({ page }) => {
-    // Record holders page has one .record-section wrapper with multiple .ibl-card subsections
-    const cards = page.locator('.record-section .ibl-card');
-    expect(await cards.count()).toBeGreaterThanOrEqual(3);
-  });
-
-  test('each card section contains data tables with rows', async ({ page }) => {
-    const cards = page.locator('.record-section .ibl-card');
-    const cardCount = await cards.count();
-
-    // CI seed guarantees data: box scores for single-game records,
-    // plus pid=3 year=2024 with games=55 for full-season averages.
-    let cardsWithRows = 0;
-    for (let i = 0; i < cardCount; i++) {
-      const card = cards.nth(i);
-      const tables = card.locator('.ibl-data-table');
-      const tableCount = await tables.count();
-      if (tableCount > 0) {
-        const rows = tables.first().locator('tbody tr');
-        if ((await rows.count()) > 0) { // e2e-hygiene-allow: counts cards with rows; outer expect asserts at least one card matches
-          cardsWithRows++;
-        }
-      }
-    }
-
-    expect(cardsWithRows).toBeGreaterThan(0);
-  });
-
-  test('player record rows contain player links', async ({ page }) => {
-    const playerLinks = page.locator('.record-section a[href*="pid="]');
-    await expect(playerLinks.first()).toBeVisible();
-  });
-
   test('player links navigate to player page', async ({ page }) => {
     const playerLink = page.locator('.record-section a[href*="pid="]').first();
     const href = await playerLink.getAttribute('href');

--- a/ibl5/tests/e2e/flows/season-archive.spec.ts
+++ b/ibl5/tests/e2e/flows/season-archive.spec.ts
@@ -6,27 +6,6 @@ import { publicStorageState } from '../helpers/public-storage-state';
 test.use({ storageState: publicStorageState() });
 
 test.describe('Season Archive flow', () => {
-  test('index page loads with title', async ({ page }) => {
-    await page.goto('modules.php?name=SeasonArchive');
-    await expect(page.locator('.ibl-title')).toContainText(/Season Archive/i);
-  });
-
-  test('index table has .season-archive-index-table class', async ({ page }) => {
-    await page.goto('modules.php?name=SeasonArchive');
-    await expect(page.locator('.season-archive-index-table')).toBeVisible();
-  });
-
-  test('index has 4 column headers: Season, HEAT Champion, IBL Champion, MVP', async ({ page }) => {
-    await page.goto('modules.php?name=SeasonArchive');
-    const headers = page.locator('.season-archive-index-table thead th');
-    await expect(headers).toHaveCount(4);
-
-    await expect(headers.nth(0)).toContainText('Season');
-    await expect(headers.nth(1)).toContainText('HEAT');
-    await expect(headers.nth(2)).toContainText('IBL');
-    await expect(headers.nth(3)).toContainText('MVP');
-  });
-
   test('index has at least 3 season rows', async ({ page }) => {
     await page.goto('modules.php?name=SeasonArchive');
     // CI seed has ibl_awards for years 2024, 2025, 2026
@@ -54,12 +33,6 @@ test.describe('Season Archive flow', () => {
     await page.goto('modules.php?name=SeasonArchive&year=1800');
     await assertNoPhpErrors(page, 'on Season Archive year=1800');
     await expect(page.locator('.season-archive-section')).toHaveCount(0);
-  });
-
-  test('index table is sortable', async ({ page }) => {
-    await page.goto('modules.php?name=SeasonArchive');
-    const sortable = page.locator('.sortable');
-    await expect(sortable.first()).toBeVisible();
   });
 
   test('no PHP errors on index page', async ({ page }) => {

--- a/ibl5/tests/e2e/flows/series-records.spec.ts
+++ b/ibl5/tests/e2e/flows/series-records.spec.ts
@@ -10,48 +10,6 @@ test.describe('Series Records flow', () => {
     await page.goto('modules.php?name=SeriesRecords');
   });
 
-  test('page loads with title', async ({ page }) => {
-    await expect(page.locator('.ibl-title')).toContainText(/Series Records/i);
-  });
-
-  test('series records matrix table is visible', async ({ page }) => {
-    await expect(page.locator('.sticky-table').first()).toBeVisible();
-  });
-
-  test('grid has header cells matching team count plus corner', async ({ page }) => {
-    const headerCells = page.locator('.sticky-table thead tr th');
-    // CI seed has ~3 teams with series data; production has 28+
-    // At minimum: corner cell + at least 2 team columns
-    expect(await headerCells.count()).toBeGreaterThanOrEqual(3);
-  });
-
-  test('header row contains team logo images', async ({ page }) => {
-    const logos = page.locator('thead th img[src*="logo/new"]');
-    // CI seed has ~3 teams; production has 28
-    expect(await logos.count()).toBeGreaterThanOrEqual(2);
-  });
-
-  test('diagonal cells contain x', async ({ page }) => {
-    // First team row — self-vs-self cell should contain "x"
-    const firstRow = page.locator('.sticky-table tbody tr').first();
-    // Cell at index 1 is the self-vs-self diagonal (index 0 is the team name)
-    const diagonalCell = firstRow.locator('td').nth(1);
-    await expect(diagonalCell).toContainText('x');
-  });
-
-  test('record cells have background-color styles', async ({ page }) => {
-    const firstRow = page.locator('.sticky-table tbody tr').first();
-    // Non-diagonal cell (index 2) should have --series-cell-bg custom property
-    const recordCell = firstRow.locator('td').nth(2);
-    const style = await recordCell.getAttribute('style');
-    expect(style).toBeTruthy();
-    expect(style!).toContain('--series-cell-bg');
-  });
-
-  test('table uses page-sticky wrapper', async ({ page }) => {
-    await expect(page.locator('.sticky-scroll-wrapper.page-sticky')).toBeVisible();
-  });
-
   test('table has team rows', async ({ page }) => {
     const rows = page.locator('.sticky-table tbody tr');
     // CI seed has ~3 teams; production has 28

--- a/ibl5/tests/e2e/flows/standings.spec.ts
+++ b/ibl5/tests/e2e/flows/standings.spec.ts
@@ -94,30 +94,6 @@ test.describe('Standings page flow', () => {
     }
   });
 
-  test('column sorting works', async ({ page }) => {
-    const firstTable = page.locator('.sortable.ibl-data-table').first();
-    await expect(firstTable).toBeVisible();
-
-    // Get initial row order by team-id
-    const rows = firstTable.locator('tbody tr[data-team-id]');
-    const rowsBefore = await rows.evaluateAll((els) =>
-      els.map((el) => el.getAttribute('data-team-id')),
-    );
-
-    // Click the Win% header (3rd th) to trigger sort
-    const winPctHeader = firstTable.locator('thead th:nth-child(3)');
-    await winPctHeader.click();
-
-    // Get row order after sort
-    const rowsAfter = await rows.evaluateAll((els) =>
-      els.map((el) => el.getAttribute('data-team-id')),
-    );
-
-    // Row order should differ (unless already sorted by that column)
-    // At minimum the table should still have the same number of rows
-    expect(rowsAfter.length).toBe(rowsBefore.length);
-  });
-
   test('no PHP errors on standings page', async ({ page }) => {
     await assertNoPhpErrors(page, 'on Standings page');
   });

--- a/ibl5/tests/e2e/flows/team-off-def-stats.spec.ts
+++ b/ibl5/tests/e2e/flows/team-off-def-stats.spec.ts
@@ -88,28 +88,6 @@ test.describe('Team Stats flow', () => {
     }
   });
 
-  test('sortable tables support client-side sorting', async ({
-    appState,
-    page,
-  }) => {
-    await appState({
-      'Current Season Phase': 'Regular Season',
-      'Current Season Ending Year': '2026',
-    });
-    await page.goto('modules.php?name=TeamOffDefStats');
-
-    const sortableTable = page.locator('.ibl-data-table.sortable').first();
-    await expect(sortableTable).toBeVisible();
-
-    const header = sortableTable.locator('thead th').nth(2);
-    await header.click();
-
-    await expect(sortableTable).toBeVisible();
-
-    await header.click();
-    await expect(sortableTable).toBeVisible();
-  });
-
   test('tables have team rows matching expected count', async ({
     appState,
     page,

--- a/ibl5/tests/e2e/flows/team-schedule.spec.ts
+++ b/ibl5/tests/e2e/flows/team-schedule.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '../fixtures/auth';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import {
+  assertScheduleStructure,
+  assertUnplayedGameDash,
+} from '../helpers/schedule-page';
 
 const TEAM_SCHEDULE_URL = 'modules.php?name=Schedule&teamid=1'; // Metros
 
@@ -13,12 +17,8 @@ test.describe('Team Schedule — smoke', () => {
     await page.goto(TEAM_SCHEDULE_URL);
   });
 
-  test('page loads with title', async ({ page }) => {
-    await expect(page.locator('.ibl-title').first()).toBeVisible();
-  });
-
-  test('no PHP errors', async ({ page }) => {
-    await assertNoPhpErrors(page, 'on Team Schedule');
+  test('shared schedule structure (title, legend, month nav, game rows, no PHP errors)', async ({ page }) => {
+    await assertScheduleStructure(page, { minGames: 1 });
   });
 
   test('team banner visible', async ({ page }) => {
@@ -29,19 +29,6 @@ test.describe('Team Schedule — smoke', () => {
     await expect(
       page.locator('.schedule-container--team').first(),
     ).toBeVisible();
-  });
-
-  test('SOS legend shows 5 tiers', async ({ page }) => {
-    await expect(page.locator('.sos-legend__item')).toHaveCount(5);
-  });
-
-  test('month nav renders', async ({ page }) => {
-    await expect(page.locator('.schedule-months__link').first()).toBeVisible();
-  });
-
-  test('game rows present', async ({ page }) => {
-    const count = await page.locator('.schedule-game').count();
-    expect(count).toBeGreaterThanOrEqual(1);
   });
 
   test('streak column rendered', async ({ page }) => {
@@ -77,13 +64,9 @@ test.describe('Team Schedule — jump button', () => {
   });
 
   test('jump button visible when unplayed games exist', async ({ page }) => {
-    // Jump button only renders when there are unplayed (upcoming) games
-    const hasUnplayed = await page.locator('.schedule-game--upcoming').count() > 0;
-    if (hasUnplayed) {
-      await expect(page.locator('.schedule-jump-btn')).toBeVisible();
-    } else {
-      await expect(page.locator('.schedule-jump-btn')).not.toBeVisible();
-    }
+    // CI seed guarantees unplayed (upcoming) Metros games, so the jump button
+    // must render unconditionally — no dual-path branch.
+    await expect(page.locator('.schedule-jump-btn')).toBeVisible();
   });
 
   test('upcoming games are highlighted', async ({ page }) => {
@@ -105,11 +88,8 @@ test.describe('Team Schedule — unplayed game rows', () => {
 
   test('dash scores shown for unplayed games', async ({ page }) => {
     // CI seed has unplayed games — scores render as "–" in <span> elements
-    const dashScore = page.locator(
-      '.schedule-game span.schedule-game__score-link',
-      { hasText: '–' },
-    );
-    await expect(dashScore.first()).toBeVisible();
+    // (also proves the unplayed score is a <span>, not an <a> link).
+    await assertUnplayedGameDash(page);
   });
 
   test('no cumulative record on unplayed games', async ({ page }) => {
@@ -124,14 +104,6 @@ test.describe('Team Schedule — unplayed game rows', () => {
     const records = first.locator('.schedule-game__record');
     const recordCount = await records.count();
     expect(recordCount).toBeLessThanOrEqual(1);
-  });
-
-  test('score is span not link when unplayed', async ({ page }) => {
-    // CI seed has unplayed games — scores render as <span>, not <a>
-    const spanScore = page.locator(
-      '.schedule-game span.schedule-game__score-link',
-    );
-    await expect(spanScore.first()).toBeVisible();
   });
 });
 

--- a/ibl5/tests/e2e/flows/team.spec.ts
+++ b/ibl5/tests/e2e/flows/team.spec.ts
@@ -16,7 +16,7 @@ test.describe('Team page flow', () => {
     // Current-season teams use a dropdown, not tabs
     const dropdown = page.locator('.ibl-view-select').first();
     await expect(dropdown).toBeVisible();
-    await expect(page.locator('.ibl-data-table, table').first()).toBeVisible();
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
   });
 
   test('team banner shows logo and action links', async ({ page }) => {
@@ -33,7 +33,7 @@ test.describe('Team page flow', () => {
 
     await dropdown.selectOption('total_s');
     // Table should update (AJAX or page reload)
-    await expect(page.locator('.ibl-data-table, table').first()).toBeVisible();
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
   });
 
   test('dropdown switches view to contracts', async ({ page }) => {
@@ -41,7 +41,7 @@ test.describe('Team page flow', () => {
     await expect(dropdown).toBeVisible();
 
     await dropdown.selectOption('contracts');
-    await expect(page.locator('.ibl-data-table, table').first()).toBeVisible();
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
   });
 
   test('dropdown switches view to averages', async ({ page }) => {
@@ -49,7 +49,7 @@ test.describe('Team page flow', () => {
     await expect(dropdown).toBeVisible();
 
     await dropdown.selectOption('avg_s');
-    await expect(page.locator('.ibl-data-table, table').first()).toBeVisible();
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
   });
 
   test('team cards display sidebar info', async ({ page }) => {
@@ -78,13 +78,13 @@ test.describe('Team page: additional display modes', () => {
   test('dropdown switches to per36mins', async ({ page }) => {
     const dropdown = page.locator('.ibl-view-select').first();
     await dropdown.selectOption('per36mins');
-    await expect(page.locator('.ibl-data-table, table').first()).toBeVisible();
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
   });
 
   test('dropdown switches to chunk', async ({ page }) => {
     const dropdown = page.locator('.ibl-view-select').first();
     await dropdown.selectOption('chunk');
-    await expect(page.locator('.ibl-data-table, table').first()).toBeVisible();
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
   });
 });
 
@@ -95,7 +95,7 @@ publicTest.describe('Team page: playoffs display mode', () => {
     await page.goto('modules.php?name=Team&op=team&teamid=1');
     const dropdown = page.locator('.ibl-view-select').first();
     await dropdown.selectOption('playoffs');
-    await publicExpect(page.locator('.ibl-data-table, table').first()).toBeVisible();
+    await publicExpect(page.locator('.ibl-data-table').first()).toBeVisible();
   });
 });
 
@@ -135,7 +135,7 @@ test.describe('Team page: dropdown content changes', () => {
     const dropdown = page.locator('.ibl-view-select').first();
 
     await dropdown.selectOption('split:home');
-    await expect(page.locator('.ibl-data-table, table').first()).toBeVisible();
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
     await assertNoPhpErrors(page, 'after switching to split:home');
   });
 
@@ -156,7 +156,7 @@ test.describe('Team page: dropdown content changes', () => {
     await page.goBack();
 
     // Back should restore ratings view (no salary columns)
-    await expect(page.locator('.ibl-data-table, table').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible({ timeout: 10000 });
     const salaryHeaders = page.locator('.ibl-data-table th.col-salary');
     await expect(salaryHeaders).toHaveCount(0, { timeout: 10000 });
   });
@@ -213,7 +213,7 @@ test.describe('Team page: error and banner states', () => {
 test.describe('Team page: historical year view', () => {
   test('historical year view renders with year in title', async ({ page }) => {
     await page.goto('modules.php?name=Team&op=team&teamid=1&yr=2024');
-    await expect(page.locator('.ibl-data-table, table').first()).toBeVisible();
+    await expect(page.locator('.ibl-data-table').first()).toBeVisible();
     await assertNoPhpErrors(page, 'on historical year view');
   });
 });

--- a/ibl5/tests/e2e/helpers/schedule-page.ts
+++ b/ibl5/tests/e2e/helpers/schedule-page.ts
@@ -1,0 +1,37 @@
+import { expect } from '../fixtures/auth';
+import type { Page } from '@playwright/test';
+import { assertNoPhpErrors } from './php-errors';
+
+/**
+ * Shared structural assertions for the Schedule pages (league + team views).
+ * Each consumer supplies its own `appState`/navigation before calling these.
+ */
+
+export async function assertScheduleStructure(
+  page: Page,
+  opts: { minGames: number },
+): Promise<void> {
+  await expect(page.locator('.ibl-title').first()).toBeVisible();
+  await assertNoPhpErrors(page, 'on Schedule');
+  await expect(page.locator('.sos-legend__item')).toHaveCount(5);
+  await expect(page.locator('.schedule-months__link').first()).toBeVisible();
+  expect(await page.locator('.schedule-game').count())
+    .toBeGreaterThanOrEqual(opts.minGames);
+}
+
+export async function assertUnplayedGameDash(page: Page): Promise<void> {
+  await expect(
+    page.locator('.schedule-game span.schedule-game__score-link', { hasText: '–' }).first(),
+  ).toBeVisible();
+}
+
+export async function assertPlayedGameScores(page: Page): Promise<void> {
+  const texts = await page.locator('.schedule-game .schedule-game__score-link').allTextContents();
+  expect(texts.filter((t) => /\d+/.test(t)).length).toBeGreaterThanOrEqual(2);
+  await expect(page.locator('.schedule-game__team--win').first()).toBeVisible();
+}
+
+export async function assertPlayoffPhaseLabels(page: Page): Promise<void> {
+  await assertNoPhpErrors(page, 'on Schedule (Playoffs)');
+  await expect(page.locator('.schedule-month__header--playoffs').first()).toBeVisible();
+}

--- a/ibl5/tests/e2e/helpers/sortable-table-page.ts
+++ b/ibl5/tests/e2e/helpers/sortable-table-page.ts
@@ -1,0 +1,25 @@
+import { expect } from '../fixtures/base';
+import type { Page } from '@playwright/test';
+import { assertNoPhpErrors } from './php-errors';
+
+/**
+ * Assert the standard structure of a sortable `.ibl-data-table` page:
+ * navigates to the URL, checks the page title, the data table is visible,
+ * it has at least `minRows` body rows, and the page contains no PHP errors.
+ *
+ * Callers that depend on season state must call `appState` themselves before
+ * invoking this helper (the helper only takes the resolved URL).
+ */
+export async function assertSortableTablePage(
+  page: Page,
+  opts: { url: string; minRows: number; expectedTitle: RegExp },
+): Promise<void> {
+  await page.goto(opts.url);
+  await expect(page.locator('.ibl-title').first()).toContainText(opts.expectedTitle);
+  await expect(page.locator('.ibl-data-table').first()).toBeVisible();
+  await expect(page.locator('.ibl-data-table tbody tr')).not.toHaveCount(0);
+  // minRows is a hard lower bound on team/data rows
+  expect(await page.locator('.ibl-data-table tbody tr').count())
+    .toBeGreaterThanOrEqual(opts.minRows);
+  await assertNoPhpErrors(page, `on ${opts.url}`);
+}


### PR DESCRIPTION
## Summary

Hardens weak read-only E2E specs and extracts two shared helpers, reducing ~612 lines of duplicated/weak assertions to focused, non-VR-redundant coverage.

**Four problems fixed:**
1. Sort tests that proved nothing (click but only assert visibility or row count unchanged) — deleted; mechanism owned by `sortable-tables.spec.ts`
2. Comma-fallback locators (e.g., `.ibl-data-table, table`) that pass even when the intended element is absent — replaced with specific selectors
3. Pure-render specs duplicating the VR gate — collapsed to PHP-errors + unique non-VR assertions (nav-links, data presence, tooltips)
4. ~80 LOC of duplicated schedule structural assertions in league/team schedule specs — extracted to shared helpers

**New shared helpers:**
- `tests/e2e/helpers/sortable-table-page.ts`: `assertSortableTablePage()` — navigate + title + `.ibl-data-table` + minRows + PHP-errors
- `tests/e2e/helpers/schedule-page.ts`: `assertScheduleStructure()`, `assertUnplayedGameDash()`, `assertPlayedGameScores()`, `assertPlayoffPhaseLabels()`

**Also:** Fixed hygiene violation in `team-schedule.spec.ts` (dual-path if/else + manual `.count() > 0` → single-path web-first assertion).

This PR is **test-only** — no changes to `classes/**` or production code.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.