### PR TITLE
engine(backup): PR9a — .plr/.sch/.sco Go readers + bundle assembler

### DIFF
--- a/engine/internal/backup/assemble.go
+++ b/engine/internal/backup/assemble.go
@@ -1,0 +1,149 @@
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// ErrUnknownTeam reports a schedule slot referencing a team that has no players
+// in the parsed roster — the "schedule references an unknown team" boundary.
+var ErrUnknownTeam = errors.New("backup: schedule references a team with no roster")
+
+// AssembleOptions carries the bundle-level metadata the backup files do not
+// themselves provide. The .sch has no game type, so the caller supplies one;
+// the zero value defaults to a regular-season game.
+type AssembleOptions struct {
+	LeagueID int
+	Seed     uint64
+	GameType bundle.GameType // 0 -> GameTypeRegular (2)
+}
+
+// ToBundle assembles a parsed .plr roster and .sch schedule into a
+// bundle.Bundle the native engine accepts. Players map onto bundle.Player by
+// the shared ibl_plr field names; each schedule slot becomes a bundle.Game
+// stamped with opts.GameType (the .sch carries none). Teams are the distinct
+// IDs referenced by the schedule, in sorted order so the output is
+// deterministic. An empty roster or schedule, or a schedule referencing a team
+// with no roster players, is a typed error rather than a silent empty bundle.
+//
+// Fields the engine reads that the .plr format does not store are zeroed here:
+//   - r_foul   — no foul rating in the .plr ratings block
+//   - stamina  — an ibl_plr column, but not present in the .plr file layout
+//   - dc_minutes — sourced from the DB depth chart, not the .plr
+//
+// The dc_of/df/oi/di/bh depth fields are also zero, which is correct (not a
+// gap): they are dead on IBL5 data and the engine deliberately never reads them
+// (see internal/sim/lineup.go). This means a backup-driven sim runs with no
+// per-player minutes/stamina signal; PR9b accounts for that when choosing
+// tolerance bands. PR9a only proves the bundle is structurally engine-valid.
+func ToBundle(players []PlrPlayer, sched []SchGame, opts AssembleOptions) (bundle.Bundle, error) {
+	if len(players) == 0 {
+		return bundle.Bundle{}, fmt.Errorf("backup: assemble: %w", bundle.ErrEmptyRoster)
+	}
+	if len(sched) == 0 {
+		return bundle.Bundle{}, fmt.Errorf("backup: assemble: %w", bundle.ErrNoSchedule)
+	}
+
+	gameType := opts.GameType
+	if gameType == 0 {
+		gameType = bundle.GameTypeRegular
+	}
+
+	rosterTeams := make(map[int]bool, 32)
+	bundlePlayers := make([]bundle.Player, 0, len(players))
+	for _, p := range players {
+		rosterTeams[p.TeamID] = true
+		bundlePlayers = append(bundlePlayers, toBundlePlayer(p))
+	}
+
+	scheduleTeams := make(map[int]bool, 32)
+	games := make([]bundle.Game, 0, len(sched))
+	for _, g := range sched {
+		if !rosterTeams[g.VisitorTeamID] {
+			return bundle.Bundle{}, fmt.Errorf("%w: visitor team %d", ErrUnknownTeam, g.VisitorTeamID)
+		}
+		if !rosterTeams[g.HomeTeamID] {
+			return bundle.Bundle{}, fmt.Errorf("%w: home team %d", ErrUnknownTeam, g.HomeTeamID)
+		}
+		scheduleTeams[g.VisitorTeamID] = true
+		scheduleTeams[g.HomeTeamID] = true
+		games = append(games, bundle.Game{
+			HomeTeamID:    g.HomeTeamID,
+			VisitorTeamID: g.VisitorTeamID,
+			Date:          fmt.Sprintf("%02d-%02d", g.Month, g.Day),
+			GameType:      gameType,
+		})
+	}
+
+	teamIDs := make([]int, 0, len(scheduleTeams))
+	for id := range scheduleTeams {
+		teamIDs = append(teamIDs, id)
+	}
+	sort.Ints(teamIDs) // deterministic ordering — never map-iteration order
+	teams := make([]bundle.Team, 0, len(teamIDs))
+	for _, id := range teamIDs {
+		teams = append(teams, bundle.Team{TeamID: id, Name: fmt.Sprintf("team-%d", id)})
+	}
+
+	return bundle.Bundle{
+		LeagueID: opts.LeagueID,
+		Seed:     opts.Seed,
+		Teams:    teams,
+		Players:  bundlePlayers,
+		Schedule: games,
+	}, nil
+}
+
+// toBundlePlayer maps a .plr record onto bundle.Player. The ODPT pairing
+// follows the .plr rating names: DO=drive offense -> r_drive_off,
+// TO=transition offense -> r_trans_off.
+func toBundlePlayer(p PlrPlayer) bundle.Player {
+	return bundle.Player{
+		PID:    p.PID,
+		Name:   p.Name,
+		TeamID: p.TeamID,
+
+		OO:       p.RatingOO,
+		OD:       p.RatingOD,
+		DriveOff: p.RatingDO,
+		DD:       p.RatingDD,
+		PO:       p.RatingPO,
+		PD:       p.RatingPD,
+		TransOff: p.RatingTO,
+		TD:       p.RatingTD,
+
+		FGA: p.RatingFGA,
+		FGP: p.RatingFGP,
+		FTA: p.RatingFTA,
+		FTP: p.RatingFTP,
+		TGA: p.Rating3GA,
+		TGP: p.Rating3GP,
+		ORB: p.RatingORB,
+		DRB: p.RatingDRB,
+		AST: p.RatingAST,
+		STL: p.RatingSTL,
+		TVR: p.RatingTVR,
+		BLK: p.RatingBLK,
+		// Foul: no .plr source -> 0.
+
+		Age:         p.Age,
+		Clutch:      p.Clutch,
+		Consistency: p.Consistency,
+		Talent:      p.Talent,
+		Skill:       p.Skill,
+		Intangibles: p.Intangibles,
+		Peak:        p.Peak,
+		// Stamina: no .plr source -> 0.
+
+		DCPGDepth:       p.PGDepth,
+		DCSGDepth:       p.SGDepth,
+		DCSFDepth:       p.SFDepth,
+		DCPFDepth:       p.PFDepth,
+		DCCDepth:        p.CDepth,
+		DCCanPlayInGame: p.CanPlayInGame,
+		// DCMinutes and DCOf/Df/Oi/Di/Bh: no .plr source -> 0 (see ToBundle doc).
+	}
+}

--- a/engine/internal/backup/assemble_test.go
+++ b/engine/internal/backup/assemble_test.go
@@ -1,0 +1,181 @@
+package backup
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/sim"
+)
+
+// makePlayer builds a PlrPlayer eligible for the lineup (CanPlayInGame=1) with
+// one position depth set and modest ratings so a smoke sim produces real play.
+func makePlayer(pid, tid, pgd, sgd, sfd, pfd, cd int) PlrPlayer {
+	return PlrPlayer{
+		Ordinal: pid, PID: pid, TeamID: tid, Name: fmt.Sprintf("P%d", pid), Pos: "PG",
+		CanPlayInGame: 1, PGDepth: pgd, SGDepth: sgd, SFDepth: sfd, PFDepth: pfd, CDepth: cd,
+		RatingFGA: 60, RatingFGP: 50, RatingFTA: 40, RatingFTP: 75, Rating3GA: 20, Rating3GP: 35,
+		RatingORB: 40, RatingDRB: 50, RatingAST: 50, RatingSTL: 40, RatingTVR: 30, RatingBLK: 30,
+		RatingOO: 5, RatingOD: 5, RatingDO: 5, RatingDD: 5, RatingPO: 5, RatingPD: 5, RatingTO: 5, RatingTD: 5,
+	}
+}
+
+// teamRoster returns 5 players for a team, one per position slot.
+func teamRoster(tid int) []PlrPlayer {
+	base := tid * 100
+	return []PlrPlayer{
+		makePlayer(base+1, tid, 1, 0, 0, 0, 0),
+		makePlayer(base+2, tid, 0, 1, 0, 0, 0),
+		makePlayer(base+3, tid, 0, 0, 1, 0, 0),
+		makePlayer(base+4, tid, 0, 0, 0, 1, 0),
+		makePlayer(base+5, tid, 0, 0, 0, 0, 1),
+	}
+}
+
+// Row #10: ToBundle populates Players/Schedule/Teams, builds date from the
+// .sch-derived Month/Day, and stamps the caller-supplied (default regular=2)
+// game type in bundle.GameType wire form.
+func TestToBundle_Assembles(t *testing.T) {
+	players := append(teamRoster(1), teamRoster(2)...)
+	sched := []SchGame{{VisitorTeamID: 1, HomeTeamID: 2, Month: 11, Day: 2, Played: true}}
+
+	b, err := ToBundle(players, sched, AssembleOptions{LeagueID: 5, Seed: 42})
+	if err != nil {
+		t.Fatalf("ToBundle: %v", err)
+	}
+	if len(b.Players) != 10 {
+		t.Errorf("players = %d, want 10", len(b.Players))
+	}
+	if len(b.Schedule) != 1 {
+		t.Fatalf("schedule = %d, want 1", len(b.Schedule))
+	}
+	if len(b.Teams) != 2 || b.Teams[0].TeamID != 1 || b.Teams[1].TeamID != 2 {
+		t.Errorf("teams = %+v, want sorted [1,2]", b.Teams)
+	}
+	if b.LeagueID != 5 || b.Seed != 42 {
+		t.Errorf("league/seed = %d/%d, want 5/42", b.LeagueID, b.Seed)
+	}
+	g := b.Schedule[0]
+	if g.Date != "11-02" {
+		t.Errorf("date = %q, want 11-02", g.Date)
+	}
+	if g.GameType != bundle.GameTypeRegular {
+		t.Errorf("game_type = %d, want %d (default regular)", g.GameType, bundle.GameTypeRegular)
+	}
+	// Mapping spot-check: r_drive_off <- ratingDO, r_trans_off <- ratingTO.
+	if b.Players[0].DriveOff != 5 || b.Players[0].TransOff != 5 || b.Players[0].FTP != 75 {
+		t.Errorf("player0 mapped ratings = %+v", b.Players[0])
+	}
+
+	// Explicit non-default game type is honored.
+	bp, err := ToBundle(players, sched, AssembleOptions{GameType: bundle.GameTypePlayoff})
+	if err != nil {
+		t.Fatalf("ToBundle playoff: %v", err)
+	}
+	if bp.Schedule[0].GameType != bundle.GameTypePlayoff {
+		t.Errorf("playoff game_type = %d, want %d", bp.Schedule[0].GameType, bundle.GameTypePlayoff)
+	}
+}
+
+// Row #11: the assembled bundle round-trips through json.Marshal -> bundle.Decode
+// identically AND drives sim.Simulate to a structurally-valid result.
+func TestToBundle_RoundTripAndSimulate(t *testing.T) {
+	players := append(teamRoster(1), teamRoster(2)...)
+	sched := []SchGame{{VisitorTeamID: 1, HomeTeamID: 2, Month: 11, Day: 2, Played: true}}
+	b, err := ToBundle(players, sched, AssembleOptions{LeagueID: 1, Seed: 7})
+	if err != nil {
+		t.Fatalf("ToBundle: %v", err)
+	}
+
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	decoded, err := bundle.Decode(raw)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !reflect.DeepEqual(b, decoded) {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", decoded, b)
+	}
+
+	res := sim.Simulate(b, 7)
+	if len(res.Games) != 1 {
+		t.Fatalf("sim games = %d, want 1", len(res.Games))
+	}
+	// Structurally valid: the game produced player box scores for both teams.
+	if len(res.Games[0].PlayerBoxes) == 0 {
+		t.Errorf("sim produced no player boxes")
+	}
+}
+
+// Row #12: an unknown team and empty inputs are typed errors, not silent empty
+// bundles.
+func TestToBundle_Errors(t *testing.T) {
+	players := teamRoster(1)
+
+	// Schedule references team 99 which has no roster.
+	_, err := ToBundle(players, []SchGame{{VisitorTeamID: 1, HomeTeamID: 99, Month: 11, Day: 2}}, AssembleOptions{})
+	if !errors.Is(err, ErrUnknownTeam) {
+		t.Errorf("unknown team: err = %v, want ErrUnknownTeam", err)
+	}
+
+	_, err = ToBundle(nil, []SchGame{{VisitorTeamID: 1, HomeTeamID: 2}}, AssembleOptions{})
+	if !errors.Is(err, bundle.ErrEmptyRoster) {
+		t.Errorf("empty roster: err = %v, want ErrEmptyRoster", err)
+	}
+
+	_, err = ToBundle(players, nil, AssembleOptions{})
+	if !errors.Is(err, bundle.ErrNoSchedule) {
+		t.Errorf("empty schedule: err = %v, want ErrNoSchedule", err)
+	}
+}
+
+// Row #13: ReadPlr/ReadSch/ToBundle are pure — identical bytes produce
+// byte-identical structs and bundles across runs (no map-order or time leak).
+func TestToBundle_Deterministic(t *testing.T) {
+	// Build a .plr with players on teams 1 and 2, and a .sch referencing both.
+	var plr strings.Builder
+	ord := 1
+	for tid := 1; tid <= 2; tid++ {
+		for i := 0; i < 3; i++ {
+			plr.WriteString(newPlrRecord(ord, tid*100+i, tid, 25, fmt.Sprintf("P%d", ord), "PG", 70, 5, 5))
+			plr.WriteString("\r\n")
+			ord++
+		}
+	}
+	plrData := plr.String()
+
+	sch := []byte(strings.Repeat(" ", schFileSize))
+	putSlot(sch, 0, "0102099101") // visitor 1, home 02, 99-101
+	schData := string(sch)
+
+	assemble := func() bundle.Bundle {
+		players, err := ReadPlr(strings.NewReader(plrData))
+		if err != nil {
+			t.Fatalf("ReadPlr: %v", err)
+		}
+		games, err := ReadSch(strings.NewReader(schData))
+		if err != nil {
+			t.Fatalf("ReadSch: %v", err)
+		}
+		b, err := ToBundle(players, games, AssembleOptions{LeagueID: 1, Seed: 99})
+		if err != nil {
+			t.Fatalf("ToBundle: %v", err)
+		}
+		return b
+	}
+
+	b1, b2 := assemble(), assemble()
+	if !reflect.DeepEqual(b1, b2) {
+		t.Errorf("non-deterministic assembly:\n b1=%+v\n b2=%+v", b1, b2)
+	}
+	// Teams must be in sorted id order regardless of roster/schedule order.
+	if len(b1.Teams) != 2 || b1.Teams[0].TeamID != 1 || b1.Teams[1].TeamID != 2 {
+		t.Errorf("teams = %+v, want sorted [1,2]", b1.Teams)
+	}
+}

--- a/engine/internal/backup/plr.go
+++ b/engine/internal/backup/plr.go
@@ -1,0 +1,268 @@
+// Package backup reads the JSB 5.60 backup file triple — .plr (binary roster),
+// .sch (binary schedule), and .sco (ASCII box-score corpus) — into in-memory
+// structs, and assembles a .plr+.sch pair into a bundle.Bundle so a historical
+// backup can drive the native engine through the same stdin→stdout contract the
+// DB-built bundle uses. This is the input/ground-truth side of the offline
+// fidelity harness (PR9); the distributional comparison itself is PR9b.
+//
+// These files are fixed-width ASCII text, NOT binary: there is no magic number,
+// no version header, and no encoding/binary. Every field is sliced by character
+// offset, mirroring the authoritative PHP parsers exactly (see the per-file
+// offset tables below). The canonical spec is ibl5/docs/JSB_FILE_FORMATS.md.
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// .plr 607-byte record offsets, transcribed verbatim from
+// ibl5/classes/PlrParser/PlrLineParser.php (the authoritative reader). Only the
+// fields that feed bundle.Player (plus identity) are mapped; the ~200 other
+// substr offsets in PlrLineParser are season/career/contract aggregates the
+// engine input does not consume, so transcribing them here would be dead code.
+//
+// Offsets verified identical across JSB 5.60 (ibl5/IBL5.plr) and 5.99
+// (default_*.plr): the ASCII column layout is version-stable, so no version
+// gate is needed (a record from either version parses correctly).
+const (
+	plrRecordSize = 607 // a full record; CRLF-separated in the file
+
+	// Identity.
+	offOrdinal = 0  // width 4 — roster slot 1..1440; >1440 = team-summary/padding row
+	offName    = 4  // width 32 — CP1252, space-padded (right-justified in practice; trimmed)
+	offAge     = 36 // width 2
+	offPID     = 38 // width 6 — ibl_plr primary key; 0 = team-summary row
+	offTeamID  = 44 // width 2 — tid
+	offPeak    = 46 // width 4
+	offPos     = 50 // width 2 — PG/SG/SF/PF/" C"
+
+	// Clutch / consistency / depth chart.
+	offClutch        = 128 // width 2
+	offConsistency   = 130 // width 2
+	offPGDepth       = 132 // width 1
+	offSGDepth       = 133 // width 1
+	offSFDepth       = 134 // width 1
+	offPFDepth       = 135 // width 1
+	offCDepth        = 136 // width 1
+	offCanPlayInGame = 137 // width 1
+
+	// Attributes.
+	offTalent      = 268 // width 2
+	offSkill       = 270 // width 2
+	offIntangibles = 272 // width 2
+
+	// Height/weight/ratings block.
+	offRating2GA = 555 // width 3 — r_fga
+	offRating2GP = 558 // width 3 — r_fgp
+	offRatingFTA = 561 // width 3 — r_fta
+	offRatingFTP = 564 // width 3 — r_ftp
+	offRating3GA = 567 // width 3 — r_3ga
+	offRating3GP = 570 // width 3 — r_3gp
+	offRatingORB = 573 // width 3 — r_orb
+	offRatingDRB = 576 // width 3 — r_drb
+	offRatingAST = 579 // width 3 — r_ast
+	offRatingSTL = 582 // width 3 — r_stl
+	offRatingTVR = 585 // width 3 — r_tvr
+	offRatingBLK = 588 // width 3 — r_blk
+
+	// ODPT ratings (2 wide each). Offense: OO/DO/PO/TO; defense: OD/DD/PD/TD.
+	offRatingOO = 591 // outside offense
+	offRatingDO = 593 // drive offense   -> bundle r_drive_off
+	offRatingPO = 595 // post offense
+	offRatingTO = 597 // transition off  -> bundle r_trans_off
+	offRatingOD = 599 // outside defense
+	offRatingDD = 601 // drive defense
+	offRatingPD = 603 // post defense
+	offRatingTD = 605 // transition defense
+
+	// A record shorter than this cannot carry a player slot; matches the
+	// strlen($line) < 200 guard in PlrLineParser::parse (blank/short padding).
+	plrMinRecordLen = 200
+	plrMaxOrdinal   = 1440
+)
+
+// ErrBadField reports a non-numeric value where a numeric field was required.
+// It names the offset and record index so a malformed corpus is diagnosable.
+var ErrBadField = errors.New("backup: non-numeric field in .plr record")
+
+// PlrPlayer is one parsed .plr player record, carrying exactly the fields that
+// map onto bundle.Player (see ToBundle). Fields the engine needs but the .plr
+// format does not store (r_foul, stamina, dc_minutes) are intentionally absent
+// here and zeroed during assembly — see the unmapped-field note in assemble.go.
+type PlrPlayer struct {
+	Ordinal int
+	PID     int
+	Name    string
+	TeamID  int
+	Pos     string
+	Age     int
+	Peak    int
+
+	Clutch        int
+	Consistency   int
+	Talent        int
+	Skill         int
+	Intangibles   int
+	CanPlayInGame int
+
+	PGDepth int
+	SGDepth int
+	SFDepth int
+	PFDepth int
+	CDepth  int
+
+	// Main ratings (0-99).
+	RatingFGA int
+	RatingFGP int
+	RatingFTA int
+	RatingFTP int
+	Rating3GA int
+	Rating3GP int
+	RatingORB int
+	RatingDRB int
+	RatingAST int
+	RatingSTL int
+	RatingTVR int
+	RatingBLK int
+
+	// ODPT ratings.
+	RatingOO int
+	RatingOD int
+	RatingDO int
+	RatingDD int
+	RatingPO int
+	RatingPD int
+	RatingTO int
+	RatingTD int
+}
+
+// ReadPlr reads a backup .plr roster from r and returns the active player
+// records. Records are CRLF-separated fixed-width lines; blank/short padding
+// lines (< 200 bytes) and team-summary/padding rows (pid==0 or ordinal>1440)
+// are skipped, mirroring PlrLineParser::parse. A non-numeric value in a numeric
+// field yields ErrBadField naming the offset and record — never a panic.
+func ReadPlr(r io.Reader) ([]PlrPlayer, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("backup: read .plr: %w", err)
+	}
+	// Mirror the PHP explode("\r\n", $data): split on CRLF, tolerate a bare
+	// trailing newline or final partial record by skipping short lines below.
+	lines := strings.Split(string(data), "\r\n")
+
+	players := make([]PlrPlayer, 0, len(lines))
+	for i, line := range lines {
+		if len(line) < plrMinRecordLen {
+			continue // blank / short padding row
+		}
+		ordinal, err := plrInt(line, offOrdinal, 4, i)
+		if err != nil {
+			return nil, err
+		}
+		pid, err := plrInt(line, offPID, 6, i)
+		if err != nil {
+			return nil, err
+		}
+		if pid == 0 || ordinal > plrMaxOrdinal {
+			continue // team-summary row (pid==0) or padding slot
+		}
+
+		p := PlrPlayer{Ordinal: ordinal, PID: pid, Name: decodeCP1252(plrSlice(line, offName, 32))}
+		p.Pos = strings.TrimSpace(plrSlice(line, offPos, 2))
+
+		// Parse every numeric field; the first non-numeric one short-circuits.
+		fields := []struct {
+			dst *int
+			off int
+			w   int
+		}{
+			{&p.TeamID, offTeamID, 2}, {&p.Age, offAge, 2}, {&p.Peak, offPeak, 4},
+			{&p.Clutch, offClutch, 2}, {&p.Consistency, offConsistency, 2},
+			{&p.Talent, offTalent, 2}, {&p.Skill, offSkill, 2}, {&p.Intangibles, offIntangibles, 2},
+			{&p.CanPlayInGame, offCanPlayInGame, 1},
+			{&p.PGDepth, offPGDepth, 1}, {&p.SGDepth, offSGDepth, 1}, {&p.SFDepth, offSFDepth, 1},
+			{&p.PFDepth, offPFDepth, 1}, {&p.CDepth, offCDepth, 1},
+			{&p.RatingFGA, offRating2GA, 3}, {&p.RatingFGP, offRating2GP, 3},
+			{&p.RatingFTA, offRatingFTA, 3}, {&p.RatingFTP, offRatingFTP, 3},
+			{&p.Rating3GA, offRating3GA, 3}, {&p.Rating3GP, offRating3GP, 3},
+			{&p.RatingORB, offRatingORB, 3}, {&p.RatingDRB, offRatingDRB, 3},
+			{&p.RatingAST, offRatingAST, 3}, {&p.RatingSTL, offRatingSTL, 3},
+			{&p.RatingTVR, offRatingTVR, 3}, {&p.RatingBLK, offRatingBLK, 3},
+			{&p.RatingOO, offRatingOO, 2}, {&p.RatingDO, offRatingDO, 2},
+			{&p.RatingPO, offRatingPO, 2}, {&p.RatingTO, offRatingTO, 2},
+			{&p.RatingOD, offRatingOD, 2}, {&p.RatingDD, offRatingDD, 2},
+			{&p.RatingPD, offRatingPD, 2}, {&p.RatingTD, offRatingTD, 2},
+		}
+		for _, f := range fields {
+			v, err := plrInt(line, f.off, f.w, i)
+			if err != nil {
+				return nil, err
+			}
+			*f.dst = v
+		}
+		players = append(players, p)
+	}
+	return players, nil
+}
+
+// plrSlice returns line[off:off+width], clamped to the line length so a short
+// (but >= 200) record yields "" for an out-of-range field rather than panicking
+// — mirroring PHP substr, which returns "" past the end.
+func plrSlice(line string, off, width int) string {
+	if off >= len(line) {
+		return ""
+	}
+	end := off + width
+	if end > len(line) {
+		end = len(line)
+	}
+	return line[off:end]
+}
+
+// plrInt slices a numeric field, trims padding, and parses it. An empty/blank
+// field is 0 (matching PHP's (int)"   "); a non-numeric value is ErrBadField.
+func plrInt(line string, off, width, rec int) (int, error) {
+	s := strings.TrimSpace(plrSlice(line, off, width))
+	if s == "" {
+		return 0, nil
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("%w: record %d offset %d width %d = %q", ErrBadField, rec, off, width, s)
+	}
+	return v, nil
+}
+
+// decodeCP1252 converts a Windows-1252 byte string to a trimmed UTF-8 string,
+// matching PlrLineParser's iconv('CP1252','UTF-8'). Pure stdlib: 0x00-0x7F and
+// 0xA0-0xFF are code-point-identical to Unicode (Latin-1); only 0x80-0x9F need
+// the CP1252 table below.
+func decodeCP1252(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c < 0x80, c >= 0xA0:
+			b.WriteRune(rune(c))
+		default:
+			if r := cp1252High[c-0x80]; r != 0 {
+				b.WriteRune(r)
+			} // 0 = undefined CP1252 code point; drop it (iconv //IGNORE)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// cp1252High maps the 0x80-0x9F range where CP1252 diverges from Latin-1. A 0
+// entry is an undefined CP1252 byte (dropped, matching iconv //IGNORE).
+var cp1252High = [32]rune{
+	0x20AC, 0, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021,
+	0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0, 0x017D, 0,
+	0, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014,
+	0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0, 0x017E, 0x0178,
+}

--- a/engine/internal/backup/plr.go
+++ b/engine/internal/backup/plr.go
@@ -1,6 +1,6 @@
-// Package backup reads the JSB 5.60 backup file triple — .plr (binary roster),
-// .sch (binary schedule), and .sco (ASCII box-score corpus) — into in-memory
-// structs, and assembles a .plr+.sch pair into a bundle.Bundle so a historical
+// Package backup reads the JSB 5.60 backup file triple — .plr (roster), .sch
+// (schedule), and .sco (box-score corpus), all fixed-width ASCII — into
+// in-memory structs, and assembles a .plr+.sch pair into a bundle.Bundle so a historical
 // backup can drive the native engine through the same stdin→stdout contract the
 // DB-built bundle uses. This is the input/ground-truth side of the offline
 // fidelity harness (PR9); the distributional comparison itself is PR9b.
@@ -79,8 +79,10 @@ const (
 	offRatingPD = 603 // post defense
 	offRatingTD = 605 // transition defense
 
-	// A record shorter than this cannot carry a player slot; matches the
-	// strlen($line) < 200 guard in PlrLineParser::parse (blank/short padding).
+	// A record shorter than this cannot carry the identity/ratings fields, so it
+	// is blank/short padding and skipped. PlrLineParser::parse has no explicit
+	// length guard (it relies on the pid==0 / ordinal>1440 checks below); this is
+	// an added defense so a truncated line can never reach a field slice.
 	plrMinRecordLen = 200
 	plrMaxOrdinal   = 1440
 )

--- a/engine/internal/backup/plr_test.go
+++ b/engine/internal/backup/plr_test.go
@@ -1,0 +1,144 @@
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// plrField writes value v left-justified at literal offset off into buf. The
+// offsets here are restated independently of plr.go's named constants so the
+// test cross-checks the offset map rather than echoing it.
+func plrField(buf []byte, off int, v string) {
+	copy(buf[off:], v)
+}
+
+// newPlrRecord builds a 607-byte player record with the identity + a handful of
+// ratings populated at their literal offsets. Unset fields stay spaces (→ 0).
+func newPlrRecord(ordinal, pid, tid, age int, name, pos string, ftp, oo, td int) string {
+	buf := []byte(strings.Repeat(" ", plrRecordSize))
+	plrField(buf, 0, itoaPad(ordinal, 4)) // ordinal
+	plrField(buf, 4, name)                // name (left-justified; reader trims)
+	plrField(buf, 36, itoaPad(age, 2))    // age
+	plrField(buf, 38, itoaPad(pid, 6))    // pid
+	plrField(buf, 44, itoaPad(tid, 2))    // tid
+	plrField(buf, 50, pos)                // position
+	plrField(buf, 137, "1")               // canPlayInGame
+	plrField(buf, 564, itoaPad(ftp, 3))   // ratingFTP
+	plrField(buf, 591, itoaPad(oo, 2))    // ratingOO
+	plrField(buf, 605, itoaPad(td, 2))    // ratingTD
+	return string(buf)
+}
+
+// itoaPad renders v right-justified in a width-w field, matching the .plr
+// space-padded right-justified integer convention.
+func itoaPad(v, w int) string {
+	return fmt.Sprintf("%*d", w, v)
+}
+
+// Row #5: ReadPlr parses fixed-width CRLF records into the expected players and
+// slices identity + ratings at the transcribed offsets.
+func TestReadPlr_ParsesFields(t *testing.T) {
+	r1 := newPlrRecord(1, 2421, 1, 32, "Magic Johnson", "PG", 86, 6, 8)
+	r2 := newPlrRecord(2, 5259, 2, 38, "Dwyane Wade", "SG", 73, 7, 7)
+	data := r1 + "\r\n" + r2 + "\r\n"
+
+	players, err := ReadPlr(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadPlr: %v", err)
+	}
+	if len(players) != 2 {
+		t.Fatalf("player count = %d, want 2", len(players))
+	}
+	p := players[0]
+	if p.PID != 2421 || p.Name != "Magic Johnson" || p.Pos != "PG" || p.TeamID != 1 || p.Age != 32 {
+		t.Errorf("player0 identity = %+v", p)
+	}
+	if p.RatingFTP != 86 || p.RatingOO != 6 || p.RatingTD != 8 {
+		t.Errorf("player0 ratings: FTP=%d OO=%d TD=%d, want 86/6/8", p.RatingFTP, p.RatingOO, p.RatingTD)
+	}
+	if p.CanPlayInGame != 1 {
+		t.Errorf("CanPlayInGame = %d, want 1", p.CanPlayInGame)
+	}
+	if players[1].PID != 5259 || players[1].Name != "Dwyane Wade" {
+		t.Errorf("player1 = %+v", players[1])
+	}
+}
+
+// Row #5 (encoding): a CP1252 accented name decodes to UTF-8.
+func TestReadPlr_CP1252Name(t *testing.T) {
+	// 0xE9 is é in CP1252/Latin-1.
+	name := "L\xf3pez" // ó
+	rec := newPlrRecord(1, 100, 1, 25, name, "SF", 70, 5, 5)
+	players, err := ReadPlr(strings.NewReader(rec + "\r\n"))
+	if err != nil {
+		t.Fatalf("ReadPlr: %v", err)
+	}
+	if players[0].Name != "López" {
+		t.Errorf("name = %q, want %q", players[0].Name, "López")
+	}
+}
+
+// Row #6: a non-numeric value in a numeric field yields ErrBadField; a
+// too-short line (< 200 bytes) is skipped, not errored.
+func TestReadPlr_BadFieldAndShortLine(t *testing.T) {
+	rec := []byte(newPlrRecord(1, 100, 1, 25, "Bad Guy", "PG", 70, 5, 5))
+	copy(rec[591:593], "XY") // ratingOO non-numeric
+	short := "   1 short line under two hundred bytes"
+	data := short + "\r\n" + string(rec) + "\r\n"
+
+	_, err := ReadPlr(strings.NewReader(data))
+	if !errors.Is(err, ErrBadField) {
+		t.Fatalf("err = %v, want ErrBadField", err)
+	}
+	if !strings.Contains(err.Error(), "591") {
+		t.Errorf("error should name offset 591: %v", err)
+	}
+
+	// The short line alone parses to zero players, no error.
+	players, err := ReadPlr(strings.NewReader(short + "\r\n"))
+	if err != nil {
+		t.Fatalf("short-only ReadPlr: %v", err)
+	}
+	if len(players) != 0 {
+		t.Errorf("short-only players = %d, want 0", len(players))
+	}
+}
+
+// Row #7: version-stability. Phase 0 verified the .plr column offsets are
+// IDENTICAL across JSB 5.60 and 5.99 (no version byte exists), so a record laid
+// out at these offsets parses regardless of which version produced it. This
+// asserts that documented finding: a "5.99-style" record (same offsets,
+// different data) reads correctly with no version gate.
+func TestReadPlr_VersionStableOffsets(t *testing.T) {
+	rec599 := newPlrRecord(1, 7, 1, 29, "Aaron McKie", "PG", 0, 7, 7)
+	players, err := ReadPlr(strings.NewReader(rec599 + "\r\n"))
+	if err != nil {
+		t.Fatalf("ReadPlr: %v", err)
+	}
+	if len(players) != 1 || players[0].PID != 7 || players[0].Name != "Aaron McKie" {
+		t.Fatalf("5.99-layout record parsed as %+v", players)
+	}
+	if players[0].RatingFTP != 0 || players[0].RatingTD != 7 {
+		t.Errorf("ratings FTP=%d TD=%d, want 0/7", players[0].RatingFTP, players[0].RatingTD)
+	}
+}
+
+// Row #8: empty input and blank/CRLF-only input both yield an empty slice with
+// no panic and no spurious player.
+func TestReadPlr_EmptyAndBlank(t *testing.T) {
+	for name, in := range map[string]string{
+		"empty":     "",
+		"crlf only": "\r\n\r\n\r\n",
+		"spaces":    strings.Repeat(" ", 50) + "\r\n",
+	} {
+		players, err := ReadPlr(strings.NewReader(in))
+		if err != nil {
+			t.Errorf("%s: err = %v", name, err)
+		}
+		if len(players) != 0 {
+			t.Errorf("%s: players = %d, want 0", name, len(players))
+		}
+	}
+}

--- a/engine/internal/backup/sch.go
+++ b/engine/internal/backup/sch.go
@@ -1,0 +1,181 @@
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// .sch compact schedule format, transcribed from
+// ibl5/classes/JsbParser/SchFileParser.php. The file is exactly 80,000 bytes:
+// 8,000 game slots of 10 bytes ([teams:4][scores:6]), grouped 16 slots per
+// calendar date. The date is derived from the slot's date group (Oct = group 0,
+// 31 day-slots per month); the record itself carries no game type.
+const (
+	schFileSize     = 80000
+	schRecordSize   = 10
+	schTeamsField   = 4
+	schScoresField  = 6
+	schSlotsPerDate = 16
+	schDaysPerMonth = 31
+	schMaxMonthOff  = 12
+)
+
+const schEmptyRecord = "0   0     "
+
+// ErrBadSize reports a .sch input whose total length is not exactly 80,000
+// bytes, mirroring SchFileParser's strict size check.
+var ErrBadSize = errors.New("backup: invalid .sch size")
+
+// SchGame is one schedule slot. Played is true once either score is positive
+// (the slot has been simulated). The .sch carries no game type, so the bundle
+// assembler stamps one; see ToBundle.
+type SchGame struct {
+	VisitorTeamID int
+	HomeTeamID    int
+	Month         int
+	Day           int
+	VisitorScore  int
+	HomeScore     int
+	Played        bool
+}
+
+// ReadSch reads a backup .sch schedule from r. It requires exactly 80,000
+// bytes (else ErrBadSize), iterates the 8,000 slots, skips empty slots and
+// invalid dates (matching SchFileParser), and derives Month/Day from each
+// slot's date group. A non-numeric value where digits are required yields
+// ErrBadField — never a panic.
+func ReadSch(r io.Reader) ([]SchGame, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("backup: read .sch: %w", err)
+	}
+	if len(data) != schFileSize {
+		return nil, fmt.Errorf("%w: expected %d bytes, got %d", ErrBadSize, schFileSize, len(data))
+	}
+	s := string(data)
+
+	games := make([]SchGame, 0)
+	bytesPerDate := schSlotsPerDate * schRecordSize
+	for dateSlot := 0; dateSlot < schFileSize/bytesPerDate; dateSlot++ {
+		if dateSlot/schDaysPerMonth >= schMaxMonthOff {
+			continue
+		}
+		month, day, ok := dateSlotToMonthDay(dateSlot)
+		if !ok {
+			continue // invalid calendar date (e.g. Nov 31, Feb 30)
+		}
+		for gameIndex := 0; gameIndex < schSlotsPerDate; gameIndex++ {
+			off := (dateSlot*schSlotsPerDate + gameIndex) * schRecordSize
+			record := s[off : off+schRecordSize]
+			if record == schEmptyRecord {
+				continue
+			}
+			vis, home, vScore, hScore, ok, err := parseSchRecord(record)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+			games = append(games, SchGame{
+				VisitorTeamID: vis,
+				HomeTeamID:    home,
+				Month:         month,
+				Day:           day,
+				VisitorScore:  vScore,
+				HomeScore:     hScore,
+				Played:        vScore > 0 || hScore > 0,
+			})
+		}
+	}
+	return games, nil
+}
+
+// parseSchRecord decodes a single 10-byte slot. ok is false when the slot is
+// empty/unschedulable (teams field too short, or a non-positive team ID),
+// mirroring SchFileParser::parseGameRecord's null returns.
+func parseSchRecord(record string) (vis, home, vScore, hScore int, ok bool, err error) {
+	if record == schEmptyRecord {
+		return 0, 0, 0, 0, false, nil
+	}
+	teamsField := strings.TrimRight(record[:schTeamsField], " ")
+	scoresField := strings.TrimRight(record[schTeamsField:schTeamsField+schScoresField], " ")
+
+	if len(teamsField) < 2 {
+		return 0, 0, 0, 0, false, nil
+	}
+	// Home is always the last 2 chars (zero-padded); visitor is the remainder.
+	home, err = atoiField(teamsField[len(teamsField)-2:])
+	if err != nil {
+		return 0, 0, 0, 0, false, err
+	}
+	vis, err = atoiField(teamsField[:len(teamsField)-2])
+	if err != nil {
+		return 0, 0, 0, 0, false, err
+	}
+	if vis <= 0 || home <= 0 {
+		return 0, 0, 0, 0, false, nil
+	}
+
+	// Unplayed games store the scores field as a bare "0".
+	if scoresField == "0" {
+		return vis, home, 0, 0, true, nil
+	}
+	if len(scoresField) < 4 {
+		return 0, 0, 0, 0, false, nil
+	}
+	hScore, err = atoiField(scoresField[len(scoresField)-3:])
+	if err != nil {
+		return 0, 0, 0, 0, false, err
+	}
+	vScore, err = atoiField(scoresField[:len(scoresField)-3])
+	if err != nil {
+		return 0, 0, 0, 0, false, err
+	}
+	return vis, home, vScore, hScore, true, nil
+}
+
+// dateSlotToMonthDay converts a date group to a calendar month/day, returning
+// ok=false for an invalid date. Offset 0 = October; the leap year 2000 is used
+// so Feb 29 validates (matching SchFileParser::dateSlotToMonthDay's checkdate).
+func dateSlotToMonthDay(dateSlot int) (month, day int, ok bool) {
+	monthOffset := dateSlot / schDaysPerMonth
+	if monthOffset >= schMaxMonthOff {
+		return 0, 0, false
+	}
+	month = ((monthOffset+9)%12 + 1)
+	day = dateSlot%schDaysPerMonth + 1
+	if day > daysInMonth2000(month) {
+		return 0, 0, false
+	}
+	return month, day, true
+}
+
+// daysInMonth2000 returns the day count for a month in the leap year 2000.
+func daysInMonth2000(month int) int {
+	switch month {
+	case 2:
+		return 29
+	case 4, 6, 9, 11:
+		return 30
+	default:
+		return 31
+	}
+}
+
+// atoiField trims a digit field and parses it; blank is 0, non-numeric is
+// ErrBadField. Shared with the .plr/.sco readers' parsing convention.
+func atoiField(s string) (int, error) {
+	t := strings.TrimSpace(s)
+	if t == "" {
+		return 0, nil
+	}
+	v, err := strconv.Atoi(t)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %q", ErrBadField, t)
+	}
+	return v, nil
+}

--- a/engine/internal/backup/sch_test.go
+++ b/engine/internal/backup/sch_test.go
@@ -1,0 +1,65 @@
+package backup
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// putSlot writes a 10-byte schedule record at game slot index n into buf.
+func putSlot(buf []byte, n int, record string) {
+	copy(buf[n*10:], record)
+}
+
+// Row #9: ReadSch parses a synthetic 80,000-byte schedule. Games live in date
+// group 0 (October, day 1); visitor/home split on the trailing 2 digits, scores
+// on the trailing 3; empty slots are skipped; played follows score > 0. A wrong
+// total size yields ErrBadSize.
+func TestReadSch_Parses(t *testing.T) {
+	buf := []byte(strings.Repeat(" ", schFileSize))
+
+	// Game 0: visitor 24, home 09, scores 132 / 131 (played).
+	putSlot(buf, 0, "2409132131")
+	// Game 1: visitor 5, home 07, unplayed (scores field is a bare "0").
+	putSlot(buf, 1, "507 0     ")
+	// Game 2: visitor 12, home 03, scores 99 / 101 (played).
+	putSlot(buf, 2, "120399101 ")
+	// Game 3: an explicit empty slot — must be skipped.
+	putSlot(buf, 3, schEmptyRecord)
+
+	games, err := ReadSch(strings.NewReader(string(buf)))
+	if err != nil {
+		t.Fatalf("ReadSch: %v", err)
+	}
+	if len(games) != 3 {
+		t.Fatalf("games = %d, want 3 (empty slot skipped)", len(games))
+	}
+
+	g0 := games[0]
+	if g0.VisitorTeamID != 24 || g0.HomeTeamID != 9 {
+		t.Errorf("game0 teams = %d/%d, want 24/9", g0.VisitorTeamID, g0.HomeTeamID)
+	}
+	if g0.Month != 10 || g0.Day != 1 {
+		t.Errorf("game0 date = %d/%d, want Oct 1 (10/1)", g0.Month, g0.Day)
+	}
+	if g0.VisitorScore != 132 || g0.HomeScore != 131 || !g0.Played {
+		t.Errorf("game0 score = %d-%d played=%v, want 132-131 played", g0.VisitorScore, g0.HomeScore, g0.Played)
+	}
+
+	g1 := games[1]
+	if g1.VisitorTeamID != 5 || g1.HomeTeamID != 7 || g1.VisitorScore != 0 || g1.HomeScore != 0 || g1.Played {
+		t.Errorf("game1 = %+v, want vis5 home7 unplayed", g1)
+	}
+
+	g2 := games[2]
+	if g2.VisitorTeamID != 12 || g2.HomeTeamID != 3 || g2.VisitorScore != 99 || g2.HomeScore != 101 || !g2.Played {
+		t.Errorf("game2 = %+v, want vis12 home3 99-101 played", g2)
+	}
+}
+
+func TestReadSch_BadSize(t *testing.T) {
+	_, err := ReadSch(strings.NewReader(strings.Repeat(" ", schFileSize-1)))
+	if !errors.Is(err, ErrBadSize) {
+		t.Errorf("err = %v, want ErrBadSize", err)
+	}
+}

--- a/engine/internal/backup/sco.go
+++ b/engine/internal/backup/sco.go
@@ -1,0 +1,267 @@
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// .sco record framing, transcribed from ibl5/classes/JsbParser/ScoFileParser.php.
+// The file opens with a 1,000,000-byte metadata header (skipped), after which
+// each completed game is a contiguous 2,000-byte record: a 58-byte game-info
+// header + 30 player/team slots of 53 bytes + trailing padding.
+const (
+	scoHeaderSize   = 1_000_000 // metadata header, skipped wholesale
+	scoRecordSize   = 2000
+	scoGameInfoSize = 58
+	scoSlotSize     = 53
+	scoSlotCount    = 30
+	scoVisitorSlots = 15 // slots 0..14 visitor, 15..29 home
+)
+
+// Game-info sub-offsets, from Boxscore::fillGameInfo. Team IDs and the date are
+// stored 0-based and the PHP adds the constants below; we mirror that so the
+// .sco team IDs agree with the 1-indexed .sch/bundle IDs (load-bearing for the
+// PR9b join between .sco ground truth and the .sch-driven sim).
+const (
+	giMonth      = 0  // width 2, raw + 10 = calendar month base (Oct=10)
+	giDay        = 2  // width 2, raw + 1
+	giVisitorTID = 6  // width 2, raw + 1
+	giHomeTID    = 8  // width 2, raw + 1
+	giVisitorQ1  = 28 // five visitor quarter scores, width 3 each (28,31,34,37,40)
+	giHomeQ1     = 43 // five home quarter scores, width 3 each (43,46,49,52,55)
+)
+
+// Player/team slot sub-offsets, from PlayerStats::fillFromBoxscoreInfoLine. The
+// "field goal" slots are 2-POINT-ONLY makes/attempts: the PHP writes them
+// straight into game_2gm/game_2ga with no fgm-3gm subtraction, and a real-corpus
+// reconciliation confirms Σ(2*TwoGM + FTM + 3*ThreeGM) == the header score. The
+// engine likewise emits 2-point-only makes, so TwoGM compares to the engine's
+// 2GM directly — there is NO total-field-goal derivation.
+const (
+	slotName    = 0  // width 16, CP1252
+	slotPos     = 16 // width 2
+	slotPID     = 18 // width 6 — 0 = team-total row
+	slotMin     = 24 // width 2
+	slotTwoGM   = 26 // width 2 — game_2gm (2-point makes)
+	slotTwoGA   = 28 // width 3 — game_2ga (2-point attempts)
+	slotFTM     = 31 // width 2
+	slotFTA     = 33 // width 2
+	slotThreeGM = 35 // width 2
+	slotThreeGA = 37 // width 2
+	slotORB     = 39 // width 2
+	slotDRB     = 41 // width 2
+	slotAST     = 43 // width 2
+	slotSTL     = 45 // width 2
+	slotTOV     = 47 // width 2
+	slotBLK     = 49 // width 2
+	slotPF      = 51 // width 2
+)
+
+// ErrShortRecord reports a .sco input that ends mid-record (truncated header or
+// a trailing partial 2,000-byte record). It names the offending record index.
+var ErrShortRecord = errors.New("backup: truncated .sco record")
+
+// ScoBox is one slot's stat line from a .sco game. TwoGM/TwoGA are 2-point-only
+// (game_2gm/game_2ga), directly comparable to the engine's emitted 2GM/2GA. A
+// team-total row has PlayerID == 0; TeamID is the visitor team for slots 0..14
+// and the home team for slots 15..29.
+type ScoBox struct {
+	TeamID   int
+	PlayerID int
+	Pos      string
+	Name     string
+	Min      int
+	TwoGM    int
+	TwoGA    int
+	FTM      int
+	FTA      int
+	ThreeGM  int
+	ThreeGA  int
+	ORB      int
+	DRB      int
+	AST      int
+	STL      int
+	TOV      int
+	BLK      int
+	PF       int
+}
+
+// ScoGame is one completed game decoded from a .sco record. GameType has no
+// source in the 58-byte game-info header (the .sco does not store it), so it is
+// always 0; it exists only to keep the ground-truth struct shape stable for
+// PR9b. VisitorScore/HomeScore are the summed quarter scores.
+type ScoGame struct {
+	VisitorTeamID int
+	HomeTeamID    int
+	VisitorScore  int
+	HomeScore     int
+	Date          string
+	GameType      int
+	Boxes         []ScoBox
+}
+
+// ReadSco reads a backup .sco box-score corpus from r. It skips the
+// 1,000,000-byte header, then decodes each 2,000-byte record. Records with no
+// non-empty player slot are padding and are skipped (mirroring the PHP
+// gameLinesProcessed > 0 gate), so the real sparse corpus does not emit phantom
+// games. A truncated header or trailing partial record yields ErrShortRecord; a
+// non-numeric slot field yields ErrBadField — never a panic.
+func ReadSco(r io.Reader) ([]ScoGame, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("backup: read .sco: %w", err)
+	}
+	if len(data) < scoHeaderSize {
+		return nil, fmt.Errorf("%w: data %d bytes shorter than the %d-byte header", ErrShortRecord, len(data), scoHeaderSize)
+	}
+
+	games := make([]ScoGame, 0)
+	recIdx := 0
+	for off := scoHeaderSize; off < len(data); off, recIdx = off+scoRecordSize, recIdx+1 {
+		if off+scoRecordSize > len(data) {
+			return nil, fmt.Errorf("%w: record %d at offset %d has only %d of %d bytes", ErrShortRecord, recIdx, off, len(data)-off, scoRecordSize)
+		}
+		rec := string(data[off : off+scoRecordSize])
+		game, ok, err := decodeScoRecord(rec, recIdx)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			games = append(games, game)
+		}
+	}
+	return games, nil
+}
+
+// decodeScoRecord decodes one 2,000-byte record. ok is false for a padding
+// record (no non-empty slot), in which case game is the zero value.
+func decodeScoRecord(rec string, recIdx int) (ScoGame, bool, error) {
+	gi := rec[:scoGameInfoSize]
+
+	visTID, err := scoInt(gi, giVisitorTID, 2, recIdx)
+	if err != nil {
+		return ScoGame{}, false, err
+	}
+	homeTID, err := scoInt(gi, giHomeTID, 2, recIdx)
+	if err != nil {
+		return ScoGame{}, false, err
+	}
+	monthRaw, err := scoInt(gi, giMonth, 2, recIdx)
+	if err != nil {
+		return ScoGame{}, false, err
+	}
+	dayRaw, err := scoInt(gi, giDay, 2, recIdx)
+	if err != nil {
+		return ScoGame{}, false, err
+	}
+
+	visScore, err := scoQuarterSum(gi, giVisitorQ1, recIdx)
+	if err != nil {
+		return ScoGame{}, false, err
+	}
+	homeScore, err := scoQuarterSum(gi, giHomeQ1, recIdx)
+	if err != nil {
+		return ScoGame{}, false, err
+	}
+
+	boxes := make([]ScoBox, 0, scoSlotCount)
+	for i := 0; i < scoSlotCount; i++ {
+		base := scoGameInfoSize + i*scoSlotSize
+		slot := rec[base : base+scoSlotSize]
+		name := decodeCP1252(scoSlice(slot, slotName, 16))
+		if name == "" {
+			continue // empty bench slot
+		}
+		box, err := decodeScoSlot(slot, name, i, visTID, homeTID, recIdx)
+		if err != nil {
+			return ScoGame{}, false, err
+		}
+		boxes = append(boxes, box)
+	}
+	if len(boxes) == 0 {
+		return ScoGame{}, false, nil // padding record
+	}
+
+	// Calendar month: raw + 10, wrapping past December (matches the non-playoff
+	// branch of Boxscore::fillGameInfo). Date is an opaque validation label.
+	month := monthRaw + 10
+	if month > 12 {
+		month -= 12
+	}
+	return ScoGame{
+		VisitorTeamID: visTID + 1,
+		HomeTeamID:    homeTID + 1,
+		VisitorScore:  visScore,
+		HomeScore:     homeScore,
+		Date:          fmt.Sprintf("%02d-%02d", month, dayRaw+1),
+		Boxes:         boxes,
+	}, true, nil
+}
+
+func decodeScoSlot(slot, name string, slotIdx, visTID, homeTID, recIdx int) (ScoBox, error) {
+	box := ScoBox{Name: name, Pos: strings.TrimSpace(scoSlice(slot, slotPos, 2))}
+	if slotIdx < scoVisitorSlots {
+		box.TeamID = visTID + 1
+	} else {
+		box.TeamID = homeTID + 1
+	}
+	fields := []struct {
+		dst *int
+		off int
+		w   int
+	}{
+		{&box.PlayerID, slotPID, 6}, {&box.Min, slotMin, 2},
+		{&box.TwoGM, slotTwoGM, 2}, {&box.TwoGA, slotTwoGA, 3},
+		{&box.FTM, slotFTM, 2}, {&box.FTA, slotFTA, 2},
+		{&box.ThreeGM, slotThreeGM, 2}, {&box.ThreeGA, slotThreeGA, 2},
+		{&box.ORB, slotORB, 2}, {&box.DRB, slotDRB, 2},
+		{&box.AST, slotAST, 2}, {&box.STL, slotSTL, 2},
+		{&box.TOV, slotTOV, 2}, {&box.BLK, slotBLK, 2}, {&box.PF, slotPF, 2},
+	}
+	for _, f := range fields {
+		v, err := scoInt(slot, f.off, f.w, recIdx)
+		if err != nil {
+			return ScoBox{}, err
+		}
+		*f.dst = v
+	}
+	return box, nil
+}
+
+func scoQuarterSum(gi string, firstOff, recIdx int) (int, error) {
+	total := 0
+	for q := 0; q < 5; q++ { // Q1..Q4 + OT
+		v, err := scoInt(gi, firstOff+q*3, 3, recIdx)
+		if err != nil {
+			return 0, err
+		}
+		total += v
+	}
+	return total, nil
+}
+
+func scoSlice(s string, off, width int) string {
+	if off >= len(s) {
+		return ""
+	}
+	end := off + width
+	if end > len(s) {
+		end = len(s)
+	}
+	return s[off:end]
+}
+
+func scoInt(s string, off, width, recIdx int) (int, error) {
+	t := strings.TrimSpace(scoSlice(s, off, width))
+	if t == "" {
+		return 0, nil
+	}
+	v, err := strconv.Atoi(t)
+	if err != nil {
+		return 0, fmt.Errorf("%w: record %d offset %d width %d = %q", ErrBadField, recIdx, off, width, t)
+	}
+	return v, nil
+}

--- a/engine/internal/backup/sco.go
+++ b/engine/internal/backup/sco.go
@@ -185,8 +185,14 @@ func decodeScoRecord(rec string, recIdx int) (ScoGame, bool, error) {
 		return ScoGame{}, false, nil // padding record
 	}
 
-	// Calendar month: raw + 10, wrapping past December (matches the non-playoff
-	// branch of Boxscore::fillGameInfo). Date is an opaque validation label.
+	// Calendar month: raw + 10, wrapping once past December (Oct=10…Sep=9). This
+	// mirrors only the regular-season branch of Boxscore::fillGameInfo; the PHP's
+	// playoff/HEAT/preseason month hacks need season context the .sco does not
+	// carry, so the Date is a best-effort regular-season label and may be wrong
+	// for playoff/HEAT records (which the .sco does not mark). Date is an opaque
+	// validation label — PR9b joins games on team IDs + score, never by parsing
+	// this string — so a mislabeled playoff date does not affect the harness.
+	// The load-bearing fields (team IDs, scores, box stats) are always correct.
 	month := monthRaw + 10
 	if month > 12 {
 		month -= 12

--- a/engine/internal/backup/sco_test.go
+++ b/engine/internal/backup/sco_test.go
@@ -1,0 +1,215 @@
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Slot/record builders restate the .sco offsets independently of sco.go's
+// constants, so the tests cross-check the offset map.
+func putRJ(buf []byte, off, w, v int) { copy(buf[off:], fmt.Sprintf("%*d", w, v)) }
+func putStr(buf []byte, off int, s string) {
+	copy(buf[off:], s)
+}
+
+type scoSlotData struct {
+	name, pos                                                         string
+	pid, min, twoGM, twoGA, ftm, fta, threeGM, threeGA, orb, drb, ast int
+	stl, tov, blk, pf                                                 int
+}
+
+func buildSlot(s scoSlotData) []byte {
+	b := []byte(strings.Repeat(" ", 53))
+	putStr(b, 0, s.name)
+	putStr(b, 16, s.pos)
+	putRJ(b, 18, 6, s.pid)
+	putRJ(b, 24, 2, s.min)
+	putRJ(b, 26, 2, s.twoGM)
+	putRJ(b, 28, 3, s.twoGA)
+	putRJ(b, 31, 2, s.ftm)
+	putRJ(b, 33, 2, s.fta)
+	putRJ(b, 35, 2, s.threeGM)
+	putRJ(b, 37, 2, s.threeGA)
+	putRJ(b, 39, 2, s.orb)
+	putRJ(b, 41, 2, s.drb)
+	putRJ(b, 43, 2, s.ast)
+	putRJ(b, 45, 2, s.stl)
+	putRJ(b, 47, 2, s.tov)
+	putRJ(b, 49, 2, s.blk)
+	putRJ(b, 51, 2, s.pf)
+	return b
+}
+
+func buildGameInfo(visTIDRaw, homeTIDRaw, monthRaw, dayRaw int, visQ, homeQ [5]int) []byte {
+	b := []byte(strings.Repeat(" ", 58))
+	putRJ(b, 0, 2, monthRaw)
+	putRJ(b, 2, 2, dayRaw)
+	putRJ(b, 6, 2, visTIDRaw)
+	putRJ(b, 8, 2, homeTIDRaw)
+	for i, q := range visQ {
+		putRJ(b, 28+i*3, 3, q)
+	}
+	for i, q := range homeQ {
+		putRJ(b, 43+i*3, 3, q)
+	}
+	return b
+}
+
+// buildRecord assembles a 2,000-byte record from game info and up to 30 slots
+// (missing trailing slots stay blank = empty).
+func buildRecord(gi []byte, slots [][]byte) string {
+	b := []byte(strings.Repeat(" ", 2000))
+	copy(b[0:], gi)
+	for i, s := range slots {
+		copy(b[58+i*53:], s)
+	}
+	return string(b)
+}
+
+func scoHeader() string { return strings.Repeat(" ", scoHeaderSize) }
+
+// Row #2: ReadSco parses a multi-game corpus (with a padding record between the
+// two real games) into the right game/box counts, scores, per-stat values, and
+// 2-point-only semantics (Σ 2*TwoGM + FTM + 3*ThreeGM == the header score).
+func TestReadSco_ParsesGames(t *testing.T) {
+	// Game A: visitor team raw 23 (-> 24), home raw 8 (-> 9), Nov 2.
+	visPlayer := scoSlotData{name: "Vis One", pos: "PG", pid: 6328, min: 30, twoGM: 2, twoGA: 5, ftm: 5, fta: 6, threeGM: 2, threeGA: 4, orb: 1, drb: 2, ast: 3, stl: 1, tov: 2, blk: 0, pf: 3}  // 2*2+5+3*2 = 15
+	homePlayer := scoSlotData{name: "Home One", pos: "C", pid: 4159, min: 33, twoGM: 3, twoGA: 7, ftm: 2, fta: 2, threeGM: 1, threeGA: 3, orb: 2, drb: 5, ast: 1, stl: 0, tov: 1, blk: 1, pf: 4} // 2*3+2+3 = 11
+	visTotal := scoSlotData{name: "Vis Team", pid: 0, twoGM: 2, ftm: 5, threeGM: 2}
+	homeTotal := scoSlotData{name: "Home Team", pid: 0, twoGM: 3, ftm: 2, threeGM: 1}
+
+	slots := make([][]byte, 30)
+	for i := range slots {
+		slots[i] = []byte(strings.Repeat(" ", 53))
+	}
+	slots[0] = buildSlot(visPlayer)
+	slots[14] = buildSlot(visTotal)   // visitor team total
+	slots[15] = buildSlot(homePlayer) // first home slot
+	slots[29] = buildSlot(homeTotal)  // home team total
+	giA := buildGameInfo(23, 8, 1, 1, [5]int{4, 4, 4, 3, 0}, [5]int{3, 3, 3, 2, 0})
+	gameA := buildRecord(giA, slots)
+
+	padding := buildRecord(buildGameInfo(0, 0, 0, 0, [5]int{}, [5]int{}), make([][]byte, 30))
+
+	// Game B: distinct teams, simple single visitor player.
+	bVis := scoSlotData{name: "B Vis", pos: "SF", pid: 100, min: 20, twoGM: 5, ftm: 0, threeGM: 0} // 10
+	slotsB := make([][]byte, 30)
+	for i := range slotsB {
+		slotsB[i] = []byte(strings.Repeat(" ", 53))
+	}
+	slotsB[0] = buildSlot(bVis)
+	giB := buildGameInfo(4, 6, 1, 2, [5]int{2, 2, 3, 3, 0}, [5]int{0, 0, 0, 0, 0})
+	gameB := buildRecord(giB, slotsB)
+
+	data := scoHeader() + gameA + padding + gameB
+
+	games, err := ReadSco(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadSco: %v", err)
+	}
+	if len(games) != 2 {
+		t.Fatalf("game count = %d, want 2 (padding record must be skipped)", len(games))
+	}
+
+	g := games[0]
+	if g.VisitorTeamID != 24 || g.HomeTeamID != 9 {
+		t.Errorf("game0 teams = %d/%d, want 24/9", g.VisitorTeamID, g.HomeTeamID)
+	}
+	if g.VisitorScore != 15 || g.HomeScore != 11 {
+		t.Errorf("game0 score = %d-%d, want 15-11", g.VisitorScore, g.HomeScore)
+	}
+	if g.Date != "11-02" {
+		t.Errorf("game0 date = %q, want 11-02", g.Date)
+	}
+	if g.GameType != 0 {
+		t.Errorf("game0 GameType = %d, want 0 (.sco has no game type)", g.GameType)
+	}
+	// 4 non-empty slots: visitor player + visitor total + home player + home total.
+	if len(g.Boxes) != 4 {
+		t.Fatalf("game0 boxes = %d, want 4", len(g.Boxes))
+	}
+
+	var vp *ScoBox
+	visPts, homePts := 0, 0
+	for i := range g.Boxes {
+		b := &g.Boxes[i]
+		if b.PlayerID == 6328 {
+			vp = b
+		}
+		if b.PlayerID != 0 { // exclude team totals
+			pts := 2*b.TwoGM + b.FTM + 3*b.ThreeGM
+			if b.TeamID == g.VisitorTeamID {
+				visPts += pts
+			} else {
+				homePts += pts
+			}
+		}
+	}
+	if vp == nil {
+		t.Fatal("visitor player pid 6328 not found")
+	}
+	if vp.TeamID != 24 || vp.Min != 30 || vp.TwoGM != 2 || vp.TwoGA != 5 || vp.FTM != 5 || vp.ThreeGM != 2 || vp.PF != 3 {
+		t.Errorf("visitor player box = %+v", *vp)
+	}
+	// 2-point-only reconciliation: player points must equal the header score.
+	if visPts != g.VisitorScore || homePts != g.HomeScore {
+		t.Errorf("reconstructed pts vis=%d home=%d, want %d/%d", visPts, homePts, g.VisitorScore, g.HomeScore)
+	}
+
+	if games[1].VisitorTeamID != 5 || games[1].HomeTeamID != 7 || games[1].VisitorScore != 10 {
+		t.Errorf("game1 = %+v", games[1])
+	}
+}
+
+// Row #3: a non-numeric slot field yields ErrBadField; a truncated final record
+// yields ErrShortRecord. Neither panics.
+func TestReadSco_Malformed(t *testing.T) {
+	slots := make([][]byte, 30)
+	for i := range slots {
+		slots[i] = []byte(strings.Repeat(" ", 53))
+	}
+	bad := buildSlot(scoSlotData{name: "Bad One", pid: 7})
+	copy(bad[26:28], "XY") // non-numeric 2GM
+	slots[0] = bad
+	rec := buildRecord(buildGameInfo(1, 2, 1, 1, [5]int{}, [5]int{}), slots)
+
+	_, err := ReadSco(strings.NewReader(scoHeader() + rec))
+	if !errors.Is(err, ErrBadField) {
+		t.Errorf("bad field: err = %v, want ErrBadField", err)
+	}
+
+	// Truncated: header + a partial record.
+	_, err = ReadSco(strings.NewReader(scoHeader() + strings.Repeat(" ", 1500)))
+	if !errors.Is(err, ErrShortRecord) {
+		t.Errorf("truncated: err = %v, want ErrShortRecord", err)
+	}
+
+	// Header itself too short.
+	_, err = ReadSco(strings.NewReader("not a real sco"))
+	if !errors.Is(err, ErrShortRecord) {
+		t.Errorf("short header: err = %v, want ErrShortRecord", err)
+	}
+}
+
+// Row #4: header-only input and an all-padding record both yield an empty slice
+// with no panic and no spurious game.
+func TestReadSco_EmptyAndPadding(t *testing.T) {
+	games, err := ReadSco(strings.NewReader(scoHeader()))
+	if err != nil {
+		t.Fatalf("header-only: %v", err)
+	}
+	if len(games) != 0 {
+		t.Errorf("header-only games = %d, want 0", len(games))
+	}
+
+	padding := buildRecord(buildGameInfo(0, 0, 0, 0, [5]int{}, [5]int{}), make([][]byte, 30))
+	games, err = ReadSco(strings.NewReader(scoHeader() + padding + padding))
+	if err != nil {
+		t.Fatalf("padding: %v", err)
+	}
+	if len(games) != 0 {
+		t.Errorf("all-padding games = %d, want 0", len(games))
+	}
+}


### PR DESCRIPTION
## Summary

First of a two-PR split of PR9 (offline JSB-engine fidelity harness). Delivers the **readers only**: a new pure-Go `engine/internal/backup` package that reads the JSB 5.60 backup triple — `.plr` (roster), `.sch` (schedule), `.sco` (box-score corpus) — into in-memory structs, plus a `.plr`+`.sch` → `bundle.Bundle` assembler so a backup can drive the engine through the existing stdin→stdout contract. PR9b (stacks on this) is the distributional comparison/tolerance harness that consumes these readers.

All files are fixed-width ASCII slicers mirroring the authoritative PHP parsers (`PlrLineParser`, `ScoFileParser`, `SchFileParser`, `Boxscore`/`PlayerStats`). No `encoding/binary`, no new dependencies (stdlib only).

## Key Phase-0 findings (corrections to the plan)

- **`.plr` column offsets are identical across JSB 5.60 and 5.99** (verified by diffing real records) → no version guard; the reader is version-stable.
- **`.sco` slot "FGM/FGA" are 2-point-only** (`game_2gm`/`game_2ga`), **NOT** total field goals. Confirmed two ways: `BoxscoreProcessor::processGameLine` writes the slot value straight into `game_2gm` with no `fgm-3gm` subtraction, and a real-corpus reconciliation against `ibl5/IBL5.sco` shows Σ(2·2GM + FTM + 3·3GM) == the game-info quarter-score sum (132==132, 131==131). So the `.sco` 2GM compares to the engine's emitted 2GM directly — **no derivation**. (The plan's "total-FG, derive `fgm-3gm`" nuance was fabricated and is dropped.)
- **`r_foul`/`stamina`/`dc_minutes` are absent from the `.plr` format** (DB-only columns / sourced from `.plb`) → zeroed during assembly and documented. The ODPT rating mapping (`r_drive_off←ratingDO`, `r_trans_off←ratingTO`, etc.) is confirmed byte-compatible with the DB path (`PlrParserService.php`).

## Verification

All 14 matrix rows automated: pre-impl baseline green; 12 unit-test rows (`*_test.go`) covering parse/negative/boundary/round-trip/smoke/determinism; `go build && go vet && go test ./...` green and gofmt-clean. Readers were additionally cross-checked against the real in-repo corpus before the synthetic fixtures were committed (breaks fixture circularity).

## Manual Testing

No manual testing needed — all changes are covered by unit tests (the engine has no UI/DB/HTTP surface).

Generated with [Claude Code](https://claude.ai/code)