### PR TITLE
CI Gates Banning Silently-Disabled Tests

### DIFF
--- a/.claude/rules/phpunit-tests.md
+++ b/.claude/rules/phpunit-tests.md
@@ -1,7 +1,7 @@
 ---
 description: PHPUnit testing rules: output parsing, behavior-focused patterns.
 paths: ibl5/tests/**/*.php
-last_verified: 2026-05-27
+last_verified: 2026-05-31
 ---
 
 # PHPUnit Testing Rules
@@ -133,7 +133,7 @@ public function testSaveDelegates(): void
 ## DON'T:
 - **NEVER** use `createMock()` when no `expects()` calls are configured — use `createStub()` instead
 - **NEVER** use `ReflectionClass` for private methods — test behavior through public APIs; if a private method needs direct testing, it should be extracted to a separate class with a public interface
-- **NEVER** use `markTestSkipped()` - delete instead
+- **NEVER** use `markTestSkipped()` to silently disable a test — delete instead. The only exception is an integration-availability skip (e.g., a service unreachable), which must carry an inline `// phpunit-hygiene-allow: <reason ≥20 chars>` marker; `bin/check-phpunit-hygiene` enforces this.
 - **NEVER** check full SQL query structure (column names, WHERE clauses, bind strings) — except security tests. For void write methods with no return value to assert on, you may use `assertQueryExecuted('table_name')` to verify the target table was hit, but don't match beyond the table name.
 
 ## Test Registration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -295,6 +295,18 @@ jobs:
       working-directory: ibl5
       run: php bin/check-baseline-drift
 
+  phpunit-hygiene:
+    name: PHPUnit hygiene gate
+    needs: [changes]
+    if: needs.changes.outputs.src == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Ban silently-disabled tests (markTestSkipped)
+        run: bin/check-phpunit-hygiene --pr
+
   shellcheck:
     name: ShellCheck (bash 3.2 compat)
     needs: [changes]
@@ -461,7 +473,7 @@ jobs:
   gate:
     name: Tests and Analysis
     if: always()
-    needs: [changes, test, audit-php, audit-js, db-integration, phpstan, shellcheck, host-mariadb-guard, update-baselines]
+    needs: [changes, test, audit-php, audit-js, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, update-baselines]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1

--- a/bin/check-e2e-hygiene
+++ b/bin/check-e2e-hygiene
@@ -235,6 +235,9 @@ run_pattern blocking "catch-false" \
 run_pattern blocking "test-skip" \
   '^\s*test\.skip\('
 
+run_pattern blocking "test-only" \
+  '(^|[^a-zA-Z0-9_.])(test|describe)(\.[a-zA-Z]+)?\.only\('
+
 run_pattern blocking "weak-gte-zero" \
   'toBeGreaterThanOrEqual\(0\)'
 

--- a/bin/check-e2e-hygiene
+++ b/bin/check-e2e-hygiene
@@ -69,7 +69,7 @@ is_skipped() {
   local file="$1"
   local rel
   rel="${file#"$ROOT/"}"
-  for pat in "${SKIP_PATHS[@]}"; do
+  for pat in "${SKIP_PATHS[@]+"${SKIP_PATHS[@]}"}"; do
     # shellcheck disable=SC2254
     case "$rel" in
       $pat) return 0 ;;

--- a/bin/check-phpunit-hygiene
+++ b/bin/check-phpunit-hygiene
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Scans PHPUnit tests for markTestSkipped(), banned by .claude/rules/phpunit-tests.md.
+# Silently-disabled tests are a hygiene anti-pattern: delete the test instead, or —
+# for a legitimate integration-availability skip — carry an inline allow marker.
+# Exits 0 (clean) or 1 (blocking violations found).
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+TESTS_DIR="$ROOT/ibl5/tests"
+
+usage() {
+  cat <<'EOF'
+Usage: bin/check-phpunit-hygiene [--pr] [--help|-h]
+
+Scans PHPUnit tests for markTestSkipped() — silently-disabled tests are banned.
+Delete the test instead, or carry an inline allow marker for a legitimate
+integration-availability skip (e.g. an external service unreachable).
+
+Modes:
+  (no args)  Scan all ibl5/tests/**/*.php
+  --pr       Scan only files changed vs origin/master
+
+Exception:
+  Per-line: // phpunit-hygiene-allow: <reason >= 20 chars>
+            (on the matched line or the immediately preceding line)
+
+See .claude/rules/phpunit-tests.md.
+EOF
+  exit 0
+}
+
+MODE="all"
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h) usage ;;
+    --pr) MODE="pr" ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# --- Build file list ---
+if [ "$MODE" = "pr" ]; then
+  SCAN_FILES=()
+  while IFS= read -r f; do
+    [ -f "$ROOT/$f" ] && SCAN_FILES+=("$ROOT/$f")
+  done < <(git -C "$ROOT" diff origin/master --name-only -- 'ibl5/tests/**/*.php')
+else
+  SCAN_FILES=()
+  while IFS= read -r f; do
+    SCAN_FILES+=("$f")
+  done < <(find "$TESTS_DIR" -name '*.php' -type f | sort)
+fi
+
+if [ ${#SCAN_FILES[@]} -eq 0 ]; then
+  echo "PASS: no PHPUnit files to scan."
+  exit 0
+fi
+
+# --- Shared helper (mirrors bin/check-e2e-hygiene) ---
+has_inline_allow() {
+  local line="$1"
+  local file="$2"
+  local lineno="$3"
+
+  if echo "$line" | grep -qE '// phpunit-hygiene-allow: .{20,}'; then
+    return 0
+  fi
+  if [ "$lineno" -gt 1 ]; then
+    local prev
+    prev=$(sed -n "$((lineno - 1))p" "$file")
+    if echo "$prev" | grep -qE '// phpunit-hygiene-allow: .{20,}'; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# --- Pattern runner (mirrors bin/check-e2e-hygiene) ---
+BLOCKING_HITS=()
+BLOCKING_TOTAL=0
+
+run_pattern() {
+  local severity="$1"
+  local label="$2"
+  shift 2
+  local grep_args=("$@")
+
+  for f in "${SCAN_FILES[@]}"; do
+    while IFS=: read -r line_num matched_line; do
+      [ -z "$line_num" ] && continue
+      if has_inline_allow "$matched_line" "$f" "$line_num"; then
+        continue
+      fi
+      local rel="${f#"$ROOT/"}"
+      local entry="[$label] $rel:$line_num: $matched_line"
+      if [ "$severity" = "blocking" ]; then
+        BLOCKING_HITS+=("$entry")
+        BLOCKING_TOTAL=$((BLOCKING_TOTAL + 1))
+      fi
+    done < <(grep -nE "${grep_args[@]}" "$f" 2>/dev/null || true)
+  done
+}
+
+# === BLOCKING patterns (exit 1 if any found) ===
+
+run_pattern blocking "mark-test-skipped" 'markTestSkipped\('
+
+# --- Report ---
+if [ "$BLOCKING_TOTAL" -eq 0 ]; then
+  echo "PASS: 0 blocking hits"
+  exit 0
+fi
+
+# Count unique files in blocking hits
+declare -a HIT_FILES=()
+for hit in "${BLOCKING_HITS[@]}"; do
+  local_file=$(echo "$hit" | sed 's/^\[[^]]*\] //' | cut -d: -f1)
+  found=false
+  for hf in "${HIT_FILES[@]+"${HIT_FILES[@]}"}"; do
+    if [ "$hf" = "$local_file" ]; then
+      found=true
+      break
+    fi
+  done
+  if [ "$found" = false ]; then
+    HIT_FILES+=("$local_file")
+  fi
+done
+
+echo "=== PHPUnit Hygiene Gate ==="
+echo ""
+for hit in "${BLOCKING_HITS[@]}"; do
+  echo "  $hit"
+done
+echo ""
+echo "FAIL: $BLOCKING_TOTAL blocking hits across ${#HIT_FILES[@]} files."
+echo "markTestSkipped() silently disables tests. Delete the test instead, or — for a"
+echo "legitimate integration-availability skip — add an inline marker on the matched"
+echo "or preceding line: // phpunit-hygiene-allow: <reason >= 20 chars>"
+echo "See .claude/rules/phpunit-tests.md."
+exit 1

--- a/ibl5/tests/Cli/CheckE2eHygieneCliTest.php
+++ b/ibl5/tests/Cli/CheckE2eHygieneCliTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class CheckE2eHygieneCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/check-e2e-hygiene');
+        self::assertNotFalse($resolved, 'bin/check-e2e-hygiene must exist');
+        $this->scriptPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/e2e-hyg-test-' . bin2hex(random_bytes(8));
+        mkdir($this->tmpDir, 0755, true);
+
+        $this->runInDir('git init -b main');
+        $this->runInDir('git config user.email "test@test.com"');
+        $this->runInDir('git config user.name "Test"');
+
+        mkdir($this->tmpDir . '/ibl5/tests/e2e', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    public function testTestOnlyExitsOne(): void
+    {
+        $spec = "import { test, expect } from '@playwright/test';\n";
+        $spec .= "test.only('focused', async ({ page }) => {\n";
+        $spec .= "  await expect(page.locator('h1')).toBeVisible();\n";
+        $spec .= "});\n";
+        $this->writeSpec('focused.spec.ts', $spec);
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('test-only', $result['output']);
+        self::assertStringContainsString('focused.spec.ts', $result['output']);
+    }
+
+    public function testDescribeOnlyExitsOne(): void
+    {
+        $spec = "import { test, expect } from '@playwright/test';\n";
+        $spec .= "test.describe.only('group', () => {\n";
+        $spec .= "  test('a', async ({ page }) => {\n";
+        $spec .= "    await expect(page.locator('h1')).toBeVisible();\n";
+        $spec .= "  });\n";
+        $spec .= "});\n";
+        $this->writeSpec('group.spec.ts', $spec);
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('test-only', $result['output']);
+    }
+
+    public function testCleanSpecExitsZero(): void
+    {
+        $spec = "import { test, expect } from '@playwright/test';\n";
+        $spec .= "test('renders heading', async ({ page }) => {\n";
+        $spec .= "  await expect(page.locator('h1')).toHaveText('Home');\n";
+        $spec .= "});\n";
+        $this->writeSpec('clean.spec.ts', $spec);
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('PASS', $result['output']);
+    }
+
+    public function testHelpFlagExitsZero(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --help 2>&1', $output, $exit);
+
+        self::assertSame(0, $exit);
+        self::assertStringContainsString('Usage:', implode("\n", $output));
+    }
+
+    /**
+     * @return array{output: string, exit: int}
+     */
+    private function runScript(): array
+    {
+        $output = [];
+        $exit = 0;
+        $cmd = 'cd ' . escapeshellarg($this->tmpDir) . ' && '
+            . 'bash ' . escapeshellarg($this->scriptPath) . ' 2>&1';
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function writeSpec(string $filename, string $content): void
+    {
+        file_put_contents($this->tmpDir . '/ibl5/tests/e2e/' . $filename, $content);
+    }
+
+    private function runInDir(string $cmd): void
+    {
+        exec('cd ' . escapeshellarg($this->tmpDir) . ' && ' . $cmd . ' 2>&1');
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/ibl5/tests/Cli/CheckPhpunitHygieneCliTest.php
+++ b/ibl5/tests/Cli/CheckPhpunitHygieneCliTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class CheckPhpunitHygieneCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/check-phpunit-hygiene');
+        self::assertNotFalse($resolved, 'bin/check-phpunit-hygiene must exist');
+        $this->scriptPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/phpunit-hyg-test-' . bin2hex(random_bytes(8));
+        mkdir($this->tmpDir, 0755, true);
+
+        $this->runInDir('git init -b main');
+        $this->runInDir('git config user.email "test@test.com"');
+        $this->runInDir('git config user.name "Test"');
+
+        mkdir($this->tmpDir . '/ibl5/tests', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    // The fixture strings below build the banned call from a split token so this
+    // test file's own source never matches the scanner's `markTestSkipped\(` pattern
+    // (the scanner walks ibl5/tests/**/*.php, which includes this file). The temp
+    // fixtures still receive the real call via string interpolation.
+    private const SKIP_FN = 'markTestSkipped';
+
+    public function testUnallowlistedMarkTestSkippedExitsOne(): void
+    {
+        $fn = self::SKIP_FN;
+        $this->writeTest('SomeTest.php', "<?php\n\$this->{$fn}('disabled for now');\n");
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('mark-test-skipped', $result['output']);
+        self::assertStringContainsString('SomeTest.php', $result['output']);
+    }
+
+    public function testAllowlistedMarkTestSkippedExitsZero(): void
+    {
+        $fn = self::SKIP_FN;
+        $php = "<?php\n";
+        $php .= "// phpunit-hygiene-allow: integration test skips when Mailpit SMTP is unreachable on localhost:1025\n";
+        $php .= "\$this->{$fn}('Mailpit is not reachable at localhost:1025');\n";
+        $this->writeTest('MailTest.php', $php);
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('PASS', $result['output']);
+    }
+
+    public function testShortReasonMarkerExitsOne(): void
+    {
+        $fn = self::SKIP_FN;
+        $php = "<?php\n";
+        $php .= "// phpunit-hygiene-allow: too short\n";
+        $php .= "\$this->{$fn}('skip it');\n";
+        $this->writeTest('ShortTest.php', $php);
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('mark-test-skipped', $result['output']);
+    }
+
+    public function testCleanTestExitsZero(): void
+    {
+        $this->writeTest('CleanTest.php', "<?php\n\$this->assertTrue(true);\n");
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('PASS', $result['output']);
+    }
+
+    public function testHelpFlagExitsZero(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --help 2>&1', $output, $exit);
+
+        self::assertSame(0, $exit);
+        self::assertStringContainsString('Usage:', implode("\n", $output));
+    }
+
+    public function testBogusArgExitsTwo(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --bogus 2>&1', $output, $exit);
+
+        self::assertSame(2, $exit);
+        self::assertStringContainsString('Unknown argument', implode("\n", $output));
+    }
+
+    /**
+     * @return array{output: string, exit: int}
+     */
+    private function runScript(): array
+    {
+        $output = [];
+        $exit = 0;
+        $cmd = 'cd ' . escapeshellarg($this->tmpDir) . ' && '
+            . 'bash ' . escapeshellarg($this->scriptPath) . ' 2>&1';
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function writeTest(string $filename, string $content): void
+    {
+        file_put_contents($this->tmpDir . '/ibl5/tests/' . $filename, $content);
+    }
+
+    private function runInDir(string $cmd): void
+    {
+        exec('cd ' . escapeshellarg($this->tmpDir) . ' && ' . $cmd . ' 2>&1');
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/ibl5/tests/Mail/MailServiceSmtpIntegrationTest.php
+++ b/ibl5/tests/Mail/MailServiceSmtpIntegrationTest.php
@@ -27,6 +27,7 @@ class MailServiceSmtpIntegrationTest extends TestCase
     protected function setUp(): void
     {
         if (!$this->isMailpitReachable()) {
+            // phpunit-hygiene-allow: integration test skips when Mailpit SMTP is unreachable on localhost:1025
             $this->markTestSkipped('Mailpit is not reachable at localhost:1025');
         }
 


### PR DESCRIPTION
## Summary

Adds two deterministic CI gates enforcing anti-patterns that existed only as prose in agent rules:

- **Gate 1:** Extends `bin/check-e2e-hygiene` with a blocking pattern for Playwright `.only` calls (`test.only(`, `describe.only(`, `test.describe.only(`)
- **Gate 2:** New `bin/check-phpunit-hygiene` scanner banning bare `markTestSkipped()` calls without an inline `// phpunit-hygiene-allow: <reason ≥20 chars>` marker
- Wires `phpunit-hygiene` job into `tests.yml` and the `gate` aggregator
- Adds CLI tests for both scanners
- Corrects `.claude/rules/phpunit-tests.md` to document the allow-marker exception

<!-- no-adr: mirrors existing bin/check-e2e-hygiene test-hygiene-gate precedent; no new architectural constraint -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.