### PR TITLE
engine(sim): steal & block attribution + fast-break/transition system (PR3b)

### DIFF
--- a/engine/internal/sim/block.go
+++ b/engine/internal/sim/block.go
@@ -3,9 +3,11 @@ package sim
 import "github.com/a-jay85/IBL5/engine/internal/result"
 
 const (
-	// blockFraction is the ceiling P(block) for a fully-rated front-contesting
-	// blocker against a cold shooter. It also reads as the rough share of 2pt/3pt
-	// misses that are blocked. Documented validation-phase stand-in.
+	// blockFraction is the pre-modifier ceiling for P(block): a fully-rated blocker
+	// against a cold shooter starts here, before the front-contest reduction and
+	// the per-made-FG penalty bring it down (so the attainable peak is slightly
+	// under this value). It also reads as the rough share of 2pt/3pt misses that
+	// are blocked. Documented validation-phase stand-in.
 	blockFraction = 0.06
 
 	// blockRatingScale maps a BLK rating to the [0, blockFraction] base: a rating

--- a/engine/internal/sim/block.go
+++ b/engine/internal/sim/block.go
@@ -1,0 +1,65 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/result"
+
+const (
+	// blockFraction is the ceiling P(block) for a fully-rated front-contesting
+	// blocker against a cold shooter. It also reads as the rough share of 2pt/3pt
+	// misses that are blocked. Documented validation-phase stand-in.
+	blockFraction = 0.06
+
+	// blockRatingScale maps a BLK rating to the [0, blockFraction] base: a rating
+	// at or above this value contests at the ceiling. Documented stand-in (the
+	// real per-game block-rate double does not exist before validation).
+	blockRatingScale = 30.0
+
+	// blockDirectionMod is the front-contest factor: base − base×0.04
+	// (00_MASTER_REFERENCE.md L1396). The behind-contest ×0.04 easy path is
+	// unmodeled in PR3b — there is no shot-direction data yet, so every contest is
+	// treated as the harder front contest. Documented.
+	blockDirectionMod = 0.04
+
+	// blockMadeFGPenalty is the per-made-FG reduction: shooters who have already
+	// made shots this game are harder to block (L1397), floored so P(block) ≥ 0.
+	blockMadeFGPenalty = 0.001
+)
+
+// blockProbability returns P(this defender blocks this missed shot), in
+// [0, blockFraction]. base = blockFraction × min(1, BLK/scale) × fatigue, reduced
+// by the front-contest factor and by blockMadeFGPenalty per field goal the
+// shooter has already made (shooterMadeFG = Game2GM + Game3GM so far), then
+// floored at 0 so it can never go negative.
+func blockProbability(defender onCourt, shooterMadeFG int) float64 {
+	ratio := float64(defender.BLK) / blockRatingScale
+	if ratio > 1 {
+		ratio = 1
+	}
+	if ratio < 0 {
+		ratio = 0
+	}
+	base := blockFraction * ratio * defender.fatigue
+	base -= base * blockDirectionMod // front contest (harder)
+	base -= blockMadeFGPenalty * float64(shooterMadeFG)
+	if base < 0 {
+		base = 0
+	}
+	return base
+}
+
+// creditBlock rolls for a block on a missed field goal. On a block it credits
+// GameBLK to the contesting DEFENDER and emits EventBlock (TeamID = offense,
+// PlayerID = shooter, DefenderID = blocker). It never changes make/miss and
+// never touches the rebound path — the miss still flows to the rebound phase
+// unchanged. The caller must only invoke this on a 2pt/3pt miss (never a free
+// throw).
+func (gs *gameState) creditBlock(offense, defense *teamState, shooter, defender onCourt) {
+	sb := offense.box(shooter.PID)
+	madeFG := sb.Game2GM + sb.Game3GM
+	if gs.rng.Float64() < blockProbability(defender, madeFG) {
+		defense.box(defender.PID).GameBLK++
+		gs.emit(result.Event{
+			Kind: result.EventBlock, Period: gs.period, Clock: gs.clock,
+			TeamID: offense.teamID, PlayerID: shooter.PID, DefenderID: defender.PID,
+		})
+	}
+}

--- a/engine/internal/sim/block_test.go
+++ b/engine/internal/sim/block_test.go
@@ -1,0 +1,138 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// --- matrix #6: a block credits the contesting defender ----------------------
+
+func TestCreditBlock_CreditsDefenderOnMiss(t *testing.T) {
+	for seed := uint64(1); seed < 500; seed++ {
+		offense, defense := twoTeams()
+		shooter := offense.players[0]
+		defender := defense.players[0]
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+
+		score0 := offense.score
+		made0 := offense.box(shooter.PID).Game2GM
+		before := len(gs.events)
+		gs.creditBlock(offense, defense, shooter, defender)
+
+		if defense.box(defender.PID).GameBLK == 0 {
+			continue // this seed did not roll a block; try the next
+		}
+
+		// A block neither scores points nor invents a make.
+		if offense.score != score0 {
+			t.Errorf("score changed on a block: %d → %d", score0, offense.score)
+		}
+		if offense.box(shooter.PID).Game2GM != made0 {
+			t.Error("block altered the shooter's made-FG count")
+		}
+		var blocks []result.Event
+		for _, e := range gs.events[before:] {
+			if e.Kind == result.EventBlock {
+				blocks = append(blocks, e)
+			}
+		}
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 EventBlock, got %d", len(blocks))
+		}
+		ev := blocks[0]
+		if ev.TeamID != offense.teamID || ev.PlayerID != shooter.PID || ev.DefenderID != defender.PID {
+			t.Errorf("EventBlock = %+v, want TeamID=%d PlayerID=%d DefenderID=%d",
+				ev, offense.teamID, shooter.PID, defender.PID)
+		}
+		if defense.box(ev.DefenderID).GameBLK != 1 {
+			t.Errorf("blocker GameBLK = %d, want 1", defense.box(ev.DefenderID).GameBLK)
+		}
+		return
+	}
+	t.Fatal("no seed in range produced a block")
+}
+
+// --- matrix #7: a block never flips a make → miss ----------------------------
+//
+// creditBlock only ever touches the defender's GameBLK and the event stream; it
+// is gated by the caller to fire solely on a missed field goal. This verifies it
+// cannot add/remove a made shot or change the score even when forced to fire.
+func TestCreditBlock_NeverFlipsMake(t *testing.T) {
+	offense, defense := twoTeams()
+	shooter := offense.players[0]
+	defender := defense.players[0]
+	// Pre-credit a made shot, as the half-court loop would on a make.
+	gs := &gameState{rng: rng.New(1), period: 1, clock: 500}
+	gs.creditMadeFieldGoal(offense, shooter, result.ShotTwoPoint, 0)
+	made0 := offense.box(shooter.PID).Game2GM
+	score0 := offense.score
+
+	// Force a block by looping seeds; assert the make and score are untouched.
+	for seed := uint64(1); seed < 500; seed++ {
+		gs.rng = rng.New(seed)
+		gs.creditBlock(offense, defense, shooter, defender)
+		if defense.box(defender.PID).GameBLK > 0 {
+			break
+		}
+	}
+	if offense.box(shooter.PID).Game2GM != made0 {
+		t.Errorf("made-FG count changed: %d → %d", made0, offense.box(shooter.PID).Game2GM)
+	}
+	if offense.score != score0 {
+		t.Errorf("score changed: %d → %d", score0, offense.score)
+	}
+}
+
+// --- matrix #8: a free-throw miss is never block-eligible --------------------
+//
+// The free-throw path (gs.freeThrows) must never credit a block or emit an
+// EventBlock — blocks fire only on 2pt/3pt misses.
+func TestFreeThrows_NeverBlocked(t *testing.T) {
+	for seed := uint64(1); seed <= 100; seed++ {
+		offense, defense := twoTeams()
+		shooter := offense.players[0]
+		defender := defense.players[0]
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+		gs.freeThrows(offense, defense, shooter, defender, 2, 0)
+		for _, e := range gs.events {
+			if e.Kind == result.EventBlock {
+				t.Fatalf("seed %d: free-throw path emitted an EventBlock", seed)
+			}
+		}
+		for _, pb := range append(offense.playerBoxes(), defense.playerBoxes()...) {
+			if pb.GameBLK != 0 {
+				t.Fatalf("seed %d: free-throw path credited a block", seed)
+			}
+		}
+	}
+}
+
+// --- matrix #9: P(block) floored ≥ 0 -----------------------------------------
+
+func TestBlockProbability_FlooredAndBounded(t *testing.T) {
+	b := richBundle()
+	blocker := newTeamState(b.Players, 3, true).players[0] // BLK = 20
+
+	// Cold shooter: positive but ≤ ceiling.
+	p0 := blockProbability(blocker, 0)
+	if p0 <= 0 || p0 > blockFraction {
+		t.Errorf("blockProbability(0 made) = %v, want (0, %v]", p0, blockFraction)
+	}
+	// Hot shooter: the per-made-FG penalty drives it to exactly 0, never negative.
+	if p := blockProbability(blocker, 1000); p != 0 {
+		t.Errorf("blockProbability(1000 made) = %v, want 0 (floored)", p)
+	}
+	// A higher made-FG count never raises the probability.
+	if blockProbability(blocker, 5) > blockProbability(blocker, 0) {
+		t.Error("made-FG penalty must not increase P(block)")
+	}
+	// An unrated blocker contests at 0.
+	var unrated onCourt
+	unrated.BLK = 0
+	unrated.fatigue = 1.0
+	if p := blockProbability(unrated, 0); p != 0 {
+		t.Errorf("blockProbability(BLK=0) = %v, want 0", p)
+	}
+}

--- a/engine/internal/sim/box_test.go
+++ b/engine/internal/sim/box_test.go
@@ -3,30 +3,58 @@ package sim
 import (
 	"testing"
 
+	"github.com/a-jay85/IBL5/engine/internal/result"
 	"github.com/a-jay85/IBL5/engine/internal/rng"
 )
 
-// --- matrix #22: box derivation rules --------------------------------------
-
+// --- matrix #1/#2: box derivation rules (PR3b contract) ---------------------
+//
+// PR3a asserted STL == BLK == AST == 0. PR3b credits steals and blocks, so the
+// contract changes: AST stays 0 (commentary-only, L1098), while total STL and
+// total BLK are now positive and every credit lands on a DEFENDER (the team not
+// on offense for that play), verified through the event stream.
 func TestBoxDerivation_DeferredStats(t *testing.T) {
-	res := Simulate(richBundle(), 1988)
+	b := richBundle()
+	teamByPID := map[int]int{}
+	for _, p := range b.Players {
+		teamByPID[p.PID] = p.TeamID
+	}
+	res := Simulate(b, 1988)
 	g := res.Games[0]
 
-	var totalPF, totalFTA int
+	var totalPF, totalFTA, totalSTL, totalBLK int
 	for _, pb := range g.PlayerBoxes {
-		// Steal/block attribution is PR3b; assists are commentary-only (L1098).
-		if pb.GameSTL != 0 || pb.GameBLK != 0 || pb.GameAST != 0 {
-			t.Errorf("player %d: STL/BLK/AST must be 0 in PR3a, got %d/%d/%d",
-				pb.PID, pb.GameSTL, pb.GameBLK, pb.GameAST)
+		if pb.GameAST != 0 { // assists are commentary-only (L1098), still 0
+			t.Errorf("player %d: GameAST must be 0, got %d", pb.PID, pb.GameAST)
 		}
 		totalPF += pb.GamePF
 		totalFTA += pb.GameFTA
+		totalSTL += pb.GameSTL
+		totalBLK += pb.GameBLK
 	}
 	if totalPF == 0 {
 		t.Error("no personal fouls charged across the game")
 	}
 	if totalFTA == 0 {
 		t.Error("no free-throw attempts across the game")
+	}
+	if totalSTL == 0 {
+		t.Error("no steals credited across the game")
+	}
+	if totalBLK == 0 {
+		t.Error("no blocks credited across the game")
+	}
+
+	// Every steal/block event must credit the DEFENDER (a player on the team that
+	// is NOT the offense, identified by the event's TeamID = offense).
+	for _, e := range g.Events {
+		switch e.Kind {
+		case result.EventSteal, result.EventBlock:
+			if teamByPID[e.DefenderID] == e.TeamID {
+				t.Errorf("%s credited DefenderID %d on the offensive team %d (must be a defender)",
+					e.Kind, e.DefenderID, e.TeamID)
+			}
+		}
 	}
 }
 

--- a/engine/internal/sim/gameloop.go
+++ b/engine/internal/sim/gameloop.go
@@ -15,9 +15,10 @@ const (
 
 // simGame plays one scheduled game: four regulation quarters plus overtime
 // while tied, alternating possessions and decrementing the clock by a tempo-
-// derived possession length. It returns the full event stream and box scores,
-// visitor team first.
-func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) result.GameResult {
+// derived possession length. It returns the full event stream and box scores
+// (visitor team first) plus the count of fast-break possessions that fired
+// (internal observability for tests; not part of the result contract).
+func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) (result.GameResult, int) {
 	visitor := newTeamState(b.Players, g.VisitorTeamID, false)
 	home := newTeamState(b.Players, g.HomeTeamID, true)
 
@@ -37,8 +38,10 @@ func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) result.GameResult {
 	playPeriod := func(period, seconds int) {
 		gs.period = period
 		gs.clock = seconds
+		gs.transitionShotRate = 0 // Stage-3 decay resets per period ("within a period")
+		pending := false
 		for gs.clock > 0 {
-			possession(gs, offense, defense, period-1)
+			pending = possession(gs, offense, defense, period-1, pending)
 			offense, defense = defense, offense
 			gs.clock -= step
 		}
@@ -62,5 +65,5 @@ func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) result.GameResult {
 		PlayerBoxes:   append(visitor.playerBoxes(), home.playerBoxes()...),
 		TeamBoxes:     []result.TeamBox{visitor.teamBox(), home.teamBox()},
 	}
-	return gr
+	return gr, gs.transitions
 }

--- a/engine/internal/sim/possession.go
+++ b/engine/internal/sim/possession.go
@@ -50,15 +50,31 @@ func turnoverThreshold(tvr int) float64 { return float64(tvr) * turnoverPropensi
 // matchup resolution, the play-outcome path, and any free throws or rebounds.
 // Offensive rebounds continue the trip; a made shot, defensive rebound, or
 // turnover ends it. The caller flips possession after every trip.
-func possession(gs *gameState, offense, defense *teamState, periodIdx int) {
+//
+// fbPending is the fast-break flag set by the prior possession (its defensive
+// rebound or steal). It is consumed unconditionally: when Stage 2 (TransOff
+// trigger) and Stage 3 (steal-success) both pass, the possession runs as a fast
+// break; otherwise it falls through to the normal half-court loop. The named
+// return fbNext re-arms the flag when THIS possession ends via a defensive
+// rebound or a steal (the team that gained the ball gets the next break).
+func possession(gs *gameState, offense, defense *teamState, periodIdx int, fbPending bool) (fbNext bool) {
 	if len(offense.players) == 0 || len(defense.players) == 0 {
-		return
+		return false
 	}
-	bh := selectBallHandler(offense, gs.rng)
 	gs.emit(result.Event{
 		Kind: result.EventPossessionStart, Period: gs.period, Clock: gs.clock, TeamID: offense.teamID,
 	})
 
+	if fbPending {
+		if gs.transitionShotRate <= 0 {
+			gs.transitionShotRate = resetTransitionShotRate(offense)
+		}
+		if transitionTriggers(offense, gs.rng) && gs.transitionStealSucceeds(defense) {
+			return gs.runTransitionPossession(offense, defense, periodIdx)
+		}
+	}
+
+	bh := selectBallHandler(offense, gs.rng)
 	for trip := 0; trip <= maxOffensiveRebounds; trip++ {
 		scoreDiff := offense.score - defense.score
 		matched := defenderAtSlot(defense, bh.slot)
@@ -80,41 +96,42 @@ func possession(gs *gameState, offense, defense *teamState, periodIdx int) {
 
 		switch selectOutcome(in, false, false, false, gs.rng) {
 		case outcome2pt:
-			if made, ended := gs.shotAttempt(offense, defense, bh, sv2, result.ShotTwoPoint, periodIdx); ended {
-				if !made {
-					if cont, next := gs.rebound(offense, defense, periodIdx); cont {
-						bh = next
-						continue
-					}
+			if made, _ := gs.shotAttempt(offense, defense, bh, sv2, result.ShotTwoPoint, periodIdx); !made {
+				gs.creditBlock(offense, defense, bh, def)
+				if cont, next := gs.rebound(offense, defense, periodIdx); cont {
+					bh = next
+					continue
 				}
-				return
+				return true // defensive rebound → fast-break pending
 			}
+			return false // made shot
 		case outcome3pt:
-			if made, ended := gs.shotAttempt(offense, defense, bh, shotValue3pt(), result.ShotThree, periodIdx); ended {
-				if !made {
-					if cont, next := gs.rebound(offense, defense, periodIdx); cont {
-						bh = next
-						continue
-					}
+			if made, _ := gs.shotAttempt(offense, defense, bh, shotValue3pt(), result.ShotThree, periodIdx); !made {
+				gs.creditBlock(offense, defense, bh, def)
+				if cont, next := gs.rebound(offense, defense, periodIdx); cont {
+					bh = next
+					continue
 				}
-				return
+				return true // defensive rebound → fast-break pending
 			}
+			return false // made shot
 		case outcomeAndOne:
 			gs.madeFieldGoal(offense, bh, result.ShotTwoPoint, periodIdx)
 			gs.freeThrows(offense, defense, bh, def, 1, periodIdx)
-			return
+			return false
 		case outcomeFoulOnly:
 			gs.freeThrows(offense, defense, bh, def, 2, periodIdx)
-			return
+			return false
 		case outcomeTurnover:
 			offense.box(bh.PID).GameTOV++
 			gs.emit(result.Event{
 				Kind: result.EventTurnover, Period: gs.period, Clock: gs.clock,
 				TeamID: offense.teamID, PlayerID: bh.PID,
 			})
-			return
+			return gs.creditSteal(offense, defense, bh) // steal → fast-break pending
 		}
 	}
+	return false
 }
 
 // shotAttempt records a field-goal attempt of the given type, rolls make/miss,

--- a/engine/internal/sim/sim.go
+++ b/engine/internal/sim/sim.go
@@ -28,7 +28,8 @@ func Simulate(b bundle.Bundle, seed uint64) result.Result {
 	r := rng.New(seed)
 	res := result.Result{Seed: seed, Games: make([]result.GameResult, 0, len(b.Schedule))}
 	for _, g := range b.Schedule {
-		res.Games = append(res.Games, simGame(b, g, r))
+		gr, _ := simGame(b, g, r)
+		res.Games = append(res.Games, gr)
 	}
 	return res
 }

--- a/engine/internal/sim/sim_test.go
+++ b/engine/internal/sim/sim_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/a-jay85/IBL5/engine/internal/bundle"
 	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
 )
 
 // --- shared test helpers (package sim) -------------------------------------
@@ -30,8 +31,8 @@ func setSlot(p *bundle.Player, slot int) {
 func mkPlayer(pid, team, slot, fgp int) bundle.Player {
 	p := bundle.Player{
 		PID: pid, TeamID: team,
-		OO: 6, DriveOff: 5, PO: 5, OD: 5, DD: 5, PD: 5, TD: 5,
-		FGP: fgp, FTP: 75, TGA: 25, FGA: 60, ORB: 20, DRB: 35,
+		OO: 6, DriveOff: 5, PO: 5, OD: 5, DD: 5, PD: 5, TD: 5, TransOff: 7,
+		FGP: fgp, FTP: 75, TGA: 25, FGA: 60, FTA: 20, ORB: 20, DRB: 35,
 		STL: 30, TVR: 40, BLK: 20, Foul: 30,
 		Stamina: 50, Clutch: 5, Consistency: 5,
 		DCMinutes: 32, DCCanPlayInGame: 1,
@@ -253,6 +254,65 @@ func TestSimulate_PossessionBalance(t *testing.T) {
 	// Strict alternation should keep the two within a small margin.
 	if diff > (v+h)/10+2 {
 		t.Errorf("possession imbalance: visitor %d, home %d", v, h)
+	}
+}
+
+// --- matrix #20/#21: steal & block attribution over a full game -------------
+
+func TestSimulate_StealBlockCreditedToDefenders(t *testing.T) {
+	b := richBundle()
+	teamByPID := map[int]int{}
+	for _, p := range b.Players {
+		teamByPID[p.PID] = p.TeamID
+	}
+	res := Simulate(b, 1988)
+	g := res.Games[0]
+
+	var totalSTL, totalBLK int
+	for _, pb := range g.PlayerBoxes {
+		totalSTL += pb.GameSTL
+		totalBLK += pb.GameBLK
+	}
+	if totalSTL == 0 {
+		t.Error("total STL == 0 over a full game")
+	}
+	if totalBLK == 0 {
+		t.Error("total BLK == 0 over a full game")
+	}
+
+	// Every steal/block event credits a player on the team that is NOT on offense
+	// (the event's TeamID is the offense), i.e. a defender.
+	steals, blocks := 0, 0
+	for _, e := range g.Events {
+		switch e.Kind {
+		case result.EventSteal:
+			steals++
+			if teamByPID[e.DefenderID] == e.TeamID {
+				t.Errorf("steal credited to offensive player %d (team %d)", e.DefenderID, e.TeamID)
+			}
+		case result.EventBlock:
+			blocks++
+			if teamByPID[e.DefenderID] == e.TeamID {
+				t.Errorf("block credited to offensive player %d (team %d)", e.DefenderID, e.TeamID)
+			}
+		}
+	}
+	if steals == 0 || blocks == 0 {
+		t.Errorf("event stream had %d steals, %d blocks; want both > 0", steals, blocks)
+	}
+}
+
+// --- matrix #22: transition possessions occur over a full game ---------------
+//
+// Fast-break possessions leave no distinct marker in the (frozen) result
+// contract, so the count is observed through simGame's internal return. The
+// guarantee that a transition is never a 3pt attempt is proven structurally by
+// TestRunTransitionPossession_NeverThreePoint (#10).
+func TestSimulate_TransitionsOccur(t *testing.T) {
+	b := richBundle()
+	_, transitions := simGame(b, b.Schedule[0], rng.New(1988))
+	if transitions == 0 {
+		t.Error("no fast-break possessions fired over a full game")
 	}
 }
 

--- a/engine/internal/sim/state.go
+++ b/engine/internal/sim/state.go
@@ -66,6 +66,19 @@ type gameState struct {
 	period int // 1-based; 1..4 regulation, 5+ overtime
 	clock  int // seconds remaining in the current period
 	events []result.Event
+
+	// transitionShotRate is the Stage-3 decaying team shot-rate threshold for
+	// fast-break steal-success (00_MASTER_REFERENCE.md L900-914). It is seeded
+	// once per period at the first fast break and decays by transitionShotRateDecay
+	// on each successful break (floor transitionShotRateFloor), so fast-break
+	// frequency falls as the period progresses. playPeriod resets it to 0 at the
+	// top of each period.
+	transitionShotRate float64
+
+	// transitions counts fast-break possessions that actually fired this game
+	// (Stage 2 and Stage 3 both passed). It is internal observability for tests;
+	// it is never serialized into the result contract.
+	transitions int
 }
 
 func (g *gameState) emit(e result.Event) { g.events = append(g.events, e) }

--- a/engine/internal/sim/state.go
+++ b/engine/internal/sim/state.go
@@ -69,8 +69,9 @@ type gameState struct {
 
 	// transitionShotRate is the Stage-3 decaying team shot-rate threshold for
 	// fast-break steal-success (00_MASTER_REFERENCE.md L900-914). It is seeded
-	// once per period at the first fast break and decays by transitionShotRateDecay
-	// on each successful break (floor transitionShotRateFloor), so fast-break
+	// once per period on the first possession that carries the fast-break pending
+	// flag (before Stage 2/3 are tested) and decays by transitionShotRateDecay on
+	// each successful break (floor transitionShotRateFloor), so fast-break
 	// frequency falls as the period progresses. playPeriod resets it to 0 at the
 	// top of each period.
 	transitionShotRate float64

--- a/engine/internal/sim/steal.go
+++ b/engine/internal/sim/steal.go
@@ -1,0 +1,67 @@
+package sim
+
+import (
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// stealFraction is the share of turnovers that are forced steals (the rest are
+// unforced: the victim keeps the GameTOV and no defender is credited a steal).
+// 00_MASTER_REFERENCE.md L1385-1390 selects the victim by offensive carelessness
+// and only "if under, a steal occurs"; PR3b has the victim already (the ball
+// handler who turned it over), so this fraction stands in for the steal-vs-
+// unforced split until the per-game turnover/steal aggregates exist (validation
+// phase). Documented stand-in.
+const stealFraction = 0.55
+
+// selectStealer picks which defender is credited a steal, by weighted random
+// over STL_rating × fatigue (a careless turnover is taken by an active, ball-
+// hawking defender). The second return is false when every defender has a zero
+// weight (an all-unrated roster): the caller still gets players[0] but the pick
+// was a fallback, never a divide-by-zero. Mirrors selectDefender/selectRebounder.
+func selectStealer(defense *teamState, r *rng.RNG) (onCourt, bool) {
+	if len(defense.players) == 0 {
+		return onCourt{}, false
+	}
+	weights := make([]float64, len(defense.players))
+	var sum float64
+	for i, p := range defense.players {
+		w := float64(p.STL) * p.fatigue
+		if w < 0 {
+			w = 0
+		}
+		weights[i] = w
+		sum += w
+	}
+	if sum <= 0 {
+		return defense.players[0], false
+	}
+	roll := r.Float64() * sum
+	var acc float64
+	for i, w := range weights {
+		acc += w
+		if roll <= acc {
+			return defense.players[i], true
+		}
+	}
+	return defense.players[len(defense.players)-1], true
+}
+
+// creditSteal resolves whether a turnover (already credited to the victim) was a
+// forced steal. On a steal it credits GameSTL to the stealing DEFENDER and emits
+// EventSteal (TeamID = offense, PlayerID = victim, DefenderID = stealer), then
+// returns true so the caller sets the fast-break pending flag. On an unforced
+// turnover it returns false and credits no stealer. It never alters the victim's
+// GameTOV (the caller credited it).
+func (gs *gameState) creditSteal(offense, defense *teamState, victim onCourt) bool {
+	if gs.rng.Float64() >= stealFraction {
+		return false // unforced turnover: no stealer
+	}
+	stealer, _ := selectStealer(defense, gs.rng)
+	defense.box(stealer.PID).GameSTL++
+	gs.emit(result.Event{
+		Kind: result.EventSteal, Period: gs.period, Clock: gs.clock,
+		TeamID: offense.teamID, PlayerID: victim.PID, DefenderID: stealer.PID,
+	})
+	return true
+}

--- a/engine/internal/sim/steal_test.go
+++ b/engine/internal/sim/steal_test.go
@@ -1,0 +1,112 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// twoTeams builds offense/defense states from richBundle (team 7 visitor, team 3
+// home), each with five fully-rated starters.
+func twoTeams() (*teamState, *teamState) {
+	b := richBundle()
+	return newTeamState(b.Players, 7, false), newTeamState(b.Players, 3, true)
+}
+
+// --- matrix #3: steal credits a defender; victim keeps the turnover ----------
+
+func TestCreditSteal_CreditsDefenderVictimKeepsTOV(t *testing.T) {
+	// Find a seed whose first Float64 falls under stealFraction so creditSteal
+	// resolves to a steal (the probabilities cannot be forced to an exact value).
+	for seed := uint64(1); seed < 200; seed++ {
+		offense, defense := twoTeams()
+		victim := offense.players[0]
+		offense.box(victim.PID).GameTOV++ // caller credits the TOV first
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+
+		before := len(gs.events)
+		if !gs.creditSteal(offense, defense, victim) {
+			continue // this seed was an unforced turnover; try the next
+		}
+
+		// Victim retains the turnover; no steal is credited to the victim.
+		if got := offense.box(victim.PID).GameTOV; got != 1 {
+			t.Fatalf("victim GameTOV = %d, want 1 (kept)", got)
+		}
+		if offense.box(victim.PID).GameSTL != 0 {
+			t.Fatalf("victim must not be credited a steal")
+		}
+
+		// Exactly one EventSteal, crediting a defender.
+		var steals []result.Event
+		for _, e := range gs.events[before:] {
+			if e.Kind == result.EventSteal {
+				steals = append(steals, e)
+			}
+		}
+		if len(steals) != 1 {
+			t.Fatalf("expected 1 EventSteal, got %d", len(steals))
+		}
+		ev := steals[0]
+		if ev.TeamID != offense.teamID {
+			t.Errorf("EventSteal TeamID = %d, want offense %d", ev.TeamID, offense.teamID)
+		}
+		if ev.PlayerID != victim.PID {
+			t.Errorf("EventSteal PlayerID = %d, want victim %d", ev.PlayerID, victim.PID)
+		}
+		// DefenderID is the stealer and must be on the defending team with a STL credit.
+		if defense.box(ev.DefenderID) == nil {
+			t.Fatalf("DefenderID %d is not on the defending team", ev.DefenderID)
+		}
+		if defense.box(ev.DefenderID).GameSTL != 1 {
+			t.Errorf("stealer %d GameSTL = %d, want 1", ev.DefenderID, defense.box(ev.DefenderID).GameSTL)
+		}
+		return
+	}
+	t.Fatal("no seed in range produced a steal")
+}
+
+// --- matrix #4: all-zero STL weights → players[0] fallback, no divide-by-zero -
+
+func TestSelectStealer_AllZeroWeightsFallsBack(t *testing.T) {
+	b := richBundle()
+	// Zero out every STL rating so the weighted sum is zero.
+	for i := range b.Players {
+		b.Players[i].STL = 0
+	}
+	defense := newTeamState(b.Players, 3, true)
+
+	got, ok := selectStealer(defense, rng.New(7))
+	if ok {
+		t.Error("ok should be false on the all-zero fallback")
+	}
+	if got.PID != defense.players[0].PID {
+		t.Errorf("fallback returned %d, want players[0] = %d", got.PID, defense.players[0].PID)
+	}
+}
+
+// --- matrix #5: the steal/unforced split is real -----------------------------
+
+func TestCreditSteal_SplitIsReal(t *testing.T) {
+	var steals, unforced int
+	for seed := uint64(1); seed <= 400; seed++ {
+		offense, defense := twoTeams()
+		victim := offense.players[0]
+		offense.box(victim.PID).GameTOV++
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+		if gs.creditSteal(offense, defense, victim) {
+			steals++
+		} else {
+			unforced++
+		}
+	}
+	// Both outcomes must occur — not every turnover is a steal, and not every
+	// turnover is unforced. (stealFraction = 0.55.)
+	if steals == 0 {
+		t.Error("no turnovers resolved to a steal")
+	}
+	if unforced == 0 {
+		t.Error("no turnovers were unforced (no stealer)")
+	}
+}

--- a/engine/internal/sim/testdata/golden.json
+++ b/engine/internal/sim/testdata/golden.json
@@ -70,23 +70,16 @@
           "period": 1,
           "clock_seconds": 694,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 1,
           "clock_seconds": 694,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 694,
-          "team_id": 7,
-          "player_id": 102
         },
         {
           "kind": "possession_start",
@@ -99,7 +92,7 @@
           "period": 1,
           "clock_seconds": 681,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -107,7 +100,31 @@
           "period": 1,
           "clock_seconds": 681,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -150,16 +167,16 @@
           "period": 1,
           "clock_seconds": 655,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
+          "player_id": 102,
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 655,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
+          "player_id": 102,
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
@@ -178,19 +195,12 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 1,
           "clock_seconds": 655,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 655,
-          "team_id": 3,
-          "player_id": 202
         },
         {
           "kind": "possession_start",
@@ -218,8 +228,49 @@
           "kind": "rebound",
           "period": 1,
           "clock_seconds": 642,
-          "team_id": 7,
-          "player_id": 101
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
         },
         {
           "kind": "possession_start",
@@ -236,43 +287,12 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 1,
           "clock_seconds": 629,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 629,
-          "team_id": 3,
-          "player_id": 202
         },
         {
           "kind": "possession_start",
@@ -285,8 +305,32 @@
           "period": 1,
           "clock_seconds": 616,
           "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 616,
+          "team_id": 3,
           "player_id": 202,
-          "shot_type": "2pt"
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
@@ -294,7 +338,7 @@
           "clock_seconds": 616,
           "team_id": 3,
           "player_id": 202,
-          "shot_type": "2pt"
+          "shot_type": "3pt"
         },
         {
           "kind": "rebound",
@@ -314,40 +358,23 @@
           "period": 1,
           "clock_seconds": 603,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
+          "player_id": 102,
+          "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 603,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
+          "player_id": 102,
+          "shot_type": "3pt"
         },
         {
           "kind": "rebound",
           "period": 1,
           "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
+          "team_id": 3,
+          "player_id": 202
         },
         {
           "kind": "possession_start",
@@ -376,7 +403,7 @@
           "period": 1,
           "clock_seconds": 590,
           "team_id": 7,
-          "player_id": 101
+          "player_id": 102
         },
         {
           "kind": "possession_start",
@@ -389,16 +416,23 @@
           "period": 1,
           "clock_seconds": 577,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 577,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 577,
+          "team_id": 3,
+          "player_id": 202
         },
         {
           "kind": "possession_start",
@@ -411,7 +445,7 @@
           "period": 1,
           "clock_seconds": 564,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -419,7 +453,7 @@
           "period": 1,
           "clock_seconds": 564,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -427,7 +461,7 @@
           "period": 1,
           "clock_seconds": 564,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "offensive_rebound": true
         },
         {
@@ -435,16 +469,16 @@
           "period": 1,
           "clock_seconds": 564,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
+          "player_id": 201,
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 564,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
+          "player_id": 201,
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
@@ -464,143 +498,102 @@
           "period": 1,
           "clock_seconds": 551,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
+          "player_id": 102,
+          "shot_type": "2pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 551,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
           "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
           "shot_type": "2pt"
         },
         {
           "kind": "rebound",
           "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 525,
+          "clock_seconds": 551,
           "team_id": 3,
           "player_id": 201
         },
         {
           "kind": "possession_start",
           "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
           "clock_seconds": 512,
           "team_id": 3
         },
@@ -609,47 +602,16 @@
           "period": 1,
           "clock_seconds": 512,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 512,
-          "team_id": 3,
           "player_id": 202,
-          "offensive_rebound": true
+          "shot_type": "3pt"
         },
         {
-          "kind": "shot_attempt",
+          "kind": "shot_make",
           "period": 1,
           "clock_seconds": 512,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 512,
-          "team_id": 7,
-          "player_id": 102
         },
         {
           "kind": "possession_start",
@@ -677,8 +639,49 @@
           "kind": "rebound",
           "period": 1,
           "clock_seconds": 499,
-          "team_id": 3,
-          "player_id": 202
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
         },
         {
           "kind": "possession_start",
@@ -692,78 +695,6 @@
           "clock_seconds": 486,
           "team_id": 3,
           "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -771,7 +702,7 @@
           "period": 1,
           "clock_seconds": 486,
           "team_id": 3,
-          "player_id": 201,
+          "player_id": 202,
           "shot_type": "3pt"
         },
         {
@@ -779,30 +710,6 @@
           "period": 1,
           "clock_seconds": 473,
           "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -838,46 +745,29 @@
           "period": 1,
           "clock_seconds": 460,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
+          "player_id": 201,
+          "shot_type": "2pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 460,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 460,
+          "team_id": 7,
+          "player_id": 102
         },
         {
           "kind": "possession_start",
           "period": 1,
           "clock_seconds": 447,
           "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -915,6 +805,30 @@
           "clock_seconds": 434,
           "team_id": 3,
           "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -973,7 +887,7 @@
           "period": 1,
           "clock_seconds": 408,
           "team_id": 3,
-          "player_id": 201,
+          "player_id": 202,
           "offensive_rebound": true
         },
         {
@@ -981,7 +895,7 @@
           "period": 1,
           "clock_seconds": 408,
           "team_id": 3,
-          "player_id": 201,
+          "player_id": 202,
           "shot_type": "3pt"
         },
         {
@@ -989,7 +903,7 @@
           "period": 1,
           "clock_seconds": 408,
           "team_id": 3,
-          "player_id": 201,
+          "player_id": 202,
           "shot_type": "3pt"
         },
         {
@@ -1003,228 +917,58 @@
           "period": 1,
           "clock_seconds": 395,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 382,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 202,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
           "period": 1,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 202,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
           "kind": "rebound",
           "period": 1,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 101,
           "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
           "period": 1,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 382,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 369,
+          "clock_seconds": 395,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 1,
-          "clock_seconds": 369,
+          "clock_seconds": 395,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
         },
         {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 356,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
           "kind": "rebound",
           "period": 1,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 343,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 317,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 317,
+          "clock_seconds": 395,
           "team_id": 3,
           "player_id": 202
         },
         {
           "kind": "possession_start",
           "period": 1,
-          "clock_seconds": 304,
+          "clock_seconds": 382,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 1,
-          "clock_seconds": 304,
+          "clock_seconds": 382,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "3pt"
@@ -1232,7 +976,7 @@
         {
           "kind": "shot_miss",
           "period": 1,
-          "clock_seconds": 304,
+          "clock_seconds": 382,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "3pt"
@@ -1240,259 +984,20 @@
         {
           "kind": "rebound",
           "period": 1,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 304,
+          "clock_seconds": 382,
           "team_id": 7,
           "player_id": 101
         },
         {
           "kind": "possession_start",
           "period": 1,
-          "clock_seconds": 291,
+          "clock_seconds": 369,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 1,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 265,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 239,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 239,
+          "clock_seconds": 369,
           "team_id": 7,
           "player_id": 102,
           "shot_type": "3pt"
@@ -1500,7 +1005,7 @@
         {
           "kind": "shot_miss",
           "period": 1,
-          "clock_seconds": 239,
+          "clock_seconds": 369,
           "team_id": 7,
           "player_id": 102,
           "shot_type": "3pt"
@@ -1508,7 +1013,31 @@
         {
           "kind": "rebound",
           "period": 1,
-          "clock_seconds": 239,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 369,
           "team_id": 7,
           "player_id": 101,
           "offensive_rebound": true
@@ -1516,7 +1045,51 @@
         {
           "kind": "shot_attempt",
           "period": 1,
-          "clock_seconds": 239,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 343,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 343,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
@@ -1524,7 +1097,7 @@
         {
           "kind": "shot_miss",
           "period": 1,
-          "clock_seconds": 239,
+          "clock_seconds": 343,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
@@ -1532,13 +1105,217 @@
         {
           "kind": "rebound",
           "period": 1,
-          "clock_seconds": 239,
+          "clock_seconds": 343,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 317,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 291,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 291,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 265,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 265,
           "team_id": 3,
           "player_id": 202
         },
         {
           "kind": "possession_start",
           "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 239,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
           "clock_seconds": 226,
           "team_id": 3
         },
@@ -1556,30 +1333,6 @@
           "clock_seconds": 226,
           "team_id": 3,
           "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 202,
           "shot_type": "3pt"
         },
         {
@@ -1600,23 +1353,23 @@
           "period": 1,
           "clock_seconds": 213,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
+          "player_id": 102,
+          "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 213,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
+          "player_id": 102,
+          "shot_type": "3pt"
         },
         {
           "kind": "rebound",
           "period": 1,
           "clock_seconds": 213,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "offensive_rebound": true
         },
         {
@@ -1624,7 +1377,7 @@
           "period": 1,
           "clock_seconds": 213,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -1632,165 +1385,110 @@
           "period": 1,
           "clock_seconds": 213,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
           "kind": "rebound",
           "period": 1,
           "clock_seconds": 213,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 187,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 187,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 174,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 161,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 161,
           "team_id": 3,
           "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 200,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 187,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 174,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 161,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
         },
         {
           "kind": "possession_start",
@@ -1829,43 +1527,12 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 1,
           "clock_seconds": 135,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 3,
-          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -1879,167 +1546,34 @@
           "clock_seconds": 122,
           "team_id": 3,
           "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 122,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 109,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 102,
           "shot_type": "3pt"
         },
         {
           "kind": "shot_make",
           "period": 1,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 109,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
           "clock_seconds": 109,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 96,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 96,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 83,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 57,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 57,
-          "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
           "period": 1,
-          "clock_seconds": 57,
+          "clock_seconds": 109,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
@@ -2047,13 +1581,156 @@
         {
           "kind": "rebound",
           "period": 1,
-          "clock_seconds": 57,
+          "clock_seconds": 109,
           "team_id": 3,
           "player_id": 202
         },
         {
           "kind": "possession_start",
           "period": 1,
+          "clock_seconds": 96,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 83,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 57,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 57,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
           "clock_seconds": 44,
           "team_id": 3
         },
@@ -2066,19 +1743,12 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 1,
           "clock_seconds": 44,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 44,
-          "team_id": 7,
-          "player_id": 101
         },
         {
           "kind": "possession_start",
@@ -2091,7 +1761,55 @@
           "period": 1,
           "clock_seconds": 31,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -2099,7 +1817,7 @@
           "period": 1,
           "clock_seconds": 31,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -2117,19 +1835,12 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 1,
           "clock_seconds": 18,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 18,
-          "team_id": 7,
-          "player_id": 101
         },
         {
           "kind": "possession_start",
@@ -2142,7 +1853,7 @@
           "period": 1,
           "clock_seconds": 5,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -2150,7 +1861,7 @@
           "period": 1,
           "clock_seconds": 5,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -2158,7 +1869,7 @@
           "period": 1,
           "clock_seconds": 5,
           "team_id": 3,
-          "player_id": 201
+          "player_id": 202
         },
         {
           "kind": "period_boundary",
@@ -2176,53 +1887,29 @@
           "period": 2,
           "clock_seconds": 720,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
+          "player_id": 202,
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
           "period": 2,
           "clock_seconds": 720,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
+          "player_id": 202,
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
           "period": 2,
           "clock_seconds": 720,
           "team_id": 7,
-          "player_id": 102
+          "player_id": 101
         },
         {
           "kind": "possession_start",
           "period": 2,
           "clock_seconds": 707,
           "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -2282,29 +1969,53 @@
           "period": 2,
           "clock_seconds": 694,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
+          "player_id": 201,
+          "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
           "period": 2,
           "clock_seconds": 694,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
+          "player_id": 201,
+          "shot_type": "3pt"
         },
         {
           "kind": "rebound",
           "period": 2,
           "clock_seconds": 694,
           "team_id": 7,
-          "player_id": 102
+          "player_id": 101
         },
         {
           "kind": "possession_start",
           "period": 2,
           "clock_seconds": 681,
           "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -2339,7 +2050,7 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 2,
           "clock_seconds": 681,
           "team_id": 7,
@@ -2347,17 +2058,34 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
           "kind": "possession_start",
           "period": 2,
           "clock_seconds": 668,
           "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -2379,14 +2107,103 @@
           "kind": "rebound",
           "period": 2,
           "clock_seconds": 668,
-          "team_id": 7,
-          "player_id": 102
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
         },
         {
           "kind": "possession_start",
           "period": 2,
           "clock_seconds": 655,
           "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -2415,16 +2232,23 @@
           "period": 2,
           "clock_seconds": 642,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 2,
           "clock_seconds": 642,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 642,
+          "team_id": 7,
+          "player_id": 102
         },
         {
           "kind": "possession_start",
@@ -2437,23 +2261,16 @@
           "period": 2,
           "clock_seconds": 629,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 2,
           "clock_seconds": 629,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 629,
-          "team_id": 3,
-          "player_id": 202
         },
         {
           "kind": "possession_start",
@@ -2470,7 +2287,7 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 2,
           "clock_seconds": 616,
           "team_id": 3,
@@ -2478,17 +2295,34 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 616,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
           "kind": "possession_start",
           "period": 2,
           "clock_seconds": 603,
           "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -2533,7 +2367,7 @@
           "period": 2,
           "clock_seconds": 590,
           "team_id": 7,
-          "player_id": 102
+          "player_id": 101
         },
         {
           "kind": "possession_start",
@@ -2562,7 +2396,7 @@
           "period": 2,
           "clock_seconds": 577,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "offensive_rebound": true
         },
         {
@@ -2570,16 +2404,23 @@
           "period": 2,
           "clock_seconds": 577,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 2,
           "clock_seconds": 577,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 577,
+          "team_id": 3,
+          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -2630,7 +2471,7 @@
           "period": 2,
           "clock_seconds": 551,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "offensive_rebound": true
         },
         {
@@ -2638,7 +2479,31 @@
           "period": 2,
           "clock_seconds": 551,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -2646,7 +2511,7 @@
           "period": 2,
           "clock_seconds": 551,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -2664,19 +2529,12 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 2,
           "clock_seconds": 538,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 538,
-          "team_id": 7,
-          "player_id": 101
         },
         {
           "kind": "possession_start",
@@ -2689,7 +2547,7 @@
           "period": 2,
           "clock_seconds": 525,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -2697,7 +2555,7 @@
           "period": 2,
           "clock_seconds": 525,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -2740,22 +2598,53 @@
           "period": 2,
           "clock_seconds": 499,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 2,
           "clock_seconds": 499,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 499,
+          "team_id": 3,
+          "player_id": 201
         },
         {
           "kind": "possession_start",
           "period": 2,
           "clock_seconds": 486,
           "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -2777,8 +2666,25 @@
           "kind": "rebound",
           "period": 2,
           "clock_seconds": 486,
-          "team_id": 7,
-          "player_id": 102
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
         },
         {
           "kind": "possession_start",
@@ -2791,7 +2697,7 @@
           "period": 2,
           "clock_seconds": 473,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -2799,55 +2705,7 @@
           "period": 2,
           "clock_seconds": 473,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -2867,12 +2725,19 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 2,
           "clock_seconds": 473,
           "team_id": 7,
           "player_id": 102,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 473,
+          "team_id": 3,
+          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -2885,55 +2750,7 @@
           "period": 2,
           "clock_seconds": 460,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
+          "player_id": 202,
           "shot_type": "3pt"
         },
         {
@@ -2941,7 +2758,7 @@
           "period": 2,
           "clock_seconds": 460,
           "team_id": 3,
-          "player_id": 201,
+          "player_id": 202,
           "shot_type": "3pt"
         },
         {
@@ -2955,7 +2772,7 @@
           "period": 2,
           "clock_seconds": 447,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -2963,7 +2780,7 @@
           "period": 2,
           "clock_seconds": 447,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -2971,3439 +2788,3567 @@
           "period": 2,
           "clock_seconds": 434,
           "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 395,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 382,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 304,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 291,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 278,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 226,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 226,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 213,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 148,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 122,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 122,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 109,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 83,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 83,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 57,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 57,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 44,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 44,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7
         },
         {
           "kind": "foul",
           "period": 2,
-          "clock_seconds": 5,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "free_throw",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "ft"
-        },
-        {
-          "kind": "period_boundary",
-          "period": 2,
-          "clock_seconds": 0
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 694,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 694,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 694,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 694,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 681,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 616,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 577,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 538,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 538,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 512,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 499,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 499,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 473,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 473,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 460,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 447,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
           "clock_seconds": 434,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 382,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 369,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 369,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 356,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 356,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 343,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 317,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 304,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 304,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 291,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 291,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 278,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 278,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 265,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 239,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 239,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 226,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 226,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 213,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 213,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 200,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 174,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 148,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 109,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 96,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 96,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 57,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 57,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 31,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 18,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 5,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 5,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "period_boundary",
-          "period": 3,
-          "clock_seconds": 0
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 720,
-          "team_id": 3
-        },
-        {
-          "kind": "foul",
-          "period": 4,
-          "clock_seconds": 720,
           "team_id": 7,
           "player_id": 101
         },
         {
           "kind": "free_throw",
-          "period": 4,
-          "clock_seconds": 720,
+          "period": 2,
+          "clock_seconds": 434,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "ft"
         },
         {
           "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 421,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 408,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 395,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 382,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 369,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 356,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 343,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 317,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 304,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 304,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 291,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 278,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 252,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 239,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 226,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 213,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 200,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 187,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 174,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 161,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 148,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 122,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 122,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 109,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 109,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 96,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 83,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 57,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 57,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 44,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 44,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 31,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 18,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "period_boundary",
+          "period": 2,
+          "clock_seconds": 0
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 707,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 694,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 694,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 694,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 681,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 668,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 655,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 642,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 629,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 616,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 603,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 577,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 564,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 538,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 538,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 512,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 512,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 499,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 499,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 486,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 473,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 460,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 447,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 395,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 382,
+          "team_id": 3
+        },
+        {
+          "kind": "foul",
+          "period": 3,
+          "clock_seconds": 382,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "free_throw",
+          "period": 3,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "ft"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 356,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 343,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 343,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 317,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 304,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 304,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 291,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 291,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 278,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 265,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 239,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 239,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 226,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 213,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 213,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 200,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 200,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 187,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 174,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 174,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 161,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 148,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 148,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 122,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 109,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 109,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 96,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 96,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 83,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 57,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 44,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 31,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 31,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 31,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 18,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 18,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 5,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 5,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 5,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "period_boundary",
+          "period": 3,
+          "clock_seconds": 0
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 720,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
           "period": 4,
           "clock_seconds": 707,
           "team_id": 7
@@ -6413,7 +6358,7 @@
           "period": 4,
           "clock_seconds": 707,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -6421,7 +6366,7 @@
           "period": 4,
           "clock_seconds": 707,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -6442,78 +6387,71 @@
           "period": 4,
           "clock_seconds": 694,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 694,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 681,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 681,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 668,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 668,
-          "team_id": 3,
           "player_id": 201,
           "shot_type": "3pt"
         },
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 668,
+          "clock_seconds": 694,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "possession_start",
           "period": 4,
+          "clock_seconds": 681,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 668,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
           "clock_seconds": 655,
           "team_id": 7
         },
@@ -6526,19 +6464,12 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 4,
           "clock_seconds": 655,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 655,
-          "team_id": 3,
-          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -6590,8 +6521,56 @@
           "kind": "rebound",
           "period": 4,
           "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 642,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 642,
           "team_id": 7,
-          "player_id": 101
+          "player_id": 102
         },
         {
           "kind": "possession_start",
@@ -6604,16 +6583,23 @@
           "period": 4,
           "clock_seconds": 629,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 629,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 629,
+          "team_id": 3,
+          "player_id": 202
         },
         {
           "kind": "possession_start",
@@ -6627,15 +6613,22 @@
           "clock_seconds": 616,
           "team_id": 3,
           "player_id": 202,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 616,
           "team_id": 3,
           "player_id": 202,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 616,
+          "team_id": 7,
+          "player_id": 102
         },
         {
           "kind": "possession_start",
@@ -6687,104 +6680,8 @@
           "kind": "rebound",
           "period": 4,
           "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 603,
           "team_id": 3,
-          "player_id": 201
+          "player_id": 202
         },
         {
           "kind": "possession_start",
@@ -6835,7 +6732,7 @@
           "period": 4,
           "clock_seconds": 577,
           "team_id": 3,
-          "player_id": 202
+          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -6849,7 +6746,7 @@
           "clock_seconds": 564,
           "team_id": 3,
           "player_id": 201,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
@@ -6857,85 +6754,20 @@
           "clock_seconds": 564,
           "team_id": 3,
           "player_id": 201,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
           "period": 4,
           "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
+          "team_id": 7,
+          "player_id": 102
         },
         {
           "kind": "possession_start",
           "period": 4,
           "clock_seconds": 551,
           "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -6971,16 +6803,16 @@
           "period": 4,
           "clock_seconds": 538,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
+          "player_id": 202,
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 538,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
+          "player_id": 202,
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
@@ -7024,7 +6856,7 @@
           "period": 4,
           "clock_seconds": 525,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -7032,7 +6864,7 @@
           "period": 4,
           "clock_seconds": 525,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -7053,7 +6885,7 @@
           "period": 4,
           "clock_seconds": 512,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -7061,7 +6893,7 @@
           "period": 4,
           "clock_seconds": 512,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -7075,7 +6907,7 @@
           "period": 4,
           "clock_seconds": 499,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -7083,7 +6915,7 @@
           "period": 4,
           "clock_seconds": 499,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -7101,11 +6933,35 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 486,
           "team_id": 3,
           "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 486,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -7119,23 +6975,23 @@
           "period": 4,
           "clock_seconds": 473,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
+          "player_id": 101,
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 473,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
+          "player_id": 101,
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
           "period": 4,
           "clock_seconds": 473,
           "team_id": 3,
-          "player_id": 202
+          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -7148,54 +7004,6 @@
           "period": 4,
           "clock_seconds": 460,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 460,
-          "team_id": 3,
           "player_id": 202,
           "shot_type": "3pt"
         },
@@ -7219,15 +7027,22 @@
           "clock_seconds": 447,
           "team_id": 7,
           "player_id": 102,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 447,
           "team_id": 7,
           "player_id": 102,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 447,
+          "team_id": 3,
+          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -7269,7 +7084,7 @@
           "period": 4,
           "clock_seconds": 421,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -7277,7 +7092,7 @@
           "period": 4,
           "clock_seconds": 421,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -7285,7 +7100,7 @@
           "period": 4,
           "clock_seconds": 421,
           "team_id": 3,
-          "player_id": 202
+          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -7298,71 +7113,16 @@
           "period": 4,
           "clock_seconds": 408,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 3,
           "player_id": 201,
-          "offensive_rebound": true
+          "shot_type": "3pt"
         },
         {
-          "kind": "shot_attempt",
+          "kind": "shot_make",
           "period": 4,
           "clock_seconds": 408,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 7,
-          "player_id": 101
         },
         {
           "kind": "possession_start",
@@ -7375,16 +7135,23 @@
           "period": 4,
           "clock_seconds": 395,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 395,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 395,
+          "team_id": 3,
+          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -7397,7 +7164,7 @@
           "period": 4,
           "clock_seconds": 382,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -7405,137 +7172,161 @@
           "period": 4,
           "clock_seconds": 382,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
           "kind": "rebound",
           "period": 4,
           "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 382,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 369,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 369,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 356,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 369,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
           "clock_seconds": 343,
           "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -7575,7 +7366,7 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 4,
           "clock_seconds": 330,
           "team_id": 3,
@@ -7583,41 +7374,37 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "rebound",
+          "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
+          "clock_seconds": 317,
+          "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
-          "kind": "rebound",
+          "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
+          "clock_seconds": 304,
+          "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 330,
+          "clock_seconds": 304,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "3pt"
@@ -7625,7 +7412,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 330,
+          "clock_seconds": 304,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "3pt"
@@ -7633,20 +7420,20 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 330,
+          "clock_seconds": 304,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 317,
+          "clock_seconds": 291,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 317,
+          "clock_seconds": 291,
           "team_id": 7,
           "player_id": 102,
           "shot_type": "3pt"
@@ -7654,7 +7441,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 317,
+          "clock_seconds": 291,
           "team_id": 7,
           "player_id": 102,
           "shot_type": "3pt"
@@ -7662,7 +7449,7 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 317,
+          "clock_seconds": 291,
           "team_id": 7,
           "player_id": 101,
           "offensive_rebound": true
@@ -7670,7 +7457,7 @@
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 317,
+          "clock_seconds": 291,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
@@ -7678,53 +7465,9 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 317,
+          "clock_seconds": 291,
           "team_id": 7,
           "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 304,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 291,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
           "shot_type": "3pt"
         },
         {
@@ -7738,16 +7481,16 @@
           "period": 4,
           "clock_seconds": 278,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
+          "player_id": 202,
+          "shot_type": "3pt"
         },
         {
           "kind": "shot_make",
           "period": 4,
           "clock_seconds": 278,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
+          "player_id": 202,
+          "shot_type": "3pt"
         },
         {
           "kind": "possession_start",
@@ -7760,31 +7503,7 @@
           "period": 4,
           "clock_seconds": 265,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -7792,7 +7511,7 @@
           "period": 4,
           "clock_seconds": 265,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
@@ -7800,6 +7519,30 @@
           "period": 4,
           "clock_seconds": 252,
           "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 252,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
@@ -7835,55 +7578,7 @@
           "period": 4,
           "clock_seconds": 239,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "2pt"
         },
         {
@@ -7891,7 +7586,31 @@
           "period": 4,
           "clock_seconds": 239,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 239,
+          "team_id": 7,
+          "player_id": 101,
           "shot_type": "2pt"
         },
         {
@@ -7912,16 +7631,23 @@
           "period": 4,
           "clock_seconds": 226,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 226,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 226,
+          "team_id": 7,
+          "player_id": 102
         },
         {
           "kind": "possession_start",
@@ -7949,202 +7675,257 @@
           "kind": "rebound",
           "period": 4,
           "clock_seconds": 213,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 200,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 200,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 187,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 174,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 161,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 161,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 148,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 135,
           "team_id": 3,
           "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 200,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 200,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 161,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
         },
         {
           "kind": "possession_start",
@@ -8179,16 +7960,23 @@
           "period": 4,
           "clock_seconds": 109,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 109,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 109,
+          "team_id": 3,
+          "player_id": 201
         },
         {
           "kind": "possession_start",
@@ -8201,32 +7989,8 @@
           "period": 4,
           "clock_seconds": 96,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 96,
-          "team_id": 3,
           "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
@@ -8234,7 +7998,7 @@
           "clock_seconds": 96,
           "team_id": 3,
           "player_id": 202,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
@@ -8283,34 +8047,78 @@
           "period": 4,
           "clock_seconds": 70,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 70,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 57,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 57,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 44,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 44,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 70,
+          "clock_seconds": 44,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
+          "player_id": 201,
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 70,
+          "clock_seconds": 44,
           "team_id": 7,
           "player_id": 101
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 57,
+          "clock_seconds": 31,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 57,
+          "clock_seconds": 31,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
@@ -8318,7 +8126,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 57,
+          "clock_seconds": 31,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "3pt"
@@ -8326,90 +8134,63 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 44,
+          "clock_seconds": 18,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 44,
+          "clock_seconds": 18,
           "team_id": 3,
           "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 44,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 31,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 101,
           "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 101,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
           "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 18,
-          "team_id": 3
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 18,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
           "period": 4,
           "clock_seconds": 18,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -8417,7 +8198,7 @@
           "period": 4,
           "clock_seconds": 18,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
@@ -8431,23 +8212,16 @@
           "period": 4,
           "clock_seconds": 5,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 4,
           "clock_seconds": 5,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 101,
           "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 5,
-          "team_id": 3,
-          "player_id": 201
         },
         {
           "kind": "period_boundary",
@@ -8461,31 +8235,31 @@
           "pos": "PG",
           "gameMIN": 36,
           "game2GM": 0,
-          "game2GA": 4,
+          "game2GA": 6,
           "gameFTM": 0,
-          "gameFTA": 2,
-          "game3GM": 25,
+          "gameFTA": 0,
+          "game3GM": 29,
           "game3GA": 76,
-          "gameORB": 26,
-          "gameDRB": 30,
+          "gameORB": 25,
+          "gameDRB": 26,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 2
         },
         {
           "pid": 102,
           "pos": "SG",
           "gameMIN": 18,
-          "game2GM": 1,
-          "game2GA": 6,
+          "game2GM": 0,
+          "game2GA": 7,
           "gameFTM": 0,
           "gameFTA": 0,
-          "game3GM": 29,
-          "game3GA": 80,
-          "gameORB": 29,
-          "gameDRB": 30,
+          "game3GM": 20,
+          "game3GA": 72,
+          "gameORB": 24,
+          "gameDRB": 29,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
@@ -8514,14 +8288,14 @@
           "pid": 201,
           "pos": "SF",
           "gameMIN": 34,
-          "game2GM": 1,
-          "game2GA": 10,
+          "game2GM": 0,
+          "game2GA": 11,
           "gameFTM": 0,
-          "gameFTA": 2,
+          "gameFTA": 4,
           "game3GM": 26,
-          "game3GA": 80,
-          "gameORB": 36,
-          "gameDRB": 25,
+          "game3GA": 74,
+          "gameORB": 28,
+          "gameDRB": 33,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
@@ -8533,18 +8307,18 @@
           "pos": "PF",
           "gameMIN": 22,
           "game2GM": 0,
-          "game2GA": 8,
+          "game2GA": 6,
           "gameFTM": 0,
           "gameFTA": 0,
-          "game3GM": 24,
-          "game3GA": 70,
-          "gameORB": 21,
-          "gameDRB": 31,
+          "game3GM": 29,
+          "game3GA": 72,
+          "gameORB": 25,
+          "gameDRB": 30,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 0
         }
       ],
       "team_boxes": [
@@ -8552,45 +8326,45 @@
           "team_id": 7,
           "is_home": false,
           "q1": 39,
-          "q2": 48,
+          "q2": 39,
           "q3": 36,
-          "q4": 41,
+          "q4": 33,
           "ot": [],
-          "game2GM": 1,
-          "game2GA": 10,
+          "game2GM": 0,
+          "game2GA": 13,
           "gameFTM": 0,
-          "gameFTA": 2,
-          "game3GM": 54,
-          "game3GA": 156,
-          "gameORB": 55,
-          "gameDRB": 60,
+          "gameFTA": 0,
+          "game3GM": 49,
+          "game3GA": 148,
+          "gameORB": 49,
+          "gameDRB": 55,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 2
         },
         {
           "team_id": 3,
           "is_home": true,
-          "q1": 33,
-          "q2": 39,
-          "q3": 39,
-          "q4": 41,
+          "q1": 54,
+          "q2": 33,
+          "q3": 33,
+          "q4": 45,
           "ot": [],
-          "game2GM": 1,
-          "game2GA": 18,
+          "game2GM": 0,
+          "game2GA": 17,
           "gameFTM": 0,
-          "gameFTA": 2,
-          "game3GM": 50,
-          "game3GA": 150,
-          "gameORB": 57,
-          "gameDRB": 56,
+          "gameFTA": 4,
+          "game3GM": 55,
+          "game3GA": 146,
+          "gameORB": 53,
+          "gameDRB": 63,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 0
         }
       ]
     }

--- a/engine/internal/sim/transition.go
+++ b/engine/internal/sim/transition.go
@@ -1,0 +1,135 @@
+package sim
+
+import (
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+const (
+	// transitionTriggerDenom is the Stage-2 trigger roll domain: a random on-court
+	// starter fires the break iff rand_int(1..transitionTriggerDenom) ≤ its
+	// TransOff rating (00_MASTER_REFERENCE.md L878-896). The denom (20) sits above
+	// the 1-9 TransOff scale so a max roll never fires for a real rating; it stands
+	// in for the unpinned coaching-mod threshold. Documented stand-in.
+	transitionTriggerDenom = 20
+
+	// transitionShotRateDecay / transitionShotRateFloor implement the Stage-3
+	// per-period decay (L912): the team shot-rate threshold drops by 2.0 on each
+	// successful fast break, floored at 2.0, so break frequency falls as the
+	// period progresses.
+	transitionShotRateDecay = 2.0
+	transitionShotRateFloor = 2.0
+)
+
+// resetTransitionShotRate is the Stage-3 base threshold: the breaking team's
+// aggregate attempt rate Σ(FGA + TGA + FTA) over its starters
+// (00_MASTER_REFERENCE.md L900-909, team DA0 = FT+2P+3P rates). Higher-tempo
+// offenses generate more fast breaks.
+func resetTransitionShotRate(breakingTeam *teamState) float64 {
+	var rate float64
+	for _, p := range breakingTeam.players {
+		rate += float64(p.FGA + p.TGA + p.FTA)
+	}
+	return rate
+}
+
+// transitionTriggers is Stage 2 (L878-896): pick a random on-court starter and
+// fire the break iff a 1..transitionTriggerDenom roll falls at or under that
+// starter's TransOff rating. A failed check means the possession proceeds as a
+// normal half-court play despite the pending flag.
+func transitionTriggers(offense *teamState, r *rng.RNG) bool {
+	if len(offense.players) == 0 {
+		return false
+	}
+	p := offense.players[r.IntN(len(offense.players))]
+	return r.IntN(transitionTriggerDenom)+1 <= p.TransOff
+}
+
+// transitionStealSucceeds is Stage 3 (L900-914): P(success) = rate / (rate + blk)
+// where rate is the decaying team shot-rate (gs.transitionShotRate) and blk is
+// the defending team's Σ BLK — block-heavy defenses convert fewer stops into
+// fast breaks. On success the shot-rate decays by transitionShotRateDecay,
+// floored at transitionShotRateFloor.
+func (gs *gameState) transitionStealSucceeds(defense *teamState) bool {
+	rate := gs.transitionShotRate
+	var blk float64
+	for _, p := range defense.players {
+		blk += float64(p.BLK)
+	}
+	span := rate + blk
+	success := true
+	if span > 0 {
+		success = gs.rng.Float64()*span <= rate
+	}
+	if success {
+		gs.transitionShotRate = rate - transitionShotRateDecay
+		if gs.transitionShotRate < transitionShotRateFloor {
+			gs.transitionShotRate = transitionShotRateFloor
+		}
+	}
+	return success
+}
+
+// transitionNet is the Stage-4 net advantage for a fast break (L916-920):
+// a fixed 5.0 minus only the defender's transition-defense rating. No position
+// penalty and no OO/DO/PO term apply; TransOff does not affect this formula.
+func transitionNet(defender onCourt) float64 {
+	return 5.0 - floor1(defender.TD)
+}
+
+// runTransitionPossession resolves a fired fast break (Stage 4). The ball handler
+// is reselected by the normal Phase-4 weighted random (L922-923); the contesting
+// transition defender supplies the 5.0−TD net. The outcome routes through the
+// existing shot/free-throw/rebound machinery with stealPlay=true, so the attempt
+// can never be a 3-pointer (allowedPaths). A defensive rebound or steal ending
+// the break re-arms the fast-break flag (returned as fbNext). Offensive rebounds
+// continue the break, bounded by maxOffensiveRebounds.
+func (gs *gameState) runTransitionPossession(offense, defense *teamState, periodIdx int) (fbNext bool) {
+	gs.transitions++
+	bh := selectBallHandler(offense, gs.rng)
+	for trip := 0; trip <= maxOffensiveRebounds; trip++ {
+		scoreDiff := offense.score - defense.score
+		matched := defenderAtSlot(defense, bh.slot)
+		pt := selectShotType(bh, matched, gs.rng)
+		def := selectDefender(defense, pt, gs.rng)
+
+		net := transitionNet(def)
+		mq := matchupQuality(bh.FGP, bh.Stamina, defense.players)
+		sv2 := applyClutch(shotValue2pt(net, bh.FGP, false), bh.Clutch, gs.period, scoreDiff)
+		in := outcomeInputs{
+			twoPtWeight:      sv2 * bh.fatigue,
+			threePtWeight:    0, // a fast break is never a 3pt attempt
+			andOneWeight:     mq*0.25 + base2pt(bh.FGP)*andOneBaseShare,
+			foulOnlyWeight:   (2.0 - bh.fatigue) * floor1(bh.Foul),
+			turnoverDefValue: turnoverThreshold(bh.TVR) * turnoverThreshold(bh.TVR),
+		}
+
+		switch selectOutcome(in, false, false, true, gs.rng) {
+		case outcome2pt:
+			if made, _ := gs.shotAttempt(offense, defense, bh, sv2, result.ShotTwoPoint, periodIdx); !made {
+				gs.creditBlock(offense, defense, bh, def)
+				if cont, next := gs.rebound(offense, defense, periodIdx); cont {
+					bh = next
+					continue
+				}
+				return true // defensive rebound re-arms the fast break
+			}
+			return false // made shot
+		case outcomeAndOne:
+			gs.madeFieldGoal(offense, bh, result.ShotTwoPoint, periodIdx)
+			gs.freeThrows(offense, defense, bh, def, 1, periodIdx)
+			return false
+		case outcomeFoulOnly:
+			gs.freeThrows(offense, defense, bh, def, 2, periodIdx)
+			return false
+		case outcomeTurnover:
+			offense.box(bh.PID).GameTOV++
+			gs.emit(result.Event{
+				Kind: result.EventTurnover, Period: gs.period, Clock: gs.clock,
+				TeamID: offense.teamID, PlayerID: bh.PID,
+			})
+			return gs.creditSteal(offense, defense, bh)
+		}
+	}
+	return false
+}

--- a/engine/internal/sim/transition_test.go
+++ b/engine/internal/sim/transition_test.go
@@ -1,0 +1,222 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// onePlayerTeam wraps a single starter as a teamState — used to neutralize the
+// random-starter draw in Stage-2 trigger boundary tests (IntN(1) == 0).
+func onePlayerTeam(p bundle.Player) *teamState {
+	return &teamState{players: []onCourt{oc(slotPG, p)}}
+}
+
+// --- matrix #10: a transition possession resolves and is never a 3pt ---------
+
+func TestRunTransitionPossession_NeverThreePoint(t *testing.T) {
+	var attempts, threes, resolved int
+	for seed := uint64(1); seed <= 300; seed++ {
+		offense, defense := twoTeams()
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+		gs.transitionShotRate = resetTransitionShotRate(offense)
+		gs.runTransitionPossession(offense, defense, 0)
+		resolved++
+		for _, e := range gs.events {
+			if e.Kind == result.EventShotAttempt {
+				attempts++
+				if e.ShotType == result.ShotThree {
+					threes++
+				}
+			}
+		}
+	}
+	if resolved == 0 {
+		t.Fatal("no transition possessions ran")
+	}
+	if attempts == 0 {
+		t.Fatal("transition possessions produced no shot attempts")
+	}
+	if threes != 0 {
+		t.Errorf("transition produced %d three-point attempts, want 0", threes)
+	}
+}
+
+// --- matrix #11: transitionNet = 5.0 − floor1(TD), no position penalty --------
+
+func TestTransitionNet(t *testing.T) {
+	cases := []struct {
+		td   int
+		want float64
+	}{
+		{5, 0.0},  // 5.0 − 5
+		{0, 4.0},  // floor1(0) = 1 → 5.0 − 1
+		{9, -4.0}, // 5.0 − 9
+		{1, 4.0},  // 5.0 − 1
+	}
+	for _, c := range cases {
+		p := mkPlayer(1, 7, slotPG, 46)
+		p.TD = c.td
+		if got := transitionNet(oc(slotPG, p)); got != c.want {
+			t.Errorf("transitionNet(TD=%d) = %v, want %v", c.td, got, c.want)
+		}
+	}
+}
+
+// --- matrix #12: Stage-2 trigger boundary ------------------------------------
+
+func TestTransitionTriggers_Boundary(t *testing.T) {
+	zero := mkPlayer(1, 7, slotPG, 46)
+	zero.TransOff = 0
+	full := mkPlayer(2, 7, slotPG, 46)
+	full.TransOff = transitionTriggerDenom // roll (1..denom) ≤ denom always holds
+
+	for seed := uint64(1); seed <= 200; seed++ {
+		r := rng.New(seed)
+		if transitionTriggers(onePlayerTeam(zero), r) {
+			t.Fatalf("seed %d: TransOff=0 must never trigger", seed)
+		}
+		if !transitionTriggers(onePlayerTeam(full), rng.New(seed)) {
+			t.Fatalf("seed %d: TransOff=denom must always trigger", seed)
+		}
+	}
+}
+
+// --- matrix #13: Stage-3 decay floors at 2.0 ---------------------------------
+
+func TestTransitionStealSucceeds_DecayFloors(t *testing.T) {
+	// blk = 0 makes success deterministic (always true for rate > 0), isolating
+	// the decay from the RNG.
+	z := mkPlayer(1, 3, slotPG, 50)
+	z.BLK = 0
+	defense := onePlayerTeam(z)
+
+	gs := &gameState{rng: rng.New(1), period: 1, clock: 500}
+	gs.transitionShotRate = 5.0
+	want := []float64{3.0, 2.0, 2.0, 2.0, 2.0} // 5→3→floor 2, then stays
+	for i, w := range want {
+		if !gs.transitionStealSucceeds(defense) {
+			t.Fatalf("call %d: expected success with blk=0", i)
+		}
+		if gs.transitionShotRate != w {
+			t.Fatalf("call %d: shot rate = %v, want %v", i, gs.transitionShotRate, w)
+		}
+		if gs.transitionShotRate < transitionShotRateFloor {
+			t.Fatalf("call %d: shot rate fell below floor", i)
+		}
+	}
+}
+
+// --- matrix #14: Stage-3 failure falls back (no transition) ------------------
+
+func TestTransitionStealSucceeds_FailsWhenRateZero(t *testing.T) {
+	// rate = 0 with blk > 0: success requires Float64()*blk ≤ 0, effectively
+	// never. The shot rate must not decay on a failure.
+	big := mkPlayer(1, 3, slotPG, 50)
+	big.BLK = 100
+	defense := onePlayerTeam(big)
+	for seed := uint64(1); seed <= 200; seed++ {
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+		gs.transitionShotRate = 0
+		if gs.transitionStealSucceeds(defense) {
+			t.Fatalf("seed %d: steal-success must fail when rate=0, blk>0", seed)
+		}
+		if gs.transitionShotRate != 0 {
+			t.Fatalf("seed %d: shot rate decayed on a failure", seed)
+		}
+	}
+}
+
+// noTransitionTeams builds offense (TransOff=0, Stage-2 always fails) and a
+// normal defense, so possession() always falls through to the half-court loop.
+func noTransitionTeams() (*teamState, *teamState) {
+	var ps []bundle.Player
+	pid := 300
+	for slot := slotPG; slot <= slotC; slot++ {
+		pid++
+		p := mkPlayer(pid, 7, slot, 46)
+		p.TransOff = 0
+		ps = append(ps, p)
+	}
+	for slot := slotPG; slot <= slotC; slot++ {
+		pid++
+		ps = append(ps, mkPlayer(pid, 3, slot, 50))
+	}
+	return newTeamState(ps, 7, false), newTeamState(ps, 3, true)
+}
+
+// classifyEnding reports whether a possession's events ended in a defensive
+// rebound or a steal — the two conditions that re-arm the fast-break flag.
+func classifyEnding(evs []result.Event) (dreb, steal, made bool) {
+	for _, e := range evs {
+		switch {
+		case e.Kind == result.EventRebound && !e.OffensiveRebound:
+			dreb = true
+		case e.Kind == result.EventSteal:
+			steal = true
+		case e.Kind == result.EventShotMake:
+			made = true
+		}
+	}
+	return
+}
+
+// --- matrix #15/#16/#17: fbNext == (defensive rebound OR steal) --------------
+
+func TestPossession_FastBreakFlagMatchesEnding(t *testing.T) {
+	var seenMade, seenDReb, seenSteal bool
+	for seed := uint64(1); seed <= 400; seed++ {
+		offense, defense := twoTeams()
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+		fbNext := possession(gs, offense, defense, 0, false)
+		dreb, steal, made := classifyEnding(gs.events)
+		if want := dreb || steal; fbNext != want {
+			t.Fatalf("seed %d: fbNext = %v, want %v (dreb=%v steal=%v)", seed, fbNext, want, dreb, steal)
+		}
+		switch {
+		case steal:
+			seenSteal = true // #17
+		case dreb:
+			seenDReb = true // #16
+		case made && !fbNext:
+			seenMade = true // #15: a made-shot possession clears the flag
+		}
+	}
+	if !seenMade {
+		t.Error("never observed a made-shot possession returning fbNext=false")
+	}
+	if !seenDReb {
+		t.Error("never observed a defensive-rebound possession returning fbNext=true")
+	}
+	if !seenSteal {
+		t.Error("never observed a steal possession returning fbNext=true")
+	}
+}
+
+// --- matrix #18: pending flag consumed unconditionally on Stage-2 failure -----
+
+func TestPossession_PendingConsumedOnStageTwoFail(t *testing.T) {
+	var seenClearedDespitePending bool
+	for seed := uint64(1); seed <= 400; seed++ {
+		offense, defense := noTransitionTeams()
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+		// fbPending = true, but TransOff=0 means Stage 2 always fails.
+		fbNext := possession(gs, offense, defense, 0, true)
+		if gs.transitions != 0 {
+			t.Fatalf("seed %d: a transition fired despite TransOff=0", seed)
+		}
+		dreb, steal, made := classifyEnding(gs.events)
+		// The return reflects THIS possession, not the stale input flag.
+		if want := dreb || steal; fbNext != want {
+			t.Fatalf("seed %d: fbNext = %v, want %v", seed, fbNext, want)
+		}
+		if made && !fbNext {
+			seenClearedDespitePending = true
+		}
+	}
+	if !seenClearedDespitePending {
+		t.Error("never observed the pending flag cleared by a made-shot possession")
+	}
+}


### PR DESCRIPTION
PR3b of the JSB native engine program (PR1 #913, PR2 #914, PR3a #915 merged). All work is Go under `engine/internal/sim/` plus a regenerated golden snapshot. No PHP/DB/web.

## What

Three interdependent mechanics, all with draws placed outside `selectOutcome`/`rollMake` so existing distribution tests stay green:

- **Steal attribution** (`steal.go`) — `stealFraction` (0.55) splits turnovers into forced steals vs unforced. A steal credits `GameSTL` to a STL×fatigue-weighted defender; the victim keeps `GameTOV`. `EventSteal` carries `PlayerID`=victim, `DefenderID`=stealer.
- **Block attribution** (`block.go`) — `blockProbability` is BLK-derived, front-contest modulated (`base − base×0.04`), reduced `0.001` per made FG, floored ≥0 and capped at `blockFraction` (0.06). `creditBlock` fires only on 2pt/3pt misses; never alters make/miss or the rebound path.
- **4-stage fast break / transition** (`transition.go`) — Stage 1: pending flag set on a defensive rebound or steal. Stage 2: `TransOff` trigger. Stage 3: decaying team shot-rate steal-success (`rate/(rate+blk)`, decay 2.0, floor 2.0, reset per period). Stage 4: `net = 5.0 − floor1(TD)`, routed with `stealPlay=true` so it can never be a 3pt attempt.

`possession()` now threads `fbPending → fbNext` (a possession ending in a defensive rebound OR steal re-arms the flag; consumed unconditionally). `gameloop` resets the shot-rate per period. `simGame` returns an internal transition count for test observability (not part of the result contract).

All pinned constants are documented validation-phase stand-ins. `golden.json` regenerated (RNG reorder from the new draws).

## Testing

24 verification-matrix rows covered across `steal_test.go`, `block_test.go`, `transition_test.go`, `box_test.go`, `sim_test.go`, and the golden snapshot. Full engine suite green (`go vet ./...` + `go test ./... -count=1`).

## Manual Testing

No manual testing needed — all changes are covered by automated tests.

Generated with [Claude Code](https://claude.ai/code)