### PR TITLE
engine(sim): PR3a — half-court possession engine + game driver

### DIFF
--- a/engine/internal/sim/ballhandler.go
+++ b/engine/internal/sim/ballhandler.go
@@ -1,0 +1,92 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/rng"
+
+// ballHandlerRating returns the ODPT rating that drives ball-handling
+// probability for a given lineup slot (00_MASTER_REFERENCE.md "Ball Handler
+// Selection"): slot 1 (PG) → drive offense, slots 2-3 (SG/SF) → outside
+// offense, slots 4-5 (PF/C) → post offense. Floored at 1 so an all-zero roster
+// still yields a valid, divide-by-zero-free distribution.
+func ballHandlerRating(p onCourt) int {
+	var r int
+	switch p.slot {
+	case slotPG:
+		r = p.DriveOff
+	case slotSG, slotSF:
+		r = p.OO
+	case slotPF, slotC:
+		r = p.PO
+	default:
+		r = p.OO
+	}
+	if r < 1 {
+		r = 1
+	}
+	return r
+}
+
+// ballHandlerShare is the JSB exponential-concentration share
+// rating / (team_total_for_that_rating − rating). The denominator is guarded so
+// a sole or dominant handler (team_total == rating) cannot divide by zero.
+func ballHandlerShare(rating, teamTotal int) float64 {
+	denom := teamTotal - rating
+	if denom <= 0 {
+		denom = 1
+	}
+	return float64(rating) / float64(denom)
+}
+
+// selectBallHandler picks which starter initiates the possession by weighted
+// random over each starter's ball-handling share. The team total is summed per
+// rating type (OO/DO/PO) exactly as the decompile does, so each starter's share
+// uses the correct denominator for its slot.
+func selectBallHandler(t *teamState, r *rng.RNG) onCourt {
+	var totOO, totDO, totPO int
+	for _, p := range t.players {
+		oo, do, po := p.OO, p.DriveOff, p.PO
+		if oo < 1 {
+			oo = 1
+		}
+		if do < 1 {
+			do = 1
+		}
+		if po < 1 {
+			po = 1
+		}
+		totOO += oo
+		totDO += do
+		totPO += po
+	}
+
+	shares := make([]float64, len(t.players))
+	var sum float64
+	for i, p := range t.players {
+		rating := ballHandlerRating(p)
+		var total int
+		switch p.slot {
+		case slotPG:
+			total = totDO
+		case slotSG, slotSF:
+			total = totOO
+		case slotPF, slotC:
+			total = totPO
+		default:
+			total = totOO
+		}
+		shares[i] = ballHandlerShare(rating, total)
+		sum += shares[i]
+	}
+
+	if sum <= 0 || len(t.players) == 0 {
+		return t.players[0]
+	}
+	roll := r.Float64() * sum
+	var acc float64
+	for i, s := range shares {
+		acc += s
+		if roll <= acc {
+			return t.players[i]
+		}
+	}
+	return t.players[len(t.players)-1]
+}

--- a/engine/internal/sim/ballhandler_test.go
+++ b/engine/internal/sim/ballhandler_test.go
@@ -1,0 +1,65 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// --- matrix #5: ball-handler share + slot→ODPT mapping ---------------------
+
+func TestBallHandlerRating_SlotMapping(t *testing.T) {
+	p := bundle.Player{OO: 7, DriveOff: 8, PO: 9}
+	cases := map[int]int{slotPG: 8, slotSG: 7, slotSF: 7, slotPF: 9, slotC: 9}
+	for slot, want := range cases {
+		if got := ballHandlerRating(oc(slot, p)); got != want {
+			t.Errorf("slot %d: rating = %d, want %d", slot, got, want)
+		}
+	}
+}
+
+func TestBallHandlerShare_Formula(t *testing.T) {
+	// share = rating / (team_total − rating)
+	if got := ballHandlerShare(4, 10); math.Abs(got-4.0/6.0) > 1e-9 {
+		t.Errorf("share = %v, want %v", got, 4.0/6.0)
+	}
+	// Denominator guard: a sole/dominant handler cannot divide by zero.
+	if got := ballHandlerShare(5, 5); got != 5.0 {
+		t.Errorf("guarded share = %v, want 5.0", got)
+	}
+}
+
+// --- matrix #6: all-1s ratings — no divide-by-zero / crash -----------------
+
+func TestSelectBallHandler_AllOnes(t *testing.T) {
+	tm := &teamState{}
+	for slot := slotPG; slot <= slotC; slot++ {
+		p := bundle.Player{OO: 1, DriveOff: 1, PO: 1}
+		tm.players = append(tm.players, oc(slot, p))
+	}
+	r := rng.New(7)
+	for i := 0; i < 1000; i++ {
+		got := selectBallHandler(tm, r) // must not panic / NaN
+		if got.slot < slotPG || got.slot > slotC {
+			t.Fatalf("invalid handler slot %d", got.slot)
+		}
+	}
+}
+
+func TestSelectBallHandler_FavorsHigherShare(t *testing.T) {
+	// One dominant outside scorer at SG should be picked far more often.
+	tm := &teamState{}
+	tm.players = append(tm.players, oc(slotPG, bundle.Player{PID: 1, DriveOff: 2, OO: 2, PO: 2}))
+	tm.players = append(tm.players, oc(slotSG, bundle.Player{PID: 2, OO: 9, DriveOff: 2, PO: 2}))
+	tm.players = append(tm.players, oc(slotSF, bundle.Player{PID: 3, OO: 2, DriveOff: 2, PO: 2}))
+	r := rng.New(11)
+	counts := map[int]int{}
+	for i := 0; i < 5000; i++ {
+		counts[selectBallHandler(tm, r).PID]++
+	}
+	if counts[2] <= counts[1] || counts[2] <= counts[3] {
+		t.Errorf("dominant handler not favored: %v", counts)
+	}
+}

--- a/engine/internal/sim/box.go
+++ b/engine/internal/sim/box.go
@@ -1,0 +1,131 @@
+package sim
+
+import (
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+)
+
+// slotName maps a lineup slot to its position string.
+func slotName(slot int) string {
+	switch slot {
+	case slotPG:
+		return "PG"
+	case slotSG:
+		return "SG"
+	case slotSF:
+		return "SF"
+	case slotPF:
+		return "PF"
+	case slotC:
+		return "C"
+	}
+	return ""
+}
+
+// bestDepthPos returns the position string of a player's lowest positive
+// depth-chart slot — used for the Pos field of non-starters (DNP/bench).
+func bestDepthPos(p bundle.Player) string {
+	best, bestDepth := "", 0
+	for slot := slotPG; slot <= slotC; slot++ {
+		d := slotDepth(p, slot)
+		if d <= 0 {
+			continue
+		}
+		if best == "" || d < bestDepth {
+			best, bestDepth = slotName(slot), d
+		}
+	}
+	return best
+}
+
+// newTeamState builds a team's live state: its fixed starters, a box-score row
+// for every rostered player in bundle order (DNP rows carry GameMIN == 0 with
+// all stats zero), and a PID index for stat accumulation. Starter minutes come
+// from dc_minutes (clamped 0..48).
+func newTeamState(allPlayers []bundle.Player, teamID int, isHome bool) *teamState {
+	starters := selectStarters(allPlayers, teamID)
+	starterSlot := make(map[int]int, len(starters))
+	for _, s := range starters {
+		starterSlot[s.PID] = s.slot
+	}
+
+	t := &teamState{
+		teamID:   teamID,
+		isHome:   isHome,
+		players:  starters,
+		byPID:    make(map[int]*result.PlayerBox),
+		quarters: make([]int, 0, 4),
+	}
+	for _, p := range allPlayers {
+		if p.TeamID != teamID {
+			continue
+		}
+		box := &result.PlayerBox{PID: p.PID}
+		if slot, ok := starterSlot[p.PID]; ok {
+			box.Pos = slotName(slot)
+			min := p.DCMinutes
+			if min < 0 {
+				min = 0
+			}
+			if min > 48 {
+				min = 48
+			}
+			box.GameMIN = min
+		} else {
+			box.Pos = bestDepthPos(p) // DNP/bench: GameMIN stays 0
+		}
+		t.boxes = append(t.boxes, box)
+		t.byPID[p.PID] = box
+	}
+	return t
+}
+
+// box returns the mutable box-score row for a PID (nil if not on the team).
+func (t *teamState) box(pid int) *result.PlayerBox { return t.byPID[pid] }
+
+// playerBoxes returns the team's player rows in bundle order.
+func (t *teamState) playerBoxes() []result.PlayerBox {
+	out := make([]result.PlayerBox, len(t.boxes))
+	for i, b := range t.boxes {
+		out[i] = *b
+	}
+	return out
+}
+
+// teamBox rolls the player rows up into team totals and lays the running
+// quarter scores into Q1–Q4 (+ OT). GameSTL/GameBLK/GameAST stay 0 here because
+// no player row ever sets them (steal/block attribution is PR3b; assists are
+// commentary-only, master-reference L1098).
+func (t *teamState) teamBox() result.TeamBox {
+	tb := result.TeamBox{TeamID: t.teamID, IsHome: t.isHome, OT: []int{}}
+	for _, b := range t.boxes {
+		tb.Game2GM += b.Game2GM
+		tb.Game2GA += b.Game2GA
+		tb.GameFTM += b.GameFTM
+		tb.GameFTA += b.GameFTA
+		tb.Game3GM += b.Game3GM
+		tb.Game3GA += b.Game3GA
+		tb.GameORB += b.GameORB
+		tb.GameDRB += b.GameDRB
+		tb.GameAST += b.GameAST
+		tb.GameSTL += b.GameSTL
+		tb.GameTOV += b.GameTOV
+		tb.GameBLK += b.GameBLK
+		tb.GamePF += b.GamePF
+	}
+	for i, pts := range t.quarters {
+		switch i {
+		case 0:
+			tb.Q1 = pts
+		case 1:
+			tb.Q2 = pts
+		case 2:
+			tb.Q3 = pts
+		case 3:
+			tb.Q4 = pts
+		default:
+			tb.OT = append(tb.OT, pts)
+		}
+	}
+	return tb
+}

--- a/engine/internal/sim/box_test.go
+++ b/engine/internal/sim/box_test.go
@@ -1,0 +1,57 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// --- matrix #22: box derivation rules --------------------------------------
+
+func TestBoxDerivation_DeferredStats(t *testing.T) {
+	res := Simulate(richBundle(), 1988)
+	g := res.Games[0]
+
+	var totalPF, totalFTA int
+	for _, pb := range g.PlayerBoxes {
+		// Steal/block attribution is PR3b; assists are commentary-only (L1098).
+		if pb.GameSTL != 0 || pb.GameBLK != 0 || pb.GameAST != 0 {
+			t.Errorf("player %d: STL/BLK/AST must be 0 in PR3a, got %d/%d/%d",
+				pb.PID, pb.GameSTL, pb.GameBLK, pb.GameAST)
+		}
+		totalPF += pb.GamePF
+		totalFTA += pb.GameFTA
+	}
+	if totalPF == 0 {
+		t.Error("no personal fouls charged across the game")
+	}
+	if totalFTA == 0 {
+		t.Error("no free-throw attempts across the game")
+	}
+}
+
+func TestFreeThrows_ChargesDefenderAndShooter(t *testing.T) {
+	b := richBundle()
+	offense := newTeamState(b.Players, 7, false)
+	defense := newTeamState(b.Players, 3, true)
+	shooter := offense.players[0]
+	defender := defense.players[0]
+	gs := &gameState{rng: rng.New(1), period: 1, clock: 600}
+
+	gs.freeThrows(offense, defense, shooter, defender, 2, 0)
+
+	if got := defense.box(defender.PID).GamePF; got != 1 {
+		t.Errorf("defender PF = %d, want 1", got)
+	}
+	sb := offense.box(shooter.PID)
+	if sb.GameFTA != 2 {
+		t.Errorf("shooter FTA = %d, want 2", sb.GameFTA)
+	}
+	if sb.GameFTM < 0 || sb.GameFTM > 2 {
+		t.Errorf("shooter FTM = %d, want 0..2", sb.GameFTM)
+	}
+	// Points scored equal makes.
+	if offense.score != sb.GameFTM {
+		t.Errorf("score %d != FTM %d", offense.score, sb.GameFTM)
+	}
+}

--- a/engine/internal/sim/freethrow.go
+++ b/engine/internal/sim/freethrow.go
@@ -1,0 +1,20 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/rng"
+
+// shootFreeThrows resolves n free-throw attempts for the shooter, one
+// independent roll each: made if FTP_value × fatigue ≥ rand_int(1,1000). Free
+// throws use current-energy fatigue (player[+0x24]) — distinct from FG make,
+// which uses base stamina — though in PR3a energy == base stamina so both are
+// ≈1.0. Returns the number made (always ≤ n).
+func shootFreeThrows(shooter onCourt, n int, r *rng.RNG) int {
+	value := shotValueFT(shooter.FTP)
+	fatigue := fatigueFactor(shooter.Stamina) // energy proxy (constant in PR3a)
+	made := 0
+	for i := 0; i < n; i++ {
+		if rollMake(value, fatigue, r) {
+			made++
+		}
+	}
+	return made
+}

--- a/engine/internal/sim/freethrow_test.go
+++ b/engine/internal/sim/freethrow_test.go
@@ -1,0 +1,42 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// --- matrix #19: per-attempt FTP make/miss; FTM ≤ FTA; 1 vs 2 attempts -----
+
+func TestShootFreeThrows(t *testing.T) {
+	r := rng.New(9)
+
+	// A 90% shooter over two attempts: made ∈ [0,2], usually high.
+	good := oc(slotPG, bundle.Player{FTP: 90, Stamina: 50})
+	totalMade, trials := 0, 5000
+	for i := 0; i < trials; i++ {
+		made := shootFreeThrows(good, 2, r)
+		if made < 0 || made > 2 {
+			t.Fatalf("made = %d, out of [0,2]", made)
+		}
+		totalMade += made
+	}
+	pct := float64(totalMade) / float64(trials*2)
+	if pct < 0.85 || pct > 0.95 {
+		t.Errorf("FT%% = %.3f, want ≈ 0.90", pct)
+	}
+
+	// And-one is a single attempt.
+	if made := shootFreeThrows(good, 1, r); made < 0 || made > 1 {
+		t.Errorf("and-one made = %d, want 0 or 1", made)
+	}
+
+	// A 0-rated shooter never makes one.
+	zero := oc(slotC, bundle.Player{FTP: 0, Stamina: 50})
+	for i := 0; i < 1000; i++ {
+		if made := shootFreeThrows(zero, 2, r); made != 0 {
+			t.Fatalf("FTP 0 made = %d, want 0", made)
+		}
+	}
+}

--- a/engine/internal/sim/gameloop.go
+++ b/engine/internal/sim/gameloop.go
@@ -1,0 +1,66 @@
+package sim
+
+import (
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+const (
+	quarterSeconds    = 720 // 12:00 regulation quarter
+	otSeconds         = 300 // 5:00 overtime period
+	regulationPeriods = 4
+	maxOvertime       = 20 // hard ceiling so a tied game always terminates
+)
+
+// simGame plays one scheduled game: four regulation quarters plus overtime
+// while tied, alternating possessions and decrementing the clock by a tempo-
+// derived possession length. It returns the full event stream and box scores,
+// visitor team first.
+func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) result.GameResult {
+	visitor := newTeamState(b.Players, g.VisitorTeamID, false)
+	home := newTeamState(b.Players, g.HomeTeamID, true)
+
+	gs := &gameState{rng: r}
+
+	// Possession length is constant per game in PR3a (factor 1.0, no per-game
+	// stat aggregates yet): average the two teams' base times.
+	baseTime := (teamBaseTime(visitor.players) + teamBaseTime(home.players)) / 2.0
+	step := possessionTime(baseTime)
+
+	// Tip-off winner starts on offense; possessions strictly alternate.
+	offense, defense := visitor, home
+	if r.IntN(2) == 1 {
+		offense, defense = home, visitor
+	}
+
+	playPeriod := func(period, seconds int) {
+		gs.period = period
+		gs.clock = seconds
+		for gs.clock > 0 {
+			possession(gs, offense, defense, period-1)
+			offense, defense = defense, offense
+			gs.clock -= step
+		}
+		gs.emit(result.Event{Kind: result.EventPeriodBoundary, Period: period, Clock: 0})
+	}
+
+	for period := 1; period <= regulationPeriods; period++ {
+		playPeriod(period, quarterSeconds)
+	}
+	for ot := 1; ot <= maxOvertime && visitor.score == home.score; ot++ {
+		playPeriod(regulationPeriods+ot, otSeconds)
+	}
+
+	gr := result.GameResult{
+		Date:          g.Date,
+		HomeTeamID:    g.HomeTeamID,
+		VisitorTeamID: g.VisitorTeamID,
+		GameOfThatDay: 1,
+		SimGameType:   int(g.GameType),
+		Events:        gs.events,
+		PlayerBoxes:   append(visitor.playerBoxes(), home.playerBoxes()...),
+		TeamBoxes:     []result.TeamBox{visitor.teamBox(), home.teamBox()},
+	}
+	return gr
+}

--- a/engine/internal/sim/golden_test.go
+++ b/engine/internal/sim/golden_test.go
@@ -57,3 +57,18 @@ func TestGolden(t *testing.T) {
 		t.Errorf("output does not match golden.json.\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
 }
+
+// #26 — determinism: the same seed must reproduce byte-identical output, and a
+// different seed must change it (otherwise the seed flow is dead).
+func TestDeterminism(t *testing.T) {
+	b := richBundle()
+	a1 := encode(t, Simulate(b, 1988))
+	a2 := encode(t, Simulate(b, 1988))
+	if !bytes.Equal(a1, a2) {
+		t.Error("same seed produced different output")
+	}
+	b3 := encode(t, Simulate(b, 1989))
+	if bytes.Equal(a1, b3) {
+		t.Error("different seeds produced identical output")
+	}
+}

--- a/engine/internal/sim/lineup.go
+++ b/engine/internal/sim/lineup.go
@@ -1,0 +1,69 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/bundle"
+
+// slotDepth returns the player's depth-chart value for the given slot (1=PG …
+// 5=C). A value <= 0 means "not in the rotation at this slot".
+func slotDepth(p bundle.Player, slot int) int {
+	switch slot {
+	case slotPG:
+		return p.DCPGDepth
+	case slotSG:
+		return p.DCSGDepth
+	case slotSF:
+		return p.DCSFDepth
+	case slotPF:
+		return p.DCPFDepth
+	case slotC:
+		return p.DCCDepth
+	}
+	return 0
+}
+
+// selectStarters picks the fixed PR3a lineup: per slot, the eligible player with
+// the lowest positive dc_*_depth. Each player starts at most one slot (greedy,
+// slots resolved PG→C); ties break toward bundle order for determinism. Players
+// who win no slot — and any with dc_can_play_in_game == 0 — do not start and end
+// the game as DNP rows. A team with fewer than five eligible players simply
+// returns fewer starters; the caller tolerates a short lineup.
+//
+// PR4 replaces this with the real 5-pass selection (dc_bh/di/oi/df/of) and
+// substitutions; PR3a is deliberately fixed-starter, no subs.
+func selectStarters(players []bundle.Player, teamID int) []onCourt {
+	roster := make([]bundle.Player, 0, len(players))
+	for _, p := range players {
+		if p.TeamID == teamID && p.DCCanPlayInGame != 0 {
+			roster = append(roster, p)
+		}
+	}
+
+	chosen := make(map[int]bool, 5)
+	starters := make([]onCourt, 0, 5)
+	for slot := slotPG; slot <= slotC; slot++ {
+		bestIdx := -1
+		bestDepth := 0
+		for i, p := range roster {
+			if chosen[p.PID] {
+				continue
+			}
+			d := slotDepth(p, slot)
+			if d <= 0 {
+				continue
+			}
+			if bestIdx == -1 || d < bestDepth {
+				bestIdx, bestDepth = i, d
+			}
+		}
+		if bestIdx == -1 {
+			continue // no eligible player for this slot
+		}
+		p := roster[bestIdx]
+		chosen[p.PID] = true
+		starters = append(starters, onCourt{
+			Player:  p,
+			slot:    slot,
+			fatigue: fatigueFactor(p.Stamina), // constant in PR3a (energy = base stamina)
+		})
+	}
+	return starters
+}

--- a/engine/internal/sim/lineup_test.go
+++ b/engine/internal/sim/lineup_test.go
@@ -1,0 +1,71 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// --- matrix #3: starter selection + constant-energy fatigue ----------------
+
+func TestSelectStarters_LowestPositiveDepthPerSlot(t *testing.T) {
+	players := []bundle.Player{
+		{PID: 1, TeamID: 7, DCPGDepth: 2, Stamina: 50, DCCanPlayInGame: 1}, // backup PG
+		{PID: 2, TeamID: 7, DCPGDepth: 1, Stamina: 50, DCCanPlayInGame: 1}, // starting PG
+		{PID: 3, TeamID: 7, DCSGDepth: 1, Stamina: 0, DCCanPlayInGame: 1},
+		{PID: 4, TeamID: 7, DCSFDepth: 1, Stamina: 99, DCCanPlayInGame: 1},
+		{PID: 5, TeamID: 7, DCPFDepth: 1, Stamina: 50, DCCanPlayInGame: 1},
+		{PID: 6, TeamID: 7, DCCDepth: 1, Stamina: 50, DCCanPlayInGame: 1},
+		{PID: 7, TeamID: 7, DCCDepth: 3, Stamina: 50, DCCanPlayInGame: 0},   // DNP flag
+		{PID: 99, TeamID: 3, DCPGDepth: 1, Stamina: 50, DCCanPlayInGame: 1}, // other team
+	}
+	starters := selectStarters(players, 7)
+	if len(starters) != 5 {
+		t.Fatalf("starters = %d, want 5", len(starters))
+	}
+	wantPID := map[int]int{slotPG: 2, slotSG: 3, slotSF: 4, slotPF: 5, slotC: 6}
+	for _, s := range starters {
+		if wantPID[s.slot] != s.PID {
+			t.Errorf("slot %d: starter PID = %d, want %d", s.slot, s.PID, wantPID[s.slot])
+		}
+		// Constant energy (= base stamina) → fatigue is exactly 1.0 for all.
+		if s.fatigue != 1.0 {
+			t.Errorf("PID %d: fatigue = %v, want 1.0", s.PID, s.fatigue)
+		}
+	}
+	// The depth-2 PG and the can't-play player must not be starters.
+	for _, s := range starters {
+		if s.PID == 1 || s.PID == 7 {
+			t.Errorf("PID %d should not start", s.PID)
+		}
+	}
+}
+
+// --- matrix #4: boundary — equal/missing depths, < 5 eligible --------------
+
+func TestSelectStarters_Boundaries(t *testing.T) {
+	// Two players tie at PG depth 1: the bundle-order-first one wins, the other
+	// is not double-assigned.
+	tie := []bundle.Player{
+		{PID: 10, TeamID: 7, DCPGDepth: 1, DCCanPlayInGame: 1},
+		{PID: 11, TeamID: 7, DCPGDepth: 1, DCCanPlayInGame: 1},
+		{PID: 12, TeamID: 7, DCSGDepth: 1, DCCanPlayInGame: 1},
+	}
+	starters := selectStarters(tie, 7)
+	if len(starters) != 2 { // only PG + SG slots fillable → < 5 eligible
+		t.Fatalf("starters = %d, want 2 (short lineup tolerated)", len(starters))
+	}
+	if starters[0].slot != slotPG || starters[0].PID != 10 {
+		t.Errorf("PG starter = PID %d (slot %d), want PID 10", starters[0].PID, starters[0].slot)
+	}
+	for _, s := range starters {
+		if s.PID == 11 {
+			t.Error("PID 11 should not start (tie loser, no other open slot)")
+		}
+	}
+
+	// Empty roster must not panic.
+	if got := selectStarters(nil, 7); len(got) != 0 {
+		t.Errorf("empty roster starters = %d, want 0", len(got))
+	}
+}

--- a/engine/internal/sim/matchup.go
+++ b/engine/internal/sim/matchup.go
@@ -1,0 +1,35 @@
+package sim
+
+// matchupQuality reimplements the deterministic 4-phase Matchup Quality
+// Calculator (FUN_004e3860). Its output feeds the play-outcome selector as the
+// "net advantage" that drives the and-one bucket weight.
+//
+// PR3a note: Phase 3 sums per-game defender aggregates (struct +0x350 / +0xDC8)
+// and Phase 4 adds the coaching-gated accumulator (CEngine+0x33F0). Neither is
+// available before PR4/PR-coaching, so both contribute 0 here, leaving
+// result = (0 + 0 − normalized) × 0.2 = −normalized × 0.2. The full four-phase
+// shape is implemented so later PRs populate the aggregates without changing
+// callers. The default-50 composite → 0.1 normalized behavior is exact.
+func matchupQuality(composite, energy int, defenders []onCourt) float64 {
+	// Phase 1 — rating normalization (composite defaults to 50 when zero).
+	if composite <= 0 {
+		composite = 50
+	}
+	normalized := float64(composite)*0.2 - 9.9
+
+	// Phase 2 — fatigue factor (1.0 in PR3a; energy = base stamina).
+	fatigue := fatigueFactor(energy)
+
+	// Phase 3 — defender loop. Per-game aggregates are 0 in PR3a, so each
+	// contribution is 0; the loop preserves the real structure.
+	var accumulated float64
+	const teamWeight = 1.0
+	for range defenders {
+		const perGameAggregate = 0.0 // +0x350 / +0xDC8 unavailable pre-PR4
+		accumulated += perGameAggregate * fatigue * teamWeight
+	}
+
+	// Phase 4 — final calibration. CEngine+0x33F0 accumulator is 0 in PR3a.
+	const phase4Accumulator = 0.0
+	return (accumulated + phase4Accumulator - normalized) * 0.2
+}

--- a/engine/internal/sim/matchup_test.go
+++ b/engine/internal/sim/matchup_test.go
@@ -1,0 +1,48 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+func threeDefenders() []onCourt {
+	return []onCourt{
+		oc(slotPG, bundle.Player{Stamina: 50}),
+		oc(slotSG, bundle.Player{Stamina: 50}),
+		oc(slotC, bundle.Player{Stamina: 50}),
+	}
+}
+
+// --- matrix #13: 4-phase deterministic; default-50 → 0.1 normalized --------
+
+func TestMatchupQuality_DefaultComposite(t *testing.T) {
+	// composite 50 → normalized 0.1 → result = (0 + 0 − 0.1) × 0.2 = −0.02.
+	got := matchupQuality(50, 50, threeDefenders())
+	if math.Abs(got-(-0.02)) > 1e-9 {
+		t.Errorf("matchupQuality(50) = %v, want -0.02", got)
+	}
+	// Deterministic: identical inputs reproduce the result exactly.
+	if again := matchupQuality(50, 50, threeDefenders()); again != got {
+		t.Errorf("non-deterministic: %v vs %v", got, again)
+	}
+}
+
+// --- matrix #14: boundary — zero composite defaults to 50; fatigue cap -----
+
+func TestMatchupQuality_Boundaries(t *testing.T) {
+	// Zero composite defaults to 50 → same −0.02.
+	if got := matchupQuality(0, 50, threeDefenders()); math.Abs(got-(-0.02)) > 1e-9 {
+		t.Errorf("zero composite = %v, want -0.02 (defaults to 50)", got)
+	}
+	// Fatigue caps at 1.0 even for very high energy — Phase-3 aggregates are 0
+	// in PR3a, so the result is unaffected and stays finite.
+	if got := matchupQuality(99, 100000, threeDefenders()); math.IsNaN(got) || math.IsInf(got, 0) {
+		t.Errorf("result not finite for huge energy: %v", got)
+	}
+	// fatigueFactor itself must cap at 1.0.
+	if got := fatigueFactor(100000); got != 1.0 {
+		t.Errorf("fatigueFactor(huge) = %v, want 1.0", got)
+	}
+}

--- a/engine/internal/sim/netadvantage.go
+++ b/engine/internal/sim/netadvantage.go
@@ -1,0 +1,29 @@
+package sim
+
+// netAdvantage is the core probability driver for a 2-point attempt:
+//
+//	net = offense_rating − position_penalty − defense_rating
+//
+// offense/defense are the ODPT pair for the chosen play type (outside → OO/OD,
+// drive → DO/DD, post → PO/PD). The shot-clock modifier subtracts 4.0 (a
+// rushed, end-of-clock look); the regular modifier is ×1.0. The playoff ×1.25
+// and ASG modes are deferred to PR7. Net may go negative — that is meaningful
+// (a bad matchup) and must not underflow.
+func netAdvantage(pt playType, handler, defender onCourt, penalty float64, shotClock bool) float64 {
+	var off, def float64
+	switch pt {
+	case playOutside:
+		off, def = floor1(handler.OO), floor1(defender.OD)
+	case playDrive:
+		off, def = floor1(handler.DriveOff), floor1(defender.DD)
+	case playPost:
+		off, def = floor1(handler.PO), floor1(defender.PD)
+	}
+
+	net := off - penalty - def
+	if shotClock {
+		net -= 4.0
+	}
+	net *= 1.0 // regular-game modifier; playoff ×1.25 deferred to PR7
+	return net
+}

--- a/engine/internal/sim/netadvantage_test.go
+++ b/engine/internal/sim/netadvantage_test.go
@@ -1,0 +1,47 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// --- matrix #11: net = offense − penalty − defense; modifiers --------------
+
+func TestNetAdvantage_Formula(t *testing.T) {
+	handler := oc(slotPG, bundle.Player{OO: 9, DriveOff: 7, PO: 4})
+	defender := oc(slotPG, bundle.Player{OD: 5, DD: 3, PD: 6})
+	const penalty = 2.0
+
+	// Outside: OO − penalty − OD = 9 − 2 − 5 = 2.0 (regular ×1.0).
+	if got := netAdvantage(playOutside, handler, defender, penalty, false); math.Abs(got-2.0) > 1e-9 {
+		t.Errorf("outside net = %v, want 2.0", got)
+	}
+	// Drive: DO − penalty − DD = 7 − 2 − 3 = 2.0.
+	if got := netAdvantage(playDrive, handler, defender, penalty, false); math.Abs(got-2.0) > 1e-9 {
+		t.Errorf("drive net = %v, want 2.0", got)
+	}
+	// Post: PO − penalty − PD = 4 − 2 − 6 = −4.0.
+	if got := netAdvantage(playPost, handler, defender, penalty, false); math.Abs(got-(-4.0)) > 1e-9 {
+		t.Errorf("post net = %v, want -4.0", got)
+	}
+	// Shot clock subtracts 4.0: outside 2.0 − 4.0 = −2.0.
+	if got := netAdvantage(playOutside, handler, defender, penalty, true); math.Abs(got-(-2.0)) > 1e-9 {
+		t.Errorf("shot-clock net = %v, want -2.0", got)
+	}
+}
+
+// --- matrix #12: boundary — shot clock can drive net negative --------------
+
+func TestNetAdvantage_GoesNegativeSafely(t *testing.T) {
+	handler := oc(slotC, bundle.Player{PO: 1})
+	defender := oc(slotC, bundle.Player{PD: 9})
+	got := netAdvantage(playPost, handler, defender, 5.0, true) // 1 − 5 − 9 − 4
+	if math.Abs(got-(-17.0)) > 1e-9 {
+		t.Errorf("net = %v, want -17.0", got)
+	}
+	if math.IsNaN(got) || math.IsInf(got, 0) {
+		t.Error("net not finite")
+	}
+}

--- a/engine/internal/sim/outcome.go
+++ b/engine/internal/sim/outcome.go
@@ -1,0 +1,107 @@
+package sim
+
+import (
+	"math"
+
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// outcomeCode is the shot-PATH the play-outcome selector returns (the two-stage
+// model: this picks the path; shot_decision later rolls make/miss inside the
+// 2pt/3pt paths). It is NOT a make/miss result.
+type outcomeCode int
+
+const (
+	outcome2pt      outcomeCode = 1 // 2-point attempt (make/miss rolled after)
+	outcome3pt      outcomeCode = 2 // 3-point attempt (make/miss rolled after)
+	outcomeAndOne   outcomeCode = 3 // made 2pt + 1 FT
+	outcomeFoulOnly outcomeCode = 4 // FTs, no field-goal attempt
+	outcomeTurnover outcomeCode = 5 // change of possession (no stealer in PR3a)
+)
+
+const turnoverDenom = 1793.0 // rand_int(1,1793) ≤ sqrt(def_value) → turnover
+
+// outcomeInputs holds the four play-outcome bucket weights plus the turnover
+// defensive value. In JSB these are copied ball-handler per-game doubles
+// (+0xD90 / +0xDB0 / +0xDE0 / +0xDF8) populated by per-half setup. PR3a has no
+// per-game doubles, so each is a documented rating-derived stand-in (assembled
+// in possession.go): 2pt = shot_value₂×fatigue, 3pt = shot_value₃×fatigue×3pt-
+// propensity, and-one = matchup_quality×0.25 + made-base, foul = (2−fatigue)×
+// defender-foul. The turnover value derives from ball-handler ball-security.
+type outcomeInputs struct {
+	twoPtWeight      float64
+	threePtWeight    float64
+	andOneWeight     float64
+	foulOnlyWeight   float64
+	turnoverDefValue float64
+}
+
+func (in outcomeInputs) weight(c outcomeCode) float64 {
+	var w float64
+	switch c {
+	case outcome2pt:
+		w = in.twoPtWeight
+	case outcome3pt:
+		w = in.threePtWeight
+	case outcomeAndOne:
+		w = in.andOneWeight
+	case outcomeFoulOnly:
+		w = in.foulOnlyWeight
+	}
+	if w < 0 {
+		return 0
+	}
+	return w
+}
+
+// allowedPaths returns the candidate path codes for the given forced mode.
+// PR3a implements the decompile's reject-retry loop by restricting the bucket
+// set up front — an equivalent, guaranteed-terminating formulation. Per spec:
+// forced_make forces {2pt-attempt(1), and-one(3)} (a high-percentage look);
+// shot_clock forces {3pt-attempt(2), foul-only(4)} (a heave or a clock-expiry
+// foul); a steal/transition play cannot be a 3pt attempt(2).
+func allowedPaths(forcedMake, shotClock, stealPlay bool) []outcomeCode {
+	switch {
+	case forcedMake:
+		return []outcomeCode{outcome2pt, outcomeAndOne}
+	case shotClock:
+		return []outcomeCode{outcome3pt, outcomeFoulOnly}
+	case stealPlay:
+		return []outcomeCode{outcome2pt, outcomeAndOne, outcomeFoulOnly}
+	default:
+		return []outcomeCode{outcome2pt, outcome3pt, outcomeAndOne, outcomeFoulOnly}
+	}
+}
+
+// selectOutcome picks the shot path by weighted random over the allowed buckets,
+// then applies the independent turnover override (suppressed under forced_make).
+func selectOutcome(in outcomeInputs, forcedMake, shotClock, stealPlay bool, r *rng.RNG) outcomeCode {
+	allowed := allowedPaths(forcedMake, shotClock, stealPlay)
+
+	var total float64
+	for _, c := range allowed {
+		total += in.weight(c)
+	}
+	path := allowed[0]
+	if total > 0 {
+		roll := r.Float64() * total
+		var acc float64
+		for _, c := range allowed {
+			acc += in.weight(c)
+			if roll <= acc {
+				path = c
+				break
+			}
+		}
+	}
+
+	// Independent turnover check (overrides the path roll). forced_make never
+	// turns over. PR3a credits no stealer — the possession just flips.
+	if !forcedMake {
+		tRoll := r.IntN(int(turnoverDenom)) + 1 // 1..1793
+		if float64(tRoll) <= math.Sqrt(in.turnoverDefValue) {
+			return outcomeTurnover
+		}
+	}
+	return path
+}

--- a/engine/internal/sim/outcome_test.go
+++ b/engine/internal/sim/outcome_test.go
@@ -1,0 +1,83 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// --- matrix #17: bucket selection at boundaries + turnover formula ---------
+
+func TestSelectOutcome_Proportional(t *testing.T) {
+	// 2pt:3pt weights 70:30, no other buckets, no turnover.
+	in := outcomeInputs{twoPtWeight: 70, threePtWeight: 30}
+	r := rng.New(2)
+	const n = 60000
+	counts := map[outcomeCode]int{}
+	for i := 0; i < n; i++ {
+		counts[selectOutcome(in, false, false, false, r)]++
+	}
+	frac2 := float64(counts[outcome2pt]) / n
+	if frac2 < 0.68 || frac2 > 0.72 {
+		t.Errorf("2pt frac = %.3f, want ≈ 0.70", frac2)
+	}
+	if counts[outcomeTurnover] != 0 {
+		t.Errorf("turnover should be impossible with def value 0, got %d", counts[outcomeTurnover])
+	}
+}
+
+func TestSelectOutcome_TurnoverFormula(t *testing.T) {
+	r := rng.New(4)
+	// sqrt(turnoverDefValue) = 1793 ≥ every rand_int(1,1793) → always turnover.
+	always := outcomeInputs{twoPtWeight: 100, turnoverDefValue: 1793 * 1793}
+	for i := 0; i < 3000; i++ {
+		if selectOutcome(always, false, false, false, r) != outcomeTurnover {
+			t.Fatal("max def value should force a turnover")
+		}
+	}
+	// Zero def value → never a turnover.
+	never := outcomeInputs{twoPtWeight: 100, turnoverDefValue: 0}
+	for i := 0; i < 3000; i++ {
+		if selectOutcome(never, false, false, false, r) == outcomeTurnover {
+			t.Fatal("zero def value should never turn over")
+		}
+	}
+}
+
+// --- matrix #18: boundaries — forced modes, single bucket, turnover --------
+
+func TestSelectOutcome_ForcedModes(t *testing.T) {
+	// All four path weights present; turnover disabled to isolate the path set.
+	in := outcomeInputs{twoPtWeight: 10, threePtWeight: 10, andOneWeight: 10, foulOnlyWeight: 10}
+	r := rng.New(6)
+
+	assertIn := func(name string, forcedMake, shotClock, steal bool, allowed map[outcomeCode]bool) {
+		for i := 0; i < 5000; i++ {
+			got := selectOutcome(in, forcedMake, shotClock, steal, r)
+			if !allowed[got] {
+				t.Fatalf("%s: produced disallowed outcome %d", name, got)
+			}
+		}
+	}
+	// forced_make → {2pt-attempt(1), and-one(3)} only; turnover suppressed.
+	assertIn("forced_make", true, false, false, map[outcomeCode]bool{outcome2pt: true, outcomeAndOne: true})
+	// shot_clock → {3pt-attempt(2), foul-only(4)} only (turnover off here).
+	assertIn("shot_clock", false, true, false, map[outcomeCode]bool{outcome3pt: true, outcomeFoulOnly: true})
+	// steal/transition play → never a 3pt attempt(2).
+	for i := 0; i < 5000; i++ {
+		if selectOutcome(in, false, false, true, r) == outcome3pt {
+			t.Fatal("steal play must never be a 3pt attempt")
+		}
+	}
+}
+
+func TestSelectOutcome_SingleBucket(t *testing.T) {
+	// Only the foul-only weight is nonzero → always selected (roll at 0..total).
+	in := outcomeInputs{foulOnlyWeight: 5}
+	r := rng.New(8)
+	for i := 0; i < 2000; i++ {
+		if got := selectOutcome(in, false, false, false, r); got != outcomeFoulOnly {
+			t.Fatalf("single-bucket selection = %d, want foul-only", got)
+		}
+	}
+}

--- a/engine/internal/sim/positionpenalty.go
+++ b/engine/internal/sim/positionpenalty.go
@@ -1,0 +1,52 @@
+package sim
+
+// positionMultipliers is the per-slot "league-average rating profile"
+// (00_MASTER_REFERENCE.md "Position Penalty"): expected_X = base × multiplier.
+// Indexed [slot-1] → {OO, DO, PO}.
+var positionMultipliers = [5][3]float64{
+	slotPG - 1: {1.0, 4.0, 4.0},
+	slotSG - 1: {3.0, 6.0, 3.0},
+	slotSF - 1: {3.0, 6.0, 3.0},
+	slotPF - 1: {3.0, 4.0, 5.0},
+	slotC - 1:  {3.0, 3.0, 6.0},
+}
+
+// penaltyBase is the rating-compression base (minutes × 1/96 + 1.0). It rises
+// from 1.0 (0 min) to 1.5 (48 min), so the penalty grows with playing time.
+func penaltyBase(minutes int) float64 {
+	if minutes < 0 {
+		minutes = 0
+	}
+	return float64(minutes)/96.0 + 1.0
+}
+
+// floor1 floors a rating at 1, matching the decompile's adjusted-rating floor.
+func floor1(r int) float64 {
+	if r < 1 {
+		return 1.0
+	}
+	return float64(r)
+}
+
+// positionPenalty is the rating-compression term subtracted from net advantage:
+//
+//	penalty = Σ((X − exp_X) × X) / (OO + DO + PO),  exp_X = base × slot_multiplier
+//
+// A rating that matches its slot's expected value contributes zero; a rating
+// above expectation pays a penalty scaling with the rating itself (so extreme
+// outside ratings at guard slots are compressed hardest), and a below-
+// expectation rating gives a small bonus. Verified against the master-reference
+// worked examples (Steph PG → +4.38, avg PG → −0.02, anti-PG → +2.38, C → 0.60).
+func positionPenalty(p onCourt) float64 {
+	oo, do, po := floor1(p.OO), floor1(p.DriveOff), floor1(p.PO)
+	base := penaltyBase(p.DCMinutes)
+	m := positionMultipliers[p.slot-1]
+	expOO, expDO, expPO := base*m[0], base*m[1], base*m[2]
+
+	num := (oo-expOO)*oo + (do-expDO)*do + (po-expPO)*po
+	den := oo + do + po
+	if den == 0 {
+		return 0
+	}
+	return num / den
+}

--- a/engine/internal/sim/positionpenalty_test.go
+++ b/engine/internal/sim/positionpenalty_test.go
@@ -1,0 +1,54 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// --- matrix #9: exact worked examples (base = 1.25 at 24 minutes) ----------
+
+func TestPositionPenalty_WorkedExamples(t *testing.T) {
+	cases := []struct {
+		name       string
+		slot       int
+		oo, do, po int
+		want       float64
+	}{
+		{"Steph-style PG", slotPG, 9, 5, 1, 4.3833},
+		{"avg PG matching exp", slotPG, 1, 5, 5, -0.0227},
+		{"anti-PG (post-up)", slotPG, 1, 5, 9, 2.3833},
+		{"Center OO1/DO2/PO9", slotC, 1, 2, 9, 0.6042},
+	}
+	for _, c := range cases {
+		p := oc(c.slot, bundle.Player{OO: c.oo, DriveOff: c.do, PO: c.po, DCMinutes: 24})
+		got := positionPenalty(p)
+		if math.Abs(got-c.want) > 0.01 {
+			t.Errorf("%s: penalty = %.4f, want ≈ %.4f", c.name, got, c.want)
+		}
+	}
+}
+
+// --- matrix #10: boundary — base at minutes 0 & 48, floor at 1 -------------
+
+func TestPenaltyBase_Bounds(t *testing.T) {
+	if got := penaltyBase(0); got != 1.0 {
+		t.Errorf("base(0) = %v, want 1.0", got)
+	}
+	if got := penaltyBase(48); got != 1.5 {
+		t.Errorf("base(48) = %v, want 1.5", got)
+	}
+	if got := penaltyBase(-5); got != 1.0 {
+		t.Errorf("base(neg) = %v, want 1.0 (clamped)", got)
+	}
+}
+
+func TestPositionPenalty_FloorAt1(t *testing.T) {
+	// Zero ratings are floored to 1 before the penalty math (no NaN/zero-div).
+	p := oc(slotPG, bundle.Player{OO: 0, DriveOff: 0, PO: 0, DCMinutes: 24})
+	got := positionPenalty(p)
+	if math.IsNaN(got) || math.IsInf(got, 0) {
+		t.Fatalf("penalty = %v, want finite", got)
+	}
+}

--- a/engine/internal/sim/possession.go
+++ b/engine/internal/sim/possession.go
@@ -1,0 +1,221 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/result"
+
+// maxOffensiveRebounds caps offensive-rebound continuations within a single
+// trip, guaranteeing the inner loop terminates even on a pathological roster.
+const maxOffensiveRebounds = 8
+
+// andOneBaseShare is the made-base term of the and-one bucket weight as a
+// fraction of the player's 2pt make value (and-ones are a small minority of
+// scoring plays). PR3a rating-derived stand-in for the per-game double +0xDE0.
+const andOneBaseShare = 0.05
+
+// turnoverPropensityScale maps a ball-handler's TVR rating to the turnover
+// roll threshold: sqrt(turnoverDefValue) ≈ TVR × scale, compared to
+// rand_int(1,1793). The scale is chosen so a typical handler turns the ball
+// over at a plausible rate; absolute turnover frequency is a validation-phase
+// calibration item (the real engine's local_44 is a per-game double of
+// unpinned scale). turnoverDefValue is squared so the spec's sqrt() recovers
+// this linear threshold.
+const turnoverPropensityScale = 5.8
+
+// defenderAtSlot returns the defender sharing the ball-handler's slot, falling
+// back to the first defender when no exact match exists (short lineup).
+func defenderAtSlot(d *teamState, slot int) onCourt {
+	for _, p := range d.players {
+		if p.slot == slot {
+			return p
+		}
+	}
+	return d.players[0]
+}
+
+// threePtPropensity is the share of a player's attempts that are 3-pointers,
+// from r_3ga / (r_fga + r_3ga). An unrated roster defaults to 0.25 so the engine
+// still attempts some 3s without dividing by zero.
+func threePtPropensity(p onCourt) float64 {
+	denom := p.FGA + p.TGA
+	if denom <= 0 {
+		return 0.25
+	}
+	return float64(p.TGA) / float64(denom)
+}
+
+// turnoverThreshold is the linear turnover roll threshold for a TVR rating; the
+// caller squares it so the outcome selector's sqrt() recovers this value.
+func turnoverThreshold(tvr int) float64 { return float64(tvr) * turnoverPropensityScale }
+
+// possession resolves one offensive trip: ball-handler selection, shot-type and
+// matchup resolution, the play-outcome path, and any free throws or rebounds.
+// Offensive rebounds continue the trip; a made shot, defensive rebound, or
+// turnover ends it. The caller flips possession after every trip.
+func possession(gs *gameState, offense, defense *teamState, periodIdx int) {
+	if len(offense.players) == 0 || len(defense.players) == 0 {
+		return
+	}
+	bh := selectBallHandler(offense, gs.rng)
+	gs.emit(result.Event{
+		Kind: result.EventPossessionStart, Period: gs.period, Clock: gs.clock, TeamID: offense.teamID,
+	})
+
+	for trip := 0; trip <= maxOffensiveRebounds; trip++ {
+		scoreDiff := offense.score - defense.score
+		matched := defenderAtSlot(defense, bh.slot)
+		pt := selectShotType(bh, matched, gs.rng)
+		def := selectDefender(defense, pt, gs.rng)
+
+		penalty := positionPenalty(bh)
+		net := netAdvantage(pt, bh, def, penalty, false)
+		mq := matchupQuality(bh.FGP, bh.Stamina, defense.players)
+
+		sv2 := applyClutch(shotValue2pt(net, bh.FGP, false), bh.Clutch, gs.period, scoreDiff)
+		in := outcomeInputs{
+			twoPtWeight:      sv2 * bh.fatigue,
+			threePtWeight:    shotValue3pt() * bh.fatigue * threePtPropensity(bh),
+			andOneWeight:     mq*0.25 + base2pt(bh.FGP)*andOneBaseShare,
+			foulOnlyWeight:   (2.0 - bh.fatigue) * floor1(bh.Foul),
+			turnoverDefValue: turnoverThreshold(bh.TVR) * turnoverThreshold(bh.TVR),
+		}
+
+		switch selectOutcome(in, false, false, false, gs.rng) {
+		case outcome2pt:
+			if made, ended := gs.shotAttempt(offense, defense, bh, sv2, result.ShotTwoPoint, periodIdx); ended {
+				if !made {
+					if cont, next := gs.rebound(offense, defense, periodIdx); cont {
+						bh = next
+						continue
+					}
+				}
+				return
+			}
+		case outcome3pt:
+			if made, ended := gs.shotAttempt(offense, defense, bh, shotValue3pt(), result.ShotThree, periodIdx); ended {
+				if !made {
+					if cont, next := gs.rebound(offense, defense, periodIdx); cont {
+						bh = next
+						continue
+					}
+				}
+				return
+			}
+		case outcomeAndOne:
+			gs.madeFieldGoal(offense, bh, result.ShotTwoPoint, periodIdx)
+			gs.freeThrows(offense, defense, bh, def, 1, periodIdx)
+			return
+		case outcomeFoulOnly:
+			gs.freeThrows(offense, defense, bh, def, 2, periodIdx)
+			return
+		case outcomeTurnover:
+			offense.box(bh.PID).GameTOV++
+			gs.emit(result.Event{
+				Kind: result.EventTurnover, Period: gs.period, Clock: gs.clock,
+				TeamID: offense.teamID, PlayerID: bh.PID,
+			})
+			return
+		}
+	}
+}
+
+// shotAttempt records a field-goal attempt of the given type, rolls make/miss,
+// and credits points/box stats. It returns (made, ended): ended is always true
+// for a single attempt; made distinguishes a basket from a miss so the caller
+// can route a miss to the rebound phase.
+func (gs *gameState) shotAttempt(offense, defense *teamState, shooter onCourt, shotValue float64, st result.ShotType, periodIdx int) (made, ended bool) {
+	box := offense.box(shooter.PID)
+	if st == result.ShotThree {
+		box.Game3GA++
+	} else {
+		box.Game2GA++
+	}
+	gs.emit(result.Event{
+		Kind: result.EventShotAttempt, Period: gs.period, Clock: gs.clock,
+		TeamID: offense.teamID, PlayerID: shooter.PID, ShotType: st,
+	})
+	if rollMake(shotValue, shooter.fatigue, gs.rng) {
+		gs.creditMadeFieldGoal(offense, shooter, st, periodIdx)
+		return true, true
+	}
+	gs.emit(result.Event{
+		Kind: result.EventShotMiss, Period: gs.period, Clock: gs.clock,
+		TeamID: offense.teamID, PlayerID: shooter.PID, ShotType: st,
+	})
+	return false, true
+}
+
+// madeFieldGoal records a guaranteed made 2pt (the and-one basket): attempt +
+// make + points.
+func (gs *gameState) madeFieldGoal(offense *teamState, shooter onCourt, st result.ShotType, periodIdx int) {
+	box := offense.box(shooter.PID)
+	if st == result.ShotThree {
+		box.Game3GA++
+	} else {
+		box.Game2GA++
+	}
+	gs.emit(result.Event{
+		Kind: result.EventShotAttempt, Period: gs.period, Clock: gs.clock,
+		TeamID: offense.teamID, PlayerID: shooter.PID, ShotType: st,
+	})
+	gs.creditMadeFieldGoal(offense, shooter, st, periodIdx)
+}
+
+// creditMadeFieldGoal increments the made counter, scores the points, and emits
+// the make event.
+func (gs *gameState) creditMadeFieldGoal(offense *teamState, shooter onCourt, st result.ShotType, periodIdx int) {
+	box := offense.box(shooter.PID)
+	pts := 2
+	if st == result.ShotThree {
+		box.Game3GM++
+		pts = 3
+	} else {
+		box.Game2GM++
+	}
+	offense.addPeriodPoints(periodIdx, pts)
+	gs.emit(result.Event{
+		Kind: result.EventShotMake, Period: gs.period, Clock: gs.clock,
+		TeamID: offense.teamID, PlayerID: shooter.PID, ShotType: st,
+	})
+}
+
+// freeThrows charges the foul to the contesting defender and resolves n
+// free-throw attempts for the shooter, scoring each make.
+func (gs *gameState) freeThrows(offense, defense *teamState, shooter, defender onCourt, n, periodIdx int) {
+	defense.box(defender.PID).GamePF++
+	gs.emit(result.Event{
+		Kind: result.EventFoul, Period: gs.period, Clock: gs.clock,
+		TeamID: defense.teamID, PlayerID: defender.PID,
+	})
+	box := offense.box(shooter.PID)
+	made := shootFreeThrows(shooter, n, gs.rng)
+	box.GameFTA += n
+	box.GameFTM += made
+	offense.addPeriodPoints(periodIdx, made)
+	gs.emit(result.Event{
+		Kind: result.EventFreeThrow, Period: gs.period, Clock: gs.clock,
+		TeamID: offense.teamID, PlayerID: shooter.PID, ShotType: result.ShotFreeThrow,
+	})
+}
+
+// rebound resolves a missed-shot rebound. It returns (offensiveRetained,
+// newHandler): when true, the offense kept the ball and newHandler continues the
+// trip; when false, the defense rebounded and the possession ends.
+func (gs *gameState) rebound(offense, defense *teamState, periodIdx int) (bool, onCourt) {
+	offStr := teamReboundStrength(offense, true)
+	defStr := teamReboundStrength(defense, false)
+	if gs.rng.Float64() < orebProbability(offStr, defStr) {
+		reb := selectRebounder(offense, true, gs.rng)
+		offense.box(reb.PID).GameORB++
+		gs.emit(result.Event{
+			Kind: result.EventRebound, Period: gs.period, Clock: gs.clock,
+			TeamID: offense.teamID, PlayerID: reb.PID, OffensiveRebound: true,
+		})
+		return true, reb
+	}
+	reb := selectRebounder(defense, false, gs.rng)
+	defense.box(reb.PID).GameDRB++
+	gs.emit(result.Event{
+		Kind: result.EventRebound, Period: gs.period, Clock: gs.clock,
+		TeamID: defense.teamID, PlayerID: reb.PID, OffensiveRebound: false,
+	})
+	return false, onCourt{}
+}

--- a/engine/internal/sim/rebound.go
+++ b/engine/internal/sim/rebound.go
@@ -1,0 +1,110 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/rng"
+
+// typeDefense returns the defender's defensive rating for a play type
+// (outside → OD, drive → DD, post → PD), floored at 1.
+func typeDefense(p onCourt, pt playType) float64 {
+	switch pt {
+	case playOutside:
+		return floor1(p.OD)
+	case playDrive:
+		return floor1(p.DD)
+	case playPost:
+		return floor1(p.PD)
+	}
+	return floor1(p.OD)
+}
+
+// selectDefender picks the contesting defender by weighted random over
+// (2.0 − fatigue) × def_rating. Tired defenders carry a larger (2−fatigue)
+// term, so offense is steered toward them; in PR3a fatigue ≈ 1.0, so the pick
+// is driven by the type-specific defensive rating. The chosen defender supplies
+// the net-advantage defense rating and is charged any foul on the possession.
+func selectDefender(d *teamState, pt playType, r *rng.RNG) onCourt {
+	weights := make([]float64, len(d.players))
+	var sum float64
+	for i, p := range d.players {
+		w := (2.0 - p.fatigue) * typeDefense(p, pt)
+		if w < 0 {
+			w = 0
+		}
+		weights[i] = w
+		sum += w
+	}
+	if sum <= 0 || len(d.players) == 0 {
+		return d.players[0]
+	}
+	roll := r.Float64() * sum
+	var acc float64
+	for i, w := range weights {
+		acc += w
+		if roll <= acc {
+			return d.players[i]
+		}
+	}
+	return d.players[len(d.players)-1]
+}
+
+// orebProbability is P(offensive rebound) = off/(off+def) × 0.5 + 0.25, floored
+// at .25 and capped at .75. Equal strengths give .50. Equal-zero strengths
+// (an all-unrated roster) are guarded to .50 with no divide-by-zero.
+func orebProbability(off, def float64) float64 {
+	denom := off + def
+	ratio := 0.5
+	if denom > 0 {
+		ratio = off / denom
+	}
+	p := ratio*0.5 + 0.25
+	if p < 0.25 {
+		p = 0.25
+	}
+	if p > 0.75 {
+		p = 0.75
+	}
+	return p
+}
+
+// teamReboundStrength sums a team's rebound rating × fatigue across its
+// starters, using offensive-rebound ratings when crashing the offensive glass
+// and defensive-rebound ratings otherwise.
+func teamReboundStrength(t *teamState, offensive bool) float64 {
+	var sum float64
+	for _, p := range t.players {
+		rating := floor1(p.DRB)
+		if offensive {
+			rating = floor1(p.ORB)
+		}
+		sum += rating * p.fatigue
+	}
+	return sum
+}
+
+// selectRebounder picks which player on the rebounding team is credited, by
+// weighted random over reb_rating × fatigue (ORB on an offensive board, DRB on
+// a defensive one).
+func selectRebounder(t *teamState, offensive bool, r *rng.RNG) onCourt {
+	weights := make([]float64, len(t.players))
+	var sum float64
+	for i, p := range t.players {
+		rating := floor1(p.DRB)
+		if offensive {
+			rating = floor1(p.ORB)
+		}
+		w := rating * p.fatigue
+		weights[i] = w
+		sum += w
+	}
+	if sum <= 0 || len(t.players) == 0 {
+		return t.players[0]
+	}
+	roll := r.Float64() * sum
+	var acc float64
+	for i, w := range weights {
+		acc += w
+		if roll <= acc {
+			return t.players[i]
+		}
+	}
+	return t.players[len(t.players)-1]
+}

--- a/engine/internal/sim/rebound_test.go
+++ b/engine/internal/sim/rebound_test.go
@@ -1,0 +1,76 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// --- matrix #20: defender weighting, OREB floor/ceil, rebounder weighting --
+
+func TestOrebProbability_FloorCeilEqual(t *testing.T) {
+	if got := orebProbability(0, 100); math.Abs(got-0.25) > 1e-9 {
+		t.Errorf("weak offense OREB = %v, want 0.25 floor", got)
+	}
+	if got := orebProbability(100, 0); math.Abs(got-0.75) > 1e-9 {
+		t.Errorf("dominant offense OREB = %v, want 0.75 ceil", got)
+	}
+	if got := orebProbability(50, 50); math.Abs(got-0.5) > 1e-9 {
+		t.Errorf("equal OREB = %v, want 0.50", got)
+	}
+}
+
+func TestSelectDefender_FavorsHigherRating(t *testing.T) {
+	d := &teamState{players: []onCourt{
+		oc(slotPG, bundle.Player{PID: 1, OD: 2, Stamina: 50}),
+		oc(slotSG, bundle.Player{PID: 2, OD: 9, Stamina: 50}), // strongest perimeter D
+		oc(slotSF, bundle.Player{PID: 3, OD: 2, Stamina: 50}),
+	}}
+	r := rng.New(13)
+	counts := map[int]int{}
+	for i := 0; i < 6000; i++ {
+		counts[selectDefender(d, playOutside, r).PID]++
+	}
+	if counts[2] <= counts[1] || counts[2] <= counts[3] {
+		t.Errorf("higher OD defender not favored: %v", counts)
+	}
+}
+
+func TestSelectRebounder_FavorsHigherRating(t *testing.T) {
+	tm := &teamState{players: []onCourt{
+		oc(slotPG, bundle.Player{PID: 1, DRB: 10, Stamina: 50}),
+		oc(slotC, bundle.Player{PID: 2, DRB: 90, Stamina: 50}), // dominant rebounder
+		oc(slotSF, bundle.Player{PID: 3, DRB: 10, Stamina: 50}),
+	}}
+	r := rng.New(17)
+	counts := map[int]int{}
+	for i := 0; i < 6000; i++ {
+		counts[selectRebounder(tm, false, r).PID]++
+	}
+	if counts[2] <= counts[1] || counts[2] <= counts[3] {
+		t.Errorf("dominant rebounder not favored: %v", counts)
+	}
+}
+
+// --- matrix #21: boundary — equal off/def → .50; all-1s no divide-by-zero --
+
+func TestRebound_Boundaries(t *testing.T) {
+	// Equal-zero strengths must not divide by zero and must give .50.
+	if got := orebProbability(0, 0); math.Abs(got-0.5) > 1e-9 {
+		t.Errorf("zero/zero OREB = %v, want 0.50", got)
+	}
+	// All-zero rebound ratings: ratings floor to 1, so selection still works.
+	tm := &teamState{players: []onCourt{
+		oc(slotPG, bundle.Player{PID: 1}),
+		oc(slotC, bundle.Player{PID: 2}),
+	}}
+	r := rng.New(19)
+	for i := 0; i < 1000; i++ {
+		got := selectRebounder(tm, true, r)
+		if got.PID != 1 && got.PID != 2 {
+			t.Fatalf("invalid rebounder PID %d", got.PID)
+		}
+	}
+}

--- a/engine/internal/sim/shotdecision.go
+++ b/engine/internal/sim/shotdecision.go
@@ -1,0 +1,75 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/rng"
+
+// PR3a calibration constants. The decompile assembles shot_value on a per-mille
+// scale (the make roll compares it to rand_int(1,1000)) using league_baseline
+// (CEngine+0x6638, the historical league-wide 2P%) and per-player per-game
+// bases (player[+0xD64] 2pt, +0xD68 FT). None of those league/per-game values
+// exist before validation phase, so PR3a derives them from the bundle's FGP/FTP
+// ratings and a named league baseline chosen to yield realistic splits
+// (~45% 2P / ~35% 3P / ~75% FT). These are documented stand-ins, refined when
+// the engine is validated against the historical .sco corpus.
+const (
+	leagueBaseline = 233.0 // per-mille; 3pt make = baseline×1.5 ≈ 350‰ (~35%)
+	fgpToPermille  = 9.0   // base 2pt make = FGP × this (FGP 50 → 450‰)
+	ftpToPermille  = 10.0  // FT make = FTP × this  (FTP 75 → 750‰)
+
+	netToShotValue   = 500.0 // _DAT_00669ef0 (0.5) × _DAT_0066ac40 (1000.0)
+	shotClock2ptMult = 1.3333333333
+	clutchScale      = 0.01
+	clutchOffset     = 0.98
+)
+
+// base2pt is the player's baseline 2pt make value in per-mille (player[+0xD64]
+// stand-in), derived from the FGP rating.
+func base2pt(fgp int) float64 { return float64(fgp) * fgpToPermille }
+
+// shotValue2pt assembles the 2-point make value. Normal:
+// net × 500 / baseline + base_2pt. Shot clock: base_2pt × 1.3333 (the corrected
+// per-player +0xD60 form — a rushed look ignores the matchup net advantage).
+func shotValue2pt(net float64, fgp int, shotClock bool) float64 {
+	if shotClock {
+		return base2pt(fgp) * shotClock2ptMult
+	}
+	return net*netToShotValue/leagueBaseline + base2pt(fgp)
+}
+
+// shotValue3pt is league-baseline × 1.5 — deliberately independent of net
+// advantage. ODPT ratings decide whether a 3pt is *attempted*, but once
+// attempted, make probability is identical for all players.
+func shotValue3pt() float64 { return leagueBaseline * 1.5 }
+
+// shotValueFT is the per-attempt free-throw value: the FTP rating, per-mille.
+func shotValueFT(ftp int) float64 { return float64(ftp) * ftpToPermille }
+
+func absInt(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+// clutchMultiplier is clutch_rating × 0.01 + 0.98 (range 0.98–1.03).
+func clutchMultiplier(clutch int) float64 {
+	return float64(clutch)*clutchScale + clutchOffset
+}
+
+// applyClutch scales a 2pt shot_value by the clutch multiplier, but only in the
+// clutch window: period 4 or later AND score differential within 5 points.
+// The 3pt path applies no clutch (its value stays league-baseline×1.5).
+func applyClutch(shotValue float64, clutch, period, scoreDiff int) float64 {
+	if period >= 4 && absInt(scoreDiff) < 6 {
+		return clutchMultiplier(clutch) * shotValue
+	}
+	return shotValue
+}
+
+// rollMake performs the final make/miss roll: effective = shot_value × fatigue;
+// made if effective ≥ rand_int(1,1000). FG make uses base-stamina fatigue
+// (≈1.0 in PR3a); free throws pass their own energy-based fatigue.
+func rollMake(shotValue, fatigue float64, r *rng.RNG) bool {
+	effective := shotValue * fatigue
+	roll := r.IntN(1000) + 1 // 1..1000
+	return effective >= float64(roll)
+}

--- a/engine/internal/sim/shotdecision_test.go
+++ b/engine/internal/sim/shotdecision_test.go
@@ -1,0 +1,78 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// --- matrix #15: shot_value assembly + clutch + fatigue --------------------
+
+func TestShotValue_Assembly(t *testing.T) {
+	// 2pt normal: net × 500 / baseline + FGP × 9
+	want2 := 2.0*netToShotValue/leagueBaseline + 50*fgpToPermille
+	if got := shotValue2pt(2.0, 50, false); math.Abs(got-want2) > 1e-9 {
+		t.Errorf("2pt = %v, want %v", got, want2)
+	}
+	// 2pt shot clock: FGP × 9 × 1.3333 (ignores net)
+	wantSC := 50 * fgpToPermille * shotClock2ptMult
+	if got := shotValue2pt(999.0, 50, true); math.Abs(got-wantSC) > 1e-6 {
+		t.Errorf("2pt shot-clock = %v, want %v", got, wantSC)
+	}
+	// 3pt: baseline × 1.5
+	if got := shotValue3pt(); math.Abs(got-leagueBaseline*1.5) > 1e-9 {
+		t.Errorf("3pt = %v, want %v", got, leagueBaseline*1.5)
+	}
+	// FT: FTP × 10
+	if got := shotValueFT(75); math.Abs(got-750) > 1e-9 {
+		t.Errorf("FT = %v, want 750", got)
+	}
+	// Clutch multiplier: rating 5 → 1.03.
+	if got := clutchMultiplier(5); math.Abs(got-1.03) > 1e-9 {
+		t.Errorf("clutchMult(5) = %v, want 1.03", got)
+	}
+}
+
+// --- matrix #16: boundaries — 3pt ignores net, rand bounds, clutch gate ----
+
+func TestShotValue3pt_IgnoresNet(t *testing.T) {
+	// There is no net parameter; the value is constant regardless of matchup.
+	if shotValue3pt() != leagueBaseline*1.5 {
+		t.Error("3pt shot value must be league-baseline×1.5, independent of net advantage")
+	}
+}
+
+func TestRollMake_Bounds(t *testing.T) {
+	r := rng.New(1)
+	// effective = 1000 ≥ rand_int(1,1000) for every roll → always made.
+	for i := 0; i < 2000; i++ {
+		if !rollMake(1000, 1.0, r) {
+			t.Fatal("shot_value 1000 should always make (roll ≤ 1000)")
+		}
+	}
+	// effective = 0.5 < 1 ≤ rand → never made.
+	for i := 0; i < 2000; i++ {
+		if rollMake(0.5, 1.0, r) {
+			t.Fatal("shot_value 0.5 should never make")
+		}
+	}
+}
+
+func TestApplyClutch_Gate(t *testing.T) {
+	const sv = 100.0
+	// In the window (Q4+, |diff| < 6): scaled by 1.03.
+	if got := applyClutch(sv, 5, 4, 0); math.Abs(got-103) > 1e-9 {
+		t.Errorf("Q4 diff 0 = %v, want 103", got)
+	}
+	if got := applyClutch(sv, 5, 5, 5); math.Abs(got-103) > 1e-9 {
+		t.Errorf("OT diff 5 = %v, want 103", got)
+	}
+	// Outside the window: unchanged.
+	if got := applyClutch(sv, 5, 3, 0); got != sv {
+		t.Errorf("pre-Q4 = %v, want %v (no clutch)", got, sv)
+	}
+	if got := applyClutch(sv, 5, 4, 6); got != sv {
+		t.Errorf("diff 6 = %v, want %v (not < 6)", got, sv)
+	}
+}

--- a/engine/internal/sim/shotselect.go
+++ b/engine/internal/sim/shotselect.go
@@ -1,0 +1,55 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/rng"
+
+// shotTypeWeights is the per-slot matchup tax/bonus table (00_MASTER_REFERENCE
+// "Shot Type Selection"), indexed [slot-1] → {OO_wt, DO_wt, PO_wt}. The offense
+// subtracts its own slot's weight and adds the defender's slot weight per
+// category, so an aligned matchup cancels and a mismatch skews attempts toward
+// the defender's weak play type. These control which play type is *attempted*,
+// not how good its net advantage is.
+var shotTypeWeights = [5][3]int{
+	slotPG - 1: {9, 9, 1},
+	slotSG - 1: {8, 8, 3},
+	slotSF - 1: {7, 7, 5},
+	slotPF - 1: {5, 5, 7},
+	slotC - 1:  {4, 4, 8},
+}
+
+// adjustedShotWeights returns the floored adjusted OO/DO/PO weights for a
+// handler defended by the given defender. Each adjusted rating is floored at 1
+// so every play type keeps a positive selection probability (no NaN/zero-sum).
+func adjustedShotWeights(handler, defender onCourt) (oo, do, po float64) {
+	off := shotTypeWeights[handler.slot-1]
+	def := shotTypeWeights[defender.slot-1]
+	adj := func(rating, offW, defW int) float64 {
+		v := rating - offW + defW
+		if v < 1 {
+			v = 1
+		}
+		return float64(v)
+	}
+	oo = adj(int(floor1(handler.OO)), off[0], def[0])
+	do = adj(int(floor1(handler.DriveOff)), off[1], def[1])
+	po = adj(int(floor1(handler.PO)), off[2], def[2])
+	return
+}
+
+// selectShotType picks the offensive play type (outside / drive / post) by
+// weighted random over the adjusted ODPT weights. P(type) = adj / Σadj.
+func selectShotType(handler, defender onCourt, r *rng.RNG) playType {
+	oo, do, po := adjustedShotWeights(handler, defender)
+	sum := oo + do + po
+	if sum <= 0 {
+		return playOutside
+	}
+	roll := r.Float64() * sum
+	switch {
+	case roll <= oo:
+		return playOutside
+	case roll <= oo+do:
+		return playDrive
+	default:
+		return playPost
+	}
+}

--- a/engine/internal/sim/shotselect_test.go
+++ b/engine/internal/sim/shotselect_test.go
@@ -1,0 +1,65 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// --- matrix #7: shot-type selection proportional to adjusted weights -------
+
+func TestSelectShotType_Proportional(t *testing.T) {
+	// Aligned PG-vs-PG matchup: the off/def weights cancel, so adjusted weights
+	// equal the floored raw ratings (OO=6, DO=3, PO=1) → 6:3:1.
+	handler := oc(slotPG, bundle.Player{OO: 6, DriveOff: 3, PO: 1})
+	defender := oc(slotPG, bundle.Player{})
+	oo, do, po := adjustedShotWeights(handler, defender)
+	if oo != 6 || do != 3 || po != 1 {
+		t.Fatalf("adjusted weights = %v/%v/%v, want 6/3/1", oo, do, po)
+	}
+
+	r := rng.New(3)
+	const n = 60000
+	counts := map[playType]int{}
+	for i := 0; i < n; i++ {
+		counts[selectShotType(handler, defender, r)]++
+	}
+	check := func(pt playType, wantFrac float64) {
+		got := float64(counts[pt]) / n
+		if got < wantFrac-0.02 || got > wantFrac+0.02 {
+			t.Errorf("playType %d frac = %.3f, want ≈ %.3f", pt, got, wantFrac)
+		}
+	}
+	check(playOutside, 0.6)
+	check(playDrive, 0.3)
+	check(playPost, 0.1)
+}
+
+// --- matrix #8: boundary — floor at 1, all-1s valid distribution -----------
+
+func TestAdjustedShotWeights_FloorAt1(t *testing.T) {
+	// A C-slot handler (off weights {4,4,8}) defended by a PG (def {9,9,1}) with
+	// minimal ratings would go negative without the floor.
+	handler := oc(slotC, bundle.Player{OO: 1, DriveOff: 1, PO: 1})
+	defender := oc(slotPG, bundle.Player{})
+	oo, do, po := adjustedShotWeights(handler, defender)
+	for _, v := range []float64{oo, do, po} {
+		if v < 1 {
+			t.Errorf("adjusted weight %v below floor 1", v)
+		}
+	}
+}
+
+func TestSelectShotType_AllOnes(t *testing.T) {
+	handler := oc(slotSF, bundle.Player{OO: 1, DriveOff: 1, PO: 1})
+	defender := oc(slotSF, bundle.Player{OO: 1, DriveOff: 1, PO: 1})
+	r := rng.New(5)
+	seen := map[playType]bool{}
+	for i := 0; i < 3000; i++ {
+		seen[selectShotType(handler, defender, r)] = true // must not panic
+	}
+	if len(seen) == 0 {
+		t.Error("no play types produced")
+	}
+}

--- a/engine/internal/sim/sim.go
+++ b/engine/internal/sim/sim.go
@@ -1,13 +1,19 @@
-// Package sim is the JSB-compatible basketball simulation core.
+// Package sim is the JSB-compatible basketball simulation core: a half-court
+// possession engine and game driver translated from the JSB 5.60 decompile
+// (see 00_MASTER_REFERENCE.md). Each possession resolves through ball-handler
+// selection → shot-type selection → position penalty → net advantage → matchup
+// quality → play-outcome path → make/miss (or free throws) → rebound/turnover,
+// emitting a per-possession event stream and accumulating box scores. The
+// driver wraps possessions in four quarters plus overtime, with a fixed
+// starting lineup and constant energy (fatigue ≈ 1.0).
 //
-// ⚠️ PLACEHOLDER (PR1 — the "walking skeleton"). This does NOT simulate
-// basketball. It emits structurally-valid, deterministic output so the full
-// input→output pipeline, the PHP↔Go JSON contract, and the golden-master
-// harness are real and tested end-to-end. The actual possession loop, lineup
-// selection, energy/fatigue, stat aggregation, injuries, and game-type modes
-// are implemented in later PRs (PR3+), each validated against the historical
-// .sco corpus by the harness this scaffolding establishes. Do not mistake these
-// degenerate stat lines for accurate output.
+// PR3a scope: half-court only. Steal/block attribution and the fast-break /
+// transition system are PR3b; substitutions and energy drain are PR4; playoff
+// and all-star modifiers are PR7. Where a JSB formula needs a per-game stat
+// aggregate or league constant that does not exist before validation phase, the
+// engine uses a documented rating-derived stand-in (see the per-file notes);
+// probabilistic decisions reimplement the *probability* via the seedable PCG
+// (rng) so a given seed always replays identically.
 package sim
 
 import (
@@ -16,8 +22,8 @@ import (
 	"github.com/a-jay85/IBL5/engine/internal/rng"
 )
 
-// Simulate runs the (placeholder) engine over every game in the bundle and
-// returns a deterministic Result keyed to the given seed.
+// Simulate runs the engine over every game in the bundle and returns a
+// deterministic Result keyed to the given seed.
 func Simulate(b bundle.Bundle, seed uint64) result.Result {
 	r := rng.New(seed)
 	res := result.Result{Seed: seed, Games: make([]result.GameResult, 0, len(b.Schedule))}
@@ -25,135 +31,4 @@ func Simulate(b bundle.Bundle, seed uint64) result.Result {
 		res.Games = append(res.Games, simGame(b, g, r))
 	}
 	return res
-}
-
-// simGame produces a deterministic placeholder result for one game. The tip-off
-// is seed-dependent so that changing the seed genuinely changes output (which
-// makes the seed-flow and golden-master tests meaningful), but the stat lines
-// themselves are fixed/degenerate.
-func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) result.GameResult {
-	gr := result.GameResult{
-		Date:          g.Date,
-		HomeTeamID:    g.HomeTeamID,
-		VisitorTeamID: g.VisitorTeamID,
-		GameOfThatDay: 1,
-		SimGameType:   int(g.GameType),
-		Events:        []result.Event{},
-		PlayerBoxes:   []result.PlayerBox{},
-	}
-
-	tipTeam := g.VisitorTeamID
-	if r.IntN(2) == 1 {
-		tipTeam = g.HomeTeamID
-	}
-	gr.Events = append(gr.Events, result.Event{
-		Kind: result.EventPossessionStart, Period: 1, Clock: 720, TeamID: tipTeam,
-	})
-
-	vLines := linesFor(b.Players, g.VisitorTeamID)
-	hLines := linesFor(b.Players, g.HomeTeamID)
-
-	// One representative scoring sequence so the event stream exercises the
-	// shot_attempt/shot_make kinds and the ShotType field.
-	if len(vLines) > 0 {
-		pid := vLines[0].PID
-		gr.Events = append(gr.Events,
-			result.Event{Kind: result.EventShotAttempt, Period: 1, Clock: 700, TeamID: g.VisitorTeamID, PlayerID: pid, ShotType: result.ShotTwoPoint},
-			result.Event{Kind: result.EventShotMake, Period: 1, Clock: 700, TeamID: g.VisitorTeamID, PlayerID: pid, ShotType: result.ShotTwoPoint},
-		)
-	}
-	gr.Events = append(gr.Events, result.Event{Kind: result.EventPeriodBoundary, Period: 4, Clock: 0})
-
-	gr.PlayerBoxes = append(gr.PlayerBoxes, vLines...)
-	gr.PlayerBoxes = append(gr.PlayerBoxes, hLines...)
-	gr.TeamBoxes = []result.TeamBox{
-		teamBox(g.VisitorTeamID, false, vLines),
-		teamBox(g.HomeTeamID, true, hLines),
-	}
-	return gr
-}
-
-// linesFor returns placeholder stat lines for every player on the given team,
-// in bundle order (so output is deterministic).
-func linesFor(players []bundle.Player, teamID int) []result.PlayerBox {
-	out := []result.PlayerBox{}
-	for _, p := range players {
-		if p.TeamID == teamID {
-			out = append(out, placeholderLine(p))
-		}
-	}
-	return out
-}
-
-// placeholderLine returns a degenerate, deterministic stat line. A player
-// flagged dc_can_play_in_game == 0 gets a DNP line (GameMIN == 0, all stats
-// zero).
-func placeholderLine(p bundle.Player) result.PlayerBox {
-	box := result.PlayerBox{PID: p.PID, Pos: posOf(p)}
-	if p.DCCanPlayInGame == 0 {
-		return box // DNP
-	}
-	min := p.DCMinutes
-	if min < 0 {
-		min = 0
-	}
-	if min > 48 {
-		min = 48
-	}
-	box.GameMIN = min
-	box.Game2GM, box.Game2GA = 1, 2
-	box.Game3GM, box.Game3GA = 0, 1
-	box.GameFTM, box.GameFTA = 1, 2
-	box.GameORB, box.GameDRB = 1, 2
-	box.GameAST, box.GameSTL, box.GameTOV, box.GameBLK, box.GamePF = 1, 1, 1, 0, 1
-	return box
-}
-
-// posOf picks the position with the best (lowest, 1=starter) depth-chart slot.
-// A slot value of 0 or below means the player is not in the rotation there.
-func posOf(p bundle.Player) string {
-	slots := []struct {
-		pos   string
-		depth int
-	}{
-		{"PG", p.DCPGDepth}, {"SG", p.DCSGDepth}, {"SF", p.DCSFDepth},
-		{"PF", p.DCPFDepth}, {"C", p.DCCDepth},
-	}
-	best := ""
-	bestDepth := 0
-	for _, s := range slots {
-		if s.depth <= 0 {
-			continue
-		}
-		if best == "" || s.depth < bestDepth {
-			best, bestDepth = s.pos, s.depth
-		}
-	}
-	return best
-}
-
-// teamBox sums the player lines into team totals and splits points across
-// quarters (placeholder: even split, remainder into Q4, no overtime).
-func teamBox(teamID int, isHome bool, lines []result.PlayerBox) result.TeamBox {
-	tb := result.TeamBox{TeamID: teamID, IsHome: isHome, OT: []int{}}
-	for _, l := range lines {
-		tb.Game2GM += l.Game2GM
-		tb.Game2GA += l.Game2GA
-		tb.GameFTM += l.GameFTM
-		tb.GameFTA += l.GameFTA
-		tb.Game3GM += l.Game3GM
-		tb.Game3GA += l.Game3GA
-		tb.GameORB += l.GameORB
-		tb.GameDRB += l.GameDRB
-		tb.GameAST += l.GameAST
-		tb.GameSTL += l.GameSTL
-		tb.GameTOV += l.GameTOV
-		tb.GameBLK += l.GameBLK
-		tb.GamePF += l.GamePF
-	}
-	pts := 2*tb.Game2GM + tb.GameFTM + 3*tb.Game3GM
-	q := pts / 4
-	tb.Q1, tb.Q2, tb.Q3 = q, q, q
-	tb.Q4 = pts - 3*q
-	return tb
 }

--- a/engine/internal/sim/sim_test.go
+++ b/engine/internal/sim/sim_test.go
@@ -7,6 +7,70 @@ import (
 	"github.com/a-jay85/IBL5/engine/internal/result"
 )
 
+// --- shared test helpers (package sim) -------------------------------------
+
+// setSlot marks a player as first-string at the given lineup slot.
+func setSlot(p *bundle.Player, slot int) {
+	switch slot {
+	case slotPG:
+		p.DCPGDepth = 1
+	case slotSG:
+		p.DCSGDepth = 1
+	case slotSF:
+		p.DCSFDepth = 1
+	case slotPF:
+		p.DCPFDepth = 1
+	case slotC:
+		p.DCCDepth = 1
+	}
+}
+
+// mkPlayer builds a fully-rated, playable starter at the given slot. Tests
+// override individual fields on the returned value as needed.
+func mkPlayer(pid, team, slot, fgp int) bundle.Player {
+	p := bundle.Player{
+		PID: pid, TeamID: team,
+		OO: 6, DriveOff: 5, PO: 5, OD: 5, DD: 5, PD: 5, TD: 5,
+		FGP: fgp, FTP: 75, TGA: 25, FGA: 60, ORB: 20, DRB: 35,
+		STL: 30, TVR: 40, BLK: 20, Foul: 30,
+		Stamina: 50, Clutch: 5, Consistency: 5,
+		DCMinutes: 32, DCCanPlayInGame: 1,
+	}
+	setSlot(&p, slot)
+	return p
+}
+
+// oc wraps a bundle.Player as an on-court starter at the given slot, with the
+// PR3a constant-energy fatigue.
+func oc(slot int, p bundle.Player) onCourt {
+	return onCourt{Player: p, slot: slot, fatigue: fatigueFactor(p.Stamina)}
+}
+
+// richBundle is an asymmetric, fully-rated two-team fixture (5 starters each)
+// used by full-game tests. The home team shoots better so games resolve to a
+// winner rather than persistently tying.
+func richBundle() bundle.Bundle {
+	var players []bundle.Player
+	pid := 100
+	for _, tm := range []struct {
+		id  int
+		fgp int
+	}{{7, 46}, {3, 50}} {
+		for slot := slotPG; slot <= slotC; slot++ {
+			pid++
+			players = append(players, mkPlayer(pid, tm.id, slot, tm.fgp))
+		}
+	}
+	return bundle.Bundle{
+		Seed:    1988,
+		Teams:   []bundle.Team{{TeamID: 3, Name: "Heat"}, {TeamID: 7, Name: "Lakers"}},
+		Players: players,
+		Schedule: []bundle.Game{
+			{HomeTeamID: 3, VisitorTeamID: 7, Date: "1988-11-04", GameType: bundle.GameTypeRegular},
+		},
+	}
+}
+
 func testBundle() bundle.Bundle {
 	return bundle.Bundle{
 		Seed:  42,
@@ -22,10 +86,8 @@ func testBundle() bundle.Bundle {
 	}
 }
 
-// #10 — the placeholder sim produces structurally-valid output for a valid
-// bundle: one game, exactly two team boxes (visitor first), a player box per
-// rostered player, a non-empty event stream, and a DNP row expressed as
-// GameMIN == 0.
+// --- matrix #1: structural output contract ---------------------------------
+
 func TestSimulate_StructurallyValid(t *testing.T) {
 	res := Simulate(testBundle(), 42)
 
@@ -49,8 +111,17 @@ func TestSimulate_StructurallyValid(t *testing.T) {
 	if len(g.Events) == 0 {
 		t.Error("event stream is empty")
 	}
+	hasBoundary := false
+	for _, e := range g.Events {
+		if e.Kind == result.EventPeriodBoundary {
+			hasBoundary = true
+			break
+		}
+	}
+	if !hasBoundary {
+		t.Error("event stream has no period boundary")
+	}
 
-	// The dc_can_play_in_game == 0 player must be a DNP row (GameMIN == 0).
 	dnp := findBox(g.PlayerBoxes, 102)
 	if dnp == nil {
 		t.Fatal("missing player box for DNP player 102")
@@ -58,19 +129,23 @@ func TestSimulate_StructurallyValid(t *testing.T) {
 	if dnp.GameMIN != 0 {
 		t.Errorf("DNP player GameMIN = %d, want 0", dnp.GameMIN)
 	}
+	// DNP row must be all-zero.
+	if *dnp != (result.PlayerBox{PID: 102, Pos: "C"}) {
+		t.Errorf("DNP row should be all-zero, got %+v", *dnp)
+	}
 
-	// An active player must have minutes and at least one event-bearing slot.
 	active := findBox(g.PlayerBoxes, 101)
 	if active == nil || active.GameMIN == 0 {
 		t.Errorf("active player 101 should have minutes, got %+v", active)
 	}
 }
 
-// A team's quarter points must sum to its total points (placeholder invariant).
+// --- matrix #2: quarter points sum to real total ---------------------------
+
 func TestSimulate_QuarterPointsSumToTotal(t *testing.T) {
 	res := Simulate(testBundle(), 42)
 	for _, tb := range res.Games[0].TeamBoxes {
-		pts := 2*tb.Game2GM + tb.GameFTM + 3*tb.Game3GM
+		pts := 2*tb.Game2GM + 3*tb.Game3GM + tb.GameFTM
 		q := tb.Q1 + tb.Q2 + tb.Q3 + tb.Q4
 		for _, ot := range tb.OT {
 			q += ot
@@ -79,6 +154,112 @@ func TestSimulate_QuarterPointsSumToTotal(t *testing.T) {
 			t.Errorf("team %d: quarters sum to %d, total points %d", tb.TeamID, q, pts)
 		}
 	}
+}
+
+// --- matrix #23: full-game termination -------------------------------------
+
+func TestSimulate_TerminatesWithWinner(t *testing.T) {
+	for _, seed := range []uint64{1, 2, 42, 1988, 99999} {
+		res := Simulate(richBundle(), seed)
+		g := res.Games[0]
+		v, h := g.TeamBoxes[0], g.TeamBoxes[1]
+		vp := 2*v.Game2GM + 3*v.Game3GM + v.GameFTM
+		hp := 2*h.Game2GM + 3*h.Game3GM + h.GameFTM
+		if vp == hp {
+			t.Errorf("seed %d: game tied %d-%d (no winner after max OT)", seed, vp, hp)
+		}
+		starts := 0
+		for _, e := range g.Events {
+			if e.Kind == result.EventPossessionStart {
+				starts++
+			}
+		}
+		if starts == 0 || starts > 600 {
+			t.Errorf("seed %d: possession count %d out of expected bounds", seed, starts)
+		}
+	}
+}
+
+// --- matrix #24: full-game internal consistency ----------------------------
+
+func TestSimulate_InternalConsistency(t *testing.T) {
+	b := richBundle()
+	teamByPID := map[int]int{}
+	for _, p := range b.Players {
+		teamByPID[p.PID] = p.TeamID
+	}
+	res := Simulate(b, 1988)
+	g := res.Games[0]
+
+	for ti, tb := range g.TeamBoxes {
+		// Recompute team totals from the player rows for this team.
+		var sum result.TeamBox
+		teamID := g.VisitorTeamID
+		if ti == 1 {
+			teamID = g.HomeTeamID
+		}
+		for _, pb := range g.PlayerBoxes {
+			if teamByPID[pb.PID] != teamID {
+				continue
+			}
+			if pb.Game2GM > pb.Game2GA || pb.Game3GM > pb.Game3GA || pb.GameFTM > pb.GameFTA {
+				t.Errorf("player %d: made > attempted (%+v)", pb.PID, pb)
+			}
+			if anyNegative(pb) {
+				t.Errorf("player %d: negative stat (%+v)", pb.PID, pb)
+			}
+			sum.Game2GM += pb.Game2GM
+			sum.Game2GA += pb.Game2GA
+			sum.Game3GM += pb.Game3GM
+			sum.Game3GA += pb.Game3GA
+			sum.GameFTM += pb.GameFTM
+			sum.GameFTA += pb.GameFTA
+		}
+		if sum.Game2GM != tb.Game2GM || sum.Game3GM != tb.Game3GM || sum.GameFTM != tb.GameFTM ||
+			sum.Game2GA != tb.Game2GA || sum.Game3GA != tb.Game3GA || sum.GameFTA != tb.GameFTA {
+			t.Errorf("team %d: team box != sum of player rows", tb.TeamID)
+		}
+
+		if tb.Game2GM > tb.Game2GA || tb.Game3GM > tb.Game3GA || tb.GameFTM > tb.GameFTA {
+			t.Errorf("team %d: made > attempted (%+v)", tb.TeamID, tb)
+		}
+		pts := 2*tb.Game2GM + 3*tb.Game3GM + tb.GameFTM
+		q := tb.Q1 + tb.Q2 + tb.Q3 + tb.Q4
+		for _, ot := range tb.OT {
+			q += ot
+		}
+		if q != pts {
+			t.Errorf("team %d: quarters %d != points %d", tb.TeamID, q, pts)
+		}
+	}
+}
+
+// --- matrix #25: full-game balance -----------------------------------------
+
+func TestSimulate_PossessionBalance(t *testing.T) {
+	res := Simulate(richBundle(), 1988)
+	g := res.Games[0]
+	byTeam := map[int]int{}
+	for _, e := range g.Events {
+		if e.Kind == result.EventPossessionStart {
+			byTeam[e.TeamID]++
+		}
+	}
+	v, h := byTeam[g.VisitorTeamID], byTeam[g.HomeTeamID]
+	diff := v - h
+	if diff < 0 {
+		diff = -diff
+	}
+	// Strict alternation should keep the two within a small margin.
+	if diff > (v+h)/10+2 {
+		t.Errorf("possession imbalance: visitor %d, home %d", v, h)
+	}
+}
+
+func anyNegative(b result.PlayerBox) bool {
+	return b.GameMIN < 0 || b.Game2GM < 0 || b.Game2GA < 0 || b.Game3GM < 0 || b.Game3GA < 0 ||
+		b.GameFTM < 0 || b.GameFTA < 0 || b.GameORB < 0 || b.GameDRB < 0 || b.GameAST < 0 ||
+		b.GameSTL < 0 || b.GameTOV < 0 || b.GameBLK < 0 || b.GamePF < 0
 }
 
 func findBox(boxes []result.PlayerBox, pid int) *result.PlayerBox {

--- a/engine/internal/sim/state.go
+++ b/engine/internal/sim/state.go
@@ -1,0 +1,86 @@
+package sim
+
+import (
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// Lineup slot numbers (1=PG … 5=C), the JSB "position slot" that three
+// mechanics read (shot-type selection, ball-handler selection, position
+// penalty). See 00_MASTER_REFERENCE.md "What IS and IS NOT Slot-Dependent".
+const (
+	slotPG = 1
+	slotSG = 2
+	slotSF = 3
+	slotPF = 4
+	slotC  = 5
+)
+
+// playType is the offensive play the shot-type selector picks. It selects which
+// ODPT pair drives the net advantage; it is NOT the 2pt-vs-3pt distinction
+// (that is decided later, as buckets 1 vs 2 of the play-outcome selector).
+type playType int
+
+const (
+	playOutside playType = iota // OO vs OD
+	playDrive                   // DO vs DD
+	playPost                    // PO vs PD
+)
+
+// onCourt is one starter plus the per-game values PR3a holds constant. Energy
+// equals base stamina (no drain/recovery until PR4), so fatigue is effectively
+// 1.0 for every player all game.
+type onCourt struct {
+	bundle.Player
+	slot    int
+	fatigue float64
+}
+
+// teamState is one team's live game state: its five starters, running score,
+// quarter splits, and a box-score row per rostered player (including DNPs).
+type teamState struct {
+	teamID   int
+	isHome   bool
+	players  []onCourt           // starters, ordered by slot (1..5); may be < 5
+	boxes    []*result.PlayerBox // one per rostered player, in bundle order
+	byPID    map[int]*result.PlayerBox
+	score    int
+	quarters []int // points per period in order; index 0 = Q1
+}
+
+// addPeriodPoints credits n points to the team in the current 0-based period
+// index, growing the quarter slice as overtime periods are reached.
+func (t *teamState) addPeriodPoints(periodIdx, n int) {
+	for len(t.quarters) <= periodIdx {
+		t.quarters = append(t.quarters, 0)
+	}
+	t.quarters[periodIdx] += n
+	t.score += n
+}
+
+// gameState threads the per-game clock, period, event stream, and RNG through
+// the possession loop.
+type gameState struct {
+	rng    *rng.RNG
+	period int // 1-based; 1..4 regulation, 5+ overtime
+	clock  int // seconds remaining in the current period
+	events []result.Event
+}
+
+func (g *gameState) emit(e result.Event) { g.events = append(g.events, e) }
+
+// fatigueFactor is the shared JSB fatigue curve: (energy/30 + 100) × 0.01,
+// capped at 1.0. Because PR3a energy is non-negative base stamina, this is
+// always 1.0 — but the formula is implemented faithfully so PR4 (energy drain)
+// drops in without changing callers.
+func fatigueFactor(energy int) float64 {
+	if energy < 0 {
+		energy = 0
+	}
+	f := (float64(energy)/30.0 + 100.0) * 0.01
+	if f > 1.0 {
+		f = 1.0
+	}
+	return f
+}

--- a/engine/internal/sim/tempo.go
+++ b/engine/internal/sim/tempo.go
@@ -1,0 +1,49 @@
+package sim
+
+// tempoFactor is the JSB "Gameplay Adjustment Factor" (CEngine+0x63b8). IBL runs
+// it at 1.0 (confirmed from IBL5.lge), so possession_time == base_time — neutral
+// NBA pace. See 00_MASTER_REFERENCE.md "Gameplay Adjustment Factor / Tempo".
+const tempoFactor = 1.0
+
+// base_time clamp bounds (00_MASTER_REFERENCE.md: hard-clamped to [13.0, 16.0]).
+const (
+	baseTimeLow  = 13.0
+	baseTimeHigh = 16.0
+)
+
+// teamBaseTime derives a per-team base possession length in [13,16] seconds.
+//
+// In JSB this is a ratio of team per-game offensive/defensive stat aggregates,
+// which PR3a does not have yet (validation-phase pin). As a stand-in we map the
+// team's average defensive ODPT composite onto the clamp range: a stronger
+// defense lengthens possessions (slower pace), a weaker one shortens them. The
+// [13,16] clamp and the (2.0−factor) form are the exact, confirmed parts.
+func teamBaseTime(starters []onCourt) float64 {
+	if len(starters) == 0 {
+		return baseTimeLow
+	}
+	var sum float64
+	for _, p := range starters {
+		// OD+DD+PD+TD, each on the 1-9 ODPT scale → defender composite 0..36.
+		sum += float64(p.OD + p.DD + p.PD + p.TD)
+	}
+	avg := sum / float64(len(starters)) // 0..36
+	bt := baseTimeLow + (avg/36.0)*(baseTimeHigh-baseTimeLow)
+	if bt < baseTimeLow {
+		bt = baseTimeLow
+	}
+	if bt > baseTimeHigh {
+		bt = baseTimeHigh
+	}
+	return bt
+}
+
+// possessionTime is the seconds one possession removes from the game clock:
+// (2.0 − factor) × base_time. At factor 1.0 it equals base_time.
+func possessionTime(baseTime float64) int {
+	pt := (2.0 - tempoFactor) * baseTime
+	if pt < 1.0 || pt > 24.0 {
+		pt = 24.0 // JSB out-of-range fallback
+	}
+	return int(pt)
+}

--- a/engine/internal/sim/testdata/golden.json
+++ b/engine/internal/sim/testdata/golden.json
@@ -17,18 +17,8437 @@
         {
           "kind": "shot_attempt",
           "period": 1,
-          "clock_seconds": 700,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 707,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 707,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 694,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 694,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 681,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 681,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 668,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 655,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 655,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 642,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 642,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 629,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 629,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 616,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 616,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 603,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 603,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 1,
-          "clock_seconds": 700,
+          "clock_seconds": 603,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 590,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 590,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 577,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 551,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 512,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 512,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 473,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 473,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 460,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 447,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 421,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 408,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 395,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 382,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 382,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 369,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 343,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 317,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 317,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 291,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 265,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 226,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 226,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 213,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 213,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 187,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 187,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 174,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 161,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 161,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 148,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 122,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 122,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 109,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 96,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 96,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 83,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 57,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 57,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 44,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 44,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 31,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 18,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 18,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 5,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 5,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "period_boundary",
+          "period": 1,
+          "clock_seconds": 0
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 720,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 720,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 707,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 694,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 694,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 668,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 668,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 642,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 629,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 629,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 616,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 616,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 603,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 590,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 590,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 577,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 564,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 551,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 538,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 538,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 512,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 512,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 499,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 486,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 486,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 460,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 447,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 434,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 395,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 382,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 304,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 291,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 278,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 226,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 226,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 213,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 148,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 122,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 122,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 109,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 83,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 83,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 57,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 57,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 44,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 44,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7
+        },
+        {
+          "kind": "foul",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "ft"
+        },
+        {
+          "kind": "period_boundary",
+          "period": 2,
+          "clock_seconds": 0
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 694,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 694,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 681,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 616,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 577,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 538,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 538,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 512,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 499,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 499,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 460,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 382,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 343,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 317,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 304,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 304,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 291,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 291,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 239,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 239,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 213,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 213,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 200,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 174,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 148,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 109,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 96,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 96,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 57,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 57,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 31,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 18,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 5,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 5,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "period_boundary",
+          "period": 3,
+          "clock_seconds": 0
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 720,
+          "team_id": 3
+        },
+        {
+          "kind": "foul",
+          "period": 4,
+          "clock_seconds": 720,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "free_throw",
+          "period": 4,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "ft"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 707,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 707,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 694,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 681,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 681,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 668,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 668,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 655,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 655,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 629,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 616,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 603,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 590,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 577,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 577,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 564,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 551,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 538,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 538,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 525,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 512,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 499,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 486,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 473,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 473,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 460,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 447,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 434,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 434,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 421,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 421,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 408,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 395,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 369,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 343,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 343,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 317,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 304,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 291,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 278,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 265,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 252,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 252,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 226,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 213,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 213,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 200,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 200,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 161,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 122,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 109,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 96,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 96,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 83,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 83,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 70,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 70,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 57,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 44,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 44,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 31,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 18,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 5,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 5,
+          "team_id": 3,
+          "player_id": 201
         },
         {
           "kind": "period_boundary",
@@ -41,17 +8460,17 @@
           "pid": 101,
           "pos": "PG",
           "gameMIN": 36,
-          "game2GM": 1,
-          "game2GA": 2,
-          "gameFTM": 1,
+          "game2GM": 0,
+          "game2GA": 4,
+          "gameFTM": 0,
           "gameFTA": 2,
-          "game3GM": 0,
-          "game3GA": 1,
-          "gameORB": 1,
-          "gameDRB": 2,
-          "gameAST": 1,
-          "gameSTL": 1,
-          "gameTOV": 1,
+          "game3GM": 25,
+          "game3GA": 76,
+          "gameORB": 26,
+          "gameDRB": 30,
+          "gameAST": 0,
+          "gameSTL": 0,
+          "gameTOV": 0,
           "gameBLK": 0,
           "gamePF": 1
         },
@@ -60,18 +8479,18 @@
           "pos": "SG",
           "gameMIN": 18,
           "game2GM": 1,
-          "game2GA": 2,
-          "gameFTM": 1,
-          "gameFTA": 2,
-          "game3GM": 0,
-          "game3GA": 1,
-          "gameORB": 1,
-          "gameDRB": 2,
-          "gameAST": 1,
-          "gameSTL": 1,
-          "gameTOV": 1,
+          "game2GA": 6,
+          "gameFTM": 0,
+          "gameFTA": 0,
+          "game3GM": 29,
+          "game3GA": 80,
+          "gameORB": 29,
+          "gameDRB": 30,
+          "gameAST": 0,
+          "gameSTL": 0,
+          "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 0
         },
         {
           "pid": 103,
@@ -96,34 +8515,34 @@
           "pos": "SF",
           "gameMIN": 34,
           "game2GM": 1,
-          "game2GA": 2,
-          "gameFTM": 1,
+          "game2GA": 10,
+          "gameFTM": 0,
           "gameFTA": 2,
-          "game3GM": 0,
-          "game3GA": 1,
-          "gameORB": 1,
-          "gameDRB": 2,
-          "gameAST": 1,
-          "gameSTL": 1,
-          "gameTOV": 1,
+          "game3GM": 26,
+          "game3GA": 80,
+          "gameORB": 36,
+          "gameDRB": 25,
+          "gameAST": 0,
+          "gameSTL": 0,
+          "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 0
         },
         {
           "pid": 202,
           "pos": "PF",
           "gameMIN": 22,
-          "game2GM": 1,
-          "game2GA": 2,
-          "gameFTM": 1,
-          "gameFTA": 2,
-          "game3GM": 0,
-          "game3GA": 1,
-          "gameORB": 1,
-          "gameDRB": 2,
-          "gameAST": 1,
-          "gameSTL": 1,
-          "gameTOV": 1,
+          "game2GM": 0,
+          "game2GA": 8,
+          "gameFTM": 0,
+          "gameFTA": 0,
+          "game3GM": 24,
+          "game3GA": 70,
+          "gameORB": 21,
+          "gameDRB": 31,
+          "gameAST": 0,
+          "gameSTL": 0,
+          "gameTOV": 0,
           "gameBLK": 0,
           "gamePF": 1
         }
@@ -132,46 +8551,46 @@
         {
           "team_id": 7,
           "is_home": false,
-          "q1": 1,
-          "q2": 1,
-          "q3": 1,
-          "q4": 3,
+          "q1": 39,
+          "q2": 48,
+          "q3": 36,
+          "q4": 41,
           "ot": [],
-          "game2GM": 2,
-          "game2GA": 4,
-          "gameFTM": 2,
-          "gameFTA": 4,
-          "game3GM": 0,
-          "game3GA": 2,
-          "gameORB": 2,
-          "gameDRB": 4,
-          "gameAST": 2,
-          "gameSTL": 2,
-          "gameTOV": 2,
+          "game2GM": 1,
+          "game2GA": 10,
+          "gameFTM": 0,
+          "gameFTA": 2,
+          "game3GM": 54,
+          "game3GA": 156,
+          "gameORB": 55,
+          "gameDRB": 60,
+          "gameAST": 0,
+          "gameSTL": 0,
+          "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 2
+          "gamePF": 1
         },
         {
           "team_id": 3,
           "is_home": true,
-          "q1": 1,
-          "q2": 1,
-          "q3": 1,
-          "q4": 3,
+          "q1": 33,
+          "q2": 39,
+          "q3": 39,
+          "q4": 41,
           "ot": [],
-          "game2GM": 2,
-          "game2GA": 4,
-          "gameFTM": 2,
-          "gameFTA": 4,
-          "game3GM": 0,
-          "game3GA": 2,
-          "gameORB": 2,
-          "gameDRB": 4,
-          "gameAST": 2,
-          "gameSTL": 2,
-          "gameTOV": 2,
+          "game2GM": 1,
+          "game2GA": 18,
+          "gameFTM": 0,
+          "gameFTA": 2,
+          "game3GM": 50,
+          "game3GA": 150,
+          "gameORB": 57,
+          "gameDRB": 56,
+          "gameAST": 0,
+          "gameSTL": 0,
+          "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 2
+          "gamePF": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary

Replaces the PR1 placeholder in `engine/internal/sim` with a real **half-court possession engine + game driver**, translated from the JSB 5.60 decompile (`00_MASTER_REFERENCE.md`). PR3a of the JSB native engine program (PR1 #913, PR2 #914 merged). All work is in the Go `engine/` module — no PHP, DB, or web.

A possession resolves through: ball-handler selection → shot-type selection → position penalty → net advantage → matchup quality → play-outcome path → make/miss (or free throws) → rebound/turnover, emitting a per-possession event stream and accumulating box scores. Possessions wrap in a driver (4×12-min quarters, OT while tied, possession alternation, tempo-derived possession length). Fixed starters, constant energy (fatigue ≈ 1.0). Stdlib only.

Per-concern files (one formula each, independently testable): `sim`, `gameloop`, `lineup`, `tempo`, `possession`, `ballhandler`, `shotselect`, `positionpenalty`, `netadvantage`, `matchup`, `shotdecision`, `freethrow`, `outcome`, `rebound`, `box`, plus `state.go` shared types. One `_test.go` per file covering all 26 verification-matrix rows.

## Plan-deviation notes (intentional — not defects)

1. **Two-stage outcome model.** `play_outcome` returns the shot **PATH** {2pt(1), 3pt(2), and-one(3), foul-only(4), TO(5)}; `shot_decision` rolls make/miss separately inside the 2pt/3pt paths. Forced modes follow corrected spec L1268–1273: `forced_make→{1,3}`, `shot_clock→{2,4}`. This **supersedes the plan's matrix #18 / Phase 8 "made/miss/and-one/foul" wording**, which described the older (superseded) model. Advisor-confirmed against the plan's own pipeline (line 11) and memory `reference_jsb_play_outcome_twostage`.
2. **Calibration constants** (`leagueBaseline=233`, `fgpToPermille`, `ftpToPermille`, `andOneBaseShare`, `turnoverPropensityScale` + the square/sqrt round-trip on the turnover value) are PR3a **rating-derived stand-ins** for per-game doubles / league values that don't exist until validation phase. Chosen to yield realistic splits (~45% 2P / ~35% 3P / ~75% FT). Refined when validated against the historical `.sco` corpus.
3. **Deferred-by-design:** foul-only always 2 FT (no 3-FT 3pt foul — bucket model carries no shot-type context); forced-make / shot-clock paths are unit-tested but **not triggered live** (PR3a is half-court, no clock truncation); `bh.FGP` used as the matchup composite proxy (PLR `+0x210` not in bundle); OREB/TOV **absolute rates** not yet NBA-calibrated (validation-phase).
4. **`state.go`** is a 16th file (shared types: slot consts, `playType`, `onCourt`, `teamState`, `gameState`, fatigue) beyond the plan's 15.
5. **OT capped at 20** periods — termination is guaranteed; a persisting exact tie is theoretical only (never occurs with non-degenerate ratings).

## Out of scope
PR3b: steal/block attribution + fast-break/transition. PR4: sub/energy. PR7: playoff/ASG modifiers.

## Manual Testing
No manual testing needed — all changes are covered by unit tests (`go test ./...`), gofmt, and `go vet`. The plan's verification matrix is fully automated (all 26 rows are CLI-executable Go tests).

🤖 Generated with [Claude Code](https://claude.ai/code)