### PR TITLE
feat(engine): archive→jsbvalidate regular-season band-calibration harness (PR9c)

### DIFF
--- a/engine/cmd/jsbcalibrate/main.go
+++ b/engine/cmd/jsbcalibrate/main.go
@@ -1,0 +1,103 @@
+// Command jsbcalibrate is the offline band-calibration harness CLI for the JSB
+// native engine (PR9c). It walks a directory tree of JSB 5.60 backup zips (each
+// zip carries a complete IBL5.plr/.sch/.sco triple — e.g. ibl5/backups), runs
+// the PR9b validation harness on each snapshot under the game type inferred from
+// its path, and either:
+//
+//	--mode calibrate : emits proposed per-game-type tolerance bands (JSON),
+//	                   derived from the percentile of engine-mean-vs-.sco
+//	                   residuals across all snapshots; or
+//	--mode gate      : applies the COMMITTED validate bands across the archive
+//	                   and emits per-game-type in-band pass rates (JSON),
+//	                   exiting nonzero if any bucket falls below --min-rate.
+//
+// Usage:
+//
+//	jsbcalibrate --archive <dir> [--mode calibrate|gate] [--runs N] [--seed S]
+//	             [--sample-stride N] [--include-olympics] [--coverage P]
+//	             [--min-rate R]
+//
+// This CLI is developer-/nightly-invoked only — it is NOT wired into CI; the
+// ~53 GB backup archive is large and not in the repo. Committing the emitted
+// calibrate-mode values into internal/validate/bands.go is a data-only follow-up.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/a-jay85/IBL5/engine/internal/calibrate"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// collectFunc is the seam to calibrate.CollectReports, injected so the CLI's
+// flag/mode/encoding paths are testable without walking a real archive.
+type collectFunc func(root string, opts calibrate.Options) ([]validate.Report, []calibrate.Skip, error)
+
+func run(args []string, stdout, stderr io.Writer) int {
+	return runWith(args, stdout, stderr, calibrate.CollectReports)
+}
+
+func runWith(args []string, stdout, stderr io.Writer, collect collectFunc) int {
+	fs := flag.NewFlagSet("jsbcalibrate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	archive := fs.String("archive", "", "root dir of JSB backup zips (required)")
+	mode := fs.String("mode", "calibrate", "calibrate | gate")
+	runs := fs.Int("runs", 50, "seeded engine runs per corpus game")
+	seed := fs.Uint64("seed", 0, "base seed; per-game seeds derive deterministically from it")
+	stride := fs.Int("sample-stride", 1, "process every Nth qualifying snapshot")
+	includeOlympics := fs.Bool("include-olympics", false, "include olympics/ snapshots (game-type 6)")
+	coverage := fs.Float64("coverage", 0.95, "calibrate: residual coverage percentile (0,1)")
+	minRate := fs.Float64("min-rate", 0.90, "gate: minimum per-stat in-band rate to pass")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *archive == "" {
+		_, _ = fmt.Fprintln(stderr, "jsbcalibrate: --archive <dir> is required")
+		return 2
+	}
+	if *mode != "calibrate" && *mode != "gate" {
+		_, _ = fmt.Fprintf(stderr, "jsbcalibrate: invalid --mode %q (valid: calibrate, gate)\n", *mode)
+		return 2
+	}
+
+	opts := calibrate.Options{
+		Runs:            *runs,
+		Seed:            *seed,
+		SampleStride:    *stride,
+		IncludeOlympics: *includeOlympics,
+		Progress:        stderr,
+	}
+	reports, skips, err := collect(*archive, opts)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "jsbcalibrate:", err)
+		return 1
+	}
+	for _, s := range skips {
+		_, _ = fmt.Fprintf(stderr, "skip %s: %s\n", s.Path, s.Reason)
+	}
+	if len(reports) == 0 {
+		_, _ = fmt.Fprintln(stderr, "jsbcalibrate: no snapshots produced reports")
+		return 1
+	}
+
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if *mode == "gate" {
+		res := calibrate.Gate(reports, *minRate)
+		_ = enc.Encode(res)
+		if !res.Pass {
+			return 1
+		}
+		return 0
+	}
+	_ = enc.Encode(calibrate.Calibrate(reports, *coverage))
+	return 0
+}

--- a/engine/cmd/jsbcalibrate/main.go
+++ b/engine/cmd/jsbcalibrate/main.go
@@ -37,19 +37,29 @@ func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
 
-// collectFunc is the seam to calibrate.CollectReports, injected so the CLI's
+// collectFunc is the seam to a calibrate collector, injected so the CLI's
 // flag/mode/encoding paths are testable without walking a real archive.
 type collectFunc func(root string, opts calibrate.Options) ([]validate.Report, []calibrate.Skip, error)
 
-func run(args []string, stdout, stderr io.Writer) int {
-	return runWith(args, stdout, stderr, calibrate.CollectReports)
+// collectors holds the two selection strategies the CLI can dispatch to.
+type collectors struct {
+	season collectFunc // set-difference per season (clean regular + playoff buckets)
+	flat   collectFunc // every zip independently, type by filename
 }
 
-func runWith(args []string, stdout, stderr io.Writer, collect collectFunc) int {
+func run(args []string, stdout, stderr io.Writer) int {
+	return runWith(args, stdout, stderr, collectors{
+		season: calibrate.CollectSeasonReports,
+		flat:   calibrate.CollectReports,
+	})
+}
+
+func runWith(args []string, stdout, stderr io.Writer, c collectors) int {
 	fs := flag.NewFlagSet("jsbcalibrate", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	archive := fs.String("archive", "", "root dir of JSB backup zips (required)")
 	mode := fs.String("mode", "calibrate", "calibrate | gate")
+	selection := fs.String("selection", "season", "snapshot selection: season (one regular snapshot/season, clean regular bucket) | flat (every zip, type by filename)")
 	runs := fs.Int("runs", 50, "seeded engine runs per corpus game")
 	seed := fs.Uint64("seed", 0, "base seed; per-game seeds derive deterministically from it")
 	stride := fs.Int("sample-stride", 1, "process every Nth qualifying snapshot")
@@ -65,6 +75,16 @@ func runWith(args []string, stdout, stderr io.Writer, collect collectFunc) int {
 	}
 	if *mode != "calibrate" && *mode != "gate" {
 		_, _ = fmt.Fprintf(stderr, "jsbcalibrate: invalid --mode %q (valid: calibrate, gate)\n", *mode)
+		return 2
+	}
+	var collect collectFunc
+	switch *selection {
+	case "season":
+		collect = c.season
+	case "flat":
+		collect = c.flat
+	default:
+		_, _ = fmt.Fprintf(stderr, "jsbcalibrate: invalid --selection %q (valid: season, flat)\n", *selection)
 		return 2
 	}
 

--- a/engine/cmd/jsbcalibrate/main_test.go
+++ b/engine/cmd/jsbcalibrate/main_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/calibrate"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// stubCollect returns canned reports/skips regardless of args, so the CLI's
+// flag/mode/encoding paths are exercised without walking a real archive.
+func stubCollect(reports []validate.Report, skips []calibrate.Skip) collectFunc {
+	return func(string, calibrate.Options) ([]validate.Report, []calibrate.Skip, error) {
+		return reports, skips, nil
+	}
+}
+
+func reportWith(gt bundle.GameType, rows ...validate.StatRow) validate.Report {
+	return validate.Report{GameType: gt, Games: []validate.GameReport{{Rows: rows}}}
+}
+
+// Row #13: calibrate mode emits a JSON CalibrationReport with per-game-type
+// proposed bands and exits 0.
+func TestRun_CalibrateEmitsJSON(t *testing.T) {
+	reports := []validate.Report{reportWith(bundle.GameTypeRegular,
+		validate.StatRow{Stat: "points", ScoVal: 110, EngineMean: 100, Pass: true},
+	)}
+	var out, errBuf bytes.Buffer
+	code := runWith([]string{"--archive", "/x", "--mode", "calibrate"}, &out, &errBuf, stubCollect(reports, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, errBuf.String())
+	}
+	var rep calibrate.CalibrationReport
+	if err := json.Unmarshal(out.Bytes(), &rep); err != nil {
+		t.Fatalf("stdout is not a CalibrationReport JSON: %v\n%s", err, out.String())
+	}
+	if len(rep.Buckets) != 1 || rep.Buckets[0].GameType != int(bundle.GameTypeRegular) {
+		t.Errorf("buckets = %+v, want one regular bucket", rep.Buckets)
+	}
+}
+
+// Row #14 (negative): gate mode exits nonzero when a stat's in-band rate is
+// below --min-rate, and the JSON reports pass=false.
+func TestRun_GateFailsBelowMinRate(t *testing.T) {
+	var rows []validate.StatRow
+	for i := 0; i < 10; i++ {
+		rows = append(rows, validate.StatRow{Stat: "points", Pass: i < 5}) // rate 0.5
+	}
+	reports := []validate.Report{reportWith(bundle.GameTypeRegular, rows...)}
+
+	var out, errBuf bytes.Buffer
+	code := runWith([]string{"--archive", "/x", "--mode", "gate", "--min-rate", "0.9"}, &out, &errBuf, stubCollect(reports, nil))
+	if code == 0 {
+		t.Fatalf("exit = 0, want nonzero (rate 0.5 < 0.9)")
+	}
+	var res calibrate.GateResult
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("stdout is not a GateResult JSON: %v", err)
+	}
+	if res.Pass {
+		t.Error("GateResult.Pass = true, want false")
+	}
+}
+
+// Gate mode exits 0 when every bucket meets the threshold.
+func TestRun_GatePasses(t *testing.T) {
+	reports := []validate.Report{reportWith(bundle.GameTypeRegular,
+		validate.StatRow{Stat: "points", Pass: true},
+	)}
+	var out, errBuf bytes.Buffer
+	code := runWith([]string{"--archive", "/x", "--mode", "gate"}, &out, &errBuf, stubCollect(reports, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, errBuf.String())
+	}
+}
+
+// Row #15 (negative): a missing --archive is a usage error (exit 2).
+func TestRun_MissingArchive(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runWith(nil, &out, &errBuf, stubCollect(nil, nil)); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "--archive") {
+		t.Errorf("expected a --archive usage message, got: %q", errBuf.String())
+	}
+}
+
+// Negative: an invalid --mode is a usage error (exit 2).
+func TestRun_InvalidMode(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runWith([]string{"--archive", "/x", "--mode", "bogus"}, &out, &errBuf, stubCollect(nil, nil))
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "invalid --mode") {
+		t.Errorf("expected an invalid --mode message, got: %q", errBuf.String())
+	}
+}
+
+// Negative: an archive that yields no reports exits 1 with a diagnostic.
+func TestRun_NoReports(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runWith([]string{"--archive", "/x"}, &out, &errBuf, stubCollect(nil, nil))
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "no snapshots") {
+		t.Errorf("expected a 'no snapshots' message, got: %q", errBuf.String())
+	}
+}

--- a/engine/cmd/jsbcalibrate/main_test.go
+++ b/engine/cmd/jsbcalibrate/main_test.go
@@ -11,12 +11,14 @@ import (
 	"github.com/a-jay85/IBL5/engine/internal/validate"
 )
 
-// stubCollect returns canned reports/skips regardless of args, so the CLI's
-// flag/mode/encoding paths are exercised without walking a real archive.
-func stubCollect(reports []validate.Report, skips []calibrate.Skip) collectFunc {
-	return func(string, calibrate.Options) ([]validate.Report, []calibrate.Skip, error) {
+// stubCollectors returns canned reports/skips from both selection strategies,
+// so the CLI's flag/mode/encoding paths are exercised without walking a real
+// archive.
+func stubCollectors(reports []validate.Report, skips []calibrate.Skip) collectors {
+	fn := func(string, calibrate.Options) ([]validate.Report, []calibrate.Skip, error) {
 		return reports, skips, nil
 	}
+	return collectors{season: fn, flat: fn}
 }
 
 func reportWith(gt bundle.GameType, rows ...validate.StatRow) validate.Report {
@@ -30,7 +32,7 @@ func TestRun_CalibrateEmitsJSON(t *testing.T) {
 		validate.StatRow{Stat: "points", ScoVal: 110, EngineMean: 100, Pass: true},
 	)}
 	var out, errBuf bytes.Buffer
-	code := runWith([]string{"--archive", "/x", "--mode", "calibrate"}, &out, &errBuf, stubCollect(reports, nil))
+	code := runWith([]string{"--archive", "/x", "--mode", "calibrate"}, &out, &errBuf, stubCollectors(reports, nil))
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, errBuf.String())
 	}
@@ -53,7 +55,7 @@ func TestRun_GateFailsBelowMinRate(t *testing.T) {
 	reports := []validate.Report{reportWith(bundle.GameTypeRegular, rows...)}
 
 	var out, errBuf bytes.Buffer
-	code := runWith([]string{"--archive", "/x", "--mode", "gate", "--min-rate", "0.9"}, &out, &errBuf, stubCollect(reports, nil))
+	code := runWith([]string{"--archive", "/x", "--mode", "gate", "--min-rate", "0.9"}, &out, &errBuf, stubCollectors(reports, nil))
 	if code == 0 {
 		t.Fatalf("exit = 0, want nonzero (rate 0.5 < 0.9)")
 	}
@@ -72,7 +74,7 @@ func TestRun_GatePasses(t *testing.T) {
 		validate.StatRow{Stat: "points", Pass: true},
 	)}
 	var out, errBuf bytes.Buffer
-	code := runWith([]string{"--archive", "/x", "--mode", "gate"}, &out, &errBuf, stubCollect(reports, nil))
+	code := runWith([]string{"--archive", "/x", "--mode", "gate"}, &out, &errBuf, stubCollectors(reports, nil))
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, errBuf.String())
 	}
@@ -81,7 +83,7 @@ func TestRun_GatePasses(t *testing.T) {
 // Row #15 (negative): a missing --archive is a usage error (exit 2).
 func TestRun_MissingArchive(t *testing.T) {
 	var out, errBuf bytes.Buffer
-	if code := runWith(nil, &out, &errBuf, stubCollect(nil, nil)); code != 2 {
+	if code := runWith(nil, &out, &errBuf, stubCollectors(nil, nil)); code != 2 {
 		t.Fatalf("exit = %d, want 2", code)
 	}
 	if !strings.Contains(errBuf.String(), "--archive") {
@@ -92,7 +94,7 @@ func TestRun_MissingArchive(t *testing.T) {
 // Negative: an invalid --mode is a usage error (exit 2).
 func TestRun_InvalidMode(t *testing.T) {
 	var out, errBuf bytes.Buffer
-	code := runWith([]string{"--archive", "/x", "--mode", "bogus"}, &out, &errBuf, stubCollect(nil, nil))
+	code := runWith([]string{"--archive", "/x", "--mode", "bogus"}, &out, &errBuf, stubCollectors(nil, nil))
 	if code != 2 {
 		t.Fatalf("exit = %d, want 2", code)
 	}
@@ -101,10 +103,22 @@ func TestRun_InvalidMode(t *testing.T) {
 	}
 }
 
+// Negative: an invalid --selection is a usage error (exit 2).
+func TestRun_InvalidSelection(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runWith([]string{"--archive", "/x", "--selection", "bogus"}, &out, &errBuf, stubCollectors(nil, nil))
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "invalid --selection") {
+		t.Errorf("expected an invalid --selection message, got: %q", errBuf.String())
+	}
+}
+
 // Negative: an archive that yields no reports exits 1 with a diagnostic.
 func TestRun_NoReports(t *testing.T) {
 	var out, errBuf bytes.Buffer
-	code := runWith([]string{"--archive", "/x"}, &out, &errBuf, stubCollect(nil, nil))
+	code := runWith([]string{"--archive", "/x"}, &out, &errBuf, stubCollectors(nil, nil))
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}

--- a/engine/internal/calibrate/aggregate.go
+++ b/engine/internal/calibrate/aggregate.go
@@ -1,0 +1,274 @@
+package calibrate
+
+import (
+	"math"
+	"sort"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// observation is one (game type, stat) data point: a single .sco ground-truth
+// value and the engine mean the harness observed for the same matchup.
+type observation struct {
+	gameType bundle.GameType
+	stat     string
+	scoVal   float64
+	mean     float64
+}
+
+// collectObservations flattens every StatRow across all reports/games into the
+// per-(game type, stat) observations the calibration consumes. Each report is
+// stamped with its game type by the validation harness.
+func collectObservations(reports []validate.Report) []observation {
+	var obs []observation
+	for _, rep := range reports {
+		for _, g := range rep.Games {
+			for _, r := range g.Rows {
+				obs = append(obs, observation{
+					gameType: rep.GameType,
+					stat:     r.Stat,
+					scoVal:   r.ScoVal,
+					mean:     r.EngineMean,
+				})
+			}
+		}
+	}
+	return obs
+}
+
+// --- calibrate mode ---------------------------------------------------------
+
+// StatCalibration is the proposed band plus the residual distribution it was
+// derived from, for one (game type, stat). InBandRate is the fraction of this
+// bucket's observations the proposed band would accept — a human's sanity check
+// that the band is neither vacuous (rate ~1 with a huge floor) nor too tight.
+type StatCalibration struct {
+	Stat             string  `json:"stat"`
+	N                int     `json:"n"`
+	MeanEngine       float64 `json:"mean_engine"`
+	P50AbsResid      float64 `json:"p50_abs_resid"`
+	P90AbsResid      float64 `json:"p90_abs_resid"`
+	P95AbsResid      float64 `json:"p95_abs_resid"`
+	P99AbsResid      float64 `json:"p99_abs_resid"`
+	ProposedRelPct   float64 `json:"proposed_rel_pct"`
+	ProposedAbsFloor float64 `json:"proposed_abs_floor"`
+	InBandRate       float64 `json:"in_band_rate"`
+}
+
+// GameTypeCalibration is the proposed bands for one game type, stats in the
+// canonical validate.StatNames order.
+type GameTypeCalibration struct {
+	GameType int               `json:"game_type"`
+	Stats    []StatCalibration `json:"stats"`
+}
+
+// CalibrationReport is the full calibrate-mode output: proposed per-game-type
+// bands derived at the requested residual coverage. Buckets are sorted by game
+// type for determinism.
+type CalibrationReport struct {
+	Coverage float64               `json:"coverage"`
+	Buckets  []GameTypeCalibration `json:"buckets"`
+}
+
+// Calibrate derives, per (game type, stat), a tolerance band whose absolute
+// floor and relative percent each cover `coverage` of the observed
+// engine-mean-vs-.sco residuals — calibrated ACROSS games (a single .sco line is
+// one noisy draw from jumpshot.exe, so per-game pass/fail would just measure
+// that draw's variance). The band keeps the harness's max(absFloor, relPct×mean)
+// shape, so its values slot straight into validate's per-game-type band tables.
+func Calibrate(reports []validate.Report, coverage float64) CalibrationReport {
+	byType := groupObservations(collectObservations(reports))
+	rep := CalibrationReport{Coverage: coverage}
+	for _, gt := range sortedGameTypes(byType) {
+		gc := GameTypeCalibration{GameType: int(gt)}
+		for _, stat := range validate.StatNames() {
+			obs := byType[gt][stat]
+			if len(obs) == 0 {
+				continue
+			}
+			gc.Stats = append(gc.Stats, calibrateStat(stat, obs, coverage))
+		}
+		rep.Buckets = append(rep.Buckets, gc)
+	}
+	return rep
+}
+
+func calibrateStat(stat string, obs []observation, coverage float64) StatCalibration {
+	n := len(obs)
+	absResid := make([]float64, n)
+	var relResid []float64
+	var sumMean float64
+	for i, o := range obs {
+		d := math.Abs(o.scoVal - o.mean)
+		absResid[i] = d
+		sumMean += o.mean
+		if o.mean >= 1 { // skip near-zero means so the ratio doesn't explode
+			relResid = append(relResid, d/o.mean)
+		}
+	}
+	sort.Float64s(absResid)
+
+	absFloor := math.Ceil(percentile(absResid, coverage))
+	if absFloor < 1 {
+		absFloor = 1 // never a zero-width band
+	}
+	relPct := 0.15 // fallback when relative spread is unmeasurable (all means < 1)
+	if len(relResid) > 0 {
+		sort.Float64s(relResid)
+		relPct = percentile(relResid, coverage)
+	}
+
+	b := validate.Band{RelPct: relPct, AbsFloor: absFloor}
+	inBand := 0
+	for _, o := range obs {
+		if withinBand(b, o.scoVal, o.mean) {
+			inBand++
+		}
+	}
+	return StatCalibration{
+		Stat:             stat,
+		N:                n,
+		MeanEngine:       sumMean / float64(n),
+		P50AbsResid:      percentile(absResid, 0.50),
+		P90AbsResid:      percentile(absResid, 0.90),
+		P95AbsResid:      percentile(absResid, 0.95),
+		P99AbsResid:      percentile(absResid, 0.99),
+		ProposedRelPct:   relPct,
+		ProposedAbsFloor: absFloor,
+		InBandRate:       float64(inBand) / float64(n),
+	}
+}
+
+// --- gate mode --------------------------------------------------------------
+
+// StatGate is one (game type, stat) in-band rate under the COMMITTED validate
+// bands (StatRow.Pass already reflects them), with its pass/fail verdict.
+type StatGate struct {
+	Stat   string  `json:"stat"`
+	N      int     `json:"n"`
+	InBand int     `json:"in_band"`
+	Rate   float64 `json:"rate"`
+	Pass   bool    `json:"pass"`
+}
+
+// GameTypeGate is the gate verdict for one game type.
+type GameTypeGate struct {
+	GameType int        `json:"game_type"`
+	Stats    []StatGate `json:"stats"`
+}
+
+// GateResult is the full gate-mode output. Pass is true only when every
+// (game type, stat) bucket's in-band rate is at least MinRate.
+type GateResult struct {
+	MinRate float64        `json:"min_rate"`
+	Pass    bool           `json:"pass"`
+	Buckets []GameTypeGate `json:"buckets"`
+}
+
+// Gate applies the committed validate bands across the archive: it tallies, per
+// (game type, stat), how many observations the harness already marked in-band
+// (StatRow.Pass), and fails any bucket whose rate falls below minRate.
+func Gate(reports []validate.Report, minRate float64) GateResult {
+	type tally struct{ n, pass int }
+	byType := map[bundle.GameType]map[string]*tally{}
+	for _, rep := range reports {
+		for _, g := range rep.Games {
+			for _, r := range g.Rows {
+				if byType[rep.GameType] == nil {
+					byType[rep.GameType] = map[string]*tally{}
+				}
+				t := byType[rep.GameType][r.Stat]
+				if t == nil {
+					t = &tally{}
+					byType[rep.GameType][r.Stat] = t
+				}
+				t.n++
+				if r.Pass {
+					t.pass++
+				}
+			}
+		}
+	}
+
+	res := GateResult{MinRate: minRate, Pass: true}
+	gts := make([]bundle.GameType, 0, len(byType))
+	for gt := range byType {
+		gts = append(gts, gt)
+	}
+	sort.Slice(gts, func(i, j int) bool { return gts[i] < gts[j] })
+	for _, gt := range gts {
+		gg := GameTypeGate{GameType: int(gt)}
+		for _, stat := range validate.StatNames() {
+			t := byType[gt][stat]
+			if t == nil {
+				continue
+			}
+			rate := float64(t.pass) / float64(t.n)
+			pass := rate >= minRate
+			if !pass {
+				res.Pass = false
+			}
+			gg.Stats = append(gg.Stats, StatGate{
+				Stat: stat, N: t.n, InBand: t.pass, Rate: rate, Pass: pass,
+			})
+		}
+		res.Buckets = append(res.Buckets, gg)
+	}
+	return res
+}
+
+// --- shared helpers ---------------------------------------------------------
+
+func groupObservations(obs []observation) map[bundle.GameType]map[string][]observation {
+	byType := map[bundle.GameType]map[string][]observation{}
+	for _, o := range obs {
+		if byType[o.gameType] == nil {
+			byType[o.gameType] = map[string][]observation{}
+		}
+		byType[o.gameType][o.stat] = append(byType[o.gameType][o.stat], o)
+	}
+	return byType
+}
+
+func sortedGameTypes(byType map[bundle.GameType]map[string][]observation) []bundle.GameType {
+	gts := make([]bundle.GameType, 0, len(byType))
+	for gt := range byType {
+		gts = append(gts, gt)
+	}
+	sort.Slice(gts, func(i, j int) bool { return gts[i] < gts[j] })
+	return gts
+}
+
+// withinBand mirrors validate.compareStat's max(absFloor, relPct×|mean|) rule.
+func withinBand(b validate.Band, scoVal, mean float64) bool {
+	tol := b.AbsFloor
+	if rel := b.RelPct * math.Abs(mean); rel > tol {
+		tol = rel
+	}
+	return math.Abs(scoVal-mean) <= tol
+}
+
+// percentile returns the value at the given quantile of an ascending-sorted
+// slice using the nearest-rank method (deterministic, no interpolation). An
+// empty slice yields 0.
+func percentile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[n-1]
+	}
+	rank := int(math.Ceil(p * float64(n)))
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > n {
+		rank = n
+	}
+	return sorted[rank-1]
+}

--- a/engine/internal/calibrate/aggregate_test.go
+++ b/engine/internal/calibrate/aggregate_test.go
@@ -1,0 +1,144 @@
+package calibrate
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+func statRow(stat string, sco, mean float64, pass bool) validate.StatRow {
+	return validate.StatRow{Stat: stat, ScoVal: sco, EngineMean: mean, Pass: pass}
+}
+
+func reportWith(gt bundle.GameType, rows ...validate.StatRow) validate.Report {
+	return validate.Report{GameType: gt, Games: []validate.GameReport{{Rows: rows}}}
+}
+
+func findStatCal(t *testing.T, rep CalibrationReport, gt bundle.GameType, stat string) StatCalibration {
+	t.Helper()
+	for _, b := range rep.Buckets {
+		if b.GameType != int(gt) {
+			continue
+		}
+		for _, s := range b.Stats {
+			if s.Stat == stat {
+				return s
+			}
+		}
+	}
+	t.Fatalf("no calibration for game_type=%d stat=%q", int(gt), stat)
+	return StatCalibration{}
+}
+
+// Row #10: Calibrate derives AbsFloor=ceil(p95(|d|)) and RelPct=p95(|d|/mean)
+// per (game type, stat) and reports the resulting in-band rate. With residuals
+// 0..19 against mean 100, p95 (nearest-rank over 20) = 18 → floor 18, rel 0.18,
+// and 19/20 observations land in band.
+func TestCalibrate_DerivesBandsAndInBandRate(t *testing.T) {
+	var rows []validate.StatRow
+	for d := 0; d < 20; d++ {
+		rows = append(rows, statRow("points", 100+float64(d), 100, true))
+	}
+	rep := Calibrate([]validate.Report{reportWith(bundle.GameTypeRegular, rows...)}, 0.95)
+
+	sc := findStatCal(t, rep, bundle.GameTypeRegular, "points")
+	if sc.N != 20 {
+		t.Errorf("N = %d, want 20", sc.N)
+	}
+	if sc.ProposedAbsFloor != 18 {
+		t.Errorf("AbsFloor = %v, want 18", sc.ProposedAbsFloor)
+	}
+	if math.Abs(sc.ProposedRelPct-0.18) > 1e-9 {
+		t.Errorf("RelPct = %v, want ~0.18", sc.ProposedRelPct)
+	}
+	if math.Abs(sc.P95AbsResid-18) > 1e-9 {
+		t.Errorf("P95AbsResid = %v, want 18", sc.P95AbsResid)
+	}
+	if math.Abs(sc.InBandRate-0.95) > 1e-9 {
+		t.Errorf("InBandRate = %v, want 0.95", sc.InBandRate)
+	}
+}
+
+// Row #11 (boundary): a degenerate single-observation, zero-residual bucket
+// yields AbsFloor >= 1 — never a zero-width band that would reject any nonzero
+// difference.
+func TestCalibrate_DegenerateBucketNeverZeroWidth(t *testing.T) {
+	rep := Calibrate([]validate.Report{
+		reportWith(bundle.GameTypeRegular, statRow("reb", 10, 10, true)),
+	}, 0.95)
+	sc := findStatCal(t, rep, bundle.GameTypeRegular, "reb")
+	if sc.N != 1 {
+		t.Fatalf("N = %d, want 1", sc.N)
+	}
+	if sc.ProposedAbsFloor < 1 {
+		t.Errorf("AbsFloor = %v, want >= 1 (no zero-width band)", sc.ProposedAbsFloor)
+	}
+}
+
+// Row #12: Calibrate segments residuals by game type — a large playoff residual
+// must not widen the regular-season band, and vice versa.
+func TestCalibrate_SegmentsByGameType(t *testing.T) {
+	reg := reportWith(bundle.GameTypeRegular,
+		statRow("points", 50, 50, true), // residual 0
+		statRow("points", 50, 50, true),
+	)
+	playoff := reportWith(bundle.GameTypePlayoff,
+		statRow("points", 80, 50, false), // residual 30
+		statRow("points", 80, 50, false),
+	)
+	rep := Calibrate([]validate.Report{reg, playoff}, 0.95)
+
+	regCal := findStatCal(t, rep, bundle.GameTypeRegular, "points")
+	playCal := findStatCal(t, rep, bundle.GameTypePlayoff, "points")
+	if regCal.ProposedAbsFloor != 1 {
+		t.Errorf("regular AbsFloor = %v, want 1 (clamped; not polluted by playoff)", regCal.ProposedAbsFloor)
+	}
+	if playCal.ProposedAbsFloor != 30 {
+		t.Errorf("playoff AbsFloor = %v, want 30 (its own residual)", playCal.ProposedAbsFloor)
+	}
+}
+
+// Gate: a bucket below min-rate flips the overall verdict to fail; a bucket at
+// or above passes.
+func TestGate_FailsBelowMinRate(t *testing.T) {
+	var rows []validate.StatRow
+	for i := 0; i < 10; i++ {
+		rows = append(rows, statRow("points", 0, 0, i < 8)) // 8/10 pass -> rate 0.8
+		rows = append(rows, statRow("reb", 0, 0, true))     // 10/10 pass -> rate 1.0
+	}
+	res := Gate([]validate.Report{reportWith(bundle.GameTypeRegular, rows...)}, 0.90)
+	if res.Pass {
+		t.Fatal("gate should FAIL: points rate 0.8 < min-rate 0.9")
+	}
+	var sawPointsFail, sawRebPass bool
+	for _, b := range res.Buckets {
+		for _, s := range b.Stats {
+			switch s.Stat {
+			case "points":
+				if !s.Pass && math.Abs(s.Rate-0.8) < 1e-9 {
+					sawPointsFail = true
+				}
+			case "reb":
+				if s.Pass && math.Abs(s.Rate-1.0) < 1e-9 {
+					sawRebPass = true
+				}
+			}
+		}
+	}
+	if !sawPointsFail || !sawRebPass {
+		t.Errorf("expected points FAIL (rate 0.8) and reb PASS (rate 1.0); got buckets %+v", res.Buckets)
+	}
+}
+
+func TestGate_PassesAtOrAboveMinRate(t *testing.T) {
+	rows := []validate.StatRow{
+		statRow("points", 0, 0, true),
+		statRow("reb", 0, 0, true),
+	}
+	res := Gate([]validate.Report{reportWith(bundle.GameTypeRegular, rows...)}, 0.90)
+	if !res.Pass {
+		t.Errorf("gate should PASS when every stat is 100%% in band: %+v", res.Buckets)
+	}
+}

--- a/engine/internal/calibrate/gametype.go
+++ b/engine/internal/calibrate/gametype.go
@@ -1,0 +1,53 @@
+// Package calibrate is the offline band-calibration harness (PR9c). It walks a
+// directory tree of JSB 5.60 backup zips (each zip carries a complete
+// IBL5.plr/.sch/.sco triple), extracts each triple one zip at a time, runs the
+// PR9b validation harness (internal/validate) on it under the game type inferred
+// from the snapshot's path, and aggregates the engine-mean-vs-.sco residuals
+// SEGMENTED BY GAME TYPE to derive calibrated tolerance bands.
+//
+// Two modes (exposed by cmd/jsbcalibrate):
+//   - calibrate: emit proposed per-game-type bands (percentile of residuals).
+//   - gate:      apply the committed validate bands across the archive and
+//     report per-game-type in-band pass rates.
+//
+// The package logic is unit-tested with synthetic in-memory zips. The full run
+// over the real ~53 GB ibl5/backups archive is a developer-/nightly-invoked
+// smoke test (realarchive_test.go, build-tag `archive`) — it is NOT wired into
+// CI, since the corpus is large and not in the repo.
+package calibrate
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// inferGameType derives the JSB game type for a snapshot from its archive path,
+// since neither the .sch nor the .sco carries one. It returns (type, true) for a
+// snapshot to process, or (0, false) for one to skip — currently only an
+// Olympics snapshot while includeOlympics is off.
+//
+// The mapping is intentionally coarse and path-based:
+//   - any path under an "olympics" segment  -> all-star (6), opt-in only;
+//   - any path naming a playoff round/final -> playoff (4);
+//   - everything else (pre-heat, heat, reg-sim, …) -> regular (2).
+//
+// NOTE (assumption): Olympics is mapped to all-star type 6, but JSB's actual
+// Olympics game type is unconfirmed and Olympics is not an exhibition all-star,
+// so it stays opt-in and out of the default regular/playoff calibration to avoid
+// polluting it.
+func inferGameType(path string, includeOlympics bool) (bundle.GameType, bool) {
+	p := strings.ToLower(filepath.ToSlash(path))
+	switch {
+	case strings.Contains(p, "olympics"):
+		if !includeOlympics {
+			return 0, false
+		}
+		return bundle.GameTypeAllStarB, true
+	case strings.Contains(p, "playoff"), strings.Contains(p, "finals"):
+		return bundle.GameTypePlayoff, true
+	default:
+		return bundle.GameTypeRegular, true
+	}
+}

--- a/engine/internal/calibrate/gametype_test.go
+++ b/engine/internal/calibrate/gametype_test.go
@@ -1,0 +1,49 @@
+package calibrate
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// Row #4: inferGameType maps real archive path shapes to the right game type.
+func TestInferGameType_Mapping(t *testing.T) {
+	cases := []struct {
+		path string
+		want bundle.GameType
+	}{
+		{"/b/02-03/02-03_01_pre-heat.zip", bundle.GameTypeRegular},
+		{"/b/02-03/02-03_05_heat-rr3.zip", bundle.GameTypeRegular},
+		{"/b/02-03/02-03_08_reg-sim01.zip", bundle.GameTypeRegular},
+		{"/b/02-03/02-03_42_playoffs-rd1-gm1-3.zip", bundle.GameTypePlayoff},
+		{"/b/02-03/02-03_46_conf-finals-gm1-3.zip", bundle.GameTypePlayoff},
+		{"/b/02-03/02-03_47_finals.zip", bundle.GameTypePlayoff},
+	}
+	for _, c := range cases {
+		got, ok := inferGameType(c.path, false)
+		if !ok {
+			t.Errorf("inferGameType(%q) skipped, want process", c.path)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("inferGameType(%q) = %d, want %d", c.path, int(got), int(c.want))
+		}
+	}
+}
+
+// Row #5 (boundary): an unknown/ambiguous path defaults to regular, and an
+// Olympics path is skipped when olympics are off, processed as all-star when on.
+func TestInferGameType_DefaultsAndOlympics(t *testing.T) {
+	if got, ok := inferGameType("/b/weird/random-snapshot.zip", false); !ok || got != bundle.GameTypeRegular {
+		t.Errorf("ambiguous path = (%d, %v), want (regular, true)", int(got), ok)
+	}
+
+	if _, ok := inferGameType("/b/olympics/2003/oly_03.zip", false); ok {
+		t.Error("olympics path with includeOlympics=false must be skipped")
+	}
+
+	got, ok := inferGameType("/b/olympics/2003/oly_03.zip", true)
+	if !ok || got != bundle.GameTypeAllStarB {
+		t.Errorf("olympics path with includeOlympics=true = (%d, %v), want (all-star-B, true)", int(got), ok)
+	}
+}

--- a/engine/internal/calibrate/realarchive_test.go
+++ b/engine/internal/calibrate/realarchive_test.go
@@ -30,13 +30,13 @@ func TestRealArchive_CalibrateEndToEnd(t *testing.T) {
 	runs := envInt("JSB_ARCHIVE_RUNS", 20)
 	stride := envInt("JSB_ARCHIVE_STRIDE", 50)
 
-	reports, skips, err := CollectReports(dir, Options{
+	reports, skips, err := CollectSeasonReports(dir, Options{
 		Runs:         runs,
 		SampleStride: stride,
 		Progress:     os.Stderr,
 	})
 	if err != nil {
-		t.Fatalf("CollectReports over real archive: %v", err)
+		t.Fatalf("CollectSeasonReports over real archive: %v", err)
 	}
 	t.Logf("reports=%d skips=%d (runs=%d stride=%d)", len(reports), len(skips), runs, stride)
 	if len(reports) == 0 {

--- a/engine/internal/calibrate/realarchive_test.go
+++ b/engine/internal/calibrate/realarchive_test.go
@@ -1,0 +1,65 @@
+//go:build archive
+
+// This suite runs the calibration harness over the REAL ~53 GB JSB backup
+// archive. It is build-tag gated behind `archive` so it is NEVER compiled by
+// `go test ./...` or engine.yml — the corpus is large and not in the repo.
+//
+// Invoke manually (stride-thin to keep it tractable):
+//
+//	cd engine && JSB_ARCHIVE_DIR=/Users/ajaynicolas/GitHub/IBL5/ibl5/backups \
+//	  go test -tags archive ./internal/calibrate -run RealArchive -v
+//
+// Override JSB_ARCHIVE_RUNS / JSB_ARCHIVE_STRIDE to trade runtime for fidelity.
+package calibrate
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+func TestRealArchive_CalibrateEndToEnd(t *testing.T) {
+	dir := os.Getenv("JSB_ARCHIVE_DIR")
+	if dir == "" {
+		dir = "/Users/ajaynicolas/GitHub/IBL5/ibl5/backups"
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("archive dir %q not available: %v", dir, err)
+	}
+
+	runs := envInt("JSB_ARCHIVE_RUNS", 20)
+	stride := envInt("JSB_ARCHIVE_STRIDE", 50)
+
+	reports, skips, err := CollectReports(dir, Options{
+		Runs:         runs,
+		SampleStride: stride,
+		Progress:     os.Stderr,
+	})
+	if err != nil {
+		t.Fatalf("CollectReports over real archive: %v", err)
+	}
+	t.Logf("reports=%d skips=%d (runs=%d stride=%d)", len(reports), len(skips), runs, stride)
+	if len(reports) == 0 {
+		t.Fatal("expected at least one report from the real archive")
+	}
+
+	cal := Calibrate(reports, 0.95)
+	if len(cal.Buckets) == 0 {
+		t.Fatal("calibration produced no buckets")
+	}
+	for _, b := range cal.Buckets {
+		t.Logf("game_type=%d stats=%d", b.GameType, len(b.Stats))
+		if len(b.Stats) == 0 {
+			t.Errorf("game_type=%d produced no stat calibrations", b.GameType)
+		}
+	}
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}

--- a/engine/internal/calibrate/season.go
+++ b/engine/internal/calibrate/season.go
@@ -1,0 +1,158 @@
+package calibrate
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// A snapshot's .sco is CUMULATIVE — a late snapshot holds every game of the
+// season to date (verified on the real archive: reg-sim01=49 games,
+// reg-sim13=549, last reg-sim=1148, the full regular season). Two facts shape
+// the season-grouped collector:
+//
+//  1. Processing every snapshot would double-count early games (re-counted in
+//     each later cumulative snapshot). So per season we take ONE snapshot.
+//
+//  2. Only REGULAR-season games can be validated today. The harness pairs each
+//     .sco game to a .sch schedule entry to build the matchup; playoff (and
+//     all-star) games are NOT in the .sch — playoff brackets are scheduled
+//     dynamically, so those .sco games are unmatched and dropped. Validating
+//     them would require synthesizing the matchup from the .sco's own team IDs,
+//     a PR9b harness-contract change tracked separately. Until then this
+//     collector emits the clean REGULAR bucket only: the season's last
+//     regular-type snapshot (complete regular season, zero unmatched games).
+
+// season is one season's selected regular snapshot. olympics seasons are
+// recorded so they can be reported as skipped (out of scope, same unmatched
+// constraint as playoffs).
+type season struct {
+	name       string
+	olympics   bool
+	regularZip string // last regular-type snapshot; "" if the season has none
+}
+
+// seasonName is the path segment immediately under root (e.g. "02-03", or
+// "olympics" for the Olympics subtree). A zip directly under root is its own
+// single-snapshot season.
+func seasonName(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.Dir(path)
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	return parts[0]
+}
+
+func isOlympicsPath(path string) bool {
+	return strings.Contains(strings.ToLower(filepath.ToSlash(path)), "olympics")
+}
+
+// groupSeasons buckets zip paths into seasons, selecting each season's last
+// regular-type snapshot by lexical (sim-step) order — valid because the
+// archive's NN index is zero-padded, so the names sort by sim step. Olympics
+// snapshots are flagged (and skipped: not yet supported, see the note above).
+func groupSeasons(zipPaths []string, root string) ([]season, []Skip) {
+	type acc struct {
+		olympics   bool
+		regularZip string
+	}
+	m := map[string]*acc{}
+	var skips []Skip
+	for _, p := range zipPaths {
+		name := seasonName(root, p)
+		a := m[name]
+		if a == nil {
+			a = &acc{}
+			m[name] = a
+		}
+		if isOlympicsPath(p) {
+			a.olympics = true
+			skips = append(skips, Skip{p, "olympics/playoff not yet supported (unscheduled games — see season.go)"})
+			continue
+		}
+		// Only regular-type snapshots seed the regular bucket; a playoff/finals
+		// snapshot is ignored here (its playoff games are unmatched anyway).
+		if gt, _ := inferGameType(p, false); gt == bundle.GameTypeRegular && p > a.regularZip {
+			a.regularZip = p
+		}
+	}
+
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	seasons := make([]season, 0, len(names))
+	for _, n := range names {
+		a := m[n]
+		seasons = append(seasons, season{name: n, olympics: a.olympics, regularZip: a.regularZip})
+	}
+	return seasons, skips
+}
+
+// CollectSeasonReports is the calibration-correct collector: it groups the
+// archive into seasons and validates ONE snapshot per season — the last
+// regular-type snapshot, the complete regular season — as the clean regular
+// bucket. --sample-stride thins by season. Playoff/all-star are out of scope
+// until the harness can validate unscheduled games.
+func CollectSeasonReports(root string, opts Options) ([]validate.Report, []Skip, error) {
+	zips, zskips, err := listArchiveZips(root)
+	if err != nil {
+		return nil, nil, err
+	}
+	seasons, gskips := groupSeasons(zips, root)
+	reports, pskips := collectSeasonReports(seasons, opts, resolveValidate(opts))
+	skips := append(append(zskips, gskips...), pskips...)
+	return reports, skips, nil
+}
+
+// collectSeasonReports is the injected-dependency core of CollectSeasonReports.
+func collectSeasonReports(seasons []season, opts Options, validateFn ValidateFunc) ([]validate.Report, []Skip) {
+	progress := opts.Progress
+	if progress == nil {
+		progress = io.Discard
+	}
+	stride := opts.SampleStride
+	if stride < 1 {
+		stride = 1
+	}
+
+	var reports []validate.Report
+	var skips []Skip
+	selected := 0
+	for _, s := range seasons {
+		if s.olympics || s.regularZip == "" {
+			if !s.olympics {
+				skips = append(skips, Skip{s.name, "season has no regular-type snapshot"})
+			}
+			continue
+		}
+		idx := selected
+		selected++
+		if idx%stride != 0 {
+			continue
+		}
+		rep, skip := processZip(s.regularZip, bundle.GameTypeRegular, opts.Runs, opts.Seed, validateFn)
+		if skip != nil {
+			skips = append(skips, *skip)
+			continue
+		}
+		_, _ = fmt.Fprintf(progress, "regular %s games=%d\n", s.regularZip, len(rep.Games))
+		reports = append(reports, *rep)
+	}
+	return reports, skips
+}
+
+// resolveValidate returns opts.Validate or the real ValidateCorpus default.
+func resolveValidate(opts Options) ValidateFunc {
+	if opts.Validate != nil {
+		return opts.Validate
+	}
+	return validate.ValidateCorpus
+}

--- a/engine/internal/calibrate/season_test.go
+++ b/engine/internal/calibrate/season_test.go
@@ -1,0 +1,100 @@
+package calibrate
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// Row: groupSeasons picks each season's last regular-type snapshot by lexical
+// (sim-step) order, and flags+skips Olympics (out of scope).
+func TestGroupSeasons_SelectsLastRegular(t *testing.T) {
+	root := "/b"
+	zips := []string{
+		"/b/02-03/02-03_08_reg-sim01.zip",
+		"/b/02-03/02-03_41_reg-sim35.zip",
+		"/b/02-03/02-03_47_finals.zip", // playoff snapshot — ignored for the regular bucket
+		"/b/88-89/88-89_30_reg-sim20.zip",
+	}
+	seasons, skips := groupSeasons(zips, root)
+	if len(skips) != 0 {
+		t.Fatalf("unexpected skips: %v", skips)
+	}
+	if len(seasons) != 2 {
+		t.Fatalf("seasons = %d, want 2", len(seasons))
+	}
+	// Sorted by name: 02-03 then 88-89. The last regular snapshot wins; the
+	// finals (playoff) snapshot is not selected.
+	if s := seasons[0]; s.name != "02-03" || s.regularZip != "/b/02-03/02-03_41_reg-sim35.zip" {
+		t.Errorf("02-03 regular selection wrong: %+v", s)
+	}
+	if s := seasons[1]; s.regularZip != "/b/88-89/88-89_30_reg-sim20.zip" {
+		t.Errorf("88-89 regular selection wrong: %+v", s)
+	}
+}
+
+// Row (negative): Olympics snapshots are flagged and recorded as Skips (not yet
+// supported — unscheduled games), never selected as a regular snapshot.
+func TestGroupSeasons_OlympicsSkipped(t *testing.T) {
+	root := "/b"
+	zips := []string{"/b/olympics/2003/oly_a.zip", "/b/olympics/2003/oly_b.zip"}
+	seasons, skips := groupSeasons(zips, root)
+	if len(skips) != 2 {
+		t.Fatalf("olympics skips = %d, want 2", len(skips))
+	}
+	if len(seasons) != 1 || !seasons[0].olympics || seasons[0].regularZip != "" {
+		t.Fatalf("olympics season wrong: %+v", seasons)
+	}
+}
+
+// recordingValidate (defined in walk_test.go) records each validate call.
+
+// Row: collectSeasonReports validates one regular report per season (the last
+// regular snapshot) under GameTypeRegular.
+func TestCollectSeasonReports_RegularPerSeason(t *testing.T) {
+	root := t.TempDir()
+	makeZip(t, filepath.Join(root, "02-03", "02-03_41_reg-sim35.zip"), fullTriple())
+	makeZip(t, filepath.Join(root, "88-89", "88-89_30_reg-sim20.zip"), fullTriple())
+
+	rv := &recordingValidate{t: t}
+	reports, skips, err := CollectSeasonReports(root, Options{Runs: 1, Validate: rv.fn})
+	if err != nil {
+		t.Fatalf("CollectSeasonReports: %v", err)
+	}
+	if len(reports) != 2 || rv.calls != 2 {
+		t.Fatalf("reports=%d calls=%d, want 2 / 2 (skips=%v)", len(reports), rv.calls, skips)
+	}
+	for i, gt := range rv.gameType {
+		if gt != bundle.GameTypeRegular {
+			t.Errorf("call %d game type = %d, want regular", i, int(gt))
+		}
+	}
+}
+
+// Row (negative): a season with no regular-type snapshot is skipped.
+func TestCollectSeasonReports_NoRegularSnapshotSkips(t *testing.T) {
+	seasons := []season{{name: "x", regularZip: ""}}
+	rv := &recordingValidate{t: t}
+	reports, skips := collectSeasonReports(seasons, Options{Runs: 1}, rv.fn)
+	if len(reports) != 0 || rv.calls != 0 || len(skips) != 1 {
+		t.Fatalf("want zero reports/calls and one skip; reports=%d calls=%d skips=%v", len(reports), rv.calls, skips)
+	}
+}
+
+// Row (sample-stride): with stride 2 over four seasons, only the 1st and 3rd
+// are processed.
+func TestCollectSeasonReports_SampleStride(t *testing.T) {
+	root := t.TempDir()
+	for _, n := range []string{"a", "b", "c", "d"} {
+		makeZip(t, filepath.Join(root, n, n+"_reg-sim.zip"), fullTriple())
+	}
+	rv := &recordingValidate{t: t}
+	reports, _, err := CollectSeasonReports(root, Options{Runs: 1, SampleStride: 2, Validate: rv.fn})
+	if err != nil {
+		t.Fatalf("CollectSeasonReports: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("reports = %d, want 2 (every 2nd of 4)", len(reports))
+	}
+}

--- a/engine/internal/calibrate/walk.go
+++ b/engine/internal/calibrate/walk.go
@@ -1,0 +1,217 @@
+package calibrate
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// maxEntryBytes caps a single extracted entry, bounding decompression even for a
+// trusted archive. The real .sco is ~8 MB; this leaves ample headroom.
+const maxEntryBytes = 128 << 20
+
+// tripleMembers are the three backup files (matched case-insensitively by
+// basename) that make up a JSB snapshot the validation harness consumes.
+var tripleMembers = []string{"ibl5.plr", "ibl5.sch", "ibl5.sco"}
+
+// ValidateFunc is the seam to internal/validate.ValidateCorpus, injected so the
+// walk's extraction/inference/skip logic is unit-testable without running the
+// engine. A nil Options.Validate defaults to validate.ValidateCorpus.
+type ValidateFunc func(dir string, runs int, seed uint64, gt bundle.GameType) (validate.Report, error)
+
+// Options configures an archive walk.
+type Options struct {
+	Runs            int          // seeded engine runs per corpus game
+	Seed            uint64       // base seed
+	SampleStride    int          // process every Nth qualifying snapshot (<1 -> 1)
+	IncludeOlympics bool         // include olympics/ snapshots (game-type 6)
+	Validate        ValidateFunc // nil -> validate.ValidateCorpus
+	Progress        io.Writer    // nil -> io.Discard; one line per processed snapshot
+}
+
+// Skip records a snapshot (or archive entry) that was not turned into a Report,
+// so nothing is silently dropped: an unreadable archive, a missing triple
+// member, or an Olympics snapshot excluded by default all surface here.
+type Skip struct {
+	Path   string
+	Reason string
+}
+
+// CollectReports walks root for *.zip backups in deterministic (lexical) order,
+// extracts each snapshot's IBL5.{plr,sch,sco} triple one zip at a time into a
+// fresh temp dir (deleted each iteration — the 53 GB archive is never exploded),
+// infers the game type from the path, and runs the validation harness on it.
+// It returns every produced Report (each stamped with its game type) plus the
+// Skips for snapshots that could not be validated. A hard filesystem error
+// (e.g. an unreadable root) is returned as err; per-zip problems become Skips.
+func CollectReports(root string, opts Options) ([]validate.Report, []Skip, error) {
+	validateFn := opts.Validate
+	if validateFn == nil {
+		validateFn = validate.ValidateCorpus
+	}
+	progress := opts.Progress
+	if progress == nil {
+		progress = io.Discard
+	}
+	stride := opts.SampleStride
+	if stride < 1 {
+		stride = 1
+	}
+
+	var files []string
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	}); err != nil {
+		return nil, nil, fmt.Errorf("calibrate: walk %q: %w", root, err)
+	}
+
+	var (
+		reports    []validate.Report
+		skips      []Skip
+		qualifying int
+	)
+	for _, path := range files {
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".zip" {
+			if isUnsupportedArchive(ext) {
+				skips = append(skips, Skip{path, "unsupported archive format (cannot read " + ext + ")"})
+			}
+			continue
+		}
+		gt, ok := inferGameType(path, opts.IncludeOlympics)
+		if !ok {
+			skips = append(skips, Skip{path, "olympics snapshot excluded (use --include-olympics)"})
+			continue
+		}
+		// Stride thinning applies to qualifying snapshots only, so excluding
+		// Olympics never consumes a stride slot.
+		idx := qualifying
+		qualifying++
+		if idx%stride != 0 {
+			continue
+		}
+		rep, skip := processZip(path, gt, opts.Runs, opts.Seed, validateFn)
+		if skip != nil {
+			skips = append(skips, *skip)
+			continue
+		}
+		_, _ = fmt.Fprintf(progress, "processed %s game_type=%d games=%d\n", path, int(gt), len(rep.Games))
+		reports = append(reports, *rep)
+	}
+	return reports, skips, nil
+}
+
+// processZip extracts one zip's triple to a temp dir and validates it. It
+// returns either a Report or a Skip (never both). The temp dir is always
+// removed before returning.
+//
+// Pairing note: a snapshot's IBL5.plr is the POST-sim rating state for the games
+// in its IBL5.sco. This is exact for calibration, not approximate: IBL player
+// ratings are held constant across a whole season (the only in-season changes —
+// injury-driven rating drops in JSB — are manually reverted to the pre-injury
+// values), so the post-sim .plr equals the ratings every game in the .sco was
+// played under. Re-simulating those games from the same-zip .plr therefore uses
+// the correct pre-game ratings.
+func processZip(path string, gt bundle.GameType, runs int, seed uint64, validateFn ValidateFunc) (*validate.Report, *Skip) {
+	tmp, err := os.MkdirTemp("", "jsbcal-*")
+	if err != nil {
+		return nil, &Skip{path, "mkdir temp: " + err.Error()}
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	found, err := extractTriple(path, tmp)
+	if err != nil {
+		return nil, &Skip{path, "extract: " + err.Error()}
+	}
+	if !found {
+		return nil, &Skip{path, "missing one of IBL5.{plr,sch,sco}"}
+	}
+	rep, err := validateFn(tmp, runs, seed, gt)
+	if err != nil {
+		return nil, &Skip{path, "validate: " + err.Error()}
+	}
+	return &rep, nil
+}
+
+// extractTriple writes the three triple members from zipPath into destDir,
+// returning found=true only when all three are present. Entries are written by
+// BASENAME ONLY (filepath.Base), so a crafted entry name like "../../IBL5.plr"
+// cannot escape destDir (zip-slip safe) even though the archive is trusted.
+func extractTriple(zipPath, destDir string) (bool, error) {
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = zr.Close() }()
+
+	got := map[string]bool{}
+	for _, f := range zr.File {
+		base := filepath.Base(f.Name)
+		if !isTripleMember(base) {
+			continue
+		}
+		dest := filepath.Join(destDir, base)
+		if err := extractOne(f, dest); err != nil {
+			return false, err
+		}
+		got[strings.ToLower(base)] = true
+	}
+	for _, m := range tripleMembers {
+		if !got[m] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// extractOne streams one zip entry to dest, bounded by maxEntryBytes.
+func extractOne(f *zip.File, dest string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rc.Close() }()
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, io.LimitReader(rc, maxEntryBytes)); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func isTripleMember(base string) bool {
+	lb := strings.ToLower(base)
+	for _, m := range tripleMembers {
+		if lb == m {
+			return true
+		}
+	}
+	return false
+}
+
+// isUnsupportedArchive reports whether ext names an archive format the walk
+// cannot read (so it is recorded as a Skip rather than silently ignored like
+// ordinary junk files, e.g. .DS_Store).
+func isUnsupportedArchive(ext string) bool {
+	switch ext {
+	case ".rar", ".7z", ".tar", ".gz", ".tgz", ".bz2":
+		return true
+	}
+	return false
+}

--- a/engine/internal/calibrate/walk.go
+++ b/engine/internal/calibrate/walk.go
@@ -17,9 +17,15 @@ import (
 // trusted archive. The real .sco is ~8 MB; this leaves ample headroom.
 const maxEntryBytes = 128 << 20
 
-// tripleMembers are the three backup files (matched case-insensitively by
-// basename) that make up a JSB snapshot the validation harness consumes.
-var tripleMembers = []string{"ibl5.plr", "ibl5.sch", "ibl5.sco"}
+// canonicalMember maps a lowercased triple-member basename to the canonical
+// name it is extracted as. Writing canonical names (not the zip's own casing)
+// guarantees a stable stem for validate.findTriples and a known path for the
+// season reader's backup.ReadSco.
+var canonicalMember = map[string]string{
+	"ibl5.plr": "IBL5.plr",
+	"ibl5.sch": "IBL5.sch",
+	"ibl5.sco": "IBL5.sco",
+}
 
 // ValidateFunc is the seam to internal/validate.ValidateCorpus, injected so the
 // walk's extraction/inference/skip logic is unit-testable without running the
@@ -52,10 +58,7 @@ type Skip struct {
 // Skips for snapshots that could not be validated. A hard filesystem error
 // (e.g. an unreadable root) is returned as err; per-zip problems become Skips.
 func CollectReports(root string, opts Options) ([]validate.Report, []Skip, error) {
-	validateFn := opts.Validate
-	if validateFn == nil {
-		validateFn = validate.ValidateCorpus
-	}
+	validateFn := resolveValidate(opts)
 	progress := opts.Progress
 	if progress == nil {
 		progress = io.Discard
@@ -65,32 +68,16 @@ func CollectReports(root string, opts Options) ([]validate.Report, []Skip, error
 		stride = 1
 	}
 
-	var files []string
-	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() {
-			files = append(files, path)
-		}
-		return nil
-	}); err != nil {
-		return nil, nil, fmt.Errorf("calibrate: walk %q: %w", root, err)
+	zips, skips, err := listArchiveZips(root)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var (
 		reports    []validate.Report
-		skips      []Skip
 		qualifying int
 	)
-	for _, path := range files {
-		ext := strings.ToLower(filepath.Ext(path))
-		if ext != ".zip" {
-			if isUnsupportedArchive(ext) {
-				skips = append(skips, Skip{path, "unsupported archive format (cannot read " + ext + ")"})
-			}
-			continue
-		}
+	for _, path := range zips {
 		gt, ok := inferGameType(path, opts.IncludeOlympics)
 		if !ok {
 			skips = append(skips, Skip{path, "olympics snapshot excluded (use --include-olympics)"})
@@ -159,18 +146,19 @@ func extractTriple(zipPath, destDir string) (bool, error) {
 
 	got := map[string]bool{}
 	for _, f := range zr.File {
-		base := filepath.Base(f.Name)
-		if !isTripleMember(base) {
+		canon, ok := canonicalMember[strings.ToLower(filepath.Base(f.Name))]
+		if !ok {
 			continue
 		}
-		dest := filepath.Join(destDir, base)
-		if err := extractOne(f, dest); err != nil {
+		// Basename-only join (canon is a literal constant) keeps extraction
+		// inside destDir — zip-slip safe even for a crafted entry name.
+		if err := extractOne(f, filepath.Join(destDir, canon)); err != nil {
 			return false, err
 		}
-		got[strings.ToLower(base)] = true
+		got[canon] = true
 	}
-	for _, m := range tripleMembers {
-		if !got[m] {
+	for _, canon := range canonicalMember {
+		if !got[canon] {
 			return false, nil
 		}
 	}
@@ -195,14 +183,34 @@ func extractOne(f *zip.File, dest string) error {
 	return out.Close()
 }
 
-func isTripleMember(base string) bool {
-	lb := strings.ToLower(base)
-	for _, m := range tripleMembers {
-		if lb == m {
-			return true
+// listArchiveZips walks root and returns every *.zip path in deterministic
+// (lexical) order, plus a Skip for each non-zip archive it cannot read (so a
+// .rar is surfaced, not silently ignored like ordinary junk). A hard filesystem
+// error (e.g. an unreadable root) is returned as err.
+func listArchiveZips(root string) ([]string, []Skip, error) {
+	var files []string
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	}); err != nil {
+		return nil, nil, fmt.Errorf("calibrate: walk %q: %w", root, err)
+	}
+	var zips []string
+	var skips []Skip
+	for _, path := range files {
+		switch ext := strings.ToLower(filepath.Ext(path)); {
+		case ext == ".zip":
+			zips = append(zips, path)
+		case isUnsupportedArchive(ext):
+			skips = append(skips, Skip{path, "unsupported archive format (cannot read " + ext + ")"})
 		}
 	}
-	return false
+	return zips, skips, nil
 }
 
 // isUnsupportedArchive reports whether ext names an archive format the walk

--- a/engine/internal/calibrate/walk_test.go
+++ b/engine/internal/calibrate/walk_test.go
@@ -1,0 +1,212 @@
+package calibrate
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// makeZip writes a zip at path whose entries are name->contents. Entry names may
+// contain slashes (to exercise basename handling / zip-slip safety).
+func makeZip(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	for name, body := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// fullTriple is the three members plus a junk file that must NOT be extracted.
+func fullTriple() map[string]string {
+	return map[string]string{
+		"IBL5.plr": "plr-bytes",
+		"IBL5.sch": "sch-bytes",
+		"IBL5.sco": "sco-bytes",
+		"IBL5.trn": "junk-should-not-extract",
+	}
+}
+
+// recordingValidate is an injected ValidateFunc that captures, per call, the
+// game type and the sorted basenames present in the temp dir at call time
+// (the dir is deleted after processZip returns, so it must be inspected here).
+type recordingValidate struct {
+	t        *testing.T
+	calls    int
+	gameType []bundle.GameType
+	contents [][]string
+}
+
+func (r *recordingValidate) fn(dir string, runs int, seed uint64, gt bundle.GameType) (validate.Report, error) {
+	r.calls++
+	r.gameType = append(r.gameType, gt)
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		r.t.Fatalf("read temp dir: %v", err)
+	}
+	var names []string
+	for _, e := range ents {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	r.contents = append(r.contents, names)
+	return validate.Report{GameType: gt, Pass: true}, nil
+}
+
+// Row #6: CollectReports extracts ONLY IBL5.{plr,sch,sco} (not the .trn junk),
+// runs validate per zip with the inferred game type, and produces one report
+// per qualifying zip.
+func TestCollectReports_ExtractsTripleAndInfersType(t *testing.T) {
+	root := t.TempDir()
+	makeZip(t, filepath.Join(root, "02-03", "02-03_08_reg-sim01.zip"), fullTriple())
+	makeZip(t, filepath.Join(root, "02-03", "02-03_47_finals.zip"), fullTriple())
+
+	rv := &recordingValidate{t: t}
+	reports, skips, err := CollectReports(root, Options{Runs: 1, Validate: rv.fn})
+	if err != nil {
+		t.Fatalf("CollectReports: %v", err)
+	}
+	if len(reports) != 2 || rv.calls != 2 {
+		t.Fatalf("reports=%d calls=%d, want 2 / 2 (skips=%v)", len(reports), rv.calls, skips)
+	}
+	// Walk is lexical: reg-sim01 sorts before finals (… _08_ < _47_).
+	if rv.gameType[0] != bundle.GameTypeRegular || rv.gameType[1] != bundle.GameTypePlayoff {
+		t.Errorf("game types = %v, want [regular playoff]", rv.gameType)
+	}
+	for i, names := range rv.contents {
+		if want := []string{"IBL5.plr", "IBL5.sch", "IBL5.sco"}; !equalStrings(names, want) {
+			t.Errorf("call %d temp dir contents = %v, want exactly %v (junk must not extract)", i, names, want)
+		}
+	}
+}
+
+// Row #7 (negative): a non-zip archive (.rar) is recorded as a Skip and the walk
+// continues to the readable zip.
+func TestCollectReports_SkipsUnsupportedArchive(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "02-03_21_reg-sim14.rar"), []byte("rar"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	makeZip(t, filepath.Join(root, "02-03_22_reg-sim15.zip"), fullTriple())
+
+	rv := &recordingValidate{t: t}
+	reports, skips, err := CollectReports(root, Options{Runs: 1, Validate: rv.fn})
+	if err != nil {
+		t.Fatalf("CollectReports: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("reports = %d, want 1", len(reports))
+	}
+	if len(skips) != 1 || filepath.Ext(skips[0].Path) != ".rar" {
+		t.Fatalf("skips = %v, want one .rar skip", skips)
+	}
+}
+
+// Row #9 (negative): a zip missing a triple member is skipped (not validated),
+// and the walk continues.
+func TestCollectReports_SkipsMissingMember(t *testing.T) {
+	root := t.TempDir()
+	makeZip(t, filepath.Join(root, "a_reg-sim.zip"), map[string]string{
+		"IBL5.plr": "p", "IBL5.sch": "s", // no .sco
+	})
+	makeZip(t, filepath.Join(root, "b_reg-sim.zip"), fullTriple())
+
+	rv := &recordingValidate{t: t}
+	reports, skips, err := CollectReports(root, Options{Runs: 1, Validate: rv.fn})
+	if err != nil {
+		t.Fatalf("CollectReports: %v", err)
+	}
+	if len(reports) != 1 || rv.calls != 1 {
+		t.Fatalf("reports=%d calls=%d, want 1 / 1", len(reports), rv.calls)
+	}
+	if len(skips) != 1 || skips[0].Reason == "" {
+		t.Fatalf("skips = %v, want one missing-member skip", skips)
+	}
+}
+
+// Row #8 (security/negative): a zip entry whose name contains a traversal prefix
+// is written by BASENAME ONLY, inside destDir — never escaping it.
+func TestExtractTriple_ZipSlipSafe(t *testing.T) {
+	root := t.TempDir()
+	zipPath := filepath.Join(root, "evil_reg-sim.zip")
+	makeZip(t, zipPath, map[string]string{
+		"../../IBL5.plr": "p", // traversal attempt
+		"IBL5.sch":       "s",
+		"IBL5.sco":       "c",
+	})
+	dest := t.TempDir()
+
+	found, err := extractTriple(zipPath, dest)
+	if err != nil {
+		t.Fatalf("extractTriple: %v", err)
+	}
+	if !found {
+		t.Fatal("expected all three members found (basename match)")
+	}
+	if _, err := os.Stat(filepath.Join(dest, "IBL5.plr")); err != nil {
+		t.Errorf("IBL5.plr should be written inside destDir: %v", err)
+	}
+	// The traversal target two levels up must NOT exist.
+	escaped := filepath.Join(dest, "..", "..", "IBL5.plr")
+	if _, err := os.Stat(escaped); err == nil {
+		t.Errorf("zip-slip: file escaped to %s", escaped)
+	}
+}
+
+// Row (sample-stride): with stride 2 over four qualifying zips, only the 1st and
+// 3rd are processed.
+func TestCollectReports_SampleStride(t *testing.T) {
+	root := t.TempDir()
+	for _, n := range []string{"a", "b", "c", "d"} {
+		makeZip(t, filepath.Join(root, n+"_reg-sim.zip"), fullTriple())
+	}
+	rv := &recordingValidate{t: t}
+	reports, _, err := CollectReports(root, Options{Runs: 1, SampleStride: 2, Validate: rv.fn})
+	if err != nil {
+		t.Fatalf("CollectReports: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("reports = %d, want 2 (every 2nd of 4)", len(reports))
+	}
+}
+
+// A non-existent root is a hard error, not a silent empty result.
+func TestCollectReports_BadRoot(t *testing.T) {
+	rv := &recordingValidate{t: t}
+	if _, _, err := CollectReports(filepath.Join(t.TempDir(), "nope"), Options{Validate: rv.fn}); err == nil {
+		t.Fatal("expected an error for a non-existent root")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/engine/internal/validate/aggregate.go
+++ b/engine/internal/validate/aggregate.go
@@ -36,6 +36,13 @@ var statNames = []string{
 	"reb", "ast", "stl", "tov", "blk", "pf",
 }
 
+// StatNames returns a copy of the fixed, ordered set of compared aggregates, so
+// downstream consumers (e.g. the jsbcalibrate harness) can iterate stats in the
+// same deterministic order the reports use without depending on map iteration.
+func StatNames() []string {
+	return append([]string(nil), statNames...)
+}
+
 // TeamStat is one team's compared aggregates for one game, normalized to a
 // single basis so the engine side and the .sco side are directly comparable.
 type TeamStat struct {

--- a/engine/internal/validate/bands.go
+++ b/engine/internal/validate/bands.go
@@ -1,5 +1,7 @@
 package validate
 
+import "github.com/a-jay85/IBL5/engine/internal/bundle"
+
 // Band is one stat's tolerance: a value passes when it lies within
 // max(AbsFloor, RelPct×engineMean) of the observed engine mean (see compareStat).
 type Band struct {
@@ -7,26 +9,25 @@ type Band struct {
 	AbsFloor float64 // absolute floor so small means still get a usable band
 }
 
-// bands is the SINGLE source of truth for tolerance calibration — one named,
-// commented entry per compared stat. Edit ONLY this table to recalibrate.
+// placeholderBands is the per-stat starting tolerance, shared across every game
+// type until corpus calibration replaces it (see the box below).
 //
 // ┌──────────────────────────────────────────────────────────────────────────┐
 // │ STARTING BANDS — NOT AUTHORITATIVE. These ±15% relative / per-stat floor   │
 // │ values are a defensible placeholder, NOT grounded in measured corpus       │
-// │ variance. They MUST be calibrated by running `jsbvalidate` against the     │
-// │ real 5.60 corpus and widening/tightening each band to absorb (a) the       │
-// │ single-.sco-draw sampling noise (one .sco line is one draw from            │
-// │ jumpshot.exe's own distribution) AND (b) the engine-vs-jumpshot model gap, │
-// │ WITHOUT making any band so wide it can never fail. Until calibrated, the   │
-// │ tagged corpus suite is a DIAGNOSTIC, not a merge gate. See OPEN #1 in the  │
-// │ PR9b plan.                                                                 │
+// │ variance. They MUST be calibrated by running `jsbcalibrate` against the    │
+// │ real 5.60 backup archive (ibl5/backups) and widening/tightening each band  │
+// │ to absorb (a) the single-.sco-draw sampling noise (one .sco line is one    │
+// │ draw from jumpshot.exe's own distribution) AND (b) the engine-vs-jumpshot  │
+// │ model gap, WITHOUT making any band so wide it can never fail. Until         │
+// │ calibrated, the tagged corpus suite is a DIAGNOSTIC, not a merge gate.     │
 // │                                                                            │
 // │ Note also: the backup-driven sim runs with no per-player minutes/stamina   │
 // │ signal (the .plr carries none — see backup.ToBundle), so the engine-side   │
 // │ distribution is wider than a DB-driven sim's; the bands must absorb that   │
 // │ too.                                                                       │
 // └──────────────────────────────────────────────────────────────────────────┘
-var bands = map[string]Band{
+var placeholderBands = map[string]Band{
 	"points": {RelPct: 0.15, AbsFloor: 8},
 	"fgm":    {RelPct: 0.15, AbsFloor: 5},
 	"fga":    {RelPct: 0.15, AbsFloor: 6},
@@ -42,11 +43,42 @@ var bands = map[string]Band{
 	"pf":     {RelPct: 0.15, AbsFloor: 4},
 }
 
-// bandFor returns the configured band for a stat, falling back to a generic
-// ±15%/floor-3 band for any stat not explicitly listed (defensive — every
-// statNames entry has an explicit band above).
-func bandFor(name string) Band {
-	if b, ok := bands[name]; ok {
+// bands is the SINGLE source of truth for tolerance calibration, now keyed by
+// game type: regular, playoff, and all-star ground truth differ systematically
+// (pace, defense, shot mix), so each game type carries its own band table.
+//
+// Every game type is currently seeded with an identical clone of
+// placeholderBands. The jsbcalibrate harness (cmd/jsbcalibrate) emits per-game-
+// type calibrated values derived from the real backup archive; replacing a game
+// type's entry with those values is a data-only follow-up edit. Edit ONLY this
+// table (or placeholderBands) to recalibrate.
+var bands = buildBands()
+
+func buildBands() map[bundle.GameType]map[string]Band {
+	out := make(map[bundle.GameType]map[string]Band)
+	for _, gt := range []bundle.GameType{
+		bundle.GameTypeRegular, bundle.GameTypeRegularAlt,
+		bundle.GameTypePlayoff, bundle.GameTypeAllStarA, bundle.GameTypeAllStarB,
+	} {
+		m := make(map[string]Band, len(placeholderBands))
+		for k, v := range placeholderBands {
+			m[k] = v
+		}
+		out[gt] = m
+	}
+	return out
+}
+
+// bandFor returns the configured band for a (game type, stat). An unknown game
+// type falls back to the regular-season table; an unknown stat (within a known
+// or fallback table) gets a generic ±15%/floor-3 band — defensive, since every
+// statNames entry has an explicit band in every game type's table.
+func bandFor(gt bundle.GameType, name string) Band {
+	m, ok := bands[gt]
+	if !ok {
+		m = bands[bundle.GameTypeRegular]
+	}
+	if b, ok := m[name]; ok {
 		return b
 	}
 	return Band{RelPct: 0.15, AbsFloor: 3}

--- a/engine/internal/validate/bands_test.go
+++ b/engine/internal/validate/bands_test.go
@@ -1,0 +1,63 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+)
+
+// Row #2: bandFor returns the band from the requested game type's table. The
+// placeholder values are currently identical across game types, so the test
+// asserts the lookup hits a populated entry for each known type rather than a
+// distinct numeric value (calibration will diverge the values later).
+func TestBandFor_KnownGameTypeAndStat(t *testing.T) {
+	for _, gt := range []bundle.GameType{
+		bundle.GameTypeRegular, bundle.GameTypeRegularAlt,
+		bundle.GameTypePlayoff, bundle.GameTypeAllStarA, bundle.GameTypeAllStarB,
+	} {
+		got := bandFor(gt, "points")
+		want := placeholderBands["points"]
+		if got != want {
+			t.Errorf("bandFor(%d, points) = %+v, want %+v", int(gt), got, want)
+		}
+	}
+}
+
+// Row #2: every statNames entry resolves to its explicit placeholder band under
+// the regular table — no stat silently falls through to the generic fallback.
+func TestBandFor_EveryStatHasExplicitBand(t *testing.T) {
+	for _, name := range statNames {
+		got := bandFor(bundle.GameTypeRegular, name)
+		want, ok := placeholderBands[name]
+		if !ok {
+			t.Fatalf("placeholderBands missing an entry for stat %q", name)
+		}
+		if got != want {
+			t.Errorf("bandFor(regular, %q) = %+v, want explicit %+v", name, got, want)
+		}
+	}
+}
+
+// Row #3 (boundary): an unknown game type falls back to the regular-season
+// table — same band a regular lookup would return, not a zero Band.
+func TestBandFor_UnknownGameTypeFallsBackToRegular(t *testing.T) {
+	const unknown = bundle.GameType(99)
+	got := bandFor(unknown, "reb")
+	want := bandFor(bundle.GameTypeRegular, "reb")
+	if got != want {
+		t.Errorf("bandFor(unknown, reb) = %+v, want regular fallback %+v", got, want)
+	}
+	if got == (Band{}) {
+		t.Error("unknown game type must not yield a zero (zero-width) band")
+	}
+}
+
+// Row #3 (boundary): an unknown stat — even within a known game type — gets the
+// generic ±15%/floor-3 defensive band, never a zero Band.
+func TestBandFor_UnknownStatGetsGenericBand(t *testing.T) {
+	got := bandFor(bundle.GameTypeRegular, "not_a_real_stat")
+	want := Band{RelPct: 0.15, AbsFloor: 3}
+	if got != want {
+		t.Errorf("bandFor(regular, unknown stat) = %+v, want generic %+v", got, want)
+	}
+}

--- a/engine/internal/validate/compare.go
+++ b/engine/internal/validate/compare.go
@@ -3,6 +3,8 @@ package validate
 import (
 	"fmt"
 	"math"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
 )
 
 // StatRow is the comparison of one stat for one team in one game.
@@ -59,8 +61,9 @@ func toleranceFor(b Band, engineMean float64) float64 {
 // observed engine means for the same matchup. visMean/homeMean are keyed by
 // statNames (from mean()); visSco/homeSco are the .sco-derived TeamStats. Rows
 // are emitted in a fixed order — visitor stats then home stats, each in
-// statNames order — so the report is deterministic.
-func compareGame(visitorTeamID, homeTeamID int, date string, visSco, homeSco TeamStat, visMean, homeMean map[string]float64) GameReport {
+// statNames order — so the report is deterministic. gameType selects the band
+// table, since regular/playoff/all-star tolerances differ.
+func compareGame(gameType bundle.GameType, visitorTeamID, homeTeamID int, date string, visSco, homeSco TeamStat, visMean, homeMean map[string]float64) GameReport {
 	gr := GameReport{
 		VisitorTeamID: visitorTeamID,
 		HomeTeamID:    homeTeamID,
@@ -76,7 +79,7 @@ func compareGame(visitorTeamID, homeTeamID int, date string, visSco, homeSco Tea
 		{homeTeamID, homeSco, homeMean},
 	} {
 		for _, name := range statNames {
-			b := bandFor(name)
+			b := bandFor(gameType, name)
 			scoVal := float64(side.sco.value(name))
 			engineMean := side.means[name]
 			pass, detail := compareStat(name, scoVal, engineMean, b)

--- a/engine/internal/validate/harness.go
+++ b/engine/internal/validate/harness.go
@@ -188,7 +188,7 @@ func ValidateCorpus(dir string, runs int, baseSeed uint64, gameType bundle.GameT
 				continue
 			}
 			consumed[schIdx] = true
-			gr := validateGame(b, b.Schedule[schIdx], sg, runs, baseSeed+uint64(gameIndex*runs))
+			gr := validateGame(b, b.Schedule[schIdx], sg, runs, baseSeed+uint64(gameIndex*runs), gameType)
 			rep.Games = append(rep.Games, gr)
 			if !gr.Pass {
 				rep.Pass = false
@@ -215,12 +215,12 @@ func matchSchedule(sched []backup.SchGame, consumed []bool, sg backup.ScoGame) i
 }
 
 // validateGame simulates one matchup `runs` times and compares the aggregated
-// per-team engine means against the .sco ground truth.
-func validateGame(b bundle.Bundle, g bundle.Game, sg backup.ScoGame, runs int, baseSeed uint64) GameReport {
+// per-team engine means against the .sco ground truth, using gameType's bands.
+func validateGame(b bundle.Bundle, g bundle.Game, sg backup.ScoGame, runs int, baseSeed uint64, gameType bundle.GameType) GameReport {
 	visMean, homeMean := simulateGameMeans(b, g, runs, baseSeed)
 	visSco := teamStatFromSco(sg, g.VisitorTeamID)
 	homeSco := teamStatFromSco(sg, g.HomeTeamID)
-	return compareGame(g.VisitorTeamID, g.HomeTeamID, sg.Date, visSco, homeSco, visMean, homeMean)
+	return compareGame(gameType, g.VisitorTeamID, g.HomeTeamID, sg.Date, visSco, homeSco, visMean, homeMean)
 }
 
 // simulateGameMeans runs the engine on the single matchup g for `runs` seeds

--- a/engine/internal/validate/harness_test.go
+++ b/engine/internal/validate/harness_test.go
@@ -24,7 +24,7 @@ func TestCompareGame_FailsOnOutOfBandStat(t *testing.T) {
 	visSco := TeamStat{Points: 200, FGM: 40, REB: 45}
 	homeSco := TeamStat{Points: 100, FGM: 40, REB: 45}
 
-	gr := compareGame(7, 3, "10-01", visSco, homeSco, visMean, homeMean)
+	gr := compareGame(bundle.GameTypeRegular, 7, 3, "10-01", visSco, homeSco, visMean, homeMean)
 	if gr.Pass {
 		t.Fatal("compareGame should FAIL when visitor points are far out of band")
 	}
@@ -106,6 +106,35 @@ func TestValidateCorpus_InBandPassesAndDeterministic(t *testing.T) {
 	WriteReport(&b2, rep2)
 	if b1.String() != b2.String() {
 		t.Error("two WriteReport outputs differ (non-deterministic)")
+	}
+}
+
+// Characterization (Row #1): the bands→game-type-keyed refactor must not change
+// observable behavior. ValidateCorpus stamped with GameTypeRegular must route
+// every stat to the regular band table — i.e. each StatRow.Tolerance equals the
+// tolerance recomputed from bandFor(GameTypeRegular, stat) at that row's engine
+// mean. A threading bug (wrong/empty game-type table) would produce a different
+// tolerance and fail here.
+func TestValidateCorpus_RegularBandsCharacterization(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	buildCorpus(t, dir, true, testRuns, seed)
+
+	rep, err := ValidateCorpus(dir, testRuns, seed, bundle.GameTypeRegular)
+	if err != nil {
+		t.Fatalf("ValidateCorpus: %v", err)
+	}
+	if len(rep.Games) == 0 {
+		t.Fatal("expected at least one validated game")
+	}
+	for _, g := range rep.Games {
+		for _, r := range g.Rows {
+			want := toleranceFor(bandFor(bundle.GameTypeRegular, r.Stat), r.EngineMean)
+			if r.Tolerance != want {
+				t.Errorf("team=%d stat=%s tolerance=%.4f, want %.4f (regular band table)",
+					r.TeamID, r.Stat, r.Tolerance, want)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the offline **band-calibration harness** for the JSB native engine: walks the JSB backup archive (`ibl5/backups`, ~53 GB of season zips), extracts each snapshot's `IBL5.{plr,sch,sco}` triple one zip at a time, runs the PR9b validation harness, and aggregates engine-mean-vs-`.sco` residuals to derive calibrated per-game-type tolerance bands.

- `internal/validate`: bands refactored to be **keyed by game type** (`bandFor(gt, name)`); placeholders cloned per type (zero behavior change, locked by a characterization test). `StatNames()` exported for deterministic ordering.
- `internal/calibrate` + `cmd/jsbcalibrate`: archive walk (zip-slip-safe, basename-only extraction), `--mode calibrate` (emits proposed per-game-type bands = `AbsFloor=ceil(p95|d|)`, `RelPct=p95(|d|/mean)`, with in-band rate for review) and `--mode gate` (applies committed bands, fails buckets below `--min-rate`). `--selection season` (default, one regular snapshot/season) | `flat` (per-zip).
- Real archive run is a `//go:build archive` smoke test — **not in CI** (corpus is large, not in the repo). Committing actual calibrated numbers into `bands.go` is a follow-up data-only edit.

## Scope (regular-season only)

Two real-archive findings reshaped scope:
1. **`.sco` is cumulative** — a late snapshot holds the whole season-to-date (reg-sim01=49 games → last reg-sim=1148 = full regular season). So the season collector takes **one snapshot per season** (no double-counting).
2. **Playoff games are not in the `.sch`** — verified: both the last reg-sim and finals `.sch` hold exactly 1148 regular entries; the finals `.sco` adds 82 *unmatched* playoff games (brackets are scheduled dynamically). The harness drops unmatched games, so the originally-planned playoff set-difference was implemented and **removed** (verified to yield 0 playoff games).

**Playoff/all-star calibration is deferred to its own PR** — it requires teaching the PR9b harness to synthesize a matchup from a `.sco` game's own team IDs when there's no `.sch` entry. Confirmed with the maintainer.

## Manual Testing

No manual testing needed — all changes are covered by unit tests (`go test`), characterization, and a build-tagged real-archive smoke test.

🤖 Generated with [Claude Code](https://claude.ai/code)