### PR TITLE
engine: PR6 in-game injuries (jsb-native-engine)

### DIFF
--- a/engine/internal/result/result.go
+++ b/engine/internal/result/result.go
@@ -26,6 +26,7 @@ const (
 	EventSubstitution    EventKind = "substitution"
 	EventFreeThrow       EventKind = "free_throw"
 	EventPeriodBoundary  EventKind = "period_boundary"
+	EventInjury          EventKind = "injury"
 )
 
 // ShotType classifies a shot attempt; carried on shot_attempt/make/miss events.
@@ -60,6 +61,14 @@ type Event struct {
 	// aggregator reconstruct GameFTA/GameFTM exactly from the event stream.
 	FTAttempts int `json:"ft_attempts,omitempty"`
 	FTMade     int `json:"ft_made,omitempty"`
+
+	// Severity / GamesMissed carry the in-game injury outcome for a single
+	// turnover. Meaningful only when Kind == EventInjury; a zero value is *not
+	// applicable* for every other kind (omitted via omitempty), exactly like the
+	// FTAttempts/FTMade convention above. The derived Injuries slice is folded
+	// from these fields by aggregateInjuries.
+	Severity    int `json:"severity,omitempty"`
+	GamesMissed int `json:"games_missed,omitempty"`
 }
 
 // PlayerBox is one player's stat line for one game. Fields map 1:1 to the RAW
@@ -114,6 +123,20 @@ type TeamBox struct {
 	GamePF  int `json:"gamePF"`
 }
 
+// Injury is one in-game injury, derived from an EventInjury in the event stream.
+// GamesMissed is the load-bearing value the PR8 loader persists to
+// ibl_jsb_transactions.injury_games_missed; Severity is retained for diagnostics
+// and validation. The 306-entry JSB description text table is deliberately not
+// modeled (PR8 leaves injury_description NULL).
+type Injury struct {
+	PID         int `json:"pid"`
+	TeamID      int `json:"team_id"`
+	GamesMissed int `json:"games_missed"`
+	Severity    int `json:"severity"`
+	Period      int `json:"period"`
+	Clock       int `json:"clock_seconds"`
+}
+
 // GameResult is the engine's full output for one scheduled game. SimGameType
 // echoes the JSB-scale input game-type (2-6) for the loader's routing; it is
 // NOT the ibl_box_scores.game_type generated column (which the database derives
@@ -128,6 +151,11 @@ type GameResult struct {
 	Events      []Event     `json:"events"`
 	PlayerBoxes []PlayerBox `json:"player_boxes"`
 	TeamBoxes   []TeamBox   `json:"team_boxes"` // visitor first, then home
+
+	// Injuries derives from the EventInjury stream (aggregateInjuries). omitempty
+	// is MANDATORY: an injury-free game (e.g. the zero-turnover golden) must omit
+	// the key entirely so the golden snapshot stays byte-stable.
+	Injuries []Injury `json:"injuries,omitempty"`
 }
 
 // Result is the engine's complete output for one bundle: one GameResult per

--- a/engine/internal/result/result_test.go
+++ b/engine/internal/result/result_test.go
@@ -153,3 +153,64 @@ func TestEvent_FreeThrowCounts(t *testing.T) {
 		t.Errorf("non-FT event must omit FT counts: %s", shot)
 	}
 }
+
+// --- matrix #5: EventInjury carries its fields; non-injury events omit them ---
+
+func TestEvent_InjuryCounts(t *testing.T) {
+	inj := Event{Kind: EventInjury, Period: 3, Clock: 240, TeamID: 7, PlayerID: 202,
+		Severity: 78, GamesMissed: 175}
+	data, err := json.Marshal(inj)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"severity":78`) || !strings.Contains(string(data), `"games_missed":175`) {
+		t.Errorf("injury event missing severity/games_missed in JSON: %s", data)
+	}
+	var back Event
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.PlayerID != 202 || back.TeamID != 7 || back.Severity != 78 || back.GamesMissed != 175 {
+		t.Errorf("injury fields lost: %+v", back)
+	}
+
+	// A non-injury event omits both fields entirely (omitempty, zero value).
+	shot, _ := json.Marshal(Event{Kind: EventShotMake, Period: 1, Clock: 700,
+		TeamID: 3, PlayerID: 101, ShotType: ShotTwoPoint})
+	if strings.Contains(string(shot), "severity") || strings.Contains(string(shot), "games_missed") {
+		t.Errorf("non-injury event must omit injury counts: %s", shot)
+	}
+}
+
+// --- matrix #6: Injury struct serializes; empty Injuries omits the key --------
+
+func TestInjury_StructAndOmitEmpty(t *testing.T) {
+	in := Injury{PID: 202, TeamID: 7, GamesMissed: 4, Severity: 2, Period: 2, Clock: 300}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back Injury
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back != in {
+		t.Errorf("Injury round-trip lost fields: got %+v want %+v", back, in)
+	}
+	// The clock tag is clock_seconds, matching the Event convention.
+	if !strings.Contains(string(data), `"clock_seconds":300`) || !strings.Contains(string(data), `"games_missed":4`) {
+		t.Errorf("Injury JSON missing expected tags: %s", data)
+	}
+
+	// A GameResult with no injuries omits the injuries key entirely (omitempty).
+	empty, _ := json.Marshal(GameResult{Date: "1988-11-04", HomeTeamID: 3, VisitorTeamID: 7})
+	if strings.Contains(string(empty), "injuries") {
+		t.Errorf("injury-free GameResult must omit the injuries key: %s", empty)
+	}
+	// A GameResult WITH injuries includes the key.
+	withInj, _ := json.Marshal(GameResult{Date: "1988-11-04", HomeTeamID: 3, VisitorTeamID: 7,
+		Injuries: []Injury{in}})
+	if !strings.Contains(string(withInj), `"injuries"`) {
+		t.Errorf("GameResult with injuries must include the key: %s", withInj)
+	}
+}

--- a/engine/internal/sim/aggregate.go
+++ b/engine/internal/sim/aggregate.go
@@ -111,6 +111,30 @@ func aggregateBoxes(events []result.Event, visitor, home rosterMeta) ([]result.P
 	return boxes, teams
 }
 
+// aggregateInjuries folds the event stream into the derived Injuries slice, a
+// sibling of aggregateBoxes' fold: each EventInjury becomes one Injury carrying
+// the injured player, team, severity, games-missed, and game clock. It returns
+// nil when there are no EventInjury events — combined with json:"injuries,
+// omitempty" this drops the key entirely on injury-free games, keeping the
+// zero-turnover golden byte-stable.
+func aggregateInjuries(events []result.Event) []result.Injury {
+	var injuries []result.Injury
+	for _, e := range events {
+		if e.Kind != result.EventInjury {
+			continue
+		}
+		injuries = append(injuries, result.Injury{
+			PID:         e.PlayerID,
+			TeamID:      e.TeamID,
+			GamesMissed: e.GamesMissed,
+			Severity:    e.Severity,
+			Period:      e.Period,
+			Clock:       e.Clock,
+		})
+	}
+	return injuries
+}
+
 // rollupTeam sums the team's player rows into one TeamBox and lays its scoring
 // out by period (Q1–Q4, then OT in order). Points bucket from EventShotMake (2
 // or 3 by ShotType) and EventFreeThrow (FTMade). A period is "reached" by any

--- a/engine/internal/sim/box.go
+++ b/engine/internal/sim/box.go
@@ -64,6 +64,7 @@ func newTeamState(allPlayers []bundle.Player, teamID int, isHome bool) *teamStat
 		energy:      make(map[int]float64),
 		minutes:     make(map[int]float64),
 		fouledOut:   make(map[int]bool),
+		injured:     make(map[int]bool),
 		fouls:       make(map[int]int),
 		quarters:    make([]int, 0, 4),
 	}

--- a/engine/internal/sim/gameloop.go
+++ b/engine/internal/sim/gameloop.go
@@ -89,6 +89,7 @@ func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) (result.GameResult, int
 		Events:        gs.events,
 		PlayerBoxes:   playerBoxes,
 		TeamBoxes:     teamBoxes,
+		Injuries:      aggregateInjuries(gs.events),
 	}
 	return gr, gs.transitions, visitor, home
 }

--- a/engine/internal/sim/injury.go
+++ b/engine/internal/sim/injury.go
@@ -1,0 +1,120 @@
+package sim
+
+import (
+	"math"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+)
+
+// injuryProbability is the per-turnover injury chance. JSB fires an injury on
+// every type-5 turnover (a rare turnover subtype); the native engine collapses
+// that to a single calibrated probability gate per turnover. 0.007 reproduces
+// the historical .trn corpus rate of ~0.2 injuries/game across both teams
+// (~213–247 injuries over a ~1150-game season). Disasm-recovered and corpus-
+// validated ground truth (memory reference_jsb_injury_formula); PR9's offline
+// harness may retune this single constant.
+const injuryProbability = 0.007
+
+// injurySeverityCap is the faithful-but-dead upper severity clamp. The formula's
+// real maximum is ~78 (the ×81 band at E=5, u≈0.4299), so 160 is never reached
+// from a real draw; it is ported for fidelity and as a defensive bound, mirroring
+// the documented-dead fatigueFactor / dc_bh patterns elsewhere in the engine.
+const injurySeverityCap = 160
+
+// energyDurationScale is _DAT_0066d358 = 2.25 exact: games-missed ≈ severity ×
+// this, minus sub-game jitter.
+const energyDurationScale = 2.25
+
+// clampInt confines v to [lo, hi].
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// clampFloat confines v to [lo, hi].
+func clampFloat(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// energyParam is the JSB per-player injury energy parameter (+0xDF8), clamped to
+// [2, 5]: (48 − min(dc_minutes, 28)) × 0.03 × ((skill+1) + (talent+1)) × 0.125 +
+// 1.0. High-minute, low-skill/talent players floor at 2; low-minute, high-rated
+// players cap at 5. (This same value doubles as the play-outcome turnover
+// def-value in outcome.go — see memory reference_jsb_injury_formula.)
+func energyParam(p bundle.Player) float64 {
+	minutes := math.Min(float64(p.DCMinutes), 28)
+	raw := (48-minutes)*0.03*float64((p.Skill+1)+(p.Talent+1))*0.125 + 1.0
+	return clampFloat(raw, 2, 5)
+}
+
+// severityBandMultiplier returns the JSB severity band multiplier for a draw u.
+// The band edges (_DAT_0066d380/378/370/368 = 0.222/0.148/0.049/0.011) accumulate
+// to 0.222 / 0.370 / 0.419 / 0.430; the rarest, highest band (×81) sits in the
+// narrow 0.419–0.430 slice, producing the corpus's ~1% career-altering injuries.
+func severityBandMultiplier(u float64) int {
+	switch {
+	case u < 0.222:
+		return 3
+	case u < 0.370:
+		return 9
+	case u < 0.419:
+		return 27
+	case u < 0.430:
+		return 81
+	default:
+		return 1
+	}
+}
+
+// severityFromU derives an injury severity in [1, injurySeverityCap] from a draw
+// u and the player's energy param E: floor(u × sqrt(E) × bandMult) + 1. The upper
+// clamp is unreachable from real draws (max ≈ 78); see injurySeverityCap.
+func severityFromU(u, E float64) int {
+	raw := u * math.Sqrt(E)
+	sev := int(math.Floor(raw*float64(severityBandMultiplier(u)))) + 1
+	return clampInt(sev, 1, injurySeverityCap)
+}
+
+// gamesMissedFromU derives the games-missed duration from a severity and a second
+// draw u2: max(floor(severity × 2.25 − u2), 1). Near-deterministic given severity
+// (±1 jitter); always ≥ 1 for any severity ≥ 1.
+func gamesMissedFromU(severity int, u2 float64) int {
+	gm := int(math.Floor(float64(severity)*energyDurationScale - u2))
+	if gm < 1 {
+		return 1
+	}
+	return gm
+}
+
+// maybeInjure runs the per-turnover injury check for the turnover-committing
+// ball-handler. It is the single shared entry point called identically from both
+// turnover branches (possession.go, transition.go), so the two paths cannot
+// diverge. It does its RNG draws in FIXED ORDER inside the turnover branch (where
+// gs.rng is already in scope): exactly 1 draw when no injury, exactly 3 when one
+// fires. checkSubstitutions never draws, so the marked-injured player's forced
+// removal stays deterministic.
+func (gs *gameState) maybeInjure(team *teamState, bh onCourt) {
+	if gs.rng.Float64() >= injuryProbability {
+		return // no injury: exactly 1 draw consumed
+	}
+	E := energyParam(bh.Player)
+	sev := severityFromU(gs.rng.Float64(), E)
+	gm := gamesMissedFromU(sev, gs.rng.Float64())
+	team.injured[bh.PID] = true
+	gs.emit(result.Event{
+		Kind: result.EventInjury, Period: gs.period, Clock: gs.clock,
+		TeamID: team.teamID, PlayerID: bh.PID, Severity: sev, GamesMissed: gm,
+	})
+}

--- a/engine/internal/sim/injury_test.go
+++ b/engine/internal/sim/injury_test.go
@@ -1,0 +1,256 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+const floatEps = 1e-9
+
+// --- matrix #1: energyParam formula + [2,5] clamp boundaries ----------------
+
+func TestEnergyParam(t *testing.T) {
+	cases := []struct {
+		name                     string
+		dcMinutes, skill, talent int
+		want                     float64
+	}{
+		// High minutes, zero ratings → floors at 2.
+		{"low clamp", 28, 0, 0, 2},
+		// Low minutes, high ratings → caps at 5 (pre-clamp ≈ 8.56).
+		{"high clamp", 0, 20, 20, 5},
+		// Mid inputs land inside [2,5] unclamped: (48-20)*0.03*12*0.125+1 = 2.26.
+		{"unclamped formula", 20, 5, 5, 2.26},
+		// min(dc_minutes, 28): 28 and 40 give the same energy (verifies the cap).
+		{"minutes cap at 28", 28, 20, 20, 4.15},
+		{"minutes cap above 28", 40, 20, 20, 4.15},
+	}
+	for _, c := range cases {
+		p := bundle.Player{DCMinutes: c.dcMinutes, Skill: c.skill, Talent: c.talent}
+		if got := energyParam(p); math.Abs(got-c.want) > floatEps {
+			t.Errorf("%s: energyParam(dc=%d,skill=%d,talent=%d) = %v, want %v",
+				c.name, c.dcMinutes, c.skill, c.talent, got, c.want)
+		}
+	}
+}
+
+// --- matrix #2: severity band-multiplier selection + floor+1 + formula max ---
+
+func TestSeverityBandMultiplier(t *testing.T) {
+	cases := []struct {
+		u    float64
+		want int
+	}{
+		{0.0, 3}, {0.221, 3}, // u < 0.222 → ×3
+		{0.222, 9}, {0.369, 9}, // [0.222, 0.370) → ×9
+		{0.370, 27}, {0.418, 27}, // [0.370, 0.419) → ×27
+		{0.419, 81}, {0.429, 81}, // [0.419, 0.430) → ×81
+		{0.430, 1}, {0.99, 1}, // u ≥ 0.430 → ×1
+	}
+	for _, c := range cases {
+		if got := severityBandMultiplier(c.u); got != c.want {
+			t.Errorf("severityBandMultiplier(%v) = %d, want %d", c.u, got, c.want)
+		}
+	}
+}
+
+func TestSeverityFromU(t *testing.T) {
+	// E = 4 → sqrt(E) = 2, so severity = floor(u × 2 × bandMult) + 1.
+	cases := []struct {
+		u    float64
+		want int
+	}{
+		{0.10, 1},   // ×3:  floor(0.6)+1
+		{0.30, 6},   // ×9:  floor(5.4)+1
+		{0.40, 22},  // ×27: floor(21.6)+1
+		{0.425, 69}, // ×81: floor(68.85)+1
+		{0.50, 2},   // ×1:  floor(1.0)+1
+	}
+	for _, c := range cases {
+		if got := severityFromU(c.u, 4); got != c.want {
+			t.Errorf("severityFromU(%v, 4) = %d, want %d", c.u, got, c.want)
+		}
+	}
+
+	// The corpus max ≈ 78 is the ×81 band at E=5, u≈0.4299.
+	if got := severityFromU(0.4299, 5); got != 78 {
+		t.Errorf("severityFromU(0.4299, 5) = %d, want 78 (corpus max)", got)
+	}
+	// No real draw at the max energy can exceed 78: sweep u ∈ [0, 0.5).
+	maxSev := 0
+	for u := 0.0; u < 0.5; u += 0.0001 {
+		if s := severityFromU(u, 5); s > maxSev {
+			maxSev = s
+		}
+	}
+	if maxSev != 78 {
+		t.Errorf("formula max over u∈[0,0.5) at E=5 = %d, want 78", maxSev)
+	}
+}
+
+// --- matrix #3: clamp boundaries (160 is unreachable through the formula) ----
+
+func TestClampHelpers(t *testing.T) {
+	if got := clampInt(200, 1, injurySeverityCap); got != 160 {
+		t.Errorf("clampInt(200,1,160) = %d, want 160", got)
+	}
+	if got := clampInt(0, 1, injurySeverityCap); got != 1 {
+		t.Errorf("clampInt(0,1,160) = %d, want 1", got)
+	}
+	if got := clampInt(50, 1, injurySeverityCap); got != 50 {
+		t.Errorf("clampInt(50,1,160) = %d, want 50 (in range)", got)
+	}
+	if got := clampFloat(10, 2, 5); got != 5 {
+		t.Errorf("clampFloat(10,2,5) = %v, want 5", got)
+	}
+	if got := clampFloat(1, 2, 5); got != 2 {
+		t.Errorf("clampFloat(1,2,5) = %v, want 2", got)
+	}
+	if got := clampFloat(3, 2, 5); got != 3 {
+		t.Errorf("clampFloat(3,2,5) = %v, want 3 (in range)", got)
+	}
+}
+
+// --- matrix #4: gamesMissedFromU boundaries + never 0/negative ---------------
+
+func TestGamesMissedFromU(t *testing.T) {
+	cases := []struct {
+		sev  int
+		u2   float64
+		want int
+	}{
+		{2, 0.0, 4}, {2, 0.6, 3}, // sev=2 → 3 or 4 (corpus mode)
+		{78, 0.0, 175}, {78, 0.9, 174}, // sev=78 → 175 (corpus max)
+		{1, 0.0, 2}, {1, 0.9, 1}, // sev=1 → 1 or 2
+	}
+	for _, c := range cases {
+		if got := gamesMissedFromU(c.sev, c.u2); got != c.want {
+			t.Errorf("gamesMissedFromU(%d, %v) = %d, want %d", c.sev, c.u2, got, c.want)
+		}
+	}
+
+	// Negative path: never 0 or negative for any severity ≥ 1, any draw.
+	for sev := 1; sev <= injurySeverityCap; sev++ {
+		for _, u2 := range []float64{0.0, 0.5, 0.999999} {
+			if got := gamesMissedFromU(sev, u2); got < 1 {
+				t.Fatalf("gamesMissedFromU(%d, %v) = %d, want ≥ 1", sev, u2, got)
+			}
+		}
+	}
+}
+
+// injTeam builds a minimal teamState carrying only the injured marker the
+// injury path needs (no roster/box machinery — maybeInjure touches only injured
+// and the event stream).
+func injTeam(teamID int) *teamState {
+	return &teamState{teamID: teamID, injured: map[int]bool{}}
+}
+
+// --- matrix #7: maybeInjure fires (and marks) on the firing draw, else not ---
+
+func TestMaybeInjure_FiresAndMarks(t *testing.T) {
+	bh := oc(slotPG, mkPlayer(101, 7, slotPG, 50))
+
+	// Seed 21's first Float64() < injuryProbability → the injury fires.
+	gsFire := &gameState{rng: rng.New(21), period: 2, clock: 333}
+	team := injTeam(7)
+	gsFire.maybeInjure(team, bh)
+	if len(gsFire.events) != 1 || gsFire.events[0].Kind != result.EventInjury {
+		t.Fatalf("expected exactly one EventInjury, got %+v", gsFire.events)
+	}
+	e := gsFire.events[0]
+	if e.PlayerID != 101 || e.TeamID != 7 {
+		t.Errorf("injury event identity = PID %d / team %d, want 101 / 7", e.PlayerID, e.TeamID)
+	}
+	if e.Severity < 1 || e.GamesMissed < 1 {
+		t.Errorf("injury severity/games-missed = %d/%d, want both ≥ 1", e.Severity, e.GamesMissed)
+	}
+	if e.Period != 2 || e.Clock != 333 {
+		t.Errorf("injury clock = P%d %ds, want P2 333s", e.Period, e.Clock)
+	}
+	if !team.injured[101] {
+		t.Error("injured PID 101 not marked in teamState.injured")
+	}
+
+	// Seed 1's first Float64() ≥ injuryProbability → no injury.
+	gsNo := &gameState{rng: rng.New(1), period: 1, clock: 600}
+	teamNo := injTeam(7)
+	gsNo.maybeInjure(teamNo, bh)
+	if len(gsNo.events) != 0 {
+		t.Errorf("no-injury draw emitted events: %+v", gsNo.events)
+	}
+	if len(teamNo.injured) != 0 {
+		t.Errorf("no-injury draw marked injured: %v", teamNo.injured)
+	}
+}
+
+// Every EventInjury in a real game is emitted only inside the turnover branch,
+// immediately after the committer's EventTurnover (same player/team).
+func TestSimulate_InjuryOnlyAfterTurnover(t *testing.T) {
+	var events []result.Event
+	for seed := uint64(1); seed <= 50; seed++ {
+		res := Simulate(richBundle(), seed)
+		evs := res.Games[0].Events
+		has := false
+		for _, e := range evs {
+			if e.Kind == result.EventInjury {
+				has = true
+				break
+			}
+		}
+		if has {
+			events = res.Games[0].Events
+			break
+		}
+	}
+	if events == nil {
+		t.Fatal("no seed in [1,50] produced an in-game injury")
+	}
+	injuries := 0
+	for i, e := range events {
+		if e.Kind != result.EventInjury {
+			continue
+		}
+		injuries++
+		if i == 0 || events[i-1].Kind != result.EventTurnover {
+			t.Fatalf("EventInjury at index %d not immediately preceded by a turnover (prev=%+v)", i, events[i-1])
+		}
+		if events[i-1].PlayerID != e.PlayerID || events[i-1].TeamID != e.TeamID {
+			t.Errorf("injury %+v does not match its preceding turnover %+v", e, events[i-1])
+		}
+	}
+	if injuries == 0 {
+		t.Fatal("selected game had no EventInjury")
+	}
+}
+
+// --- matrix #8: fixed-order draw discipline (1 draw no injury, 3 if injured) -
+
+func TestMaybeInjure_DrawCount(t *testing.T) {
+	bh := oc(slotPG, mkPlayer(101, 7, slotPG, 50))
+
+	// No injury (seed 1): exactly 1 draw consumed. A reference RNG advanced by 1
+	// must then track gs.rng exactly.
+	gs1 := &gameState{rng: rng.New(1)}
+	gs1.maybeInjure(injTeam(7), bh)
+	ref1 := rng.New(1)
+	ref1.Float64() // the single probability roll
+	if gs1.rng.Float64() != ref1.Float64() {
+		t.Error("no-injury path did not consume exactly 1 RNG draw")
+	}
+
+	// Injury (seed 21): exactly 3 draws consumed (prob, severity, games-missed).
+	gs3 := &gameState{rng: rng.New(21)}
+	gs3.maybeInjure(injTeam(7), bh)
+	ref3 := rng.New(21)
+	ref3.Float64() // probability roll (fires)
+	ref3.Float64() // severity draw
+	ref3.Float64() // games-missed draw
+	if gs3.rng.Float64() != ref3.Float64() {
+		t.Error("injury path did not consume exactly 3 RNG draws in fixed order")
+	}
+}

--- a/engine/internal/sim/injuryaggregate_test.go
+++ b/engine/internal/sim/injuryaggregate_test.go
@@ -1,0 +1,58 @@
+package sim
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/result"
+)
+
+// --- matrix #13: aggregateInjuries folds each EventInjury into an Injury ------
+
+func TestAggregateInjuries_FoldsEvents(t *testing.T) {
+	events := []result.Event{
+		{Kind: result.EventTurnover, Period: 1, Clock: 700, TeamID: 7, PlayerID: 201},
+		{Kind: result.EventInjury, Period: 1, Clock: 700, TeamID: 7, PlayerID: 201, Severity: 2, GamesMissed: 4},
+		{Kind: result.EventShotMake, Period: 2, Clock: 400, TeamID: 3, PlayerID: 101},
+		{Kind: result.EventInjury, Period: 4, Clock: 33, TeamID: 3, PlayerID: 103, Severity: 78, GamesMissed: 175},
+	}
+	got := aggregateInjuries(events)
+	want := []result.Injury{
+		{PID: 201, TeamID: 7, GamesMissed: 4, Severity: 2, Period: 1, Clock: 700},
+		{PID: 103, TeamID: 3, GamesMissed: 175, Severity: 78, Period: 4, Clock: 33},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("aggregateInjuries returned %d injuries, want %d (%+v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("injury[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// --- matrix #14: zero EventInjury → empty slice AND omitted JSON key ----------
+
+func TestAggregateInjuries_NoneOmitsKey(t *testing.T) {
+	events := []result.Event{
+		{Kind: result.EventTurnover, Period: 1, Clock: 700, TeamID: 7, PlayerID: 201},
+		{Kind: result.EventShotMake, Period: 2, Clock: 400, TeamID: 3, PlayerID: 101},
+	}
+	got := aggregateInjuries(events)
+	if len(got) != 0 {
+		t.Errorf("aggregateInjuries with no injury events = %+v, want empty", got)
+	}
+
+	gr := result.GameResult{
+		Date: "1988-11-04", HomeTeamID: 3, VisitorTeamID: 7,
+		Injuries: aggregateInjuries(events),
+	}
+	data, err := json.Marshal(gr)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "injuries") {
+		t.Errorf("injury-free GameResult must omit the injuries key: %s", data)
+	}
+}

--- a/engine/internal/sim/possession.go
+++ b/engine/internal/sim/possession.go
@@ -127,6 +127,7 @@ func possession(gs *gameState, offense, defense *teamState, periodIdx int, fbPen
 				Kind: result.EventTurnover, Period: gs.period, Clock: gs.clock,
 				TeamID: offense.teamID, PlayerID: bh.PID,
 			})
+			gs.maybeInjure(offense, bh)                 // per-turnover injury check on the committer
 			return gs.creditSteal(offense, defense, bh) // steal → fast-break pending
 		}
 	}

--- a/engine/internal/sim/sim_test.go
+++ b/engine/internal/sim/sim_test.go
@@ -179,9 +179,28 @@ func TestSimulate_MinutesConservation(t *testing.T) {
 // rotationBundle's lone, foul-prone center has no backup, so it can never be
 // pulled for foul-trouble — it plays until it fouls out, then is removed for
 // good. Its minutes must stop short of a player who played the whole game.
+//
+// The seed is scanned deterministically rather than hardcoded: PR6's per-turnover
+// injury draws shifted the RNG sequence so the historical seed 1988 no longer
+// forces a foul-out. The test's intent is the foul-out → minutes-stop invariant,
+// not any particular seed, so it uses the first seed that produces a foul-out.
 func TestSimulate_FoulOutStopsMinutes(t *testing.T) {
-	res := Simulate(rotationBundle(), 1988)
-	g := res.Games[0]
+	var g result.GameResult
+	for seed := uint64(1); seed <= 200; seed++ {
+		res := Simulate(rotationBundle(), seed)
+		for _, pb := range res.Games[0].PlayerBoxes {
+			if pb.GamePF >= 6 {
+				g = res.Games[0]
+				break
+			}
+		}
+		if g.Date != "" {
+			break
+		}
+	}
+	if g.Date == "" {
+		t.Fatal("no seed in [1,200] produced a foul-out in the rotation game (fixture no longer forces one)")
+	}
 
 	maxMin := 0
 	var fouledOut []result.PlayerBox
@@ -194,7 +213,7 @@ func TestSimulate_FoulOutStopsMinutes(t *testing.T) {
 		}
 	}
 	if len(fouledOut) == 0 {
-		t.Fatal("no player fouled out in the rotation game (fixture/seed no longer forces a foul-out)")
+		t.Fatal("no player fouled out in the selected rotation game")
 	}
 	for _, pb := range fouledOut {
 		if pb.GameMIN == 0 {
@@ -570,4 +589,60 @@ func findBox(boxes []result.PlayerBox, pid int) *result.PlayerBox {
 		}
 	}
 	return nil
+}
+
+// --- matrix #16: injury rate over a season-sized run ------------------------
+//
+// Three assertions over a fixed-seed, season-sized schedule:
+//  1. Mechanical invariant (always true): injuries ≤ total turnovers — an injury
+//     can only fire on a turnover possession.
+//  2. Statistical, fixture-INDEPENDENT: the injury count is Binomial(turnovers,
+//     injuryProbability), so |injuries − p·turnovers| ≤ 4σ where σ =
+//     sqrt(p·(1−p)·turnovers). The fixed seed makes this deterministic; 4σ is a
+//     principled bound, not a cuff around the observed value.
+//  3. Calibration, fixture-DEPENDENT: injuries/game lands in the corpus band
+//     [0.15, 0.25]. This only holds because richBundle turns the ball over at a
+//     corpus-like ~34×/game (measured); it validates the calibrated constant
+//     against the ~0.2/game corpus rate.
+func TestSimulate_InjuryRateBand(t *testing.T) {
+	const n = 1200
+	base := richBundle()
+	sched := make([]bundle.Game, 0, n)
+	for i := 0; i < n; i++ {
+		sched = append(sched, base.Schedule[0])
+	}
+	base.Schedule = sched
+
+	res := Simulate(base, 1988)
+	var turnovers, injuries int
+	for _, g := range res.Games {
+		for _, e := range g.Events {
+			switch e.Kind {
+			case result.EventTurnover:
+				turnovers++
+			case result.EventInjury:
+				injuries++
+			}
+		}
+	}
+
+	if injuries > turnovers {
+		t.Fatalf("injuries (%d) exceed turnovers (%d) — impossible", injuries, turnovers)
+	}
+	if turnovers == 0 {
+		t.Fatal("no turnovers over a season-sized run")
+	}
+
+	expected := injuryProbability * float64(turnovers)
+	sigma := math.Sqrt(injuryProbability * (1 - injuryProbability) * float64(turnovers))
+	if math.Abs(float64(injuries)-expected) > 4*sigma {
+		t.Errorf("injuries = %d, expected ≈ %.1f ± %.1f (4σ) over %d turnovers — rate gate off",
+			injuries, expected, 4*sigma, turnovers)
+	}
+
+	perGame := float64(injuries) / float64(n)
+	if perGame < 0.15 || perGame > 0.25 {
+		t.Errorf("injuries/game = %.4f (%d over %d games), want corpus band [0.15, 0.25] "+
+			"(turnovers/game = %.2f)", perGame, injuries, n, float64(turnovers)/float64(n))
+	}
 }

--- a/engine/internal/sim/state.go
+++ b/engine/internal/sim/state.go
@@ -64,10 +64,15 @@ type teamState struct {
 	// players who hit the 6th foul and can never re-enter. fouls is the live
 	// per-player personal-foul tally read by checkSubstitutions for foul-out /
 	// foul-trouble decisions — decision state kept live (like the score), NOT the
-	// output: the box GamePF is derived from EventFoul by aggregateBoxes.
+	// output: the box GamePF is derived from EventFoul by aggregateBoxes. injured
+	// mirrors fouledOut: players hurt mid-game who can never re-enter (set by
+	// maybeInjure, read by checkSubstitutions for permanent removal). No
+	// games-missed is stored — EventInjury carries it and the Injuries slice
+	// derives from the event stream, so the boolean is all removal needs.
 	energy    map[int]float64
 	minutes   map[int]float64
 	fouledOut map[int]bool
+	injured   map[int]bool
 	fouls     map[int]int
 
 	score    int

--- a/engine/internal/sim/substitution.go
+++ b/engine/internal/sim/substitution.go
@@ -39,6 +39,8 @@ func foulThreshold(period, clock int) int {
 // this is a hard invariant, enforced by the rng-free signature.
 //
 // Per on-court player, in slot order, the first matching trigger fires:
+//   - Injury (marked by maybeInjure): permanent removal, same swap-or-play-short
+//     behavior as foul-out. Highest priority; an injured player never stays.
 //   - Foul-out (PF > 5): permanent removal. Swap in the best eligible backup at
 //     the slot if one exists; otherwise the player is removed and the team plays
 //     short (the possession loop already tolerates < 5).
@@ -50,11 +52,14 @@ func foulThreshold(period, clock int) int {
 func checkSubstitutions(t *teamState, period, clock int, emit func(result.Event)) {
 	threshold := foulThreshold(period, clock)
 
-	// Backups may not be anyone currently on court or already fouled out; as the
-	// sweep brings players in, they too become unavailable.
-	taken := make(map[int]bool, len(t.players)+len(t.fouledOut))
+	// Backups may not be anyone currently on court, already fouled out, or
+	// injured; as the sweep brings players in, they too become unavailable.
+	taken := make(map[int]bool, len(t.players)+len(t.fouledOut)+len(t.injured))
 	for pid := range t.fouledOut {
 		taken[pid] = true
+	}
+	for pid := range t.injured {
+		taken[pid] = true // an injured player must never re-enter as a backup
 	}
 	for i := range t.players {
 		taken[t.players[i].PID] = true
@@ -65,13 +70,16 @@ func checkSubstitutions(t *teamState, period, clock int, emit func(result.Event)
 		out := t.players[i]
 		pf := t.fouls[out.PID]
 
-		foulOut := pf > foulOutLimit
-		foulTrouble := !foulOut && pf >= threshold
-		fatigued := !foulOut && !foulTrouble && t.energy[out.PID] < 0
+		// Injury and foul-out are both permanent removals and rank highest; an
+		// injured player (already marked by maybeInjure) is never re-added to next.
+		inj := t.injured[out.PID]
+		foulOut := !inj && pf > foulOutLimit
+		foulTrouble := !inj && !foulOut && pf >= threshold
+		fatigued := !inj && !foulOut && !foulTrouble && t.energy[out.PID] < 0
 
 		if foulOut {
 			t.fouledOut[out.PID] = true
-		} else if !foulTrouble && !fatigued {
+		} else if !inj && !foulTrouble && !fatigued {
 			next = append(next, out) // no trigger: stays on court
 			continue
 		}
@@ -81,7 +89,7 @@ func checkSubstitutions(t *teamState, period, clock int, emit func(result.Event)
 			ok = false // fatigue sub needs a strictly fresher option
 		}
 		if !ok {
-			if foulOut {
+			if foulOut || inj {
 				continue // removed; team plays short (no replacement available)
 			}
 			next = append(next, out) // foul-trouble/fatigue with no backup: stay

--- a/engine/internal/sim/substitution_test.go
+++ b/engine/internal/sim/substitution_test.go
@@ -162,3 +162,66 @@ func TestCheckSubstitutions_FatiguedFresherBackupSwaps(t *testing.T) {
 		t.Errorf("events = %d, want 2 (out + in)", len(events))
 	}
 }
+
+// --- matrix #9: injured player removed at next sweep, best backup swapped in --
+
+func TestCheckSubstitutions_InjuredRemovedSwapsBackup(t *testing.T) {
+	tm := subTeam()
+	tm.injured[1] = true // PG injured mid-game (already marked by maybeInjure)
+
+	var events []result.Event
+	checkSubstitutions(tm, 1, 600, func(e result.Event) { events = append(events, e) })
+
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want exactly 2 (out + in)", len(events))
+	}
+	if events[0].PlayerID != 1 || events[1].PlayerID != 11 {
+		t.Errorf("swap order = out %d / in %d, want 1 / 11", events[0].PlayerID, events[1].PlayerID)
+	}
+	on := onCourtPIDs(tm)
+	if on[1] || !on[11] {
+		t.Errorf("after injury: on-court = %v, want 11 in / 1 out", on)
+	}
+}
+
+// --- matrix #10: injured player never eligible as a backup (barred via taken) -
+
+func TestCheckSubstitutions_InjuredPermanent(t *testing.T) {
+	tm := subTeam()
+	tm.injured[1] = true
+	checkSubstitutions(tm, 1, 600, func(result.Event) {}) // 1 out (injured), 11 in
+
+	// Now injure the replacement too. PID 1 is barred (injured), so 11 is removed
+	// and the team plays short — 1 must NOT return.
+	tm.injured[11] = true
+	checkSubstitutions(tm, 1, 600, func(result.Event) {})
+
+	on := onCourtPIDs(tm)
+	if on[1] {
+		t.Error("injured PID 1 re-entered the lineup as a backup")
+	}
+	if on[11] {
+		t.Error("injured PID 11 still on court")
+	}
+}
+
+// --- matrix #11: injury with no available backup → team plays short, no panic -
+
+func TestCheckSubstitutions_InjuredNoBackupPlaysShort(t *testing.T) {
+	tm := subTeam()
+	tm.injured[5] = true // C has no backup
+
+	before := len(tm.players)
+	var events []result.Event
+	checkSubstitutions(tm, 1, 600, func(e result.Event) { events = append(events, e) })
+
+	if len(tm.players) != before-1 {
+		t.Errorf("players = %d, want %d (C removed, no replacement)", len(tm.players), before-1)
+	}
+	if onCourtPIDs(tm)[5] {
+		t.Error("injured C (PID 5) still on court")
+	}
+	if len(events) != 0 {
+		t.Errorf("events = %d, want 0 (no replacement to swap in)", len(events))
+	}
+}

--- a/engine/internal/sim/transition.go
+++ b/engine/internal/sim/transition.go
@@ -127,6 +127,7 @@ func (gs *gameState) runTransitionPossession(offense, defense *teamState, period
 				Kind: result.EventTurnover, Period: gs.period, Clock: gs.clock,
 				TeamID: offense.teamID, PlayerID: bh.PID,
 			})
+			gs.maybeInjure(offense, bh) // per-turnover injury check on the committer
 			return gs.creditSteal(offense, defense, bh)
 		}
 	}


### PR DESCRIPTION
## Summary

PR6 of the 9-PR Phase-1 JSB native rewrite. Adds the JSB **in-game injury mechanic** to the Go engine — a pure stdin→stdout transform under `engine/`. No PHP, DB, web route, or security surface (PR8 will persist injuries to `ibl_jsb_transactions`).

On a turnover, a per-turnover probability gate (`p=0.007`, corpus-calibrated) may injure the committing ball-handler. Disasm-recovered + corpus-validated formulas (memory `reference_jsb_injury_formula`) derive:
- **energy param** ∈ [2,5] from dc_minutes/skill/talent,
- **severity** ∈ [1,160] (multimodal band multipliers; real max ≈ 78 = corpus max),
- **games-missed** ≈ severity × 2.25 (± sub-game jitter).

The injured player is marked in `teamState.injured` (mirrors `fouledOut`), permanently removed at the next dead-ball substitution sweep, and barred from re-entering as a backup. An `EventInjury` is emitted and folded into a derived `GameResult.Injuries` slice.

## Key design points
- **One shared `maybeInjure` entry point**, called identically from both turnover branches (`possession.go`, `transition.go`) — the paths cannot diverge. Fixed RNG draw order: exactly 1 draw if no injury, 3 if injured.
- **Determinism preserved:** `checkSubstitutions` stays RNG-free (structurally — its signature takes no `*rng.RNG`).
- **Golden byte-stable, no regen:** the zero-turnover golden never calls `maybeInjure`; `omitempty` on `Injuries`/`Severity`/`GamesMissed` drops the keys entirely.

## Verification
All 17 verification-matrix rows are covered by committed Go tests (`go test ./...` green; build + vet + gofmt clean). `TestSimulate_FoulOutStopsMinutes` was re-characterized to scan seeds: PR6's turnover-branch draws shifted the RNG so seed 1988 no longer forces a foul-out (the foul-out is that test's *precondition*, not its assertion).

## Manual Testing

No manual testing needed — all changes are covered by automated Go unit tests. The engine has no UI/UX, HTTP, or DB surface.

Generated with [Claude Code](https://claude.ai/code)