### PR TITLE
engine(validate): PR9b — offline distributional validation harness

### DIFF
--- a/engine/cmd/jsbvalidate/main.go
+++ b/engine/cmd/jsbvalidate/main.go
@@ -1,0 +1,77 @@
+// Command jsbvalidate is the offline distributional fidelity harness CLI for
+// the JSB native engine (PR9b). It reads a directory of JSB 5.60 backup triples
+// (.plr/.sch/.sco), runs the engine N seeded times per corpus game, aggregates
+// per-team/per-stat distributions, and compares them against the .sco
+// ground-truth aggregates within tolerance bands — printing a PASS/FAIL report
+// and exiting nonzero on any out-of-band stat, unmatched game, or read error.
+//
+// Usage:
+//
+//	jsbvalidate --corpus <dir> [--runs N] [--seed S] [--game-type T]
+//
+// The bar is statistical, not byte-exact: the Go engine's RNG differs from
+// jumpshot.exe, so validation is aggregate-within-tolerance over many seeds.
+//
+// --game-type stamps every assembled game, since neither the .sch nor the .sco
+// carries one. It defaults to 2 (regular season). A corpus of playoff (4) or
+// all-star (5/6) backups MUST be run with the matching type, or the regular
+// vs. non-regular basis mismatch makes the comparison meaningless. The
+// tolerance bands are STARTING values pending corpus calibration (see the PR9b
+// plan, OPEN #1), so a FAIL today is a diagnostic, not necessarily a bug.
+//
+// This CLI is developer-/nightly-invoked only — it is NOT wired into CI; the
+// corpus files are large and not in the repo.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is the testable entrypoint: it takes args and output streams explicitly
+// so tests can drive it without the process globals. It returns the process
+// exit code (0 = all stats in band, nonzero = any FAIL, unmatched game, or
+// usage/read error).
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("jsbvalidate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	corpus := fs.String("corpus", "", "directory of .plr/.sch/.sco backup triples (required)")
+	runs := fs.Int("runs", 200, "seeded engine runs per corpus game")
+	seed := fs.Uint64("seed", 0, "base seed; per-game seeds derive deterministically from it")
+	gameType := fs.Int("game-type", int(bundle.GameTypeRegular),
+		"JSB game type stamped on every game: 2/3 regular, 4 playoff, 5/6 all-star")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *corpus == "" {
+		fmt.Fprintln(stderr, "jsbvalidate: --corpus <dir> is required")
+		return 2
+	}
+	switch *gameType {
+	case 2, 3, 4, 5, 6: // regular / regular-alt / playoff / all-star A / all-star B
+	default:
+		fmt.Fprintf(stderr, "jsbvalidate: invalid --game-type %d (valid: 2,3 regular; 4 playoff; 5,6 all-star)\n", *gameType)
+		return 2
+	}
+	gt := bundle.GameType(*gameType)
+
+	rep, err := validate.ValidateCorpus(*corpus, *runs, *seed, gt)
+	if err != nil {
+		fmt.Fprintln(stderr, "jsbvalidate:", err)
+		return 1
+	}
+	validate.WriteReport(stdout, rep)
+	if !rep.Pass {
+		return 1
+	}
+	return 0
+}

--- a/engine/cmd/jsbvalidate/main_test.go
+++ b/engine/cmd/jsbvalidate/main_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+const cmdRuns = 5
+
+// --- compact fixed-width encoders (inverse of the PR9a backup readers) ------
+//
+// Duplicated in miniature from internal/validate/fixtures_test.go because test
+// helpers are not exported across packages. They write just enough of a
+// .plr/.sch/.sco triple to drive the engine through the CLI.
+
+func putRJ(buf []byte, off, w, v int) { copy(buf[off:off+w], fmt.Sprintf("%*d", w, v)) }
+func putStr(buf []byte, off, w int, s string) {
+	if len(s) > w {
+		s = s[:w]
+	}
+	copy(buf[off:off+w], s)
+}
+
+func plrRecord(ordinal, pid, teamID, slot, fgp int, name string) []byte {
+	buf := make([]byte, 607)
+	for i := range buf {
+		buf[i] = ' '
+	}
+	putRJ(buf, 0, 4, ordinal)
+	putStr(buf, 4, 32, name)
+	putRJ(buf, 36, 2, 27)
+	putRJ(buf, 38, 6, pid)
+	putRJ(buf, 44, 2, teamID)
+	putRJ(buf, 46, 4, 27)
+	putStr(buf, 50, 2, "PG")
+	putRJ(buf, 128, 2, 5)
+	putRJ(buf, 130, 2, 5)
+	putRJ(buf, []int{132, 133, 134, 135, 136}[slot], 1, 1)
+	putRJ(buf, 137, 1, 1)
+	putRJ(buf, 268, 2, 50)
+	putRJ(buf, 270, 2, 50)
+	putRJ(buf, 272, 2, 50)
+	putRJ(buf, 555, 3, 60)
+	putRJ(buf, 558, 3, fgp)
+	putRJ(buf, 561, 3, 20)
+	putRJ(buf, 564, 3, 75)
+	putRJ(buf, 567, 3, 25)
+	putRJ(buf, 570, 3, 33)
+	putRJ(buf, 573, 3, 20)
+	putRJ(buf, 576, 3, 35)
+	putRJ(buf, 579, 3, 30)
+	putRJ(buf, 582, 3, 30)
+	putRJ(buf, 585, 3, 40)
+	putRJ(buf, 588, 3, 20)
+	putRJ(buf, 591, 2, 6)
+	putRJ(buf, 593, 2, 5)
+	putRJ(buf, 595, 2, 5)
+	putRJ(buf, 597, 2, 7)
+	putRJ(buf, 599, 2, 5)
+	putRJ(buf, 601, 2, 5)
+	putRJ(buf, 603, 2, 5)
+	putRJ(buf, 605, 2, 5)
+	return buf
+}
+
+func writePlr(t *testing.T, path string) {
+	t.Helper()
+	var recs []string
+	ord, pid := 0, 100
+	for _, tm := range []struct{ id, fgp int }{{7, 46}, {3, 50}} {
+		for slot := 0; slot < 5; slot++ {
+			ord++
+			pid++
+			recs = append(recs, string(plrRecord(ord, pid, tm.id, slot, tm.fgp, fmt.Sprintf("P%d", pid))))
+		}
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(recs, "\r\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeSch(t *testing.T, path string, vis, home, vScore, hScore int) {
+	t.Helper()
+	buf := make([]byte, 80000)
+	for i := 0; i < 8000; i++ {
+		copy(buf[i*10:], "0   0     ")
+	}
+	teams := fmt.Sprintf("%d%02d", vis, home)
+	for len(teams) < 4 {
+		teams += " "
+	}
+	scores := fmt.Sprintf("%d%03d", vScore, hScore)
+	for len(scores) < 6 {
+		scores += " "
+	}
+	copy(buf[0:10], teams[:4]+scores[:6])
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type box struct {
+	pid                                                int
+	twoGM, twoGA, ftm, fta, threeGM, threeGA, orb, drb int
+	ast, stl, tov, blk, pf                             int
+}
+
+func putSlot(rec []byte, idx int, b box) {
+	base := 58 + idx*53
+	putStr(rec, base, 16, fmt.Sprintf("PL%d", b.pid))
+	putStr(rec, base+16, 2, "PG")
+	putRJ(rec, base+18, 6, b.pid)
+	putRJ(rec, base+24, 2, 30)
+	putRJ(rec, base+26, 2, b.twoGM)
+	putRJ(rec, base+28, 3, b.twoGA)
+	putRJ(rec, base+31, 2, b.ftm)
+	putRJ(rec, base+33, 2, b.fta)
+	putRJ(rec, base+35, 2, b.threeGM)
+	putRJ(rec, base+37, 2, b.threeGA)
+	putRJ(rec, base+39, 2, b.orb)
+	putRJ(rec, base+41, 2, b.drb)
+	putRJ(rec, base+43, 2, b.ast)
+	putRJ(rec, base+45, 2, b.stl)
+	putRJ(rec, base+47, 2, b.tov)
+	putRJ(rec, base+49, 2, b.blk)
+	putRJ(rec, base+51, 2, b.pf)
+}
+
+func writeSco(t *testing.T, path string, vis, home, vScore, hScore int, visBox, homeBox box) {
+	t.Helper()
+	rec := make([]byte, 2000)
+	for i := range rec {
+		rec[i] = ' '
+	}
+	putRJ(rec, 6, 2, vis-1)
+	putRJ(rec, 8, 2, home-1)
+	putRJ(rec, 28, 3, vScore)
+	putRJ(rec, 43, 3, hScore)
+	putSlot(rec, 0, visBox)
+	putSlot(rec, 15, homeBox)
+	data := append([]byte(strings.Repeat(" ", 1_000_000)), rec...)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func round(f float64) int {
+	if f < 0 {
+		return int(f - 0.5)
+	}
+	return int(f + 0.5)
+}
+
+// boxFromMeans builds a .sco player row whose summed stats reproduce the rounded
+// per-stat means for one team.
+func boxFromMeans(pid int, m map[string]float64) box {
+	tgm, tga := round(m["tgm"]), round(m["tga"])
+	return box{
+		pid:     pid,
+		twoGM:   round(m["fgm"]) - tgm,
+		twoGA:   round(m["fga"]) - tga,
+		ftm:     round(m["ftm"]),
+		fta:     round(m["fta"]),
+		threeGM: tgm,
+		threeGA: tga,
+		orb:     round(m["reb"]),
+		ast:     round(m["ast"]),
+		stl:     round(m["stl"]),
+		tov:     round(m["tov"]),
+		blk:     round(m["blk"]),
+		pf:      round(m["pf"]),
+	}
+}
+
+// buildCorpus writes a one-game synthetic triple. It first runs the harness on a
+// placeholder .sco (scores 1-1, matching the placeholder .sch) to read the
+// engine's observed means from the exported Report, then rewrites the .sch/.sco
+// with real scores and either means-engineered boxes (inBand → PASS) or zeroed
+// boxes (out of band → FAIL).
+func buildCorpus(t *testing.T, dir string, inBand bool, runs int, seed uint64) {
+	t.Helper()
+	plr := filepath.Join(dir, "synth.plr")
+	sch := filepath.Join(dir, "synth.sch")
+	sco := filepath.Join(dir, "synth.sco")
+	writePlr(t, plr)
+	writeSch(t, sch, 7, 3, 1, 1)
+	writeSco(t, sco, 7, 3, 1, 1, box{pid: 1}, box{pid: 2})
+
+	rep, err := validate.ValidateCorpus(dir, runs, seed, bundle.GameTypeRegular)
+	if err != nil {
+		t.Fatalf("placeholder ValidateCorpus: %v", err)
+	}
+	if len(rep.Games) != 1 {
+		t.Fatalf("placeholder report games = %d, want 1", len(rep.Games))
+	}
+	means := map[int]map[string]float64{7: {}, 3: {}}
+	for _, r := range rep.Games[0].Rows {
+		means[r.TeamID][r.Stat] = r.EngineMean
+	}
+	visPts, homePts := round(means[7]["points"]), round(means[3]["points"])
+
+	writeSch(t, sch, 7, 3, visPts, homePts)
+	if inBand {
+		writeSco(t, sco, 7, 3, visPts, homePts, boxFromMeans(1, means[7]), boxFromMeans(2, means[3]))
+	} else {
+		writeSco(t, sco, 7, 3, visPts, homePts, box{pid: 1}, box{pid: 2})
+	}
+}
+
+// Row #10: the CLI prints a PASS report and exits 0 on an in-band corpus, and
+// prints FAIL rows and exits nonzero on an out-of-band corpus.
+func TestRun_PassAndFail(t *testing.T) {
+	passDir := t.TempDir()
+	buildCorpus(t, passDir, true, cmdRuns, 1000)
+	var out, errBuf bytes.Buffer
+	code := run([]string{"--corpus", passDir, "--runs", fmt.Sprint(cmdRuns), "--seed", "1000"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("in-band CLI exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, out.String(), errBuf.String())
+	}
+	if !strings.Contains(out.String(), "RESULT: PASS") {
+		t.Errorf("expected a PASS result line, got:\n%s", out.String())
+	}
+
+	failDir := t.TempDir()
+	buildCorpus(t, failDir, false, cmdRuns, 1000)
+	out.Reset()
+	errBuf.Reset()
+	code = run([]string{"--corpus", failDir, "--runs", fmt.Sprint(cmdRuns), "--seed", "1000"}, &out, &errBuf)
+	if code == 0 {
+		t.Fatalf("out-of-band CLI exit = 0, want nonzero\nstdout:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "RESULT: FAIL") {
+		t.Errorf("expected a FAIL result line, got:\n%s", out.String())
+	}
+}
+
+// Row #11: the CLI is deterministic — two invocations on the same corpus with
+// the same --seed/--runs produce byte-identical reports.
+func TestRun_Deterministic(t *testing.T) {
+	dir := t.TempDir()
+	buildCorpus(t, dir, true, cmdRuns, 2024)
+	args := []string{"--corpus", dir, "--runs", fmt.Sprint(cmdRuns), "--seed", "2024"}
+
+	var a, b bytes.Buffer
+	if code := run(args, &a, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("run 1 exit = %d", code)
+	}
+	if code := run(args, &b, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("run 2 exit = %d", code)
+	}
+	if a.String() != b.String() {
+		t.Errorf("CLI output not byte-identical across runs:\n--- run1 ---\n%s\n--- run2 ---\n%s", a.String(), b.String())
+	}
+}
+
+// Negative: a missing --corpus is a usage error (exit 2), not a panic.
+func TestRun_MissingCorpus(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := run(nil, &out, &errBuf); code != 2 {
+		t.Fatalf("missing --corpus exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "--corpus") {
+		t.Errorf("expected a --corpus usage message, got: %q", errBuf.String())
+	}
+}
+
+// Negative: an invalid --game-type is rejected with a usage error (exit 2).
+func TestRun_InvalidGameType(t *testing.T) {
+	dir := t.TempDir()
+	buildCorpus(t, dir, true, cmdRuns, 1)
+	var out, errBuf bytes.Buffer
+	code := run([]string{"--corpus", dir, "--game-type", "9"}, &out, &errBuf)
+	if code != 2 {
+		t.Fatalf("invalid --game-type exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "invalid --game-type") {
+		t.Errorf("expected an invalid game-type message, got: %q", errBuf.String())
+	}
+}

--- a/engine/internal/backup/plr.go
+++ b/engine/internal/backup/plr.go
@@ -17,7 +17,21 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"unicode"
 )
+
+// trimPad strips leading/trailing field padding. Real backup files pad fixed-
+// width fields with spaces in most records but with NUL bytes (0x00) in the
+// trailing padding records of a .sco corpus, so trimming whitespace alone leaves
+// "\x00\x00" in a numeric/name field and turns a padding record into a parse
+// error. Treating NUL as padding (alongside any Unicode space) lets those
+// records collapse to "" and be skipped, matching how space-padded records are
+// already handled.
+func trimPad(s string) string {
+	return strings.TrimFunc(s, func(r rune) bool {
+		return r == 0 || unicode.IsSpace(r)
+	})
+}
 
 // .plr 607-byte record offsets, transcribed verbatim from
 // ibl5/classes/PlrParser/PlrLineParser.php (the authoritative reader). Only the
@@ -257,7 +271,7 @@ func decodeCP1252(s string) string {
 			} // 0 = undefined CP1252 code point; drop it (iconv //IGNORE)
 		}
 	}
-	return strings.TrimSpace(b.String())
+	return trimPad(b.String())
 }
 
 // cp1252High maps the 0x80-0x9F range where CP1252 diverges from Latin-1. A 0

--- a/engine/internal/backup/sco.go
+++ b/engine/internal/backup/sco.go
@@ -68,8 +68,11 @@ const (
 	slotPF      = 51 // width 2
 )
 
-// ErrShortRecord reports a .sco input that ends mid-record (truncated header or
-// a trailing partial 2,000-byte record). It names the offending record index.
+// ErrShortRecord reports a .sco input that ends mid-record: a truncated header,
+// or a trailing record shorter than the game-info + slot content
+// (scoContentSize). A trailing record that carries full content but omits its
+// padding is NOT an error — real files end that way (see ReadSco). It names the
+// offending record index.
 var ErrShortRecord = errors.New("backup: truncated .sco record")
 
 // ScoBox is one slot's stat line from a .sco game. TwoGM/TwoGA are 2-point-only
@@ -115,7 +118,9 @@ type ScoGame struct {
 // 1,000,000-byte header, then decodes each 2,000-byte record. Records with no
 // non-empty player slot are padding and are skipped (mirroring the PHP
 // gameLinesProcessed > 0 gate), so the real sparse corpus does not emit phantom
-// games. A truncated header or trailing partial record yields ErrShortRecord; a
+// games. The LAST record may omit its trailing padding (real files end after
+// the scoContentSize content); it is still decoded. A truncated header, or a
+// trailing record shorter than scoContentSize, yields ErrShortRecord; a
 // non-numeric slot field yields ErrBadField — never a panic.
 func ReadSco(r io.Reader) ([]ScoGame, error) {
 	data, err := io.ReadAll(r)

--- a/engine/internal/backup/sco.go
+++ b/engine/internal/backup/sco.go
@@ -19,6 +19,14 @@ const (
 	scoSlotSize     = 53
 	scoSlotCount    = 30
 	scoVisitorSlots = 15 // slots 0..14 visitor, 15..29 home
+
+	// scoContentSize is the live portion of a record: the game-info header plus
+	// the 30 player/team slots, before the trailing padding that rounds each
+	// record up to scoRecordSize. Real .sco files write this padding between
+	// records but omit it after the LAST record, so the file can end with a
+	// content-only (1,648-byte) final record. ReadSco tolerates that tail as long
+	// as the full content is present.
+	scoContentSize = scoGameInfoSize + scoSlotCount*scoSlotSize // 1648
 )
 
 // Game-info sub-offsets, from Boxscore::fillGameInfo. Team IDs and the date are
@@ -121,10 +129,18 @@ func ReadSco(r io.Reader) ([]ScoGame, error) {
 	games := make([]ScoGame, 0)
 	recIdx := 0
 	for off := scoHeaderSize; off < len(data); off, recIdx = off+scoRecordSize, recIdx+1 {
-		if off+scoRecordSize > len(data) {
-			return nil, fmt.Errorf("%w: record %d at offset %d has only %d of %d bytes", ErrShortRecord, recIdx, off, len(data)-off, scoRecordSize)
+		end := off + scoRecordSize
+		if end > len(data) {
+			// The final record may omit its trailing padding. Decode it as long as
+			// the full game-info + slot content is present; anything shorter is a
+			// genuinely truncated record.
+			if len(data)-off >= scoContentSize {
+				end = len(data)
+			} else {
+				return nil, fmt.Errorf("%w: record %d at offset %d has only %d of %d bytes", ErrShortRecord, recIdx, off, len(data)-off, scoRecordSize)
+			}
 		}
-		rec := string(data[off : off+scoRecordSize])
+		rec := string(data[off:end])
 		game, ok, err := decodeScoRecord(rec, recIdx)
 		if err != nil {
 			return nil, err
@@ -261,7 +277,7 @@ func scoSlice(s string, off, width int) string {
 }
 
 func scoInt(s string, off, width, recIdx int) (int, error) {
-	t := strings.TrimSpace(scoSlice(s, off, width))
+	t := trimPad(scoSlice(s, off, width))
 	if t == "" {
 		return 0, nil
 	}

--- a/engine/internal/backup/sco_padding_test.go
+++ b/engine/internal/backup/sco_padding_test.go
@@ -1,0 +1,59 @@
+package backup
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// These tests lock in the two real-corpus .sco quirks discovered when the PR9b
+// harness was first run against an actual JSB 5.60 backup (the synthetic PR9a
+// fixtures only ever used space padding and fully-padded records):
+//   1. trailing padding records are filled with NUL bytes (0x00), not spaces;
+//   2. the LAST record omits its trailing padding, ending after the 1,648-byte
+//      game-info + slot content.
+
+// A NUL-filled padding record must be skipped like a space-filled one, not
+// rejected as a non-numeric field.
+func TestReadSco_NullPaddingRecordSkipped(t *testing.T) {
+	gi := buildGameInfo(6, 8, 0, 0, [5]int{50}, [5]int{48})
+	real := buildRecord(gi, [][]byte{buildSlot(scoSlotData{name: "PLAYER", pid: 11, twoGM: 5, twoGA: 10})})
+	nullRec := strings.Repeat("\x00", scoRecordSize)
+	data := scoHeader() + real + nullRec
+
+	games, err := ReadSco(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadSco with a NUL padding record: %v", err)
+	}
+	if len(games) != 1 {
+		t.Fatalf("games = %d, want 1 (the NUL-filled record must be skipped as padding)", len(games))
+	}
+}
+
+// The final record may carry only its 1,648-byte content with no trailing
+// padding; ReadSco must still decode it rather than report truncation.
+func TestReadSco_UnpaddedFinalRecord(t *testing.T) {
+	gi := buildGameInfo(6, 8, 0, 0, [5]int{50}, [5]int{48})
+	full := buildRecord(gi, [][]byte{buildSlot(scoSlotData{name: "PLAYER", pid: 11, twoGM: 5, twoGA: 10})})
+	contentOnly := full[:scoContentSize] // drop the trailing padding
+	data := scoHeader() + contentOnly
+
+	games, err := ReadSco(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadSco with an unpadded final record: %v", err)
+	}
+	if len(games) != 1 {
+		t.Fatalf("games = %d, want 1 (the unpadded final record must decode)", len(games))
+	}
+	if games[0].VisitorTeamID != 7 {
+		t.Errorf("visitor team = %d, want 7", games[0].VisitorTeamID)
+	}
+}
+
+// A trailing record shorter than the content size is still a genuine truncation.
+func TestReadSco_ShortFinalRecordErrors(t *testing.T) {
+	data := scoHeader() + strings.Repeat(" ", scoContentSize-1)
+	if _, err := ReadSco(strings.NewReader(data)); !errors.Is(err, ErrShortRecord) {
+		t.Fatalf("err = %v, want ErrShortRecord for a sub-content-size tail", err)
+	}
+}

--- a/engine/internal/validate/aggregate.go
+++ b/engine/internal/validate/aggregate.go
@@ -1,0 +1,165 @@
+// Package validate is the offline distributional fidelity harness (PR9b). It
+// takes a JSB 5.60 backup triple (.plr/.sch/.sco, read via the backup package
+// from PR9a), runs the native engine N seeded times per corpus game, aggregates
+// per-team/per-stat distributions, and compares the observed engine means
+// against the .sco ground-truth aggregates within tolerance bands.
+//
+// The bar is statistical, not byte-exact: the Go engine's RNG differs from
+// jumpshot.exe, so a single game never reproduces a specific .sco line. A stat
+// PASSES when the .sco value lies inside the tolerance band around the observed
+// engine mean (see compare.go / bands.go). The whole harness is reproducible
+// from a base seed.
+//
+// The aggregation/comparison/driver code in this file (and bands.go, compare.go,
+// harness.go) is normally compiled and unit-tested by `go test ./...`. Only the
+// large real-corpus suite (validate_test.go) is build-tag-gated behind
+// `//go:build validate`.
+package validate
+
+import (
+	"github.com/a-jay85/IBL5/engine/internal/backup"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+)
+
+// statNames is the fixed, ordered set of compared aggregates. Iterating this
+// slice (never a map) keeps every report deterministic. Team points is the
+// headline; the rest catch a model that gets points right by a wrong shot mix.
+//
+// "fgm"/"fga" are TOTAL field goals on BOTH sides: the engine emits 2-point-only
+// makes (Game2GM) plus threes (Game3GM), and the .sco likewise stores 2-point
+// makes (TwoGM) separate from threes (ThreeGM) — there is no pre-summed total-FG
+// field in either, so total FG is reconstructed by summing 2pt+3pt on each side.
+// "tgm"/"tga" isolate the three-point component so a wrong 2pt/3pt mix that
+// nets the same total FG still surfaces.
+var statNames = []string{
+	"points", "fgm", "fga", "ftm", "fta", "tgm", "tga",
+	"reb", "ast", "stl", "tov", "blk", "pf",
+}
+
+// TeamStat is one team's compared aggregates for one game, normalized to a
+// single basis so the engine side and the .sco side are directly comparable.
+type TeamStat struct {
+	Points int
+	FGM    int // total field goals made = 2pt makes + 3pt makes
+	FGA    int // total field goals attempted = 2pt att + 3pt att
+	FTM    int
+	FTA    int
+	TGM    int // three-point makes
+	TGA    int // three-point attempts
+	REB    int // total rebounds = ORB + DRB
+	AST    int
+	STL    int
+	TOV    int
+	BLK    int
+	PF     int
+}
+
+// value returns the named stat. The name must be one of statNames; an unknown
+// name returns 0 (the caller only ever passes statNames entries).
+func (s TeamStat) value(name string) int {
+	switch name {
+	case "points":
+		return s.Points
+	case "fgm":
+		return s.FGM
+	case "fga":
+		return s.FGA
+	case "ftm":
+		return s.FTM
+	case "fta":
+		return s.FTA
+	case "tgm":
+		return s.TGM
+	case "tga":
+		return s.TGA
+	case "reb":
+		return s.REB
+	case "ast":
+		return s.AST
+	case "stl":
+		return s.STL
+	case "tov":
+		return s.TOV
+	case "blk":
+		return s.BLK
+	case "pf":
+		return s.PF
+	default:
+		return 0
+	}
+}
+
+// teamStatFromBox normalizes one engine TeamBox to the comparison basis: points
+// are the quarter totals plus every overtime period, total FG is 2GM+3GM (and
+// 2GA+3GA), and rebounds are ORB+DRB.
+func teamStatFromBox(tb result.TeamBox) TeamStat {
+	points := tb.Q1 + tb.Q2 + tb.Q3 + tb.Q4
+	for _, ot := range tb.OT {
+		points += ot
+	}
+	return TeamStat{
+		Points: points,
+		FGM:    tb.Game2GM + tb.Game3GM,
+		FGA:    tb.Game2GA + tb.Game3GA,
+		FTM:    tb.GameFTM,
+		FTA:    tb.GameFTA,
+		TGM:    tb.Game3GM,
+		TGA:    tb.Game3GA,
+		REB:    tb.GameORB + tb.GameDRB,
+		AST:    tb.GameAST,
+		STL:    tb.GameSTL,
+		TOV:    tb.GameTOV,
+		BLK:    tb.GameBLK,
+		PF:     tb.GamePF,
+	}
+}
+
+// teamStatFromSco normalizes the .sco ground truth for one team to the same
+// basis. Points come from the authoritative summed quarter scores in the
+// game-info header (VisitorScore/HomeScore); the shooting/rebound/etc. totals
+// are summed over that team's PLAYER rows. The PlayerID==0 team-total row is
+// deliberately skipped so the player rows are not double-counted.
+func teamStatFromSco(sg backup.ScoGame, teamID int) TeamStat {
+	ts := TeamStat{}
+	switch teamID {
+	case sg.VisitorTeamID:
+		ts.Points = sg.VisitorScore
+	case sg.HomeTeamID:
+		ts.Points = sg.HomeScore
+	}
+	for _, b := range sg.Boxes {
+		if b.TeamID != teamID || b.PlayerID == 0 {
+			continue // other team, or the team-total row (avoid double-count)
+		}
+		ts.FGM += b.TwoGM + b.ThreeGM
+		ts.FGA += b.TwoGA + b.ThreeGA
+		ts.FTM += b.FTM
+		ts.FTA += b.FTA
+		ts.TGM += b.ThreeGM
+		ts.TGA += b.ThreeGA
+		ts.REB += b.ORB + b.DRB
+		ts.AST += b.AST
+		ts.STL += b.STL
+		ts.TOV += b.TOV
+		ts.BLK += b.BLK
+		ts.PF += b.PF
+	}
+	return ts
+}
+
+// mean returns the per-stat mean across the N sampled TeamStats (one per seeded
+// run). The result is keyed by statNames; an empty input yields a zero map.
+func mean(samples []TeamStat) map[string]float64 {
+	out := make(map[string]float64, len(statNames))
+	if len(samples) == 0 {
+		return out
+	}
+	for _, name := range statNames {
+		sum := 0
+		for _, s := range samples {
+			sum += s.value(name)
+		}
+		out[name] = float64(sum) / float64(len(samples))
+	}
+	return out
+}

--- a/engine/internal/validate/aggregate_test.go
+++ b/engine/internal/validate/aggregate_test.go
@@ -1,0 +1,81 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/backup"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+)
+
+// Row #2: teamStatFromBox normalizes the engine TeamBox to the comparison basis
+// — points = quarters + every OT period, total FG = 2GM+3GM (and 2GA+3GA),
+// rebounds = ORB+DRB, threes isolated.
+func TestTeamStatFromBox(t *testing.T) {
+	tb := result.TeamBox{
+		TeamID: 7,
+		Q1:     20, Q2: 22, Q3: 18, Q4: 25, OT: []int{8, 6},
+		Game2GM: 30, Game2GA: 60, GameFTM: 14, GameFTA: 18,
+		Game3GM: 9, Game3GA: 24, GameORB: 12, GameDRB: 33,
+		GameAST: 21, GameSTL: 8, GameTOV: 13, GameBLK: 5, GamePF: 19,
+	}
+	got := teamStatFromBox(tb)
+	want := TeamStat{
+		Points: 20 + 22 + 18 + 25 + 8 + 6, // quarters + both OT periods
+		FGM:    30 + 9, FGA: 60 + 24,
+		FTM: 14, FTA: 18,
+		TGM: 9, TGA: 24,
+		REB: 12 + 33,
+		AST: 21, STL: 8, TOV: 13, BLK: 5, PF: 19,
+	}
+	if got != want {
+		t.Errorf("teamStatFromBox =\n %+v\nwant\n %+v", got, want)
+	}
+}
+
+// Row #2: teamStatFromSco sums the team's PLAYER rows on the same basis, takes
+// points from the authoritative header score, and SKIPS the PlayerID==0
+// team-total row so player stats are never double-counted (advisor blind-spot).
+func TestTeamStatFromSco_SkipsTeamTotalRow(t *testing.T) {
+	sg := backup.ScoGame{
+		VisitorTeamID: 7, HomeTeamID: 3,
+		VisitorScore: 101, HomeScore: 99,
+		Boxes: []backup.ScoBox{
+			// Two visitor player rows.
+			{TeamID: 7, PlayerID: 11, TwoGM: 8, TwoGA: 15, FTM: 4, FTA: 5, ThreeGM: 2, ThreeGA: 6, ORB: 3, DRB: 5, AST: 6, STL: 2, TOV: 3, BLK: 1, PF: 4},
+			{TeamID: 7, PlayerID: 12, TwoGM: 6, TwoGA: 12, FTM: 2, FTA: 2, ThreeGM: 1, ThreeGA: 3, ORB: 2, DRB: 7, AST: 4, STL: 1, TOV: 2, BLK: 0, PF: 3},
+			// Visitor TEAM-TOTAL row (PID==0): must be ignored, not summed.
+			{TeamID: 7, PlayerID: 0, TwoGM: 999, TwoGA: 999, FTM: 999, ThreeGM: 999, ORB: 999, AST: 999},
+			// A home player row — must not leak into the visitor total.
+			{TeamID: 3, PlayerID: 21, TwoGM: 50, TwoGA: 99, ThreeGM: 9, ORB: 9, AST: 9},
+		},
+	}
+	got := teamStatFromSco(sg, 7)
+	want := TeamStat{
+		Points: 101, // from header, not box sum
+		FGM:    (8 + 2) + (6 + 1), FGA: (15 + 6) + (12 + 3),
+		FTM: 4 + 2, FTA: 5 + 2,
+		TGM: 2 + 1, TGA: 6 + 3,
+		REB: (3 + 5) + (2 + 7),
+		AST: 6 + 4, STL: 2 + 1, TOV: 3 + 2, BLK: 1 + 0, PF: 4 + 3,
+	}
+	if got != want {
+		t.Errorf("teamStatFromSco(visitor) =\n %+v\nwant\n %+v", got, want)
+	}
+	if home := teamStatFromSco(sg, 3); home.Points != 99 {
+		t.Errorf("home points = %d, want 99 (header)", home.Points)
+	}
+}
+
+func TestMean(t *testing.T) {
+	samples := []TeamStat{
+		{Points: 100, FGM: 40},
+		{Points: 110, FGM: 42},
+	}
+	m := mean(samples)
+	if m["points"] != 105 || m["fgm"] != 41 {
+		t.Errorf("mean points=%v fgm=%v, want 105 / 41", m["points"], m["fgm"])
+	}
+	if got := mean(nil); len(got) != 0 {
+		t.Errorf("mean(nil) = %v, want empty", got)
+	}
+}

--- a/engine/internal/validate/bands.go
+++ b/engine/internal/validate/bands.go
@@ -1,0 +1,53 @@
+package validate
+
+// Band is one stat's tolerance: a value passes when it lies within
+// max(AbsFloor, RelPct×engineMean) of the observed engine mean (see compareStat).
+type Band struct {
+	RelPct   float64 // relative tolerance as a fraction of the engine mean
+	AbsFloor float64 // absolute floor so small means still get a usable band
+}
+
+// bands is the SINGLE source of truth for tolerance calibration — one named,
+// commented entry per compared stat. Edit ONLY this table to recalibrate.
+//
+// ┌──────────────────────────────────────────────────────────────────────────┐
+// │ STARTING BANDS — NOT AUTHORITATIVE. These ±15% relative / per-stat floor   │
+// │ values are a defensible placeholder, NOT grounded in measured corpus       │
+// │ variance. They MUST be calibrated by running `jsbvalidate` against the     │
+// │ real 5.60 corpus and widening/tightening each band to absorb (a) the       │
+// │ single-.sco-draw sampling noise (one .sco line is one draw from            │
+// │ jumpshot.exe's own distribution) AND (b) the engine-vs-jumpshot model gap, │
+// │ WITHOUT making any band so wide it can never fail. Until calibrated, the   │
+// │ tagged corpus suite is a DIAGNOSTIC, not a merge gate. See OPEN #1 in the  │
+// │ PR9b plan.                                                                 │
+// │                                                                            │
+// │ Note also: the backup-driven sim runs with no per-player minutes/stamina   │
+// │ signal (the .plr carries none — see backup.ToBundle), so the engine-side   │
+// │ distribution is wider than a DB-driven sim's; the bands must absorb that   │
+// │ too.                                                                       │
+// └──────────────────────────────────────────────────────────────────────────┘
+var bands = map[string]Band{
+	"points": {RelPct: 0.15, AbsFloor: 8},
+	"fgm":    {RelPct: 0.15, AbsFloor: 5},
+	"fga":    {RelPct: 0.15, AbsFloor: 6},
+	"ftm":    {RelPct: 0.15, AbsFloor: 3},
+	"fta":    {RelPct: 0.15, AbsFloor: 4},
+	"tgm":    {RelPct: 0.15, AbsFloor: 3},
+	"tga":    {RelPct: 0.15, AbsFloor: 4},
+	"reb":    {RelPct: 0.15, AbsFloor: 4},
+	"ast":    {RelPct: 0.15, AbsFloor: 4},
+	"stl":    {RelPct: 0.15, AbsFloor: 3},
+	"tov":    {RelPct: 0.15, AbsFloor: 3},
+	"blk":    {RelPct: 0.15, AbsFloor: 3},
+	"pf":     {RelPct: 0.15, AbsFloor: 4},
+}
+
+// bandFor returns the configured band for a stat, falling back to a generic
+// ±15%/floor-3 band for any stat not explicitly listed (defensive — every
+// statNames entry has an explicit band above).
+func bandFor(name string) Band {
+	if b, ok := bands[name]; ok {
+		return b
+	}
+	return Band{RelPct: 0.15, AbsFloor: 3}
+}

--- a/engine/internal/validate/compare.go
+++ b/engine/internal/validate/compare.go
@@ -1,0 +1,98 @@
+package validate
+
+import (
+	"fmt"
+	"math"
+)
+
+// StatRow is the comparison of one stat for one team in one game.
+type StatRow struct {
+	TeamID     int
+	Stat       string
+	ScoVal     float64 // the single .sco ground-truth observation
+	EngineMean float64 // observed engine mean across the N seeded runs
+	Tolerance  float64 // the band actually applied = max(absFloor, relPct×mean)
+	Pass       bool
+	Detail     string
+}
+
+// GameReport is the full comparison for one corpus game: every stat for both
+// teams. Pass is true only when every row passes.
+type GameReport struct {
+	VisitorTeamID int
+	HomeTeamID    int
+	Date          string
+	Pass          bool
+	Rows          []StatRow
+}
+
+// compareStat decides whether a single .sco value is within tolerance of the
+// observed engine mean. The band is max(absFloor, relPct×mean): the relative
+// term dominates for large means, the floor for small ones. The edge is
+// INCLUSIVE — a value exactly at the band boundary passes.
+func compareStat(name string, scoVal, engineMean float64, b Band) (pass bool, detail string) {
+	tol := b.AbsFloor
+	if rel := b.RelPct * math.Abs(engineMean); rel > tol {
+		tol = rel
+	}
+	diff := math.Abs(scoVal - engineMean)
+	pass = diff <= tol
+	verdict := "PASS"
+	if !pass {
+		verdict = "FAIL"
+	}
+	detail = fmt.Sprintf("%-6s %s sco=%.0f mean=%.2f |diff|=%.2f tol=%.2f",
+		name, verdict, scoVal, engineMean, diff, tol)
+	return pass, detail
+}
+
+// toleranceFor recomputes the applied band for reporting (mirrors compareStat).
+func toleranceFor(b Band, engineMean float64) float64 {
+	tol := b.AbsFloor
+	if rel := b.RelPct * math.Abs(engineMean); rel > tol {
+		tol = rel
+	}
+	return tol
+}
+
+// compareGame compares one .sco game's per-team ground truth against the
+// observed engine means for the same matchup. visMean/homeMean are keyed by
+// statNames (from mean()); visSco/homeSco are the .sco-derived TeamStats. Rows
+// are emitted in a fixed order — visitor stats then home stats, each in
+// statNames order — so the report is deterministic.
+func compareGame(visitorTeamID, homeTeamID int, date string, visSco, homeSco TeamStat, visMean, homeMean map[string]float64) GameReport {
+	gr := GameReport{
+		VisitorTeamID: visitorTeamID,
+		HomeTeamID:    homeTeamID,
+		Date:          date,
+		Pass:          true,
+	}
+	for _, side := range []struct {
+		teamID int
+		sco    TeamStat
+		means  map[string]float64
+	}{
+		{visitorTeamID, visSco, visMean},
+		{homeTeamID, homeSco, homeMean},
+	} {
+		for _, name := range statNames {
+			b := bandFor(name)
+			scoVal := float64(side.sco.value(name))
+			engineMean := side.means[name]
+			pass, detail := compareStat(name, scoVal, engineMean, b)
+			gr.Rows = append(gr.Rows, StatRow{
+				TeamID:     side.teamID,
+				Stat:       name,
+				ScoVal:     scoVal,
+				EngineMean: engineMean,
+				Tolerance:  toleranceFor(b, engineMean),
+				Pass:       pass,
+				Detail:     detail,
+			})
+			if !pass {
+				gr.Pass = false
+			}
+		}
+	}
+	return gr
+}

--- a/engine/internal/validate/compare_test.go
+++ b/engine/internal/validate/compare_test.go
@@ -1,0 +1,44 @@
+package validate
+
+import "testing"
+
+// Row #3: compareStat uses max(absFloor, relPct×mean) — the relative term
+// dominates for large means, the floor for small ones — and passes when the
+// .sco value is inside that band.
+func TestCompareStat_BandSelection(t *testing.T) {
+	b := Band{RelPct: 0.15, AbsFloor: 8}
+
+	// Large mean: relative band (0.15×100 = 15) dominates the floor (8).
+	if pass, _ := compareStat("points", 112, 100, b); !pass {
+		t.Error("sco 112 vs mean 100 should pass (within ±15 relative band)")
+	}
+	if pass, _ := compareStat("points", 120, 100, b); pass {
+		t.Error("sco 120 vs mean 100 should FAIL (outside ±15 relative band)")
+	}
+
+	// Small mean: floor (8) dominates the relative term (0.15×4 = 0.6).
+	if pass, _ := compareStat("ftm", 11, 4, b); !pass {
+		t.Error("sco 11 vs mean 4 should pass (within ±8 floor band)")
+	}
+	if pass, _ := compareStat("ftm", 13, 4, b); pass {
+		t.Error("sco 13 vs mean 4 should FAIL (outside ±8 floor band)")
+	}
+}
+
+// Row #4: the band edge is INCLUSIVE — a value exactly at the boundary passes,
+// one epsilon beyond fails.
+func TestCompareStat_InclusiveEdge(t *testing.T) {
+	b := Band{RelPct: 0.10, AbsFloor: 5} // mean 50 -> band = max(5, 5) = 5
+	mean := 50.0
+
+	if pass, _ := compareStat("x", mean+5, mean, b); !pass {
+		t.Error("value exactly at the band edge (+5) must pass (inclusive)")
+	}
+	if pass, _ := compareStat("x", mean-5, mean, b); !pass {
+		t.Error("value exactly at the lower band edge (-5) must pass (inclusive)")
+	}
+	const eps = 1e-9
+	if pass, _ := compareStat("x", mean+5+eps, mean, b); pass {
+		t.Error("value one epsilon beyond the edge must FAIL")
+	}
+}

--- a/engine/internal/validate/fixtures_test.go
+++ b/engine/internal/validate/fixtures_test.go
@@ -1,0 +1,314 @@
+package validate
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/backup"
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// This file builds SYNTHETIC .plr/.sch/.sco corpora on disk for the harness
+// tests. The encoders are the byte-level inverse of the PR9a readers
+// (backup.ReadPlr/ReadSch/ReadSco), reproducing only the fields the readers and
+// the engine actually consume — enough to exercise the full read→assemble→
+// simulate→compare path without any large developer-local corpus file.
+//
+// The corpora are deliberately small (2 teams × 5 starters, one game). The
+// in-band .sco is engineered from the engine's OWN observed means so the happy
+// path passes deterministically; the out-of-band .sco zeroes the box stats so
+// the FAIL path is exercised too.
+
+func putRJ(buf []byte, off, w, v int) { copy(buf[off:off+w], fmt.Sprintf("%*d", w, v)) }
+
+func putStr(buf []byte, off, w int, s string) {
+	if len(s) > w {
+		s = s[:w]
+	}
+	copy(buf[off:off+w], s)
+}
+
+func round(f float64) int { return int(math.Round(f)) }
+
+// --- .plr roster encoder ----------------------------------------------------
+
+// plrSpec carries just the .plr fields the engine reads. Slot is 0..4
+// (PG..C); the player is stamped depth 1 at that slot and dc_can_play_in_game=1.
+type plrSpec struct {
+	ordinal, pid, teamID, slot, fgp int
+	name                            string
+}
+
+// plr offsets — mirror backup/plr.go exactly.
+func encodePlrRecord(p plrSpec) []byte {
+	buf := make([]byte, 607)
+	for i := range buf {
+		buf[i] = ' '
+	}
+	putRJ(buf, 0, 4, p.ordinal) // ordinal
+	putStr(buf, 4, 32, p.name)  // name
+	putRJ(buf, 36, 2, 27)       // age
+	putRJ(buf, 38, 6, p.pid)    // pid
+	putRJ(buf, 44, 2, p.teamID) // teamid
+	putRJ(buf, 46, 4, 27)       // peak
+	putStr(buf, 50, 2, "PG")    // pos (label only; engine uses depth slots)
+	putRJ(buf, 128, 2, 5)       // clutch
+	putRJ(buf, 130, 2, 5)       // consistency
+	depthOff := []int{132, 133, 134, 135, 136}
+	putRJ(buf, depthOff[p.slot], 1, 1) // depth 1 at the chosen slot
+	putRJ(buf, 137, 1, 1)              // can_play_in_game
+	putRJ(buf, 268, 2, 50)             // talent
+	putRJ(buf, 270, 2, 50)             // skill
+	putRJ(buf, 272, 2, 50)             // intangibles
+	putRJ(buf, 555, 3, 60)             // FGA
+	putRJ(buf, 558, 3, p.fgp)          // FGP
+	putRJ(buf, 561, 3, 20)             // FTA
+	putRJ(buf, 564, 3, 75)             // FTP
+	putRJ(buf, 567, 3, 25)             // 3GA
+	putRJ(buf, 570, 3, 33)             // 3GP
+	putRJ(buf, 573, 3, 20)             // ORB
+	putRJ(buf, 576, 3, 35)             // DRB
+	putRJ(buf, 579, 3, 30)             // AST
+	putRJ(buf, 582, 3, 30)             // STL
+	putRJ(buf, 585, 3, 40)             // TVR
+	putRJ(buf, 588, 3, 20)             // BLK
+	putRJ(buf, 591, 2, 6)              // OO
+	putRJ(buf, 593, 2, 5)              // DO
+	putRJ(buf, 595, 2, 5)              // PO
+	putRJ(buf, 597, 2, 7)              // TO
+	putRJ(buf, 599, 2, 5)              // OD
+	putRJ(buf, 601, 2, 5)              // DD
+	putRJ(buf, 603, 2, 5)              // PD
+	putRJ(buf, 605, 2, 5)              // TD
+	return buf
+}
+
+func writePlr(t *testing.T, path string, specs []plrSpec) {
+	t.Helper()
+	recs := make([]string, 0, len(specs))
+	for _, s := range specs {
+		recs = append(recs, string(encodePlrRecord(s)))
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(recs, "\r\n")), 0o644); err != nil {
+		t.Fatalf("write .plr: %v", err)
+	}
+}
+
+// starterSpecs is the canonical synthetic roster: 5 starters each for teams 7
+// (visitor) and 3 (home), the home side shooting better so games resolve.
+func starterSpecs() []plrSpec {
+	specs := make([]plrSpec, 0, 10)
+	ord, pid := 0, 100
+	for _, tm := range []struct{ id, fgp int }{{7, 46}, {3, 50}} {
+		for slot := 0; slot < 5; slot++ {
+			ord++
+			pid++
+			specs = append(specs, plrSpec{ordinal: ord, pid: pid, teamID: tm.id, slot: slot, fgp: tm.fgp, name: fmt.Sprintf("P%d", pid)})
+		}
+	}
+	return specs
+}
+
+// --- .sch schedule encoder --------------------------------------------------
+
+type schSpec struct {
+	vis, home, vScore, hScore, dateSlot, slotInDate int
+}
+
+func encodeSch(games []schSpec) []byte {
+	buf := make([]byte, 80000)
+	empty := "0   0     "
+	for i := 0; i < 8000; i++ {
+		copy(buf[i*10:], empty)
+	}
+	for _, g := range games {
+		off := (g.dateSlot*16 + g.slotInDate) * 10
+		teams := fmt.Sprintf("%d%02d", g.vis, g.home)
+		for len(teams) < 4 {
+			teams += " "
+		}
+		scores := fmt.Sprintf("%d%03d", g.vScore, g.hScore)
+		for len(scores) < 6 {
+			scores += " "
+		}
+		copy(buf[off:off+10], teams[:4]+scores[:6])
+	}
+	return buf
+}
+
+func writeSch(t *testing.T, path string, games []schSpec) {
+	t.Helper()
+	if err := os.WriteFile(path, encodeSch(games), 0o644); err != nil {
+		t.Fatalf("write .sch: %v", err)
+	}
+}
+
+// --- .sco box-score encoder -------------------------------------------------
+
+type scoBoxSpec struct {
+	pid                                                int
+	name                                               string
+	twoGM, twoGA, ftm, fta, threeGM, threeGA, orb, drb int
+	ast, stl, tov, blk, pf                             int
+}
+
+type scoGameSpec struct {
+	visTID, homeTID     int // 1-based; encoder writes raw = id-1
+	visScore, homeScore int
+	visBoxes, homeBoxes []scoBoxSpec
+}
+
+func putSlot(rec []byte, slotIdx int, b scoBoxSpec) {
+	base := 58 + slotIdx*53
+	putStr(rec, base+0, 16, b.name)
+	putStr(rec, base+16, 2, "PG")
+	putRJ(rec, base+18, 6, b.pid)
+	putRJ(rec, base+24, 2, 30) // minutes (unused by comparison)
+	putRJ(rec, base+26, 2, b.twoGM)
+	putRJ(rec, base+28, 3, b.twoGA)
+	putRJ(rec, base+31, 2, b.ftm)
+	putRJ(rec, base+33, 2, b.fta)
+	putRJ(rec, base+35, 2, b.threeGM)
+	putRJ(rec, base+37, 2, b.threeGA)
+	putRJ(rec, base+39, 2, b.orb)
+	putRJ(rec, base+41, 2, b.drb)
+	putRJ(rec, base+43, 2, b.ast)
+	putRJ(rec, base+45, 2, b.stl)
+	putRJ(rec, base+47, 2, b.tov)
+	putRJ(rec, base+49, 2, b.blk)
+	putRJ(rec, base+51, 2, b.pf)
+}
+
+func encodeScoRecord(g scoGameSpec) []byte {
+	rec := make([]byte, 2000)
+	for i := range rec {
+		rec[i] = ' '
+	}
+	putRJ(rec, 0, 2, 0)           // month raw (decode +10 = Oct)
+	putRJ(rec, 2, 2, 0)           // day raw (decode +1)
+	putRJ(rec, 6, 2, g.visTID-1)  // visitor team raw
+	putRJ(rec, 8, 2, g.homeTID-1) // home team raw
+	putRJ(rec, 28, 3, g.visScore) // visitor Q1 (rest blank -> 0)
+	putRJ(rec, 43, 3, g.homeScore)
+	for i, b := range g.visBoxes {
+		putSlot(rec, i, b)
+	}
+	for i, b := range g.homeBoxes {
+		putSlot(rec, 15+i, b)
+	}
+	return rec
+}
+
+func scoHeader() string { return strings.Repeat(" ", 1_000_000) }
+
+func writeSco(t *testing.T, path string, games []scoGameSpec) {
+	t.Helper()
+	var sb strings.Builder
+	sb.WriteString(scoHeader())
+	for _, g := range games {
+		sb.Write(encodeScoRecord(g))
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("write .sco: %v", err)
+	}
+}
+
+// boxFromMeans turns a per-stat mean map into one .sco player row whose summed
+// stats reproduce the rounded means (one row per team, so teamStatFromSco's
+// PID!=0 sum equals it). 2GM = round(fgm) - round(tgm); ORB carries all rebounds.
+func boxFromMeans(pid int, name string, m map[string]float64) scoBoxSpec {
+	tgm := round(m["tgm"])
+	tga := round(m["tga"])
+	return scoBoxSpec{
+		pid: pid, name: name,
+		twoGM:   round(m["fgm"]) - tgm,
+		twoGA:   round(m["fga"]) - tga,
+		ftm:     round(m["ftm"]),
+		fta:     round(m["fta"]),
+		threeGM: tgm,
+		threeGA: tga,
+		orb:     round(m["reb"]),
+		ast:     round(m["ast"]),
+		stl:     round(m["stl"]),
+		tov:     round(m["tov"]),
+		blk:     round(m["blk"]),
+		pf:      round(m["pf"]),
+	}
+}
+
+// corpusPaths returns the triple file paths for a stem inside dir.
+func corpusPaths(dir, stem string) (plr, sch, sco string) {
+	return filepath.Join(dir, stem+".plr"),
+		filepath.Join(dir, stem+".sch"),
+		filepath.Join(dir, stem+".sco")
+}
+
+// assembleSynthBundle reads back the written .plr/.sch to produce exactly the
+// bundle ValidateCorpus will assemble, so engineered .sco values match the
+// engine means the harness computes.
+func assembleSynthBundle(t *testing.T, plrPath, schPath string) bundle.Bundle {
+	t.Helper()
+	pf, err := os.Open(plrPath)
+	if err != nil {
+		t.Fatalf("open .plr: %v", err)
+	}
+	defer pf.Close()
+	players, err := backup.ReadPlr(pf)
+	if err != nil {
+		t.Fatalf("read .plr: %v", err)
+	}
+	sf, err := os.Open(schPath)
+	if err != nil {
+		t.Fatalf("open .sch: %v", err)
+	}
+	defer sf.Close()
+	sched, err := backup.ReadSch(sf)
+	if err != nil {
+		t.Fatalf("read .sch: %v", err)
+	}
+	b, err := backup.ToBundle(players, sched, backup.AssembleOptions{GameType: bundle.GameTypeRegular})
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	return b
+}
+
+// buildCorpus writes a one-game synthetic triple under dir. When inBand, the
+// .sco is engineered from the engine's observed means (rounded) so every stat
+// passes; otherwise the box stats are zeroed so the shooting/rebound/etc. stats
+// fall far out of band (FAIL). runs/baseSeed must match the ValidateCorpus call
+// the test makes. The .sch and .sco carry identical scores so the .sco↔.sch
+// match succeeds.
+func buildCorpus(t *testing.T, dir string, inBand bool, runs int, baseSeed uint64, extraUnmatched ...scoGameSpec) {
+	t.Helper()
+	plr, sch, sco := corpusPaths(dir, "synth")
+	writePlr(t, plr, starterSpecs())
+	// Placeholder schedule; scores rewritten below once means are known.
+	writeSch(t, sch, []schSpec{{vis: 7, home: 3, vScore: 1, hScore: 1}})
+
+	b := assembleSynthBundle(t, plr, sch)
+	visMean, homeMean := simulateGameMeans(b, b.Schedule[0], runs, baseSeed)
+	visPts, homePts := round(visMean["points"]), round(homeMean["points"])
+
+	// Rewrite .sch with the real scores so the .sco↔.sch tuple match succeeds.
+	writeSch(t, sch, []schSpec{{vis: 7, home: 3, vScore: visPts, hScore: homePts}})
+
+	var visBox, homeBox scoBoxSpec
+	if inBand {
+		visBox = boxFromMeans(1, "VIS", visMean)
+		homeBox = boxFromMeans(2, "HOME", homeMean)
+	} else {
+		visBox = scoBoxSpec{pid: 1, name: "VIS"} // all-zero box -> far out of band
+		homeBox = scoBoxSpec{pid: 2, name: "HOME"}
+	}
+	games := []scoGameSpec{{
+		visTID: 7, homeTID: 3, visScore: visPts, homeScore: homePts,
+		visBoxes: []scoBoxSpec{visBox}, homeBoxes: []scoBoxSpec{homeBox},
+	}}
+	games = append(games, extraUnmatched...)
+	writeSco(t, sco, games)
+}

--- a/engine/internal/validate/format.go
+++ b/engine/internal/validate/format.go
@@ -1,0 +1,37 @@
+package validate
+
+import (
+	"fmt"
+	"io"
+)
+
+// WriteReport renders a Report as a deterministic, human-readable PASS/FAIL
+// listing: a header, one GAME block per validated game with one line per stat
+// per team, an UNMATCHED line per unpairable .sco game, and a final RESULT
+// line. The output depends only on the Report contents (no timestamps, no
+// map-iteration order), so two runs over the same corpus are byte-identical.
+func WriteReport(w io.Writer, rep Report) {
+	fmt.Fprintf(w, "JSB validation report — runs=%d base_seed=%d game_type=%d\n",
+		rep.Runs, rep.BaseSeed, int(rep.GameType))
+	for _, g := range rep.Games {
+		verdict := "PASS"
+		if !g.Pass {
+			verdict = "FAIL"
+		}
+		fmt.Fprintf(w, "GAME visitor=%d home=%d date=%s %s\n",
+			g.VisitorTeamID, g.HomeTeamID, g.Date, verdict)
+		for _, r := range g.Rows {
+			fmt.Fprintf(w, "  team=%d %s\n", r.TeamID, r.Detail)
+		}
+	}
+	for _, u := range rep.Unmatched {
+		fmt.Fprintf(w, "UNMATCHED stem=%s visitor=%d home=%d scores=%d-%d: %s\n",
+			u.Stem, u.VisitorTeamID, u.HomeTeamID, u.VisitorScore, u.HomeScore, u.Reason)
+	}
+	result := "PASS"
+	if !rep.Pass {
+		result = "FAIL"
+	}
+	fmt.Fprintf(w, "RESULT: %s (%d games, %d unmatched)\n",
+		result, len(rep.Games), len(rep.Unmatched))
+}

--- a/engine/internal/validate/harness.go
+++ b/engine/internal/validate/harness.go
@@ -1,0 +1,253 @@
+package validate
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/a-jay85/IBL5/engine/internal/backup"
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/sim"
+)
+
+// ErrNoCorpus reports a corpus directory that contains no complete
+// .plr/.sch/.sco triple — an empty dir, or files that do not share a stem.
+var ErrNoCorpus = errors.New("validate: no .plr/.sch/.sco triple found in corpus dir")
+
+// UnmatchedGame is a .sco ground-truth game that could not be paired with a
+// schedule entry, so the engine could not be pointed at the same matchup. It is
+// reported (never silently dropped) and forces the Report to FAIL — an
+// unvalidatable ground-truth game is a corpus-integrity signal, not a pass.
+type UnmatchedGame struct {
+	Stem          string
+	VisitorTeamID int
+	HomeTeamID    int
+	VisitorScore  int
+	HomeScore     int
+	Reason        string
+}
+
+// Report is the harness's full result over a corpus directory. Pass is true
+// only when every game's every stat passed AND no .sco game was left unmatched.
+// Same (dir, runs, baseSeed, gameType) always yields an identical Report.
+type Report struct {
+	Runs      int
+	BaseSeed  uint64
+	GameType  bundle.GameType
+	Pass      bool
+	Games     []GameReport
+	Unmatched []UnmatchedGame
+}
+
+// triple names one backup file set sharing a stem within the corpus dir.
+type triple struct {
+	stem string
+	plr  string
+	sch  string
+	sco  string
+}
+
+// findTriples groups the .plr/.sch/.sco files in dir by shared stem and returns
+// only the complete triples, sorted by stem for deterministic processing order.
+func findTriples(dir string) ([]triple, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("validate: read corpus dir: %w", err)
+	}
+	byStem := map[string]*triple{}
+	get := func(stem string) *triple {
+		if t, ok := byStem[stem]; ok {
+			return t
+		}
+		t := &triple{stem: stem}
+		byStem[stem] = t
+		return t
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		ext := strings.ToLower(filepath.Ext(name))
+		stem := strings.TrimSuffix(name, filepath.Ext(name))
+		full := filepath.Join(dir, name)
+		switch ext {
+		case ".plr":
+			get(stem).plr = full
+		case ".sch":
+			get(stem).sch = full
+		case ".sco":
+			get(stem).sco = full
+		}
+	}
+	stems := make([]string, 0, len(byStem))
+	for stem := range byStem {
+		stems = append(stems, stem)
+	}
+	sort.Strings(stems)
+	triples := make([]triple, 0, len(stems))
+	for _, stem := range stems {
+		t := byStem[stem]
+		if t.plr != "" && t.sch != "" && t.sco != "" {
+			triples = append(triples, *t)
+		}
+	}
+	if len(triples) == 0 {
+		return nil, ErrNoCorpus
+	}
+	return triples, nil
+}
+
+// readTriple reads and assembles one triple into a bundle plus the parsed
+// schedule (kept for .sco↔.sch matching, which needs the historical scores the
+// assembled bundle.Game discards) and the .sco ground-truth games.
+func readTriple(t triple, gameType bundle.GameType) (bundle.Bundle, []backup.SchGame, []backup.ScoGame, error) {
+	players, err := readFile(t.plr, backup.ReadPlr)
+	if err != nil {
+		return bundle.Bundle{}, nil, nil, err
+	}
+	sched, err := readFile(t.sch, backup.ReadSch)
+	if err != nil {
+		return bundle.Bundle{}, nil, nil, err
+	}
+	scoGames, err := readFile(t.sco, backup.ReadSco)
+	if err != nil {
+		return bundle.Bundle{}, nil, nil, err
+	}
+	b, err := backup.ToBundle(players, sched, backup.AssembleOptions{GameType: gameType})
+	if err != nil {
+		return bundle.Bundle{}, nil, nil, fmt.Errorf("validate: assemble %q: %w", t.stem, err)
+	}
+	return b, sched, scoGames, nil
+}
+
+// readFile opens path and applies a backup reader, wrapping any error with the
+// path so a malformed corpus file is diagnosable.
+func readFile[T any](path string, read func(io.Reader) ([]T, error)) ([]T, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("validate: open %q: %w", path, err)
+	}
+	defer f.Close()
+	out, err := read(f)
+	if err != nil {
+		return nil, fmt.Errorf("validate: parse %q: %w", path, err)
+	}
+	return out, nil
+}
+
+// ValidateCorpus runs the full harness over every complete triple in dir. For
+// each .sco game it locates the matching schedule entry (by the historical
+// (visitor, home, visitorScore, homeScore) tuple both files carry — bundle.Game
+// has no scores and (visitor, home) alone is not unique across a season), runs
+// the engine `runs` times on that single matchup (seed =
+// baseSeed + gameIndex*runs + runIndex), aggregates the per-team distributions,
+// and compares them to the .sco ground truth within the tolerance bands.
+//
+// gameType stamps every assembled game (neither .sch nor .sco carries one). The
+// CLI exposes this; pass bundle.GameTypeRegular for a regular-season corpus.
+// NOTE: a mixed corpus (e.g. playoff or all-star backups) compared under a
+// single game type is a systematic basis mismatch — calibrate per game type.
+//
+// Determinism: same (dir, runs, baseSeed, gameType) yields a byte-identical
+// Report. No map-iteration order leaks into the output (triples sorted by stem;
+// .sco games kept in file order; stat rows emitted in statNames order).
+func ValidateCorpus(dir string, runs int, baseSeed uint64, gameType bundle.GameType) (Report, error) {
+	if runs <= 0 {
+		return Report{}, fmt.Errorf("validate: runs must be >= 1, got %d", runs)
+	}
+	triples, err := findTriples(dir)
+	if err != nil {
+		return Report{}, err
+	}
+	rep := Report{Runs: runs, BaseSeed: baseSeed, GameType: gameType, Pass: true}
+	gameIndex := 0
+	for _, t := range triples {
+		b, sched, scoGames, err := readTriple(t, gameType)
+		if err != nil {
+			return Report{}, err
+		}
+		consumed := make([]bool, len(sched))
+		for _, sg := range scoGames {
+			schIdx := matchSchedule(sched, consumed, sg)
+			if schIdx < 0 {
+				rep.Unmatched = append(rep.Unmatched, UnmatchedGame{
+					Stem:          t.stem,
+					VisitorTeamID: sg.VisitorTeamID,
+					HomeTeamID:    sg.HomeTeamID,
+					VisitorScore:  sg.VisitorScore,
+					HomeScore:     sg.HomeScore,
+					Reason:        "no schedule entry with matching (visitor, home, scores)",
+				})
+				rep.Pass = false
+				gameIndex++
+				continue
+			}
+			consumed[schIdx] = true
+			gr := validateGame(b, b.Schedule[schIdx], sg, runs, baseSeed+uint64(gameIndex*runs))
+			rep.Games = append(rep.Games, gr)
+			if !gr.Pass {
+				rep.Pass = false
+			}
+			gameIndex++
+		}
+	}
+	return rep, nil
+}
+
+// matchSchedule returns the index of the first unconsumed schedule game whose
+// (visitor, home, visitorScore, homeScore) equals the .sco game's, or -1.
+func matchSchedule(sched []backup.SchGame, consumed []bool, sg backup.ScoGame) int {
+	for i, s := range sched {
+		if consumed[i] {
+			continue
+		}
+		if s.VisitorTeamID == sg.VisitorTeamID && s.HomeTeamID == sg.HomeTeamID &&
+			s.VisitorScore == sg.VisitorScore && s.HomeScore == sg.HomeScore {
+			return i
+		}
+	}
+	return -1
+}
+
+// validateGame simulates one matchup `runs` times and compares the aggregated
+// per-team engine means against the .sco ground truth.
+func validateGame(b bundle.Bundle, g bundle.Game, sg backup.ScoGame, runs int, baseSeed uint64) GameReport {
+	visMean, homeMean := simulateGameMeans(b, g, runs, baseSeed)
+	visSco := teamStatFromSco(sg, g.VisitorTeamID)
+	homeSco := teamStatFromSco(sg, g.HomeTeamID)
+	return compareGame(g.VisitorTeamID, g.HomeTeamID, sg.Date, visSco, homeSco, visMean, homeMean)
+}
+
+// simulateGameMeans runs the engine on the single matchup g for `runs` seeds
+// (baseSeed+0 .. baseSeed+runs-1) and returns the per-team mean TeamStat keyed
+// by statNames. Each run is an independent single-game sub-bundle so one game's
+// distribution is isolated from the rest of the schedule.
+func simulateGameMeans(b bundle.Bundle, g bundle.Game, runs int, baseSeed uint64) (visMean, homeMean map[string]float64) {
+	sub := bundle.Bundle{
+		LeagueID: b.LeagueID,
+		Teams:    b.Teams,
+		Players:  b.Players,
+		Schedule: []bundle.Game{g},
+	}
+	visSamples := make([]TeamStat, 0, runs)
+	homeSamples := make([]TeamStat, 0, runs)
+	for run := 0; run < runs; run++ {
+		res := sim.Simulate(sub, baseSeed+uint64(run))
+		gr := res.Games[0]
+		for _, tb := range gr.TeamBoxes {
+			ts := teamStatFromBox(tb)
+			switch tb.TeamID {
+			case g.VisitorTeamID:
+				visSamples = append(visSamples, ts)
+			case g.HomeTeamID:
+				homeSamples = append(homeSamples, ts)
+			}
+		}
+	}
+	return mean(visSamples), mean(homeSamples)
+}

--- a/engine/internal/validate/harness_test.go
+++ b/engine/internal/validate/harness_test.go
@@ -1,0 +1,200 @@
+package validate
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/backup"
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+const testRuns = 8 // small N keeps `go test ./...` fast (advisor guidance)
+
+// Row #5 (unit): compareGame reports FAIL when any single stat is out of band,
+// proving the harness can actually fail — a harness that always passes proves
+// nothing.
+func TestCompareGame_FailsOnOutOfBandStat(t *testing.T) {
+	visMean := map[string]float64{"points": 100, "fgm": 40, "reb": 45}
+	homeMean := map[string]float64{"points": 100, "fgm": 40, "reb": 45}
+	// Visitor points wildly off; everything else matches.
+	visSco := TeamStat{Points: 200, FGM: 40, REB: 45}
+	homeSco := TeamStat{Points: 100, FGM: 40, REB: 45}
+
+	gr := compareGame(7, 3, "10-01", visSco, homeSco, visMean, homeMean)
+	if gr.Pass {
+		t.Fatal("compareGame should FAIL when visitor points are far out of band")
+	}
+	var sawFail bool
+	for _, r := range gr.Rows {
+		if r.TeamID == 7 && r.Stat == "points" && !r.Pass {
+			sawFail = true
+		}
+	}
+	if !sawFail {
+		t.Error("expected the visitor points row to be marked FAIL")
+	}
+}
+
+// Row #9 (unit): matchSchedule pairs a .sco game to the schedule entry sharing
+// (visitor, home, visitorScore, homeScore), consuming each entry once, and
+// returns -1 when no entry matches.
+func TestMatchSchedule(t *testing.T) {
+	sched := []backup.SchGame{
+		{VisitorTeamID: 7, HomeTeamID: 3, VisitorScore: 100, HomeScore: 98},
+		{VisitorTeamID: 7, HomeTeamID: 3, VisitorScore: 100, HomeScore: 98}, // dup matchup, different game
+	}
+	consumed := make([]bool, len(sched))
+
+	sg := backup.ScoGame{VisitorTeamID: 7, HomeTeamID: 3, VisitorScore: 100, HomeScore: 98}
+	if i := matchSchedule(sched, consumed, sg); i != 0 {
+		t.Fatalf("first match = %d, want 0", i)
+	}
+	consumed[0] = true
+	if i := matchSchedule(sched, consumed, sg); i != 1 {
+		t.Fatalf("second match = %d, want 1 (first consumed)", i)
+	}
+	consumed[1] = true
+	if i := matchSchedule(sched, consumed, sg); i != -1 {
+		t.Fatalf("third match = %d, want -1 (all consumed)", i)
+	}
+
+	noMatch := backup.ScoGame{VisitorTeamID: 7, HomeTeamID: 3, VisitorScore: 77, HomeScore: 77}
+	if i := matchSchedule(sched, make([]bool, len(sched)), noMatch); i != -1 {
+		t.Fatalf("unmatched scores = %d, want -1", i)
+	}
+}
+
+// Row #6 + happy path: ValidateCorpus on the in-band synthetic corpus passes,
+// and is deterministic — same (dir, runs, seed, gameType) yields an identical
+// Report and identical report bytes across two runs.
+func TestValidateCorpus_InBandPassesAndDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	buildCorpus(t, dir, true, testRuns, seed)
+
+	rep1, err := ValidateCorpus(dir, testRuns, seed, bundle.GameTypeRegular)
+	if err != nil {
+		t.Fatalf("ValidateCorpus: %v", err)
+	}
+	if !rep1.Pass {
+		for _, g := range rep1.Games {
+			for _, r := range g.Rows {
+				if !r.Pass {
+					t.Logf("FAIL row: %s", r.Detail)
+				}
+			}
+		}
+		t.Fatal("in-band corpus should PASS")
+	}
+	if len(rep1.Games) != 1 || len(rep1.Unmatched) != 0 {
+		t.Fatalf("games=%d unmatched=%d, want 1 / 0", len(rep1.Games), len(rep1.Unmatched))
+	}
+
+	rep2, err := ValidateCorpus(dir, testRuns, seed, bundle.GameTypeRegular)
+	if err != nil {
+		t.Fatalf("ValidateCorpus (2nd): %v", err)
+	}
+	if !reflect.DeepEqual(rep1, rep2) {
+		t.Error("two ValidateCorpus runs produced different Reports (non-deterministic)")
+	}
+	var b1, b2 bytes.Buffer
+	WriteReport(&b1, rep1)
+	WriteReport(&b2, rep2)
+	if b1.String() != b2.String() {
+		t.Error("two WriteReport outputs differ (non-deterministic)")
+	}
+}
+
+// Row #5 (corpus): the out-of-band synthetic corpus drives ValidateCorpus to a
+// FAILing Report (box stats zeroed → far outside the bands).
+func TestValidateCorpus_OutOfBandFails(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	buildCorpus(t, dir, false, testRuns, seed)
+
+	rep, err := ValidateCorpus(dir, testRuns, seed, bundle.GameTypeRegular)
+	if err != nil {
+		t.Fatalf("ValidateCorpus: %v", err)
+	}
+	if rep.Pass {
+		t.Fatal("out-of-band corpus should FAIL")
+	}
+}
+
+// Row #7 (negative): an empty corpus dir, and a dir with no complete triple,
+// both yield ErrNoCorpus — never a panic or a vacuous PASS.
+func TestValidateCorpus_EmptyDir(t *testing.T) {
+	if _, err := ValidateCorpus(t.TempDir(), testRuns, 1, bundle.GameTypeRegular); !errors.Is(err, ErrNoCorpus) {
+		t.Fatalf("empty dir error = %v, want ErrNoCorpus", err)
+	}
+
+	// A .plr with no sibling .sch/.sco is not a complete triple.
+	dir := t.TempDir()
+	writePlr(t, dir+"/lonely.plr", starterSpecs())
+	if _, err := ValidateCorpus(dir, testRuns, 1, bundle.GameTypeRegular); !errors.Is(err, ErrNoCorpus) {
+		t.Fatalf("incomplete triple error = %v, want ErrNoCorpus", err)
+	}
+}
+
+// Row #8 (negative): a corpus whose .plr has a malformed numeric field surfaces
+// the PR9a typed reader error (ErrBadField), not a panic or a silent mis-parse.
+func TestValidateCorpus_MalformedPlr(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	buildCorpus(t, dir, true, testRuns, seed)
+
+	plr, _, _ := corpusPaths(dir, "synth")
+	data, err := os.ReadFile(plr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt the 6-byte pid field (offset 38) of the first record with letters.
+	copy(data[38:44], []byte("XXXXXX"))
+	if err := os.WriteFile(plr, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ValidateCorpus(dir, testRuns, seed, bundle.GameTypeRegular)
+	if !errors.Is(err, backup.ErrBadField) {
+		t.Fatalf("malformed .plr error = %v, want ErrBadField", err)
+	}
+}
+
+// Row #9 (corpus): a .sco game with no matching schedule entry is REPORTED in
+// Unmatched (not silently dropped) and forces the Report to FAIL.
+func TestValidateCorpus_UnmatchedScoGame(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	// One matched game + one extra .sco game whose scores match no .sch entry.
+	extra := scoGameSpec{
+		visTID: 7, homeTID: 3, visScore: 77, homeScore: 77,
+		visBoxes:  []scoBoxSpec{{pid: 1, name: "VIS"}},
+		homeBoxes: []scoBoxSpec{{pid: 2, name: "HOME"}},
+	}
+	buildCorpus(t, dir, true, testRuns, seed, extra)
+
+	rep, err := ValidateCorpus(dir, testRuns, seed, bundle.GameTypeRegular)
+	if err != nil {
+		t.Fatalf("ValidateCorpus: %v", err)
+	}
+	if len(rep.Unmatched) != 1 {
+		t.Fatalf("unmatched = %d, want 1", len(rep.Unmatched))
+	}
+	if rep.Pass {
+		t.Error("a corpus with an unmatched .sco game must FAIL")
+	}
+	if rep.Unmatched[0].VisitorScore != 77 {
+		t.Errorf("unmatched visitorScore = %d, want 77", rep.Unmatched[0].VisitorScore)
+	}
+
+	// The unmatched game must be surfaced in the rendered report, not dropped.
+	var buf bytes.Buffer
+	WriteReport(&buf, rep)
+	if !strings.Contains(buf.String(), "UNMATCHED") || !strings.Contains(buf.String(), "RESULT: FAIL") {
+		t.Errorf("report should render an UNMATCHED line and a FAIL result:\n%s", buf.String())
+	}
+}

--- a/engine/internal/validate/validate_test.go
+++ b/engine/internal/validate/validate_test.go
@@ -1,0 +1,85 @@
+//go:build validate
+
+// This corpus suite is gated behind the `validate` build tag, so the normal
+// `go test ./...` (and the engine.yml CI) NEVER compiles or runs it. Invoke it
+// explicitly against a developer-local corpus:
+//
+//	cd engine && JSB_CORPUS_DIR=/path/to/triples \
+//	  go test -tags validate ./internal/validate/ -run ValidateCorpusReal
+//
+// The corpus files are large 5.60 backup triples (.plr/.sch/.sco) that are NOT
+// committed to the repo (see the PR9b plan, Fixtures & corpus provisioning). The
+// tolerance bands are STARTING values pending calibration (OPEN #1), so this
+// suite is a DIAGNOSTIC a developer/nightly runs, not a per-PR merge gate.
+package validate
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// Master 5.60 corpus candidates (developer-local; point JSB_CORPUS_DIR at one):
+//   - ~/Downloads/IBL52007ConfFinalsGm4-7/   (PLAYOFF — run with JSB_CORPUS_GAMETYPE=4)
+//   - ~/Downloads/2007IBLFinalsEnd/           (PLAYOFF — game type 4)
+//   - ~/Downloads/Olympics2003/              (ALL-STAR scale — game type 5 or 6)
+//   - ibl5/IBL5.{plr,sch,sco}                 (regular season — game type 2)
+//
+// The 5.99 default_*.plr files are a DIFFERENT engine version (PR9a's reader
+// layout targets 5.60); they are unsupported here.
+//
+// IMPORTANT: neither the .sch nor the .sco stores a game type, so every game is
+// stamped with JSB_CORPUS_GAMETYPE (default 2, regular). A playoff/all-star
+// corpus run under the default regular type is a systematic basis mismatch —
+// set JSB_CORPUS_GAMETYPE to match the corpus.
+func TestValidateCorpusReal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real-corpus suite in -short mode")
+	}
+	dir := os.Getenv("JSB_CORPUS_DIR")
+	if dir == "" {
+		t.Skip("JSB_CORPUS_DIR unset; set it to a dir of 5.60 .plr/.sch/.sco triples (corpus is not in the repo)")
+	}
+
+	runs := 200
+	if v := os.Getenv("JSB_CORPUS_RUNS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			t.Fatalf("JSB_CORPUS_RUNS=%q is not a positive integer", v)
+		}
+		runs = n
+	}
+
+	gameType := bundle.GameTypeRegular
+	if v := os.Getenv("JSB_CORPUS_GAMETYPE"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			t.Fatalf("JSB_CORPUS_GAMETYPE=%q is not an integer", v)
+		}
+		gameType = bundle.GameType(n)
+	}
+
+	rep, err := ValidateCorpus(dir, runs, 0, gameType)
+	if err != nil {
+		t.Fatalf("ValidateCorpus(%q): %v", dir, err)
+	}
+
+	t.Logf("validated %d games, %d unmatched (runs=%d, game_type=%d)",
+		len(rep.Games), len(rep.Unmatched), runs, int(gameType))
+	if !rep.Pass {
+		for _, u := range rep.Unmatched {
+			t.Logf("UNMATCHED stem=%s %d@%d scores=%d-%d: %s",
+				u.Stem, u.VisitorTeamID, u.HomeTeamID, u.VisitorScore, u.HomeScore, u.Reason)
+		}
+		for _, g := range rep.Games {
+			for _, r := range g.Rows {
+				if !r.Pass {
+					t.Logf("OUT-OF-BAND game(%d@%d) team=%d %s", g.VisitorTeamID, g.HomeTeamID, r.TeamID, r.Detail)
+				}
+			}
+		}
+		t.Fatal("corpus has out-of-band stats or unmatched games (diagnostic — bands are uncalibrated, see OPEN #1)")
+	}
+}


### PR DESCRIPTION
## Summary

PR9b delivers the **offline distributional fidelity harness** for the native JSB engine (stacks on PR9a #932, now in master). It runs the engine N seeded times per backup-corpus game, aggregates per-team/per-stat distributions, and compares the observed means against the `.sco` ground truth **within tolerance bands** — the bar is statistical, not byte-exact (the Go RNG differs from `jumpshot.exe`).

Delivered as (a) a build-tag-gated `go test` corpus suite that does NOT run in normal CI, and (b) a `cmd/jsbvalidate` PASS/FAIL report CLI.

## What's here

- `engine/internal/validate/` — aggregation, tolerance bands (single-file calibration surface), comparison, and the corpus driver + tests.
- `engine/cmd/jsbvalidate/` — the report CLI with `--corpus`/`--runs`/`--seed`/`--game-type`.
- `engine/internal/validate/validate_test.go` — `//go:build validate` real-corpus suite, `JSB_CORPUS_DIR`-driven; kept off `go test ./...` / `engine.yml`.

## Resolved deviations from the plan (each documented in code)

1. **`.sco` FGM is 2pt-only** (no total `<fgm>` field, per PR9a) → total FG reconstructed by summing 2pt+3pt on **both** sides.
2. **`.sco`↔`.sch` matched by the 4-tuple** `(visitor, home, visitorScore, homeScore)` — `bundle.Game` has no score and `(vis,home)` is non-unique across a season.
3. **Added `--game-type` flag** — the corpus is mostly playoff/all-star and neither `.sch` nor `.sco` stores a game type.
4. **No PR9a encoders existed** (only unexported `_test.go` builders) → test-only fixed-width encoders.

## Backup-reader fixes (surfaced by running the harness on real data)

PR9a's `.sco` reader was only exercised against synthetic space-padded fixtures. Running the shipped CLI against `~/Downloads/2007IBLFinalsEnd` surfaced two real-file quirks, fixed here with regression tests:
- NUL-byte field padding (real `.sco` pads trailing records with `0x00`, not spaces) → treated as empty.
- An unpadded final record (real `.sco` omits the last record's trailing padding) → tolerated when full content is present.

Post-fix: **521 of 604** real `.sco` games match the schedule; the full pipeline runs end-to-end (RESULT: FAIL, as expected — tolerance bands are STARTING values pending calibration, OPEN #1; the tagged suite is a diagnostic, not a merge gate).

## Manual Testing

No manual testing needed — all verification is automated (Go unit tests + the build-tag-gated corpus suite). No PHP/DB/web/UI surface.

🤖 Generated with [Claude Code](https://claude.ai/code)