### PR TITLE
docs(rules): remove redundant style.css rule; reconcile Tailwind manual-build contradiction

### DIFF
--- a/.claude/rules/css-architecture.md
+++ b/.claude/rules/css-architecture.md
@@ -3,7 +3,7 @@ description: CSS architecture: all styles live in ibl5/design/components/; inlin
 paths:
   - "**/design/**/*.css"
   - "**/*View.php"
-last_verified: 2026-05-29
+last_verified: 2026-05-31
 ---
 
 # CSS Architecture Reference
@@ -74,7 +74,7 @@ Need a data table?
 - **`base.css` scopes `overflow-x: auto` to `table:not(.ibl-data-table)`** in `@layer base`. Modern `.ibl-data-table` tables are unaffected. Sticky variants still set `overflow: visible` to override `.ibl-data-table`'s own `overflow: hidden` (used for border-radius clipping).
 - **Rounded corners require `overflow: hidden`** to clip, but that breaks sticky. Solution: set `overflow: visible` on the table and apply `border-radius` directly to corner cells. For Pattern 4, corner `th` cells also need `box-shadow` in `var(--page-bg, #eeeeee)` to mask rows scrolling behind the rounded corners.
 - **`--page-bg` CSS variable** is set on `<body>` by `theme.php` from `$bgcolor1` (dev: `#BBBBBB`, prod: `#EEEEEE`).
-- **`css:watch` may not rebuild.** After editing CSS, verify the compiled output contains your new rules: `grep -c "your-class" themes/IBL/style/style.css`. If 0, manually rebuild.
+- **`css:watch` may not rebuild.** After editing CSS, verify the compiled output contains your new rules: `grep -c "your-class" themes/IBL/style/style.css`. If 0, manually rebuild (this is the sanctioned recovery case — see `.claude/rules/css-auto-rebuild.md`).
 
 ## Overflow Rules
 

--- a/.claude/rules/css-auto-rebuild.md
+++ b/.claude/rules/css-auto-rebuild.md
@@ -1,7 +1,7 @@
 ---
-description: Tailwind CSS is auto-rebuilt by the ibl5-tailwind Docker container — never run manual build commands.
+description: Tailwind CSS is auto-rebuilt by the ibl5-tailwind container; manual builds are recovery-only.
 paths: "**/*.css"
-last_verified: 2026-05-28
+last_verified: 2026-05-31
 ---
 
 # CSS Auto-Rebuild (Tailwind)
@@ -10,7 +10,8 @@ The `ibl5-tailwind` Docker container runs `@tailwindcss/cli --watch=always` cont
 
 ## Rules
 
-- **Never run `bunx @tailwindcss/cli`, `bun run css:build`, or any manual Tailwind build command.** The watcher handles it.
+- **Do not run manual Tailwind build commands (`bunx @tailwindcss/cli`, `bun run css:build`) as a routine step** — the `ibl5-tailwind` watcher rebuilds `themes/IBL/style/style.css` automatically on save. Never pass `--minify` locally (CI handles minification).
+- **Recovery (the one sanctioned exception):** run a single one-off `bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css` when the watcher misses a change — notably after a `git checkout`/branch switch — or when compiled output is verified stale. Confirm staleness first: `grep -c "your-class" themes/IBL/style/style.css`.
 - After editing CSS source files, the compiled output is available within ~1 second — just reload the page.
 - If the compiled CSS appears stale, check the container is running: `docker compose ps tailwind`. Restart it if needed: `docker compose restart tailwind`.
 - In CI, `css:build` runs as part of the Docker image build — no manual step needed there either.

--- a/.claude/rules/environment.md
+++ b/.claude/rules/environment.md
@@ -3,7 +3,7 @@ description: Environment setup: CSS build, IBLbot, and environment-specific gotc
 paths:
   - "**/design/**/*.css"
   - "**/IBLbot/**/*"
-last_verified: 2026-04-25
+last_verified: 2026-05-31
 ---
 
 # Environment Commands
@@ -14,12 +14,13 @@ last_verified: 2026-04-25
 # DEVELOPMENT: Auto-rebuilds on save
 bun run css:watch
 
-# LOCAL BUILDS: Rebuild CSS without minification (for commits)
+# RECOVERY: one-off rebuild when the watcher misses a change (e.g. after a branch switch)
 bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css
 ```
 
+- See `.claude/rules/css-auto-rebuild.md` — this is the sanctioned recovery exception to the no-manual-build rule, not a routine step.
 - **NEVER use `--minify` locally.** Minification is handled by GitHub Actions on merge/push.
-- **NEVER commit `themes/IBL/style/style.css`.** It is gitignored and built on production. Only commit the source CSS files in `design/`.
+- The compiled `themes/IBL/style/style.css` is `.gitignore`-enforced (built on production) — only commit the source CSS files in `design/`.
 
 ## IBLbot (Discord Bot)
 

--- a/.claude/rules/playwright-tests.md
+++ b/.claude/rules/playwright-tests.md
@@ -1,7 +1,7 @@
 ---
 description: Playwright E2E testing rules, Docker requirements, and actionability pitfalls.
 paths: ibl5/tests/e2e/**/*.ts
-last_verified: 2026-05-28
+last_verified: 2026-05-31
 ---
 
 # Playwright E2E Testing Rules
@@ -36,7 +36,7 @@ This runs with `--workers=1 --retries=2` (CI-matching retries, single worker). U
 
 1. **Verify Docker is running:** `docker compose ps` — if no containers are up, run `docker compose up -d`
 2. **Verify `.env.test` exists** with valid credentials — copy from `.env.test.example` if missing
-3. **Rebuild CSS after branch switches:** `css:watch` may not detect source changes from `git checkout`. Run `bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css`
+3. **Rebuild CSS after branch switches:** `css:watch` may not detect source changes from `git checkout`. Run `bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css`. See `.claude/rules/css-auto-rebuild.md` — this is the sanctioned recovery exception to the no-manual-build rule, not a routine step.
 
 ## Test Categories
 
@@ -364,7 +364,7 @@ The E2E tests run in GitHub Actions via `.github/workflows/e2e-tests.yml`. Key d
 ## Worktree & Environment Gotchas
 
 - **`bin/e2e-wt.sh <name>` runs Playwright from the worktree's `ibl5/` dir** — test files and `BASE_URL` both resolve to the worktree, so TS test changes are picked up without any extra steps.
-- **Rebuild CSS after switching branches.** `css:watch` may not detect source file changes from `git checkout`. Run `bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css` after switching.
+- **Rebuild CSS after switching branches.** `css:watch` may not detect source file changes from `git checkout`. Run `bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css` after switching. See `.claude/rules/css-auto-rebuild.md` — this is the sanctioned recovery exception to the no-manual-build rule, not a routine step.
 - **E2E tests that submit login/registration forms can trigger auth throttling.** The `auth_users_throttling` table accumulates failed attempts. If `auth.setup.ts` fails with "Too many login attempts", clear: `DELETE FROM auth_users_throttling WHERE 1=1;`. CI is unaffected (fresh DB per run).
 
 ## Completion Criteria


### PR DESCRIPTION
## Summary

Pure-documentation PR touching four always-loaded agent rules under `.claude/rules/`.

**Fix 1:** Remove the redundant `NEVER commit style.css` imperative from `environment.md` — this is already enforced deterministically by `.gitignore` (`git check-ignore` confirmed). Replace with a factual note preserving the positive `design/` guidance.

**Fix 2:** Reconcile a four-file contradiction. `css-auto-rebuild.md` stated an absolute "never run any manual Tailwind build command," but `environment.md`, `playwright-tests.md` (two locations), and `css-architecture.md` all legitimately instructed a one-off manual rebuild as recovery. The reconciliation establishes one coherent policy:
- Watcher handles routine rebuilds — never run manual builds routinely, never with `--minify` locally
- A single manual rebuild is the sanctioned recovery when the watcher misses a change (notably after `git checkout`/branch switch) or compiled output is verified stale
- Three consumer files each gain a cross-reference to `css-auto-rebuild.md` as the canonical rule

**Decision-trigger:** `.claude/rules/*.md` ADR gate uses `--diff-filter=A` (ADDED files only) — all four files are MODIFIED, so the ADR gate does not fire.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
