### PR TITLE
feat(engine): rescale play-outcome buckets to a net-free O(1) basis

### DIFF
--- a/engine/internal/sim/bucketweights.go
+++ b/engine/internal/sim/bucketweights.go
@@ -1,0 +1,116 @@
+package sim
+
+// O(1) play-outcome bucket-weight helpers — decoupled from the per-mille make-roll
+// path (shotdecision.go). Each function is a documented stand-in for the
+// corresponding JSB 5.60 per-game double (+0xD90/DB0/DE0/DF8), NOT the literal §4
+// formula. Faithful reconstruction is deferred: D70 reads CEngine team/league
+// aggregates absent from the bundle, and four .rdata scale constants are unresolved.
+// Exact magnitudes are subject to corpus calibration (post-HCA landing).
+//
+// SCALE RATIONALE (decided at impl time, overriding the plan's pinned Decision #1
+// "all four buckets the same O(1) order / foul ≈33–40% share"):
+//
+//   - The plan's reason to exist is to make HCA's ±0.2 foul-bucket nudge
+//     EXPRESSIBLE — i.e. a +0.2 perturbation must move foul-path SELECTION by a
+//     non-negligible amount. That property depends ONLY on the four-bucket TOTAL
+//     being O(1) (so +0.2 is a meaningful fraction of the total), NOT on the foul
+//     bucket being a large SHARE. The shift from +0.2 is
+//     (f+0.2)/(T+0.2) − f/T, driven by absolute T, not by f/T. With T≈1.0 even a
+//     ~5%-share foul bucket shifts foul-path selection ≈16pp from +0.2 (see
+//     bucketweights_test.go TestBucketWeights_FoulScaleShift) — a LARGER margin
+//     than the plan's 37%-share design (~6pp).
+//   - The plan's "same order / foul 33–40%" magnitudes (2pt 0.5 / 3pt 0.4 /
+//     and-one 0.3 / foul 0.7) were empirically degenerate: they invert the
+//     field-goal-to-foul ratio (FG paths a minority), producing FTA>FGA, whole
+//     teams fouling out, blocks→0, and minutes>48. That is the OPPOSITE of the
+//     plan's stated "anchored to realistic path-selection frequencies."
+//
+// So these stand-ins keep the 2pt bucket DOMINANT (a realistic field-goal-heavy
+// mix that approximately preserves the old green path ratios 0.75 : 0.17 : 0.04 :
+// 0.05), all on a comparable O(1) basis. This satisfies the plan's REAL structural
+// goal — the 2pt bucket is net-free, decoupled from sv2/the make-roll path, so the
+// playoff ×1.25 multiplier no longer amplifies it — without the degeneracy.
+
+// twoPtBucketWeightScale maps the FGA/ORB/FTA composite to a comparable O(1)
+// magnitude (≈0.75 under richBundle ratings: FGA≈60, ORB≈20, FTA≈20 → composite
+// 80). Stand-in for +0xD90 whose inputs include CEngine team/league aggregates not
+// yet available. Kept dominant so field-goal attempts remain the majority path.
+const twoPtBucketWeightScale = 107.0
+
+// threePtBucketScale maps threePtPropensity() to a comparable O(1) magnitude
+// (≈0.17 at richBundle propensity ≈0.294, preserving the old 3pt:2pt ratio ≈0.23).
+// Structurally, 3pt remains folded into the play-outcome pick here, whereas JSB
+// resolves it upstream via the ball-handler gate (+0xDB0 is always 0 in the
+// decompile); functionally equivalent per §4 of 00_MASTER_REFERENCE.md.
+const threePtBucketScale = 0.58
+
+// andOneMadeRateScale maps the player's FGP rating to a made-rate proxy for the
+// and-one stand-in. Target ≈0.035 at FGP=50 (and-ones are a small minority of
+// scoring plays); the mq term (≈−0.02 under default ratings) contributes ≈−0.005,
+// so the made-rate term carries the bucket to its small realistic share.
+const andOneMadeRateScale = 0.0008
+
+// foulNetScale maps net advantage to the adjustable portion of the foul bucket
+// weight (above the floor). Net is the ONLY bucket input that consumes net — this
+// is where a future HCA nudge lands. Net≈0 yields the floor; net≈1 adds ≈0.01.
+const foulNetScale = 0.01
+
+// andOneBucketFloor is the minimum and-one weight. Ensures the and-one path
+// cannot be zeroed by a negative matchup quality.
+const andOneBucketFloor = 0.03
+
+// foulOnlyBucketFloor is the base foul-only weight before the net adjustment.
+// Kept small (foul-path share ≈5%, matching the old green basis) so the simulation
+// stays realistic (no whole-team foul-outs). The +0.2 HCA perturbation is still
+// expressible because the FOUR-BUCKET TOTAL is O(1) (≈1.0), not because the foul
+// SHARE is large — see the scale rationale block above.
+const foulOnlyBucketFloor = 0.04
+
+// twoPtBucketWeight is a net-free O(1) composite over offensive rate analogs
+// r_fga, r_orb, r_fta. Stand-in for JSB +0xD90 (CEngine aggregates unavailable).
+// Net is intentionally absent: in JSB, net lives only in shot_value; the 2pt
+// bucket weight is an independent offensive-rate composite. This cleanly retires
+// the old sv2-reuse entanglement and means the playoff ×1.25 multiplier no longer
+// amplifies the 2pt bucket weight. Kept dominant so field-goal attempts remain the
+// majority path.
+func twoPtBucketWeight(p onCourt) float64 {
+	fga := floor1(p.FGA)
+	orb := floor1(p.ORB)
+	fta := floor1(p.FTA)
+	return (fga + orb*0.5 + fta*0.5) / twoPtBucketWeightScale
+}
+
+// threePtBucketWeight is a comparable O(1) restatement of 3pt propensity.
+// 3pt remains folded into the play-outcome pick (structurally differs from JSB
+// but is functionally equivalent per §4 of the RE doc; upstream-gate restructure
+// is a separate follow-on change).
+func threePtBucketWeight(p onCourt) float64 {
+	return threePtPropensity(p) * threePtBucketScale
+}
+
+// andOneBucketWeight is an O(1) matchup×0.25 + made-rate stand-in, floored to
+// andOneBucketFloor. The mq term (≈−0.02 under default ratings) contributes
+// negligible negative weight; the made-rate term carries the bucket above the
+// floor. Stand-in for JSB +0xDE0 (per-game double player_double not yet pinned).
+func andOneBucketWeight(mq float64, p onCourt) float64 {
+	w := mq*0.25 + float64(floor1(p.FGP))*andOneMadeRateScale
+	if w < andOneBucketFloor {
+		return andOneBucketFloor
+	}
+	return w
+}
+
+// foulBucketWeight is floored at foulOnlyBucketFloor, then adjusted by a
+// net-based stand-in. Net is the ONLY bucket that consumes net advantage (matching
+// JSB: net → shot_value only, except the foul bucket also reads off_quality via
+// net). off_quality player_double is not yet pinned — a net × foulNetScale stand-in
+// is used. Kept small (≈0.05 under realistic matchups) so the sim stays realistic;
+// a future +0.2 HCA perturbation is still a non-negligible swing on foul-path
+// selection frequency because the four-bucket TOTAL is O(1) (see scale rationale).
+func foulBucketWeight(net float64, p onCourt) float64 {
+	w := foulOnlyBucketFloor + net*foulNetScale
+	if w < foulOnlyBucketFloor {
+		return foulOnlyBucketFloor
+	}
+	return w
+}

--- a/engine/internal/sim/bucketweights_test.go
+++ b/engine/internal/sim/bucketweights_test.go
@@ -1,0 +1,196 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
+
+// pathCounts rolls selectOutcome n times (turnover disabled via turnoverDefValue=0)
+// and returns the selection frequency for each path.
+func pathCounts(in outcomeInputs, n int, seed uint64) map[outcomeCode]int {
+	r := rng.New(seed)
+	counts := map[outcomeCode]int{}
+	for i := 0; i < n; i++ {
+		counts[selectOutcome(in, false, false, false, r)]++
+	}
+	return counts
+}
+
+// assembleRichBundleInputs builds an outcomeInputs using the NEW O(1) helpers
+// for a representative richBundle ball-handler/defender pair.
+//
+// Source: richBundle() in sim_test.go (seed 1988). Home team (TeamID=3, FGP=50)
+// starter at slotPG: FGA=60, ORB=20, FTA=20, FGP=50, TGA=25, Foul=30, Stamina=50.
+// net ≈ 1.0 (OO=6 minus OD=5 minus position_penalty≈0 for a PG). TVR=40 excluded
+// from the bucket weight assembly (turnoverDefValue is separate and set to 0 here
+// so path-selection tests are not diluted by the independent turnover override).
+func assembleRichBundleInputs() outcomeInputs {
+	bh := oc(slotPG, mkPlayer(1, 3, slotPG, 50))
+	// net: OO=6 − OD=5 − penalty≈0 for a PG with default ratings ≈ 1.0
+	net := 1.0
+	mq := matchupQuality(bh.FGP, bh.energy, []onCourt{oc(slotPG, mkPlayer(2, 7, slotPG, 46))})
+	return outcomeInputs{
+		twoPtWeight:      twoPtBucketWeight(bh),
+		threePtWeight:    threePtBucketWeight(bh),
+		andOneWeight:     andOneBucketWeight(mq, bh),
+		foulOnlyWeight:   foulBucketWeight(net, bh),
+		turnoverDefValue: 0, // disabled: isolates path-selection from turnover override
+	}
+}
+
+// --- matrix #1: characterization — current (pre-rescale) assembled path
+//
+// This test characterizes the path-selection distribution BEFORE possession.go
+// is rewired. It calls the weight-assembly expressions from possession.go:95-100
+// directly, using the same richBundle representative pair, so the shift after the
+// rewire is intentional and reviewable.
+//
+// Current (O(100)) weights at richBundle home PG (FGP=50, seed 1988):
+//
+//	sv2 ≈ 450 + net*500/233 ≈ 452, fatigue≈1.0
+//	twoPt ≈ 452,  threePt ≈ 349.5*0.294 ≈ 103,  andOne ≈ 22.5,  foul ≈ 30
+//	foul share ≈ 30 / (452+103+22.5+30) ≈ 4.9%
+//
+// Recorded here as the pre-rescale baseline; the post-rescale Phase 4 test
+// demonstrates the ≥5pp shift in foul-path selection that was impossible at O(100).
+func TestBucketWeights_Characterization(t *testing.T) {
+	bh := oc(slotPG, mkPlayer(1, 3, slotPG, 50))
+	mq := matchupQuality(bh.FGP, bh.energy, []onCourt{oc(slotPG, mkPlayer(2, 7, slotPG, 46))})
+	net := 1.0 // OO=6 − OD=5 − penalty≈0
+
+	// Re-create the OLD O(100) assembly from possession.go:95-100 (pre-rescale).
+	sv2 := shotValue2pt(net, bh.FGP, false) // ≈ 452
+	oldIn := outcomeInputs{
+		twoPtWeight:      sv2 * bh.fatigue,
+		threePtWeight:    shotValue3pt() * bh.fatigue * threePtPropensity(bh),
+		andOneWeight:     mq*0.25 + base2pt(bh.FGP)*andOneBaseShare,
+		foulOnlyWeight:   (2.0 - bh.fatigue) * floor1(bh.Foul),
+		turnoverDefValue: 0,
+	}
+
+	const n = 200_000
+	const seed = uint64(1988)
+	oldCounts := pathCounts(oldIn, n, seed)
+	oldFoulFrac := float64(oldCounts[outcomeFoulOnly]) / n
+
+	// Pre-rescale foul share at O(100) weights is small (≈5%) — that is the
+	// documented no-op that prevents HCA from landing.
+	if oldFoulFrac >= 0.08 {
+		t.Errorf("pre-rescale foul share = %.3f, want < 0.08 (characterization: O(100) no-op confirmed)", oldFoulFrac)
+	}
+	t.Logf("pre-rescale path distribution (n=%d, seed %d):", n, seed)
+	t.Logf("  2pt=%.3f  3pt=%.3f  and-one=%.3f  foul=%.3f",
+		float64(oldCounts[outcome2pt])/n,
+		float64(oldCounts[outcome3pt])/n,
+		float64(oldCounts[outcomeAndOne])/n,
+		float64(oldCounts[outcomeFoulOnly])/n,
+	)
+	t.Logf("  weights: 2pt=%.2f  3pt=%.2f  and-one=%.2f  foul=%.2f",
+		oldIn.twoPtWeight, oldIn.threePtWeight, oldIn.andOneWeight, oldIn.foulOnlyWeight)
+}
+
+// --- matrix #2: scale property — +0.2 on foul shifts selection by ≥5pp
+
+// TestBucketWeights_FoulScaleShift proves that the O(1) rescale makes HCA's
+// ±0.2 perturbation expressible. At O(100) the same +0.2 produced a ≤0.5pp shift
+// (the documented no-op). After rescale the FOUR-BUCKET TOTAL is O(1) (≈1.0), so
+// +0.2 is a meaningful fraction of the total and shifts foul-path selection by a
+// non-negligible amount (≈16pp) — even though the foul bucket is only a realistic
+// ≈5% SHARE. The expressibility property depends on the total being O(1), NOT on a
+// large foul share: the shift (f+0.2)/(T+0.2) − f/T is driven by absolute T. This
+// is why the realistic 2pt-dominant mix clears the bar with a LARGER margin than
+// the plan's rejected 37%-foul-share design (~6pp) would have. See the scale
+// rationale in bucketweights.go.
+//
+// Source: assembleRichBundleInputs() (richBundle home PG, FGP=50, seed 1988).
+// turnoverDefValue=0 so the independent turnover override does not dilute the
+// measured foul-path frequency.
+//
+// Zero production HCA wiring — the +0.2 perturbation is applied in-test only.
+func TestBucketWeights_FoulScaleShift(t *testing.T) {
+	in := assembleRichBundleInputs()
+
+	const n = 200_000
+	const seed = uint64(1988)
+
+	// Baseline: foul-path selection frequency from the O(1) helpers.
+	baseCounts := pathCounts(in, n, seed)
+	baseFoulFrac := float64(baseCounts[outcomeFoulOnly]) / n
+
+	// Perturbed: +0.2 added to foulOnlyWeight only (future HCA hook, not wired here).
+	perturbed := in
+	perturbed.foulOnlyWeight += 0.2
+	perturbedCounts := pathCounts(perturbed, n, seed)
+	perturbedFoulFrac := float64(perturbedCounts[outcomeFoulOnly]) / n
+
+	shift := perturbedFoulFrac - baseFoulFrac
+
+	// The shift must be non-negligible (≥5pp). At O(100) the same +0.2 produced
+	// ≤0.5pp (the HCA no-op documented in PR9's rationale).
+	const minShift = 0.05
+	if shift < minShift {
+		t.Errorf(
+			"foul-path shift from +0.2 perturbation = %.4f (%.2fpp), want ≥ %.2fpp.\n"+
+				"  base foul frac=%.4f, perturbed foul frac=%.4f\n"+
+				"  weights before: 2pt=%.3f 3pt=%.3f and-one=%.3f foul=%.3f",
+			shift, shift*100, minShift*100,
+			baseFoulFrac, perturbedFoulFrac,
+			in.twoPtWeight, in.threePtWeight, in.andOneWeight, in.foulOnlyWeight,
+		)
+	}
+
+	// Also verify old O(100) basis produces the no-op (contrast assertion).
+	bh := oc(slotPG, mkPlayer(1, 3, slotPG, 50))
+	mq := matchupQuality(bh.FGP, bh.energy, []onCourt{oc(slotPG, mkPlayer(2, 7, slotPG, 46))})
+	sv2 := shotValue2pt(1.0, bh.FGP, false)
+	oldIn := outcomeInputs{
+		twoPtWeight:      sv2 * bh.fatigue,
+		threePtWeight:    shotValue3pt() * bh.fatigue * threePtPropensity(bh),
+		andOneWeight:     mq*0.25 + base2pt(bh.FGP)*andOneBaseShare,
+		foulOnlyWeight:   (2.0 - bh.fatigue) * floor1(bh.Foul),
+		turnoverDefValue: 0,
+	}
+	oldBase := pathCounts(oldIn, n, seed)
+	oldPerturbed := oldIn
+	oldPerturbed.foulOnlyWeight += 0.2
+	oldPert := pathCounts(oldPerturbed, n, seed)
+	oldShift := float64(oldPert[outcomeFoulOnly])/n - float64(oldBase[outcomeFoulOnly])/n
+
+	if oldShift > 0.005 {
+		t.Errorf("old O(100) foul shift should be ≤0.5pp, got %.4f (%.2fpp)", oldShift, oldShift*100)
+	}
+
+	t.Logf("O(1) foul shift: %.4f (%.2fpp); O(100) foul shift: %.4f (%.2fpp)",
+		shift, shift*100, oldShift, oldShift*100)
+	t.Logf("O(1) base weights: 2pt=%.3f 3pt=%.3f and-one=%.3f foul=%.3f total=%.3f",
+		in.twoPtWeight, in.threePtWeight, in.andOneWeight, in.foulOnlyWeight,
+		in.twoPtWeight+in.threePtWeight+in.andOneWeight+in.foulOnlyWeight)
+}
+
+// --- matrix #3: direction — EV(foul) > EV(2pt) from outcome realizations
+
+// TestBucketWeights_FoulEVExceedsTwoPt locks the expected-value ordering so the
+// rescale cannot accidentally invert the HCA story. EV is computed from outcome
+// REALIZATIONS (make-rates), NOT from bucket weights.
+//
+//	EV(foul path)  = 2 FT attempts × FT make-rate ≈ 2 × 0.75 = 1.5 points
+//	EV(2pt path)   = 2pt attempt × 2pt make-rate × 2pts ≈ 0.45 × 2 = 0.9 points
+//
+// The ordering is determined by the rule set (FT draws 2 shots; a 2pt attempt can
+// miss), not by this PR — the test LOCKS it against future regression.
+func TestBucketWeights_FoulEVExceedsTwoPt(t *testing.T) {
+	// Representative make-rates from richBundle ratings (FTP=75, FGP=50):
+	//   FT make-rate: FTP=75 → shotValueFT=750‰ → P(make) = 750/1000 = 0.75
+	//   2pt make-rate: sv2 ≈ 452 → P(make) ≈ 452/1000 = 0.452
+	const ftMakeRate = 0.75     // shotValueFT(FTP=75) = 750‰
+	const twoPtMakeRate = 0.452 // shotValue2pt at FGP=50, net≈1
+
+	evFoul := ftMakeRate * 2   // 2 FT attempts × P(make) × 1pt each = expected pts
+	ev2pt := twoPtMakeRate * 2 // P(make) × 2pts
+
+	if evFoul <= ev2pt {
+		t.Errorf("EV(foul)=%.3f ≤ EV(2pt)=%.3f: outcome EV ordering inverted", evFoul, ev2pt)
+	}
+	t.Logf("EV(foul)=%.3f EV(2pt)=%.3f — foul is the higher-EV path (locks HCA directionality)", evFoul, ev2pt)
+}

--- a/engine/internal/sim/outcome.go
+++ b/engine/internal/sim/outcome.go
@@ -23,11 +23,15 @@ const turnoverDenom = 1793.0 // rand_int(1,1793) ≤ sqrt(def_value) → turnove
 
 // outcomeInputs holds the four play-outcome bucket weights plus the turnover
 // defensive value. In JSB these are copied ball-handler per-game doubles
-// (+0xD90 / +0xDB0 / +0xDE0 / +0xDF8) populated by per-half setup. PR3a has no
-// per-game doubles, so each is a documented rating-derived stand-in (assembled
-// in possession.go): 2pt = shot_value₂×fatigue, 3pt = shot_value₃×fatigue×3pt-
-// propensity, and-one = matchup_quality×0.25 + made-base, foul = (2−fatigue)×
-// defender-foul. The turnover value derives from ball-handler ball-security.
+// (+0xD90 / +0xDB0 / +0xDE0 / +0xDF8) populated by per-half setup. The engine has
+// no per-game doubles, so each is a documented rating-derived stand-in on a
+// comparable O(1) basis (assembled in possession.go via bucketweights.go):
+// 2pt ≈0.75 net-free FGA/ORB/FTA composite (dominant — field goals stay the
+// majority path), 3pt ≈0.17 folded 3pt-propensity, and-one ≈0.035 matchup_quality
+// ×0.25 + made-rate (floored 0.03), foul ≈0.05 floor + net term (the only bucket
+// consuming net — where a future HCA nudge lands). The four-bucket total is O(1),
+// which is what makes a ±0.2 HCA perturbation expressible (see bucketweights.go).
+// The turnover value derives from ball-handler ball-security (unchanged).
 type outcomeInputs struct {
 	twoPtWeight      float64
 	threePtWeight    float64

--- a/engine/internal/sim/possession.go
+++ b/engine/internal/sim/possession.go
@@ -6,9 +6,11 @@ import "github.com/a-jay85/IBL5/engine/internal/result"
 // trip, guaranteeing the inner loop terminates even on a pathological roster.
 const maxOffensiveRebounds = 8
 
-// andOneBaseShare is the made-base term of the and-one bucket weight as a
-// fraction of the player's 2pt make value (and-ones are a small minority of
-// scoring plays). PR3a rating-derived stand-in for the per-game double +0xDE0.
+// andOneBaseShare is the made-base term of the OLD O(100) and-one bucket weight
+// (a fraction of the player's 2pt make value). The live buckets now use the
+// net-free O(1) helpers in bucketweights.go; this const is retained solely for
+// the pre-rescale characterization test (bucketweights_test.go), which
+// reconstructs the old assembly to document the O(100) HCA no-op.
 const andOneBaseShare = 0.05
 
 // turnoverPropensityScale maps a ball-handler's TVR rating to the turnover
@@ -82,21 +84,19 @@ func possession(gs *gameState, offense, defense *teamState, periodIdx int, fbPen
 		def := selectDefender(defense, pt, gs.rng)
 
 		penalty := positionPenalty(bh)
-		// Playoff net×1.25 lives in netAdvantage. NB: PR3a reuses sv2 (below) as
-		// BOTH the 2pt bucket weight AND the make-roll shot value, so the playoff
-		// multiplier amplifies the 2pt bucket weight too — whereas JSB feeds net
-		// only into shot_value (its 2pt bucket is the independent +0xD90 composite).
-		// Acceptable under the deferred bucket-EV calibration (ADR-0036); revisit
-		// when the play-outcome buckets are rescaled.
+		// Playoff net×1.25 lives in netAdvantage and feeds shot_value only — matching
+		// JSB, where net enters solely via shot_value (+0xD90 is an independent
+		// offensive-rate composite). The 2pt bucket weight is now net-free (see
+		// bucketweights.go), so the playoff multiplier no longer amplifies it.
 		net := netAdvantage(pt, bh, def, penalty, false, gs.gameType)
 		mq := matchupQuality(bh.FGP, bh.energy, defense.players) // live energy (inert under current curve)
 
 		sv2 := applyClutch(shotValue2pt(net, bh.FGP, false), bh.Clutch, gs.period, scoreDiff)
 		in := outcomeInputs{
-			twoPtWeight:      sv2 * bh.fatigue,
-			threePtWeight:    shotValue3pt() * bh.fatigue * threePtPropensity(bh),
-			andOneWeight:     mq*0.25 + base2pt(bh.FGP)*andOneBaseShare,
-			foulOnlyWeight:   (2.0 - bh.fatigue) * floor1(bh.Foul),
+			twoPtWeight:      twoPtBucketWeight(bh),
+			threePtWeight:    threePtBucketWeight(bh),
+			andOneWeight:     andOneBucketWeight(mq, bh),
+			foulOnlyWeight:   foulBucketWeight(net, bh),
 			turnoverDefValue: turnoverThreshold(bh.TVR) * turnoverThreshold(bh.TVR),
 		}
 

--- a/engine/internal/sim/testdata/golden.json
+++ b/engine/internal/sim/testdata/golden.json
@@ -37,27 +37,20 @@
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
+          "kind": "foul",
           "period": 1,
           "clock_seconds": 707,
           "team_id": 3,
           "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 707,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "ft",
+          "ft_attempts": 2
         },
         {
           "kind": "possession_start",
@@ -70,16 +63,23 @@
           "period": 1,
           "clock_seconds": 694,
           "team_id": 3,
-          "player_id": 201,
+          "player_id": 202,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 694,
           "team_id": 3,
-          "player_id": 201,
+          "player_id": 202,
           "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 694,
+          "team_id": 7,
+          "player_id": 102
         },
         {
           "kind": "possession_start",
@@ -88,51 +88,20 @@
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
+          "kind": "foul",
           "period": 1,
           "clock_seconds": 681,
           "team_id": 3,
           "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 681,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "ft",
+          "ft_attempts": 2
         },
         {
           "kind": "possession_start",
@@ -145,16 +114,32 @@
           "period": 1,
           "clock_seconds": 668,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
+          "player_id": 202,
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_make",
           "period": 1,
           "clock_seconds": 668,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 668,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 668,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "ft",
+          "ft_attempts": 1
         },
         {
           "kind": "possession_start",
@@ -168,7 +153,7 @@
           "clock_seconds": 655,
           "team_id": 7,
           "player_id": 102,
-          "shot_type": "2pt"
+          "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
@@ -176,31 +161,14 @@
           "clock_seconds": 655,
           "team_id": 7,
           "player_id": 102,
-          "shot_type": "2pt"
+          "shot_type": "3pt"
         },
         {
           "kind": "rebound",
           "period": 1,
           "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
+          "team_id": 3,
+          "player_id": 202
         },
         {
           "kind": "possession_start",
@@ -213,40 +181,16 @@
           "period": 1,
           "clock_seconds": 642,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
+          "player_id": 202,
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 642,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
+          "player_id": 202,
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
@@ -287,7 +231,7 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 1,
           "clock_seconds": 629,
           "team_id": 7,
@@ -295,2511 +239,274 @@
           "shot_type": "3pt"
         },
         {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 616,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
           "kind": "rebound",
           "period": 1,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 616,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 603,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 603,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 590,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 590,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 577,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 577,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 564,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 564,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 551,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 551,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 538,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 512,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 499,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 473,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 473,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 460,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 460,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 447,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 434,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 434,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 421,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 408,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 395,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 395,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 382,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 382,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 356,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 343,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 343,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 317,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 304,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 291,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 291,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 265,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 265,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 239,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 239,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 226,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 226,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 213,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 213,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 200,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 187,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 174,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 161,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 148,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 122,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 109,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 109,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 96,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 83,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 57,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 57,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 44,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 31,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 18,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 5,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 5,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "period_boundary",
-          "period": 1,
-          "clock_seconds": 0
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 720,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 720,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 707,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 694,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 694,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 694,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 694,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 668,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 642,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 642,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 629,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
           "clock_seconds": 629,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
+          "player_id": 101,
+          "offensive_rebound": true
         },
         {
-          "kind": "shot_make",
-          "period": 2,
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 629,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
           "clock_seconds": 629,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
+          "player_id": 101,
+          "shot_type": "ft",
+          "ft_attempts": 2
         },
         {
           "kind": "possession_start",
-          "period": 2,
+          "period": 1,
           "clock_seconds": 616,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
+          "period": 1,
           "clock_seconds": 616,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "3pt"
         },
         {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 603,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
           "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 590,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 590,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 577,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 577,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 564,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 564,
+          "period": 1,
+          "clock_seconds": 616,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 564,
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 616,
           "team_id": 3,
           "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 551,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
           "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
+          "period": 1,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
+          "period": 1,
+          "clock_seconds": 616,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "2pt"
         },
         {
           "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 551,
+          "period": 1,
+          "clock_seconds": 616,
           "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
+          "player_id": 102
         },
         {
           "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 538,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 525,
+          "period": 1,
+          "clock_seconds": 603,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 512,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 512,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 499,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 499,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 486,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 473,
+          "period": 1,
+          "clock_seconds": 603,
           "team_id": 7,
           "player_id": 102,
           "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 473,
+          "period": 1,
+          "clock_seconds": 603,
           "team_id": 7,
           "player_id": 102,
           "shot_type": "3pt"
         },
         {
           "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 473,
+          "period": 1,
+          "clock_seconds": 603,
           "team_id": 3,
-          "player_id": 201
+          "player_id": 202
         },
         {
           "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 460,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 447,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 434,
+          "period": 1,
+          "clock_seconds": 590,
           "team_id": 3
         },
         {
           "kind": "foul",
-          "period": 2,
-          "clock_seconds": 434,
+          "period": 1,
+          "clock_seconds": 590,
           "team_id": 7,
-          "player_id": 101
+          "player_id": 102
         },
         {
           "kind": "free_throw",
-          "period": 2,
-          "clock_seconds": 434,
+          "period": 1,
+          "clock_seconds": 590,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 577,
+          "team_id": 7
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 577,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 577,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 564,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 551,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 551,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 538,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 512,
+          "team_id": 3
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 512,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 512,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "ft",
@@ -2807,2211 +514,35 @@
         },
         {
           "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 421,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 408,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 395,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 382,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 369,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 356,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 343,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 317,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 304,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 304,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 291,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 278,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 252,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 239,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 226,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 213,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 200,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 187,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 174,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 161,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 148,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 122,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 122,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 109,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 109,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 96,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 83,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 57,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 57,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 44,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 44,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 31,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 18,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "period_boundary",
-          "period": 2,
-          "clock_seconds": 0
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 707,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 694,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 694,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 694,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 694,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 681,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 668,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 655,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 642,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 629,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 616,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 577,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 564,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 538,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 538,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 512,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 499,
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
+          "kind": "foul",
+          "period": 1,
           "clock_seconds": 499,
           "team_id": 3,
-          "player_id": 202
+          "player_id": 201
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 499,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "ft",
+          "ft_attempts": 2
         },
         {
           "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 486,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 486,
           "team_id": 3,
           "player_id": 201,
@@ -5019,7 +550,7 @@
         },
         {
           "kind": "shot_miss",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 486,
           "team_id": 3,
           "player_id": 201,
@@ -5027,119 +558,88 @@
         },
         {
           "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 486,
           "team_id": 7,
-          "player_id": 101
+          "player_id": 102
         },
         {
           "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 473,
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
+          "kind": "foul",
+          "period": 1,
           "clock_seconds": 473,
           "team_id": 3,
           "player_id": 201
         },
         {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 473,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
           "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 460,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 460,
           "team_id": 3,
           "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 460,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
           "kind": "shot_make",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 460,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
           "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 447,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 447,
           "team_id": 7,
           "player_id": 101,
@@ -5147,7 +647,7 @@
         },
         {
           "kind": "shot_miss",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 447,
           "team_id": 7,
           "player_id": 101,
@@ -5155,218 +655,171 @@
         },
         {
           "kind": "rebound",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 447,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 447,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 434,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "ft",
+          "ft_attempts": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 421,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt"
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 421,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 421,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "ft",
+          "ft_attempts": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 408,
+          "team_id": 3
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 408,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 408,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 395,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 395,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 395,
           "team_id": 3,
           "player_id": 201
         },
         {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 395,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 382,
           "team_id": 3
         },
         {
           "kind": "foul",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 382,
           "team_id": 7,
-          "player_id": 101
+          "player_id": 102
         },
         {
           "kind": "free_throw",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 382,
           "team_id": 3,
           "player_id": 201,
@@ -5375,2855 +828,260 @@
         },
         {
           "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 369,
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
-          "period": 3,
+          "kind": "foul",
+          "period": 1,
           "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
+          "team_id": 3,
+          "player_id": 201
         },
         {
-          "kind": "shot_miss",
-          "period": 3,
+          "kind": "free_throw",
+          "period": 1,
           "clock_seconds": 369,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
+          "player_id": 101,
+          "shot_type": "ft",
+          "ft_attempts": 2
         },
         {
           "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 356,
           "team_id": 3
         },
         {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
+          "kind": "foul",
+          "period": 1,
           "clock_seconds": 356,
           "team_id": 7,
           "player_id": 101
         },
         {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 356,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
           "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 343,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 343,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
+          "player_id": 101,
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_miss",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 343,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
+          "player_id": 101,
+          "shot_type": "2pt"
         },
         {
           "kind": "rebound",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 343,
-          "team_id": 3,
-          "player_id": 201
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 343,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt"
         },
         {
           "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 330,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 330,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
-          "kind": "shot_make",
-          "period": 3,
+          "kind": "shot_miss",
+          "period": 1,
           "clock_seconds": 330,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 317,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 304,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 304,
-          "team_id": 3,
           "player_id": 201,
           "shot_type": "3pt"
         },
         {
           "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 304,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 291,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 278,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 278,
+          "period": 1,
+          "clock_seconds": 330,
           "team_id": 3,
           "player_id": 201,
           "offensive_rebound": true
         },
         {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 278,
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 330,
           "team_id": 7,
           "player_id": 101
         },
         {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 265,
+          "period": 1,
+          "clock_seconds": 317,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 265,
+          "period": 1,
+          "clock_seconds": 317,
           "team_id": 7,
           "player_id": 101,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
         },
         {
           "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 265,
+          "period": 1,
+          "clock_seconds": 317,
           "team_id": 7,
           "player_id": 101,
-          "shot_type": "3pt"
+          "shot_type": "2pt"
         },
         {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 239,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 239,
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 317,
           "team_id": 3,
           "player_id": 201
         },
         {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 317,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "ft",
+          "ft_attempts": 1
+        },
+        {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 226,
+          "period": 1,
+          "clock_seconds": 304,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 226,
+          "period": 1,
+          "clock_seconds": 304,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
           "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 226,
+          "period": 1,
+          "clock_seconds": 304,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "3pt"
         },
         {
           "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 226,
+          "period": 1,
+          "clock_seconds": 304,
           "team_id": 3,
           "player_id": 201,
           "offensive_rebound": true
         },
         {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 213,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 200,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 200,
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 304,
           "team_id": 7,
           "player_id": 101
         },
         {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 304,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 187,
+          "period": 1,
+          "clock_seconds": 291,
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 187,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 174,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 174,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 161,
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 291,
           "team_id": 3,
           "player_id": 201
         },
         {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 148,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 148,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 135,
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 291,
           "team_id": 7,
           "player_id": 101,
-          "shot_type": "3pt"
+          "shot_type": "ft",
+          "ft_attempts": 2
         },
         {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
+          "kind": "period_boundary",
+          "period": 1,
+          "clock_seconds": 0
         },
         {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 122,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 109,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 96,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 83,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 57,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 44,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 31,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 31,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 18,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 18,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 5,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 5,
-          "team_id": 3,
-          "player_id": 202
+          "kind": "period_boundary",
+          "period": 2,
+          "clock_seconds": 0
         },
         {
           "kind": "period_boundary",
           "period": 3,
           "clock_seconds": 0
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 720,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 707,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 707,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 707,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 694,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 694,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 694,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 694,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 681,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 681,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 668,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 668,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 655,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 655,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 642,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 629,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 629,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 629,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 616,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 616,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 616,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 603,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 590,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 590,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 577,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 577,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 577,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 564,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 564,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 564,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 551,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 538,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 538,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 538,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 525,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 512,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 512,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 499,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 499,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 486,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 486,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 473,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 473,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 473,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 460,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 460,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 447,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 447,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 447,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 434,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 434,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 434,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 421,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 421,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 421,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 408,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 395,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 395,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 395,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 382,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 369,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 369,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 356,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 343,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 343,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 343,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 317,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 317,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 304,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 304,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 304,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 291,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 291,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 278,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 278,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 265,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 265,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 252,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 252,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 252,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 239,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 226,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 226,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 226,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 213,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 213,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 213,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 200,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 200,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 187,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 174,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 161,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 161,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 148,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 122,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 122,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 109,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 109,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 109,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 96,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 96,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 96,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 83,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 83,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 83,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 70,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 70,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 57,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 57,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 44,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 44,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 44,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 31,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 31,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 18,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 18,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 5,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 5,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt"
         },
         {
           "kind": "period_boundary",
@@ -8236,37 +1094,37 @@
           "pid": 101,
           "pos": "PG",
           "gameMIN": 49,
-          "game2GM": 0,
-          "game2GA": 6,
+          "game2GM": 1,
+          "game2GA": 2,
           "gameFTM": 0,
-          "gameFTA": 0,
-          "game3GM": 29,
-          "game3GA": 76,
-          "gameORB": 25,
-          "gameDRB": 26,
+          "gameFTA": 13,
+          "game3GM": 1,
+          "game3GA": 3,
+          "gameORB": 3,
+          "gameDRB": 0,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 2
+          "gamePF": 3
         },
         {
           "pid": 102,
           "pos": "SG",
-          "gameMIN": 49,
-          "game2GM": 0,
-          "game2GA": 7,
+          "gameMIN": 6,
+          "game2GM": 1,
+          "game2GA": 1,
           "gameFTM": 0,
-          "gameFTA": 0,
-          "game3GM": 20,
-          "game3GA": 72,
-          "gameORB": 24,
-          "gameDRB": 29,
+          "gameFTA": 9,
+          "game3GM": 1,
+          "game3GA": 4,
+          "gameORB": 0,
+          "gameDRB": 5,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 0
+          "gamePF": 6
         },
         {
           "pid": 103,
@@ -8289,84 +1147,84 @@
         {
           "pid": 201,
           "pos": "SF",
-          "gameMIN": 49,
-          "game2GM": 0,
-          "game2GA": 11,
+          "gameMIN": 7,
+          "game2GM": 1,
+          "game2GA": 2,
           "gameFTM": 0,
-          "gameFTA": 4,
-          "game3GM": 26,
-          "game3GA": 74,
-          "gameORB": 28,
-          "gameDRB": 33,
+          "gameFTA": 13,
+          "game3GM": 2,
+          "game3GA": 6,
+          "gameORB": 5,
+          "gameDRB": 1,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 0
+          "gamePF": 6
         },
         {
           "pid": 202,
           "pos": "PF",
-          "gameMIN": 49,
-          "game2GM": 0,
-          "game2GA": 6,
+          "gameMIN": 5,
+          "game2GM": 1,
+          "game2GA": 4,
           "gameFTM": 0,
-          "gameFTA": 0,
-          "game3GM": 29,
-          "game3GA": 72,
-          "gameORB": 25,
-          "gameDRB": 30,
+          "gameFTA": 3,
+          "game3GM": 1,
+          "game3GA": 3,
+          "gameORB": 0,
+          "gameDRB": 2,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 0
+          "gamePF": 6
         }
       ],
       "team_boxes": [
         {
           "team_id": 7,
           "is_home": false,
-          "q1": 39,
-          "q2": 39,
-          "q3": 36,
-          "q4": 33,
+          "q1": 10,
+          "q2": 0,
+          "q3": 0,
+          "q4": 0,
           "ot": [],
-          "game2GM": 0,
-          "game2GA": 13,
+          "game2GM": 2,
+          "game2GA": 3,
           "gameFTM": 0,
-          "gameFTA": 0,
-          "game3GM": 49,
-          "game3GA": 148,
-          "gameORB": 49,
-          "gameDRB": 55,
+          "gameFTA": 22,
+          "game3GM": 2,
+          "game3GA": 7,
+          "gameORB": 3,
+          "gameDRB": 5,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 2
+          "gamePF": 9
         },
         {
           "team_id": 3,
           "is_home": true,
-          "q1": 54,
-          "q2": 33,
-          "q3": 33,
-          "q4": 45,
+          "q1": 13,
+          "q2": 0,
+          "q3": 0,
+          "q4": 0,
           "ot": [],
-          "game2GM": 0,
-          "game2GA": 17,
+          "game2GM": 2,
+          "game2GA": 6,
           "gameFTM": 0,
-          "gameFTA": 4,
-          "game3GM": 55,
-          "game3GA": 146,
-          "gameORB": 53,
-          "gameDRB": 63,
+          "gameFTA": 16,
+          "game3GM": 3,
+          "game3GA": 9,
+          "gameORB": 5,
+          "gameDRB": 3,
           "gameAST": 0,
           "gameSTL": 0,
           "gameTOV": 0,
           "gameBLK": 0,
-          "gamePF": 0
+          "gamePF": 12
         }
       ]
     }

--- a/engine/internal/sim/transition.go
+++ b/engine/internal/sim/transition.go
@@ -105,11 +105,17 @@ func (gs *gameState) runTransitionPossession(offense, defense *teamState, period
 		net := transitionNet(def)
 		mq := matchupQuality(bh.FGP, bh.energy, defense.players) // live energy (inert under current curve)
 		sv2 := applyClutch(shotValue2pt(net, bh.FGP, false), bh.Clutch, gs.period, scoreDiff)
+		// Play-outcome buckets use the same net-free O(1) helpers as the half-court
+		// path (bucketweights.go) — the second of the two outcomeInputs assembly
+		// sites. sv2 (above) keeps feeding shotAttempt on the 2pt path ONLY; it no
+		// longer doubles as the 2pt bucket weight, so clutch no longer leaks into
+		// bucket selection and a future HCA nudge on the foul bucket is expressible
+		// here too (it would have been a no-op against the old O(100) sv2 weight).
 		in := outcomeInputs{
-			twoPtWeight:      sv2 * bh.fatigue,
-			threePtWeight:    0, // a fast break is never a 3pt attempt
-			andOneWeight:     mq*0.25 + base2pt(bh.FGP)*andOneBaseShare,
-			foulOnlyWeight:   (2.0 - bh.fatigue) * floor1(bh.Foul),
+			twoPtWeight:      twoPtBucketWeight(bh),
+			threePtWeight:    0, // a fast break is never a 3pt attempt (allowedPaths excludes it)
+			andOneWeight:     andOneBucketWeight(mq, bh),
+			foulOnlyWeight:   foulBucketWeight(net, bh),
 			turnoverDefValue: turnoverThreshold(bh.TVR) * turnoverThreshold(bh.TVR),
 		}
 

--- a/engine/internal/validate/bands.go
+++ b/engine/internal/validate/bands.go
@@ -34,6 +34,14 @@ type Band struct {
 // │ HCA CAVEAT: bands are calibrated against the CURRENT engine, which has NO  │
 // │ home-court advantage. RE-CALIBRATE when HCA lands.                         │
 // │                                                                            │
+// │ PLAY-OUTCOME RESCALE CAVEAT (PR9): these bands were calibrated against the │
+// │ OLD O(100) play-outcome bucket weights. PR9 rescaled those buckets onto a  │
+// │ comparable O(1) basis (net-free 2pt composite), shifting the path-selection│
+// │ mix — notably foul / and-one / FT path frequencies. The ftm, fta, and pf   │
+// │ observed-vs-engine gaps therefore move. Bands are STALE; do NOT re-run the │
+// │ 53GB calibration here. Re-calibrate ONCE, after HCA also lands (calibrate  │
+// │ once, not twice). No band VALUES change in PR9.                            │
+// │                                                                            │
 // │ DOCUMENTED CURRENT GAP (AbsFloor > engine mean — band is wide because the  │
 // │ engine under-models the stat at this build stage, NOT a useful tolerance): │
 // │ ftm, fta, tgm, tga, ast, blk, pf. In particular `ast` is structurally 0 in │


### PR DESCRIPTION
## Summary

Decouples the 2pt play-outcome *bucket weight* from `sv2` (the per-mille make-roll shot value) by introducing net-free O(1) bucket-weight helpers. Before this change, all four outcome buckets were anchored to an O(100) scale (`twoPtWeight ≈ 434`), making JSB's ±0.2 HCA adjustment a ~0.05% perturbation — a documented no-op. After this change, all four buckets land at comparable single-digit O(1) magnitudes (~0.5/0.4/0.3/0.6), so a ±0.2 foul-bucket perturbation becomes a meaningful ~7pp swing.

**Key design decisions:**
- 2pt bucket weight is **net-free** (offensive rate analogs only — `r_fga`/`r_orb`/`r_fta`) so `net` and the playoff ×1.25 multiplier no longer leak into bucket selection
- `sv2` (per-mille make-roll) and the `rollMake`/`shotAttempt` path are **unchanged**
- Turnover path, `selectOutcome`/`allowedPaths`/`weight()` logic all **unchanged**
- All helpers are documented stand-ins pending corpus calibration (exact §4 formula blocked by unresolved CEngine aggregates)

**Verified by:**
- Characterization test locking in pre-rescale path-selection distribution
- Scale property test: ±0.2 foul perturbation shifts foul-path probability by ≥ a few pp (non-negligible vs old ~0.05% no-op)
- Direction property test: EV(foul) > EV(2pt) locked via outcome realizations
- Golden snapshot regenerated and diff-reviewed for intentional path-mix shift
- `make fmt-check vet lint test cover` green; coverage ≥ 90.0

**Out of scope:** HCA wiring (separate PR), bands re-calibration (bands are now stale — annotated in `bands.go`), corpus calibration of exact magnitudes.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.