### PR TITLE
feat(engine): add season-aggregate validation layer (standings/pace/point-diff)

### DIFF
--- a/engine/cmd/jsbcalibrate/main_test.go
+++ b/engine/cmd/jsbcalibrate/main_test.go
@@ -163,3 +163,43 @@ func TestRun_NoReports(t *testing.T) {
 		t.Errorf("expected a 'no snapshots' message, got: %q", errBuf.String())
 	}
 }
+
+// Row #13: calibrate mode emits the season_aggregates readout (standings detail
+// + residuals) from the same run; gate mode does NOT carry it.
+func TestRun_CalibrateEmitsSeasonAggregates(t *testing.T) {
+	reports := []validate.Report{{
+		Label:    "04-05",
+		GameType: bundle.GameTypeRegular,
+		Games: []validate.GameReport{{
+			HomeTeamID:            7,
+			VisitorTeamID:         3,
+			EngineHomeWinFraction: 0.6,
+			Rows: []validate.StatRow{
+				{TeamID: 3, Stat: "points", ScoVal: 99, EngineMean: 100},
+				{TeamID: 7, Stat: "points", ScoVal: 108, EngineMean: 105},
+			},
+		}},
+	}}
+
+	var out, errBuf bytes.Buffer
+	if code := runWith([]string{"--archive", "/x", "--mode", "calibrate"}, &out, &errBuf, stubCollectors(reports, nil)); code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, errBuf.String())
+	}
+	var rep calibrate.CalibrationReport
+	if err := json.Unmarshal(out.Bytes(), &rep); err != nil {
+		t.Fatalf("stdout is not a CalibrationReport JSON: %v\n%s", err, out.String())
+	}
+	if len(rep.SeasonAggregates.Seasons) != 1 || rep.SeasonAggregates.Seasons[0].Label != "04-05" {
+		t.Fatalf("season_aggregates.seasons = %+v, want one labeled 04-05", rep.SeasonAggregates.Seasons)
+	}
+	if len(rep.SeasonAggregates.Residuals) != 1 {
+		t.Errorf("season_aggregates.residuals = %+v, want one bucket", rep.SeasonAggregates.Residuals)
+	}
+
+	// Gate mode encodes a GateResult, which has no season_aggregates field.
+	var gout, gerr bytes.Buffer
+	_ = runWith([]string{"--archive", "/x", "--mode", "gate", "--min-rate", "0"}, &gout, &gerr, stubCollectors(reports, nil))
+	if strings.Contains(gout.String(), "season_aggregates") {
+		t.Errorf("gate output should not carry season_aggregates:\n%s", gout.String())
+	}
+}

--- a/engine/internal/calibrate/aggregate.go
+++ b/engine/internal/calibrate/aggregate.go
@@ -66,12 +66,14 @@ type GameTypeCalibration struct {
 // CalibrationReport is the full calibrate-mode output: proposed per-game-type
 // bands derived at the requested residual coverage. Buckets are sorted by game
 // type for determinism. HomeMargins carries the per-game-type home-court-margin
-// readout (the HCA fidelity signal); it rides along on the same run so one
-// calibrate pass yields both bands and margins.
+// readout (the HCA fidelity signal) and SeasonAggregates carries the team-level
+// season standings/pace fidelity readout; both ride along on the same run so one
+// calibrate pass yields bands, margins, and season aggregates.
 type CalibrationReport struct {
-	Coverage    float64                 `json:"coverage"`
-	Buckets     []GameTypeCalibration   `json:"buckets"`
-	HomeMargins []HomeMarginCalibration `json:"home_margins"`
+	Coverage         float64                 `json:"coverage"`
+	Buckets          []GameTypeCalibration   `json:"buckets"`
+	HomeMargins      []HomeMarginCalibration `json:"home_margins"`
+	SeasonAggregates SeasonAggregateReport   `json:"season_aggregates"`
 }
 
 // Calibrate derives, per (game type, stat), a tolerance band whose absolute
@@ -95,6 +97,7 @@ func Calibrate(reports []validate.Report, coverage float64) CalibrationReport {
 		rep.Buckets = append(rep.Buckets, gc)
 	}
 	rep.HomeMargins = CollectHomeMargins(reports)
+	rep.SeasonAggregates = CollectSeasonAggregates(reports)
 	return rep
 }
 

--- a/engine/internal/calibrate/aggregate_test.go
+++ b/engine/internal/calibrate/aggregate_test.go
@@ -165,3 +165,26 @@ func TestGate_PassesAtOrAboveMinRate(t *testing.T) {
 		t.Errorf("gate should PASS when every stat is 100%% in band: %+v", res.Buckets)
 	}
 }
+
+// Row #12: calibrate also surfaces the team-level season aggregates (standings
+// detail + per-game-type residuals) from the same run as bands + home-margins.
+func TestCalibrate_PopulatesSeasonAggregates(t *testing.T) {
+	rep := Calibrate([]validate.Report{
+		aggReport("04-05", bundle.GameTypeRegular, wfGame(7, 3, 0.6, 105, 108, 100, 99)),
+	}, 0.95)
+
+	if len(rep.SeasonAggregates.Seasons) != 1 {
+		t.Fatalf("Seasons len = %d, want 1: %+v", len(rep.SeasonAggregates.Seasons), rep.SeasonAggregates.Seasons)
+	}
+	sa := rep.SeasonAggregates.Seasons[0]
+	if sa.Label != "04-05" || sa.GameType != int(bundle.GameTypeRegular) {
+		t.Errorf("season header = %+v, want label 04-05 / regular", sa)
+	}
+	if len(rep.SeasonAggregates.Residuals) != 1 || rep.SeasonAggregates.Residuals[0].GameType != int(bundle.GameTypeRegular) {
+		t.Errorf("residuals = %+v, want one regular bucket", rep.SeasonAggregates.Residuals)
+	}
+	// Bands and home-margins are surfaced from the same call.
+	if len(rep.Buckets) != 1 || len(rep.HomeMargins) != 1 {
+		t.Errorf("expected bands + home-margins from the same call: buckets=%d margins=%d", len(rep.Buckets), len(rep.HomeMargins))
+	}
+}

--- a/engine/internal/calibrate/season.go
+++ b/engine/internal/calibrate/season.go
@@ -158,6 +158,7 @@ func collectSeasonReports(seasons []season, opts Options, validateFn, validateUn
 			skips = append(skips, *skip)
 			continue
 		}
+		rep.Label = s.name
 		_, _ = fmt.Fprintf(progress, "regular %s games=%d\n", s.regularZip, len(rep.Games))
 		reports = append(reports, *rep)
 
@@ -170,6 +171,7 @@ func collectSeasonReports(seasons []season, opts Options, validateFn, validateUn
 				skips = append(skips, *pskip)
 				continue
 			}
+			prep.Label = s.name + " (playoffs)"
 			_, _ = fmt.Fprintf(progress, "playoff %s games=%d excluded=%d\n", s.finalsZip, len(prep.Games), len(prep.Excluded))
 			reports = append(reports, *prep)
 		}

--- a/engine/internal/calibrate/season_test.go
+++ b/engine/internal/calibrate/season_test.go
@@ -176,3 +176,29 @@ func TestCollectSeasonReports_SampleStride(t *testing.T) {
 		t.Fatalf("reports = %d, want 2 (every 2nd of 4)", len(reports))
 	}
 }
+
+// Row #6: the season collector stamps each report's Label — the season name for
+// the regular bucket, "<name> (playoffs)" for the playoff bucket.
+func TestCollectSeasonReports_StampsLabel(t *testing.T) {
+	root := neutralTempDir(t)
+	makeZip(t, filepath.Join(root, "02-03", "02-03_41_reg-sim35.zip"), fullTriple())
+	makeZip(t, filepath.Join(root, "02-03", "02-03_47_finals.zip"), fullTriple())
+
+	rvReg := &recordingValidate{t: t}
+	rvPof := &recordingValidate{t: t}
+	reports, _, err := CollectSeasonReports(root, Options{
+		Runs: 1, Validate: rvReg.fn, ValidateUnscheduled: rvPof.fn,
+	})
+	if err != nil {
+		t.Fatalf("CollectSeasonReports: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("reports = %d, want 2", len(reports))
+	}
+	if reports[0].Label != "02-03" {
+		t.Errorf("regular label = %q, want %q", reports[0].Label, "02-03")
+	}
+	if reports[1].Label != "02-03 (playoffs)" {
+		t.Errorf("playoff label = %q, want %q", reports[1].Label, "02-03 (playoffs)")
+	}
+}

--- a/engine/internal/calibrate/standings.go
+++ b/engine/internal/calibrate/standings.go
@@ -1,0 +1,247 @@
+package calibrate
+
+import (
+	"math"
+	"sort"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// TeamStanding is one team's season tallies within one report (one season
+// bucket), engine vs .sco. The points fields are per-game means so engine and
+// .sco are directly comparable regardless of games played.
+//
+// EngineExpectedWins is Σ per-game win-fraction (a home game adds the home
+// win-fraction, an away game adds 1−it). It is runs-stable: it converges to
+// Σ P(win) as runs grow, rather than rounding each game to a 0/1 win the way a
+// single mean-margin sign would (which inflates favorites' records as √N — see
+// memory reference_jsb_winshare_runs_artifact). ScoWins is the single .sco
+// realization, so |EngineExpectedWins − ScoWins| carries an irreducible
+// binomial noise floor of ~√Σp(1−p) ≈ 3–5 wins over an 82-game season even for
+// a faithful engine; read the residual percentiles, not a zero floor.
+type TeamStanding struct {
+	TeamID                int     `json:"team_id"`
+	GamesPlayed           int     `json:"games_played"`
+	EngineExpectedWins    float64 `json:"engine_expected_wins"`
+	ScoWins               int     `json:"sco_wins"`
+	EnginePointsForPG     float64 `json:"engine_points_for_pg"`
+	ScoPointsForPG        float64 `json:"sco_points_for_pg"`
+	EnginePointsAgainstPG float64 `json:"engine_points_against_pg"`
+	ScoPointsAgainstPG    float64 `json:"sco_points_against_pg"`
+	EnginePointDiffPG     float64 `json:"engine_point_diff_pg"` // PF−PA; runs-stable, the team-level margin_gap analog
+	ScoPointDiffPG        float64 `json:"sco_point_diff_pg"`
+}
+
+// SeasonAggregate is one report (one season bucket) rolled up per team, plus the
+// league pace (mean total points per game across both teams). Teams are sorted
+// by TeamID for determinism.
+type SeasonAggregate struct {
+	Label        string         `json:"label"`
+	GameType     int            `json:"game_type"`
+	NumGames     int            `json:"num_games"`
+	EnginePacePG float64        `json:"engine_pace_pg"`
+	ScoPacePG    float64        `json:"sco_pace_pg"`
+	Teams        []TeamStanding `json:"teams"`
+}
+
+// StandingsResidual is the per-game-type fidelity signal: percentiles of the
+// engine-vs-.sco gaps across every (season, team) row. The expected-wins
+// residual is runs-stable but never zero (binomial noise, see TeamStanding);
+// the point-differential residual is a pure linear mean (runs-stable, no noise
+// floor). N is the number of contributing (season, team) rows.
+type StandingsResidual struct {
+	GameType     int     `json:"game_type"`
+	N            int     `json:"n"`
+	WinsP50      float64 `json:"wins_resid_p50"`
+	WinsP90      float64 `json:"wins_resid_p90"`
+	WinsP95      float64 `json:"wins_resid_p95"`
+	WinsP99      float64 `json:"wins_resid_p99"`
+	PointDiffP50 float64 `json:"point_diff_resid_p50"`
+	PointDiffP90 float64 `json:"point_diff_resid_p90"`
+	PointDiffP95 float64 `json:"point_diff_resid_p95"`
+	PointDiffP99 float64 `json:"point_diff_resid_p99"`
+}
+
+// SeasonAggregateReport is the full season-aggregate readout: the per-season
+// standings detail plus the per-game-type residual rollup that is the actual
+// fidelity signal.
+type SeasonAggregateReport struct {
+	Seasons   []SeasonAggregate   `json:"seasons"`
+	Residuals []StandingsResidual `json:"residuals"`
+}
+
+// teamAcc accumulates one team's running season sums while CollectSeasonAggregates
+// walks a report's games.
+type teamAcc struct {
+	gp         int
+	engWins    float64
+	scoWins    int
+	engFor     float64
+	engAgainst float64
+	scoFor     float64
+	scoAgainst float64
+}
+
+// residAcc collects one game type's per-(season,team) residuals across reports.
+type residAcc struct {
+	wins      []float64
+	pointDiff []float64
+}
+
+// CollectSeasonAggregates derives the team-level season aggregates from
+// already-built validation reports — no engine run, no corpus walk (mirrors
+// CollectHomeMargins). Each report is one season bucket: its games are rolled up
+// per team into wins/points, and the engine-vs-.sco gaps feed the per-game-type
+// residual rollup.
+//
+// A game contributes nothing when its home and visitor team IDs collide or when
+// either side is missing a "points" row — both are degenerate inputs, not real
+// matchups (same guards as CollectHomeMargins). A report with no contributing
+// games yields no SeasonAggregate. A game type with no contributing rows yields
+// no StandingsResidual, so every emitted residual bucket has N >= 1.
+//
+// Intended input is the season collector's one-snapshot-per-bucket reports
+// (CollectSeasonReports). Each report becomes one SeasonAggregate, so feeding it
+// --selection flat's reports instead double-counts: a season's cumulative .sco
+// recurs at 49, 549, … 1148 games across snapshots, over-weighting heavily
+// archived seasons in the residual rollup. Same no-dedup property as
+// CollectHomeMargins; the committed calibration runs with --selection season.
+func CollectSeasonAggregates(reports []validate.Report) SeasonAggregateReport {
+	out := SeasonAggregateReport{}
+	resid := map[bundle.GameType]*residAcc{}
+
+	for _, rep := range reports {
+		acc := map[int]*teamAcc{}
+		numGames := 0
+		var engPace, scoPace float64
+
+		for _, g := range rep.Games {
+			if g.HomeTeamID == g.VisitorTeamID {
+				continue // collision: not a real home/away matchup
+			}
+			homePts, okHome := pointsFor(g, g.HomeTeamID)
+			visPts, okVis := pointsFor(g, g.VisitorTeamID)
+			if !okHome || !okVis {
+				continue // missing a "points" row on one side
+			}
+			numGames++
+			engPace += homePts.EngineMean + visPts.EngineMean
+			scoPace += homePts.ScoVal + visPts.ScoVal
+
+			h := team(acc, g.HomeTeamID)
+			h.gp++
+			h.engWins += g.EngineHomeWinFraction
+			h.engFor += homePts.EngineMean
+			h.engAgainst += visPts.EngineMean
+			h.scoFor += homePts.ScoVal
+			h.scoAgainst += visPts.ScoVal
+			if homePts.ScoVal > visPts.ScoVal {
+				h.scoWins++
+			}
+
+			v := team(acc, g.VisitorTeamID)
+			v.gp++
+			v.engWins += 1 - g.EngineHomeWinFraction
+			v.engFor += visPts.EngineMean
+			v.engAgainst += homePts.EngineMean
+			v.scoFor += visPts.ScoVal
+			v.scoAgainst += homePts.ScoVal
+			if visPts.ScoVal > homePts.ScoVal {
+				v.scoWins++
+			}
+		}
+
+		if numGames == 0 {
+			continue // no validatable matchups in this snapshot
+		}
+
+		sa := SeasonAggregate{
+			Label:        rep.Label,
+			GameType:     int(rep.GameType),
+			NumGames:     numGames,
+			EnginePacePG: engPace / float64(numGames),
+			ScoPacePG:    scoPace / float64(numGames),
+		}
+		ra := residual(resid, rep.GameType)
+		for _, id := range sortedTeamIDs(acc) {
+			t := acc[id]
+			gp := float64(t.gp)
+			ts := TeamStanding{
+				TeamID:                id,
+				GamesPlayed:           t.gp,
+				EngineExpectedWins:    t.engWins,
+				ScoWins:               t.scoWins,
+				EnginePointsForPG:     t.engFor / gp,
+				ScoPointsForPG:        t.scoFor / gp,
+				EnginePointsAgainstPG: t.engAgainst / gp,
+				ScoPointsAgainstPG:    t.scoAgainst / gp,
+				EnginePointDiffPG:     (t.engFor - t.engAgainst) / gp,
+				ScoPointDiffPG:        (t.scoFor - t.scoAgainst) / gp,
+			}
+			sa.Teams = append(sa.Teams, ts)
+			ra.wins = append(ra.wins, math.Abs(ts.EngineExpectedWins-float64(ts.ScoWins)))
+			ra.pointDiff = append(ra.pointDiff, math.Abs(ts.EnginePointDiffPG-ts.ScoPointDiffPG))
+		}
+		out.Seasons = append(out.Seasons, sa)
+	}
+
+	for _, gt := range sortedResidGameTypes(resid) {
+		ra := resid[gt]
+		sort.Float64s(ra.wins)
+		sort.Float64s(ra.pointDiff)
+		out.Residuals = append(out.Residuals, StandingsResidual{
+			GameType:     int(gt),
+			N:            len(ra.wins),
+			WinsP50:      percentile(ra.wins, 0.50),
+			WinsP90:      percentile(ra.wins, 0.90),
+			WinsP95:      percentile(ra.wins, 0.95),
+			WinsP99:      percentile(ra.wins, 0.99),
+			PointDiffP50: percentile(ra.pointDiff, 0.50),
+			PointDiffP90: percentile(ra.pointDiff, 0.90),
+			PointDiffP95: percentile(ra.pointDiff, 0.95),
+			PointDiffP99: percentile(ra.pointDiff, 0.99),
+		})
+	}
+	return out
+}
+
+// team returns the accumulator for id, creating it on first sight.
+func team(acc map[int]*teamAcc, id int) *teamAcc {
+	t := acc[id]
+	if t == nil {
+		t = &teamAcc{}
+		acc[id] = t
+	}
+	return t
+}
+
+// residual returns the residual accumulator for gt, creating it on first sight.
+func residual(resid map[bundle.GameType]*residAcc, gt bundle.GameType) *residAcc {
+	ra := resid[gt]
+	if ra == nil {
+		ra = &residAcc{}
+		resid[gt] = ra
+	}
+	return ra
+}
+
+// sortedTeamIDs returns the team IDs in ascending order for deterministic output.
+func sortedTeamIDs(acc map[int]*teamAcc) []int {
+	ids := make([]int, 0, len(acc))
+	for id := range acc {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	return ids
+}
+
+// sortedResidGameTypes returns the residual game types in ascending order.
+func sortedResidGameTypes(resid map[bundle.GameType]*residAcc) []bundle.GameType {
+	gts := make([]bundle.GameType, 0, len(resid))
+	for gt := range resid {
+		gts = append(gts, gt)
+	}
+	sort.Slice(gts, func(i, j int) bool { return gts[i] < gts[j] })
+	return gts
+}

--- a/engine/internal/calibrate/standings_test.go
+++ b/engine/internal/calibrate/standings_test.go
@@ -1,0 +1,190 @@
+package calibrate
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/bundle"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// wfGame builds a one-game GameReport with a "points" row per side (tagged with
+// the side's team ID, the shape CollectSeasonAggregates pairs on) plus the home
+// win-fraction the season-aggregate layer consumes.
+func wfGame(homeID, visID int, winFrac, homeEng, homeSco, visEng, visSco float64) validate.GameReport {
+	return validate.GameReport{
+		HomeTeamID:            homeID,
+		VisitorTeamID:         visID,
+		EngineHomeWinFraction: winFrac,
+		Rows: []validate.StatRow{
+			{TeamID: visID, Stat: "points", ScoVal: visSco, EngineMean: visEng},
+			{TeamID: homeID, Stat: "points", ScoVal: homeSco, EngineMean: homeEng},
+		},
+	}
+}
+
+func aggReport(label string, gt bundle.GameType, games ...validate.GameReport) validate.Report {
+	return validate.Report{Label: label, GameType: gt, Games: games}
+}
+
+// standingFor returns the TeamStanding for teamID within a SeasonAggregate.
+func standingFor(t *testing.T, sa SeasonAggregate, teamID int) TeamStanding {
+	t.Helper()
+	for _, ts := range sa.Teams {
+		if ts.TeamID == teamID {
+			return ts
+		}
+	}
+	t.Fatalf("no standing for team %d in %+v", teamID, sa.Teams)
+	return TeamStanding{}
+}
+
+// Row #7: two reciprocal games (team 1 beats team 2 home and away) roll up to
+// the hand-computed per-team wins, points, point-differential, and league pace.
+func TestCollectSeasonAggregates_RollsUpPerTeam(t *testing.T) {
+	// Game A: home 1 vs vis 2, winFrac 1.0, eng 110/100, sco 108/99.
+	// Game B: home 2 vs vis 1, winFrac 0.0, eng 95/105, sco 96/107.
+	rep := aggReport("s1", bundle.GameTypeRegular,
+		wfGame(1, 2, 1.0, 110, 108, 100, 99),
+		wfGame(2, 1, 0.0, 95, 96, 105, 107),
+	)
+	got := CollectSeasonAggregates([]validate.Report{rep})
+
+	if len(got.Seasons) != 1 {
+		t.Fatalf("Seasons len = %d, want 1: %+v", len(got.Seasons), got.Seasons)
+	}
+	sa := got.Seasons[0]
+	if sa.Label != "s1" || sa.GameType != int(bundle.GameTypeRegular) || sa.NumGames != 2 {
+		t.Errorf("season header wrong: %+v", sa)
+	}
+	if sa.EnginePacePG != 205 || sa.ScoPacePG != 205 {
+		t.Errorf("pace = eng %v / sco %v, want 205 / 205", sa.EnginePacePG, sa.ScoPacePG)
+	}
+	// Teams sorted by ID → [1, 2].
+	if len(sa.Teams) != 2 || sa.Teams[0].TeamID != 1 || sa.Teams[1].TeamID != 2 {
+		t.Fatalf("teams not sorted by ID: %+v", sa.Teams)
+	}
+
+	t1 := standingFor(t, sa, 1)
+	if t1.GamesPlayed != 2 || t1.EngineExpectedWins != 2.0 || t1.ScoWins != 2 {
+		t.Errorf("team1 record = gp %d exp %v sco %d, want 2 / 2.0 / 2", t1.GamesPlayed, t1.EngineExpectedWins, t1.ScoWins)
+	}
+	if t1.EnginePointsForPG != 107.5 || t1.EnginePointsAgainstPG != 97.5 || t1.EnginePointDiffPG != 10 {
+		t.Errorf("team1 engine pts = for %v against %v diff %v, want 107.5 / 97.5 / 10", t1.EnginePointsForPG, t1.EnginePointsAgainstPG, t1.EnginePointDiffPG)
+	}
+	if t1.ScoPointsForPG != 107.5 || t1.ScoPointsAgainstPG != 97.5 || t1.ScoPointDiffPG != 10 {
+		t.Errorf("team1 sco pts = for %v against %v diff %v, want 107.5 / 97.5 / 10", t1.ScoPointsForPG, t1.ScoPointsAgainstPG, t1.ScoPointDiffPG)
+	}
+
+	t2 := standingFor(t, sa, 2)
+	if t2.EngineExpectedWins != 0.0 || t2.ScoWins != 0 || t2.EnginePointDiffPG != -10 {
+		t.Errorf("team2 = exp %v sco %d diff %v, want 0.0 / 0 / -10", t2.EngineExpectedWins, t2.ScoWins, t2.EnginePointDiffPG)
+	}
+
+	// Engine matches .sco exactly → zero residuals.
+	if len(got.Residuals) != 1 || got.Residuals[0].GameType != int(bundle.GameTypeRegular) {
+		t.Fatalf("residuals = %+v, want one regular bucket", got.Residuals)
+	}
+	r := got.Residuals[0]
+	if r.N != 2 || r.WinsP90 != 0 || r.PointDiffP90 != 0 {
+		t.Errorf("residual = %+v, want N=2 and zero gaps", r)
+	}
+}
+
+// Row #8 (the core fix): a 0.6 home win-fraction contributes 0.6 to the home
+// team's expected wins and 0.4 to the visitor's — NOT 1.0/0.0 the way a
+// mean-margin sign would round it.
+func TestCollectSeasonAggregates_ExpectedWinsIsFractionalNotRounded(t *testing.T) {
+	rep := aggReport("s1", bundle.GameTypeRegular,
+		wfGame(1, 2, 0.6, 104, 104, 100, 100),
+	)
+	got := CollectSeasonAggregates([]validate.Report{rep})
+	sa := got.Seasons[0]
+	if w := standingFor(t, sa, 1).EngineExpectedWins; math.Abs(w-0.6) > 1e-9 {
+		t.Errorf("home expected wins = %v, want 0.6 (fractional, not rounded to 1.0)", w)
+	}
+	if w := standingFor(t, sa, 2).EngineExpectedWins; math.Abs(w-0.4) > 1e-9 {
+		t.Errorf("visitor expected wins = %v, want 0.4 (fractional, not rounded to 0.0)", w)
+	}
+}
+
+// Row #9 (negative — the readout surfaces a real gap): when the engine's
+// expected wins diverge far from the .sco wins, the wins residual is large, not
+// a vacuous zero. Team 1 goes 4-0 in the .sco but the engine gives each game a
+// coin-flip win-fraction → expected wins 2.0, residual 2.0.
+func TestCollectSeasonAggregates_DetectsWinGap(t *testing.T) {
+	rep := aggReport("s1", bundle.GameTypeRegular,
+		wfGame(1, 2, 0.5, 100, 101, 100, 99),
+		wfGame(1, 2, 0.5, 100, 101, 100, 99),
+		wfGame(1, 2, 0.5, 100, 101, 100, 99),
+		wfGame(1, 2, 0.5, 100, 101, 100, 99),
+	)
+	got := CollectSeasonAggregates([]validate.Report{rep})
+	if w := standingFor(t, got.Seasons[0], 1).EngineExpectedWins; math.Abs(w-2.0) > 1e-9 {
+		t.Fatalf("team1 expected wins = %v, want 2.0", w)
+	}
+	if standingFor(t, got.Seasons[0], 1).ScoWins != 4 {
+		t.Fatalf("team1 sco wins = %d, want 4", standingFor(t, got.Seasons[0], 1).ScoWins)
+	}
+	if got.Residuals[0].WinsP90 < 1.5 {
+		t.Errorf("WinsP90 = %v, want a large (≥1.5) residual surfacing the gap", got.Residuals[0].WinsP90)
+	}
+}
+
+// Row #10 (negative — guards): collisions and games missing a points row are
+// skipped; a report with no validatable game yields no SeasonAggregate; empty
+// input yields an empty report (no panic, no divide-by-zero).
+func TestCollectSeasonAggregates_Guards(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		got := CollectSeasonAggregates(nil)
+		if len(got.Seasons) != 0 || len(got.Residuals) != 0 {
+			t.Errorf("empty input → %+v, want empty report", got)
+		}
+	})
+
+	t.Run("collision-only report yields no season", func(t *testing.T) {
+		rep := aggReport("s1", bundle.GameTypeRegular, wfGame(5, 5, 1.0, 100, 100, 90, 90))
+		got := CollectSeasonAggregates([]validate.Report{rep})
+		if len(got.Seasons) != 0 || len(got.Residuals) != 0 {
+			t.Errorf("collision-only → %+v, want no season/residual", got)
+		}
+	})
+
+	t.Run("missing points row is skipped", func(t *testing.T) {
+		// One valid game and one game with no "points" rows; only the valid one counts.
+		bad := validate.GameReport{HomeTeamID: 1, VisitorTeamID: 2} // no Rows
+		rep := aggReport("s1", bundle.GameTypeRegular,
+			wfGame(1, 2, 1.0, 110, 110, 100, 100),
+			bad,
+		)
+		got := CollectSeasonAggregates([]validate.Report{rep})
+		if len(got.Seasons) != 1 || got.Seasons[0].NumGames != 1 {
+			t.Fatalf("NumGames = %+v, want exactly the one valid game", got.Seasons)
+		}
+		if standingFor(t, got.Seasons[0], 1).GamesPlayed != 1 {
+			t.Errorf("team1 GP = %d, want 1 (bad game skipped)", standingFor(t, got.Seasons[0], 1).GamesPlayed)
+		}
+	})
+}
+
+// Row #11: the same reports always produce an identical report (teams sorted by
+// ID, residuals sorted by game type), regardless of map iteration order.
+func TestCollectSeasonAggregates_Deterministic(t *testing.T) {
+	reports := []validate.Report{
+		aggReport("playoffs", bundle.GameTypePlayoff, wfGame(3, 1, 0.7, 99, 100, 95, 92)),
+		aggReport("reg", bundle.GameTypeRegular,
+			wfGame(2, 4, 0.55, 101, 103, 98, 97),
+			wfGame(4, 2, 0.45, 100, 99, 102, 105),
+		),
+	}
+	a := CollectSeasonAggregates(reports)
+	b := CollectSeasonAggregates(reports)
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("non-deterministic output:\n a=%+v\n b=%+v", a, b)
+	}
+	// Residuals sorted ascending by game type (regular 2 before playoff 4).
+	if len(a.Residuals) != 2 || a.Residuals[0].GameType != int(bundle.GameTypeRegular) || a.Residuals[1].GameType != int(bundle.GameTypePlayoff) {
+		t.Errorf("residuals not sorted by game type: %+v", a.Residuals)
+	}
+}

--- a/engine/internal/calibrate/walk.go
+++ b/engine/internal/calibrate/walk.go
@@ -103,6 +103,7 @@ func CollectReports(root string, opts Options) ([]validate.Report, []Skip, error
 			skips = append(skips, *skip)
 			continue
 		}
+		rep.Label = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 		_, _ = fmt.Fprintf(progress, "processed %s game_type=%d games=%d\n", path, int(gt), len(rep.Games))
 		reports = append(reports, *rep)
 	}

--- a/engine/internal/calibrate/walk_test.go
+++ b/engine/internal/calibrate/walk_test.go
@@ -235,6 +235,24 @@ func TestCollectReports_BadRoot(t *testing.T) {
 	}
 }
 
+// Row #6: the flat collector stamps each report's Label with the snapshot
+// basename (extension stripped).
+func TestCollectReports_StampsLabel(t *testing.T) {
+	root := t.TempDir()
+	makeZip(t, filepath.Join(root, "02-03_41_reg-sim35.zip"), fullTriple())
+	rv := &recordingValidate{t: t}
+	reports, _, err := CollectReports(root, Options{Runs: 1, Validate: rv.fn})
+	if err != nil {
+		t.Fatalf("CollectReports: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("reports = %d, want 1", len(reports))
+	}
+	if reports[0].Label != "02-03_41_reg-sim35" {
+		t.Errorf("label = %q, want %q", reports[0].Label, "02-03_41_reg-sim35")
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/engine/internal/validate/aggregate.go
+++ b/engine/internal/validate/aggregate.go
@@ -170,3 +170,29 @@ func mean(samples []TeamStat) map[string]float64 {
 	}
 	return out
 }
+
+// homeWinFraction returns the fraction of seeded runs in which the home team
+// outscored the visitor, pairing samples by run index (homeSamples[i] and
+// visSamples[i] come from the same seed). A tied run counts 0.5 so the estimate
+// stays unbiased — a tie is reachable only after the 20-overtime termination
+// ceiling (sim/gameloop.go), so it is rare but possible. n == 0 is unreachable
+// (the harness guards runs >= 1) and yields 0.5 (no information).
+func homeWinFraction(homeSamples, visSamples []TeamStat) float64 {
+	n := len(homeSamples)
+	if len(visSamples) < n {
+		n = len(visSamples)
+	}
+	if n == 0 {
+		return 0.5
+	}
+	wins := 0.0
+	for i := 0; i < n; i++ {
+		switch {
+		case homeSamples[i].Points > visSamples[i].Points:
+			wins++
+		case homeSamples[i].Points == visSamples[i].Points:
+			wins += 0.5
+		}
+	}
+	return wins / float64(n)
+}

--- a/engine/internal/validate/aggregate_test.go
+++ b/engine/internal/validate/aggregate_test.go
@@ -79,3 +79,37 @@ func TestMean(t *testing.T) {
 		t.Errorf("mean(nil) = %v, want empty", got)
 	}
 }
+
+// pts builds a slice of TeamStats carrying only points, one per seeded run.
+func pts(points ...int) []TeamStat {
+	out := make([]TeamStat, len(points))
+	for i, p := range points {
+		out[i] = TeamStat{Points: p}
+	}
+	return out
+}
+
+func TestHomeWinFraction(t *testing.T) {
+	cases := []struct {
+		name      string
+		home, vis []TeamStat
+		want      float64
+	}{
+		{"all home wins", pts(110, 100, 95), pts(100, 90, 80), 1.0},
+		{"all visitor wins", pts(90, 80), pts(100, 95), 0.0},
+		{"three of five home", pts(101, 101, 101, 99, 99), pts(100, 100, 100, 100, 100), 0.6},
+		// run0 ties (100==100 → 0.5), run1 home wins (110>100 → 1.0) → 1.5/2.
+		{"tie counts half", pts(100, 110), pts(100, 100), 0.75},
+		// n==0 guard (unreachable in the harness, runs>=1): no information → 0.5.
+		{"empty guard", nil, nil, 0.5},
+		// mismatched lengths pair by the shorter (only run0 compared: 110>100).
+		{"pairs by min length", pts(110, 90), pts(100), 1.0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := homeWinFraction(c.home, c.vis); got != c.want {
+				t.Errorf("homeWinFraction = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/engine/internal/validate/compare.go
+++ b/engine/internal/validate/compare.go
@@ -26,6 +26,14 @@ type GameReport struct {
 	Date          string
 	Pass          bool
 	Rows          []StatRow
+	// EngineHomeWinFraction is the fraction of seeded runs in which the home team
+	// outscored the visitor (a tied run counts 0.5). It is a runs-stable estimate
+	// of P(home win) — unlike a single mean-margin sign, which rounds every game
+	// to a 0/1 win and inflates favorites' records as √N (see memory
+	// reference_jsb_winshare_runs_artifact). Consumed by the season-aggregate
+	// collector; it is not part of the Pass verdict and is not printed by
+	// WriteReport (keeping the text report byte-identical).
+	EngineHomeWinFraction float64
 }
 
 // compareStat decides whether a single .sco value is within tolerance of the

--- a/engine/internal/validate/fixtures_test.go
+++ b/engine/internal/validate/fixtures_test.go
@@ -291,7 +291,7 @@ func buildCorpus(t *testing.T, dir string, inBand bool, runs int, baseSeed uint6
 	writeSch(t, sch, []schSpec{{vis: 7, home: 3, vScore: 1, hScore: 1}})
 
 	b := assembleSynthBundle(t, plr, sch)
-	visMean, homeMean := simulateGameMeans(b, b.Schedule[0], runs, baseSeed)
+	visMean, homeMean, _ := simulateGameMeans(b, b.Schedule[0], runs, baseSeed)
 	visPts, homePts := round(visMean["points"]), round(homeMean["points"])
 
 	// Rewrite .sch with the real scores so the .sco↔.sch tuple match succeeds.

--- a/engine/internal/validate/harness.go
+++ b/engine/internal/validate/harness.go
@@ -65,6 +65,11 @@ type Report struct {
 	// zeroed); it does NOT affect Pass — a snapshot is still validatable on team
 	// stats without the per-player minutes signal.
 	MissingPlb []string
+	// Label is an optional human identifier for the snapshot/season this report
+	// covers (e.g. "04-05" or "04-05 (playoffs)"), stamped by the calibrate
+	// collectors so the season-aggregate output is attributable. Default "";
+	// additive and NOT printed by WriteReport (the text report stays byte-stable).
+	Label string
 }
 
 // triple names one backup file set sharing a stem within the corpus dir. plr/
@@ -354,17 +359,21 @@ func matchSchedule(sched []backup.SchGame, consumed []bool, sg backup.ScoGame) i
 // validateGame simulates one matchup `runs` times and compares the aggregated
 // per-team engine means against the .sco ground truth, using gameType's bands.
 func validateGame(b bundle.Bundle, g bundle.Game, sg backup.ScoGame, runs int, baseSeed uint64, gameType bundle.GameType) GameReport {
-	visMean, homeMean := simulateGameMeans(b, g, runs, baseSeed)
+	visMean, homeMean, homeWinFrac := simulateGameMeans(b, g, runs, baseSeed)
 	visSco := teamStatFromSco(sg, g.VisitorTeamID)
 	homeSco := teamStatFromSco(sg, g.HomeTeamID)
-	return compareGame(gameType, g.VisitorTeamID, g.HomeTeamID, sg.Date, visSco, homeSco, visMean, homeMean)
+	gr := compareGame(gameType, g.VisitorTeamID, g.HomeTeamID, sg.Date, visSco, homeSco, visMean, homeMean)
+	gr.EngineHomeWinFraction = homeWinFrac
+	return gr
 }
 
 // simulateGameMeans runs the engine on the single matchup g for `runs` seeds
 // (baseSeed+0 .. baseSeed+runs-1) and returns the per-team mean TeamStat keyed
-// by statNames. Each run is an independent single-game sub-bundle so one game's
-// distribution is isolated from the rest of the schedule.
-func simulateGameMeans(b bundle.Bundle, g bundle.Game, runs int, baseSeed uint64) (visMean, homeMean map[string]float64) {
+// by statNames, plus the home team's win fraction over those runs (the
+// runs-stable P(home win) estimate the season-aggregate layer needs). Each run
+// is an independent single-game sub-bundle so one game's distribution is
+// isolated from the rest of the schedule.
+func simulateGameMeans(b bundle.Bundle, g bundle.Game, runs int, baseSeed uint64) (visMean, homeMean map[string]float64, homeWinFrac float64) {
 	sub := bundle.Bundle{
 		LeagueID: b.LeagueID,
 		Teams:    b.Teams,
@@ -386,5 +395,5 @@ func simulateGameMeans(b bundle.Bundle, g bundle.Game, runs int, baseSeed uint64
 			}
 		}
 	}
-	return mean(visSamples), mean(homeSamples)
+	return mean(visSamples), mean(homeSamples), homeWinFraction(homeSamples, visSamples)
 }

--- a/engine/internal/validate/harness_test.go
+++ b/engine/internal/validate/harness_test.go
@@ -109,6 +109,28 @@ func TestValidateCorpus_InBandPassesAndDeterministic(t *testing.T) {
 	}
 }
 
+// Row #4: validateGame stamps each GameReport with the home win-fraction over
+// the seeded runs — a real value in [0,1]. Determinism across runs is already
+// covered by the reflect.DeepEqual report comparison above (the field is part
+// of the report); here we assert it is populated and well-formed.
+func TestValidateCorpus_PopulatesHomeWinFraction(t *testing.T) {
+	dir := t.TempDir()
+	const seed = uint64(1000)
+	buildCorpus(t, dir, true, testRuns, seed)
+
+	rep, err := ValidateCorpus(dir, testRuns, seed, bundle.GameTypeRegular)
+	if err != nil {
+		t.Fatalf("ValidateCorpus: %v", err)
+	}
+	if len(rep.Games) != 1 {
+		t.Fatalf("games = %d, want 1", len(rep.Games))
+	}
+	wf := rep.Games[0].EngineHomeWinFraction
+	if wf < 0 || wf > 1 {
+		t.Errorf("EngineHomeWinFraction = %v, want a fraction in [0,1]", wf)
+	}
+}
+
 // Characterization (Row #1): the bands→game-type-keyed refactor must not change
 // observable behavior. ValidateCorpus stamped with GameTypeRegular must route
 // every stat to the regular band table — i.e. each StatRow.Tolerance equals the


### PR DESCRIPTION
## Summary

Adds the team-level season-aggregate fidelity readout the acceptance bar names as the missing layer that answers "can we cut over." Validation previously topped out at per-game team-stat; this rolls the already-built per-season validation reports up per team into engine-vs-.sco standings, pace, and point-differential, plus a per-game-type residual rollup that is the actual fidelity signal.

**Standings** use expected-wins from per-game win-fraction, not mean-margin signs. `simulateGameMeans` already retains the per-run samples, so it now also returns the home win-fraction (ties count 0.5, reachable only after the 20-OT ceiling) — a runs-stable estimate of P(home win). A mean-margin sign at runs=50 would round every game to a 0/1 win and inflate favorites' records as √N (the same artifact documented for win-share); expected-wins = Σ win-fraction avoids that and carries only interpretable binomial noise.

**Pace and point-differential** are pure linear means (runs-stable), derived directly from existing points rows. The readout rides on `CalibrationReport` alongside bands + home-margins (no new CLI mode, no archive re-walk), and each report is stamped with a season `Label` so the output is attributable.

Per-player statistical leaders remain out of scope (need per-player box retention through the harness) — a follow-up PR.

## Changes

- `engine/internal/calibrate/standings.go` — new: expected-wins, standings gap, pace, point-diff computation
- `engine/internal/calibrate/standings_test.go` — new: win-fraction (tie/empty/min-length boundaries), fractional expected-wins fix, gap detection, degenerate-input guards
- `engine/internal/calibrate/aggregate.go` / `season.go` / `walk.go` — wired season Label through to `CalibrationReport`
- `engine/internal/validate/` — aggregate season harness; compare.go + harness test extensions
- `engine/cmd/jsbcalibrate/main_test.go` — CLI JSON output coverage for standings fields

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)
<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>