### PR TITLE
ci(IBL6): deterministic readiness gate to fix deploy startup race

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,8 +183,13 @@ jobs:
             echo "Start IBL6" > /tmp/ibl5-last-deploy-step
             cd www/IBL6
             mkdir -p logs
-            pm2 restart ibl6 --update-env 2>/dev/null \
-              || pm2 start ecosystem.config.cjs --only ibl6
+            # delete + start (not restart --update-env) so pm2 re-reads script,
+            # wait_ready, and listen_timeout from ecosystem.config.cjs. With
+            # wait_ready, this start call blocks until IBL6 signals ready, so it
+            # is itself the readiness gate. The app is already stopped (see the
+            # "Stop IBL6 to free resources" step), so delete adds no real downtime.
+            pm2 delete ibl6 2>/dev/null || true
+            pm2 start ecosystem.config.cjs --only ibl6 --update-env
             pm2 save
             echo "IBL6 started (PID: $(pm2 pid ibl6))"
           '
@@ -192,19 +197,29 @@ jobs:
       - name: Smoke test IBL6
         if: ${{ !cancelled() }}
         run: |
-          for i in 1 2 3; do
-            if curl -fsS --max-time 10 https://ibl6.iblhoops.net/ >/dev/null 2>&1; then
-              echo "IBL6 smoke test passed (attempt $i)"
-              exit 0
-            fi
-            echo "Attempt $i failed, waiting 5s..."
-            sleep 5
-          done
-          echo "Smoke test failed after 3 attempts, restarting IBL6..."
+          poll() {
+            for i in $(seq 1 "$1"); do
+              if curl -fsS --max-time 10 https://ibl6.iblhoops.net/health >/dev/null 2>&1; then
+                echo "IBL6 healthy (attempt $i)"
+                return 0
+              fi
+              echo "Attempt $i failed, waiting 5s..."
+              sleep 5
+            done
+            return 1
+          }
+          # ~30s warmup budget for proxy/TLS after pm2 already reported ready.
+          if poll 6; then exit 0; fi
+          echo "Smoke test failed after warmup, restarting IBL6..."
           ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} 'pm2 restart ibl6'
-          sleep 5
-          curl -fsS --max-time 10 https://ibl6.iblhoops.net/ >/dev/null 2>&1
-          echo "IBL6 recovered after restart"
+          # Retry the poll instead of a single un-retried curl; restart re-honors
+          # the wait_ready config it was started with.
+          if poll 6; then
+            echo "IBL6 recovered after restart"
+            exit 0
+          fi
+          echo "IBL6 still down after restart"
+          exit 1
 
   notify-deploy-failure:
     name: Notify Deploy Failure

--- a/IBL6/ecosystem.config.cjs
+++ b/IBL6/ecosystem.config.cjs
@@ -2,13 +2,17 @@ module.exports = {
   apps: [
     {
       name: 'ibl6',
-      script: 'build/index.js',
+      script: 'server.js',
       cwd: '/home/iblhoops/public_html/IBL6',
       node_args: '--max-old-space-size=128',
       env: {
         PORT: 3001,
         UV_THREADPOOL_SIZE: 2
       },
+      // server.js emits process.send('ready') once the HTTP server is listening,
+      // so `pm2 start` blocks until IBL6 is actually serving (or listen_timeout).
+      wait_ready: true,
+      listen_timeout: 10000,
       max_memory_restart: '200M',
       min_uptime: '10s',
       max_restarts: 10,

--- a/IBL6/server.js
+++ b/IBL6/server.js
@@ -1,0 +1,33 @@
+// Custom pm2 entry point for IBL6.
+//
+// It boots the unchanged @sveltejs/adapter-node server (which keeps all of the
+// adapter's origin/CSRF/body-size handling) and then emits a pm2 readiness
+// signal once the HTTP server is actually listening. Paired with
+// `wait_ready: true` in ecosystem.config.cjs, this makes `pm2 start` block
+// until IBL6 is genuinely serving requests, eliminating the deploy smoke-test
+// startup race (the server used to be curled within ~0.6s of fork).
+//
+// adapter-node's build/index.js calls server.listen() unconditionally at import
+// time and exports the polka instance, whose underlying http.Server is exposed
+// as `server.server`.
+import { server } from './build/index.js';
+
+function signalReady() {
+	if (typeof process.send === 'function') {
+		process.send('ready');
+	}
+}
+
+const httpServer = server.server;
+
+if (httpServer && httpServer.listening) {
+	// listen() already fired before this module finished evaluating.
+	signalReady();
+} else if (httpServer) {
+	httpServer.once('listening', signalReady);
+} else {
+	// Defensive fallback: if the adapter ever stops exposing the http server,
+	// signal on the next tick so pm2 doesn't block until listen_timeout. The
+	// deploy smoke test still gates real reachability over the proxy.
+	process.nextTick(signalReady);
+}


### PR DESCRIPTION
## Problem

IBL6 deploys fail the smoke test, then "recover later" ([example run](https://github.com/a-jay85/IBL5/actions/runs/26664980248/job/78596322590)). Root cause is a startup race, not a real outage:

- The smoke test curls the server **~0.6s after `pm2` forks it** — before it's listening.
- Retry budget was only ~15s (3×5s).
- The recovery branch `pm2 restart`s (resetting the boot clock to 0), waits 5s, then does a **single un-retried `curl`** with `bash -e` — that line is what errored the step. So the app recovers on its own, but the test already hard-failed.

## Fix — deterministic readiness

- **`IBL6/server.js`** (new): custom pm2 entry that wraps adapter-node's `build/index.js` (keeping all of its origin/CSRF/body-size handling) and emits `process.send('ready')` once the HTTP server is actually `listening`.
- **`IBL6/ecosystem.config.cjs`**: `script` → `server.js`, plus `wait_ready: true` + `listen_timeout: 10000`, so `pm2 start` blocks until IBL6 is genuinely serving (or times out).
- **`.github/workflows/main.yml`**:
  - Start step uses `pm2 delete` + `pm2 start` (not `restart --update-env`) so pm2 actually re-reads `script`/`wait_ready` — `--update-env` only refreshes env vars, and the old `|| start` fallback never fired since restart succeeds. With `wait_ready`, this start call *is* the readiness gate.
  - Smoke test polls `/health` with a retried recovery instead of a single curl.

## Verification

- Local `child_process.fork` IPC harness: `ready` message fires and `/health` returns `200 {"ok":true}`. Build green.
- Note: PR CI runs IBL6 E2E (`vite preview`) and confirms no regression, but **does not exercise the deploy/smoke path** — `main.yml` only runs on push to `production`. Real validation is the next production deploy run.