### PR TITLE
engine(sim): game-type gating — playoff net×1.25 + fast-break special_sub (PR7)

### DIFF
--- a/engine/internal/sim/gameloop.go
+++ b/engine/internal/sim/gameloop.go
@@ -24,7 +24,7 @@ func simGame(b bundle.Bundle, g bundle.Game, r *rng.RNG) (result.GameResult, int
 	visitor := newTeamState(b.Players, g.VisitorTeamID, false)
 	home := newTeamState(b.Players, g.HomeTeamID, true)
 
-	gs := &gameState{rng: r, madeFG: map[int]int{}}
+	gs := &gameState{rng: r, gameType: g.GameType, madeFG: map[int]int{}}
 
 	// Possession length is constant per game in PR3a (factor 1.0, no per-game
 	// stat aggregates yet): average the two teams' base times.

--- a/engine/internal/sim/gametype.go
+++ b/engine/internal/sim/gametype.go
@@ -1,0 +1,30 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/bundle"
+
+// Game-type-gated effects (JSB CEngine+0x63b4). PR7 implements the two in-engine,
+// per-game effects gated on the PLAYOFF type; all other gated behaviors
+// (season-record/stat/career/confidence/conditioning) are between-game
+// persistence concerns handled outside this pure transform. ASG (5/6) has no
+// in-engine effect here — its only JSB-gated per-game effect is zeroing the
+// home-court-advantage magnitude, and HCA is not modeled (deferred; see
+// docs/decisions and the RE notes). Coaching is already neutral.
+const (
+	// playoffNetMultiplier amplifies the 2pt half-court net advantage in playoff
+	// games (00_MASTER_REFERENCE.md L1022-1027: net × 1.25 when game_type==4,
+	// else ×1.0). Applies ONLY to the half-court net (netAdvantage) — NOT the
+	// transition net (fixed 5.0−TD) nor the 3pt path (league-baseline×1.5).
+	playoffNetMultiplier = 1.25
+
+	// playoffFastBreakSub is the playoff "special_sub" subtracted from the
+	// fast-break trigger threshold (00_MASTER_REFERENCE.md L880-896:
+	// triggers = roll ≤ TransOff + coaching_mod − special_sub; special_sub=1 iff
+	// game_type==4, confirmed at possession_handler_RAW.c:185). coaching_mod is 0
+	// (neutral coaching), so the playoff trigger is roll ≤ TransOff − 1 — fast
+	// breaks fire slightly less often in the playoffs.
+	playoffFastBreakSub = 1
+)
+
+// isPlayoff reports whether the game type is a playoff game (the only type that
+// triggers the net×1.25 amplifier and the fast-break special_sub).
+func isPlayoff(gt bundle.GameType) bool { return gt == bundle.GameTypePlayoff }

--- a/engine/internal/sim/gametype_test.go
+++ b/engine/internal/sim/gametype_test.go
@@ -1,0 +1,73 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// isPlayoff is true ONLY for game_type 4; every other valid type is false.
+func TestIsPlayoff(t *testing.T) {
+	cases := []struct {
+		gt   bundle.GameType
+		want bool
+	}{
+		{bundle.GameTypeRegular, false},    // 2
+		{bundle.GameTypeRegularAlt, false}, // 3
+		{bundle.GameTypePlayoff, true},     // 4
+		{bundle.GameTypeAllStarA, false},   // 5
+		{bundle.GameTypeAllStarB, false},   // 6
+	}
+	for _, c := range cases {
+		if got := isPlayoff(c.gt); got != c.want {
+			t.Errorf("isPlayoff(%d) = %v, want %v", int(c.gt), got, c.want)
+		}
+	}
+}
+
+// gameWithType returns the richBundle plus a Game scheduled with the given type.
+func gameWithType(gt bundle.GameType) (bundle.Bundle, bundle.Game) {
+	b := richBundle()
+	g := b.Schedule[0]
+	g.GameType = gt
+	return b, g
+}
+
+// TestGameType_GatingWiredEndToEnd proves game_type threads from bundle.Game →
+// gameState → the gated decisions (net×1.25, special_sub): a playoff game and a
+// regular game on the SAME fixture and SAME seed must diverge. (Unit tests cover
+// the gated functions in isolation; this confirms the integration.)
+func TestGameType_GatingWiredEndToEnd(t *testing.T) {
+	const seed = 1988
+	bReg, gReg := gameWithType(bundle.GameTypeRegular)
+	bPo, gPo := gameWithType(bundle.GameTypePlayoff)
+
+	reg, regTrans, regV, regH := simGame(bReg, gReg, rng.New(seed))
+	po, poTrans, poV, poH := simGame(bPo, gPo, rng.New(seed))
+
+	if regV.score == poV.score && regH.score == poH.score && regTrans == poTrans &&
+		len(reg.Events) == len(po.Events) {
+		t.Errorf("playoff and regular games are identical on the same seed — game_type not wired "+
+			"(reg %d-%d trans=%d events=%d; po %d-%d trans=%d events=%d)",
+			regV.score, regH.score, regTrans, len(reg.Events),
+			poV.score, poH.score, poTrans, len(po.Events))
+	}
+}
+
+// TestGameType_SameTypeDeterministic confirms threading game_type adds no
+// nondeterminism: identical type + seed → byte-identical event stream.
+func TestGameType_SameTypeDeterministic(t *testing.T) {
+	const seed = 1988
+	b, g := gameWithType(bundle.GameTypePlayoff)
+	a1, _, _, _ := simGame(b, g, rng.New(seed))
+	a2, _, _, _ := simGame(b, g, rng.New(seed))
+	if len(a1.Events) != len(a2.Events) {
+		t.Fatalf("nondeterministic: event counts %d vs %d", len(a1.Events), len(a2.Events))
+	}
+	for i := range a1.Events {
+		if a1.Events[i] != a2.Events[i] {
+			t.Fatalf("nondeterministic at event %d: %+v vs %+v", i, a1.Events[i], a2.Events[i])
+		}
+	}
+}

--- a/engine/internal/sim/netadvantage.go
+++ b/engine/internal/sim/netadvantage.go
@@ -1,15 +1,19 @@
 package sim
 
+import "github.com/a-jay85/IBL5/engine/internal/bundle"
+
 // netAdvantage is the core probability driver for a 2-point attempt:
 //
 //	net = offense_rating − position_penalty − defense_rating
 //
 // offense/defense are the ODPT pair for the chosen play type (outside → OO/OD,
 // drive → DO/DD, post → PO/PD). The shot-clock modifier subtracts 4.0 (a
-// rushed, end-of-clock look); the regular modifier is ×1.0. The playoff ×1.25
-// and ASG modes are deferred to PR7. Net may go negative — that is meaningful
-// (a bad matchup) and must not underflow.
-func netAdvantage(pt playType, handler, defender onCourt, penalty float64, shotClock bool) float64 {
+// rushed, end-of-clock look). Playoff games (gt == GameTypePlayoff) amplify the
+// net advantage ×1.25 (00_MASTER_REFERENCE.md L1022-1027); all other game types
+// ×1.0. Net may go negative — that is meaningful (a bad matchup) and must not
+// underflow; the playoff multiplier is applied to the signed net (it amplifies
+// both good and bad matchups, as in the decompile).
+func netAdvantage(pt playType, handler, defender onCourt, penalty float64, shotClock bool, gt bundle.GameType) float64 {
 	var off, def float64
 	switch pt {
 	case playOutside:
@@ -24,6 +28,8 @@ func netAdvantage(pt playType, handler, defender onCourt, penalty float64, shotC
 	if shotClock {
 		net -= 4.0
 	}
-	net *= 1.0 // regular-game modifier; playoff ×1.25 deferred to PR7
+	if isPlayoff(gt) {
+		net *= playoffNetMultiplier
+	}
 	return net
 }

--- a/engine/internal/sim/netadvantage_test.go
+++ b/engine/internal/sim/netadvantage_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/a-jay85/IBL5/engine/internal/bundle"
 )
 
-// --- matrix #11: net = offense − penalty − defense; modifiers --------------
+// --- net = offense − penalty − defense; modifiers --------------------------
 
 func TestNetAdvantage_Formula(t *testing.T) {
 	handler := oc(slotPG, bundle.Player{OO: 9, DriveOff: 7, PO: 4})
@@ -15,33 +15,72 @@ func TestNetAdvantage_Formula(t *testing.T) {
 	const penalty = 2.0
 
 	// Outside: OO − penalty − OD = 9 − 2 − 5 = 2.0 (regular ×1.0).
-	if got := netAdvantage(playOutside, handler, defender, penalty, false); math.Abs(got-2.0) > 1e-9 {
+	if got := netAdvantage(playOutside, handler, defender, penalty, false, bundle.GameTypeRegular); math.Abs(got-2.0) > 1e-9 {
 		t.Errorf("outside net = %v, want 2.0", got)
 	}
 	// Drive: DO − penalty − DD = 7 − 2 − 3 = 2.0.
-	if got := netAdvantage(playDrive, handler, defender, penalty, false); math.Abs(got-2.0) > 1e-9 {
+	if got := netAdvantage(playDrive, handler, defender, penalty, false, bundle.GameTypeRegular); math.Abs(got-2.0) > 1e-9 {
 		t.Errorf("drive net = %v, want 2.0", got)
 	}
 	// Post: PO − penalty − PD = 4 − 2 − 6 = −4.0.
-	if got := netAdvantage(playPost, handler, defender, penalty, false); math.Abs(got-(-4.0)) > 1e-9 {
+	if got := netAdvantage(playPost, handler, defender, penalty, false, bundle.GameTypeRegular); math.Abs(got-(-4.0)) > 1e-9 {
 		t.Errorf("post net = %v, want -4.0", got)
 	}
 	// Shot clock subtracts 4.0: outside 2.0 − 4.0 = −2.0.
-	if got := netAdvantage(playOutside, handler, defender, penalty, true); math.Abs(got-(-2.0)) > 1e-9 {
+	if got := netAdvantage(playOutside, handler, defender, penalty, true, bundle.GameTypeRegular); math.Abs(got-(-2.0)) > 1e-9 {
 		t.Errorf("shot-clock net = %v, want -2.0", got)
 	}
 }
 
-// --- matrix #12: boundary — shot clock can drive net negative --------------
+// --- boundary — shot clock can drive net negative --------------------------
 
 func TestNetAdvantage_GoesNegativeSafely(t *testing.T) {
 	handler := oc(slotC, bundle.Player{PO: 1})
 	defender := oc(slotC, bundle.Player{PD: 9})
-	got := netAdvantage(playPost, handler, defender, 5.0, true) // 1 − 5 − 9 − 4
+	got := netAdvantage(playPost, handler, defender, 5.0, true, bundle.GameTypeRegular) // 1 − 5 − 9 − 4
 	if math.Abs(got-(-17.0)) > 1e-9 {
 		t.Errorf("net = %v, want -17.0", got)
 	}
 	if math.IsNaN(got) || math.IsInf(got, 0) {
 		t.Error("net not finite")
+	}
+}
+
+// --- playoff net × 1.25 (game_type==4) -------------------------------------
+
+func TestNetAdvantage_PlayoffMultiplier(t *testing.T) {
+	handler := oc(slotPG, bundle.Player{OO: 9, DriveOff: 7, PO: 4})
+	defender := oc(slotPG, bundle.Player{OD: 5, DD: 3, PD: 6})
+	const penalty = 2.0
+
+	// Positive matchup amplified: regular 2.0 → playoff 2.5.
+	if got := netAdvantage(playOutside, handler, defender, penalty, false, bundle.GameTypePlayoff); math.Abs(got-2.5) > 1e-9 {
+		t.Errorf("playoff outside net = %v, want 2.5 (2.0 × 1.25)", got)
+	}
+	// Negative matchup ALSO amplified (the multiplier hits the signed net):
+	// regular −4.0 → playoff −5.0.
+	if got := netAdvantage(playPost, handler, defender, penalty, false, bundle.GameTypePlayoff); math.Abs(got-(-5.0)) > 1e-9 {
+		t.Errorf("playoff post net = %v, want -5.0 (-4.0 × 1.25)", got)
+	}
+	// Shot-clock subtraction happens BEFORE the multiplier: (2.0 − 4.0) × 1.25 = −2.5.
+	if got := netAdvantage(playOutside, handler, defender, penalty, true, bundle.GameTypePlayoff); math.Abs(got-(-2.5)) > 1e-9 {
+		t.Errorf("playoff shot-clock net = %v, want -2.5", got)
+	}
+}
+
+// --- boundary: only PLAYOFF gets the multiplier; every other type is ×1.0 ---
+
+func TestNetAdvantage_NonPlayoffIsUnmultiplied(t *testing.T) {
+	handler := oc(slotPG, bundle.Player{OO: 9})
+	defender := oc(slotPG, bundle.Player{OD: 5})
+	const penalty = 2.0 // outside net = 9 − 2 − 5 = 2.0
+
+	for _, gt := range []bundle.GameType{
+		bundle.GameTypeRegular, bundle.GameTypeRegularAlt,
+		bundle.GameTypeAllStarA, bundle.GameTypeAllStarB,
+	} {
+		if got := netAdvantage(playOutside, handler, defender, penalty, false, gt); math.Abs(got-2.0) > 1e-9 {
+			t.Errorf("game_type %d net = %v, want 2.0 (no playoff multiplier)", int(gt), got)
+		}
 	}
 }

--- a/engine/internal/sim/possession.go
+++ b/engine/internal/sim/possession.go
@@ -69,7 +69,7 @@ func possession(gs *gameState, offense, defense *teamState, periodIdx int, fbPen
 		if gs.transitionShotRate <= 0 {
 			gs.transitionShotRate = resetTransitionShotRate(offense)
 		}
-		if transitionTriggers(offense, gs.rng) && gs.transitionStealSucceeds(defense) {
+		if transitionTriggers(offense, gs.gameType, gs.rng) && gs.transitionStealSucceeds(defense) {
 			return gs.runTransitionPossession(offense, defense, periodIdx)
 		}
 	}
@@ -82,7 +82,13 @@ func possession(gs *gameState, offense, defense *teamState, periodIdx int, fbPen
 		def := selectDefender(defense, pt, gs.rng)
 
 		penalty := positionPenalty(bh)
-		net := netAdvantage(pt, bh, def, penalty, false)
+		// Playoff net×1.25 lives in netAdvantage. NB: PR3a reuses sv2 (below) as
+		// BOTH the 2pt bucket weight AND the make-roll shot value, so the playoff
+		// multiplier amplifies the 2pt bucket weight too — whereas JSB feeds net
+		// only into shot_value (its 2pt bucket is the independent +0xD90 composite).
+		// Acceptable under the deferred bucket-EV calibration (ADR-0036); revisit
+		// when the play-outcome buckets are rescaled.
+		net := netAdvantage(pt, bh, def, penalty, false, gs.gameType)
 		mq := matchupQuality(bh.FGP, bh.energy, defense.players) // live energy (inert under current curve)
 
 		sv2 := applyClutch(shotValue2pt(net, bh.FGP, false), bh.Clutch, gs.period, scoreDiff)

--- a/engine/internal/sim/state.go
+++ b/engine/internal/sim/state.go
@@ -92,10 +92,11 @@ func (t *teamState) addPeriodPoints(periodIdx, n int) {
 // gameState threads the per-game clock, period, event stream, and RNG through
 // the possession loop.
 type gameState struct {
-	rng    *rng.RNG
-	period int // 1-based; 1..4 regulation, 5+ overtime
-	clock  int // seconds remaining in the current period
-	events []result.Event
+	rng      *rng.RNG
+	gameType bundle.GameType // read-only; gates playoff (net×1.25, fast-break special_sub). Never serialized.
+	period   int             // 1-based; 1..4 regulation, 5+ overtime
+	clock    int             // seconds remaining in the current period
+	events   []result.Event
 
 	// madeFG is the live per-shooter made-field-goal tally, keyed by PID. It is
 	// decision state (the block-probability penalty reads it — block.go), kept

--- a/engine/internal/sim/transition.go
+++ b/engine/internal/sim/transition.go
@@ -1,6 +1,7 @@
 package sim
 
 import (
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
 	"github.com/a-jay85/IBL5/engine/internal/result"
 	"github.com/a-jay85/IBL5/engine/internal/rng"
 )
@@ -35,14 +36,22 @@ func resetTransitionShotRate(breakingTeam *teamState) float64 {
 
 // transitionTriggers is Stage 2 (L878-896): pick a random on-court starter and
 // fire the break iff a 1..transitionTriggerDenom roll falls at or under that
-// starter's TransOff rating. A failed check means the possession proceeds as a
-// normal half-court play despite the pending flag.
-func transitionTriggers(offense *teamState, r *rng.RNG) bool {
+// starter's TransOff rating, minus the playoff special_sub. A failed check means
+// the possession proceeds as a normal half-court play despite the pending flag.
+// In playoff games the effective threshold is TransOff − 1 (special_sub), so
+// fast breaks fire slightly less often (coaching_mod is 0 — neutral coaching).
+// The two RNG draws (starter pick, then trigger roll) are unchanged in count and
+// order, so determinism is preserved for non-playoff games.
+func transitionTriggers(offense *teamState, gt bundle.GameType, r *rng.RNG) bool {
 	if len(offense.players) == 0 {
 		return false
 	}
 	p := offense.players[r.IntN(len(offense.players))]
-	return r.IntN(transitionTriggerDenom)+1 <= p.TransOff
+	specialSub := 0
+	if isPlayoff(gt) {
+		specialSub = playoffFastBreakSub
+	}
+	return r.IntN(transitionTriggerDenom)+1 <= p.TransOff-specialSub
 }
 
 // transitionStealSucceeds is Stage 3 (L900-914): P(success) = rate / (rate + blk)

--- a/engine/internal/sim/transition_test.go
+++ b/engine/internal/sim/transition_test.go
@@ -75,12 +75,46 @@ func TestTransitionTriggers_Boundary(t *testing.T) {
 
 	for seed := uint64(1); seed <= 200; seed++ {
 		r := rng.New(seed)
-		if transitionTriggers(onePlayerTeam(zero), r) {
+		if transitionTriggers(onePlayerTeam(zero), bundle.GameTypeRegular, r) {
 			t.Fatalf("seed %d: TransOff=0 must never trigger", seed)
 		}
-		if !transitionTriggers(onePlayerTeam(full), rng.New(seed)) {
+		if !transitionTriggers(onePlayerTeam(full), bundle.GameTypeRegular, rng.New(seed)) {
 			t.Fatalf("seed %d: TransOff=denom must always trigger", seed)
 		}
+	}
+}
+
+// --- playoff special_sub: trigger threshold is TransOff − 1 ------------------
+
+func TestTransitionTriggers_PlayoffSpecialSub(t *testing.T) {
+	// TransOff=1: regular triggers iff the roll lands its minimum (rand_int(1..20)
+	// ≤ 1); playoff subtracts 1 → threshold 0 → can NEVER trigger. This isolates
+	// the special_sub deterministically.
+	p := mkPlayer(1, 7, slotPG, 46)
+	p.TransOff = 1
+
+	var regHits, poHits, divergent int
+	for seed := uint64(1); seed <= 400; seed++ {
+		reg := transitionTriggers(onePlayerTeam(p), bundle.GameTypeRegular, rng.New(seed))
+		po := transitionTriggers(onePlayerTeam(p), bundle.GameTypePlayoff, rng.New(seed))
+		if reg {
+			regHits++
+		}
+		if po {
+			poHits++
+		}
+		if reg && !po {
+			divergent++ // same seed, regular fires but playoff (−1) does not
+		}
+	}
+	if poHits != 0 {
+		t.Errorf("playoff special_sub: TransOff=1 must NEVER trigger in playoffs, got %d hits", poHits)
+	}
+	if regHits == 0 {
+		t.Fatal("test setup: regular TransOff=1 never triggered across 400 seeds — cannot demonstrate special_sub")
+	}
+	if divergent == 0 {
+		t.Error("special_sub produced no observable divergence between regular and playoff")
 	}
 }
 

--- a/ibl5/docs/decisions/0036-engine-defers-hca-pending-bucket-ev-calibration.md
+++ b/ibl5/docs/decisions/0036-engine-defers-hca-pending-bucket-ev-calibration.md
@@ -1,0 +1,36 @@
+---
+description: The Go sim engine defers home-court advantage until play-outcome bucket EVs are corpus-calibrated; ASG mode is an in-engine no-op until then.
+last_verified: 2026-05-31
+---
+
+# ADR-0036: Engine defers home-court advantage pending bucket-EV calibration
+
+**Status:** Accepted
+**Date:** 2026-05-31
+
+## Context
+
+PR7 ("game-type modes") set out to gate playoff and All-Star (ASG) behavior in the native Go sim engine (ADR-0035). JSB's only *in-engine, per-game* ASG effect is zeroing the home-court-advantage (HCA) magnitude — so a meaningful ASG mode requires HCA to exist first. A reverse-engineering trace of `jumpshot.exe` established that HCA cannot be ported faithfully onto the engine's current PR3a play-outcome model: HCA's three live sites are a ±0.2 nudge on **O(1)-scale** play-outcome buckets (the foul bucket is a ~0.6 floor; the 3pt/foul rating composites `+0xDB0`/`+0xDE0` are dead-zero, so JSB's foul weight is floor-driven and 3pt comes from a separate shot-type gate). The PR3a engine uses **O(100s)-scale** stand-in buckets (`leagueBaseline=233`, `fgpToPermille=9` — both flagged "refined when validated against the corpus"), against which a literal ±0.2 is a no-op, and a scaled version is *anti*-home because foul-path EV (~1.5) exceeds 2pt-path EV (~0.96). HCA's correct sign is therefore entangled with bucket EVs that do not yet exist.
+
+## Decision
+
+The engine ships **playoff gating only** (net advantage ×1.25 and the fast-break `special_sub`, both `game_type==4`, decompile-confirmed and golden-stable). **HCA is deferred** until the play-outcome bucket EVs are corpus-calibrated — at which point HCA is implemented as the JSB ±0.2 bucket nudge on the then-O(1) buckets, correctly signed by construction. Until then **ASG (game_type 5/6) is a deliberate in-engine no-op**: it is accepted, validated, and tagged on output (`SimGameType`), but triggers no per-game behavioral change (its only effect, HCA-zeroing, is moot while HCA is unmodeled; coaching is already neutral). This deferral is enforced by the absence of any HCA code path, not by a rule.
+
+## Alternatives Considered
+
+- **Implement HCA now with the literal JSB ±0.2** — Rejected because: on the O(100s) PR3a buckets it is a statistically undetectable no-op (measured home win-rate 0.4975→0.5105).
+- **Implement HCA now with a magnitude scaled to the PR3a buckets** — Rejected because: it produces a *wrong-signed* effect (home win-rate dropped to 0.3875), since boosting the 2pt path while cutting the higher-EV foul path lowers home scoring under the uncalibrated stand-in EVs.
+- **Build the off-quality `+0xD78/+0xDE0/…` infrastructure to host site-3 HCA** — Rejected because: large, speculative, and unverified as sufficient; the foul bucket is a floor in JSB, not that composite, so it would not reproduce the mechanism.
+
+## Consequences
+
+- Positive: PR7's shipped behavior (playoff ×1.25, `special_sub`) is faithful, deterministic, and golden byte-stable — no calibration dependency.
+- Positive: the deferral is recorded with the precise unblock (corpus-calibrate bucket EVs, then add the ±0.2 nudge), so a future PR has a concrete spec rather than a rediscovery.
+- Negative: ASG games simulate identically to regular-season games in-engine until HCA lands; consumers must not read "ASG mode" as behaviorally distinct yet.
+
+## References
+
+- `ibl5/docs/decisions/0035-native-go-sim-engine.md` — the engine this defers within.
+- `engine/internal/sim/gametype.go` — the playoff gating that did ship; documents the ASG no-op.
+- `engine/internal/sim/netadvantage.go` — `playoffNetMultiplier` (×1.25) application site.
+- The RE trace establishing the bucket-scale/EV entanglement lives in the JSB decompile notes (`COMPOSITE_DOUBLES_TRACE.md`), outside this repo.


### PR DESCRIPTION
## Summary

PR7 of the jsb-native-engine program. Threads `game_type` into the Go sim engine and gates the two **playoff** (`game_type==4`) in-engine effects that are decompile-confirmed and need no calibration:

- **Half-court net advantage ×1.25** (`netadvantage.go`, master-ref L1022-1027) — applied to the signed 2pt net only; the transition net (`5.0−TD`) and the 3pt path (`baseline×1.5`) are untouched.
- **Fast-break `special_sub`** (`transition.go`, master-ref L880-896, confirmed `possession_handler_RAW.c:185`) — playoff trigger threshold is `TransOff − 1`, so fast breaks fire slightly less often.

## Scope correction (roadmap said "playoff / ASG")

Implementation (a reverse-engineering trace of `jumpshot.exe`) proved **HCA — the only in-engine ASG effect — cannot land faithfully on the current PR3a play-outcome model**: HCA is a ±0.2 nudge on JSB's O(1) buckets (the foul bucket is a ~0.6 floor; the 3pt/foul rating composites `+0xDB0`/`+0xDE0` are dead-zero), whereas the engine uses O(100s) stand-in buckets, against which literal ±0.2 is a no-op and a scaled version is *anti*-home. Its correct sign is entangled with uncalibrated stand-in EVs.

**So ASG (5/6) is a deliberate in-engine no-op** — accepted, validated, and tagged on output, but no behavioral change (its only effect, HCA-zeroing, is moot while HCA is unmodeled; coaching is already neutral). The decision and its unblock (corpus-calibrate bucket EVs, then add the ±0.2 nudge) are recorded in **ADR-0036**. A reviewer should NOT read "ASG does nothing in-engine" as a bug.

## Determinism

Golden byte-stable — the golden bundle is `game_type 2`, so no gate fires; `TestGolden` passes with no `-update`. Threading adds zero RNG draws (comparison-RHS change only), so `TestDeterminism` is green.

## Tests

`isPlayoff` predicate table; `netAdvantage` playoff ×1.25 (positive + negative net) and non-playoff no-op boundary; `transitionTriggers` playoff `special_sub` (never-triggers boundary + same-seed divergence); end-to-end integration (playoff vs regular `simGame` diverge) + same-type determinism; golden + determinism unchanged. All via `go test ./...`.

## Manual Testing

No manual testing needed — all changes are covered by automated tests.

Generated with [Claude Code](https://claude.ai/code)