### PR TITLE
refactor: centralize CP1252->UTF-8 decode in PlrFieldSerializer::toUtf8

### DIFF
--- a/ibl5/classes/JsbParser/DraFileParser.php
+++ b/ibl5/classes/JsbParser/DraFileParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JsbParser;
 
 use JsbParser\Contracts\DraFileParserInterface;
+use PlrParser\PlrFieldSerializer;
 
 /**
  * Parser for JSB .dra (Draft Results) text files.
@@ -98,7 +99,7 @@ class DraFileParser implements DraFileParserInterface
                         $playerName = trim(substr($remainder, 2));
 
                         // Convert CP1252 to UTF-8
-                        $playerName = mb_convert_encoding($playerName, 'UTF-8', 'Windows-1252');
+                        $playerName = PlrFieldSerializer::toUtf8($playerName);
 
                         $currentPicks[] = [
                             'round' => $currentRound,

--- a/ibl5/classes/JsbParser/Importers/AwaImporter.php
+++ b/ibl5/classes/JsbParser/Importers/AwaImporter.php
@@ -8,6 +8,7 @@ use JsbParser\AwaFileParser;
 use JsbParser\CarFileParser;
 use JsbParser\Contracts\JsbImportRepositoryInterface;
 use JsbParser\JsbImportResult;
+use PlrParser\PlrFieldSerializer;
 
 class AwaImporter
 {
@@ -42,7 +43,7 @@ class AwaImporter
         /** @var array<int, string> $pidNameMap */
         $pidNameMap = [];
         foreach ($carParsed['players'] as $player) {
-            $name = mb_convert_encoding($player['name'], 'UTF-8', 'Windows-1252');
+            $name = PlrFieldSerializer::toUtf8($player['name']);
             $pidNameMap[$player['block_index']] = $name;
         }
 

--- a/ibl5/classes/JsbParser/RcbFileParser.php
+++ b/ibl5/classes/JsbParser/RcbFileParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JsbParser;
 
 use JsbParser\Contracts\RcbFileParserInterface;
+use PlrParser\PlrFieldSerializer;
 
 /**
  * Parser for JSB .rcb (Record Book) text files.
@@ -95,9 +96,7 @@ class RcbFileParser implements RcbFileParserInterface
      */
     private static function toUtf8(string $cp1252String): string
     {
-        $result = mb_convert_encoding($cp1252String, 'UTF-8', 'Windows-1252');
-
-        return is_string($result) ? $result : $cp1252String;
+        return PlrFieldSerializer::toUtf8($cp1252String);
     }
 
     /**

--- a/ibl5/classes/PlrParser/Contracts/PlrFieldSerializerInterface.php
+++ b/ibl5/classes/PlrParser/Contracts/PlrFieldSerializerInterface.php
@@ -41,4 +41,17 @@ interface PlrFieldSerializerInterface
      * @return string The CP1252 encoded string
      */
     public static function toCP1252(string $utf8String): string;
+
+    /**
+     * Convert a Windows-1252 (CP1252) encoded string to UTF-8.
+     *
+     * The canonical read-direction decode for the JSB parser cluster: all .plr,
+     * .rcb, .dra, and .awa name fields route through here so the decode semantics
+     * stay consistent (mb_convert_encoding with a null-safe fallback). Must be
+     * called after fixed-width substr/trim extraction, never on whole-file bytes.
+     *
+     * @param string $cp1252String The Windows-1252 (CP1252) encoded string
+     * @return string The UTF-8 encoded string
+     */
+    public static function toUtf8(string $cp1252String): string;
 }

--- a/ibl5/classes/PlrParser/PlrFieldSerializer.php
+++ b/ibl5/classes/PlrParser/PlrFieldSerializer.php
@@ -58,4 +58,16 @@ class PlrFieldSerializer implements PlrFieldSerializerInterface
         }
         return $result;
     }
+
+    /**
+     * @see PlrFieldSerializerInterface::toUtf8()
+     */
+    public static function toUtf8(string $cp1252String): string
+    {
+        $result = mb_convert_encoding($cp1252String, 'UTF-8', 'Windows-1252');
+        if (!is_string($result)) {
+            return $cp1252String;
+        }
+        return $result;
+    }
 }

--- a/ibl5/classes/PlrParser/PlrFileWriter.php
+++ b/ibl5/classes/PlrParser/PlrFileWriter.php
@@ -330,8 +330,7 @@ class PlrFileWriter implements PlrFileWriterInterface
     public static function readPlayerName(string $line): string
     {
         $nameRaw = trim(substr($line, 4, 32));
-        $converted = iconv('CP1252', 'UTF-8//IGNORE', $nameRaw);
-        return is_string($converted) ? $converted : $nameRaw;
+        return PlrFieldSerializer::toUtf8($nameRaw);
     }
 
     /**

--- a/ibl5/classes/PlrParser/PlrLineParser.php
+++ b/ibl5/classes/PlrParser/PlrLineParser.php
@@ -29,8 +29,7 @@ class PlrLineParser implements PlrLineParserInterface
 
         // Extract name and convert from Windows 1252 to UTF-8 to preserve accent marks
         $nameRaw = trim(substr($line, 4, 32));
-        $nameConverted = iconv('CP1252', 'UTF-8//IGNORE', $nameRaw);
-        $name = $nameConverted !== false ? $nameConverted : $nameRaw;
+        $name = PlrFieldSerializer::toUtf8($nameRaw);
 
         return [
             'ordinal' => $ordinal,

--- a/ibl5/classes/PlrParser/PlrOrdinalMap.php
+++ b/ibl5/classes/PlrParser/PlrOrdinalMap.php
@@ -80,7 +80,7 @@ final class PlrOrdinalMap
             }
 
             $rawName = trim(substr($line, self::NAME_OFFSET, self::NAME_WIDTH));
-            $name = mb_convert_encoding($rawName, 'UTF-8', 'Windows-1252');
+            $name = PlrFieldSerializer::toUtf8($rawName);
 
             $map[$ordinal] = [
                 'pid' => $pid,

--- a/ibl5/tests/PlrParser/PlrFieldSerializerTest.php
+++ b/ibl5/tests/PlrParser/PlrFieldSerializerTest.php
@@ -91,6 +91,39 @@ class PlrFieldSerializerTest extends TestCase
         $this->assertSame($ascii, PlrFieldSerializer::toCP1252($ascii));
     }
 
+    public function testToUtf8ConvertsAccentedCharacters(): void
+    {
+        // José in CP1252 (é = 0xe9) → José in UTF-8 (é = 0xc3 0xa9)
+        $cp1252 = "Jos\xe9";
+        $this->assertSame("Jos\xc3\xa9", PlrFieldSerializer::toUtf8($cp1252));
+    }
+
+    public function testToUtf8PreservesAscii(): void
+    {
+        $ascii = 'John Smith';
+        $this->assertSame($ascii, PlrFieldSerializer::toUtf8($ascii));
+    }
+
+    public function testToUtf8MapsUndefinedCp1252ByteToUnicode(): void
+    {
+        // 0x81 is an undefined slot in CP1252. This locks the *consolidated*
+        // decode behavior: mb_convert_encoding maps it to U+0081 (UTF-8
+        // 0xc2 0x81), whereas the old iconv('CP1252','UTF-8//IGNORE') variant
+        // silently dropped the byte ("AB"). Standardizing on this output is the
+        // point of the consolidation (PR 3). The is_string() fallback in toUtf8
+        // is defensive — mb_convert_encoding never returns false for these
+        // hardcoded encodings, so no input can exercise it.
+        $this->assertSame("A\xc2\x81B", PlrFieldSerializer::toUtf8("A\x81B"));
+    }
+
+    public function testRoundTripPreservesAccents(): void
+    {
+        // José García round-trips UTF-8 → CP1252 → UTF-8 unchanged.
+        $utf8 = "Jos\xc3\xa9 Garc\xc3\xada";
+        $cp1252 = PlrFieldSerializer::toCP1252($utf8);
+        $this->assertSame($utf8, PlrFieldSerializer::toUtf8($cp1252));
+    }
+
     public function testFormatIntProducesCorrectLength(): void
     {
         for ($width = 1; $width <= 6; $width++) {

--- a/ibl5/tests/PlrParser/PlrLineParserTest.php
+++ b/ibl5/tests/PlrParser/PlrLineParserTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PlrParser;
+
+use PlrParser\PlrLineParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \PlrParser\PlrLineParser
+ */
+class PlrLineParserTest extends TestCase
+{
+    /**
+     * Build a 607-byte .plr record line carrying ordinal, name, age, and pid.
+     *
+     * Only the fields exercised by these tests are populated; the rest of the
+     * fixed-width record is space-padded. Offsets mirror PlrLineParser::parse():
+     * ordinal(0,4) | name(4,32) | age(36,2) | pid(38,6) | teamid(44,2).
+     */
+    private function buildPlrLine(int $ordinal, string $name, int $pid, int $teamid = 1): string
+    {
+        $line = str_pad((string) $ordinal, 4, ' ', STR_PAD_LEFT); // 0-3
+        $line .= str_pad($name, 32);                              // 4-35
+        $line .= str_pad('25', 2, ' ', STR_PAD_LEFT);            // 36-37 (age)
+        $line .= str_pad((string) $pid, 6, ' ', STR_PAD_LEFT);   // 38-43
+        $line .= str_pad((string) $teamid, 2, ' ', STR_PAD_LEFT); // 44-45
+
+        return str_pad($line, 607); // full record width
+    }
+
+    public function testParsesAsciiName(): void
+    {
+        $result = PlrLineParser::parse($this->buildPlrLine(1, 'John Smith', 12345));
+
+        $this->assertNotNull($result);
+        $this->assertSame('John Smith', $result['name']);
+        $this->assertSame(1, $result['ordinal']);
+        $this->assertSame(12345, $result['pid']);
+    }
+
+    public function testParsesAccentedNameFromCp1252(): void
+    {
+        // "José Garcia" in CP1252 (é = 0xe9) decodes to UTF-8 (é = 0xc3 0xa9).
+        $result = PlrLineParser::parse($this->buildPlrLine(2, "Jos\xe9 Garcia", 67890));
+
+        $this->assertNotNull($result);
+        $this->assertSame('José Garcia', $result['name']);
+    }
+
+    public function testMapsUndefinedCp1252ByteToUnicode(): void
+    {
+        // 0x81 is undefined in CP1252. This locks the consolidated decode (PR 3):
+        // the shared PlrFieldSerializer::toUtf8 maps it to U+0081 (0xc2 0x81),
+        // whereas the previous iconv('CP1252','UTF-8//IGNORE') variant in this
+        // parser silently dropped the byte ("AB"). Standardizing on the mb
+        // behavior is the latent-bug fix this PR makes.
+        $result = PlrLineParser::parse($this->buildPlrLine(3, "A\x81B", 11111));
+
+        $this->assertNotNull($result);
+        $this->assertSame("A\xc2\x81B", $result['name']);
+    }
+
+    public function testReturnsNullForZeroPid(): void
+    {
+        $this->assertNull(PlrLineParser::parse($this->buildPlrLine(1, 'Empty Slot', 0)));
+    }
+
+    public function testReturnsNullForOrdinalAbove1440(): void
+    {
+        $this->assertNull(PlrLineParser::parse($this->buildPlrLine(1441, 'Over Limit', 99999)));
+    }
+}


### PR DESCRIPTION
## Summary

Routes all 6 read-direction CP1252→UTF-8 decode sites through a new canonical `PlrFieldSerializer::toUtf8()` method. Standardizes on `mb_convert_encoding` semantics + null-safe fallback (the safest existing variant), eliminating divergent `iconv //IGNORE` silent-drop vs. `mb_convert_encoding` substitute behavior across the parser cluster.

**Sites routed:**
- `PlrFileWriter.php:333`, `PlrLineParser.php:32` (replaced `iconv`)
- `PlrOrdinalMap.php:83`
- `RcbFileParser.php:96` (delegating call)
- `DraFileParser.php:101`, `AwaImporter.php:45`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.