### PR TITLE
feat(engine): DB→bundle builder (PR2 of native engine program)

### DIFF
--- a/ibl5/classes/EngineBundle/BundleSerializer.php
+++ b/ibl5/classes/EngineBundle/BundleSerializer.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle;
+
+use EngineBundle\Contracts\BundleSerializerInterface;
+use EngineBundle\Dto\Bundle;
+
+/**
+ * Serializes a {@see Bundle} to the JSON the Go engine decodes
+ * (engine/internal/bundle/bundle.go).
+ *
+ * This class is the single source of the JSON key spelling. Player fields are
+ * already keyed by the contract names (see {@see \EngineBundle\Dto\Player::FIELDS}),
+ * so they pass through; teams, games, and the envelope are mapped explicitly
+ * here — notably the schedule's `home_teamid`/`visitor_teamid`/`game_date` →
+ * `home_team_id`/`visitor_team_id`/`date`.
+ *
+ * Goal is decode-compatibility, not byte-identity: JSON object key order is
+ * irrelevant to Go's json.Unmarshal.
+ */
+final class BundleSerializer implements BundleSerializerInterface
+{
+    /**
+     * @see BundleSerializerInterface::serialize()
+     */
+    public function serialize(Bundle $bundle): string
+    {
+        $teams = [];
+        foreach ($bundle->teams as $team) {
+            $teams[] = [
+                'teamid' => $team->teamid,
+                'name' => $team->name,
+            ];
+        }
+
+        $players = [];
+        foreach ($bundle->players as $player) {
+            // Keys already equal the Go contract tags (== ibl_plr columns).
+            $players[] = $player->fields;
+        }
+
+        $schedule = [];
+        foreach ($bundle->schedule as $game) {
+            $schedule[] = [
+                'home_team_id' => $game->homeTeamId,
+                'visitor_team_id' => $game->visitorTeamId,
+                'date' => $game->date,
+                'game_type' => $game->gameType,
+            ];
+        }
+
+        $payload = [
+            'league_id' => $bundle->leagueId,
+            'seed' => $bundle->seed,
+            'teams' => $teams,
+            'players' => $players,
+            'schedule' => $schedule,
+        ];
+
+        return json_encode($payload, JSON_THROW_ON_ERROR);
+    }
+}

--- a/ibl5/classes/EngineBundle/Contracts/BundleSerializerInterface.php
+++ b/ibl5/classes/EngineBundle/Contracts/BundleSerializerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle\Contracts;
+
+use EngineBundle\Dto\Bundle;
+
+/**
+ * Serializes a {@see Bundle} to the JSON shape the Go engine decodes
+ * (engine/internal/bundle/bundle.go). This interface owns the contract: the
+ * JSON key spelling for teams, games, and the bundle envelope lives in the
+ * implementation, the single place that translates PHP/DB names to Go tags.
+ */
+interface BundleSerializerInterface
+{
+    public function serialize(Bundle $bundle): string;
+}

--- a/ibl5/classes/EngineBundle/Contracts/EngineBundleRepositoryInterface.php
+++ b/ibl5/classes/EngineBundle/Contracts/EngineBundleRepositoryInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle\Contracts;
+
+use EngineBundle\Dto\Game;
+use EngineBundle\Dto\Player;
+use EngineBundle\Dto\Team;
+
+/**
+ * Reads the live database for the three inputs the engine bundle needs:
+ * rosterable players, real teams, and the games still to simulate.
+ */
+interface EngineBundleRepositoryInterface
+{
+    /**
+     * All rosterable players (ordinal <= 1440 AND pid <> 0), each narrowed to
+     * the engine contract fields (see {@see Player::FIELDS}).
+     *
+     * @return list<Player>
+     */
+    public function getPlayers(): array;
+
+    /**
+     * All real franchises (teamid 1..{@see \League\League::MAX_REAL_TEAMID}),
+     * `name` = team_city + ' ' + team_name.
+     *
+     * @return list<Team>
+     */
+    public function getTeams(): array;
+
+    /**
+     * Games still to simulate for a season: unplayed games, identified by
+     * {@code visitor_score = 0 AND home_score = 0} (the league's canonical
+     * unplayed convention — see PowerRankingsUpdater / ScheduleHighlighter),
+     * optionally bounded by an inclusive game_date range.
+     *
+     * @param int         $seasonYear ibl_schedule.season_year
+     * @param string|null $startDate  inclusive lower bound (Y-m-d) or null
+     * @param string|null $endDate    inclusive upper bound (Y-m-d) or null
+     * @param int         $gameType   JSB game-type flag stamped on each Game (caller decides; default regular)
+     * @return list<Game>
+     */
+    public function getUnplayedGames(
+        int $seasonYear,
+        ?string $startDate = null,
+        ?string $endDate = null,
+        int $gameType = 2,
+    ): array;
+}

--- a/ibl5/classes/EngineBundle/Dto/Bundle.php
+++ b/ibl5/classes/EngineBundle/Dto/Bundle.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle\Dto;
+
+/**
+ * The complete engine input bundle: league id, seed, teams, players, and the
+ * games to simulate. Serialized to JSON by {@see \EngineBundle\BundleSerializer}
+ * for the Go engine to decode (engine/internal/bundle/bundle.go).
+ */
+final class Bundle
+{
+    /**
+     * @param list<Team>   $teams
+     * @param list<Player> $players
+     * @param list<Game>   $schedule
+     */
+    public function __construct(
+        public readonly int $leagueId,
+        public readonly int $seed,
+        public readonly array $teams,
+        public readonly array $players,
+        public readonly array $schedule,
+    ) {
+    }
+}

--- a/ibl5/classes/EngineBundle/Dto/Game.php
+++ b/ibl5/classes/EngineBundle/Dto/Game.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle\Dto;
+
+/**
+ * One scheduled game in the engine input bundle.
+ *
+ * Property names use PHP convention; the JSON key remapping to the Go contract
+ * (`home_team_id`, `visitor_team_id`, `date`, `game_type`) lives in
+ * {@see \EngineBundle\BundleSerializer}. The `ibl_schedule` source columns are
+ * `home_teamid` / `visitor_teamid` / `game_date` — neither matches the Go tag,
+ * so the mapping is explicit.
+ */
+final class Game
+{
+    public function __construct(
+        public readonly int $homeTeamId,
+        public readonly int $visitorTeamId,
+        public readonly string $date,
+        public readonly int $gameType,
+    ) {
+    }
+}

--- a/ibl5/classes/EngineBundle/Dto/Player.php
+++ b/ibl5/classes/EngineBundle/Dto/Player.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle\Dto;
+
+/**
+ * One player in the engine input bundle.
+ *
+ * The field names in {@see Player::FIELDS} are the SINGLE SOURCE OF TRUTH for
+ * the player contract: they are simultaneously (a) the `ibl_plr` column names,
+ * (b) the JSON keys the Go engine decodes (see engine/internal/bundle/bundle.go),
+ * and (c) the columns the repository SELECTs. They match 1:1 — no translation —
+ * which is the whole point of PR2's contract design.
+ *
+ * Every field is an int except `name`. Narrowing in {@see Player::fromRow()}
+ * guarantees ints serialize as JSON numbers (the Go struct expects numbers).
+ */
+final class Player
+{
+    /**
+     * The 44 contract fields, in Go-struct order. Column name == JSON key.
+     * (3 identity + 8 ODPT + 13 main ratings + 8 attributes + 12 depth.)
+     *
+     * @var list<string>
+     */
+    public const FIELDS = [
+        'pid', 'name', 'teamid',
+        // ODPT ratings (1-9)
+        'oo', 'od', 'r_drive_off', 'dd', 'po', 'pd', 'r_trans_off', 'td',
+        // Main ratings (0-99)
+        'r_fga', 'r_fgp', 'r_fta', 'r_ftp', 'r_3ga', 'r_3gp',
+        'r_orb', 'r_drb', 'r_ast', 'r_stl', 'r_tvr', 'r_blk', 'r_foul',
+        // Attributes
+        'age', 'stamina', 'clutch', 'consistency', 'talent', 'skill', 'intangibles', 'peak',
+        // Depth-chart settings
+        'dc_minutes', 'dc_pg_depth', 'dc_sg_depth', 'dc_sf_depth', 'dc_pf_depth', 'dc_c_depth',
+        'dc_can_play_in_game', 'dc_of', 'dc_df', 'dc_oi', 'dc_di', 'dc_bh',
+    ];
+
+    /** The only non-integer field. */
+    private const STRING_FIELDS = ['name'];
+
+    /**
+     * @param array<string, int|string> $fields keyed by {@see Player::FIELDS}; ints for all but `name`
+     */
+    public function __construct(public readonly array $fields)
+    {
+    }
+
+    /**
+     * Build a Player from a raw `ibl_plr` row, narrowing each contract field to
+     * its proper scalar type (mixed → int/string) so the JSON contract holds.
+     * Missing columns default to 0 / '' — but the SELECT lists every field, so
+     * this only guards against a NULL value.
+     *
+     * @param array<string, mixed> $row
+     */
+    public static function fromRow(array $row): self
+    {
+        $fields = [];
+        foreach (self::FIELDS as $field) {
+            $value = $row[$field] ?? null;
+            if (in_array($field, self::STRING_FIELDS, true)) {
+                $fields[$field] = is_string($value) ? $value : '';
+            } else {
+                $fields[$field] = is_int($value) ? $value : 0;
+            }
+        }
+
+        return new self($fields);
+    }
+}

--- a/ibl5/classes/EngineBundle/Dto/Team.php
+++ b/ibl5/classes/EngineBundle/Dto/Team.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle\Dto;
+
+/**
+ * One team in the engine input bundle. Serializes to {@code {"teamid": int, "name": string}}.
+ */
+final class Team
+{
+    public function __construct(
+        public readonly int $teamid,
+        public readonly string $name,
+    ) {
+    }
+}

--- a/ibl5/classes/EngineBundle/EmptyRosterException.php
+++ b/ibl5/classes/EngineBundle/EmptyRosterException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle;
+
+/**
+ * Thrown when no rosterable players are found, so the builder fails fast rather
+ * than emitting a bundle the engine would reject (its {@code ErrEmptyRoster}).
+ */
+final class EmptyRosterException extends \RuntimeException
+{
+}

--- a/ibl5/classes/EngineBundle/EmptyScheduleException.php
+++ b/ibl5/classes/EngineBundle/EmptyScheduleException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle;
+
+/**
+ * Thrown when a sim window yields zero games to simulate, so the builder fails
+ * fast in PHP with a clear message rather than emitting a bundle the engine
+ * would reject (its {@code ErrNoSchedule}).
+ */
+final class EmptyScheduleException extends \RuntimeException
+{
+}

--- a/ibl5/classes/EngineBundle/EngineBundleRepository.php
+++ b/ibl5/classes/EngineBundle/EngineBundleRepository.php
@@ -79,7 +79,7 @@ final class EngineBundleRepository extends \BaseMysqliRepository implements Engi
     ): array {
         // Canonical "unplayed" convention: both scores 0 (see PowerRankingsUpdater
         // line 129, ScheduleHighlighter). box_id is NOT a played flag.
-        $sql = "SELECT season_year, game_date, visitor_teamid, home_teamid
+        $sql = "SELECT game_date, visitor_teamid, home_teamid
                 FROM `ibl_schedule`
                 WHERE visitor_score = 0 AND home_score = 0 AND season_year = ?";
         $types = 'i';

--- a/ibl5/classes/EngineBundle/EngineBundleRepository.php
+++ b/ibl5/classes/EngineBundle/EngineBundleRepository.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle;
+
+use EngineBundle\Contracts\EngineBundleRepositoryInterface;
+use EngineBundle\Dto\Game;
+use EngineBundle\Dto\Player;
+use EngineBundle\Dto\Team;
+use League\League;
+
+/**
+ * Reads players, teams, and unplayed games for the engine input bundle.
+ *
+ * Mirrors the JsbExportRepository read pattern (static SELECT + per-field
+ * is_int/is_string narrowing). All reads are prepared statements via
+ * BaseMysqliRepository; the only user-supplied parameters are the season year
+ * and optional date range on getUnplayedGames(), which are bound, never
+ * interpolated.
+ */
+final class EngineBundleRepository extends \BaseMysqliRepository implements EngineBundleRepositoryInterface
+{
+    /**
+     * @see EngineBundleRepositoryInterface::getPlayers()
+     */
+    public function getPlayers(): array
+    {
+        // Column list is built from the hardcoded contract field list (no user
+        // input) — column name == JSON tag, so no aliasing is needed.
+        $columns = implode(', ', Player::FIELDS);
+
+        $rows = $this->fetchAll(
+            "SELECT $columns
+             FROM `ibl_plr`
+             WHERE ordinal <= 1440 AND pid <> 0
+             ORDER BY pid",
+        );
+
+        $players = [];
+        foreach ($rows as $row) {
+            $players[] = Player::fromRow($row);
+        }
+
+        return $players;
+    }
+
+    /**
+     * @see EngineBundleRepositoryInterface::getTeams()
+     */
+    public function getTeams(): array
+    {
+        $rows = $this->fetchAll(
+            "SELECT teamid, CONCAT(team_city, ' ', team_name) AS name
+             FROM `ibl_team_info`
+             WHERE teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
+             ORDER BY teamid",
+        );
+
+        $teams = [];
+        foreach ($rows as $row) {
+            $teams[] = new Team(
+                is_int($row['teamid']) ? $row['teamid'] : 0,
+                is_string($row['name']) ? $row['name'] : '',
+            );
+        }
+
+        return $teams;
+    }
+
+    /**
+     * @see EngineBundleRepositoryInterface::getUnplayedGames()
+     */
+    public function getUnplayedGames(
+        int $seasonYear,
+        ?string $startDate = null,
+        ?string $endDate = null,
+        int $gameType = 2,
+    ): array {
+        // Canonical "unplayed" convention: both scores 0 (see PowerRankingsUpdater
+        // line 129, ScheduleHighlighter). box_id is NOT a played flag.
+        $sql = "SELECT season_year, game_date, visitor_teamid, home_teamid
+                FROM `ibl_schedule`
+                WHERE visitor_score = 0 AND home_score = 0 AND season_year = ?";
+        $types = 'i';
+        $params = [$seasonYear];
+
+        // Bind the date bounds conditionally (mysqli has no NULL bind type).
+        if ($startDate !== null) {
+            $sql .= " AND game_date >= ?";
+            $types .= 's';
+            $params[] = $startDate;
+        }
+        if ($endDate !== null) {
+            $sql .= " AND game_date <= ?";
+            $types .= 's';
+            $params[] = $endDate;
+        }
+        $sql .= " ORDER BY game_date, id";
+
+        $rows = $this->fetchAll($sql, $types, ...$params);
+
+        $games = [];
+        foreach ($rows as $row) {
+            $games[] = new Game(
+                is_int($row['home_teamid']) ? $row['home_teamid'] : 0,
+                is_int($row['visitor_teamid']) ? $row['visitor_teamid'] : 0,
+                is_string($row['game_date']) ? $row['game_date'] : '',
+                $gameType,
+            );
+        }
+
+        return $games;
+    }
+}

--- a/ibl5/classes/EngineBundle/EngineBundleService.php
+++ b/ibl5/classes/EngineBundle/EngineBundleService.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineBundle;
+
+use EngineBundle\Contracts\BundleSerializerInterface;
+use EngineBundle\Contracts\EngineBundleRepositoryInterface;
+use EngineBundle\Dto\Bundle;
+
+/**
+ * Builds the engine input bundle JSON from the live database for a sim window.
+ *
+ * This is the production path: a real sim run calls buildBundleJson() to feed
+ * the Go engine. The caller decides which games and what game_type; the service
+ * does NOT infer playoff/ASG (ibl_schedule has no game-type column — that
+ * classification is a later PR's concern). Fails fast with a typed exception
+ * when the window has no games or no roster, rather than emitting a bundle the
+ * engine would reject.
+ */
+final class EngineBundleService
+{
+    /** IBL main league. */
+    public const DEFAULT_LEAGUE_ID = 1;
+
+    /** JSB regular-season game type (see engine GameType enum: 2/3 regular). */
+    public const DEFAULT_GAME_TYPE = 2;
+
+    public function __construct(
+        private readonly EngineBundleRepositoryInterface $repository,
+        private readonly BundleSerializerInterface $serializer,
+    ) {
+    }
+
+    /**
+     * Build the bundle JSON for a season's unplayed games.
+     *
+     * @param int         $seasonYear ibl_schedule.season_year
+     * @param string|null $startDate  inclusive game_date lower bound (Y-m-d) or null
+     * @param string|null $endDate    inclusive game_date upper bound (Y-m-d) or null
+     * @param int         $gameType   JSB game-type flag stamped on every game (default regular)
+     * @param int|null    $seed       explicit seed, or null to generate one in [0, PHP_INT_MAX]
+     * @param int         $leagueId   league id recorded in the bundle
+     *
+     * @throws EmptyScheduleException when the window yields no games to simulate
+     * @throws EmptyRosterException   when no rosterable players exist
+     */
+    public function buildBundleJson(
+        int $seasonYear,
+        ?string $startDate = null,
+        ?string $endDate = null,
+        int $gameType = self::DEFAULT_GAME_TYPE,
+        ?int $seed = null,
+        int $leagueId = self::DEFAULT_LEAGUE_ID,
+    ): string {
+        $schedule = $this->repository->getUnplayedGames($seasonYear, $startDate, $endDate, $gameType);
+        if ($schedule === []) {
+            throw new EmptyScheduleException(
+                "No unplayed games to simulate for season $seasonYear in the given window.",
+            );
+        }
+
+        $players = $this->repository->getPlayers();
+        if ($players === []) {
+            throw new EmptyRosterException('No rosterable players found (ordinal <= 1440, pid <> 0).');
+        }
+
+        $teams = $this->repository->getTeams();
+
+        // Seed in [0, PHP_INT_MAX] so it round-trips as a JSON number into Go's
+        // uint64 without overflowing PHP's signed int. The seed is recorded in
+        // the bundle (and echoed by the engine) so any run can be replayed.
+        $resolvedSeed = $seed ?? random_int(0, PHP_INT_MAX);
+
+        $bundle = new Bundle($leagueId, $resolvedSeed, $teams, $players, $schedule);
+
+        return $this->serializer->serialize($bundle);
+    }
+}

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -213,6 +213,9 @@
         <testsuite name="JsbParser Module Tests">
             <directory>tests/JsbParser</directory>
         </testsuite>
+        <testsuite name="EngineBundle Module Tests">
+            <directory>tests/EngineBundle</directory>
+        </testsuite>
         <testsuite name="Migration Module Tests">
             <directory>tests/Migration</directory>
         </testsuite>

--- a/ibl5/scripts/build-engine-bundle.php
+++ b/ibl5/scripts/build-engine-bundle.php
@@ -58,9 +58,12 @@ if (!is_string($yearOpt) || !ctype_digit($yearOpt)) {
     exit(1);
 }
 
+// Only non-negative integers are valid for every option (game-type, seed,
+// league-id). Reject negatives — a negative seed would wrap to a garbage value
+// in the engine's uint64 seed field. Invalid input falls back to the default.
 $intOpt = static function (string $key) use ($opts): ?int {
     $v = $opts[$key] ?? null;
-    return is_string($v) && ($v === '0' || ctype_digit(ltrim($v, '-'))) ? (int) $v : null;
+    return is_string($v) && ctype_digit($v) ? (int) $v : null;
 };
 $strOpt = static function (string $key) use ($opts): ?string {
     $v = $opts[$key] ?? null;

--- a/ibl5/scripts/build-engine-bundle.php
+++ b/ibl5/scripts/build-engine-bundle.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Build the native-engine input bundle JSON from the live database and print it
+ * to stdout. Pipe it into the Go engine: `php build-engine-bundle.php --year=2026 | jsbsim`.
+ *
+ * This is PR2 of the JSB native engine program — the production DB→bundle path.
+ * It does NOT invoke the engine or write results (that is PR8).
+ *
+ * Usage:
+ *   php build-engine-bundle.php --year=2026
+ *   php build-engine-bundle.php --year=2026 --start=2026-03-01 --end=2026-03-31
+ *   php build-engine-bundle.php --year=2026 --game-type=4 --seed=12345 --league-id=1
+ */
+
+use EngineBundle\BundleSerializer;
+use EngineBundle\EngineBundleRepository;
+use EngineBundle\EngineBundleService;
+
+// ── CLI-only guard ──────────────────────────────────────────────────────────
+if (PHP_SAPI !== 'cli') {
+    echo 'This script must be run from the command line.';
+    exit(1);
+}
+
+// ── Minimal bootstrap (mirrors scripts/bulkJsbImport.php) ─────────────────────
+$_SERVER['PHP_SELF'] = 'build-engine-bundle.php';
+$_SERVER['SERVER_NAME'] = 'localhost';
+$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// Worktree fix: vendor/ symlinks to the main repo, so PSR-4 resolves classes/
+// there; register the local classes/ dir so this worktree's code is used.
+$localClassesDir = realpath(__DIR__ . '/../classes');
+if ($localClassesDir !== false) {
+    spl_autoload_register(static function (string $class) use ($localClassesDir): void {
+        $path = $localClassesDir . '/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($path)) {
+            require_once $path;
+        }
+    });
+}
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../db/db.php';
+
+/** @var \mysqli $mysqli_db */
+
+// ── Parse CLI options ─────────────────────────────────────────────────────────
+$opts = getopt('', ['year:', 'start::', 'end::', 'game-type::', 'seed::', 'league-id::']);
+
+$yearOpt = $opts['year'] ?? null;
+if (!is_string($yearOpt) || !ctype_digit($yearOpt)) {
+    fwrite(STDERR, "build-engine-bundle: --year=<season_year> is required (integer).\n");
+    exit(1);
+}
+
+$intOpt = static function (string $key) use ($opts): ?int {
+    $v = $opts[$key] ?? null;
+    return is_string($v) && ($v === '0' || ctype_digit(ltrim($v, '-'))) ? (int) $v : null;
+};
+$strOpt = static function (string $key) use ($opts): ?string {
+    $v = $opts[$key] ?? null;
+    return is_string($v) && $v !== '' ? $v : null;
+};
+
+$service = new EngineBundleService(
+    new EngineBundleRepository($mysqli_db),
+    new BundleSerializer(),
+);
+
+try {
+    echo $service->buildBundleJson(
+        (int) $yearOpt,
+        $strOpt('start'),
+        $strOpt('end'),
+        $intOpt('game-type') ?? EngineBundleService::DEFAULT_GAME_TYPE,
+        $intOpt('seed'),
+        $intOpt('league-id') ?? EngineBundleService::DEFAULT_LEAGUE_ID,
+    ), PHP_EOL;
+} catch (\EngineBundle\EmptyScheduleException | \EngineBundle\EmptyRosterException $e) {
+    fwrite(STDERR, 'build-engine-bundle: ' . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/ibl5/tests/DatabaseIntegration/EngineBundleRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/EngineBundleRepositoryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use PHPUnit\Framework\Attributes\Group;
+
+use EngineBundle\Dto\Player;
+use EngineBundle\EngineBundleRepository;
+
+/**
+ * Tests EngineBundleRepository against real MariaDB — player, team, and
+ * unplayed-game reads for the engine input bundle. Self-inserts fixtures
+ * (transaction-rolled-back per test) so assertions don't depend on seed data.
+ */
+#[Group('database')]
+class EngineBundleRepositoryTest extends DatabaseTestCase
+{
+    private EngineBundleRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new EngineBundleRepository($this->db);
+    }
+
+    /** @return Player|null */
+    private function findPlayer(int $pid): ?Player
+    {
+        foreach ($this->repo->getPlayers() as $player) {
+            if ($player->fields['pid'] === $pid) {
+                return $player;
+            }
+        }
+        return null;
+    }
+
+    // ── getPlayers ───────────────────────────────────────────────────
+
+    public function testGetPlayersReturnsAll45ContractFieldsWithIntTeamid(): void
+    {
+        $this->insertTestPlayer(200000100, 'Bundle Test Player', [
+            'teamid' => 4,
+            'ordinal' => 50,
+            'oo' => 7,
+            'r_drive_off' => 6,
+            'r_3ga' => 40,
+            'dc_minutes' => 34,
+            'dc_can_play_in_game' => 1,
+            'stamina' => 88,
+        ]);
+
+        $player = $this->findPlayer(200000100);
+        self::assertNotNull($player, 'inserted player should be returned by getPlayers()');
+
+        // Every contract field present (structural invariant), no extras.
+        self::assertSame(Player::FIELDS, array_keys($player->fields));
+
+        // teamid is a native int (column is `teamid`, not `tid`).
+        self::assertIsInt($player->fields['teamid']);
+        self::assertSame(4, $player->fields['teamid']);
+        self::assertSame('Bundle Test Player', $player->fields['name']);
+        self::assertSame(7, $player->fields['oo']);
+        self::assertSame(6, $player->fields['r_drive_off']);
+        self::assertSame(34, $player->fields['dc_minutes']);
+    }
+
+    public function testGetPlayersExcludesHighOrdinals(): void
+    {
+        $this->insertTestPlayer(200000101, 'High Ordinal', ['ordinal' => 1500]);
+        self::assertNull($this->findPlayer(200000101), 'ordinal > 1440 must be excluded');
+    }
+
+    public function testGetPlayersNeverIncludesPidZero(): void
+    {
+        foreach ($this->repo->getPlayers() as $player) {
+            self::assertNotSame(0, $player->fields['pid']);
+        }
+    }
+
+    // ── getUnplayedGames ─────────────────────────────────────────────
+
+    public function testGetUnplayedGamesReturnsOnlyUnplayedForYear(): void
+    {
+        // Two unplayed (scores 0/0) + one played (scores > 0) in an isolated year.
+        $this->insertScheduleRow(2099, '2099-01-10', 2, 0, 1, 0);
+        $this->insertScheduleRow(2099, '2099-02-20', 4, 0, 3, 0);
+        $this->insertScheduleRow(2099, '2099-03-30', 6, 110, 5, 99); // played → excluded
+
+        $games = $this->repo->getUnplayedGames(2099);
+
+        self::assertCount(2, $games);
+        // Ordered by game_date; verify the home/visitor/date mapping.
+        self::assertSame('2099-01-10', $games[0]->date);
+        self::assertSame(1, $games[0]->homeTeamId);
+        self::assertSame(2, $games[0]->visitorTeamId);
+        self::assertSame(3, $games[1]->homeTeamId);
+    }
+
+    public function testGetUnplayedGamesEmptyWhenNoneUnplayed(): void
+    {
+        $this->insertScheduleRow(2098, '2098-01-10', 2, 101, 1, 95); // played only
+        self::assertSame([], $this->repo->getUnplayedGames(2098));
+    }
+
+    public function testGetUnplayedGamesAppliesDateRange(): void
+    {
+        $this->insertScheduleRow(2097, '2097-01-10', 2, 0, 1, 0);
+        $this->insertScheduleRow(2097, '2097-12-10', 4, 0, 3, 0);
+
+        // Range covering only the January game.
+        $games = $this->repo->getUnplayedGames(2097, '2097-01-01', '2097-06-30');
+        self::assertCount(1, $games);
+        self::assertSame('2097-01-10', $games[0]->date);
+    }
+
+    /**
+     * Security: the date bound is a bound parameter, not interpolated SQL. An
+     * injection-style endDate must NOT leak rows (an interpolated `OR '1'='1'`
+     * would return both inserted games; a bound literal returns none).
+     */
+    public function testGetUnplayedGamesDateParamIsBoundNotInterpolated(): void
+    {
+        $this->insertScheduleRow(2096, '2096-01-10', 2, 0, 1, 0);
+        $this->insertScheduleRow(2096, '2096-12-10', 4, 0, 3, 0);
+
+        $games = $this->repo->getUnplayedGames(2096, null, "2096-06-01' OR '1'='1");
+
+        // If the param were interpolated, the always-true OR would return both
+        // rows. Binding treats the value as a (non-)date literal → no leak.
+        self::assertLessThan(2, count($games));
+    }
+
+    // ── getTeams ─────────────────────────────────────────────────────
+
+    public function testGetTeamsConcatenatesCityAndName(): void
+    {
+        $teams = $this->repo->getTeams();
+        self::assertNotEmpty($teams, 'seed provides real teams 1..28');
+
+        // Cross-check the CONCAT against a direct column read (seed-independent).
+        $first = $teams[0];
+        $stmt = $this->db->prepare('SELECT team_city, team_name FROM `ibl_team_info` WHERE teamid = ?');
+        self::assertNotFalse($stmt);
+        $teamid = $first->teamid; // bind_param binds by reference; readonly props can't be bound directly
+        $stmt->bind_param('i', $teamid);
+        $stmt->execute();
+        /** @var array{team_city: string, team_name: string}|null $row */
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        self::assertNotNull($row);
+
+        self::assertSame($row['team_city'] . ' ' . $row['team_name'], $first->name);
+
+        // Real-team range only (Free Agents teamid 0 excluded).
+        foreach ($teams as $team) {
+            self::assertGreaterThanOrEqual(1, $team->teamid);
+            self::assertLessThanOrEqual(28, $team->teamid);
+        }
+    }
+}

--- a/ibl5/tests/EngineBundle/BundleSerializerTest.php
+++ b/ibl5/tests/EngineBundle/BundleSerializerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\EngineBundle;
+
+use EngineBundle\BundleSerializer;
+use EngineBundle\Dto\Bundle;
+use EngineBundle\Dto\Game;
+use EngineBundle\Dto\Player;
+use EngineBundle\Dto\Team;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies the serializer emits JSON whose keys/types match the Go engine
+ * contract in engine/internal/bundle/bundle.go exactly.
+ */
+class BundleSerializerTest extends TestCase
+{
+    private BundleSerializer $serializer;
+
+    protected function setUp(): void
+    {
+        $this->serializer = new BundleSerializer();
+    }
+
+    /**
+     * Decode a serialized one-of-each bundle to an assoc array.
+     *
+     * @param array<string, int|string> $playerOverrides
+     * @return array<string, mixed>
+     */
+    private function serializeAndDecode(array $playerOverrides = []): array
+    {
+        $row = array_fill_keys(Player::FIELDS, 0);
+        $row['name'] = 'Test Player';
+        $row = array_merge($row, $playerOverrides);
+
+        $bundle = new Bundle(
+            leagueId: 1,
+            seed: 42,
+            teams: [new Team(3, 'New York Metros')],
+            players: [Player::fromRow($row)],
+            schedule: [new Game(homeTeamId: 3, visitorTeamId: 7, date: '2026-03-12', gameType: 2)],
+        );
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($this->serializer->serialize($bundle), true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
+    }
+
+    public function testBundleEnvelopeHasContractKeys(): void
+    {
+        $decoded = $this->serializeAndDecode();
+        self::assertSame(
+            ['league_id', 'seed', 'teams', 'players', 'schedule'],
+            array_keys($decoded),
+        );
+        self::assertSame(1, $decoded['league_id']);
+        self::assertSame(42, $decoded['seed']);
+    }
+
+    public function testPlayerHasExactlyTheContractKeys(): void
+    {
+        $decoded = $this->serializeAndDecode();
+        /** @var list<array<string, mixed>> $players */
+        $players = $decoded['players'];
+        self::assertCount(1, $players);
+
+        // Exact contract: same keys, same order, nothing extra, nothing missing.
+        self::assertSame(Player::FIELDS, array_keys($players[0]));
+        // 3 identity + 8 ODPT + 13 main ratings + 8 attributes + 12 depth = 44.
+        self::assertCount(44, Player::FIELDS);
+    }
+
+    public function testPlayerScalarTypesMatchContract(): void
+    {
+        $decoded = $this->serializeAndDecode(['pid' => 101, 'teamid' => 3, 'oo' => 7, 'dc_minutes' => 34]);
+        /** @var list<array<string, mixed>> $players */
+        $players = $decoded['players'];
+        $p = $players[0];
+
+        self::assertIsInt($p['pid']);
+        self::assertIsInt($p['teamid']);
+        self::assertIsInt($p['oo']);
+        self::assertIsInt($p['dc_minutes']);
+        self::assertIsString($p['name']);
+        self::assertSame(101, $p['pid']);
+        self::assertSame('Test Player', $p['name']);
+    }
+
+    public function testTeamKeysMatchContract(): void
+    {
+        $decoded = $this->serializeAndDecode();
+        /** @var list<array<string, mixed>> $teams */
+        $teams = $decoded['teams'];
+        self::assertSame(['teamid', 'name'], array_keys($teams[0]));
+        self::assertSame(3, $teams[0]['teamid']);
+        self::assertSame('New York Metros', $teams[0]['name']);
+    }
+
+    public function testGameKeysAreRemappedToContract(): void
+    {
+        $decoded = $this->serializeAndDecode();
+        /** @var list<array<string, mixed>> $schedule */
+        $schedule = $decoded['schedule'];
+        // The DB columns are home_teamid/visitor_teamid/game_date — the contract
+        // tags are home_team_id/visitor_team_id/date. Assert the remapped form.
+        self::assertSame(['home_team_id', 'visitor_team_id', 'date', 'game_type'], array_keys($schedule[0]));
+        self::assertSame(3, $schedule[0]['home_team_id']);
+        self::assertSame(7, $schedule[0]['visitor_team_id']);
+        self::assertSame('2026-03-12', $schedule[0]['date']);
+        self::assertSame(2, $schedule[0]['game_type']);
+    }
+
+    /**
+     * Negative: a player row missing some fields must still emit all 45 keys
+     * (defaulted), never a silently-dropped key that would break the contract.
+     */
+    public function testMissingPlayerFieldsStillEmitAllContractKeys(): void
+    {
+        // fromRow with only a couple of fields present.
+        $player = Player::fromRow(['pid' => 5, 'name' => 'Sparse']);
+        $bundle = new Bundle(1, 1, [], [$player], [new Game(1, 2, '2026-01-01', 2)]);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($this->serializer->serialize($bundle), true, 512, JSON_THROW_ON_ERROR);
+        /** @var list<array<string, mixed>> $players */
+        $players = $decoded['players'];
+
+        self::assertSame(Player::FIELDS, array_keys($players[0]));
+        self::assertSame(5, $players[0]['pid']);
+        self::assertSame('Sparse', $players[0]['name']);
+        self::assertSame(0, $players[0]['dc_minutes']); // defaulted, present, int
+    }
+}

--- a/ibl5/tests/EngineBundle/BundleSerializerTest.php
+++ b/ibl5/tests/EngineBundle/BundleSerializerTest.php
@@ -114,8 +114,8 @@ class BundleSerializerTest extends TestCase
     }
 
     /**
-     * Negative: a player row missing some fields must still emit all 45 keys
-     * (defaulted), never a silently-dropped key that would break the contract.
+     * Negative: a player row missing some fields must still emit all 44 contract
+     * keys (defaulted), never a silently-dropped key that would break the contract.
      */
     public function testMissingPlayerFieldsStillEmitAllContractKeys(): void
     {

--- a/ibl5/tests/EngineBundle/EngineBundleServiceTest.php
+++ b/ibl5/tests/EngineBundle/EngineBundleServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\EngineBundle;
+
+use EngineBundle\BundleSerializer;
+use EngineBundle\Contracts\EngineBundleRepositoryInterface;
+use EngineBundle\Dto\Game;
+use EngineBundle\Dto\Player;
+use EngineBundle\Dto\Team;
+use EngineBundle\EmptyRosterException;
+use EngineBundle\EmptyScheduleException;
+use EngineBundle\EngineBundleService;
+use PHPUnit\Framework\TestCase;
+
+class EngineBundleServiceTest extends TestCase
+{
+    private function aGame(int $gameType = 2): Game
+    {
+        return new Game(homeTeamId: 1, visitorTeamId: 2, date: '2026-03-12', gameType: $gameType);
+    }
+
+    private function aPlayer(): Player
+    {
+        return Player::fromRow(['pid' => 101, 'name' => 'Test Player', 'teamid' => 1]);
+    }
+
+    /**
+     * @param list<Game>   $games
+     * @param list<Player> $players
+     */
+    private function stubRepo(array $games, array $players, ?Team $team = null): EngineBundleRepositoryInterface
+    {
+        $repo = self::createStub(EngineBundleRepositoryInterface::class);
+        $repo->method('getUnplayedGames')->willReturn($games);
+        $repo->method('getPlayers')->willReturn($players);
+        $repo->method('getTeams')->willReturn($team !== null ? [$team] : []);
+        return $repo;
+    }
+
+    /** @return array<string, mixed> */
+    private function buildAndDecode(EngineBundleRepositoryInterface $repo, ?int $seed = 42, int $gameType = 2): array
+    {
+        $service = new EngineBundleService($repo, new BundleSerializer());
+        $json = $service->buildBundleJson(2026, null, null, $gameType, $seed);
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
+    }
+
+    // ── Empty guards (negative paths) ────────────────────────────────
+
+    public function testThrowsWhenNoGamesToSimulate(): void
+    {
+        $service = new EngineBundleService($this->stubRepo([], [$this->aPlayer()]), new BundleSerializer());
+        $this->expectException(EmptyScheduleException::class);
+        $service->buildBundleJson(2026);
+    }
+
+    public function testThrowsWhenRosterEmpty(): void
+    {
+        $service = new EngineBundleService($this->stubRepo([$this->aGame()], []), new BundleSerializer());
+        $this->expectException(EmptyRosterException::class);
+        $service->buildBundleJson(2026);
+    }
+
+    // ── game_type flow ───────────────────────────────────────────────
+
+    public function testForwardsGameTypeToRepositoryAndOutput(): void
+    {
+        // Verify the service passes the caller's game_type to the repository,
+        // and the resulting game carries it in the output.
+        $repo = $this->createMock(EngineBundleRepositoryInterface::class);
+        $repo->expects($this->once())
+            ->method('getUnplayedGames')
+            ->with(2026, null, null, 4)
+            ->willReturn([$this->aGame(4)]);
+        $repo->method('getPlayers')->willReturn([$this->aPlayer()]);
+        $repo->method('getTeams')->willReturn([]);
+
+        $decoded = $this->buildAndDecode($repo, seed: 1, gameType: 4);
+        /** @var list<array<string, mixed>> $schedule */
+        $schedule = $decoded['schedule'];
+        self::assertSame(4, $schedule[0]['game_type']);
+    }
+
+    public function testDefaultGameTypeIsRegularSeason(): void
+    {
+        $decoded = $this->buildAndDecode($this->stubRepo([$this->aGame(2)], [$this->aPlayer()]));
+        /** @var list<array<string, mixed>> $schedule */
+        $schedule = $decoded['schedule'];
+        self::assertSame(2, $schedule[0]['game_type']);
+        self::assertSame(EngineBundleService::DEFAULT_GAME_TYPE, $schedule[0]['game_type']);
+    }
+
+    // ── seed ─────────────────────────────────────────────────────────
+
+    public function testPreservesExplicitSeed(): void
+    {
+        $decoded = $this->buildAndDecode($this->stubRepo([$this->aGame()], [$this->aPlayer()]), seed: 999);
+        self::assertSame(999, $decoded['seed']);
+    }
+
+    public function testGeneratesSeedInRangeWhenNull(): void
+    {
+        $decoded = $this->buildAndDecode($this->stubRepo([$this->aGame()], [$this->aPlayer()]), seed: null);
+        self::assertIsInt($decoded['seed']);
+        self::assertGreaterThanOrEqual(0, $decoded['seed']);
+        self::assertLessThanOrEqual(PHP_INT_MAX, $decoded['seed']);
+    }
+}


### PR DESCRIPTION
## What

PR2 of the JSB native engine program (PR1 #913 merged). Adds the **production path** that builds the engine's JSON input bundle from the live database, structurally compatible with the Go contract on master (`engine/internal/bundle/bundle.go`).

Plan: `~/.claude/plans/jsb-native-engine-pr2-db-bundle-builder.md`.

## Contents — new `ibl5/classes/EngineBundle/` module (Repository/Service split + `Contracts/` + `Dto/`)

- **`EngineBundleRepository`** — three reads via `BaseMysqliRepository` prepared statements:
  - `ibl_plr`: the 44 contract columns (column `teamid`, **not** `tid` — migration 114 unified it; no alias needed), filter `ordinal <= 1440 AND pid <> 0`.
  - `ibl_team_info`: real teams (1..`MAX_REAL_TEAMID`), `name` = `team_city + ' ' + team_name`.
  - `ibl_schedule`: unplayed games = `visitor_score = 0 AND home_score = 0` (the league's canonical convention per `PowerRankingsUpdater`/`ScheduleHighlighter` — **not** `box_id`); bound `season_year` + optional date range.
- **`BundleSerializer`** — single source of JSON-key spelling. Players pass through (keys == `ibl_plr` columns == Go tags); schedule remapped (`home_teamid`→`home_team_id`, `game_date`→`date`).
- **`EngineBundleService`** — window + `game_type` + seed → JSON; fails fast with typed `EmptyScheduleException`/`EmptyRosterException`; seed bounded to `[0, PHP_INT_MAX]` (round-trips into Go `uint64`). Caller supplies `game_type` (default 2); does not infer playoff/ASG (no schedule column — PR7/PR8).
- **`scripts/build-engine-bundle.php`** — thin CLI in `scripts/` (not `bin/`, so no ADR decision-trigger).

## Verification

- **Go/PHP field parity exact** — the Go `Player` struct's 44 `json:` tags equal `Player::FIELDS` (guards against silent zero-fill, which `json.Unmarshal` can't catch).
- **Cross-language contract** — a PHP-built bundle decodes in the real engine (exit 0); empty/malformed bundles are rejected (exit nonzero).
- **852 DB-integration tests** pass (self-inserting fixtures); **12 EngineBundle unit tests**; production + tests PHPStan clean; full suite (5790) green.
- **CLI end-to-end** — `--year=2008` → 880 KB bundle → engine exit 0; empty-window year → nonzero + stderr.

## Scope

Does NOT invoke the engine or write results (PR8). The `.plr`→bundle converter is deferred to PR9 — the `.plr` lacks `dc_minutes`/`stamina`/dc-roles (needs `.plb` + RE), and the engine's exact field needs aren't final until PR3–7.

## Manual Testing

No manual testing needed — all verification is automated (unit, DB-integration, cross-language contract, CLI).

Generated with [Claude Code](https://claude.ai/code)