### PR TITLE
feat(engine): validate unscheduled playoff .sco games (PR9d)

### DIFF
--- a/engine/internal/calibrate/realarchive_test.go
+++ b/engine/internal/calibrate/realarchive_test.go
@@ -16,6 +16,8 @@ import (
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
 )
 
 func TestRealArchive_CalibrateEndToEnd(t *testing.T) {
@@ -43,15 +45,45 @@ func TestRealArchive_CalibrateEndToEnd(t *testing.T) {
 		t.Fatal("expected at least one report from the real archive")
 	}
 
+	// A selected season's finals snapshot may itself contain no playoff games
+	// (e.g. its last snapshot is an end-of-season capture taken before the
+	// postseason, observed on 95-96), so the stride-thinned sample only WARRANTS
+	// a playoff bucket when it actually produced ≥1 playoff game. Gate the
+	// assertion on that, so the test cannot false-negative on correct code.
+	playoffGamesSampled := 0
+	for _, rep := range reports {
+		if rep.GameType == bundle.GameTypePlayoff {
+			playoffGamesSampled += len(rep.Games)
+		}
+	}
+
 	cal := Calibrate(reports, 0.95)
 	if len(cal.Buckets) == 0 {
 		t.Fatal("calibration produced no buckets")
 	}
+	var sawRegular, sawPlayoff bool
 	for _, b := range cal.Buckets {
 		t.Logf("game_type=%d stats=%d", b.GameType, len(b.Stats))
 		if len(b.Stats) == 0 {
 			t.Errorf("game_type=%d produced no stat calibrations", b.GameType)
 		}
+		switch b.GameType {
+		case int(bundle.GameTypeRegular):
+			sawRegular = true
+		case int(bundle.GameTypePlayoff):
+			sawPlayoff = true
+		}
+	}
+	if !sawRegular {
+		t.Error("expected a regular (game_type=2) bucket")
+	}
+	// PR9d: the playoff bucket comes from each selected season's finals snapshot
+	// via ValidateUnscheduled. Require a game_type=4 bucket with non-empty bands
+	// ONLY when the sample actually contained playoff games (otherwise the
+	// stride may have landed only on no-playoff finals snapshots — see above).
+	t.Logf("playoff games sampled=%d", playoffGamesSampled)
+	if playoffGamesSampled > 0 && !sawPlayoff {
+		t.Error("sample contained playoff games but produced no playoff (game_type=4) bucket (PR9d)")
 	}
 }
 

--- a/engine/internal/calibrate/season.go
+++ b/engine/internal/calibrate/season.go
@@ -17,24 +17,27 @@ import (
 // the season-grouped collector:
 //
 //  1. Processing every snapshot would double-count early games (re-counted in
-//     each later cumulative snapshot). So per season we take ONE snapshot.
+//     each later cumulative snapshot). So per season we take ONE snapshot per
+//     bucket: the last regular-type snapshot for the regular bucket, and the
+//     finals (last overall) snapshot for the playoff bucket.
 //
-//  2. Only REGULAR-season games can be validated today. The harness pairs each
-//     .sco game to a .sch schedule entry to build the matchup; playoff (and
-//     all-star) games are NOT in the .sch — playoff brackets are scheduled
-//     dynamically, so those .sco games are unmatched and dropped. Validating
-//     them would require synthesizing the matchup from the .sco's own team IDs,
-//     a PR9b harness-contract change tracked separately. Until then this
-//     collector emits the clean REGULAR bucket only: the season's last
-//     regular-type snapshot (complete regular season, zero unmatched games).
+//  2. REGULAR games are validated via validate.ValidateCorpus, which pairs each
+//     .sco game to a .sch schedule entry. PLAYOFF games are NOT in the .sch
+//     (playoff brackets are scheduled dynamically, from Schedule.htm in prod),
+//     so they are validated via validate.ValidateUnscheduled — the complement
+//     path that synthesizes each unmatched .sco game's matchup from its own
+//     team IDs (PR9d). All-star/Olympics calibration is still out of scope:
+//     Olympics national-team rosters are not a clean .plr-franchise sim.
 
-// season is one season's selected regular snapshot. olympics seasons are
-// recorded so they can be reported as skipped (out of scope, same unmatched
-// constraint as playoffs).
+// season is one season's selected snapshots. olympics seasons are recorded so
+// they can be reported as skipped (out of scope — national-team rosters need
+// separate handling). finalsZip is the last snapshot overall (lexical/sim-step
+// order); when it differs from regularZip it carries the playoff games.
 type season struct {
 	name       string
 	olympics   bool
 	regularZip string // last regular-type snapshot; "" if the season has none
+	finalsZip  string // last snapshot overall; "" if the season has none
 }
 
 // seasonName is the path segment immediately under root (e.g. "02-03", or
@@ -53,14 +56,18 @@ func isOlympicsPath(path string) bool {
 	return strings.Contains(strings.ToLower(filepath.ToSlash(path)), "olympics")
 }
 
-// groupSeasons buckets zip paths into seasons, selecting each season's last
-// regular-type snapshot by lexical (sim-step) order — valid because the
-// archive's NN index is zero-padded, so the names sort by sim step. Olympics
-// snapshots are flagged (and skipped: not yet supported, see the note above).
+// groupSeasons buckets zip paths into seasons, selecting two snapshots per
+// season by lexical (sim-step) order — valid because the archive's NN index is
+// zero-padded, so the names sort by sim step: the last regular-type snapshot
+// (regularZip, the complete regular season) and the last snapshot overall
+// (finalsZip, which carries the playoff games when a finals snapshot exists).
+// Olympics snapshots are flagged (and skipped: not yet supported, see the note
+// above).
 func groupSeasons(zipPaths []string, root string) ([]season, []Skip) {
 	type acc struct {
 		olympics   bool
 		regularZip string
+		finalsZip  string
 	}
 	m := map[string]*acc{}
 	var skips []Skip
@@ -73,11 +80,15 @@ func groupSeasons(zipPaths []string, root string) ([]season, []Skip) {
 		}
 		if isOlympicsPath(p) {
 			a.olympics = true
-			skips = append(skips, Skip{p, "olympics/playoff not yet supported (unscheduled games — see season.go)"})
+			skips = append(skips, Skip{p, "olympics not yet supported (national-team rosters — see season.go)"})
 			continue
 		}
-		// Only regular-type snapshots seed the regular bucket; a playoff/finals
-		// snapshot is ignored here (its playoff games are unmatched anyway).
+		// The last snapshot overall is the finals snapshot (playoff bucket); the
+		// last regular-type snapshot seeds the regular bucket. When the season has
+		// no finals snapshot, finalsZip == regularZip and no playoff bucket forms.
+		if p > a.finalsZip {
+			a.finalsZip = p
+		}
 		if gt, _ := inferGameType(p, false); gt == bundle.GameTypeRegular && p > a.regularZip {
 			a.regularZip = p
 		}
@@ -91,29 +102,33 @@ func groupSeasons(zipPaths []string, root string) ([]season, []Skip) {
 	seasons := make([]season, 0, len(names))
 	for _, n := range names {
 		a := m[n]
-		seasons = append(seasons, season{name: n, olympics: a.olympics, regularZip: a.regularZip})
+		seasons = append(seasons, season{name: n, olympics: a.olympics, regularZip: a.regularZip, finalsZip: a.finalsZip})
 	}
 	return seasons, skips
 }
 
 // CollectSeasonReports is the calibration-correct collector: it groups the
-// archive into seasons and validates ONE snapshot per season — the last
-// regular-type snapshot, the complete regular season — as the clean regular
-// bucket. --sample-stride thins by season. Playoff/all-star are out of scope
-// until the harness can validate unscheduled games.
+// archive into seasons and, per season, validates the last regular-type
+// snapshot as the REGULAR bucket and (when a distinct finals snapshot exists)
+// its unmatched .sco games as the PLAYOFF bucket. --sample-stride thins by
+// season; both buckets for a selected season are produced together. All-star
+// and Olympics remain out of scope.
 func CollectSeasonReports(root string, opts Options) ([]validate.Report, []Skip, error) {
 	zips, zskips, err := listArchiveZips(root)
 	if err != nil {
 		return nil, nil, err
 	}
 	seasons, gskips := groupSeasons(zips, root)
-	reports, pskips := collectSeasonReports(seasons, opts, resolveValidate(opts))
+	reports, pskips := collectSeasonReports(seasons, opts, resolveValidate(opts), resolveValidateUnscheduled(opts))
 	skips := append(append(zskips, gskips...), pskips...)
 	return reports, skips, nil
 }
 
 // collectSeasonReports is the injected-dependency core of CollectSeasonReports.
-func collectSeasonReports(seasons []season, opts Options, validateFn ValidateFunc) ([]validate.Report, []Skip) {
+// validateFn handles the regular (scheduled) bucket; validateUnscheduledFn
+// handles the playoff (unscheduled) bucket — both seams so the season grouping
+// and bucket selection are unit-testable without running the engine.
+func collectSeasonReports(seasons []season, opts Options, validateFn, validateUnscheduledFn ValidateFunc) ([]validate.Report, []Skip) {
 	progress := opts.Progress
 	if progress == nil {
 		progress = io.Discard
@@ -145,6 +160,19 @@ func collectSeasonReports(seasons []season, opts Options, validateFn ValidateFun
 		}
 		_, _ = fmt.Fprintf(progress, "regular %s games=%d\n", s.regularZip, len(rep.Games))
 		reports = append(reports, *rep)
+
+		// Playoff bucket: the finals snapshot's unmatched .sco games, validated
+		// via the unscheduled path. Only when a distinct finals snapshot exists
+		// (otherwise finalsZip == regularZip = no playoffs captured).
+		if s.finalsZip != "" && s.finalsZip != s.regularZip {
+			prep, pskip := processZip(s.finalsZip, bundle.GameTypePlayoff, opts.Runs, opts.Seed, validateUnscheduledFn)
+			if pskip != nil {
+				skips = append(skips, *pskip)
+				continue
+			}
+			_, _ = fmt.Fprintf(progress, "playoff %s games=%d excluded=%d\n", s.finalsZip, len(prep.Games), len(prep.Excluded))
+			reports = append(reports, *prep)
+		}
 	}
 	return reports, skips
 }
@@ -155,4 +183,13 @@ func resolveValidate(opts Options) ValidateFunc {
 		return opts.Validate
 	}
 	return validate.ValidateCorpus
+}
+
+// resolveValidateUnscheduled returns opts.ValidateUnscheduled or the real
+// validate.ValidateUnscheduled default (the playoff-bucket seam).
+func resolveValidateUnscheduled(opts Options) ValidateFunc {
+	if opts.ValidateUnscheduled != nil {
+		return opts.ValidateUnscheduled
+	}
+	return validate.ValidateUnscheduled
 }

--- a/engine/internal/calibrate/season_test.go
+++ b/engine/internal/calibrate/season_test.go
@@ -1,20 +1,38 @@
 package calibrate
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/a-jay85/IBL5/engine/internal/bundle"
 )
 
-// Row: groupSeasons picks each season's last regular-type snapshot by lexical
-// (sim-step) order, and flags+skips Olympics (out of scope).
+// neutralTempDir returns a temp dir whose path contains none of the substrings
+// inferGameType keys on ("finals"/"playoff"/"olympics"). t.TempDir() embeds the
+// test name, so a test named for the playoff bucket would otherwise poison every
+// snapshot's inferred game type via its own path. Production archive roots are
+// clean, so this only matters for trigger-worded test names.
+func neutralTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "jsbcal-test-")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// Row #6: groupSeasons picks each season's last regular-type snapshot for the
+// regular bucket AND its last snapshot overall (the finals) for the playoff
+// bucket; the finals selection is distinct from the regular one when a playoff
+// snapshot exists. Olympics are flagged+skipped (out of scope).
 func TestGroupSeasons_SelectsLastRegular(t *testing.T) {
 	root := "/b"
 	zips := []string{
 		"/b/02-03/02-03_08_reg-sim01.zip",
 		"/b/02-03/02-03_41_reg-sim35.zip",
-		"/b/02-03/02-03_47_finals.zip", // playoff snapshot — ignored for the regular bucket
+		"/b/02-03/02-03_47_finals.zip", // playoff snapshot — the finals (last overall)
 		"/b/88-89/88-89_30_reg-sim20.zip",
 	}
 	seasons, skips := groupSeasons(zips, root)
@@ -24,18 +42,22 @@ func TestGroupSeasons_SelectsLastRegular(t *testing.T) {
 	if len(seasons) != 2 {
 		t.Fatalf("seasons = %d, want 2", len(seasons))
 	}
-	// Sorted by name: 02-03 then 88-89. The last regular snapshot wins; the
-	// finals (playoff) snapshot is not selected.
-	if s := seasons[0]; s.name != "02-03" || s.regularZip != "/b/02-03/02-03_41_reg-sim35.zip" {
-		t.Errorf("02-03 regular selection wrong: %+v", s)
+	// Sorted by name: 02-03 then 88-89. The last regular snapshot is the regular
+	// bucket; the finals snapshot is the (distinct) playoff bucket.
+	if s := seasons[0]; s.name != "02-03" ||
+		s.regularZip != "/b/02-03/02-03_41_reg-sim35.zip" ||
+		s.finalsZip != "/b/02-03/02-03_47_finals.zip" {
+		t.Errorf("02-03 selection wrong: %+v", s)
 	}
-	if s := seasons[1]; s.regularZip != "/b/88-89/88-89_30_reg-sim20.zip" {
-		t.Errorf("88-89 regular selection wrong: %+v", s)
+	// 88-89 has no finals snapshot: finalsZip == regularZip, so no playoff bucket.
+	if s := seasons[1]; s.regularZip != "/b/88-89/88-89_30_reg-sim20.zip" ||
+		s.finalsZip != s.regularZip {
+		t.Errorf("88-89 selection wrong (expected no distinct finals): %+v", s)
 	}
 }
 
 // Row (negative): Olympics snapshots are flagged and recorded as Skips (not yet
-// supported — unscheduled games), never selected as a regular snapshot.
+// supported — national-team rosters), never selected as a regular/finals snapshot.
 func TestGroupSeasons_OlympicsSkipped(t *testing.T) {
 	root := "/b"
 	zips := []string{"/b/olympics/2003/oly_a.zip", "/b/olympics/2003/oly_b.zip"}
@@ -43,7 +65,7 @@ func TestGroupSeasons_OlympicsSkipped(t *testing.T) {
 	if len(skips) != 2 {
 		t.Fatalf("olympics skips = %d, want 2", len(skips))
 	}
-	if len(seasons) != 1 || !seasons[0].olympics || seasons[0].regularZip != "" {
+	if len(seasons) != 1 || !seasons[0].olympics || seasons[0].regularZip != "" || seasons[0].finalsZip != "" {
 		t.Fatalf("olympics season wrong: %+v", seasons)
 	}
 }
@@ -53,7 +75,7 @@ func TestGroupSeasons_OlympicsSkipped(t *testing.T) {
 // Row: collectSeasonReports validates one regular report per season (the last
 // regular snapshot) under GameTypeRegular.
 func TestCollectSeasonReports_RegularPerSeason(t *testing.T) {
-	root := t.TempDir()
+	root := neutralTempDir(t)
 	makeZip(t, filepath.Join(root, "02-03", "02-03_41_reg-sim35.zip"), fullTriple())
 	makeZip(t, filepath.Join(root, "88-89", "88-89_30_reg-sim20.zip"), fullTriple())
 
@@ -75,17 +97,73 @@ func TestCollectSeasonReports_RegularPerSeason(t *testing.T) {
 // Row (negative): a season with no regular-type snapshot is skipped.
 func TestCollectSeasonReports_NoRegularSnapshotSkips(t *testing.T) {
 	seasons := []season{{name: "x", regularZip: ""}}
-	rv := &recordingValidate{t: t}
-	reports, skips := collectSeasonReports(seasons, Options{Runs: 1}, rv.fn)
-	if len(reports) != 0 || rv.calls != 0 || len(skips) != 1 {
-		t.Fatalf("want zero reports/calls and one skip; reports=%d calls=%d skips=%v", len(reports), rv.calls, skips)
+	rvReg := &recordingValidate{t: t}
+	rvPof := &recordingValidate{t: t}
+	reports, skips := collectSeasonReports(seasons, Options{Runs: 1}, rvReg.fn, rvPof.fn)
+	if len(reports) != 0 || rvReg.calls != 0 || rvPof.calls != 0 || len(skips) != 1 {
+		t.Fatalf("want zero reports/calls and one skip; reports=%d reg=%d pof=%d skips=%v",
+			len(reports), rvReg.calls, rvPof.calls, skips)
+	}
+}
+
+// Row #7: a season with a distinct finals snapshot emits TWO reports — a
+// regular (type 2) via the scheduled path and a playoff (type 4) via the
+// unscheduled path, the latter routed the finals snapshot.
+func TestCollectSeasonReports_RegularAndPlayoffBuckets(t *testing.T) {
+	root := neutralTempDir(t)
+	makeZip(t, filepath.Join(root, "02-03", "02-03_41_reg-sim35.zip"), fullTriple())
+	makeZip(t, filepath.Join(root, "02-03", "02-03_47_finals.zip"), fullTriple())
+
+	rvReg := &recordingValidate{t: t}
+	rvPof := &recordingValidate{t: t}
+	reports, skips, err := CollectSeasonReports(root, Options{
+		Runs: 1, Validate: rvReg.fn, ValidateUnscheduled: rvPof.fn,
+	})
+	if err != nil {
+		t.Fatalf("CollectSeasonReports: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("reports = %d, want 2 (regular + playoff) (skips=%v)", len(reports), skips)
+	}
+	if rvReg.calls != 1 || rvPof.calls != 1 {
+		t.Fatalf("calls reg=%d pof=%d, want 1 / 1", rvReg.calls, rvPof.calls)
+	}
+	if rvReg.gameType[0] != bundle.GameTypeRegular {
+		t.Errorf("regular call game type = %d, want regular (2)", int(rvReg.gameType[0]))
+	}
+	if rvPof.gameType[0] != bundle.GameTypePlayoff {
+		t.Errorf("playoff call game type = %d, want playoff (4)", int(rvPof.gameType[0]))
+	}
+	// Reports are appended regular-then-playoff per season.
+	if reports[0].GameType != bundle.GameTypeRegular || reports[1].GameType != bundle.GameTypePlayoff {
+		t.Errorf("report game types = [%d %d], want [2 4]", int(reports[0].GameType), int(reports[1].GameType))
+	}
+}
+
+// Row #8 (negative/boundary): a season whose finals == last-regular snapshot
+// (no playoffs captured) emits only the regular report — the unscheduled path
+// is never invoked.
+func TestCollectSeasonReports_NoFinalsEmitsOnlyRegular(t *testing.T) {
+	root := neutralTempDir(t)
+	makeZip(t, filepath.Join(root, "02-03", "02-03_41_reg-sim35.zip"), fullTriple())
+
+	rvReg := &recordingValidate{t: t}
+	rvPof := &recordingValidate{t: t}
+	reports, skips, err := CollectSeasonReports(root, Options{
+		Runs: 1, Validate: rvReg.fn, ValidateUnscheduled: rvPof.fn,
+	})
+	if err != nil {
+		t.Fatalf("CollectSeasonReports: %v", err)
+	}
+	if len(reports) != 1 || rvReg.calls != 1 || rvPof.calls != 0 {
+		t.Fatalf("reports=%d reg=%d pof=%d, want 1 / 1 / 0 (skips=%v)", len(reports), rvReg.calls, rvPof.calls, skips)
 	}
 }
 
 // Row (sample-stride): with stride 2 over four seasons, only the 1st and 3rd
 // are processed.
 func TestCollectSeasonReports_SampleStride(t *testing.T) {
-	root := t.TempDir()
+	root := neutralTempDir(t)
 	for _, n := range []string{"a", "b", "c", "d"} {
 		makeZip(t, filepath.Join(root, n, n+"_reg-sim.zip"), fullTriple())
 	}

--- a/engine/internal/calibrate/walk.go
+++ b/engine/internal/calibrate/walk.go
@@ -34,12 +34,13 @@ type ValidateFunc func(dir string, runs int, seed uint64, gt bundle.GameType) (v
 
 // Options configures an archive walk.
 type Options struct {
-	Runs            int          // seeded engine runs per corpus game
-	Seed            uint64       // base seed
-	SampleStride    int          // process every Nth qualifying snapshot (<1 -> 1)
-	IncludeOlympics bool         // include olympics/ snapshots (game-type 6)
-	Validate        ValidateFunc // nil -> validate.ValidateCorpus
-	Progress        io.Writer    // nil -> io.Discard; one line per processed snapshot
+	Runs                int          // seeded engine runs per corpus game
+	Seed                uint64       // base seed
+	SampleStride        int          // process every Nth qualifying snapshot (<1 -> 1)
+	IncludeOlympics     bool         // include olympics/ snapshots (game-type 6)
+	Validate            ValidateFunc // nil -> validate.ValidateCorpus (regular/scheduled bucket)
+	ValidateUnscheduled ValidateFunc // nil -> validate.ValidateUnscheduled (playoff bucket)
+	Progress            io.Writer    // nil -> io.Discard; one line per processed snapshot
 }
 
 // Skip records a snapshot (or archive entry) that was not turned into a Report,

--- a/engine/internal/validate/format.go
+++ b/engine/internal/validate/format.go
@@ -34,9 +34,21 @@ func WriteReport(w io.Writer, rep Report) {
 		p("UNMATCHED stem=%s visitor=%d home=%d scores=%d-%d: %s\n",
 			u.Stem, u.VisitorTeamID, u.HomeTeamID, u.VisitorScore, u.HomeScore, u.Reason)
 	}
+	// EXCLUDED lines (ValidateUnscheduled's sim-validity guard) are emitted only
+	// when present, and the RESULT line gains its count only then, so a
+	// ValidateCorpus report (always zero-excluded) renders byte-identically.
+	for _, e := range rep.Excluded {
+		p("EXCLUDED stem=%s visitor=%d home=%d date=%s: %s\n",
+			e.Stem, e.VisitorTeamID, e.HomeTeamID, e.Date, e.Reason)
+	}
 	result := "PASS"
 	if !rep.Pass {
 		result = "FAIL"
+	}
+	if len(rep.Excluded) > 0 {
+		p("RESULT: %s (%d games, %d unmatched, %d excluded)\n",
+			result, len(rep.Games), len(rep.Unmatched), len(rep.Excluded))
+		return
 	}
 	p("RESULT: %s (%d games, %d unmatched)\n",
 		result, len(rep.Games), len(rep.Unmatched))

--- a/engine/internal/validate/harness.go
+++ b/engine/internal/validate/harness.go
@@ -47,6 +47,8 @@ type ExcludedGame struct {
 
 // Report is the harness's full result over a corpus directory. Pass is true
 // only when every game's every stat passed AND no .sco game was left unmatched.
+// Excluded games (ValidateUnscheduled's rosterless sim-validity skips) are a
+// third outcome that does NOT affect Pass — they are reported for visibility.
 // Same (dir, runs, baseSeed, gameType) always yields an identical Report.
 type Report struct {
 	Runs      int

--- a/engine/internal/validate/harness.go
+++ b/engine/internal/validate/harness.go
@@ -31,6 +31,20 @@ type UnmatchedGame struct {
 	Reason        string
 }
 
+// ExcludedGame is an unmatched .sco game that ValidateUnscheduled could not
+// simulate because a participating team has no .plr roster in the bundle, so the
+// engine cannot build a lineup. It is reported (never silently dropped) so a
+// malformed/edge .sco surfaces; unlike an UnmatchedGame in ValidateCorpus it
+// does NOT force the Report to FAIL — it is an expected defensive skip, and the
+// Phase-4 archive scan (not this report's Pass) asserts zero exclusions.
+type ExcludedGame struct {
+	Stem          string
+	VisitorTeamID int
+	HomeTeamID    int
+	Date          string
+	Reason        string
+}
+
 // Report is the harness's full result over a corpus directory. Pass is true
 // only when every game's every stat passed AND no .sco game was left unmatched.
 // Same (dir, runs, baseSeed, gameType) always yields an identical Report.
@@ -41,6 +55,7 @@ type Report struct {
 	Pass      bool
 	Games     []GameReport
 	Unmatched []UnmatchedGame
+	Excluded  []ExcludedGame
 }
 
 // triple names one backup file set sharing a stem within the corpus dir.
@@ -197,6 +212,85 @@ func ValidateCorpus(dir string, runs int, baseSeed uint64, gameType bundle.GameT
 		}
 	}
 	return rep, nil
+}
+
+// ValidateUnscheduled is the exact complement of ValidateCorpus: it simulates
+// the .sco games that have NO .sch match — playoff games, which are never in the
+// binary .sch (the production playoff schedule is parsed from Schedule.htm). A
+// .sco game carries its own VisitorTeamID/HomeTeamID/Date, and the engine
+// derives lineups from the .plr rosters, so an unmatched game's matchup is
+// synthesized directly (no schedule needed) and simulated under gameType.
+//
+// matchSchedule decides "unmatched" with the SAME predicate ValidateCorpus uses
+// to decide "matched" (consuming each .sch entry once), so the two paths are
+// exact complements over a corpus's .sco games.
+//
+// Sim-validity guard: a synthesized game whose visitor or home team has no .plr
+// roster cannot be given a lineup, so it is skipped and recorded in
+// Report.Excluded (never silently dropped). On a real finals snapshot this set
+// is empty — the All-Star/Rising-Stars games live in the 1,000,000-byte .sco
+// header that backup.ReadSco skips wholesale, so they never reach the harness.
+//
+// Determinism: same (dir, runs, baseSeed, gameType) yields a byte-identical
+// Report. .sco games are kept in file order; the per-game seed advances by a
+// monotonic index over INCLUDED (simulated) games only.
+func ValidateUnscheduled(dir string, runs int, baseSeed uint64, gameType bundle.GameType) (Report, error) {
+	if runs <= 0 {
+		return Report{}, fmt.Errorf("validate: runs must be >= 1, got %d", runs)
+	}
+	triples, err := findTriples(dir)
+	if err != nil {
+		return Report{}, err
+	}
+	rep := Report{Runs: runs, BaseSeed: baseSeed, GameType: gameType, Pass: true}
+	gameIndex := 0
+	for _, t := range triples {
+		b, sched, scoGames, err := readTriple(t, gameType)
+		if err != nil {
+			return Report{}, err
+		}
+		hasLineup := lineupTeams(b)
+		consumed := make([]bool, len(sched))
+		for _, sg := range scoGames {
+			if schIdx := matchSchedule(sched, consumed, sg); schIdx >= 0 {
+				consumed[schIdx] = true
+				continue // scheduled game — ValidateCorpus's domain, not ours
+			}
+			if !hasLineup[sg.VisitorTeamID] || !hasLineup[sg.HomeTeamID] {
+				rep.Excluded = append(rep.Excluded, ExcludedGame{
+					Stem:          t.stem,
+					VisitorTeamID: sg.VisitorTeamID,
+					HomeTeamID:    sg.HomeTeamID,
+					Date:          sg.Date,
+					Reason:        "no .plr roster for a participating team — cannot build a lineup",
+				})
+				continue
+			}
+			g := bundle.Game{
+				VisitorTeamID: sg.VisitorTeamID,
+				HomeTeamID:    sg.HomeTeamID,
+				Date:          sg.Date,
+				GameType:      gameType,
+			}
+			gr := validateGame(b, g, sg, runs, baseSeed+uint64(gameIndex*runs), gameType)
+			rep.Games = append(rep.Games, gr)
+			if !gr.Pass {
+				rep.Pass = false
+			}
+			gameIndex++
+		}
+	}
+	return rep, nil
+}
+
+// lineupTeams returns the set of team IDs with at least one player in the
+// bundle, i.e. the teams the engine can build a lineup for.
+func lineupTeams(b bundle.Bundle) map[int]bool {
+	set := make(map[int]bool)
+	for _, p := range b.Players {
+		set[p.TeamID] = true
+	}
+	return set
 }
 
 // matchSchedule returns the index of the first unconsumed schedule game whose

--- a/engine/internal/validate/harness_test.go
+++ b/engine/internal/validate/harness_test.go
@@ -227,3 +227,139 @@ func TestValidateCorpus_UnmatchedScoGame(t *testing.T) {
 		t.Errorf("report should render an UNMATCHED line and a FAIL result:\n%s", buf.String())
 	}
 }
+
+// Row #2: ValidateUnscheduled simulates an unmatched .sco game between two
+// rostered franchises (7 vs 3) under the given game type — the matchup is
+// synthesized from the .sco's own team IDs, and the game lands in Report.Games
+// (NOT Unmatched, NOT Excluded). The matched (scheduled) game is skipped.
+// Pass is intentionally NOT asserted: to be unmatched the .sco scores must
+// differ from the only rostered matchup's .sch scores, so the synthesized game
+// is points-out-of-band by construction (advisor guidance).
+func TestValidateUnscheduled_SimulatesUnmatchedGame(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	extra := scoGameSpec{
+		visTID: 7, homeTID: 3, visScore: 77, homeScore: 77,
+		visBoxes:  []scoBoxSpec{{pid: 1, name: "VIS"}},
+		homeBoxes: []scoBoxSpec{{pid: 2, name: "HOME"}},
+	}
+	buildCorpus(t, dir, true, testRuns, seed, extra)
+
+	rep, err := ValidateUnscheduled(dir, testRuns, seed, bundle.GameTypePlayoff)
+	if err != nil {
+		t.Fatalf("ValidateUnscheduled: %v", err)
+	}
+	if len(rep.Games) != 1 {
+		t.Fatalf("games = %d, want 1 (the unmatched game, simulated)", len(rep.Games))
+	}
+	if len(rep.Unmatched) != 0 || len(rep.Excluded) != 0 {
+		t.Fatalf("unmatched=%d excluded=%d, want 0 / 0", len(rep.Unmatched), len(rep.Excluded))
+	}
+	if rep.GameType != bundle.GameTypePlayoff {
+		t.Errorf("report game type = %d, want playoff (4)", int(rep.GameType))
+	}
+	g := rep.Games[0]
+	if g.VisitorTeamID != 7 || g.HomeTeamID != 3 || g.Date != "10-01" {
+		t.Errorf("synthesized game = visitor=%d home=%d date=%q, want 7/3/10-01", g.VisitorTeamID, g.HomeTeamID, g.Date)
+	}
+}
+
+// Row #3: ValidateUnscheduled is deterministic — two runs over the same corpus
+// yield an identical Report and identical rendered bytes.
+func TestValidateUnscheduled_Deterministic(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	extra := scoGameSpec{
+		visTID: 7, homeTID: 3, visScore: 77, homeScore: 77,
+		visBoxes:  []scoBoxSpec{{pid: 1, name: "VIS"}},
+		homeBoxes: []scoBoxSpec{{pid: 2, name: "HOME"}},
+	}
+	buildCorpus(t, dir, true, testRuns, seed, extra)
+
+	rep1, err := ValidateUnscheduled(dir, testRuns, seed, bundle.GameTypePlayoff)
+	if err != nil {
+		t.Fatalf("ValidateUnscheduled: %v", err)
+	}
+	rep2, err := ValidateUnscheduled(dir, testRuns, seed, bundle.GameTypePlayoff)
+	if err != nil {
+		t.Fatalf("ValidateUnscheduled (2nd): %v", err)
+	}
+	if !reflect.DeepEqual(rep1, rep2) {
+		t.Error("two ValidateUnscheduled runs produced different Reports (non-deterministic)")
+	}
+	var b1, b2 bytes.Buffer
+	WriteReport(&b1, rep1)
+	WriteReport(&b2, rep2)
+	if b1.String() != b2.String() {
+		t.Error("two WriteReport outputs differ (non-deterministic)")
+	}
+}
+
+// Row #4 (negative): the sim-validity guard. An unmatched .sco game whose team
+// ID has no .plr roster (team 11, absent from starterSpecs) is recorded in
+// Report.Excluded with a reason and never simulated. The box slot is filled so
+// ReadSco does not drop the record as padding (advisor guidance).
+func TestValidateUnscheduled_RosterlessTeamExcluded(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	rosterless := scoGameSpec{
+		visTID: 11, homeTID: 3, visScore: 88, homeScore: 88,
+		visBoxes:  []scoBoxSpec{{pid: 9, name: "GHOST"}},
+		homeBoxes: []scoBoxSpec{{pid: 2, name: "HOME"}},
+	}
+	buildCorpus(t, dir, true, testRuns, seed, rosterless)
+
+	rep, err := ValidateUnscheduled(dir, testRuns, seed, bundle.GameTypePlayoff)
+	if err != nil {
+		t.Fatalf("ValidateUnscheduled: %v", err)
+	}
+	if len(rep.Games) != 0 {
+		t.Fatalf("games = %d, want 0 (the rosterless game must not be simulated)", len(rep.Games))
+	}
+	if len(rep.Excluded) != 1 {
+		t.Fatalf("excluded = %d, want 1", len(rep.Excluded))
+	}
+	if e := rep.Excluded[0]; e.VisitorTeamID != 11 || e.HomeTeamID != 3 || e.Reason == "" {
+		t.Errorf("excluded game = %+v, want visitor=11 home=3 with a reason", e)
+	}
+
+	// The exclusion is surfaced in the rendered report, not dropped.
+	var buf bytes.Buffer
+	WriteReport(&buf, rep)
+	if !strings.Contains(buf.String(), "EXCLUDED") || !strings.Contains(buf.String(), "excluded)") {
+		t.Errorf("report should render an EXCLUDED line and excluded count:\n%s", buf.String())
+	}
+}
+
+// Row #5 (boundary): a corpus whose only .sco game IS scheduled (matches the
+// .sch) has no unmatched games, so ValidateUnscheduled returns zero Games, zero
+// Excluded, and Pass true — it never touches ValidateCorpus's domain.
+func TestValidateUnscheduled_NoUnmatchedGames(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	buildCorpus(t, dir, true, testRuns, seed) // only the matched game, no extras
+
+	rep, err := ValidateUnscheduled(dir, testRuns, seed, bundle.GameTypePlayoff)
+	if err != nil {
+		t.Fatalf("ValidateUnscheduled: %v", err)
+	}
+	if len(rep.Games) != 0 || len(rep.Excluded) != 0 {
+		t.Fatalf("games=%d excluded=%d, want 0 / 0", len(rep.Games), len(rep.Excluded))
+	}
+	if !rep.Pass {
+		t.Error("a corpus with no unmatched games must PASS (nothing failed)")
+	}
+}
+
+// ValidateUnscheduled shares ValidateCorpus's guards: runs<=0 is an error, and
+// an empty corpus dir yields ErrNoCorpus (never a panic or a vacuous PASS).
+func TestValidateUnscheduled_GuardsAndEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	buildCorpus(t, dir, true, testRuns, 1)
+	if _, err := ValidateUnscheduled(dir, 0, 1, bundle.GameTypePlayoff); err == nil {
+		t.Error("runs=0 should be an error")
+	}
+	if _, err := ValidateUnscheduled(t.TempDir(), testRuns, 1, bundle.GameTypePlayoff); !errors.Is(err, ErrNoCorpus) {
+		t.Fatalf("empty dir error = %v, want ErrNoCorpus", err)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to PR9c (#947). Engine-only (Go). Adds **playoff** band calibration by validating the `.sco` games that have no `.sch` schedule entry.

Playoff games are never in the binary `.sch` (prod derives the playoff schedule from `Schedule.htm`). But a `.sco` game carries its own `VisitorTeamID`/`HomeTeamID`/`Date`, and the engine derives lineups from the `.plr` rosters — so an unmatched game's matchup can be **synthesized directly** and simulated, no schedule needed.

## What changed

- **`validate.ValidateUnscheduled`** — the exact complement of `ValidateCorpus`: simulates the `.sco` games with **no** `.sch` match, synthesizing `bundle.Game{vis,home,date,gametype}` from the `.sco`'s own IDs and reusing `matchSchedule`/`validateGame`. The matched-path (`ValidateCorpus`) is untouched.
- **Sim-validity guard** — an unmatched game whose team has no `.plr` roster is skipped and recorded in `Report.Excluded` (non-failing, never dropped). `WriteReport` emits `EXCLUDED` lines + count only when present, so `ValidateCorpus` output stays byte-identical.
- **Calibrate playoff bucket** — `groupSeasons` selects the finals (last-overall) snapshot beside the last-regular snapshot; `collectSeasonReports` routes the finals snapshot through an injectable `ValidateUnscheduled` seam under `GameTypePlayoff`. `Calibrate`/`Gate` segment by `Report.GameType`, so playoff bands fall out with no aggregation change.

## No ASG contamination (verified)

The All-Star/Rising-Stars games live in the 1,000,000-byte `.sco` header that `backup.ReadSco` skips wholesale, so they never reach the harness. A throwaway cross-season probe over `ibl5/backups` (7 seasons, **508 unmatched playoff games**) confirmed **0 exclusions** and **0 All-Star team IDs (50/51)** — the unmatched set is pure playoffs. Probe deleted after use (like PR9c's `_schprobe`).

## Verification

- Unit tests (rows 1–8): green — `go test ./...`
- **Real-archive (row 9)**, run locally on 03-04: regular bucket 1147 games (type 2) + **playoff bucket 83 games (type 4)**, 0 excluded, 13 stat bands each. Build-tag gated (`//go:build archive`), excluded from CI.
- Full engine gate: `make -C engine fmt-check vet lint cover` (golangci-lint v2.12.2) — 0 lint issues, coverage **92.8%** ≥ 90% floor.
- `engine.yml` unchanged.

## Manual Testing

No manual testing needed — all changes are covered by automated tests.

🤖 Generated with [Claude Code](https://claude.ai/code)