### PR TITLE
ci(smoke): classify uniform WAF-block as inconclusive; skip docs-only reverts

### DIFF
--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -40,6 +40,9 @@ jobs:
     outputs:
       # 'false' on skip paths (stale guard) because skipped != failure
       ibl6_failed: ${{ steps.ibl6.outcome == 'failure' }}
+      # 'true' when the IBL5 smoke was INCONCLUSIVE (prober WAF-blocked, exit 3).
+      # Routes to notify-inconclusive instead of gating auto-rollback.
+      ibl5_inconclusive: ${{ steps.ibl5.outputs.inconclusive }}
 
     steps:
       - uses: actions/checkout@v6
@@ -73,10 +76,24 @@ jobs:
         run: sleep 15
 
       - name: Run IBL5 smoke checks (gates auto-rollback)
+        id: ibl5
         if: steps.guard.outputs.stale != 'true'
         run: |
           chmod +x bin/smoke-prod
+          # Capture the exit code without tripping `bash -e`. Exit 3 means the
+          # run was INCONCLUSIVE (prober WAF-blocked, not a real regression):
+          # surface it as an output and exit 0 so smoke.result == 'success' and
+          # the rollback gate's `failure` condition is false by construction.
+          # A real failure (exit 1) still propagates and gates auto-rollback.
+          set +e
           bin/smoke-prod --scope=ibl5 "$BASE_URL"
+          code=$?
+          set -e
+          if [ "$code" -eq 3 ]; then
+            echo "inconclusive=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          exit "$code"
 
       - name: Run IBL6 smoke checks (notify-only)
         id: ibl6
@@ -114,12 +131,35 @@ jobs:
           COMMIT_SHA=$(git log -1 --pretty=%H)
           echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
           echo "commit_msg=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
+
+          # Loop-guard: never revert a revert (would ping-pong production).
           if echo "$COMMIT_MSG" | grep -q "^Revert "; then
             echo "should_revert=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=already-revert" >> "$GITHUB_OUTPUT"
             echo "HEAD is already a revert commit — skipping to prevent loop"
-          else
-            echo "should_revert=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          # Docs-only guard: a deploy that changed only docs/markdown cannot
+          # break runtime, so a smoke failure on it is never that commit's
+          # fault. Defense-in-depth alongside the exit-3 inconclusive path,
+          # for a non-uniform failure that coincides with a docs-only deploy.
+          if [ "$(git cat-file -p HEAD | grep -c '^parent ')" -gt 1 ]; then
+            DIFF_BASE="HEAD^1"
+          else
+            DIFF_BASE="HEAD~1"
+          fi
+          CHANGED=$(git diff --name-only "$DIFF_BASE" HEAD)
+          NON_DOCS=$(echo "$CHANGED" | grep -vE '(\.md$|^docs/|^ibl5/docs/)' || true)
+          if [ -n "$CHANGED" ] && [ -z "$NON_DOCS" ]; then
+            echo "should_revert=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=docs-only" >> "$GITHUB_OUTPUT"
+            echo "HEAD changed only docs/markdown — skipping revert"
+            exit 0
+          fi
+
+          echo "should_revert=true" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=" >> "$GITHUB_OUTPUT"
 
       - name: Revert production commit
         id: revert
@@ -148,13 +188,16 @@ jobs:
           COMMIT_MSG: ${{ steps.check.outputs.commit_msg }}
           COMMIT_SHA: ${{ steps.check.outputs.commit_sha }}
           SHOULD_REVERT: ${{ steps.check.outputs.should_revert }}
+          SKIP_REASON: ${{ steps.check.outputs.skip_reason }}
           REVERT_OUTCOME: ${{ steps.revert.outcome }}
           OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SHORT_SHA="${COMMIT_SHA:0:7}"
 
-          if [ "$SHOULD_REVERT" = "false" ]; then
+          if [ "$SHOULD_REVERT" = "false" ] && [ "$SKIP_REASON" = "docs-only" ]; then
+            MSG=$(printf 'Production smoke test FAILED on a docs-only deploy (%s) — NOT reverting (cannot affect runtime). Likely transient/prober; please check.\n\nRun: %s' "$SHORT_SHA" "$RUN_URL")
+          elif [ "$SHOULD_REVERT" = "false" ]; then
             MSG=$(printf 'Production smoke test FAILED but HEAD is already a revert — manual intervention required.\n\nCommit: %s\nRun: %s' "$SHORT_SHA" "$RUN_URL")
           elif [ "$REVERT_OUTCOME" = "failure" ]; then
             MSG=$(printf 'Production smoke test FAILED and auto-revert FAILED (push rejected?) — manual intervention required.\n\nCommit: %s\nRun: %s' "$SHORT_SHA" "$RUN_URL")
@@ -211,6 +254,7 @@ jobs:
     if: >-
       always() &&
       needs.smoke.outputs.ibl6_failed == 'true' &&
+      needs.smoke.outputs.ibl5_inconclusive != 'true' &&
       needs.smoke.result == 'success'
     timeout-minutes: 5
 
@@ -230,6 +274,43 @@ jobs:
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           MSG=$(printf 'IBL6 smoke FAILED; IBL5 unaffected. No rollback.\n\nRun: %s' "$RUN_URL")
+
+          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
+            '{content: {receivingUserDiscordID: $id, message: $msg}}')
+
+          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
+            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
+            || echo "IBLbot notification failed (bot may be down)"
+
+  notify-inconclusive:
+    name: Notify Smoke Inconclusive
+    runs-on: ubuntu-latest
+    needs: smoke
+    # Fire ONLY when IBL5 smoke was inconclusive (prober WAF-blocked, exit 3).
+    # Both conjuncts are required: a plain success lacks ibl5_inconclusive, and
+    # a real failure sets smoke.result == 'failure' (→ rollback path, not here).
+    if: >-
+      always() &&
+      needs.smoke.outputs.ibl5_inconclusive == 'true' &&
+      needs.smoke.result == 'success'
+    timeout-minutes: 5
+
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+        env:
+          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Send Discord DM
+        env:
+          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
+        run: |
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG=$(printf 'IBL5 smoke INCONCLUSIVE (uniform WAF-class block — likely runner-IP). NO rollback; production untouched. Run: %s' "$RUN_URL")
 
           PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
             '{content: {receivingUserDiscordID: $id, message: $msg}}')

--- a/bin/smoke-prod
+++ b/bin/smoke-prod
@@ -12,8 +12,12 @@
 #
 # Exit code:
 #   0 — all in-scope checks passed
-#   1 — one or more in-scope checks failed
+#   1 — one or more in-scope checks failed (real failure: heterogeneous, 5xx, or bad body)
 #   2 — usage error (bad arguments)
+#   3 — inconclusive: every in-scope check failed with an identical WAF-class
+#       status (403/415/429). The prober was almost certainly blocked (e.g.
+#       LiteSpeed banned the runner IP), NOT a real regression — callers
+#       (.github/workflows/smoke-prod.yml) MUST NOT auto-rollback on this code.
 #
 # Environment variables:
 #   SMOKE_IBL6_URL          Override the IBL6 probe URL (default: https://ibl6.iblhoops.net/)
@@ -91,6 +95,19 @@ IBL6_PASS=0
 IBL6_FAIL=0
 ERRORS=""
 
+# WAF-uniformity trackers (drive the exit-3 "inconclusive" classification).
+# A real regression is heterogeneous (some 200, a 5xx, or a 200-with-bad-body);
+# a uniform non-5xx WAF-class code across every check means the prober itself
+# was blocked, not the app. WAF_CODES is the set of statuses LiteSpeed returns
+# when it bans/blocks a client. UNIFORM_WAF starts true and is cleared the
+# moment uniformity is broken (a pass, a non-WAF status, a second WAF code, or
+# any body failure).
+WAF_CODES="403 415 429"
+STATUS_FAILS=0       # count of HTTP-status failures (any code)
+WAF_STATUS_FAILS=0   # subset of STATUS_FAILS whose code is in WAF_CODES
+WAF_CODE=""          # the single WAF code observed so far
+UNIFORM_WAF=1        # 1 while every failure is the same WAF-class status
+
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
 
@@ -116,6 +133,17 @@ check() {
     if ! echo "$accept" | grep -qw "$status"; then
         eval "${category}_FAIL=\$(( ${category}_FAIL + 1 ))"
         ERRORS="${ERRORS}\n  FAIL: $name — HTTP $status (expected $accept)"
+        STATUS_FAILS=$(( STATUS_FAILS + 1 ))
+        if echo "$WAF_CODES" | grep -qw "$status"; then
+            WAF_STATUS_FAILS=$(( WAF_STATUS_FAILS + 1 ))
+            if [ -z "$WAF_CODE" ]; then
+                WAF_CODE="$status"
+            elif [ "$status" != "$WAF_CODE" ]; then
+                UNIFORM_WAF=0   # a second distinct WAF code breaks uniformity
+            fi
+        else
+            UNIFORM_WAF=0       # a non-WAF status (e.g. 5xx) is a real failure
+        fi
         return
     fi
 
@@ -123,18 +151,35 @@ check() {
         if grep -qiE "Fatal error|Parse error|Warning:|Uncaught|Stack trace:" "$TMPFILE"; then
             eval "${category}_FAIL=\$(( ${category}_FAIL + 1 ))"
             ERRORS="${ERRORS}\n  FAIL: $name — PHP error detected"
+            UNIFORM_WAF=0       # acceptable status but a bad body — real failure
             return
         fi
 
         if ! grep -qi "$expect" "$TMPFILE"; then
             eval "${category}_FAIL=\$(( ${category}_FAIL + 1 ))"
             ERRORS="${ERRORS}\n  FAIL: $name — missing expected content: $expect"
+            UNIFORM_WAF=0       # acceptable status but missing content — real failure
             return
         fi
     fi
 
     eval "${category}_PASS=\$(( ${category}_PASS + 1 ))"
+    UNIFORM_WAF=0               # any pass means the prober reached the app
     echo "  OK: $name"
+}
+
+# A scope is "inconclusive" (exit 3) iff it ran >=2 checks, none passed, every
+# failure was an HTTP-status failure (no body failures), and all those statuses
+# were the same WAF-class code. Conservative by design: it never suppresses a
+# heterogeneous outage, a 5xx, or a 200-with-bad-body. Args: total pass fail.
+is_inconclusive() {
+    local total="$1" pass="$2" fail="$3"
+    [ "$total" -ge 2 ] || return 1
+    [ "$pass" -eq 0 ] || return 1
+    [ "$STATUS_FAILS" -eq "$fail" ] || return 1
+    [ "$WAF_STATUS_FAILS" -eq "$STATUS_FAILS" ] || return 1
+    [ "$UNIFORM_WAF" -eq 1 ] || return 1
+    return 0
 }
 
 # --- Run checks ------------------------------------------------------------------
@@ -192,13 +237,34 @@ else
     fi
 fi
 
-if [ "$SCOPE" = "ibl5" ] && [ "$IBL5_FAIL" -gt 0 ]; then
-    echo -e "\nFailures:$ERRORS"
-    exit 1
-elif [ "$SCOPE" = "ibl6" ] && [ "$IBL6_FAIL" -gt 0 ]; then
-    echo -e "\nFailures:$ERRORS"
-    exit 1
-elif [ "$SCOPE" = "all" ] && [ "$TOTAL_FAIL" -gt 0 ]; then
-    echo -e "\nFailures:$ERRORS"
-    exit 1
+# Exit 3 (inconclusive) MUST be tested before exit 1: an inconclusive run has
+# every check failed, so the "*_FAIL > 0 -> exit 1" branch would otherwise
+# shadow it. IBL6 has a single check, so its scope can never be inconclusive
+# (the >=2-checks guard fails) and its existing notify-only behavior is intact.
+INCONCLUSIVE_MSG="\nINCONCLUSIVE: uniform HTTP $WAF_CODE across all checks — prober likely WAF-blocked (no auto-rollback).$ERRORS"
+
+if [ "$SCOPE" = "ibl5" ]; then
+    if is_inconclusive "$((IBL5_PASS + IBL5_FAIL))" "$IBL5_PASS" "$IBL5_FAIL"; then
+        echo -e "$INCONCLUSIVE_MSG"
+        exit 3
+    elif [ "$IBL5_FAIL" -gt 0 ]; then
+        echo -e "\nFailures:$ERRORS"
+        exit 1
+    fi
+elif [ "$SCOPE" = "ibl6" ]; then
+    if is_inconclusive "$((IBL6_PASS + IBL6_FAIL))" "$IBL6_PASS" "$IBL6_FAIL"; then
+        echo -e "$INCONCLUSIVE_MSG"
+        exit 3
+    elif [ "$IBL6_FAIL" -gt 0 ]; then
+        echo -e "\nFailures:$ERRORS"
+        exit 1
+    fi
+elif [ "$SCOPE" = "all" ]; then
+    if is_inconclusive "$((TOTAL_PASS + TOTAL_FAIL))" "$TOTAL_PASS" "$TOTAL_FAIL"; then
+        echo -e "$INCONCLUSIVE_MSG"
+        exit 3
+    elif [ "$TOTAL_FAIL" -gt 0 ]; then
+        echo -e "\nFailures:$ERRORS"
+        exit 1
+    fi
 fi

--- a/ibl5/docs/decisions/0038-smoke-inconclusive-state.md
+++ b/ibl5/docs/decisions/0038-smoke-inconclusive-state.md
@@ -1,0 +1,45 @@
+---
+description: The production smoke test distinguishes an INCONCLUSIVE result (prober blocked by the WAF, or a docs-only deploy) from a real FAILURE, so transient prober-side issues no longer trigger an auto-rollback of healthy production.
+last_verified: 2026-06-02
+---
+
+# ADR-0038: Smoke "Inconclusive" State Gates Auto-Rollback
+
+**Status:** Accepted
+**Date:** 2026-06-02
+
+## Context
+
+`smoke-prod.yml` runs `bin/smoke-prod` from a GitHub-hosted runner after every production deploy. A failing run triggers an **auto-rollback**: the `rollback-and-notify` job reverts the deployed commit and redeploys. The gate is binary — `bin/smoke-prod` exits `0` (pass) or `1` (fail), and any `1` is treated as "the deploy broke production."
+
+That binary is too coarse, because a smoke failure is not always the deploy's fault. The prober and the app are reached over different paths:
+
+- The runner's egress IP is subject to LiteSpeed's per-IP WAF. When that counter trips (e.g. back-to-back deploys, or the daily scheduled run sharing a banned IP range), LiteSpeed returns a blanket **HTTP 415** to *every* request — homepage, dynamic pages, and even the static CSS asset — while real browsers and other IPs get clean `200`s.
+
+On 2026-06-02 this misfired: a runner-IP WAF block returned uniform `415` on all 7 IBL5 checks, the gate read it as a deploy failure, and it auto-reverted an innocent **docs-only** commit (`66d572331 docs(jsb): document .eng league tuning file format`). A scheduled run ~10h earlier — with no deploy — had the identical `415` signature, and the reverted diff was pure markdown that cannot affect any HTTP response. Both facts prove the failure was prober-side, not the app.
+
+The discriminator is the *shape* of the failure. A real regression is **heterogeneous** (some endpoints `200`, others `5xx`, or a `200` with a PHP-error body). A prober-side WAF block is **uniform**: every check fails with the same non-`5xx` WAF-class status. The gate had no way to express that difference.
+
+## Decision
+
+Add a third smoke outcome — **INCONCLUSIVE** — that is notify-only and never gates auto-rollback. Two independent mitigations:
+
+### A. Uniform WAF-class status ⇒ `bin/smoke-prod` exit code 3
+
+A scope is inconclusive iff **all** of: it ran ≥2 checks; **zero** passed; **every** failure was an HTTP-status failure (no body/PHP-error/missing-content failure); and all those statuses are **identical** and in the WAF-class set `{403, 415, 429}`. Such a run exits **3**. The predicate is deliberately conservative — a single passing check, a `5xx`, a `200`-with-bad-body, or two distinct status codes all break uniformity and fall back to a real `exit 1`. (IBL6 has a single check, so its scope can never be inconclusive; its existing notify-only behavior is unchanged.)
+
+The `smoke-prod.yml` IBL5 step captures the exit code: on `3` it sets an `ibl5_inconclusive=true` output and **exits 0**, so `smoke.result == 'success'` and the rollback gate's `needs.smoke.result == 'failure'` condition is false *by construction*. A new `notify-inconclusive` job (mirroring the existing `notify-ibl6-degradation` notify-only job) DMs the owner.
+
+### B. Docs-only deploys never gate a revert (defense-in-depth)
+
+In `rollback-and-notify`'s "Check revert eligibility" step, after the existing `^Revert ` loop-guard, the deployed commit's changed files are diffed against its parent. If **every** changed path matches `(\.md$|^docs/|^ibl5/docs/)`, the revert is skipped (`skip_reason=docs-only`) and the owner is DM'd. Any single non-docs path (added, modified, or deleted) keeps the revert eligible; an empty diff is never treated as docs-only.
+
+## Alternatives Considered
+
+- **Widen the retry/backoff in `bin/smoke-prod`.** Rejected: the existing retry is same-IP, and a per-IP WAF ban persists for the whole run window (the 10h-prior scheduled run had the identical `415`). More retries only delay the same false positive and risk masking a real slow-burn outage.
+- **Exempt the prober from the WAF** via a shared-secret header LiteSpeed allowlists, or by probing from on-box `localhost`. These address the WAF root cause and remain the right long-term fix, but each requires server-side / deploy-host coordination and is higher blast-radius. Deferred as follow-ups; the inconclusive classification here is purely prober-side, single-PR, and makes the root-cause work non-urgent.
+
+## Consequences
+
+- A transient WAF block now produces an owner DM and **no rollback** — production stays on the deployed commit. If production were genuinely down, the failure would be heterogeneous or `5xx` and would still gate a rollback.
+- The classifier is one-shot-verified (curl-stub exit-code scenarios) rather than CI-gated regression; a `bats` harness for `bin/smoke-prod` is a deferred follow-up. CI `shellcheck` continues to guard syntax/bash-3.2 compatibility.


### PR DESCRIPTION
## Summary

Adds a third smoke-test outcome — **INCONCLUSIVE** — for cases where `bin/smoke-prod` returns uniform WAF-class statuses (403/415/429) across all checks, meaning the runner IP was blocked by LiteSpeed, not the app. Also guards against reverting docs-only deploys.

**Root cause (2026-06-02):** A runner-IP WAF block returned uniform `415` on all 7 IBL5 checks. The binary gate read it as a deploy failure and auto-reverted an innocent docs-only commit (`66d572331`). A scheduled run ~10h prior had the identical signature with no deploy.

## Changes

- **`bin/smoke-prod`:** Exit code 3 when ≥2 checks ran, zero passed, and every failure is the identical WAF-class HTTP status. Conservatively falls back to exit 1 on any heterogeneous failure (5xx, mixed codes, bad body).
- **`smoke-prod.yml`:** Captures exit 3 as `ibl5_inconclusive=true` output; exits 0 so the rollback gate's `failure` condition is false by construction. New `notify-inconclusive` job DMs owner. Docs-only deploy guard in `rollback-and-notify`. IBL6 unchanged (single-check scope can never be inconclusive).
- **ADR-0038:** Decision record for the inconclusive-state classification.

## Decision triggers

- `bin/smoke-prod` (≥50 LOC, new bin/ script logic) → ADR-0038 written
- `.github/workflows/smoke-prod.yml` (CI workflow change) → ADR-0038 written

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.