### PR TITLE
feat(engine): land calibrated tolerance bands from the real 5.60 archive

### DIFF
--- a/engine/internal/validate/bands.go
+++ b/engine/internal/validate/bands.go
@@ -9,59 +9,93 @@ type Band struct {
 	AbsFloor float64 // absolute floor so small means still get a usable band
 }
 
-// placeholderBands is the per-stat starting tolerance, shared across every game
-// type until corpus calibration replaces it (see the box below).
-//
 // ┌──────────────────────────────────────────────────────────────────────────┐
-// │ STARTING BANDS — NOT AUTHORITATIVE. These ±15% relative / per-stat floor   │
-// │ values are a defensible placeholder, NOT grounded in measured corpus       │
-// │ variance. They MUST be calibrated by running `jsbcalibrate` against the    │
-// │ real 5.60 backup archive (ibl5/backups) and widening/tightening each band  │
-// │ to absorb (a) the single-.sco-draw sampling noise (one .sco line is one    │
-// │ draw from jumpshot.exe's own distribution) AND (b) the engine-vs-jumpshot  │
-// │ model gap, WITHOUT making any band so wide it can never fail. Until         │
-// │ calibrated, the tagged corpus suite is a DIAGNOSTIC, not a merge gate.     │
+// │ CALIBRATED BANDS — provenance below. These are NOT a fidelity proof.       │
 // │                                                                            │
-// │ Note also: the backup-driven sim runs with no per-player minutes/stamina   │
-// │ signal (the .plr carries none — see backup.ToBundle), so the engine-side   │
-// │ distribution is wider than a DB-driven sim's; the bands must absorb that   │
-// │ too.                                                                       │
+// │ Derived by running jsbcalibrate in --mode calibrate against the real 5.60  │
+// │ backup archive and transcribing the proposed per-game-type bands:          │
+// │                                                                            │
+// │   engine git SHA : eee188415be48489ca91e4f650f1f1ec232a0dd3 (master base)  │
+// │   seed           : 20240601                                                │
+// │   coverage       : 0.95 (bands cover the 95th abs-residual percentile)     │
+// │   selection      : season  (one clean regular snapshot/season + playoffs)  │
+// │   runs           : 50       (seeded engine runs per corpus game)           │
+// │   sample-stride  : 1        (every selected season; ~20 seasons)           │
+// │   corpus         : ibl5/backups (olympics excluded)                        │
+// │   date           : 2026-06-01                                              │
+// │   n observations : 35782 regular (gt 2), 2184 playoff (gt 4)               │
+// │                                                                            │
+// │ Audit artifact (the raw CalibrationReport JSON) is committed at            │
+// │   internal/validate/testdata/calibration-5.60-20240601.json                │
+// │ for documentation ONLY. The band VALUES live hardcoded in this file;       │
+// │ nothing reads that JSON at runtime. Re-running calibration regenerates     │
+// │ the JSON; the literals below must then be re-transcribed by hand.          │
+// │                                                                            │
+// │ HCA CAVEAT: bands are calibrated against the CURRENT engine, which has NO  │
+// │ home-court advantage. RE-CALIBRATE when HCA lands.                         │
+// │                                                                            │
+// │ DOCUMENTED CURRENT GAP (AbsFloor > engine mean — band is wide because the  │
+// │ engine under-models the stat at this build stage, NOT a useful tolerance): │
+// │ ftm, fta, tgm, tga, ast, blk, pf. In particular `ast` is structurally 0 in │
+// │ the engine (commentary-only, master-reference L1098), so its band absorbs  │
+// │ the full .sco assist total as the gap. These wide bands are the recorded   │
+// │ baseline of the engine-vs-jumpshot model gap; band WIDTH is the fidelity   │
+// │ signal, and the bands tighten as the engine matures.                       │
 // └──────────────────────────────────────────────────────────────────────────┘
-var placeholderBands = map[string]Band{
-	"points": {RelPct: 0.15, AbsFloor: 8},
-	"fgm":    {RelPct: 0.15, AbsFloor: 5},
-	"fga":    {RelPct: 0.15, AbsFloor: 6},
-	"ftm":    {RelPct: 0.15, AbsFloor: 3},
-	"fta":    {RelPct: 0.15, AbsFloor: 4},
-	"tgm":    {RelPct: 0.15, AbsFloor: 3},
-	"tga":    {RelPct: 0.15, AbsFloor: 4},
-	"reb":    {RelPct: 0.15, AbsFloor: 4},
-	"ast":    {RelPct: 0.15, AbsFloor: 4},
-	"stl":    {RelPct: 0.15, AbsFloor: 3},
-	"tov":    {RelPct: 0.15, AbsFloor: 3},
-	"blk":    {RelPct: 0.15, AbsFloor: 3},
-	"pf":     {RelPct: 0.15, AbsFloor: 4},
+
+// regularBands holds the calibrated regular-season (game_type 2) tolerances.
+var regularBands = map[string]Band{
+	"points": {RelPct: 0.512775, AbsFloor: 48},
+	"fgm":    {RelPct: 0.343837, AbsFloor: 15},
+	"fga":    {RelPct: 0.251896, AbsFloor: 23},
+	"ftm":    {RelPct: 7.843537, AbsFloor: 25},
+	"fta":    {RelPct: 7.293839, AbsFloor: 31},
+	"tgm":    {RelPct: 1.835052, AbsFloor: 8},
+	"tga":    {RelPct: 1.203065, AbsFloor: 14},
+	"reb":    {RelPct: 0.307448, AbsFloor: 16},
+	"ast":    {RelPct: 0.15, AbsFloor: 31},
+	"stl":    {RelPct: 0.798658, AbsFloor: 13},
+	"tov":    {RelPct: 0.744712, AbsFloor: 23},
+	"blk":    {RelPct: 9.15625, AbsFloor: 11},
+	"pf":     {RelPct: 5.75, AbsFloor: 23},
 }
 
-// bands is the SINGLE source of truth for tolerance calibration, now keyed by
-// game type: regular, playoff, and all-star ground truth differ systematically
-// (pace, defense, shot mix), so each game type carries its own band table.
-//
-// Every game type is currently seeded with an identical clone of
-// placeholderBands. The jsbcalibrate harness (cmd/jsbcalibrate) emits per-game-
-// type calibrated values derived from the real backup archive; replacing a game
-// type's entry with those values is a data-only follow-up edit. Edit ONLY this
-// table (or placeholderBands) to recalibrate.
+// playoffBands holds the calibrated playoff (game_type 4) tolerances.
+var playoffBands = map[string]Band{
+	"points": {RelPct: 0.499774, AbsFloor: 46},
+	"fgm":    {RelPct: 0.32658, AbsFloor: 14},
+	"fga":    {RelPct: 0.249437, AbsFloor: 23},
+	"ftm":    {RelPct: 8.027778, AbsFloor: 25},
+	"fta":    {RelPct: 7.413462, AbsFloor: 31},
+	"tgm":    {RelPct: 1.777778, AbsFloor: 7},
+	"tga":    {RelPct: 1.223926, AbsFloor: 13},
+	"reb":    {RelPct: 0.307484, AbsFloor: 15},
+	"ast":    {RelPct: 0.15, AbsFloor: 31},
+	"stl":    {RelPct: 0.757576, AbsFloor: 12},
+	"tov":    {RelPct: 0.746193, AbsFloor: 22},
+	"blk":    {RelPct: 9.576923, AbsFloor: 11},
+	"pf":     {RelPct: 5.914894, AbsFloor: 23},
+}
+
+// bands is the SINGLE source of truth for tolerance calibration, keyed by game
+// type. Regular and playoff carry their own calibrated tables; the alt/all-star
+// types inherit a copy of the calibrated Regular table (see buildBands).
 var bands = buildBands()
 
 func buildBands() map[bundle.GameType]map[string]Band {
-	out := make(map[bundle.GameType]map[string]Band)
+	out := map[bundle.GameType]map[string]Band{
+		bundle.GameTypeRegular: regularBands,
+		bundle.GameTypePlayoff: playoffBands,
+	}
+	// The season collector skips olympics and inferGameType never emits 5, so the
+	// corpus produces NO all-star/alt snapshots — these buckets are uncalibrated.
+	// They inherit a copy of the calibrated Regular table: non-authoritative,
+	// flagged for future calibration when an all-star/alt corpus exists.
 	for _, gt := range []bundle.GameType{
-		bundle.GameTypeRegular, bundle.GameTypeRegularAlt,
-		bundle.GameTypePlayoff, bundle.GameTypeAllStarA, bundle.GameTypeAllStarB,
+		bundle.GameTypeRegularAlt, bundle.GameTypeAllStarA, bundle.GameTypeAllStarB,
 	} {
-		m := make(map[string]Band, len(placeholderBands))
-		for k, v := range placeholderBands {
+		m := make(map[string]Band, len(regularBands))
+		for k, v := range regularBands {
 			m[k] = v
 		}
 		out[gt] = m

--- a/engine/internal/validate/bands_test.go
+++ b/engine/internal/validate/bands_test.go
@@ -6,31 +6,43 @@ import (
 	"github.com/a-jay85/IBL5/engine/internal/bundle"
 )
 
-// Row #2: bandFor returns the band from the requested game type's table. The
-// placeholder values are currently identical across game types, so the test
-// asserts the lookup hits a populated entry for each known type rather than a
-// distinct numeric value (calibration will diverge the values later).
+// expectedTable maps each game type to the band table bandFor must resolve to:
+// Regular and Playoff carry their own calibrated tables; RegularAlt and the two
+// all-star types inherit a copy of the calibrated Regular table (buildBands).
+var expectedTable = map[bundle.GameType]map[string]Band{
+	bundle.GameTypeRegular:    regularBands,
+	bundle.GameTypeRegularAlt: regularBands,
+	bundle.GameTypePlayoff:    playoffBands,
+	bundle.GameTypeAllStarA:   regularBands,
+	bundle.GameTypeAllStarB:   regularBands,
+}
+
+// Row #2/#3: bandFor returns the calibrated band for the requested game type.
+// Regular and playoff now diverge, so the test asserts each game type resolves
+// to its expected table's value (playoff distinct from regular; alt/all-star
+// inherit regular).
 func TestBandFor_KnownGameTypeAndStat(t *testing.T) {
-	for _, gt := range []bundle.GameType{
-		bundle.GameTypeRegular, bundle.GameTypeRegularAlt,
-		bundle.GameTypePlayoff, bundle.GameTypeAllStarA, bundle.GameTypeAllStarB,
-	} {
+	for gt, table := range expectedTable {
 		got := bandFor(gt, "points")
-		want := placeholderBands["points"]
+		want := table["points"]
 		if got != want {
 			t.Errorf("bandFor(%d, points) = %+v, want %+v", int(gt), got, want)
 		}
 	}
+	// Guard the divergence is real: playoff points must differ from regular.
+	if bandFor(bundle.GameTypePlayoff, "points") == bandFor(bundle.GameTypeRegular, "points") {
+		t.Error("playoff and regular points bands are identical — calibration did not diverge")
+	}
 }
 
-// Row #2: every statNames entry resolves to its explicit placeholder band under
+// Row #2: every statNames entry resolves to its explicit calibrated band under
 // the regular table — no stat silently falls through to the generic fallback.
 func TestBandFor_EveryStatHasExplicitBand(t *testing.T) {
 	for _, name := range statNames {
 		got := bandFor(bundle.GameTypeRegular, name)
-		want, ok := placeholderBands[name]
+		want, ok := regularBands[name]
 		if !ok {
-			t.Fatalf("placeholderBands missing an entry for stat %q", name)
+			t.Fatalf("regularBands missing an entry for stat %q", name)
 		}
 		if got != want {
 			t.Errorf("bandFor(regular, %q) = %+v, want explicit %+v", name, got, want)
@@ -59,5 +71,53 @@ func TestBandFor_UnknownStatGetsGenericBand(t *testing.T) {
 	want := Band{RelPct: 0.15, AbsFloor: 3}
 	if got != want {
 		t.Errorf("bandFor(regular, unknown stat) = %+v, want generic %+v", got, want)
+	}
+}
+
+// Sanity-bound ceilings: generous round backstops against a decimal-place
+// transcription error from the calibration JSON — NOT a fidelity claim. The
+// landed maxima (2026-06-01 run) are RelPct≈9.58 and AbsFloor=48; these ceilings
+// sit well above so a misplaced decimal (e.g. 95.8 or 480) trips the test.
+const (
+	relCeiling      = 50.0
+	absFloorCeiling = 100.0
+)
+
+// Row #2: every landed band in all five game-type tables is structurally valid —
+// every statNames entry is present (no missing stat), no band is zero-width or
+// negative, and no band exceeds the transcription-backstop ceilings. This does
+// NOT assert the bands are tight (many are deliberately wide — see the bands.go
+// provenance note's documented current gap); it only catches a vacuous-infinite,
+// zero, or fat-fingered band.
+func TestBands_SanityBounds(t *testing.T) {
+	allTypes := []bundle.GameType{
+		bundle.GameTypeRegular, bundle.GameTypeRegularAlt, bundle.GameTypePlayoff,
+		bundle.GameTypeAllStarA, bundle.GameTypeAllStarB,
+	}
+	for _, gt := range allTypes {
+		table, ok := bands[gt]
+		if !ok {
+			t.Fatalf("bands has no table for game type %d", int(gt))
+		}
+		// Every canonical stat must have an explicit entry — no missing stat.
+		for _, name := range statNames {
+			b, ok := table[name]
+			if !ok {
+				t.Errorf("game type %d table missing stat %q", int(gt), name)
+				continue
+			}
+			if b.RelPct < 0 || b.AbsFloor < 0 {
+				t.Errorf("game type %d stat %q has a negative band %+v", int(gt), name, b)
+			}
+			if b.RelPct == 0 && b.AbsFloor == 0 {
+				t.Errorf("game type %d stat %q is a zero-width band (never fails meaningfully)", int(gt), name)
+			}
+			if b.RelPct >= relCeiling {
+				t.Errorf("game type %d stat %q RelPct %v >= ceiling %v (transcription error?)", int(gt), name, b.RelPct, relCeiling)
+			}
+			if b.AbsFloor >= absFloorCeiling {
+				t.Errorf("game type %d stat %q AbsFloor %v >= ceiling %v (transcription error?)", int(gt), name, b.AbsFloor, absFloorCeiling)
+			}
+		}
 	}
 }

--- a/engine/internal/validate/testdata/calibration-5.60-20240601.json
+++ b/engine/internal/validate/testdata/calibration-5.60-20240601.json
@@ -1,0 +1,327 @@
+{
+  "coverage": 0.95,
+  "buckets": [
+    {
+      "game_type": 2,
+      "stats": [
+        {
+          "stat": "points",
+          "n": 35782,
+          "mean_engine": 93.94234307752554,
+          "p50_abs_resid": 23.799999999999997,
+          "p90_abs_resid": 42.16,
+          "p95_abs_resid": 47.2,
+          "p99_abs_resid": 57.34,
+          "proposed_rel_pct": 0.5127745405647692,
+          "proposed_abs_floor": 48,
+          "in_band_rate": 0.9588899446649153
+        },
+        {
+          "stat": "fgm",
+          "n": 35782,
+          "mean_engine": 43.28254932647729,
+          "p50_abs_resid": 5.439999999999998,
+          "p90_abs_resid": 12.560000000000002,
+          "p95_abs_resid": 14.719999999999999,
+          "p99_abs_resid": 19.04,
+          "proposed_rel_pct": 0.34383688600556084,
+          "proposed_abs_floor": 15,
+          "in_band_rate": 0.9577161701414119
+        },
+        {
+          "stat": "fga",
+          "n": 35782,
+          "mean_engine": 92.86439885976131,
+          "p50_abs_resid": 8.519999999999996,
+          "p90_abs_resid": 19.480000000000004,
+          "p95_abs_resid": 22.900000000000006,
+          "p99_abs_resid": 29.739999999999995,
+          "proposed_rel_pct": 0.2518958803033408,
+          "proposed_abs_floor": 23,
+          "in_band_rate": 0.9548935218825108
+        },
+        {
+          "stat": "ftm",
+          "n": 35782,
+          "mean_engine": 3.149756302051271,
+          "p50_abs_resid": 12.36,
+          "p90_abs_resid": 21.34,
+          "p95_abs_resid": 24.240000000000002,
+          "p99_abs_resid": 29.759999999999998,
+          "proposed_rel_pct": 7.843537414965986,
+          "proposed_abs_floor": 25,
+          "in_band_rate": 0.9669945782795819
+        },
+        {
+          "stat": "fta",
+          "n": 35782,
+          "mean_engine": 4.203962886367471,
+          "p50_abs_resid": 15.82,
+          "p90_abs_resid": 26.72,
+          "p95_abs_resid": 30.1,
+          "p99_abs_resid": 36.74,
+          "proposed_rel_pct": 7.293838862559243,
+          "proposed_abs_floor": 31,
+          "in_band_rate": 0.9653736515566486
+        },
+        {
+          "stat": "tgm",
+          "n": 35782,
+          "mean_engine": 4.227488122519688,
+          "p50_abs_resid": 2.34,
+          "p90_abs_resid": 6.12,
+          "p95_abs_resid": 7.38,
+          "p99_abs_resid": 9.84,
+          "proposed_rel_pct": 1.8350515463917527,
+          "proposed_abs_floor": 8,
+          "in_band_rate": 0.9752389469565703
+        },
+        {
+          "stat": "tga",
+          "n": 35782,
+          "mean_engine": 12.112342518584864,
+          "p50_abs_resid": 5,
+          "p90_abs_resid": 11.5,
+          "p95_abs_resid": 13.58,
+          "p99_abs_resid": 18,
+          "proposed_rel_pct": 1.203065134099617,
+          "proposed_abs_floor": 14,
+          "in_band_rate": 0.9703202727628416
+        },
+        {
+          "stat": "reb",
+          "n": 35782,
+          "mean_engine": 49.58184953328476,
+          "p50_abs_resid": 5.140000000000001,
+          "p90_abs_resid": 12.68,
+          "p95_abs_resid": 15.200000000000003,
+          "p99_abs_resid": 20.200000000000003,
+          "proposed_rel_pct": 0.3074484944532489,
+          "proposed_abs_floor": 16,
+          "in_band_rate": 0.9637247778212509
+        },
+        {
+          "stat": "ast",
+          "n": 35782,
+          "mean_engine": 0,
+          "p50_abs_resid": 20,
+          "p90_abs_resid": 28,
+          "p95_abs_resid": 31,
+          "p99_abs_resid": 35,
+          "proposed_rel_pct": 0.15,
+          "proposed_abs_floor": 31,
+          "in_band_rate": 0.9629143144597843
+        },
+        {
+          "stat": "stl",
+          "n": 35782,
+          "mean_engine": 15.560174389357753,
+          "p50_abs_resid": 7.16,
+          "p90_abs_resid": 11.58,
+          "p95_abs_resid": 12.64,
+          "p99_abs_resid": 14.48,
+          "proposed_rel_pct": 0.7986577181208053,
+          "proposed_abs_floor": 13,
+          "in_band_rate": 0.9698451735509475
+        },
+        {
+          "stat": "tov",
+          "n": 35782,
+          "mean_engine": 28.28834665474256,
+          "p50_abs_resid": 14.559999999999999,
+          "p90_abs_resid": 20.46,
+          "p95_abs_resid": 22.08,
+          "p99_abs_resid": 24.78,
+          "proposed_rel_pct": 0.7447118891320205,
+          "proposed_abs_floor": 23,
+          "in_band_rate": 0.9721088815605612
+        },
+        {
+          "stat": "blk",
+          "n": 35782,
+          "mean_engine": 0.982189927896706,
+          "p50_abs_resid": 4.58,
+          "p90_abs_resid": 8.94,
+          "p95_abs_resid": 10.26,
+          "p99_abs_resid": 13.18,
+          "proposed_rel_pct": 9.15625,
+          "proposed_abs_floor": 11,
+          "in_band_rate": 0.9734223911463864
+        },
+        {
+          "stat": "pf",
+          "n": 35782,
+          "mean_engine": 4.033671678497572,
+          "p50_abs_resid": 14.34,
+          "p90_abs_resid": 20.7,
+          "p95_abs_resid": 22.5,
+          "p99_abs_resid": 26.2,
+          "proposed_rel_pct": 5.75,
+          "proposed_abs_floor": 23,
+          "in_band_rate": 0.9668827902297245
+        }
+      ]
+    },
+    {
+      "game_type": 4,
+      "stats": [
+        {
+          "stat": "points",
+          "n": 2184,
+          "mean_engine": 93.06518315018334,
+          "p50_abs_resid": 23.319999999999993,
+          "p90_abs_resid": 40.620000000000005,
+          "p95_abs_resid": 45.36,
+          "p99_abs_resid": 54.7,
+          "proposed_rel_pct": 0.4997744700045105,
+          "proposed_abs_floor": 46,
+          "in_band_rate": 0.9610805860805861
+        },
+        {
+          "stat": "fgm",
+          "n": 2184,
+          "mean_engine": 42.97086996336996,
+          "p50_abs_resid": 5.119999999999997,
+          "p90_abs_resid": 11.899999999999999,
+          "p95_abs_resid": 13.979999999999997,
+          "p99_abs_resid": 18.42,
+          "proposed_rel_pct": 0.326579835986493,
+          "proposed_abs_floor": 14,
+          "in_band_rate": 0.9546703296703297
+        },
+        {
+          "stat": "fga",
+          "n": 2184,
+          "mean_engine": 91.17488095238117,
+          "p50_abs_resid": 8.540000000000006,
+          "p90_abs_resid": 19.180000000000007,
+          "p95_abs_resid": 22.299999999999997,
+          "p99_abs_resid": 28.099999999999994,
+          "proposed_rel_pct": 0.24943719045475007,
+          "proposed_abs_floor": 23,
+          "in_band_rate": 0.9587912087912088
+        },
+        {
+          "stat": "ftm",
+          "n": 2184,
+          "mean_engine": 3.1111355311355333,
+          "p50_abs_resid": 12.52,
+          "p90_abs_resid": 21.46,
+          "p95_abs_resid": 24.3,
+          "p99_abs_resid": 30.34,
+          "proposed_rel_pct": 8.027777777777779,
+          "proposed_abs_floor": 25,
+          "in_band_rate": 0.9661172161172161
+        },
+        {
+          "stat": "fta",
+          "n": 2184,
+          "mean_engine": 4.143992673992675,
+          "p50_abs_resid": 16.22,
+          "p90_abs_resid": 26.52,
+          "p95_abs_resid": 30.02,
+          "p99_abs_resid": 36.96,
+          "proposed_rel_pct": 7.413461538461538,
+          "proposed_abs_floor": 31,
+          "in_band_rate": 0.9684065934065934
+        },
+        {
+          "stat": "tgm",
+          "n": 2184,
+          "mean_engine": 4.012307692307686,
+          "p50_abs_resid": 2.04,
+          "p90_abs_resid": 5.6,
+          "p95_abs_resid": 6.82,
+          "p99_abs_resid": 9.34,
+          "proposed_rel_pct": 1.777777777777778,
+          "proposed_abs_floor": 7,
+          "in_band_rate": 0.9702380952380952
+        },
+        {
+          "stat": "tga",
+          "n": 2184,
+          "mean_engine": 11.494963369963392,
+          "p50_abs_resid": 4.5600000000000005,
+          "p90_abs_resid": 11.14,
+          "p95_abs_resid": 12.86,
+          "p99_abs_resid": 17.6,
+          "proposed_rel_pct": 1.2239263803680982,
+          "proposed_abs_floor": 13,
+          "in_band_rate": 0.9720695970695971
+        },
+        {
+          "stat": "reb",
+          "n": 2184,
+          "mean_engine": 48.204010989010975,
+          "p50_abs_resid": 5.119999999999997,
+          "p90_abs_resid": 12.240000000000002,
+          "p95_abs_resid": 14.780000000000001,
+          "p99_abs_resid": 19.92,
+          "proposed_rel_pct": 0.30748422001803427,
+          "proposed_abs_floor": 15,
+          "in_band_rate": 0.956959706959707
+        },
+        {
+          "stat": "ast",
+          "n": 2184,
+          "mean_engine": 0,
+          "p50_abs_resid": 20,
+          "p90_abs_resid": 28,
+          "p95_abs_resid": 31,
+          "p99_abs_resid": 37,
+          "proposed_rel_pct": 0.15,
+          "proposed_abs_floor": 31,
+          "in_band_rate": 0.9629120879120879
+        },
+        {
+          "stat": "stl",
+          "n": 2184,
+          "mean_engine": 15.231703296703257,
+          "p50_abs_resid": 6.26,
+          "p90_abs_resid": 10.8,
+          "p95_abs_resid": 12,
+          "p99_abs_resid": 13.6,
+          "proposed_rel_pct": 0.7575757575757576,
+          "proposed_abs_floor": 12,
+          "in_band_rate": 0.9610805860805861
+        },
+        {
+          "stat": "tov",
+          "n": 2184,
+          "mean_engine": 27.722545787545773,
+          "p50_abs_resid": 14,
+          "p90_abs_resid": 19.9,
+          "p95_abs_resid": 21.34,
+          "p99_abs_resid": 23.84,
+          "proposed_rel_pct": 0.7461928934010152,
+          "proposed_abs_floor": 22,
+          "in_band_rate": 0.9734432234432234
+        },
+        {
+          "stat": "blk",
+          "n": 2184,
+          "mean_engine": 1.0292765567765576,
+          "p50_abs_resid": 5,
+          "p90_abs_resid": 9.56,
+          "p95_abs_resid": 10.94,
+          "p99_abs_resid": 13.44,
+          "proposed_rel_pct": 9.576923076923077,
+          "proposed_abs_floor": 11,
+          "in_band_rate": 0.9674908424908425
+        },
+        {
+          "stat": "pf",
+          "n": 2184,
+          "mean_engine": 3.985119047619051,
+          "p50_abs_resid": 14.52,
+          "p90_abs_resid": 20.88,
+          "p95_abs_resid": 22.6,
+          "p99_abs_resid": 25.96,
+          "proposed_rel_pct": 5.914893617021278,
+          "proposed_abs_floor": 23,
+          "in_band_rate": 0.9661172161172161
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Runs the calibration harness against the real 53GB `ibl5/backups` archive with `--selection season --seed 20240601 --runs 50 --sample-stride 1 --coverage 0.95`, captures the `CalibrationReport` JSON as a provenance artifact, and transcribes the per-game-type proposed bands into `bands.go`.

**What changes:**
- `bands.go`: Replaces `placeholderBands` + clone loop with explicit `regularBands`/`playoffBands` literal tables (calibrated from bucket 2/4). `GameTypeRegularAlt`, `GameTypeAllStarA`, `GameTypeAllStarB` inherit the Regular table with an inline note (corpus produces no all-star snapshots). Replaces placeholder comment box with provenance note (SHA, seed, coverage, selection, runs, stride, corpus, date, HCA caveat).
- `bands_test.go`: Updates existing assertions to calibrated values; adds `TestBands_SanityBounds` asserting every landed band is below stated ceilings and every `statNames` entry is present in every game-type table.
- `testdata/calibration-5.60-20240601.json`: Raw `CalibrationReport` JSON — audit only, not read at runtime.

**Not a fidelity proof.** Calibrating and gating on the same corpus at 0.95 coverage is near-tautological by design (Step 5 verifies transcription integrity / sets regression baseline). Authoritative fidelity sign-off requires HCA + season-aggregate validation (separate PRs). The provenance note and PR prose state this explicitly.

**HCA caveat:** These bands are calibrated against the current HCA-less engine. `bands.go` records this; re-calibration required when HCA lands.

**`compare_test.go` unchanged:** `TestCompareStat_BandSelection` and `TestCompareStat_InclusiveEdge` construct local `Band{...}` literals and test `compareStat`'s `max(absFloor, relPct×mean)` math — they never read the `bands` table. No edit required.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.