### PR TITLE
feat(engine): scaffold native Go sim engine (PR1 walking skeleton)

### DIFF
--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -1,0 +1,74 @@
+name: Engine
+
+on:
+  push:
+    branches: [ master, develop ]
+    paths:
+      - 'engine/**'
+      - '.github/workflows/engine.yml'
+  pull_request:
+    branches: [ master, develop ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      engine: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.engine == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            engine:
+              - 'engine/**'
+              - '.github/workflows/engine.yml'
+
+  engine:
+    name: Go build, vet, test
+    needs: [changes]
+    if: needs.changes.outputs.engine == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: engine/go.mod
+
+      - name: Build
+        working-directory: engine
+        run: go build ./...
+
+      - name: Vet
+        working-directory: engine
+        run: go vet ./...
+
+      - name: Test
+        working-directory: engine
+        run: go test ./...
+
+  gate:
+    name: Engine
+    if: always()
+    needs: [changes, engine]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -1,0 +1,2 @@
+# Compiled binary output (see Makefile `build` target).
+/bin/

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -1,0 +1,19 @@
+# JSB native simulation engine — build/test targets.
+# Lives here (not in repo-root bin/) so the engine toolchain is self-contained
+# and does not add a bin/* script that would trip the ADR decision-trigger gate.
+
+.PHONY: build vet test golden-update
+
+# Compile the jsbsim CLI to ./bin/jsbsim.
+build:
+	go build -o bin/jsbsim ./cmd/jsbsim
+
+vet:
+	go vet ./...
+
+test:
+	go test ./...
+
+# Regenerate the golden-master snapshot after an intentional output change.
+golden-update:
+	go test ./internal/sim -run Golden -update

--- a/engine/cmd/jsbsim/main.go
+++ b/engine/cmd/jsbsim/main.go
@@ -1,0 +1,67 @@
+// Command jsbsim runs the JSB-compatible basketball simulation engine.
+//
+// It reads a simulation input bundle as JSON on stdin and writes the result as
+// JSON on stdout. The engine is a pure transform: it touches no database, no
+// network, and no files beyond stdin/stdout. The PHP side builds the bundle
+// (from the database, or from a historical backup .plr for validation) and
+// loads the result into the IBL5 updateAllTheThings pipeline.
+//
+// Usage:
+//
+//	jsbsim [--seed N] < bundle.json > result.json
+//
+// --seed N (N >= 0) overrides the seed carried in the bundle; the seed actually
+// used is echoed in the output so any run can be replayed.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/sim"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "jsbsim:", err)
+		os.Exit(1)
+	}
+}
+
+// run is the testable entrypoint: it takes the args, input, and output
+// explicitly so tests can drive it without touching the process globals.
+func run(args []string, stdin io.Reader, stdout io.Writer) error {
+	fs := flag.NewFlagSet("jsbsim", flag.ContinueOnError)
+	seedOverride := fs.Int64("seed", -1, "override the bundle seed (N >= 0); -1 uses the bundle's own seed")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return fmt.Errorf("reading stdin: %w", err)
+	}
+
+	b, err := bundle.Decode(data)
+	if err != nil {
+		return err
+	}
+
+	seed := b.Seed
+	if *seedOverride >= 0 {
+		seed = uint64(*seedOverride)
+	}
+
+	res := sim.Simulate(b, seed)
+
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(res); err != nil {
+		return fmt.Errorf("encoding result: %w", err)
+	}
+	return nil
+}

--- a/engine/cmd/jsbsim/main_test.go
+++ b/engine/cmd/jsbsim/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const oneGameBundle = `{
+  "seed": 42,
+  "teams": [{"teamid": 3, "name": "Heat"}, {"teamid": 7, "name": "Lakers"}],
+  "players": [
+    {"pid": 101, "teamid": 3, "dc_minutes": 34, "dc_pg_depth": 1, "dc_can_play_in_game": 1},
+    {"pid": 201, "teamid": 7, "dc_minutes": 30, "dc_sg_depth": 1, "dc_can_play_in_game": 1}
+  ],
+  "schedule": [{"home_team_id": 3, "visitor_team_id": 7, "date": "1988-11-04", "game_type": 2}]
+}`
+
+// #2 (negative) — malformed bundle JSON makes run return an error (the process
+// would exit nonzero) and writes nothing usable to stdout.
+func TestRun_MalformedJSONErrors(t *testing.T) {
+	var out bytes.Buffer
+	err := run(nil, strings.NewReader("{not valid json"), &out)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+// #2 (negative) — a structurally-invalid bundle (empty roster) also errors.
+func TestRun_EmptyRosterErrors(t *testing.T) {
+	var out bytes.Buffer
+	j := `{"seed":1,"players":[],"schedule":[{"home_team_id":3,"visitor_team_id":7,"date":"d","game_type":2}]}`
+	if err := run(nil, strings.NewReader(j), &out); err == nil {
+		t.Fatal("expected error for empty roster, got nil")
+	}
+}
+
+// #9 — the --seed flag overrides the bundle seed, and the seed actually used is
+// echoed in the output.
+func TestRun_SeedOverrideEchoed(t *testing.T) {
+	// Without override: output echoes the bundle seed (42).
+	var out bytes.Buffer
+	if err := run(nil, strings.NewReader(oneGameBundle), &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if seed := decodeSeed(t, out.Bytes()); seed != 42 {
+		t.Errorf("no override: seed = %d, want 42", seed)
+	}
+
+	// With override: output echoes the overriding seed (777).
+	out.Reset()
+	if err := run([]string{"--seed", "777"}, strings.NewReader(oneGameBundle), &out); err != nil {
+		t.Fatalf("run --seed 777: %v", err)
+	}
+	if seed := decodeSeed(t, out.Bytes()); seed != 777 {
+		t.Errorf("override: seed = %d, want 777", seed)
+	}
+}
+
+func decodeSeed(t *testing.T, data []byte) uint64 {
+	t.Helper()
+	var res struct {
+		Seed uint64 `json:"seed"`
+	}
+	if err := json.Unmarshal(data, &res); err != nil {
+		t.Fatalf("decoding output: %v", err)
+	}
+	return res.Seed
+}

--- a/engine/go.mod
+++ b/engine/go.mod
@@ -1,0 +1,11 @@
+module github.com/a-jay85/IBL5/engine
+
+go 1.22
+
+// Pin the exact toolchain so the seedable-PRNG golden-master snapshots are
+// reproducible across machines and CI. RNG source consumption (math/rand/v2)
+// is not guaranteed byte-identical across minor Go versions, and golden tests
+// are the engine's primary regression mechanism — so the version that
+// generates a golden must equal the version that verifies it. The `go` command
+// honors this directive (GOTOOLCHAIN=auto), auto-downloading if needed.
+toolchain go1.26.3

--- a/engine/internal/bundle/bundle.go
+++ b/engine/internal/bundle/bundle.go
@@ -1,0 +1,168 @@
+// Package bundle defines the engine's input contract: the simulation "bundle"
+// the PHP side builds from the database (or, for validation, from a historical
+// backup .plr) and hands to the engine as JSON on stdin.
+//
+// JSON tags deliberately match the source-of-truth ibl_plr column names so the
+// PHP bundle-builder (a later PR) maps 1:1 with no translation layer.
+package bundle
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// GameType is the JSB game-type flag (CEngine+0x63b4 in the decompile). Only the
+// values IBL actually runs are valid: 2/3 regular season, 4 playoff, 5/6
+// all-star game. Exhibition (1) is intentionally rejected — IBL never runs it.
+type GameType int
+
+const (
+	GameTypeRegular    GameType = 2
+	GameTypeRegularAlt GameType = 3
+	GameTypePlayoff    GameType = 4
+	GameTypeAllStarA   GameType = 5
+	GameTypeAllStarB   GameType = 6
+)
+
+func (g GameType) valid() bool {
+	switch g {
+	case GameTypeRegular, GameTypeRegularAlt, GameTypePlayoff, GameTypeAllStarA, GameTypeAllStarB:
+		return true
+	}
+	return false
+}
+
+// UnmarshalJSON decodes an integer game-type and rejects any value IBL does not
+// use, so a bad game_type fails fast at the contract boundary rather than deep
+// in the sim.
+func (g *GameType) UnmarshalJSON(data []byte) error {
+	var v int
+	if err := json.Unmarshal(data, &v); err != nil {
+		return fmt.Errorf("game_type: %w", err)
+	}
+	gt := GameType(v)
+	if !gt.valid() {
+		return fmt.Errorf("game_type: unknown value %d (valid: 2,3 regular; 4 playoff; 5,6 all-star)", v)
+	}
+	*g = gt
+	return nil
+}
+
+// Team identifies one franchise in the bundle.
+type Team struct {
+	TeamID int    `json:"teamid"`
+	Name   string `json:"name"`
+}
+
+// Player carries the source-of-truth ratings from ibl_plr plus depth-chart
+// settings. JSON tags equal the ibl_plr column names exactly.
+type Player struct {
+	PID    int    `json:"pid"`
+	Name   string `json:"name"`
+	TeamID int    `json:"teamid"`
+
+	// ODPT ratings, 1-9 scale (paired order: offense/defense per play type).
+	OO       int `json:"oo"`          // outside offense
+	OD       int `json:"od"`          // outside defense
+	DriveOff int `json:"r_drive_off"` // drive offense
+	DD       int `json:"dd"`          // drive defense
+	PO       int `json:"po"`          // post offense
+	PD       int `json:"pd"`          // post defense
+	TransOff int `json:"r_trans_off"` // transition offense
+	TD       int `json:"td"`          // transition defense
+
+	// Main ratings, 0-99 scale.
+	FGA  int `json:"r_fga"`
+	FGP  int `json:"r_fgp"`
+	FTA  int `json:"r_fta"`
+	FTP  int `json:"r_ftp"`
+	TGA  int `json:"r_3ga"`
+	TGP  int `json:"r_3gp"`
+	ORB  int `json:"r_orb"`
+	DRB  int `json:"r_drb"`
+	AST  int `json:"r_ast"`
+	STL  int `json:"r_stl"`
+	TVR  int `json:"r_tvr"`
+	BLK  int `json:"r_blk"`
+	Foul int `json:"r_foul"`
+
+	// Attributes.
+	Age         int `json:"age"`
+	Stamina     int `json:"stamina"`
+	Clutch      int `json:"clutch"`
+	Consistency int `json:"consistency"`
+	Talent      int `json:"talent"`
+	Skill       int `json:"skill"`
+	Intangibles int `json:"intangibles"`
+	Peak        int `json:"peak"`
+
+	// Depth-chart settings.
+	DCMinutes       int `json:"dc_minutes"`
+	DCPGDepth       int `json:"dc_pg_depth"`
+	DCSGDepth       int `json:"dc_sg_depth"`
+	DCSFDepth       int `json:"dc_sf_depth"`
+	DCPFDepth       int `json:"dc_pf_depth"`
+	DCCDepth        int `json:"dc_c_depth"`
+	DCCanPlayInGame int `json:"dc_can_play_in_game"`
+	DCOf            int `json:"dc_of"`
+	DCDf            int `json:"dc_df"`
+	DCOi            int `json:"dc_oi"`
+	DCDi            int `json:"dc_di"`
+	DCBh            int `json:"dc_bh"`
+}
+
+// Game is one scheduled matchup to simulate.
+type Game struct {
+	HomeTeamID    int      `json:"home_team_id"`
+	VisitorTeamID int      `json:"visitor_team_id"`
+	Date          string   `json:"date"`
+	GameType      GameType `json:"game_type"`
+}
+
+// Bundle is the complete engine input for one sim run.
+type Bundle struct {
+	LeagueID int      `json:"league_id"`
+	Seed     uint64   `json:"seed"`
+	Teams    []Team   `json:"teams"`
+	Players  []Player `json:"players"`
+	Schedule []Game   `json:"schedule"`
+}
+
+// Validation errors surfaced at the contract boundary.
+var (
+	ErrEmptyRoster = errors.New("bundle: players is empty")
+	ErrNoSchedule  = errors.New("bundle: schedule is empty")
+)
+
+// Decode reads and validates a bundle from JSON. Structurally-invalid input
+// (bad JSON, unknown game_type, empty roster) is rejected here so it surfaces
+// as a clean error rather than a panic inside the sim.
+func Decode(data []byte) (Bundle, error) {
+	var b Bundle
+	if err := json.Unmarshal(data, &b); err != nil {
+		return Bundle{}, err
+	}
+	if err := b.Validate(); err != nil {
+		return Bundle{}, err
+	}
+	return b, nil
+}
+
+// Validate checks invariants that must hold for any bundle, whether decoded
+// from JSON or constructed in code. (game_type is already validated during
+// unmarshal; the loop here defends bundles built directly in Go.)
+func (b Bundle) Validate() error {
+	if len(b.Players) == 0 {
+		return ErrEmptyRoster
+	}
+	if len(b.Schedule) == 0 {
+		return ErrNoSchedule
+	}
+	for i, g := range b.Schedule {
+		if !g.GameType.valid() {
+			return fmt.Errorf("bundle: schedule[%d]: invalid game_type %d", i, int(g.GameType))
+		}
+	}
+	return nil
+}

--- a/engine/internal/bundle/bundle_test.go
+++ b/engine/internal/bundle/bundle_test.go
@@ -1,0 +1,110 @@
+package bundle
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// validBundleJSON is a minimal but complete bundle covering one player and one
+// regular-season game.
+const validBundleJSON = `{
+  "league_id": 1,
+  "seed": 42,
+  "teams": [{"teamid": 3, "name": "Heat"}, {"teamid": 7, "name": "Lakers"}],
+  "players": [{
+    "pid": 101, "name": "Test Player", "teamid": 3,
+    "oo": 5, "od": 4, "r_drive_off": 6, "dd": 3, "po": 2, "pd": 5, "r_trans_off": 7, "td": 4,
+    "r_fga": 70, "r_fgp": 48, "r_fta": 30, "r_ftp": 80, "r_3ga": 40, "r_3gp": 36,
+    "r_orb": 20, "r_drb": 50, "r_ast": 45, "r_stl": 15, "r_tvr": 12, "r_blk": 8, "r_foul": 25,
+    "age": 27, "stamina": 88, "clutch": 5, "consistency": 3,
+    "talent": 80, "skill": 75, "intangibles": 60, "peak": 28,
+    "dc_minutes": 34, "dc_pg_depth": 1, "dc_sg_depth": 0, "dc_sf_depth": 0,
+    "dc_pf_depth": 0, "dc_c_depth": 0, "dc_can_play_in_game": 1,
+    "dc_of": 3, "dc_df": 3, "dc_oi": 3, "dc_di": 3, "dc_bh": 3
+  }],
+  "schedule": [{"home_team_id": 3, "visitor_team_id": 7, "date": "1988-11-04", "game_type": 2}]
+}`
+
+// #1 — a valid bundle decodes with every rating, attribute, depth, and schedule
+// field populated, and round-trips back to JSON.
+func TestDecode_RoundTripPopulatesAllFields(t *testing.T) {
+	b, err := Decode([]byte(validBundleJSON))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if b.Seed != 42 || b.LeagueID != 1 {
+		t.Fatalf("top-level: seed=%d league=%d", b.Seed, b.LeagueID)
+	}
+	if len(b.Players) != 1 || len(b.Schedule) != 1 || len(b.Teams) != 2 {
+		t.Fatalf("counts: players=%d schedule=%d teams=%d", len(b.Players), len(b.Schedule), len(b.Teams))
+	}
+	p := b.Players[0]
+	// Spot-check one field from each group to prove tags bound correctly.
+	if p.DriveOff != 6 || p.TransOff != 7 {
+		t.Errorf("ODPT renamed cols: r_drive_off=%d r_trans_off=%d", p.DriveOff, p.TransOff)
+	}
+	if p.TGA != 40 || p.TVR != 12 {
+		t.Errorf("main ratings: r_3ga=%d r_tvr=%d", p.TGA, p.TVR)
+	}
+	if p.DCMinutes != 34 || p.DCCanPlayInGame != 1 || p.DCPGDepth != 1 {
+		t.Errorf("depth: dc_minutes=%d dc_can_play_in_game=%d dc_pg_depth=%d", p.DCMinutes, p.DCCanPlayInGame, p.DCPGDepth)
+	}
+	if p.Stamina != 88 || p.Peak != 28 {
+		t.Errorf("attributes: stamina=%d peak=%d", p.Stamina, p.Peak)
+	}
+	if b.Schedule[0].GameType != GameTypeRegular {
+		t.Errorf("game_type = %d, want 2", int(b.Schedule[0].GameType))
+	}
+
+	// Round-trip back to JSON and decode again — must be stable.
+	out, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if _, err := Decode(out); err != nil {
+		t.Fatalf("re-Decode of marshaled bundle: %v", err)
+	}
+}
+
+// #3 (boundary) — an unknown game_type value is rejected at decode time.
+func TestDecode_RejectsUnknownGameType(t *testing.T) {
+	for _, gt := range []int{0, 1, 7, 99} {
+		j := `{"seed":1,"players":[{"pid":1,"teamid":3}],"schedule":[{"home_team_id":3,"visitor_team_id":7,"date":"d","game_type":` + itoa(gt) + `}]}`
+		if _, err := Decode([]byte(j)); err == nil {
+			t.Errorf("game_type %d: expected rejection, got nil error", gt)
+		}
+	}
+}
+
+// #4 (boundary) — an empty roster is handled with a typed error, not a panic.
+func TestDecode_RejectsEmptyRoster(t *testing.T) {
+	j := `{"seed":1,"players":[],"schedule":[{"home_team_id":3,"visitor_team_id":7,"date":"d","game_type":2}]}`
+	_, err := Decode([]byte(j))
+	if !errors.Is(err, ErrEmptyRoster) {
+		t.Fatalf("empty roster: err = %v, want ErrEmptyRoster", err)
+	}
+}
+
+// itoa avoids pulling in strconv for a one-liner in test data construction.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/engine/internal/result/result.go
+++ b/engine/internal/result/result.go
@@ -1,0 +1,129 @@
+// Package result defines the engine's output contract: the structured result
+// the engine writes as JSON on stdout, which the PHP loader (a later PR) commits
+// to the database.
+//
+// The per-possession event stream is the single source of truth: both the box
+// scores in this PR and the play-by-play commentary in a later PR derive from
+// it. The box-score structs map 1:1 to the RAW columns of ibl_box_scores /
+// ibl_box_scores_teams; they deliberately omit the MySQL-generated columns
+// (calc_points, calc_rebounds, calc_fg_made, game_type, season_year), which the
+// database computes and the engine must never emit.
+package result
+
+// EventKind is the discriminator for a per-possession Event.
+type EventKind string
+
+const (
+	EventPossessionStart EventKind = "possession_start"
+	EventShotAttempt     EventKind = "shot_attempt"
+	EventShotMake        EventKind = "shot_make"
+	EventShotMiss        EventKind = "shot_miss"
+	EventRebound         EventKind = "rebound"
+	EventTurnover        EventKind = "turnover"
+	EventSteal           EventKind = "steal"
+	EventBlock           EventKind = "block"
+	EventFoul            EventKind = "foul"
+	EventSubstitution    EventKind = "substitution"
+	EventFreeThrow       EventKind = "free_throw"
+	EventPeriodBoundary  EventKind = "period_boundary"
+)
+
+// ShotType classifies a shot attempt; carried on shot_attempt/make/miss events.
+type ShotType string
+
+const (
+	ShotTwoPoint  ShotType = "2pt"
+	ShotThree     ShotType = "3pt"
+	ShotFreeThrow ShotType = "ft"
+)
+
+// Event is one structured per-possession event. Which fields are meaningful
+// depends on Kind; a zero value means "not applicable to this event kind".
+type Event struct {
+	Kind   EventKind `json:"kind"`
+	Period int       `json:"period"`
+	Clock  int       `json:"clock_seconds"` // seconds remaining in the period
+
+	TeamID     int `json:"team_id,omitempty"`
+	PlayerID   int `json:"player_id,omitempty"`
+	DefenderID int `json:"defender_id,omitempty"` // opposing player for steals/blocks
+
+	ShotType ShotType `json:"shot_type,omitempty"`
+
+	// OffensiveRebound distinguishes an offensive (true) from a defensive
+	// (false) rebound. Only meaningful when Kind == EventRebound.
+	OffensiveRebound bool `json:"offensive_rebound,omitempty"`
+}
+
+// PlayerBox is one player's stat line for one game. Fields map 1:1 to the RAW
+// columns of ibl_box_scores. A did-not-play row is expressed as GameMIN == 0
+// (the PR8 loader enforces that convention on write).
+type PlayerBox struct {
+	PID     int    `json:"pid"`
+	Pos     string `json:"pos"`
+	GameMIN int    `json:"gameMIN"`
+	Game2GM int    `json:"game2GM"`
+	Game2GA int    `json:"game2GA"`
+	GameFTM int    `json:"gameFTM"`
+	GameFTA int    `json:"gameFTA"`
+	Game3GM int    `json:"game3GM"`
+	Game3GA int    `json:"game3GA"`
+	GameORB int    `json:"gameORB"`
+	GameDRB int    `json:"gameDRB"`
+	GameAST int    `json:"gameAST"`
+	GameSTL int    `json:"gameSTL"`
+	GameTOV int    `json:"gameTOV"`
+	GameBLK int    `json:"gameBLK"`
+	GamePF  int    `json:"gamePF"`
+}
+
+// TeamBox is one team's totals for one game, mapping to ibl_box_scores_teams.
+// The two TeamBoxes in a GameResult are ordered visitor-first; the
+// visitor=lower-team-id dedupe convention is enforced by the PR8 loader.
+type TeamBox struct {
+	TeamID int  `json:"team_id"`
+	IsHome bool `json:"is_home"`
+
+	Q1 int   `json:"q1"`
+	Q2 int   `json:"q2"`
+	Q3 int   `json:"q3"`
+	Q4 int   `json:"q4"`
+	OT []int `json:"ot"` // points per overtime period in order; empty when no OT
+
+	Game2GM int `json:"game2GM"`
+	Game2GA int `json:"game2GA"`
+	GameFTM int `json:"gameFTM"`
+	GameFTA int `json:"gameFTA"`
+	Game3GM int `json:"game3GM"`
+	Game3GA int `json:"game3GA"`
+	GameORB int `json:"gameORB"`
+	GameDRB int `json:"gameDRB"`
+	GameAST int `json:"gameAST"`
+	GameSTL int `json:"gameSTL"`
+	GameTOV int `json:"gameTOV"`
+	GameBLK int `json:"gameBLK"`
+	GamePF  int `json:"gamePF"`
+}
+
+// GameResult is the engine's full output for one scheduled game. SimGameType
+// echoes the JSB-scale input game-type (2-6) for the loader's routing; it is
+// NOT the ibl_box_scores.game_type generated column (which the database derives
+// on a 1-3 scale).
+type GameResult struct {
+	Date          string `json:"date"`
+	HomeTeamID    int    `json:"home_team_id"`
+	VisitorTeamID int    `json:"visitor_team_id"`
+	GameOfThatDay int    `json:"game_of_that_day"`
+	SimGameType   int    `json:"sim_game_type"`
+
+	Events      []Event     `json:"events"`
+	PlayerBoxes []PlayerBox `json:"player_boxes"`
+	TeamBoxes   []TeamBox   `json:"team_boxes"` // visitor first, then home
+}
+
+// Result is the engine's complete output for one bundle: one GameResult per
+// scheduled game, plus the seed actually used so the run can be replayed.
+type Result struct {
+	Seed  uint64       `json:"seed"`
+	Games []GameResult `json:"games"`
+}

--- a/engine/internal/result/result.go
+++ b/engine/internal/result/result.go
@@ -56,8 +56,9 @@ type Event struct {
 }
 
 // PlayerBox is one player's stat line for one game. Fields map 1:1 to the RAW
-// columns of ibl_box_scores. A did-not-play row is expressed as GameMIN == 0
-// (the PR8 loader enforces that convention on write).
+// columns of ibl_box_scores. The engine establishes the did-not-play invariant
+// (a DNP row is emitted as GameMIN == 0 with all stats zero); the PR8 loader
+// persists that row as-is.
 type PlayerBox struct {
 	PID     int    `json:"pid"`
 	Pos     string `json:"pos"`
@@ -78,8 +79,9 @@ type PlayerBox struct {
 }
 
 // TeamBox is one team's totals for one game, mapping to ibl_box_scores_teams.
-// The two TeamBoxes in a GameResult are ordered visitor-first; the
-// visitor=lower-team-id dedupe convention is enforced by the PR8 loader.
+// The engine emits the two TeamBoxes in a GameResult visitor-first. Separately,
+// the PR8 loader enforces the database row-identity dedupe convention
+// (visitor = lower team id) when persisting the pair.
 type TeamBox struct {
 	TeamID int  `json:"team_id"`
 	IsHome bool `json:"is_home"`

--- a/engine/internal/result/result_test.go
+++ b/engine/internal/result/result_test.go
@@ -1,0 +1,111 @@
+package result
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// jsonTagNames returns the JSON field names (tag before any comma) declared on
+// a struct type.
+func jsonTagNames(t reflect.Type) []string {
+	var names []string
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		names = append(names, strings.Split(tag, ",")[0])
+	}
+	return names
+}
+
+// #5 — the box-score structs map to RAW ibl_box_scores columns only and never
+// emit the MySQL-generated columns.
+func TestBoxStructs_OmitGeneratedColumns(t *testing.T) {
+	generated := map[string]bool{
+		"calc_points": true, "calc_rebounds": true, "calc_fg_made": true,
+		"game_type": true, "season_year": true,
+	}
+	for _, typ := range []reflect.Type{reflect.TypeOf(PlayerBox{}), reflect.TypeOf(TeamBox{})} {
+		for _, name := range jsonTagNames(typ) {
+			if generated[name] {
+				t.Errorf("%s emits generated column %q — engine must not produce it", typ.Name(), name)
+			}
+		}
+	}
+}
+
+// #6 — team box rows carry quarter-by-quarter points including overtime plus
+// the full set of team stat totals.
+func TestTeamBox_HasQuartersOvertimeAndTotals(t *testing.T) {
+	tb := TeamBox{
+		TeamID: 3, IsHome: true,
+		Q1: 25, Q2: 22, Q3: 28, Q4: 20, OT: []int{8, 6},
+		Game2GM: 40, Game2GA: 80, GameFTM: 15, GameFTA: 20,
+		Game3GM: 9, Game3GA: 25, GameORB: 12, GameDRB: 33,
+		GameAST: 24, GameSTL: 8, GameTOV: 13, GameBLK: 5, GamePF: 19,
+	}
+	data, err := json.Marshal(tb)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back TeamBox
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.Q1 != 25 || back.Q4 != 20 {
+		t.Errorf("quarters lost: Q1=%d Q4=%d", back.Q1, back.Q4)
+	}
+	if len(back.OT) != 2 || back.OT[0] != 8 || back.OT[1] != 6 {
+		t.Errorf("overtime periods lost: %v", back.OT)
+	}
+	if back.Game3GM != 9 || back.GameBLK != 5 || back.GamePF != 19 {
+		t.Errorf("stat totals lost: 3GM=%d BLK=%d PF=%d", back.Game3GM, back.GameBLK, back.GamePF)
+	}
+}
+
+// #7 — each modeled event kind round-trips carrying its required fields.
+func TestEvent_KindsCarryRequiredFields(t *testing.T) {
+	events := []Event{
+		{Kind: EventPossessionStart, Period: 1, Clock: 720, TeamID: 3},
+		{Kind: EventShotAttempt, Period: 1, Clock: 700, TeamID: 3, PlayerID: 101, ShotType: ShotThree},
+		{Kind: EventShotMake, Period: 1, Clock: 700, TeamID: 3, PlayerID: 101, ShotType: ShotThree},
+		{Kind: EventShotMiss, Period: 2, Clock: 300, TeamID: 7, PlayerID: 202, ShotType: ShotTwoPoint},
+		{Kind: EventRebound, Period: 2, Clock: 299, TeamID: 3, PlayerID: 101, OffensiveRebound: true},
+		{Kind: EventTurnover, Period: 3, Clock: 120, TeamID: 7, PlayerID: 202},
+		{Kind: EventSteal, Period: 3, Clock: 120, TeamID: 3, PlayerID: 101, DefenderID: 202},
+		{Kind: EventBlock, Period: 3, Clock: 90, TeamID: 3, PlayerID: 101, DefenderID: 202},
+		{Kind: EventFoul, Period: 4, Clock: 60, TeamID: 7, PlayerID: 202},
+		{Kind: EventSubstitution, Period: 4, Clock: 60, TeamID: 3, PlayerID: 103},
+		{Kind: EventFreeThrow, Period: 4, Clock: 60, TeamID: 7, PlayerID: 202, ShotType: ShotFreeThrow},
+		{Kind: EventPeriodBoundary, Period: 4, Clock: 0},
+	}
+	data, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back []Event
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(back) != len(events) {
+		t.Fatalf("event count: got %d want %d", len(back), len(events))
+	}
+	// Shot events must retain player id + shot type.
+	shot := back[1]
+	if shot.Kind != EventShotAttempt || shot.PlayerID != 101 || shot.ShotType != ShotThree {
+		t.Errorf("shot_attempt lost fields: %+v", shot)
+	}
+	// Rebound must retain its offensive flag.
+	reb := back[4]
+	if reb.Kind != EventRebound || !reb.OffensiveRebound {
+		t.Errorf("rebound lost offensive flag: %+v", reb)
+	}
+	// Steal/block must retain the defender.
+	steal := back[6]
+	if steal.Kind != EventSteal || steal.DefenderID != 202 {
+		t.Errorf("steal lost defender: %+v", steal)
+	}
+}

--- a/engine/internal/rng/rng.go
+++ b/engine/internal/rng/rng.go
@@ -1,0 +1,32 @@
+// Package rng provides a seedable, deterministic pseudo-random number generator
+// for the JSB simulation engine.
+//
+// JSB itself used the MSVC C runtime rand() with no srand() call, so its runs
+// were non-reproducible across invocations. This engine instead records a seed
+// per run: the same seed always yields the same sequence, which lets any
+// simulation be replayed exactly (for audit, regression tests, and bug repro).
+package rng
+
+import "math/rand/v2"
+
+// RNG is a deterministic source of pseudo-randomness. Always construct via New;
+// never reach for the package-global rand functions, so that engine output
+// depends only on the recorded seed.
+type RNG struct {
+	src *rand.Rand
+}
+
+// New returns an RNG seeded from the given seed. math/rand/v2's PCG is a
+// stdlib, seedable, deterministic source. PCG takes two 64-bit words; we derive
+// the second from the first (golden-ratio mix) so a single seed fully
+// determines the stream.
+func New(seed uint64) *RNG {
+	return &RNG{src: rand.New(rand.NewPCG(seed, seed^0x9e3779b97f4a7c15))}
+}
+
+// Float64 returns a deterministic value in [0, 1).
+func (r *RNG) Float64() float64 { return r.src.Float64() }
+
+// IntN returns a deterministic value in [0, n). It panics if n <= 0, matching
+// math/rand/v2.IntN semantics.
+func (r *RNG) IntN(n int) int { return r.src.IntN(n) }

--- a/engine/internal/rng/rng_test.go
+++ b/engine/internal/rng/rng_test.go
@@ -1,0 +1,40 @@
+package rng
+
+import "testing"
+
+// #8 — the PRNG is deterministic: the same seed yields the same sequence, and
+// different seeds diverge.
+func TestRNG_DeterministicBySeed(t *testing.T) {
+	a := New(12345)
+	b := New(12345)
+	for i := 0; i < 100; i++ {
+		if got, want := a.Float64(), b.Float64(); got != want {
+			t.Fatalf("Float64 diverged at %d: %v != %v", i, got, want)
+		}
+	}
+
+	a = New(12345)
+	b = New(12345)
+	for i := 0; i < 100; i++ {
+		if got, want := a.IntN(1000), b.IntN(1000); got != want {
+			t.Fatalf("IntN diverged at %d: %d != %d", i, got, want)
+		}
+	}
+}
+
+func TestRNG_DifferentSeedsDiverge(t *testing.T) {
+	a := New(1)
+	b := New(2)
+	// With 50 draws the odds of identical sequences from distinct seeds are
+	// vanishingly small; any match indicates the seed is not threaded.
+	identical := true
+	for i := 0; i < 50; i++ {
+		if a.Float64() != b.Float64() {
+			identical = false
+			break
+		}
+	}
+	if identical {
+		t.Fatal("seeds 1 and 2 produced identical sequences — seed not threaded")
+	}
+}

--- a/engine/internal/sim/golden_test.go
+++ b/engine/internal/sim/golden_test.go
@@ -1,0 +1,59 @@
+package sim
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+var update = flag.Bool("update", false, "regenerate golden files from current output")
+
+// encode mirrors the cmd/jsbsim encoding exactly (indented JSON via Encoder, so
+// a trailing newline is included) so the golden bytes match real CLI output.
+func encode(t *testing.T, v any) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// #11 — golden master: a fixed input fixture run at its fixed seed must produce
+// byte-stable output. Run `go test ./internal/sim -run Golden -update` to
+// regenerate after an intentional output change.
+func TestGolden(t *testing.T) {
+	in, err := os.ReadFile(filepath.Join("testdata", "bundle.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	b, err := bundle.Decode(in)
+	if err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+
+	got := encode(t, Simulate(b, b.Seed))
+
+	goldenPath := filepath.Join("testdata", "golden.json")
+	if *update {
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden (run with -update to create): %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("output does not match golden.json.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}

--- a/engine/internal/sim/sim.go
+++ b/engine/internal/sim/sim.go
@@ -1,0 +1,159 @@
+// Package sim is the JSB-compatible basketball simulation core.
+//
+// ⚠️ PLACEHOLDER (PR1 — the "walking skeleton"). This does NOT simulate
+// basketball. It emits structurally-valid, deterministic output so the full
+// input→output pipeline, the PHP↔Go JSON contract, and the golden-master
+// harness are real and tested end-to-end. The actual possession loop, lineup
+// selection, energy/fatigue, stat aggregation, injuries, and game-type modes
+// are implemented in later PRs (PR3+), each validated against the historical
+// .sco corpus by the harness this scaffolding establishes. Do not mistake these
+// degenerate stat lines for accurate output.
+package sim
+
+import (
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// Simulate runs the (placeholder) engine over every game in the bundle and
+// returns a deterministic Result keyed to the given seed.
+func Simulate(b bundle.Bundle, seed uint64) result.Result {
+	r := rng.New(seed)
+	res := result.Result{Seed: seed, Games: make([]result.GameResult, 0, len(b.Schedule))}
+	for _, g := range b.Schedule {
+		res.Games = append(res.Games, simGame(b, g, r))
+	}
+	return res
+}
+
+// simGame produces a deterministic placeholder result for one game. The tip-off
+// is seed-dependent so that changing the seed genuinely changes output (which
+// makes the seed-flow and golden-master tests meaningful), but the stat lines
+// themselves are fixed/degenerate.
+func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) result.GameResult {
+	gr := result.GameResult{
+		Date:          g.Date,
+		HomeTeamID:    g.HomeTeamID,
+		VisitorTeamID: g.VisitorTeamID,
+		GameOfThatDay: 1,
+		SimGameType:   int(g.GameType),
+		Events:        []result.Event{},
+		PlayerBoxes:   []result.PlayerBox{},
+	}
+
+	tipTeam := g.VisitorTeamID
+	if r.IntN(2) == 1 {
+		tipTeam = g.HomeTeamID
+	}
+	gr.Events = append(gr.Events, result.Event{
+		Kind: result.EventPossessionStart, Period: 1, Clock: 720, TeamID: tipTeam,
+	})
+
+	vLines := linesFor(b.Players, g.VisitorTeamID)
+	hLines := linesFor(b.Players, g.HomeTeamID)
+
+	// One representative scoring sequence so the event stream exercises the
+	// shot_attempt/shot_make kinds and the ShotType field.
+	if len(vLines) > 0 {
+		pid := vLines[0].PID
+		gr.Events = append(gr.Events,
+			result.Event{Kind: result.EventShotAttempt, Period: 1, Clock: 700, TeamID: g.VisitorTeamID, PlayerID: pid, ShotType: result.ShotTwoPoint},
+			result.Event{Kind: result.EventShotMake, Period: 1, Clock: 700, TeamID: g.VisitorTeamID, PlayerID: pid, ShotType: result.ShotTwoPoint},
+		)
+	}
+	gr.Events = append(gr.Events, result.Event{Kind: result.EventPeriodBoundary, Period: 4, Clock: 0})
+
+	gr.PlayerBoxes = append(gr.PlayerBoxes, vLines...)
+	gr.PlayerBoxes = append(gr.PlayerBoxes, hLines...)
+	gr.TeamBoxes = []result.TeamBox{
+		teamBox(g.VisitorTeamID, false, vLines),
+		teamBox(g.HomeTeamID, true, hLines),
+	}
+	return gr
+}
+
+// linesFor returns placeholder stat lines for every player on the given team,
+// in bundle order (so output is deterministic).
+func linesFor(players []bundle.Player, teamID int) []result.PlayerBox {
+	out := []result.PlayerBox{}
+	for _, p := range players {
+		if p.TeamID == teamID {
+			out = append(out, placeholderLine(p))
+		}
+	}
+	return out
+}
+
+// placeholderLine returns a degenerate, deterministic stat line. A player
+// flagged dc_can_play_in_game == 0 gets a DNP line (GameMIN == 0, all stats
+// zero).
+func placeholderLine(p bundle.Player) result.PlayerBox {
+	box := result.PlayerBox{PID: p.PID, Pos: posOf(p)}
+	if p.DCCanPlayInGame == 0 {
+		return box // DNP
+	}
+	min := p.DCMinutes
+	if min < 0 {
+		min = 0
+	}
+	if min > 48 {
+		min = 48
+	}
+	box.GameMIN = min
+	box.Game2GM, box.Game2GA = 1, 2
+	box.Game3GM, box.Game3GA = 0, 1
+	box.GameFTM, box.GameFTA = 1, 2
+	box.GameORB, box.GameDRB = 1, 2
+	box.GameAST, box.GameSTL, box.GameTOV, box.GameBLK, box.GamePF = 1, 1, 1, 0, 1
+	return box
+}
+
+// posOf picks the position with the best (lowest, 1=starter) depth-chart slot.
+// A slot value of 0 or below means the player is not in the rotation there.
+func posOf(p bundle.Player) string {
+	slots := []struct {
+		pos   string
+		depth int
+	}{
+		{"PG", p.DCPGDepth}, {"SG", p.DCSGDepth}, {"SF", p.DCSFDepth},
+		{"PF", p.DCPFDepth}, {"C", p.DCCDepth},
+	}
+	best := ""
+	bestDepth := 0
+	for _, s := range slots {
+		if s.depth <= 0 {
+			continue
+		}
+		if best == "" || s.depth < bestDepth {
+			best, bestDepth = s.pos, s.depth
+		}
+	}
+	return best
+}
+
+// teamBox sums the player lines into team totals and splits points across
+// quarters (placeholder: even split, remainder into Q4, no overtime).
+func teamBox(teamID int, isHome bool, lines []result.PlayerBox) result.TeamBox {
+	tb := result.TeamBox{TeamID: teamID, IsHome: isHome, OT: []int{}}
+	for _, l := range lines {
+		tb.Game2GM += l.Game2GM
+		tb.Game2GA += l.Game2GA
+		tb.GameFTM += l.GameFTM
+		tb.GameFTA += l.GameFTA
+		tb.Game3GM += l.Game3GM
+		tb.Game3GA += l.Game3GA
+		tb.GameORB += l.GameORB
+		tb.GameDRB += l.GameDRB
+		tb.GameAST += l.GameAST
+		tb.GameSTL += l.GameSTL
+		tb.GameTOV += l.GameTOV
+		tb.GameBLK += l.GameBLK
+		tb.GamePF += l.GamePF
+	}
+	pts := 2*tb.Game2GM + tb.GameFTM + 3*tb.Game3GM
+	q := pts / 4
+	tb.Q1, tb.Q2, tb.Q3 = q, q, q
+	tb.Q4 = pts - 3*q
+	return tb
+}

--- a/engine/internal/sim/sim_test.go
+++ b/engine/internal/sim/sim_test.go
@@ -1,0 +1,91 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+)
+
+func testBundle() bundle.Bundle {
+	return bundle.Bundle{
+		Seed:  42,
+		Teams: []bundle.Team{{TeamID: 3, Name: "Heat"}, {TeamID: 7, Name: "Lakers"}},
+		Players: []bundle.Player{
+			{PID: 101, TeamID: 3, DCMinutes: 34, DCPGDepth: 1, DCCanPlayInGame: 1},
+			{PID: 102, TeamID: 3, DCMinutes: 0, DCCDepth: 1, DCCanPlayInGame: 0}, // DNP
+			{PID: 201, TeamID: 7, DCMinutes: 30, DCSGDepth: 1, DCCanPlayInGame: 1},
+		},
+		Schedule: []bundle.Game{
+			{HomeTeamID: 3, VisitorTeamID: 7, Date: "1988-11-04", GameType: bundle.GameTypeRegular},
+		},
+	}
+}
+
+// #10 — the placeholder sim produces structurally-valid output for a valid
+// bundle: one game, exactly two team boxes (visitor first), a player box per
+// rostered player, a non-empty event stream, and a DNP row expressed as
+// GameMIN == 0.
+func TestSimulate_StructurallyValid(t *testing.T) {
+	res := Simulate(testBundle(), 42)
+
+	if res.Seed != 42 {
+		t.Errorf("seed = %d, want 42", res.Seed)
+	}
+	if len(res.Games) != 1 {
+		t.Fatalf("games = %d, want 1", len(res.Games))
+	}
+	g := res.Games[0]
+
+	if len(g.TeamBoxes) != 2 {
+		t.Fatalf("team boxes = %d, want 2", len(g.TeamBoxes))
+	}
+	if g.TeamBoxes[0].TeamID != g.VisitorTeamID || g.TeamBoxes[0].IsHome {
+		t.Errorf("team box order: first box should be the visitor (team %d), got %+v", g.VisitorTeamID, g.TeamBoxes[0])
+	}
+	if len(g.PlayerBoxes) != 3 {
+		t.Fatalf("player boxes = %d, want 3 (all rostered players incl. DNP)", len(g.PlayerBoxes))
+	}
+	if len(g.Events) == 0 {
+		t.Error("event stream is empty")
+	}
+
+	// The dc_can_play_in_game == 0 player must be a DNP row (GameMIN == 0).
+	dnp := findBox(g.PlayerBoxes, 102)
+	if dnp == nil {
+		t.Fatal("missing player box for DNP player 102")
+	}
+	if dnp.GameMIN != 0 {
+		t.Errorf("DNP player GameMIN = %d, want 0", dnp.GameMIN)
+	}
+
+	// An active player must have minutes and at least one event-bearing slot.
+	active := findBox(g.PlayerBoxes, 101)
+	if active == nil || active.GameMIN == 0 {
+		t.Errorf("active player 101 should have minutes, got %+v", active)
+	}
+}
+
+// A team's quarter points must sum to its total points (placeholder invariant).
+func TestSimulate_QuarterPointsSumToTotal(t *testing.T) {
+	res := Simulate(testBundle(), 42)
+	for _, tb := range res.Games[0].TeamBoxes {
+		pts := 2*tb.Game2GM + tb.GameFTM + 3*tb.Game3GM
+		q := tb.Q1 + tb.Q2 + tb.Q3 + tb.Q4
+		for _, ot := range tb.OT {
+			q += ot
+		}
+		if q != pts {
+			t.Errorf("team %d: quarters sum to %d, total points %d", tb.TeamID, q, pts)
+		}
+	}
+}
+
+func findBox(boxes []result.PlayerBox, pid int) *result.PlayerBox {
+	for i := range boxes {
+		if boxes[i].PID == pid {
+			return &boxes[i]
+		}
+	}
+	return nil
+}

--- a/engine/internal/sim/testdata/bundle.json
+++ b/engine/internal/sim/testdata/bundle.json
@@ -1,0 +1,18 @@
+{
+  "league_id": 1,
+  "seed": 1988,
+  "teams": [
+    {"teamid": 3, "name": "Heat"},
+    {"teamid": 7, "name": "Lakers"}
+  ],
+  "players": [
+    {"pid": 101, "name": "Visitor Starter", "teamid": 7, "dc_minutes": 36, "dc_pg_depth": 1, "dc_can_play_in_game": 1},
+    {"pid": 102, "name": "Visitor Bench", "teamid": 7, "dc_minutes": 18, "dc_sg_depth": 2, "dc_can_play_in_game": 1},
+    {"pid": 103, "name": "Visitor DNP", "teamid": 7, "dc_minutes": 0, "dc_c_depth": 3, "dc_can_play_in_game": 0},
+    {"pid": 201, "name": "Home Starter", "teamid": 3, "dc_minutes": 34, "dc_sf_depth": 1, "dc_can_play_in_game": 1},
+    {"pid": 202, "name": "Home Bench", "teamid": 3, "dc_minutes": 22, "dc_pf_depth": 2, "dc_can_play_in_game": 1}
+  ],
+  "schedule": [
+    {"home_team_id": 3, "visitor_team_id": 7, "date": "1988-11-04", "game_type": 2}
+  ]
+}

--- a/engine/internal/sim/testdata/golden.json
+++ b/engine/internal/sim/testdata/golden.json
@@ -1,0 +1,179 @@
+{
+  "seed": 1988,
+  "games": [
+    {
+      "date": "1988-11-04",
+      "home_team_id": 3,
+      "visitor_team_id": 7,
+      "game_of_that_day": 1,
+      "sim_game_type": 2,
+      "events": [
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 720,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 700,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 700,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "period_boundary",
+          "period": 4,
+          "clock_seconds": 0
+        }
+      ],
+      "player_boxes": [
+        {
+          "pid": 101,
+          "pos": "PG",
+          "gameMIN": 36,
+          "game2GM": 1,
+          "game2GA": 2,
+          "gameFTM": 1,
+          "gameFTA": 2,
+          "game3GM": 0,
+          "game3GA": 1,
+          "gameORB": 1,
+          "gameDRB": 2,
+          "gameAST": 1,
+          "gameSTL": 1,
+          "gameTOV": 1,
+          "gameBLK": 0,
+          "gamePF": 1
+        },
+        {
+          "pid": 102,
+          "pos": "SG",
+          "gameMIN": 18,
+          "game2GM": 1,
+          "game2GA": 2,
+          "gameFTM": 1,
+          "gameFTA": 2,
+          "game3GM": 0,
+          "game3GA": 1,
+          "gameORB": 1,
+          "gameDRB": 2,
+          "gameAST": 1,
+          "gameSTL": 1,
+          "gameTOV": 1,
+          "gameBLK": 0,
+          "gamePF": 1
+        },
+        {
+          "pid": 103,
+          "pos": "C",
+          "gameMIN": 0,
+          "game2GM": 0,
+          "game2GA": 0,
+          "gameFTM": 0,
+          "gameFTA": 0,
+          "game3GM": 0,
+          "game3GA": 0,
+          "gameORB": 0,
+          "gameDRB": 0,
+          "gameAST": 0,
+          "gameSTL": 0,
+          "gameTOV": 0,
+          "gameBLK": 0,
+          "gamePF": 0
+        },
+        {
+          "pid": 201,
+          "pos": "SF",
+          "gameMIN": 34,
+          "game2GM": 1,
+          "game2GA": 2,
+          "gameFTM": 1,
+          "gameFTA": 2,
+          "game3GM": 0,
+          "game3GA": 1,
+          "gameORB": 1,
+          "gameDRB": 2,
+          "gameAST": 1,
+          "gameSTL": 1,
+          "gameTOV": 1,
+          "gameBLK": 0,
+          "gamePF": 1
+        },
+        {
+          "pid": 202,
+          "pos": "PF",
+          "gameMIN": 22,
+          "game2GM": 1,
+          "game2GA": 2,
+          "gameFTM": 1,
+          "gameFTA": 2,
+          "game3GM": 0,
+          "game3GA": 1,
+          "gameORB": 1,
+          "gameDRB": 2,
+          "gameAST": 1,
+          "gameSTL": 1,
+          "gameTOV": 1,
+          "gameBLK": 0,
+          "gamePF": 1
+        }
+      ],
+      "team_boxes": [
+        {
+          "team_id": 7,
+          "is_home": false,
+          "q1": 1,
+          "q2": 1,
+          "q3": 1,
+          "q4": 3,
+          "ot": [],
+          "game2GM": 2,
+          "game2GA": 4,
+          "gameFTM": 2,
+          "gameFTA": 4,
+          "game3GM": 0,
+          "game3GA": 2,
+          "gameORB": 2,
+          "gameDRB": 4,
+          "gameAST": 2,
+          "gameSTL": 2,
+          "gameTOV": 2,
+          "gameBLK": 0,
+          "gamePF": 2
+        },
+        {
+          "team_id": 3,
+          "is_home": true,
+          "q1": 1,
+          "q2": 1,
+          "q3": 1,
+          "q4": 3,
+          "ot": [],
+          "game2GM": 2,
+          "game2GA": 4,
+          "gameFTM": 2,
+          "gameFTA": 4,
+          "game3GM": 0,
+          "game3GA": 2,
+          "gameORB": 2,
+          "gameDRB": 4,
+          "gameAST": 2,
+          "gameSTL": 2,
+          "gameTOV": 2,
+          "gameBLK": 0,
+          "gamePF": 2
+        }
+      ]
+    }
+  ]
+}

--- a/ibl5/docs/decisions/0035-native-go-sim-engine.md
+++ b/ibl5/docs/decisions/0035-native-go-sim-engine.md
@@ -1,0 +1,38 @@
+---
+description: Replace the JSB jumpshot.exe binary round-trip with a native Go sim engine as a pure stdin/stdout transform.
+last_verified: 2026-05-30
+---
+
+# ADR-0035: Native Go Simulation Engine
+
+**Status:** Accepted
+**Date:** 2026-05-30
+
+## Context
+
+Game simulation has always been performed by JSB (`jumpshot.exe`), a closed Windows binary run manually by a community member, who returns binary output files (`.sco`, `.plr`, `.car`, etc.) that IBL parses byte-by-byte through a large parser/importer/exporter layer. This couples the league to outdated Windows tooling, gives us no control over the engine, and forces a brittle binary-file translation layer between sim output and the website. JSB also seeds its RNG from system time with no `srand()`, so runs are non-reproducible. We have fully reverse-engineered the parts of the engine IBL uses, so a native reimplementation is now feasible.
+
+## Decision
+
+We will build a native simulation engine in **Go**, living in the monorepo at `engine/`, structured as a **pure stdin/stdout transform**: it reads a JSON input bundle (rosters, ratings, depth charts, schedule) and writes a JSON result (a per-possession event stream plus box-score rows), touching no database, network, or files. The PHP side builds the bundle and loads the result; the existing derivation steps (standings, power rankings, snapshots, history) are unchanged. The engine uses a **seedable PRNG** (`math/rand/v2` PCG) with the seed recorded per run, making every simulation reproducible. The Go module and its tests are enforced in CI by `.github/workflows/engine.yml` (build, vet, test).
+
+## Alternatives Considered
+
+- **Keep running the JSB binary** — status quo. Rejected because: no control over the engine, depends on manual Windows execution, and forces the brittle binary-file translation layer we want to delete.
+- **Reimplement in PHP, inline with the app** — one language, no new toolchain. Rejected because: a full-season possession sim is CPU-bound and PHP would be too slow and awkward to make deterministic/testable as an isolated unit.
+- **Reimplement in Rust** — comparable performance and safety. Rejected because: Go has a gentler concurrency model for batch-simming a season and produces cleaner, more maintainable code for this team's needs; performance is more than adequate.
+
+## Consequences
+
+- Positive: full control over and extensibility of the engine; no dependency on Windows or `jumpshot.exe`.
+- Positive: reproducible sims (seed recorded per run) enable deterministic golden-master tests, replay, and audit — capabilities JSB never had.
+- Positive: the binary-file round-trip and JSB parser/importer/exporter classes can be retired; sim output flows directly to the database.
+- Negative: adds a second language and its toolchain to the repo, and shifts the maintenance burden of the simulation rules onto the team.
+
+## References
+
+- `engine/go.mod` — the Go module (monorepo root).
+- `engine/cmd/jsbsim/main.go` — the pure stdin/stdout CLI entrypoint.
+- `engine/internal/rng/rng.go` — the seedable PCG PRNG.
+- `.github/workflows/engine.yml` — CI enforcement (build, vet, test).
+- `ibl5/docs/JSB_FILE_FORMATS.md` — the binary file formats this engine's contract replaces.


### PR DESCRIPTION
## What

First PR of the program to replace JSB (`jumpshot.exe`) with a native Go simulation engine integrated into IBL5. This is the **walking skeleton**: the complete PHP↔Go JSON contract, Go module scaffold, seedable PRNG, CI, and a golden-master harness — with a **deliberately trivial placeholder sim**. Every later PR fills in real basketball formulas, each validated by the harness this PR establishes.

Plan: `~/.claude/plans/jsb-native-engine-pr1-walking-skeleton.md` (PR1 of a 9-PR Phase-1 program).

## Contents

- **`engine/`** Go module (monorepo root):
  - `internal/bundle` — input contract. JSON tags equal `ibl_plr` column names so the PR2 bundle-builder maps 1:1. `game_type` enum rejects values IBL never runs.
  - `internal/result` — output contract. Per-possession **event stream** (single source for box scores now + commentary later) + player/team box rows mapping 1:1 to **raw** `ibl_box_scores`/`ibl_box_scores_teams` columns (no MySQL-generated `calc_*`/`game_type`/`season_year`).
  - `internal/rng` — seedable `math/rand/v2` PCG; seed recorded per run (replay/audit).
  - `internal/sim` — **placeholder** (clearly commented), so the pipeline + golden test run end-to-end against real code.
  - `cmd/jsbsim` — pure stdin→stdout CLI, `--seed` override.
- **Pinned toolchain** (`go1.26.3`) so golden snapshots are reproducible across machines/CI (RNG output isn't guaranteed stable across Go minor versions; golden-master is the engine's primary regression mechanism).
- **`.github/workflows/engine.yml`** — build/vet/test, path-filtered to `engine/**`.
- **ADR-0035** — native Go sim engine decision (resolves the new-workflow ADR trigger).

The engine touches no DB, network, or web — that's PR2 (bundle builder) and PR8 (result loader).

## Verification

All 13 verification-matrix items are automated and green locally: Go build/vet, 5 test packages (contract round-trip, generated-column exclusion, event-stream fields, RNG determinism, seed override, golden-master, structural validity, negative paths — malformed JSON, unknown game_type, empty roster), and `check-docs`.

## Manual Testing

No manual testing needed — all verification is automated (Go test suite + CI).

Generated with [Claude Code](https://claude.ai/code)