### PR TITLE
PHPStan Test-Baseline Burndown — PR 5 of 6: Dynamic Static-Call Style

### DIFF
--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -32,7 +32,6 @@
         "property.unusedType": 1,
         "staticMethod.alreadyNarrowedType": 37,
         "staticMethod.deprecated": 1,
-        "staticMethod.dynamicCall": 218,
         "ternary.shortNotAllowed": 10
     }
 }

--- a/ibl5/phpstan-tests-baseline.neon
+++ b/ibl5/phpstan-tests-baseline.neon
@@ -31,99 +31,9 @@ parameters:
 			path: tests/AllStarAppearances/AllStarAppearancesViewTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/GameBoxscoreControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/GameBoxscoreControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/GameDetailControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/GameDetailControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::anything().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Api/Controller/GameListControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Api/Controller/GameListControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/GameListControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/InjuriesControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Api/Controller/InjuriesControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::anything().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/LeadersControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/Api/Controller/LeadersControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 5
-			path: tests/Api/Controller/LeadersControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/PlayerDetailControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/PlayerDetailControllerTest.php
-
-		-
 			rawMessage: 'Call to function array_filter() requires parameter #2 to be passed to avoid loose comparison semantics.'
 			identifier: arrayFilter.strict
 			count: 1
-			path: tests/Api/Controller/PlayerExportControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
 			path: tests/Api/Controller/PlayerExportControllerTest.php
 
 		-
@@ -131,138 +41,6 @@ parameters:
 			identifier: ternary.shortNotAllowed
 			count: 1
 			path: tests/Api/Controller/PlayerExportControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/Api/Controller/PlayerHistoryControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Api/Controller/PlayerHistoryControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Api/Controller/PlayerListControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Api/Controller/PlayerListControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::anything().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Api/Controller/PlayerStatsControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Api/Controller/PlayerStatsControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Api/Controller/PlayerStatsControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Api/Controller/SeasonControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/Api/Controller/SeasonControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Api/Controller/StandingsControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/StandingsControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/TeamDetailControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Api/Controller/TeamDetailControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Api/Controller/TeamListControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/Api/Controller/TeamListControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Api/Controller/TeamRosterControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Api/Controller/TeamRosterControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::stringContains().'
-			identifier: staticMethod.dynamicCall
-			count: 5
-			path: tests/Api/Controller/TradeAcceptControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 5
-			path: tests/Api/Controller/TradeAcceptControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::stringContains().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/Api/Controller/TradeDeclineControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/Api/Controller/TradeDeclineControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 10
-			path: tests/Api/Middleware/RateLimiterTest.php
 
 		-
 			rawMessage: Casting to string something that's already string.
@@ -301,18 +79,6 @@ parameters:
 			path: tests/Api/Transformer/TeamTransformerTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::anything().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/ApiKeys/ApiKeysServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 6
-			path: tests/ApiKeys/ApiKeysServiceTest.php
-
-		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertInstanceOf() with ''Auth\\Contracts\\AuthRepositoryInterface'' and Auth\AuthRepository will always evaluate to true.'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
@@ -331,12 +97,6 @@ parameters:
 			path: tests/Auth/AuthServiceTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Auth/AuthServiceUsernameTest.php
-
-		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertSame() with 42 and 42 will always evaluate to true.'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
@@ -349,28 +109,10 @@ parameters:
 			path: tests/AwardHistory/AwardHistoryViewTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Bootstrap/Api/ApiKeyAuthBootstrapTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Bootstrap/Api/ApiRoutingBootstrapTest.php
-
-		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertInstanceOf() with ''Bootstrap\\Contracts\\BootstrapStepInterface'' and Bootstrap\RateLimitingBootstrap will always evaluate to true.'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
 			path: tests/Bootstrap/Api/RateLimitingBootstrapTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Bootstrap/Api/RequestParsingBootstrapTest.php
 
 		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertInstanceOf() with ''Bootstrap\\Contracts\\ContainerInterface'' and Bootstrap\Contracts\ContainerInterface will always evaluate to true.'
@@ -403,18 +145,6 @@ parameters:
 			path: tests/Bootstrap/ApplicationTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Bootstrap/AuthUsernameAccessorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Bootstrap/CookieDecodeTest.php
-
-		-
 			rawMessage: Function check_html not found.
 			identifier: function.notFound
 			count: 2
@@ -433,12 +163,6 @@ parameters:
 			path: tests/Bootstrap/SecurityBootstrapTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Bootstrap/SecurityBootstrapTest.php
-
-		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertInstanceOf() with ''Bootstrap\\Application'' and Bootstrap\Application will always evaluate to true.'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
@@ -448,12 +172,6 @@ parameters:
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Boxscore\\Contracts\\BoxscoreProcessorInterface'' and Boxscore\BoxscoreProcessor will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 2
-			path: tests/Boxscore/BoxscoreProcessorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 12
 			path: tests/Boxscore/BoxscoreProcessorTest.php
 
 		-
@@ -491,12 +209,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/CapSpace/CapSpaceViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 7
-			path: tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
 
 		-
 			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
@@ -673,12 +385,6 @@ parameters:
 			path: tests/ContractRulesTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/DatabaseIntegration/AwardGenerationServiceIntegrationTest.php
-
-		-
 			rawMessage: 'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).'
 			identifier: phpunit.assertCount
 			count: 1
@@ -689,12 +395,6 @@ parameters:
 			identifier: argument.type
 			count: 15
 			path: tests/DatabaseIntegration/AwardHistoryRepositoryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 10
-			path: tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
 
 		-
 			rawMessage: Casting to int something that's already int.
@@ -733,12 +433,6 @@ parameters:
 			path: tests/DatabaseIntegration/CrossTableColumnNamingTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::fail().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/DatabaseIntegration/DatabaseTestCase.php
-
-		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertTrue() with true will always evaluate to true.'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
@@ -749,12 +443,6 @@ parameters:
 			identifier: argument.type
 			count: 8
 			path: tests/DatabaseIntegration/FreeAgencyRepositoryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/DatabaseIntegration/LeagueControlPanelRepositoryTest.php
 
 		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertNotNull() with int will always evaluate to true.'
@@ -811,39 +499,15 @@ parameters:
 			path: tests/DatabaseIntegration/TeamOffDefStatsRepositoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/DatabaseIntegration/TeamOlympicsLoadTest.php
-
-		-
 			rawMessage: Casting to int something that's already int.
 			identifier: cast.useless
 			count: 1
 			path: tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/DatabaseIntegration/UpdateAllTheThings/ScheduleAtomicityTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''DepthChartEntry\\DepthChartEntryApiHandler'' and DepthChartEntry\DepthChartEntryApiHandler will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/DepthChartEntry/DepthChartEntryApiHandlerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
 			path: tests/DepthChartEntry/DepthChartEntryApiHandlerTest.php
 
 		-
@@ -857,18 +521,6 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 3
 			path: tests/DepthChartEntry/DepthChartEntryControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 5
-			path: tests/DepthChartEntry/DepthChartEntryControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/DepthChartEntry/DepthChartEntryProcessorTest.php
 
 		-
 			rawMessage: 'Parameter #1 $player of method DepthChartEntry\DepthChartEntryView::renderPlayerRow() expects array{pid: int, name: string, nickname: string|null, age: int|null, teamid: int, teamname: string|null, pos: string, stamina: int|null, ..., ...<string, mixed>}, array{pid: 1, name: ''Round Trip Player'', pos: ''SG'', injured: 0, stamina: 60, dc_pg_depth: 0, dc_sg_depth: 1, dc_sf_depth: 2, ...} given.'
@@ -967,12 +619,6 @@ parameters:
 			path: tests/DepthChartEntry/DepthChartEntrySubmissionHandlerTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/DepthChartEntry/DepthChartEntrySubmissionHandlerTest.php
-
-		-
 			rawMessage: 'Parameter #1 $depthChartData of method DepthChartEntry\DepthChartEntryValidator::validate() expects array{playerData: list<array{name: string, pg: int, sg: int, sf: int, pf: int, c: int, canPlayInGame: int, min: int, ...}>, activePlayers: int, pos_1: int, pos_2: int, pos_3: int, pos_4: int, pos_5: int, hasStarterAtMultiplePositions: bool, ...}, array{activePlayers: 10, pos_1: 2, pos_2: 2, pos_3: 2, pos_4: 2, pos_5: 2, hasStarterAtMultiplePositions: false, nameOfProblemStarter: ''''} given.'
 			identifier: argument.type
 			count: 1
@@ -1021,18 +667,6 @@ parameters:
 			path: tests/DepthChartEntry/DepthChartEntryValidatorTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/DepthChartEntry/DepthChartEntryViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/DepthChartEntry/DepthChartEntryViewXssTest.php
-
-		-
 			rawMessage: @@covers value \Discord references an invalid class or function.
 			identifier: phpunit.covers
 			count: 1
@@ -1063,28 +697,10 @@ parameters:
 			path: tests/Discord/DiscordIntegrationTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Discord/DiscordIntegrationTest.php
-
-		-
 			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
 			identifier: empty.notAllowed
 			count: 4
 			path: tests/Discord/DiscordTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Discord/DiscordTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Draft/DraftRepositoryTest.php
 
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Draft\\Contracts\\DraftSelectionHandlerInterface'' and Draft\DraftSelectionHandler will always evaluate to true.'
@@ -1096,12 +712,6 @@ parameters:
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Draft\\DraftSelectionHandler'' and Draft\DraftSelectionHandler will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 3
-			path: tests/Draft/DraftSelectionHandlerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
 			path: tests/Draft/DraftSelectionHandlerTest.php
 
 		-
@@ -1127,12 +737,6 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/DraftHistory/DraftHistoryApiHandlerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/DraftHistory/DraftHistoryRepositoryTest.php
 
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''DraftHistory\\Contracts\\DraftHistoryViewInterface'' and DraftHistory\DraftHistoryView will always evaluate to true.'
@@ -1357,12 +961,6 @@ parameters:
 			path: tests/Extension/ExtensionRepositoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::fail().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Extension/ExtensionRepositoryTest.php
-
-		-
 			rawMessage: 'Array has 2 duplicate keys with value ''teamid'' (''teamid'', ''teamid'').'
 			identifier: array.duplicateKey
 			count: 1
@@ -1389,12 +987,6 @@ parameters:
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Extension\\ExtensionService'' and Extension\ExtensionService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Extension/ExtensionServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
 			count: 1
 			path: tests/Extension/ExtensionServiceTest.php
 
@@ -1438,12 +1030,6 @@ parameters:
 			path: tests/FranchiseRecordBook/FranchiseRecordBookApiHandlerTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/FranchiseRecordBook/FranchiseRecordBookServiceTest.php
-
-		-
 			rawMessage: 'Parameter #1 $offer of method FreeAgency\CommonContractValidator::calculateOfferValue() expects array{year1: int, year2: int, year3: int, year4?: int, year5?: int, year6?: int}, array{} given.'
 			identifier: argument.type
 			count: 1
@@ -1472,12 +1058,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/FreeAgency/CommonContractValidatorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 12
-			path: tests/FreeAgency/FreeAgencyAdminProcessorTest.php
 
 		-
 			rawMessage: 'Parameter #2 $signings of method FreeAgency\FreeAgencyAdminProcessor::executeSignings() expects list<array{playerId: int, teamId: int, teamName: string, offers: array{offer1: int, offer2: int, offer3: int, offer4: int, offer5: int, offer6: int}, offerYears: int, usedMle: bool, usedLle: bool}>, array{array{playerId: int, teamId: int, teamName: string, offers: array{offer1: int, offer2: int, offer3: int, offer4: int, offer5: int, offer6: int}, offerYears: int, offerTotal: float, usedMle: bool, usedLle: bool}} given.'
@@ -1510,28 +1090,10 @@ parameters:
 			path: tests/FreeAgency/FreeAgencyAdminRepositoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/FreeAgency/FreeAgencyCapCalculatorTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''FreeAgency\\FreeAgencyController'' and FreeAgency\FreeAgencyController will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/FreeAgency/FreeAgencyControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 5
-			path: tests/FreeAgency/FreeAgencyControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/FreeAgency/FreeAgencyDemandCalculatorTest.php
 
 		-
 			rawMessage: 'Property Tests\FreeAgency\MockDemandRepository::$playerDemands (array{dem1: int, dem2: int, dem3: int, dem4: int, dem5: int, dem6: int}) does not accept default value of type array{}.'
@@ -1544,12 +1106,6 @@ parameters:
 			identifier: property.defaultValue
 			count: 1
 			path: tests/FreeAgency/FreeAgencyDemandCalculatorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/FreeAgency/FreeAgencyOfferValidatorTest.php
 
 		-
 			rawMessage: 'Array has 2 duplicate keys with value ''r_tvr'' (''r_tvr'', ''r_tvr'').'
@@ -1567,12 +1123,6 @@ parameters:
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''FreeAgency\\FreeAgencyProcessor'' and FreeAgency\FreeAgencyProcessor will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 2
-			path: tests/FreeAgency/FreeAgencyProcessorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 13
 			path: tests/FreeAgency/FreeAgencyProcessorTest.php
 
 		-
@@ -1603,12 +1153,6 @@ parameters:
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Player\\Player'' and Player\Player will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/FreeAgency/FreeAgencyServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 27
 			path: tests/FreeAgency/FreeAgencyServiceTest.php
 
 		-
@@ -1645,12 +1189,6 @@ parameters:
 			rawMessage: Access to an undefined property PHPUnit\Framework\MockObject\Stub&Player\Player::$yearsOfExperience.
 			identifier: property.notFound
 			count: 2
-			path: tests/FreeAgency/FreeAgencyViewXssTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 4
 			path: tests/FreeAgency/FreeAgencyViewXssTest.php
 
 		-
@@ -1798,24 +1336,6 @@ parameters:
 			path: tests/JsbParser/HofFileParserTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/JsbParser/JsbExportServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/JsbParser/JsbImportServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::fail().'
-			identifier: staticMethod.dynamicCall
-			count: 5
-			path: tests/JsbParser/SchFileParserTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertSame() with 1000000 and 1000000 will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -1858,12 +1378,6 @@ parameters:
 			path: tests/JsbParser/ScoFileParserTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/LastSimRecap/LastSimRecapServiceTest.php
-
-		-
 			rawMessage: 'Call to function array_filter() requires parameter #2 to be passed to avoid loose comparison semantics.'
 			identifier: arrayFilter.strict
 			count: 1
@@ -1874,12 +1388,6 @@ parameters:
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
 			path: tests/LastSimRecap/LastSimRecapViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/LastSimRecap/NewsModuleIntegrationTest.php
 
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertSame() with ''ibl'' and ''ibl'' will always evaluate to true.'
@@ -1912,57 +1420,15 @@ parameters:
 			path: tests/LeagueConfig/LeagueConfigRepositoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::fail().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/LeagueConfig/LeagueConfigServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isArray().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/LeagueConfig/LeagueConfigServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isInt().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/LeagueConfig/LeagueConfigServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 9
-			path: tests/LeagueConfig/LeagueConfigServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::fail().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/LeagueConfig/LgeFileParserTest.php
-
-		-
 			rawMessage: 'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).'
 			identifier: phpunit.assertCount
 			count: 1
 			path: tests/LeagueConfig/LgeFileParserTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/LeagueControlPanel/AwardGenerationServiceTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''LeagueControlPanel\\Contracts\\LeagueControlPanelProcessorInterface'' and LeagueControlPanel\LeagueControlPanelProcessor will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/LeagueControlPanel/LeagueControlPanelProcessorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 37
 			path: tests/LeagueControlPanel/LeagueControlPanelProcessorTest.php
 
 		-
@@ -1985,21 +1451,9 @@ parameters:
 			path: tests/LeagueControlPanel/LeagueControlPanelRepositoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/LeagueControlPanel/LeagueControlPanelRepositoryTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''LeagueControlPanel\\Contracts\\LeagueControlPanelServiceInterface'' and LeagueControlPanel\LeagueControlPanelService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/LeagueControlPanel/LeagueControlPanelServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 6
 			path: tests/LeagueControlPanel/LeagueControlPanelServiceTest.php
 
 		-
@@ -2021,12 +1475,6 @@ parameters:
 			path: tests/LeagueSchedule/LeagueScheduleServiceTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 28
-			path: tests/LeagueSchedule/LeagueScheduleServiceTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''LeagueSchedule\\Contracts\\LeagueScheduleViewInterface'' and LeagueSchedule\LeagueScheduleView will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -2045,12 +1493,6 @@ parameters:
 			path: tests/LeagueStarters/LeagueStartersApiHandlerTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/LeagueStarters/LeagueStartersApiHandlerTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''LeagueStarters\\Contracts\\LeagueStartersServiceInterface'' and LeagueStarters\LeagueStartersService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -2060,12 +1502,6 @@ parameters:
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''LeagueStarters\\LeagueStartersService'' and LeagueStarters\LeagueStartersService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/LeagueStarters/LeagueStartersServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 4
 			path: tests/LeagueStarters/LeagueStartersServiceTest.php
 
 		-
@@ -2135,82 +1571,16 @@ parameters:
 			path: tests/Logging/LoggerFactoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::fail().'
-			identifier: staticMethod.dynamicCall
-			count: 6
-			path: tests/Mail/MailServiceSmtpIntegrationTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::markTestSkipped().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Mail/MailServiceSmtpIntegrationTest.php
-
-		-
 			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
 			identifier: ternary.shortNotAllowed
 			count: 3
 			path: tests/Migration/MigrationFileIntegrityTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::fail().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Migration/MigrationRunnerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Migration/MigrationRunnerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Module/EntryPoints/ApiKeysEntryPointTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Module/EntryPoints/ModuleEntryPointTestCase.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Module/EntryPoints/StandingsEntryPointTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Module/EntryPoints/TeamEntryPointTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/Module/ModuleAccessControlTest.php
-
-		-
 			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
 			identifier: ternary.shortNotAllowed
 			count: 1
 			path: tests/Module/ModuleRegistryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Navigation/Views/NavigationViewsXssTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Negotiation/NegotiationDemandCalculatorTest.php
 
 		-
 			rawMessage: 'Parameter #2 $teamFactors of method Negotiation\NegotiationDemandCalculator::calculateDemands() expects array{wins: int, losses: int, tradition_wins: int, tradition_losses: int, money_committed_at_position: int}, array{} given.'
@@ -2237,12 +1607,6 @@ parameters:
 			path: tests/Negotiation/NegotiationRepositoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 9
-			path: tests/Negotiation/NegotiationRepositoryTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Negotiation\\Contracts\\NegotiationServiceInterface'' and Negotiation\NegotiationService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -2255,18 +1619,6 @@ parameters:
 			path: tests/Negotiation/NegotiationServiceTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Negotiation/NegotiationServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Negotiation/NegotiationValidatorTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''NextSim\\Contracts\\NextSimServiceInterface'' and NextSim\NextSimService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -2275,12 +1627,6 @@ parameters:
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''NextSim\\NextSimService'' and NextSim\NextSimService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/NextSim/NextSimServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
 			count: 1
 			path: tests/NextSim/NextSimServiceTest.php
 
@@ -2327,12 +1673,6 @@ parameters:
 			path: tests/NextSim/NextSimViewTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 6
-			path: tests/NextSim/NextSimViewTest.php
-
-		-
 			rawMessage: Access to an undefined property PHPUnit\Framework\MockObject\Stub&Player\Player::$age.
 			identifier: property.notFound
 			count: 1
@@ -2360,12 +1700,6 @@ parameters:
 			rawMessage: Access to an undefined property PHPUnit\Framework\MockObject\Stub&Player\Player::$position.
 			identifier: property.notFound
 			count: 1
-			path: tests/NextSim/NextSimViewXssTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 5
 			path: tests/NextSim/NextSimViewXssTest.php
 
 		-
@@ -2429,18 +1763,6 @@ parameters:
 			path: tests/PageLayout/PageLayoutHeaderSideEffectTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/PageLayout/PageLayoutHeaderSideEffectTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Player/PlayerContractValidatorTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Player\\PlayerData'' and Player\PlayerData will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -2451,30 +1773,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/Player/PlayerImageHelperTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Player/PlayerPageControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Player/PlayerPageServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Player/PlayerRepositoryFieldMapTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Player/PlayerStatsTest.php
 
 		-
 			rawMessage: 'Property Tests\Player\PlayerViewFactoryTest::$mockDb is never read, only written.'
@@ -2489,20 +1787,8 @@ parameters:
 			path: tests/Player/Stats/Views/PlayerHeatAveragesViewTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Player/Stats/Views/PlayerHeatAveragesViewTest.php
-
-		-
 			rawMessage: 'Call to internal method PHPUnit\Framework\TestCase::addToAssertionCount() from outside its root namespace PHPUnit.'
 			identifier: method.internal
-			count: 1
-			path: tests/Player/Stats/Views/PlayerHeatTotalsViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
 			count: 1
 			path: tests/Player/Stats/Views/PlayerHeatTotalsViewTest.php
 
@@ -2513,20 +1799,8 @@ parameters:
 			path: tests/Player/Stats/Views/PlayerOlympicAveragesViewTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Player/Stats/Views/PlayerOlympicAveragesViewTest.php
-
-		-
 			rawMessage: 'Call to internal method PHPUnit\Framework\TestCase::addToAssertionCount() from outside its root namespace PHPUnit.'
 			identifier: method.internal
-			count: 1
-			path: tests/Player/Stats/Views/PlayerOlympicTotalsViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
 			count: 1
 			path: tests/Player/Stats/Views/PlayerOlympicTotalsViewTest.php
 
@@ -2537,20 +1811,8 @@ parameters:
 			path: tests/Player/Stats/Views/PlayerPlayoffAveragesViewTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Player/Stats/Views/PlayerPlayoffAveragesViewTest.php
-
-		-
 			rawMessage: 'Call to internal method PHPUnit\Framework\TestCase::addToAssertionCount() from outside its root namespace PHPUnit.'
 			identifier: method.internal
-			count: 1
-			path: tests/Player/Stats/Views/PlayerPlayoffTotalsViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
 			count: 1
 			path: tests/Player/Stats/Views/PlayerPlayoffTotalsViewTest.php
 
@@ -2561,12 +1823,6 @@ parameters:
 			path: tests/Player/Stats/Views/PlayerSeasonTableRendererTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Player/Views/CardBaseStylesXssTest.php
-
-		-
 			rawMessage: '''
 				Call to deprecated method getStyles() of class Player\Views\PlayerStatsCardView:
 				CSS is now centralized in design/components/player-cards.css.
@@ -2575,18 +1831,6 @@ parameters:
 			identifier: staticMethod.deprecated
 			count: 1
 			path: tests/Player/Views/PlayerStatsCardViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::anything().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/PlayerDatabase/PlayerDatabaseRepositoryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 8
-			path: tests/PlayerDatabase/PlayerDatabaseRepositoryTest.php
 
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''PlayerMovement\\Contracts\\PlayerMovementRepositoryInterface'' and PlayerMovement\PlayerMovementRepository will always evaluate to true.'
@@ -2619,24 +1863,6 @@ parameters:
 			path: tests/PlrParser/PlrParserRepositoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/PlrParser/PlrParserServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/PlrParser/PlrParserServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/PlrParser/PlrReconstructionServiceTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''BaseMysqliRepository'' and ProjectedDraftOrder\ProjectedDraftOrderRepository will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -2655,45 +1881,15 @@ parameters:
 			path: tests/ProjectedDraftOrder/ProjectedDraftOrderServiceTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/ProjectedDraftOrder/ProjectedDraftOrderServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/ProjectedDraftOrder/ProjectedDraftOrderServiceTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''ProjectedDraftOrder\\Contracts\\ProjectedDraftOrderViewInterface'' and ProjectedDraftOrder\ProjectedDraftOrderView will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/ProjectedDraftOrder/ProjectedDraftOrderViewTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/RecordHolders/CachedRecordHoldersServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/RecordHolders/RecordBreakingDetectorTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertNotFalse() with int|string|null will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 2
-			path: tests/RecordHolders/RecordHoldersServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
 			path: tests/RecordHolders/RecordHoldersServiceTest.php
 
 		-
@@ -2706,12 +1902,6 @@ parameters:
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''RookieOption\\RookieOptionController'' and RookieOption\RookieOptionController will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/RookieOption/RookieOptionControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
 			path: tests/RookieOption/RookieOptionControllerTest.php
 
 		-
@@ -2743,18 +1933,6 @@ parameters:
 			identifier: property.notFound
 			count: 1
 			path: tests/RookieOption/RookieOptionValidatorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 5
-			path: tests/RookieOption/RookieOptionValidatorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/SavedDepthChart/SavedDepthChartApiHandlerTest.php
 
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''SavedDepthChart\\Contracts\\SavedDepthChartServiceInterface'' and SavedDepthChart\SavedDepthChartService will always evaluate to true.'
@@ -2799,18 +1977,6 @@ parameters:
 			path: tests/SeasonArchive/SeasonArchiveServiceTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/SeasonArchive/SeasonArchiveServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/SeasonArchive/SeasonArchiveServiceTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''SeasonArchive\\Contracts\\SeasonArchiveViewInterface'' and SeasonArchive\SeasonArchiveView will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -2823,22 +1989,10 @@ parameters:
 			path: tests/SeasonHighs/SeasonHighsServiceTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 16
-			path: tests/SeasonHighs/SeasonHighsServiceTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''SeasonHighs\\Contracts\\SeasonHighsViewInterface'' and SeasonHighs\SeasonHighsView will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/SeasonHighs/SeasonHighsViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/SeasonLeaderboards/CachedSeasonLeaderboardsRepositoryTest.php
 
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''BaseMysqliRepository'' and SeasonLeaderboards\SeasonLeaderboardsRepository will always evaluate to true.'
@@ -2857,24 +2011,6 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/SeasonLeaderboards/SeasonLeaderboardsRepositoryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/SeasonLeaderboards/SeasonLeaderboardsServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/SeasonLeaderboards/SeasonLeaderboardsViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/SeasonLeaderboards/SeasonLeaderboardsViewXssTest.php
 
 		-
 			rawMessage: 'Call to function property_exists() with Tests\WideUnit\Mocks\Season and ''showDraftLink'' will always evaluate to true.'
@@ -2943,12 +2079,6 @@ parameters:
 			path: tests/SeasonTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/SeasonTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''SeriesRecords\\Contracts\\SeriesRecordsControllerInterface'' and SeriesRecords\SeriesRecordsController will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -2958,12 +2088,6 @@ parameters:
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''SeriesRecords\\SeriesRecordsController'' and SeriesRecords\SeriesRecordsController will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/SeriesRecords/SeriesRecordsControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
 			path: tests/SeriesRecords/SeriesRecordsControllerTest.php
 
 		-
@@ -2985,28 +2109,10 @@ parameters:
 			path: tests/SeriesRecords/SeriesRecordsRepositoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Settings/SettingsServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Standings/OlympicsStandingsViewTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Standings\\Contracts\\StandingsRepositoryInterface'' and Standings\StandingsRepository will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Standings/StandingsRepositoryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Standings/StandingsViewXssTest.php
 
 		-
 			rawMessage: 'Parameter #1 $games of method Statistics\TeamStatsCalculator::calculate() expects list<array{visitor_teamid: int, visitor_score: int, home_teamid: int, home_score: int}>, array{array{visitor_score: 100, home_score: 95}} given.'
@@ -3039,32 +2145,14 @@ parameters:
 			path: tests/Team/TeamControllerTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 6
-			path: tests/Team/TeamControllerTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Team\\Contracts\\TeamServiceInterface'' and Team\TeamService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Team/TeamServiceTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Team/TeamServiceTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Team\\Contracts\\TeamTableServiceInterface'' and Team\TeamTableService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Team/TeamTableServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
 			count: 1
 			path: tests/Team/TeamTableServiceTest.php
 
@@ -3171,12 +2259,6 @@ parameters:
 			path: tests/TeamSchedule/TeamScheduleServiceTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/TeamSchedule/TeamScheduleServiceTest.php
-
-		-
 			rawMessage: 'Parameter #2 $games of method TeamSchedule\TeamScheduleView::render() expects list<array{game: LeagueSchedule\Game, currentMonth: string, opposingTeam: Team\Team, opponentText: string, highlight: string, gameResult: string, wins: int, losses: int, ...}>, array{array<string, mixed>, array<string, mixed>} given.'
 			identifier: argument.type
 			count: 1
@@ -3231,12 +2313,6 @@ parameters:
 			path: tests/Trading/CashTransactionHandlerTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Trading/CashTransactionHandlerTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Trading\\Contracts\\TradeCashRepositoryInterface'' and Trading\TradeCashRepository will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -3247,24 +2323,6 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Trading/TradeCashRepositoryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::anything().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Trading/TradeOfferTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::callback().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Trading/TradeOfferTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 15
-			path: tests/Trading/TradeOfferTest.php
 
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Trading\\Contracts\\TradeProcessorInterface'' and Trading\TradeProcessor will always evaluate to true.'
@@ -3279,26 +2337,8 @@ parameters:
 			path: tests/Trading/TradeProcessorTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Trading/TradeProcessorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 7
-			path: tests/Trading/TradeQueueProcessorTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertTrue() with true will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Trading/TradeRosterPreviewApiHandlerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
 			count: 1
 			path: tests/Trading/TradeRosterPreviewApiHandlerTest.php
 
@@ -3339,21 +2379,9 @@ parameters:
 			path: tests/Trading/TradingControllerAcceptOfferTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 7
-			path: tests/Trading/TradingControllerAcceptOfferTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Trading\\TradingController'' and Trading\TradingController will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/Trading/TradingControllerOfferTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 8
 			path: tests/Trading/TradingControllerOfferTest.php
 
 		-
@@ -3369,28 +2397,10 @@ parameters:
 			path: tests/Trading/TradingControllerRejectOfferTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 7
-			path: tests/Trading/TradingControllerRejectOfferTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Trading\\Contracts\\TradingControllerInterface'' and Trading\TradingController will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Trading/TradingControllerReviewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 8
-			path: tests/Trading/TradingControllerReviewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 9
-			path: tests/Trading/TradingControllerRosterPreviewTest.php
 
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Trading\\Contracts\\TradingControllerInterface'' and Trading\TradingController will always evaluate to true.'
@@ -3402,12 +2412,6 @@ parameters:
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Trading\\TradingController'' and Trading\TradingController will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/Trading/TradingControllerSubmitOfferTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 7
 			path: tests/Trading/TradingControllerSubmitOfferTest.php
 
 		-
@@ -3471,28 +2475,10 @@ parameters:
 			path: tests/Trading/TradingRepositoryTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 69
-			path: tests/Trading/TradingServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/Trading/TradingViewTest.php
-
-		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertInstanceOf() with ''TrainingCampRatingsDiff\\Contracts\\TrainingCampRatingsDiffRepositoryInterface'' and TrainingCampRatingsDiff\TrainingCampRatingsDiffRepository will always evaluate to true.'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
 			path: tests/TrainingCampRatingsDiff/TrainingCampRatingsDiffRepositoryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/TrainingCampRatingsDiff/TrainingCampRatingsDiffServiceTest.php
 
 		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertInstanceOf() with ''TrainingCampRatingsDiff\\Contracts\\TrainingCampRatingsDiffViewInterface'' and TrainingCampRatingsDiff\TrainingCampRatingsDiffView will always evaluate to true.'
@@ -3505,12 +2491,6 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/TransactionHistory/TransactionHistoryViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 11
-			path: tests/UI/Tables/PlayerRowTransformerTest.php
 
 		-
 			rawMessage: 'Parameter #2 $result of static method UI\Tables\PlayerRowTransformer::resolveWithStats() expects iterable<int, array<string, mixed>|Player\Player>, array<int, stdClass> given.'
@@ -3543,51 +2523,15 @@ parameters:
 			path: tests/Unit/BulkImport/ArchiveExtractorTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Unit/BulkImport/BackupArchiveLocatorTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 7
-			path: tests/Unit/BulkImport/BulkImportRunnerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::anything().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Unit/BulkImport/FileTypeHandlerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/Unit/BulkImport/FileTypeHandlerTest.php
-
-		-
 			rawMessage: 'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).'
 			identifier: phpunit.assertCount
 			count: 1
 			path: tests/Unit/BulkImport/JsbFileTypeTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/UpdateAllTheThings/JsbSourceResolverTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\PowerRankingsUpdater'' and Updater\PowerRankingsUpdater will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 2
-			path: tests/UpdateAllTheThings/PowerRankingsUpdaterTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
 			path: tests/UpdateAllTheThings/PowerRankingsUpdaterTest.php
 
 		-
@@ -3597,21 +2541,9 @@ parameters:
 			path: tests/UpdateAllTheThings/ScheduleUpdaterTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/UpdateAllTheThings/ScheduleUpdaterTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\StandingsUpdater'' and Updater\StandingsUpdater will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 2
-			path: tests/UpdateAllTheThings/StandingsUpdaterTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
 			path: tests/UpdateAllTheThings/StandingsUpdaterTest.php
 
 		-
@@ -3627,33 +2559,15 @@ parameters:
 			path: tests/UpdateAllTheThings/Steps/EndOfSeasonImportStepTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/UpdateAllTheThings/Steps/EndOfSeasonImportStepTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\Contracts\\PipelineStepInterface'' and Updater\Steps\ExtendDepthChartsStep will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/UpdateAllTheThings/Steps/ExtendDepthChartsStepTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/UpdateAllTheThings/Steps/ExtendDepthChartsStepTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\Contracts\\PipelineStepInterface'' and Updater\Steps\ExtractFromBackupStep will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
 			path: tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
 
 		-
@@ -3669,21 +2583,9 @@ parameters:
 			path: tests/UpdateAllTheThings/Steps/ImportLeagueConfigStepTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/UpdateAllTheThings/Steps/ImportLeagueConfigStepTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\Contracts\\PipelineStepInterface'' and Updater\Steps\ParseJsbFilesStep will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/UpdateAllTheThings/Steps/ParseJsbFilesStepTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
 			path: tests/UpdateAllTheThings/Steps/ParseJsbFilesStepTest.php
 
 		-
@@ -3693,21 +2595,9 @@ parameters:
 			path: tests/UpdateAllTheThings/Steps/ParsePlayerFileStepTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/UpdateAllTheThings/Steps/ParsePlayerFileStepTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\Contracts\\PipelineStepInterface'' and Updater\Steps\ProcessAllStarGamesStep will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/UpdateAllTheThings/Steps/ProcessAllStarGamesStepTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 4
 			path: tests/UpdateAllTheThings/Steps/ProcessAllStarGamesStepTest.php
 
 		-
@@ -3717,21 +2607,9 @@ parameters:
 			path: tests/UpdateAllTheThings/Steps/ProcessBoxscoresStepTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/UpdateAllTheThings/Steps/ProcessBoxscoresStepTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\Contracts\\PipelineStepInterface'' and Updater\Steps\RefreshIblHistStep will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/UpdateAllTheThings/Steps/RefreshIblHistStepTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
 			path: tests/UpdateAllTheThings/Steps/RefreshIblHistStepTest.php
 
 		-
@@ -3741,21 +2619,9 @@ parameters:
 			path: tests/UpdateAllTheThings/Steps/RefreshPlayoffSeriesResultsStepTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/UpdateAllTheThings/Steps/RefreshPlayoffSeriesResultsStepTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\Contracts\\PipelineStepInterface'' and Updater\Steps\RefreshTeamSeasonRecordsStep will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/UpdateAllTheThings/Steps/RefreshTeamSeasonRecordsStepTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
 			path: tests/UpdateAllTheThings/Steps/RefreshTeamSeasonRecordsStepTest.php
 
 		-
@@ -3771,21 +2637,9 @@ parameters:
 			path: tests/UpdateAllTheThings/Steps/SnapshotPlrStepTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/UpdateAllTheThings/Steps/SnapshotPlrStepTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\Contracts\\PipelineStepInterface'' and Updater\Steps\UpdatePowerRankingsStep will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/UpdateAllTheThings/Steps/UpdatePowerRankingsStepTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
 			path: tests/UpdateAllTheThings/Steps/UpdatePowerRankingsStepTest.php
 
 		-
@@ -3795,33 +2649,15 @@ parameters:
 			path: tests/UpdateAllTheThings/Steps/UpdateScheduleStepTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/UpdateAllTheThings/Steps/UpdateScheduleStepTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\Contracts\\PipelineStepInterface'' and Updater\Steps\UpdateStandingsStep will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/UpdateAllTheThings/Steps/UpdateStandingsStepTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/UpdateAllTheThings/Steps/UpdateStandingsStepTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Updater\\Contracts\\UpdaterServiceInterface'' and Updater\UpdaterService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/UpdateAllTheThings/UpdaterServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 12
 			path: tests/UpdateAllTheThings/UpdaterServiceTest.php
 
 		-
@@ -3837,39 +2673,9 @@ parameters:
 			path: tests/Updater/ScheduleUpdaterTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/Updater/ScheduleUpdaterTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 11
-			path: tests/Updater/UpdaterControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 6
-			path: tests/Updater/UpdaterServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/Validation/CommonValidatorTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Voting\\Contracts\\VotingBallotServiceInterface'' and Voting\VotingBallotService will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: tests/Voting/VotingBallotServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 16
 			path: tests/Voting/VotingBallotServiceTest.php
 
 		-
@@ -3877,12 +2683,6 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Voting/VotingBallotViewTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 19
-			path: tests/Voting/VotingSubmissionServiceTest.php
 
 		-
 			rawMessage: 'Parameter #2 $ballot of method Voting\VotingSubmissionService::submitEoyVote() expects array{mvp_1: string, mvp_2: string, mvp_3: string, six_1: string, six_2: string, six_3: string, roy_1: string, roy_2: string, ...}, array{mvp_1: string, mvp_2: string, mvp_3: string, six_1: string, six_2: string, six_3: string, roy_1: string, roy_2: string, ..., ...<string, ''John Doe, My Team''>} given.'
@@ -3903,12 +2703,6 @@ parameters:
 			path: tests/Voting/VotingSubmissionViewTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 4
-			path: tests/VotingResults/VotingResultsServiceTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Waivers\\Contracts\\WaiversControllerInterface'' and Waivers\WaiversController will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -3925,18 +2719,6 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Waivers/WaiversControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 7
-			path: tests/Waivers/WaiversControllerTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 6
-			path: tests/Waivers/WaiversProcessorTest.php
 
 		-
 			rawMessage: 'Parameter #1 $playerData of method Waivers\WaiversProcessor::determineContractData() expects array{pid: int, name: string, nickname: string|null, age: int|null, teamid: int, teamname: string|null, pos: string, stamina: int|null, ..., ...<string, mixed>}, array{salary_yr1: 0, exp: 8} given.'
@@ -3963,21 +2745,9 @@ parameters:
 			path: tests/Waivers/WaiversProcessorTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 6
-			path: tests/Waivers/WaiversProcessorWriteTest.php
-
-		-
 			rawMessage: 'Call to static method PHPUnit\Framework\Assert::assertInstanceOf() with ''Waivers\\Contracts\\WaiversServiceInterface'' and Waivers\WaiversService will always evaluate to true.'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
-			path: tests/Waivers/WaiversServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 5
 			path: tests/Waivers/WaiversServiceTest.php
 
 		-
@@ -4023,12 +2793,6 @@ parameters:
 			path: tests/WideUnit/Draft/DraftWideUnitTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/WideUnit/Draft/DraftWideUnitTest.php
-
-		-
 			rawMessage: 'Array has 2 duplicate keys with value ''teamid'' (''teamid'', ''teamid'').'
 			identifier: array.duplicateKey
 			count: 1
@@ -4051,12 +2815,6 @@ parameters:
 			identifier: property.deprecatedClass
 			count: 1
 			path: tests/WideUnit/Extension/ExtensionWideUnitTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/WideUnit/FreeAgency/FreeAgencyWideUnitTest.php
 
 		-
 			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
@@ -4097,12 +2855,6 @@ parameters:
 		-
 			rawMessage: 'Array has 2 duplicate keys with value ''teamid'' (''teamid'', ''teamid'').'
 			identifier: array.duplicateKey
-			count: 1
-			path: tests/WideUnit/ModifierConsistencyTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
 			count: 1
 			path: tests/WideUnit/ModifierConsistencyTest.php
 
@@ -4149,18 +2901,6 @@ parameters:
 			path: tests/WideUnit/ModifierConsistencyTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/WideUnit/Negotiation/NegotiationWideUnitTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/WideUnit/Schedule/ScheduleWideUnitTest.php
-
-		-
 			rawMessage: 'Parameter #2 $games of method TeamSchedule\TeamScheduleView::render() expects list<array{game: LeagueSchedule\Game, currentMonth: string, opposingTeam: Team\Team, opponentText: string, highlight: string, gameResult: string, wins: int, losses: int, ...}>, array{array<string, mixed>, array<string, mixed>} given.'
 			identifier: argument.type
 			count: 1
@@ -4171,12 +2911,6 @@ parameters:
 			identifier: argument.type
 			count: 3
 			path: tests/WideUnit/Schedule/ScheduleWideUnitTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/WideUnit/Trading/TradeWideUnitTest.php
 
 		-
 			rawMessage: 'Parameter #1 $data of method Tests\WideUnit\Mocks\MockDatabase::setMockData() expects list<array<string, mixed>>, array{array{salary_yr1: 1000, salary_yr2: 1500, salary_yr3: 0, salary_yr4: 0, salary_yr5: 0, salary_yr6: 0, 0: 1000, 1: 1500, ...}} given.'
@@ -4203,20 +2937,8 @@ parameters:
 			path: tests/WideUnit/Voting/VotingWideUnitTest.php
 
 		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 7
-			path: tests/WideUnit/Waivers/WaiversWideUnitTest.php
-
-		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertTrue() with true will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/WideUnit/WideUnitTestCase.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::fail().'
-			identifier: staticMethod.dynamicCall
 			count: 1
 			path: tests/WideUnit/WideUnitTestCase.php
 
@@ -4237,33 +2959,3 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/YourAccount/YourAccountRepositoryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/YourAccount/YourAccountRepositoryTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::anything().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/YourAccount/YourAccountServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::logicalAnd().'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/YourAccount/YourAccountServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::stringContains().'
-			identifier: staticMethod.dynamicCall
-			count: 9
-			path: tests/YourAccount/YourAccountServiceTest.php
-
-		-
-			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/YourAccount/YourAccountServiceTest.php

--- a/ibl5/tests/Api/Controller/GameBoxscoreControllerTest.php
+++ b/ibl5/tests/Api/Controller/GameBoxscoreControllerTest.php
@@ -154,7 +154,7 @@ class GameBoxscoreControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     return isset($data['game'], $data['visitor'], $data['home'])
                         && $data['game']['uuid'] === self::GAME_UUID
                         && $data['game']['status'] === 'completed'
@@ -163,9 +163,9 @@ class GameBoxscoreControllerTest extends WideUnitTestCase
                         && count($data['visitor']['players']) === 2
                         && count($data['home']['players']) === 2;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->callback(function (array $headers): bool {
+                self::callback(function (array $headers): bool {
                     return isset($headers['ETag'])
                         && $headers['Cache-Control'] === 'public, max-age=60';
                 })
@@ -237,7 +237,7 @@ class GameBoxscoreControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     $visitorPlayers = $data['visitor']['players'] ?? [];
                     $homePlayers = $data['home']['players'] ?? [];
 
@@ -254,9 +254,9 @@ class GameBoxscoreControllerTest extends WideUnitTestCase
                         && in_array('Home Player One', $homeNames, true)
                         && in_array('Home Player Two', $homeNames, true);
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle(['uuid' => self::GAME_UUID], [], $responder);

--- a/ibl5/tests/Api/Controller/GameDetailControllerTest.php
+++ b/ibl5/tests/Api/Controller/GameDetailControllerTest.php
@@ -52,7 +52,7 @@ class GameDetailControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     return $data['uuid'] === self::GAME_UUID
                         && $data['season'] === 2026
                         && $data['date'] === '2026-03-15'
@@ -72,9 +72,9 @@ class GameDetailControllerTest extends WideUnitTestCase
                         && $data['home']['score'] === 115
                         && $data['home']['team_id'] === 14;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->callback(function (array $headers): bool {
+                self::callback(function (array $headers): bool {
                     return isset($headers['ETag'])
                         && $headers['Cache-Control'] === 'public, max-age=60';
                 })
@@ -125,10 +125,10 @@ class GameDetailControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->isArray(),
-                $this->isArray(),
+                self::isArray(),
+                self::isArray(),
                 200,
-                $this->callback(function (array $headers) use ($expectedTag): bool {
+                self::callback(function (array $headers) use ($expectedTag): bool {
                     return $headers['ETag'] === $expectedTag;
                 })
             );

--- a/ibl5/tests/Api/Controller/GameListControllerTest.php
+++ b/ibl5/tests/Api/Controller/GameListControllerTest.php
@@ -45,7 +45,7 @@ class GameListControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     if (count($data) !== 1) {
                         return false;
                     }
@@ -55,9 +55,9 @@ class GameListControllerTest extends WideUnitTestCase
                         && $first['visitor']['name'] === 'Celtics'
                         && $first['home']['name'] === 'Jazz';
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);
@@ -89,13 +89,13 @@ class GameListControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->anything(),
-                $this->callback(function (array $meta): bool {
+                self::anything(),
+                self::callback(function (array $meta): bool {
                     return ($meta['sort'] ?? '') === 'game_date'
                         && ($meta['order'] ?? '') === 'desc';
                 }),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);

--- a/ibl5/tests/Api/Controller/InjuriesControllerTest.php
+++ b/ibl5/tests/Api/Controller/InjuriesControllerTest.php
@@ -32,7 +32,7 @@ class InjuriesControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     if (count($data) !== 1) {
                         return false;
                     }
@@ -41,11 +41,11 @@ class InjuriesControllerTest extends WideUnitTestCase
                         && $first['player']['name'] === 'Kevin Martin'
                         && $first['injury']['days_remaining'] === 5;
                 }),
-                $this->callback(function (array $meta): bool {
+                self::callback(function (array $meta): bool {
                     return ($meta['total'] ?? 0) === 1;
                 }),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);
@@ -62,11 +62,11 @@ class InjuriesControllerTest extends WideUnitTestCase
             ->method('success')
             ->with(
                 [],
-                $this->callback(function (array $meta): bool {
+                self::callback(function (array $meta): bool {
                     return ($meta['total'] ?? -1) === 0;
                 }),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);

--- a/ibl5/tests/Api/Controller/LeadersControllerTest.php
+++ b/ibl5/tests/Api/Controller/LeadersControllerTest.php
@@ -52,7 +52,7 @@ class LeadersControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     if (count($data) !== 1) {
                         return false;
                     }
@@ -62,9 +62,9 @@ class LeadersControllerTest extends WideUnitTestCase
                         && $first['team']['name'] === 'Celtics'
                         && $first['season'] === 2007;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);
@@ -80,12 +80,12 @@ class LeadersControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->anything(),
-                $this->callback(function (array $meta): bool {
+                self::anything(),
+                self::callback(function (array $meta): bool {
                     return ($meta['category'] ?? '') === 'rpg';
                 }),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], ['category' => 'rpg'], $responder);
@@ -101,12 +101,12 @@ class LeadersControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->anything(),
-                $this->callback(function (array $meta): bool {
+                self::anything(),
+                self::callback(function (array $meta): bool {
                     return ($meta['category'] ?? '') === 'ppg';
                 }),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);
@@ -122,12 +122,12 @@ class LeadersControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->anything(),
-                $this->callback(function (array $meta): bool {
+                self::anything(),
+                self::callback(function (array $meta): bool {
                     return ($meta['category'] ?? '') === 'ppg';
                 }),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], ['category' => 'invalid'], $responder);

--- a/ibl5/tests/Api/Controller/PlayerDetailControllerTest.php
+++ b/ibl5/tests/Api/Controller/PlayerDetailControllerTest.php
@@ -78,7 +78,7 @@ class PlayerDetailControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     return $data['uuid'] === self::PLAYER_UUID
                         && $data['pid'] === 42
                         && $data['name'] === 'John Smith'
@@ -115,9 +115,9 @@ class PlayerDetailControllerTest extends WideUnitTestCase
                         && $data['stats']['ft_percentage'] === 0.833
                         && $data['stats']['three_pt_percentage'] === 0.400;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->callback(function (array $headers): bool {
+                self::callback(function (array $headers): bool {
                     return isset($headers['ETag'])
                         && $headers['Cache-Control'] === 'public, max-age=60';
                 })
@@ -168,10 +168,10 @@ class PlayerDetailControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->isArray(),
-                $this->isArray(),
+                self::isArray(),
+                self::isArray(),
                 200,
-                $this->callback(function (array $headers) use ($expectedTag): bool {
+                self::callback(function (array $headers) use ($expectedTag): bool {
                     return $headers['ETag'] === $expectedTag;
                 })
             );

--- a/ibl5/tests/Api/Controller/PlayerExportControllerTest.php
+++ b/ibl5/tests/Api/Controller/PlayerExportControllerTest.php
@@ -72,7 +72,7 @@ class PlayerExportControllerTest extends WideUnitTestCase
         ]);
 
         $controller = new PlayerExportController($this->mockDb);
-        $responder = $this->createStub(JsonResponder::class);
+        $responder = self::createStub(JsonResponder::class);
 
         $output = $this->captureOutput(function () use ($controller, $responder): void {
             $controller->handle([], [], $responder);
@@ -92,7 +92,7 @@ class PlayerExportControllerTest extends WideUnitTestCase
         ]);
 
         $controller = new PlayerExportController($this->mockDb);
-        $responder = $this->createStub(JsonResponder::class);
+        $responder = self::createStub(JsonResponder::class);
 
         $output = $this->captureOutput(function () use ($controller, $responder): void {
             $controller->handle([], [], $responder);
@@ -118,7 +118,7 @@ class PlayerExportControllerTest extends WideUnitTestCase
         ]);
 
         $controller = new PlayerExportController($this->mockDb);
-        $responder = $this->createStub(JsonResponder::class);
+        $responder = self::createStub(JsonResponder::class);
 
         $output = $this->captureOutput(function () use ($controller, $responder): void {
             $controller->handle([], [], $responder);

--- a/ibl5/tests/Api/Controller/PlayerHistoryControllerTest.php
+++ b/ibl5/tests/Api/Controller/PlayerHistoryControllerTest.php
@@ -71,7 +71,7 @@ class PlayerHistoryControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     if (count($data) !== 2) {
                         return false;
                     }
@@ -101,11 +101,11 @@ class PlayerHistoryControllerTest extends WideUnitTestCase
                         && $first['stats']['personal_fouls'] === 170
                         && $first['salary'] === 4500000;
                 }),
-                $this->callback(function (array $meta): bool {
+                self::callback(function (array $meta): bool {
                     return $meta['total'] === 2;
                 }),
                 200,
-                $this->callback(function (array $headers): bool {
+                self::callback(function (array $headers): bool {
                     return isset($headers['ETag'])
                         && $headers['Cache-Control'] === 'public, max-age=60';
                 })
@@ -156,12 +156,12 @@ class PlayerHistoryControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->isArray(),
-                $this->callback(function (array $meta): bool {
+                self::isArray(),
+                self::callback(function (array $meta): bool {
                     return $meta['total'] === 2;
                 }),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle(['uuid' => self::PLAYER_UUID], [], $responder);

--- a/ibl5/tests/Api/Controller/PlayerListControllerTest.php
+++ b/ibl5/tests/Api/Controller/PlayerListControllerTest.php
@@ -86,7 +86,7 @@ class PlayerListControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     if (count($data) !== 1) {
                         return false;
                     }
@@ -105,9 +105,9 @@ class PlayerListControllerTest extends WideUnitTestCase
                         && $first['stats']['games_played'] === 55
                         && $first['stats']['points_per_game'] === 27.5;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);

--- a/ibl5/tests/Api/Controller/PlayerStatsControllerTest.php
+++ b/ibl5/tests/Api/Controller/PlayerStatsControllerTest.php
@@ -19,7 +19,7 @@ class PlayerStatsControllerTest extends WideUnitTestCase
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(404, 'not_found', $this->anything());
+            ->with(404, 'not_found', self::anything());
 
         $controller->handle(['uuid' => 'nonexistent-uuid'], [], $responder);
     }
@@ -61,15 +61,15 @@ class PlayerStatsControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     return $data['uuid'] === 'player-uuid-123'
                         && $data['career_totals']['games'] === 500
                         && $data['career_averages']['points_per_game'] === 24.0
                         && $data['draft']['year'] === 2010;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle(['uuid' => 'player-uuid-123'], [], $responder);

--- a/ibl5/tests/Api/Controller/SeasonControllerTest.php
+++ b/ibl5/tests/Api/Controller/SeasonControllerTest.php
@@ -57,7 +57,7 @@ class SeasonControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     return $data['phase'] === self::PHASE
                         && $data['last_sim']['number'] === self::SIM_NUMBER
                         && $data['last_sim']['phase_sim_number'] === self::PHASE_SIM_NUMBER
@@ -65,9 +65,9 @@ class SeasonControllerTest extends WideUnitTestCase
                         && $data['last_sim']['end_date'] === self::SIM_END_DATE
                         && $data['projected_next_sim_end_date'] === self::PROJECTED_NEXT_SIM_END_DATE;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);
@@ -99,10 +99,10 @@ class SeasonControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->isArray(),
-                $this->isArray(),
+                self::isArray(),
+                self::isArray(),
                 200,
-                $this->callback(function (array $headers) use ($expectedTag): bool {
+                self::callback(function (array $headers) use ($expectedTag): bool {
                     return isset($headers['ETag'])
                         && $headers['ETag'] === $expectedTag
                         && $headers['Cache-Control'] === 'public, max-age=60';

--- a/ibl5/tests/Api/Controller/StandingsControllerTest.php
+++ b/ibl5/tests/Api/Controller/StandingsControllerTest.php
@@ -56,7 +56,7 @@ class StandingsControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     if (count($data) !== 1) {
                         return false;
                     }
@@ -67,9 +67,9 @@ class StandingsControllerTest extends WideUnitTestCase
                         && $first['record']['league'] === '40-22'
                         && $first['clinched']['division'] === true;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);
@@ -86,11 +86,11 @@ class StandingsControllerTest extends WideUnitTestCase
             ->method('success')
             ->with(
                 [],
-                $this->callback(function (array $meta): bool {
+                self::callback(function (array $meta): bool {
                     return ($meta['conference'] ?? null) === 'Eastern';
                 }),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle(['conference' => 'East'], [], $responder);

--- a/ibl5/tests/Api/Controller/TeamDetailControllerTest.php
+++ b/ibl5/tests/Api/Controller/TeamDetailControllerTest.php
@@ -51,7 +51,7 @@ class TeamDetailControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     return $data['uuid'] === self::TEAM_UUID
                         && $data['city'] === 'Boston'
                         && $data['name'] === 'Celtics'
@@ -61,9 +61,9 @@ class TeamDetailControllerTest extends WideUnitTestCase
                         && $data['record']['home'] === '30-11'
                         && $data['standings']['win_percentage'] === 0.61;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->callback(function (array $headers): bool {
+                self::callback(function (array $headers): bool {
                     return isset($headers['ETag'])
                         && $headers['Cache-Control'] === 'public, max-age=60';
                 })
@@ -114,10 +114,10 @@ class TeamDetailControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->isArray(),
-                $this->isArray(),
+                self::isArray(),
+                self::isArray(),
                 200,
-                $this->callback(function (array $headers) use ($expectedTag): bool {
+                self::callback(function (array $headers) use ($expectedTag): bool {
                     return $headers['ETag'] === $expectedTag;
                 })
             );

--- a/ibl5/tests/Api/Controller/TeamListControllerTest.php
+++ b/ibl5/tests/Api/Controller/TeamListControllerTest.php
@@ -49,7 +49,7 @@ class TeamListControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     if (count($data) !== 1) {
                         return false;
                     }
@@ -63,9 +63,9 @@ class TeamListControllerTest extends WideUnitTestCase
                         && $first['conference'] === 'Eastern'
                         && $first['division'] === 'Atlantic';
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);
@@ -100,13 +100,13 @@ class TeamListControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->isArray(),
-                $this->callback(function (array $meta): bool {
+                self::isArray(),
+                self::callback(function (array $meta): bool {
                     return ($meta['sort'] ?? '') === 'team_name'
                         && ($meta['order'] ?? '') === 'asc';
                 }),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle([], [], $responder);

--- a/ibl5/tests/Api/Controller/TeamRosterControllerTest.php
+++ b/ibl5/tests/Api/Controller/TeamRosterControllerTest.php
@@ -86,7 +86,7 @@ class TeamRosterControllerTest extends WideUnitTestCase
         $responder->expects($this->once())
             ->method('success')
             ->with(
-                $this->callback(function (array $data): bool {
+                self::callback(function (array $data): bool {
                     if (count($data) !== 1) {
                         return false;
                     }
@@ -102,9 +102,9 @@ class TeamRosterControllerTest extends WideUnitTestCase
                         && $first['stats']['games_played'] === 60
                         && $first['stats']['points_per_game'] === 29.4;
                 }),
-                $this->isArray(),
+                self::isArray(),
                 200,
-                $this->isArray()
+                self::isArray()
             );
 
         $controller->handle(['uuid' => self::TEAM_UUID], [], $responder);

--- a/ibl5/tests/Api/Controller/TradeAcceptControllerTest.php
+++ b/ibl5/tests/Api/Controller/TradeAcceptControllerTest.php
@@ -13,36 +13,36 @@ class TradeAcceptControllerTest extends WideUnitTestCase
 {
     public function testReturns400WhenOfferIdMissing(): void
     {
-        $controller = new TradeAcceptController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new TradeAcceptController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $responder = $this->createMock(JsonResponder::class);
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(400, 'bad_request', $this->stringContains('offerId'));
+            ->with(400, 'bad_request', self::stringContains('offerId'));
 
         $controller->handle([], [], $responder, ['discord_user_id' => '123']);
     }
 
     public function testReturns400WhenDiscordUserIdMissing(): void
     {
-        $controller = new TradeAcceptController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new TradeAcceptController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $responder = $this->createMock(JsonResponder::class);
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(400, 'bad_request', $this->stringContains('discord_user_id'));
+            ->with(400, 'bad_request', self::stringContains('discord_user_id'));
 
         $controller->handle(['offerId' => '42'], [], $responder, []);
     }
 
     public function testReturns400WhenBodyIsNull(): void
     {
-        $controller = new TradeAcceptController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new TradeAcceptController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $responder = $this->createMock(JsonResponder::class);
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(400, 'bad_request', $this->stringContains('discord_user_id'));
+            ->with(400, 'bad_request', self::stringContains('discord_user_id'));
 
         $controller->handle(['offerId' => '42'], [], $responder, null);
     }
@@ -51,12 +51,12 @@ class TradeAcceptControllerTest extends WideUnitTestCase
     {
         $this->mockDb->setMockData([]);
 
-        $controller = new TradeAcceptController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new TradeAcceptController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $responder = $this->createMock(JsonResponder::class);
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(404, 'not_found', $this->stringContains('not found'));
+            ->with(404, 'not_found', self::stringContains('not found'));
 
         $controller->handle(
             ['offerId' => '999'],
@@ -86,12 +86,12 @@ class TradeAcceptControllerTest extends WideUnitTestCase
             ],
         ]);
 
-        $controller = new TradeAcceptController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new TradeAcceptController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $responder = $this->createMock(JsonResponder::class);
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(403, 'forbidden', $this->stringContains('not authorized'));
+            ->with(403, 'forbidden', self::stringContains('not authorized'));
 
         $controller->handle(
             ['offerId' => '42'],

--- a/ibl5/tests/Api/Controller/TradeDeclineControllerTest.php
+++ b/ibl5/tests/Api/Controller/TradeDeclineControllerTest.php
@@ -13,24 +13,24 @@ class TradeDeclineControllerTest extends WideUnitTestCase
 {
     public function testReturns400WhenOfferIdMissing(): void
     {
-        $controller = new TradeDeclineController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new TradeDeclineController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $responder = $this->createMock(JsonResponder::class);
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(400, 'bad_request', $this->stringContains('offerId'));
+            ->with(400, 'bad_request', self::stringContains('offerId'));
 
         $controller->handle([], [], $responder, ['discord_user_id' => '123']);
     }
 
     public function testReturns400WhenDiscordUserIdMissing(): void
     {
-        $controller = new TradeDeclineController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new TradeDeclineController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $responder = $this->createMock(JsonResponder::class);
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(400, 'bad_request', $this->stringContains('discord_user_id'));
+            ->with(400, 'bad_request', self::stringContains('discord_user_id'));
 
         $controller->handle(['offerId' => '42'], [], $responder, []);
     }
@@ -39,12 +39,12 @@ class TradeDeclineControllerTest extends WideUnitTestCase
     {
         $this->mockDb->setMockData([]);
 
-        $controller = new TradeDeclineController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new TradeDeclineController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $responder = $this->createMock(JsonResponder::class);
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(404, 'not_found', $this->stringContains('not found'));
+            ->with(404, 'not_found', self::stringContains('not found'));
 
         $controller->handle(
             ['offerId' => '999'],
@@ -72,12 +72,12 @@ class TradeDeclineControllerTest extends WideUnitTestCase
             ],
         ]);
 
-        $controller = new TradeDeclineController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new TradeDeclineController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $responder = $this->createMock(JsonResponder::class);
 
         $responder->expects($this->once())
             ->method('error')
-            ->with(403, 'forbidden', $this->stringContains('not authorized'));
+            ->with(403, 'forbidden', self::stringContains('not authorized'));
 
         $controller->handle(
             ['offerId' => '42'],

--- a/ibl5/tests/Api/Middleware/RateLimiterTest.php
+++ b/ibl5/tests/Api/Middleware/RateLimiterTest.php
@@ -44,7 +44,7 @@ class RateLimiterTest extends TestCase
 
     public function testAllowsRequestAtExactLimit(): void
     {
-        $stubRepo = $this->createStub(RateLimitRepository::class);
+        $stubRepo = self::createStub(RateLimitRepository::class);
         $rateLimiter = new RateLimiter($stubRepo);
         $apiKey = $this->makeApiKey();
 
@@ -56,8 +56,8 @@ class RateLimiterTest extends TestCase
 
     public function testRejectsRequestOverLimit(): void
     {
-        $stubRepo = $this->createStub(RateLimitRepository::class);
-        $fixedClock = $this->createStub(ClockInterface::class);
+        $stubRepo = self::createStub(RateLimitRepository::class);
+        $fixedClock = self::createStub(ClockInterface::class);
         $fixedClock->method('now')->willReturn(1_700_000_000);
 
         $rateLimiter = new RateLimiter($stubRepo, $fixedClock);
@@ -75,7 +75,7 @@ class RateLimiterTest extends TestCase
 
     public function testElevatedTierHasHigherLimit(): void
     {
-        $stubRepo = $this->createStub(RateLimitRepository::class);
+        $stubRepo = self::createStub(RateLimitRepository::class);
         $rateLimiter = new RateLimiter($stubRepo);
         $apiKey = $this->makeApiKey('elevated');
 
@@ -87,7 +87,7 @@ class RateLimiterTest extends TestCase
 
     public function testElevatedTierRejectsOver300(): void
     {
-        $stubRepo = $this->createStub(RateLimitRepository::class);
+        $stubRepo = self::createStub(RateLimitRepository::class);
         $rateLimiter = new RateLimiter($stubRepo);
         $apiKey = $this->makeApiKey('elevated');
 
@@ -117,7 +117,7 @@ class RateLimiterTest extends TestCase
 
     public function testUnknownTierDefaultsToStandard(): void
     {
-        $stubRepo = $this->createStub(RateLimitRepository::class);
+        $stubRepo = self::createStub(RateLimitRepository::class);
         $rateLimiter = new RateLimiter($stubRepo);
         $apiKey = $this->makeApiKey('unknown_tier');
 
@@ -156,7 +156,7 @@ class RateLimiterTest extends TestCase
 
     public function testLimitHeadersAdvertisesStandardLimit(): void
     {
-        $rateLimiter = new RateLimiter($this->createStub(RateLimitRepository::class));
+        $rateLimiter = new RateLimiter(self::createStub(RateLimitRepository::class));
         $this->assertSame(
             ['X-RateLimit-Limit' => '60'],
             $rateLimiter->limitHeaders($this->makeApiKey('standard')),
@@ -165,7 +165,7 @@ class RateLimiterTest extends TestCase
 
     public function testLimitHeadersAdvertisesElevatedLimit(): void
     {
-        $rateLimiter = new RateLimiter($this->createStub(RateLimitRepository::class));
+        $rateLimiter = new RateLimiter(self::createStub(RateLimitRepository::class));
         $this->assertSame(
             ['X-RateLimit-Limit' => '300'],
             $rateLimiter->limitHeaders($this->makeApiKey('elevated')),
@@ -174,13 +174,13 @@ class RateLimiterTest extends TestCase
 
     public function testLimitHeadersAreEmptyForUnlimitedTier(): void
     {
-        $rateLimiter = new RateLimiter($this->createStub(RateLimitRepository::class));
+        $rateLimiter = new RateLimiter(self::createStub(RateLimitRepository::class));
         $this->assertSame([], $rateLimiter->limitHeaders($this->makeApiKey('unlimited')));
     }
 
     public function testLimitHeadersUnknownTierDefaultsToStandard(): void
     {
-        $rateLimiter = new RateLimiter($this->createStub(RateLimitRepository::class));
+        $rateLimiter = new RateLimiter(self::createStub(RateLimitRepository::class));
         $this->assertSame(
             ['X-RateLimit-Limit' => '60'],
             $rateLimiter->limitHeaders($this->makeApiKey('mystery_tier')),

--- a/ibl5/tests/ApiKeys/ApiKeysServiceTest.php
+++ b/ibl5/tests/ApiKeys/ApiKeysServiceTest.php
@@ -41,7 +41,7 @@ class ApiKeysServiceTest extends TestCase
 
     public function testGenerateKeyForUserThrowsWhenActiveKeyExists(): void
     {
-        $stubRepo = $this->createStub(ApiKeysRepositoryInterface::class);
+        $stubRepo = self::createStub(ApiKeysRepositoryInterface::class);
         $stubRepo->method('findByUserId')->willReturn([
             'key_prefix' => 'ibl_test',
             'permission_level' => 'public',
@@ -84,7 +84,7 @@ class ApiKeysServiceTest extends TestCase
 
         $mockRepo->expects($this->once())
             ->method('createKey')
-            ->with(42, $this->anything(), $this->anything(), 'someGM');
+            ->with(42, self::anything(), self::anything(), 'someGM');
 
         $service = new ApiKeysService($mockRepo);
         $service->generateKeyForUser(42, 'someGM');
@@ -103,7 +103,7 @@ class ApiKeysServiceTest extends TestCase
 
     public function testGetUserKeyStatusReturnsNullWhenNoKey(): void
     {
-        $stubRepo = $this->createStub(ApiKeysRepositoryInterface::class);
+        $stubRepo = self::createStub(ApiKeysRepositoryInterface::class);
         $stubRepo->method('findByUserId')->willReturn(null);
 
         $service = new ApiKeysService($stubRepo);
@@ -112,7 +112,7 @@ class ApiKeysServiceTest extends TestCase
 
     public function testGetUserKeyStatusReturnsNullForInactiveKey(): void
     {
-        $stubRepo = $this->createStub(ApiKeysRepositoryInterface::class);
+        $stubRepo = self::createStub(ApiKeysRepositoryInterface::class);
         $stubRepo->method('findByUserId')->willReturn([
             'key_prefix' => 'ibl_test',
             'permission_level' => 'public',
@@ -136,7 +136,7 @@ class ApiKeysServiceTest extends TestCase
             'created_at' => '2026-01-01 00:00:00',
             'last_used_at' => '2026-03-20 10:00:00',
         ];
-        $stubRepo = $this->createStub(ApiKeysRepositoryInterface::class);
+        $stubRepo = self::createStub(ApiKeysRepositoryInterface::class);
         $stubRepo->method('findByUserId')->willReturn($keyData);
 
         $service = new ApiKeysService($stubRepo);
@@ -165,7 +165,7 @@ class ApiKeysServiceTest extends TestCase
 
     public function testGenerateKeyEmitsAuditLogWithKeyPrefixNotRawKey(): void
     {
-        $stubRepo = $this->createStub(ApiKeysRepositoryInterface::class);
+        $stubRepo = self::createStub(ApiKeysRepositoryInterface::class);
         $stubRepo->method('findByUserId')->willReturn(null);
 
         $service = new ApiKeysService($stubRepo);
@@ -183,7 +183,7 @@ class ApiKeysServiceTest extends TestCase
 
     public function testRevokeKeyEmitsAuditLog(): void
     {
-        $stubRepo = $this->createStub(ApiKeysRepositoryInterface::class);
+        $stubRepo = self::createStub(ApiKeysRepositoryInterface::class);
 
         $service = new ApiKeysService($stubRepo);
         $service->revokeKeyForUser(5);

--- a/ibl5/tests/Auth/AuthServiceUsernameTest.php
+++ b/ibl5/tests/Auth/AuthServiceUsernameTest.php
@@ -14,7 +14,7 @@ final class AuthServiceUsernameTest extends TestCase
 
     protected function setUp(): void
     {
-        $stubRepo = $this->createStub(AuthRepositoryInterface::class);
+        $stubRepo = self::createStub(AuthRepositoryInterface::class);
         $this->authService = new AuthService($stubRepo);
 
         if (session_status() === PHP_SESSION_NONE) {

--- a/ibl5/tests/Bootstrap/Api/ApiKeyAuthBootstrapTest.php
+++ b/ibl5/tests/Bootstrap/Api/ApiKeyAuthBootstrapTest.php
@@ -17,8 +17,8 @@ final class ApiKeyAuthBootstrapTest extends TestCase
         $_GET['key'] = '';
 
         $container = new Container();
-        $container->set('api.responder', $this->createStub(JsonResponder::class));
-        $container->set(\mysqli::class, $this->createStub(\mysqli::class));
+        $container->set('api.responder', self::createStub(JsonResponder::class));
+        $container->set(\mysqli::class, self::createStub(\mysqli::class));
 
         $step = new ApiKeyAuthBootstrap();
         $step->boot($container);

--- a/ibl5/tests/Bootstrap/Api/ApiRoutingBootstrapTest.php
+++ b/ibl5/tests/Bootstrap/Api/ApiRoutingBootstrapTest.php
@@ -15,7 +15,7 @@ final class ApiRoutingBootstrapTest extends TestCase
     public function testValidRouteStoresControllerAndParams(): void
     {
         $container = new Container();
-        $container->set('api.responder', $this->createStub(JsonResponder::class));
+        $container->set('api.responder', self::createStub(JsonResponder::class));
         $container->set('api.route', 'teams');
         $container->set('api.method', 'GET');
 
@@ -30,7 +30,7 @@ final class ApiRoutingBootstrapTest extends TestCase
     public function testUnknownRouteTerminates(): void
     {
         $container = new Container();
-        $container->set('api.responder', $this->createStub(JsonResponder::class));
+        $container->set('api.responder', self::createStub(JsonResponder::class));
         $container->set('api.route', 'nonexistent/endpoint');
         $container->set('api.method', 'GET');
 

--- a/ibl5/tests/Bootstrap/Api/RequestParsingBootstrapTest.php
+++ b/ibl5/tests/Bootstrap/Api/RequestParsingBootstrapTest.php
@@ -16,7 +16,7 @@ final class RequestParsingBootstrapTest extends TestCase
     protected function setUp(): void
     {
         $this->container = new Container();
-        $this->container->set('api.responder', $this->createStub(JsonResponder::class));
+        $this->container->set('api.responder', self::createStub(JsonResponder::class));
     }
 
     public function testGetRequestSetsMethodAndRoute(): void

--- a/ibl5/tests/Bootstrap/AuthUsernameAccessorTest.php
+++ b/ibl5/tests/Bootstrap/AuthUsernameAccessorTest.php
@@ -17,7 +17,7 @@ final class AuthUsernameAccessorTest extends TestCase
 
     public function testAuthUsernameResolvesToUsernameWhenAuthenticated(): void
     {
-        $mockAuth = $this->createStub(AuthServiceInterface::class);
+        $mockAuth = self::createStub(AuthServiceInterface::class);
         $mockAuth->method('getUsername')->willReturn('testuser');
 
         $container = new Container();
@@ -29,7 +29,7 @@ final class AuthUsernameAccessorTest extends TestCase
 
     public function testAuthUsernameResolvesToEmptyStringWhenNotAuthenticated(): void
     {
-        $mockAuth = $this->createStub(AuthServiceInterface::class);
+        $mockAuth = self::createStub(AuthServiceInterface::class);
         $mockAuth->method('getUsername')->willReturn(null);
 
         $container = new Container();

--- a/ibl5/tests/Bootstrap/CookieDecodeTest.php
+++ b/ibl5/tests/Bootstrap/CookieDecodeTest.php
@@ -16,7 +16,7 @@ final class CookieDecodeTest extends TestCase
 
     public function testCookieDecodeReturnsArrayWhenAuthenticated(): void
     {
-        $mockAuth = $this->createStub(AuthServiceInterface::class);
+        $mockAuth = self::createStub(AuthServiceInterface::class);
         $mockAuth->method('getCookieArray')->willReturn([1, 'testuser', '0', 'email@test.com']);
 
         $GLOBALS['authService'] = $mockAuth;
@@ -31,7 +31,7 @@ final class CookieDecodeTest extends TestCase
 
     public function testCookieDecodeReturnsNullWhenNotAuthenticated(): void
     {
-        $mockAuth = $this->createStub(AuthServiceInterface::class);
+        $mockAuth = self::createStub(AuthServiceInterface::class);
         $mockAuth->method('getCookieArray')->willReturn(null);
 
         $GLOBALS['authService'] = $mockAuth;
@@ -45,7 +45,7 @@ final class CookieDecodeTest extends TestCase
     public function testCookieDecodeSetsGlobalCookieArray(): void
     {
         $expected = [1, 'testuser', '0', 'email@test.com'];
-        $mockAuth = $this->createStub(AuthServiceInterface::class);
+        $mockAuth = self::createStub(AuthServiceInterface::class);
         $mockAuth->method('getCookieArray')->willReturn($expected);
 
         $GLOBALS['authService'] = $mockAuth;

--- a/ibl5/tests/Bootstrap/SecurityBootstrapTest.php
+++ b/ibl5/tests/Bootstrap/SecurityBootstrapTest.php
@@ -15,7 +15,7 @@ final class SecurityBootstrapTest extends TestCase
         $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0';
         $_SERVER['HTTP_ACCEPT_ENCODING'] = 'gzip, deflate, br';
 
-        $container = $this->createStub(\Bootstrap\Contracts\ContainerInterface::class);
+        $container = self::createStub(\Bootstrap\Contracts\ContainerInterface::class);
         $bootstrap = new SecurityBootstrap();
 
         // redirectFacebookBot calls exit() on FB UA — use a normal UA

--- a/ibl5/tests/Boxscore/BoxscoreProcessorTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreProcessorTest.php
@@ -175,7 +175,7 @@ class BoxscoreProcessorTest extends TestCase
             ['sim' => 1, 'start_date' => '2025-01-01', 'end_date' => '2025-01-07'],
         ]);
 
-        $leagueContext = $this->createStub(\League\LeagueContext::class);
+        $leagueContext = self::createStub(\League\LeagueContext::class);
         $processor = new BoxscoreProcessor($this->mockDb, null, null, $leagueContext);
 
         $this->assertInstanceOf(BoxscoreProcessorInterface::class, $processor);
@@ -189,7 +189,7 @@ class BoxscoreProcessorTest extends TestCase
             ['sim' => 1, 'start_date' => '2025-01-01', 'end_date' => '2025-01-07'],
         ]);
 
-        $olympicsContext = $this->createStub(\League\LeagueContext::class);
+        $olympicsContext = self::createStub(\League\LeagueContext::class);
         $olympicsContext->method('isOlympics')->willReturn(true);
         $olympicsContext->method('getTableName')->willReturnArgument(0);
 
@@ -395,7 +395,7 @@ class BoxscoreProcessorTest extends TestCase
         // with the current mock Season. Let's create a custom Season mock.
 
         // Actually, the simplest fix: create a stub for Season with custom behavior.
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->lastSimEndDate = '2025-12-01';
         $seasonStub->lastSimNumber = 3;
         $seasonStub->lastSimStartDate = '2025-11-25';
@@ -421,7 +421,7 @@ class BoxscoreProcessorTest extends TestCase
         $mockDb->setReturnTrue(true);
 
         $repository = new BoxscoreRepository($mockDb);
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->lastSimEndDate = '';
         $seasonStub->method('getFirstBoxScoreDate')->willReturn('2025-11-01');
         $seasonStub->method('getLastBoxScoreDate')->willReturn('2025-11-08');
@@ -446,7 +446,7 @@ class BoxscoreProcessorTest extends TestCase
         $mockDb->setReturnTrue(true);
 
         $repository = new BoxscoreRepository($mockDb);
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->lastSimEndDate = '2025-12-01';
         $seasonStub->lastSimStartDate = '2025-11-25';
         $seasonStub->method('getLastBoxScoreDate')->willReturn('2025-12-01');
@@ -474,7 +474,7 @@ class BoxscoreProcessorTest extends TestCase
         $mockDb->onQuery('(?s)SELECT.*ibl_box_scores_teams.*WHERE', []);
 
         $repository = new BoxscoreRepository($mockDb);
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->lastSimEndDate = '';
         $seasonStub->method('getLastBoxScoreDate')->willReturn('2026-01-11');
         $seasonStub->method('getFirstBoxScoreDate')->willReturn('2026-01-11');
@@ -505,7 +505,7 @@ class BoxscoreProcessorTest extends TestCase
         $mockDb->onQuery('(?s)COUNT.*teamid IS NULL', [['cnt' => 0]]);
 
         $repository = new BoxscoreRepository($mockDb);
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->lastSimEndDate = '';
 
         $scoFile = $this->buildScoFileWithOneGame($this->buildGameInfoLine(3, 10));
@@ -531,7 +531,7 @@ class BoxscoreProcessorTest extends TestCase
         ]]);
 
         $repository = new BoxscoreRepository($mockDb);
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->lastSimEndDate = '';
 
         $scoFile = $this->buildScoFileWithOneGame($this->buildGameInfoLine(3, 10));
@@ -552,7 +552,7 @@ class BoxscoreProcessorTest extends TestCase
         $mockDb->setReturnTrue(true);
 
         $repository = new BoxscoreRepository($mockDb);
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->method('getLastBoxScoreDate')->willReturn('2026-01-15');
 
         $processor = new BoxscoreProcessor($mockDb, $repository, $seasonStub);
@@ -568,7 +568,7 @@ class BoxscoreProcessorTest extends TestCase
         $mockDb->setReturnTrue(true);
 
         $repository = new BoxscoreRepository($mockDb);
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->method('getLastBoxScoreDate')->willReturn('');
 
         $processor = new BoxscoreProcessor($mockDb, $repository, $seasonStub);
@@ -584,7 +584,7 @@ class BoxscoreProcessorTest extends TestCase
         $mockDb->setReturnTrue(true);
 
         $repository = new BoxscoreRepository($mockDb);
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->lastSimEndDate = '';
 
         $processor = new BoxscoreProcessor($mockDb, $repository, $seasonStub);
@@ -602,7 +602,7 @@ class BoxscoreProcessorTest extends TestCase
         $mockDb->onQuery('(?s)SELECT.*ibl_box_scores_teams.*WHERE', []);
 
         $repository = new BoxscoreRepository($mockDb);
-        $seasonStub = $this->createStub(Season::class);
+        $seasonStub = self::createStub(Season::class);
         $seasonStub->lastSimEndDate = '';
         $seasonStub->method('getLastBoxScoreDate')->willReturn('2026-01-11');
         $seasonStub->method('getFirstBoxScoreDate')->willReturn('2026-01-11');

--- a/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
@@ -59,7 +59,7 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
 
     public function testSortsByRequestedColumnDesc(): void
     {
-        $stubInner = $this->createStub(CareerLeaderboardsRepositoryInterface::class);
+        $stubInner = self::createStub(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($stubInner, $this->cache);
 
         $rows = [
@@ -79,7 +79,7 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
 
     public function testActiveOnlyFilterExcludesRetiredPlayers(): void
     {
-        $stubInner = $this->createStub(CareerLeaderboardsRepositoryInterface::class);
+        $stubInner = self::createStub(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($stubInner, $this->cache);
 
         $rows = [
@@ -98,7 +98,7 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
 
     public function testLimitRestrictsResultCount(): void
     {
-        $stubInner = $this->createStub(CareerLeaderboardsRepositoryInterface::class);
+        $stubInner = self::createStub(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($stubInner, $this->cache);
 
         $rows = $this->createSampleRows();
@@ -111,7 +111,7 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
 
     public function testZeroLimitReturnsAllRows(): void
     {
-        $stubInner = $this->createStub(CareerLeaderboardsRepositoryInterface::class);
+        $stubInner = self::createStub(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($stubInner, $this->cache);
 
         $rows = $this->createSampleRows();
@@ -166,7 +166,7 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
 
     public function testInvalidateCacheDeletesAllTwelveKeys(): void
     {
-        $stubInner = $this->createStub(CareerLeaderboardsRepositoryInterface::class);
+        $stubInner = self::createStub(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($stubInner, $this->cache);
 
         // Pre-populate cache
@@ -191,7 +191,7 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
 
     public function testTiesResolveByPidAscAsInt(): void
     {
-        $stubInner = $this->createStub(CareerLeaderboardsRepositoryInterface::class);
+        $stubInner = self::createStub(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($stubInner, $this->cache);
 
         $rows = [
@@ -210,7 +210,7 @@ final class CachedCareerLeaderboardsRepositoryTest extends TestCase
 
     public function testCombinesActiveFilterSortAndLimit(): void
     {
-        $stubInner = $this->createStub(CareerLeaderboardsRepositoryInterface::class);
+        $stubInner = self::createStub(CareerLeaderboardsRepositoryInterface::class);
         $repository = new CachedCareerLeaderboardsRepository($stubInner, $this->cache);
 
         $rows = [

--- a/ibl5/tests/DatabaseIntegration/AwardGenerationServiceIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/AwardGenerationServiceIntegrationTest.php
@@ -29,7 +29,7 @@ class AwardGenerationServiceIntegrationTest extends DatabaseTestCase
         parent::setUp();
 
         $repository = new LeagueControlPanelRepository($this->db);
-        $this->stubVoting = $this->createStub(VotingResultsServiceInterface::class);
+        $this->stubVoting = self::createStub(VotingResultsServiceInterface::class);
         $this->service = new AwardGenerationService($repository, $this->stubVoting);
 
         $this->tempDir = sys_get_temp_dir() . '/award_gen_int_' . uniqid();

--- a/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
@@ -296,7 +296,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
 
     public function testRewriteTableNamesNoOpForIblContext(): void
     {
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(false);
 
         $repo = new TestableBaseMysqliRepository($this->db, $context);
@@ -306,7 +306,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
 
     public function testRewriteTableNamesRewritesAllSixteenTablesForOlympics(): void
     {
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
 
         $repo = new TestableBaseMysqliRepository($this->db, $context);
@@ -343,7 +343,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
 
     public function testRewriteTableNamesHandlesSubstringCollisions(): void
     {
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
 
         $repo = new TestableBaseMysqliRepository($this->db, $context);
@@ -367,7 +367,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
         // rewritten alongside its FROM clause. The previous backtick-only
         // str_replace left it dangling, so rewriting `FROM `ibl_plr`` while
         // leaving `ibl_plr.name` produced "Unknown table 'ibl_plr'".
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
 
         $repo = new TestableBaseMysqliRepository($this->db, $context);
@@ -391,7 +391,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
         // `gm_username` column does not exist on ibl_olympics_team_info.
         // Backtick-quoting is the opt-in signal; bare references must NOT be
         // rewritten.
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
 
         $repo = new TestableBaseMysqliRepository($this->db, $context);
@@ -409,7 +409,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
 
     public function testRewriteTableNamesIsIdempotent(): void
     {
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
 
         $repo = new TestableBaseMysqliRepository($this->db, $context);
@@ -427,7 +427,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
     {
         // Gold-standard regression: the exact Team::load() shape that fataled in
         // CI ("Unknown table 'ibl5.ibl_team_info'"). After rewriting it must run.
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
 
         $repo = new TestableBaseMysqliRepository($this->db, $context);
@@ -466,7 +466,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
 
     public function testRewriteTableNamesUsesSharedContextFallback(): void
     {
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
 
         \BaseMysqliRepository::setSharedLeagueContext($context);
@@ -485,7 +485,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
         // ibl_jsb_hall_of_fame, ibl_plb_snapshots). They must pass through the
         // rewrite untouched even when backtick-quoted under Olympics, or queries
         // would fatal on a non-existent table.
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
         \BaseMysqliRepository::setSharedLeagueContext($context);
 
@@ -500,7 +500,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
 
     public function testFetchAllRealTeamsUsesOlympicsTableWithOlympicsContext(): void
     {
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
 
         $repo = new TestableBaseMysqliRepository($this->db, $context);

--- a/ibl5/tests/DatabaseIntegration/DatabaseTestCase.php
+++ b/ibl5/tests/DatabaseIntegration/DatabaseTestCase.php
@@ -34,7 +34,7 @@ abstract class DatabaseTestCase extends TestCase
         $this->db->real_connect($host, $user, $pass, $name);
 
         if ($this->db->connect_errno !== 0) {
-            $this->fail('Database connection failed: ' . $this->db->connect_error);
+            self::fail('Database connection failed: ' . $this->db->connect_error);
         }
 
         $this->db->begin_transaction();

--- a/ibl5/tests/DatabaseIntegration/LeagueControlPanelRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/LeagueControlPanelRepositoryTest.php
@@ -398,7 +398,7 @@ class LeagueControlPanelRepositoryTest extends DatabaseTestCase
 
     public function testUpdateSettingOnlyUpdatesCorrectLeagueRow(): void
     {
-        $olympicsContext = $this->createStub(LeagueContext::class);
+        $olympicsContext = self::createStub(LeagueContext::class);
         $olympicsContext->method('getCurrentLeague')->willReturn(LeagueContext::LEAGUE_OLYMPICS);
         $olympicsRepo = new LeagueControlPanelRepository($this->db, $olympicsContext);
 
@@ -413,7 +413,7 @@ class LeagueControlPanelRepositoryTest extends DatabaseTestCase
         $this->repo->setShowDraftLink('On');
         self::assertSame('On', $this->repo->getSetting('Show Draft Link'));
 
-        $olympicsContext = $this->createStub(LeagueContext::class);
+        $olympicsContext = self::createStub(LeagueContext::class);
         $olympicsContext->method('getCurrentLeague')->willReturn(LeagueContext::LEAGUE_OLYMPICS);
         $olympicsRepo = new LeagueControlPanelRepository($this->db, $olympicsContext);
 

--- a/ibl5/tests/DatabaseIntegration/TeamOlympicsLoadTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamOlympicsLoadTest.php
@@ -39,7 +39,7 @@ class TeamOlympicsLoadTest extends DatabaseTestCase
             'owner_email' => 'gm@test',
         ]);
 
-        $context = $this->createStub(LeagueContext::class);
+        $context = self::createStub(LeagueContext::class);
         $context->method('isOlympics')->willReturn(true);
         \BaseMysqliRepository::setSharedLeagueContext($context);
 

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/PipelineIntegrationTestCase.php
@@ -267,7 +267,7 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
         $jsbResolver = new PlayerIdResolver($this->db);
         $jsbService = new JsbImportService($jsbRepo, $jsbResolver);
 
-        $schResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $schResolver = self::createStub(JsbSourceResolverInterface::class);
         $schResolver->method('getContents')->willReturnCallback(
             static function (string $ext) use ($schPath): ?string {
                 if ($ext === 'sch' && is_file($schPath)) {
@@ -286,7 +286,7 @@ abstract class PipelineIntegrationTestCase extends DatabaseTestCase
         // Step 1: ImportLeagueConfigStep — SKIPPED (pre-seeded via seedLeagueConfig)
 
         $tempDir = $this->tempDir;
-        $jsbFileResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $jsbFileResolver = self::createStub(JsbSourceResolverInterface::class);
         $jsbFileResolver->method('getContents')->willReturnCallback(
             static function (string $ext) use ($tempDir): ?string {
                 $path = $tempDir . '/IBL5.' . $ext;

--- a/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/ScheduleAtomicityTest.php
+++ b/ibl5/tests/DatabaseIntegration/UpdateAllTheThings/ScheduleAtomicityTest.php
@@ -97,7 +97,7 @@ class ScheduleAtomicityTest extends PipelineIntegrationTestCase
 
     private function makeScheduleUpdater(Season $season, string $schPath): \Updater\ScheduleUpdater
     {
-        $schResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $schResolver = self::createStub(JsbSourceResolverInterface::class);
         $schResolver->method('getContents')->willReturnCallback(
             static function (string $ext) use ($schPath): ?string {
                 if ($ext === 'sch' && is_file($schPath)) {

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryApiHandlerTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryApiHandlerTest.php
@@ -19,8 +19,8 @@ class DepthChartEntryApiHandlerTest extends WideUnitTestCase
     {
         $handler = new DepthChartEntryApiHandler(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
-            $this->createStub(\League\LeagueContext::class)
+            self::createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(\League\LeagueContext::class)
         );
 
         $this->assertInstanceOf(DepthChartEntryApiHandler::class, $handler);

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryControllerTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryControllerTest.php
@@ -26,7 +26,7 @@ class DepthChartEntryControllerTest extends TestCase
     {
         $this->mockDb = new MockDatabase();
         $GLOBALS['mysqli_db'] = $this->mockDb;
-        $this->stubCommonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->stubCommonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
     }
 
     protected function tearDown(): void
@@ -40,14 +40,14 @@ class DepthChartEntryControllerTest extends TestCase
 
     public function testControllerCanBeInstantiated(): void
     {
-        $controller = new DepthChartEntryController($this->mockDb, $this->stubCommonRepo, $this->createStub(\League\LeagueContext::class));
+        $controller = new DepthChartEntryController($this->mockDb, $this->stubCommonRepo, self::createStub(\League\LeagueContext::class));
         
         $this->assertInstanceOf(DepthChartEntryController::class, $controller);
     }
 
     public function testControllerImplementsCorrectInterface(): void
     {
-        $controller = new DepthChartEntryController($this->mockDb, $this->stubCommonRepo, $this->createStub(\League\LeagueContext::class));
+        $controller = new DepthChartEntryController($this->mockDb, $this->stubCommonRepo, self::createStub(\League\LeagueContext::class));
         
         $this->assertInstanceOf(
             \DepthChartEntry\Contracts\DepthChartEntryControllerInterface::class,
@@ -61,8 +61,8 @@ class DepthChartEntryControllerTest extends TestCase
 
     public function testMultipleControllersCanBeInstantiated(): void
     {
-        $controller1 = new DepthChartEntryController($this->mockDb, $this->stubCommonRepo, $this->createStub(\League\LeagueContext::class));
-        $controller2 = new DepthChartEntryController($this->mockDb, $this->stubCommonRepo, $this->createStub(\League\LeagueContext::class));
+        $controller1 = new DepthChartEntryController($this->mockDb, $this->stubCommonRepo, self::createStub(\League\LeagueContext::class));
+        $controller2 = new DepthChartEntryController($this->mockDb, $this->stubCommonRepo, self::createStub(\League\LeagueContext::class));
 
         $this->assertInstanceOf(DepthChartEntryController::class, $controller1);
         $this->assertInstanceOf(DepthChartEntryController::class, $controller2);

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryProcessorTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryProcessorTest.php
@@ -262,7 +262,7 @@ class DepthChartEntryProcessorTest extends TestCase
      */
     public function testFormDisplaysCorrectDatabaseValuesForAllSettings(): void
     {
-        $view = new DepthChartEntryView($this->createStub(\League\LeagueContext::class), new \DepthChartEntry\DepthChartEntryService());
+        $view = new DepthChartEntryView(self::createStub(\League\LeagueContext::class), new \DepthChartEntry\DepthChartEntryService());
 
         // Simulate a player record from the database with various depth values
         $playerFromDb = [
@@ -393,7 +393,7 @@ class DepthChartEntryProcessorTest extends TestCase
      */
     public function testCompleteRoundTripPreservesPositionDepthValues(): void
     {
-        $view = new DepthChartEntryView($this->createStub(\League\LeagueContext::class), new \DepthChartEntry\DepthChartEntryService());
+        $view = new DepthChartEntryView(self::createStub(\League\LeagueContext::class), new \DepthChartEntry\DepthChartEntryService());
 
         // Step 1: Player has these values in database
         $dbPlayer = [
@@ -502,7 +502,7 @@ class DepthChartEntryProcessorTest extends TestCase
      */
     public function testZeroValuesAreHandledCorrectly(): void
     {
-        $view = new DepthChartEntryView($this->createStub(\League\LeagueContext::class), new \DepthChartEntry\DepthChartEntryService());
+        $view = new DepthChartEntryView(self::createStub(\League\LeagueContext::class), new \DepthChartEntry\DepthChartEntryService());
 
         // Player with all zero position depths except C=1
         $player = [

--- a/ibl5/tests/DepthChartEntry/DepthChartEntrySubmissionHandlerTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntrySubmissionHandlerTest.php
@@ -27,7 +27,7 @@ class DepthChartEntrySubmissionHandlerTest extends TestCase
     {
         $this->mockDb = new MockDatabase();
         $GLOBALS['mysqli_db'] = $this->mockDb;
-        $this->stubCommonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->stubCommonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
     }
 
     protected function tearDown(): void

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryViewTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryViewTest.php
@@ -16,7 +16,7 @@ class DepthChartEntryViewTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->view = new DepthChartEntryView($this->createStub(\League\LeagueContext::class), new \DepthChartEntry\DepthChartEntryService());
+        $this->view = new DepthChartEntryView(self::createStub(\League\LeagueContext::class), new \DepthChartEntry\DepthChartEntryService());
     }
 
     /**

--- a/ibl5/tests/DepthChartEntry/DepthChartEntryViewXssTest.php
+++ b/ibl5/tests/DepthChartEntry/DepthChartEntryViewXssTest.php
@@ -14,7 +14,7 @@ final class DepthChartEntryViewXssTest extends TestCase
 
     protected function setUp(): void
     {
-        $leagueContext = $this->createStub(LeagueContext::class);
+        $leagueContext = self::createStub(LeagueContext::class);
         $this->view = new DepthChartEntryView($leagueContext, new \DepthChartEntry\DepthChartEntryService());
     }
 

--- a/ibl5/tests/Discord/DiscordIntegrationTest.php
+++ b/ibl5/tests/Discord/DiscordIntegrationTest.php
@@ -25,7 +25,7 @@ class DiscordIntegrationTest extends WideUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->mockCommonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->mockCommonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
     }
 
     // ============================================

--- a/ibl5/tests/Discord/DiscordTest.php
+++ b/ibl5/tests/Discord/DiscordTest.php
@@ -17,7 +17,7 @@ class DiscordTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mockCommonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->mockCommonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
     }
 
     /**

--- a/ibl5/tests/Draft/DraftRepositoryTest.php
+++ b/ibl5/tests/Draft/DraftRepositoryTest.php
@@ -18,7 +18,7 @@ class DraftRepositoryTest extends TestCase
     protected function setUp(): void
     {
         $this->mockDb = new MockDatabase();
-        $this->mockCommonRepository = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->mockCommonRepository = self::createStub(TeamIdentityRepositoryInterface::class);
         $this->mockCommonRepository->method('getTidFromTeamname')->willReturn(1);
         $this->repository = new DraftRepository($this->mockDb, $this->mockCommonRepository);
     }
@@ -196,7 +196,7 @@ class DraftRepositoryTest extends TestCase
 
     public function testCreatePlayerFromDraftClassReturnsFalseWhenTeamNotFound(): void
     {
-        $stubNoTeam = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $stubNoTeam = self::createStub(TeamIdentityRepositoryInterface::class);
         $stubNoTeam->method('getTidFromTeamname')->willReturn(null);
         $repository = new DraftRepository($this->mockDb, $stubNoTeam);
 

--- a/ibl5/tests/Draft/DraftSelectionHandlerTest.php
+++ b/ibl5/tests/Draft/DraftSelectionHandlerTest.php
@@ -39,10 +39,10 @@ class DraftSelectionHandlerTest extends TestCase
     private function setupMockDependencies(): void
     {
         // Stub CommonMysqliRepository (no expectations needed)
-        $this->mockCommonRepository = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->mockCommonRepository = self::createStub(TeamIdentityRepositoryInterface::class);
 
         // Mock Season object
-        $this->mockSeason = $this->createStub(Season::class);
+        $this->mockSeason = self::createStub(Season::class);
         $this->mockSeason->beginningYear = 2024;
         $this->mockSeason->endingYear = 2025;
         $this->mockSeason->phase = 'Draft';

--- a/ibl5/tests/DraftHistory/DraftHistoryRepositoryTest.php
+++ b/ibl5/tests/DraftHistory/DraftHistoryRepositoryTest.php
@@ -11,7 +11,7 @@ final class DraftHistoryRepositoryTest extends TestCase
 {
     public function testGetFirstDraftYearReturns1988(): void
     {
-        $mockDb = $this->createStub(\mysqli::class);
+        $mockDb = self::createStub(\mysqli::class);
         $repository = new DraftHistoryRepository($mockDb);
 
         $this->assertSame(1988, $repository->getFirstDraftYear());

--- a/ibl5/tests/Extension/ExtensionRepositoryTest.php
+++ b/ibl5/tests/Extension/ExtensionRepositoryTest.php
@@ -258,6 +258,6 @@ class ExtensionRepositoryTest extends TestCase
                 return;
             }
         }
-        $this->fail("Expected a query containing '{$substring}' but none was found. Queries: " . implode("\n", $queries));
+        self::fail("Expected a query containing '{$substring}' but none was found. Queries: " . implode("\n", $queries));
     }
 }

--- a/ibl5/tests/Extension/ExtensionServiceTest.php
+++ b/ibl5/tests/Extension/ExtensionServiceTest.php
@@ -270,7 +270,7 @@ class ExtensionServiceTest extends TestCase
         ]);
         $this->mockDb->setMockData([$mockData]);
 
-        $stubTeamQueryRepo = $this->createStub(TeamQueryRepositoryInterface::class);
+        $stubTeamQueryRepo = self::createStub(TeamQueryRepositoryInterface::class);
 
         $playerRow = $mockData;
         $playerRow['pid'] = $extendedPlayerPid;

--- a/ibl5/tests/FranchiseRecordBook/FranchiseRecordBookServiceTest.php
+++ b/ibl5/tests/FranchiseRecordBook/FranchiseRecordBookServiceTest.php
@@ -20,7 +20,7 @@ class FranchiseRecordBookServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->repository = $this->createStub(FranchiseRecordBookRepositoryInterface::class);
+        $this->repository = self::createStub(FranchiseRecordBookRepositoryInterface::class);
         $this->service = new FranchiseRecordBookService($this->repository);
     }
 

--- a/ibl5/tests/FreeAgency/FreeAgencyAdminProcessorTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyAdminProcessorTest.php
@@ -48,7 +48,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
             $this->makeSigning(1, 10, 'Miami', 500, 600, 0, 0, 0, 0, 2, false, false),
         ];
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('executeSigningsTransactionally')
             ->willReturn(['successCount' => 1, 'errorCount' => 1]);
 
@@ -80,7 +80,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
 
     public function testExecuteSigningsNoOperations(): void
     {
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $processor = new FreeAgencyAdminProcessor($stub, $this->mockDb);
 
         $result = $processor->executeSignings(1, [], 'FA Day 1', '', '');
@@ -112,7 +112,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
 
     public function testProcessDayEmptyOffersReturnsEmptyResults(): void
     {
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([]);
         $stub->method('getPlayerDemandsBatch')->willReturn([]);
 
@@ -136,7 +136,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
     {
         $offer = $this->makeOfferRow('Player A', 100, 'Miami', 1, 200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.0);
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([$offer]);
         // Demands: dem1=1000, rest 0 → total=1000, years=1
         // day 1: demands = (1000/1)*((11-1)/10) = 1000
@@ -167,7 +167,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
         // perceivedValue 800.0 > 200.0 → signing
         $offer = $this->makeOfferRow('Star Player', 100, 'Miami', 1, 500, 550, 600, 0, 0, 0, 0, 0, 0, 0, 800.0);
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([$offer]);
         $stub->method('getPlayerDemandsBatch')->willReturn([
             100 => ['dem1' => 200, 'dem2' => 200, 'dem3' => 200, 'dem4' => 0, 'dem5' => 0, 'dem6' => 0],
@@ -203,7 +203,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
         // 150 > 100 → not auto-rejected; 150 <= 200 → rejected
         $offer = $this->makeOfferRow('Player B', 200, 'Chicago', 2, 400, 0, 0, 0, 0, 0, 0, 0, 0, 0, 150.0);
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([$offer]);
         $stub->method('getPlayerDemandsBatch')->willReturn([
             200 => ['dem1' => 200, 'dem2' => 0, 'dem3' => 0, 'dem4' => 0, 'dem5' => 0, 'dem6' => 0],
@@ -232,7 +232,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
         $offer1 = $this->makeOfferRow('Star Player', 100, 'Miami', 1, 500, 550, 600, 0, 0, 0, 0, 0, 0, 0, 800.0);
         $offer2 = $this->makeOfferRow('Star Player', 100, 'Chicago', 2, 400, 450, 500, 0, 0, 0, 0, 0, 0, 0, 600.0);
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([$offer1, $offer2]);
         $stub->method('getPlayerDemandsBatch')->willReturn([
             100 => ['dem1' => 200, 'dem2' => 200, 'dem3' => 200, 'dem4' => 0, 'dem5' => 0, 'dem6' => 0],
@@ -261,7 +261,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
         $offerChicago = $this->makeOfferRow('Star Player', 100, 'Chicago', 2, 400, 450, 500, 0, 0, 0, 0, 0, 0, 0, 600.0);
         $offerBoston = $this->makeOfferRow('Star Player', 100, 'Boston', 3, 300, 350, 400, 0, 0, 0, 0, 0, 0, 0, 500.0);
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([$offerMiami, $offerChicago, $offerBoston]);
         $stub->method('getPlayerDemandsBatch')->willReturn([
             100 => ['dem1' => 200, 'dem2' => 200, 'dem3' => 200, 'dem4' => 0, 'dem5' => 0, 'dem6' => 0],
@@ -298,7 +298,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
         $offerMiami = $this->makeOfferRow('Player B', 200, 'Miami', 1, 400, 0, 0, 0, 0, 0, 0, 0, 0, 0, 600.0);
         $offerChicago = $this->makeOfferRow('Player B', 200, 'Chicago', 2, 300, 0, 0, 0, 0, 0, 0, 0, 0, 0, 500.0);
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([$offerMiami, $offerChicago]);
         $stub->method('getPlayerDemandsBatch')->willReturn([
             200 => ['dem1' => 800, 'dem2' => 0, 'dem3' => 0, 'dem4' => 0, 'dem5' => 0, 'dem6' => 0],
@@ -342,7 +342,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
         //         500.0 > 100 → not auto-reject; 500 > 200 → signing
         $offer = $this->makeOfferRow('Player C', 300, 'Miami', 1, 400, 0, 0, 0, 0, 0, 0, 0, 0, 0, 500.0);
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([$offer]);
         $stub->method('getPlayerDemandsBatch')->willReturn([
             300 => ['dem1' => 2000, 'dem2' => 0, 'dem3' => 0, 'dem4' => 0, 'dem5' => 0, 'dem6' => 0],
@@ -373,7 +373,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
         // Any perceivedValue > 0 → signing
         $offer = $this->makeOfferRow('No Demand Player', 400, 'Miami', 1, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50.0);
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([$offer]);
         $stub->method('getPlayerDemandsBatch')->willReturn([]); // empty — no demands for pid 400
 
@@ -400,7 +400,7 @@ class FreeAgencyAdminProcessorTest extends TestCase
         $offerB = $this->makeOfferRow('Player B', 200, 'Chicago', 2, 400, 0, 0, 0, 0, 0, 0, 0, 0, 0, 150.0);
         $offerC = $this->makeOfferRow('Player C', 300, 'Boston', 3, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.0);
 
-        $stub = $this->createStub(FreeAgencyAdminRepositoryInterface::class);
+        $stub = self::createStub(FreeAgencyAdminRepositoryInterface::class);
         $stub->method('getAllOffersWithBirdYears')->willReturn([$offerA, $offerB, $offerC]);
         $stub->method('getPlayerDemandsBatch')->willReturn([
             100 => ['dem1' => 200, 'dem2' => 200, 'dem3' => 200, 'dem4' => 0, 'dem5' => 0, 'dem6' => 0],

--- a/ibl5/tests/FreeAgency/FreeAgencyCapCalculatorTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyCapCalculatorTest.php
@@ -235,7 +235,7 @@ class FreeAgencyCapCalculatorTest extends TestCase
         ]);
 
         $team = $this->createMockTeamEntity();
-        $mockSeason = $this->createStub(Season::class);
+        $mockSeason = self::createStub(Season::class);
         $mockTeamQueryRepo = $this->createMockTeamQueryRepo([], []);
         $calculator = new FreeAgencyCapCalculator($this->mockDb, $team, $mockSeason, $mockTeamQueryRepo);
 
@@ -258,7 +258,7 @@ class FreeAgencyCapCalculatorTest extends TestCase
         ]);
 
         $team = $this->createMockTeamEntity();
-        $mockSeason = $this->createStub(Season::class);
+        $mockSeason = self::createStub(Season::class);
         $mockTeamQueryRepo = $this->createMockTeamQueryRepo([], []);
         $calculator = new FreeAgencyCapCalculator($this->mockDb, $team, $mockSeason, $mockTeamQueryRepo);
 
@@ -303,7 +303,7 @@ class FreeAgencyCapCalculatorTest extends TestCase
         ];
 
         $team = $this->createMockTeamEntity();
-        $mockSeason = $this->createStub(Season::class);
+        $mockSeason = self::createStub(Season::class);
         $mockTeamQueryRepo = $this->createMockTeamQueryRepo($players, []);
         $calculator = new FreeAgencyCapCalculator($this->mockDb, $team, $mockSeason, $mockTeamQueryRepo);
 

--- a/ibl5/tests/FreeAgency/FreeAgencyControllerTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyControllerTest.php
@@ -23,14 +23,14 @@ class FreeAgencyControllerTest extends TestCase
         $mockDb = new MockDatabase();
 
         $loginBoxCalled = false;
-        $nukeCompat = $this->createStub(\Utilities\NukeCompat::class);
+        $nukeCompat = self::createStub(\Utilities\NukeCompat::class);
         $nukeCompat->method('isUser')->willReturn(false);
         $nukeCompat->method('loginBox')->willReturnCallback(function () use (&$loginBoxCalled): void {
             $loginBoxCalled = true;
         });
 
-        $commonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
-        $authService = $this->createStub(\Auth\AuthService::class);
+        $commonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
+        $authService = self::createStub(\Auth\AuthService::class);
         $controller = new FreeAgencyController($mockDb, $commonRepo, $authService, $nukeCompat);
         $controller->handleRequest(null, '', 0);
 
@@ -40,8 +40,8 @@ class FreeAgencyControllerTest extends TestCase
     public function testControllerCanBeInstantiated(): void
     {
         $mockDb = new MockDatabase();
-        $commonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
-        $authService = $this->createStub(\Auth\AuthService::class);
+        $commonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
+        $authService = self::createStub(\Auth\AuthService::class);
         $controller = new FreeAgencyController($mockDb, $commonRepo, $authService);
 
         $this->assertInstanceOf(FreeAgencyController::class, $controller);

--- a/ibl5/tests/FreeAgency/FreeAgencyDemandCalculatorTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyDemandCalculatorTest.php
@@ -719,7 +719,7 @@ class FreeAgencyDemandCalculatorTest extends TestCase
         int $playerID = 1,
         string $currentTeam = 'Test Team'
     ): Player {
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
 
         $player->method('getFreeAgencyPlayForWinner')->willReturn($playForWinner);
         $player->method('getFreeAgencyTradition')->willReturn($tradition);

--- a/ibl5/tests/FreeAgency/FreeAgencyOfferValidatorTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyOfferValidatorTest.php
@@ -571,7 +571,7 @@ class FreeAgencyOfferValidatorTest extends TestCase
 
     private function createTeamStub(int $hasMLE = 0, int $hasLLE = 0, int $teamid = 1): Team
     {
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->has_mle = $hasMLE;
         $team->has_lle = $hasLLE;
         $team->teamid = $teamid;
@@ -583,7 +583,7 @@ class FreeAgencyOfferValidatorTest extends TestCase
      */
     private function createRepositoryStub(bool $pendingMle = false, bool $pendingLle = false): FreeAgencyRepositoryInterface
     {
-        $repository = $this->createStub(FreeAgencyRepositoryInterface::class);
+        $repository = self::createStub(FreeAgencyRepositoryInterface::class);
         $repository->method('hasPendingMleOffer')->willReturn($pendingMle);
         $repository->method('hasPendingLleOffer')->willReturn($pendingLle);
         return $repository;

--- a/ibl5/tests/FreeAgency/FreeAgencyProcessorTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyProcessorTest.php
@@ -169,7 +169,7 @@ class FreeAgencyProcessorTest extends TestCase
 
         $processor = new FreeAgencyProcessor(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
             $calculator,
             $capturingRepo,
         );
@@ -190,7 +190,7 @@ class FreeAgencyProcessorTest extends TestCase
 
         $processor = new FreeAgencyProcessor(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
             $calculator,
             $capturingRepo,
         );
@@ -210,7 +210,7 @@ class FreeAgencyProcessorTest extends TestCase
 
         $processor = new FreeAgencyProcessor(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
             $calculator,
             $capturingRepo,
         );
@@ -231,7 +231,7 @@ class FreeAgencyProcessorTest extends TestCase
 
         $processor = new FreeAgencyProcessor(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
             $calculator,
             $capturingRepo,
         );
@@ -251,7 +251,7 @@ class FreeAgencyProcessorTest extends TestCase
 
         $processor = new FreeAgencyProcessor(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
             $calculator,
             $capturingRepo,
         );
@@ -275,7 +275,7 @@ class FreeAgencyProcessorTest extends TestCase
 
         $processor = new FreeAgencyProcessor(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
             $calculator,
             $capturingRepo,
         );
@@ -299,7 +299,7 @@ class FreeAgencyProcessorTest extends TestCase
 
     public function testProcessorAcceptsDatabaseAndCommonRepoInConstructor(): void
     {
-        $processor = new FreeAgencyProcessor($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $processor = new FreeAgencyProcessor($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $this->assertInstanceOf(FreeAgencyProcessor::class, $processor);
     }
 
@@ -308,7 +308,7 @@ class FreeAgencyProcessorTest extends TestCase
         $calculator = new StubDemandCalculator();
         $repository = new CapturingRepository();
 
-        $processor = new FreeAgencyProcessor($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class), $calculator, $repository);
+        $processor = new FreeAgencyProcessor($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class), $calculator, $repository);
         $this->assertInstanceOf(FreeAgencyProcessor::class, $processor);
     }
 
@@ -320,7 +320,7 @@ class FreeAgencyProcessorTest extends TestCase
     {
         $this->mockDb->setMockData([$this->getCompletePlayerData()]);
 
-        $processor = new FreeAgencyProcessor($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $processor = new FreeAgencyProcessor($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $result = $processor->deleteOffers('Test Team', 1);
 
         $this->assertIsArray($result);
@@ -331,7 +331,7 @@ class FreeAgencyProcessorTest extends TestCase
     {
         $this->mockDb->setMockData([$this->getCompletePlayerData()]);
 
-        $processor = new FreeAgencyProcessor($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $processor = new FreeAgencyProcessor($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
         $processor->deleteOffers('Test Team', 1);
 
         $queries = $this->mockDb->getExecutedQueries();
@@ -355,7 +355,7 @@ class FreeAgencyProcessorTest extends TestCase
 
         $processor = new FreeAgencyProcessor(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
             new StubDemandCalculator(),
             $capturingRepo,
         );
@@ -382,7 +382,7 @@ class FreeAgencyProcessorTest extends TestCase
 
         $processor = new FreeAgencyProcessor(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
             new StubDemandCalculator(),
             $capturingRepo,
         );
@@ -419,7 +419,7 @@ class FreeAgencyProcessorTest extends TestCase
 
         $processor = new FreeAgencyProcessor(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
             new StubDemandCalculator(),
             $signingRepo,
         );

--- a/ibl5/tests/FreeAgency/FreeAgencyServiceTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyServiceTest.php
@@ -28,9 +28,9 @@ class FreeAgencyServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepo = $this->createStub(FreeAgencyRepositoryInterface::class);
-        $this->stubDemandRepo = $this->createStub(FreeAgencyDemandRepositoryInterface::class);
-        $this->stubTeamQueryRepo = $this->createStub(TeamQueryRepositoryInterface::class);
+        $this->stubRepo = self::createStub(FreeAgencyRepositoryInterface::class);
+        $this->stubDemandRepo = self::createStub(FreeAgencyDemandRepositoryInterface::class);
+        $this->stubTeamQueryRepo = self::createStub(TeamQueryRepositoryInterface::class);
         $this->stubTeamQueryRepo->method('getRosterUnderContractOrderedByOrdinal')->willReturn([]);
         $this->stubTeamQueryRepo->method('getFreeAgencyOffers')->willReturn([]);
         $this->mockDb = new MockDatabase();
@@ -42,7 +42,7 @@ class FreeAgencyServiceTest extends TestCase
     {
         $this->stubRepo->method('getExistingOffer')->willReturn(null);
 
-        $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->createStub(\mysqli::class), $this->stubTeamQueryRepo);
+        $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, self::createStub(\mysqli::class), $this->stubTeamQueryRepo);
         $result = $service->getExistingOffer(1, 100);
 
         $this->assertSame(0, $result['offer1']);
@@ -61,7 +61,7 @@ class FreeAgencyServiceTest extends TestCase
             'offer6' => 250,
         ]);
 
-        $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->createStub(\mysqli::class), $this->stubTeamQueryRepo);
+        $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, self::createStub(\mysqli::class), $this->stubTeamQueryRepo);
         $result = $service->getExistingOffer(1, 100);
 
         $this->assertSame(500, $result['offer1']);
@@ -83,7 +83,7 @@ class FreeAgencyServiceTest extends TestCase
             'offer6' => null,
         ]);
 
-        $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->createStub(\mysqli::class), $this->stubTeamQueryRepo);
+        $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, self::createStub(\mysqli::class), $this->stubTeamQueryRepo);
         $result = $service->getExistingOffer(1, 100);
 
         $this->assertSame(500, $result['offer1']);
@@ -105,7 +105,7 @@ class FreeAgencyServiceTest extends TestCase
             'offer6' => '250',
         ]);
 
-        $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->createStub(\mysqli::class), $this->stubTeamQueryRepo);
+        $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, self::createStub(\mysqli::class), $this->stubTeamQueryRepo);
         $result = $service->getExistingOffer(1, 100);
 
         foreach ($result as $value) {
@@ -121,11 +121,11 @@ class FreeAgencyServiceTest extends TestCase
 
         $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->mockDb, $this->stubTeamQueryRepo);
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'Test Team';
         $team->teamid = 1;
 
-        $season = $this->createStub(\Season\Season::class);
+        $season = self::createStub(\Season\Season::class);
 
         $result = $service->getMainPageData($team, $season);
 
@@ -150,11 +150,11 @@ class FreeAgencyServiceTest extends TestCase
 
         $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->mockDb, $this->stubTeamQueryRepo);
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'Test Team';
         $team->teamid = 1;
 
-        $season = $this->createStub(\Season\Season::class);
+        $season = self::createStub(\Season\Season::class);
 
         $result = $service->getMainPageData($team, $season);
 
@@ -168,11 +168,11 @@ class FreeAgencyServiceTest extends TestCase
 
         $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->mockDb, $this->stubTeamQueryRepo);
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'Test Team';
         $team->teamid = 1;
 
-        $season = $this->createStub(\Season\Season::class);
+        $season = self::createStub(\Season\Season::class);
 
         $result = $service->getMainPageData($team, $season);
 
@@ -197,11 +197,11 @@ class FreeAgencyServiceTest extends TestCase
 
         $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->mockDb, $this->stubTeamQueryRepo);
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'Test Team';
         $team->teamid = 1;
 
-        $season = $this->createStub(\Season\Season::class);
+        $season = self::createStub(\Season\Season::class);
 
         $result = $service->getNegotiationData(1, $team, $season);
 
@@ -226,11 +226,11 @@ class FreeAgencyServiceTest extends TestCase
 
         $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->mockDb, $this->stubTeamQueryRepo);
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'Test Team';
         $team->teamid = 1;
 
-        $season = $this->createStub(\Season\Season::class);
+        $season = self::createStub(\Season\Season::class);
 
         $result = $service->getNegotiationData(1, $team, $season);
 
@@ -252,11 +252,11 @@ class FreeAgencyServiceTest extends TestCase
 
         $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->mockDb, $this->stubTeamQueryRepo);
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'Test Team';
         $team->teamid = 1;
 
-        $season = $this->createStub(\Season\Season::class);
+        $season = self::createStub(\Season\Season::class);
 
         $result = $service->getNegotiationData(1, $team, $season);
 
@@ -288,11 +288,11 @@ class FreeAgencyServiceTest extends TestCase
 
         $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->mockDb, $this->stubTeamQueryRepo);
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'Test Team';
         $team->teamid = 1;
 
-        $season = $this->createStub(\Season\Season::class);
+        $season = self::createStub(\Season\Season::class);
 
         $result = $service->getNegotiationData(1, $team, $season);
 
@@ -309,7 +309,7 @@ class FreeAgencyServiceTest extends TestCase
 
     public function testGetMainPageDataPartitionsRosterIntoContractedAndUnsigned(): void
     {
-        $teamQueryRepo = $this->createStub(TeamQueryRepositoryInterface::class);
+        $teamQueryRepo = self::createStub(TeamQueryRepositoryInterface::class);
 
         $contractedPlayer = $this->getBasePlayerData();
         $contractedPlayer['pid'] = 10;
@@ -337,11 +337,11 @@ class FreeAgencyServiceTest extends TestCase
 
         $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->mockDb, $teamQueryRepo);
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'Test Team';
         $team->teamid = 1;
 
-        $season = $this->createStub(\Season\Season::class);
+        $season = self::createStub(\Season\Season::class);
         $season->phase = 'Free Agency';
         $season->endingYear = 2026;
 
@@ -355,7 +355,7 @@ class FreeAgencyServiceTest extends TestCase
 
     public function testGetMainPageDataPreBuildsOfferPlayers(): void
     {
-        $teamQueryRepo = $this->createStub(TeamQueryRepositoryInterface::class);
+        $teamQueryRepo = self::createStub(TeamQueryRepositoryInterface::class);
         $teamQueryRepo->method('getRosterUnderContractOrderedByOrdinal')->willReturn([]);
         $teamQueryRepo->method('getFreeAgencyOffers')->willReturn([
             ['pid' => 5, 'teamid' => 1, 'team' => 'Test', 'name' => 'Offered', 'offer1' => 400, 'offer2' => 350, 'offer3' => 0, 'offer4' => 0, 'offer5' => 0, 'offer6' => 0],
@@ -367,11 +367,11 @@ class FreeAgencyServiceTest extends TestCase
 
         $service = new FreeAgencyService($this->stubRepo, $this->stubDemandRepo, $this->mockDb, $teamQueryRepo);
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'Test Team';
         $team->teamid = 1;
 
-        $season = $this->createStub(\Season\Season::class);
+        $season = self::createStub(\Season\Season::class);
 
         $result = $service->getMainPageData($team, $season);
 

--- a/ibl5/tests/FreeAgency/FreeAgencyViewXssTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyViewXssTest.php
@@ -16,7 +16,7 @@ class FreeAgencyViewXssTest extends TestCase
     {
         $xssPayload = '<script>alert("xss")</script>';
 
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
         $player->position = 'PG';
         $player->name = 'Test Player';
         $player->playerID = 1;
@@ -24,7 +24,7 @@ class FreeAgencyViewXssTest extends TestCase
         $player->birdYears = 0;
         $player->yearsOfExperience = 5;
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'TestTeam';
         $team->teamid = 1;
 
@@ -57,7 +57,7 @@ class FreeAgencyViewXssTest extends TestCase
 
     public function testNegotiationViewShowsNoSpotsWarningWithXssTeam(): void
     {
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
         $player->position = 'SG';
         $player->name = '<img src=x onerror=alert(1)>';
         $player->playerID = 2;
@@ -65,7 +65,7 @@ class FreeAgencyViewXssTest extends TestCase
         $player->birdYears = 0;
         $player->yearsOfExperience = 3;
 
-        $team = $this->createStub(Team::class);
+        $team = self::createStub(Team::class);
         $team->name = 'TestTeam';
         $team->teamid = 1;
 

--- a/ibl5/tests/JsbParser/JsbExportServiceTest.php
+++ b/ibl5/tests/JsbParser/JsbExportServiceTest.php
@@ -21,7 +21,7 @@ class JsbExportServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepo = $this->createStub(JsbExportRepositoryInterface::class);
+        $this->stubRepo = self::createStub(JsbExportRepositoryInterface::class);
     }
 
     private function makeService(): JsbExportService

--- a/ibl5/tests/JsbParser/JsbImportServiceTest.php
+++ b/ibl5/tests/JsbParser/JsbImportServiceTest.php
@@ -24,8 +24,8 @@ class JsbImportServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepo = $this->createStub(JsbImportRepositoryInterface::class);
-        $this->stubResolver = $this->createStub(PlayerIdResolver::class);
+        $this->stubRepo = self::createStub(JsbImportRepositoryInterface::class);
+        $this->stubResolver = self::createStub(PlayerIdResolver::class);
     }
 
     private function makeService(?PlayerIdResolver $resolver = null): JsbImportService

--- a/ibl5/tests/JsbParser/SchFileParserTest.php
+++ b/ibl5/tests/JsbParser/SchFileParserTest.php
@@ -255,7 +255,7 @@ class SchFileParserTest extends TestCase
     {
         $schFile = dirname(__DIR__, 2) . '/IBL5.sch';
         if (!file_exists($schFile)) {
-            $this->fail("Test .sch file not found at: {$schFile}");
+            self::fail("Test .sch file not found at: {$schFile}");
         }
 
         $data = file_get_contents($schFile);
@@ -279,7 +279,7 @@ class SchFileParserTest extends TestCase
     {
         $schFile = dirname(__DIR__, 2) . '/IBL5.sch';
         if (!file_exists($schFile)) {
-            $this->fail("Test .sch file not found at: {$schFile}");
+            self::fail("Test .sch file not found at: {$schFile}");
         }
 
         $games = SchFileParser::parseFile($schFile);
@@ -315,7 +315,7 @@ class SchFileParserTest extends TestCase
     {
         $schFile = dirname(__DIR__, 2) . '/IBL5.sch';
         if (!file_exists($schFile)) {
-            $this->fail("Test .sch file not found at: {$schFile}");
+            self::fail("Test .sch file not found at: {$schFile}");
         }
 
         $games = SchFileParser::parseFile($schFile);
@@ -347,7 +347,7 @@ class SchFileParserTest extends TestCase
     {
         $schFile = dirname(__DIR__, 2) . '/IBL5.sch';
         if (!file_exists($schFile)) {
-            $this->fail("Test .sch file not found at: {$schFile}");
+            self::fail("Test .sch file not found at: {$schFile}");
         }
 
         $games = SchFileParser::parseFile($schFile);
@@ -364,7 +364,7 @@ class SchFileParserTest extends TestCase
     {
         $schFile = dirname(__DIR__, 2) . '/IBL5.sch';
         if (!file_exists($schFile)) {
-            $this->fail("Test .sch file not found at: {$schFile}");
+            self::fail("Test .sch file not found at: {$schFile}");
         }
 
         $games = SchFileParser::parseFile($schFile);

--- a/ibl5/tests/LastSimRecap/LastSimRecapServiceTest.php
+++ b/ibl5/tests/LastSimRecap/LastSimRecapServiceTest.php
@@ -20,7 +20,7 @@ class LastSimRecapServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->playerLookup = $this->createStub(PlayerLookupRepositoryInterface::class);
+        $this->playerLookup = self::createStub(PlayerLookupRepositoryInterface::class);
         $this->playerLookup->method('getPlayerByID')->willReturn(null);
     }
 

--- a/ibl5/tests/LastSimRecap/NewsModuleIntegrationTest.php
+++ b/ibl5/tests/LastSimRecap/NewsModuleIntegrationTest.php
@@ -23,7 +23,7 @@ class NewsModuleIntegrationTest extends TestCase
     public function testServiceReturnsNullForUnknownTeam(): void
     {
         $repo = $this->repoWithGames([]);
-        $playerLookup = $this->createStub(PlayerLookupRepositoryInterface::class);
+        $playerLookup = self::createStub(PlayerLookupRepositoryInterface::class);
         $playerLookup->method('getPlayerByID')->willReturn(null);
         $svc = new LastSimRecapService($repo, $playerLookup);
 
@@ -33,7 +33,7 @@ class NewsModuleIntegrationTest extends TestCase
     public function testServiceReturnsEmptySlateForTeamWithNoGames(): void
     {
         $repo = $this->repoWithGames([]);
-        $playerLookup = $this->createStub(PlayerLookupRepositoryInterface::class);
+        $playerLookup = self::createStub(PlayerLookupRepositoryInterface::class);
         $playerLookup->method('getPlayerByID')->willReturn(null);
         $svc = new LastSimRecapService($repo, $playerLookup);
 
@@ -54,7 +54,7 @@ class NewsModuleIntegrationTest extends TestCase
                 'year' => 2026,
             ],
         ]);
-        $playerLookup = $this->createStub(PlayerLookupRepositoryInterface::class);
+        $playerLookup = self::createStub(PlayerLookupRepositoryInterface::class);
         $playerLookup->method('getPlayerByID')->willReturn(null);
         $svc = new LastSimRecapService($repo, $playerLookup);
 

--- a/ibl5/tests/LeagueConfig/LeagueConfigServiceTest.php
+++ b/ibl5/tests/LeagueConfig/LeagueConfigServiceTest.php
@@ -14,13 +14,13 @@ class LeagueConfigServiceTest extends TestCase
     {
         $lgeFile = dirname(__DIR__, 2) . '/IBL5.lge';
         if (!file_exists($lgeFile)) {
-            $this->fail("Test .lge file not found at: {$lgeFile}");
+            self::fail("Test .lge file not found at: {$lgeFile}");
         }
 
         $mockRepository = $this->createMock(LeagueConfigRepositoryInterface::class);
         $mockRepository->expects($this->once())
             ->method('upsertSeasonConfig')
-            ->with($this->isInt(), $this->isArray())
+            ->with(self::isInt(), self::isArray())
             ->willReturn(28);
 
         $service = new LeagueConfigService($mockRepository);
@@ -41,7 +41,7 @@ class LeagueConfigServiceTest extends TestCase
 
     public function testProcessLgeFileReturnsErrorForMissingFile(): void
     {
-        $stubRepository = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepository = self::createStub(LeagueConfigRepositoryInterface::class);
         $service = new LeagueConfigService($stubRepository);
 
         $result = $service->processLgeFile('/nonexistent/IBL5.lge');
@@ -56,7 +56,7 @@ class LeagueConfigServiceTest extends TestCase
 
     public function testCrossCheckReturnsEmptyWhenAllMatch(): void
     {
-        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo = self::createStub(LeagueConfigRepositoryInterface::class);
         $stubRepo->method('getConfigForSeason')->willReturn([
             ['team_slot' => 1, 'team_name' => 'Miami'],
             ['team_slot' => 2, 'team_name' => 'New York'],
@@ -74,7 +74,7 @@ class LeagueConfigServiceTest extends TestCase
 
     public function testCrossCheckReturnsErrorWhenNoConfigFound(): void
     {
-        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo = self::createStub(LeagueConfigRepositoryInterface::class);
         $stubRepo->method('getConfigForSeason')->willReturn([]);
 
         $service = new LeagueConfigService($stubRepo);
@@ -86,7 +86,7 @@ class LeagueConfigServiceTest extends TestCase
 
     public function testCrossCheckReturnsErrorWhenNoFranchiseDataFound(): void
     {
-        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo = self::createStub(LeagueConfigRepositoryInterface::class);
         $stubRepo->method('getConfigForSeason')->willReturn([
             ['team_slot' => 1, 'team_name' => 'Miami'],
         ]);
@@ -101,7 +101,7 @@ class LeagueConfigServiceTest extends TestCase
 
     public function testCrossCheckDetectsMissingSlotInFranchiseMap(): void
     {
-        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo = self::createStub(LeagueConfigRepositoryInterface::class);
         $stubRepo->method('getConfigForSeason')->willReturn([
             ['team_slot' => 1, 'team_name' => 'Miami'],
             ['team_slot' => 99, 'team_name' => 'Phantom Team'],
@@ -120,7 +120,7 @@ class LeagueConfigServiceTest extends TestCase
 
     public function testCrossCheckDetectsNameMismatch(): void
     {
-        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo = self::createStub(LeagueConfigRepositoryInterface::class);
         $stubRepo->method('getConfigForSeason')->willReturn([
             ['team_slot' => 1, 'team_name' => 'Miami Heat'],
         ]);
@@ -140,7 +140,7 @@ class LeagueConfigServiceTest extends TestCase
     {
         $lgeFile = dirname(__DIR__, 2) . '/IBL5.lge';
         if (!file_exists($lgeFile)) {
-            $this->fail("Test .lge file not found at: {$lgeFile}");
+            self::fail("Test .lge file not found at: {$lgeFile}");
         }
 
         $data = file_get_contents($lgeFile);
@@ -149,7 +149,7 @@ class LeagueConfigServiceTest extends TestCase
         $mockRepository = $this->createMock(LeagueConfigRepositoryInterface::class);
         $mockRepository->expects($this->once())
             ->method('upsertSeasonConfig')
-            ->with($this->isInt(), $this->isArray())
+            ->with(self::isInt(), self::isArray())
             ->willReturn(28);
 
         $service = new LeagueConfigService($mockRepository);
@@ -162,7 +162,7 @@ class LeagueConfigServiceTest extends TestCase
 
     public function testProcessLgeDataReturnsErrorForInvalidSize(): void
     {
-        $stubRepository = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepository = self::createStub(LeagueConfigRepositoryInterface::class);
         $service = new LeagueConfigService($stubRepository);
 
         $result = $service->processLgeData('too short');
@@ -178,13 +178,13 @@ class LeagueConfigServiceTest extends TestCase
     {
         $lgeFile = dirname(__DIR__, 2) . '/IBL5.lge';
         if (!file_exists($lgeFile)) {
-            $this->fail("Test .lge file not found at: {$lgeFile}");
+            self::fail("Test .lge file not found at: {$lgeFile}");
         }
 
         $data = file_get_contents($lgeFile);
         self::assertIsString($data);
 
-        $stubRepository = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepository = self::createStub(LeagueConfigRepositoryInterface::class);
         $stubRepository->method('upsertSeasonConfig')->willReturn(28);
 
         $service = new LeagueConfigService($stubRepository);
@@ -197,7 +197,7 @@ class LeagueConfigServiceTest extends TestCase
 
     public function testCrossCheckDetectsFranchiseNotInLgeFile(): void
     {
-        $stubRepo = $this->createStub(LeagueConfigRepositoryInterface::class);
+        $stubRepo = self::createStub(LeagueConfigRepositoryInterface::class);
         $stubRepo->method('getConfigForSeason')->willReturn([
             ['team_slot' => 1, 'team_name' => 'Miami'],
         ]);

--- a/ibl5/tests/LeagueConfig/LgeFileParserTest.php
+++ b/ibl5/tests/LeagueConfig/LgeFileParserTest.php
@@ -29,7 +29,7 @@ class LgeFileParserTest extends TestCase
     {
         $path = self::lgeFile();
         if (!file_exists($path)) {
-            $this->fail("Test .lge file not found at: {$path}");
+            self::fail("Test .lge file not found at: {$path}");
         }
         return $path;
     }

--- a/ibl5/tests/LeagueControlPanel/AwardGenerationServiceTest.php
+++ b/ibl5/tests/LeagueControlPanel/AwardGenerationServiceTest.php
@@ -25,8 +25,8 @@ class AwardGenerationServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepository = $this->createStub(LeagueControlPanelRepositoryInterface::class);
-        $this->stubVotingService = $this->createStub(VotingResultsServiceInterface::class);
+        $this->stubRepository = self::createStub(LeagueControlPanelRepositoryInterface::class);
+        $this->stubVotingService = self::createStub(VotingResultsServiceInterface::class);
         $this->service = new AwardGenerationService($this->stubRepository, $this->stubVotingService);
         $this->tempDir = sys_get_temp_dir() . '/award_gen_test_' . uniqid();
         mkdir($this->tempDir);
@@ -101,7 +101,7 @@ class AwardGenerationServiceTest extends TestCase
     public function testInsertsGmOfTheYear(): void
     {
         $mockRepository = $this->createMock(LeagueControlPanelRepositoryInterface::class);
-        $stubVotingService = $this->createStub(VotingResultsServiceInterface::class);
+        $stubVotingService = self::createStub(VotingResultsServiceInterface::class);
         $service = new AwardGenerationService($mockRepository, $stubVotingService);
 
         $stubVotingService->method('getEndOfYearResults')->willReturn([

--- a/ibl5/tests/LeagueControlPanel/LeagueControlPanelProcessorTest.php
+++ b/ibl5/tests/LeagueControlPanel/LeagueControlPanelProcessorTest.php
@@ -42,8 +42,8 @@ class LeagueControlPanelProcessorTest extends TestCase
 
     public function testImplementsInterface(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
-        $awardStub = $this->createStub(AwardGenerationServiceInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
+        $awardStub = self::createStub(AwardGenerationServiceInterface::class);
         $processor = new LeagueControlPanelProcessor($stub, $awardStub);
 
         $this->assertInstanceOf(LeagueControlPanelProcessorInterface::class, $processor);
@@ -87,7 +87,7 @@ class LeagueControlPanelProcessorTest extends TestCase
             ->method('setSeasonPhase')
             ->with('Regular Season');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_season_phase', ['SeasonPhase' => 'Regular Season']);
 
         $this->assertTrue($result['success']);
@@ -133,7 +133,7 @@ class LeagueControlPanelProcessorTest extends TestCase
             ->method('setSimLengthInDays')
             ->with(7);
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_sim_length', ['SimLengthInDays' => '7']);
 
         $this->assertTrue($result['success']);
@@ -158,7 +158,7 @@ class LeagueControlPanelProcessorTest extends TestCase
             ->method('setAllowTrades')
             ->with('Yes');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_allow_trades', ['Trades' => 'Yes']);
 
         $this->assertTrue($result['success']);
@@ -183,7 +183,7 @@ class LeagueControlPanelProcessorTest extends TestCase
             ->method('setAllowWaivers')
             ->with('No');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_allow_waivers', ['Waivers' => 'No']);
 
         $this->assertTrue($result['success']);
@@ -207,7 +207,7 @@ class LeagueControlPanelProcessorTest extends TestCase
             ->method('setShowDraftLink')
             ->with('On');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_show_draft_link', ['ShowDraftLink' => 'On']);
 
         $this->assertTrue($result['success']);
@@ -232,7 +232,7 @@ class LeagueControlPanelProcessorTest extends TestCase
             ->method('setFreeAgencyNotifications')
             ->with('On');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('toggle_fa_notifications', ['FANotifs' => 'On']);
 
         $this->assertTrue($result['success']);
@@ -247,7 +247,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock->expects($this->once())
             ->method('activateTriviaMode');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('activate_trivia', []);
 
         $this->assertTrue($result['success']);
@@ -260,7 +260,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock->expects($this->once())
             ->method('deactivateTriviaMode');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('deactivate_trivia', []);
 
         $this->assertTrue($result['success']);
@@ -276,7 +276,7 @@ class LeagueControlPanelProcessorTest extends TestCase
             ->method('deleteDraftPlaceholders')
             ->willReturn(5);
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('delete_draft_placeholders', []);
 
         $this->assertTrue($result['success']);
@@ -292,7 +292,7 @@ class LeagueControlPanelProcessorTest extends TestCase
             ->method('deleteOutdatedBuyoutsAndCash')
             ->willReturn(3);
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('delete_outdated_buyouts_cash', []);
 
         $this->assertTrue($result['success']);
@@ -307,7 +307,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock->expects($this->once())
             ->method('resetAllContractExtensions');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('reset_contract_extensions', []);
 
         $this->assertTrue($result['success']);
@@ -320,7 +320,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock->expects($this->once())
             ->method('resetAllMlesAndLles');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('reset_mles_lles', []);
 
         $this->assertTrue($result['success']);
@@ -333,7 +333,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock->expects($this->once())
             ->method('resetAllStarVoting');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('reset_asg_voting', []);
 
         $this->assertTrue($result['success']);
@@ -346,7 +346,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock->expects($this->once())
             ->method('resetEndOfYearVoting');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('reset_eoy_voting', []);
 
         $this->assertTrue($result['success']);
@@ -359,7 +359,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock->expects($this->once())
             ->method('setWaiversToFreeAgents');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_waivers_to_free_agents', []);
 
         $this->assertTrue($result['success']);
@@ -384,7 +384,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock->expects($this->once())
             ->method('setFreeAgencyFactorsForPfw');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_fa_factors_pfw', ['current_phase' => 'Draft']);
 
         $this->assertTrue($result['success']);
@@ -397,7 +397,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock->expects($this->once())
             ->method('setFreeAgencyFactorsForPfw');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_fa_factors_pfw', ['current_phase' => 'Free Agency']);
 
         $this->assertTrue($result['success']);
@@ -407,12 +407,12 @@ class LeagueControlPanelProcessorTest extends TestCase
 
     public function testGenerateAwardsFailsOutsidePlayoffsOrDraft(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getSetting')->willReturnMap([
             ['Current Season Phase', 'Regular Season'],
         ]);
 
-        $processor = new LeagueControlPanelProcessor($stub, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($stub, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('generate_awards', []);
 
         $this->assertFalse($result['success']);
@@ -421,13 +421,13 @@ class LeagueControlPanelProcessorTest extends TestCase
 
     public function testGenerateAwardsFailsWhenYearSettingMissing(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getSetting')->willReturnMap([
             ['Current Season Phase', 'Playoffs'],
             ['Current Season Ending Year', null],
         ]);
 
-        $processor = new LeagueControlPanelProcessor($stub, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($stub, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('generate_awards', []);
 
         $this->assertFalse($result['success']);
@@ -436,13 +436,13 @@ class LeagueControlPanelProcessorTest extends TestCase
 
     public function testGenerateAwardsFailsWhenLeadersHtmMissing(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getSetting')->willReturnMap([
             ['Current Season Phase', 'Playoffs'],
             ['Current Season Ending Year', '2026'],
         ]);
 
-        $processor = new LeagueControlPanelProcessor($stub, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($stub, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('generate_awards', []);
 
         $this->assertFalse($result['success']);
@@ -453,7 +453,7 @@ class LeagueControlPanelProcessorTest extends TestCase
     {
         file_put_contents(self::$tempRoot . '/Leaders.htm', '<html></html>');
 
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getSetting')->willReturnMap([
             ['Current Season Phase', 'Playoffs'],
             ['Current Season Ending Year', '2026'],
@@ -477,13 +477,13 @@ class LeagueControlPanelProcessorTest extends TestCase
     {
         file_put_contents(self::$tempRoot . '/Leaders.htm', '<html></html>');
 
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getSetting')->willReturnMap([
             ['Current Season Phase', 'Draft'],
             ['Current Season Ending Year', '2026'],
         ]);
 
-        $awardStub = $this->createStub(AwardGenerationServiceInterface::class);
+        $awardStub = self::createStub(AwardGenerationServiceInterface::class);
         $awardStub->method('generateSeasonAwards')
             ->willReturn(['success' => true, 'message' => 'Awards generated.', 'inserted' => 5, 'skipped' => 0]);
 
@@ -507,12 +507,12 @@ class LeagueControlPanelProcessorTest extends TestCase
 
     public function testSetFinalsMvpFailsWhenYearSettingMissing(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getSetting')->willReturnMap([
             ['Current Season Ending Year', null],
         ]);
 
-        $processor = new LeagueControlPanelProcessor($stub, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($stub, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_finals_mvp', ['finals_mvp_name' => 'James Harden']);
 
         $this->assertFalse($result['success']);
@@ -529,7 +529,7 @@ class LeagueControlPanelProcessorTest extends TestCase
             ->method('upsertAward')
             ->with(2026, 'IBL Finals MVP', 'James Harden');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $result = $processor->dispatch('set_finals_mvp', ['finals_mvp_name' => 'James Harden']);
 
         $this->assertTrue($result['success']);
@@ -547,7 +547,7 @@ class LeagueControlPanelProcessorTest extends TestCase
         $mock = $this->createMock(LeagueControlPanelRepositoryInterface::class);
         $mock->expects($this->once())->method('setSeasonPhase')->with('Preseason');
 
-        $processor = new LeagueControlPanelProcessor($mock, $this->createStub(AwardGenerationServiceInterface::class));
+        $processor = new LeagueControlPanelProcessor($mock, self::createStub(AwardGenerationServiceInterface::class));
         $processor->dispatch('set_season_phase', ['SeasonPhase' => 'Preseason']);
 
         $this->assertTrue($handler->hasInfoThatContains('admin_action'));
@@ -580,7 +580,7 @@ class LeagueControlPanelProcessorTest extends TestCase
 
         $processor = new LeagueControlPanelProcessor(
             $mock,
-            $this->createStub(AwardGenerationServiceInterface::class),
+            self::createStub(AwardGenerationServiceInterface::class),
             LeagueContext::LEAGUE_OLYMPICS,
         );
         $result = $processor->dispatch('set_sim_length', ['SimLengthInDays' => '5']);
@@ -625,15 +625,15 @@ class LeagueControlPanelProcessorTest extends TestCase
 
     private function createProcessorWithStub(): LeagueControlPanelProcessor
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
-        $awardStub = $this->createStub(AwardGenerationServiceInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
+        $awardStub = self::createStub(AwardGenerationServiceInterface::class);
         return new LeagueControlPanelProcessor($stub, $awardStub);
     }
 
     private function createOlympicsProcessorWithStub(): LeagueControlPanelProcessor
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
-        $awardStub = $this->createStub(AwardGenerationServiceInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
+        $awardStub = self::createStub(AwardGenerationServiceInterface::class);
         return new LeagueControlPanelProcessor($stub, $awardStub, LeagueContext::LEAGUE_OLYMPICS);
     }
 }

--- a/ibl5/tests/LeagueControlPanel/LeagueControlPanelRepositoryTest.php
+++ b/ibl5/tests/LeagueControlPanel/LeagueControlPanelRepositoryTest.php
@@ -96,7 +96,7 @@ class LeagueControlPanelRepositoryTest extends TestCase
 
     private function createMockDatabase(): \mysqli
     {
-        return $this->createStub(\mysqli::class);
+        return self::createStub(\mysqli::class);
     }
 
     /**
@@ -104,7 +104,7 @@ class LeagueControlPanelRepositoryTest extends TestCase
      */
     private function createMockDatabaseWithPreparedStatement(array|null $returnData): \mysqli
     {
-        $mockResult = $this->createStub(\mysqli_result::class);
+        $mockResult = self::createStub(\mysqli_result::class);
 
         if ($returnData === null) {
             $mockResult->method('fetch_assoc')->willReturn(null);
@@ -116,13 +116,13 @@ class LeagueControlPanelRepositoryTest extends TestCase
             $mockResult->method('fetch_assoc')->willReturnOnConsecutiveCalls(...array_merge($returnData, [null]));
         }
 
-        $stubStmt = $this->createStub(\mysqli_stmt::class);
+        $stubStmt = self::createStub(\mysqli_stmt::class);
         $stubStmt->method('bind_param')->willReturn(true);
         $stubStmt->method('execute')->willReturn(true);
         $stubStmt->method('get_result')->willReturn($mockResult);
         $stubStmt->method('close')->willReturn(true);
 
-        $stubDb = $this->createStub(\mysqli::class);
+        $stubDb = self::createStub(\mysqli::class);
         $stubDb->method('prepare')->willReturn($stubStmt);
 
         return $stubDb;

--- a/ibl5/tests/LeagueControlPanel/LeagueControlPanelServiceTest.php
+++ b/ibl5/tests/LeagueControlPanel/LeagueControlPanelServiceTest.php
@@ -17,7 +17,7 @@ class LeagueControlPanelServiceTest extends TestCase
 {
     public function testImplementsInterface(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getBulkSettings')->willReturn([]);
         $stub->method('getSimLengthInDays')->willReturn(3);
 
@@ -28,7 +28,7 @@ class LeagueControlPanelServiceTest extends TestCase
 
     public function testGetPanelDataReturnsCompleteShape(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getBulkSettings')->willReturn([
             'Current Season Phase' => 'Regular Season',
             'Allow Trades' => 'Yes',
@@ -55,7 +55,7 @@ class LeagueControlPanelServiceTest extends TestCase
 
     public function testGetPanelDataDefaultsForMissingSettings(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getBulkSettings')->willReturn([]);
         $stub->method('getSimLengthInDays')->willReturn(3);
 
@@ -74,7 +74,7 @@ class LeagueControlPanelServiceTest extends TestCase
 
     public function testGetPanelDataCastsEndingYearToInt(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getBulkSettings')->willReturn([
             'Current Season Ending Year' => '2025',
         ]);
@@ -88,7 +88,7 @@ class LeagueControlPanelServiceTest extends TestCase
 
     public function testGetPanelDataOlympicsReturnsDefaultsForIblOnlySettings(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getBulkSettings')->willReturn([
             'Current Season Phase' => 'Regular Season',
             'Current Season Ending Year' => '2026',
@@ -107,7 +107,7 @@ class LeagueControlPanelServiceTest extends TestCase
 
     public function testGetPanelDataOlympicsReturnsFalseForHasFinalsMvp(): void
     {
-        $stub = $this->createStub(LeagueControlPanelRepositoryInterface::class);
+        $stub = self::createStub(LeagueControlPanelRepositoryInterface::class);
         $stub->method('getBulkSettings')->willReturn([
             'Current Season Ending Year' => '2026',
         ]);

--- a/ibl5/tests/LeagueSchedule/LeagueScheduleServiceTest.php
+++ b/ibl5/tests/LeagueSchedule/LeagueScheduleServiceTest.php
@@ -15,7 +15,7 @@ class LeagueScheduleServiceTest extends TestCase
 {
     public function testImplementsInterface(): void
     {
-        $mockRepo = $this->createStub(LeagueScheduleRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueScheduleRepositoryInterface::class);
         $service = new LeagueScheduleService($mockRepo);
 
         $this->assertInstanceOf(LeagueScheduleServiceInterface::class, $service);
@@ -23,18 +23,18 @@ class LeagueScheduleServiceTest extends TestCase
 
     public function testGetSchedulePageDataReturnsExpectedStructure(): void
     {
-        $mockRepo = $this->createStub(LeagueScheduleRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueScheduleRepositoryInterface::class);
         $mockRepo->method('getAllGamesWithBoxScoreInfo')->willReturn([]);
         $mockRepo->method('getTeamRecords')->willReturn([]);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->projectedNextSimEndDate = new \DateTime('2025-11-15');
         $season->phase = 'Regular Season';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getSimLengthInDays')->willReturn(7);
 
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
 
         $service = new LeagueScheduleService($mockRepo);
         $result = $service->getSchedulePageData($season, $league, $commonRepo);
@@ -53,7 +53,7 @@ class LeagueScheduleServiceTest extends TestCase
 
     public function testOrganizesGamesByMonth(): void
     {
-        $mockRepo = $this->createStub(LeagueScheduleRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueScheduleRepositoryInterface::class);
         $mockRepo->method('getAllGamesWithBoxScoreInfo')->willReturn([
             [
                 'id' => 1,
@@ -83,14 +83,14 @@ class LeagueScheduleServiceTest extends TestCase
             4 => '18-17',
         ]);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->projectedNextSimEndDate = new \DateTime('2025-10-15');
         $season->phase = 'Regular Season';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getSimLengthInDays')->willReturn(7);
 
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
         $commonRepo->method('getTeamnameFromTeamID')->willReturnMap([
             [1, 'Team A'],
             [2, 'Team B'],
@@ -109,7 +109,7 @@ class LeagueScheduleServiceTest extends TestCase
 
     public function testIdentifiesUpcomingGames(): void
     {
-        $mockRepo = $this->createStub(LeagueScheduleRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueScheduleRepositoryInterface::class);
         $mockRepo->method('getAllGamesWithBoxScoreInfo')->willReturn([
             [
                 'id' => 1,
@@ -124,14 +124,14 @@ class LeagueScheduleServiceTest extends TestCase
         ]);
         $mockRepo->method('getTeamRecords')->willReturn([]);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->projectedNextSimEndDate = new \DateTime('2025-11-15');
         $season->phase = 'Regular Season';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getSimLengthInDays')->willReturn(7);
 
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
         $commonRepo->method('getTeamnameFromTeamID')->willReturn('Team');
 
         $service = new LeagueScheduleService($mockRepo);
@@ -145,7 +145,7 @@ class LeagueScheduleServiceTest extends TestCase
 
     public function testPlayoffPhaseReordersMonths(): void
     {
-        $mockRepo = $this->createStub(LeagueScheduleRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueScheduleRepositoryInterface::class);
         $mockRepo->method('getAllGamesWithBoxScoreInfo')->willReturn([
             [
                 'id' => 1,
@@ -170,14 +170,14 @@ class LeagueScheduleServiceTest extends TestCase
         ]);
         $mockRepo->method('getTeamRecords')->willReturn([]);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->projectedNextSimEndDate = new \DateTime('2025-10-15');
         $season->phase = 'Playoffs';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getSimLengthInDays')->willReturn(7);
 
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
         $commonRepo->method('getTeamnameFromTeamID')->willReturn('Team');
 
         $service = new LeagueScheduleService($mockRepo);
@@ -194,7 +194,7 @@ class LeagueScheduleServiceTest extends TestCase
 
     public function testVisitorWonAndHomeWonFlags(): void
     {
-        $mockRepo = $this->createStub(LeagueScheduleRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueScheduleRepositoryInterface::class);
         $mockRepo->method('getAllGamesWithBoxScoreInfo')->willReturn([
             [
                 'id' => 1,
@@ -209,14 +209,14 @@ class LeagueScheduleServiceTest extends TestCase
         ]);
         $mockRepo->method('getTeamRecords')->willReturn([]);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->projectedNextSimEndDate = new \DateTime('2025-10-15');
         $season->phase = 'Regular Season';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getSimLengthInDays')->willReturn(7);
 
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
         $commonRepo->method('getTeamnameFromTeamID')->willReturn('Team');
 
         $service = new LeagueScheduleService($mockRepo);
@@ -236,15 +236,15 @@ class LeagueScheduleServiceTest extends TestCase
             ->willReturn([]);
         $mockRepo->method('getTeamRecords')->willReturn([]);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->endingYear = 2026;
         $season->projectedNextSimEndDate = new \DateTime('2025-11-15');
         $season->phase = 'Regular Season';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getSimLengthInDays')->willReturn(7);
 
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
 
         $service = new LeagueScheduleService($mockRepo);
         $service->getSchedulePageData($season, $league, $commonRepo);
@@ -252,18 +252,18 @@ class LeagueScheduleServiceTest extends TestCase
 
     public function testRegularSeasonIsNotPlayoffPhase(): void
     {
-        $mockRepo = $this->createStub(LeagueScheduleRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueScheduleRepositoryInterface::class);
         $mockRepo->method('getAllGamesWithBoxScoreInfo')->willReturn([]);
         $mockRepo->method('getTeamRecords')->willReturn([]);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->projectedNextSimEndDate = new \DateTime('2025-11-15');
         $season->phase = 'Regular Season';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getSimLengthInDays')->willReturn(7);
 
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
 
         $service = new LeagueScheduleService($mockRepo);
         $result = $service->getSchedulePageData($season, $league, $commonRepo);

--- a/ibl5/tests/LeagueStarters/LeagueStartersApiHandlerTest.php
+++ b/ibl5/tests/LeagueStarters/LeagueStartersApiHandlerTest.php
@@ -17,8 +17,8 @@ class LeagueStartersApiHandlerTest extends WideUnitTestCase
     {
         $handler = new LeagueStartersApiHandler(
             $this->mockDb,
-            $this->createStub(TeamIdentityRepositoryInterface::class),
-            $this->createStub(\Auth\AuthService::class)
+            self::createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(\Auth\AuthService::class)
         );
 
         $this->assertInstanceOf(LeagueStartersApiHandler::class, $handler);

--- a/ibl5/tests/LeagueStarters/LeagueStartersServiceTest.php
+++ b/ibl5/tests/LeagueStarters/LeagueStartersServiceTest.php
@@ -86,7 +86,7 @@ class LeagueStartersServiceTest extends TestCase
 
     public function testBatchLoadReturnsCorrectPositionBuckets(): void
     {
-        $mockRepo = $this->createStub(LeagueStartersRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueStartersRepositoryInterface::class);
         $mockRepo->method('getAllStartersWithTeamData')->willReturn([
             $this->makeStarterRow(101, 1, 'PG', 'Test Team'),
             $this->makeStarterRow(102, 1, 'SG', 'Test Team'),
@@ -115,7 +115,7 @@ class LeagueStartersServiceTest extends TestCase
 
     public function testMissingSlotsUsePlaceholder(): void
     {
-        $mockRepo = $this->createStub(LeagueStartersRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueStartersRepositoryInterface::class);
         $mockRepo->method('getAllStartersWithTeamData')->willReturn([
             $this->makeStarterRow(101, 1, 'PG', 'Test Team'),
         ]);
@@ -139,7 +139,7 @@ class LeagueStartersServiceTest extends TestCase
 
     public function testPlaceholderSetsTeamProperties(): void
     {
-        $mockRepo = $this->createStub(LeagueStartersRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueStartersRepositoryInterface::class);
         $mockRepo->method('getAllStartersWithTeamData')->willReturn([]);
         $mockRepo->method('getPlaceholderRow')->willReturn(
             TestDataFactory::createPlayer(['pid' => 4040404, 'teamid' => 0, 'name' => 'Placeholder', 'loyalty' => 0, 'playing_time' => 0, 'winner' => 0, 'tradition' => 0, 'security' => 0])
@@ -160,7 +160,7 @@ class LeagueStartersServiceTest extends TestCase
 
     public function testPlaceholderLoadedOnlyOnce(): void
     {
-        $mockRepo = $this->createStub(LeagueStartersRepositoryInterface::class);
+        $mockRepo = self::createStub(LeagueStartersRepositoryInterface::class);
         $mockRepo->method('getAllStartersWithTeamData')->willReturn([]);
         $mockRepo->method('getPlaceholderRow')->willReturn(
             TestDataFactory::createPlayer(['pid' => 4040404, 'teamid' => 0, 'name' => 'Placeholder', 'loyalty' => 0, 'playing_time' => 0, 'winner' => 0, 'tradition' => 0, 'security' => 0])

--- a/ibl5/tests/Mail/MailServiceSmtpIntegrationTest.php
+++ b/ibl5/tests/Mail/MailServiceSmtpIntegrationTest.php
@@ -28,7 +28,7 @@ class MailServiceSmtpIntegrationTest extends TestCase
     {
         if (!$this->isMailpitReachable()) {
             // phpunit-hygiene-allow: integration test skips when Mailpit SMTP is unreachable on localhost:1025
-            $this->markTestSkipped('Mailpit is not reachable at localhost:1025');
+            self::markTestSkipped('Mailpit is not reachable at localhost:1025');
         }
 
         $this->deleteAllMailpitMessages();
@@ -131,19 +131,19 @@ class MailServiceSmtpIntegrationTest extends TestCase
     {
         $ch = curl_init(self::MAILPIT_API_URL . '/messages');
         if ($ch === false) {
-            $this->fail('Failed to initialize curl for Mailpit API');
+            self::fail('Failed to initialize curl for Mailpit API');
         }
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $response = curl_exec($ch);
         unset($ch);
 
         if (!is_string($response)) {
-            $this->fail('Mailpit API returned non-string response');
+            self::fail('Mailpit API returned non-string response');
         }
 
         $data = json_decode($response, true);
         if (!is_array($data) || !isset($data['messages'])) {
-            $this->fail('Mailpit API returned unexpected format');
+            self::fail('Mailpit API returned unexpected format');
         }
 
         /** @var list<array{ID: string, Subject: string, From: array{Address: string, Name: string}, To: list<array{Address: string, Name: string}>}> */
@@ -157,19 +157,19 @@ class MailServiceSmtpIntegrationTest extends TestCase
     {
         $ch = curl_init(self::MAILPIT_API_URL . '/message/' . $id);
         if ($ch === false) {
-            $this->fail('Failed to initialize curl for Mailpit message API');
+            self::fail('Failed to initialize curl for Mailpit message API');
         }
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $response = curl_exec($ch);
         unset($ch);
 
         if (!is_string($response)) {
-            $this->fail('Mailpit message API returned non-string response');
+            self::fail('Mailpit message API returned non-string response');
         }
 
         $data = json_decode($response, true);
         if (!is_array($data)) {
-            $this->fail('Mailpit message API returned unexpected format');
+            self::fail('Mailpit message API returned unexpected format');
         }
 
         /** @var array{Text: string, HTML: string} */

--- a/ibl5/tests/Migration/MigrationRunnerTest.php
+++ b/ibl5/tests/Migration/MigrationRunnerTest.php
@@ -136,7 +136,7 @@ final class MigrationRunnerTest extends TestCase
     public function testRunPendingThrowsOnMissingFile(): void
     {
         // Use a fake file resolver that reports a file that doesn't exist on disk
-        $fakeResolver = $this->createStub(MigrationFileResolver::class);
+        $fakeResolver = self::createStub(MigrationFileResolver::class);
         $fakeResolver->method('getAvailableMigrations')
             ->willReturn(['001_ghost.sql']);
         $fakeResolver->method('getFullPath')
@@ -161,7 +161,7 @@ final class MigrationRunnerTest extends TestCase
 
         try {
             $runner->runPending();
-            $this->fail('Expected RuntimeException');
+            self::fail('Expected RuntimeException');
         } catch (\RuntimeException) {
             // First migration failed, second should not have been attempted
             $this->assertCount(1, $this->executedSql);
@@ -190,7 +190,7 @@ final class MigrationRunnerTest extends TestCase
      */
     private function createStubRepository(bool $failOnSql = false): MigrationRepositoryInterface
     {
-        $stub = $this->createStub(MigrationRepositoryInterface::class);
+        $stub = self::createStub(MigrationRepositoryInterface::class);
 
         $stub->method('getRanMigrations')
             ->willReturnCallback(fn(): array => $this->ranMigrations);

--- a/ibl5/tests/Module/EntryPoints/ApiKeysEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/ApiKeysEntryPointTest.php
@@ -23,7 +23,7 @@ class ApiKeysEntryPointTest extends ModuleEntryPointTestCase
     {
         $this->authenticateAs($username);
 
-        $authStub = $this->createStub(\Auth\Contracts\AuthServiceInterface::class);
+        $authStub = self::createStub(\Auth\Contracts\AuthServiceInterface::class);
         $authStub->method('isAuthenticated')->willReturn(true);
         $authStub->method('isAdmin')->willReturn(false);
         $authStub->method('getCookieArray')->willReturn([$username, $username, '']);

--- a/ibl5/tests/Module/EntryPoints/ModuleEntryPointTestCase.php
+++ b/ibl5/tests/Module/EntryPoints/ModuleEntryPointTestCase.php
@@ -156,7 +156,7 @@ abstract class ModuleEntryPointTestCase extends WideUnitTestCase
     private function setDefaultGlobals(): void
     {
         // Auth stub — unauthenticated by default
-        $authStub = $this->createStub(\Auth\Contracts\AuthServiceInterface::class);
+        $authStub = self::createStub(\Auth\Contracts\AuthServiceInterface::class);
         $authStub->method('isAuthenticated')->willReturn(false);
         $authStub->method('isAdmin')->willReturn(false);
         $authStub->method('getCookieArray')->willReturn(null);
@@ -164,7 +164,7 @@ abstract class ModuleEntryPointTestCase extends WideUnitTestCase
 
         // League context stub. getConfig() must return the keys callers read
         // (notably 'images_path' for views that render team logos).
-        $lcStub = $this->createStub(\League\LeagueContext::class);
+        $lcStub = self::createStub(\League\LeagueContext::class);
         $lcStub->method('getConfig')->willReturn([
             'title' => 'Internet Basketball League',
             'short_name' => 'IBL',
@@ -228,7 +228,7 @@ abstract class ModuleEntryPointTestCase extends WideUnitTestCase
      */
     protected function authenticateAs(string $username): void
     {
-        $authStub = $this->createStub(\Auth\Contracts\AuthServiceInterface::class);
+        $authStub = self::createStub(\Auth\Contracts\AuthServiceInterface::class);
         $authStub->method('isAuthenticated')->willReturn(true);
         $authStub->method('isAdmin')->willReturn(false);
         $authStub->method('getCookieArray')->willReturn([$username, $username, '']);

--- a/ibl5/tests/Module/EntryPoints/StandingsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/StandingsEntryPointTest.php
@@ -35,7 +35,7 @@ class StandingsEntryPointTest extends ModuleEntryPointTestCase
     {
         \League\OlympicsTeamFilter::resetCache();
 
-        $lcStub = $this->createStub(\League\LeagueContext::class);
+        $lcStub = self::createStub(\League\LeagueContext::class);
         $lcStub->method('isOlympics')->willReturn(true);
         $lcStub->method('getCurrentLeague')->willReturn('olympics');
         $lcStub->method('getConfig')->willReturn([

--- a/ibl5/tests/Module/EntryPoints/TeamEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/TeamEntryPointTest.php
@@ -15,7 +15,7 @@ class TeamEntryPointTest extends ModuleEntryPointTestCase
         $this->mockDb->onQuery('ibl_schedule', []);
         $this->mockDb->onQuery('ibl_sim_dates', []);
 
-        $lcStub = $this->createStub(\League\LeagueContext::class);
+        $lcStub = self::createStub(\League\LeagueContext::class);
         $lcStub->method('getConfig')->willReturn(['images_path' => 'images/']);
         $GLOBALS['leagueContext'] = $lcStub;
     }

--- a/ibl5/tests/Module/ModuleAccessControlTest.php
+++ b/ibl5/tests/Module/ModuleAccessControlTest.php
@@ -14,10 +14,10 @@ class ModuleAccessControlTest extends TestCase
 {
     private function createAccessControl(string $phase, string $triviaMode = 'Off'): ModuleAccessControl
     {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->phase = $phase;
 
-        $leagueContext = $this->createStub(LeagueContext::class);
+        $leagueContext = self::createStub(LeagueContext::class);
         $leagueContext->method('isModuleEnabled')->willReturn(true);
 
         $mockDb = new MockDatabase();
@@ -30,10 +30,10 @@ class ModuleAccessControlTest extends TestCase
 
     private function createAccessControlWithDisabledModule(string $phase, string $disabledModule): ModuleAccessControl
     {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->phase = $phase;
 
-        $leagueContext = $this->createStub(LeagueContext::class);
+        $leagueContext = self::createStub(LeagueContext::class);
         $leagueContext->method('isModuleEnabled')->willReturnCallback(
             static fn (string $module): bool => $module !== $disabledModule
         );

--- a/ibl5/tests/Navigation/Views/NavigationViewsXssTest.php
+++ b/ibl5/tests/Navigation/Views/NavigationViewsXssTest.php
@@ -88,7 +88,7 @@ class NavigationViewsXssTest extends TestCase
             currentLeague: 'ibl',
         );
 
-        $menuBuilder = $this->createStub(NavigationMenuBuilderInterface::class);
+        $menuBuilder = self::createStub(NavigationMenuBuilderInterface::class);
         $menuBuilder->method('getMenuStructure')->willReturn([]);
         $menuBuilder->method('getMyTeamMenu')->willReturn(null);
         $menuBuilder->method('getAccountMenu')->willReturn([

--- a/ibl5/tests/Negotiation/NegotiationDemandCalculatorTest.php
+++ b/ibl5/tests/Negotiation/NegotiationDemandCalculatorTest.php
@@ -29,7 +29,7 @@ class NegotiationDemandCalculatorTest extends TestCase
     protected function setUp(): void
     {
         $this->mockDb = new MockDatabase();
-        $this->calculator = new NegotiationDemandCalculator($this->mockDb, $this->createStub(SalaryCapRepositoryInterface::class));
+        $this->calculator = new NegotiationDemandCalculator($this->mockDb, self::createStub(SalaryCapRepositoryInterface::class));
     }
 
     protected function tearDown(): void

--- a/ibl5/tests/Negotiation/NegotiationRepositoryTest.php
+++ b/ibl5/tests/Negotiation/NegotiationRepositoryTest.php
@@ -39,14 +39,14 @@ class NegotiationRepositoryTest extends TestCase
 
     public function testRepositoryCanBeInstantiated(): void
     {
-        $repository = new NegotiationRepository($this->mockDb, $this->createStub(SalaryCapRepositoryInterface::class));
+        $repository = new NegotiationRepository($this->mockDb, self::createStub(SalaryCapRepositoryInterface::class));
         
         $this->assertInstanceOf(NegotiationRepository::class, $repository);
     }
 
     public function testRepositoryImplementsCorrectInterface(): void
     {
-        $repository = new NegotiationRepository($this->mockDb, $this->createStub(SalaryCapRepositoryInterface::class));
+        $repository = new NegotiationRepository($this->mockDb, self::createStub(SalaryCapRepositoryInterface::class));
         
         $this->assertInstanceOf(
             \Negotiation\Contracts\NegotiationRepositoryInterface::class,
@@ -56,7 +56,7 @@ class NegotiationRepositoryTest extends TestCase
 
     public function testRepositoryExtendsBaseMysqliRepository(): void
     {
-        $repository = new NegotiationRepository($this->mockDb, $this->createStub(SalaryCapRepositoryInterface::class));
+        $repository = new NegotiationRepository($this->mockDb, self::createStub(SalaryCapRepositoryInterface::class));
         
         $this->assertInstanceOf(
             \BaseMysqliRepository::class,
@@ -70,7 +70,7 @@ class NegotiationRepositoryTest extends TestCase
 
     public function testGetTeamPerformanceReturnsDefaultsWhenNoData(): void
     {
-        $repository = new NegotiationRepository($this->mockDb, $this->createStub(SalaryCapRepositoryInterface::class));
+        $repository = new NegotiationRepository($this->mockDb, self::createStub(SalaryCapRepositoryInterface::class));
         $this->mockDb->setMockData([]);
 
         $result = $repository->getTeamPerformance('Test Team');
@@ -84,7 +84,7 @@ class NegotiationRepositoryTest extends TestCase
 
     public function testGetTeamPerformanceReturnsTeamData(): void
     {
-        $repository = new NegotiationRepository($this->mockDb, $this->createStub(SalaryCapRepositoryInterface::class));
+        $repository = new NegotiationRepository($this->mockDb, self::createStub(SalaryCapRepositoryInterface::class));
         $this->mockDb->setMockData([
             [
                 'contract_wins' => 50,
@@ -107,7 +107,7 @@ class NegotiationRepositoryTest extends TestCase
 
     public function testGetPositionSalaryCommitmentReturnsZeroWhenNoPlayers(): void
     {
-        $repository = new NegotiationRepository($this->mockDb, $this->createStub(SalaryCapRepositoryInterface::class));
+        $repository = new NegotiationRepository($this->mockDb, self::createStub(SalaryCapRepositoryInterface::class));
         $this->mockDb->setMockData([]);
 
         $result = $repository->getPositionSalaryCommitment('Test Team', 'G', 'Excluded Player');
@@ -122,7 +122,7 @@ class NegotiationRepositoryTest extends TestCase
 
     public function testGetTeamCapSpaceNextSeasonReturnsHardCapWhenNoSalaryData(): void
     {
-        $commonRepo = $this->createStub(SalaryCapRepositoryInterface::class);
+        $commonRepo = self::createStub(SalaryCapRepositoryInterface::class);
         $commonRepo->method('getTeamCapSpaceNextSeason')->willReturn(League::HARD_CAP_MAX);
         $repository = new NegotiationRepository($this->mockDb, $commonRepo);
 
@@ -133,7 +133,7 @@ class NegotiationRepositoryTest extends TestCase
 
     public function testGetTeamCapSpaceNextSeasonReturnsCapMinusSalary(): void
     {
-        $commonRepo = $this->createStub(SalaryCapRepositoryInterface::class);
+        $commonRepo = self::createStub(SalaryCapRepositoryInterface::class);
         $commonRepo->method('getTeamCapSpaceNextSeason')->willReturn(League::HARD_CAP_MAX - 5000);
         $repository = new NegotiationRepository($this->mockDb, $commonRepo);
 
@@ -148,7 +148,7 @@ class NegotiationRepositoryTest extends TestCase
 
     public function testMultipleRepositoriesCanBeInstantiated(): void
     {
-        $commonRepo = $this->createStub(SalaryCapRepositoryInterface::class);
+        $commonRepo = self::createStub(SalaryCapRepositoryInterface::class);
         $repo1 = new NegotiationRepository($this->mockDb, $commonRepo);
         $repo2 = new NegotiationRepository($this->mockDb, $commonRepo);
         

--- a/ibl5/tests/Negotiation/NegotiationServiceTest.php
+++ b/ibl5/tests/Negotiation/NegotiationServiceTest.php
@@ -64,7 +64,7 @@ class NegotiationServiceTest extends TestCase
 
     public function testProcessNegotiationReturnsHtmlOutput(): void
     {
-        $mockSeason = $this->createStub(\Season\Season::class);
+        $mockSeason = self::createStub(\Season\Season::class);
         $mockSeason->phase = 'Regular Season';
         $mockSeason->endingYear = 2026;
         $mockSeason->beginningYear = 2025;
@@ -100,7 +100,7 @@ class NegotiationServiceTest extends TestCase
 
     private function buildService(?\Season\Season $season = null): NegotiationService
     {
-        $commonRepo = $this->createStub(SalaryCapRepositoryInterface::class);
+        $commonRepo = self::createStub(SalaryCapRepositoryInterface::class);
         return new NegotiationService(
             $this->mockDb,
             new NegotiationRepository($this->mockDb, $commonRepo),

--- a/ibl5/tests/Negotiation/NegotiationValidatorTest.php
+++ b/ibl5/tests/Negotiation/NegotiationValidatorTest.php
@@ -27,7 +27,7 @@ class NegotiationValidatorTest extends TestCase
     protected function setUp(): void
     {
         $this->mockDb = new MockDatabase();
-        $this->mockSeason = $this->createStub(\Season\Season::class);
+        $this->mockSeason = self::createStub(\Season\Season::class);
         $this->mockSeason->phase = 'Regular Season';
         $this->mockSeason->endingYear = 2026;
         $this->mockSeason->beginningYear = 2025;

--- a/ibl5/tests/NextSim/NextSimServiceTest.php
+++ b/ibl5/tests/NextSim/NextSimServiceTest.php
@@ -23,7 +23,7 @@ class NextSimServiceTest extends TestCase
     {
         $this->mockDb = new MockDatabase();
         $GLOBALS['mysqli_db'] = $this->mockDb;
-        $this->stubRepository = $this->createStub(TeamScheduleRepositoryInterface::class);
+        $this->stubRepository = self::createStub(TeamScheduleRepositoryInterface::class);
     }
 
     protected function tearDown(): void

--- a/ibl5/tests/NextSim/NextSimViewTest.php
+++ b/ibl5/tests/NextSim/NextSimViewTest.php
@@ -29,12 +29,12 @@ class NextSimViewTest extends TestCase
 
     protected function setUp(): void
     {
-        $mockSeason = $this->createStub(Season::class);
+        $mockSeason = self::createStub(Season::class);
         $mockSeason->lastSimEndDate = '2025-01-01';
 
         $this->view = new NextSimView($mockSeason);
 
-        $this->userTeam = $this->createStub(Team::class);
+        $this->userTeam = self::createStub(Team::class);
         $this->userTeam->teamid = 1;
         $this->userTeam->city = 'Test';
         $this->userTeam->name = 'Team';
@@ -44,7 +44,7 @@ class NextSimViewTest extends TestCase
 
         $this->userStarters = [];
         foreach (\JSB::PLAYER_POSITIONS as $position) {
-            $player = $this->createStub(Player::class);
+            $player = self::createStub(Player::class);
             $player->playerID = 100;
             $player->name = 'User ' . $position;
             $player->decoratedName = 'User ' . $position;
@@ -212,7 +212,7 @@ class NextSimViewTest extends TestCase
      */
     private function createGameData(): array
     {
-        $oppTeam = $this->createStub(Team::class);
+        $oppTeam = self::createStub(Team::class);
         $oppTeam->teamid = 2;
         $oppTeam->city = 'Rival';
         $oppTeam->name = 'Foes';
@@ -220,12 +220,12 @@ class NextSimViewTest extends TestCase
         $oppTeam->color2 = 'FFFF00';
         $oppTeam->seasonRecord = '8-7';
 
-        $game = $this->createStub(Game::class);
+        $game = self::createStub(Game::class);
         $game->date = '2025-01-02';
 
         $oppStarters = [];
         foreach (\JSB::PLAYER_POSITIONS as $position) {
-            $player = $this->createStub(Player::class);
+            $player = self::createStub(Player::class);
             $player->playerID = 200;
             $player->name = 'Opp ' . $position;
             $player->decoratedName = 'Opp ' . $position;

--- a/ibl5/tests/NextSim/NextSimViewXssTest.php
+++ b/ibl5/tests/NextSim/NextSimViewXssTest.php
@@ -23,12 +23,12 @@ final class NextSimViewXssTest extends TestCase
 
     protected function setUp(): void
     {
-        $mockSeason = $this->createStub(Season::class);
+        $mockSeason = self::createStub(Season::class);
         $mockSeason->lastSimEndDate = '2025-01-01';
 
         $this->view = new NextSimView($mockSeason);
 
-        $this->userTeam = $this->createStub(Team::class);
+        $this->userTeam = self::createStub(Team::class);
         $this->userTeam->teamid = 1;
         $this->userTeam->name = 'Safe Team';
         $this->userTeam->color1 = 'FF0000';
@@ -37,7 +37,7 @@ final class NextSimViewXssTest extends TestCase
 
         $this->userStarters = [];
         foreach (\JSB::PLAYER_POSITIONS as $position) {
-            $player = $this->createStub(Player::class);
+            $player = self::createStub(Player::class);
             $player->playerID = 100;
             $player->decoratedName = 'Safe Player';
             $player->position = $position;
@@ -53,14 +53,14 @@ final class NextSimViewXssTest extends TestCase
         $xss = '<script>alert(1)</script>';
         $escaped = '&lt;script&gt;';
 
-        $oppTeam = $this->createStub(Team::class);
+        $oppTeam = self::createStub(Team::class);
         $oppTeam->teamid = 2;
         $oppTeam->name = $xss;
         $oppTeam->color1 = '00FF00';
         $oppTeam->color2 = 'FFFF00';
         $oppTeam->seasonRecord = '5-5';
 
-        $game = $this->createStub(Game::class);
+        $game = self::createStub(Game::class);
         $game->date = '2025-01-02';
 
         $games = [

--- a/ibl5/tests/PageLayout/PageLayoutHeaderSideEffectTest.php
+++ b/ibl5/tests/PageLayout/PageLayoutHeaderSideEffectTest.php
@@ -23,7 +23,7 @@ final class PageLayoutHeaderSideEffectTest extends TestCase
     {
         $expectedCookie = [1, 'testuser', '0', 'email@test.com'];
 
-        $mockAuth = $this->createStub(AuthServiceInterface::class);
+        $mockAuth = self::createStub(AuthServiceInterface::class);
         $mockAuth->method('getCookieArray')->willReturn($expectedCookie);
         $mockAuth->method('isAuthenticated')->willReturn(true);
         $GLOBALS['authService'] = $mockAuth;
@@ -37,7 +37,7 @@ final class PageLayoutHeaderSideEffectTest extends TestCase
 
     public function testCookieDecodeReturnsNullForUnauthenticatedUser(): void
     {
-        $mockAuth = $this->createStub(AuthServiceInterface::class);
+        $mockAuth = self::createStub(AuthServiceInterface::class);
         $mockAuth->method('getCookieArray')->willReturn(null);
         $mockAuth->method('isAuthenticated')->willReturn(false);
         $GLOBALS['authService'] = $mockAuth;

--- a/ibl5/tests/Player/PlayerContractValidatorTest.php
+++ b/ibl5/tests/Player/PlayerContractValidatorTest.php
@@ -348,7 +348,7 @@ class PlayerContractValidatorTest extends TestCase
 
     private function createMockSeason(int $endingYear): Season&\PHPUnit\Framework\MockObject\Stub
     {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->endingYear = $endingYear;
         return $season;
     }

--- a/ibl5/tests/Player/PlayerPageControllerTest.php
+++ b/ibl5/tests/Player/PlayerPageControllerTest.php
@@ -18,7 +18,7 @@ class PlayerPageControllerTest extends WideUnitTestCase
     {
         parent::setUp();
 
-        $this->stubRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->stubRepo = self::createStub(TeamIdentityRepositoryInterface::class);
         $this->stubRepo->method('getTeamnameFromUsername')->willReturn('Heat');
         $this->stubRepo->method('getTeamnameFromTeamID')->willReturn('Heat');
 
@@ -192,7 +192,7 @@ class PlayerPageControllerTest extends WideUnitTestCase
         $this->mockDb->onQuery('ibl_hist', [$histRow]);
         $this->mockDb->setMockData([$retiredRow]);
 
-        $this->stubRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->stubRepo = self::createStub(TeamIdentityRepositoryInterface::class);
         $this->stubRepo->method('getTeamnameFromUsername')->willReturn('Free Agents');
 
         $controller = new PlayerPageController($this->mockDb, $this->stubRepo);

--- a/ibl5/tests/Player/PlayerPageServiceTest.php
+++ b/ibl5/tests/Player/PlayerPageServiceTest.php
@@ -19,7 +19,7 @@ class PlayerPageServiceTest extends TestCase
     {
         // Mock database connection
         $this->db = new MockDatabase();
-        $this->service = new PlayerPageService($this->db, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $this->service = new PlayerPageService($this->db, self::createStub(TeamIdentityRepositoryInterface::class));
     }
 
     public function testCanShowRenegotiationButtonReturnsTrueWhenAllConditionsMet(): void
@@ -185,7 +185,7 @@ class PlayerPageServiceTest extends TestCase
         bool $canRookieOpt = false
     ): Player {
         // Use createStub since we're only configuring return values, not verifying expectations
-        $stub = $this->createStub(Player::class);
+        $stub = self::createStub(Player::class);
 
         $stub->method('wasRookieOptioned')->willReturn($wasRookieOptioned);
         $stub->method('canRenegotiateContract')->willReturn($canRenegotiate);

--- a/ibl5/tests/Player/PlayerRepositoryFieldMapTest.php
+++ b/ibl5/tests/Player/PlayerRepositoryFieldMapTest.php
@@ -14,7 +14,7 @@ class PlayerRepositoryFieldMapTest extends TestCase
 
     protected function setUp(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
         $this->repository = new PlayerRepository($db);
     }
 

--- a/ibl5/tests/Player/PlayerStatsTest.php
+++ b/ibl5/tests/Player/PlayerStatsTest.php
@@ -17,7 +17,7 @@ class PlayerStatsTest extends TestCase
 
     protected function setUp(): void
     {
-        $repo = $this->createStub(PlayerStatsRepositoryInterface::class);
+        $repo = self::createStub(PlayerStatsRepositoryInterface::class);
         $this->stats = new TestablePlayerStats($repo);
     }
 

--- a/ibl5/tests/Player/Stats/Views/PlayerHeatAveragesViewTest.php
+++ b/ibl5/tests/Player/Stats/Views/PlayerHeatAveragesViewTest.php
@@ -18,7 +18,7 @@ class PlayerHeatAveragesViewTest extends TestCase
 
     public function testRenderAveragesMatchesSnapshot(): void
     {
-        $repository = $this->createStub(PlayerStatsRepository::class);
+        $repository = self::createStub(PlayerStatsRepository::class);
         $repository->method('getHeatStats')->willReturn(TournamentViewFixtures::twoSeasonRows());
         $repository->method('getHeatCareerAverages')->willReturn(TournamentViewFixtures::careerAveragesRow());
 
@@ -30,7 +30,7 @@ class PlayerHeatAveragesViewTest extends TestCase
 
     public function testRenderAveragesWithNoCareerRow(): void
     {
-        $repository = $this->createStub(PlayerStatsRepository::class);
+        $repository = self::createStub(PlayerStatsRepository::class);
         $repository->method('getHeatStats')->willReturn(TournamentViewFixtures::twoSeasonRows());
         $repository->method('getHeatCareerAverages')->willReturn(null);
 

--- a/ibl5/tests/Player/Stats/Views/PlayerHeatTotalsViewTest.php
+++ b/ibl5/tests/Player/Stats/Views/PlayerHeatTotalsViewTest.php
@@ -18,7 +18,7 @@ class PlayerHeatTotalsViewTest extends TestCase
 
     public function testRenderTotalsMatchesSnapshot(): void
     {
-        $repository = $this->createStub(PlayerStatsRepository::class);
+        $repository = self::createStub(PlayerStatsRepository::class);
         $repository->method('getHeatStats')->willReturn(TournamentViewFixtures::twoSeasonRows());
 
         $view = new PlayerHeatTotalsView($repository, new PlayerSeasonTableRenderer());

--- a/ibl5/tests/Player/Stats/Views/PlayerOlympicAveragesViewTest.php
+++ b/ibl5/tests/Player/Stats/Views/PlayerOlympicAveragesViewTest.php
@@ -18,7 +18,7 @@ class PlayerOlympicAveragesViewTest extends TestCase
 
     public function testRenderAveragesMatchesSnapshot(): void
     {
-        $repository = $this->createStub(PlayerStatsRepository::class);
+        $repository = self::createStub(PlayerStatsRepository::class);
         $repository->method('getOlympicsStats')->willReturn(TournamentViewFixtures::twoSeasonRows());
         $repository->method('getOlympicsCareerAverages')->willReturn(TournamentViewFixtures::careerAveragesRow());
 
@@ -30,7 +30,7 @@ class PlayerOlympicAveragesViewTest extends TestCase
 
     public function testRenderAveragesWithNoCareerRow(): void
     {
-        $repository = $this->createStub(PlayerStatsRepository::class);
+        $repository = self::createStub(PlayerStatsRepository::class);
         $repository->method('getOlympicsStats')->willReturn(TournamentViewFixtures::twoSeasonRows());
         $repository->method('getOlympicsCareerAverages')->willReturn(null);
 

--- a/ibl5/tests/Player/Stats/Views/PlayerOlympicTotalsViewTest.php
+++ b/ibl5/tests/Player/Stats/Views/PlayerOlympicTotalsViewTest.php
@@ -18,7 +18,7 @@ class PlayerOlympicTotalsViewTest extends TestCase
 
     public function testRenderTotalsMatchesSnapshot(): void
     {
-        $repository = $this->createStub(PlayerStatsRepository::class);
+        $repository = self::createStub(PlayerStatsRepository::class);
         $repository->method('getOlympicsStats')->willReturn(TournamentViewFixtures::twoSeasonRows());
 
         $view = new PlayerOlympicTotalsView($repository, new PlayerSeasonTableRenderer());

--- a/ibl5/tests/Player/Stats/Views/PlayerPlayoffAveragesViewTest.php
+++ b/ibl5/tests/Player/Stats/Views/PlayerPlayoffAveragesViewTest.php
@@ -18,7 +18,7 @@ class PlayerPlayoffAveragesViewTest extends TestCase
 
     public function testRenderAveragesMatchesSnapshot(): void
     {
-        $repository = $this->createStub(PlayerStatsRepository::class);
+        $repository = self::createStub(PlayerStatsRepository::class);
         $repository->method('getPlayoffStats')->willReturn(TournamentViewFixtures::twoSeasonRows());
         $repository->method('getPlayoffCareerAverages')->willReturn(TournamentViewFixtures::careerAveragesRow());
 
@@ -30,7 +30,7 @@ class PlayerPlayoffAveragesViewTest extends TestCase
 
     public function testRenderAveragesWithNoCareerRow(): void
     {
-        $repository = $this->createStub(PlayerStatsRepository::class);
+        $repository = self::createStub(PlayerStatsRepository::class);
         $repository->method('getPlayoffStats')->willReturn(TournamentViewFixtures::twoSeasonRows());
         $repository->method('getPlayoffCareerAverages')->willReturn(null);
 

--- a/ibl5/tests/Player/Stats/Views/PlayerPlayoffTotalsViewTest.php
+++ b/ibl5/tests/Player/Stats/Views/PlayerPlayoffTotalsViewTest.php
@@ -18,7 +18,7 @@ class PlayerPlayoffTotalsViewTest extends TestCase
 
     public function testRenderTotalsMatchesSnapshot(): void
     {
-        $repository = $this->createStub(PlayerStatsRepository::class);
+        $repository = self::createStub(PlayerStatsRepository::class);
         $repository->method('getPlayoffStats')->willReturn(TournamentViewFixtures::twoSeasonRows());
 
         $view = new PlayerPlayoffTotalsView($repository, new PlayerSeasonTableRenderer());

--- a/ibl5/tests/Player/Views/CardBaseStylesXssTest.php
+++ b/ibl5/tests/Player/Views/CardBaseStylesXssTest.php
@@ -18,7 +18,7 @@ class CardBaseStylesXssTest extends TestCase
 
     public function testPreparePlayerDataEscapesPlayerName(): void
     {
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
         $player->method('getName')->willReturn(self::XSS_PAYLOAD);
         $player->method('getNickname')->willReturn('');
         $player->method('getPosition')->willReturn('PG');
@@ -42,7 +42,7 @@ class CardBaseStylesXssTest extends TestCase
 
     public function testPreparePlayerDataEscapesNickname(): void
     {
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
         $player->method('getName')->willReturn('Normal Name');
         $player->method('getNickname')->willReturn(self::XSS_PAYLOAD);
         $player->method('getPosition')->willReturn('PG');

--- a/ibl5/tests/PlayerDatabase/PlayerDatabaseRepositoryTest.php
+++ b/ibl5/tests/PlayerDatabase/PlayerDatabaseRepositoryTest.php
@@ -33,7 +33,7 @@ final class PlayerDatabaseRepositoryTest extends TestCase
 
         $this->mockDb->expects($this->once())
             ->method('prepare')
-            ->with($this->callback(function ($query) {
+            ->with(self::callback(function ($query) {
                 $q = str_replace('`', '', $query);
                 return strpos($q, 'SELECT ibl_plr.*') !== false
                     && strpos($q, 'LEFT JOIN ibl_team_info') !== false
@@ -109,7 +109,7 @@ final class PlayerDatabaseRepositoryTest extends TestCase
 
         $this->mockDb->expects($this->once())
             ->method('prepare')
-            ->with($this->callback(function ($query) {
+            ->with(self::callback(function ($query) {
                 return strpos($query, 'retired = 0') !== false;
             }))
             ->willReturn($mockStmt);
@@ -142,7 +142,7 @@ final class PlayerDatabaseRepositoryTest extends TestCase
 
         $this->mockDb->expects($this->once())
             ->method('prepare')
-            ->with($this->callback(function ($query) {
+            ->with(self::callback(function ($query) {
                 return strpos($query, 'name LIKE ?') !== false;
             }))
             ->willReturn($mockStmt);
@@ -164,7 +164,7 @@ final class PlayerDatabaseRepositoryTest extends TestCase
 
         $this->mockDb->expects($this->once())
             ->method('prepare')
-            ->with($this->callback(function ($query) {
+            ->with(self::callback(function ($query) {
                 return strpos($query, 'college LIKE ?') !== false;
             }))
             ->willReturn($mockStmt);
@@ -186,7 +186,7 @@ final class PlayerDatabaseRepositoryTest extends TestCase
 
         $this->mockDb->expects($this->once())
             ->method('prepare')
-            ->with($this->callback(function ($query) {
+            ->with(self::callback(function ($query) {
                 return strpos($query, 'pos = ?') !== false;
             }))
             ->willReturn($mockStmt);
@@ -208,7 +208,7 @@ final class PlayerDatabaseRepositoryTest extends TestCase
 
         $this->mockDb->expects($this->once())
             ->method('prepare')
-            ->with($this->callback(function ($query) {
+            ->with(self::callback(function ($query) {
                 return strpos($query, 'age <= ?') !== false;
             }))
             ->willReturn($mockStmt);
@@ -230,7 +230,7 @@ final class PlayerDatabaseRepositoryTest extends TestCase
 
         $this->mockDb->expects($this->once())
             ->method('prepare')
-            ->with($this->callback(function ($query) {
+            ->with(self::callback(function ($query) {
                 return strpos($query, 'oo >= ?') !== false;
             }))
             ->willReturn($mockStmt);
@@ -258,7 +258,7 @@ final class PlayerDatabaseRepositoryTest extends TestCase
 
         $this->mockDb->expects($this->once())
             ->method('prepare')
-            ->with($this->callback(function ($query) {
+            ->with(self::callback(function ($query) {
                 return strpos($query, 'WHERE pid = ?') !== false;
             }))
             ->willReturn($mockStmt);
@@ -316,7 +316,7 @@ final class PlayerDatabaseRepositoryTest extends TestCase
         if ($expectedBindTypes !== null) {
             $mockStmt->expects($this->once())
                 ->method('bind_param')
-                ->with($expectedBindTypes, $this->anything())
+                ->with($expectedBindTypes, self::anything())
                 ->willReturn(true);
         }
 

--- a/ibl5/tests/PlrParser/PlrParserServiceTest.php
+++ b/ibl5/tests/PlrParser/PlrParserServiceTest.php
@@ -24,9 +24,9 @@ class PlrParserServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepository = $this->createStub(PlrParserRepositoryInterface::class);
+        $this->stubRepository = self::createStub(PlrParserRepositoryInterface::class);
 
-        $this->stubSeason = $this->createStub(Season::class);
+        $this->stubSeason = self::createStub(Season::class);
         $this->stubSeason->endingYear = 2026;
 
         $this->service = new PlrParserService(
@@ -733,7 +733,7 @@ class PlrParserServiceTest extends TestCase
         $mockRepo = $this->createMock(PlrParserRepositoryInterface::class);
         $mockRepo->expects($this->once())
             ->method('upsertSnapshot')
-            ->with($this->callback(static function (array $data): bool {
+            ->with(self::callback(static function (array $data): bool {
                 // Season stats
                 return array_key_exists('stats_gs', $data)
                     && array_key_exists('stats_pts', $data)

--- a/ibl5/tests/PlrParser/PlrReconstructionServiceTest.php
+++ b/ibl5/tests/PlrParser/PlrReconstructionServiceTest.php
@@ -366,7 +366,7 @@ class PlrReconstructionServiceTest extends TestCase
         array $teamStats = [],
         array $teamPlayoffStats = [],
     ): PlrBoxScoreRepositoryInterface {
-        $repo = $this->createStub(PlrBoxScoreRepositoryInterface::class);
+        $repo = self::createStub(PlrBoxScoreRepositoryInterface::class);
         $repo->method('sumStatsByGameTypeThroughDate')->willReturnCallback(
             static function (int $seasonYear, int $gameType, string $endDate) use ($regular, $playoffs): array {
                 return $gameType === PlrBoxScoreRepositoryInterface::GAME_TYPE_REGULAR_SEASON

--- a/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderServiceTest.php
+++ b/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderServiceTest.php
@@ -23,7 +23,7 @@ class ProjectedDraftOrderServiceTest extends TestCase
     protected function setUp(): void
     {
         $this->setUpAuditLogCapture();
-        $this->stubRepository = $this->createStub(ProjectedDraftOrderRepositoryInterface::class);
+        $this->stubRepository = self::createStub(ProjectedDraftOrderRepositoryInterface::class);
         $this->service = new ProjectedDraftOrderService($this->stubRepository);
     }
 
@@ -508,7 +508,7 @@ class ProjectedDraftOrderServiceTest extends TestCase
             ->method('saveFinalDraftOrder')
             ->with(
                 2026,
-                $this->callback(static function (array $picks) use ($reversedLottery): bool {
+                self::callback(static function (array $picks) use ($reversedLottery): bool {
                     // 28 round-1 + 28 round-2 = 56 total
                     if (count($picks) !== 56) {
                         return false;
@@ -621,7 +621,7 @@ class ProjectedDraftOrderServiceTest extends TestCase
     public function testSaveLotteryOrderEmitsAuditLog(): void
     {
         $standings = $this->buildFullLeagueStandings();
-        $stubRepo = $this->createStub(ProjectedDraftOrderRepositoryInterface::class);
+        $stubRepo = self::createStub(ProjectedDraftOrderRepositoryInterface::class);
         $stubRepo->method('getAllTeamsWithStandings')->willReturn($standings);
         $stubRepo->method('getPlayedGames')->willReturn([]);
         $stubRepo->method('getPickOwnership')->willReturn([]);

--- a/ibl5/tests/RecordHolders/CachedRecordHoldersServiceTest.php
+++ b/ibl5/tests/RecordHolders/CachedRecordHoldersServiceTest.php
@@ -92,7 +92,7 @@ final class CachedRecordHoldersServiceTest extends TestCase
 
     public function testInvalidateCacheDeletesCacheEntry(): void
     {
-        $stubInner = $this->createStub(RecordHoldersServiceInterface::class);
+        $stubInner = self::createStub(RecordHoldersServiceInterface::class);
         $service = new CachedRecordHoldersService($stubInner, $this->cache);
 
         $records = $this->createSampleRecords();

--- a/ibl5/tests/RecordHolders/RecordBreakingDetectorTest.php
+++ b/ibl5/tests/RecordHolders/RecordBreakingDetectorTest.php
@@ -37,7 +37,7 @@ final class RecordBreakingDetectorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mockRepository = $this->createStub(RecordHoldersRepositoryInterface::class);
+        $this->mockRepository = self::createStub(RecordHoldersRepositoryInterface::class);
         $this->detector = new RecordBreakingDetector($this->mockRepository);
     }
 

--- a/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
+++ b/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
@@ -17,7 +17,7 @@ final class RecordHoldersServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mockRepository = $this->createStub(RecordHoldersRepositoryInterface::class);
+        $this->mockRepository = self::createStub(RecordHoldersRepositoryInterface::class);
         $this->service = new RecordHoldersService($this->mockRepository);
     }
 

--- a/ibl5/tests/RookieOption/RookieOptionControllerTest.php
+++ b/ibl5/tests/RookieOption/RookieOptionControllerTest.php
@@ -28,14 +28,14 @@ class RookieOptionControllerTest extends TestCase
 
     public function testCanBeInstantiated(): void
     {
-        $controller = new RookieOptionController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new RookieOptionController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
 
         $this->assertInstanceOf(RookieOptionController::class, $controller);
     }
 
     public function testImplementsInterface(): void
     {
-        $controller = new RookieOptionController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new RookieOptionController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
 
         $this->assertInstanceOf(RookieOptionControllerInterface::class, $controller);
     }

--- a/ibl5/tests/RookieOption/RookieOptionValidatorTest.php
+++ b/ibl5/tests/RookieOption/RookieOptionValidatorTest.php
@@ -27,7 +27,7 @@ class RookieOptionValidatorTest extends TestCase
      */
     public function testValidatePlayerOwnershipSuccess(): void
     {
-        $mockPlayer = $this->createStub(Player::class);
+        $mockPlayer = self::createStub(Player::class);
         $mockPlayer->method('getTeamName')->willReturn('Test Team');
         $mockPlayer->method('getPosition')->willReturn('PG');
         $mockPlayer->method('getName')->willReturn('Test Player');
@@ -43,7 +43,7 @@ class RookieOptionValidatorTest extends TestCase
      */
     public function testValidatePlayerOwnershipFailure(): void
     {
-        $mockPlayer = $this->createStub(Player::class);
+        $mockPlayer = self::createStub(Player::class);
         $mockPlayer->method('getTeamName')->willReturn('Other Team');
         $mockPlayer->method('getPosition')->willReturn('SG');
         $mockPlayer->method('getName')->willReturn('Other Player');
@@ -61,7 +61,7 @@ class RookieOptionValidatorTest extends TestCase
      */
     public function testValidateEligibilityNotEligible(): void
     {
-        $mockPlayer = $this->createStub(Player::class);
+        $mockPlayer = self::createStub(Player::class);
         $mockPlayer->method('getPosition')->willReturn('SF');
         $mockPlayer->method('getName')->willReturn('Ineligible Player');
         $mockPlayer->method('canRookieOption')
@@ -81,7 +81,7 @@ class RookieOptionValidatorTest extends TestCase
      */
     public function testValidateEligibilityFirstRoundSuccess(): void
     {
-        $mockPlayer = $this->createStub(Player::class);
+        $mockPlayer = self::createStub(Player::class);
         $mockPlayer->method('getPosition')->willReturn('PF');
         $mockPlayer->method('getName')->willReturn('Eligible Player');
         $mockPlayer->method('canRookieOption')
@@ -101,7 +101,7 @@ class RookieOptionValidatorTest extends TestCase
      */
     public function testValidateEligibilitySecondRoundSuccess(): void
     {
-        $mockPlayer = $this->createStub(Player::class);
+        $mockPlayer = self::createStub(Player::class);
         $mockPlayer->method('getPosition')->willReturn('C');
         $mockPlayer->method('getName')->willReturn('Second Round Player');
         $mockPlayer->method('canRookieOption')

--- a/ibl5/tests/SavedDepthChart/SavedDepthChartApiHandlerTest.php
+++ b/ibl5/tests/SavedDepthChart/SavedDepthChartApiHandlerTest.php
@@ -18,7 +18,7 @@ class SavedDepthChartApiHandlerTest extends WideUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->handler = new SavedDepthChartApiHandler($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $this->handler = new SavedDepthChartApiHandler($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
     }
 
     public function testHandleUnknownActionReturnsError(): void

--- a/ibl5/tests/SeasonArchive/SeasonArchiveServiceTest.php
+++ b/ibl5/tests/SeasonArchive/SeasonArchiveServiceTest.php
@@ -402,7 +402,7 @@ class SeasonArchiveServiceTest extends TestCase
         // Verify that getPlayerIdsByNames is called with all collected names
         $this->mockRepository->expects($this->once())
             ->method('getPlayerIdsByNames')
-            ->with($this->callback(static function (array $names): bool {
+            ->with(self::callback(static function (array $names): bool {
                 return in_array('MVP Player', $names, true)
                     && in_array('Team Player', $names, true)
                     && in_array('Roster Player', $names, true);
@@ -444,7 +444,7 @@ class SeasonArchiveServiceTest extends TestCase
 
         $this->mockRepository->expects($this->once())
             ->method('getPlayerIdsByNames')
-            ->with($this->callback(static function (array $names) use ($expectedNames): bool {
+            ->with(self::callback(static function (array $names) use ($expectedNames): bool {
                 foreach ($expectedNames as $expected) {
                     if (!in_array($expected, $names, true)) {
                         return false;
@@ -460,7 +460,7 @@ class SeasonArchiveServiceTest extends TestCase
 
     public function testAccumulatorResetsBetweenCalls(): void
     {
-        $stubRepo = $this->createStub(SeasonArchiveRepositoryInterface::class);
+        $stubRepo = self::createStub(SeasonArchiveRepositoryInterface::class);
         $stubRepo->method('getTeamConferences')->willReturn([]);
         $stubRepo->method('getPlayoffResultsByYear')->willReturn([]);
         $stubRepo->method('getTeamAwardsByYear')->willReturn([]);

--- a/ibl5/tests/SeasonHighs/SeasonHighsServiceTest.php
+++ b/ibl5/tests/SeasonHighs/SeasonHighsServiceTest.php
@@ -17,7 +17,7 @@ class SeasonHighsServiceTest extends TestCase
 {
     public function testImplementsServiceInterface(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $season = $this->createStubSeason(2024, 2025);
         $service = new SeasonHighsService($repo, $season);
 
@@ -26,7 +26,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testGetSeasonHighsDataReturnsExpectedStructure(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getSeasonHighsBatch')->willReturnCallback(self::emptyBatchFor(...));
         $season = $this->createStubSeason(2024, 2025);
         $service = new SeasonHighsService($repo, $season);
@@ -39,7 +39,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testGetSeasonHighsDataReturnsNineStatCategories(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getSeasonHighsBatch')->willReturnCallback(self::emptyBatchFor(...));
         $season = $this->createStubSeason(2024, 2025);
         $service = new SeasonHighsService($repo, $season);
@@ -52,7 +52,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testGetSeasonHighsDataIncludesPointsStat(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getSeasonHighsBatch')->willReturnCallback(self::emptyBatchFor(...));
         $season = $this->createStubSeason(2024, 2025);
         $service = new SeasonHighsService($repo, $season);
@@ -79,7 +79,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testRegularSeasonUsesCorrectDateRange(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getSeasonHighsBatch')
             ->willReturnCallback(function (array $stats, string $suffix, string $start, string $end): array {
                 // Regular season: Nov 2024 to May 2025
@@ -95,7 +95,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testPlayoffsUsesCorrectDateRange(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getSeasonHighsBatch')
             ->willReturnCallback(function (array $stats, string $suffix, string $start, string $end): array {
                 // Playoffs: June 2025
@@ -111,7 +111,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testSeasonHighsHandlesEntriesWithoutBoxId(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getSeasonHighsBatch')
             ->willReturnCallback(function (array $stats): array {
                 $result = [];
@@ -149,7 +149,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testGetHomeAwayHighsReturnsHomeAndAwayKeys(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getSeasonHighsBatch')->willReturnCallback(self::emptyBatchFor(...));
         $season = $this->createStubSeason(2024, 2025);
         $service = new SeasonHighsService($repo, $season);
@@ -162,7 +162,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testGetHomeAwayHighsHasEightStatCategories(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getSeasonHighsBatch')->willReturnCallback(self::emptyBatchFor(...));
         $season = $this->createStubSeason(2024, 2025);
         $service = new SeasonHighsService($repo, $season);
@@ -229,7 +229,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testValidateAgainstRcbReturnsEmptyWhenRcbEmpty(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getRcbSeasonHighs')->willReturn([]);
         $season = $this->createStubSeason(2024, 2025);
         $service = new SeasonHighsService($repo, $season);
@@ -242,7 +242,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testValidateAgainstRcbReturnsEmptyWhenBoxScoreEmpty(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getRcbSeasonHighs')->willReturn([
             ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Test Player', 'player_position' => 'SF', 'stat_value' => 40, 'record_season_year' => 2024],
         ]);
@@ -257,7 +257,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testValidateAgainstRcbDetectsValueDiscrepancy(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getRcbSeasonHighs')->willReturn([
             ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Test Player', 'player_position' => 'SF', 'stat_value' => 50, 'record_season_year' => 2024],
         ]);
@@ -279,7 +279,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testValidateAgainstRcbDetectsPlayerDiscrepancy(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getRcbSeasonHighs')->willReturn([
             ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Other Player', 'player_position' => 'PG', 'stat_value' => 40, 'record_season_year' => 2024],
         ]);
@@ -299,7 +299,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testValidateAgainstRcbAcceptsMatchingData(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getRcbSeasonHighs')->willReturn([
             ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Test Player', 'player_position' => 'SF', 'stat_value' => 40, 'record_season_year' => 2024],
         ]);
@@ -317,7 +317,7 @@ class SeasonHighsServiceTest extends TestCase
 
     public function testValidateAgainstRcbHandlesTruncatedNames(): void
     {
-        $repo = $this->createStub(SeasonHighsRepositoryInterface::class);
+        $repo = self::createStub(SeasonHighsRepositoryInterface::class);
         $repo->method('getRcbSeasonHighs')->willReturn([
             ['stat_category' => 'pts', 'ranking' => 1, 'player_name' => 'Test Play', 'player_position' => 'SF', 'stat_value' => 40, 'record_season_year' => 2024],
         ]);
@@ -360,7 +360,7 @@ class SeasonHighsServiceTest extends TestCase
      */
     private function createStubSeason(int $beginningYear, int $endingYear): Season
     {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->beginningYear = $beginningYear;
         $season->endingYear = $endingYear;
 

--- a/ibl5/tests/SeasonLeaderboards/CachedSeasonLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/SeasonLeaderboards/CachedSeasonLeaderboardsRepositoryTest.php
@@ -58,7 +58,7 @@ final class CachedSeasonLeaderboardsRepositoryTest extends TestCase
 
     public function testReturnsAllRowsWithoutFilteringOrSorting(): void
     {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
+        $stubInner = self::createStub(SeasonLeaderboardsRepositoryInterface::class);
         $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
 
         $rows = [
@@ -135,7 +135,7 @@ final class CachedSeasonLeaderboardsRepositoryTest extends TestCase
 
     public function testInvalidateCacheDeletesAllThreeKeys(): void
     {
-        $stubInner = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
+        $stubInner = self::createStub(SeasonLeaderboardsRepositoryInterface::class);
         $repository = new CachedSeasonLeaderboardsRepository($stubInner, $this->cache);
 
         $this->cache->set('season_leaderboards:leaders', [['pid' => 1]], 86400);

--- a/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsServiceTest.php
+++ b/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsServiceTest.php
@@ -15,7 +15,7 @@ final class SeasonLeaderboardsServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepo = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
+        $this->stubRepo = self::createStub(SeasonLeaderboardsRepositoryInterface::class);
         $this->stubRepo->method('getSeasonLeaders')
             ->willReturn(['results' => [], 'count' => 0]);
         $this->service = new SeasonLeaderboardsService($this->stubRepo);
@@ -26,7 +26,7 @@ final class SeasonLeaderboardsServiceTest extends TestCase
      */
     private function buildServiceWithRows(array $rows): SeasonLeaderboardsService
     {
-        $stub = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
+        $stub = self::createStub(SeasonLeaderboardsRepositoryInterface::class);
         $stub->method('getSeasonLeaders')
             ->willReturn(['results' => $rows, 'count' => count($rows)]);
         return new SeasonLeaderboardsService($stub);

--- a/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsViewTest.php
+++ b/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsViewTest.php
@@ -16,7 +16,7 @@ final class SeasonLeaderboardsViewTest extends TestCase
 
     protected function setUp(): void
     {
-        $stubRepo = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
+        $stubRepo = self::createStub(SeasonLeaderboardsRepositoryInterface::class);
         $this->service = new SeasonLeaderboardsService($stubRepo);
 
         $this->view = new SeasonLeaderboardsView($this->service);

--- a/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsViewXssTest.php
+++ b/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsViewXssTest.php
@@ -15,7 +15,7 @@ final class SeasonLeaderboardsViewXssTest extends TestCase
 
     protected function setUp(): void
     {
-        $stubRepo = $this->createStub(SeasonLeaderboardsRepositoryInterface::class);
+        $stubRepo = self::createStub(SeasonLeaderboardsRepositoryInterface::class);
         $service = new SeasonLeaderboardsService($stubRepo);
         $this->view = new SeasonLeaderboardsView($service);
     }

--- a/ibl5/tests/SeasonTest.php
+++ b/ibl5/tests/SeasonTest.php
@@ -211,7 +211,7 @@ class SeasonTest extends \PHPUnit\Framework\TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('tradesAllowedProvider')]
     public function testAreTradesAllowed(string $phase, string $allowTrades, bool $expected): void
     {
-        $season = new \Tests\WideUnit\Mocks\Season($this->createStub(\mysqli::class));
+        $season = new \Tests\WideUnit\Mocks\Season(self::createStub(\mysqli::class));
         $season->phase = $phase;
         $season->allowTrades = $allowTrades;
 

--- a/ibl5/tests/SeriesRecords/SeriesRecordsControllerTest.php
+++ b/ibl5/tests/SeriesRecords/SeriesRecordsControllerTest.php
@@ -28,14 +28,14 @@ class SeriesRecordsControllerTest extends TestCase
 
     public function testCanBeInstantiated(): void
     {
-        $controller = new SeriesRecordsController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new SeriesRecordsController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
 
         $this->assertInstanceOf(SeriesRecordsController::class, $controller);
     }
 
     public function testImplementsInterface(): void
     {
-        $controller = new SeriesRecordsController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $controller = new SeriesRecordsController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
 
         $this->assertInstanceOf(SeriesRecordsControllerInterface::class, $controller);
     }

--- a/ibl5/tests/Settings/SettingsServiceTest.php
+++ b/ibl5/tests/Settings/SettingsServiceTest.php
@@ -16,7 +16,7 @@ class SettingsServiceTest extends TestCase
         string $showDraftLink = 'Off',
         string $freeAgencyNotificationsState = ''
     ): Season {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->allowTrades = $allowTrades;
         $season->allowWaivers = $allowWaivers;
         $season->showDraftLink = $showDraftLink;

--- a/ibl5/tests/Standings/OlympicsStandingsViewTest.php
+++ b/ibl5/tests/Standings/OlympicsStandingsViewTest.php
@@ -18,7 +18,7 @@ class OlympicsStandingsViewTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepository = $this->createStub(StandingsRepositoryInterface::class);
+        $this->stubRepository = self::createStub(StandingsRepositoryInterface::class);
     }
 
     /**

--- a/ibl5/tests/Standings/StandingsViewXssTest.php
+++ b/ibl5/tests/Standings/StandingsViewXssTest.php
@@ -46,7 +46,7 @@ final class StandingsViewXssTest extends TestCase
         $xss = '<script>alert(1)</script>';
         $escaped = '&lt;script&gt;';
 
-        $stubRepo = $this->createStub(StandingsRepositoryInterface::class);
+        $stubRepo = self::createStub(StandingsRepositoryInterface::class);
         $stubRepo->method('getStandingsByRegion')->willReturn([
             $this->makeStandingsRow(['team_name' => $xss]),
         ]);
@@ -54,7 +54,7 @@ final class StandingsViewXssTest extends TestCase
         $stubRepo->method('getAllPythagoreanStats')->willReturn([]);
         $stubRepo->method('getSeriesRecords')->willReturn([]);
 
-        $stubSeriesService = $this->createStub(SeriesRecordsServiceInterface::class);
+        $stubSeriesService = self::createStub(SeriesRecordsServiceInterface::class);
         $stubSeriesService->method('buildSeriesMatrix')->willReturn([]);
 
         $view = new StandingsView($stubRepo, 2025, $stubSeriesService);

--- a/ibl5/tests/Team/TeamControllerTest.php
+++ b/ibl5/tests/Team/TeamControllerTest.php
@@ -28,14 +28,14 @@ class TeamControllerTest extends TestCase
 
     public function testCanBeInstantiated(): void
     {
-        $controller = new TeamController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class), $this->createStub(\Auth\AuthService::class), $this->createStub(\League\LeagueContext::class));
+        $controller = new TeamController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class), self::createStub(\Auth\AuthService::class), self::createStub(\League\LeagueContext::class));
 
         $this->assertInstanceOf(TeamController::class, $controller);
     }
 
     public function testImplementsInterface(): void
     {
-        $controller = new TeamController($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class), $this->createStub(\Auth\AuthService::class), $this->createStub(\League\LeagueContext::class));
+        $controller = new TeamController($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class), self::createStub(\Auth\AuthService::class), self::createStub(\League\LeagueContext::class));
 
         $this->assertInstanceOf(TeamControllerInterface::class, $controller);
     }

--- a/ibl5/tests/Team/TeamServiceTest.php
+++ b/ibl5/tests/Team/TeamServiceTest.php
@@ -22,7 +22,7 @@ class TeamServiceTest extends TestCase
     {
         $mockDb = new MockDatabase();
         $repository = new \Team\TeamRepository($mockDb);
-        $this->service = new TeamService($mockDb, $repository, $this->createStub(\League\LeagueContext::class));
+        $this->service = new TeamService($mockDb, $repository, self::createStub(\League\LeagueContext::class));
     }
 
     public function testImplementsInterface(): void

--- a/ibl5/tests/Team/TeamTableServiceTest.php
+++ b/ibl5/tests/Team/TeamTableServiceTest.php
@@ -145,7 +145,7 @@ class TeamTableServiceTest extends TestCase
 
     private function createSeasonStub(string $phase): Season
     {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->phase = $phase;
         return $season;
     }

--- a/ibl5/tests/TeamSchedule/TeamScheduleServiceTest.php
+++ b/ibl5/tests/TeamSchedule/TeamScheduleServiceTest.php
@@ -24,7 +24,7 @@ class TeamScheduleServiceTest extends TestCase
     {
         $this->mockDb = new MockDatabase();
         $GLOBALS['mysqli_db'] = $this->mockDb;
-        $this->stubRepository = $this->createStub(TeamScheduleRepositoryInterface::class);
+        $this->stubRepository = self::createStub(TeamScheduleRepositoryInterface::class);
     }
 
     protected function tearDown(): void

--- a/ibl5/tests/Trading/CashTransactionHandlerTest.php
+++ b/ibl5/tests/Trading/CashTransactionHandlerTest.php
@@ -22,7 +22,7 @@ class CashTransactionHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->mockDb = new MockDatabase();
-        $this->mockCommonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->mockCommonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
     }
 
     // ============================================

--- a/ibl5/tests/Trading/TradeOfferTest.php
+++ b/ibl5/tests/Trading/TradeOfferTest.php
@@ -35,8 +35,8 @@ class TradeOfferTest extends TestCase
         ?TradeCashRepositoryInterface $cashRepo = null,
         ?BuyoutLedgerRepositoryInterface $cashConsiderationRepo = null,
     ): TradeOffer {
-        $cashRepoStub = $cashRepo ?? $this->createStub(TradeCashRepositoryInterface::class);
-        $cashConsiderationRepoStub = $cashConsiderationRepo ?? $this->createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashRepoStub = $cashRepo ?? self::createStub(TradeCashRepositoryInterface::class);
+        $cashConsiderationRepoStub = $cashConsiderationRepo ?? self::createStub(BuyoutLedgerRepositoryInterface::class);
 
         return new class ($offerRepository, $assetRepository, $validator, $cashHandler, $commonRepo, $season, $discord, $cashRepoStub, $cashConsiderationRepoStub) extends TradeOffer {
             // @phpstan-ignore constructor.missingParentCall (intentional: TradeOffer's real constructor wires concrete Season/TradeValidator/CashTransactionHandler/Discord against a live DB; this double skips it to inject test stubs directly)
@@ -93,11 +93,11 @@ class TradeOfferTest extends TestCase
     private function makeStubs(): array
     {
         $offerRepository = $this->createMock(TradeOfferRepositoryInterface::class);
-        $assetRepository = $this->createStub(TradeAssetRepositoryInterface::class);
-        $validator = $this->createStub(TradeValidator::class);
-        $cashHandler = $this->createStub(CashTransactionHandler::class);
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
-        $season = $this->createStub(Season::class);
+        $assetRepository = self::createStub(TradeAssetRepositoryInterface::class);
+        $validator = self::createStub(TradeValidator::class);
+        $cashHandler = self::createStub(CashTransactionHandler::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $season = self::createStub(Season::class);
 
         return [$offerRepository, $assetRepository, $validator, $cashHandler, $commonRepo, $season];
     }
@@ -238,11 +238,11 @@ class TradeOfferTest extends TestCase
     public function testCreateTradeOfferCountsUserPlayersSent(): void
     {
         $offerRepository = $this->createMock(TradeOfferRepositoryInterface::class);
-        $assetRepository = $this->createStub(TradeAssetRepositoryInterface::class);
+        $assetRepository = self::createStub(TradeAssetRepositoryInterface::class);
         $validator = $this->createMock(TradeValidator::class);
-        $cashHandler = $this->createStub(CashTransactionHandler::class);
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
-        $season = $this->createStub(Season::class);
+        $cashHandler = self::createStub(CashTransactionHandler::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $season = self::createStub(Season::class);
 
         $offerRepository->expects($this->once())->method('generateNextTradeOfferId')->willReturn(1);
         $validator->expects($this->once())->method('validateMinimumCashAmounts')->willReturn(['valid' => true, 'error' => null]);
@@ -268,8 +268,8 @@ class TradeOfferTest extends TestCase
 
         $validator->expects($this->once())->method('validateRosterLimits')
             ->with(
-                $this->anything(),
-                $this->anything(),
+                self::anything(),
+                self::anything(),
                 2, // 2 user players sent (indices 0,1 < switchCounter=2)
                 1, // 1 partner player sent (index 2 >= switchCounter=2)
             )
@@ -392,7 +392,7 @@ class TradeOfferTest extends TestCase
 
         // Discord should never be called
         $discord = $this->createMock(Discord::class);
-        $discord->expects($this->never())->method($this->anything());
+        $discord->expects($this->never())->method(self::anything());
 
         $offer = $this->makeTradeOffer($offerRepository, $assetRepository, $validator, $cashHandler, $commonRepo, $season, $discord);
         $result = $offer->createTradeOffer($this->makeTradeData());
@@ -403,11 +403,11 @@ class TradeOfferTest extends TestCase
     public function testCreateTradeOfferSelfTradeZeroesCapSent(): void
     {
         $offerRepository = $this->createMock(TradeOfferRepositoryInterface::class);
-        $assetRepository = $this->createStub(TradeAssetRepositoryInterface::class);
+        $assetRepository = self::createStub(TradeAssetRepositoryInterface::class);
         $validator = $this->createMock(TradeValidator::class);
-        $cashHandler = $this->createStub(CashTransactionHandler::class);
-        $commonRepo = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
-        $season = $this->createStub(Season::class);
+        $cashHandler = self::createStub(CashTransactionHandler::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $season = self::createStub(Season::class);
 
         $offerRepository->expects($this->once())->method('generateNextTradeOfferId')->willReturn(1);
         $validator->expects($this->once())->method('validateMinimumCashAmounts')->willReturn(['valid' => true, 'error' => null]);
@@ -419,7 +419,7 @@ class TradeOfferTest extends TestCase
 
         // Cap validation: for self-trade, sent amounts should be zeroed
         $validator->expects($this->once())->method('validateSalaryCaps')
-            ->with($this->callback(static function (array $capData): bool {
+            ->with(self::callback(static function (array $capData): bool {
                 return $capData['userCapSentToPartner'] === 0
                     && $capData['partnerCapSentToUser'] === 0;
             }))

--- a/ibl5/tests/Trading/TradeProcessorTest.php
+++ b/ibl5/tests/Trading/TradeProcessorTest.php
@@ -21,7 +21,7 @@ class TradeProcessorTest extends TestCase
     protected function setUp(): void
     {
         $this->mockDb = new MockDatabase();
-        $this->mockCommonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->mockCommonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
     }
 
     // ============================================

--- a/ibl5/tests/Trading/TradeQueueProcessorTest.php
+++ b/ibl5/tests/Trading/TradeQueueProcessorTest.php
@@ -15,7 +15,7 @@ class TradeQueueProcessorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubCommonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->stubCommonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
     }
 
     // ============================================
@@ -24,7 +24,7 @@ class TradeQueueProcessorTest extends TestCase
 
     public function testEmptyQueueReturnsZeroCounts(): void
     {
-        $stub = $this->createStub(TradeExecutionRepositoryInterface::class);
+        $stub = self::createStub(TradeExecutionRepositoryInterface::class);
         $stub->method('getQueuedTrades')->willReturn([]);
         $processor = new TradeQueueProcessor($stub, $this->stubCommonRepo);
 
@@ -119,7 +119,7 @@ class TradeQueueProcessorTest extends TestCase
     {
         $trade = $this->makeQueuedTrade(2, 'pick_transfer', ['pick_id' => 10, 'new_owner' => 'Miami', 'new_owner_id' => 7], 'Pick to Miami');
 
-        $stub = $this->createStub(TradeExecutionRepositoryInterface::class);
+        $stub = self::createStub(TradeExecutionRepositoryInterface::class);
         $stub->method('getQueuedTrades')->willReturn([$trade]);
         $stub->method('executeQueuedPickTransfer')->willReturn(0);
 
@@ -134,7 +134,7 @@ class TradeQueueProcessorTest extends TestCase
     {
         $trade = $this->makeQueuedTrade(3, 'pick_transfer', ['pick_id' => 10], 'Missing owner');
 
-        $stub = $this->createStub(TradeExecutionRepositoryInterface::class);
+        $stub = self::createStub(TradeExecutionRepositoryInterface::class);
         $stub->method('getQueuedTrades')->willReturn([$trade]);
 
         $processor = new TradeQueueProcessor($stub, $this->stubCommonRepo);
@@ -157,7 +157,7 @@ class TradeQueueProcessorTest extends TestCase
             'tradeline' => 'Bad trade',
         ];
 
-        $stub = $this->createStub(TradeExecutionRepositoryInterface::class);
+        $stub = self::createStub(TradeExecutionRepositoryInterface::class);
         $stub->method('getQueuedTrades')->willReturn([$trade]);
 
         $processor = new TradeQueueProcessor($stub, $this->stubCommonRepo);
@@ -171,7 +171,7 @@ class TradeQueueProcessorTest extends TestCase
     {
         $trade = $this->makeQueuedTrade(1, 'salary_adjustment', ['amount' => 100], 'Unknown op');
 
-        $stub = $this->createStub(TradeExecutionRepositoryInterface::class);
+        $stub = self::createStub(TradeExecutionRepositoryInterface::class);
         $stub->method('getQueuedTrades')->willReturn([$trade]);
 
         $processor = new TradeQueueProcessor($stub, $this->stubCommonRepo);
@@ -193,7 +193,7 @@ class TradeQueueProcessorTest extends TestCase
             $this->makeQueuedTrade(3, 'pick_transfer', ['pick_id' => 5, 'new_owner' => 'LA', 'new_owner_id' => 6], 'Trade 3'),
         ];
 
-        $stub = $this->createStub(TradeExecutionRepositoryInterface::class);
+        $stub = self::createStub(TradeExecutionRepositoryInterface::class);
         $stub->method('getQueuedTrades')->willReturn($trades);
         $stub->method('executeQueuedPlayerTransfer')
             ->willReturnMap([

--- a/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
+++ b/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
@@ -18,7 +18,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $this->mockDb = new MockDatabase();
 
-        $this->stubTradeAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
+        $this->stubTradeAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
     }
 
     protected function tearDown(): void

--- a/ibl5/tests/Trading/TradingControllerAcceptOfferTest.php
+++ b/ibl5/tests/Trading/TradingControllerAcceptOfferTest.php
@@ -35,13 +35,13 @@ class TradingControllerAcceptOfferTest extends TestCase
         ?TradeProcessorInterface $processor = null,
     ): TradingController {
         return new TradingController(
-            $this->createStub(TradingServiceInterface::class),
-            $processor ?? $this->createStub(TradeProcessorInterface::class),
-            $offerRepo ?? $this->createStub(TradeOfferRepositoryInterface::class),
-            $this->createStub(TradeOfferInterface::class),
-            $this->createStub(TradingViewInterface::class),
-            $this->createStub(TeamIdentityRepositoryInterface::class),
-            $this->createStub(\Utilities\NukeCompat::class),
+            self::createStub(TradingServiceInterface::class),
+            $processor ?? self::createStub(TradeProcessorInterface::class),
+            $offerRepo ?? self::createStub(TradeOfferRepositoryInterface::class),
+            self::createStub(TradeOfferInterface::class),
+            self::createStub(TradingViewInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(\Utilities\NukeCompat::class),
             $this->mockDb,
         );
     }

--- a/ibl5/tests/Trading/TradingControllerOfferTest.php
+++ b/ibl5/tests/Trading/TradingControllerOfferTest.php
@@ -27,13 +27,13 @@ class TradingControllerOfferTest extends TestCase
         ?\Utilities\NukeCompat $nukeCompat = null,
     ): TradingController {
         return new TradingController(
-            $this->createStub(TradingServiceInterface::class),
-            $this->createStub(TradeProcessorInterface::class),
-            $this->createStub(TradeOfferRepositoryInterface::class),
-            $this->createStub(TradeOfferInterface::class),
-            $this->createStub(TradingViewInterface::class),
-            $this->createStub(TeamIdentityRepositoryInterface::class),
-            $nukeCompat ?? $this->createStub(\Utilities\NukeCompat::class),
+            self::createStub(TradingServiceInterface::class),
+            self::createStub(TradeProcessorInterface::class),
+            self::createStub(TradeOfferRepositoryInterface::class),
+            self::createStub(TradeOfferInterface::class),
+            self::createStub(TradingViewInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
+            $nukeCompat ?? self::createStub(\Utilities\NukeCompat::class),
             $this->mockDb,
         );
     }
@@ -41,7 +41,7 @@ class TradingControllerOfferTest extends TestCase
     public function testRedirectsToLoginWhenUserNotAuthenticated(): void
     {
         $loginBoxCalled = false;
-        $nukeCompat = $this->createStub(\Utilities\NukeCompat::class);
+        $nukeCompat = self::createStub(\Utilities\NukeCompat::class);
         $nukeCompat->method('isUser')->willReturn(false);
         $nukeCompat->method('loginBox')->willReturnCallback(function () use (&$loginBoxCalled): void {
             $loginBoxCalled = true;

--- a/ibl5/tests/Trading/TradingControllerRejectOfferTest.php
+++ b/ibl5/tests/Trading/TradingControllerRejectOfferTest.php
@@ -34,13 +34,13 @@ class TradingControllerRejectOfferTest extends TestCase
         ?TradeOfferRepositoryInterface $offerRepo = null,
     ): TradingController {
         return new TradingController(
-            $this->createStub(TradingServiceInterface::class),
-            $this->createStub(TradeProcessorInterface::class),
-            $offerRepo ?? $this->createStub(TradeOfferRepositoryInterface::class),
-            $this->createStub(TradeOfferInterface::class),
-            $this->createStub(TradingViewInterface::class),
-            $this->createStub(TeamIdentityRepositoryInterface::class),
-            $this->createStub(\Utilities\NukeCompat::class),
+            self::createStub(TradingServiceInterface::class),
+            self::createStub(TradeProcessorInterface::class),
+            $offerRepo ?? self::createStub(TradeOfferRepositoryInterface::class),
+            self::createStub(TradeOfferInterface::class),
+            self::createStub(TradingViewInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(\Utilities\NukeCompat::class),
             $this->mockDb,
         );
     }

--- a/ibl5/tests/Trading/TradingControllerReviewTest.php
+++ b/ibl5/tests/Trading/TradingControllerReviewTest.php
@@ -27,11 +27,11 @@ class TradingControllerReviewTest extends TestCase
     {
         $this->mockDb = new MockDatabase();
 
-        $this->stubService = $this->createStub(TradingServiceInterface::class);
-        $this->stubProcessor = $this->createStub(TradeProcessorInterface::class);
-        $this->stubOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $this->stubTradeOffer = $this->createStub(TradeOfferInterface::class);
-        $this->stubTeamIdentityRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->stubService = self::createStub(TradingServiceInterface::class);
+        $this->stubProcessor = self::createStub(TradeProcessorInterface::class);
+        $this->stubOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $this->stubTradeOffer = self::createStub(TradeOfferInterface::class);
+        $this->stubTeamIdentityRepo = self::createStub(TeamIdentityRepositoryInterface::class);
     }
 
     private function buildController(
@@ -44,9 +44,9 @@ class TradingControllerReviewTest extends TestCase
             $this->stubProcessor,
             $this->stubOfferRepo,
             $this->stubTradeOffer,
-            $view ?? $this->createStub(TradingViewInterface::class),
+            $view ?? self::createStub(TradingViewInterface::class),
             $this->stubTeamIdentityRepo,
-            $nukeCompat ?? $this->createStub(\Utilities\NukeCompat::class),
+            $nukeCompat ?? self::createStub(\Utilities\NukeCompat::class),
             $this->mockDb,
         );
     }
@@ -54,7 +54,7 @@ class TradingControllerReviewTest extends TestCase
     public function testRedirectsToLoginWhenUserNotAuthenticated(): void
     {
         $loginBoxCalled = false;
-        $nukeCompat = $this->createStub(\Utilities\NukeCompat::class);
+        $nukeCompat = self::createStub(\Utilities\NukeCompat::class);
         $nukeCompat->method('isUser')->willReturn(false);
         $nukeCompat->method('loginBox')->willReturnCallback(function () use (&$loginBoxCalled): void {
             $loginBoxCalled = true;

--- a/ibl5/tests/Trading/TradingControllerRosterPreviewTest.php
+++ b/ibl5/tests/Trading/TradingControllerRosterPreviewTest.php
@@ -33,13 +33,13 @@ class TradingControllerRosterPreviewTest extends TestCase
         ?TeamIdentityRepositoryInterface $teamIdentityRepo = null,
     ): TradingController {
         return new TradingController(
-            $this->createStub(TradingServiceInterface::class),
-            $this->createStub(TradeProcessorInterface::class),
-            $this->createStub(TradeOfferRepositoryInterface::class),
-            $this->createStub(TradeOfferInterface::class),
-            $this->createStub(TradingViewInterface::class),
-            $teamIdentityRepo ?? $this->createStub(TeamIdentityRepositoryInterface::class),
-            $nukeCompat ?? $this->createStub(\Utilities\NukeCompat::class),
+            self::createStub(TradingServiceInterface::class),
+            self::createStub(TradeProcessorInterface::class),
+            self::createStub(TradeOfferRepositoryInterface::class),
+            self::createStub(TradeOfferInterface::class),
+            self::createStub(TradingViewInterface::class),
+            $teamIdentityRepo ?? self::createStub(TeamIdentityRepositoryInterface::class),
+            $nukeCompat ?? self::createStub(\Utilities\NukeCompat::class),
             $this->mockDb,
         );
     }
@@ -58,7 +58,7 @@ class TradingControllerRosterPreviewTest extends TestCase
 
     public function testReturnsEmptyHtmlJsonWhenNotAuthenticated(): void
     {
-        $nukeCompat = $this->createStub(\Utilities\NukeCompat::class);
+        $nukeCompat = self::createStub(\Utilities\NukeCompat::class);
         $nukeCompat->method('isUser')->willReturn(false);
 
         $controller = $this->buildController(nukeCompat: $nukeCompat);
@@ -73,7 +73,7 @@ class TradingControllerRosterPreviewTest extends TestCase
 
     public function testDelegatesHandlerForAuthenticatedUser(): void
     {
-        $nukeCompat = $this->createStub(\Utilities\NukeCompat::class);
+        $nukeCompat = self::createStub(\Utilities\NukeCompat::class);
         $nukeCompat->method('isUser')->willReturn(true);
         $nukeCompat->method('cookieDecode')->willReturn(['', 'testuser']);
 

--- a/ibl5/tests/Trading/TradingControllerSubmitOfferTest.php
+++ b/ibl5/tests/Trading/TradingControllerSubmitOfferTest.php
@@ -33,13 +33,13 @@ class TradingControllerSubmitOfferTest extends TestCase
     private function buildController(): TradingController
     {
         return new TradingController(
-            $this->createStub(TradingServiceInterface::class),
-            $this->createStub(TradeProcessorInterface::class),
-            $this->createStub(TradeOfferRepositoryInterface::class),
-            $this->createStub(TradeOfferInterface::class),
-            $this->createStub(TradingViewInterface::class),
-            $this->createStub(TeamIdentityRepositoryInterface::class),
-            $this->createStub(\Utilities\NukeCompat::class),
+            self::createStub(TradingServiceInterface::class),
+            self::createStub(TradeProcessorInterface::class),
+            self::createStub(TradeOfferRepositoryInterface::class),
+            self::createStub(TradeOfferInterface::class),
+            self::createStub(TradingViewInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(\Utilities\NukeCompat::class),
             $this->mockDb,
         );
     }

--- a/ibl5/tests/Trading/TradingServiceTest.php
+++ b/ibl5/tests/Trading/TradingServiceTest.php
@@ -159,9 +159,9 @@ class TradingServiceTest extends TestCase
     public function testGetTradeReviewPageDataReturnsEmptyOffersWhenNoneExist(): void
     {
         $mockOfferRepo = $this->createMock(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
         $mockFormRepo = $this->createMock(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
         $mockCommon = $this->createMock(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->expects($this->atLeastOnce())->method('getTeamnameFromUsername')
@@ -184,9 +184,9 @@ class TradingServiceTest extends TestCase
     public function testGetTradeReviewPageDataFiltersToUserTeamOnly(): void
     {
         $mockOfferRepo = $this->createMock(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
         $mockFormRepo = $this->createMock(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
         $mockCommon = $this->createMock(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->expects($this->atLeastOnce())->method('getTeamnameFromUsername')
@@ -213,9 +213,9 @@ class TradingServiceTest extends TestCase
     public function testGetTradeReviewPageDataSetsHasHammerCorrectly(): void
     {
         $mockOfferRepo = $this->createMock(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
         $mockFormRepo = $this->createMock(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
         $mockCommon = $this->createMock(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->expects($this->atLeastOnce())->method('getTeamnameFromUsername')
@@ -242,9 +242,9 @@ class TradingServiceTest extends TestCase
     public function testGetTradeReviewPageDataBuildsTeamListExcludingFreeAgents(): void
     {
         $mockOfferRepo = $this->createMock(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
         $mockFormRepo = $this->createMock(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
         $mockCommon = $this->createMock(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->expects($this->atLeastOnce())->method('getTeamnameFromUsername')
@@ -272,11 +272,11 @@ class TradingServiceTest extends TestCase
 
     public function testCashWithMultipleYearsProducesMultipleItems(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -301,11 +301,11 @@ class TradingServiceTest extends TestCase
 
     public function testCashZeroAmountYearsAreOmitted(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -329,11 +329,11 @@ class TradingServiceTest extends TestCase
 
     public function testCashYearLabelsAreCorrectlyComputed(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -371,11 +371,11 @@ class TradingServiceTest extends TestCase
 
     public function testCashAllZeroProducesNoItems(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -397,11 +397,11 @@ class TradingServiceTest extends TestCase
 
     public function testCashNullDetailsProducesNoItems(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -420,11 +420,11 @@ class TradingServiceTest extends TestCase
 
     public function testCashDescriptionIncludesTeamNames(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -453,11 +453,11 @@ class TradingServiceTest extends TestCase
 
     public function testGetTradeReviewPageDataCollectsPlayerPids(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -482,11 +482,11 @@ class TradingServiceTest extends TestCase
 
     public function testGetTradeReviewPageDataEnrichesTeamIds(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -512,11 +512,11 @@ class TradingServiceTest extends TestCase
 
     public function testGetTradeReviewPageDataIncludesCashPreviewData(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -545,11 +545,11 @@ class TradingServiceTest extends TestCase
 
     public function testGetTradeReviewPageDataPreviewDataIncludesSeasonInfo(): void
     {
-        $mockOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $mockAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $mockFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $mockCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $mockCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $mockOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $mockAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $mockFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $mockCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $mockCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         $mockCommon->method('getTeamnameFromUsername')->willReturn('Lakers');
         $mockCommon->method('getTidFromTeamname')->willReturn(1);
@@ -578,18 +578,18 @@ class TradingServiceTest extends TestCase
 
     private function createServiceWithStubs(): TradingService
     {
-        $stubOfferRepo = $this->createStub(TradeOfferRepositoryInterface::class);
-        $stubAssetRepo = $this->createStub(TradeAssetRepositoryInterface::class);
-        $stubFormRepo = $this->createStub(TradeFormRepositoryInterface::class);
-        $stubCashRepo = $this->createStub(TradeCashRepositoryInterface::class);
-        $stubCommon = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $stubOfferRepo = self::createStub(TradeOfferRepositoryInterface::class);
+        $stubAssetRepo = self::createStub(TradeAssetRepositoryInterface::class);
+        $stubFormRepo = self::createStub(TradeFormRepositoryInterface::class);
+        $stubCashRepo = self::createStub(TradeCashRepositoryInterface::class);
+        $stubCommon = self::createStub(TeamIdentityRepositoryInterface::class);
 
         return new TradingService($stubOfferRepo, $stubAssetRepo, $stubFormRepo, $stubCommon, $this->mockDb, $stubCashRepo);
     }
 
     private function createSeasonStub(string $phase): Season
     {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->phase = $phase;
         $season->endingYear = 2025;
         $season->beginningYear = 2024;
@@ -640,7 +640,7 @@ class TradingServiceTest extends TestCase
         $db->onQuery('ibl_cash_considerations', []);
         $_SERVER['SERVER_NAME'] = 'localhost';
 
-        $commonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
         $tradeOffer = new \Trading\TradeOffer($db, $commonRepo, 'localhost');
 
         // Prepare trade data: Team A offers to Team B
@@ -706,7 +706,7 @@ class TradingServiceTest extends TestCase
         $db->onQuery('ibl_cash_considerations', []);
         $_SERVER['SERVER_NAME'] = 'localhost';
 
-        $commonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
         $tradeOffer = new \Trading\TradeOffer($db, $commonRepo, 'localhost');
 
         // Team A offers cash to Team B
@@ -759,7 +759,7 @@ class TradingServiceTest extends TestCase
     {
         $db = new QueryAwareMockDatabase();
         $_SERVER['SERVER_NAME'] = 'localhost';
-        $commonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
         $tradeOffer = new \Trading\TradeOffer($db, $commonRepo, 'localhost');
 
         // Team A sends Player 1 to Team B
@@ -805,7 +805,7 @@ class TradingServiceTest extends TestCase
     {
         $db = new QueryAwareMockDatabase();
         $_SERVER['SERVER_NAME'] = 'localhost';
-        $commonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
         $tradeOffer = new \Trading\TradeOffer($db, $commonRepo, 'localhost');
 
         // Team A sends Player 1 + cash to Team B
@@ -858,7 +858,7 @@ class TradingServiceTest extends TestCase
     {
         $db = new QueryAwareMockDatabase();
         $_SERVER['SERVER_NAME'] = 'localhost';
-        $commonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
         $tradeOffer = new \Trading\TradeOffer($db, $commonRepo, 'localhost');
 
         // Team A sends 2025 1st round pick to Team B

--- a/ibl5/tests/Trading/TradingViewTest.php
+++ b/ibl5/tests/Trading/TradingViewTest.php
@@ -473,7 +473,7 @@ class TradingViewTest extends TestCase
 
     public function testRenderTradesClosedShowsMessage(): void
     {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->method('areWaiversAllowed')->willReturn(false);
 
         $html = $this->view->renderTradesClosed($season);
@@ -484,7 +484,7 @@ class TradingViewTest extends TestCase
 
     public function testRenderTradesClosedShowsWaiverLinksWhenOpen(): void
     {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->method('areWaiversAllowed')->willReturn(true);
 
         $html = $this->view->renderTradesClosed($season);

--- a/ibl5/tests/TrainingCampRatingsDiff/TrainingCampRatingsDiffServiceTest.php
+++ b/ibl5/tests/TrainingCampRatingsDiff/TrainingCampRatingsDiffServiceTest.php
@@ -18,7 +18,7 @@ class TrainingCampRatingsDiffServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepo = $this->createStub(TrainingCampRatingsDiffRepositoryInterface::class);
+        $this->stubRepo = self::createStub(TrainingCampRatingsDiffRepositoryInterface::class);
         $this->service  = new TrainingCampRatingsDiffService($this->stubRepo);
     }
 

--- a/ibl5/tests/UI/Tables/PlayerRowTransformerTest.php
+++ b/ibl5/tests/UI/Tables/PlayerRowTransformerTest.php
@@ -15,7 +15,7 @@ class PlayerRowTransformerTest extends TestCase
 {
     public function testResolveWithStatsReturnsEmptyForEmptyInput(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
         $result = PlayerRowTransformer::resolveWithStats($db, [], '');
 
@@ -24,7 +24,7 @@ class PlayerRowTransformerTest extends TestCase
 
     public function testResolvePlayersReturnsEmptyForEmptyInput(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
         $result = PlayerRowTransformer::resolvePlayers($db, [], '');
 
@@ -33,9 +33,9 @@ class PlayerRowTransformerTest extends TestCase
 
     public function testResolvePlayersFiltersOutPipeNames(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
         $player->method('getName')->willReturn('|Placeholder');
 
         $result = PlayerRowTransformer::resolvePlayers($db, [$player], '');
@@ -45,9 +45,9 @@ class PlayerRowTransformerTest extends TestCase
 
     public function testResolvePlayersAcceptsPlayerInstances(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
         $player->method('getName')->willReturn('John Doe');
 
         $result = PlayerRowTransformer::resolvePlayers($db, [$player], '');
@@ -58,7 +58,7 @@ class PlayerRowTransformerTest extends TestCase
 
     public function testResolveWithStatsSkipsNonArrayNonPlayerForCurrentSeason(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
         // Pass an iterable with a non-array/non-Player element
         $result = PlayerRowTransformer::resolveWithStats($db, [new \stdClass()], '');
@@ -68,9 +68,9 @@ class PlayerRowTransformerTest extends TestCase
 
     public function testResolvePlayersSkipsNonArrayForHistorical(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
 
         // For historical ($yr !== ""), non-array items should be skipped
         $result = PlayerRowTransformer::resolvePlayers($db, [$player], '2024');
@@ -80,9 +80,9 @@ class PlayerRowTransformerTest extends TestCase
 
     public function testResolveWithStatsSkipsNonArrayForHistorical(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
 
         // For historical ($yr !== ""), non-array items should be skipped
         $result = PlayerRowTransformer::resolveWithStats($db, [$player], '2024');

--- a/ibl5/tests/Unit/BulkImport/BackupArchiveLocatorTest.php
+++ b/ibl5/tests/Unit/BulkImport/BackupArchiveLocatorTest.php
@@ -17,7 +17,7 @@ class BackupArchiveLocatorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubExtractor = $this->createStub(ArchiveExtractorInterface::class);
+        $this->stubExtractor = self::createStub(ArchiveExtractorInterface::class);
         $this->locator = new BackupArchiveLocator($this->stubExtractor);
 
         $this->tmpDir = sys_get_temp_dir() . '/backup-locator-test-' . uniqid();

--- a/ibl5/tests/Unit/BulkImport/BulkImportRunnerTest.php
+++ b/ibl5/tests/Unit/BulkImport/BulkImportRunnerTest.php
@@ -40,11 +40,11 @@ class BulkImportRunnerTest extends TestCase
         $this->backupsDir = sys_get_temp_dir() . '/ibl5_runner_test_' . bin2hex(random_bytes(8));
         mkdir($this->backupsDir, 0700, true);
 
-        $this->stubExtractor = $this->createStub(ArchiveExtractorInterface::class);
-        $this->stubJsb = $this->createStub(JsbImportServiceInterface::class);
-        $stubBoxscore = $this->createStub(BoxscoreProcessor::class);
-        $stubPlr = $this->createStub(PlrParserServiceInterface::class);
-        $stubLge = $this->createStub(LeagueConfigService::class);
+        $this->stubExtractor = self::createStub(ArchiveExtractorInterface::class);
+        $this->stubJsb = self::createStub(JsbImportServiceInterface::class);
+        $stubBoxscore = self::createStub(BoxscoreProcessor::class);
+        $stubPlr = self::createStub(PlrParserServiceInterface::class);
+        $stubLge = self::createStub(LeagueConfigService::class);
 
         $this->handler = new FileTypeHandler(
             $this->stubJsb,
@@ -53,8 +53,8 @@ class BulkImportRunnerTest extends TestCase
             $stubLge,
         );
 
-        $this->stubResolver = $this->createStub(PlayerIdResolver::class);
-        $stubDb = $this->createStub(\mysqli::class);
+        $this->stubResolver = self::createStub(PlayerIdResolver::class);
+        $stubDb = self::createStub(\mysqli::class);
 
         $this->runner = new BulkImportRunner(
             $this->stubExtractor,

--- a/ibl5/tests/Unit/BulkImport/FileTypeHandlerTest.php
+++ b/ibl5/tests/Unit/BulkImport/FileTypeHandlerTest.php
@@ -37,10 +37,10 @@ class FileTypeHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubJsb = $this->createStub(JsbImportServiceInterface::class);
-        $this->stubBoxscore = $this->createStub(BoxscoreProcessor::class);
-        $this->stubPlr = $this->createStub(PlrParserServiceInterface::class);
-        $this->stubLge = $this->createStub(LeagueConfigService::class);
+        $this->stubJsb = self::createStub(JsbImportServiceInterface::class);
+        $this->stubBoxscore = self::createStub(BoxscoreProcessor::class);
+        $this->stubPlr = self::createStub(PlrParserServiceInterface::class);
+        $this->stubLge = self::createStub(LeagueConfigService::class);
 
         $this->handler = new FileTypeHandler(
             $this->stubJsb,
@@ -121,9 +121,9 @@ class FileTypeHandlerTest extends TestCase
         $mockJsb->expects($this->once())
             ->method('processRcbFile')
             ->with(
-                $this->anything(),
-                $this->anything(),
-                $this->anything(),
+                self::anything(),
+                self::anything(),
+                self::anything(),
                 false,
             )
             ->willReturn($expected);

--- a/ibl5/tests/UpdateAllTheThings/JsbSourceResolverTest.php
+++ b/ibl5/tests/UpdateAllTheThings/JsbSourceResolverTest.php
@@ -19,8 +19,8 @@ class JsbSourceResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubLocator = $this->createStub(BackupArchiveLocatorInterface::class);
-        $this->stubExtractor = $this->createStub(ArchiveExtractorInterface::class);
+        $this->stubLocator = self::createStub(BackupArchiveLocatorInterface::class);
+        $this->stubExtractor = self::createStub(ArchiveExtractorInterface::class);
         $this->tempDir = sys_get_temp_dir() . '/jsb_resolver_test_' . uniqid();
         mkdir($this->tempDir, 0777, true);
     }

--- a/ibl5/tests/UpdateAllTheThings/PowerRankingsUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/PowerRankingsUpdaterTest.php
@@ -264,7 +264,7 @@ class PowerRankingsUpdaterTest extends TestCase
 
     public function testConstructorAcceptsOptionalLeagueContext(): void
     {
-        $leagueContext = $this->createStub(\League\LeagueContext::class);
+        $leagueContext = self::createStub(\League\LeagueContext::class);
         $updater = new PowerRankingsUpdater($this->mockDb, $this->mockSeason, null, $leagueContext);
         $this->assertInstanceOf(PowerRankingsUpdater::class, $updater);
     }

--- a/ibl5/tests/UpdateAllTheThings/ScheduleUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/ScheduleUpdaterTest.php
@@ -248,7 +248,7 @@ class ScheduleUpdaterTest extends TestCase
      */
     public function testIsRealTeamGameFiltersPlaceholderTeamsForOlympics(): void
     {
-        $olympicsContext = $this->createStub(LeagueContext::class);
+        $olympicsContext = self::createStub(LeagueContext::class);
         $olympicsContext->method('getCurrentLeague')->willReturn(LeagueContext::LEAGUE_OLYMPICS);
         $olympicsContext->method('isOlympics')->willReturn(true);
         $olympicsContext->method('getTableName')->willReturnCallback(
@@ -293,7 +293,7 @@ class ScheduleUpdaterTest extends TestCase
      */
     public function testOlympicsContextTruncatesOlympicsScheduleTable(): void
     {
-        $olympicsContext = $this->createStub(LeagueContext::class);
+        $olympicsContext = self::createStub(LeagueContext::class);
         $olympicsContext->method('getCurrentLeague')->willReturn(LeagueContext::LEAGUE_OLYMPICS);
         $olympicsContext->method('isOlympics')->willReturn(true);
         $olympicsContext->method('getTableName')->willReturnCallback(

--- a/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
@@ -561,7 +561,7 @@ class StandingsUpdaterTest extends TestCase
 
     public function testOlympicsSkipsTeamAwardUpsert(): void
     {
-        $olympicsContext = $this->createStub(\League\LeagueContext::class);
+        $olympicsContext = self::createStub(\League\LeagueContext::class);
         $olympicsContext->method('getTableName')->willReturnCallback(
             static function (string $table): string {
                 return match ($table) {
@@ -628,7 +628,7 @@ class StandingsUpdaterTest extends TestCase
         // Drive the executeQuery() rewrite path: the repo's backtick-quoted
         // tables are rewritten to Olympics equivalents when the context is
         // Olympics (isOlympics() === true), via LeagueContext::TABLE_MAP.
-        $olympicsContext = $this->createStub(\League\LeagueContext::class);
+        $olympicsContext = self::createStub(\League\LeagueContext::class);
         $olympicsContext->method('isOlympics')->willReturn(true);
 
         $olympicsRepo = new StandingsRepository($this->mockDb, $olympicsContext);
@@ -652,7 +652,7 @@ class StandingsUpdaterTest extends TestCase
 
     public function testOlympicsContextFetchTeamMapQueriesOlympicsLeagueConfig(): void
     {
-        $olympicsContext = $this->createStub(\League\LeagueContext::class);
+        $olympicsContext = self::createStub(\League\LeagueContext::class);
         $olympicsContext->method('isOlympics')->willReturn(true);
 
         $olympicsRepo = new StandingsRepository($this->mockDb, $olympicsContext);

--- a/ibl5/tests/UpdateAllTheThings/Steps/EndOfSeasonImportStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/EndOfSeasonImportStepTest.php
@@ -23,9 +23,9 @@ class EndOfSeasonImportStepTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepo = $this->createStub(JsbImportRepositoryInterface::class);
-        $this->stubService = $this->createStub(JsbImportService::class);
-        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $this->stubRepo = self::createStub(JsbImportRepositoryInterface::class);
+        $this->stubService = self::createStub(JsbImportService::class);
+        $this->stubResolver = self::createStub(JsbSourceResolverInterface::class);
     }
 
     private function createStep(): EndOfSeasonImportStep

--- a/ibl5/tests/UpdateAllTheThings/Steps/ExtendDepthChartsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ExtendDepthChartsStepTest.php
@@ -13,7 +13,7 @@ class ExtendDepthChartsStepTest extends TestCase
 {
     public function testImplementsPipelineStepInterface(): void
     {
-        $stubRepo = $this->createStub(SavedDepthChartRepository::class);
+        $stubRepo = self::createStub(SavedDepthChartRepository::class);
         $step = new ExtendDepthChartsStep($stubRepo, '2026-02-27', 15);
 
         $this->assertInstanceOf(PipelineStepInterface::class, $step);
@@ -21,7 +21,7 @@ class ExtendDepthChartsStepTest extends TestCase
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $stubRepo = $this->createStub(SavedDepthChartRepository::class);
+        $stubRepo = self::createStub(SavedDepthChartRepository::class);
         $step = new ExtendDepthChartsStep($stubRepo, '2026-02-27', 15);
 
         $this->assertSame('Saved depth charts updated', $step->getLabel());
@@ -44,7 +44,7 @@ class ExtendDepthChartsStepTest extends TestCase
 
     public function testExecuteCapturesOutputBufferLog(): void
     {
-        $stubRepo = $this->createStub(SavedDepthChartRepository::class);
+        $stubRepo = self::createStub(SavedDepthChartRepository::class);
         $stubRepo->method('extendActiveDepthCharts')->willReturnCallback(static function (): int {
             echo '<p>Extending DCs...</p>';
             return 3;

--- a/ibl5/tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ExtractFromBackupStepTest.php
@@ -19,8 +19,8 @@ class ExtractFromBackupStepTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubLocator = $this->createStub(BackupArchiveLocatorInterface::class);
-        $this->stubSeason = $this->createStub(Season::class);
+        $this->stubLocator = self::createStub(BackupArchiveLocatorInterface::class);
+        $this->stubSeason = self::createStub(Season::class);
         $this->stubSeason->beginningYear = 2025;
         $this->stubSeason->endingYear = 2026;
     }

--- a/ibl5/tests/UpdateAllTheThings/Steps/ImportLeagueConfigStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ImportLeagueConfigStepTest.php
@@ -26,10 +26,10 @@ class ImportLeagueConfigStepTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubRepo = $this->createStub(LeagueConfigRepository::class);
-        $this->stubService = $this->createStub(LeagueConfigService::class);
-        $this->stubView = $this->createStub(LeagueConfigView::class);
-        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $this->stubRepo = self::createStub(LeagueConfigRepository::class);
+        $this->stubService = self::createStub(LeagueConfigService::class);
+        $this->stubView = self::createStub(LeagueConfigView::class);
+        $this->stubResolver = self::createStub(JsbSourceResolverInterface::class);
     }
 
     public function testImplementsPipelineStepInterface(): void

--- a/ibl5/tests/UpdateAllTheThings/Steps/ParseJsbFilesStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ParseJsbFilesStepTest.php
@@ -20,8 +20,8 @@ class ParseJsbFilesStepTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubService = $this->createStub(JsbImportService::class);
-        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $this->stubService = self::createStub(JsbImportService::class);
+        $this->stubResolver = self::createStub(JsbSourceResolverInterface::class);
     }
 
     private function createStep(): ParseJsbFilesStep

--- a/ibl5/tests/UpdateAllTheThings/Steps/ParsePlayerFileStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ParsePlayerFileStepTest.php
@@ -20,8 +20,8 @@ class ParsePlayerFileStepTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubService = $this->createStub(PlrParserServiceInterface::class);
-        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $this->stubService = self::createStub(PlrParserServiceInterface::class);
+        $this->stubResolver = self::createStub(JsbSourceResolverInterface::class);
     }
 
     public function testImplementsPipelineStepInterface(): void

--- a/ibl5/tests/UpdateAllTheThings/Steps/ProcessAllStarGamesStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ProcessAllStarGamesStepTest.php
@@ -25,10 +25,10 @@ class ProcessAllStarGamesStepTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubProcessor = $this->createStub(BoxscoreProcessor::class);
-        $this->stubRepo = $this->createStub(BoxscoreRepository::class);
-        $this->stubView = $this->createStub(BoxscoreView::class);
-        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $this->stubProcessor = self::createStub(BoxscoreProcessor::class);
+        $this->stubRepo = self::createStub(BoxscoreRepository::class);
+        $this->stubView = self::createStub(BoxscoreView::class);
+        $this->stubResolver = self::createStub(JsbSourceResolverInterface::class);
     }
 
     public function testImplementsPipelineStepInterface(): void

--- a/ibl5/tests/UpdateAllTheThings/Steps/ProcessBoxscoresStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/ProcessBoxscoresStepTest.php
@@ -22,9 +22,9 @@ class ProcessBoxscoresStepTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubProcessor = $this->createStub(BoxscoreProcessor::class);
-        $this->stubView = $this->createStub(BoxscoreView::class);
-        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $this->stubProcessor = self::createStub(BoxscoreProcessor::class);
+        $this->stubView = self::createStub(BoxscoreView::class);
+        $this->stubResolver = self::createStub(JsbSourceResolverInterface::class);
     }
 
     public function testImplementsPipelineStepInterface(): void

--- a/ibl5/tests/UpdateAllTheThings/Steps/RefreshIblHistStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/RefreshIblHistStepTest.php
@@ -12,13 +12,13 @@ class RefreshIblHistStepTest extends TestCase
 {
     public function testImplementsPipelineStepInterface(): void
     {
-        $stub = $this->createStub(\mysqli::class);
+        $stub = self::createStub(\mysqli::class);
         $this->assertInstanceOf(PipelineStepInterface::class, new RefreshIblHistStep($stub));
     }
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $stub = $this->createStub(\mysqli::class);
+        $stub = self::createStub(\mysqli::class);
         $this->assertSame('ibl_hist refreshed', (new RefreshIblHistStep($stub))->getLabel());
     }
 }

--- a/ibl5/tests/UpdateAllTheThings/Steps/RefreshPlayoffSeriesResultsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/RefreshPlayoffSeriesResultsStepTest.php
@@ -12,13 +12,13 @@ class RefreshPlayoffSeriesResultsStepTest extends TestCase
 {
     public function testImplementsPipelineStepInterface(): void
     {
-        $stub = $this->createStub(\mysqli::class);
+        $stub = self::createStub(\mysqli::class);
         $this->assertInstanceOf(PipelineStepInterface::class, new RefreshPlayoffSeriesResultsStep($stub));
     }
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $stub = $this->createStub(\mysqli::class);
+        $stub = self::createStub(\mysqli::class);
         $this->assertSame(
             'playoff series results refreshed',
             (new RefreshPlayoffSeriesResultsStep($stub))->getLabel(),

--- a/ibl5/tests/UpdateAllTheThings/Steps/RefreshTeamSeasonRecordsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/RefreshTeamSeasonRecordsStepTest.php
@@ -12,13 +12,13 @@ class RefreshTeamSeasonRecordsStepTest extends TestCase
 {
     public function testImplementsPipelineStepInterface(): void
     {
-        $stub = $this->createStub(\mysqli::class);
+        $stub = self::createStub(\mysqli::class);
         $this->assertInstanceOf(PipelineStepInterface::class, new RefreshTeamSeasonRecordsStep($stub));
     }
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $stub = $this->createStub(\mysqli::class);
+        $stub = self::createStub(\mysqli::class);
         $this->assertSame(
             'team season records refreshed',
             (new RefreshTeamSeasonRecordsStep($stub))->getLabel(),

--- a/ibl5/tests/UpdateAllTheThings/Steps/SnapshotPlrStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/SnapshotPlrStepTest.php
@@ -24,9 +24,9 @@ class SnapshotPlrStepTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubJsbRepo = $this->createStub(JsbImportRepositoryInterface::class);
-        $this->stubPlrService = $this->createStub(PlrParserServiceInterface::class);
-        $this->stubResolver = $this->createStub(JsbSourceResolverInterface::class);
+        $this->stubJsbRepo = self::createStub(JsbImportRepositoryInterface::class);
+        $this->stubPlrService = self::createStub(PlrParserServiceInterface::class);
+        $this->stubResolver = self::createStub(JsbSourceResolverInterface::class);
     }
 
     private function createStep(): SnapshotPlrStep

--- a/ibl5/tests/UpdateAllTheThings/Steps/UpdatePowerRankingsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/UpdatePowerRankingsStepTest.php
@@ -13,7 +13,7 @@ class UpdatePowerRankingsStepTest extends TestCase
 {
     public function testImplementsPipelineStepInterface(): void
     {
-        $stubUpdater = $this->createStub(PowerRankingsUpdater::class);
+        $stubUpdater = self::createStub(PowerRankingsUpdater::class);
         $step = new UpdatePowerRankingsStep($stubUpdater);
 
         $this->assertInstanceOf(PipelineStepInterface::class, $step);
@@ -21,7 +21,7 @@ class UpdatePowerRankingsStepTest extends TestCase
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $stubUpdater = $this->createStub(PowerRankingsUpdater::class);
+        $stubUpdater = self::createStub(PowerRankingsUpdater::class);
         $step = new UpdatePowerRankingsStep($stubUpdater);
 
         $this->assertSame('Power rankings updated', $step->getLabel());
@@ -41,7 +41,7 @@ class UpdatePowerRankingsStepTest extends TestCase
 
     public function testExecuteCapturesOutputBufferLog(): void
     {
-        $stubUpdater = $this->createStub(PowerRankingsUpdater::class);
+        $stubUpdater = self::createStub(PowerRankingsUpdater::class);
         $stubUpdater->method('update')->willReturnCallback(static function (): void {
             echo '<p>Calculating power rankings...</p>';
         });

--- a/ibl5/tests/UpdateAllTheThings/Steps/UpdateScheduleStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/UpdateScheduleStepTest.php
@@ -13,7 +13,7 @@ class UpdateScheduleStepTest extends TestCase
 {
     public function testImplementsPipelineStepInterface(): void
     {
-        $stubUpdater = $this->createStub(ScheduleUpdater::class);
+        $stubUpdater = self::createStub(ScheduleUpdater::class);
         $step = new UpdateScheduleStep($stubUpdater);
 
         $this->assertInstanceOf(PipelineStepInterface::class, $step);
@@ -21,7 +21,7 @@ class UpdateScheduleStepTest extends TestCase
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $stubUpdater = $this->createStub(ScheduleUpdater::class);
+        $stubUpdater = self::createStub(ScheduleUpdater::class);
         $step = new UpdateScheduleStep($stubUpdater);
 
         $this->assertSame('Schedule updated', $step->getLabel());
@@ -41,7 +41,7 @@ class UpdateScheduleStepTest extends TestCase
 
     public function testExecuteCapturesOutputBufferLog(): void
     {
-        $stubUpdater = $this->createStub(ScheduleUpdater::class);
+        $stubUpdater = self::createStub(ScheduleUpdater::class);
         $stubUpdater->method('update')->willReturnCallback(static function (): void {
             echo '<p>Updating schedule...</p>';
         });

--- a/ibl5/tests/UpdateAllTheThings/Steps/UpdateStandingsStepTest.php
+++ b/ibl5/tests/UpdateAllTheThings/Steps/UpdateStandingsStepTest.php
@@ -13,7 +13,7 @@ class UpdateStandingsStepTest extends TestCase
 {
     public function testImplementsPipelineStepInterface(): void
     {
-        $stubUpdater = $this->createStub(StandingsUpdater::class);
+        $stubUpdater = self::createStub(StandingsUpdater::class);
         $step = new UpdateStandingsStep($stubUpdater);
 
         $this->assertInstanceOf(PipelineStepInterface::class, $step);
@@ -21,7 +21,7 @@ class UpdateStandingsStepTest extends TestCase
 
     public function testGetLabelReturnsExpectedLabel(): void
     {
-        $stubUpdater = $this->createStub(StandingsUpdater::class);
+        $stubUpdater = self::createStub(StandingsUpdater::class);
         $step = new UpdateStandingsStep($stubUpdater);
 
         $this->assertSame('Standings updated', $step->getLabel());
@@ -41,7 +41,7 @@ class UpdateStandingsStepTest extends TestCase
 
     public function testExecuteCapturesOutputBufferLog(): void
     {
-        $stubUpdater = $this->createStub(StandingsUpdater::class);
+        $stubUpdater = self::createStub(StandingsUpdater::class);
         $stubUpdater->method('update')->willReturnCallback(static function (): void {
             echo '<p>Computing standings...</p>';
         });

--- a/ibl5/tests/UpdateAllTheThings/UpdaterServiceTest.php
+++ b/ibl5/tests/UpdateAllTheThings/UpdaterServiceTest.php
@@ -40,14 +40,14 @@ class UpdaterServiceTest extends TestCase
     {
         $executionOrder = [];
 
-        $step1 = $this->createStub(PipelineStepInterface::class);
+        $step1 = self::createStub(PipelineStepInterface::class);
         $step1->method('getLabel')->willReturn('Step 1');
         $step1->method('execute')->willReturnCallback(static function () use (&$executionOrder): StepResult {
             $executionOrder[] = 'Step 1';
             return StepResult::success('Step 1');
         });
 
-        $step2 = $this->createStub(PipelineStepInterface::class);
+        $step2 = self::createStub(PipelineStepInterface::class);
         $step2->method('getLabel')->willReturn('Step 2');
         $step2->method('execute')->willReturnCallback(static function () use (&$executionOrder): StepResult {
             $executionOrder[] = 'Step 2';
@@ -69,7 +69,7 @@ class UpdaterServiceTest extends TestCase
     {
         $events = [];
 
-        $step = $this->createStub(PipelineStepInterface::class);
+        $step = self::createStub(PipelineStepInterface::class);
         $step->method('getLabel')->willReturn('Test Step');
         $step->method('execute')->willReturnCallback(static function () use (&$events): StepResult {
             $events[] = 'execute';
@@ -92,15 +92,15 @@ class UpdaterServiceTest extends TestCase
 
     public function testRunCountsSuccessesAndErrors(): void
     {
-        $successStep = $this->createStub(PipelineStepInterface::class);
+        $successStep = self::createStub(PipelineStepInterface::class);
         $successStep->method('getLabel')->willReturn('Success');
         $successStep->method('execute')->willReturn(StepResult::success('Success'));
 
-        $failStep = $this->createStub(PipelineStepInterface::class);
+        $failStep = self::createStub(PipelineStepInterface::class);
         $failStep->method('getLabel')->willReturn('Fail');
         $failStep->method('execute')->willReturn(StepResult::failure('Fail', 'Error'));
 
-        $skipStep = $this->createStub(PipelineStepInterface::class);
+        $skipStep = self::createStub(PipelineStepInterface::class);
         $skipStep->method('getLabel')->willReturn('Skip');
         $skipStep->method('execute')->willReturn(StepResult::skipped('Skip', 'No file'));
 
@@ -120,11 +120,11 @@ class UpdaterServiceTest extends TestCase
 
     public function testRunContinuesAfterStepFailure(): void
     {
-        $failStep = $this->createStub(PipelineStepInterface::class);
+        $failStep = self::createStub(PipelineStepInterface::class);
         $failStep->method('getLabel')->willReturn('Failing');
         $failStep->method('execute')->willReturn(StepResult::failure('Failing', 'Boom'));
 
-        $afterStep = $this->createStub(PipelineStepInterface::class);
+        $afterStep = self::createStub(PipelineStepInterface::class);
         $afterStep->method('getLabel')->willReturn('After');
         $afterStep->method('execute')->willReturn(StepResult::success('After'));
 
@@ -143,11 +143,11 @@ class UpdaterServiceTest extends TestCase
 
     public function testRunCatchesExceptionsAndContinues(): void
     {
-        $throwingStep = $this->createStub(PipelineStepInterface::class);
+        $throwingStep = self::createStub(PipelineStepInterface::class);
         $throwingStep->method('getLabel')->willReturn('Thrower');
         $throwingStep->method('execute')->willThrowException(new \RuntimeException('Database gone'));
 
-        $afterStep = $this->createStub(PipelineStepInterface::class);
+        $afterStep = self::createStub(PipelineStepInterface::class);
         $afterStep->method('getLabel')->willReturn('After');
         $afterStep->method('execute')->willReturn(StepResult::success('After'));
 
@@ -168,7 +168,7 @@ class UpdaterServiceTest extends TestCase
 
     public function testRunResetsCountsBetweenRuns(): void
     {
-        $step = $this->createStub(PipelineStepInterface::class);
+        $step = self::createStub(PipelineStepInterface::class);
         $step->method('getLabel')->willReturn('Test');
         $step->method('execute')->willReturn(StepResult::success('Test'));
 
@@ -194,7 +194,7 @@ class UpdaterServiceTest extends TestCase
     public function testRunReturnsResultsInStepOrder(): void
     {
         for ($i = 1; $i <= 3; $i++) {
-            $step = $this->createStub(PipelineStepInterface::class);
+            $step = self::createStub(PipelineStepInterface::class);
             $step->method('getLabel')->willReturn('Step ' . $i);
             $step->method('execute')->willReturn(StepResult::success('Step ' . $i));
             $this->service->addStep($step);

--- a/ibl5/tests/Updater/ScheduleUpdaterTest.php
+++ b/ibl5/tests/Updater/ScheduleUpdaterTest.php
@@ -29,12 +29,12 @@ class ScheduleUpdaterTest extends TestCase
         bool $olympics = false,
         ?JsbSourceResolverInterface $sourceResolver = null,
     ): TestableScheduleUpdater {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->endingYear = $endingYear;
         $season->beginningYear = $endingYear - 1;
         $season->phase = $phase;
 
-        $leagueContext = $this->createStub(LeagueContext::class);
+        $leagueContext = self::createStub(LeagueContext::class);
         $leagueContext->method('getCurrentLeague')->willReturn($olympics ? 'olympics' : 'IBL');
         $leagueContext->method('isOlympics')->willReturn($olympics);
         $leagueContext->method('getTableName')->willReturnCallback(
@@ -106,7 +106,7 @@ class ScheduleUpdaterTest extends TestCase
     private function createUpdaterForFullRun(array $teams, array $games): TestableScheduleUpdater
     {
         $this->mockDb->setMockData($teams);
-        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver = self::createStub(JsbSourceResolverInterface::class);
         $resolver->method('getContents')->willReturn($this->buildSchBytes($games));
 
         return $this->createUpdater(sourceResolver: $resolver);

--- a/ibl5/tests/Updater/UpdaterControllerTest.php
+++ b/ibl5/tests/Updater/UpdaterControllerTest.php
@@ -19,8 +19,8 @@ class UpdaterControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stubService = $this->createStub(UpdaterService::class);
-        $this->stubView = $this->createStub(UpdaterViewInterface::class);
+        $this->stubService = self::createStub(UpdaterService::class);
+        $this->stubView = self::createStub(UpdaterViewInterface::class);
 
         $this->stubService->method('getSuccessCount')->willReturn(0);
         $this->stubService->method('getErrorCount')->willReturn(0);
@@ -50,7 +50,7 @@ class UpdaterControllerTest extends TestCase
 
     public function testRunOutputsSummary(): void
     {
-        $mockService = $this->createStub(UpdaterService::class);
+        $mockService = self::createStub(UpdaterService::class);
         $mockService->method('getSuccessCount')->willReturn(5);
         $mockService->method('getErrorCount')->willReturn(2);
 
@@ -72,7 +72,7 @@ class UpdaterControllerTest extends TestCase
     #[DataProvider('stepProgressLabelProvider')]
     public function testGetStepProgressLabelMapsKnownLabels(string $stepLabel, string $expectedProgress): void
     {
-        $step = $this->createStub(PipelineStepInterface::class);
+        $step = self::createStub(PipelineStepInterface::class);
         $step->method('getLabel')->willReturn($stepLabel);
 
         $mockView = $this->createMock(UpdaterViewInterface::class);
@@ -86,7 +86,7 @@ class UpdaterControllerTest extends TestCase
             ->with($expectedProgress)
             ->willReturn('<start>');
 
-        $mockService = $this->createStub(UpdaterService::class);
+        $mockService = self::createStub(UpdaterService::class);
         $mockService->method('getSuccessCount')->willReturn(0);
         $mockService->method('getErrorCount')->willReturn(0);
         $mockService->method('run')->willReturnCallback(
@@ -137,12 +137,12 @@ class UpdaterControllerTest extends TestCase
             ->with('Test step', 'detail text')
             ->willReturn('<done>');
 
-        $service = $this->createStub(UpdaterService::class);
+        $service = self::createStub(UpdaterService::class);
         $service->method('getSuccessCount')->willReturn(0);
         $service->method('getErrorCount')->willReturn(0);
         $service->method('run')->willReturnCallback(
             function (callable $onStart, callable $onComplete) use ($result): array {
-                $step = $this->createStub(PipelineStepInterface::class);
+                $step = self::createStub(PipelineStepInterface::class);
                 $step->method('getLabel')->willReturn('Test step');
                 $onStart($step);
                 $onComplete($result);
@@ -169,12 +169,12 @@ class UpdaterControllerTest extends TestCase
             ->with('Failed step', 'Something broke')
             ->willReturn('<error>');
 
-        $service = $this->createStub(UpdaterService::class);
+        $service = self::createStub(UpdaterService::class);
         $service->method('getSuccessCount')->willReturn(0);
         $service->method('getErrorCount')->willReturn(0);
         $service->method('run')->willReturnCallback(
             function (callable $onStart, callable $onComplete) use ($result): array {
-                $step = $this->createStub(PipelineStepInterface::class);
+                $step = self::createStub(PipelineStepInterface::class);
                 $step->method('getLabel')->willReturn('Failed step');
                 $onStart($step);
                 $onComplete($result);
@@ -324,12 +324,12 @@ class UpdaterControllerTest extends TestCase
 
     private function stubServiceWithResult(StepResult $result): UpdaterService
     {
-        $service = $this->createStub(UpdaterService::class);
+        $service = self::createStub(UpdaterService::class);
         $service->method('getSuccessCount')->willReturn(0);
         $service->method('getErrorCount')->willReturn(0);
         $service->method('run')->willReturnCallback(
             function (callable $onStart, callable $onComplete) use ($result): array {
-                $step = $this->createStub(PipelineStepInterface::class);
+                $step = self::createStub(PipelineStepInterface::class);
                 $step->method('getLabel')->willReturn($result->label);
                 $onStart($step);
                 $onComplete($result);

--- a/ibl5/tests/Updater/UpdaterServiceTest.php
+++ b/ibl5/tests/Updater/UpdaterServiceTest.php
@@ -109,7 +109,7 @@ class UpdaterServiceTest extends TestCase
 
     public function testFailedStepIncrementsErrorCount(): void
     {
-        $step = $this->createStub(PipelineStepInterface::class);
+        $step = self::createStub(PipelineStepInterface::class);
         $step->method('getLabel')->willReturn('Failing step');
         $step->method('execute')->willReturn(StepResult::failure('Failing step', 'Something broke'));
         $this->service->addStep($step);
@@ -128,7 +128,7 @@ class UpdaterServiceTest extends TestCase
         $this->service->addStep($this->createSuccessStep('OK 1'));
         $this->service->addStep($this->createSuccessStep('OK 2'));
 
-        $failStep = $this->createStub(PipelineStepInterface::class);
+        $failStep = self::createStub(PipelineStepInterface::class);
         $failStep->method('getLabel')->willReturn('Fail');
         $failStep->method('execute')->willReturn(StepResult::failure('Fail', 'error'));
         $this->service->addStep($failStep);
@@ -144,7 +144,7 @@ class UpdaterServiceTest extends TestCase
 
     public function testThrowingStepProducesFailureResult(): void
     {
-        $step = $this->createStub(PipelineStepInterface::class);
+        $step = self::createStub(PipelineStepInterface::class);
         $step->method('getLabel')->willReturn('Boom');
         $step->method('execute')->willThrowException(new \RuntimeException('Unexpected error'));
         $this->service->addStep($step);
@@ -162,7 +162,7 @@ class UpdaterServiceTest extends TestCase
 
     public function testThrowingStepStillCallsOnStepComplete(): void
     {
-        $step = $this->createStub(PipelineStepInterface::class);
+        $step = self::createStub(PipelineStepInterface::class);
         $step->method('getLabel')->willReturn('Boom');
         $step->method('execute')->willThrowException(new \RuntimeException('err'));
         $this->service->addStep($step);
@@ -209,7 +209,7 @@ class UpdaterServiceTest extends TestCase
 
     public function testStepLabelUsedInExceptionWrapping(): void
     {
-        $step = $this->createStub(PipelineStepInterface::class);
+        $step = self::createStub(PipelineStepInterface::class);
         $step->method('getLabel')->willReturn('Custom Label');
         $step->method('execute')->willThrowException(new \RuntimeException('msg'));
         $this->service->addStep($step);
@@ -224,7 +224,7 @@ class UpdaterServiceTest extends TestCase
 
     private function createSuccessStep(string $label): PipelineStepInterface
     {
-        $step = $this->createStub(PipelineStepInterface::class);
+        $step = self::createStub(PipelineStepInterface::class);
         $step->method('getLabel')->willReturn($label);
         $step->method('execute')->willReturn(StepResult::success($label));
         return $step;

--- a/ibl5/tests/Validation/CommonValidatorTest.php
+++ b/ibl5/tests/Validation/CommonValidatorTest.php
@@ -19,7 +19,7 @@ class CommonValidatorTest extends TestCase
 
     private function createPlayerStub(?string $teamName, ?string $position = null, ?string $name = null): Player
     {
-        $player = $this->createStub(Player::class);
+        $player = self::createStub(Player::class);
         $player->method('getTeamName')->willReturn($teamName);
         $player->method('getPosition')->willReturn($position);
         $player->method('getName')->willReturn($name);

--- a/ibl5/tests/Voting/VotingBallotServiceTest.php
+++ b/ibl5/tests/Voting/VotingBallotServiceTest.php
@@ -14,7 +14,7 @@ class VotingBallotServiceTest extends TestCase
 {
     public function testImplementsInterface(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
         $service = new VotingBallotService($db);
 
         $this->assertInstanceOf(VotingBallotServiceInterface::class, $service);
@@ -22,12 +22,12 @@ class VotingBallotServiceTest extends TestCase
 
     public function testGetBallotDataReturnsASGCategoriesForRegularSeason(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->phase = 'Regular Season';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getAllStarCandidatesResult')->willReturn([]);
 
         $service = new VotingBallotService($db);
@@ -42,12 +42,12 @@ class VotingBallotServiceTest extends TestCase
 
     public function testGetBallotDataReturnsEOYCategoriesForPlayoffs(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->phase = 'Playoffs';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getMVPCandidatesResult')->willReturn([]);
         $league->method('getSixthPersonOfTheYearCandidatesResult')->willReturn([]);
         $league->method('getRookieOfTheYearCandidatesResult')->willReturn([]);
@@ -65,12 +65,12 @@ class VotingBallotServiceTest extends TestCase
 
     public function testASGCategoryTitlesAreCorrect(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->phase = 'Regular Season';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getAllStarCandidatesResult')->willReturn([]);
 
         $service = new VotingBallotService($db);
@@ -84,12 +84,12 @@ class VotingBallotServiceTest extends TestCase
 
     public function testEOYCategoryTitlesAreCorrect(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->phase = 'Draft';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getMVPCandidatesResult')->willReturn([]);
         $league->method('getSixthPersonOfTheYearCandidatesResult')->willReturn([]);
         $league->method('getRookieOfTheYearCandidatesResult')->willReturn([]);
@@ -106,12 +106,12 @@ class VotingBallotServiceTest extends TestCase
 
     public function testGMCandidatesAreBuiltCorrectly(): void
     {
-        $db = $this->createStub(\mysqli::class);
+        $db = self::createStub(\mysqli::class);
 
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->phase = 'Playoffs';
 
-        $league = $this->createStub(League::class);
+        $league = self::createStub(League::class);
         $league->method('getMVPCandidatesResult')->willReturn([]);
         $league->method('getSixthPersonOfTheYearCandidatesResult')->willReturn([]);
         $league->method('getRookieOfTheYearCandidatesResult')->willReturn([]);

--- a/ibl5/tests/Voting/VotingSubmissionServiceTest.php
+++ b/ibl5/tests/Voting/VotingSubmissionServiceTest.php
@@ -37,7 +37,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validEoyBallot();
         $ballot[$field] = 'Star Player, My Team';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('My Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -62,7 +62,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validEoyBallot();
         $ballot[$field] = 'John Doe, My Team';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('My Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -86,7 +86,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validEoyBallot();
         $ballot['mvp_1'] = '';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -98,7 +98,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validEoyBallot();
         $ballot['six_2'] = '';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -110,7 +110,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validEoyBallot();
         $ballot['roy_3'] = '';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -122,7 +122,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validEoyBallot();
         $ballot['gm_1'] = '';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -137,7 +137,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot['mvp_1'] = 'Same Player, Knicks';
         $ballot['mvp_2'] = 'Same Player, Knicks';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -150,7 +150,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot['six_1'] = 'Same Bench, Hawks';
         $ballot['six_3'] = 'Same Bench, Hawks';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -163,7 +163,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot['roy_2'] = 'Same Rookie, Nets';
         $ballot['roy_3'] = 'Same Rookie, Nets';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -176,7 +176,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot['gm_1'] = 'Same GM, Celtics';
         $ballot['gm_2'] = 'Same GM, Celtics';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -193,7 +193,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot['roy_1'] = 'Same Rookie, Nets';
         $ballot['roy_2'] = 'Same Rookie, Nets'; // duplicate
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertTrue($result->hasErrors());
@@ -266,7 +266,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validAsgBallot();
         $ballot['east_f1'] = 'Star Player, My Team';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitAsgVote('My Team', $ballot, self::validAsgRawPost());
 
         $this->assertTrue($result->hasErrors());
@@ -280,7 +280,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validAsgBallot();
         $ballot['west_f3'] = '';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitAsgVote('Other Team', $ballot, self::validAsgRawPost());
 
         $this->assertTrue($result->hasErrors());
@@ -296,7 +296,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $rawPost = self::validAsgRawPost();
         $rawPost['ECF'] = ['p1', 'p2', 'p3', 'p4', 'p5']; // 5 is too many
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitAsgVote('Other Team', $ballot, $rawPost);
 
         $this->assertTrue($result->hasErrors());
@@ -312,7 +312,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot['east_f1'] = 'Star, My Team'; // self-vote
         $ballot['west_b2'] = '';              // missing
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $result = $service->submitAsgVote('My Team', $ballot, self::validAsgRawPost());
 
         $this->assertTrue($result->hasErrors());
@@ -373,7 +373,7 @@ final class VotingSubmissionServiceTest extends TestCase
     public function testEoySuccessEmitsAuditLog(): void
     {
         $ballot = self::validEoyBallot();
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $service->submitEoyVote('Test Team', $ballot);
 
         $this->assertAuditLogEmitted('eoy_vote_submitted');
@@ -388,7 +388,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validEoyBallot();
         $ballot['mvp_1'] = '';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $service->submitEoyVote('Other Team', $ballot);
 
         $this->assertAuditLogNotEmitted('eoy_vote_submitted');
@@ -397,7 +397,7 @@ final class VotingSubmissionServiceTest extends TestCase
     public function testAsgSuccessEmitsAuditLog(): void
     {
         $ballot = self::validAsgBallot();
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $service->submitAsgVote('Test Team', $ballot, self::validAsgRawPost());
 
         $this->assertAuditLogEmitted('asg_vote_submitted');
@@ -412,7 +412,7 @@ final class VotingSubmissionServiceTest extends TestCase
         $ballot = self::validAsgBallot();
         $ballot['east_f1'] = '';
 
-        $service = new VotingSubmissionService($this->createStub(VotingRepositoryInterface::class));
+        $service = new VotingSubmissionService(self::createStub(VotingRepositoryInterface::class));
         $service->submitAsgVote('Other Team', $ballot, self::validAsgRawPost());
 
         $this->assertAuditLogNotEmitted('asg_vote_submitted');

--- a/ibl5/tests/VotingResults/VotingResultsServiceTest.php
+++ b/ibl5/tests/VotingResults/VotingResultsServiceTest.php
@@ -15,7 +15,7 @@ final class VotingResultsServiceTest extends TestCase
 {
     public function testGetAllStarResultsReturnsFourCategoriesWithCorrectTitles(): void
     {
-        $repository = $this->createStub(VotingRepositoryInterface::class);
+        $repository = self::createStub(VotingRepositoryInterface::class);
         $repository->method('fetchAllStarTotals')->willReturn([]);
 
         $service = new VotingResultsService($repository);
@@ -30,7 +30,7 @@ final class VotingResultsServiceTest extends TestCase
 
     public function testGetAllStarResultsReturnsRowsFromRepository(): void
     {
-        $repository = $this->createStub(VotingRepositoryInterface::class);
+        $repository = self::createStub(VotingRepositoryInterface::class);
         $repository->method('fetchAllStarTotals')->willReturnOnConsecutiveCalls(
             [
                 ['name' => 'Mason Lee', 'votes' => 5, 'pid' => 101],
@@ -53,7 +53,7 @@ final class VotingResultsServiceTest extends TestCase
 
     public function testGetEndOfYearResultsReturnsFourCategoriesWithCorrectTitles(): void
     {
-        $repository = $this->createStub(VotingRepositoryInterface::class);
+        $repository = self::createStub(VotingRepositoryInterface::class);
         $repository->method('fetchEndOfYearTotals')->willReturn([]);
 
         $service = new VotingResultsService($repository);
@@ -68,7 +68,7 @@ final class VotingResultsServiceTest extends TestCase
 
     public function testGetEndOfYearResultsReturnsRowsFromRepository(): void
     {
-        $repository = $this->createStub(VotingRepositoryInterface::class);
+        $repository = self::createStub(VotingRepositoryInterface::class);
         $repository->method('fetchEndOfYearTotals')->willReturnOnConsecutiveCalls(
             [
                 ['name' => 'Alana Cruz', 'votes' => 21, 'pid' => 200],

--- a/ibl5/tests/Waivers/WaiversControllerTest.php
+++ b/ibl5/tests/Waivers/WaiversControllerTest.php
@@ -18,13 +18,13 @@ class WaiversControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $serviceStub = $this->createStub(WaiversServiceInterface::class);
-        $processorStub = $this->createStub(WaiversProcessorInterface::class);
-        $viewStub = $this->createStub(WaiversViewInterface::class);
-        $teamIdentityRepoStub = $this->createStub(TeamIdentityRepositoryInterface::class);
-        $salaryCapRepoStub = $this->createStub(SalaryCapRepositoryInterface::class);
-        $nukeCompatStub = $this->createStub(\Utilities\NukeCompat::class);
-        $dbStub = $this->createStub(\mysqli::class);
+        $serviceStub = self::createStub(WaiversServiceInterface::class);
+        $processorStub = self::createStub(WaiversProcessorInterface::class);
+        $viewStub = self::createStub(WaiversViewInterface::class);
+        $teamIdentityRepoStub = self::createStub(TeamIdentityRepositoryInterface::class);
+        $salaryCapRepoStub = self::createStub(SalaryCapRepositoryInterface::class);
+        $nukeCompatStub = self::createStub(\Utilities\NukeCompat::class);
+        $dbStub = self::createStub(\mysqli::class);
 
         $this->controller = new WaiversController(
             $serviceStub,

--- a/ibl5/tests/Waivers/WaiversProcessorTest.php
+++ b/ibl5/tests/Waivers/WaiversProcessorTest.php
@@ -21,12 +21,12 @@ class WaiversProcessorTest extends TestCase
 
     protected function setUp(): void
     {
-        $repoStub = $this->createStub(WaiversRepositoryInterface::class);
-        $teamIdentityRepoStub = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
-        $playerLookupRepoStub = $this->createStub(\Repositories\Contracts\PlayerLookupRepositoryInterface::class);
-        $validatorStub = $this->createStub(WaiversValidatorInterface::class);
-        $newsServiceStub = $this->createStub(\Topics\News\NewsRepository::class);
-        $dbStub = $this->createStub(\mysqli::class);
+        $repoStub = self::createStub(WaiversRepositoryInterface::class);
+        $teamIdentityRepoStub = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $playerLookupRepoStub = self::createStub(\Repositories\Contracts\PlayerLookupRepositoryInterface::class);
+        $validatorStub = self::createStub(WaiversValidatorInterface::class);
+        $newsServiceStub = self::createStub(\Topics\News\NewsRepository::class);
+        $dbStub = self::createStub(\mysqli::class);
 
         $this->processor = new WaiversProcessor(
             $repoStub,

--- a/ibl5/tests/Waivers/WaiversProcessorWriteTest.php
+++ b/ibl5/tests/Waivers/WaiversProcessorWriteTest.php
@@ -24,12 +24,12 @@ class WaiversProcessorWriteTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->repoStub = $this->createStub(WaiversRepositoryInterface::class);
-        $this->teamIdentityRepoStub = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
-        $this->playerLookupRepoStub = $this->createStub(\Repositories\Contracts\PlayerLookupRepositoryInterface::class);
-        $this->validatorStub = $this->createStub(WaiversValidatorInterface::class);
-        $this->newsServiceStub = $this->createStub(\Topics\News\NewsRepository::class);
-        $dbStub = $this->createStub(\mysqli::class);
+        $this->repoStub = self::createStub(WaiversRepositoryInterface::class);
+        $this->teamIdentityRepoStub = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $this->playerLookupRepoStub = self::createStub(\Repositories\Contracts\PlayerLookupRepositoryInterface::class);
+        $this->validatorStub = self::createStub(WaiversValidatorInterface::class);
+        $this->newsServiceStub = self::createStub(\Topics\News\NewsRepository::class);
+        $dbStub = self::createStub(\mysqli::class);
 
         $this->processor = new WaiversProcessor(
             $this->repoStub,

--- a/ibl5/tests/Waivers/WaiversServiceTest.php
+++ b/ibl5/tests/Waivers/WaiversServiceTest.php
@@ -12,11 +12,11 @@ class WaiversServiceTest extends TestCase
 {
     public function testImplementsInterface(): void
     {
-        $commonRepoStub = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
-        $processorStub = $this->createStub(\Waivers\Contracts\WaiversProcessorInterface::class);
-        $viewStub = $this->createStub(\Waivers\Contracts\WaiversViewInterface::class);
-        $teamQueryRepoStub = $this->createStub(\Team\Contracts\TeamQueryRepositoryInterface::class);
-        $dbStub = $this->createStub(\mysqli::class);
+        $commonRepoStub = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $processorStub = self::createStub(\Waivers\Contracts\WaiversProcessorInterface::class);
+        $viewStub = self::createStub(\Waivers\Contracts\WaiversViewInterface::class);
+        $teamQueryRepoStub = self::createStub(\Team\Contracts\TeamQueryRepositoryInterface::class);
+        $dbStub = self::createStub(\mysqli::class);
 
         $service = new WaiversService(
             $commonRepoStub,

--- a/ibl5/tests/WideUnit/Draft/DraftWideUnitTest.php
+++ b/ibl5/tests/WideUnit/Draft/DraftWideUnitTest.php
@@ -36,11 +36,11 @@ class DraftWideUnitTest extends WideUnitTestCase
         parent::setUp();
 
         // Stub CommonMysqliRepository (no expectations needed)
-        $this->mockCommonRepository = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $this->mockCommonRepository = self::createStub(TeamIdentityRepositoryInterface::class);
         $this->mockCommonRepository->method('getTidFromTeamname')->willReturn(1);
 
         // Create mock Season
-        $this->mockSeason = $this->createStub(Season::class);
+        $this->mockSeason = self::createStub(Season::class);
         $this->mockSeason->endingYear = 2025;
         $this->mockSeason->freeAgencyNotificationsState = 'Off';
 

--- a/ibl5/tests/WideUnit/FreeAgency/FreeAgencyWideUnitTest.php
+++ b/ibl5/tests/WideUnit/FreeAgency/FreeAgencyWideUnitTest.php
@@ -32,7 +32,7 @@ class FreeAgencyWideUnitTest extends WideUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->processor = new FreeAgencyProcessor($this->mockDb, $this->createStub(TeamIdentityRepositoryInterface::class));
+        $this->processor = new FreeAgencyProcessor($this->mockDb, self::createStub(TeamIdentityRepositoryInterface::class));
 
         // Prevent Discord notifications during tests
         $_SERVER['SERVER_NAME'] = 'localhost';

--- a/ibl5/tests/WideUnit/ModifierConsistencyTest.php
+++ b/ibl5/tests/WideUnit/ModifierConsistencyTest.php
@@ -96,7 +96,7 @@ class ModifierConsistencyTest extends TestCase
             ],
         ]);
 
-        $calculator = new NegotiationDemandCalculator($mockDb, $this->createStub(SalaryCapRepositoryInterface::class));
+        $calculator = new NegotiationDemandCalculator($mockDb, self::createStub(SalaryCapRepositoryInterface::class));
 
         $expectedWinner = \ContractRules::calculateWinnerModifier(self::WINS, self::LOSSES, self::WINNER_PREF);
         $expectedTradition = \ContractRules::calculateTraditionModifier(self::TRAD_WINS, self::TRAD_LOSSES, self::TRADITION_PREF);

--- a/ibl5/tests/WideUnit/Negotiation/NegotiationWideUnitTest.php
+++ b/ibl5/tests/WideUnit/Negotiation/NegotiationWideUnitTest.php
@@ -35,12 +35,12 @@ class NegotiationWideUnitTest extends WideUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->mockSeason = $this->createStub(\Season\Season::class);
+        $this->mockSeason = self::createStub(\Season\Season::class);
         $this->mockSeason->phase = 'Regular Season';
         $this->mockSeason->endingYear = 2026;
         $this->mockSeason->beginningYear = 2025;
         $db = $this->mockDb;
-        $commonRepo = $this->createStub(SalaryCapRepositoryInterface::class);
+        $commonRepo = self::createStub(SalaryCapRepositoryInterface::class);
         $this->service = new NegotiationService(
             $db,
             new NegotiationRepository($db, $commonRepo),

--- a/ibl5/tests/WideUnit/Schedule/ScheduleWideUnitTest.php
+++ b/ibl5/tests/WideUnit/Schedule/ScheduleWideUnitTest.php
@@ -899,7 +899,7 @@ class ScheduleWideUnitTest extends WideUnitTestCase
      */
     private function createMockSeason(string $projectedNextSimEndDate): Season
     {
-        $season = $this->createStub(Season::class);
+        $season = self::createStub(Season::class);
         $season->projectedNextSimEndDate = date_create($projectedNextSimEndDate);
         // lastSimEndDate is stored as string (DATE column format) in the Season class
         $lastSimEndDate = date_create($projectedNextSimEndDate)->modify('-7 days');

--- a/ibl5/tests/WideUnit/Trading/TradeWideUnitTest.php
+++ b/ibl5/tests/WideUnit/Trading/TradeWideUnitTest.php
@@ -33,7 +33,7 @@ class TradeWideUnitTest extends WideUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $commonRepo = $this->createStub(TeamIdentityRepositoryInterface::class);
+        $commonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
         $this->processor = new TradeProcessor($this->mockDb, $commonRepo);
         
         // Prevent Discord notifications during tests

--- a/ibl5/tests/WideUnit/Waivers/WaiversWideUnitTest.php
+++ b/ibl5/tests/WideUnit/Waivers/WaiversWideUnitTest.php
@@ -37,12 +37,12 @@ class WaiversWideUnitTest extends WideUnitTestCase
     {
         parent::setUp();
         $this->repository = new WaiversRepository($this->mockDb);
-        $repoStub = $this->createStub(\Waivers\Contracts\WaiversRepositoryInterface::class);
-        $teamIdentityRepoStub = $this->createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
-        $playerLookupRepoStub = $this->createStub(\Repositories\Contracts\PlayerLookupRepositoryInterface::class);
-        $validatorStub = $this->createStub(\Waivers\Contracts\WaiversValidatorInterface::class);
-        $newsServiceStub = $this->createStub(\Topics\News\NewsRepository::class);
-        $dbStub = $this->createStub(\mysqli::class);
+        $repoStub = self::createStub(\Waivers\Contracts\WaiversRepositoryInterface::class);
+        $teamIdentityRepoStub = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $playerLookupRepoStub = self::createStub(\Repositories\Contracts\PlayerLookupRepositoryInterface::class);
+        $validatorStub = self::createStub(\Waivers\Contracts\WaiversValidatorInterface::class);
+        $newsServiceStub = self::createStub(\Topics\News\NewsRepository::class);
+        $dbStub = self::createStub(\mysqli::class);
         $this->processor = new WaiversProcessor($repoStub, $teamIdentityRepoStub, $playerLookupRepoStub, $validatorStub, $newsServiceStub, $dbStub);
         $this->validator = new WaiversValidator();
 
@@ -793,7 +793,7 @@ class WaiversWideUnitTest extends WideUnitTestCase
      */
     private function createMockSeason(string $phase): Season
     {
-        $stubSeason = $this->createStub(Season::class);
+        $stubSeason = self::createStub(Season::class);
         $stubSeason->phase = $phase;
         $stubSeason->method('isOffseasonPhase')->willReturn(
             $phase === 'Draft' || $phase === 'Free Agency'

--- a/ibl5/tests/WideUnit/WideUnitTestCase.php
+++ b/ibl5/tests/WideUnit/WideUnitTestCase.php
@@ -128,7 +128,7 @@ abstract class WideUnitTestCase extends TestCase
         
         foreach ($queries as $query) {
             if (stripos($query, $querySubstring) !== false) {
-                $this->fail(
+                self::fail(
                     "Query containing '$querySubstring' was executed but should not have been.\n" .
                     "Matched query: $query"
                 );

--- a/ibl5/tests/YourAccount/YourAccountRepositoryTest.php
+++ b/ibl5/tests/YourAccount/YourAccountRepositoryTest.php
@@ -11,7 +11,7 @@ class YourAccountRepositoryTest extends TestCase
 {
     public function testRepositoryCanBeInstantiated(): void
     {
-        $stub = $this->createStub(\mysqli::class);
+        $stub = self::createStub(\mysqli::class);
         $repo = new YourAccountRepository($stub);
         $this->assertInstanceOf(YourAccountRepository::class, $repo);
     }

--- a/ibl5/tests/YourAccount/YourAccountServiceTest.php
+++ b/ibl5/tests/YourAccount/YourAccountServiceTest.php
@@ -29,9 +29,9 @@ class YourAccountServiceTest extends TestCase
     {
         $this->setUpAuthLogCapture();
 
-        $this->stubAuthService = $this->createStub(AuthServiceInterface::class);
-        $this->stubCommonRepository = $this->createStub(TeamIdentityRepositoryInterface::class);
-        $this->stubMailService = $this->createStub(MailServiceInterface::class);
+        $this->stubAuthService = self::createStub(AuthServiceInterface::class);
+        $this->stubCommonRepository = self::createStub(TeamIdentityRepositoryInterface::class);
+        $this->stubMailService = self::createStub(MailServiceInterface::class);
 
         $this->service = $this->buildService();
     }
@@ -151,7 +151,7 @@ class YourAccountServiceTest extends TestCase
             ->with(
                 'user@test.com',
                 'New User Account Activation',
-                $this->stringContains('newuser'),
+                self::stringContains('newuser'),
                 'admin@iblhoops.net',
             );
 
@@ -288,15 +288,15 @@ class YourAccountServiceTest extends TestCase
         $mockMail->expects($this->once())
             ->method('send')
             ->with(
-                $this->anything(),
-                $this->anything(),
-                $this->logicalAnd(
-                    $this->stringContains('confirm_email'),
-                    $this->stringContains('my-selector'),
-                    $this->stringContains('my-token'),
-                    $this->stringContains('https://iblhoops.net'),
+                self::anything(),
+                self::anything(),
+                self::logicalAnd(
+                    self::stringContains('confirm_email'),
+                    self::stringContains('my-selector'),
+                    self::stringContains('my-token'),
+                    self::stringContains('https://iblhoops.net'),
                 ),
-                $this->anything(),
+                self::anything(),
             );
 
         $this->service = $this->buildService(authService: $mockAuth, mailService: $mockMail);
@@ -381,11 +381,11 @@ class YourAccountServiceTest extends TestCase
             ->method('send')
             ->with(
                 'user@test.com',
-                $this->stringContains('Password Reset'),
-                $this->logicalAnd(
-                    $this->stringContains('sel-reset'),
-                    $this->stringContains('tok-reset'),
-                    $this->stringContains('reset_password'),
+                self::stringContains('Password Reset'),
+                self::logicalAnd(
+                    self::stringContains('sel-reset'),
+                    self::stringContains('tok-reset'),
+                    self::stringContains('reset_password'),
                 ),
                 'admin@iblhoops.net',
             );


### PR DESCRIPTION
## Summary

Converts dynamic static-call style (`SomeClass::method()` called on `$this` or instance variables) to canonical `self::` / `static::` / `parent::` calls in test files, eliminating the corresponding PHPStan baseline entries.

This is part of the ongoing 6-PR series to burn down the PHPStan test-code baseline.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

## Checklist
- [x] PHPStan baseline entries reduced
- [x] All existing tests pass
- [x] No production code modified

Generated with [Claude Code](https://claude.ai/code)