### PR TITLE
fix(layout): favicon link + main landmark on every page (#906)

### DIFF
--- a/ibl5/classes/PageLayout/PageLayout.php
+++ b/ibl5/classes/PageLayout/PageLayout.php
@@ -166,9 +166,8 @@ class PageLayout
             echo "</SCRIPT>\n\n";
         }
 
-        if (file_exists("themes/$ThemeSel/images/favicon.ico")) {
-            echo "<link REL=\"shortcut icon\" HREF=\"themes/$ThemeSel/images/favicon.ico\" TYPE=\"image/x-icon\">\n";
-        }
+        // Root-absolute path so it resolves independently of the conditional <base href> and module depth.
+        echo "<link rel=\"icon\" href=\"/ibl5/favicon.ico\" type=\"image/x-icon\">\n";
         // Google Fonts (inlined from includes/custom_files/custom_head.php)
         echo '<link rel="preconnect" href="https://fonts.googleapis.com">';
         echo '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>';

--- a/ibl5/tests/Unit/PageLayout/PageLayoutTest.php
+++ b/ibl5/tests/Unit/PageLayout/PageLayoutTest.php
@@ -100,6 +100,43 @@ class PageLayoutTest extends TestCase
         self::assertStringContainsString('<title>', $output);
     }
 
+    public function testHeaderNonBoostedEmitsExpectedHeadResources(): void
+    {
+        // Characterization: lock the non-boosted <head> baseline before editing it.
+        unset($_SERVER['HTTP_HX_BOOSTED']);
+        ob_start();
+        PageLayout::header();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('<title>', $output);
+        self::assertStringContainsString('StyleSheet', $output);
+        self::assertStringContainsString('fonts.googleapis.com/css2', $output);
+    }
+
+    public function testHeaderNonBoostedEmitsFaviconLink(): void
+    {
+        unset($_SERVER['HTTP_HX_BOOSTED']);
+        ob_start();
+        PageLayout::header();
+        $output = (string) ob_get_clean();
+
+        // Favicon emitted unconditionally with a root-absolute, depth-independent href.
+        self::assertStringContainsString('rel="icon"', $output);
+        self::assertStringContainsString('href="/ibl5/favicon.ico"', $output);
+    }
+
+    public function testHeaderNonBoostedFaviconHrefIsRootAbsolute(): void
+    {
+        unset($_SERVER['HTTP_HX_BOOSTED']);
+        ob_start();
+        PageLayout::header();
+        $output = (string) ob_get_clean();
+
+        // The old theme-relative favicon path must be gone (it resolved against <base href>/module depth).
+        self::assertStringNotContainsString('images/favicon.ico', $output);
+        self::assertStringNotContainsString('shortcut icon', $output);
+    }
+
     public function testHeaderNonBoostedSkipsRecordHitWhenNoDb(): void
     {
         unset($_SERVER['HTTP_HX_BOOSTED']);

--- a/ibl5/tests/e2e/smoke/navigation.spec.ts
+++ b/ibl5/tests/e2e/smoke/navigation.spec.ts
@@ -97,6 +97,28 @@ test.describe('Navigation bar smoke tests (public)', () => {
 
 });
 
+// Shared-layout Lighthouse fixes (issue #906): every page must expose exactly one
+// main landmark (role="main" on #site-content) and a favicon <link> in <head>.
+// Verified across the homepage and a module page (Schedule previously failed
+// landmark-one-main in the Lighthouse audit).
+test.describe('Shared layout landmark and favicon (public)', () => {
+  for (const path of ['index.php', 'modules.php?name=Schedule']) {
+    test(`exactly one main landmark on ${path}`, async ({ page }) => {
+      await page.goto(path);
+      await assertNoPhpErrors(page, `on ${path}`);
+      // Not zero (landmark present) and not duplicate (duplicate also fails the audit).
+      await expect(page.locator('main, [role="main"]')).toHaveCount(1);
+    });
+
+    test(`favicon link present in head on ${path}`, async ({ page }) => {
+      await page.goto(path);
+      await assertNoPhpErrors(page, `on ${path}`);
+      // Head links are never "visible"; assert attachment instead.
+      await expect(page.locator('link[rel="icon"]')).toBeAttached();
+    });
+  }
+});
+
 test.describe('Navigation bar smoke tests (mobile viewport)', () => {
   test.use({ navigationTimeout: 30_000 });
   test.use({ viewport: { width: 375, height: 812 } });

--- a/ibl5/themes/IBL/theme.php
+++ b/ibl5/themes/IBL/theme.php
@@ -115,7 +115,7 @@ function themeheader()
     echo $navView->render();
 
     echo "<body bgcolor=\"$bgcolor1\" style=\"--page-bg: $bgcolor1;\"" . ($teamId ? " data-user-team-id=\"$teamId\"" : '') . ">";
-    echo "<div class=\"site-content\" id=\"site-content\" hx-boost=\"true\" hx-target=\"#site-content\" hx-swap=\"innerHTML show:window:top\" hx-indicator=\"#site-content\">\n";
+    echo "<div class=\"site-content\" id=\"site-content\" role=\"main\" hx-boost=\"true\" hx-target=\"#site-content\" hx-swap=\"innerHTML show:window:top\" hx-indicator=\"#site-content\">\n";
 }
 
 function themefooter()


### PR DESCRIPTION
## Summary

Two shared-layout Lighthouse fixes from issue #906 that lift scores across all 55 audited pages, each a one-line change in code that renders on every page:

1. **Favicon 404 (Best Practices — `errors-in-console`, all pages).** `PageLayout::header()` only emitted a favicon `<link>` if `themes/IBL/images/favicon.ico` existed — it doesn't. Browsers then probed domain-root `/favicon.ico` and 404'd, the sole console error capping Best Practices at 0.96 everywhere. Now emits an unconditional, root-absolute `<link rel="icon" href="/ibl5/favicon.ico">` (depth-independent of the conditional `<base href>`).
2. **Missing `<main>` landmark (Accessibility — `landmark-one-main`, all pages).** Added `role="main"` to the `#site-content` wrapper in `theme.php` (the sole content region; nav renders outside it).

## Verification (Schedule, re-audited on worktree)

| Metric | Before | After |
|--------|--------|-------|
| Best Practices | 0.96 | **1.00** |
| `landmark-one-main` | fail | **pass** |
| `errors-in-console` (favicon 404) | fail | **clean** |
| Accessibility | 0.88 | 0.91 |

Residual Accessibility loss on Schedule is the out-of-scope `color-contrast`/`target-size` (module-specific). The `display=block`→`swap` font change was investigated and excluded — nullified by the existing FOUT visibility gate (a separate UX decision needing measurement).

## Test plan
- PHPUnit `tests/Unit/PageLayout/PageLayoutTest.php`: favicon link present, root-absolute, old path gone (12/12 green).
- E2E `tests/e2e/smoke/navigation.spec.ts`: exactly one `[role="main"]` + favicon link on index.php and Schedule (5/5 green).
- CLI Lighthouse re-audit confirming the table above.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

Generated with [Claude Code](https://claude.ai/code)