### PR TITLE
fix: three small defect fixes (heading tag, 1-on-1 state reset, PlrParser N+1)

### DIFF
--- a/ibl5/classes/OneOnOneGame/OneOnOneGameEngine.php
+++ b/ibl5/classes/OneOnOneGame/OneOnOneGameEngine.php
@@ -77,6 +77,10 @@ class OneOnOneGameEngine implements OneOnOneGameEngineInterface
         // Coin flip to determine starting possession
         $coinFlip = rand(1, 2);
         $possession = $coinFlip; // 1 = player1, 2 = player2
+
+        // Reset per-game possession state so a prior simulateGame() call on this
+        // same instance cannot leak a stale possession into this run.
+        $this->currentPossession = $possession;
         $result->coinFlipResult = $this->textGenerator->getCoinFlipText(
             $coinFlip === 1,
             $result->player1Name,

--- a/ibl5/classes/PlrParser/PlrParserService.php
+++ b/ibl5/classes/PlrParser/PlrParserService.php
@@ -18,16 +18,13 @@ use Season\Season;
 class PlrParserService implements PlrParserServiceInterface
 {
     private PlrParserRepositoryInterface $repository;
-    private \Repositories\Contracts\TeamIdentityRepositoryInterface $commonRepository;
     private Season $season;
 
     public function __construct(
         PlrParserRepositoryInterface $repository,
-        \Repositories\Contracts\TeamIdentityRepositoryInterface $commonRepository,
         Season $season,
     ) {
         $this->repository = $repository;
-        $this->commonRepository = $commonRepository;
         $this->season = $season;
     }
 
@@ -184,10 +181,6 @@ class PlrParserService implements PlrParserServiceInterface
             ? (int) (100 - round($personalFoulsPerMinute / $maxFoulRatio * 100, 0))
             : 0;
 
-        // Team name for historical stats
-        $teamid = (int) $raw['teamid'];
-        $teamName = $this->commonRepository->getTeamnameFromTeamID($teamid) ?? '';
-
         return array_merge($raw, [
             'seasonFGM' => $seasonFGM,
             'seasonFGA' => $seasonFGA,
@@ -202,7 +195,6 @@ class PlrParserService implements PlrParserServiceInterface
             'heightIN' => $heightIN,
             'draftYear' => $draftYear,
             'ratingFOUL' => $ratingFOUL,
-            'teamName' => $teamName,
         ]);
     }
 

--- a/ibl5/classes/TeamOffDefStats/TeamOffDefStatsView.php
+++ b/ibl5/classes/TeamOffDefStats/TeamOffDefStatsView.php
@@ -46,7 +46,7 @@ class TeamOffDefStatsView implements TeamOffDefStatsViewInterface
         $differentials = $data['differentials'] ?? [];
 
         $html = '<div class="league-stats-container">';
-        $html .= '<h2 class="ibl-title">League-wide Statistics</h1>';
+        $html .= '<h2 class="ibl-title">League-wide Statistics</h2>';
 
         // Team Offense Totals
         $html .= '<h2 class="ibl-table-title">Team Offense Totals</h2>';

--- a/ibl5/phpstan-tests-baseline.neon
+++ b/ibl5/phpstan-tests-baseline.neon
@@ -3481,13 +3481,13 @@ parameters:
 		-
 			rawMessage: 'Parameter #1 $player1Data of method OneOnOneGame\OneOnOneGameEngine::simulateGame() expects array{pid: int, name: string, oo: int, r_drive_off: int, po: int, od: int, dd: int, pd: int, ...}, array given.'
 			identifier: argument.type
-			count: 7
+			count: 12
 			path: tests/OneOnOneGame/OneOnOneGameEngineTest.php
 
 		-
 			rawMessage: 'Parameter #2 $player2Data of method OneOnOneGame\OneOnOneGameEngine::simulateGame() expects array{pid: int, name: string, oo: int, r_drive_off: int, po: int, od: int, dd: int, pd: int, ...}, array given.'
 			identifier: argument.type
-			count: 7
+			count: 12
 			path: tests/OneOnOneGame/OneOnOneGameEngineTest.php
 
 		-
@@ -4121,7 +4121,7 @@ parameters:
 		-
 			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
 			identifier: staticMethod.dynamicCall
-			count: 3
+			count: 2
 			path: tests/PlrParser/PlrParserServiceTest.php
 
 		-
@@ -4853,7 +4853,7 @@ parameters:
 		-
 			rawMessage: 'Parameter #1 $data of method TeamOffDefStats\TeamOffDefStatsView::render() expects array{teams: list<array{teamid: int, team_city: string, team_name: string, color1: string, color2: string, offense_totals: array{games: string, fgm: string, fga: string, ftm: string, fta: string, tgm: string, tga: string, orb: string, ...}, offense_averages: array{fgm: string, fga: string, fgp: string, ftm: string, fta: string, ftp: string, tgm: string, tga: string, ...}, defense_totals: array{games: string, fgm: string, fga: string, ftm: string, fta: string, tgm: string, tga: string, orb: string, ...}, ...}>, league: array{totals: array{games: string, fgm: string, fga: string, ftm: string, fta: string, tgm: string, tga: string, orb: string, ...}, averages: array{fgm: string, fga: string, fgp: string, ftm: string, fta: string, ftp: string, tgm: string, tga: string, ...}, games: int}, differentials: list<array{teamid: int, team_city: string, team_name: string, color1: string, color2: string, differentials: array{fgm: string, fga: string, fgp: string, ftm: string, fta: string, ftp: string, tgm: string, tga: string, ...}}>}, array given.'
 			identifier: argument.type
-			count: 9
+			count: 10
 			path: tests/TeamOffDefStats/TeamOffDefStatsViewTest.php
 
 		-

--- a/ibl5/scripts/bulkJsbImport.php
+++ b/ibl5/scripts/bulkJsbImport.php
@@ -116,9 +116,8 @@ $resolver = new JsbParser\PlayerIdResolver($mysqli_db);
 $jsbService = new JsbParser\JsbImportService($repository, $resolver);
 $boxscoreProcessor = new Boxscore\BoxscoreProcessor($mysqli_db);
 $plrRepo = new PlrParser\PlrParserRepository($mysqli_db);
-$commonRepo = new Repositories\TeamIdentityRepository($mysqli_db);
 $season = new Season\Season($mysqli_db);
-$plrService = new PlrParser\PlrParserService($plrRepo, $commonRepo, $season);
+$plrService = new PlrParser\PlrParserService($plrRepo, $season);
 $lgeRepo = new LeagueConfig\LeagueConfigRepository($mysqli_db);
 $lgeService = new LeagueConfig\LeagueConfigService($lgeRepo);
 

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -104,10 +104,6 @@ try {
     echo $view->renderInitStatus('mainfile.php loaded');
     flush();
 
-    $commonRepository = new \Repositories\TeamIdentityRepository($mysqli_db);
-    echo $view->renderInitStatus('CommonRepository initialized');
-    flush();
-
     $season = new \Season\Season($mysqli_db);
 
     // Season year override for historical imports (e.g., Olympics 2003)
@@ -132,7 +128,7 @@ try {
     $lgeView = new LeagueConfig\LeagueConfigView();
 
     $plrRepo = new PlrParser\PlrParserRepository($mysqli_db, $leagueContext);
-    $plrService = new PlrParser\PlrParserService($plrRepo, $commonRepository, $season);
+    $plrService = new PlrParser\PlrParserService($plrRepo, $season);
 
     $boxscoreProcessor = new Boxscore\BoxscoreProcessor($mysqli_db, null, $season, $leagueContext);
     $boxscoreRepo = new Boxscore\BoxscoreRepository($mysqli_db, $leagueContext);

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
@@ -14,7 +14,6 @@ use PlrParser\PlrParserRepository;
 use PlrParser\PlrParserService;
 use SavedDepthChart\SavedDepthChartRepository;
 use Season\Season;
-use Repositories\TeamIdentityRepository;
 use Tests\DatabaseIntegration\DatabaseTestCase;
 use Updater\Contracts\JsbSourceResolverInterface;
 use Updater\Steps;
@@ -255,9 +254,8 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
     ): UpdaterService {
         $service = new UpdaterService();
 
-        $commonRepo = new TeamIdentityRepository($this->db);
         $plrRepo = new PlrParserRepository($this->db);
-        $plrService = new PlrParserService($plrRepo, $commonRepo, $season);
+        $plrService = new PlrParserService($plrRepo, $season);
 
         $boxscoreProcessor = new BoxscoreProcessor($this->db, null, $season);
         $boxscoreRepo = new BoxscoreRepository($this->db);

--- a/ibl5/tests/OneOnOneGame/OneOnOneGameEngineTest.php
+++ b/ibl5/tests/OneOnOneGame/OneOnOneGameEngineTest.php
@@ -261,6 +261,54 @@ final class OneOnOneGameEngineTest extends TestCase
         }
     }
 
+    /**
+     * Characterization: with the RNG seeded to a fixed value, a single
+     * simulateGame() run is fully deterministic — re-seeding to the same value
+     * reproduces a byte-identical play-by-play. Locks current behavior.
+     */
+    public function testSimulateGameIsDeterministicForFixedSeed(): void
+    {
+        $player1Data = $this->createMockPlayerData('Player One');
+        $player2Data = $this->createMockPlayerData('Player Two');
+
+        mt_srand(424242);
+        $first = $this->engine->simulateGame($player1Data, $player2Data, 'Owner');
+
+        mt_srand(424242);
+        $second = $this->engine->simulateGame($player1Data, $player2Data, 'Owner');
+
+        $this->assertSame($first->player1Score, $second->player1Score);
+        $this->assertSame($first->player2Score, $second->player2Score);
+        $this->assertSame($first->playByPlay, $second->playByPlay);
+    }
+
+    /**
+     * Repeated-invocation boundary: running simulateGame() twice on the same
+     * instance must not carry possession (or any per-game state) from the first
+     * run into the next. A run made after an intervening "dirtying" run, with
+     * the RNG re-seeded, reproduces the original run exactly — proving the
+     * per-game possession state is reset on each call, not stale.
+     */
+    public function testSimulateGameDoesNotLeakStateBetweenRuns(): void
+    {
+        $player1Data = $this->createMockPlayerData('Player One');
+        $player2Data = $this->createMockPlayerData('Player Two');
+
+        mt_srand(424242);
+        $first = $this->engine->simulateGame($player1Data, $player2Data, 'Owner');
+
+        // Intervening run on the same instance dirties any per-game state.
+        $this->engine->simulateGame($player1Data, $player2Data, 'Owner');
+
+        // Re-seeding to the original seed must reproduce the first run exactly.
+        mt_srand(424242);
+        $afterReset = $this->engine->simulateGame($player1Data, $player2Data, 'Owner');
+
+        $this->assertSame($first->player1Score, $afterReset->player1Score);
+        $this->assertSame($first->player2Score, $afterReset->player2Score);
+        $this->assertSame($first->playByPlay, $afterReset->playByPlay);
+    }
+
     // ========== Helper Methods ==========
 
     /**

--- a/ibl5/tests/PlrParser/PlrParserServiceTest.php
+++ b/ibl5/tests/PlrParser/PlrParserServiceTest.php
@@ -19,9 +19,6 @@ class PlrParserServiceTest extends TestCase
     /** @var PlrParserRepositoryInterface&\PHPUnit\Framework\MockObject\Stub */
     private PlrParserRepositoryInterface $stubRepository;
 
-    /** @var \Repositories\Contracts\TeamIdentityRepositoryInterface&\PHPUnit\Framework\MockObject\Stub */
-    private \Repositories\Contracts\TeamIdentityRepositoryInterface $stubCommonRepo;
-
     /** @var Season&\PHPUnit\Framework\MockObject\Stub */
     private Season $stubSeason;
 
@@ -29,15 +26,11 @@ class PlrParserServiceTest extends TestCase
     {
         $this->stubRepository = $this->createStub(PlrParserRepositoryInterface::class);
 
-        $this->stubCommonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
-        $this->stubCommonRepo->method('getTeamnameFromTeamID')->willReturn('Test Team');
-
         $this->stubSeason = $this->createStub(Season::class);
         $this->stubSeason->endingYear = 2026;
 
         $this->service = new PlrParserService(
             $this->stubRepository,
-            $this->stubCommonRepo,
             $this->stubSeason,
         );
     }
@@ -303,6 +296,43 @@ class PlrParserServiceTest extends TestCase
         $this->assertSame(100, $derived['ratingFOUL']);
     }
 
+    /**
+     * The discarded teamName N+1 lookup was removed: computeDerivedFields no
+     * longer emits a 'teamName' key. Consumers JOIN on teamid for the name.
+     */
+    public function testComputeDerivedFieldsDoesNotEmitTeamNameKey(): void
+    {
+        $raw = $this->buildRawParsedData(['teamid' => 5]);
+
+        $derived = $this->service->computeDerivedFields($raw, 0.1);
+
+        $this->assertArrayNotHasKey('teamName', $derived);
+        // teamid is still carried through (consumers JOIN for the name).
+        $this->assertSame(5, $derived['teamid']);
+    }
+
+    /**
+     * Guard the persisted derived columns: removing the teamName lookup must
+     * not alter any other derived field that upsert/snapshot payloads read.
+     */
+    public function testComputeDerivedFieldsPreservesPersistedColumns(): void
+    {
+        $raw = $this->buildRawParsedData();
+
+        $derived = $this->service->computeDerivedFields($raw, 0.1);
+
+        foreach (
+            [
+                'seasonFGM', 'seasonFGA', 'seasonREB', 'seasonPTS',
+                'careerFGM', 'careerFGA', 'careerREB', 'careerPTS',
+                'currentSeasonSalary', 'heightFT', 'heightIN',
+                'draftYear', 'ratingFOUL',
+            ] as $key
+        ) {
+            $this->assertArrayHasKey($key, $derived);
+        }
+    }
+
     public function testComputeDerivedFieldsFoulRatingWithZeroMaxRatio(): void
     {
         $raw = $this->buildRawParsedData([
@@ -362,7 +392,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
         $mockRepo->expects($this->once())->method('upsertPlayer');
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrFile($tmpFile);
 
         $this->assertSame(1, $result->playersUpserted);
@@ -377,7 +407,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
         $mockRepo->expects($this->never())->method('upsertPlayer');
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrFile($tmpFile);
 
         $this->assertSame(0, $result->playersUpserted);
@@ -392,7 +422,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
         $mockRepo->expects($this->once())->method('upsertPlayer');
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrData($data);
 
         $this->assertSame(1, $result->playersUpserted);
@@ -408,7 +438,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
         $mockRepo->expects($this->never())->method('upsertPlayer');
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrData($line . "\r\n");
 
         $this->assertSame(0, $result->playersUpserted);
@@ -422,7 +452,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
         $mockRepo->expects($this->exactly(2))->method('upsertPlayer');
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrData($data);
 
         $this->assertSame(2, $result->playersUpserted);
@@ -682,7 +712,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo->expects($this->once())->method('upsertSnapshot');
         $mockRepo->expects($this->never())->method('upsertPlayer');
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrFileForYear(
             $tmpFile,
             2001,
@@ -729,7 +759,7 @@ class PlrParserServiceTest extends TestCase
                     && array_key_exists('unk_548', $data);
             }));
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrFileForYear(
             $tmpFile,
             2001,
@@ -751,7 +781,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo->expects($this->once())->method('upsertPlayer');
         $mockRepo->expects($this->never())->method('upsertSnapshot');
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrFileForYear($tmpFile, 2001, PlrImportMode::Live);
 
         $this->assertSame(1, $result->playersUpserted);
@@ -767,7 +797,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo->expects($this->once())->method('upsertSnapshot');
         $mockRepo->expects($this->never())->method('upsertPlayer');
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrDataForYear(
             $data,
             2001,
@@ -788,7 +818,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo->expects($this->once())->method('upsertPlayer');
         $mockRepo->expects($this->never())->method('upsertSnapshot');
 
-        $service = new PlrParserService($mockRepo, $this->stubCommonRepo, $this->stubSeason);
+        $service = new PlrParserService($mockRepo, $this->stubSeason);
         $result = $service->processPlrDataForYear($data, 2001, PlrImportMode::Live);
 
         $this->assertSame(1, $result->playersUpserted);

--- a/ibl5/tests/TeamOffDefStats/TeamOffDefStatsViewTest.php
+++ b/ibl5/tests/TeamOffDefStats/TeamOffDefStatsViewTest.php
@@ -75,6 +75,20 @@ class TeamOffDefStatsViewTest extends TestCase
     }
 
     /**
+     * Test that the League-wide Statistics heading is a well-formed <h2>
+     * and does not contain a malformed </h1> closing tag.
+     */
+    public function testRenderLeagueWideHeadingClosesWithH2(): void
+    {
+        $data = $this->createMinimalViewData();
+
+        $result = $this->view->render($data);
+
+        $this->assertStringContainsString('<h2 class="ibl-title">League-wide Statistics</h2>', $result);
+        $this->assertStringNotContainsString('League-wide Statistics</h1>', $result);
+    }
+
+    /**
      * Test that team rows include data-team-id for client-side highlighting
      */
     public function testRenderIncludesDataTeamIdAttribute(): void


### PR DESCRIPTION
## Summary

Three independent correctness fixes found during the classes audit (Tier 1 §1.6):

1. **Malformed heading tag** —  was closing `<h2>` with `</h1>`. Fixed to `</h2>`.
2. **Stale per-game state in OneOnOneGameEngine** — `$currentPossession` was never reset between `simulateGame()` calls. Added reset at the top of `simulateGame()`.
3. **PlrParser N+1 query removed** — Deleted the unnecessary `getTeamnameFromTeamID()` call and `'teamName'` key from `computeDerivedFields()`. Consumers JOIN for the name via `teamid`.

Each fix has characterization + regression tests.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)