### PR TITLE
engine(validate): fix errcheck lint failures from PR9b

### DIFF
--- a/engine/cmd/jsbvalidate/main.go
+++ b/engine/cmd/jsbvalidate/main.go
@@ -53,20 +53,20 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if *corpus == "" {
-		fmt.Fprintln(stderr, "jsbvalidate: --corpus <dir> is required")
+		_, _ = fmt.Fprintln(stderr, "jsbvalidate: --corpus <dir> is required")
 		return 2
 	}
 	switch *gameType {
 	case 2, 3, 4, 5, 6: // regular / regular-alt / playoff / all-star A / all-star B
 	default:
-		fmt.Fprintf(stderr, "jsbvalidate: invalid --game-type %d (valid: 2,3 regular; 4 playoff; 5,6 all-star)\n", *gameType)
+		_, _ = fmt.Fprintf(stderr, "jsbvalidate: invalid --game-type %d (valid: 2,3 regular; 4 playoff; 5,6 all-star)\n", *gameType)
 		return 2
 	}
 	gt := bundle.GameType(*gameType)
 
 	rep, err := validate.ValidateCorpus(*corpus, *runs, *seed, gt)
 	if err != nil {
-		fmt.Fprintln(stderr, "jsbvalidate:", err)
+		_, _ = fmt.Fprintln(stderr, "jsbvalidate:", err)
 		return 1
 	}
 	validate.WriteReport(stdout, rep)

--- a/engine/internal/validate/fixtures_test.go
+++ b/engine/internal/validate/fixtures_test.go
@@ -256,7 +256,7 @@ func assembleSynthBundle(t *testing.T, plrPath, schPath string) bundle.Bundle {
 	if err != nil {
 		t.Fatalf("open .plr: %v", err)
 	}
-	defer pf.Close()
+	defer func() { _ = pf.Close() }()
 	players, err := backup.ReadPlr(pf)
 	if err != nil {
 		t.Fatalf("read .plr: %v", err)
@@ -265,7 +265,7 @@ func assembleSynthBundle(t *testing.T, plrPath, schPath string) bundle.Bundle {
 	if err != nil {
 		t.Fatalf("open .sch: %v", err)
 	}
-	defer sf.Close()
+	defer func() { _ = sf.Close() }()
 	sched, err := backup.ReadSch(sf)
 	if err != nil {
 		t.Fatalf("read .sch: %v", err)

--- a/engine/internal/validate/format.go
+++ b/engine/internal/validate/format.go
@@ -10,28 +10,34 @@ import (
 // per team, an UNMATCHED line per unpairable .sco game, and a final RESULT
 // line. The output depends only on the Report contents (no timestamps, no
 // map-iteration order), so two runs over the same corpus are byte-identical.
+//
+// Write errors are intentionally ignored (via the p closure), as the report is
+// a diagnostic printed to stdout — mirroring the engine's other CLI output
+// paths, where the os.Stderr/os.Stdout write error is not actionable.
 func WriteReport(w io.Writer, rep Report) {
-	fmt.Fprintf(w, "JSB validation report — runs=%d base_seed=%d game_type=%d\n",
+	p := func(format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
+
+	p("JSB validation report — runs=%d base_seed=%d game_type=%d\n",
 		rep.Runs, rep.BaseSeed, int(rep.GameType))
 	for _, g := range rep.Games {
 		verdict := "PASS"
 		if !g.Pass {
 			verdict = "FAIL"
 		}
-		fmt.Fprintf(w, "GAME visitor=%d home=%d date=%s %s\n",
+		p("GAME visitor=%d home=%d date=%s %s\n",
 			g.VisitorTeamID, g.HomeTeamID, g.Date, verdict)
 		for _, r := range g.Rows {
-			fmt.Fprintf(w, "  team=%d %s\n", r.TeamID, r.Detail)
+			p("  team=%d %s\n", r.TeamID, r.Detail)
 		}
 	}
 	for _, u := range rep.Unmatched {
-		fmt.Fprintf(w, "UNMATCHED stem=%s visitor=%d home=%d scores=%d-%d: %s\n",
+		p("UNMATCHED stem=%s visitor=%d home=%d scores=%d-%d: %s\n",
 			u.Stem, u.VisitorTeamID, u.HomeTeamID, u.VisitorScore, u.HomeScore, u.Reason)
 	}
 	result := "PASS"
 	if !rep.Pass {
 		result = "FAIL"
 	}
-	fmt.Fprintf(w, "RESULT: %s (%d games, %d unmatched)\n",
+	p("RESULT: %s (%d games, %d unmatched)\n",
 		result, len(rep.Games), len(rep.Unmatched))
 }

--- a/engine/internal/validate/harness.go
+++ b/engine/internal/validate/harness.go
@@ -132,7 +132,7 @@ func readFile[T any](path string, read func(io.Reader) ([]T, error)) ([]T, error
 	if err != nil {
 		return nil, fmt.Errorf("validate: open %q: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	out, err := read(f)
 	if err != nil {
 		return nil, fmt.Errorf("validate: parse %q: %w", path, err)


### PR DESCRIPTION
## Summary

PR9b (#933) merged with a red `engine.yml` CI run — its golangci-lint gate (errcheck) failed. The lint binary is not installed in the local/nightly env, so it was deferred to CI per the post-plan Go track, and the repo had no required-status gating, so #933 auto-merged before CI completed. This restores master green.

## errcheck findings fixed

errcheck excludes writes to the concrete `os.Stdout`/`os.Stderr` (why `jsbsim` passes) but not to an `io.Writer` parameter:

- `internal/validate/format.go` `WriteReport`: routes every `fmt.Fprintf` through a local `p` closure that blank-assigns the error once — also avoids the staticcheck `QF1012` `WriteString(fmt.Sprintf(...))` anti-pattern.
- `cmd/jsbvalidate/main.go`: blank-assign the three stderr diagnostic writes.
- `internal/validate/harness.go` (`readFile`) and `internal/validate/fixtures_test.go` (`assembleSynthBundle`): `defer func() { _ = f.Close() }()`.

## Verification

`golangci-lint v2.12.2` (the CI-pinned version, installed locally for this fix) reports **0 issues**. `go build`/`go vet`/`go test ./...` green; `go build -tags validate ./...` compiles; coverage 93.3% (floor 90%).

## Manual Testing

No manual testing needed — lint/test-only fix, fully covered by the CI gate it restores.

🤖 Generated with [Claude Code](https://claude.ai/code)