### PR TITLE
fix(engine): make SHADOW step safe to leave enabled in production

### DIFF
--- a/ibl5/classes/EngineBundle/Contracts/EngineBundleRepositoryInterface.php
+++ b/ibl5/classes/EngineBundle/Contracts/EngineBundleRepositoryInterface.php
@@ -40,6 +40,7 @@ interface EngineBundleRepositoryInterface
      * @param string|null $startDate  inclusive lower bound (Y-m-d) or null
      * @param string|null $endDate    inclusive upper bound (Y-m-d) or null
      * @param int         $gameType   JSB game-type flag stamped on each Game (caller decides; default regular)
+     * @param int|null    $limit      max rows to return (earliest first by game_date, id), or null for all
      * @return list<Game>
      */
     public function getUnplayedGames(
@@ -47,5 +48,6 @@ interface EngineBundleRepositoryInterface
         ?string $startDate = null,
         ?string $endDate = null,
         int $gameType = 2,
+        ?int $limit = null,
     ): array;
 }

--- a/ibl5/classes/EngineBundle/EngineBundleRepository.php
+++ b/ibl5/classes/EngineBundle/EngineBundleRepository.php
@@ -76,6 +76,7 @@ final class EngineBundleRepository extends \BaseMysqliRepository implements Engi
         ?string $startDate = null,
         ?string $endDate = null,
         int $gameType = 2,
+        ?int $limit = null,
     ): array {
         // Canonical "unplayed" convention: both scores 0 (see PowerRankingsUpdater
         // line 129, ScheduleHighlighter). box_id is NOT a played flag.
@@ -97,6 +98,14 @@ final class EngineBundleRepository extends \BaseMysqliRepository implements Engi
             $params[] = $endDate;
         }
         $sql .= " ORDER BY game_date, id";
+
+        // Cap per-run work to the earliest $limit games (bound, never interpolated)
+        // so callers can keep a single sim run within memory bounds.
+        if ($limit !== null) {
+            $sql .= " LIMIT ?";
+            $types .= 'i';
+            $params[] = $limit;
+        }
 
         $rows = $this->fetchAll($sql, $types, ...$params);
 

--- a/ibl5/classes/EngineBundle/EngineBundleService.php
+++ b/ibl5/classes/EngineBundle/EngineBundleService.php
@@ -41,6 +41,7 @@ final class EngineBundleService
      * @param int         $gameType   JSB game-type flag stamped on every game (default regular)
      * @param int|null    $seed       explicit seed, or null to generate one in [0, PHP_INT_MAX]
      * @param int         $leagueId   league id recorded in the bundle
+     * @param int|null    $maxGames   cap the unplayed-game window to the earliest N games, or null for all
      *
      * @throws EmptyScheduleException when the window yields no games to simulate
      * @throws EmptyRosterException   when no rosterable players exist
@@ -52,8 +53,9 @@ final class EngineBundleService
         int $gameType = self::DEFAULT_GAME_TYPE,
         ?int $seed = null,
         int $leagueId = self::DEFAULT_LEAGUE_ID,
+        ?int $maxGames = null,
     ): string {
-        $schedule = $this->repository->getUnplayedGames($seasonYear, $startDate, $endDate, $gameType);
+        $schedule = $this->repository->getUnplayedGames($seasonYear, $startDate, $endDate, $gameType, $maxGames);
         if ($schedule === []) {
             throw new EmptyScheduleException(
                 "No unplayed games to simulate for season $seasonYear in the given window.",

--- a/ibl5/classes/EngineShadow/EngineShadowLoader.php
+++ b/ibl5/classes/EngineShadow/EngineShadowLoader.php
@@ -67,6 +67,11 @@ final class EngineShadowLoader
         $gameOfThatDay = $this->intVal($game, 'game_of_that_day');
         $simGameType = $this->intVal($game, 'sim_game_type');
 
+        // Re-runs replace, not append: clear any prior shadow rows for this game
+        // first. Runs inside the per-game transaction() wrapper from load(), so a
+        // mid-game failure rolls the delete back too (atomic delete+insert).
+        $this->repository->deleteShadowGame($date, $visitorTeamId, $homeTeamId, $gameOfThatDay);
+
         $playerRows = 0;
         foreach ($this->arrVal($game, 'player_boxes') as $pb) {
             if (!is_array($pb)) {

--- a/ibl5/classes/EngineShadow/EngineShadowRepository.php
+++ b/ibl5/classes/EngineShadow/EngineShadowRepository.php
@@ -73,6 +73,40 @@ class EngineShadowRepository extends \BaseMysqliRepository
     }
 
     /**
+     * Delete any existing shadow rows for one game (from BOTH shadow tables) so a
+     * re-run replaces rather than appends. Called by the loader at the top of each
+     * per-game transaction, so the delete+insert for a game is atomic. Identity
+     * keys are bound (`siii`) — never interpolated. Returns total rows removed.
+     */
+    public function deleteShadowGame(
+        string $gameDate,
+        int $visitorTeamId,
+        int $homeTeamId,
+        int $gameOfThatDay,
+    ): int {
+        $deleted = $this->execute(
+            "DELETE FROM `ibl_box_scores_engine_shadow`
+             WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND game_of_that_day = ?",
+            'siii',
+            $gameDate,
+            $visitorTeamId,
+            $homeTeamId,
+            $gameOfThatDay,
+        );
+        $deleted += $this->execute(
+            "DELETE FROM `ibl_box_scores_engine_shadow_teams`
+             WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND game_of_that_day = ?",
+            'siii',
+            $gameDate,
+            $visitorTeamId,
+            $homeTeamId,
+            $gameOfThatDay,
+        );
+
+        return $deleted;
+    }
+
+    /**
      * Insert one engine player box row. teamid/pos are nullable (a pid missing
      * from ibl_plr yields a NULL teamid).
      */

--- a/ibl5/classes/Updater/Steps/EngineShadowStep.php
+++ b/ibl5/classes/Updater/Steps/EngineShadowStep.php
@@ -24,6 +24,14 @@ use Updater\StepResult;
  */
 final class EngineShadowStep implements PipelineStepInterface
 {
+    /**
+     * Per-run cap on shadowed games. The engine slurps its whole Result JSON
+     * into a 128MB PHP process; an unbounded season window (hundreds of games,
+     * ~360MB result) OOMs with an uncatchable E_ERROR. 20 games (~9MB result)
+     * was proven safe under 128MB with margin. Public so tests can reference it.
+     */
+    public const SHADOW_MAX_GAMES_PER_RUN = 20;
+
     public function __construct(
         private readonly EngineBundleService $bundleService,
         private readonly EngineRunnerInterface $runner,
@@ -45,7 +53,10 @@ final class EngineShadowStep implements PipelineStepInterface
         }
 
         try {
-            $bundleJson = $this->bundleService->buildBundleJson($this->seasonYear);
+            $bundleJson = $this->bundleService->buildBundleJson(
+                $this->seasonYear,
+                maxGames: self::SHADOW_MAX_GAMES_PER_RUN,
+            );
         } catch (EmptyScheduleException | EmptyRosterException $e) {
             return StepResult::skipped($this->getLabel(), 'Nothing to shadow-sim: ' . $e->getMessage());
         }

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -211,25 +211,6 @@ try {
         $boxscoreProcessor, $boxscoreView, $sourceResolver,
     ));
 
-    // Shadow sim: run the native Go engine in parallel with the canonical .sco
-    // import and write its output to droppable shadow tables for comparison.
-    // Default OFF — never slows or risks the canonical import until fidelity is
-    // validated. IBL-only (the engine bundle is IBL-scoped).
-    if (!$isOlympics) {
-        $engineShadowEnabled = filter_var(
-            getenv('ENGINE_SHADOW_ENABLED') ?: '',
-            FILTER_VALIDATE_BOOLEAN,
-        );
-        $bundleRepo = new EngineBundle\EngineBundleRepository($mysqli_db, $leagueContext);
-        $bundleService = new EngineBundle\EngineBundleService($bundleRepo, new EngineBundle\BundleSerializer());
-        $engineRunner = new EngineRunner\EngineRunner();
-        $engineShadowRepo = new EngineShadow\EngineShadowRepository($mysqli_db, $leagueContext);
-        $engineShadowLoader = new EngineShadow\EngineShadowLoader($engineShadowRepo);
-        $updaterService->addStep(new Updater\Steps\EngineShadowStep(
-            $bundleService, $engineRunner, $engineShadowLoader, $season->endingYear, $engineShadowEnabled,
-        ));
-    }
-
     // IBL-only: All-Star games don't exist in Olympics
     if (!$isOlympics) {
         $updaterService->addStep(new Updater\Steps\ProcessAllStarGamesStep(
@@ -270,6 +251,29 @@ try {
             $plrService, $jsbRepo, $season->endingYear, $sourceResolver,
         ));
         $updaterService->addStep(new Updater\Steps\RefreshIblHistStep($mysqli_db));
+    }
+
+    // Shadow sim: run the native Go engine over a bounded game window and write its
+    // output to droppable shadow tables for engine-vs-JSB comparison. Default OFF —
+    // never slows or risks the canonical import until fidelity is validated. IBL-only
+    // (the engine bundle is IBL-scoped). Registered LAST so that even a catastrophic,
+    // uncatchable engine fatal (e.g. OOM, an E_ERROR the step's catch can't trap)
+    // skips nothing downstream — shadow reads inputs and writes only shadow tables,
+    // so nothing else depends on it. The per-run game cap (EngineShadowStep::
+    // SHADOW_MAX_GAMES_PER_RUN) keeps a single run within the PHP memory limit.
+    if (!$isOlympics) {
+        $engineShadowEnabled = filter_var(
+            getenv('ENGINE_SHADOW_ENABLED') ?: '',
+            FILTER_VALIDATE_BOOLEAN,
+        );
+        $bundleRepo = new EngineBundle\EngineBundleRepository($mysqli_db, $leagueContext);
+        $bundleService = new EngineBundle\EngineBundleService($bundleRepo, new EngineBundle\BundleSerializer());
+        $engineRunner = new EngineRunner\EngineRunner();
+        $engineShadowRepo = new EngineShadow\EngineShadowRepository($mysqli_db, $leagueContext);
+        $engineShadowLoader = new EngineShadow\EngineShadowLoader($engineShadowRepo);
+        $updaterService->addStep(new Updater\Steps\EngineShadowStep(
+            $bundleService, $engineRunner, $engineShadowLoader, $season->endingYear, $engineShadowEnabled,
+        ));
     }
 
     $controller = new Updater\UpdaterController($updaterService, $view);

--- a/ibl5/tests/DatabaseIntegration/EngineBundleRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/EngineBundleRepositoryTest.php
@@ -132,6 +132,50 @@ class EngineBundleRepositoryTest extends DatabaseTestCase
         self::assertLessThan(2, count($games));
     }
 
+    // ── getUnplayedGames LIMIT cap ───────────────────────────────────
+
+    public function testGetUnplayedGamesLimitReturnsEarliestN(): void
+    {
+        // 5 unplayed games across distinct dates in an isolated future year.
+        $this->insertScheduleRow(2095, '2095-01-05', 2, 0, 1, 0);
+        $this->insertScheduleRow(2095, '2095-01-10', 4, 0, 3, 0);
+        $this->insertScheduleRow(2095, '2095-01-15', 6, 0, 5, 0);
+        $this->insertScheduleRow(2095, '2095-01-20', 8, 0, 7, 0);
+        $this->insertScheduleRow(2095, '2095-01-25', 10, 0, 9, 0);
+
+        $games = $this->repo->getUnplayedGames(2095, null, null, 2, 3);
+
+        // Exactly N, and the earliest 3 by game_date, id (ordering preserved under LIMIT).
+        self::assertCount(3, $games);
+        self::assertSame('2095-01-05', $games[0]->date);
+        self::assertSame('2095-01-10', $games[1]->date);
+        self::assertSame('2095-01-15', $games[2]->date);
+    }
+
+    public function testGetUnplayedGamesLimitLargerThanAvailableReturnsAll(): void
+    {
+        $this->insertScheduleRow(2094, '2094-01-05', 2, 0, 1, 0);
+        $this->insertScheduleRow(2094, '2094-01-10', 4, 0, 3, 0);
+        $this->insertScheduleRow(2094, '2094-01-15', 6, 0, 5, 0);
+        $this->insertScheduleRow(2094, '2094-01-20', 8, 0, 7, 0);
+        $this->insertScheduleRow(2094, '2094-01-25', 10, 0, 9, 0);
+
+        self::assertCount(5, $this->repo->getUnplayedGames(2094, null, null, 2, 50));
+    }
+
+    public function testGetUnplayedGamesNullLimitReturnsAll(): void
+    {
+        // Negative: limit omitted/null ⇒ unlimited behavior preserved.
+        $this->insertScheduleRow(2093, '2093-01-05', 2, 0, 1, 0);
+        $this->insertScheduleRow(2093, '2093-01-10', 4, 0, 3, 0);
+        $this->insertScheduleRow(2093, '2093-01-15', 6, 0, 5, 0);
+        $this->insertScheduleRow(2093, '2093-01-20', 8, 0, 7, 0);
+        $this->insertScheduleRow(2093, '2093-01-25', 10, 0, 9, 0);
+
+        self::assertCount(5, $this->repo->getUnplayedGames(2093));
+        self::assertCount(5, $this->repo->getUnplayedGames(2093, null, null, 2, null));
+    }
+
     // ── getTeams ─────────────────────────────────────────────────────
 
     public function testGetTeamsConcatenatesCityAndName(): void

--- a/ibl5/tests/DatabaseIntegration/EngineShadowLoaderTest.php
+++ b/ibl5/tests/DatabaseIntegration/EngineShadowLoaderTest.php
@@ -142,6 +142,56 @@ final class EngineShadowLoaderTest extends DatabaseTestCase
         self::assertSame($canonicalTeamsBefore, $this->countRows('ibl_box_scores_teams'));
     }
 
+    #[Test]
+    public function reRunReplacesRowsRatherThanAppending(): void
+    {
+        $loader = new EngineShadowLoader(new EngineShadowRepository($this->db));
+
+        $loader->load($this->resultJson());
+        $loader->load($this->resultJson()); // same game again
+
+        // Count the TABLE, not the loader return (which is 4/2 on every run
+        // regardless of dedupe). A broken dedupe leaves 8/4 here.
+        self::assertSame(4, $this->countShadowRowsForGame('ibl_box_scores_engine_shadow'), 'player rows doubled — dedupe failed');
+        self::assertSame(2, $this->countShadowRowsForGame('ibl_box_scores_engine_shadow_teams'), 'team rows doubled — dedupe failed');
+    }
+
+    #[Test]
+    public function reRunDedupeLeavesUnrelatedGameIntact(): void
+    {
+        $repo = new EngineShadowRepository($this->db);
+
+        // Pre-seed an unrelated game (different date AND keys) directly.
+        $repo->insertShadowPlayerBox(
+            '2089-05-05', 6, 5, 1,
+            42, 5, 'PG',
+            30, 5, 10, 4, 5, 2, 6, 2, 6, 5, 2, 2, 1, 3,
+            999, 2,
+        );
+
+        // Load the fixture game twice; dedupe is scoped to the fixture's keys only.
+        $loader = new EngineShadowLoader($repo);
+        $loader->load($this->resultJson());
+        $loader->load($this->resultJson());
+
+        self::assertSame(1, $this->countPlayerRowsForDate('2089-05-05'), 'unrelated game rows must be untouched by dedupe');
+    }
+
+    private function countPlayerRowsForDate(string $date): int
+    {
+        $stmt = $this->db->prepare(
+            "SELECT COUNT(*) AS cnt FROM `ibl_box_scores_engine_shadow` WHERE game_date = ?"
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('s', $date);
+        $stmt->execute();
+        /** @var array{cnt: int} $row */
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        return (int) $row['cnt'];
+    }
+
     /** @return array<string, mixed> */
     private function fetchPlayerRow(int $pid): array
     {

--- a/ibl5/tests/DatabaseIntegration/EngineShadowRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/EngineShadowRepositoryTest.php
@@ -53,4 +53,62 @@ final class EngineShadowRepositoryTest extends DatabaseTestCase
         self::assertSame(5, $map[701] ?? null);
         self::assertArrayNotHasKey(7029999, $map, 'unknown pid must not appear in the map');
     }
+
+    #[Test]
+    public function deleteShadowGameRemovesMatchingRowsFromBothTablesOnly(): void
+    {
+        $repo = new EngineShadowRepository($this->db);
+
+        // Target game (date 2090-01-10, visitor 3 @ home 1, game_of_that_day 1):
+        // one player row + one team row in each shadow table.
+        $repo->insertShadowPlayerBox(
+            '2090-01-10', 3, 1, 1,
+            42, 3, 'PG',
+            30, 5, 10, 4, 5, 2, 6, 2, 6, 5, 2, 2, 1, 3,
+            111, 2,
+        );
+        $repo->insertShadowTeamBox(
+            '2090-01-10', 3, 1, 1, 3,
+            38, 80, 18, 24, 6, 18, 10, 30, 22, 8, 14, 4, 18,
+            28, 26, 24, 25, 0, 30, 27, 26, 24, 0,
+            111, 2,
+        );
+
+        // Unrelated game on the same date but a different game_of_that_day (2):
+        // must survive the targeted delete.
+        $repo->insertShadowPlayerBox(
+            '2090-01-10', 6, 5, 2,
+            77, 5, 'SG',
+            25, 4, 9, 1, 2, 0, 1, 1, 4, 3, 1, 2, 0, 2,
+            111, 2,
+        );
+
+        $deleted = $repo->deleteShadowGame('2090-01-10', 3, 1, 1);
+
+        // Two rows removed (one per table) for the matching game.
+        self::assertSame(2, $deleted);
+        self::assertSame(0, $this->countGameRows('ibl_box_scores_engine_shadow', '2090-01-10', 3, 1, 1));
+        self::assertSame(0, $this->countGameRows('ibl_box_scores_engine_shadow_teams', '2090-01-10', 3, 1, 1));
+
+        // Negative/boundary: the other game's row is untouched.
+        self::assertSame(1, $this->countGameRows('ibl_box_scores_engine_shadow', '2090-01-10', 6, 5, 2));
+    }
+
+    private function countGameRows(string $table, string $date, int $visitorTid, int $homeTid, int $gameOfThatDay): int
+    {
+        $allowed = ['ibl_box_scores_engine_shadow', 'ibl_box_scores_engine_shadow_teams'];
+        self::assertContains($table, $allowed, 'unexpected shadow table name');
+        $stmt = $this->db->prepare(
+            "SELECT COUNT(*) AS cnt FROM `$table`
+             WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND game_of_that_day = ?"
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('siii', $date, $visitorTid, $homeTid, $gameOfThatDay);
+        $stmt->execute();
+        /** @var array{cnt: int} $row */
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        return (int) $row['cnt'];
+    }
 }

--- a/ibl5/tests/EngineBundle/EngineBundleServiceTest.php
+++ b/ibl5/tests/EngineBundle/EngineBundleServiceTest.php
@@ -74,7 +74,7 @@ class EngineBundleServiceTest extends TestCase
         $repo = $this->createMock(EngineBundleRepositoryInterface::class);
         $repo->expects($this->once())
             ->method('getUnplayedGames')
-            ->with(2026, null, null, 4)
+            ->with(2026, null, null, 4, null)
             ->willReturn([$this->aGame(4)]);
         $repo->method('getPlayers')->willReturn([$this->aPlayer()]);
         $repo->method('getTeams')->willReturn([]);
@@ -83,6 +83,39 @@ class EngineBundleServiceTest extends TestCase
         /** @var list<array<string, mixed>> $schedule */
         $schedule = $decoded['schedule'];
         self::assertSame(4, $schedule[0]['game_type']);
+    }
+
+    // ── maxGames cap passthrough ─────────────────────────────────────
+
+    public function testForwardsMaxGamesToRepository(): void
+    {
+        // The cap is the 5th positional arg of getUnplayedGames; the service
+        // threads buildBundleJson's $maxGames straight through.
+        $repo = $this->createMock(EngineBundleRepositoryInterface::class);
+        $repo->expects($this->once())
+            ->method('getUnplayedGames')
+            ->with(2026, null, null, 2, 7)
+            ->willReturn([$this->aGame()]);
+        $repo->method('getPlayers')->willReturn([$this->aPlayer()]);
+        $repo->method('getTeams')->willReturn([]);
+
+        $service = new EngineBundleService($repo, new BundleSerializer());
+        $service->buildBundleJson(2026, null, null, 2, null, 1, 7);
+    }
+
+    public function testOmittingMaxGamesForwardsNull(): void
+    {
+        // Negative/default: no cap passed ⇒ null reaches the repo (unlimited).
+        $repo = $this->createMock(EngineBundleRepositoryInterface::class);
+        $repo->expects($this->once())
+            ->method('getUnplayedGames')
+            ->with(2026, null, null, 2, null)
+            ->willReturn([$this->aGame()]);
+        $repo->method('getPlayers')->willReturn([$this->aPlayer()]);
+        $repo->method('getTeams')->willReturn([]);
+
+        $service = new EngineBundleService($repo, new BundleSerializer());
+        $service->buildBundleJson(2026);
     }
 
     public function testDefaultGameTypeIsRegularSeason(): void

--- a/ibl5/tests/Updater/Steps/EngineShadowStepTest.php
+++ b/ibl5/tests/Updater/Steps/EngineShadowStepTest.php
@@ -110,6 +110,16 @@ final class EngineShadowStepTest extends TestCase
                 return $fn();
             }
 
+            // Dedupe delete is a no-op here so execute() counts only inserts.
+            public function deleteShadowGame(
+                string $gameDate,
+                int $visitorTeamId,
+                int $homeTeamId,
+                int $gameOfThatDay,
+            ): int {
+                return 0;
+            }
+
             protected function execute(string $query, string $types = '', mixed ...$params): int
             {
                 if (str_contains($query, 'engine_shadow_teams')) {
@@ -156,6 +166,44 @@ final class EngineShadowStepTest extends TestCase
         self::assertStringContainsString('1 games', $result->detail);
         self::assertStringContainsString('2 player rows', $result->detail);
         self::assertStringContainsString('2 team rows', $result->detail);
+    }
+
+    #[Test]
+    public function passesGameCapThroughServiceToRepository(): void
+    {
+        // EngineBundleService is final (cannot be mocked), so assert the cap on
+        // the seam below it: a createMock repo proves step → service → repo
+        // threads SHADOW_MAX_GAMES_PER_RUN as getUnplayedGames' 5th arg.
+        $repo = $this->createMock(EngineBundleRepositoryInterface::class);
+        $repo->expects($this->once())
+            ->method('getUnplayedGames')
+            ->with(
+                self::SEASON_YEAR,
+                null,
+                null,
+                EngineBundleService::DEFAULT_GAME_TYPE,
+                EngineShadowStep::SHADOW_MAX_GAMES_PER_RUN,
+            )
+            ->willReturn([new Game(1, 3, '2026-03-10', 2)]);
+        $repo->method('getPlayers')->willReturn([new Player(['pid' => 1])]);
+        $repo->method('getTeams')->willReturn([new Team(1, 'Team One')]);
+
+        // Empty-games result ⇒ the loader (unconnected mysqli) is a clean no-op:
+        // collectPids([]) → getTeamIdsForPids([]) short-circuits before any DB.
+        $runner = self::createStub(EngineRunnerInterface::class);
+        $runner->method('run')->willReturn('{"seed":1,"games":[]}');
+
+        $step = new EngineShadowStep(
+            new EngineBundleService($repo, new BundleSerializer()),
+            $runner,
+            $this->loaderWithoutDb(),
+            self::SEASON_YEAR,
+            enabled: true,
+        );
+
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
     }
 
     #[Test]


### PR DESCRIPTION
## Problem

When `ENGINE_SHADOW_ENABLED` is on, `EngineShadowStep` sims **all** unplayed games for the season in one run. On a full season the engine Result JSON is ~360MB; `EngineRunner::run()` slurps it whole into a 128MB PHP process → fatal OOM. That OOM is an `E_ERROR`, **not** catchable by the step's `catch(\Throwable)`, so it bypasses the step's isolation and **halts `updateAllTheThings.php` mid-pipeline**: canonical box scores are committed (safe), but All-Star, playoff/season-record refresh, and JSB parse never run.

## Fix (PHP-only; no Go-engine changes)

1. **Game-count cap** — `getUnplayedGames` gains a trailing `?int $limit = null` (bound `LIMIT ?`, never interpolated); `buildBundleJson` gains `?int $maxGames = null` passthrough; `EngineShadowStep` caps each run at `SHADOW_MAX_GAMES_PER_RUN = 20` (~9MB result, proven safe under 128MB with margin).
2. **Per-game dedupe** — `EngineShadowRepository::deleteShadowGame()` clears prior rows from **both** shadow tables at the top of each per-game `transaction()`, so re-runs **replace** rather than append (atomic delete+insert).
3. **Reorder** — the shadow step is now the **last** IBL-only step, so even a catastrophic uncatchable fatal skips nothing downstream. Shadow only reads inputs and writes droppable shadow tables; nothing downstream depends on it.

All trailing params default to `null`/unlimited — behavior-preserving for every existing caller (`scripts/build-engine-bundle.php` stays unlimited).

## Testing

- Full `composer test:all` green: 6608 tests, 35299 assertions (0 failures/errors).
- New/changed DB-integration + unit tests: 20 green (LIMIT cap, earliest-N ordering, dedupe replace-not-append, unrelated-game-untouched, cap threading).
- PHPStan production: clean. `php -l` + grep confirm the shadow `addStep` is last before `$controller->run()`.

## Manual Testing

No manual testing needed — all changes are covered by unit and DB-integration tests. The defended failure (uncatchable `E_ERROR`) is verified positionally (the step is last) since a fatal cannot be runtime-tested.

Generated with [Claude Code](https://claude.ai/code)