### PR TITLE
feat(engine): add home-court-margin instrument to the calibration harness

### DIFF
--- a/engine/cmd/jsbcalibrate/main_test.go
+++ b/engine/cmd/jsbcalibrate/main_test.go
@@ -45,6 +45,43 @@ func TestRun_CalibrateEmitsJSON(t *testing.T) {
 	}
 }
 
+// calibrate mode also emits the per-game-type home_margins readout (the HCA
+// signal) alongside buckets, from the same run. Home pts Engine=108/Sco=110
+// (TeamID 7), visitor Engine=100/Sco=100 (TeamID 3) → engine margin 8, sco
+// margin 10, gap −2.
+func TestRun_CalibrateEmitsHomeMargins(t *testing.T) {
+	reports := []validate.Report{{
+		GameType: bundle.GameTypeRegular,
+		Games: []validate.GameReport{{
+			HomeTeamID:    7,
+			VisitorTeamID: 3,
+			Rows: []validate.StatRow{
+				{TeamID: 3, Stat: "points", ScoVal: 100, EngineMean: 100},
+				{TeamID: 7, Stat: "points", ScoVal: 110, EngineMean: 108},
+			},
+		}},
+	}}
+	var out, errBuf bytes.Buffer
+	code := runWith([]string{"--archive", "/x", "--mode", "calibrate"}, &out, &errBuf, stubCollectors(reports, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, errBuf.String())
+	}
+	var rep calibrate.CalibrationReport
+	if err := json.Unmarshal(out.Bytes(), &rep); err != nil {
+		t.Fatalf("stdout is not a CalibrationReport JSON: %v\n%s", err, out.String())
+	}
+	if len(rep.HomeMargins) != 1 {
+		t.Fatalf("home_margins len = %d, want 1: %+v", len(rep.HomeMargins), rep.HomeMargins)
+	}
+	hm := rep.HomeMargins[0]
+	if hm.GameType != int(bundle.GameTypeRegular) {
+		t.Errorf("home_margins GameType = %d, want %d", hm.GameType, int(bundle.GameTypeRegular))
+	}
+	if hm.MarginGap != -2 {
+		t.Errorf("MarginGap = %v, want -2", hm.MarginGap)
+	}
+}
+
 // Row #14 (negative): gate mode exits nonzero when a stat's in-band rate is
 // below --min-rate, and the JSON reports pass=false.
 func TestRun_GateFailsBelowMinRate(t *testing.T) {

--- a/engine/internal/calibrate/aggregate.go
+++ b/engine/internal/calibrate/aggregate.go
@@ -65,10 +65,13 @@ type GameTypeCalibration struct {
 
 // CalibrationReport is the full calibrate-mode output: proposed per-game-type
 // bands derived at the requested residual coverage. Buckets are sorted by game
-// type for determinism.
+// type for determinism. HomeMargins carries the per-game-type home-court-margin
+// readout (the HCA fidelity signal); it rides along on the same run so one
+// calibrate pass yields both bands and margins.
 type CalibrationReport struct {
-	Coverage float64               `json:"coverage"`
-	Buckets  []GameTypeCalibration `json:"buckets"`
+	Coverage    float64                 `json:"coverage"`
+	Buckets     []GameTypeCalibration   `json:"buckets"`
+	HomeMargins []HomeMarginCalibration `json:"home_margins"`
 }
 
 // Calibrate derives, per (game type, stat), a tolerance band whose absolute
@@ -91,6 +94,7 @@ func Calibrate(reports []validate.Report, coverage float64) CalibrationReport {
 		}
 		rep.Buckets = append(rep.Buckets, gc)
 	}
+	rep.HomeMargins = CollectHomeMargins(reports)
 	return rep
 }
 

--- a/engine/internal/calibrate/aggregate_test.go
+++ b/engine/internal/calibrate/aggregate_test.go
@@ -100,6 +100,29 @@ func TestCalibrate_SegmentsByGameType(t *testing.T) {
 	}
 }
 
+// Calibrate surfaces HomeMargins alongside Buckets from a single call: a Regular
+// report with paired home/visitor "points" rows yields one margin bucket (gap ≈0
+// when the engine agrees with .sco) AND the usual per-stat band buckets.
+// (ptsGame/marginReport are defined in homemargin_test.go, same package.)
+func TestCalibrate_PopulatesHomeMargins(t *testing.T) {
+	rep := Calibrate([]validate.Report{
+		marginReport(bundle.GameTypeRegular, ptsGame(7, 3, 105, 105, 100, 100)),
+	}, 0.95)
+
+	if len(rep.HomeMargins) != 1 {
+		t.Fatalf("HomeMargins len = %d, want 1: %+v", len(rep.HomeMargins), rep.HomeMargins)
+	}
+	if rep.HomeMargins[0].GameType != int(bundle.GameTypeRegular) {
+		t.Errorf("HomeMargins GameType = %d, want %d", rep.HomeMargins[0].GameType, int(bundle.GameTypeRegular))
+	}
+	if math.Abs(rep.HomeMargins[0].MarginGap) > 1e-9 {
+		t.Errorf("MarginGap = %v, want ≈0", rep.HomeMargins[0].MarginGap)
+	}
+	if len(rep.Buckets) != 1 || rep.Buckets[0].GameType != int(bundle.GameTypeRegular) {
+		t.Errorf("Buckets = %+v, want one regular bucket (surfaced from the same call)", rep.Buckets)
+	}
+}
+
 // Gate: a bucket below min-rate flips the overall verdict to fail; a bucket at
 // or above passes.
 func TestGate_FailsBelowMinRate(t *testing.T) {

--- a/engine/internal/calibrate/homemargin.go
+++ b/engine/internal/calibrate/homemargin.go
@@ -1,0 +1,117 @@
+package calibrate
+
+import (
+	"sort"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// HomeMarginCalibration is the per-game-type home-court-margin readout: the mean
+// home-minus-visitor point margin the engine produced, the same margin from the
+// .sco ground truth, and the gap between them. MarginGap is the home-court-
+// advantage fidelity signal — PR2 tunes the engine's quality stand-in scales
+// until it approaches 0.
+//
+// This is derived separately from the per-stat bands in CalibrationReport.Buckets
+// because the band collector flattens every StatRow into per-(game type, stat)
+// pools, discarding the home/visitor PAIRING that a margin requires.
+type HomeMarginCalibration struct {
+	GameType           int     `json:"game_type"`
+	N                  int     `json:"n"`                     // games contributing to this bucket
+	EngineHomeMargin   float64 `json:"engine_home_margin"`    // mean(home pts EngineMean − visitor pts EngineMean)
+	ScoHomeMargin      float64 `json:"sco_home_margin"`       // mean(home pts ScoVal − visitor pts ScoVal)
+	MarginGap          float64 `json:"margin_gap"`            // EngineHomeMargin − ScoHomeMargin
+	EngineHomeWinShare float64 `json:"engine_home_win_share"` // fraction of games with engine home margin > 0
+	ScoHomeWinShare    float64 `json:"sco_home_win_share"`    // fraction of games with .sco home margin > 0
+	WinShareGap        float64 `json:"win_share_gap"`         // EngineHomeWinShare − ScoHomeWinShare
+}
+
+// homeMarginAcc accumulates one game type's running sums while CollectHomeMargins
+// walks the reports.
+type homeMarginAcc struct {
+	n          int
+	sumEngine  float64
+	sumSco     float64
+	engineWins int
+	scoWins    int
+}
+
+// CollectHomeMargins derives the per-game-type home-court margin from already-built
+// validation reports — no engine run, no corpus walk. For each game it pairs the
+// home and visitor "points" rows (matched by TeamID) and accumulates the engine
+// and .sco home margins; the means and win-shares are emitted per game type,
+// sorted ascending by game type for determinism.
+//
+// A game contributes nothing when its home and visitor team IDs collide or when
+// either side is missing a "points" row — both are degenerate inputs, not real
+// matchups. A game type with no contributing games is omitted entirely, so every
+// emitted bucket has N >= 1 (the win-share division is divide-by-zero-safe).
+func CollectHomeMargins(reports []validate.Report) []HomeMarginCalibration {
+	byType := map[bundle.GameType]*homeMarginAcc{}
+	for _, rep := range reports {
+		for _, g := range rep.Games {
+			if g.HomeTeamID == g.VisitorTeamID {
+				continue // collision: not a real home/away matchup
+			}
+			homePts, okHome := pointsFor(g, g.HomeTeamID)
+			visPts, okVis := pointsFor(g, g.VisitorTeamID)
+			if !okHome || !okVis {
+				continue // missing a "points" row on one side
+			}
+			acc := byType[rep.GameType]
+			if acc == nil {
+				acc = &homeMarginAcc{}
+				byType[rep.GameType] = acc
+			}
+			acc.n++
+			acc.sumEngine += homePts.EngineMean - visPts.EngineMean
+			acc.sumSco += homePts.ScoVal - visPts.ScoVal
+			if homePts.EngineMean > visPts.EngineMean {
+				acc.engineWins++
+			}
+			if homePts.ScoVal > visPts.ScoVal {
+				acc.scoWins++
+			}
+		}
+	}
+
+	gts := make([]bundle.GameType, 0, len(byType))
+	for gt := range byType {
+		gts = append(gts, gt)
+	}
+	sort.Slice(gts, func(i, j int) bool { return gts[i] < gts[j] })
+
+	out := make([]HomeMarginCalibration, 0, len(gts))
+	for _, gt := range gts {
+		acc := byType[gt]
+		n := float64(acc.n)
+		eng := acc.sumEngine / n
+		sco := acc.sumSco / n
+		engWin := float64(acc.engineWins) / n
+		scoWin := float64(acc.scoWins) / n
+		out = append(out, HomeMarginCalibration{
+			GameType:           int(gt),
+			N:                  acc.n,
+			EngineHomeMargin:   eng,
+			ScoHomeMargin:      sco,
+			MarginGap:          eng - sco,
+			EngineHomeWinShare: engWin,
+			ScoHomeWinShare:    scoWin,
+			WinShareGap:        engWin - scoWin,
+		})
+	}
+	return out
+}
+
+// pointsFor returns the "points" StatRow for the given team in a game and whether
+// it was found. The validation harness emits exactly one "points" row per team
+// (compareGame), so the first match is the team's points.
+func pointsFor(g validate.GameReport, teamID int) (validate.StatRow, bool) {
+	for _, r := range g.Rows {
+		if r.Stat == "points" && r.TeamID == teamID {
+			return r, true
+		}
+	}
+	return validate.StatRow{}, false
+}

--- a/engine/internal/calibrate/homemargin_test.go
+++ b/engine/internal/calibrate/homemargin_test.go
@@ -1,0 +1,147 @@
+package calibrate
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// ptsGame builds a one-game GameReport carrying a "points" row for each side,
+// tagged with the side's team ID — the shape CollectHomeMargins pairs on.
+func ptsGame(homeID, visID int, homeEngine, homeSco, visEngine, visSco float64) validate.GameReport {
+	return validate.GameReport{
+		HomeTeamID:    homeID,
+		VisitorTeamID: visID,
+		Rows: []validate.StatRow{
+			{TeamID: visID, Stat: "points", ScoVal: visSco, EngineMean: visEngine},
+			{TeamID: homeID, Stat: "points", ScoVal: homeSco, EngineMean: homeEngine},
+		},
+	}
+}
+
+func marginReport(gt bundle.GameType, games ...validate.GameReport) validate.Report {
+	return validate.Report{GameType: gt, Games: games}
+}
+
+// Row #1: the margin and win-share are derived from the paired home/visitor
+// "points" rows. Home Engine=108/Sco=110 (TeamID 7), visitor Engine=101/Sco=100
+// (TeamID 3) → engine margin +7, sco margin +10, gap −3, both home-wins.
+func TestCollectHomeMargins_DerivesMargin(t *testing.T) {
+	got := CollectHomeMargins([]validate.Report{
+		marginReport(bundle.GameTypeRegular, ptsGame(7, 3, 108, 110, 101, 100)),
+	})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %+v", len(got), got)
+	}
+	m := got[0]
+	if m.GameType != int(bundle.GameTypeRegular) {
+		t.Errorf("GameType = %d, want %d", m.GameType, int(bundle.GameTypeRegular))
+	}
+	if m.N != 1 {
+		t.Errorf("N = %d, want 1", m.N)
+	}
+	if m.EngineHomeMargin != 7 {
+		t.Errorf("EngineHomeMargin = %v, want 7", m.EngineHomeMargin)
+	}
+	if m.ScoHomeMargin != 10 {
+		t.Errorf("ScoHomeMargin = %v, want 10", m.ScoHomeMargin)
+	}
+	if m.MarginGap != -3 {
+		t.Errorf("MarginGap = %v, want -3", m.MarginGap)
+	}
+	if m.EngineHomeWinShare != 1 || m.ScoHomeWinShare != 1 {
+		t.Errorf("win shares = (%v, %v), want (1, 1)", m.EngineHomeWinShare, m.ScoHomeWinShare)
+	}
+	if m.WinShareGap != 0 {
+		t.Errorf("WinShareGap = %v, want 0", m.WinShareGap)
+	}
+}
+
+// Row #2 (sign/zero boundary): when the engine home margin agrees with the .sco
+// home margin (both +5), MarginGap is ≈0 — the no-HCA-error case PR2 tunes
+// toward.
+func TestCollectHomeMargins_ZeroGapWhenEngineAgreesWithSco(t *testing.T) {
+	got := CollectHomeMargins([]validate.Report{
+		marginReport(bundle.GameTypeRegular, ptsGame(7, 3, 105, 105, 100, 100)),
+	})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].EngineHomeMargin != 5 || got[0].ScoHomeMargin != 5 {
+		t.Fatalf("margins = (%v, %v), want (5, 5)", got[0].EngineHomeMargin, got[0].ScoHomeMargin)
+	}
+	if math.Abs(got[0].MarginGap) > 1e-9 {
+		t.Errorf("MarginGap = %v, want ≈0", got[0].MarginGap)
+	}
+}
+
+// Row #3 (N=0 / collision boundary): a game whose home and visitor team IDs
+// collide is not a real matchup → skipped, bucket omitted, no panic, empty slice.
+func TestCollectHomeMargins_OmitsEmptyBucket(t *testing.T) {
+	got := CollectHomeMargins([]validate.Report{
+		marginReport(bundle.GameTypeRegular, ptsGame(5, 5, 100, 100, 90, 90)),
+	})
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0 (collision game skipped, bucket omitted): %+v", len(got), got)
+	}
+}
+
+// Row #4 (defensive boundary): a game missing a "points" row contributes nothing
+// — no panic, bucket omitted when it is the only game.
+func TestCollectHomeMargins_SkipsGameMissingPointsRow(t *testing.T) {
+	noPoints := validate.GameReport{
+		HomeTeamID:    7,
+		VisitorTeamID: 3,
+		Rows: []validate.StatRow{
+			{TeamID: 7, Stat: "reb", ScoVal: 40, EngineMean: 41},
+			{TeamID: 3, Stat: "reb", ScoVal: 38, EngineMean: 37},
+		},
+	}
+	got := CollectHomeMargins([]validate.Report{marginReport(bundle.GameTypeRegular, noPoints)})
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0 (no points row → skipped): %+v", len(got), got)
+	}
+}
+
+// Row #5 (ordering determinism): buckets are emitted ascending by game type —
+// Regular (2) before Playoff (4) — regardless of report order.
+func TestCollectHomeMargins_SortedByGameType(t *testing.T) {
+	got := CollectHomeMargins([]validate.Report{
+		marginReport(bundle.GameTypePlayoff, ptsGame(7, 3, 100, 100, 95, 95)),
+		marginReport(bundle.GameTypeRegular, ptsGame(7, 3, 100, 100, 95, 95)),
+	})
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].GameType != int(bundle.GameTypeRegular) || got[1].GameType != int(bundle.GameTypePlayoff) {
+		t.Errorf("order = [%d, %d], want [%d, %d]",
+			got[0].GameType, got[1].GameType, int(bundle.GameTypeRegular), int(bundle.GameTypePlayoff))
+	}
+}
+
+// Row #6 (aggregation + win-share fraction): two games with engine margins +10
+// and −2 → mean EngineHomeMargin 4, N 2; one home-win and one home-loss →
+// EngineHomeWinShare 0.5.
+func TestCollectHomeMargins_AggregatesAcrossGames(t *testing.T) {
+	got := CollectHomeMargins([]validate.Report{
+		marginReport(bundle.GameTypeRegular,
+			ptsGame(7, 3, 60, 60, 50, 50), // +10, home win
+			ptsGame(7, 3, 48, 48, 50, 50), // −2,  home loss
+		),
+	})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	m := got[0]
+	if m.N != 2 {
+		t.Errorf("N = %d, want 2", m.N)
+	}
+	if m.EngineHomeMargin != 4 {
+		t.Errorf("EngineHomeMargin = %v, want 4 (mean of +10 and −2)", m.EngineHomeMargin)
+	}
+	if math.Abs(m.EngineHomeWinShare-0.5) > 1e-9 {
+		t.Errorf("EngineHomeWinShare = %v, want 0.5 (one win of two)", m.EngineHomeWinShare)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a measurement-only instrument to the `calibrate` package that derives the engine-vs-corpus home-court point margin per game type, then surfaces it on the existing `CalibrationReport` so a single `--mode calibrate` run emits both bands and margins.

The margin is derived entirely from data already present in `[]validate.Report` — no new corpus walk, no change to sim code, HCA constants, or band values. This is purely additive: a new file `homemargin.go` holding `HomeMarginCalibration` and `CollectHomeMargins`, plus one new field on `CalibrationReport` populated inside `Calibrate()`.

**PR1 of 2.** PR2 (`hca-calibration-2-tune-recalibrate-bands`) stacks on this branch.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.