### PR TITLE
fix: document LEFT JOIN pid column in searchAwards row shape (offsetAccess.notFound)

### DIFF
--- a/ibl5/classes/AwardHistory/AwardHistoryRepository.php
+++ b/ibl5/classes/AwardHistory/AwardHistoryRepository.php
@@ -58,7 +58,7 @@ class AwardHistoryRepository extends BaseMysqliRepository implements AwardHistor
         $whereClause = $where->toWhereClause();
         $query = "SELECT a.year, a.award, a.name, a.table_id, p.pid FROM `ibl_awards` a LEFT JOIN `ibl_plr` p ON a.name = p.name WHERE $whereClause ORDER BY $sortColumn ASC";
 
-        /** @var array<int, array{year: int, award: string, name: string, table_id: int}> $results */
+        /** @var array<int, array{year: int, award: string, name: string, table_id: int, pid: int|null}> $results */
         $results = $this->fetchAll($query, $where->getTypes(), ...$where->getParams());
 
         return [

--- a/ibl5/classes/AwardHistory/Contracts/AwardHistoryRepositoryInterface.php
+++ b/ibl5/classes/AwardHistory/Contracts/AwardHistoryRepositoryInterface.php
@@ -25,7 +25,7 @@ interface AwardHistoryRepositoryInterface
      *     sortby: int
      * } $params Validated parameters from AwardHistoryValidatorInterface
      * @return array{
-     *     results: array<int, array{year: int, award: string, name: string, table_id: int}>,
+     *     results: array<int, array{year: int, award: string, name: string, table_id: int, pid: int|null}>,
      *     count: int
      * } Search results:
      *     - results: array of award records from `ibl_awards` table
@@ -48,7 +48,8 @@ interface AwardHistoryRepositoryInterface
      *  - award: varchar(128) - Award name/type
      *  - name: varchar(32) - Player name
      *  - table_id: int(11) AUTO_INCREMENT PRIMARY KEY
-     * 
+     *  - pid: int(11)|null - Player id from LEFT JOIN ibl_plr on name (null if no matching player)
+     *
      * Examples:
      *  $result = $repo->searchAwards(['name' => 'Smith', 'award' => null, 'year' => null, 'sortby' => 1]);
      *  // Returns all awards for players with 'Smith' in name, sorted by name

--- a/ibl5/classes/AwardHistory/Contracts/AwardHistoryServiceInterface.php
+++ b/ibl5/classes/AwardHistory/Contracts/AwardHistoryServiceInterface.php
@@ -22,7 +22,7 @@ interface AwardHistoryServiceInterface
      * 
      * @param array<string, mixed> $rawParams Raw POST parameters from form
      * @return array{
-     *     awards: array<int, array{year: int, award: string, name: string, table_id: int}>,
+     *     awards: array<int, array{year: int, award: string, name: string, table_id: int, pid: int|null}>,
      *     count: int,
      *     params: array{name: string|null, award: string|null, year: int|null, sortby: int}
      * } Search results:

--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -27,7 +27,6 @@
         "missingType.property": 25,
         "missingType.return": 219,
         "new.deprecatedClass": 2,
-        "offsetAccess.notFound": 1,
         "phpunit.assertCount": 3,
         "phpunit.assertEquals": 52,
         "phpunit.covers": 3,

--- a/ibl5/phpstan-tests-baseline.neon
+++ b/ibl5/phpstan-tests-baseline.neon
@@ -883,12 +883,6 @@ parameters:
 			path: tests/DatabaseIntegration/AwardGenerationServiceIntegrationTest.php
 
 		-
-			rawMessage: 'Offset ''pid'' does not exist on array{year: int, award: string, name: string, table_id: int}.'
-			identifier: offsetAccess.notFound
-			count: 2
-			path: tests/DatabaseIntegration/AwardHistoryRepositoryTest.php
-
-		-
 			rawMessage: 'Parameter #1 $params of method AwardHistory\AwardHistoryRepository::searchAwards() expects array{name: string|null, award: string|null, year: int|null, sortby: int}, array<string, mixed> given.'
 			identifier: argument.type
 			count: 15


### PR DESCRIPTION
## Summary

Documents the `pid: int|null` column in `AwardHistoryRepository::searchAwards()` row shape PHPDocs. This is a LEFT JOIN (`ibl_awards LEFT JOIN ibl_plr ON a.name = p.name`), so `p.pid` is nullable at the result-set level even though `ibl_plr.pid` is `NOT NULL` as a column.

Clears 2 `offsetAccess.notFound` occurrences deferred from PR #902.

**Files changed:**
- `AwardHistoryRepositoryInterface.php`: add `pid: int|null` to `@return` row shape
- `AwardHistoryRepository.php`: add `pid: int|null` to `@var` row shape
- `AwardHistoryServiceInterface.php`: propagate `pid: int|null` through service interface
- `phpstan-tests-baseline.neon`: drop 2 `offsetAccess.notFound` occurrences
- `phpstan-baseline-counts.json`: updated drift counts

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

Generated with [Claude Code](https://claude.ai/code)
