### PR TITLE
feat(nightly): staleness gate + post-plan budget prose + conformance auto-merge gate

### DIFF
--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -293,6 +293,12 @@ Both comments end with: `Generated with [Claude Code](https://claude.ai/code)` a
 
 ### Phase 5.0: Plan→test conformance — skip if `PLAN_FOUND=none` or `! $HAS_MATRIX`
 
+At Phase 5.0 START, clear the conformance bridge file so each run begins from a clean slate (an empty file means "nothing unresolved"):
+
+```bash
+: > /tmp/post-plan-missing-tests-$PPID
+```
+
 Read the Verification Matrix from `$PLAN_FILE`. Collect the test-file path from the "Test file / location" column of every row whose Test type is PHPUnit, API-test, E2E, or Visual-regression. Confirm the PR diff actually wrote each one:
 
 ```bash
@@ -302,6 +308,10 @@ grep -qF "$T" /tmp/post-plan-changed-$PPID || echo "MISSING: $T (matrix planned 
 ```
 
 For each `MISSING:` test the impl silently dropped planned coverage — now likelier to matter, since the matrix carries the negative-path and security rows `/plan` gates 9 and 12 require. Write the missing test, run it green, and checkpoint (same as Phase 6 test authoring). Skip a planned test **only** if its target behavior was cut from the implementation; note that in a PR comment rather than writing a hollow test.
+
+A `MISSING:` item is **resolved** when its test was authored-and-run-green OR was explicitly cut-from-implementation with a PR comment noting the cut. An item that is neither — a planned test the diff never wrote and which you did not author or explicitly cut — is **unresolved**.
+
+At Phase 5.0 END, append each remaining **UNRESOLVED** `MISSING:` item (path + reason) to `/tmp/post-plan-missing-tests-$PPID`, one per line. Authored-green or cut-with-comment items are NOT written. This bridge file is consulted by the Phase 6.5 auto-merge gate.
 
 **PHPUnit + PHPStan — direct Bash (no agent):** **Skip if** `! $HAS_PHP`. The PostToolUse hook already ran both during edits, and a PHP-less diff cannot regress either suite. Run both as direct Bash calls with `run_in_background: true` so they execute in parallel with the E2E agent below. Output is ~5 lines each — agent overhead (~25K tokens) is never justified.
 
@@ -394,11 +404,11 @@ Enable auto-merge **before** watching CI. This is the earliest point both gating
 
 **Already merged?** If `gh pr view --json state --jq '.state'` returns `MERGED`, there is nothing to arm — skip to Phase 7 (which will early-exit).
 
-Both conditions must be true: (1) PR says "No manual testing needed", (2) no review/audit findings scored >= 80.
+**All three** conditions must be true: (1) PR says "No manual testing needed", (2) no review/audit findings scored >= 80, (3) no unresolved `MISSING:` planned-test items remain from Phase 5.0 — i.e. `/tmp/post-plan-missing-tests-$PPID` is absent or empty. Phase 5.0 is skipped entirely when `PLAN_FOUND=none` or `! $HAS_MATRIX`, so this bridge file frequently never exists; **absent/empty = PASS (non-blocking)**. Only a non-empty file blocks: `[ -s /tmp/post-plan-missing-tests-$PPID ]` → condition (3) fails.
 
 If met: `gh pr merge --squash --auto --delete-branch`. The `--auto` flag queues the merge — it does **not** merge now, it arms; GitHub executes it once all required status checks pass. Do not sync local to master here; the merge has not happened yet.
 
-If not met: do **not** arm auto-merge. Report which condition(s) blocked — the user merges manually after review. Continue to Phase 7 regardless, to monitor and fix CI.
+If not met: do **not** arm auto-merge. Report which condition(s) blocked — the user merges manually after review. When condition (3) is the blocker, cite which planned test is missing by `cat`-ing the bridge file (`cat /tmp/post-plan-missing-tests-$PPID`) into the report. Continue to Phase 7 regardless, to monitor and fix CI.
 
 ---
 
@@ -414,7 +424,7 @@ If not met: do **not** arm auto-merge. Report which condition(s) blocked — the
 
 0. **Early-exit on merged PR:** Before any polling, run `gh pr view <pr> --json state --jq '.state'`. If `MERGED`, skip the rest of Phase 7 and continue at Phase 8 — the auto-merge armed in Phase 6.5 has already fired (required checks were already green) and watching CI to completion adds nothing but wall-clock burn. This is the load-bearing optimization that keeps the nightly loop from burning a full watch timeout on an already-shipped PR.
 1. **Wait for checks to register:** Poll `gh pr checks <pr> --json name,state 2>/dev/null | jq 'length'` up to 4 times with 15s waits. If count stays 0, warn user and continue to Phase 8.
-2. **Block until CI settles:** `gh pr checks <pr> --watch --fail-fast --interval 20` (Bash timeout 1200000 = 20 min cap — leaves a 10-min cushion under `MAX_PP_SECS=1800` for Phases 8-11 cleanup). The gh CLI handles the polling and exit logic itself; do not re-implement it in jq. Exit codes: `0` = all checks passed, `8` = at least one failed, other = transport error.
+2. **Block until CI settles:** `gh pr checks <pr> --watch --fail-fast --interval 20` (Bash timeout 1200000 = 20 min cap — leaves a ~40-min cushion under `MAX_PP_SECS=3600` for Phase 5.0 conformance + Phases 8-11 cleanup). The gh CLI handles the polling and exit logic itself; do not re-implement it in jq. Exit codes: `0` = all checks passed, `8` = at least one failed, other = transport error.
 3. **If exit 0** → Phase 8. (Mid-watch merge detection was intentionally dropped: `gh pr checks --watch` exits as soon as the last check settles, so the only window auto-merge could fire inside the watch is the ~5–30s between final-check-pass and auto-merge action — not worth a hand-rolled poll loop. Step 0 already covers the case where the PR merged before Phase 7 started.)
 4. **If exit 8:** Get failed checks via `gh pr checks <pr> --json name,state,link --jq '[.[] | select(.state == "FAILURE")]'` (uppercase `FAILURE`, field is `state` not `conclusion`). Download logs (`gh run view <id> --log-failed`). **Fix all failures** — master's CI is green, so any failure on this PR is this PR's fault (even in files outside the diff). The only exception is a flaky test that passes on retry with no code change; note it in a PR comment and move on. Fix, commit, push, loop back to step 1. After 3 iterations, report failures to user and continue to Phase 8 — auto-merge will fire when CI eventually passes.
 5. **If bash times out (20 min elapsed):** Run one final `gh pr checks <pr>` (no `--watch`) to capture settled state. If it now exits 0, continue to Phase 8. If 8, jump to step 4. Otherwise report to user and continue to Phase 8 — do not re-enter watch.
@@ -542,7 +552,7 @@ Kill known lingering patterns so their tool results deliver immediately (cache w
 pkill -f 'bin/e2e-wt\.sh' 2>/dev/null
 pkill -f 'bunx.*playwright' 2>/dev/null
 pkill -f 'gh pr checks.*--watch' 2>/dev/null
-rm -f /tmp/post-plan-spec-diff-$PPID /tmp/post-plan-spec-prod-diff-$PPID 2>/dev/null
+rm -f /tmp/post-plan-spec-diff-$PPID /tmp/post-plan-spec-prod-diff-$PPID /tmp/post-plan-missing-tests-$PPID 2>/dev/null
 echo "Background process cleanup complete"
 ```
 

--- a/bin/check-plan-staleness
+++ b/bin/check-plan-staleness
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/check-plan-staleness — staleness guard for nightly queued plans.
+#
+# Takes one argument: a plan file path (in production, the queue symlink that
+# points at ~/.claude/plans/<name>.md). Scans the plan body for repo-path
+# reference tokens and exits non-zero, printing each unresolved token, when the
+# plan references files that no longer exist in the current checkout. A stale
+# plan would otherwise burn all three nightly attempts as a poison pill.
+#
+# Token resolution mirrors bin/check-docs::scanReferences() (PHP), reimplemented
+# in Bash since check-docs is not callable for a single out-of-repo plan file:
+#   - tokens come from markdown links `[...](target)` and backtick spans `...`
+#   - the part before the first '#', '?', or whitespace is kept
+#   - only tokens prefixed bin/ ibl5/ .claude/ .github/ are repo paths
+#   - glob/placeholder metacharacters and non-charset tokens are skipped
+#   - survivors are de-duplicated and tested with [ -e "$REPO_ROOT/$token" ]
+#
+# Exit codes: 0 = all tokens resolve (or none), 1 = stale (unresolved tokens
+# printed as "STALE: <token>"), 2 = usage error / plan file missing.
+#
+# Bash 3.2 / macOS compatible: no mapfile, no declare -A; temp files collect
+# tokens. The `shell=bash` directive above keeps shellcheck's SC3xxx
+# (sh-dialect) warnings from firing on the intentional bashisms.
+
+set -u
+
+usage() {
+    echo "Usage: bin/check-plan-staleness <plan-file>" >&2
+}
+
+PLAN_FILE="${1:-}"
+if [ -z "$PLAN_FILE" ] || [ ! -e "$PLAN_FILE" ]; then
+    usage
+    exit 2
+fi
+
+# Resolve the repo root from THIS SCRIPT's own location — never from the plan
+# file (which lives outside the repo) or the cwd. Walk up until a .git dir/file
+# is found. This is the load-bearing correctness point: resolving tokens
+# relative to the out-of-repo plan file would mark every token unresolved.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+while [ "$REPO_ROOT" != "/" ] && [ ! -e "$REPO_ROOT/.git" ]; do
+    REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+if [ "$REPO_ROOT" = "/" ]; then
+    echo "error: could not locate repo root" >&2
+    exit 2
+fi
+
+TOKENS_FILE="$(mktemp)"
+SEEN_FILE="$(mktemp)"
+MISSING_FILE="$(mktemp)"
+trap 'rm -f "$TOKENS_FILE" "$SEEN_FILE" "$MISSING_FILE"' EXIT
+
+# Collect candidate tokens. grep follows the symlink at $PLAN_FILE for its
+# content. Markdown link targets and backtick-span contents are extracted, then
+# the surrounding syntax is stripped. A no-match grep exits 1 harmlessly (no
+# `set -e`).
+{
+    grep -oE '\[[^]]*\]\([^)[:space:]]+\)' "$PLAN_FILE" | sed -E 's/^\[[^]]*\]\(//; s/\)$//'
+    # shellcheck disable=SC2016  # backticks are literal markdown-span delimiters, not command substitution
+    grep -oE '`[^`]+`' "$PLAN_FILE" | sed -E 's/^`//; s/`$//'
+} >> "$TOKENS_FILE"
+
+while IFS= read -r token; do
+    # Keep only the part before the first '#', '?', or whitespace.
+    token="$(printf '%s' "$token" | sed -E 's/[[:space:]#?].*$//')"
+    [ -n "$token" ] || continue
+
+    # Only the four in-scope repo-path prefixes (narrower than check-docs).
+    case "$token" in
+        bin/*|ibl5/*|.claude/*|.github/*) : ;;
+        *) continue ;;
+    esac
+
+    # Skip glob/placeholder metacharacters (this also drops `<placeholder>`).
+    case "$token" in
+        *[\*\?\[\]\{\}\<\>]*) continue ;;
+    esac
+
+    # Validate charset; this also drops `$VAR/...` shell-variable tokens.
+    if ! printf '%s' "$token" | grep -qE '^[A-Za-z0-9._/-]+$'; then
+        continue
+    fi
+
+    # De-duplicate.
+    if grep -qxF "$token" "$SEEN_FILE"; then
+        continue
+    fi
+    printf '%s\n' "$token" >> "$SEEN_FILE"
+
+    if [ ! -e "$REPO_ROOT/$token" ]; then
+        printf '%s\n' "$token" >> "$MISSING_FILE"
+    fi
+done < "$TOKENS_FILE"
+
+if [ -s "$MISSING_FILE" ]; then
+    while IFS= read -r m; do
+        echo "STALE: $m"
+    done < "$MISSING_FILE"
+    exit 1
+fi
+
+exit 0

--- a/bin/nightly-prompt-impl
+++ b/bin/nightly-prompt-impl
@@ -39,6 +39,33 @@ If `$NIGHTLY_DIR/handoff/${PLAN_FILE}.json` exists, implementation was already c
 
 IMPORTANT: Only check for THIS plan's handoff file. Ignore any other .json files in the handoff directory — they belong to other plans being processed by the bash loop.
 
+## Step 2.5: Staleness Guard (run BEFORE any worktree is created)
+
+This gate is DISTINCT from the Step 3 ambiguity skip. It catches plans that reference repo paths which have since been renamed, moved, or deleted on master — a stale plan would otherwise burn all three nightly attempts as a poison pill. Moving the symlink to `skipped/` here, before a worktree exists, is the entire purpose of this gate.
+
+First, freshen local master so the guard checks the freshly-pulled tree. Without this, a file deleted on origin still resolves against stale local master and the guard wrongly passes a plan that genuinely IS stale — the exact case this gate exists to catch. (This also pre-stages the same pull Step 5 "Fresh start" does, so it is not wasted work.)
+
+```bash
+git -C /Users/ajaynicolas/GitHub/IBL5 fetch origin master
+git -C /Users/ajaynicolas/GitHub/IBL5 checkout master
+git -C /Users/ajaynicolas/GitHub/IBL5 pull origin master
+```
+
+Then run the staleness check against the queue symlink path. The guard resolves repo paths against the freshly-pulled master:
+
+```bash
+/Users/ajaynicolas/GitHub/IBL5/bin/check-plan-staleness "$PLAN_PATH"
+```
+
+If `bin/check-plan-staleness` exits non-zero, the plan is STALE. Take the skip-with-report path IMMEDIATELY — before any worktree is created, no partial work, no handoff:
+
+1. Capture the unresolved paths the helper printed (its `STALE: <token>` lines).
+2. `mv "$NIGHTLY_DIR/queue/$PLAN_FILE" "$NIGHTLY_DIR/skipped/"`
+3. Write a STALENESS-specific report to `$NIGHTLY_DIR/reports/$(date +%Y-%m-%d)-skipped-<slug>.md` (derive `<slug>` from the plan title). The title and body must make it visibly a **staleness skip** — clearly distinct wording from the ambiguity skip — and must list the specific unresolved repo paths the helper emitted.
+4. STOP.
+
+If `bin/check-plan-staleness` exits 0, the plan is fresh — continue to Step 3.
+
 ## Step 3: Validate the Plan
 
 The plan must have:


### PR DESCRIPTION
## Summary

Three nightly pipeline hardening changes shipped as one PR:

- **C (stale-plan guard):** New `bin/check-plan-staleness` helper + wired into `bin/nightly-prompt-impl`. Plans referencing deleted/renamed repo paths are skipped (with a staleness report) before any worktree is created, preventing three-attempt poison-pills.
- **D (budget bump):** `MAX_PP_SECS` 1800→3600 in `bin/nightly-run`; Phase 7 cushion prose updated to reflect the new 40-min cushion.
- **E (conformance gate):** Phase 5.0 now writes unresolved `MISSING:` tests to `/tmp/post-plan-missing-tests-$PPID`; Phase 8 consults it as a third auto-merge precondition; Phase 11 teardown removes it.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: small operational helper for the nightly pipeline, not an architectural decision; mirrors existing bin/check-docs token-resolution approach -->