### PR TITLE
fix(nightly): staleness guard stops false-positiving on new files & ibl5/bin tokens

### DIFF
--- a/bin/check-plan-staleness
+++ b/bin/check-plan-staleness
@@ -92,9 +92,35 @@ while IFS= read -r token; do
     fi
     printf '%s\n' "$token" >> "$SEEN_FILE"
 
-    if [ ! -e "$REPO_ROOT/$token" ]; then
-        printf '%s\n' "$token" >> "$MISSING_FILE"
+    # A token resolves if it exists at the repo root. For bare bin/ tokens it
+    # also resolves at ibl5/bin/ — CI runs those scripts under
+    # `working-directory: ibl5`, so plans reference them in the bare bin/ form
+    # (e.g. `bin/check-baseline-drift`) even though the file is ibl5/bin/<x>.
+    if [ -e "$REPO_ROOT/$token" ]; then
+        continue
     fi
+    case "$token" in
+        bin/*)
+            if [ -e "$REPO_ROOT/ibl5/$token" ]; then
+                continue
+            fi
+            ;;
+    esac
+
+    # Not on disk. Before flagging it stale, check whether the plan references
+    # this token in a CREATION context — a file the plan itself creates is not a
+    # poison-pill stale path. The guard catches renamed/moved/deleted paths, not
+    # to-be-created ones. We require the creation cue to appear on a line that
+    # also contains the token (same-line), so a "Create X" elsewhere can't mask
+    # a genuinely stale Y. `post-impl` is the verification-matrix timing column
+    # for new artifacts; `pre-impl` rows reference existing files (which resolve
+    # on disk and never reach here).
+    if grep -F -- "$token" "$PLAN_FILE" \
+        | grep -qE '([Cc]reate|[Nn]ew file|[Aa]dd(s|ing)? (a )?new|[Ii]ntroduce|[Ss]caffold|throwaway|scratch|post-impl)'; then
+        continue
+    fi
+
+    printf '%s\n' "$token" >> "$MISSING_FILE"
 done < "$TOKENS_FILE"
 
 if [ -s "$MISSING_FILE" ]; then

--- a/bin/test-check-plan-staleness
+++ b/bin/test-check-plan-staleness
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-check-plan-staleness — regression test for bin/check-plan-staleness.
+#
+# The guard relaxes two false-positive classes (bare bin/ tokens that live at
+# ibl5/bin/, and to-be-created files referenced in a creation context). This
+# test pins both the relaxations AND the negative case: a missing path that is
+# NOT in a creation context must still be flagged stale. Without the negative
+# case, a relaxed guard could silently stop catching real poison-pill plans.
+#
+# Run: bin/test-check-plan-staleness  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GUARD="$SCRIPT_DIR/check-plan-staleness"
+TMP="$(mktemp -d)"
+trap 'rm -f "$TMP"/*.md 2>/dev/null; rmdir "$TMP" 2>/dev/null' EXIT
+
+FAILED=0
+
+# assert <name> <expected-exit> <plan-body>
+assert() {
+    name="$1"; want="$2"; body="$3"
+    f="$TMP/$name.md"
+    printf '%s\n' "$body" > "$f"
+    "$GUARD" "$f" >/dev/null 2>&1
+    got=$?
+    if [ "$got" -ne "$want" ]; then
+        echo "FAIL: $name — expected exit $want, got $got"
+        FAILED=1
+    else
+        echo "ok: $name (exit $got)"
+    fi
+}
+
+# A genuinely stale path referenced as something that should already exist must
+# still flag (exit 1). This is the load-bearing negative case.
+assert "stale-modify" 1 'Modify the existing helper `ibl5/classes/DoesNotExistAnywhere.php` to add a method.'
+
+# Same nonexistent path, but in a creation context, must pass (exit 0).
+assert "create-new-file" 0 'Create `ibl5/classes/DoesNotExistAnywhere.php` exposing a new handler.'
+
+# A verification-matrix row for a new (post-impl) test file must pass.
+assert "post-impl-test" 0 '| 2 | thing works | PHPUnit | post-impl | `ibl5/tests/Brand/NewThingTest.php` |'
+
+# A bare bin/ token whose real home is ibl5/bin/ must resolve (exit 0).
+assert "ibl5-bin-token" 0 'CI runs `bin/check-baseline-drift` under working-directory ibl5.'
+
+# A bare bin/ token that exists at neither root bin/ nor ibl5/bin/, with no
+# creation cue, must still flag stale (exit 1).
+assert "stale-bin-token" 1 'Run `bin/this-script-does-not-exist-at-all` as part of the job.'
+
+# An existing repo path must always pass (exit 0).
+assert "existing-path" 0 'See `bin/check-plan-staleness` for the guard itself.'
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
## Why

The nightly staleness guard `bin/check-plan-staleness` (shipped in #890) skipped three fresh, implementable plans last night by mis-flagging two false-positive token classes. The #890 review even predicted this ("cannot distinguish to-be-created from deleted", scored 75, dropped).

## What

- **`ibl5/bin/` resolution** — bare `bin/<x>` tokens (how plans reference scripts CI runs under `working-directory: ibl5`) now resolve at `ibl5/bin/<x>` too, not just repo root. Fixes `bin/check-baseline-drift` false flag.
- **To-be-created files** — a missing token is skipped when the plan references it on a line carrying a creation cue (`Create`, `new file`, `post-impl` matrix row, `throwaway`, etc.). Same-line requirement so a `Create X` elsewhere can't mask a genuinely stale `Y`.
- **Regression test** `bin/test-check-plan-staleness` pins both relaxations **and** the load-bearing negative case: a missing path referenced as already-existing (`Modify ...`) still flags stale (exit 1). Guards against silently neutering the guard.

## Verification

| # | What | Type | Result |
|---|------|------|--------|
| 1 | New-file / ibl5-bin tokens no longer flag; missing-non-creation tokens still flag | CLI-executable | `bin/test-check-plan-staleness` → all 6 cases pass |
| 2 | The 3 spuriously-skipped plans now exit 0 | CLI-executable | add-analyse-tests, axis16-2, roster all exit 0 |
| 3 | No regression on currently-queued plans | CLI-executable | all queued plans still exit 0 |
| 4 | shellcheck clean | CLI-executable | clean on both scripts |

<!-- no-adr: regression test for the existing #890 staleness guard; no new architectural constraint, decision already captured by #890 -->