### PR TITLE
engine(ci): add golangci-lint, gofmt check, and coverage floor

### DIFF
--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -36,7 +36,7 @@ jobs:
               - '.github/workflows/engine.yml'
 
   engine:
-    name: Go build, vet, test
+    name: Go build, vet, lint, test
     needs: [changes]
     if: needs.changes.outputs.engine == 'true'
     runs-on: ubuntu-latest
@@ -56,13 +56,44 @@ jobs:
         working-directory: engine
         run: go build ./...
 
+      # Fail if any Go file is not gofmt-formatted. Code is currently clean.
+      - name: Gofmt check
+        working-directory: engine
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
       - name: Vet
         working-directory: engine
         run: go vet ./...
 
-      - name: Test
+      # Pinned version = deterministic gate (same philosophy as the go.mod
+      # toolchain pin). Bump deliberately; never float to latest.
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.12.2
+          working-directory: engine
+
+      # Run tests with coverage and enforce a floor. The floor is a ratchet:
+      # current total is 95.3%; raise this as coverage improves, never lower it.
+      # Kept in sync with COVER_MIN in engine/Makefile.
+      - name: Test with coverage floor
         working-directory: engine
-        run: go test ./...
+        env:
+          COVER_MIN: "90.0"
+        run: |
+          go test -coverprofile=cover.out ./...
+          total="$(go tool cover -func=cover.out | awk '/^total:/ {gsub(/%/, "", $3); print $3}')"
+          echo "total coverage: $total% (floor: $COVER_MIN%)"
+          if awk "BEGIN { exit !($total < $COVER_MIN) }"; then
+            echo "coverage $total% is below floor $COVER_MIN%"
+            exit 1
+          fi
 
   gate:
     name: Engine

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -74,7 +74,7 @@ jobs:
       # Pinned version = deterministic gate (same philosophy as the go.mod
       # toolchain pin). Bump deliberately; never float to latest.
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.2
           working-directory: engine

--- a/engine/.golangci.yml
+++ b/engine/.golangci.yml
@@ -1,0 +1,23 @@
+# golangci-lint config for the JSB native engine.
+# Conservative, high-signal correctness linters only — no opinionated style
+# linters (lll, wsl, funlen, gochecknoglobals, exhaustruct, etc.), which would
+# generate noise without catching bugs in a byte-golden simulation engine.
+#
+# Pinned to schema version 2 (golangci-lint v2.x). CI pins the binary version
+# in .github/workflows/engine.yml so the gate is deterministic — same
+# philosophy as the toolchain pin in go.mod.
+version: "2"
+
+linters:
+  # The "standard" set is errcheck, govet, ineffassign, staticcheck, unused —
+  # exactly the correctness-focused linters we want.
+  default: standard
+
+  settings:
+    govet:
+      # fieldalignment reorders struct fields to save memory. In a byte-golden
+      # engine, struct layout changes are high-risk and the memory win is
+      # irrelevant, so we never want it. It is not in govet's default analyzer
+      # set, but disable it explicitly to document the intent.
+      disable:
+        - fieldalignment

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -1,8 +1,16 @@
 # JSB native simulation engine — build/test targets.
 # Lives here (not in repo-root bin/) so the engine toolchain is self-contained
 # and does not add a bin/* script that would trip the ADR decision-trigger gate.
+#
+# These targets mirror the gates in .github/workflows/engine.yml so that
+# `make fmt-check lint cover` locally reproduces what CI enforces.
 
-.PHONY: build vet test golden-update
+# Coverage floor — a ratchet, not an aspiration. Current total is 95.3%; this
+# floor sits below that with headroom so routine refactors don't trip it.
+# Raise it as coverage improves; never lower it. Kept in sync with engine.yml.
+COVER_MIN := 90.0
+
+.PHONY: build vet test golden-update lint fmt-check cover
 
 # Compile the jsbsim CLI to ./bin/jsbsim.
 build:
@@ -17,3 +25,26 @@ test:
 # Regenerate the golden-master snapshot after an intentional output change.
 golden-update:
 	go test ./internal/sim -run Golden -update
+
+# Static analysis — requires golangci-lint v2.x on PATH (CI pins the version).
+lint:
+	golangci-lint run ./...
+
+# Fail if any Go file is not gofmt-formatted.
+fmt-check:
+	@unformatted="$$(gofmt -l .)"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "The following files are not gofmt-formatted:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
+
+# Run tests with coverage and enforce the COVER_MIN floor.
+cover:
+	go test -coverprofile=cover.out ./...
+	@total="$$(go tool cover -func=cover.out | awk '/^total:/ {gsub(/%/, "", $$3); print $$3}')"; \
+	echo "total coverage: $$total% (floor: $(COVER_MIN)%)"; \
+	if awk "BEGIN { exit !($$total < $(COVER_MIN)) }"; then \
+		echo "coverage $$total% is below floor $(COVER_MIN)%"; \
+		exit 1; \
+	fi


### PR DESCRIPTION
## Summary

Locks in the engine's currently-clean static state with three CI gates in the `engine` job, plus matching Makefile targets so local == CI. **No code changes** — purely additive CI/config.

Verified current state before adding gates: `gofmt -l` clean, `golangci-lint run` reports 0 issues, total coverage **95.3%**.

## Changes

| File | What |
|---|---|
| `engine/.golangci.yml` (new) | golangci-lint schema v2, standard correctness linters (errcheck/govet/ineffassign/staticcheck/unused). `fieldalignment` disabled — struct-field reordering is high-risk in a byte-golden engine and the memory win is irrelevant. |
| `.github/workflows/engine.yml` | Adds **gofmt check**, **golangci-lint** (pinned `v2.12.2`), and a **coverage floor** step to the engine job. |
| `engine/Makefile` | Adds `lint` / `fmt-check` / `cover` targets mirroring the CI gates. |

## Design decisions

- **Coverage floor = 90.0%**, a *ratchet* below the current 95.3% with headroom so routine refactors don't trip it. Raise as coverage improves; never lower. Floor logic verified to actually fail when coverage is below it.
- **golangci-lint version pinned** — an unpinned linter is a nondeterministic gate. Same philosophy as the `go.mod` toolchain pin that keeps golden snapshots reproducible.
- **`fieldalignment` disabled** — the engine's golden tests assert byte-for-byte output; struct layout changes are not worth the risk.

## Verification

All green on the branch:
- `gofmt -l .` → clean
- `golangci-lint run ./...` → 0 issues
- `go vet ./...` → clean
- `go test ./...` → all pass, **including `TestGolden`** (proves zero behavior change)
- coverage total 95.3% ≥ 90.0% floor

<!-- no-adr: modifies existing engine.yml (adr-check ci-workflow trigger is add-only, --diff-filter=A); .golangci.yml is not a trigger pattern -->