### PR TITLE
ci: make ssh-keyscan non-fatal in deploy workflows

### DIFF
--- a/.github/workflows/log-review.yml
+++ b/.github/workflows/log-review.yml
@@ -24,7 +24,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
         env:
           DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
         env:
           DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
 
@@ -241,7 +241,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
         env:
           DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
 

--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -139,7 +139,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
         env:
           DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
 
@@ -185,7 +185,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
         env:
           DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
 
@@ -220,7 +220,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
         env:
           DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
 


### PR DESCRIPTION
## Problem

Production deploy [run 26677710498](https://github.com/a-jay85/IBL5/actions/runs/26677710498) failed — but not because of code. The prod deploy server was unreachable (`ssh: connect to host *** port ***: Connection timed out`).

The first symptom was the **Setup SSH** step exiting 1: under `bash -e`, a transient `ssh-keyscan` failure aborts the step *before* the authoritative ssh deploy step runs, masking the real cause.

## Fix

Append `|| true` to every `ssh-keyscan ... >> ~/.ssh/known_hosts` so known_hosts population is best-effort and the real ssh step becomes the failure gate (which surfaces the actual timeout/error).

- `main.yml` (2), `log-review.yml` (1), `smoke-prod.yml` (3)
- `db-backup.yml` already had the guard — left unchanged.

Matches the existing pattern noted for the notify job. No-op when the host is reachable.

<!-- no-adr: edits existing CI workflows, no new architectural constraint; consistent with prior keyscan guard -->