### PR TITLE
CSS token consolidation + doc-drift fixes (PR1/2)

### DIFF
--- a/.claude/rules/css-architecture.md
+++ b/.claude/rules/css-architecture.md
@@ -3,7 +3,7 @@ description: CSS architecture: all styles live in ibl5/design/components/; inlin
 paths:
   - "**/design/**/*.css"
   - "**/*View.php"
-last_verified: 2026-04-11
+last_verified: 2026-05-29
 ---
 
 # CSS Architecture Reference
@@ -121,8 +121,6 @@ These CSS selectors set `white-space: nowrap` — check them before debugging te
 | `cards.css` | `.ibl-card__meta` | Card metadata |
 | `player-cards.css` | `.stats-grid a`, `th`, `td` | Stats card cells |
 | `existing-components.css` | Various (7 selectors) | Legacy components |
-| `sco-parser.css` | `.sco-play-text` | Play-by-play text |
-| `saved-depth-charts.css` | `.saved-dc-table td` | Depth chart cells |
 
 ## Common Cell/Row Modifier Classes
 
@@ -134,7 +132,6 @@ These CSS selectors set `white-space: nowrap` — check them before debugging te
 | `.sticky-col` | Sticky first column (single) | `<td>`, `<th>` |
 | `.sticky-col-1/2/3` | Multi-column sticky | `<td>`, `<th>` |
 | `.sticky-corner` | Top-left corner cell (sticky header+col) | `<th>` |
-| `.ratings-highlight` | Team-colored highlight row | `<tr>` |
 | `.ratings-separator` | Zero-padding divider row | `<tr>` |
 | `.user-team-row` | Yellow highlight for user's team | `<tr>` |
 | `.drafted` | Grayed-out drafted player row | `<tr>` |

--- a/ibl5/design/CSS_TABLE_MAP.md
+++ b/ibl5/design/CSS_TABLE_MAP.md
@@ -8,15 +8,13 @@
 ├── .responsive-table  (adds mobile sticky columns)
 ├── .sticky-table  (adds sticky header + first column)
 ├── .league-stats-table  (league-wide stat styling)
-├── .compare-players-table  (player comparison)
 ├── .depth-chart-table  (depth chart form)
 ├── .contact-table  (contact list, max-width: 800px)
 ├── .voting-results-table  (vote counts, max-width: 420px)
 ├── .voting-form-table  (ballot with checkboxes/radios)
 ├── .draft-table  (draft selection form)
 ├── .draft-pick-table  (draft pick locator matrix, styled to match ibl-data-table)
-├── .draft-history-table  (mobile column constraints)
-└── .injury-table  (card layout on mobile)
+└── .draft-history-table  (mobile column constraints)
 ```
 
 ## Wrapper / Layout Classes
@@ -72,7 +70,6 @@ Affects ALL data tables site-wide:
 
 | Selector | View |
 |----------|------|
-| `.injury-table` | InjuriesView |
 | `.league-stats-table` | TeamOffDefStatsView |
 | `.depth-chart-table` | DepthChartEntryView |
 | `.draft-pick-table` | DraftPickLocatorView (styled to match `.ibl-data-table`, uses `.sticky-table`) |
@@ -86,7 +83,7 @@ These are used inside multiple table types.
 
 | Class | What It Styles | Where Used |
 |-------|---------------|------------|
-| `.ibl-team-cell` / `--colored` | Team logo + name flex cell | Standings, Free Agency, all team columns |
+| `.ibl-team-cell__name` / `__city` / `__logo` / `__text` / `--colored` | Team logo + name flex cell | Standings, Free Agency, all team columns |
 | `.ibl-player-cell` | Player photo + name flex cell | Rosters, draft, leaderboards |
 | `.ibl-stat-value` / `--highlight` / `--positive` / `--negative` | Right-aligned stat numbers | All stat display tables |
 | `.rank-cell` | Bold navy rank number | Leaderboards, standings |
@@ -104,7 +101,6 @@ These are used inside multiple table types.
 | `.ibl-table-row--highlight` | Orange accent background |
 | `.ibl-table-row--user-team` | Light yellow (#ffffcc) |
 | `.ibl-table-row--winner` | Bold weight, orange color |
-| `tr.ratings-highlight` | Team color highlight (15% mix, `.team-table` only) |
 | `tr.ratings-separator` | Zero-padding divider row (`.team-table` only) |
 
 ## HTML Structural Patterns
@@ -188,17 +184,17 @@ Module-specific table styles live in `design/components/tables/<feature>.css`. E
 |------|--------|
 | `tables/season-highs.css` | `.stat-table`, `.season-highs-discrepancy-panel` |
 | `tables/voting.css` | `.voting-results-table`, `.voting-form-table`, `.voting-submission-feedback` |
-| `tables/trading.css` | Trading module tables (`.trade-table`, `.trade-offer-table`, etc.) |
+| `tables/trading.css` | Trading module: `.ibl-data-table` rosters, `.trade-offer-card*`, `.trading-*` layout/roster selectors |
 | `tables/draft-history.css` | `.draft-history-table` |
 | `tables/league-stats.css` | `.league-stats-table` |
 | `tables/contact-list.css` | `.contact-table` |
-| `tables/transaction-history.css` | `.transaction-history-table` |
+| `tables/transaction-history.css` | `.txn-table` (on `.ibl-data-table`) |
 | `tables/depth-chart.css` | Depth Chart table mobile rules extracted from `tables.css` |
 | `tables/draft-pick-locator.css` | `.draft-pick-table` |
-| `tables/record-holders.css` | `.record-holders-table` |
+| `tables/record-holders.css` | `.record-table` / `--*col*` variants, `.record-category*`, `.record-section*` |
 | `tables/projected-draft-order.css` | `.projected-draft-order-table` |
 | `tables/player-movement.css` | `.player-movement-table` |
-| `tables/franchise-record-book.css` | `.record-book-*` selectors |
+| `tables/franchise-record-book.css` | `.record-book-section-title`, `.record-book-team-selector`, `.record-book-retired-cell` |
 | `tables/free-agency.css` | `.fa-table`, `.fa-*` selectors |
 
 ### When to add a new module file

--- a/ibl5/design/base.css
+++ b/ibl5/design/base.css
@@ -76,13 +76,13 @@ A:link,
 A:active,
 A:visited {
     background: none;
-    color: #363636;
+    color: var(--gray-700);
     text-decoration: underline;
 }
 
 A:hover {
     background: none;
-    color: #363636;
+    color: var(--gray-700);
     text-decoration: underline;
 }
 
@@ -108,7 +108,7 @@ A:hover {
 
 .storytitle {
     background: none;
-    color: #363636;
+    color: var(--gray-700);
     font-size: 1.5rem;
     font-weight: bold;
     font-family: var(--font-display);
@@ -117,7 +117,7 @@ A:hover {
 
 .storycat {
     background: none;
-    color: #363636;
+    color: var(--gray-700);
     font-size: 1rem;
     font-weight: bold;
     font-family: var(--font-display);

--- a/ibl5/design/components/forms.css
+++ b/ibl5/design/components/forms.css
@@ -351,7 +351,7 @@
     color: var(--navy-700);
     text-decoration: none;
     font-weight: 500;
-    transition: color 150ms ease;
+    transition: color var(--transition-fast);
 }
 
 .ibl-link:hover {

--- a/ibl5/design/components/htmx.css
+++ b/ibl5/design/components/htmx.css
@@ -1,7 +1,7 @@
 @layer components {
     #site-content.htmx-request {
         opacity: 0.7;
-        transition: opacity 200ms;
+        transition: opacity var(--transition-base);
     }
 
     /* Tab/dropdown loading state — HTMX adds .htmx-request to the triggering
@@ -10,7 +10,7 @@
     .table-scroll-container:has(.htmx-request),
     .nextsim-tab-container:has(.htmx-request) {
         opacity: 0.5;
-        transition: opacity 200ms;
+        transition: opacity var(--transition-base);
         pointer-events: none;
     }
 }

--- a/ibl5/design/components/last-sim-recap.css
+++ b/ibl5/design/components/last-sim-recap.css
@@ -446,7 +446,7 @@ a.last-sim-recap__player-name:hover { text-decoration: underline }
     display: block;
     width: 55%;
     height: var(--last-sim-recap-bar-h, 0px);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     position: absolute;
     left: 22.5%;
 }
@@ -523,7 +523,7 @@ a.last-sim-recap__player-name:hover { text-decoration: underline }
     color: var(--gray-500);
     background: var(--gray-100);
     padding: 1px 5px;
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     letter-spacing: .06em;
     vertical-align: 3px;
 }
@@ -612,7 +612,7 @@ a.last-sim-recap__player-name:hover { text-decoration: underline }
     background: var(--navy-800);
     color: #fff;
     padding: 1px 6px;
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     letter-spacing: .1em;
     font-size: .667rem;
 }

--- a/ibl5/design/components/navigation.css
+++ b/ibl5/design/components/navigation.css
@@ -163,14 +163,14 @@
      * the four buttons form a visually consistent row.
      */
     .team-action-link--discord {
-        background: #5865f2;
-        border-color: #4752c4;
+        background: var(--color-discord);
+        border-color: var(--color-discord-hover);
     }
 
     .team-action-link--discord:hover,
     .team-action-link--discord:focus-visible {
-        background: #4752c4;
-        border-color: #5865f2;
+        background: var(--color-discord-hover);
+        border-color: var(--color-discord);
     }
 }
 
@@ -298,7 +298,7 @@
 .mobile-section {
     opacity: 0;
     transform: translateX(20px);
-    transition: opacity 0.3s ease, transform 0.3s ease;
+    transition: opacity var(--transition-slow), transform var(--transition-slow);
 }
 
 .mobile-menu-open .mobile-section:nth-child(1) { transition-delay: 0.05s; }
@@ -507,7 +507,7 @@ span.nav-dropdown-item a:hover {
     justify-content: space-between;
     padding: 0.875rem 1.25rem;
     color: white;
-    transition: background-color 150ms ease;
+    transition: background-color var(--transition-fast);
 }
 
 .mobile-dropdown-btn:hover {
@@ -708,7 +708,7 @@ span.nav-dropdown-item a:hover {
     height: 28px;
     object-fit: contain;
     /* Closed state: delay fading back IN until the X has fully faded out. */
-    transition: opacity 160ms ease 160ms;
+    transition: opacity var(--transition-fast) 150ms;
 }
 
 .nav-hamburger-close-icon {
@@ -721,7 +721,7 @@ span.nav-dropdown-item a:hover {
     opacity: 0;
     pointer-events: none;
     /* Closed state: no delay — X fades OUT first when closing. */
-    transition: opacity 160ms ease;
+    transition: opacity var(--transition-fast);
 }
 
 #nav-hamburger[aria-expanded="true"] .nav-team-logo-hamburger {
@@ -733,7 +733,7 @@ span.nav-dropdown-item a:hover {
 #nav-hamburger[aria-expanded="true"] .nav-hamburger-close-icon {
     opacity: 1;
     /* Opening: X fades IN only after the logo has fully faded out. */
-    transition-delay: 160ms;
+    transition-delay: 150ms;
 }
 
 /* ==========================================================================
@@ -752,7 +752,7 @@ span.nav-dropdown-item a:hover {
     justify-content: center;
     color: white;
     border-radius: var(--radius-lg);
-    transition: background-color 150ms ease;
+    transition: background-color var(--transition-fast);
 }
 
 .nav-icon-btn:hover {
@@ -768,7 +768,7 @@ span.nav-dropdown-item a:hover {
     font-weight: 600;
     font-family: var(--font-display);
     color: var(--gray-300);
-    transition: color 200ms ease;
+    transition: color var(--transition-base);
 }
 
 .nav-trigger:hover {
@@ -781,7 +781,7 @@ span.nav-dropdown-item a:hover {
     transform: translateY(-0.25rem);
     opacity: 0;
     visibility: hidden;
-    transition: all 200ms ease;
+    transition: all var(--transition-base);
     z-index: 50;
 }
 
@@ -834,7 +834,7 @@ span.nav-dropdown-item a:hover {
     border-radius: var(--radius-xl);
     padding: 0.625rem 2rem 0.625rem 0.75rem;
     cursor: pointer;
-    transition: all 150ms ease;
+    transition: all var(--transition-fast);
 }
 
 .nav-select:hover {
@@ -868,7 +868,7 @@ span.nav-dropdown-item a:hover {
     border-radius: var(--radius-xl);
     padding: 0.625rem 0.75rem;
     cursor: pointer;
-    transition: all 150ms ease;
+    transition: all var(--transition-fast);
 }
 
 .nav-logout-btn:hover {
@@ -905,7 +905,7 @@ span.nav-dropdown-item a:hover {
     padding: 0.75rem 1rem 0.75rem 2.75rem;
     font-size: 1rem;
     color: white;
-    transition: all 150ms ease;
+    transition: all var(--transition-fast);
 }
 
 .nav-login-input::placeholder {
@@ -937,15 +937,15 @@ span.nav-dropdown-item a:hover {
     font-weight: 700;
     padding: 0.875rem 1rem;
     border-radius: var(--radius-xl);
-    box-shadow: 0 10px 15px -3px rgba(249, 115, 22, 0.25);
-    transition: all 200ms ease;
+    box-shadow: var(--shadow-accent-lift);
+    transition: all var(--transition-base);
     font-size: 1rem;
     letter-spacing: var(--tracking-display);
 }
 
 .nav-login-btn:hover {
     background: linear-gradient(to right, var(--accent-400), var(--accent-500));
-    box-shadow: 0 10px 15px -3px rgba(249, 115, 22, 0.4);
+    box-shadow: var(--shadow-accent-lift-strong);
 }
 
 .nav-login-btn:active {
@@ -971,7 +971,7 @@ span.nav-dropdown-item a:hover {
     background: rgba(255, 255, 255, 0.05);
     border-radius: var(--radius-md);
     cursor: pointer;
-    transition: all 150ms ease;
+    transition: all var(--transition-fast);
 }
 
 .nav-login-checkbox:checked {
@@ -997,12 +997,12 @@ span.nav-dropdown-item a:hover {
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 10px 15px -3px rgba(249, 115, 22, 0.25);
-    transition: box-shadow 150ms ease;
+    box-shadow: var(--shadow-accent-lift);
+    transition: box-shadow var(--transition-fast);
 }
 
 .group:hover .nav-logo-icon {
-    box-shadow: 0 10px 15px -3px rgba(249, 115, 22, 0.4);
+    box-shadow: var(--shadow-accent-lift-strong);
 }
 
 .nav-overlay {
@@ -1012,7 +1012,7 @@ span.nav-dropdown-item a:hover {
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
     z-index: 40;
-    transition: opacity 300ms ease;
+    transition: opacity var(--transition-slow);
 }
 
 .nav-desktop {

--- a/ibl5/design/components/player-cards.css
+++ b/ibl5/design/components/player-cards.css
@@ -696,7 +696,7 @@
     justify-content: center;
     cursor: pointer;
     z-index: 10;
-    transition: all 0.3s ease;
+    transition: all var(--transition-slow);
     box-shadow: var(--pc-shadow-sm);
 }
 
@@ -726,7 +726,7 @@
     border-radius: var(--pc-radius-sm);
     opacity: 0;
     pointer-events: none;
-    transition: opacity 0.3s, transform 0.3s;
+    transition: opacity var(--transition-slow), transform var(--transition-slow);
 }
 
 .flip-icon:hover::before {
@@ -818,7 +818,7 @@
     padding: var(--pc-pad-md) var(--pc-pad-lg);
     border-radius: var(--pc-radius-md);
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: all var(--transition-slow);
     box-shadow: var(--pc-shadow-sm);
     border: none;
     text-transform: uppercase;
@@ -835,7 +835,7 @@
     width: 14px;
     height: 14px;
     fill: var(--card-grad-mid);
-    transition: transform 0.3s ease;
+    transition: transform var(--transition-slow);
 }
 
 .stats-flip-toggle:hover svg {

--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -120,7 +120,7 @@
 
 /* Row styling */
 .ibl-data-table tbody tr {
-    transition: background-color 150ms ease;
+    transition: background-color var(--transition-fast);
 }
 
 .ibl-data-table tbody tr:nth-child(odd) {
@@ -140,7 +140,7 @@
     color: var(--gray-800);
     text-decoration: none;
     font-weight: 500;
-    transition: color 150ms ease;
+    transition: color var(--transition-fast);
 }
 
 .ibl-data-table a:hover {
@@ -788,7 +788,7 @@ tr:has(.contract-hint-cell):focus-within .contract-hint-cell {
     background: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.08));
     pointer-events: none;
     opacity: 1;
-    transition: opacity 0.3s ease;
+    transition: opacity var(--transition-slow);
     border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
     z-index: 2;
 }
@@ -1344,7 +1344,7 @@ td.ibl-team-cell--colored {
     border-radius: var(--radius-sm);
     opacity: 0;
     visibility: hidden;
-    transition: opacity 150ms ease, visibility 150ms ease;
+    transition: opacity var(--transition-fast), visibility var(--transition-fast);
     z-index: 100;
     pointer-events: none;
     margin-right: 8px;
@@ -1362,7 +1362,7 @@ td.ibl-team-cell--colored {
     border-left-color: var(--navy-900);
     opacity: 0;
     visibility: hidden;
-    transition: opacity 150ms ease, visibility 150ms ease;
+    transition: opacity var(--transition-fast), visibility var(--transition-fast);
     z-index: 100;
     margin-right: -2px;
 }

--- a/ibl5/design/components/tables/trading.css
+++ b/ibl5/design/components/tables/trading.css
@@ -170,7 +170,7 @@
     color: var(--navy-700);
     text-decoration: none;
     font-weight: 500;
-    transition: color 150ms ease;
+    transition: color var(--transition-fast);
 }
 
 .ibl-link:hover {

--- a/ibl5/design/input.css
+++ b/ibl5/design/input.css
@@ -87,6 +87,10 @@
   --color-gray-800: #1f2937;
   --color-gray-900: #111827;
 
+  /* Discord brand */
+  --color-discord: #5865f2;
+  --color-discord-hover: #4752c4;
+
   /* Type scale */
   --text-2xs:   0.6875rem;
   --text-xs:    0.75rem;

--- a/ibl5/design/tokens/tokens.css
+++ b/ibl5/design/tokens/tokens.css
@@ -85,6 +85,10 @@
     --error-400: var(--color-error-400);
     --error-700: var(--color-error-700);
 
+    /* Discord brand */
+    --discord: var(--color-discord);
+    --discord-hover: var(--color-discord-hover);
+
     /* ========================================================================
        Typography
        ======================================================================== */
@@ -122,6 +126,8 @@
     --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
     --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
     --shadow-glow: 0 0 20px rgb(249 115 22 / 0.3);
+    --shadow-accent-lift: 0 10px 15px -3px rgba(249, 115, 22, 0.25);
+    --shadow-accent-lift-strong: 0 10px 15px -3px rgba(249, 115, 22, 0.4);
 
     /* ========================================================================
        Transitions


### PR DESCRIPTION
## Summary

Consolidates scattered CSS literals onto design-system tokens across \`ibl5/design/\` and fixes two drifted docs. Splits into value-preserving token swaps, three small value-shifting swaps, and zero-render doc fixes.

**Token additions**
- \`--color-discord\` / \`--color-discord-hover\` (+ \`tokens.css\` aliases) — Discord brand
- \`--shadow-accent-lift\` / \`--shadow-accent-lift-strong\` — nav accent "lift" shadow

**Value-preserving swaps**
- B2: nav Discord button colors → \`var(--color-discord*)\`
- B3: 4 nav accent-lift \`box-shadow\` sites → tokens
- B4: \`transition:\` shorthands (nav, tables, player-cards, htmx, forms, trading) → \`var(--transition-fast|base|slow)\`. \`transition-delay\` longhands left raw (token bundles a cubic-bezier and would break the staggered nav-dropdown cascade).

**Value-shifting swaps (intentional render change — baselines must refresh)**
- C1: recap chip radius \`3px\` → \`var(--radius-sm)\` (+1px)
- C2: nav hamburger cross-fade \`160ms\` → \`150ms\`
- C3: legacy body-link/story \`#363636\` → \`var(--gray-700)\` (#374151)

**Doc-drift**
- \`.claude/rules/css-architecture.md\`: removed \`.ratings-highlight\`/\`.sco-play-text\`/\`.saved-dc-table\` rows (deleted in base via #882); bumped \`last_verified\`.
- \`design/CSS_TABLE_MAP.md\`: removed/corrected entries for classes deleted in base; corrected \`.ibl-team-cell\` row to live BEM children.

> [!NOTE]
> **B4 easing caveat:** converting \`ease\` → the token's \`cubic-bezier(0.4,0,0.2,1)\` changes the easing curve mid-transition. Zero visual-diff only because visual-regression captures settled start/end frames, not intermediate frames.

> [!IMPORTANT]
> C1/C3 shift rendered pixels — apply the \`update-baselines\` label so visual-regression baselines regenerate.

<!-- no-adr: removing stale references to CSS classes deleted in the base branch; no new architectural decision -->

## Manual Testing

No manual testing needed — all changes are covered by automated tests (visual-regression screenshot diffs against regenerated baselines; no UI was newly designed or redesigned).

Generated with [Claude Code](https://claude.ai/code)