### PR TITLE
feat(phpstan): SQL safety, duplicate-modifier, bare-column, strict-types self-coverage (10.12/10.13/10.19/10.21/10.24)

### DIFF
--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1617,6 +1617,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** New `BanDirectMysqliQueryRule` flagging `->query()` on `\mysqli` outside `BaseMysqliRepository`/`Database\MySQL`.
 **Est. effort:** M (needs type-scope check)
 **Risk if untouched:** Silent `false` on failures vs typed exception.
+**Status:** Rule landed (2026-05-31) — `BanDirectMysqliQueryRule` (`ibl.directMysqliQuery`). Flags `->query()` on a `\mysqli`-typed receiver outside the DB-access boundary; allowlist: `BaseMysqliRepository.php` + `Database/MySQL.php`. 7 baseline occurrences across the 3 Updater steps. Refactoring them to `execute()` deferred.
 
 ### 10.13 SQL ORDER BY / Table-Name Interpolation Without Whitelist Enforcement
 **Location:** `AwardHistory/AwardHistoryRepository.php:59`, `Statistics/TeamStatsCalculator.php:52,194`, `SeasonLeaderboards/SeasonLeaderboardsRepository.php:80`
@@ -1624,6 +1625,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** New `BanSqlStringInterpolationRule` — flag SQL strings (`SELECT|INSERT|UPDATE|DELETE|FROM|JOIN|ORDER BY`) with interpolated vars; allow `QueryConditions::toWhereClause()`.
 **Est. effort:** M
 **Risk if untouched:** Pattern is contagious; first user-controlled use is a real injection.
+**Status:** Rule landed (2026-05-31) — `BanSqlStringInterpolationRule` (`ibl.sqlStringInterpolation`). Flags `InterpolatedString` SQL literals via an anchored SQL-statement pattern, so prose mentioning SQL keywords as English words is NOT matched. `SeasonLeaderboards:80` is dot-concatenation, correctly NOT a site. Plan estimated 3 sites; the rule found 66 genuine interpolated-SQL sites across ~40 files (32 baseline entries) — all baselined. Refactoring (e.g. AwardHistory `$sortColumn` → match-validated enum) deferred to a separate plan.
 
 ### 10.14 `time()` / `date()` / `strtotime()` — No Clock Abstraction
 **Location:** `Draft/DraftSelectionHandler.php:60`, `Cache/PageCache.php:87,112`, `Cache/DatabaseCache.php:52,83`, `Security/CsrfGuard.php:98,209,263`, `LeagueSchedule/LeagueScheduleView.php:89-121`, several more
@@ -1631,6 +1633,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Introduce `Services\ClockInterface::now(): int` first; then `BanDirectTimeCallsRule`; allow `NukeCompat`, `LegacyFunctions`, Clock impl.
 **Est. effort:** L
 **Risk if untouched:** CSRF expiry, cache TTL, draft timestamps not unit-testable.
+**Status:** Still open — explicitly deferred by `maintenance-25` (which landed the SQL/time-axis rules 10.12/10.13/10.19/10.21/10.24). `ClockInterface`/`SystemClock` exist at `classes/Api/Middleware/{Contracts/ClockInterface,SystemClock}.php` but are scoped to Api/Middleware; ~64 direct `time()`/`date()`/`strtotime()` sites across 8+ files. Wiring a global Clock + banning direct calls is its own L-effort plan.
 
 ### 10.15 `echo ob_get_clean()` Anti-Pattern in `DebugOutput`
 **Location:** `UI/DebugOutput.php:61,79`
@@ -1664,6 +1667,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** New `BanDuplicateModifierMethodRule` — flag methods named `calculate*Modifier` outside `ContractRules`.
 **Est. effort:** S
 **Risk if untouched:** Formula drift root cause re-introducible.
+**Status:** Rule landed (2026-05-31) — `BanDuplicateModifierMethodRule` (`ibl.duplicateModifierMethod`). Flags `/^calculate.+Modifier$/` methods outside `ContractRules.php`; skips interface/abstract declarations and suffixless `calculateModifier()` helpers (`NegotiationDemandCalculator`/`FreeAgencyDemandCalculator` are NOT matched). 5 baseline sites (`ExtensionOfferEvaluator`); delegating them to `ContractRules` deferred.
 
 ### 10.20 `assertNotNull` on Known-Non-Null Value Slips Through
 **Location:** `RequireMeaningfulAssertionsRule` is AST-only
@@ -1678,6 +1682,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Extend `BanInconsistentColumnNamesRule` to match unbackticked occurrences too.
 **Est. effort:** M
 **Risk if untouched:** Column renames leave silent runtime errors.
+**Status:** Rule landed (2026-05-31) — `BanBareColumnIdentifierRule` (`ibl.bareColumnIdentifier`). NOT an extension of `BanInconsistentColumnNamesRule` (global `name`/`value` matching would false-positive every table). New rule narrowly targets bare `ibl_<table>.<column>` qualified refs — the `ibl_` prefix disambiguates them; bare unqualified columns, alias-qualified columns (`p.name`), and `ibl_plr.*` are NOT flagged. Zero false positives in a trial `composer run analyse` → ships blocking (no advisory downgrade needed). 23 baseline occurrences across 3 files (`FreeAgencyAdminRepository`, `PlayerDatabaseRepository`, `Team`).
 
 ### 10.22 `json_decode` Without `JSON_THROW_ON_ERROR`
 **Location:** `Cache/DatabaseCache.php:52`, `Utilities/TestCookieOverrides.php`, `Negotiation/NegotiationRepository.php`, `Trading/TradeQueueProcessor.php`
@@ -1701,6 +1706,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Extend check to `phpstan-rules/`.
 **Est. effort:** S
 **Risk if untouched:** Rule files self-exempt; coercion bugs in rules.
+**Status:** Completed (2026-05-31) — `RequireStrictTypesRule` scope extended to also cover `phpstan-rules/`. All rule files already declare `strict_types` — no baseline change. Modifies an existing rule (no new file) so `adr-check` does not fire.
 
 ### 10.25 Baseline Burn-Down Targets (no new rule)
 **Location:** `phpstan-baseline.neon` — `ibl.unescapedOutput` (0), `ibl.cookieBeforeHeader` (0 — zero-floored), `ibl.inlineCss` (0 — now inline `@phpstan-ignore`), `ibl.deprecatedHtmlTag` (0) — all zero as of 2026-05-29 audit (was 17/0/6/3)

--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -2,6 +2,7 @@
     "phpstan-baseline.neon": {
         "ibl.directHeader": 1,
         "ibl.directMysqliQuery": 3,
+        "ibl.duplicateModifierMethod": 5,
         "ibl.hardcodedEnvString": 8,
         "ibl.sqlStringInterpolation": 32
     },

--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -1,6 +1,7 @@
 {
     "phpstan-baseline.neon": {
         "ibl.directHeader": 1,
+        "ibl.directMysqliQuery": 3,
         "ibl.hardcodedEnvString": 8
     },
     "phpstan-tests-baseline.neon": {

--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -1,5 +1,6 @@
 {
     "phpstan-baseline.neon": {
+        "ibl.bareColumnIdentifier": 17,
         "ibl.directHeader": 1,
         "ibl.directMysqliQuery": 3,
         "ibl.duplicateModifierMethod": 5,

--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -2,7 +2,8 @@
     "phpstan-baseline.neon": {
         "ibl.directHeader": 1,
         "ibl.directMysqliQuery": 3,
-        "ibl.hardcodedEnvString": 8
+        "ibl.hardcodedEnvString": 8,
+        "ibl.sqlStringInterpolation": 32
     },
     "phpstan-tests-baseline.neon": {
         "argument.type": 94,

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -1,10 +1,76 @@
 parameters:
 	ignoreErrors:
 		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/Api/Repository/ApiGameRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/Api/Repository/ApiLeadersRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/Api/Repository/ApiPlayerRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/Api/Repository/ApiTeamRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/AwardHistory/AwardHistoryRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/BaseMysqliRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/BasketballStats/Tables/PeriodAverages.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/Bootstrap/ConfigBootstrap.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/Boxscore/Boxscore.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/CareerLeaderboards/CareerLeaderboardsRepository.php
+
+		-
 			rawMessage: Hardcoded environment string "localhost" is banned. Inject an environment/config flag instead of branching on a literal host name.
 			identifier: ibl.hardcodedEnvString
 			count: 1
 			path: classes/Debug/DebugSession.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/EngineBundle/EngineBundleRepository.php
 
 		-
 			rawMessage: Hardcoded environment string "127.0.0.1" is banned. Inject an environment/config flag instead of branching on a literal host name.
@@ -19,6 +85,36 @@ parameters:
 			path: classes/Extension/ExtensionService.php
 
 		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/JsbParser/JsbImportRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 4
+			path: classes/JsbParser/PlayerIdResolver.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/LastSimRecap/LastSimRecapRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/League/League.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/Migration/SchemaValidator.php
+
+		-
 			rawMessage: Hardcoded environment string "localhost" is banned. Inject an environment/config flag instead of branching on a literal host name.
 			identifier: ibl.hardcodedEnvString
 			count: 1
@@ -29,6 +125,90 @@ parameters:
 			identifier: ibl.hardcodedEnvString
 			count: 1
 			path: classes/PageLayout/PageLayout.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 3
+			path: classes/Player/Stats/PlayerStatsRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/PlrParser/PlrParserRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/ProjectedDraftOrder/ProjectedDraftOrderRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 5
+			path: classes/RecordHolders/RecordHoldersRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/RookieOption/RookieOptionRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 4
+			path: classes/Search/SearchRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/SeasonHighs/SeasonHighsRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/SeasonLeaderboards/SeasonLeaderboardsRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 10
+			path: classes/Standings/StandingsRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/Statistics/TeamStatsCalculator.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/TeamOffDefStats/TeamOffDefStatsRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 2
+			path: classes/Topics/TopicsRepository.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/Trading/BuyoutLedgerRepository.php
 
 		-
 			rawMessage: Hardcoded environment string "localhost" is banned. Inject an environment/config flag instead of branching on a literal host name.
@@ -55,6 +235,12 @@ parameters:
 			path: classes/Trading/TradingController.php
 
 		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/TransactionHistory/TransactionHistoryRepository.php
+
+		-
 			rawMessage: 'Direct \mysqli::query() is banned outside the DB-access boundary. Use a BaseMysqliRepository helper (execute()/fetchOne()/fetchAll()) instead — raw query() bypasses prepared-statement parameterization.'
 			identifier: ibl.directMysqliQuery
 			count: 2
@@ -71,3 +257,9 @@ parameters:
 			identifier: ibl.directMysqliQuery
 			count: 3
 			path: classes/Updater/Steps/RefreshTeamSeasonRecordsStep.php
+
+		-
+			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringInterpolation
+			count: 4
+			path: classes/Voting/VotingRepository.php

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -115,6 +115,36 @@ parameters:
 			path: classes/Extension/ExtensionService.php
 
 		-
+			rawMessage: 'Table-qualified column ''ibl_fa_offers.name'' must be wrapped in backticks (`ibl_fa_offers`.`name`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/FreeAgency/FreeAgencyAdminRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_fa_offers.perceivedvalue'' must be wrapped in backticks (`ibl_fa_offers`.`perceivedvalue`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/FreeAgency/FreeAgencyAdminRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_fa_offers.pid'' must be wrapped in backticks (`ibl_fa_offers`.`pid`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/FreeAgency/FreeAgencyAdminRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.bird'' must be wrapped in backticks (`ibl_plr`.`bird`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/FreeAgency/FreeAgencyAdminRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.pid'' must be wrapped in backticks (`ibl_plr`.`pid`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/FreeAgency/FreeAgencyAdminRepository.php
+
+		-
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringInterpolation
 			count: 2
@@ -165,6 +195,54 @@ parameters:
 		-
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringInterpolation
+			count: 1
+			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.age'' must be wrapped in backticks (`ibl_plr`.`age`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.bird'' must be wrapped in backticks (`ibl_plr`.`bird`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 2
+			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.college'' must be wrapped in backticks (`ibl_plr`.`college`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.exp'' must be wrapped in backticks (`ibl_plr`.`exp`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 2
+			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.name'' must be wrapped in backticks (`ibl_plr`.`name`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.pid'' must be wrapped in backticks (`ibl_plr`.`pid`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.pos'' must be wrapped in backticks (`ibl_plr`.`pos`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_plr.retired'' must be wrapped in backticks (`ibl_plr`.`retired`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
 			count: 1
 			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
 
@@ -221,6 +299,30 @@ parameters:
 			identifier: ibl.sqlStringInterpolation
 			count: 2
 			path: classes/Statistics/TeamStatsCalculator.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_standings.league_record'' must be wrapped in backticks (`ibl_standings`.`league_record`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 2
+			path: classes/Team/Team.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_standings.teamid'' must be wrapped in backticks (`ibl_standings`.`teamid`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 2
+			path: classes/Team/Team.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_team_info.team_name'' must be wrapped in backticks (`ibl_team_info`.`team_name`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 1
+			path: classes/Team/Team.php
+
+		-
+			rawMessage: 'Table-qualified column ''ibl_team_info.teamid'' must be wrapped in backticks (`ibl_team_info`.`teamid`) for PHPStan rename safety.'
+			identifier: ibl.bareColumnIdentifier
+			count: 3
+			path: classes/Team/Team.php
 
 		-
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -53,3 +53,21 @@ parameters:
 			identifier: ibl.directHeader
 			count: 1
 			path: classes/Trading/TradingController.php
+
+		-
+			rawMessage: 'Direct \mysqli::query() is banned outside the DB-access boundary. Use a BaseMysqliRepository helper (execute()/fetchOne()/fetchAll()) instead — raw query() bypasses prepared-statement parameterization.'
+			identifier: ibl.directMysqliQuery
+			count: 2
+			path: classes/Updater/Steps/RefreshIblHistStep.php
+
+		-
+			rawMessage: 'Direct \mysqli::query() is banned outside the DB-access boundary. Use a BaseMysqliRepository helper (execute()/fetchOne()/fetchAll()) instead — raw query() bypasses prepared-statement parameterization.'
+			identifier: ibl.directMysqliQuery
+			count: 2
+			path: classes/Updater/Steps/RefreshPlayoffSeriesResultsStep.php
+
+		-
+			rawMessage: 'Direct \mysqli::query() is banned outside the DB-access boundary. Use a BaseMysqliRepository helper (execute()/fetchOne()/fetchAll()) instead — raw query() bypasses prepared-statement parameterization.'
+			identifier: ibl.directMysqliQuery
+			count: 3
+			path: classes/Updater/Steps/RefreshTeamSeasonRecordsStep.php

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -73,6 +73,36 @@ parameters:
 			path: classes/EngineBundle/EngineBundleRepository.php
 
 		-
+			rawMessage: 'Method calculateCombinedModifier() duplicates a contract-modifier formula. Modifier calculations must live in ContractRules to keep salary-formula logic centralized — delegate to ContractRules::calculateCombinedModifier() instead of re-implementing it here.'
+			identifier: ibl.duplicateModifierMethod
+			count: 1
+			path: classes/Extension/ExtensionOfferEvaluator.php
+
+		-
+			rawMessage: 'Method calculateLoyaltyModifier() duplicates a contract-modifier formula. Modifier calculations must live in ContractRules to keep salary-formula logic centralized — delegate to ContractRules::calculateLoyaltyModifier() instead of re-implementing it here.'
+			identifier: ibl.duplicateModifierMethod
+			count: 1
+			path: classes/Extension/ExtensionOfferEvaluator.php
+
+		-
+			rawMessage: 'Method calculatePlayingTimeModifier() duplicates a contract-modifier formula. Modifier calculations must live in ContractRules to keep salary-formula logic centralized — delegate to ContractRules::calculatePlayingTimeModifier() instead of re-implementing it here.'
+			identifier: ibl.duplicateModifierMethod
+			count: 1
+			path: classes/Extension/ExtensionOfferEvaluator.php
+
+		-
+			rawMessage: 'Method calculateTraditionModifier() duplicates a contract-modifier formula. Modifier calculations must live in ContractRules to keep salary-formula logic centralized — delegate to ContractRules::calculateTraditionModifier() instead of re-implementing it here.'
+			identifier: ibl.duplicateModifierMethod
+			count: 1
+			path: classes/Extension/ExtensionOfferEvaluator.php
+
+		-
+			rawMessage: 'Method calculateWinnerModifier() duplicates a contract-modifier formula. Modifier calculations must live in ContractRules to keep salary-formula logic centralized — delegate to ContractRules::calculateWinnerModifier() instead of re-implementing it here.'
+			identifier: ibl.duplicateModifierMethod
+			count: 1
+			path: classes/Extension/ExtensionOfferEvaluator.php
+
+		-
 			rawMessage: Hardcoded environment string "127.0.0.1" is banned. Inject an environment/config flag instead of branching on a literal host name.
 			identifier: ibl.hardcodedEnvString
 			count: 1

--- a/ibl5/phpstan-rules/BanBareColumnIdentifierRule.php
+++ b/ibl5/phpstan-rules/BanBareColumnIdentifierRule.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Bans bare (unbackticked) table-qualified column references in SQL — e.g.
+ * `ibl_plr.pid` or `ibl_team_info.team_name` written without backticks.
+ *
+ * This extends BanBareTableIdentifierRule (which covers FROM/JOIN/UPDATE/INTO/DELETE
+ * table tokens) into the SELECT/WHERE/ORDER BY/SET column clauses. The target is
+ * deliberately narrow: only `ibl_<table>.<column>` qualified references, which are
+ * unambiguously identifiers thanks to the `ibl_` prefix. Bare unqualified columns
+ * (`name`, `pid`) and alias-qualified columns (`p.name`) are NOT flagged — they
+ * cannot be disambiguated from keywords/aliases without a column inventory, so
+ * flagging them would produce a false-positive flood.
+ *
+ * Both the table and column halves should be backticked for rename safety:
+ * `` `ibl_plr`.`pid` `` (or reference via a backticked-table alias).
+ *
+ * @implements Rule<String_>
+ */
+final class BanBareColumnIdentifierRule implements Rule
+{
+    // Match ibl_<table>.<column> where the table half is not already inside backticks
+    // and the column half is a plain word (so `ibl_plr.*` is excluded — `*` is not a
+    // column identifier and cannot be backticked).
+    private const PATTERN = '/(?<![`\'"\w.])(ibl_[a-z_]+)\.([a-zA-Z_][a-zA-Z0-9_]*)\b(?!`)/i';
+
+    public function getNodeType(): string
+    {
+        return String_::class;
+    }
+
+    /**
+     * @param String_ $node
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $file = $scope->getFile();
+
+        if (!str_contains($file, DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR)) {
+            return [];
+        }
+
+        if (preg_match_all(self::PATTERN, $node->value, $matches, PREG_SET_ORDER) === 0) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($matches as $m) {
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                "Table-qualified column '%s.%s' must be wrapped in backticks (`%s`.`%s`) for "
+                . 'PHPStan rename safety.',
+                $m[1],
+                $m[2],
+                $m[1],
+                $m[2],
+            ))
+                ->identifier('ibl.bareColumnIdentifier')
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/ibl5/phpstan-rules/BanDirectMysqliQueryRule.php
+++ b/ibl5/phpstan-rules/BanDirectMysqliQueryRule.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Bans direct \mysqli::query() calls outside the DB-access boundary.
+ *
+ * Raw query() bypasses prepared-statement parameterization. DB access must go
+ * through a repository helper (BaseMysqliRepository::execute()/fetchOne()/fetchAll())
+ * which prepares and binds. The boundary classes that wrap \mysqli directly
+ * (BaseMysqliRepository, Database\MySQL) are allowlisted.
+ *
+ * @implements Rule<MethodCall>
+ */
+final class BanDirectMysqliQueryRule implements Rule
+{
+    /**
+     * Path tails of the DB-access-boundary classes permitted to call \mysqli::query() directly.
+     *
+     * @var list<string>
+     */
+    private const ALLOWED_FILE_TAILS = [
+        DIRECTORY_SEPARATOR . 'BaseMysqliRepository.php',
+        DIRECTORY_SEPARATOR . 'Database' . DIRECTORY_SEPARATOR . 'MySQL.php',
+    ];
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        if ($node->name->name !== 'query') {
+            return [];
+        }
+
+        $file = $scope->getFile();
+
+        if (!str_contains($file, DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR)) {
+            return [];
+        }
+
+        foreach (self::ALLOWED_FILE_TAILS as $tail) {
+            if (str_ends_with($file, $tail)) {
+                return [];
+            }
+        }
+
+        $receiverType = $scope->getType($node->var);
+        if (!in_array('mysqli', $receiverType->getObjectClassNames(), true)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'Direct \mysqli::query() is banned outside the DB-access boundary. '
+                . 'Use a BaseMysqliRepository helper (execute()/fetchOne()/fetchAll()) instead — '
+                . 'raw query() bypasses prepared-statement parameterization.'
+            )
+                ->identifier('ibl.directMysqliQuery')
+                ->build(),
+        ];
+    }
+}

--- a/ibl5/phpstan-rules/BanDuplicateModifierMethodRule.php
+++ b/ibl5/phpstan-rules/BanDuplicateModifierMethodRule.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Bans `calculate*Modifier()` methods outside ContractRules.
+ *
+ * Contract-modifier formulas must live in ContractRules so the league's salary
+ * logic is centralized. A `calculate<Something>Modifier()` method anywhere else
+ * is a parallel re-implementation that will drift from the canonical formula.
+ *
+ * Only concrete implementations are flagged — interface/abstract declarations
+ * (null body) are skipped. A suffixless `calculateModifier()` is a private helper,
+ * not a duplicate, and does not match the pattern.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final class BanDuplicateModifierMethodRule implements Rule
+{
+    private const METHOD_PATTERN = '/^calculate.+Modifier$/';
+    private const CANONICAL_FILE = 'ContractRules.php';
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // Concrete implementations only — interface/abstract declarations have no body.
+        if ($node->stmts === null) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+        if (preg_match(self::METHOD_PATTERN, $methodName) !== 1) {
+            return [];
+        }
+
+        $file = $scope->getFile();
+        if (!str_contains($file, DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR)) {
+            return [];
+        }
+        if (str_ends_with($file, DIRECTORY_SEPARATOR . self::CANONICAL_FILE)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Method %s() duplicates a contract-modifier formula. Modifier calculations must '
+                . 'live in ContractRules to keep salary-formula logic centralized — delegate to '
+                . 'ContractRules::%s() instead of re-implementing it here.',
+                $methodName,
+                $methodName,
+            ))
+                ->identifier('ibl.duplicateModifierMethod')
+                ->build(),
+        ];
+    }
+}

--- a/ibl5/phpstan-rules/BanSqlStringInterpolationRule.php
+++ b/ibl5/phpstan-rules/BanSqlStringInterpolationRule.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanRules;
+
+use PhpParser\Node;
+use PhpParser\Node\InterpolatedStringPart;
+use PhpParser\Node\Scalar\InterpolatedString;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Bans variable interpolation inside SQL string literals.
+ *
+ * An InterpolatedString node ("... $var ..." / "... {$expr} ...") that also
+ * contains SQL keywords is an injection-shaped construct: the interpolated value
+ * is spliced directly into the query text. Use bound parameters (prepared
+ * statements) for values, and validated-enum/match() lookups for identifiers
+ * (table/column names) instead.
+ *
+ * Plain concatenation ("..." . CONST) and parameterized literals ("WHERE x = ?")
+ * are NOT InterpolatedString nodes, so they are correctly ignored.
+ *
+ * @implements Rule<InterpolatedString>
+ */
+final class BanSqlStringInterpolationRule implements Rule
+{
+    /**
+     * Matches a literal that *begins* (after leading whitespace) with a SQL DML verb
+     * or a SQL clause keyword. Anchoring at the start is what distinguishes a real
+     * query/fragment from prose that merely mentions a keyword ("...offer from the
+     * team...") — prose strings that open with an interpolated value do not begin
+     * with a SQL token, so they are not matched.
+     */
+    private const SQL_STATEMENT_PATTERN = '/^\s*(SELECT|INSERT\s+INTO|UPDATE|DELETE\s+FROM|REPLACE\s+INTO|WHERE|ORDER\s+BY|GROUP\s+BY|HAVING|LEFT\s+JOIN|RIGHT\s+JOIN|INNER\s+JOIN)\b/i';
+
+    public function getNodeType(): string
+    {
+        return InterpolatedString::class;
+    }
+
+    /**
+     * @param InterpolatedString $node
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $file = $scope->getFile();
+
+        if (!str_contains($file, DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR)) {
+            return [];
+        }
+
+        $literal = '';
+        foreach ($node->parts as $part) {
+            if ($part instanceof InterpolatedStringPart) {
+                $literal .= $part->value;
+            }
+        }
+
+        if (preg_match(self::SQL_STATEMENT_PATTERN, $literal) !== 1) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'SQL string uses variable interpolation. Splicing a variable into query '
+                . 'text risks SQL injection. Use bound parameters (?) for values, and a '
+                . 'validated allowlist/match() for identifiers (table/column names).'
+            )
+                ->identifier('ibl.sqlStringInterpolation')
+                ->build(),
+        ];
+    }
+}

--- a/ibl5/phpstan-rules/RequireStrictTypesRule.php
+++ b/ibl5/phpstan-rules/RequireStrictTypesRule.php
@@ -13,7 +13,8 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * Enforces declare(strict_types=1) at the top of every PHP file in classes/.
+ * Enforces declare(strict_types=1) at the top of every PHP file in classes/
+ * and phpstan-rules/ (the rule files enforce strictness, so they must comply too).
  *
  * @implements Rule<FileNode>
  */
@@ -32,8 +33,11 @@ final class RequireStrictTypesRule implements Rule
     {
         $file = $scope->getFile();
 
-        // Only enforce in classes/ directory
-        if (!str_contains($file, DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR)) {
+        // Enforce in classes/ and phpstan-rules/ (the rule files must also comply).
+        if (
+            !str_contains($file, DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR)
+            && !str_contains($file, DIRECTORY_SEPARATOR . 'phpstan-rules' . DIRECTORY_SEPARATOR)
+        ) {
             return [];
         }
 

--- a/ibl5/phpstan.neon
+++ b/ibl5/phpstan.neon
@@ -148,3 +148,7 @@ services:
         class: PHPStanRules\BanSqlStringInterpolationRule
         tags:
             - phpstan.rules.rule
+    -
+        class: PHPStanRules\BanDuplicateModifierMethodRule
+        tags:
+            - phpstan.rules.rule

--- a/ibl5/phpstan.neon
+++ b/ibl5/phpstan.neon
@@ -144,3 +144,7 @@ services:
         class: PHPStanRules\BanDirectMysqliQueryRule
         tags:
             - phpstan.rules.rule
+    -
+        class: PHPStanRules\BanSqlStringInterpolationRule
+        tags:
+            - phpstan.rules.rule

--- a/ibl5/phpstan.neon
+++ b/ibl5/phpstan.neon
@@ -152,3 +152,7 @@ services:
         class: PHPStanRules\BanDuplicateModifierMethodRule
         tags:
             - phpstan.rules.rule
+    -
+        class: PHPStanRules\BanBareColumnIdentifierRule
+        tags:
+            - phpstan.rules.rule

--- a/ibl5/phpstan.neon
+++ b/ibl5/phpstan.neon
@@ -140,3 +140,7 @@ services:
         class: PHPStanRules\BanHardcodedEnvironmentStringsRule
         tags:
             - phpstan.rules.rule
+    -
+        class: PHPStanRules\BanDirectMysqliQueryRule
+        tags:
+            - phpstan.rules.rule

--- a/ibl5/tests/PHPStanRules/BanBareColumnIdentifierRuleTest.php
+++ b/ibl5/tests/PHPStanRules/BanBareColumnIdentifierRuleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanRules\BanBareColumnIdentifierRule;
+
+/**
+ * @extends RuleTestCase<BanBareColumnIdentifierRule>
+ */
+final class BanBareColumnIdentifierRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new BanBareColumnIdentifierRule();
+    }
+
+    public function testFlagsBareTableQualifiedColumns(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/BareColumnIdentifier.php'],
+            [
+                [
+                    "Table-qualified column 'ibl_plr.pid' must be wrapped in backticks "
+                    . '(`ibl_plr`.`pid`) for PHPStan rename safety.',
+                    5,
+                ],
+                [
+                    "Table-qualified column 'ibl_team_info.team_name' must be wrapped in backticks "
+                    . '(`ibl_team_info`.`team_name`) for PHPStan rename safety.',
+                    6,
+                ],
+                [
+                    "Table-qualified column 'ibl_plr.retired' must be wrapped in backticks "
+                    . '(`ibl_plr`.`retired`) for PHPStan rename safety.',
+                    7,
+                ],
+            ],
+        );
+    }
+
+    public function testAllowsBacktickedAliasedBareAndStarColumns(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/BacktickedColumnIdentifier.php'],
+            [],
+        );
+    }
+}

--- a/ibl5/tests/PHPStanRules/BanDirectMysqliQueryRuleTest.php
+++ b/ibl5/tests/PHPStanRules/BanDirectMysqliQueryRuleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanRules\BanDirectMysqliQueryRule;
+
+/**
+ * @extends RuleTestCase<BanDirectMysqliQueryRule>
+ */
+final class BanDirectMysqliQueryRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new BanDirectMysqliQueryRule();
+    }
+
+    public function testFlagsDirectMysqliQuery(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/DirectMysqliQuery.php'],
+            [
+                [
+                    'Direct \mysqli::query() is banned outside the DB-access boundary. '
+                    . 'Use a BaseMysqliRepository helper (execute()/fetchOne()/fetchAll()) instead — '
+                    . 'raw query() bypasses prepared-statement parameterization.',
+                    7,
+                ],
+                [
+                    'Direct \mysqli::query() is banned outside the DB-access boundary. '
+                    . 'Use a BaseMysqliRepository helper (execute()/fetchOne()/fetchAll()) instead — '
+                    . 'raw query() bypasses prepared-statement parameterization.',
+                    8,
+                ],
+            ],
+        );
+    }
+
+    public function testAllowsQueryInDbAccessBoundary(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/BaseMysqliRepository.php'],
+            [],
+        );
+    }
+
+    public function testIgnoresQueryOnNonMysqliReceiver(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/NonMysqliQuery.php'],
+            [],
+        );
+    }
+}

--- a/ibl5/tests/PHPStanRules/BanDuplicateModifierMethodRuleTest.php
+++ b/ibl5/tests/PHPStanRules/BanDuplicateModifierMethodRuleTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanRules\BanDuplicateModifierMethodRule;
+
+/**
+ * @extends RuleTestCase<BanDuplicateModifierMethodRule>
+ */
+final class BanDuplicateModifierMethodRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new BanDuplicateModifierMethodRule();
+    }
+
+    public function testFlagsCalculateModifierMethodsOutsideContractRules(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/DuplicateModifierMethod.php'],
+            [
+                [
+                    'Method calculateWinnerModifier() duplicates a contract-modifier formula. '
+                    . 'Modifier calculations must live in ContractRules to keep salary-formula '
+                    . 'logic centralized — delegate to ContractRules::calculateWinnerModifier() '
+                    . 'instead of re-implementing it here.',
+                    7,
+                ],
+                [
+                    'Method calculateLoyaltyModifier() duplicates a contract-modifier formula. '
+                    . 'Modifier calculations must live in ContractRules to keep salary-formula '
+                    . 'logic centralized — delegate to ContractRules::calculateLoyaltyModifier() '
+                    . 'instead of re-implementing it here.',
+                    12,
+                ],
+            ],
+        );
+    }
+
+    public function testAllowsModifierMethodsInsideContractRules(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/ContractRules.php'],
+            [],
+        );
+    }
+
+    public function testIgnoresInterfaceDeclarations(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/ModifierInterface.php'],
+            [],
+        );
+    }
+}

--- a/ibl5/tests/PHPStanRules/BanSqlStringInterpolationRuleTest.php
+++ b/ibl5/tests/PHPStanRules/BanSqlStringInterpolationRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanRules\BanSqlStringInterpolationRule;
+
+/**
+ * @extends RuleTestCase<BanSqlStringInterpolationRule>
+ */
+final class BanSqlStringInterpolationRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new BanSqlStringInterpolationRule();
+    }
+
+    public function testFlagsInterpolatedSqlStrings(): void
+    {
+        $message = 'SQL string uses variable interpolation. Splicing a variable into query '
+            . 'text risks SQL injection. Use bound parameters (?) for values, and a '
+            . 'validated allowlist/match() for identifiers (table/column names).';
+
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/SqlStringInterpolation.php'],
+            [
+                [$message, 7],
+                [$message, 8],
+                [$message, 9],
+            ],
+        );
+    }
+
+    public function testAllowsConcatenationParameterizedAndProse(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/SafeSqlString.php'],
+            [],
+        );
+    }
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/BacktickedColumnIdentifier.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/BacktickedColumnIdentifier.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+$backticked = "SELECT `ibl_plr`.`pid` FROM `ibl_plr`";
+$aliased = "SELECT p.name FROM `ibl_plr` p";
+$bareUnqualified = "SELECT name, pid FROM `ibl_plr`";
+$star = "SELECT ibl_plr.* FROM `ibl_plr`";

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/BareColumnIdentifier.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/BareColumnIdentifier.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$select = "SELECT ibl_plr.pid FROM ibl_plr";
+$qualified = "SELECT ibl_team_info.team_name FROM ibl_team_info";
+$where = "DELETE WHERE ibl_plr.retired = 0";

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/BaseMysqliRepository.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/BaseMysqliRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+// Filename matches the DB-access-boundary allowlist, so \mysqli::query() is permitted here.
+function boundaryQuery(\mysqli $db): void
+{
+    $db->query('SELECT 1');
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/ContractRules.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/ContractRules.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+// Filename matches the canonical allowlist — modifier formulas are permitted here.
+final class ContractRules
+{
+    public static function calculateWinnerModifier(): float
+    {
+        return 1.0;
+    }
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/DirectMysqliQuery.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/DirectMysqliQuery.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+function runDirectQueries(\mysqli $db): void
+{
+    $db->query('DELETE FROM `ibl_hist`');
+    $db->query('INSERT INTO `ibl_hist` VALUES (1)');
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/DuplicateModifierMethod.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/DuplicateModifierMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+final class SomeEvaluator
+{
+    public function calculateWinnerModifier(): float
+    {
+        return 1.0;
+    }
+
+    public function calculateLoyaltyModifier(): float
+    {
+        return 1.0;
+    }
+
+    public function calculateModifier(): float
+    {
+        return 1.0;
+    }
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/ModifierInterface.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/ModifierInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+// Interface declarations have no body and must not be flagged as duplicates.
+interface ModifierInterface
+{
+    public function calculateWinnerModifier(): float;
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/NonMysqliQuery.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/NonMysqliQuery.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+final class FakeConnection
+{
+    public function query(string $sql): void
+    {
+    }
+}
+
+function nonMysqliQuery(FakeConnection $conn): void
+{
+    $conn->query('SELECT 1');
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/SafeSqlString.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/SafeSqlString.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+const SAFE_MAX_ID = 100;
+
+function buildSafeQueries(string $player, string $team, int $n, int $round): array
+{
+    // Concatenation, not interpolation — these are String_ nodes joined by Concat,
+    // never an InterpolatedString. (Encodes the SeasonLeaderboards:80 correction.)
+    $concat = "SELECT * FROM ibl_plr WHERE pid < " . SAFE_MAX_ID . " ORDER BY pid";
+    // Parameterized — plain string literal, no interpolation.
+    $param = "SELECT * FROM ibl_plr WHERE pid = ?";
+    // Prose that mentions SQL keywords as English words ("from") but opens with an
+    // interpolated value, so the literal does not begin with a SQL token.
+    $discord = "{$player} today accepted a contract offer from the {$team}";
+    // Prose opening with "With" — the CTE keyword is intentionally excluded so that
+    // "With pick #..." announcement text is not mistaken for a SQL statement.
+    $announce = "With pick #$n in round $round of the draft";
+
+    return [$concat, $param, $discord, $announce];
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/SqlStringInterpolation.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/SqlStringInterpolation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+function buildInterpolatedQueries(string $id, string $col): array
+{
+    $select = "SELECT * FROM ibl_plr WHERE pid = $id";
+    $update = "UPDATE ibl_plr SET name = 'x' WHERE pid = $id";
+    $order  = "SELECT * FROM ibl_plr ORDER BY {$col}";
+
+    return [$select, $update, $order];
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/phpstan-rules/MissingStrictTypesRuleFixture.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/phpstan-rules/MissingStrictTypesRuleFixture.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PHPStanRules;
+
+// Intentionally missing declare(strict_types=1) — a phpstan-rules/ file must be flagged.
+final class MissingStrictTypesRuleFixture
+{
+}

--- a/ibl5/tests/PHPStanRules/RequireStrictTypesRuleTest.php
+++ b/ibl5/tests/PHPStanRules/RequireStrictTypesRuleTest.php
@@ -39,6 +39,19 @@ final class RequireStrictTypesRuleTest extends RuleTestCase
         );
     }
 
+    public function testFlagsFileMissingStrictTypesDeclarationInsidePhpstanRulesDirectory(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/phpstan-rules/MissingStrictTypesRuleFixture.php'],
+            [
+                [
+                    'Missing declare(strict_types=1) at the top of the file.',
+                    3,
+                ],
+            ],
+        );
+    }
+
     public function testAllowsFileOutsideClassesDirectoryEvenWithoutStrictTypes(): void
     {
         $this->analyse(


### PR DESCRIPTION
## Summary

Lands 5 PHPStan rules from the Axis-10 backlog:

- **10.12** `BanDirectMysqliQueryRule` — flags `$db->query()` on bare `\mysqli` receivers outside `BaseMysqliRepository`/`Database/MySQL`; baselines 7 Updater sites.
- **10.13** `BanSqlStringInterpolationRule` — flags double-quoted strings containing a SQL keyword + interpolated `$var`/`{$var}`; 66 genuine sites baselined (anchored SQL-statement pattern eliminates prose false-positives).
- **10.19** `BanDuplicateModifierMethodRule` — flags `calculate.+Modifier` methods outside `ContractRules.php`; baselines 5 `ExtensionOfferEvaluator` sites.
- **10.21** `BanBareColumnIdentifierRule` — ships **blocking** (not advisory); narrow `ibl_table.column` scope yielded 23 genuine sites, zero false positives; all baselined.
- **10.24** Extends `RequireStrictTypesRule` scope to cover `phpstan-rules/` files themselves.

Companion tests added for all five rules. Backlog items 10.12/10.13/10.19/10.21/10.24 marked Completed in docs.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

## ADR

<!-- no-adr: enforces existing ADR-0001/0014; no new architectural constraint -->

All four new rule files enforce existing architectural constraints (DB-access boundary, SQL safety, formula centralization) already documented in ADR-0001/ADR-0014. No new constraint introduced.