### PR TITLE
test(e2e): fix updater-awards / vr-anchors shared-DB collisions (#906)

### DIFF
--- a/ibl5/tests/e2e/flows/league-control-panel.spec.ts
+++ b/ibl5/tests/e2e/flows/league-control-panel.spec.ts
@@ -1,16 +1,28 @@
 import { test, expect } from '../fixtures/auth';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { setAward } from '../helpers/test-state';
 
 // Finals MVP flow — sets Finals MVP for the current season year.
 // Uses auth fixture (admin access required for leagueControlPanel.php).
 // The LCP reads settings from DB directly (not cookie overrides), so
 // the test uses the LCP's own Set Season Phase form to switch to Playoffs.
-// CI uses a fresh DB per run; local re-runs may need manual cleanup:
-//   DELETE FROM ibl_awards WHERE Award='IBL Finals MVP';
-//   UPDATE ibl_settings SET value='Free Agency' WHERE name='Current Season Phase';
+// This flow INSERTS a real 'IBL Finals MVP' award row for SEASON_YEAR; the
+// afterAll below deletes it so it cannot leak into concurrent workers. Without
+// cleanup it persisted in the shared DB and flipped updater-awards' hasFinalsMvp
+// (which reads ibl_awards directly, not via cookie override) — #906 follow-up.
+
+const SEASON_YEAR = 2026; // CI seed 'Current Season Ending Year'
 
 test.describe('LeagueControlPanel — Finals MVP flow', () => {
   test.describe.configure({ mode: 'serial' });
+
+  test.afterEach(async ({ request }) => {
+    // Remove the Finals MVP award this flow inserts so it cannot contaminate
+    // updater-awards (which requires the 2026 'IBL Finals MVP' row to be absent).
+    // afterEach (not afterAll) keeps the cross-worker contamination window to the
+    // single test that creates the award, rather than the whole serial describe.
+    await setAward(request, SEASON_YEAR, 'IBL Finals MVP', false);
+  });
 
   test('page loads without PHP errors', async ({ page }) => {
     await page.goto('leagueControlPanel.php');
@@ -40,8 +52,13 @@ test.describe('LeagueControlPanel — Finals MVP flow', () => {
     const mvpButton = page.locator('button[value="set_finals_mvp"]');
     await expect(mvpButton).toBeVisible();
 
-    // Step 3: Fill and submit Finals MVP
-    await mvpInput.fill('E2E Test MVP');
+    // Step 3: Fill and submit Finals MVP.
+    // Use the '__e2e_test' sentinel name so the afterEach cleanup (which deletes
+    // ibl_awards rows WHERE name='__e2e_test', matching test-state.php's
+    // set-award handler) actually removes this real, form-inserted award row.
+    // A human-readable name would slip past that name-scoped delete and leak the
+    // 2026 'IBL Finals MVP' award into updater-awards (which reads it by year+award).
+    await mvpInput.fill('__e2e_test');
     await Promise.all([
       page.waitForURL(/success=/),
       mvpButton.click(),
@@ -51,7 +68,7 @@ test.describe('LeagueControlPanel — Finals MVP flow', () => {
     await assertNoPhpErrors(page, 'after Finals MVP submission');
     await expect(page.locator('.ibl-alert--success')).toBeVisible();
     const body = await page.locator('body').textContent();
-    expect(body).toContain('E2E Test MVP');
+    expect(body).toContain('__e2e_test');
 
     // Step 5: Reload and verify input is hidden (hasFinalsMvp is now true)
     await page.reload();

--- a/ibl5/tests/e2e/vr-manifest.ts
+++ b/ibl5/tests/e2e/vr-manifest.ts
@@ -170,7 +170,13 @@ export const VR_MANIFEST: VrRow[] = [
     notes: 'Admin-only documentation; static content.' },
   { name: 'trading', auth: 'auth', url: 'modules.php?name=Trading',
     anchor: '.trading-team-select',
-    states: [{ name: 'default', appState: { 'Allow Trades': 'Yes' } }],
+    // Pin the phase via cookie override (Season honors TestCookieOverrides).
+    // 'Allow Trades' alone is insufficient: areTradesAllowed() short-circuits to
+    // false in Playoffs *before* checking that setting, so a concurrent test that
+    // transiently writes DB phase=Playoffs (updater-awards, league-control-panel)
+    // would hide .trading-team-select. 'Free Agency' matches the CI seed default,
+    // so the screenshot baseline is unchanged while making this row immune.
+    states: [{ name: 'default', appState: { 'Current Season Phase': 'Free Agency', 'Allow Trades': 'Yes' } }],
     viewports: ['desktop', 'mobile'] },
   { name: 'training-camp-ratings-diff', auth: 'auth', url: 'modules.php?name=TrainingCampRatingsDiff',
     anchor: '.ratings-diff-page', viewports: ['desktop', 'mobile'],


### PR DESCRIPTION
## Summary

Two E2E specs failed deterministically in a **local single-DB full-suite run** (`bin/e2e-wt.sh`) — `updater-awards.spec.ts:136` and `vr-anchors-discriminate` "trading anchor resolves". Both trace to global-DB state mutated by concurrent admin tests. **CI is unaffected** (the 4 shards are separate DBs, so the mutators and readers currently land in different DBs) — this is a *latent* reshuffle risk (#884/#886 class) plus a hard local-run failure that surfaced in post-plan Phase 5.

Root causes (investigated from #906):

1. **`vr-manifest.ts` trading row** only pinned `Allow Trades: Yes`, which `Season::areTradesAllowed()` **ignores in Playoffs** (it short-circuits to `false` before checking that setting). When `updater-awards` / `league-control-panel` transiently write DB `phase=Playoffs`, `.trading-team-select` disappeared. Now pins `Current Season Phase: Free Agency` via the cookie override (`Season` honors `TestCookieOverrides`), making the row immune. `Free Agency` is the CI seed default, so the screenshot baseline is unchanged.

2. **`league-control-panel.spec.ts`** Finals MVP flow inserted a *real* award row via the admin form with a human name (`'E2E Test MVP'`), but the `set-award` cleanup endpoint only deletes rows named `'__e2e_test'`. The award leaked and flipped `updater-awards`' `hasFinalsMvp` (which reads `ibl_awards` by year+award, any name). Now types the `'__e2e_test'` sentinel so the existing cleanup matches, plus an `afterEach` that removes it.

## Verification

Local full E2E suite (`bin/e2e-wt.sh`) on fresh seed, repeated runs: both target specs pass deterministically; no new hard failures. PHP-free change (E2E TypeScript only).

## Out of scope

Fully isolating the destructive season updater from all readers in a local full-suite run needs a **dedicated non-sharded CI job** — config-based Playwright project isolation is infeasible with sharding (dependencies run in full per shard). Tracked in #910.

## Manual Testing

No manual testing needed — all changes are covered by the E2E suite.

Generated with [Claude Code](https://claude.ai/code)