### PR TITLE
Olympics Compatibility PR2: Remove resolveTable() — complete the auto-rewrite migration

### DIFF
--- a/ibl5/classes/Api/Repository/ApiGameRepository.php
+++ b/ibl5/classes/Api/Repository/ApiGameRepository.php
@@ -14,14 +14,9 @@ use League\LeagueContext;
  */
 class ApiGameRepository extends \BaseMysqliRepository
 {
-    private string $boxScoresTable;
-    private string $boxScoresTeamsTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->boxScoresTable = $this->resolveTable('ibl_box_scores');
-        $this->boxScoresTeamsTable = $this->resolveTable('ibl_box_scores_teams');
     }
 
     /**
@@ -95,7 +90,7 @@ class ApiGameRepository extends \BaseMysqliRepository
     {
         /** @var list<BoxscoreTeamRow> */
         return $this->fetchAll(
-            "SELECT * FROM {$this->boxScoresTeamsTable} WHERE visitor_teamid = ? AND home_teamid = ? AND game_date = ? ORDER BY id ASC",
+            "SELECT * FROM `ibl_box_scores_teams` WHERE visitor_teamid = ? AND home_teamid = ? AND game_date = ? ORDER BY id ASC",
             'iis',
             $visitorTeamId,
             $homeTeamId,
@@ -113,7 +108,7 @@ class ApiGameRepository extends \BaseMysqliRepository
         /** @var list<BoxscorePlayerRow> */
         return $this->fetchAll(
             "SELECT b.*, COALESCE(p.name, b.name) AS name, p.uuid AS player_uuid, p.teamid AS player_tid
-             FROM {$this->boxScoresTable} b
+             FROM `ibl_box_scores` b
              LEFT JOIN `ibl_plr` p ON b.pid = p.pid
              WHERE b.game_date = ? AND b.visitor_teamid = ? AND b.home_teamid = ?
              ORDER BY b.id ASC",

--- a/ibl5/classes/Api/Repository/ApiTeamRepository.php
+++ b/ibl5/classes/Api/Repository/ApiTeamRepository.php
@@ -14,14 +14,9 @@ use League\LeagueContext;
  */
 class ApiTeamRepository extends \BaseMysqliRepository
 {
-    private string $teamInfoTable;
-    private string $standingsTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
-        $this->standingsTable = $this->resolveTable('ibl_standings');
     }
 
     /**
@@ -38,8 +33,8 @@ class ApiTeamRepository extends \BaseMysqliRepository
             "SELECT t.teamid, t.uuid, t.team_city, t.team_name, t.owner_name, t.arena,
                     s.conference, s.division,
                     t.discord_id
-             FROM {$this->teamInfoTable} t
-             LEFT JOIN {$this->standingsTable} s ON t.teamid = s.teamid
+             FROM `ibl_team_info` t
+             LEFT JOIN `ibl_standings` s ON t.teamid = s.teamid
              WHERE t.teamid BETWEEN 1 AND ?
              ORDER BY {$orderBy}
              LIMIT ? OFFSET ?",
@@ -57,7 +52,7 @@ class ApiTeamRepository extends \BaseMysqliRepository
     {
         /** @var array{total: int}|null $row */
         $row = $this->fetchOne(
-            "SELECT COUNT(*) AS total FROM {$this->teamInfoTable} WHERE teamid BETWEEN 1 AND ?",
+            "SELECT COUNT(*) AS total FROM `ibl_team_info` WHERE teamid BETWEEN 1 AND ?",
             'i',
             League::MAX_REAL_TEAMID
         );
@@ -88,8 +83,8 @@ class ApiTeamRepository extends \BaseMysqliRepository
                     s.away_wins AS away_wins,
                     s.away_losses AS away_losses,
                     s.games_unplayed AS games_remaining
-             FROM {$this->teamInfoTable} t
-             LEFT JOIN {$this->standingsTable} s ON t.teamid = s.teamid
+             FROM `ibl_team_info` t
+             LEFT JOIN `ibl_standings` s ON t.teamid = s.teamid
              WHERE t.uuid = ?",
             's',
             $uuid

--- a/ibl5/classes/BaseMysqliRepository.php
+++ b/ibl5/classes/BaseMysqliRepository.php
@@ -92,7 +92,8 @@ abstract class BaseMysqliRepository
 
     /**
      * Optional league context for multi-league table resolution.
-     * When set, resolveTable() maps IBL table names to their league-specific equivalents.
+     * When set (or via the static shared context), rewriteTableNames() maps
+     * backtick-quoted IBL table names to their league-specific equivalents.
      */
     protected ?\League\LeagueContext $leagueContext;
 
@@ -138,19 +139,6 @@ abstract class BaseMysqliRepository
     public static function clearSharedLeagueContext(): void
     {
         self::$sharedLeagueContext = null;
-    }
-
-    /**
-     * Resolve a table name through LeagueContext (if set), else return as-is.
-     *
-     * @param string $iblTableName The IBL table name (e.g., 'ibl_standings')
-     * @return string The resolved table name (e.g., 'ibl_olympics_standings' if Olympics)
-     */
-    protected function resolveTable(string $iblTableName): string
-    {
-        return $this->leagueContext !== null
-            ? $this->leagueContext->getTableName($iblTableName)
-            : $iblTableName;
     }
 
     /**
@@ -483,9 +471,10 @@ abstract class BaseMysqliRepository
      */
     protected function gameOfThatDaySubquery(): string
     {
-        $table = $this->resolveTable('ibl_box_scores_teams');
+        // Backtick `ibl_box_scores_teams` so the executeQuery() rewrite resolves
+        // it to the Olympics table on Olympics pages (stats subquery).
         return "(SELECT game_date, visitor_teamid, home_teamid, MIN(game_of_that_day) AS game_of_that_day
-             FROM {$table}
+             FROM `ibl_box_scores_teams`
              GROUP BY game_date, visitor_teamid, home_teamid)";
     }
 

--- a/ibl5/classes/Boxscore/BoxscoreRepository.php
+++ b/ibl5/classes/Boxscore/BoxscoreRepository.php
@@ -20,9 +20,6 @@ use Season\Season;
  */
 class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreRepositoryInterface
 {
-    private string $playerTable;
-    private string $teamTable;
-
     /**
      * Constructor
      *
@@ -31,8 +28,6 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->playerTable = $this->resolveTable('ibl_box_scores');
-        $this->teamTable = $this->resolveTable('ibl_box_scores_teams');
     }
 
     /**
@@ -84,14 +79,14 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
     {
         $this->transactional(function () use ($startDate, $endDate): void {
             $this->execute(
-                "DELETE FROM {$this->playerTable} WHERE game_date BETWEEN ? AND ?",
+                "DELETE FROM `ibl_box_scores` WHERE game_date BETWEEN ? AND ?",
                 "ss",
                 $startDate,
                 $endDate
             );
 
             $this->execute(
-                "DELETE FROM {$this->teamTable} WHERE game_date BETWEEN ? AND ?",
+                "DELETE FROM `ibl_box_scores_teams` WHERE game_date BETWEEN ? AND ?",
                 "ss",
                 $startDate,
                 $endDate
@@ -109,7 +104,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
         return $this->fetchOne(
             "SELECT visitor_q1_points, visitor_q2_points, visitor_q3_points, visitor_q4_points, visitor_ot_points,
                     home_q1_points, home_q2_points, home_q3_points, home_q4_points, home_ot_points
-             FROM {$this->teamTable}
+             FROM `ibl_box_scores_teams`
              WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND game_of_that_day = ?
              LIMIT 1",
             "siii",
@@ -126,7 +121,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
     public function deleteTeamBoxscoresByGame(string $date, int $visitor_teamid, int $home_teamid, int $game_of_that_day): int
     {
         return $this->execute(
-            "DELETE FROM {$this->teamTable}
+            "DELETE FROM `ibl_box_scores_teams`
              WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND game_of_that_day = ?",
             "siii",
             $date,
@@ -142,7 +137,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
     public function deletePlayerBoxscoresByGame(string $date, int $visitor_teamid, int $home_teamid): int
     {
         return $this->execute(
-            "DELETE FROM {$this->playerTable}
+            "DELETE FROM `ibl_box_scores`
              WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ?",
             "sii",
             $date,
@@ -158,7 +153,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
     {
         /** @var array{cnt: int}|null $row */
         $row = $this->fetchOne(
-            "SELECT COUNT(*) AS cnt FROM {$this->playerTable}
+            "SELECT COUNT(*) AS cnt FROM `ibl_box_scores`
              WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND pid <> 0 AND teamid IS NULL
              LIMIT 1",
             "sii",
@@ -177,7 +172,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
     {
         /** @var list<array{name: string}> $rows */
         $rows = $this->fetchAll(
-            "SELECT name FROM {$this->teamTable}
+            "SELECT name FROM `ibl_box_scores_teams`
              WHERE game_date = ? AND visitor_teamid = " . League::ALL_STAR_AWAY_TEAMID . " AND home_teamid = " . League::ALL_STAR_HOME_TEAMID . "
              ORDER BY id ASC
              LIMIT 2",
@@ -203,7 +198,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
         /** @var list<array{id: int, game_date: string, name: string, visitor_teamid: int, home_teamid: int}> $rows */
         $rows = $this->fetchAll(
             "SELECT id, game_date, name, visitor_teamid, home_teamid
-             FROM {$this->teamTable}
+             FROM `ibl_box_scores_teams`
              WHERE name IN ('Team Away', 'Team Home')
                AND visitor_teamid = " . League::ALL_STAR_AWAY_TEAMID . " AND home_teamid = " . League::ALL_STAR_HOME_TEAMID . "
              ORDER BY game_date ASC, id ASC",
@@ -221,7 +216,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
         /** @var list<array{name: string}> $rows */
         $rows = $this->fetchAll(
             "SELECT COALESCE(p.name, bs.name) AS name
-             FROM {$this->playerTable} bs
+             FROM `ibl_box_scores` bs
              LEFT JOIN `ibl_plr` p ON bs.pid = p.pid
              WHERE bs.game_date = ? AND bs.visitor_teamid = " . League::ALL_STAR_AWAY_TEAMID . " AND bs.home_teamid = " . League::ALL_STAR_HOME_TEAMID . " AND bs.teamid = ?
              ORDER BY bs.id ASC",
@@ -244,7 +239,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
     public function renameAllStarTeam(int $recordId, string $newName): int
     {
         return $this->execute(
-            "UPDATE {$this->teamTable} SET name = ? WHERE id = ?",
+            "UPDATE `ibl_box_scores_teams` SET name = ? WHERE id = ?",
             "si",
             $newName,
             $recordId
@@ -291,7 +286,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
         int $personalFouls,
     ): int {
         return $this->execute(
-            Boxscore::teamInsertSql($this->teamTable),
+            Boxscore::teamInsertSql('`ibl_box_scores_teams`'),
             "ssiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii",
             $date,
             $name,
@@ -365,7 +360,7 @@ class BoxscoreRepository extends \BaseMysqliRepository implements BoxscoreReposi
         int $personalFouls,
     ): int {
         return $this->execute(
-            Boxscore::playerInsertSql($this->playerTable),
+            Boxscore::playerInsertSql('`ibl_box_scores`'),
             "ssssiiiiiiiiiiiiiiiiiiiiiiiii",
             $date,
             $uuid,

--- a/ibl5/classes/JsbParser/JsbImportRepository.php
+++ b/ibl5/classes/JsbParser/JsbImportRepository.php
@@ -16,32 +16,9 @@ use League\LeagueContext;
  */
 class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepositoryInterface
 {
-    private string $histTable;
-    private string $jsbHistoryTable;
-    private string $jsbTransactionsTable;
-    private string $rcbAlltimeTable;
-    private string $rcbSeasonTable;
-    private string $plrTable;
-    private string $teamInfoTable;
-    private string $plbSnapshotsTable;
-    private string $draftResultsTable;
-    private string $retiredPlayersTable;
-    private string $hallOfFameTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->histTable = $this->resolveTable('ibl_hist');
-        $this->jsbHistoryTable = $this->resolveTable('ibl_jsb_history');
-        $this->jsbTransactionsTable = $this->resolveTable('ibl_jsb_transactions');
-        $this->rcbAlltimeTable = $this->resolveTable('ibl_rcb_alltime_records');
-        $this->rcbSeasonTable = $this->resolveTable('ibl_rcb_season_records');
-        $this->plrTable = $this->resolveTable('ibl_plr');
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
-        $this->plbSnapshotsTable = $this->resolveTable('ibl_plb_snapshots');
-        $this->draftResultsTable = $this->resolveTable('ibl_jsb_draft_results');
-        $this->retiredPlayersTable = $this->resolveTable('ibl_jsb_retired_players');
-        $this->hallOfFameTable = $this->resolveTable('ibl_jsb_hall_of_fame');
     }
 
     /**
@@ -111,7 +88,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertTransaction(array $record): int
     {
         return $this->execute(
-            "INSERT INTO {$this->jsbTransactionsTable}
+            "INSERT INTO `ibl_jsb_transactions`
                 (season_year, transaction_month, transaction_day, transaction_type,
                  pid, player_name, from_teamid, to_teamid,
                  injury_games_missed, injury_description, trade_group_id,
@@ -149,7 +126,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertHistoryRecord(array $record): int
     {
         return $this->execute(
-            "INSERT INTO {$this->jsbHistoryTable}
+            "INSERT INTO `ibl_jsb_history`
                 (season_year, team_name, teamid, wins, losses, made_playoffs,
                  playoff_result, playoff_round_reached, won_championship, source_file)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -259,7 +236,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
 
         // Try direct lookup first
         $row = $this->fetchOne(
-            "SELECT teamid FROM {$this->teamInfoTable} WHERE team_name = ? LIMIT 1",
+            "SELECT teamid FROM `ibl_team_info` WHERE team_name = ? LIMIT 1",
             's',
             $teamName
         );
@@ -275,7 +252,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
         if (isset(self::TEAM_NAME_ALIASES[$teamName])) {
             $aliasName = self::TEAM_NAME_ALIASES[$teamName];
             $row = $this->fetchOne(
-                "SELECT teamid FROM {$this->teamInfoTable} WHERE team_name = ? LIMIT 1",
+                "SELECT teamid FROM `ibl_team_info` WHERE team_name = ? LIMIT 1",
                 's',
                 $aliasName
             );
@@ -290,7 +267,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
 
         // Try looking in hist table for historical team names
         $row = $this->fetchOne(
-            "SELECT teamid FROM {$this->histTable} WHERE team = ? AND teamid > 0 LIMIT 1",
+            "SELECT teamid FROM `ibl_hist` WHERE team = ? AND teamid > 0 LIMIT 1",
             's',
             $teamName
         );
@@ -314,7 +291,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function fetchMaxTradeGroupId(): int
     {
         $row = $this->fetchOne(
-            "SELECT COALESCE(MAX(trade_group_id), 0) AS max_id FROM {$this->jsbTransactionsTable}",
+            "SELECT COALESCE(MAX(trade_group_id), 0) AS max_id FROM `ibl_jsb_transactions`",
             ''
         );
 
@@ -333,7 +310,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function replaceRcbAlltimeRecords(array $records): int
     {
         return $this->transactional(function () use ($records): int {
-            $this->execute("DELETE FROM {$this->rcbAlltimeTable}");
+            $this->execute("DELETE FROM `ibl_rcb_alltime_records`");
 
             $total = 0;
             $columns = '(scope, teamid, record_type, stat_category, ranking,'
@@ -362,7 +339,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
                     $params[] = $r['source_file'];
                 }
                 $total += $this->execute(
-                    "INSERT INTO {$this->rcbAlltimeTable} {$columns} VALUES {$placeholders}",
+                    "INSERT INTO `ibl_rcb_alltime_records` {$columns} VALUES {$placeholders}",
                     $types,
                     ...$params
                 );
@@ -379,7 +356,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     {
         return $this->transactional(function () use ($seasonYear, $records): int {
             $this->execute(
-                "DELETE FROM {$this->rcbSeasonTable} WHERE season_year = ?",
+                "DELETE FROM `ibl_rcb_season_records` WHERE season_year = ?",
                 'i',
                 $seasonYear
             );
@@ -410,7 +387,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
                     $params[] = $r['source_file'];
                 }
                 $total += $this->execute(
-                    "INSERT INTO {$this->rcbSeasonTable} {$columns} VALUES {$placeholders}",
+                    "INSERT INTO `ibl_rcb_season_records` {$columns} VALUES {$placeholders}",
                     $types,
                     ...$params
                 );
@@ -429,7 +406,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function getPlayerName(int $pid): ?string
     {
         $row = $this->fetchOne(
-            "SELECT name FROM {$this->plrTable} WHERE pid = ? LIMIT 1",
+            "SELECT name FROM `ibl_plr` WHERE pid = ? LIMIT 1",
             'i',
             $pid
         );
@@ -447,7 +424,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertPlbSnapshot(array $record): int
     {
         return $this->execute(
-            "INSERT INTO {$this->plbSnapshotsTable}
+            "INSERT INTO `ibl_plb_snapshots`
                 (season_year, sim_number, source_archive, teamid, slot_index,
                  pid, player_name, dc_minutes, dc_of, dc_df, dc_oi, dc_di, dc_bh)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -485,7 +462,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertDraftResult(array $record): int
     {
         return $this->execute(
-            "INSERT INTO {$this->draftResultsTable}
+            "INSERT INTO `ibl_jsb_draft_results`
                 (draft_year, round, pick, team_name, pos, player_name, pid)
             VALUES (?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
@@ -510,7 +487,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertRetiredPlayer(array $record): int
     {
         return $this->execute(
-            "INSERT INTO {$this->retiredPlayersTable}
+            "INSERT INTO `ibl_jsb_retired_players`
                 (jsb_pid, retirement_year, player_name, pid)
             VALUES (?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
@@ -530,7 +507,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertHofInductee(array $record): int
     {
         return $this->execute(
-            "INSERT INTO {$this->hallOfFameTable}
+            "INSERT INTO `ibl_jsb_hall_of_fame`
                 (jsb_pid, player_name, pos, induction_year, pid)
             VALUES (?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
@@ -553,7 +530,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function hasChampionForSeason(int $seasonYear): bool
     {
         $row = $this->fetchOne(
-            "SELECT COUNT(*) AS cnt FROM {$this->jsbHistoryTable}
+            "SELECT COUNT(*) AS cnt FROM `ibl_jsb_history`
              WHERE season_year = ? AND won_championship = 1",
             'i',
             $seasonYear,

--- a/ibl5/classes/JsbParser/JsbImportRepository.php
+++ b/ibl5/classes/JsbParser/JsbImportRepository.php
@@ -424,6 +424,8 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertPlbSnapshot(array $record): int
     {
         return $this->execute(
+            // Backticked for the rename-safety rule only; not in
+            // LeagueContext::TABLE_MAP, so the Olympics rewrite never touches it.
             "INSERT INTO `ibl_plb_snapshots`
                 (season_year, sim_number, source_archive, teamid, slot_index,
                  pid, player_name, dc_minutes, dc_of, dc_df, dc_oi, dc_di, dc_bh)
@@ -462,6 +464,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertDraftResult(array $record): int
     {
         return $this->execute(
+            // Non-TABLE_MAP table: backtick is rename-safety only, never rewritten.
             "INSERT INTO `ibl_jsb_draft_results`
                 (draft_year, round, pick, team_name, pos, player_name, pid)
             VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -487,6 +490,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertRetiredPlayer(array $record): int
     {
         return $this->execute(
+            // Non-TABLE_MAP table: backtick is rename-safety only, never rewritten.
             "INSERT INTO `ibl_jsb_retired_players`
                 (jsb_pid, retirement_year, player_name, pid)
             VALUES (?, ?, ?, ?)
@@ -507,6 +511,7 @@ class JsbImportRepository extends \BaseMysqliRepository implements JsbImportRepo
     public function upsertHofInductee(array $record): int
     {
         return $this->execute(
+            // Non-TABLE_MAP table: backtick is rename-safety only, never rewritten.
             "INSERT INTO `ibl_jsb_hall_of_fame`
                 (jsb_pid, player_name, pos, induction_year, pid)
             VALUES (?, ?, ?, ?, ?)

--- a/ibl5/classes/LastSimRecap/LastSimRecapRepository.php
+++ b/ibl5/classes/LastSimRecap/LastSimRecapRepository.php
@@ -20,24 +20,9 @@ use League\LeagueContext;
  */
 class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRecapRepositoryInterface
 {
-    private string $simDatesTable;
-    private string $scheduleTable;
-    private string $boxScoresTable;
-    private string $boxScoresTeamsTable;
-    private string $transactionsTable;
-    private string $plrTable;
-    private string $teamInfoTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->simDatesTable = $this->resolveTable('ibl_sim_dates');
-        $this->scheduleTable = $this->resolveTable('ibl_schedule');
-        $this->boxScoresTable = $this->resolveTable('ibl_box_scores');
-        $this->boxScoresTeamsTable = $this->resolveTable('ibl_box_scores_teams');
-        $this->transactionsTable = $this->resolveTable('ibl_jsb_transactions');
-        $this->plrTable = $this->resolveTable('ibl_plr');
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
     }
 
     /**
@@ -47,7 +32,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
     {
         /** @var array{sim:int,start_date:string|null,end_date:string|null}|null $row */
         $row = $this->fetchOne(
-            "SELECT sim, start_date, end_date FROM {$this->simDatesTable} ORDER BY sim DESC LIMIT 1"
+            "SELECT sim, start_date, end_date FROM `ibl_sim_dates` ORDER BY sim DESC LIMIT 1"
         );
 
         if ($row === null || $row['start_date'] === null || $row['end_date'] === null) {
@@ -69,7 +54,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
         /** @var list<array{id:int,box_id:int,game_date:string,visitor_teamid:int,visitor_score:int,home_teamid:int,home_score:int,season_year:int}> $rows */
         $rows = $this->fetchAll(
             "SELECT id, box_id, game_date, visitor_teamid, visitor_score, home_teamid, home_score, season_year
-             FROM {$this->scheduleTable}
+             FROM `ibl_schedule`
              WHERE game_date BETWEEN ? AND ?
                AND (visitor_teamid = ? OR home_teamid = ?)
              ORDER BY game_date ASC, id ASC",
@@ -114,7 +99,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
                     home_q1_points, home_q2_points, home_q3_points, home_q4_points, home_ot_points,
                     visitor_wins, visitor_losses, home_wins, home_losses,
                     COALESCE(game_of_that_day, 0) AS game_of_that_day
-             FROM {$this->boxScoresTeamsTable}
+             FROM `ibl_box_scores_teams`
              WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ?
              ORDER BY id ASC
              LIMIT 1",
@@ -180,8 +165,8 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
                        DATEDIFF(DATE_ADD({$dateExpr}, INTERVAL t.injury_games_missed DAY), ?) AS days_remaining,
                        DATE_FORMAT(DATE_ADD({$dateExpr}, INTERVAL t.injury_games_missed DAY), '%Y-%m-%d') AS return_date,
                        ({$dateExpr} = ?) AS is_new
-                FROM {$this->transactionsTable} t
-                JOIN {$this->plrTable} p ON p.pid = t.pid
+                FROM `ibl_jsb_transactions` t
+                JOIN `ibl_plr` p ON p.pid = t.pid
                 WHERE t.transaction_type = 1
                   AND t.pid IN ($placeholders)
                   AND t.injury_games_missed IS NOT NULL
@@ -226,7 +211,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
     {
         /** @var list<array{pid:int}> $rows */
         $rows = $this->fetchAll(
-            "SELECT pid FROM {$this->plrTable} WHERE teamid = ? AND retired = 0",
+            "SELECT pid FROM `ibl_plr` WHERE teamid = ? AND retired = 0",
             "i",
             $tid
         );
@@ -249,7 +234,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
                         WHEN pf_depth = 1 THEN 'PF'
                         WHEN c_depth  = 1 THEN 'C'
                     END AS pos
-             FROM {$this->plrTable}
+             FROM `ibl_plr`
              WHERE teamid = ?
                AND retired = 0
                AND (pg_depth = 1 OR sg_depth = 1 OR sf_depth = 1 OR pf_depth = 1 OR c_depth = 1)",
@@ -324,7 +309,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
     {
         /** @var array{game_date:string|null,visitor_teamid:int|null,home_teamid:int|null}|null $game */
         $game = $this->fetchOne(
-            "SELECT game_date, visitor_teamid, home_teamid FROM {$this->scheduleTable} WHERE id = ? LIMIT 1",
+            "SELECT game_date, visitor_teamid, home_teamid FROM `ibl_schedule` WHERE id = ? LIMIT 1",
             "i",
             $schedId
         );
@@ -336,7 +321,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
         /** @var list<array{pid:int,pos:string,game_min:int}> $rows */
         $rows = $this->fetchAll(
             "SELECT pid, pos, game_min
-             FROM {$this->boxScoresTable}
+             FROM `ibl_box_scores`
              WHERE game_date = ?
                AND visitor_teamid = ?
                AND home_teamid = ?
@@ -368,7 +353,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
     {
         /** @var array{game_date:string|null,visitor_teamid:int|null,home_teamid:int|null}|null $game */
         $game = $this->fetchOne(
-            "SELECT game_date, visitor_teamid, home_teamid FROM {$this->scheduleTable} WHERE id = ? LIMIT 1",
+            "SELECT game_date, visitor_teamid, home_teamid FROM `ibl_schedule` WHERE id = ? LIMIT 1",
             "i",
             $schedId
         );
@@ -380,7 +365,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
         /** @var array{pid:int,name:string,pos:string,calc_points:int|null,calc_rebounds:int|null,game_ast:int|null,game_stl:int|null,game_blk:int|null,game_min:int|null}|null $row */
         $row = $this->fetchOne(
             "SELECT pid, name, pos, calc_points, calc_rebounds, game_ast, game_stl, game_blk, game_min
-             FROM {$this->boxScoresTable}
+             FROM `ibl_box_scores`
              WHERE game_date = ?
                AND visitor_teamid = ?
                AND home_teamid = ?
@@ -432,7 +417,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
                       OR (home_teamid    = ? AND home_score    < visitor_score)
                     THEN 1 ELSE 0
                 END) AS losses
-             FROM {$this->scheduleTable}
+             FROM `ibl_schedule`
              WHERE (visitor_teamid = ? OR home_teamid = ?)
                AND game_date <= ?
                AND (visitor_score > 0 OR home_score > 0)",
@@ -453,7 +438,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
     {
         /** @var array{teamid:int,team_city:string,team_name:string}|null $row */
         $row = $this->fetchOne(
-            "SELECT teamid, team_city, team_name FROM {$this->teamInfoTable} WHERE teamid = ? LIMIT 1",
+            "SELECT teamid, team_city, team_name FROM `ibl_team_info` WHERE teamid = ? LIMIT 1",
             "i",
             $tid
         );

--- a/ibl5/classes/LastSimRecap/LastSimRecapRepository.php
+++ b/ibl5/classes/LastSimRecap/LastSimRecapRepository.php
@@ -32,6 +32,7 @@ class LastSimRecapRepository extends \BaseMysqliRepository implements LastSimRec
     {
         /** @var array{sim:int,start_date:string|null,end_date:string|null}|null $row */
         $row = $this->fetchOne(
+            // `ibl_sim_dates` is not in TABLE_MAP — backtick is rename-safety only, never rewritten.
             "SELECT sim, start_date, end_date FROM `ibl_sim_dates` ORDER BY sim DESC LIMIT 1"
         );
 

--- a/ibl5/classes/LeagueConfig/LeagueConfigRepository.php
+++ b/ibl5/classes/LeagueConfig/LeagueConfigRepository.php
@@ -14,12 +14,9 @@ use LeagueConfig\Contracts\LeagueConfigRepositoryInterface;
  */
 class LeagueConfigRepository extends \BaseMysqliRepository implements LeagueConfigRepositoryInterface
 {
-    private string $table;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->table = $this->resolveTable('ibl_league_config');
     }
 
     /**
@@ -28,7 +25,7 @@ class LeagueConfigRepository extends \BaseMysqliRepository implements LeagueConf
     public function hasConfigForSeason(int $seasonEndingYear): bool
     {
         $row = $this->fetchOne(
-            "SELECT COUNT(*) AS total FROM {$this->table} WHERE season_ending_year = ?",
+            "SELECT COUNT(*) AS total FROM `ibl_league_config` WHERE season_ending_year = ?",
             'i',
             $seasonEndingYear,
         );
@@ -51,7 +48,7 @@ class LeagueConfigRepository extends \BaseMysqliRepository implements LeagueConf
         $affectedTotal = 0;
 
         $query = <<<SQL
-            INSERT INTO {$this->table}
+            INSERT INTO `ibl_league_config`
                 (season_ending_year, team_slot, team_name, conference, division,
                  playoff_qualifiers_per_conf, playoff_round1_format, playoff_round2_format,
                  playoff_round3_format, playoff_round4_format, team_count)
@@ -98,7 +95,7 @@ class LeagueConfigRepository extends \BaseMysqliRepository implements LeagueConf
     {
         /** @var list<LeagueConfigRow> */
         return $this->fetchAll(
-            "SELECT * FROM {$this->table} WHERE season_ending_year = ? ORDER BY team_slot ASC",
+            "SELECT * FROM `ibl_league_config` WHERE season_ending_year = ? ORDER BY team_slot ASC",
             'i',
             $seasonEndingYear,
         );

--- a/ibl5/classes/LeagueSchedule/LeagueScheduleRepository.php
+++ b/ibl5/classes/LeagueSchedule/LeagueScheduleRepository.php
@@ -16,14 +16,9 @@ use LeagueSchedule\Contracts\LeagueScheduleRepositoryInterface;
  */
 class LeagueScheduleRepository extends \BaseMysqliRepository implements LeagueScheduleRepositoryInterface
 {
-    private string $scheduleTable;
-    private string $standingsTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->scheduleTable = $this->resolveTable('ibl_schedule');
-        $this->standingsTable = $this->resolveTable('ibl_standings');
     }
 
     /**
@@ -35,7 +30,7 @@ class LeagueScheduleRepository extends \BaseMysqliRepository implements LeagueSc
     {
         $query = "SELECT s.id, s.game_date, s.visitor_teamid, s.visitor_score, s.home_teamid, s.home_score, s.box_id,
                   bst.game_of_that_day
-                  FROM {$this->scheduleTable} s
+                  FROM `ibl_schedule` s
                   LEFT JOIN " . $this->gameOfThatDaySubquery() . " bst ON bst.game_date = s.game_date AND bst.visitor_teamid = s.visitor_teamid AND bst.home_teamid = s.home_teamid
                   WHERE s.season_year = ?
                   ORDER BY s.game_date ASC, s.id ASC";
@@ -57,7 +52,7 @@ class LeagueScheduleRepository extends \BaseMysqliRepository implements LeagueSc
     public function getTeamRecords(): array
     {
         $rows = $this->fetchAll(
-            "SELECT teamid, league_record FROM {$this->standingsTable} ORDER BY teamid ASC"
+            "SELECT teamid, league_record FROM `ibl_standings` ORDER BY teamid ASC"
         );
 
         /** @var array<int, string> $records */

--- a/ibl5/classes/Navigation/NavigationRepository.php
+++ b/ibl5/classes/Navigation/NavigationRepository.php
@@ -14,14 +14,23 @@ use Navigation\Contracts\NavigationRepositoryInterface;
  */
 class NavigationRepository extends \BaseMysqliRepository implements NavigationRepositoryInterface
 {
-    private string $teamInfoTable;
-    private string $standingsTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
-        $this->standingsTable = $this->resolveTable('ibl_standings');
+    }
+
+    /**
+     * Navigation is identity-scoped: resolveTeamId() reads the IBL-only
+     * gm_username column, and the team-nav dropdown intentionally stays on the
+     * IBL league (this repo receives no instance context in production, so its
+     * only Olympics signal would be the static shared context). Override the
+     * rewrite to a no-op so its backtick-quoted tables are never routed to the
+     * Olympics equivalents that lack those columns — the #878 regression.
+     * Olympics-aware nav is a separate feature decision.
+     */
+    protected function rewriteTableNames(string $query): string
+    {
+        return $query;
     }
 
     /** @see NavigationRepositoryInterface::resolveTeamId() */
@@ -29,7 +38,7 @@ class NavigationRepository extends \BaseMysqliRepository implements NavigationRe
     {
         $row = $this->fetchOne(
             "SELECT teamid
-             FROM {$this->teamInfoTable}
+             FROM `ibl_team_info`
              WHERE gm_username = ?
              LIMIT 1",
             's',
@@ -52,8 +61,8 @@ class NavigationRepository extends \BaseMysqliRepository implements NavigationRe
     {
         $rows = $this->fetchAll(
             "SELECT ti.teamid, ti.team_name, ti.team_city, s.division, s.conference
-             FROM {$this->teamInfoTable} ti
-             JOIN {$this->standingsTable} s ON ti.team_name = s.team_name
+             FROM `ibl_team_info` ti
+             JOIN `ibl_standings` s ON ti.team_name = s.team_name
              ORDER BY s.conference, s.division, ti.team_city",
             ''
         );

--- a/ibl5/classes/PlrParser/PlrBoxScoreRepository.php
+++ b/ibl5/classes/PlrParser/PlrBoxScoreRepository.php
@@ -14,16 +14,9 @@ use PlrParser\Contracts\PlrBoxScoreRepositoryInterface;
  */
 class PlrBoxScoreRepository extends \BaseMysqliRepository implements PlrBoxScoreRepositoryInterface
 {
-    private string $boxScoresTable;
-    private string $boxScoresTeamsTable;
-    private string $simDatesTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->boxScoresTable = $this->resolveTable('ibl_box_scores');
-        $this->boxScoresTeamsTable = $this->resolveTable('ibl_box_scores_teams');
-        $this->simDatesTable = $this->resolveTable('ibl_sim_dates');
     }
 
     /**
@@ -52,7 +45,7 @@ class PlrBoxScoreRepository extends \BaseMysqliRepository implements PlrBoxScore
                 SUM(game_tov) AS tov,
                 SUM(game_blk) AS blk,
                 SUM(game_pf) AS pf
-            FROM {$this->boxScoresTable}
+            FROM `ibl_box_scores`
             WHERE season_year = ?
               AND game_type = ?
               AND game_date <= ?
@@ -116,7 +109,7 @@ class PlrBoxScoreRepository extends \BaseMysqliRepository implements PlrBoxScore
                     + (game_stl >= 10)
                     + (game_blk >= 10)
                 ) >= 3 THEN 1 ELSE 0 END) AS triples
-            FROM {$this->boxScoresTable}
+            FROM `ibl_box_scores`
             WHERE season_year = ?
               AND game_type = ?
               AND game_date <= ?
@@ -151,7 +144,7 @@ class PlrBoxScoreRepository extends \BaseMysqliRepository implements PlrBoxScore
     {
         /** @var array{last_date: string|null}|null $row */
         $row = $this->fetchOne(
-            "SELECT MAX(game_date) AS last_date FROM {$this->boxScoresTable} WHERE season_year = ? AND game_type = ?",
+            "SELECT MAX(game_date) AS last_date FROM `ibl_box_scores` WHERE season_year = ? AND game_type = ?",
             'ii',
             $seasonYear,
             $gameType,
@@ -185,7 +178,7 @@ class PlrBoxScoreRepository extends \BaseMysqliRepository implements PlrBoxScore
                 SUM(game_tov) AS tov,
                 SUM(game_blk) AS blk,
                 SUM(game_pf) AS pf
-            FROM {$this->boxScoresTable}
+            FROM `ibl_box_scores`
             WHERE pid = ? AND season_year = ? AND game_type = 1
             GROUP BY game_date
             ORDER BY game_date
@@ -257,7 +250,7 @@ class PlrBoxScoreRepository extends \BaseMysqliRepository implements PlrBoxScore
                         PARTITION BY game_date, game_of_that_day, visitor_teamid, home_teamid
                         ORDER BY id
                     ) AS rn
-                FROM {$this->boxScoresTeamsTable}
+                FROM `ibl_box_scores_teams`
                 WHERE season_year = ?
                   AND game_type = ?
                   AND game_date <= ?
@@ -332,7 +325,7 @@ class PlrBoxScoreRepository extends \BaseMysqliRepository implements PlrBoxScore
 
         /** @var list<array{end_date: string}> $rows */
         $rows = $this->fetchAll(
-            "SELECT end_date FROM {$this->simDatesTable}
+            "SELECT end_date FROM `ibl_sim_dates`
              WHERE end_date BETWEEN ? AND ? ORDER BY sim",
             'ss',
             $start,

--- a/ibl5/classes/PlrParser/PlrBoxScoreRepository.php
+++ b/ibl5/classes/PlrParser/PlrBoxScoreRepository.php
@@ -325,6 +325,7 @@ class PlrBoxScoreRepository extends \BaseMysqliRepository implements PlrBoxScore
 
         /** @var list<array{end_date: string}> $rows */
         $rows = $this->fetchAll(
+            // `ibl_sim_dates` is not in TABLE_MAP — backtick is rename-safety only, never rewritten.
             "SELECT end_date FROM `ibl_sim_dates`
              WHERE end_date BETWEEN ? AND ? ORDER BY sim",
             'ss',

--- a/ibl5/classes/PlrParser/PlrParserRepository.php
+++ b/ibl5/classes/PlrParser/PlrParserRepository.php
@@ -15,14 +15,9 @@ use PlrParser\Contracts\PlrParserRepositoryInterface;
  */
 class PlrParserRepository extends \BaseMysqliRepository implements PlrParserRepositoryInterface
 {
-    private string $plrTable;
-    private string $snapshotsTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->plrTable = $this->resolveTable('ibl_plr');
-        $this->snapshotsTable = $this->resolveTable('ibl_plr_snapshots');
     }
 
     /**
@@ -32,7 +27,7 @@ class PlrParserRepository extends \BaseMysqliRepository implements PlrParserRepo
      */
     public function upsertPlayer(array $data): int
     {
-        $query = "INSERT INTO {$this->plrTable}
+        $query = "INSERT INTO `ibl_plr`
             (`ordinal`, `name`, `age`, `pid`, `teamid`, `peak`, `pos`,
              `oo`, `od`, `r_drive_off`, `dd`, `po`, `pd`, `r_trans_off`, `td`,
              `clutch`, `consistency`,
@@ -374,7 +369,7 @@ class PlrParserRepository extends \BaseMysqliRepository implements PlrParserRepo
             $updateClauses[] = '`' . $col . '` = VALUES(`' . $col . '`)';
         }
 
-        $query = "INSERT INTO {$this->snapshotsTable} ({$colList})
+        $query = "INSERT INTO `ibl_plr_snapshots` ({$colList})
             VALUES ({$placeholders})
             ON DUPLICATE KEY UPDATE " . implode(', ', $updateClauses);
 

--- a/ibl5/classes/RecordHolders/RecordHoldersRepository.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersRepository.php
@@ -48,18 +48,9 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
     /** @var array<int, string> Team ID → team name lookup cache */
     private array $teamNameCache = [];
 
-    private string $boxScoresTable;
-    private string $boxScoresTeamsTable;
-    private string $scheduleTable;
-    private string $teamInfoTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->boxScoresTable = $this->resolveTable('ibl_box_scores');
-        $this->boxScoresTeamsTable = $this->resolveTable('ibl_box_scores_teams');
-        $this->scheduleTable = $this->resolveTable('ibl_schedule');
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
     }
 
     /**
@@ -85,14 +76,14 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                 bs.game_ast AS assists,
                 bs.game_stl AS steals,
                 bs.game_blk AS blocks
-            FROM {$this->boxScoresTable} bs
+            FROM `ibl_box_scores` bs
             JOIN `ibl_plr` p ON p.pid = bs.pid
             JOIN `ibl_hist` h ON h.pid = bs.pid AND h.year = (" . self::SEASON_YEAR_EXPRESSION . ")
-            LEFT JOIN {$this->scheduleTable} sch ON sch.game_date = bs.game_date
+            LEFT JOIN `ibl_schedule` sch ON sch.game_date = bs.game_date
                 AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
             LEFT JOIN _game_of_day bst ON bst.game_date = bs.game_date
                 AND bst.visitor_teamid = bs.visitor_teamid AND bst.home_teamid = bs.home_teamid
-            LEFT JOIN {$this->teamInfoTable} opp ON opp.teamid = CASE
+            LEFT JOIN `ibl_team_info` opp ON opp.teamid = CASE
                 WHEN h.teamid = bs.visitor_teamid THEN bs.home_teamid
                 ELSE bs.visitor_teamid END
             WHERE (
@@ -194,11 +185,11 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                 CASE WHEN t.teamid = bs.visitor_teamid THEN bs.home_teamid ELSE bs.visitor_teamid END AS oppTid,
                 opp.team_name AS opp_team_name,
                 {$expression} AS value
-            FROM {$this->boxScoresTeamsTable} bs
-            JOIN {$this->teamInfoTable} t ON t.team_name = bs.name
-            LEFT JOIN {$this->scheduleTable} sch ON sch.game_date = bs.game_date
+            FROM `ibl_box_scores_teams` bs
+            JOIN `ibl_team_info` t ON t.team_name = bs.name
+            LEFT JOIN `ibl_schedule` sch ON sch.game_date = bs.game_date
                 AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
-            LEFT JOIN {$this->teamInfoTable} opp ON opp.teamid = CASE
+            LEFT JOIN `ibl_team_info` opp ON opp.teamid = CASE
                 WHEN t.teamid = bs.visitor_teamid THEN bs.home_teamid
                 ELSE bs.visitor_teamid END
             WHERE bs.visitor_teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
@@ -263,9 +254,9 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                     AND bs.home_teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
                 GROUP BY bs.game_date, bs.visitor_teamid, bs.home_teamid
             ) sub
-            JOIN {$this->teamInfoTable} winner_t ON winner_t.teamid = sub.winner_id
-            JOIN {$this->teamInfoTable} loser_t ON loser_t.teamid = sub.loser_id
-            LEFT JOIN {$this->scheduleTable} sch ON sch.game_date = sub.game_date
+            JOIN `ibl_team_info` winner_t ON winner_t.teamid = sub.winner_id
+            JOIN `ibl_team_info` loser_t ON loser_t.teamid = sub.loser_id
+            LEFT JOIN `ibl_schedule` sch ON sch.game_date = sub.game_date
                 AND sch.visitor_teamid = sub.visitor_teamid AND sch.home_teamid = sub.home_teamid
             LEFT JOIN _game_of_day bst ON bst.game_date = sub.game_date
                 AND bst.visitor_teamid = sub.visitor_teamid AND bst.home_teamid = sub.home_teamid
@@ -308,7 +299,7 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                 twl.wins,
                 twl.losses
             FROM `ibl_team_win_loss` twl
-            JOIN {$this->teamInfoTable} ti ON ti.team_name = twl.currentname
+            JOIN `ibl_team_info` ti ON ti.team_name = twl.currentname
             WHERE ti.teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
                 AND (twl.wins + twl.losses) > 0
             ORDER BY (twl.wins / (twl.wins + twl.losses)) {$safeOrder},
@@ -374,7 +365,7 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
     {
         if ($this->teamNameCache === []) {
             /** @var list<array{teamid: int, team_name: string}> $rows */
-            $rows = $this->fetchAll("SELECT teamid, team_name FROM {$this->teamInfoTable} WHERE teamid BETWEEN 1 AND ?", 'i', League::MAX_REAL_TEAMID);
+            $rows = $this->fetchAll("SELECT teamid, team_name FROM `ibl_team_info` WHERE teamid BETWEEN 1 AND ?", 'i', League::MAX_REAL_TEAMID);
             foreach ($rows as $row) {
                 $this->teamNameCache[$row['teamid']] = $row['team_name'];
             }
@@ -570,7 +561,7 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                 COUNT(DISTINCT pr.year) AS count,
                 GROUP_CONCAT(DISTINCT pr.year ORDER BY pr.year ASC SEPARATOR ', ') AS years
             FROM vw_playoff_series_results pr
-            JOIN {$this->teamInfoTable} t ON t.teamid = pr.winner_tid OR t.teamid = pr.loser_tid
+            JOIN `ibl_team_info` t ON t.teamid = pr.winner_tid OR t.teamid = pr.loser_tid
             WHERE t.teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
             GROUP BY t.team_name
             ORDER BY count DESC, t.team_name ASC
@@ -630,14 +621,14 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                     CASE WHEN h.teamid = bs.visitor_teamid THEN bs.home_teamid ELSE bs.visitor_teamid END AS oppTid,
                     opp.team_name AS opp_team_name,
                     {$expression} AS value
-                FROM {$this->boxScoresTable} bs
+                FROM `ibl_box_scores` bs
                 JOIN `ibl_plr` p ON p.pid = bs.pid
                 JOIN `ibl_hist` h ON h.pid = bs.pid AND h.year = (" . self::SEASON_YEAR_EXPRESSION . ")
-                LEFT JOIN {$this->scheduleTable} sch ON sch.game_date = bs.game_date
+                LEFT JOIN `ibl_schedule` sch ON sch.game_date = bs.game_date
                     AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
                 LEFT JOIN _game_of_day bst ON bst.game_date = bs.game_date
                     AND bst.visitor_teamid = bs.visitor_teamid AND bst.home_teamid = bs.home_teamid
-                LEFT JOIN {$this->teamInfoTable} opp ON opp.teamid = CASE
+                LEFT JOIN `ibl_team_info` opp ON opp.teamid = CASE
                     WHEN h.teamid = bs.visitor_teamid THEN bs.home_teamid
                     ELSE bs.visitor_teamid END
                 WHERE {$dateFilter}
@@ -704,11 +695,11 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
                     CASE WHEN t.teamid = bs.visitor_teamid THEN bs.home_teamid ELSE bs.visitor_teamid END AS oppTid,
                     opp.team_name AS opp_team_name,
                     {$config['expression']} AS value
-                FROM {$this->boxScoresTeamsTable} bs
-                JOIN {$this->teamInfoTable} t ON t.team_name = bs.name
-                LEFT JOIN {$this->scheduleTable} sch ON sch.game_date = bs.game_date
+                FROM `ibl_box_scores_teams` bs
+                JOIN `ibl_team_info` t ON t.team_name = bs.name
+                LEFT JOIN `ibl_schedule` sch ON sch.game_date = bs.game_date
                     AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
-                LEFT JOIN {$this->teamInfoTable} opp ON opp.teamid = CASE
+                LEFT JOIN `ibl_team_info` opp ON opp.teamid = CASE
                     WHEN t.teamid = bs.visitor_teamid THEN bs.home_teamid
                     ELSE bs.visitor_teamid END
                 WHERE {$dateFilter}
@@ -971,7 +962,7 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
 
         /** @var list<array{game_date: string}> $rows */
         $rows = $this->fetchAll(
-            "SELECT DISTINCT game_date FROM {$this->boxScoresTable} WHERE game_date > ? AND game_date <= ? ORDER BY game_date ASC",
+            "SELECT DISTINCT game_date FROM `ibl_box_scores` WHERE game_date > ? AND game_date <= ? ORDER BY game_date ASC",
             'ss',
             $floor,
             $simEnd

--- a/ibl5/classes/SavedDepthChart/SavedDepthChartRepository.php
+++ b/ibl5/classes/SavedDepthChart/SavedDepthChartRepository.php
@@ -15,16 +15,9 @@ use SavedDepthChart\Contracts\SavedDepthChartRepositoryInterface;
  */
 class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDepthChartRepositoryInterface
 {
-    private string $headerTable;
-    private string $playersTable;
-    private string $plrTable;
-
     public function __construct(\mysqli $db, ?\League\LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->headerTable = $this->resolveTable('ibl_saved_depth_charts');
-        $this->playersTable = $this->resolveTable('ibl_saved_depth_chart_players');
-        $this->plrTable = $this->resolveTable('ibl_plr');
     }
 
     /**
@@ -41,7 +34,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     ): int {
         if ($name !== null) {
             $this->execute(
-                "INSERT INTO {$this->headerTable}
+                "INSERT INTO `ibl_saved_depth_charts`
                     (teamid, username, name, phase, season_year, sim_start_date, sim_number_start, is_active)
                  VALUES (?, ?, ?, ?, ?, ?, ?, 1)",
                 "isssisi",
@@ -55,7 +48,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
             );
         } else {
             $this->execute(
-                "INSERT INTO {$this->headerTable}
+                "INSERT INTO `ibl_saved_depth_charts`
                     (teamid, username, phase, season_year, sim_start_date, sim_number_start, is_active)
                  VALUES (?, ?, ?, ?, ?, ?, 1)",
                 "issisi",
@@ -79,7 +72,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     {
         foreach ($playerSnapshots as $snapshot) {
             $this->execute(
-                "INSERT INTO {$this->playersTable}
+                "INSERT INTO `ibl_saved_depth_chart_players`
                     (depth_chart_id, pid, player_name, ordinal,
                      dc_pg_depth, dc_sg_depth, dc_sf_depth, dc_pf_depth, dc_c_depth,
                      dc_can_play_in_game, dc_minutes, dc_of, dc_df, dc_oi, dc_di, dc_bh)
@@ -111,7 +104,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     public function deactivateForTeam(int $teamid, string $simEndDate, int $simNumberEnd): void
     {
         $this->execute(
-            "UPDATE {$this->headerTable}
+            "UPDATE `ibl_saved_depth_charts`
              SET is_active = 0, sim_end_date = ?, sim_number_end = ?
              WHERE teamid = ? AND is_active = 1",
             "sii",
@@ -127,7 +120,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     public function deactivateOthersForTeam(int $teamid, int $excludeId, string $simEndDate, int $simNumberEnd): void
     {
         $this->execute(
-            "UPDATE {$this->headerTable}
+            "UPDATE `ibl_saved_depth_charts`
              SET is_active = 0, sim_end_date = ?, sim_number_end = ?
              WHERE teamid = ? AND is_active = 1 AND id != ?",
             "siii",
@@ -146,7 +139,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     {
         /** @var list<SavedDepthChartRow> */
         return $this->fetchAll(
-            "SELECT * FROM {$this->headerTable} WHERE teamid = ? ORDER BY created_at DESC, id DESC",
+            "SELECT * FROM `ibl_saved_depth_charts` WHERE teamid = ? ORDER BY created_at DESC, id DESC",
             "i",
             $teamid
         );
@@ -160,7 +153,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     {
         /** @var SavedDepthChartRow|null */
         return $this->fetchOne(
-            "SELECT * FROM {$this->headerTable} WHERE id = ? AND teamid = ? LIMIT 1",
+            "SELECT * FROM `ibl_saved_depth_charts` WHERE id = ? AND teamid = ? LIMIT 1",
             "ii",
             $id,
             $teamid
@@ -175,7 +168,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     {
         /** @var list<SavedDepthChartPlayerRow> */
         return $this->fetchAll(
-            "SELECT * FROM {$this->playersTable} WHERE depth_chart_id = ? ORDER BY ordinal ASC",
+            "SELECT * FROM `ibl_saved_depth_chart_players` WHERE depth_chart_id = ? ORDER BY ordinal ASC",
             "i",
             $depthChartId
         );
@@ -187,7 +180,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     public function updateName(int $id, int $teamid, string $newName): bool
     {
         $affected = $this->execute(
-            "UPDATE {$this->headerTable} SET name = ? WHERE id = ? AND teamid = ?",
+            "UPDATE `ibl_saved_depth_charts` SET name = ? WHERE id = ? AND teamid = ?",
             "sii",
             $newName,
             $id,
@@ -203,7 +196,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     public function updateDepthChartPlayers(int $depthChartId, array $playerSnapshots): void
     {
         $this->execute(
-            "DELETE FROM {$this->playersTable} WHERE depth_chart_id = ?",
+            "DELETE FROM `ibl_saved_depth_chart_players` WHERE depth_chart_id = ?",
             "i",
             $depthChartId
         );
@@ -217,7 +210,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     public function extendActiveDepthCharts(string $newEndDate, int $newSimNumber): int
     {
         return $this->execute(
-            "UPDATE {$this->headerTable} SET sim_end_date = ?, sim_number_end = ? WHERE is_active = 1",
+            "UPDATE `ibl_saved_depth_charts` SET sim_end_date = ?, sim_number_end = ? WHERE is_active = 1",
             "si",
             $newEndDate,
             $newSimNumber
@@ -230,7 +223,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     public function reactivate(int $id, int $teamid): bool
     {
         $affected = $this->execute(
-            "UPDATE {$this->headerTable} SET is_active = 1 WHERE id = ? AND teamid = ?",
+            "UPDATE `ibl_saved_depth_charts` SET is_active = 1 WHERE id = ? AND teamid = ?",
             "ii",
             $id,
             $teamid
@@ -246,7 +239,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     {
         /** @var SavedDepthChartRow|null */
         return $this->fetchOne(
-            "SELECT * FROM {$this->headerTable} WHERE teamid = ? ORDER BY created_at DESC, id DESC LIMIT 1",
+            "SELECT * FROM `ibl_saved_depth_charts` WHERE teamid = ? ORDER BY created_at DESC, id DESC LIMIT 1",
             "i",
             $teamid
         );
@@ -262,7 +255,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
         return $this->fetchAll(
             "SELECT pid, name, ordinal, dc_pg_depth, dc_sg_depth, dc_sf_depth, dc_pf_depth, dc_c_depth,
                     dc_can_play_in_game, dc_minutes, dc_of, dc_df, dc_oi, dc_di, dc_bh
-             FROM {$this->plrTable}
+             FROM `ibl_plr`
              WHERE teamid = ? AND retired = '0' AND ordinal <= ?
              ORDER BY ordinal ASC",
             "ii",
@@ -279,7 +272,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     {
         /** @var SavedDepthChartRow|null */
         return $this->fetchOne(
-            "SELECT * FROM {$this->headerTable} WHERE teamid = ? AND is_active = 1 ORDER BY updated_at DESC, id DESC LIMIT 1",
+            "SELECT * FROM `ibl_saved_depth_charts` WHERE teamid = ? AND is_active = 1 ORDER BY updated_at DESC, id DESC LIMIT 1",
             "i",
             $teamid
         );
@@ -325,7 +318,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
     {
         /** @var SavedDepthChartRow|null $header */
         $header = $this->fetchOne(
-            "SELECT * FROM {$this->headerTable}
+            "SELECT * FROM `ibl_saved_depth_charts`
              WHERE teamid = ?
                AND sim_start_date <= ?
                AND (sim_end_date >= ? OR sim_end_date IS NULL)
@@ -351,7 +344,7 @@ class SavedDepthChartRepository extends \BaseMysqliRepository implements SavedDe
                         WHEN dc_pf_depth = 1 THEN 'PF'
                         WHEN dc_c_depth  = 1 THEN 'C'
                     END AS pos
-             FROM {$this->playersTable}
+             FROM `ibl_saved_depth_chart_players`
              WHERE depth_chart_id = ?
                AND (dc_pg_depth = 1 OR dc_sg_depth = 1 OR dc_sf_depth = 1 OR dc_pf_depth = 1 OR dc_c_depth = 1)",
             "i",

--- a/ibl5/classes/Season/SeasonQueryRepository.php
+++ b/ibl5/classes/Season/SeasonQueryRepository.php
@@ -16,15 +16,11 @@ use Season\Contracts\SeasonQueryRepositoryInterface;
  */
 class SeasonQueryRepository extends \BaseMysqliRepository implements SeasonQueryRepositoryInterface
 {
-    private string $boxScoresTable;
-    private string $scheduleTable;
     private string $league;
 
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->boxScoresTable = $this->resolveTable('ibl_box_scores');
-        $this->scheduleTable = $this->resolveTable('ibl_schedule');
         $this->league = $leagueContext !== null ? $leagueContext->getCurrentLeague() : LeagueContext::LEAGUE_IBL;
     }
 
@@ -99,7 +95,7 @@ class SeasonQueryRepository extends \BaseMysqliRepository implements SeasonQuery
     {
         /** @var array{game_date: string}|null $result */
         $result = $this->fetchOne(
-            "SELECT game_date FROM {$this->boxScoresTable} ORDER BY game_date ASC LIMIT 1"
+            "SELECT game_date FROM `ibl_box_scores` ORDER BY game_date ASC LIMIT 1"
         );
 
         return $result['game_date'] ?? '';
@@ -114,7 +110,7 @@ class SeasonQueryRepository extends \BaseMysqliRepository implements SeasonQuery
     {
         /** @var array{game_date: string}|null $result */
         $result = $this->fetchOne(
-            "SELECT game_date FROM {$this->boxScoresTable} ORDER BY game_date DESC LIMIT 1"
+            "SELECT game_date FROM `ibl_box_scores` ORDER BY game_date DESC LIMIT 1"
         );
 
         return $result['game_date'] ?? '';
@@ -173,7 +169,7 @@ class SeasonQueryRepository extends \BaseMysqliRepository implements SeasonQuery
 
         /** @var array{max_date: string|null}|null $result */
         $result = $this->fetchOne(
-            "SELECT MAX(game_date) AS max_date FROM {$this->scheduleTable} WHERE game_date < ?",
+            "SELECT MAX(game_date) AS max_date FROM `ibl_schedule` WHERE game_date < ?",
             "s",
             $playoffsStart
         );

--- a/ibl5/classes/SeasonArchive/SeasonArchiveRepository.php
+++ b/ibl5/classes/SeasonArchive/SeasonArchiveRepository.php
@@ -27,14 +27,9 @@ use SeasonArchive\Contracts\SeasonArchiveRepositoryInterface;
  */
 class SeasonArchiveRepository extends BaseMysqliRepository implements SeasonArchiveRepositoryInterface
 {
-    private string $teamInfoTable;
-    private string $standingsTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
-        $this->standingsTable = $this->resolveTable('ibl_standings');
     }
 
     /**
@@ -182,7 +177,7 @@ class SeasonArchiveRepository extends BaseMysqliRepository implements SeasonArch
             JOIN `ibl_gm_tenures` gt ON ga.name = gt.gm_display_name
                 AND ga.year >= gt.start_season_year
                 AND (gt.end_season_year IS NULL OR ga.year <= gt.end_season_year)
-            JOIN {$this->teamInfoTable} ti ON gt.franchise_id = ti.teamid
+            JOIN `ibl_team_info` ti ON gt.franchise_id = ti.teamid
             ORDER BY ga.year ASC"
         );
     }
@@ -196,7 +191,7 @@ class SeasonArchiveRepository extends BaseMysqliRepository implements SeasonArch
         return $this->fetchAll(
             "SELECT gt.gm_display_name, gt.start_season_year, gt.end_season_year, ti.team_name
             FROM `ibl_gm_tenures` gt
-            JOIN {$this->teamInfoTable} ti ON gt.franchise_id = ti.teamid
+            JOIN `ibl_team_info` ti ON gt.franchise_id = ti.teamid
             ORDER BY gt.start_season_year ASC"
         );
     }
@@ -210,7 +205,7 @@ class SeasonArchiveRepository extends BaseMysqliRepository implements SeasonArch
         return $this->fetchAll(
             "SELECT hwl.year, hwl.currentname, hwl.namethatyear, hwl.wins, hwl.losses
             FROM `ibl_heat_win_loss` hwl
-            JOIN {$this->teamInfoTable} ti ON ti.team_name = hwl.currentname
+            JOIN `ibl_team_info` ti ON ti.team_name = hwl.currentname
             WHERE hwl.year = ?
                 AND ti.teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
             ORDER BY hwl.wins DESC, hwl.losses ASC",
@@ -267,7 +262,7 @@ class SeasonArchiveRepository extends BaseMysqliRepository implements SeasonArch
     public function getTeamConferences(): array
     {
         $rows = $this->fetchAll(
-            "SELECT team_name, conference FROM {$this->standingsTable} WHERE conference <> ''"
+            "SELECT team_name, conference FROM `ibl_standings` WHERE conference <> ''"
         );
 
         $map = [];

--- a/ibl5/classes/SeasonHighs/SeasonHighsRepository.php
+++ b/ibl5/classes/SeasonHighs/SeasonHighsRepository.php
@@ -20,20 +20,9 @@ use SeasonHighs\Contracts\SeasonHighsServiceInterface;
  */
 class SeasonHighsRepository extends \BaseMysqliRepository implements SeasonHighsRepositoryInterface
 {
-    private string $boxScoresTable;
-    private string $boxScoresTeamsTable;
-    private string $teamInfoTable;
-    private string $scheduleTable;
-    private string $playerTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->boxScoresTable = $this->resolveTable('ibl_box_scores');
-        $this->boxScoresTeamsTable = $this->resolveTable('ibl_box_scores_teams');
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
-        $this->scheduleTable = $this->resolveTable('ibl_schedule');
-        $this->playerTable = $this->resolveTable('ibl_plr');
     }
 
     /**
@@ -74,10 +63,10 @@ class SeasonHighsRepository extends \BaseMysqliRepository implements SeasonHighs
                 bs.`game_date` AS `date`, sch.`box_id`,
                 COALESCE(bs.`game_of_that_day`, 0) AS game_of_that_day,
                 {$statExpression} AS `{$safeStatName}`
-                FROM {$this->boxScoresTable} bs
-                JOIN {$this->playerTable} p ON bs.pid = p.pid
-                LEFT JOIN {$this->teamInfoTable} t ON p.teamid = t.teamid
-                LEFT JOIN {$this->scheduleTable} sch ON sch.game_date = bs.game_date AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
+                FROM `ibl_box_scores` bs
+                JOIN `ibl_plr` p ON bs.pid = p.pid
+                LEFT JOIN `ibl_team_info` t ON p.teamid = t.teamid
+                LEFT JOIN `ibl_schedule` sch ON sch.game_date = bs.game_date AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
                 WHERE bs.`game_date` BETWEEN ? AND ?{$locationCondition}
                 ORDER BY `{$safeStatName}` DESC, bs.`game_date` ASC
                 LIMIT {$limit}";
@@ -89,9 +78,9 @@ class SeasonHighsRepository extends \BaseMysqliRepository implements SeasonHighs
                 bs.`name`, bs.`game_date` AS `date`, sch.`box_id`,
                 COALESCE(bs.`game_of_that_day`, 0) AS game_of_that_day,
                 {$statExpression} AS `{$safeStatName}`
-                FROM {$this->boxScoresTeamsTable} bs
-                JOIN {$this->teamInfoTable} t ON bs.name = t.team_name
-                LEFT JOIN {$this->scheduleTable} sch ON sch.game_date = bs.game_date AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
+                FROM `ibl_box_scores_teams` bs
+                JOIN `ibl_team_info` t ON bs.name = t.team_name
+                LEFT JOIN `ibl_schedule` sch ON sch.game_date = bs.game_date AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
                 WHERE bs.`game_date` BETWEEN ? AND ?
                 ORDER BY `{$safeStatName}` DESC, bs.`game_date` ASC
                 LIMIT {$limit}";
@@ -154,10 +143,10 @@ class SeasonHighsRepository extends \BaseMysqliRepository implements SeasonHighs
                     bs.`game_date` AS `date`, sch.`box_id`,
                     COALESCE(bs.`game_of_that_day`, 0) AS game_of_that_day,
                     ({$statExpression}) AS stat_value
-                    FROM {$this->boxScoresTable} bs
-                    JOIN {$this->playerTable} p ON bs.pid = p.pid
-                    LEFT JOIN {$this->teamInfoTable} t ON p.teamid = t.teamid
-                    LEFT JOIN {$this->scheduleTable} sch ON sch.game_date = bs.game_date AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
+                    FROM `ibl_box_scores` bs
+                    JOIN `ibl_plr` p ON bs.pid = p.pid
+                    LEFT JOIN `ibl_team_info` t ON p.teamid = t.teamid
+                    LEFT JOIN `ibl_schedule` sch ON sch.game_date = bs.game_date AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
                     WHERE bs.`game_date` BETWEEN ? AND ?{$locationCondition}
                     ORDER BY stat_value DESC, bs.`game_date` ASC
                     LIMIT {$safeLimit})";
@@ -166,9 +155,9 @@ class SeasonHighsRepository extends \BaseMysqliRepository implements SeasonHighs
                     bs.`name`, bs.`game_date` AS `date`, sch.`box_id`,
                     COALESCE(bs.`game_of_that_day`, 0) AS game_of_that_day,
                     ({$statExpression}) AS stat_value
-                    FROM {$this->boxScoresTeamsTable} bs
-                    JOIN {$this->teamInfoTable} t ON bs.name = t.team_name
-                    LEFT JOIN {$this->scheduleTable} sch ON sch.game_date = bs.game_date AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
+                    FROM `ibl_box_scores_teams` bs
+                    JOIN `ibl_team_info` t ON bs.name = t.team_name
+                    LEFT JOIN `ibl_schedule` sch ON sch.game_date = bs.game_date AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
                     WHERE bs.`game_date` BETWEEN ? AND ?
                     ORDER BY stat_value DESC, bs.`game_date` ASC
                     LIMIT {$safeLimit})";

--- a/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsRepository.php
+++ b/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsRepository.php
@@ -18,12 +18,9 @@ use SeasonLeaderboards\Contracts\SeasonLeaderboardsRepositoryInterface;
  */
 class SeasonLeaderboardsRepository extends \BaseMysqliRepository implements SeasonLeaderboardsRepositoryInterface
 {
-    private string $teamInfoTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
     }
 
     /**
@@ -55,7 +52,7 @@ class SeasonLeaderboardsRepository extends \BaseMysqliRepository implements Seas
         // NOTE: $sortBy is validated in getSortColumn() against a strict whitelist
         $query = "SELECT h.*, t.team_city, t.color1, t.color2
             FROM `ibl_hist` h
-            LEFT JOIN {$this->teamInfoTable} t ON h.teamid = t.teamid
+            LEFT JOIN `ibl_team_info` t ON h.teamid = t.teamid
             WHERE {$where->toWhereClause()} ORDER BY $sortBy DESC, h.pid ASC"
             . ($limit > 0 ? " LIMIT $limit" : "");
 
@@ -77,7 +74,7 @@ class SeasonLeaderboardsRepository extends \BaseMysqliRepository implements Seas
     {
         /** @var list<TeamRow> $rows */
         $rows = $this->fetchAll(
-            "SELECT teamid AS teamid, team_name AS Team FROM {$this->teamInfoTable} WHERE teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . " ORDER BY teamid ASC"
+            "SELECT teamid AS teamid, team_name AS Team FROM `ibl_team_info` WHERE teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . " ORDER BY teamid ASC"
         );
         return $rows;
     }

--- a/ibl5/classes/Standings/StandingsRepository.php
+++ b/ibl5/classes/Standings/StandingsRepository.php
@@ -27,21 +27,11 @@ use Standings\Contracts\StandingsRepositoryInterface;
  */
 class StandingsRepository extends \BaseMysqliRepository implements StandingsRepositoryInterface
 {
-    private string $standingsTable;
-    private string $powerTable;
-    private string $teamInfoTable;
-    private string $scheduleTable;
-    private string $leagueConfigTable;
     private string $teamAwardsTable;
 
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->standingsTable = $this->resolveTable('ibl_standings');
-        $this->powerTable = $this->resolveTable('ibl_power');
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
-        $this->scheduleTable = $this->resolveTable('ibl_schedule');
-        $this->leagueConfigTable = $this->resolveTable('ibl_league_config');
         $this->teamAwardsTable = 'ibl_team_awards';
     }
 
@@ -102,8 +92,8 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
             (s.away_wins + s.away_losses) AS awayGames,
             t.color1,
             t.color2
-            FROM {$this->standingsTable} s
-            JOIN {$this->teamInfoTable} t ON s.teamid = t.teamid
+            FROM `ibl_standings` s
+            JOIN `ibl_team_info` t ON s.teamid = t.teamid
             WHERE s.{$columns['grouping']} = ?
             ORDER BY s.{$columns['gbColumn']} ASC,
                 (COALESCE(s.clinched_league, 0) * 4
@@ -137,8 +127,8 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
                 (s.away_wins + s.away_losses) AS awayGames,
                 s.conference, s.division,
                 t.color1, t.color2
-            FROM {$this->standingsTable} s
-            JOIN {$this->teamInfoTable} t ON s.teamid = t.teamid",
+            FROM `ibl_standings` s
+            JOIN `ibl_team_info` t ON s.teamid = t.teamid",
             ""
         );
     }
@@ -152,7 +142,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
     {
         /** @var StreakRow|null */
         return $this->fetchOne(
-            "SELECT last_win, last_loss, streak_type, streak, ranking, sos, remaining_sos, sos_rank, remaining_sos_rank FROM {$this->powerTable} WHERE teamid = ?",
+            "SELECT last_win, last_loss, streak_type, streak, ranking, sos, remaining_sos, sos_rank, remaining_sos_rank FROM `ibl_power` WHERE teamid = ?",
             "i",
             $teamId
         );
@@ -196,7 +186,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
     {
         /** @var list<array{teamid: int, last_win: int, last_loss: int, streak_type: string, streak: int, ranking: int, sos: float|string, remaining_sos: float|string, sos_rank: int, remaining_sos_rank: int}> $rows */
         $rows = $this->fetchAll(
-            "SELECT teamid, last_win, last_loss, streak_type, streak, ranking, sos, remaining_sos, sos_rank, remaining_sos_rank FROM {$this->powerTable}",
+            "SELECT teamid, last_win, last_loss, streak_type, streak, ranking, sos, remaining_sos, sos_rank, remaining_sos_rank FROM `ibl_power`",
             ""
         );
 
@@ -269,7 +259,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
     public function upsertStandings(array $params): void
     {
         $this->execute(
-            "INSERT INTO {$this->standingsTable} (
+            "INSERT INTO `ibl_standings` (
                 teamid, team_name, league_record, wins, losses, pct, games_unplayed,
                 conference, conf_gb, conf_record,
                 division, div_gb, div_record,
@@ -339,7 +329,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
     public function updateMagicNumber(int $teamid, int $magicNumber, string $magicNumberColumn): void
     {
         $this->execute(
-            "UPDATE {$this->standingsTable} SET {$magicNumberColumn} = ? WHERE teamid = ?",
+            "UPDATE `ibl_standings` SET {$magicNumberColumn} = ? WHERE teamid = ?",
             "ii",
             $magicNumber,
             $teamid
@@ -352,7 +342,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
     public function updateClinchedFlag(string $teamName, string $clinchedColumn): void
     {
         $this->execute(
-            "UPDATE {$this->standingsTable} SET {$clinchedColumn} = 1 WHERE team_name = ?",
+            "UPDATE `ibl_standings` SET {$clinchedColumn} = 1 WHERE team_name = ?",
             "s",
             $teamName
         );
@@ -384,7 +374,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
         /** @var list<array{teamid: int, team_name: string, home_wins: int, home_losses: int, away_wins: int, away_losses: int}> */
         return $this->fetchAll(
             "SELECT teamid, team_name, home_wins, home_losses, away_wins, away_losses
-            FROM {$this->standingsTable}
+            FROM `ibl_standings`
             WHERE {$grouping} = ?
             ORDER BY pct DESC",
             "s",
@@ -403,7 +393,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
             /** @var list<array{teamid: int, team_name: string, wins: int}> */
             return $this->fetchAll(
                 "SELECT teamid, team_name, home_wins + away_wins AS wins
-                FROM {$this->standingsTable}
+                FROM `ibl_standings`
                 WHERE {$grouping} = ?
                 ORDER BY wins DESC
                 LIMIT 2",
@@ -415,7 +405,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
         /** @var list<array{teamid: int, team_name: string, wins: int}> */
         return $this->fetchAll(
             "SELECT teamid, team_name, home_wins + away_wins AS wins
-            FROM {$this->standingsTable}
+            FROM `ibl_standings`
             ORDER BY wins DESC
             LIMIT 2",
             ""
@@ -433,7 +423,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
             /** @var array{losses: int}|null */
             return $this->fetchOne(
                 "SELECT home_losses + away_losses AS losses
-                FROM {$this->standingsTable}
+                FROM `ibl_standings`
                 WHERE {$grouping} = ?
                     AND team_name <> ?
                 ORDER BY losses ASC
@@ -447,7 +437,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
         /** @var array{losses: int}|null */
         return $this->fetchOne(
             "SELECT home_losses + away_losses AS losses
-            FROM {$this->standingsTable}
+            FROM `ibl_standings`
             WHERE team_name <> ?
             ORDER BY losses ASC
             LIMIT 1",
@@ -463,13 +453,13 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
     {
         if ($grouping !== null && $grouping !== '' && $region !== null && $region !== '') {
             $result = $this->fetchOne(
-                "SELECT MAX(games_unplayed) AS maxLeft FROM {$this->standingsTable} WHERE {$grouping} = ?",
+                "SELECT MAX(games_unplayed) AS maxLeft FROM `ibl_standings` WHERE {$grouping} = ?",
                 "s",
                 $region
             );
         } else {
             $result = $this->fetchOne(
-                "SELECT MAX(games_unplayed) AS maxLeft FROM {$this->standingsTable}",
+                "SELECT MAX(games_unplayed) AS maxLeft FROM `ibl_standings`",
                 ""
             );
         }
@@ -489,7 +479,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
                     WHEN (visitor_teamid = ? AND visitor_score > home_score) OR (home_teamid = ? AND home_score > visitor_score) THEN 1
                     ELSE 0
                 END) AS team1_wins
-            FROM {$this->scheduleTable}
+            FROM `ibl_schedule`
             WHERE visitor_score > 0 AND home_score > 0
             AND game_date BETWEEN ? AND ?
             AND ((visitor_teamid = ? AND home_teamid = ?) OR (visitor_teamid = ? AND home_teamid = ?))",
@@ -522,7 +512,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
         /** @var list<array{team_slot: int, team_name: string, conference: string, division: string}> $rows */
         $rows = $this->fetchAll(
             "SELECT team_slot, team_name, conference, division
-            FROM {$this->leagueConfigTable}
+            FROM `ibl_league_config`
             WHERE season_ending_year = ?",
             "i",
             $seasonEndingYear
@@ -551,7 +541,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
         /** @var list<array{visitor_teamid: int, visitor_score: int, home_teamid: int, home_score: int}> */
         return $this->fetchAll(
             "SELECT visitor_teamid, visitor_score, home_teamid, home_score
-            FROM {$this->scheduleTable}
+            FROM `ibl_schedule`
             WHERE visitor_score > 0 AND home_score > 0
             AND game_date BETWEEN ? AND ?
             ORDER BY game_date ASC",
@@ -571,7 +561,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
         /** @var list<array{team_name: string, wins: int}> */
         return $this->fetchAll(
             "SELECT team_name, home_wins + away_wins AS wins
-            FROM {$this->standingsTable}
+            FROM `ibl_standings`
             WHERE conference = ?
             ORDER BY wins DESC
             LIMIT 8",
@@ -590,7 +580,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
         /** @var list<array{losses: int}> */
         return $this->fetchAll(
             "SELECT home_losses + away_losses AS losses
-            FROM {$this->standingsTable}
+            FROM `ibl_standings`
             WHERE conference = ?
             ORDER BY losses DESC
             LIMIT 6",
@@ -609,10 +599,10 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
         /** @var list<array{teamid: int, game_count: int}> $rows */
         $rows = $this->fetchAll(
             "SELECT teamid, COUNT(*) AS game_count FROM (
-                SELECT visitor_teamid AS teamid FROM {$this->scheduleTable}
+                SELECT visitor_teamid AS teamid FROM `ibl_schedule`
                 WHERE game_date BETWEEN ? AND ?
                 UNION ALL
-                SELECT home_teamid AS teamid FROM {$this->scheduleTable}
+                SELECT home_teamid AS teamid FROM `ibl_schedule`
                 WHERE game_date BETWEEN ? AND ?
             ) AS all_games
             GROUP BY teamid",

--- a/ibl5/classes/Team/TeamRepository.php
+++ b/ibl5/classes/Team/TeamRepository.php
@@ -25,16 +25,9 @@ use Team\Contracts\TeamRepositoryInterface;
  */
 class TeamRepository extends \BaseMysqliRepository implements TeamRepositoryInterface
 {
-    private string $teamInfoTable;
-    private string $standingsTable;
-    private string $powerTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->teamInfoTable = $this->resolveTable('ibl_team_info');
-        $this->standingsTable = $this->resolveTable('ibl_standings');
-        $this->powerTable = $this->resolveTable('ibl_power');
     }
 
     /**
@@ -45,7 +38,7 @@ class TeamRepository extends \BaseMysqliRepository implements TeamRepositoryInte
     {
         /** @var TeamInfoRow|null */
         return $this->fetchOne(
-            "SELECT * FROM {$this->teamInfoTable} WHERE teamid = ?",
+            "SELECT * FROM `ibl_team_info` WHERE teamid = ?",
             "i",
             $teamid
         );
@@ -64,9 +57,9 @@ class TeamRepository extends \BaseMysqliRepository implements TeamRepositoryInte
                 s.home_record, s.away_record, s.games_unplayed,
                 p.ranking, p.last_win, p.last_loss, p.streak_type, p.streak,
                 p.sos, p.remaining_sos
-            FROM {$this->standingsTable} s
-            JOIN {$this->powerTable} p ON s.teamid = p.teamid
-            JOIN {$this->teamInfoTable} t ON s.teamid = t.teamid
+            FROM `ibl_standings` s
+            JOIN `ibl_power` p ON s.teamid = p.teamid
+            JOIN `ibl_team_info` t ON s.teamid = t.teamid
             WHERE t.team_name = ?",
             "s",
             $teamName
@@ -86,8 +79,8 @@ class TeamRepository extends \BaseMysqliRepository implements TeamRepositoryInte
                 s.home_record, s.away_record, s.games_unplayed,
                 p.ranking, p.last_win, p.last_loss, p.streak_type, p.streak,
                 p.sos, p.remaining_sos
-            FROM {$this->standingsTable} s
-            JOIN {$this->powerTable} p ON s.teamid = p.teamid
+            FROM `ibl_standings` s
+            JOIN `ibl_power` p ON s.teamid = p.teamid
             WHERE s.division = ?
             ORDER BY s.div_gb ASC",
             "s",
@@ -108,8 +101,8 @@ class TeamRepository extends \BaseMysqliRepository implements TeamRepositoryInte
                 s.home_record, s.away_record, s.games_unplayed,
                 p.ranking, p.last_win, p.last_loss, p.streak_type, p.streak,
                 p.sos, p.remaining_sos
-            FROM {$this->standingsTable} s
-            JOIN {$this->powerTable} p ON s.teamid = p.teamid
+            FROM `ibl_standings` s
+            JOIN `ibl_power` p ON s.teamid = p.teamid
             WHERE s.conference = ?
             ORDER BY s.conf_gb ASC",
             "s",

--- a/ibl5/classes/TeamSchedule/TeamScheduleRepository.php
+++ b/ibl5/classes/TeamSchedule/TeamScheduleRepository.php
@@ -17,12 +17,9 @@ use TeamSchedule\Contracts\TeamScheduleRepositoryInterface;
  */
 class TeamScheduleRepository extends \BaseMysqliRepository implements TeamScheduleRepositoryInterface
 {
-    private string $scheduleTable;
-
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
-        $this->scheduleTable = $this->resolveTable('ibl_schedule');
     }
 
     /**
@@ -35,7 +32,7 @@ class TeamScheduleRepository extends \BaseMysqliRepository implements TeamSchedu
         /** @var list<ScheduleRow> */
         return $this->fetchAll(
             "SELECT s.*, bst.game_of_that_day
-            FROM {$this->scheduleTable} s
+            FROM `ibl_schedule` s
             LEFT JOIN " . $this->gameOfThatDaySubquery() . " bst ON bst.game_date = s.game_date AND bst.visitor_teamid = s.visitor_teamid AND bst.home_teamid = s.home_teamid
             WHERE s.season_year = ? AND (s.visitor_teamid = ? OR s.home_teamid = ?)
             ORDER BY s.game_date ASC",
@@ -55,7 +52,7 @@ class TeamScheduleRepository extends \BaseMysqliRepository implements TeamSchedu
     {
         /** @var list<ProjectedGameRow> */
         return $this->fetchAll(
-            "SELECT * FROM `{$this->scheduleTable}`
+            "SELECT * FROM `ibl_schedule`
              WHERE season_year = ?
                AND (visitor_teamid = ? OR home_teamid = ?)
                AND game_date BETWEEN ADDDATE(?, 1) AND ?

--- a/ibl5/classes/Updater/PowerRankingsUpdater.php
+++ b/ibl5/classes/Updater/PowerRankingsUpdater.php
@@ -23,17 +23,15 @@ class PowerRankingsUpdater extends \BaseMysqliRepository {
     }
 
     public function update(): void {
-        $powerTable = $this->resolveTable('ibl_power');
-        $teamInfoTable = $this->resolveTable('ibl_team_info');
         $isOlympics = $this->leagueContext !== null && $this->leagueContext->isOlympics();
 
-        echo "<p>Updating the {$powerTable} database table...<p>";
+        echo "<p>Updating the `ibl_power` database table...<p>";
 
         $log = '';
 
         $teams = $this->fetchAll(
             "SELECT teamid, streak_type, streak
-            FROM {$powerTable}
+            FROM `ibl_power`
             ORDER BY teamid ASC",
             ""
         );
@@ -41,7 +39,7 @@ class PowerRankingsUpdater extends \BaseMysqliRepository {
         // Load team names for log messages
         /** @var list<array{teamid: int, team_name: string}> $teamInfoRows */
         $teamInfoRows = $this->fetchAll(
-            "SELECT teamid, team_name FROM {$teamInfoTable}",
+            "SELECT teamid, team_name FROM `ibl_team_info`",
             ""
         );
         /** @var array<int, string> $teamNames */
@@ -79,12 +77,12 @@ class PowerRankingsUpdater extends \BaseMysqliRepository {
         // Reset the sim's Depth Chart sent status (IBL-only — Olympics doesn't have sim depth)
         if (!$isOlympics) {
             $this->execute(
-                "UPDATE {$teamInfoTable} SET sim_depth = 'No Depth Chart'",
+                "UPDATE `ibl_team_info` SET sim_depth = 'No Depth Chart'",
                 ""
             );
         }
 
-        echo "<p>The {$powerTable} table has been updated.<p>";
+        echo "<p>The `ibl_power` table has been updated.<p>";
     }
 
     protected function determineMonth(): int {
@@ -98,14 +96,13 @@ class PowerRankingsUpdater extends \BaseMysqliRepository {
      */
     private function fetchAllPlayedGames(int $month): array
     {
-        $scheduleTable = $this->resolveTable('ibl_schedule');
         $startDate = $this->season->beginningYear . "-$month-01";
         $endDate = $this->season->endingYear . "-05-30";
 
         /** @var list<array{visitor_teamid: int, visitor_score: int, home_teamid: int, home_score: int}> */
         return $this->fetchAll(
             "SELECT visitor_teamid, visitor_score, home_teamid, home_score
-            FROM {$scheduleTable}
+            FROM `ibl_schedule`
             WHERE visitor_score > 0 AND home_score > 0
             AND game_date BETWEEN ? AND ?
             ORDER BY game_date ASC",
@@ -122,14 +119,13 @@ class PowerRankingsUpdater extends \BaseMysqliRepository {
      */
     private function fetchAllUnplayedGames(int $month): array
     {
-        $scheduleTable = $this->resolveTable('ibl_schedule');
         $startDate = $this->season->beginningYear . "-$month-01";
         $endDate = $this->season->endingYear . "-05-30";
 
         /** @var list<array{visitor_teamid: int, home_teamid: int}> */
         return $this->fetchAll(
             "SELECT visitor_teamid, home_teamid
-            FROM {$scheduleTable}
+            FROM `ibl_schedule`
             WHERE visitor_score = 0 AND home_score = 0
             AND game_date BETWEEN ? AND ?
             ORDER BY game_date ASC",
@@ -189,7 +185,6 @@ class PowerRankingsUpdater extends \BaseMysqliRepository {
      * @param TeamStats $stats
      */
     private function updateTeamStats(int $teamid, string $teamName, array $stats): string {
-        $powerTable = $this->resolveTable('ibl_power');
         $log = '';
 
         $winPoints = $stats['winPoints'] + $stats['wins'];
@@ -201,7 +196,7 @@ class PowerRankingsUpdater extends \BaseMysqliRepository {
 
         // Update power table (slim schema: only ranking, last 10, streak)
         $this->execute(
-            "UPDATE {$powerTable} SET
+            "UPDATE `ibl_power` SET
             last_win = ?,
             last_loss = ?,
             streak_type = ?,
@@ -231,15 +226,12 @@ class PowerRankingsUpdater extends \BaseMysqliRepository {
      */
     private function calculateAndStoreSos(array $allPlayedGames, int $month): void
     {
-        $standingsTable = $this->resolveTable('ibl_standings');
-        $powerTable = $this->resolveTable('ibl_power');
-
         echo '<p>Calculating Strength of Schedule...<p>';
 
         // Load team win percentages from standings
         /** @var list<array{teamid: int, wins: int, losses: int}> $standingsRows */
         $standingsRows = $this->fetchAll(
-            "SELECT teamid, wins, losses FROM {$standingsTable}",
+            "SELECT teamid, wins, losses FROM `ibl_standings`",
             ""
         );
 
@@ -301,7 +293,7 @@ class PowerRankingsUpdater extends \BaseMysqliRepository {
             $remainingSosRank = $remainingSosRanks[$teamid] ?? 0;
 
             $this->execute(
-                "UPDATE {$powerTable} SET
+                "UPDATE `ibl_power` SET
                 sos = ?,
                 remaining_sos = ?,
                 sos_rank = ?,

--- a/ibl5/classes/Updater/ScheduleUpdater.php
+++ b/ibl5/classes/Updater/ScheduleUpdater.php
@@ -76,19 +76,18 @@ class ScheduleUpdater extends \BaseMysqliRepository {
      */
     private function preloadTeamNameMap(): void
     {
-        $teamInfoTable = $this->resolveTable('ibl_team_info');
         $isOlympics = $this->leagueContext !== null && $this->leagueContext->isOlympics();
 
         if ($isOlympics) {
             /** @var list<array{team_name: string, teamid: int, is_real_team: int}> $rows */
             $rows = $this->fetchAll(
-                "SELECT team_name, teamid, is_real_team FROM {$teamInfoTable}",
+                "SELECT team_name, teamid, is_real_team FROM `ibl_team_info`",
                 "",
             );
         } else {
             /** @var list<array{team_name: string, teamid: int}> $rows */
             $rows = $this->fetchAll(
-                "SELECT team_name, teamid FROM {$teamInfoTable} WHERE teamid BETWEEN 1 AND ?",
+                "SELECT team_name, teamid FROM `ibl_team_info` WHERE teamid BETWEEN 1 AND ?",
                 "i",
                 League::MAX_REAL_TEAMID,
             );
@@ -145,7 +144,7 @@ class ScheduleUpdater extends \BaseMysqliRepository {
      *
      * @return string Log of inserted playoff games
      */
-    private function insertPlayoffGamesFromScheduleHtm(string $scheduleTable): string
+    private function insertPlayoffGamesFromScheduleHtm(): string
     {
         $ibl5Root = \Bootstrap\AppPaths::root();
         $leagueDir = $this->leagueContext !== null ? $this->leagueContext->getCurrentLeague() : 'IBL';
@@ -189,7 +188,7 @@ class ScheduleUpdater extends \BaseMysqliRepository {
             $uuid = UuidGenerator::generateUuid();
 
             $this->execute(
-                "INSERT INTO {$scheduleTable} (
+                "INSERT INTO `ibl_schedule` (
                     season_year, box_id, game_date, visitor_teamid, visitor_score, home_teamid, home_score, uuid
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 "iisiiiis",
@@ -209,9 +208,7 @@ class ScheduleUpdater extends \BaseMysqliRepository {
     }
 
     public function update(): void {
-        $scheduleTable = $this->resolveTable('ibl_schedule');
-
-        echo "Updating the {$scheduleTable} database table...<p>";
+        echo "Updating the `ibl_schedule` database table...<p>";
 
         $log = '';
 
@@ -221,9 +218,9 @@ class ScheduleUpdater extends \BaseMysqliRepository {
         // sees only the games inserted so far — the early season, since inserts
         // run in date order. Wrapping it commits the new schedule all at once
         // and rolls the DELETE back if any insert fails.
-        $this->transactional(function () use (&$log, $scheduleTable): void {
-            $this->execute("DELETE FROM {$scheduleTable}", '');
-            $log .= "DELETE FROM {$scheduleTable}<p>";
+        $this->transactional(function () use (&$log): void {
+            $this->execute("DELETE FROM `ibl_schedule`", '');
+            $log .= "DELETE FROM `ibl_schedule`<p>";
 
             $this->preloadTeamNameMap();
 
@@ -302,7 +299,7 @@ class ScheduleUpdater extends \BaseMysqliRepository {
 
                 try {
                     $this->execute(
-                        "INSERT INTO {$scheduleTable} (
+                        "INSERT INTO `ibl_schedule` (
                             season_year,
                             box_id,
                             game_date,
@@ -331,11 +328,11 @@ class ScheduleUpdater extends \BaseMysqliRepository {
                 }
             }
 
-            $log .= $this->insertPlayoffGamesFromScheduleHtm($scheduleTable);
+            $log .= $this->insertPlayoffGamesFromScheduleHtm();
         });
 
-        \UI\DebugOutput::display($log, "{$scheduleTable} SQL Queries");
+        \UI\DebugOutput::display($log, "`ibl_schedule` SQL Queries");
 
-        echo "The {$scheduleTable} database table has been updated.<p>";
+        echo "The `ibl_schedule` database table has been updated.<p>";
     }
 }

--- a/ibl5/classes/Updater/Steps/PreseasonCleanupRepository.php
+++ b/ibl5/classes/Updater/Steps/PreseasonCleanupRepository.php
@@ -13,13 +13,12 @@ final class PreseasonCleanupRepository extends \BaseMysqliRepository
 {
     public function hasPreseasonBoxScores(int $beginningYear): bool
     {
-        $boxScoresTable = $this->resolveTable('ibl_box_scores_teams');
         $startDate = sprintf('%d-09-01', $beginningYear);
         $endDate = sprintf('%d-09-30', $beginningYear);
 
         /** @var array{cnt: int}|null $row */
         $row = $this->fetchOne(
-            "SELECT COUNT(*) AS cnt FROM {$boxScoresTable} WHERE game_date BETWEEN ? AND ?",
+            "SELECT COUNT(*) AS cnt FROM `ibl_box_scores_teams` WHERE game_date BETWEEN ? AND ?",
             "ss",
             $startDate,
             $endDate,

--- a/ibl5/tests/Boxscore/BoxscoreRepositoryTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreRepositoryTest.php
@@ -31,6 +31,9 @@ class BoxscoreRepositoryTest extends TestCase
             ini_set('error_log', $this->previousErrorLog);
             $this->previousErrorLog = false;
         }
+        // setSharedLeagueContext() writes a static slot that leaks into every
+        // later test in the process; always clear it.
+        BoxscoreRepository::clearSharedLeagueContext();
         parent::tearDown();
     }
 
@@ -194,18 +197,14 @@ class BoxscoreRepositoryTest extends TestCase
 
     public function testOlympicsContextUsesOlympicsTables(): void
     {
-        $leagueContext = $this->createStub(LeagueContext::class);
-        $leagueContext->method('getTableName')->willReturnCallback(
-            static function (string $table): string {
-                return match ($table) {
-                    'ibl_box_scores' => 'ibl_olympics_box_scores',
-                    'ibl_box_scores_teams' => 'ibl_olympics_box_scores_teams',
-                    default => $table,
-                };
-            }
-        );
+        // Drive the production STATIC path: the repo gets no instance context;
+        // the backtick-quoted table names in its SQL are rewritten by
+        // executeQuery()->rewriteTableNames() because the shared context is Olympics.
+        $context = new LeagueContext();
+        $context->setLeague(LeagueContext::LEAGUE_OLYMPICS);
+        BoxscoreRepository::setSharedLeagueContext($context);
 
-        $repo = new BoxscoreRepository($this->mockDb, $leagueContext);
+        $repo = new BoxscoreRepository($this->mockDb);
         $this->mockDb->setReturnTrue(true);
 
         $repo->deletePreseasonBoxScores(2025);
@@ -218,18 +217,11 @@ class BoxscoreRepositoryTest extends TestCase
 
     public function testOlympicsContextInsertsIntoOlympicsTables(): void
     {
-        $leagueContext = $this->createStub(LeagueContext::class);
-        $leagueContext->method('getTableName')->willReturnCallback(
-            static function (string $table): string {
-                return match ($table) {
-                    'ibl_box_scores' => 'ibl_olympics_box_scores',
-                    'ibl_box_scores_teams' => 'ibl_olympics_box_scores_teams',
-                    default => $table,
-                };
-            }
-        );
+        $context = new LeagueContext();
+        $context->setLeague(LeagueContext::LEAGUE_OLYMPICS);
+        BoxscoreRepository::setSharedLeagueContext($context);
 
-        $repo = new BoxscoreRepository($this->mockDb, $leagueContext);
+        $repo = new BoxscoreRepository($this->mockDb);
         $this->mockDb->setReturnTrue(true);
 
         $repo->insertTeamBoxscore(

--- a/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
@@ -37,23 +37,6 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
         new TestableBaseMysqliRepository($badDb);
     }
 
-    // ==================== resolveTable ====================
-
-    public function testResolveTableWithoutLeagueContext(): void
-    {
-        self::assertSame('ibl_standings', $this->repo->callResolveTable('ibl_standings'));
-    }
-
-    public function testResolveTableWithLeagueContext(): void
-    {
-        $context = $this->createStub(LeagueContext::class);
-        $context->method('getTableName')
-            ->willReturnCallback(static fn (string $table): string => str_replace('ibl_', 'ibl_olympics_', $table));
-
-        $repo = new TestableBaseMysqliRepository($this->db, $context);
-        self::assertSame('ibl_olympics_standings', $repo->callResolveTable('ibl_standings'));
-    }
-
     // ==================== executeQuery errors ====================
 
     public function testExecuteQueryThrowsOnTypeMismatch(): void
@@ -495,6 +478,26 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
         self::assertStringContainsString('`ibl_olympics_plr`', $result);
     }
 
+    public function testNonMappedTablesAreNeverRewrittenUnderOlympicsContext(): void
+    {
+        // Tables with no LeagueContext::TABLE_MAP entry have no Olympics
+        // equivalent (ibl_sim_dates, ibl_jsb_draft_results, ibl_jsb_retired_players,
+        // ibl_jsb_hall_of_fame, ibl_plb_snapshots). They must pass through the
+        // rewrite untouched even when backtick-quoted under Olympics, or queries
+        // would fatal on a non-existent table.
+        $context = $this->createStub(LeagueContext::class);
+        $context->method('isOlympics')->willReturn(true);
+        \BaseMysqliRepository::setSharedLeagueContext($context);
+
+        $repo = new TestableBaseMysqliRepository($this->db);
+
+        foreach (['ibl_sim_dates', 'ibl_jsb_draft_results', 'ibl_jsb_retired_players', 'ibl_jsb_hall_of_fame', 'ibl_plb_snapshots'] as $nonMapped) {
+            $query = "SELECT * FROM `{$nonMapped}` LIMIT 1";
+            $result = $repo->callRewriteTableNames($query);
+            self::assertSame($query, $result, "Non-mapped table '{$nonMapped}' must not be rewritten");
+        }
+    }
+
     public function testFetchAllRealTeamsUsesOlympicsTableWithOlympicsContext(): void
     {
         $context = $this->createStub(LeagueContext::class);
@@ -540,11 +543,6 @@ class TestableBaseMysqliRepository extends \BaseMysqliRepository
     public function callRewriteTableNames(string $query): string
     {
         return $this->rewriteTableNames($query);
-    }
-
-    public function callResolveTable(string $table): string
-    {
-        return $this->resolveTable($table);
     }
 
     public function callExecuteQuery(string $query, string $types = '', mixed ...$params): object

--- a/ibl5/tests/Navigation/NavigationRepositoryTest.php
+++ b/ibl5/tests/Navigation/NavigationRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Navigation;
 
+use League\LeagueContext;
 use Navigation\NavigationRepository;
 use Tests\WideUnit\WideUnitTestCase;
 
@@ -15,6 +16,14 @@ class NavigationRepositoryTest extends WideUnitTestCase
     {
         parent::setUp();
         $this->repository = new NavigationRepository($this->mockDb);
+    }
+
+    protected function tearDown(): void
+    {
+        // setSharedLeagueContext() writes a static slot that leaks into every
+        // later test in the process; always clear it.
+        \BaseMysqliRepository::clearSharedLeagueContext();
+        parent::tearDown();
     }
 
     public function testResolveTeamIdReturnsIdForValidUser(): void
@@ -61,5 +70,47 @@ class NavigationRepositoryTest extends WideUnitTestCase
         $result = $this->repository->getTeamsData();
 
         $this->assertNull($result);
+    }
+
+    // ── Olympics static-path identity lock (the #878 regression) ──────────
+    // NavigationRepository receives NO instance LeagueContext in production
+    // (themes/IBL/theme.php constructs `new NavigationRepository($mysqli_db)`),
+    // so the only Olympics signal it could see is the STATIC shared context.
+    // resolveTeamId() reads the IBL-only `gm_username` column; it MUST stay on
+    // ibl_team_info even under Olympics, or it fatals on the missing column.
+
+    public function testResolveTeamIdStaysOnIblTeamInfoUnderOlympicsStaticContext(): void
+    {
+        $context = new LeagueContext();
+        $context->setLeague(LeagueContext::LEAGUE_OLYMPICS);
+        \BaseMysqliRepository::setSharedLeagueContext($context);
+
+        $this->mockDb->setMockData([['teamid' => 5]]);
+
+        $result = $this->repository->resolveTeamId('TestUser');
+
+        $this->assertSame(5, $result);
+        $this->assertQueryExecuted('ibl_team_info');
+        $this->assertQueryNotExecuted('ibl_olympics_team_info');
+    }
+
+    public function testGetTeamsDataReturnsIblTeamsUnderOlympicsStaticContext(): void
+    {
+        $context = new LeagueContext();
+        $context->setLeague(LeagueContext::LEAGUE_OLYMPICS);
+        \BaseMysqliRepository::setSharedLeagueContext($context);
+
+        $this->mockDb->setMockData([
+            ['teamid' => 1, 'team_name' => 'Celtics', 'team_city' => 'Boston', 'conference' => 'Eastern', 'division' => 'Atlantic'],
+        ]);
+
+        $result = $this->repository->getTeamsData();
+
+        $this->assertNotNull($result);
+        $this->assertSame('Celtics', $result['Eastern']['Atlantic'][0]['team_name']);
+        $this->assertQueryExecuted('ibl_team_info');
+        $this->assertQueryExecuted('ibl_standings');
+        $this->assertQueryNotExecuted('ibl_olympics_team_info');
+        $this->assertQueryNotExecuted('ibl_olympics_standings');
     }
 }

--- a/ibl5/tests/Season/SeasonConstructorTest.php
+++ b/ibl5/tests/Season/SeasonConstructorTest.php
@@ -42,10 +42,20 @@ class SeasonConstructorTest extends TestCase
 
         $repo = new SeasonQueryRepository($mockDb, $leagueContext);
 
-        $refProp = new \ReflectionProperty(SeasonQueryRepository::class, 'scheduleTable');
-        $scheduleTable = $refProp->getValue($repo);
+        // Drive the executeQuery() rewrite path (the production mechanism), not
+        // the removed resolveTable() property. With an Olympics context the
+        // backtick-quoted `ibl_schedule` is rewritten to its Olympics equivalent.
+        $repo->getLastRegularSeasonGameDate(2025);
 
-        $this->assertSame('ibl_olympics_schedule', $scheduleTable);
+        $scheduleQueries = array_filter(
+            $mockDb->getExecutedQueries(),
+            static fn (string $q): bool => stripos($q, 'schedule') !== false,
+        );
+        $this->assertNotEmpty($scheduleQueries);
+        foreach ($scheduleQueries as $q) {
+            $this->assertStringContainsString('ibl_olympics_schedule', $q);
+            $this->assertStringNotContainsString('FROM `ibl_schedule`', $q);
+        }
 
         unset($_SESSION['current_league']);
     }

--- a/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
@@ -625,17 +625,11 @@ class StandingsUpdaterTest extends TestCase
 
     public function testOlympicsContextUpsertsOlympicsStandingsTable(): void
     {
+        // Drive the executeQuery() rewrite path: the repo's backtick-quoted
+        // tables are rewritten to Olympics equivalents when the context is
+        // Olympics (isOlympics() === true), via LeagueContext::TABLE_MAP.
         $olympicsContext = $this->createStub(\League\LeagueContext::class);
-        $olympicsContext->method('getTableName')->willReturnCallback(
-            static function (string $table): string {
-                return match ($table) {
-                    'ibl_standings' => 'ibl_olympics_standings',
-                    'ibl_schedule' => 'ibl_olympics_schedule',
-                    'ibl_league_config' => 'ibl_olympics_league_config',
-                    default => $table,
-                };
-            }
-        );
+        $olympicsContext->method('isOlympics')->willReturn(true);
 
         $olympicsRepo = new StandingsRepository($this->mockDb, $olympicsContext);
         $updater = new TestableStandingsUpdater($olympicsRepo, $this->mockSeason, true);
@@ -659,16 +653,7 @@ class StandingsUpdaterTest extends TestCase
     public function testOlympicsContextFetchTeamMapQueriesOlympicsLeagueConfig(): void
     {
         $olympicsContext = $this->createStub(\League\LeagueContext::class);
-        $olympicsContext->method('getTableName')->willReturnCallback(
-            static function (string $table): string {
-                return match ($table) {
-                    'ibl_standings' => 'ibl_olympics_standings',
-                    'ibl_schedule' => 'ibl_olympics_schedule',
-                    'ibl_league_config' => 'ibl_olympics_league_config',
-                    default => $table,
-                };
-            }
-        );
+        $olympicsContext->method('isOlympics')->willReturn(true);
 
         $olympicsRepo = new StandingsRepository($this->mockDb, $olympicsContext);
         $updater = new \Updater\StandingsUpdater($olympicsRepo, $this->mockSeason, true);


### PR DESCRIPTION
## Summary

Removes `resolveTable()` from `BaseMysqliRepository` and all 22 consumer repos, completing the Olympics table-resolution migration started in #878 (PR1). All Olympics resolution now flows through the `executeQuery()` auto-rewrite mechanism exclusively.

### Key design decisions
- **Identity-lock (NavigationRepository):** Bare table literals + `rewriteTableNames()` no-op override, so IBL GM/auth lookups never route to `ibl_olympics_team_info` (the #878 regression)
- **Non-TABLE_MAP tables:** Bare literals (cosmetic — rewrite loop never touches them regardless)
- **Stats/display repos:** Backtick-quoted literals, opting into Olympics rewrite

### Deviations from plan
- **Navigation IBL-lock:** Plan said "write bare"; resolved via IBL-lock pattern (mirrors TeamIdentityRepository) — backtick + rewriteTableNames() no-op — to satisfy BanBareTableIdentifierRule in classes/
- **Non-TABLE_MAP tables:** Same rule forces backticks; safe because not in TABLE_MAP so rewrite loop never touches them; new DI test validates this
- **ScheduleUpdater private method:** Dropped the now-meaningless `$scheduleTable` parameter from private `insertPlayoffGamesFromScheduleHtm()` (single internal caller, PHPStan-clean)

## Verification

composer run analyse: clean. Full PHPUnit: 5775 pass, 0 failures/errors. DB-integration (bin/db-test-up): 839 pass. E2E (rows #9/#10) run by CI.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.