### PR TITLE
feat: add --since changed-files mode to check-docs enforcing on-touch rule

### DIFF
--- a/.claude/rules/doc-freshness.md
+++ b/.claude/rules/doc-freshness.md
@@ -1,6 +1,6 @@
 ---
 description: Frontmatter schema, 60-day staleness policy, on-touch verification rule, and dead-reference rules enforced by bin/check-docs
-last_verified: 2026-05-28
+last_verified: 2026-05-31
 paths: "**/*.md"
 ---
 
@@ -24,6 +24,8 @@ paths: "glob-or-list"  # only meaningful for .claude/rules/*
 ## On-Touch Rule
 
 When editing any in-scope `.md` file, verify its content still matches reality, confirm the `description` field accurately reflects the content, and bump `last_verified` to today — all in the same edit.
+
+This is enforced in CI by `bin/check-docs --since=<base-ref>`, which fails any PR that changes an in-scope `.md` body without bumping `last_verified` (a base-vs-head value comparison, never date-equality-to-today, so a PR opened one day and merged later does not false-fail).
 
 ## Dead-Reference Rule
 

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -30,3 +32,7 @@ jobs:
 
       - name: Run bin/check-docs
         run: bin/check-docs
+
+      - name: Run bin/check-docs (on-touch / changed-files)
+        if: github.event_name == 'pull_request'
+        run: bin/check-docs --since=${{ github.event.pull_request.base.sha }}

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -446,6 +446,10 @@ function checkChanged(string $base, string $repoRoot, \DateTimeImmutable $today)
     $changedRel = [];
     $diffCode = 0;
     exec($diffCmd, $changedRel, $diffCode);
+    if ($diffCode !== 0) {
+        fwrite(STDERR, sprintf("check-docs: unable to diff against base ref '%s' (git exit %d). Is it a valid commit? In CI, ensure fetch-depth: 0.\n", $base, $diffCode));
+        exit(2);
+    }
 
     // Intersect with the in-scope set so scoping/exclusions are reused, not
     // re-implemented.

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -505,6 +505,11 @@ $opts = ['fix_dates' => false, 'include_memory' => false, 'verbose' => false, 's
 foreach (array_slice($argv, 1) as $arg) {
     if (str_starts_with($arg, '--since=')) {
         $opts['since'] = substr($arg, strlen('--since='));
+        if (trim($opts['since']) === '') {
+            fwrite(STDERR, "check-docs: --since= requires a base ref (e.g. --since=master or --since=<sha>)\n");
+            fwrite(STDERR, usage());
+            exit(2);
+        }
         continue;
     }
     switch ($arg) {

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -61,10 +61,15 @@ Options:
   --include-memory   Also scan Claude Code memory for this repo
                      (auto-derived from the main repo path; works from
                      worktrees). Off in CI.
+  --since=<ref>      Changed-files (PR) mode: every in-scope .md whose body
+                     changed vs <ref> must also bump last_verified. Each
+                     changed file is also run through the full-scan checks
+                     (future-date, staleness, dead-ref). Pure base-vs-head
+                     value comparison — never date-equality-to-today.
   --verbose, -v      Show passing files too.
   --help, -h         Show this message.
 
-Exit 0 on success, 1 on any validation failure.
+Exit 0 on success, 1 on any validation failure, 2 on a usage error.
 
 USAGE;
 }
@@ -412,10 +417,92 @@ function fixDates(array $files, \DateTimeImmutable $today): int
     return $updated;
 }
 
+/**
+ * Changed-files (PR) mode. For each in-scope .md that changed between $base and
+ * HEAD, fail when its body changed but the parsed `last_verified` value did NOT
+ * change (the On-Touch Rule), and additionally run the full-scan checkFile()
+ * rules (future-date, staleness, dead-ref, missing frontmatter).
+ *
+ * The bump check compares the parsed frontmatter VALUE base-vs-head — never
+ * date-equality-to-today — so a PR opened Monday and merged Wednesday does not
+ * false-fail, and body text that literally contains `last_verified:` (e.g. inside
+ * a code fence) cannot trip the check. The value comparison subsumes every case:
+ * body-changed-not-bumped fails (values equal), date-bumped passes (values
+ * differ), newly-added-with-date passes (base null != date), added-without-date
+ * fails (null === null).
+ *
+ * @return list<string> diagnostic lines, each prefixed with the repo-relative path.
+ */
+function checkChanged(string $base, string $repoRoot, \DateTimeImmutable $today): array
+{
+    $escapedRoot = escapeshellarg($repoRoot);
+    $escapedBase = escapeshellarg($base);
+
+    $diffCmd = sprintf(
+        'git -C %s diff --name-only --diff-filter=AM %s...HEAD 2>/dev/null',
+        $escapedRoot,
+        $escapedBase
+    );
+    $changedRel = [];
+    $diffCode = 0;
+    exec($diffCmd, $changedRel, $diffCode);
+
+    // Intersect with the in-scope set so scoping/exclusions are reused, not
+    // re-implemented.
+    $inScopeSet = [];
+    foreach (collectFiles($repoRoot, false) as $abs) {
+        $inScopeSet[$abs] = true;
+    }
+
+    $issues = [];
+    foreach ($changedRel as $rel) {
+        $rel = trim($rel);
+        if ($rel === '') {
+            continue;
+        }
+        $abs = $repoRoot . '/' . $rel;
+        if (!isset($inScopeSet[$abs])) {
+            continue;
+        }
+
+        $headContent = is_file($abs) ? file_get_contents($abs) : false;
+        $headFm = $headContent !== false ? parseFrontmatter($headContent) : null;
+
+        // Base blob: command fails when the file did not exist at $base (added)
+        // => treat base frontmatter as null.
+        $showCmd = sprintf('git -C %s show %s:%s 2>/dev/null', $escapedRoot, $escapedBase, escapeshellarg($rel));
+        $baseOut = [];
+        $baseCode = 0;
+        exec($showCmd, $baseOut, $baseCode);
+        $baseFm = $baseCode === 0 ? parseFrontmatter(implode("\n", $baseOut)) : null;
+
+        $headLv = $headFm['last_verified'] ?? null;
+        $baseLv = $baseFm['last_verified'] ?? null;
+
+        if ($headLv === $baseLv) {
+            $issues[] = sprintf(
+                '%s: body changed but last_verified not bumped (still %s)',
+                $rel,
+                $headLv ?? '(none)'
+            );
+        }
+
+        foreach (checkFile($abs, $repoRoot, $today) as $fileIssue) {
+            $issues[] = sprintf('%s: %s', $rel, $fileIssue);
+        }
+    }
+
+    return $issues;
+}
+
 // --- main ---
 
-$opts = ['fix_dates' => false, 'include_memory' => false, 'verbose' => false];
+$opts = ['fix_dates' => false, 'include_memory' => false, 'verbose' => false, 'since' => null];
 foreach (array_slice($argv, 1) as $arg) {
+    if (str_starts_with($arg, '--since=')) {
+        $opts['since'] = substr($arg, strlen('--since='));
+        continue;
+    }
     switch ($arg) {
         case '--fix-dates':
             $opts['fix_dates'] = true;
@@ -440,6 +527,21 @@ foreach (array_slice($argv, 1) as $arg) {
 
 $root = repoRoot();
 $today = new \DateTimeImmutable('today');
+
+if ($opts['since'] !== null) {
+    $issues = checkChanged($opts['since'], $root, $today);
+    if ($issues === []) {
+        echo "On-touch doc check passed (changed files vs {$opts['since']}).\n";
+        exit(0);
+    }
+    echo "On-touch doc check FAILED:\n";
+    foreach ($issues as $issue) {
+        echo "     - {$issue}\n";
+    }
+    echo "\n" . count($issues) . " issue(s) in changed docs.\n";
+    exit(1);
+}
+
 $files = collectFiles($root, $opts['include_memory']);
 sort($files);
 

--- a/ibl5/tests/Cli/CheckDocsCliTest.php
+++ b/ibl5/tests/Cli/CheckDocsCliTest.php
@@ -234,4 +234,14 @@ final class CheckDocsCliTest extends TestCase
         $this->assertSame(1, $code, $output);
         $this->assertStringContainsString('last_verified not bumped', $output);
     }
+
+    #[Test]
+    public function sinceBadRefExitsTwo(): void
+    {
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($this->freshDate()), 'base');
+
+        [$code, $output] = $this->runScript('--since=deadbeef123nonexistent');
+        $this->assertSame(2, $code, $output);
+        $this->assertStringContainsString('unable to diff against base ref', $output);
+    }
 }

--- a/ibl5/tests/Cli/CheckDocsCliTest.php
+++ b/ibl5/tests/Cli/CheckDocsCliTest.php
@@ -244,4 +244,14 @@ final class CheckDocsCliTest extends TestCase
         $this->assertSame(2, $code, $output);
         $this->assertStringContainsString('unable to diff against base ref', $output);
     }
+
+    #[Test]
+    public function sinceEmptyRefExitsTwo(): void
+    {
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($this->freshDate()), 'base');
+
+        [$code, $output] = $this->runScript('--since=');
+        $this->assertSame(2, $code, $output);
+        $this->assertStringContainsString('requires a base ref', $output);
+    }
 }

--- a/ibl5/tests/Cli/CheckDocsCliTest.php
+++ b/ibl5/tests/Cli/CheckDocsCliTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CLI-level tests for bin/check-docs.
+ *
+ * Builds a throwaway git repo per test so the changed-files (--since) mode runs
+ * against real git plumbing rather than mocks. Because bin/check-docs resolves
+ * its repo root from __DIR__ (the script location), the script is copied into
+ * the tmp repo's bin/ so the walk-up lands on the throwaway repo, not the real
+ * IBL5 checkout.
+ */
+#[Group('cli')]
+final class CheckDocsCliTest extends TestCase
+{
+    private string $tmpDir;
+    private string $scriptPath;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/cdocs-cli-' . uniqid('', true);
+        mkdir($this->tmpDir, 0o777, true);
+
+        // Copy the real script into the tmp repo so repoRoot() (which walks up
+        // from __DIR__) resolves to the throwaway repo.
+        $repoScript = realpath(__DIR__ . '/../../../bin/check-docs');
+        $this->assertIsString($repoScript, 'bin/check-docs not found');
+        mkdir($this->tmpDir . '/bin', 0o777, true);
+        copy($repoScript, $this->tmpDir . '/bin/check-docs');
+        $this->scriptPath = $this->tmpDir . '/bin/check-docs';
+
+        $this->runGit('init -q');
+        $this->runGit('config user.email test@example.com');
+        $this->runGit('config user.name Test');
+        $this->runGit('config commit.gpgsign false');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tmpDir);
+    }
+
+    /**
+     * Run the script inside the tmp repo. Returns [exitCode, combinedOutput].
+     *
+     * @return array{int, string}
+     */
+    private function runScript(string $args = ''): array
+    {
+        $cmd = sprintf(
+            'cd %s && php %s %s 2>&1',
+            escapeshellarg($this->tmpDir),
+            escapeshellarg($this->scriptPath),
+            $args
+        );
+        $output = [];
+        $code = 0;
+        exec($cmd, $output, $code);
+        return [$code, implode("\n", $output)];
+    }
+
+    private function runGit(string $args): void
+    {
+        $cmd = sprintf('cd %s && git %s 2>&1', escapeshellarg($this->tmpDir), $args);
+        exec($cmd);
+    }
+
+    private function commitFile(string $relPath, string $content, string $message): void
+    {
+        $full = $this->tmpDir . '/' . $relPath;
+        @mkdir(dirname($full), 0o777, true);
+        file_put_contents($full, $content);
+        $this->runGit('add -A');
+        $this->runGit(sprintf('commit -q -m %s', escapeshellarg($message)));
+    }
+
+    private function currentSha(): string
+    {
+        $cmd = sprintf('cd %s && git rev-parse HEAD 2>&1', escapeshellarg($this->tmpDir));
+        return trim((string) shell_exec($cmd));
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+        rmdir($dir);
+    }
+
+    /** Build a valid in-scope doc body with the given last_verified date. */
+    private function doc(string $lastVerified, string $body = 'Original body text.'): string
+    {
+        return "---\n"
+            . "description: Sample doc for testing.\n"
+            . "last_verified: {$lastVerified}\n"
+            . "---\n\n"
+            . "# Sample\n\n"
+            . "{$body}\n";
+    }
+
+    /** A recent (fresh) ISO date well within the 60-day staleness window. */
+    private function freshDate(int $daysAgo = 5): string
+    {
+        return (new \DateTimeImmutable("today -{$daysAgo} days"))->format('Y-m-d');
+    }
+
+    // --- Phase 1: characterization (lock in existing full-scan contract) ---
+
+    #[Test]
+    public function helpExitsZeroAndShowsUsage(): void
+    {
+        [$code, $output] = $this->runScript('--help');
+        $this->assertSame(0, $code, $output);
+        $this->assertStringContainsString('Usage:', $output);
+    }
+
+    #[Test]
+    public function bogusFlagExitsTwo(): void
+    {
+        [$code, $output] = $this->runScript('--bogus');
+        $this->assertSame(2, $code, $output);
+        $this->assertStringContainsString('unknown flag', $output);
+    }
+
+    #[Test]
+    public function fullScanWithValidDocExitsZero(): void
+    {
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($this->freshDate()), 'add doc');
+        [$code, $output] = $this->runScript();
+        $this->assertSame(0, $code, $output);
+        $this->assertStringContainsString('docs verified', $output);
+    }
+
+    #[Test]
+    public function fullScanWithStaleDocExitsOne(): void
+    {
+        $this->commitFile('ibl5/docs/sample.md', $this->doc('2026-01-01'), 'add stale doc');
+        [$code, $output] = $this->runScript();
+        $this->assertSame(1, $code, $output);
+        $this->assertStringContainsString('stale', $output);
+    }
+
+    // --- Phase 2: changed-files (--since) mode ---
+
+    #[Test]
+    public function sinceBodyChangedNotBumpedExitsOne(): void
+    {
+        $date = $this->freshDate();
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($date, 'Original body.'), 'base');
+        $base = $this->currentSha();
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($date, 'Edited body.'), 'edit body only');
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(1, $code, $output);
+        $this->assertStringContainsString('last_verified not bumped', $output);
+    }
+
+    #[Test]
+    public function sinceBodyChangedAndBumpedExitsZero(): void
+    {
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($this->freshDate(20), 'Original body.'), 'base');
+        $base = $this->currentSha();
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($this->freshDate(2), 'Edited body.'), 'edit + bump');
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(0, $code, $output);
+    }
+
+    #[Test]
+    public function sinceOutOfScopeChangeExitsZero(): void
+    {
+        $date = $this->freshDate();
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($date), 'base in-scope doc');
+        $this->commitFile('notes/scratch.md', "no frontmatter\n", 'base out-of-scope');
+        $base = $this->currentSha();
+        $this->commitFile('notes/scratch.md', "no frontmatter, edited\n", 'edit out-of-scope only');
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(0, $code, $output);
+    }
+
+    #[Test]
+    public function sinceFutureDateExitsOne(): void
+    {
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($this->freshDate(), 'Original body.'), 'base');
+        $base = $this->currentSha();
+        $future = (new \DateTimeImmutable('today +30 days'))->format('Y-m-d');
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($future, 'Edited body.'), 'edit + future date');
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(1, $code, $output);
+        $this->assertStringContainsString('in the future', $output);
+    }
+
+    #[Test]
+    public function sinceAddedDocWithDateExitsZero(): void
+    {
+        $this->commitFile('ibl5/docs/existing.md', $this->doc($this->freshDate()), 'base');
+        $base = $this->currentSha();
+        $this->commitFile('ibl5/docs/added.md', $this->doc($this->freshDate()), 'add new doc with date');
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(0, $code, $output);
+    }
+
+    #[Test]
+    public function sinceAddedDocWithoutDateExitsOne(): void
+    {
+        $this->commitFile('ibl5/docs/existing.md', $this->doc($this->freshDate()), 'base');
+        $base = $this->currentSha();
+        $noDate = "---\ndescription: Added without a date.\n---\n\n# Added\n\nBody.\n";
+        $this->commitFile('ibl5/docs/added.md', $noDate, 'add new doc without date');
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(1, $code, $output);
+        $this->assertStringContainsString('last_verified not bumped', $output);
+    }
+}


### PR DESCRIPTION
## Summary

Adds deterministic CI enforcement of the doc-freshness On-Touch Rule. `bin/check-docs --since=<ref>` fails any PR whose in-scope `.md` body changed without bumping `last_verified` (base-vs-head value comparison, not date-equality-to-today).

**Changes:**
- `bin/check-docs`: `--since` argv parsing + `checkChanged()` reusing `collectFiles()` / `parseFrontmatter()` / `checkFile()`
- `ibl5/tests/Cli/CheckDocsCliTest.php` (new): 9 PHPUnit cases (characterization + `--since` modes)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.