### PR TITLE
engine(sim): derive box scores from the event stream (PR5)

### DIFF
--- a/engine/internal/result/result.go
+++ b/engine/internal/result/result.go
@@ -53,6 +53,13 @@ type Event struct {
 	// OffensiveRebound distinguishes an offensive (true) from a defensive
 	// (false) rebound. Only meaningful when Kind == EventRebound.
 	OffensiveRebound bool `json:"offensive_rebound,omitempty"`
+
+	// FTAttempts / FTMade carry the free-throw counts for a single trip to the
+	// line. Meaningful only when Kind == EventFreeThrow; a zero value is *not
+	// applicable* for every other kind (omitted via omitempty). They let the box
+	// aggregator reconstruct GameFTA/GameFTM exactly from the event stream.
+	FTAttempts int `json:"ft_attempts,omitempty"`
+	FTMade     int `json:"ft_made,omitempty"`
 }
 
 // PlayerBox is one player's stat line for one game. Fields map 1:1 to the RAW

--- a/engine/internal/result/result_test.go
+++ b/engine/internal/result/result_test.go
@@ -109,3 +109,47 @@ func TestEvent_KindsCarryRequiredFields(t *testing.T) {
 		t.Errorf("steal lost defender: %+v", steal)
 	}
 }
+
+// #3 — EventFreeThrow carries ft_attempts/ft_made for box reconstruction; the
+// fields are omitempty, so non-FT events never emit them, and a 0-made trip
+// round-trips ft_made == 0.
+func TestEvent_FreeThrowCounts(t *testing.T) {
+	// A made 1-of-2 trip emits both counts.
+	ft := Event{Kind: EventFreeThrow, Period: 4, Clock: 60, TeamID: 7, PlayerID: 202,
+		ShotType: ShotFreeThrow, FTAttempts: 2, FTMade: 1}
+	data, err := json.Marshal(ft)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"ft_attempts":2`) || !strings.Contains(string(data), `"ft_made":1`) {
+		t.Errorf("free throw missing counts in JSON: %s", data)
+	}
+	var back Event
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.FTAttempts != 2 || back.FTMade != 1 {
+		t.Errorf("counts lost: FTAttempts=%d FTMade=%d", back.FTAttempts, back.FTMade)
+	}
+
+	// A 0-of-2 trip omits ft_made (omitempty) but still round-trips to 0.
+	zeroMade, _ := json.Marshal(Event{Kind: EventFreeThrow, Period: 1, Clock: 700,
+		TeamID: 7, PlayerID: 202, ShotType: ShotFreeThrow, FTAttempts: 2, FTMade: 0})
+	if strings.Contains(string(zeroMade), "ft_made") {
+		t.Errorf("ft_made should be omitted when 0: %s", zeroMade)
+	}
+	var backZero Event
+	if err := json.Unmarshal(zeroMade, &backZero); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if backZero.FTMade != 0 || backZero.FTAttempts != 2 {
+		t.Errorf("0-made trip lost counts: FTAttempts=%d FTMade=%d", backZero.FTAttempts, backZero.FTMade)
+	}
+
+	// A non-FT event omits both fields entirely.
+	shot, _ := json.Marshal(Event{Kind: EventShotMake, Period: 1, Clock: 700,
+		TeamID: 3, PlayerID: 101, ShotType: ShotTwoPoint})
+	if strings.Contains(string(shot), "ft_attempts") || strings.Contains(string(shot), "ft_made") {
+		t.Errorf("non-FT event must omit FT counts: %s", shot)
+	}
+}

--- a/engine/internal/sim/aggregate.go
+++ b/engine/internal/sim/aggregate.go
@@ -1,0 +1,178 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/result"
+
+// playerMeta is the per-player roster metadata the aggregator needs but cannot
+// reconstruct from the event stream: identity (PID), position (Pos), and minutes
+// (GameMIN, the PR4b possession-time accumulator). A DNP carries GameMIN == 0 and
+// emits no events, so it can only be surfaced from this metadata.
+type playerMeta struct {
+	PID     int
+	Pos     string
+	GameMIN int
+}
+
+// rosterMeta is one team's identity plus its ordered player roster (bundle
+// order). teamID/isHome are not derivable from events — a steal/block event
+// carries the offense's TeamID, and DNPs emit nothing — so they are supplied
+// here to label the TeamBox and to route each event's counter to the right team.
+type rosterMeta struct {
+	teamID  int
+	isHome  bool
+	players []playerMeta
+}
+
+// aggregateBoxes derives every output PlayerBox stat counter and TeamBox total +
+// quarter split purely by folding over the event stream, joined with the two
+// teams' roster metadata. It is the single source of truth for the box score:
+// the sim emits events and feeds roster metadata; nothing else writes box stats.
+//
+// It emits one PlayerBox per rostered player, visitor team first then home (in
+// bundle order). Players with no events yield an all-zero stat line carrying
+// their Pos and GameMIN (DNP == GameMIN 0). GameAST is always 0 (commentary-only,
+// master-reference L1098).
+func aggregateBoxes(events []result.Event, visitor, home rosterMeta) ([]result.PlayerBox, []result.TeamBox) {
+	boxes := make([]result.PlayerBox, 0, len(visitor.players)+len(home.players))
+	for _, m := range visitor.players {
+		boxes = append(boxes, result.PlayerBox{PID: m.PID, Pos: m.Pos, GameMIN: m.GameMIN})
+	}
+	for _, m := range home.players {
+		boxes = append(boxes, result.PlayerBox{PID: m.PID, Pos: m.Pos, GameMIN: m.GameMIN})
+	}
+
+	// Index the output rows for O(1) folding, and map every PID to its team so
+	// steal/block credit and team rollups route correctly.
+	byPID := make(map[int]*result.PlayerBox, len(boxes))
+	for i := range boxes {
+		byPID[boxes[i].PID] = &boxes[i]
+	}
+	pidTeam := make(map[int]int, len(boxes))
+	for _, m := range visitor.players {
+		pidTeam[m.PID] = visitor.teamID
+	}
+	for _, m := range home.players {
+		pidTeam[m.PID] = home.teamID
+	}
+
+	for _, e := range events {
+		switch e.Kind {
+		case result.EventShotAttempt:
+			if b := byPID[e.PlayerID]; b != nil {
+				if e.ShotType == result.ShotThree {
+					b.Game3GA++
+				} else {
+					b.Game2GA++
+				}
+			}
+		case result.EventShotMake:
+			if b := byPID[e.PlayerID]; b != nil {
+				if e.ShotType == result.ShotThree {
+					b.Game3GM++
+				} else {
+					b.Game2GM++
+				}
+			}
+		case result.EventRebound:
+			if b := byPID[e.PlayerID]; b != nil {
+				if e.OffensiveRebound {
+					b.GameORB++
+				} else {
+					b.GameDRB++
+				}
+			}
+		case result.EventTurnover:
+			if b := byPID[e.PlayerID]; b != nil {
+				b.GameTOV++
+			}
+		case result.EventFoul:
+			if b := byPID[e.PlayerID]; b != nil {
+				b.GamePF++
+			}
+		case result.EventSteal:
+			if b := byPID[e.DefenderID]; b != nil { // the stealer, on the defending team
+				b.GameSTL++
+			}
+		case result.EventBlock:
+			if b := byPID[e.DefenderID]; b != nil { // the blocker, on the defending team
+				b.GameBLK++
+			}
+		case result.EventFreeThrow:
+			if b := byPID[e.PlayerID]; b != nil {
+				b.GameFTA += e.FTAttempts
+				b.GameFTM += e.FTMade
+			}
+		}
+	}
+
+	teams := []result.TeamBox{
+		rollupTeam(visitor, byPID, pidTeam, events),
+		rollupTeam(home, byPID, pidTeam, events),
+	}
+	return boxes, teams
+}
+
+// rollupTeam sums the team's player rows into one TeamBox and lays its scoring
+// out by period (Q1–Q4, then OT in order). Points bucket from EventShotMake (2
+// or 3 by ShotType) and EventFreeThrow (FTMade). A period is "reached" by any
+// EventShotMake OR EventFreeThrow for the team — mirroring the live path, which
+// calls addPeriodPoints on every made FG and every FT trip (even a 0-made trip),
+// so a 0-made free throw still extends the quarter slice.
+func rollupTeam(meta rosterMeta, byPID map[int]*result.PlayerBox, pidTeam map[int]int, events []result.Event) result.TeamBox {
+	tb := result.TeamBox{TeamID: meta.teamID, IsHome: meta.isHome, OT: []int{}}
+	for _, m := range meta.players {
+		b := byPID[m.PID]
+		tb.Game2GM += b.Game2GM
+		tb.Game2GA += b.Game2GA
+		tb.GameFTM += b.GameFTM
+		tb.GameFTA += b.GameFTA
+		tb.Game3GM += b.Game3GM
+		tb.Game3GA += b.Game3GA
+		tb.GameORB += b.GameORB
+		tb.GameDRB += b.GameDRB
+		tb.GameAST += b.GameAST
+		tb.GameSTL += b.GameSTL
+		tb.GameTOV += b.GameTOV
+		tb.GameBLK += b.GameBLK
+		tb.GamePF += b.GamePF
+	}
+
+	periodPts := map[int]int{}
+	maxPeriod := 0
+	for _, e := range events {
+		var pts int
+		switch e.Kind {
+		case result.EventShotMake:
+			if e.ShotType == result.ShotThree {
+				pts = 3
+			} else {
+				pts = 2
+			}
+		case result.EventFreeThrow:
+			pts = e.FTMade // may be 0; still extends the quarter slice
+		default:
+			continue
+		}
+		if pidTeam[e.PlayerID] != meta.teamID {
+			continue
+		}
+		periodPts[e.Period] += pts
+		if e.Period > maxPeriod {
+			maxPeriod = e.Period
+		}
+	}
+	for p := 1; p <= maxPeriod; p++ {
+		switch p {
+		case 1:
+			tb.Q1 = periodPts[p]
+		case 2:
+			tb.Q2 = periodPts[p]
+		case 3:
+			tb.Q3 = periodPts[p]
+		case 4:
+			tb.Q4 = periodPts[p]
+		default:
+			tb.OT = append(tb.OT, periodPts[p])
+		}
+	}
+	return tb
+}

--- a/engine/internal/sim/aggregate_test.go
+++ b/engine/internal/sim/aggregate_test.go
@@ -1,0 +1,264 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/result"
+)
+
+// twoTeamMeta builds visitor (team 7: PIDs 1,2,3) and home (team 3: PIDs 4,5,6)
+// roster metadata for the aggregator, each player at a stub position with 20 min.
+func twoTeamMeta() (rosterMeta, rosterMeta) {
+	visitor := rosterMeta{teamID: 7, isHome: false, players: []playerMeta{
+		{PID: 1, Pos: "PG", GameMIN: 20}, {PID: 2, Pos: "SG", GameMIN: 20}, {PID: 3, Pos: "SF", GameMIN: 20},
+	}}
+	home := rosterMeta{teamID: 3, isHome: true, players: []playerMeta{
+		{PID: 4, Pos: "PG", GameMIN: 20}, {PID: 5, Pos: "SG", GameMIN: 20}, {PID: 6, Pos: "SF", GameMIN: 20},
+	}}
+	return visitor, home
+}
+
+func boxOf(boxes []result.PlayerBox, pid int) *result.PlayerBox {
+	for i := range boxes {
+		if boxes[i].PID == pid {
+			return &boxes[i]
+		}
+	}
+	return nil
+}
+
+// --- matrix #4: every event kind maps to the right field / ID ---------------
+
+func TestAggregate_EventKindMapping(t *testing.T) {
+	visitor, home := twoTeamMeta()
+	// Visitor (team 7) on offense; PID 1 the ball-handler, defenders are home PIDs.
+	events := []result.Event{
+		{Kind: result.EventShotAttempt, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+		{Kind: result.EventShotMake, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+		{Kind: result.EventShotAttempt, Period: 1, TeamID: 7, PlayerID: 2, ShotType: result.ShotThree},
+		{Kind: result.EventShotMake, Period: 1, TeamID: 7, PlayerID: 2, ShotType: result.ShotThree},
+		{Kind: result.EventRebound, Period: 1, TeamID: 7, PlayerID: 3, OffensiveRebound: true},
+		{Kind: result.EventRebound, Period: 1, TeamID: 3, PlayerID: 4, OffensiveRebound: false},
+		{Kind: result.EventTurnover, Period: 1, TeamID: 7, PlayerID: 1},
+		{Kind: result.EventFoul, Period: 1, TeamID: 3, PlayerID: 5},
+		{Kind: result.EventSteal, Period: 1, TeamID: 7, PlayerID: 1, DefenderID: 4},
+		{Kind: result.EventBlock, Period: 1, TeamID: 7, PlayerID: 1, DefenderID: 6},
+		{Kind: result.EventFreeThrow, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotFreeThrow, FTAttempts: 2, FTMade: 2},
+	}
+	boxes, _ := aggregateBoxes(events, visitor, home)
+
+	p1 := boxOf(boxes, 1)
+	if p1.Game2GA != 1 || p1.Game2GM != 1 {
+		t.Errorf("PID1 2pt: GA=%d GM=%d, want 1/1", p1.Game2GA, p1.Game2GM)
+	}
+	if p1.GameTOV != 1 {
+		t.Errorf("PID1 TOV = %d, want 1", p1.GameTOV)
+	}
+	if p1.GameFTA != 2 || p1.GameFTM != 2 {
+		t.Errorf("PID1 FT: FTA=%d FTM=%d, want 2/2", p1.GameFTA, p1.GameFTM)
+	}
+	if p2 := boxOf(boxes, 2); p2.Game3GA != 1 || p2.Game3GM != 1 {
+		t.Errorf("PID2 3pt: GA=%d GM=%d, want 1/1", p2.Game3GA, p2.Game3GM)
+	}
+	if p3 := boxOf(boxes, 3); p3.GameORB != 1 || p3.GameDRB != 0 {
+		t.Errorf("PID3 ORB/DRB = %d/%d, want 1/0", p3.GameORB, p3.GameDRB)
+	}
+	if p4 := boxOf(boxes, 4); p4.GameDRB != 1 || p4.GameSTL != 1 {
+		t.Errorf("PID4 (defender) DRB/STL = %d/%d, want 1/1", p4.GameDRB, p4.GameSTL)
+	}
+	if p5 := boxOf(boxes, 5); p5.GamePF != 1 {
+		t.Errorf("PID5 (fouler) PF = %d, want 1", p5.GamePF)
+	}
+	if p6 := boxOf(boxes, 6); p6.GameBLK != 1 {
+		t.Errorf("PID6 (blocker) BLK = %d, want 1", p6.GameBLK)
+	}
+	// AST is always 0.
+	for _, b := range boxes {
+		if b.GameAST != 0 {
+			t.Errorf("PID%d AST = %d, want 0 (commentary-only)", b.PID, b.GameAST)
+		}
+	}
+	// Output order is visitor then home, in roster order.
+	wantOrder := []int{1, 2, 3, 4, 5, 6}
+	for i, w := range wantOrder {
+		if boxes[i].PID != w {
+			t.Errorf("box[%d] PID = %d, want %d (visitor-first roster order)", i, boxes[i].PID, w)
+		}
+	}
+}
+
+// --- matrix #5: a missed shot yields an attempt without a make ---------------
+
+func TestAggregate_MissIsAttemptWithoutMake(t *testing.T) {
+	visitor, home := twoTeamMeta()
+	events := []result.Event{
+		{Kind: result.EventShotAttempt, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+		{Kind: result.EventShotMiss, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+	}
+	boxes, _ := aggregateBoxes(events, visitor, home)
+	p1 := boxOf(boxes, 1)
+	if p1.Game2GA != 1 {
+		t.Errorf("Game2GA = %d, want 1", p1.Game2GA)
+	}
+	if p1.Game2GM != 0 {
+		t.Errorf("Game2GM = %d, want 0 (a miss is not a make)", p1.Game2GM)
+	}
+}
+
+// --- matrix #6: a DNP player (no events) is an all-zero row with Pos/GameMIN --
+
+func TestAggregate_DNPAllZeroRow(t *testing.T) {
+	visitor := rosterMeta{teamID: 7, players: []playerMeta{{PID: 1, Pos: "PG", GameMIN: 30}, {PID: 9, Pos: "C", GameMIN: 0}}}
+	home := rosterMeta{teamID: 3, isHome: true, players: []playerMeta{{PID: 4, Pos: "PG", GameMIN: 30}}}
+	events := []result.Event{
+		{Kind: result.EventShotAttempt, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+	}
+	boxes, _ := aggregateBoxes(events, visitor, home)
+
+	dnp := boxOf(boxes, 9)
+	if dnp == nil {
+		t.Fatal("DNP player 9 missing from output")
+	}
+	if *dnp != (result.PlayerBox{PID: 9, Pos: "C", GameMIN: 0}) {
+		t.Errorf("DNP row should be all-zero with Pos/GameMIN, got %+v", *dnp)
+	}
+}
+
+// --- matrix #7: an and-one aggregates to make + FT + points ------------------
+
+func TestAggregate_AndOne(t *testing.T) {
+	visitor, home := twoTeamMeta()
+	events := []result.Event{
+		{Kind: result.EventShotAttempt, Period: 2, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+		{Kind: result.EventShotMake, Period: 2, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+		{Kind: result.EventFreeThrow, Period: 2, TeamID: 7, PlayerID: 1, ShotType: result.ShotFreeThrow, FTAttempts: 1, FTMade: 1},
+	}
+	boxes, teams := aggregateBoxes(events, visitor, home)
+	p1 := boxOf(boxes, 1)
+	if p1.Game2GM != 1 || p1.Game2GA != 1 || p1.GameFTM != 1 || p1.GameFTA != 1 {
+		t.Errorf("and-one row = %+v, want 2GM/2GA/FTM/FTA = 1/1/1/1", *p1)
+	}
+	// Visitor scored 2 (FG) + 1 (FT) = 3 in Q2.
+	vis := teams[0]
+	if vis.Q2 != 3 {
+		t.Errorf("visitor Q2 = %d, want 3 (and-one)", vis.Q2)
+	}
+	pts := 2*vis.Game2GM + 3*vis.Game3GM + vis.GameFTM
+	if pts != 3 {
+		t.Errorf("visitor points = %d, want 3", pts)
+	}
+}
+
+// --- matrix #8: steal/block credit the defender on the non-offense team ------
+
+func TestAggregate_StealBlockCreditDefenderTeam(t *testing.T) {
+	visitor, home := twoTeamMeta()
+	// Offense is visitor (team 7); defenders 4 and 6 are on home (team 3).
+	events := []result.Event{
+		{Kind: result.EventSteal, Period: 1, TeamID: 7, PlayerID: 1, DefenderID: 4},
+		{Kind: result.EventBlock, Period: 1, TeamID: 7, PlayerID: 2, DefenderID: 6},
+	}
+	boxes, teams := aggregateBoxes(events, visitor, home)
+
+	// Credits land on the home defenders, not the visitor offense.
+	if boxOf(boxes, 4).GameSTL != 1 || boxOf(boxes, 6).GameBLK != 1 {
+		t.Errorf("defender credits wrong: STL(4)=%d BLK(6)=%d", boxOf(boxes, 4).GameSTL, boxOf(boxes, 6).GameBLK)
+	}
+	for _, pid := range []int{1, 2, 3} { // visitor offense gets nothing
+		if b := boxOf(boxes, pid); b.GameSTL != 0 || b.GameBLK != 0 {
+			t.Errorf("offense PID%d wrongly credited STL=%d BLK=%d", pid, b.GameSTL, b.GameBLK)
+		}
+	}
+	// Team rollups: home (defense) carries the STL/BLK; visitor carries none.
+	if teams[0].GameSTL != 0 || teams[0].GameBLK != 0 {
+		t.Errorf("visitor team STL/BLK = %d/%d, want 0/0", teams[0].GameSTL, teams[0].GameBLK)
+	}
+	if teams[1].GameSTL != 1 || teams[1].GameBLK != 1 {
+		t.Errorf("home team STL/BLK = %d/%d, want 1/1", teams[1].GameSTL, teams[1].GameBLK)
+	}
+}
+
+// --- matrix #9: GameFTM never exceeds GameFTA (1-of-2 trip) ------------------
+
+func TestAggregate_FTMNeverExceedsFTA(t *testing.T) {
+	visitor, home := twoTeamMeta()
+	events := []result.Event{
+		{Kind: result.EventFreeThrow, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotFreeThrow, FTAttempts: 2, FTMade: 1},
+	}
+	boxes, _ := aggregateBoxes(events, visitor, home)
+	p1 := boxOf(boxes, 1)
+	if p1.GameFTA != 2 || p1.GameFTM != 1 {
+		t.Errorf("FT 1-of-2: FTA=%d FTM=%d, want 2/1", p1.GameFTA, p1.GameFTM)
+	}
+	if p1.GameFTM > p1.GameFTA {
+		t.Errorf("FTM %d > FTA %d", p1.GameFTM, p1.GameFTA)
+	}
+}
+
+// --- matrix #10: team rollup == Σ player rows; quarters bucket by period -----
+
+func TestAggregate_TeamRollupAndQuarterBucketing(t *testing.T) {
+	visitor, home := twoTeamMeta()
+	events := []result.Event{
+		// Q1: PID1 makes a 2 (2 pts).
+		{Kind: result.EventShotAttempt, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+		{Kind: result.EventShotMake, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+		// Q3: PID2 makes a 3 (3 pts) — Q2 is unscored, must read 0.
+		{Kind: result.EventShotAttempt, Period: 3, TeamID: 7, PlayerID: 2, ShotType: result.ShotThree},
+		{Kind: result.EventShotMake, Period: 3, TeamID: 7, PlayerID: 2, ShotType: result.ShotThree},
+		// OT (period 5): PID1 hits 2 FTs (2 pts).
+		{Kind: result.EventFreeThrow, Period: 5, TeamID: 7, PlayerID: 1, ShotType: result.ShotFreeThrow, FTAttempts: 2, FTMade: 2},
+	}
+	boxes, teams := aggregateBoxes(events, visitor, home)
+
+	vis := teams[0]
+	if vis.Q1 != 2 || vis.Q2 != 0 || vis.Q3 != 3 || vis.Q4 != 0 {
+		t.Errorf("visitor quarters = %d/%d/%d/%d, want 2/0/3/0", vis.Q1, vis.Q2, vis.Q3, vis.Q4)
+	}
+	if len(vis.OT) != 1 || vis.OT[0] != 2 {
+		t.Errorf("visitor OT = %v, want [2]", vis.OT)
+	}
+	// Team totals == Σ player rows.
+	var sum result.TeamBox
+	for _, pid := range []int{1, 2, 3} {
+		b := boxOf(boxes, pid)
+		sum.Game2GM += b.Game2GM
+		sum.Game3GM += b.Game3GM
+		sum.GameFTM += b.GameFTM
+	}
+	if sum.Game2GM != vis.Game2GM || sum.Game3GM != vis.Game3GM || sum.GameFTM != vis.GameFTM {
+		t.Errorf("team rollup != Σ player rows: got %+v vs sum %+v", vis, sum)
+	}
+	// quarters sum to points.
+	q := vis.Q1 + vis.Q2 + vis.Q3 + vis.Q4
+	for _, ot := range vis.OT {
+		q += ot
+	}
+	if pts := 2*vis.Game2GM + 3*vis.Game3GM + vis.GameFTM; q != pts {
+		t.Errorf("quarters %d != points %d", q, pts)
+	}
+	// Home team scored nothing: empty (non-nil) OT, zero quarters.
+	if home := teams[1]; home.Q1 != 0 || len(home.OT) != 0 {
+		t.Errorf("home should be scoreless: %+v", home)
+	}
+}
+
+// --- 0-made free throw still extends the quarter slice ------------------------
+//
+// The live path calls addPeriodPoints on every FT trip (even 0-made), so a trip
+// whose only scoring event in a period misses both still "reaches" that period.
+// The aggregator must mirror this or the OT slice length drifts from the golden.
+func TestAggregate_ZeroMadeFreeThrowReachesPeriod(t *testing.T) {
+	visitor, home := twoTeamMeta()
+	events := []result.Event{
+		{Kind: result.EventShotAttempt, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+		{Kind: result.EventShotMake, Period: 1, TeamID: 7, PlayerID: 1, ShotType: result.ShotTwoPoint},
+		// OT with a 0-made trip: 0 points, but the OT period is reached.
+		{Kind: result.EventFreeThrow, Period: 5, TeamID: 7, PlayerID: 1, ShotType: result.ShotFreeThrow, FTAttempts: 2, FTMade: 0},
+	}
+	_, teams := aggregateBoxes(events, visitor, home)
+	vis := teams[0]
+	if len(vis.OT) != 1 || vis.OT[0] != 0 {
+		t.Errorf("visitor OT = %v, want [0] (0-made trip still reaches the period)", vis.OT)
+	}
+}

--- a/engine/internal/sim/block.go
+++ b/engine/internal/sim/block.go
@@ -48,17 +48,15 @@ func blockProbability(defender onCourt, shooterMadeFG int) float64 {
 	return base
 }
 
-// creditBlock rolls for a block on a missed field goal. On a block it credits
-// GameBLK to the contesting DEFENDER and emits EventBlock (TeamID = offense,
-// PlayerID = shooter, DefenderID = blocker). It never changes make/miss and
-// never touches the rebound path — the miss still flows to the rebound phase
-// unchanged. The caller must only invoke this on a 2pt/3pt miss (never a free
-// throw).
+// creditBlock rolls for a block on a missed field goal. On a block it emits
+// EventBlock (TeamID = offense, PlayerID = shooter, DefenderID = blocker) — from
+// which aggregateBoxes credits GameBLK to the contesting DEFENDER. The block
+// penalty reads the live per-shooter made-FG tally (gs.madeFG), not a box row,
+// so it stays correct after box stats became event-derived. It never changes
+// make/miss and never touches the rebound path — the miss still flows to the
+// rebound phase unchanged. The caller must only invoke this on a 2pt/3pt miss.
 func (gs *gameState) creditBlock(offense, defense *teamState, shooter, defender onCourt) {
-	sb := offense.box(shooter.PID)
-	madeFG := sb.Game2GM + sb.Game3GM
-	if gs.rng.Float64() < blockProbability(defender, madeFG) {
-		defense.box(defender.PID).GameBLK++
+	if gs.rng.Float64() < blockProbability(defender, gs.madeFG[shooter.PID]) {
 		gs.emit(result.Event{
 			Kind: result.EventBlock, Period: gs.period, Clock: gs.clock,
 			TeamID: offense.teamID, PlayerID: shooter.PID, DefenderID: defender.PID,

--- a/engine/internal/sim/block_test.go
+++ b/engine/internal/sim/block_test.go
@@ -9,6 +9,9 @@ import (
 
 // --- matrix #6: a block credits the contesting defender ----------------------
 
+// creditBlock no longer writes box rows: a block is signalled solely by the
+// emitted EventBlock (TeamID = offense, PlayerID = shooter, DefenderID = blocker),
+// from which aggregateBoxes credits the defender's GameBLK.
 func TestCreditBlock_CreditsDefenderOnMiss(t *testing.T) {
 	for seed := uint64(1); seed < 500; seed++ {
 		offense, defense := twoTeams()
@@ -17,11 +20,17 @@ func TestCreditBlock_CreditsDefenderOnMiss(t *testing.T) {
 		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
 
 		score0 := offense.score
-		made0 := offense.box(shooter.PID).Game2GM
+		made0 := gs.madeFG[shooter.PID]
 		before := len(gs.events)
 		gs.creditBlock(offense, defense, shooter, defender)
 
-		if defense.box(defender.PID).GameBLK == 0 {
+		var blocks []result.Event
+		for _, e := range gs.events[before:] {
+			if e.Kind == result.EventBlock {
+				blocks = append(blocks, e)
+			}
+		}
+		if len(blocks) == 0 {
 			continue // this seed did not roll a block; try the next
 		}
 
@@ -29,14 +38,8 @@ func TestCreditBlock_CreditsDefenderOnMiss(t *testing.T) {
 		if offense.score != score0 {
 			t.Errorf("score changed on a block: %d → %d", score0, offense.score)
 		}
-		if offense.box(shooter.PID).Game2GM != made0 {
-			t.Error("block altered the shooter's made-FG count")
-		}
-		var blocks []result.Event
-		for _, e := range gs.events[before:] {
-			if e.Kind == result.EventBlock {
-				blocks = append(blocks, e)
-			}
+		if gs.madeFG[shooter.PID] != made0 {
+			t.Error("block altered the shooter's live made-FG tally")
 		}
 		if len(blocks) != 1 {
 			t.Fatalf("expected 1 EventBlock, got %d", len(blocks))
@@ -46,8 +49,8 @@ func TestCreditBlock_CreditsDefenderOnMiss(t *testing.T) {
 			t.Errorf("EventBlock = %+v, want TeamID=%d PlayerID=%d DefenderID=%d",
 				ev, offense.teamID, shooter.PID, defender.PID)
 		}
-		if defense.box(ev.DefenderID).GameBLK != 1 {
-			t.Errorf("blocker GameBLK = %d, want 1", defense.box(ev.DefenderID).GameBLK)
+		if defense.box(ev.DefenderID).GameBLK != 0 {
+			t.Error("creditBlock must not write GameBLK (box is event-derived)")
 		}
 		return
 	}
@@ -56,9 +59,9 @@ func TestCreditBlock_CreditsDefenderOnMiss(t *testing.T) {
 
 // --- matrix #7: a block never flips a make → miss ----------------------------
 //
-// creditBlock only ever touches the defender's GameBLK and the event stream; it
-// is gated by the caller to fire solely on a missed field goal. This verifies it
-// cannot add/remove a made shot or change the score even when forced to fire.
+// creditBlock only ever emits an EventBlock; it is gated by the caller to fire
+// solely on a missed field goal. This verifies it cannot add/remove a made shot
+// (tracked by the live madeFG tally) or change the score even when forced to fire.
 func TestCreditBlock_NeverFlipsMake(t *testing.T) {
 	offense, defense := twoTeams()
 	shooter := offense.players[0]
@@ -66,19 +69,26 @@ func TestCreditBlock_NeverFlipsMake(t *testing.T) {
 	// Pre-credit a made shot, as the half-court loop would on a make.
 	gs := &gameState{rng: rng.New(1), period: 1, clock: 500}
 	gs.creditMadeFieldGoal(offense, shooter, result.ShotTwoPoint, 0)
-	made0 := offense.box(shooter.PID).Game2GM
+	made0 := gs.madeFG[shooter.PID]
 	score0 := offense.score
 
-	// Force a block by looping seeds; assert the make and score are untouched.
-	for seed := uint64(1); seed < 500; seed++ {
+	// Force a block by looping seeds; assert the make tally and score are untouched.
+	blocked := false
+	for seed := uint64(1); seed < 500 && !blocked; seed++ {
 		gs.rng = rng.New(seed)
+		before := len(gs.events)
 		gs.creditBlock(offense, defense, shooter, defender)
-		if defense.box(defender.PID).GameBLK > 0 {
-			break
+		for _, e := range gs.events[before:] {
+			if e.Kind == result.EventBlock {
+				blocked = true
+			}
 		}
 	}
-	if offense.box(shooter.PID).Game2GM != made0 {
-		t.Errorf("made-FG count changed: %d → %d", made0, offense.box(shooter.PID).Game2GM)
+	if !blocked {
+		t.Fatal("no seed in range produced a block")
+	}
+	if gs.madeFG[shooter.PID] != made0 {
+		t.Errorf("live made-FG tally changed: %d → %d", made0, gs.madeFG[shooter.PID])
 	}
 	if offense.score != score0 {
 		t.Errorf("score changed: %d → %d", score0, offense.score)
@@ -99,11 +109,6 @@ func TestFreeThrows_NeverBlocked(t *testing.T) {
 		for _, e := range gs.events {
 			if e.Kind == result.EventBlock {
 				t.Fatalf("seed %d: free-throw path emitted an EventBlock", seed)
-			}
-		}
-		for _, pb := range append(offense.playerBoxes(), defense.playerBoxes()...) {
-			if pb.GameBLK != 0 {
-				t.Fatalf("seed %d: free-throw path credited a block", seed)
 			}
 		}
 	}

--- a/engine/internal/sim/box.go
+++ b/engine/internal/sim/box.go
@@ -42,9 +42,10 @@ func bestDepthPos(p bundle.Player) string {
 
 // newTeamState builds a team's live state: its starters, a box-score row for
 // every rostered player in bundle order (DNP rows carry GameMIN == 0 with all
-// stats zero), a PID index for stat accumulation, the eligible-roster candidate
-// pool for substitutions, and the live energy/minutes maps (seeded to each
-// eligible player's Stamina ceiling / 0 seconds). GameMIN is now accumulated
+// stats zero), a PID index over those rows (roster-metadata lookups; stats are
+// event-derived by aggregateBoxes), the eligible-roster candidate pool for
+// substitutions, and the live energy/minutes maps (seeded to each eligible
+// player's Stamina ceiling / 0 seconds). GameMIN is now accumulated
 // on-court time finalized at game end (see finalizeMinutes) — every player,
 // starter or bench, begins at 0; only seconds actually spent on court count.
 func newTeamState(allPlayers []bundle.Player, teamID int, isHome bool) *teamState {

--- a/engine/internal/sim/box.go
+++ b/engine/internal/sim/box.go
@@ -63,6 +63,7 @@ func newTeamState(allPlayers []bundle.Player, teamID int, isHome bool) *teamStat
 		energy:      make(map[int]float64),
 		minutes:     make(map[int]float64),
 		fouledOut:   make(map[int]bool),
+		fouls:       make(map[int]int),
 		quarters:    make([]int, 0, 4),
 	}
 	for _, p := range allPlayers {
@@ -104,52 +105,7 @@ func (t *teamState) finalizeMinutes() {
 	}
 }
 
-// box returns the mutable box-score row for a PID (nil if not on the team).
+// box returns the box-score row for a PID (nil if not on the team). After PR5 the
+// row carries only roster metadata (PID/Pos/GameMIN); its stat counters are
+// derived from the event stream by aggregateBoxes. Tests still assert through it.
 func (t *teamState) box(pid int) *result.PlayerBox { return t.byPID[pid] }
-
-// playerBoxes returns the team's player rows in bundle order.
-func (t *teamState) playerBoxes() []result.PlayerBox {
-	out := make([]result.PlayerBox, len(t.boxes))
-	for i, b := range t.boxes {
-		out[i] = *b
-	}
-	return out
-}
-
-// teamBox rolls the player rows up into team totals and lays the running
-// quarter scores into Q1–Q4 (+ OT). GameSTL/GameBLK/GameAST stay 0 here because
-// no player row ever sets them (steal/block attribution is PR3b; assists are
-// commentary-only, master-reference L1098).
-func (t *teamState) teamBox() result.TeamBox {
-	tb := result.TeamBox{TeamID: t.teamID, IsHome: t.isHome, OT: []int{}}
-	for _, b := range t.boxes {
-		tb.Game2GM += b.Game2GM
-		tb.Game2GA += b.Game2GA
-		tb.GameFTM += b.GameFTM
-		tb.GameFTA += b.GameFTA
-		tb.Game3GM += b.Game3GM
-		tb.Game3GA += b.Game3GA
-		tb.GameORB += b.GameORB
-		tb.GameDRB += b.GameDRB
-		tb.GameAST += b.GameAST
-		tb.GameSTL += b.GameSTL
-		tb.GameTOV += b.GameTOV
-		tb.GameBLK += b.GameBLK
-		tb.GamePF += b.GamePF
-	}
-	for i, pts := range t.quarters {
-		switch i {
-		case 0:
-			tb.Q1 = pts
-		case 1:
-			tb.Q2 = pts
-		case 2:
-			tb.Q3 = pts
-		case 3:
-			tb.Q4 = pts
-		default:
-			tb.OT = append(tb.OT, pts)
-		}
-	}
-	return tb
-}

--- a/engine/internal/sim/box_test.go
+++ b/engine/internal/sim/box_test.go
@@ -91,6 +91,9 @@ func TestBoxDerivation_DeferredStats(t *testing.T) {
 	}
 }
 
+// freeThrows no longer writes box rows: it emits an EventFoul on the defender and
+// an EventFreeThrow carrying FTAttempts/FTMade (aggregateBoxes derives GamePF /
+// GameFTA / GameFTM from those), and moves only the live score.
 func TestFreeThrows_ChargesDefenderAndShooter(t *testing.T) {
 	b := richBundle()
 	offense := newTeamState(b.Players, 7, false)
@@ -101,18 +104,39 @@ func TestFreeThrows_ChargesDefenderAndShooter(t *testing.T) {
 
 	gs.freeThrows(offense, defense, shooter, defender, 2, 0)
 
-	if got := defense.box(defender.PID).GamePF; got != 1 {
-		t.Errorf("defender PF = %d, want 1", got)
+	var foul, ft *result.Event
+	for i := range gs.events {
+		switch gs.events[i].Kind {
+		case result.EventFoul:
+			foul = &gs.events[i]
+		case result.EventFreeThrow:
+			ft = &gs.events[i]
+		}
 	}
-	sb := offense.box(shooter.PID)
-	if sb.GameFTA != 2 {
-		t.Errorf("shooter FTA = %d, want 2", sb.GameFTA)
+	if foul == nil {
+		t.Fatal("no EventFoul emitted")
 	}
-	if sb.GameFTM < 0 || sb.GameFTM > 2 {
-		t.Errorf("shooter FTM = %d, want 0..2", sb.GameFTM)
+	if foul.TeamID != defense.teamID || foul.PlayerID != defender.PID {
+		t.Errorf("foul = %+v, want TeamID=%d PlayerID=%d", *foul, defense.teamID, defender.PID)
 	}
-	// Points scored equal makes.
-	if offense.score != sb.GameFTM {
-		t.Errorf("score %d != FTM %d", offense.score, sb.GameFTM)
+	if ft == nil {
+		t.Fatal("no EventFreeThrow emitted")
+	}
+	if ft.TeamID != offense.teamID || ft.PlayerID != shooter.PID {
+		t.Errorf("free throw = %+v, want TeamID=%d PlayerID=%d", *ft, offense.teamID, shooter.PID)
+	}
+	if ft.FTAttempts != 2 {
+		t.Errorf("FTAttempts = %d, want 2", ft.FTAttempts)
+	}
+	if ft.FTMade < 0 || ft.FTMade > 2 {
+		t.Errorf("FTMade = %d, want 0..2", ft.FTMade)
+	}
+	// The shooter still scores his makes via the live score path.
+	if offense.score != ft.FTMade {
+		t.Errorf("score %d != FTMade %d", offense.score, ft.FTMade)
+	}
+	// No box row is mutated by the helper.
+	if offense.box(shooter.PID).GameFTA != 0 || defense.box(defender.PID).GamePF != 0 {
+		t.Error("freeThrows must not write box rows (box is event-derived)")
 	}
 }

--- a/engine/internal/sim/gameloop.go
+++ b/engine/internal/sim/gameloop.go
@@ -16,13 +16,15 @@ const (
 // simGame plays one scheduled game: four regulation quarters plus overtime
 // while tied, alternating possessions and decrementing the clock by a tempo-
 // derived possession length. It returns the full event stream and box scores
-// (visitor team first) plus the count of fast-break possessions that fired
-// (internal observability for tests; not part of the result contract).
-func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) (result.GameResult, int) {
+// (visitor team first), the count of fast-break possessions that fired, and the
+// two live teamStates — the latter two are internal observability for tests (the
+// live quarter tally lets the conservation test cross-check the event-derived
+// box), not part of the result contract.
+func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) (result.GameResult, int, *teamState, *teamState) {
 	visitor := newTeamState(b.Players, g.VisitorTeamID, false)
 	home := newTeamState(b.Players, g.HomeTeamID, true)
 
-	gs := &gameState{rng: r}
+	gs := &gameState{rng: r, madeFG: map[int]int{}}
 
 	// Possession length is constant per game in PR3a (factor 1.0, no per-game
 	// stat aggregates yet): average the two teams' base times.
@@ -73,6 +75,11 @@ func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) (result.GameResult, int
 	visitor.finalizeMinutes()
 	home.finalizeMinutes()
 
+	// The box score is derived purely from the event stream, joined with each
+	// team's roster metadata (PID/Pos set at construction, GameMIN by
+	// finalizeMinutes). The live teamState.boxes carry only that metadata now.
+	playerBoxes, teamBoxes := aggregateBoxes(gs.events, rosterMetaOf(visitor), rosterMetaOf(home))
+
 	gr := result.GameResult{
 		Date:          g.Date,
 		HomeTeamID:    g.HomeTeamID,
@@ -80,8 +87,18 @@ func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) (result.GameResult, int
 		GameOfThatDay: 1,
 		SimGameType:   int(g.GameType),
 		Events:        gs.events,
-		PlayerBoxes:   append(visitor.playerBoxes(), home.playerBoxes()...),
-		TeamBoxes:     []result.TeamBox{visitor.teamBox(), home.teamBox()},
+		PlayerBoxes:   playerBoxes,
+		TeamBoxes:     teamBoxes,
 	}
-	return gr, gs.transitions
+	return gr, gs.transitions, visitor, home
+}
+
+// rosterMetaOf snapshots a team's roster metadata (identity, position, finalized
+// minutes) in bundle order for the box aggregator.
+func rosterMetaOf(t *teamState) rosterMeta {
+	rm := rosterMeta{teamID: t.teamID, isHome: t.isHome, players: make([]playerMeta, 0, len(t.boxes))}
+	for _, b := range t.boxes {
+		rm.players = append(rm.players, playerMeta{PID: b.PID, Pos: b.Pos, GameMIN: b.GameMIN})
+	}
+	return rm
 }

--- a/engine/internal/sim/possession.go
+++ b/engine/internal/sim/possession.go
@@ -123,7 +123,6 @@ func possession(gs *gameState, offense, defense *teamState, periodIdx int, fbPen
 			gs.freeThrows(offense, defense, bh, def, 2, periodIdx)
 			return false
 		case outcomeTurnover:
-			offense.box(bh.PID).GameTOV++
 			gs.emit(result.Event{
 				Kind: result.EventTurnover, Period: gs.period, Clock: gs.clock,
 				TeamID: offense.teamID, PlayerID: bh.PID,
@@ -135,16 +134,11 @@ func possession(gs *gameState, offense, defense *teamState, periodIdx int, fbPen
 }
 
 // shotAttempt records a field-goal attempt of the given type, rolls make/miss,
-// and credits points/box stats. It returns (made, ended): ended is always true
-// for a single attempt; made distinguishes a basket from a miss so the caller
-// can route a miss to the rebound phase.
+// and scores points on a make. It emits the attempt event (the box-score
+// Game2GA/Game3GA counters are derived from it by aggregateBoxes). It returns
+// (made, ended): ended is always true for a single attempt; made distinguishes a
+// basket from a miss so the caller can route a miss to the rebound phase.
 func (gs *gameState) shotAttempt(offense, defense *teamState, shooter onCourt, shotValue float64, st result.ShotType, periodIdx int) (made, ended bool) {
-	box := offense.box(shooter.PID)
-	if st == result.ShotThree {
-		box.Game3GA++
-	} else {
-		box.Game2GA++
-	}
 	gs.emit(result.Event{
 		Kind: result.EventShotAttempt, Period: gs.period, Clock: gs.clock,
 		TeamID: offense.teamID, PlayerID: shooter.PID, ShotType: st,
@@ -162,15 +156,9 @@ func (gs *gameState) shotAttempt(offense, defense *teamState, shooter onCourt, s
 	return false, true
 }
 
-// madeFieldGoal records a guaranteed made 2pt (the and-one basket): attempt +
-// make + points.
+// madeFieldGoal records a guaranteed made 2pt (the and-one basket): it emits the
+// attempt event then credits the make.
 func (gs *gameState) madeFieldGoal(offense *teamState, shooter onCourt, st result.ShotType, periodIdx int) {
-	box := offense.box(shooter.PID)
-	if st == result.ShotThree {
-		box.Game3GA++
-	} else {
-		box.Game2GA++
-	}
 	gs.emit(result.Event{
 		Kind: result.EventShotAttempt, Period: gs.period, Clock: gs.clock,
 		TeamID: offense.teamID, PlayerID: shooter.PID, ShotType: st,
@@ -178,18 +166,20 @@ func (gs *gameState) madeFieldGoal(offense *teamState, shooter onCourt, st resul
 	gs.creditMadeFieldGoal(offense, shooter, st, periodIdx)
 }
 
-// creditMadeFieldGoal increments the made counter, scores the points, and emits
-// the make event.
+// creditMadeFieldGoal scores the points (live score, read for clutch/OT), bumps
+// the live per-shooter made-FG tally (read by the block-probability penalty),
+// and emits the make event. The box-score Game2GM/Game3GM counters are derived
+// from that event by aggregateBoxes — no box row is written here.
 func (gs *gameState) creditMadeFieldGoal(offense *teamState, shooter onCourt, st result.ShotType, periodIdx int) {
-	box := offense.box(shooter.PID)
 	pts := 2
 	if st == result.ShotThree {
-		box.Game3GM++
 		pts = 3
-	} else {
-		box.Game2GM++
 	}
 	offense.addPeriodPoints(periodIdx, pts)
+	if gs.madeFG == nil {
+		gs.madeFG = map[int]int{}
+	}
+	gs.madeFG[shooter.PID]++
 	gs.emit(result.Event{
 		Kind: result.EventShotMake, Period: gs.period, Clock: gs.clock,
 		TeamID: offense.teamID, PlayerID: shooter.PID, ShotType: st,
@@ -197,21 +187,21 @@ func (gs *gameState) creditMadeFieldGoal(offense *teamState, shooter onCourt, st
 }
 
 // freeThrows charges the foul to the contesting defender and resolves n
-// free-throw attempts for the shooter, scoring each make.
+// free-throw attempts for the shooter, scoring each make. It emits the foul and
+// free-throw events (the latter carrying FTAttempts/FTMade so aggregateBoxes can
+// reconstruct GamePF/GameFTA/GameFTM); only the live score is mutated here.
 func (gs *gameState) freeThrows(offense, defense *teamState, shooter, defender onCourt, n, periodIdx int) {
-	defense.box(defender.PID).GamePF++
+	defense.fouls[defender.PID]++ // live PF tally for foul-out/trouble subs (box PF is event-derived)
 	gs.emit(result.Event{
 		Kind: result.EventFoul, Period: gs.period, Clock: gs.clock,
 		TeamID: defense.teamID, PlayerID: defender.PID,
 	})
-	box := offense.box(shooter.PID)
 	made := shootFreeThrows(shooter, n, gs.rng)
-	box.GameFTA += n
-	box.GameFTM += made
 	offense.addPeriodPoints(periodIdx, made)
 	gs.emit(result.Event{
 		Kind: result.EventFreeThrow, Period: gs.period, Clock: gs.clock,
 		TeamID: offense.teamID, PlayerID: shooter.PID, ShotType: result.ShotFreeThrow,
+		FTAttempts: n, FTMade: made,
 	})
 }
 
@@ -223,7 +213,6 @@ func (gs *gameState) rebound(offense, defense *teamState, periodIdx int) (bool, 
 	defStr := teamReboundStrength(defense, false)
 	if gs.rng.Float64() < orebProbability(offStr, defStr) {
 		reb := selectRebounder(offense, true, gs.rng)
-		offense.box(reb.PID).GameORB++
 		gs.emit(result.Event{
 			Kind: result.EventRebound, Period: gs.period, Clock: gs.clock,
 			TeamID: offense.teamID, PlayerID: reb.PID, OffensiveRebound: true,
@@ -231,7 +220,6 @@ func (gs *gameState) rebound(offense, defense *teamState, periodIdx int) (bool, 
 		return true, reb
 	}
 	reb := selectRebounder(defense, false, gs.rng)
-	defense.box(reb.PID).GameDRB++
 	gs.emit(result.Event{
 		Kind: result.EventRebound, Period: gs.period, Clock: gs.clock,
 		TeamID: defense.teamID, PlayerID: reb.PID, OffensiveRebound: false,

--- a/engine/internal/sim/sim.go
+++ b/engine/internal/sim/sim.go
@@ -28,7 +28,7 @@ func Simulate(b bundle.Bundle, seed uint64) result.Result {
 	r := rng.New(seed)
 	res := result.Result{Seed: seed, Games: make([]result.GameResult, 0, len(b.Schedule))}
 	for _, g := range b.Schedule {
-		gr, _ := simGame(b, g, r)
+		gr, _, _, _ := simGame(b, g, r)
 		res.Games = append(res.Games, gr)
 	}
 	return res

--- a/engine/internal/sim/sim_test.go
+++ b/engine/internal/sim/sim_test.go
@@ -463,9 +463,97 @@ func TestSimulate_StealBlockCreditedToDefenders(t *testing.T) {
 // TestRunTransitionPossession_NeverThreePoint (#10).
 func TestSimulate_TransitionsOccur(t *testing.T) {
 	b := richBundle()
-	_, transitions := simGame(b, b.Schedule[0], rng.New(1988))
+	_, transitions, _, _ := simGame(b, b.Schedule[0], rng.New(1988))
 	if transitions == 0 {
 		t.Error("no fast-break possessions fired over a full game")
+	}
+}
+
+// --- matrix #11: event-derived box conserves against the live tally ----------
+//
+// The box score is now derived purely from the event stream (aggregateBoxes),
+// while the live teamState.quarters tally is still accumulated for in-game
+// clutch/OT decisions. This proves the two agree end-to-end: the output TeamBox
+// quarters (event-derived) equal the live tally bucketed Q1–Q4/OT, and the usual
+// invariants hold (quarters == points, team == Σ player rows, made ≤ attempted,
+// no negatives).
+func TestSimulate_EventDerivedConservation(t *testing.T) {
+	b := richBundle()
+	teamByPID := map[int]int{}
+	for _, p := range b.Players {
+		teamByPID[p.PID] = p.TeamID
+	}
+	gr, _, visitor, home := simGame(b, b.Schedule[0], rng.New(1988))
+
+	for ti, tb := range gr.TeamBoxes {
+		live := visitor
+		teamID := gr.VisitorTeamID
+		if ti == 1 {
+			live, teamID = home, gr.HomeTeamID
+		}
+
+		// Event-derived quarters must equal the live possession-time tally exactly,
+		// including overtime periods.
+		wantQ := live.quarters
+		gotQ := append([]int{tb.Q1, tb.Q2, tb.Q3, tb.Q4}, tb.OT...)
+		for len(gotQ) > 0 && gotQ[len(gotQ)-1] == 0 && len(gotQ) > len(wantQ) {
+			gotQ = gotQ[:len(gotQ)-1] // trim trailing unreached regulation quarters
+		}
+		if len(gotQ) < len(wantQ) {
+			t.Fatalf("team %d: event-derived quarters %v shorter than live tally %v", teamID, gotQ, wantQ)
+		}
+		for i, want := range wantQ {
+			if gotQ[i] != want {
+				t.Errorf("team %d Q%d: event-derived %d != live tally %d", teamID, i+1, gotQ[i], want)
+			}
+		}
+		for i := len(wantQ); i < len(gotQ); i++ {
+			if gotQ[i] != 0 {
+				t.Errorf("team %d: event-derived quarter %d = %d past live tally (want 0)", teamID, i+1, gotQ[i])
+			}
+		}
+
+		// team == Σ player rows; made ≤ attempted; no negatives.
+		var sum result.TeamBox
+		for _, pb := range gr.PlayerBoxes {
+			if teamByPID[pb.PID] != teamID {
+				continue
+			}
+			if pb.Game2GM > pb.Game2GA || pb.Game3GM > pb.Game3GA || pb.GameFTM > pb.GameFTA {
+				t.Errorf("player %d: made > attempted (%+v)", pb.PID, pb)
+			}
+			if anyNegative(pb) {
+				t.Errorf("player %d: negative stat (%+v)", pb.PID, pb)
+			}
+			sum.Game2GM += pb.Game2GM
+			sum.Game2GA += pb.Game2GA
+			sum.Game3GM += pb.Game3GM
+			sum.Game3GA += pb.Game3GA
+			sum.GameFTM += pb.GameFTM
+			sum.GameFTA += pb.GameFTA
+			sum.GameSTL += pb.GameSTL
+			sum.GameBLK += pb.GameBLK
+			sum.GameTOV += pb.GameTOV
+			sum.GamePF += pb.GamePF
+			sum.GameORB += pb.GameORB
+			sum.GameDRB += pb.GameDRB
+		}
+		if sum.Game2GM != tb.Game2GM || sum.Game3GM != tb.Game3GM || sum.GameFTM != tb.GameFTM ||
+			sum.Game2GA != tb.Game2GA || sum.Game3GA != tb.Game3GA || sum.GameFTA != tb.GameFTA ||
+			sum.GameSTL != tb.GameSTL || sum.GameBLK != tb.GameBLK || sum.GameTOV != tb.GameTOV ||
+			sum.GamePF != tb.GamePF || sum.GameORB != tb.GameORB || sum.GameDRB != tb.GameDRB {
+			t.Errorf("team %d: team box != sum of player rows", teamID)
+		}
+
+		// quarters == points.
+		pts := 2*tb.Game2GM + 3*tb.Game3GM + tb.GameFTM
+		q := tb.Q1 + tb.Q2 + tb.Q3 + tb.Q4
+		for _, ot := range tb.OT {
+			q += ot
+		}
+		if q != pts {
+			t.Errorf("team %d: quarters %d != points %d", teamID, q, pts)
+		}
 	}
 }
 

--- a/engine/internal/sim/state.go
+++ b/engine/internal/sim/state.go
@@ -61,10 +61,14 @@ type teamState struct {
 	// energy/minutes are keyed by PID for every eligible player (on court or
 	// bench). energy may go negative (drain is unfloored); minutes accumulates
 	// on-court seconds and is finalized into GameMIN at game end. fouledOut marks
-	// players who hit the 6th foul and can never re-enter.
+	// players who hit the 6th foul and can never re-enter. fouls is the live
+	// per-player personal-foul tally read by checkSubstitutions for foul-out /
+	// foul-trouble decisions — decision state kept live (like the score), NOT the
+	// output: the box GamePF is derived from EventFoul by aggregateBoxes.
 	energy    map[int]float64
 	minutes   map[int]float64
 	fouledOut map[int]bool
+	fouls     map[int]int
 
 	score    int
 	quarters []int // points per period in order; index 0 = Q1
@@ -87,6 +91,12 @@ type gameState struct {
 	period int // 1-based; 1..4 regulation, 5+ overtime
 	clock  int // seconds remaining in the current period
 	events []result.Event
+
+	// madeFG is the live per-shooter made-field-goal tally, keyed by PID. It is
+	// decision state (the block-probability penalty reads it — block.go), kept
+	// live like the score, NOT part of the output contract. The box score's
+	// Game2GM/Game3GM are now derived from the event stream by aggregateBoxes.
+	madeFG map[int]int
 
 	// transitionShotRate is the Stage-3 decaying team shot-rate threshold for
 	// fast-break steal-success (00_MASTER_REFERENCE.md L900-914). It is seeded

--- a/engine/internal/sim/steal.go
+++ b/engine/internal/sim/steal.go
@@ -47,18 +47,16 @@ func selectStealer(defense *teamState, r *rng.RNG) (onCourt, bool) {
 	return defense.players[len(defense.players)-1], true
 }
 
-// creditSteal resolves whether a turnover (already credited to the victim) was a
-// forced steal. On a steal it credits GameSTL to the stealing DEFENDER and emits
-// EventSteal (TeamID = offense, PlayerID = victim, DefenderID = stealer), then
+// creditSteal resolves whether a turnover was a forced steal. On a steal it
+// emits EventSteal (TeamID = offense, PlayerID = victim, DefenderID = stealer) —
+// from which aggregateBoxes credits GameSTL to the stealing DEFENDER — then
 // returns true so the caller sets the fast-break pending flag. On an unforced
-// turnover it returns false and credits no stealer. It never alters the victim's
-// GameTOV (the caller credited it).
+// turnover it returns false and emits no steal event.
 func (gs *gameState) creditSteal(offense, defense *teamState, victim onCourt) bool {
 	if gs.rng.Float64() >= stealFraction {
 		return false // unforced turnover: no stealer
 	}
 	stealer, _ := selectStealer(defense, gs.rng)
-	defense.box(stealer.PID).GameSTL++
 	gs.emit(result.Event{
 		Kind: result.EventSteal, Period: gs.period, Clock: gs.clock,
 		TeamID: offense.teamID, PlayerID: victim.PID, DefenderID: stealer.PID,

--- a/engine/internal/sim/steal_test.go
+++ b/engine/internal/sim/steal_test.go
@@ -16,26 +16,20 @@ func twoTeams() (*teamState, *teamState) {
 
 // --- matrix #3: steal credits a defender; victim keeps the turnover ----------
 
+// creditSteal no longer writes box rows: it emits a single EventSteal crediting a
+// defender (PlayerID = victim, DefenderID = stealer) — aggregateBoxes derives the
+// victim's GameTOV (from the caller's EventTurnover) and the stealer's GameSTL.
 func TestCreditSteal_CreditsDefenderVictimKeepsTOV(t *testing.T) {
 	// Find a seed whose first Float64 falls under stealFraction so creditSteal
 	// resolves to a steal (the probabilities cannot be forced to an exact value).
 	for seed := uint64(1); seed < 200; seed++ {
 		offense, defense := twoTeams()
 		victim := offense.players[0]
-		offense.box(victim.PID).GameTOV++ // caller credits the TOV first
 		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
 
 		before := len(gs.events)
 		if !gs.creditSteal(offense, defense, victim) {
 			continue // this seed was an unforced turnover; try the next
-		}
-
-		// Victim retains the turnover; no steal is credited to the victim.
-		if got := offense.box(victim.PID).GameTOV; got != 1 {
-			t.Fatalf("victim GameTOV = %d, want 1 (kept)", got)
-		}
-		if offense.box(victim.PID).GameSTL != 0 {
-			t.Fatalf("victim must not be credited a steal")
 		}
 
 		// Exactly one EventSteal, crediting a defender.
@@ -55,12 +49,16 @@ func TestCreditSteal_CreditsDefenderVictimKeepsTOV(t *testing.T) {
 		if ev.PlayerID != victim.PID {
 			t.Errorf("EventSteal PlayerID = %d, want victim %d", ev.PlayerID, victim.PID)
 		}
-		// DefenderID is the stealer and must be on the defending team with a STL credit.
+		// DefenderID is the stealer and must be on the defending team.
 		if defense.box(ev.DefenderID) == nil {
 			t.Fatalf("DefenderID %d is not on the defending team", ev.DefenderID)
 		}
-		if defense.box(ev.DefenderID).GameSTL != 1 {
-			t.Errorf("stealer %d GameSTL = %d, want 1", ev.DefenderID, defense.box(ev.DefenderID).GameSTL)
+		if ev.DefenderID == victim.PID {
+			t.Error("stealer must not be the victim")
+		}
+		// The helper writes no box rows (steal/turnover are event-derived).
+		if defense.box(ev.DefenderID).GameSTL != 0 {
+			t.Error("creditSteal must not write GameSTL (box is event-derived)")
 		}
 		return
 	}
@@ -93,7 +91,6 @@ func TestCreditSteal_SplitIsReal(t *testing.T) {
 	for seed := uint64(1); seed <= 400; seed++ {
 		offense, defense := twoTeams()
 		victim := offense.players[0]
-		offense.box(victim.PID).GameTOV++
 		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
 		if gs.creditSteal(offense, defense, victim) {
 			steals++

--- a/engine/internal/sim/substitution.go
+++ b/engine/internal/sim/substitution.go
@@ -63,7 +63,7 @@ func checkSubstitutions(t *teamState, period, clock int, emit func(result.Event)
 	next := make([]onCourt, 0, len(t.players))
 	for i := range t.players {
 		out := t.players[i]
-		pf := t.box(out.PID).GamePF
+		pf := t.fouls[out.PID]
 
 		foulOut := pf > foulOutLimit
 		foulTrouble := !foulOut && pf >= threshold

--- a/engine/internal/sim/substitution_test.go
+++ b/engine/internal/sim/substitution_test.go
@@ -54,7 +54,7 @@ func TestFoulThreshold_PhaseTable(t *testing.T) {
 
 func TestCheckSubstitutions_FoulOutEmitsOutThenIn(t *testing.T) {
 	tm := subTeam()
-	tm.box(1).GamePF = 6 // PG over the foul-out limit
+	tm.fouls[1] = 6 // PG over the foul-out limit (live tally drives subs; box PF is event-derived)
 
 	var events []result.Event
 	checkSubstitutions(tm, 1, 600, func(e result.Event) { events = append(events, e) })
@@ -86,12 +86,12 @@ func TestCheckSubstitutions_FoulOutEmitsOutThenIn(t *testing.T) {
 
 func TestCheckSubstitutions_FoulOutPermanent(t *testing.T) {
 	tm := subTeam()
-	tm.box(1).GamePF = 6
+	tm.fouls[1] = 6
 	checkSubstitutions(tm, 1, 600, func(result.Event) {}) // 1 out, 11 in
 
 	// Now foul out the replacement too. No other PG backup exists (1 is barred),
 	// so 11 is removed and the team plays short — 1 must NOT return.
-	tm.box(11).GamePF = 6
+	tm.fouls[11] = 6
 	checkSubstitutions(tm, 1, 600, func(result.Event) {})
 
 	on := onCourtPIDs(tm)
@@ -110,7 +110,7 @@ func TestCheckSubstitutions_FoulOutPermanent(t *testing.T) {
 
 func TestCheckSubstitutions_FoulOutNoBackupPlaysShort(t *testing.T) {
 	tm := subTeam()
-	tm.box(5).GamePF = 6 // C has no backup
+	tm.fouls[5] = 6 // C has no backup
 
 	before := len(tm.players)
 	var events []result.Event

--- a/engine/internal/sim/testdata/golden.json
+++ b/engine/internal/sim/testdata/golden.json
@@ -2802,7 +2802,8 @@
           "clock_seconds": 434,
           "team_id": 3,
           "player_id": 201,
-          "shot_type": "ft"
+          "shot_type": "ft",
+          "ft_attempts": 2
         },
         {
           "kind": "possession_start",
@@ -5369,7 +5370,8 @@
           "clock_seconds": 382,
           "team_id": 3,
           "player_id": 201,
-          "shot_type": "ft"
+          "shot_type": "ft",
+          "ft_attempts": 2
         },
         {
           "kind": "possession_start",

--- a/engine/internal/sim/transition.go
+++ b/engine/internal/sim/transition.go
@@ -123,7 +123,6 @@ func (gs *gameState) runTransitionPossession(offense, defense *teamState, period
 			gs.freeThrows(offense, defense, bh, def, 2, periodIdx)
 			return false
 		case outcomeTurnover:
-			offense.box(bh.PID).GameTOV++
 			gs.emit(result.Event{
 				Kind: result.EventTurnover, Period: gs.period, Clock: gs.clock,
 				TeamID: offense.teamID, PlayerID: bh.PID,


### PR DESCRIPTION
## Summary

PR5 of the jsb-native-engine. Makes real the architectural intent already in `result.go`: **the per-possession event stream is the single source of truth.** The sim previously double-booked — emitting events *and* mutating `teamState.box(pid).GameXXX` inline. PR5 strips the inline box-stat mutations and introduces a pure aggregator (`engine/internal/sim/aggregate.go`) that folds the event stream, joined with per-team roster metadata, into every output `PlayerBox` counter and `TeamBox` total + quarter split.

## What changed

- **`result.Event`** gains `FTAttempts`/`FTMade` (`omitempty`) — the one stat the stream couldn't reconstruct (free throws carried no count). They fold exactly into `GameFTA`/`GameFTM`.
- **`aggregate.go`** (new) — `aggregateBoxes(events, visitor, home rosterMeta)` derives all box stats purely from events, visitor-first, with DNP all-zero rows and 0-made-FT period-reach handling.
- **Inline box mutations stripped** from possession / transition / steal / block / rebound helpers; they now emit-only.
- **Live decision state stays live** (not read from box rows):
  - score → clutch/OT (`addPeriodPoints`)
  - new `gameState.madeFG` per-shooter tally → block-probability penalty
  - new `teamState.fouls` per-player tally → foul-out / foul-trouble subs. **This closes a third load-bearing live read the plan missed:** `checkSubstitutions` read box `GamePF`, which is now event-derived and would have read 0 forever.
- **Golden regenerated additive-only:** only `ft_attempts` lines added inside `events`; `player_boxes`/`team_boxes` byte-unchanged. The box *values* are identical — this refactors how the box is produced, not what it contains.

## Testing

- Helper unit tests migrated from box-state to event/tally assertions.
- New aggregator unit tests (mapping, miss→GA-without-GM, DNP, and-one, steal/block defender attribution, FTM≤FTA, team rollup + quarter bucketing, 0-made-FT period-reach).
- New FT-field round-trip test and full-game conservation test (event-derived team quarters == live `teamState` tally).
- `go build ./... && go vet ./... && go test ./...` all green.

## Manual Testing

No manual testing needed — all changes are covered by unit tests.

Generated with [Claude Code](https://claude.ai/code)