### PR TITLE
ci: gate test-code PHPStan via composer run analyse:tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,8 @@ jobs:
               - 'ibl5/composer.lock'
               - 'ibl5/phpunit.xml'
               - 'ibl5/phpstan.neon'
+              - 'ibl5/phpstan-tests.neon'
+              - 'ibl5/phpstan-tests-baseline.neon'
               - 'ibl5/phpstan-rules/**'
               - 'ibl5/tests/DatabaseIntegration/Fixtures/**'
               - '.github/workflows/tests.yml'
@@ -284,6 +286,10 @@ jobs:
     - name: Run PHPStan
       working-directory: ibl5
       run: composer run analyse
+
+    - name: Run PHPStan (tests)
+      working-directory: ibl5
+      run: composer run analyse:tests
 
     - name: Check baseline drift
       working-directory: ibl5


### PR DESCRIPTION
## Summary

Add `composer run analyse:tests` as a CI gate in the `phpstan` job so that test-code PHPStan violations (level 6) are caught in CI, mirroring the existing production-code gate. Also register the two test-PHPStan config files (`phpstan-tests.neon`, `phpstan-tests-baseline.neon`) in the `src` paths-filter so config-only edits trigger the job.

Scope: one file edited (`.github/workflows/tests.yml`), no PHP/DB/UI behavior change.

## Changes

- **`.github/workflows/tests.yml`**: Insert `Run PHPStan (tests)` step between `Run PHPStan` and `Check baseline drift`; add `phpstan-tests.neon` and `phpstan-tests-baseline.neon` to the `src` paths-filter.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.