### PR TITLE
engine(sim): real JSB 5-pass starter selection + ranked rotation (PR4a)

### DIFF
--- a/engine/internal/sim/lineup.go
+++ b/engine/internal/sim/lineup.go
@@ -1,6 +1,11 @@
 package sim
 
-import "github.com/a-jay85/IBL5/engine/internal/bundle"
+import (
+	"math"
+	"sort"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
 
 // slotDepth returns the player's depth-chart value for the given slot (1=PG …
 // 5=C). A value <= 0 means "not in the rotation at this slot".
@@ -20,15 +25,129 @@ func slotDepth(p bundle.Player, slot int) int {
 	return 0
 }
 
-// selectStarters picks the fixed PR3a lineup: per slot, the eligible player with
-// the lowest positive dc_*_depth. Each player starts at most one slot (greedy,
-// slots resolved PG→C); ties break toward bundle order for determinism. Players
-// who win no slot — and any with dc_can_play_in_game == 0 — do not start and end
-// the game as DNP rows. A team with fewer than five eligible players simply
-// returns fewer starters; the caller tolerates a short lineup.
+// posmatch reports whether a player's natural position (its lowest positive
+// depth-chart slot) matches the given slot. It is the fallback-path gate of the
+// JSB 5-pass: a dc<=0 candidate is only eligible for a slot when its natural
+// position is that slot.
 //
-// PR4 replaces this with the real 5-pass selection (dc_bh/di/oi/df/of) and
-// substitutions; PR3a is deliberately fixed-starter, no subs.
+// On IBL5 data this is provably dead: bestDepthPos only ever returns a slot
+// where slotDepth(p, slot) > 0, so it can never equal a slot where the
+// candidate's dc is <= 0 — the two conditions are mutually exclusive for all
+// inputs. We port the predicate for fidelity (mirroring the always-1.0
+// fatigueFactor and the forced-zero dc_bh fields) and document the deadness; a
+// stored natural-position field would be needed to make the +48 band reachable.
+func posmatch(p bundle.Player, slot int) bool {
+	return bestDepthPos(p) == slotName(slot)
+}
+
+// qualityScore is the pure JSB 5-pass candidate score for a slot. dc is the
+// candidate's depth ordinal at the slot (slotDepth); minutes is dc_minutes; pm
+// is whether the candidate's natural position matches the slot (posmatch).
+//
+//   - Bonus path (dc > 0, no position check):
+//     dc<5 && min>=12 → min+192; dc<5 && min<12 → min+144; dc>=5 → min.
+//   - Fallback path (dc <= 0, position must match):
+//     pm && min>=12 → min+48; pm && min<12 → min; else 0.
+//
+// The +96 "already in another slot" JSB tier is intentionally omitted: chosen
+// starters are removed from the greedy pool, so no candidate is ever "already in
+// another slot" during the starter pass.
+//
+// NOTE: score == 0 does NOT mean "unqualified" — qualityScore(5, 0, _) == 0 for
+// a genuinely-eligible deep-bench player. Eligibility is the separate predicate
+// dc>0 || posmatch (see candidatesForSlot); callers never filter on score.
+func qualityScore(dc, minutes int, pm bool) int {
+	if dc > 0 {
+		if dc < 5 {
+			if minutes >= 12 {
+				return minutes + 192
+			}
+			return minutes + 144
+		}
+		return minutes // dc >= 5: no band bonus
+	}
+	// Fallback path (dc <= 0): only position-matching candidates score.
+	if pm {
+		if minutes >= 12 {
+			return minutes + 48
+		}
+		return minutes
+	}
+	return 0
+}
+
+// dcSortKey maps a candidate's slot depth to its sort key: positive depths sort
+// ascending (depth 1 is best), while dc<=0 (fallback candidates) sort last so
+// any bonus candidate beats any fallback candidate.
+func dcSortKey(dc int) int {
+	if dc <= 0 {
+		return math.MaxInt
+	}
+	return dc
+}
+
+// slotCandidate is one ranked candidate for a slot during the 5-pass.
+type slotCandidate struct {
+	player bundle.Player
+	idx    int // roster (bundle) order, for deterministic tie-break
+	dc     int
+	score  int
+}
+
+// candidatesForSlot builds the ranked, eligible candidates for one slot from the
+// roster, skipping any PID in `taken`. Eligibility is dc>0 (bonus path) or
+// posmatch (fallback path); ineligible players are excluded so an unfillable
+// slot stays empty (short lineups are preserved). Ranking: dc ASC (dc<=0 last),
+// then score DESC, then bundle order ASC.
+func candidatesForSlot(roster []bundle.Player, slot int, taken map[int]bool) []slotCandidate {
+	cands := make([]slotCandidate, 0, len(roster))
+	for i, p := range roster {
+		if taken[p.PID] {
+			continue
+		}
+		dc := slotDepth(p, slot)
+		pm := posmatch(p, slot)
+		if dc <= 0 && !pm {
+			continue // ineligible for this slot
+		}
+		cands = append(cands, slotCandidate{
+			player: p,
+			idx:    i,
+			dc:     dc,
+			score:  qualityScore(dc, p.DCMinutes, pm),
+		})
+	}
+	sort.SliceStable(cands, func(a, b int) bool {
+		ka, kb := dcSortKey(cands[a].dc), dcSortKey(cands[b].dc)
+		if ka != kb {
+			return ka < kb // dc ASC primary (dc<=0 sorts last)
+		}
+		if cands[a].score != cands[b].score {
+			return cands[a].score > cands[b].score // score DESC secondary
+		}
+		return cands[a].idx < cands[b].idx // bundle order tertiary
+	})
+	return cands
+}
+
+// selectStarters runs the real JSB five-pass starter selection. Pass i (PG→C)
+// fills slot i with the top-ranked eligible candidate from the team's roster
+// (TeamID match, dc_can_play_in_game != 0, not already chosen), ranked by the
+// qualityScore + dc-ASC/score-DESC/bundle-order comparator. Each chosen starter
+// is removed from the pool so no player fills two slots. Players who win no slot
+// — and any with dc_can_play_in_game == 0 — do not start and end the game as DNP
+// rows. A team with fewer than five eligible players returns fewer starters; the
+// caller tolerates a short lineup.
+//
+// The 5-pass operates on the depth ordinals dc_pg_depth…dc_c_depth + dc_minutes,
+// the live IBL5 depth fields. The JSB-internal dc_bh/di/oi/df/of fields are dead
+// on IBL5 data (DepthChartEntryRepository forces them to 0) and are deliberately
+// not read; reading them would score every candidate identically. The fallback
+// +48 band (dc<=0 + posmatch) is ported for fidelity but is unreachable
+// end-to-end, since posmatch implies dc>0 (see posmatch).
+//
+// PR3a held energy = base stamina (fatigue ≈ 1.0); PR4b adds energy
+// drain/recovery, minutes, and substitutions on top of this selection.
 func selectStarters(players []bundle.Player, teamID int) []onCourt {
 	roster := make([]bundle.Player, 0, len(players))
 	for _, p := range players {
@@ -40,24 +159,11 @@ func selectStarters(players []bundle.Player, teamID int) []onCourt {
 	chosen := make(map[int]bool, 5)
 	starters := make([]onCourt, 0, 5)
 	for slot := slotPG; slot <= slotC; slot++ {
-		bestIdx := -1
-		bestDepth := 0
-		for i, p := range roster {
-			if chosen[p.PID] {
-				continue
-			}
-			d := slotDepth(p, slot)
-			if d <= 0 {
-				continue
-			}
-			if bestIdx == -1 || d < bestDepth {
-				bestIdx, bestDepth = i, d
-			}
-		}
-		if bestIdx == -1 {
+		cands := candidatesForSlot(roster, slot, chosen)
+		if len(cands) == 0 {
 			continue // no eligible player for this slot
 		}
-		p := roster[bestIdx]
+		p := cands[0].player
 		chosen[p.PID] = true
 		starters = append(starters, onCourt{
 			Player:  p,
@@ -66,4 +172,39 @@ func selectStarters(players []bundle.Player, teamID int) []onCourt {
 		})
 	}
 	return starters
+}
+
+// rankedRotation returns, per slot (index 0=PG … 4=C), the eligible non-starters
+// for that slot ordered by the same qualityScore + comparator selectStarters
+// uses. It is the ranked rotation source PR4b's substitution logic will consume;
+// PR4a computes and tests it, but the game driver does not yet call it. The JSB
+// "self-backup when no position-matching non-starter exists" fallback is left to
+// PR4b's consuming caller, which decides what to do with an empty list.
+func rankedRotation(players []bundle.Player, teamID int, starters []onCourt) [][]onCourt {
+	roster := make([]bundle.Player, 0, len(players))
+	for _, p := range players {
+		if p.TeamID == teamID && p.DCCanPlayInGame != 0 {
+			roster = append(roster, p)
+		}
+	}
+
+	starterPID := make(map[int]bool, len(starters))
+	for _, s := range starters {
+		starterPID[s.PID] = true
+	}
+
+	rotation := make([][]onCourt, slotC) // slotC == 5
+	for slot := slotPG; slot <= slotC; slot++ {
+		cands := candidatesForSlot(roster, slot, starterPID)
+		bench := make([]onCourt, 0, len(cands))
+		for _, c := range cands {
+			bench = append(bench, onCourt{
+				Player:  c.player,
+				slot:    slot,
+				fatigue: fatigueFactor(c.player.Stamina),
+			})
+		}
+		rotation[slot-1] = bench
+	}
+	return rotation
 }

--- a/engine/internal/sim/lineup_test.go
+++ b/engine/internal/sim/lineup_test.go
@@ -69,3 +69,158 @@ func TestSelectStarters_Boundaries(t *testing.T) {
 		t.Errorf("empty roster starters = %d, want 0", len(got))
 	}
 }
+
+// --- matrix #3, #7: pure qualityScore bands --------------------------------
+
+func TestQualityScore_Bands(t *testing.T) {
+	cases := []struct {
+		name    string
+		dc      int
+		minutes int
+		pm      bool
+		want    int
+	}{
+		// Bonus path (dc > 0); posmatch is ignored.
+		{"dc<5 min>=12 → +192", 1, 12, false, 204},
+		{"dc<5 min<12 → +144", 1, 5, false, 149},
+		{"dc>=5 → no bonus", 5, 30, false, 30},
+		{"dc>=5 min=0 → 0 (eligible, not unqualified)", 5, 0, false, 0},
+		// Fallback path (dc <= 0): only posmatch scores. These two ARE the
+		// mandated "fallback-path position-match when dc<=0" verification,
+		// exercised at helper level since the end-to-end path is unreachable.
+		{"fallback posmatch min>=12 → +48", 0, 30, true, 78},
+		{"fallback posmatch min<12 → +0", 0, 5, true, 5},
+		{"fallback no posmatch → 0", 0, 30, false, 0},
+	}
+	for _, c := range cases {
+		if got := qualityScore(c.dc, c.minutes, c.pm); got != c.want {
+			t.Errorf("%s: qualityScore(%d,%d,%v) = %d, want %d", c.name, c.dc, c.minutes, c.pm, got, c.want)
+		}
+	}
+}
+
+// --- matrix #8: dc-ASC beats score ------------------------------------------
+
+func TestSelectStarters_DcAscBeatsScore(t *testing.T) {
+	// A (dc=1, low minutes) and B (dc=2, high minutes) compete for PG. B's score
+	// (30+192=222) exceeds A's (10+192=202), but dc is primary so A starts.
+	players := []bundle.Player{
+		{PID: 1, TeamID: 7, DCPGDepth: 1, DCMinutes: 10, DCCanPlayInGame: 1},
+		{PID: 2, TeamID: 7, DCPGDepth: 2, DCMinutes: 30, DCCanPlayInGame: 1},
+	}
+	starters := selectStarters(players, 7)
+	if len(starters) != 1 || starters[0].slot != slotPG || starters[0].PID != 1 {
+		t.Fatalf("PG starter = %+v, want PID 1 (dc=1 beats dc=2)", starters)
+	}
+}
+
+// --- matrix #9: minutes tie-break (equal dc → higher minutes wins) ----------
+
+func TestSelectStarters_MinutesTieBreak(t *testing.T) {
+	// Equal dc at PG; higher dc_minutes yields the higher band/score and wins.
+	players := []bundle.Player{
+		{PID: 1, TeamID: 7, DCPGDepth: 1, DCMinutes: 10, DCCanPlayInGame: 1},
+		{PID: 2, TeamID: 7, DCPGDepth: 1, DCMinutes: 30, DCCanPlayInGame: 1},
+	}
+	starters := selectStarters(players, 7)
+	if len(starters) != 1 || starters[0].PID != 2 {
+		t.Fatalf("PG starter = %+v, want PID 2 (higher minutes wins tie)", starters)
+	}
+}
+
+// --- matrix #10: multi-slot player consumed by earliest pass ----------------
+
+func TestSelectStarters_MultiSlotGreedyRemoval(t *testing.T) {
+	// PID 1 is depth-1 at both PG and SG. The PG pass consumes it; the SG slot
+	// then falls to PID 2, and PID 1 is not double-assigned.
+	players := []bundle.Player{
+		{PID: 1, TeamID: 7, DCPGDepth: 1, DCSGDepth: 1, DCMinutes: 30, DCCanPlayInGame: 1},
+		{PID: 2, TeamID: 7, DCSGDepth: 2, DCMinutes: 20, DCCanPlayInGame: 1},
+	}
+	starters := selectStarters(players, 7)
+	if len(starters) != 2 {
+		t.Fatalf("starters = %d, want 2", len(starters))
+	}
+	wantPID := map[int]int{slotPG: 1, slotSG: 2}
+	for _, s := range starters {
+		if wantPID[s.slot] != s.PID {
+			t.Errorf("slot %d: PID = %d, want %d", s.slot, s.PID, wantPID[s.slot])
+		}
+	}
+}
+
+// --- matrix #11: all can't-play → empty lineup, no panic --------------------
+
+func TestSelectStarters_AllCantPlay(t *testing.T) {
+	players := []bundle.Player{
+		{PID: 1, TeamID: 7, DCPGDepth: 1, DCCanPlayInGame: 0},
+		{PID: 2, TeamID: 7, DCSGDepth: 1, DCCanPlayInGame: 0},
+	}
+	if got := selectStarters(players, 7); len(got) != 0 {
+		t.Errorf("starters = %d, want 0 (all DCCanPlayInGame==0)", len(got))
+	}
+}
+
+// --- matrix #12: dead dc_bh/di/oi/df/of fields are ignored -------------------
+
+func TestSelectStarters_DeadFieldsIgnored(t *testing.T) {
+	base := []bundle.Player{
+		{PID: 1, TeamID: 7, DCPGDepth: 1, DCMinutes: 30, DCCanPlayInGame: 1},
+		{PID: 2, TeamID: 7, DCSGDepth: 1, DCMinutes: 20, DCCanPlayInGame: 1},
+		{PID: 3, TeamID: 7, DCSFDepth: 1, DCMinutes: 25, DCCanPlayInGame: 1},
+	}
+	withDead := make([]bundle.Player, len(base))
+	copy(withDead, base)
+	for i := range withDead {
+		withDead[i].DCBh = 9
+		withDead[i].DCDi = 9
+		withDead[i].DCOi = 9
+		withDead[i].DCDf = 9
+		withDead[i].DCOf = 9
+	}
+
+	a := selectStarters(base, 7)
+	b := selectStarters(withDead, 7)
+	if len(a) != len(b) {
+		t.Fatalf("dead fields changed lineup length: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].PID != b[i].PID || a[i].slot != b[i].slot {
+			t.Errorf("slot %d: dead-field selection differs: PID %d vs %d", a[i].slot, a[i].PID, b[i].PID)
+		}
+	}
+}
+
+// --- matrix #13: ranked-rotation per-slot ordering --------------------------
+
+func TestRankedRotation_PerSlotOrdering(t *testing.T) {
+	players := []bundle.Player{
+		{PID: 1, TeamID: 7, DCPGDepth: 1, DCMinutes: 36, DCCanPlayInGame: 1}, // starter
+		{PID: 2, TeamID: 7, DCPGDepth: 2, DCMinutes: 20, DCCanPlayInGame: 1}, // backup A: dc2 score 212
+		{PID: 3, TeamID: 7, DCPGDepth: 3, DCMinutes: 30, DCCanPlayInGame: 1}, // backup B: dc3 score 222
+		{PID: 4, TeamID: 7, DCPGDepth: 2, DCMinutes: 10, DCCanPlayInGame: 1}, // backup C: dc2 score 154
+	}
+	starters := selectStarters(players, 7)
+	if len(starters) != 1 || starters[0].PID != 1 {
+		t.Fatalf("PG starter = %+v, want PID 1", starters)
+	}
+	rotation := rankedRotation(players, 7, starters)
+	pg := rotation[slotPG-1]
+	// Comparator: dc ASC primary → dc2 backups (2,4) before dc3 (3); among dc2,
+	// score DESC → A(212) before C(154). Want order: 2, 4, 3.
+	wantPG := []int{2, 4, 3}
+	if len(pg) != len(wantPG) {
+		t.Fatalf("PG rotation = %d entries, want %d", len(pg), len(wantPG))
+	}
+	for i, want := range wantPG {
+		if pg[i].PID != want {
+			t.Errorf("PG rotation[%d] = PID %d, want %d", i, pg[i].PID, want)
+		}
+	}
+	// The starter must not appear in its own slot's rotation.
+	for _, oc := range pg {
+		if oc.PID == 1 {
+			t.Error("starter PID 1 should not appear in PG rotation")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

PR4a of the jsb-native-engine PR4 split. Replaces the placeholder lowest-positive-depth `selectStarters` in `engine/internal/sim/lineup.go` with the real JSB five-pass starter selection, operating on the live IBL5 depth ordinals `dc_pg_depth…dc_c_depth` + `dc_minutes`. Pure refactor of starter *selection* — energy/minutes/substitutions are PR4b (stacks on this branch).

### What changed
- **`qualityScore(dc, minutes, pm)`** — pure JSB bonus/fallback bands (dc<5/min≥12→+192, dc<5/min<12→+144, dc≥5→min; fallback posmatch +48/+0).
- **`candidatesForSlot`** — dc-ASC / score-DESC / bundle-order comparator, with eligibility (`dc>0 || posmatch`) kept *separate* from score so `qualityScore(5,0)==0` deep-bench players stay eligible and unfillable slots stay empty (short lineups preserved).
- **`selectStarters`** — 5-pass PG→C, greedy removal so no player fills two slots.
- **`rankedRotation`** (unexported) — per-slot ranked non-starters; computed + tested, consumed by PR4b.

### Design decisions (resolved against repo evidence, not deferred)
- **Depth-ordinal mapping, not literal `dc_bh/di/oi/df/of`** — those fields are dead on IBL5 data (`DepthChartEntryRepository` forces them to 0). Test #12 guards against regressing to them.
- **dc-ASC primary** (per the plan's mandated "dc=1 beats dc=2" row). Open question #1 (band magnitudes look score-primary-designed) carried to PR4b before rotation order is consumed.
- **Fallback +48 band ported but provably unreachable** end-to-end (`bestDepthPos` ⟹ dc>0, so posmatch ⟹ dc>0). Verified at the `qualityScore` helper level instead.

### Verification
- All 15 matrix rows green (Go table/unit tests in `lineup_test.go`).
- `go build/vet/test ./...` all pass.
- Golden `testdata/golden.json` byte-identical (no equal-dc collisions in `bundle.json`).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.ai/code)