### PR TITLE
Harden the E2E pre-merge safety net (PR #887 root-cause)

### DIFF
--- a/.claude/rules/plan-verification.md
+++ b/.claude/rules/plan-verification.md
@@ -1,6 +1,6 @@
 ---
-description: Requires plans to classify every verification step into the test-type taxonomy at plan-write time, preventing manual-testing items from deferring to post-plan cleanup.
-last_verified: 2026-05-28
+description: Requires plans to classify every verification step into the test-type taxonomy at plan-write time, preventing manual-testing items from deferring to post-plan cleanup, and grounds seed/DOM-dependent E2E assertions in real fixtures.
+last_verified: 2026-05-29
 ---
 
 # Plan Verification Matrix
@@ -64,6 +64,20 @@ These patterns **require** at least one E2E row in the verification matrix, even
 When a plan introduces any of these patterns, the planner must add a corresponding E2E row — one row per distinct user-visible state. For example, a toggle that shows/hides UI needs two E2E rows: one verifying the ON state, one verifying OFF.
 
 If E2E coverage is blocked by a missing test fixture (e.g., no CI seed user for an admin-gated feature), the plan must include a phase that creates the fixture. "No fixture exists" is not a reason to downgrade to PHPUnit.
+
+### Seed- and DOM-grounded E2E assertions
+
+Any E2E verification-matrix row that asserts a **seed-** or **DOM-dependent** value — a row count, a dropdown/option value, sort order or direction, filter results, or "control X exists / is a `<select>` vs. radio" — must **cite its source**, never an assumed value. An assertion grounded in an imagined value is how PR #887 shipped: it expected a display-cap count (~500, full-league) while the CI seed has only ~24 career rows, so the test was deterministically red the moment it ran.
+
+The source must be one of:
+
+- A specific row or count from `ibl5/tests/e2e/fixtures/ci-seed.sql` (cite the table and the rows that produce the expected value), or
+- The rendered form DOM, fetched live from the worktree stack: `curl http://<slug>.localhost/ibl5/modules.php?name=X` (cite the element the assertion targets).
+
+Two gotchas this rule exists to catch (cross-referenced from memory):
+
+- **Sort direction is not "ascending by default."** `ibl5/jslib/sorttable.js` sorts **descending** on first click. An assertion on first-click sort order must match that, not an assumed ascending order. See memory `reference_sorttable_descending_first`.
+- **Seed cardinality is small.** The CI seed is a fixture, not production — counts, option lists, and "is the list non-empty" assertions must be grounded in what the seed actually contains. See memory `feedback_e2e_seed_grounding`.
 
 ## Hot-file thresholds
 

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -5,7 +5,7 @@ disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
   - Skill
-last_verified: 2026-05-28
+last_verified: 2026-05-29
 ---
 
 # Post-Plan Orchestrator
@@ -338,6 +338,22 @@ Prompt MUST ALSO include this long-run handling rule: "`bin/e2e-wt.sh` can excee
 
 If either fails, fix in worktree, commit, push, and re-run the failing track.
 
+### Phase 5 END: emit `PHASE5_VERIFY_STATUS`
+
+**After** the fix-and-rerun loop above has resolved (every launched track green) or given up (a deterministic failure survives), aggregate the three Phase 5 tracks — PHPUnit, PHPStan (both direct Bash, skipped when `! $HAS_PHP`), and the E2E Haiku sub-agent — into one status. The E2E track runs in a sub-agent whose shell state does not persist, so you (Opus) read its reported pass/fail from context, combine it with the PHPUnit/PHPStan results, and write the flag. Persist it for durability across the per-phase cap (same `$PPID` temp-file pattern Phase 3 / Phase 5.0 use):
+
+```bash
+# PHASE5_VERIFY_STATUS: pass = every launched track green (or only-flaky-on-retry);
+#                       fail = a deterministic failure survived the fix-and-rerun loop;
+#                       skipped = no track ran (e.g. ! $HAS_PHP and E2E mapped to nothing).
+echo "PHASE5_VERIFY_STATUS=$PHASE5_VERIFY_STATUS" > /tmp/post-plan-phase5-status-$PPID
+```
+
+Rules for the value:
+- A flaky failure (e.g. shared-session/CSRF) that passes on retry **with no code change** counts as `pass` — only a deterministic failure surviving the loop is `fail`.
+- `skipped` is NOT `fail`: when no track ran (PHP-less PR whose E2E mapped to nothing — `bin/e2e-for-pr` exit 0 with empty stdout), the value is `skipped`.
+- Record the status **after** the loop resolves or gives up — never mid-fix.
+
 ---
 
 ## Phase 6: Manual Testing Automation
@@ -400,15 +416,22 @@ Using the Sonnet agent's classifications:
 
 ## Phase 6.5: Arm Auto-Merge
 
-Enable auto-merge **before** watching CI. This is the earliest point both gating conditions are known — review/audit findings are scored in Phase 4, manual-testing is resolved in Phase 6 — and arming here (rather than after the watch) is the whole point: if this post-plan phase is later killed mid-watch by the per-phase cap (`MAX_PP_SECS`) or a usage limit, GitHub still holds the queued merge and fires it once required checks pass, with no further agent action needed. Arming after the watch (the old Phase 8 placement) meant any phase that ran out of budget during the watch shipped a PR that was never set to auto-merge.
+Enable auto-merge **before** watching CI. This is the earliest point all gating conditions are known — review/audit findings are scored in Phase 4, manual-testing is resolved in Phase 6, and Phase 5's local verification status is recorded at its END — and arming here (rather than after the watch) is the whole point: if this post-plan phase is later killed mid-watch by the per-phase cap (`MAX_PP_SECS`) or a usage limit, GitHub still holds the queued merge and fires it once required checks pass, with no further agent action needed. Arming after the watch (the old Phase 8 placement) meant any phase that ran out of budget during the watch shipped a PR that was never set to auto-merge.
 
 **Already merged?** If `gh pr view --json state --jq '.state'` returns `MERGED`, there is nothing to arm — skip to Phase 7 (which will early-exit).
 
-**All three** conditions must be true: (1) PR says "No manual testing needed", (2) no review/audit findings scored >= 80, (3) no unresolved `MISSING:` planned-test items remain from Phase 5.0 — i.e. `/tmp/post-plan-missing-tests-$PPID` is absent or empty. Phase 5.0 is skipped entirely when `PLAN_FOUND=none` or `! $HAS_MATRIX`, so this bridge file frequently never exists; **absent/empty = PASS (non-blocking)**. Only a non-empty file blocks: `[ -s /tmp/post-plan-missing-tests-$PPID ]` → condition (3) fails.
+**All four** conditions must be true: (1) PR says "No manual testing needed", (2) no review/audit findings scored >= 80, (3) no unresolved `MISSING:` planned-test items remain from Phase 5.0 — i.e. `/tmp/post-plan-missing-tests-$PPID` is absent or empty. Phase 5.0 is skipped entirely when `PLAN_FOUND=none` or `! $HAS_MATRIX`, so this bridge file frequently never exists; **absent/empty = PASS (non-blocking)**. Only a non-empty file blocks: `[ -s /tmp/post-plan-missing-tests-$PPID ]` → condition (3) fails. (4) Phase 5's local verification did not deterministically fail — i.e. `PHASE5_VERIFY_STATUS` is `pass` or `skipped`, **not** `fail`. This is the condition #887 lacked: it armed auto-merge with red E2E because no gate checked Phase 5's result.
+
+**Condition (4) blocks on the VALUE, not file presence** — the status file is non-empty for `pass` and `skipped` too (it always contains `PHASE5_VERIFY_STATUS=...`), so the `[ -s ... ]` idiom condition (3) uses would wrongly block every `pass`/`skipped`. Block only on the literal `fail` value; **absent file OR `pass` OR `skipped` = PASS (non-blocking)** — a `skipped` status (docs-only / PHP-less PR with no mapped E2E) must NOT block, or every such PR would stop arming, a regression worse than #887:
+
+```bash
+# condition (4): fails ONLY when the status is the literal `fail`
+grep -q 'PHASE5_VERIFY_STATUS=fail' /tmp/post-plan-phase5-status-$PPID 2>/dev/null && echo "BLOCKED: Phase 5 deterministic failure"
+```
 
 If met: `gh pr merge --squash --auto --delete-branch`. The `--auto` flag queues the merge — it does **not** merge now, it arms; GitHub executes it once all required status checks pass. Do not sync local to master here; the merge has not happened yet.
 
-If not met: do **not** arm auto-merge. Report which condition(s) blocked — the user merges manually after review. When condition (3) is the blocker, cite which planned test is missing by `cat`-ing the bridge file (`cat /tmp/post-plan-missing-tests-$PPID`) into the report. Continue to Phase 7 regardless, to monitor and fix CI.
+If not met: do **not** arm auto-merge. Report which condition(s) blocked — the user merges manually after review. When condition (3) is the blocker, cite which planned test is missing by `cat`-ing the bridge file (`cat /tmp/post-plan-missing-tests-$PPID`) into the report. When condition (4) is the blocker, report which Phase 5 track failed (PHPUnit / PHPStan / E2E). Continue to Phase 7 regardless, to monitor and fix CI — the fix-and-rerun there clears the red track so a later run can arm.
 
 ---
 

--- a/ibl5/bin/e2e-local.sh
+++ b/ibl5/bin/e2e-local.sh
@@ -8,6 +8,20 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 IBL5_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Worktree-footgun guard: this is the MAIN-checkout runner — it seeds ibl5_e2e_test,
+# injects the .e2e-active guard into the symlink-resolved MAIN config.php, and runs
+# Playwright against http://main.localhost/ibl5/ (the dev/main stack). A worktree copy
+# physically lives at .../worktrees/<slug>/ibl5, so $IBL5_DIR (the script's own resolved
+# path) is the deterministic, cwd-independent detection key. Fire before any DB/config
+# side effect. (CONFIG_DIR is readlink-resolved back to main, so it can't be used here.)
+if [[ "$IBL5_DIR" == */worktrees/* ]]; then
+    echo "ERROR: e2e-local.sh is the MAIN-checkout E2E runner and serves http://main.localhost/ibl5/." >&2
+    echo "       You are inside a worktree — it would seed ibl5_e2e_test but Playwright would hit the MAIN stack, not this worktree's <slug>.localhost DB." >&2
+    echo "       Use the worktree-correct path instead:" >&2
+    echo "         bin/wt-up <slug> --seed && bin/e2e-wt.sh <slug>" >&2
+    exit 1
+fi
+
 # Resolve config.php's real directory (follows symlinks to main repo)
 CONFIG_DIR="$(cd "$(dirname "$(readlink "$IBL5_DIR/config.php" || echo "$IBL5_DIR/config.php")")" && pwd)"
 


### PR DESCRIPTION
## Summary

PR #887 — a nightly-authored, E2E-spec-only PR — armed auto-merge while 5 deterministic E2E tests were red on CI. Root cause: post-plan Phase 6.5 armed auto-merge without checking Phase 5's local verification result. This PR adds three coordinated, prose/script-only guards (no PHP, no `classes/`, no migrations).

### 1. Worktree-footgun guard in `ibl5/bin/e2e-local.sh`
`e2e-local.sh` is the MAIN-checkout runner — it seeds `ibl5_e2e_test`, injects the `.e2e-active` guard into the symlink-resolved MAIN `config.php`, and runs Playwright against `http://main.localhost/ibl5/`. Run from inside a worktree, it serves the MAIN stack, not the worktree's `<slug>.localhost` seeded DB. Added a fail-fast guard keyed on `$IBL5_DIR` (the script's own resolved path, cwd-independent), firing before any DB/config side effect with a pointer to `bin/wt-up <slug> --seed && bin/e2e-wt.sh <slug>`.

### 2. Phase 5 status flag + Phase 6.5 gating condition in `post-plan/SKILL.md`
Phase 5 now emits `PHASE5_VERIFY_STATUS` (`pass | fail | skipped`) at its END, after the fix-and-rerun loop resolves. Phase 6.5 adds a gating condition that blocks arming auto-merge on a deterministic `fail` — the condition #887 lacked. `skipped`/`pass` never block (docs-only / PHP-less PRs still arm); the check matches the literal `fail` value, not file presence.

### 3. Seed-/DOM-grounded E2E assertion rule in `.claude/rules/plan-verification.md`
Any E2E matrix row asserting a seed- or DOM-dependent value must cite `ibl5/tests/e2e/fixtures/ci-seed.sql` or the rendered DOM, never an assumed value (#887's failing assertion expected ~500 full-league rows while ci-seed has ~24).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: hardening an existing agent rule; no new architectural constraint introduced -->