### PR TITLE
feat(engine): wire .plb minutes + uniform stamina ceiling into backup bundle

### DIFF
--- a/engine/internal/backup/assemble.go
+++ b/engine/internal/backup/assemble.go
@@ -19,6 +19,10 @@ type AssembleOptions struct {
 	LeagueID int
 	Seed     uint64
 	GameType bundle.GameType // 0 -> GameTypeRegular (2)
+	// Minutes maps a player ordinal -> dc_minutes, parsed from the snapshot's
+	// .plb depth-chart file (see ReadPlb). A nil map means no .plb was present:
+	// every player's DCMinutes falls back to 0, the historical behavior.
+	Minutes map[int]int
 }
 
 // ToBundle assembles a parsed .plr roster and .sch schedule into a
@@ -29,16 +33,22 @@ type AssembleOptions struct {
 // deterministic. An empty roster or schedule, or a schedule referencing a team
 // with no roster players, is a typed error rather than a silent empty bundle.
 //
-// Fields the engine reads that the .plr format does not store are zeroed here:
-//   - r_foul   — no foul rating in the .plr ratings block
-//   - stamina  — an ibl_plr column, but not present in the .plr file layout
-//   - dc_minutes — sourced from the DB depth chart, not the .plr
+// Two engine inputs are NOT per-player fields of the .plr text record and are
+// supplied here instead of read from it:
+//   - stamina — the energy ceiling. The .plr does not carry a per-player stamina
+//     rating (verified: DB ibl_plr.stamina matches no .plr offset, and JSB zeroes
+//     the ceiling on .plr load, then sets it from the conditioning roll whose
+//     .plr source is a constant 100 across all players). So the faithful ceiling
+//     is the uniform constant 100, which we assign directly rather than reading
+//     the variable-width .plr tail block. See ibl5/docs/JSB_FILE_FORMATS.md.
+//   - dc_minutes — the GM depth-chart minutes, sourced from the snapshot's .plb
+//     file via opts.Minutes (keyed by player Ordinal). A nil map -> 0 (no .plb).
 //
-// The dc_of/df/oi/di/bh depth fields are also zero, which is correct (not a
-// gap): they are dead on IBL5 data and the engine deliberately never reads them
-// (see internal/sim/lineup.go). This means a backup-driven sim runs with no
-// per-player minutes/stamina signal; PR9b accounts for that when choosing
-// tolerance bands. PR9a only proves the bundle is structurally engine-valid.
+// Still zeroed (correct, not a gap):
+//   - r_foul — no foul rating in the .plr ratings block.
+//   - dc_of/df/oi/di/bh — dead on IBL5 data; the engine deliberately never reads
+//     them (see internal/sim/lineup.go), and the .plb carries them but we do not
+//     wire them since populating dead fields only churns output.
 func ToBundle(players []PlrPlayer, sched []SchGame, opts AssembleOptions) (bundle.Bundle, error) {
 	if len(players) == 0 {
 		return bundle.Bundle{}, fmt.Errorf("backup: assemble: %w", bundle.ErrEmptyRoster)
@@ -56,7 +66,7 @@ func ToBundle(players []PlrPlayer, sched []SchGame, opts AssembleOptions) (bundl
 	bundlePlayers := make([]bundle.Player, 0, len(players))
 	for _, p := range players {
 		rosterTeams[p.TeamID] = true
-		bundlePlayers = append(bundlePlayers, toBundlePlayer(p))
+		bundlePlayers = append(bundlePlayers, toBundlePlayer(p, opts.Minutes))
 	}
 
 	scheduleTeams := make(map[int]bool, 32)
@@ -99,8 +109,9 @@ func ToBundle(players []PlrPlayer, sched []SchGame, opts AssembleOptions) (bundl
 
 // toBundlePlayer maps a .plr record onto bundle.Player. The ODPT pairing
 // follows the .plr rating names: DO=drive offense -> r_drive_off,
-// TO=transition offense -> r_trans_off.
-func toBundlePlayer(p PlrPlayer) bundle.Player {
+// TO=transition offense -> r_trans_off. minutes maps player ordinal ->
+// dc_minutes from the .plb (nil -> 0).
+func toBundlePlayer(p PlrPlayer, minutes map[int]int) bundle.Player {
 	return bundle.Player{
 		PID:    p.PID,
 		Name:   p.Name,
@@ -136,7 +147,9 @@ func toBundlePlayer(p PlrPlayer) bundle.Player {
 		Skill:       p.Skill,
 		Intangibles: p.Intangibles,
 		Peak:        p.Peak,
-		// Stamina: no .plr source -> 0.
+		// Stamina is the energy ceiling. The .plr carries no per-player stamina;
+		// JSB's faithful ceiling is the uniform constant 100 (see ToBundle doc).
+		Stamina: 100,
 
 		DCPGDepth:       p.PGDepth,
 		DCSGDepth:       p.SGDepth,
@@ -144,6 +157,8 @@ func toBundlePlayer(p PlrPlayer) bundle.Player {
 		DCPFDepth:       p.PFDepth,
 		DCCDepth:        p.CDepth,
 		DCCanPlayInGame: p.CanPlayInGame,
-		// DCMinutes and DCOf/Df/Oi/Di/Bh: no .plr source -> 0 (see ToBundle doc).
+		// DCMinutes from the .plb (keyed by Ordinal; missing/nil -> 0). DCOf/Df/
+		// Oi/Di/Bh stay 0 — dead fields the engine never reads (see ToBundle doc).
+		DCMinutes: minutes[p.Ordinal],
 	}
 }

--- a/engine/internal/backup/assemble_test.go
+++ b/engine/internal/backup/assemble_test.go
@@ -135,6 +135,78 @@ func TestToBundle_Errors(t *testing.T) {
 	}
 }
 
+// Row 6 (characterization): with a nil Minutes map (no .plb), every assembled
+// player's DCMinutes falls back to 0 — locks the historical behavior across the
+// toBundlePlayer signature change.
+func TestToBundle_NoPlb_ZeroMinutes(t *testing.T) {
+	players := append(teamRoster(1), teamRoster(2)...)
+	sched := []SchGame{{VisitorTeamID: 1, HomeTeamID: 2, Month: 11, Day: 2}}
+	b, err := ToBundle(players, sched, AssembleOptions{}) // nil Minutes
+	if err != nil {
+		t.Fatalf("ToBundle: %v", err)
+	}
+	for _, p := range b.Players {
+		if p.DCMinutes != 0 {
+			t.Errorf("player pid=%d DCMinutes = %d, want 0 (no .plb)", p.PID, p.DCMinutes)
+		}
+	}
+}
+
+// Row 7: a populated Minutes map sets Player.DCMinutes by Ordinal (missing
+// ordinal -> 0), AND every assembled player's Stamina is the uniform energy
+// ceiling 100 (previously unasserted — the zeroed default never had a test).
+func TestToBundle_StaminaAndMinutes(t *testing.T) {
+	players := append(teamRoster(1), teamRoster(2)...)
+	sched := []SchGame{{VisitorTeamID: 1, HomeTeamID: 2, Month: 11, Day: 2}}
+	// teamRoster's makePlayer sets Ordinal == PID; team1 -> 101..105, team2 -> 201..205.
+	minutes := map[int]int{101: 40, 102: 16, 201: 38}
+	b, err := ToBundle(players, sched, AssembleOptions{Minutes: minutes})
+	if err != nil {
+		t.Fatalf("ToBundle: %v", err)
+	}
+	byPID := map[int]bundle.Player{}
+	for _, p := range b.Players {
+		byPID[p.PID] = p
+	}
+	for pid, want := range map[int]int{101: 40, 102: 16, 201: 38, 105: 0 /* no map entry */} {
+		if got := byPID[pid].DCMinutes; got != want {
+			t.Errorf("pid %d DCMinutes = %d, want %d", pid, got, want)
+		}
+	}
+	for _, p := range b.Players {
+		if p.Stamina != 100 {
+			t.Errorf("player pid=%d Stamina = %d, want 100 (uniform energy ceiling)", p.PID, p.Stamina)
+		}
+	}
+}
+
+// Row 5: a Minutes map carrying an ordinal that matches no player is harmless —
+// the orphan key is ignored and real players still map correctly.
+func TestToBundle_PlbOrdinalNoMatch(t *testing.T) {
+	players := append(teamRoster(1), teamRoster(2)...)
+	sched := []SchGame{{VisitorTeamID: 1, HomeTeamID: 2, Month: 11, Day: 2}}
+	minutes := map[int]int{9999: 30, 101: 22} // ordinal 9999 matches no player
+	b, err := ToBundle(players, sched, AssembleOptions{Minutes: minutes})
+	if err != nil {
+		t.Fatalf("ToBundle with orphan ordinal: %v", err)
+	}
+	var found bool
+	for _, p := range b.Players {
+		if p.PID == 101 {
+			found = true
+			if p.DCMinutes != 22 {
+				t.Errorf("pid 101 DCMinutes = %d, want 22", p.DCMinutes)
+			}
+		}
+		if p.DCMinutes == 30 {
+			t.Errorf("orphan ordinal 9999 leaked onto pid=%d", p.PID)
+		}
+	}
+	if !found {
+		t.Fatal("pid 101 missing from assembled bundle")
+	}
+}
+
 // Row #13: ReadPlr/ReadSch/ToBundle are pure — identical bytes produce
 // byte-identical structs and bundles across runs (no map-order or time leak).
 func TestToBundle_Deterministic(t *testing.T) {

--- a/engine/internal/backup/plb.go
+++ b/engine/internal/backup/plb.go
@@ -1,0 +1,88 @@
+package backup
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// .plb depth-chart layout, transcribed from
+// ibl5/classes/JsbParser/PlbFileParser.php (the authoritative reader). Each line
+// is one team; each 12-char slot is one roster ordinal's depth-chart entry:
+//
+//	dc_minutes(2) | dc_of(2) | dc_df(2) | dc_oi(2) | dc_di(2) | dc_bh(2)
+//
+// Only dc_minutes feeds the engine — the of/df/oi/di/bh fields are dead on IBL5
+// data and the sim deliberately never reads them (see internal/sim/lineup.go),
+// so they are not parsed.
+const (
+	plbTeamsPerFile = 32
+	plbSlotsPerTeam = 30
+	plbCharsPerSlot = 12
+	// A line shorter than this cannot carry 30 full slots, so it is blank/short
+	// padding and skipped — mirrors PlbFileParser::MIN_LINE_LENGTH (30 * 12).
+	plbMinLineLen = plbSlotsPerTeam * plbCharsPerSlot // 360
+	// Only teams 1..28 are real IBL franchises; lines beyond that are skipped,
+	// mirroring PlbImporter's `$teamid > 28` guard.
+	plbMaxTeamID = 28
+)
+
+// ReadPlb reads a backup .plb depth-chart file from r and returns a map of
+// player ordinal -> dc_minutes (the GM-assigned per-player target minutes). The
+// ordinal is derived positionally: ordinal = (teamID-1)*30 + slotIndex + 1, with
+// teamID = lineIndex + 1 — matching PlrParser/PlrOrdinalMap.php, so the result
+// keys join directly onto PlrPlayer.Ordinal in ToBundle.
+//
+// Records are CRLF-separated (matching ReadPlr's convention). A short line
+// (< 360 chars) or a line for teamID > 28 is skipped. Every parsed slot yields a
+// map entry, including dc_minutes == 0 (a real player may legitimately be
+// assigned 0). The minutes field is a LENIENT cast (empty/non-numeric -> 0),
+// like PHP's (int)substr: this is a best-effort signal, not an identity field,
+// so a malformed slot degrades to 0 minutes rather than failing an otherwise-
+// valid snapshot. The only error is an io.ReadAll failure.
+func ReadPlb(r io.Reader) (map[int]int, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("backup: read .plb: %w", err)
+	}
+	lines := strings.Split(string(data), "\r\n")
+
+	out := make(map[int]int)
+	limit := len(lines)
+	if limit > plbTeamsPerFile {
+		limit = plbTeamsPerFile
+	}
+	for lineIndex := 0; lineIndex < limit; lineIndex++ {
+		line := lines[lineIndex]
+		if len(line) < plbMinLineLen {
+			continue // blank / short padding row
+		}
+		teamID := lineIndex + 1
+		if teamID > plbMaxTeamID {
+			continue
+		}
+		for slot := 0; slot < plbSlotsPerTeam; slot++ {
+			off := slot * plbCharsPerSlot
+			ordinal := (teamID-1)*plbSlotsPerTeam + slot + 1
+			out[ordinal] = plbInt(line, off, 2)
+		}
+	}
+	return out, nil
+}
+
+// plbInt slices a 2-char minutes field, trims padding, and parses it leniently:
+// an empty or non-numeric field yields 0 (matching PHP's (int)substr cast).
+// Unlike plrInt it never errors — a malformed depth-chart slot must not fail the
+// whole snapshot, since dc_minutes is a best-effort signal, not identity.
+func plbInt(line string, off, width int) int {
+	s := strings.TrimSpace(plrSlice(line, off, width))
+	if s == "" {
+		return 0
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return v
+}

--- a/engine/internal/backup/plb_test.go
+++ b/engine/internal/backup/plb_test.go
@@ -1,0 +1,99 @@
+package backup
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// plbLine builds one 360-char .plb team line from per-slot dc_minutes (slots
+// beyond len(mins) are zero). Each 12-char slot is minutes(2, right-justified)
+// followed by 10 chars of of/df/oi/di/bh padding (zeros — the reader ignores
+// them).
+func plbLine(mins []int) string {
+	var b strings.Builder
+	for slot := 0; slot < plbSlotsPerTeam; slot++ {
+		m := 0
+		if slot < len(mins) {
+			m = mins[slot]
+		}
+		fmt.Fprintf(&b, "%2d%s", m, "0000000000")
+	}
+	return b.String()
+}
+
+// Row 1: ReadPlb maps slot->ordinal via (teamid-1)*30+slot+1 across teams.
+func TestReadPlb_SlotOrdinalMapping(t *testing.T) {
+	data := strings.Join([]string{
+		plbLine([]int{40}),       // team 1 (line 0): slot 0 = 40 -> ordinal 1
+		plbLine([]int{0, 0, 25}), // team 2 (line 1): slot 2 = 25 -> ordinal 33
+	}, "\r\n")
+	m, err := ReadPlb(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadPlb: %v", err)
+	}
+	if m[1] != 40 {
+		t.Errorf("ordinal 1 (team1 slot0) = %d, want 40", m[1])
+	}
+	if m[31] != 0 {
+		t.Errorf("ordinal 31 (team2 slot0) = %d, want 0", m[31])
+	}
+	if m[33] != 25 {
+		t.Errorf("ordinal 33 (team2 slot2) = %d, want 25", m[33])
+	}
+}
+
+// Row 2: a line shorter than 360 chars is skipped (no ordinals for that team).
+func TestReadPlb_ShortLineSkipped(t *testing.T) {
+	data := strings.Join([]string{plbLine([]int{40}), "tooshort"}, "\r\n")
+	m, err := ReadPlb(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadPlb: %v", err)
+	}
+	if m[1] != 40 {
+		t.Errorf("team1 slot0 = %d, want 40", m[1])
+	}
+	if _, ok := m[31]; ok {
+		t.Errorf("short team-2 line should yield no ordinals, got an entry for ordinal 31")
+	}
+}
+
+// Row 3: a line index > 27 (teamid > 28) is skipped entirely.
+func TestReadPlb_TeamIDOver28Skipped(t *testing.T) {
+	lines := make([]string, 29) // lines 0..28 => teams 1..29
+	for i := range lines {
+		lines[i] = plbLine([]int{i + 1}) // slot0 = i+1, so each team is distinguishable
+	}
+	m, err := ReadPlb(strings.NewReader(strings.Join(lines, "\r\n")))
+	if err != nil {
+		t.Fatalf("ReadPlb: %v", err)
+	}
+	// team 28 (lineIndex 27) slot0 -> ordinal (28-1)*30+1 = 811, value 28.
+	if m[811] != 28 {
+		t.Errorf("team28 slot0 (ord 811) = %d, want 28", m[811])
+	}
+	// team 29 (lineIndex 28) must be skipped -> ordinal 841 absent.
+	if _, ok := m[841]; ok {
+		t.Errorf("team 29 (lineIndex 28) must be skipped, got an entry for ordinal 841")
+	}
+}
+
+// Row 4: a slot with dc_minutes == 0 still produces a map entry (not skipped),
+// since a real player may legitimately be assigned 0.
+func TestReadPlb_ZeroMinutesAttaches(t *testing.T) {
+	data := plbLine([]int{0, 16}) // slot 0 = 0, slot 1 = 16
+	m, err := ReadPlb(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadPlb: %v", err)
+	}
+	v, ok := m[1]
+	if !ok {
+		t.Fatalf("slot 0 (ord 1) should have a map entry even at 0 minutes")
+	}
+	if v != 0 {
+		t.Errorf("ord 1 = %d, want 0", v)
+	}
+	if m[2] != 16 {
+		t.Errorf("ord 2 = %d, want 16", m[2])
+	}
+}

--- a/engine/internal/calibrate/walk.go
+++ b/engine/internal/calibrate/walk.go
@@ -17,15 +17,22 @@ import (
 // trusted archive. The real .sco is ~8 MB; this leaves ample headroom.
 const maxEntryBytes = 128 << 20
 
-// canonicalMember maps a lowercased triple-member basename to the canonical
-// name it is extracted as. Writing canonical names (not the zip's own casing)
-// guarantees a stable stem for validate.findTriples and a known path for the
-// season reader's backup.ReadSco.
+// canonicalMember maps a lowercased member basename to the canonical name it is
+// extracted as. Writing canonical names (not the zip's own casing) guarantees a
+// stable stem for validate.findTriples and a known path for the season reader's
+// backup.ReadSco. IBL5.plb (depth chart) is extracted when present but is NOT
+// required (see requiredMembers) — a snapshot lacking it validates with zero
+// minutes, reported by the harness as MissingPlb.
 var canonicalMember = map[string]string{
 	"ibl5.plr": "IBL5.plr",
 	"ibl5.sch": "IBL5.sch",
 	"ibl5.sco": "IBL5.sco",
+	"ibl5.plb": "IBL5.plb",
 }
+
+// requiredMembers are the canonical members that MUST all be present for a
+// snapshot to be validatable. The optional IBL5.plb is intentionally absent.
+var requiredMembers = []string{"IBL5.plr", "IBL5.sch", "IBL5.sco"}
 
 // ValidateFunc is the seam to internal/validate.ValidateCorpus, injected so the
 // walk's extraction/inference/skip logic is unit-testable without running the
@@ -134,9 +141,10 @@ func processZip(path string, gt bundle.GameType, runs int, seed uint64, validate
 	return &rep, nil
 }
 
-// extractTriple writes the three triple members from zipPath into destDir,
-// returning found=true only when all three are present. Entries are written by
-// BASENAME ONLY (filepath.Base), so a crafted entry name like "../../IBL5.plr"
+// extractTriple writes the canonical members from zipPath into destDir,
+// returning found=true only when all requiredMembers are present (the optional
+// IBL5.plb is extracted when present but never gates found). Entries are written
+// by BASENAME ONLY (filepath.Base), so a crafted entry name like "../../IBL5.plr"
 // cannot escape destDir (zip-slip safe) even though the archive is trusted.
 func extractTriple(zipPath, destDir string) (bool, error) {
 	zr, err := zip.OpenReader(zipPath)
@@ -158,7 +166,7 @@ func extractTriple(zipPath, destDir string) (bool, error) {
 		}
 		got[canon] = true
 	}
-	for _, canon := range canonicalMember {
+	for _, canon := range requiredMembers {
 		if !got[canon] {
 			return false, nil
 		}

--- a/engine/internal/calibrate/walk_test.go
+++ b/engine/internal/calibrate/walk_test.go
@@ -174,6 +174,42 @@ func TestExtractTriple_ZipSlipSafe(t *testing.T) {
 	}
 }
 
+// Row 10: IBL5.plb is extracted when present, but it is OPTIONAL — a zip lacking
+// it still yields found=true (only the .plr/.sch/.sco triple is required).
+func TestExtractTriple_PlbOptional(t *testing.T) {
+	// (a) zip WITH a .plb: extracted, found=true.
+	withPlb := fullTriple()
+	withPlb["IBL5.plb"] = "plb-bytes"
+	zipA := filepath.Join(t.TempDir(), "with_reg-sim.zip")
+	makeZip(t, zipA, withPlb)
+	destA := t.TempDir()
+	found, err := extractTriple(zipA, destA)
+	if err != nil {
+		t.Fatalf("extractTriple with .plb: %v", err)
+	}
+	if !found {
+		t.Error("found = false, want true (required triple present)")
+	}
+	if _, err := os.Stat(filepath.Join(destA, "IBL5.plb")); err != nil {
+		t.Errorf("IBL5.plb should be extracted when present: %v", err)
+	}
+
+	// (b) zip WITHOUT a .plb: still found=true, and no .plb written.
+	zipB := filepath.Join(t.TempDir(), "without_reg-sim.zip")
+	makeZip(t, zipB, fullTriple())
+	destB := t.TempDir()
+	found, err = extractTriple(zipB, destB)
+	if err != nil {
+		t.Fatalf("extractTriple without .plb: %v", err)
+	}
+	if !found {
+		t.Error("found = false, want true (.plb is optional)")
+	}
+	if _, err := os.Stat(filepath.Join(destB, "IBL5.plb")); !os.IsNotExist(err) {
+		t.Errorf("IBL5.plb should be absent, stat err = %v", err)
+	}
+}
+
 // Row (sample-stride): with stride 2 over four qualifying zips, only the 1st and
 // 3rd are processed.
 func TestCollectReports_SampleStride(t *testing.T) {

--- a/engine/internal/validate/format.go
+++ b/engine/internal/validate/format.go
@@ -41,6 +41,12 @@ func WriteReport(w io.Writer, rep Report) {
 		p("EXCLUDED stem=%s visitor=%d home=%d date=%s: %s\n",
 			e.Stem, e.VisitorTeamID, e.HomeTeamID, e.Date, e.Reason)
 	}
+	// MISSING_PLB lines surface snapshots whose depth chart was absent (minutes
+	// defaulted to 0). Emitted only when present, so a snapshot that has its .plb
+	// renders byte-identically; this is visibility only and does not affect Pass.
+	for _, stem := range rep.MissingPlb {
+		p("MISSING_PLB stem=%s: no .plb depth chart — dc_minutes defaulted to 0\n", stem)
+	}
 	result := "PASS"
 	if !rep.Pass {
 		result = "FAIL"

--- a/engine/internal/validate/harness.go
+++ b/engine/internal/validate/harness.go
@@ -15,7 +15,9 @@ import (
 )
 
 // ErrNoCorpus reports a corpus directory that contains no complete
-// .plr/.sch/.sco triple — an empty dir, or files that do not share a stem.
+// .plr/.sch/.sco triple — an empty dir, or files that do not share a stem. The
+// .plb depth-chart file is an OPTIONAL fourth member (supplies per-player
+// dc_minutes); its absence is reported via Report.MissingPlb, never required.
 var ErrNoCorpus = errors.New("validate: no .plr/.sch/.sco triple found in corpus dir")
 
 // UnmatchedGame is a .sco ground-truth game that could not be paired with a
@@ -58,14 +60,21 @@ type Report struct {
 	Games     []GameReport
 	Unmatched []UnmatchedGame
 	Excluded  []ExcludedGame
+	// MissingPlb lists the stems whose snapshot had no .plb depth chart, so every
+	// player's dc_minutes defaulted to 0. Reported for visibility (never silently
+	// zeroed); it does NOT affect Pass — a snapshot is still validatable on team
+	// stats without the per-player minutes signal.
+	MissingPlb []string
 }
 
-// triple names one backup file set sharing a stem within the corpus dir.
+// triple names one backup file set sharing a stem within the corpus dir. plr/
+// sch/sco are required; plb is the optional depth-chart member ("" if absent).
 type triple struct {
 	stem string
 	plr  string
 	sch  string
 	sco  string
+	plb  string
 }
 
 // findTriples groups the .plr/.sch/.sco files in dir by shared stem and returns
@@ -99,6 +108,8 @@ func findTriples(dir string) ([]triple, error) {
 			get(stem).sch = full
 		case ".sco":
 			get(stem).sco = full
+		case ".plb":
+			get(stem).plb = full
 		}
 	}
 	stems := make([]string, 0, len(byStem))
@@ -135,11 +146,35 @@ func readTriple(t triple, gameType bundle.GameType) (bundle.Bundle, []backup.Sch
 	if err != nil {
 		return bundle.Bundle{}, nil, nil, err
 	}
-	b, err := backup.ToBundle(players, sched, backup.AssembleOptions{GameType: gameType})
+	// The .plb is optional; a missing one yields a nil map -> dc_minutes 0.
+	var minutes map[int]int
+	if t.plb != "" {
+		minutes, err = readPlb(t.plb)
+		if err != nil {
+			return bundle.Bundle{}, nil, nil, err
+		}
+	}
+	b, err := backup.ToBundle(players, sched, backup.AssembleOptions{GameType: gameType, Minutes: minutes})
 	if err != nil {
 		return bundle.Bundle{}, nil, nil, fmt.Errorf("validate: assemble %q: %w", t.stem, err)
 	}
 	return b, sched, scoGames, nil
+}
+
+// readPlb opens a .plb depth-chart file and parses it into an ordinal->minutes
+// map. It cannot use the generic readFile helper (which returns []T); the
+// error-wrapping mirrors readFile so a malformed .plb is diagnosable by path.
+func readPlb(path string) (map[int]int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("validate: open %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	m, err := backup.ReadPlb(f)
+	if err != nil {
+		return nil, fmt.Errorf("validate: parse %q: %w", path, err)
+	}
+	return m, nil
 }
 
 // readFile opens path and applies a backup reader, wrapping any error with the
@@ -187,6 +222,9 @@ func ValidateCorpus(dir string, runs int, baseSeed uint64, gameType bundle.GameT
 		b, sched, scoGames, err := readTriple(t, gameType)
 		if err != nil {
 			return Report{}, err
+		}
+		if t.plb == "" {
+			rep.MissingPlb = append(rep.MissingPlb, t.stem)
 		}
 		consumed := make([]bool, len(sched))
 		for _, sg := range scoGames {
@@ -250,6 +288,9 @@ func ValidateUnscheduled(dir string, runs int, baseSeed uint64, gameType bundle.
 		b, sched, scoGames, err := readTriple(t, gameType)
 		if err != nil {
 			return Report{}, err
+		}
+		if t.plb == "" {
+			rep.MissingPlb = append(rep.MissingPlb, t.stem)
 		}
 		hasLineup := lineupTeams(b)
 		consumed := make([]bool, len(sched))

--- a/engine/internal/validate/harness_test.go
+++ b/engine/internal/validate/harness_test.go
@@ -363,3 +363,68 @@ func TestValidateUnscheduled_GuardsAndEmptyDir(t *testing.T) {
 		t.Fatalf("empty dir error = %v, want ErrNoCorpus", err)
 	}
 }
+
+// writePlb writes a minimal valid .plb (one 360-char line) at path. Content is
+// irrelevant to findTriples (which groups by extension) and parses to all-zero
+// minutes for ReadPlb; the valid length keeps it from being skipped as padding.
+func writePlb(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.Repeat("0", 360)), 0o644); err != nil {
+		t.Fatalf("write .plb: %v", err)
+	}
+}
+
+// Row 8: findTriples returns a complete triple with plb=="" when no .plb is
+// present, and picks up the .plb path once one sharing the stem is added.
+func TestFindTriples_PlbOptional(t *testing.T) {
+	dir := t.TempDir()
+	buildCorpus(t, dir, true, testRuns, 1)
+
+	triples, err := findTriples(dir)
+	if err != nil {
+		t.Fatalf("findTriples: %v", err)
+	}
+	if len(triples) != 1 {
+		t.Fatalf("triples = %d, want 1", len(triples))
+	}
+	if triples[0].plb != "" {
+		t.Errorf("plb = %q, want empty (no .plb yet)", triples[0].plb)
+	}
+
+	writePlb(t, dir+"/synth.plb")
+	triples, err = findTriples(dir)
+	if err != nil {
+		t.Fatalf("findTriples after .plb: %v", err)
+	}
+	if len(triples) != 1 {
+		t.Fatalf("triples = %d, want 1", len(triples))
+	}
+	if triples[0].plb == "" {
+		t.Error("plb path empty after writing synth.plb")
+	}
+}
+
+// Row 9: a snapshot missing its .plb is reported in Report.MissingPlb (rendered
+// as a MISSING_PLB line) and validation still runs with zero minutes — the
+// missing depth chart does NOT force the report to FAIL.
+func TestValidateCorpus_MissingPlbReported(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(2000)
+	buildCorpus(t, dir, true, testRuns, seed) // in-band, no .plb
+
+	rep, err := ValidateCorpus(dir, testRuns, seed, bundle.GameTypeRegular)
+	if err != nil {
+		t.Fatalf("ValidateCorpus: %v", err)
+	}
+	if len(rep.MissingPlb) != 1 || rep.MissingPlb[0] != "synth" {
+		t.Fatalf("MissingPlb = %v, want [synth]", rep.MissingPlb)
+	}
+	if !rep.Pass {
+		t.Error("a missing .plb must NOT force FAIL (in-band corpus should still pass)")
+	}
+	var buf bytes.Buffer
+	WriteReport(&buf, rep)
+	if !strings.Contains(buf.String(), "MISSING_PLB stem=synth") {
+		t.Errorf("report should render a MISSING_PLB line:\n%s", buf.String())
+	}
+}

--- a/ibl5/docs/JSB_FILE_FORMATS.md
+++ b/ibl5/docs/JSB_FILE_FORMATS.md
@@ -13,6 +13,7 @@ Reverse-engineered specifications for the binary and text data files produced by
 
 - [IBL5.car — Career Statistics](#ibl5car--career-statistics)
 - [IBL5.plr — Player Records](#ibl5plr--player-records)
+- [IBL5.plb — Depth Charts](#ibl5plb--depth-charts)
 - [IBL5.his — Historical Results](#ibl5his--historical-results)
 - [IBL5.rcb — Record Book](#ibl5rcb--record-book)
 - [IBL5.trn — Transactions](#ibl5trn--transactions)
@@ -170,8 +171,10 @@ block across all 657 `IBL5.plr` players (5238/5256 field comparisons match; the
 | 135 | 1 | `PFDepth` |
 | 136 | 1 | `CDepth` |
 | 137 | 1 | `canPlayInGame` |
-| 138 | 2 | Matchup composite rating (0-99, engine default 50; loaded to struct +0x210, feeds matchup-quality calc FUN_004e3860). Parsed as `unk_138`. |
+| 138 | 2 | Matchup composite rating (0-99, engine default 50; loaded to struct +0x210, feeds matchup-quality calc FUN_004e3860). Parsed as `unk_138`. Observed constant `39` in IBL data; **not** the stamina rating — see note. |
 | 140 | 4 | `injuryDaysLeft` |
+
+> **Note — stamina is not a per-player `.plr` field.** A prior hypothesis placed the stamina/"conditioning" rating at offset 138, but offset 138 is the matchup composite rating (above), not stamina. Stamina is absent from the `.plr` entirely: the DB `ibl_plr.stamina` (varied ~0–33) matches no `.plr` offset under any encoding (the `.plr` was verified same-season as the DB via exact per-pid age match), and `PlrFileWriter` writes no stamina field. JSB zeroes the energy ceiling on `.plr` load and sets it at runtime from the conditioning roll, whose `.plr` source (offset 546, 3 chars) is a constant `100` across all players. So there is no per-player stamina/energy differentiation stored in the `.plr`; the engine-faithful energy ceiling is the uniform constant 100. The Go backup assembler (`engine/internal/backup/assemble.go`) sets `Stamina = 100` accordingly rather than reading a `.plr` field.
 
 #### Season Stats (144-207) — reconstructed from `ibl_box_scores`
 
@@ -433,6 +436,40 @@ Franchise rows are indexed by position: ordinal 1441 = team ID 1, ordinal 1468 =
 - **Left-justified strings** with space padding (player names, team names).
 - **CP1252** for non-ASCII characters (accented names). Readers must `iconv('CP1252', 'UTF-8//IGNORE', $raw)` before display.
 - **CRLF** line endings between records. Player records are *exactly* 607 bytes; franchise team rows are 607-608 bytes (variable trailing tail). `PlrFileWriter::applyChangesToRecord()` asserts length invariance.
+
+---
+
+## IBL5.plb — Depth Charts
+
+**Format:** Fixed-width ASCII, CRLF-separated lines | **Encoding:** ASCII
+
+Carries each GM's submitted depth-chart settings — most importantly the per-player **target minutes** (`dc_minutes`), the only per-player minutes signal the engine consumes (`engine/internal/sim/lineup.go` uses it for lineup/rotation selection). The DB-driven production bundle sources these from the depth-chart tables; the backup harness sources them from this file.
+
+### Structure
+
+- **One line per team**, line index 0–31. Only lines 0–27 (`teamid = lineIndex + 1`, teams 1–28) are real IBL franchises; lines beyond are skipped.
+- **30 slots per line**, 12 chars each (≥ 360 chars per usable line; shorter lines are blank/padding and skipped).
+- Each slot maps to a player by roster ordinal: **`ordinal = (teamid - 1) * 30 + slotIndex + 1`**, joining onto the `.plr` ordinal (offset 0).
+
+### Per-slot layout (12 chars)
+
+| Offset | Width | Field | Used by engine? |
+|--------|-------|-------|-----------------|
+| 0 | 2 | `dc_minutes` | **Yes** — lineup/rotation selection |
+| 2 | 2 | `dc_of` | No (dead field) |
+| 4 | 2 | `dc_df` | No (dead field) |
+| 6 | 2 | `dc_oi` | No (dead field) |
+| 8 | 2 | `dc_di` | No (dead field) |
+| 10 | 2 | `dc_bh` | No (dead field) |
+
+A team's `dc_minutes` across its playing slots sums to ≈ 240 (5 players × 48 minutes).
+
+### Readers
+
+- **PHP (authoritative):** `classes/JsbParser/PlbFileParser.php`; slot→player resolution in `classes/PlrParser/PlrOrdinalMap.php`.
+- **Go (backup harness):** `engine/internal/backup/plb.go` (`ReadPlb` → ordinal→minutes map, wired into the bundle by `engine/internal/backup/assemble.go`).
+
+The `dc_of/df/oi/di/bh` fields are parsed by the PHP importer (for DB storage) but **not** by the Go reader — the engine never reads them.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the backup-corpus **minutes/stamina signal** gap so offline (archive-driven) engine sims carry the same per-player rotation signal as production.

- **Minutes** — new Go `.plb` depth-chart reader (`ReadPlb`) → ordinal→`dc_minutes` map (slot→ordinal = `(teamid-1)*30+slot+1`, mirroring `PlrOrdinalMap.php`), threaded through `AssembleOptions.Minutes`. The engine already consumes `DCMinutes` in `lineup.go qualityScore`; the backup assembler previously zeroed it (flattening every rotation).
- **Stamina** — set `Player.Stamina` (the energy ceiling) to the uniform constant **100** instead of `0`. Stamina is *not* a per-player `.plr` field (verified: DB `ibl_plr.stamina` matches no `.plr` offset; JSB zeroes the ceiling on load and sets it from the conditioning roll whose `.plr` source is constant 100). 100 is the faithful value.
- `.plb` is an **optional** 4th corpus member: a missing one is **reported** (`Report.MissingPlb` / `MISSING_PLB` line), never silently zeroed, and does not force FAIL.
- Docs: new `.plb` format section + corrected `.plr` offset-138/stamina record in `JSB_FILE_FORMATS.md`.

`dc_of/df/oi/di/bh` stay unwired (dead fields the engine never reads).

## Note on stacked commit

This branch is based on the local-master commit `docs(jsb): resolve .plr offset 138 = matchup composite rating`, which is **not yet on origin/master**. Until master is pushed, this PR's diff includes that doc commit; it will drop out once master advances.

## Manual Testing

No manual testing needed — all changes are covered by Go unit tests (`go test ./...`, 12 matrix rows incl. `.plb` parse, slot→ordinal mapping, `Stamina=100`, missing-`.plb` reporting, optional extraction).