### PR TITLE
feat(engine): select most-complete regular snapshot + medGP floor

### DIFF
--- a/engine/internal/calibrate/season.go
+++ b/engine/internal/calibrate/season.go
@@ -18,8 +18,11 @@ import (
 //
 //  1. Processing every snapshot would double-count early games (re-counted in
 //     each later cumulative snapshot). So per season we take ONE snapshot per
-//     bucket: the last regular-type snapshot for the regular bucket, and the
-//     finals (last overall) snapshot for the playoff bucket.
+//     bucket: the MOST-COMPLETE regular-type snapshot for the regular bucket
+//     (the candidate whose .sco holds the most games — see collectSeasonReports;
+//     lexical-last is NOT a reliable completeness signal, since a misclassified
+//     or partial mid-season backup can sort last), and the finals (last overall)
+//     snapshot for the playoff bucket.
 //
 //  2. REGULAR games are validated via validate.ValidateCorpus, which pairs each
 //     .sco game to a .sch schedule entry. PLAYOFF games are NOT in the .sch
@@ -29,15 +32,26 @@ import (
 //     team IDs (PR9d). All-star/Olympics calibration is still out of scope:
 //     Olympics national-team rosters are not a clean .plr-franchise sim.
 
+// minSeasonMedianGP is the proxy-medGP floor below which a season is treated as
+// incomplete in the archive and skipped (rather than reported as if complete).
+// Every complete season has medGP≈82 regardless of era (each team plays 82
+// games), so a floor of 70 drops genuinely-partial seasons (07-08 preseason-only,
+// 06-07/90-91/91-92/92-93 mid-season-truncated backups) without dropping any
+// complete one. proxyMedGP = 2 * games / distinctTeams, computed pre-sim from the
+// chosen snapshot's .sco so a doomed season costs one cheap .sco read, not a sim.
+const minSeasonMedianGP = 70
+
 // season is one season's selected snapshots. olympics seasons are recorded so
 // they can be reported as skipped (out of scope — national-team rosters need
-// separate handling). finalsZip is the last snapshot overall (lexical/sim-step
-// order); when it differs from regularZip it carries the playoff games.
+// separate handling). regularCandidates holds EVERY regular-type snapshot for
+// the season (in lexical order); collectSeasonReports picks the most-complete one
+// by .sco game count. finalsZip is the last snapshot overall (lexical/sim-step
+// order); it carries the playoff games when it is a playoff-typed snapshot.
 type season struct {
-	name       string
-	olympics   bool
-	regularZip string // last regular-type snapshot; "" if the season has none
-	finalsZip  string // last snapshot overall; "" if the season has none
+	name              string
+	olympics          bool
+	regularCandidates []string // every regular-type snapshot; empty if the season has none
+	finalsZip         string   // last snapshot overall; "" if the season has none
 }
 
 // seasonName is the path segment immediately under root (e.g. "02-03", or
@@ -56,18 +70,19 @@ func isOlympicsPath(path string) bool {
 	return strings.Contains(strings.ToLower(filepath.ToSlash(path)), "olympics")
 }
 
-// groupSeasons buckets zip paths into seasons, selecting two snapshots per
-// season by lexical (sim-step) order — valid because the archive's NN index is
-// zero-padded, so the names sort by sim step: the last regular-type snapshot
-// (regularZip, the complete regular season) and the last snapshot overall
-// (finalsZip, which carries the playoff games when a finals snapshot exists).
-// Olympics snapshots are flagged (and skipped: not yet supported, see the note
-// above).
+// groupSeasons buckets zip paths into seasons. It collects EVERY regular-type
+// snapshot per season (regularCandidates, in lexical order) — collectSeasonReports
+// then picks the most-complete one by .sco game count — and the last snapshot
+// overall (finalsZip, which carries the playoff games when it is a playoff-typed
+// snapshot). The archive's NN index is zero-padded, so lexical order is sim-step
+// order; that still seeds finalsZip, but the regular bucket no longer trusts it
+// for completeness (a partial backup can sort last). Olympics snapshots are
+// flagged (and skipped: not yet supported, see the note above).
 func groupSeasons(zipPaths []string, root string) ([]season, []Skip) {
 	type acc struct {
-		olympics   bool
-		regularZip string
-		finalsZip  string
+		olympics          bool
+		regularCandidates []string
+		finalsZip         string
 	}
 	m := map[string]*acc{}
 	var skips []Skip
@@ -83,14 +98,14 @@ func groupSeasons(zipPaths []string, root string) ([]season, []Skip) {
 			skips = append(skips, Skip{p, "olympics not yet supported (national-team rosters — see season.go)"})
 			continue
 		}
-		// The last snapshot overall is the finals snapshot (playoff bucket); the
-		// last regular-type snapshot seeds the regular bucket. When the season has
-		// no finals snapshot, finalsZip == regularZip and no playoff bucket forms.
+		// The last snapshot overall is the finals snapshot (playoff bucket); every
+		// regular-type snapshot is a regular-bucket candidate. zipPaths is lexical,
+		// so regularCandidates accumulates in lexical order.
 		if p > a.finalsZip {
 			a.finalsZip = p
 		}
-		if gt, _ := inferGameType(p, false); gt == bundle.GameTypeRegular && p > a.regularZip {
-			a.regularZip = p
+		if gt, _ := inferGameType(p, false); gt == bundle.GameTypeRegular {
+			a.regularCandidates = append(a.regularCandidates, p)
 		}
 	}
 
@@ -102,33 +117,37 @@ func groupSeasons(zipPaths []string, root string) ([]season, []Skip) {
 	seasons := make([]season, 0, len(names))
 	for _, n := range names {
 		a := m[n]
-		seasons = append(seasons, season{name: n, olympics: a.olympics, regularZip: a.regularZip, finalsZip: a.finalsZip})
+		seasons = append(seasons, season{name: n, olympics: a.olympics, regularCandidates: a.regularCandidates, finalsZip: a.finalsZip})
 	}
 	return seasons, skips
 }
 
 // CollectSeasonReports is the calibration-correct collector: it groups the
-// archive into seasons and, per season, validates the last regular-type
-// snapshot as the REGULAR bucket and (when a distinct finals snapshot exists)
-// its unmatched .sco games as the PLAYOFF bucket. --sample-stride thins by
-// season; both buckets for a selected season are produced together. All-star
-// and Olympics remain out of scope.
+// archive into seasons and, per season, validates the MOST-COMPLETE regular-type
+// snapshot as the REGULAR bucket and (when a distinct playoff snapshot exists)
+// its unmatched .sco games as the PLAYOFF bucket. A season whose best regular
+// snapshot is still incomplete (proxy medGP below minSeasonMedianGP) is skipped
+// rather than reported as if complete. --sample-stride thins by season; both
+// buckets for a selected season are produced together. All-star and Olympics
+// remain out of scope.
 func CollectSeasonReports(root string, opts Options) ([]validate.Report, []Skip, error) {
 	zips, zskips, err := listArchiveZips(root)
 	if err != nil {
 		return nil, nil, err
 	}
 	seasons, gskips := groupSeasons(zips, root)
-	reports, pskips := collectSeasonReports(seasons, opts, resolveValidate(opts), resolveValidateUnscheduled(opts))
+	reports, pskips := collectSeasonReports(seasons, opts, resolveValidate(opts), resolveValidateUnscheduled(opts), resolveCountSco(opts))
 	skips := append(append(zskips, gskips...), pskips...)
 	return reports, skips, nil
 }
 
 // collectSeasonReports is the injected-dependency core of CollectSeasonReports.
 // validateFn handles the regular (scheduled) bucket; validateUnscheduledFn
-// handles the playoff (unscheduled) bucket — both seams so the season grouping
-// and bucket selection are unit-testable without running the engine.
-func collectSeasonReports(seasons []season, opts Options, validateFn, validateUnscheduledFn ValidateFunc) ([]validate.Report, []Skip) {
+// handles the playoff (unscheduled) bucket; countFn counts each regular
+// candidate's .sco games/teams for the max-games selection and medGP floor — all
+// seams so the season grouping and bucket selection are unit-testable without
+// running the engine or building multi-megabyte .sco fixtures.
+func collectSeasonReports(seasons []season, opts Options, validateFn, validateUnscheduledFn ValidateFunc, countFn CountScoFunc) ([]validate.Report, []Skip) {
 	progress := opts.Progress
 	if progress == nil {
 		progress = io.Discard
@@ -142,7 +161,7 @@ func collectSeasonReports(seasons []season, opts Options, validateFn, validateUn
 	var skips []Skip
 	selected := 0
 	for _, s := range seasons {
-		if s.olympics || s.regularZip == "" {
+		if s.olympics || len(s.regularCandidates) == 0 {
 			if !s.olympics {
 				skips = append(skips, Skip{s.name, "season has no regular-type snapshot"})
 			}
@@ -153,30 +172,73 @@ func collectSeasonReports(seasons []season, opts Options, validateFn, validateUn
 		if idx%stride != 0 {
 			continue
 		}
-		rep, skip := processZip(s.regularZip, bundle.GameTypeRegular, opts.Runs, opts.Seed, validateFn)
+
+		// Pick the most-complete regular snapshot by .sco game count (cumulative,
+		// so most games = furthest into the season), and compute the pre-sim proxy
+		// medGP from it. A candidate whose .sco cannot be counted is recorded as a
+		// Skip but does not disqualify the season — a later candidate may count.
+		regularZip, games, teams, cskips := selectMostComplete(s.regularCandidates, countFn)
+		skips = append(skips, cskips...)
+		if regularZip == "" {
+			skips = append(skips, Skip{s.name, "season has no readable regular snapshot"})
+			continue
+		}
+		if proxyMedGP := 2 * float64(games) / float64(max(teams, 1)); proxyMedGP < minSeasonMedianGP {
+			skips = append(skips, Skip{s.name, fmt.Sprintf(
+				"regular season incomplete in archive (proxy medGP %.0f < floor %d)", proxyMedGP, minSeasonMedianGP)})
+			continue
+		}
+
+		rep, skip := processZip(regularZip, bundle.GameTypeRegular, opts.Runs, opts.Seed, validateFn)
 		if skip != nil {
 			skips = append(skips, *skip)
 			continue
 		}
 		rep.Label = s.name
-		_, _ = fmt.Fprintf(progress, "regular %s games=%d\n", s.regularZip, len(rep.Games))
+		_, _ = fmt.Fprintf(progress, "regular %s games=%d\n", regularZip, len(rep.Games))
 		reports = append(reports, *rep)
 
-		// Playoff bucket: the finals snapshot's unmatched .sco games, validated
-		// via the unscheduled path. Only when a distinct finals snapshot exists
-		// (otherwise finalsZip == regularZip = no playoffs captured).
-		if s.finalsZip != "" && s.finalsZip != s.regularZip {
-			prep, pskip := processZip(s.finalsZip, bundle.GameTypePlayoff, opts.Runs, opts.Seed, validateUnscheduledFn)
-			if pskip != nil {
-				skips = append(skips, *pskip)
-				continue
+		// Playoff bucket: the finals snapshot's unmatched .sco games, validated via
+		// the unscheduled path. Only when finalsZip is a genuinely playoff-typed
+		// snapshot — never a regular snapshot that merely sorts last (which, after
+		// max-games selection, can differ from the chosen regular snapshot).
+		if s.finalsZip != "" {
+			if gt, _ := inferGameType(s.finalsZip, false); gt == bundle.GameTypePlayoff {
+				prep, pskip := processZip(s.finalsZip, bundle.GameTypePlayoff, opts.Runs, opts.Seed, validateUnscheduledFn)
+				if pskip != nil {
+					skips = append(skips, *pskip)
+					continue
+				}
+				prep.Label = s.name + " (playoffs)"
+				_, _ = fmt.Fprintf(progress, "playoff %s games=%d excluded=%d\n", s.finalsZip, len(prep.Games), len(prep.Excluded))
+				reports = append(reports, *prep)
 			}
-			prep.Label = s.name + " (playoffs)"
-			_, _ = fmt.Fprintf(progress, "playoff %s games=%d excluded=%d\n", s.finalsZip, len(prep.Games), len(prep.Excluded))
-			reports = append(reports, *prep)
 		}
 	}
 	return reports, skips
+}
+
+// selectMostComplete counts each candidate's .sco and returns the path with the
+// most games (the cumulative-completeness signal), along with that snapshot's
+// game and distinct-team counts. Candidates whose .sco cannot be counted are
+// returned as Skips and excluded from the running max; if none can be counted,
+// best is "". Ties keep the first (lexically-earliest) candidate.
+func selectMostComplete(candidates []string, countFn CountScoFunc) (best string, games, teams int, skips []Skip) {
+	games = -1
+	for _, c := range candidates {
+		g, t, err := countFn(c)
+		if err != nil {
+			skips = append(skips, Skip{c, "count .sco: " + err.Error()})
+			continue
+		}
+		if g > games {
+			best, games, teams = c, g, t
+		}
+	}
+	if best == "" {
+		return "", 0, 0, skips
+	}
+	return best, games, teams, skips
 }
 
 // resolveValidate returns opts.Validate or the real ValidateCorpus default.
@@ -194,4 +256,13 @@ func resolveValidateUnscheduled(opts Options) ValidateFunc {
 		return opts.ValidateUnscheduled
 	}
 	return validate.ValidateUnscheduled
+}
+
+// resolveCountSco returns opts.CountSco or the real countScoGames default (the
+// season-selection .sco game/team counter seam).
+func resolveCountSco(opts Options) CountScoFunc {
+	if opts.CountSco != nil {
+		return opts.CountSco
+	}
+	return countScoGames
 }

--- a/engine/internal/calibrate/season_test.go
+++ b/engine/internal/calibrate/season_test.go
@@ -1,12 +1,30 @@
 package calibrate
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/a-jay85/IBL5/engine/internal/bundle"
 )
+
+// okCount is a CountScoFunc stub reporting a complete season (1148 games / 28
+// teams → medGP≈82) for any path, so the public CollectSeasonReports tests that
+// build placeholder "sco-bytes" zips clear the medGP floor without a real .sco.
+func okCount(string) (int, int, error) { return 1148, 28, nil }
+
+// countMap is a CountScoFunc stub returning per-path (games, teams) from a map;
+// an unknown path returns (0, 0) (medGP 0 → below the floor).
+func countMap(m map[string][2]int) CountScoFunc {
+	return func(p string) (int, int, error) {
+		if gt, ok := m[p]; ok {
+			return gt[0], gt[1], nil
+		}
+		return 0, 0, nil
+	}
+}
 
 // neutralTempDir returns a temp dir whose path contains none of the substrings
 // inferGameType keys on ("finals"/"playoff"/"olympics"). t.TempDir() embeds the
@@ -23,11 +41,11 @@ func neutralTempDir(t *testing.T) string {
 	return dir
 }
 
-// Row #6: groupSeasons picks each season's last regular-type snapshot for the
-// regular bucket AND its last snapshot overall (the finals) for the playoff
-// bucket; the finals selection is distinct from the regular one when a playoff
-// snapshot exists. Olympics are flagged+skipped (out of scope).
-func TestGroupSeasons_SelectsLastRegular(t *testing.T) {
+// groupSeasons collects EVERY regular-type snapshot per season (in lexical
+// order) as a candidate, and the last snapshot overall (the finals) for the
+// playoff bucket. The most-complete candidate is chosen later, in
+// collectSeasonReports. Olympics are flagged+skipped (out of scope).
+func TestGroupSeasons_CollectsRegularCandidates(t *testing.T) {
 	root := "/b"
 	zips := []string{
 		"/b/02-03/02-03_08_reg-sim01.zip",
@@ -42,44 +60,61 @@ func TestGroupSeasons_SelectsLastRegular(t *testing.T) {
 	if len(seasons) != 2 {
 		t.Fatalf("seasons = %d, want 2", len(seasons))
 	}
-	// Sorted by name: 02-03 then 88-89. The last regular snapshot is the regular
-	// bucket; the finals snapshot is the (distinct) playoff bucket.
+	// Sorted by name: 02-03 then 88-89. Both reg-sim snapshots are regular
+	// candidates (the finals is NOT); the finals snapshot is the playoff bucket.
+	wantCands := []string{"/b/02-03/02-03_08_reg-sim01.zip", "/b/02-03/02-03_41_reg-sim35.zip"}
 	if s := seasons[0]; s.name != "02-03" ||
-		s.regularZip != "/b/02-03/02-03_41_reg-sim35.zip" ||
+		!equalStrings(s.regularCandidates, wantCands) ||
 		s.finalsZip != "/b/02-03/02-03_47_finals.zip" {
 		t.Errorf("02-03 selection wrong: %+v", s)
 	}
-	// 88-89 has no finals snapshot: finalsZip == regularZip, so no playoff bucket.
-	if s := seasons[1]; s.regularZip != "/b/88-89/88-89_30_reg-sim20.zip" ||
-		s.finalsZip != s.regularZip {
-		t.Errorf("88-89 selection wrong (expected no distinct finals): %+v", s)
+	// 88-89 has no finals snapshot: finalsZip == its only regular snapshot (which,
+	// being regular-typed, forms no playoff bucket in collectSeasonReports).
+	if s := seasons[1]; !equalStrings(s.regularCandidates, []string{"/b/88-89/88-89_30_reg-sim20.zip"}) ||
+		s.finalsZip != "/b/88-89/88-89_30_reg-sim20.zip" {
+		t.Errorf("88-89 selection wrong: %+v", s)
 	}
 }
 
-// Row #1 (characterization, pre-impl): the CURRENT collector selects the
-// regular bucket purely by LEXICAL order — the lexically-greatest regular-type
-// snapshot wins, with no awareness of how many games its .sco actually holds.
-// This locks the bug before the fix: on the real archive (06-07, 90-91, …) the
-// lexically-last regular snapshot is a PARTIAL mid-season backup, yet it is
-// selected over an earlier, more-complete one. Here reg-sim85 sorts last and is
-// chosen even though (in reality) reg-sim15 is the complete cumulative snapshot.
-func TestGroupSeasons_LexicalLastSelection_Characterization(t *testing.T) {
-	root := "/b"
-	zips := []string{
-		"/b/06-07/06-07_25_reg-sim15.zip", // earlier; the complete cumulative snapshot in reality
-		"/b/06-07/06-07_95_reg-sim85.zip", // lexically last; a partial mid-season backup in reality
+// Row #2 (post-impl): selection picks the candidate whose .sco holds the MOST
+// games — the cumulative-completeness signal — regardless of path sort order.
+// Here the 1148-game candidate sorts in the MIDDLE (reg-sim15), between a
+// 549-game first (reg-sim05) and a 49-game last (reg-sim85), so a max-games
+// pick is observably different from both a first- and a last-by-path pick. This
+// is the fix for the lexical-last bug locked by the pre-impl characterization.
+func TestCollectSeasonReports_SelectsMostCompleteRegular(t *testing.T) {
+	root := neutralTempDir(t)
+	first := filepath.Join(root, "06-07", "06-07_10_reg-sim05.zip")  // sorts first; 549 games
+	middle := filepath.Join(root, "06-07", "06-07_25_reg-sim15.zip") // sorts middle; 1148 games (max)
+	last := filepath.Join(root, "06-07", "06-07_95_reg-sim85.zip")   // sorts last; 49 games
+	for _, p := range []string{first, middle, last} {
+		makeZip(t, p, fullTriple())
 	}
-	seasons, skips := groupSeasons(zips, root)
-	if len(skips) != 0 {
-		t.Fatalf("unexpected skips: %v", skips)
+
+	var progress bytes.Buffer
+	rv := &recordingValidate{t: t}
+	reports, skips, err := CollectSeasonReports(root, Options{
+		Runs:     1,
+		Validate: rv.fn,
+		Progress: &progress,
+		CountSco: countMap(map[string][2]int{
+			first:  {549, 28},
+			middle: {1148, 28},
+			last:   {49, 28},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("CollectSeasonReports: %v", err)
 	}
-	if len(seasons) != 1 {
-		t.Fatalf("seasons = %d, want 1", len(seasons))
+	if len(reports) != 1 || rv.calls != 1 {
+		t.Fatalf("reports=%d calls=%d, want 1 / 1 (skips=%v)", len(reports), rv.calls, skips)
 	}
-	// Current behavior: lexically-last regular snapshot is the regular bucket,
-	// regardless of completeness.
-	if s := seasons[0]; s.regularZip != "/b/06-07/06-07_95_reg-sim85.zip" {
-		t.Errorf("regularZip = %q, want lexically-last %q", s.regularZip, "/b/06-07/06-07_95_reg-sim85.zip")
+	out := progress.String()
+	if !strings.Contains(out, "regular "+middle+" ") {
+		t.Errorf("progress did not select the max-games (middle) candidate:\n%s", out)
+	}
+	if strings.Contains(out, first) || strings.Contains(out, last) {
+		t.Errorf("progress selected a non-max candidate:\n%s", out)
 	}
 }
 
@@ -92,22 +127,22 @@ func TestGroupSeasons_OlympicsSkipped(t *testing.T) {
 	if len(skips) != 2 {
 		t.Fatalf("olympics skips = %d, want 2", len(skips))
 	}
-	if len(seasons) != 1 || !seasons[0].olympics || seasons[0].regularZip != "" || seasons[0].finalsZip != "" {
+	if len(seasons) != 1 || !seasons[0].olympics || len(seasons[0].regularCandidates) != 0 || seasons[0].finalsZip != "" {
 		t.Fatalf("olympics season wrong: %+v", seasons)
 	}
 }
 
 // recordingValidate (defined in walk_test.go) records each validate call.
 
-// Row: collectSeasonReports validates one regular report per season (the last
-// regular snapshot) under GameTypeRegular.
+// Row: collectSeasonReports validates one regular report per season (the
+// most-complete regular snapshot) under GameTypeRegular.
 func TestCollectSeasonReports_RegularPerSeason(t *testing.T) {
 	root := neutralTempDir(t)
 	makeZip(t, filepath.Join(root, "02-03", "02-03_41_reg-sim35.zip"), fullTriple())
 	makeZip(t, filepath.Join(root, "88-89", "88-89_30_reg-sim20.zip"), fullTriple())
 
 	rv := &recordingValidate{t: t}
-	reports, skips, err := CollectSeasonReports(root, Options{Runs: 1, Validate: rv.fn})
+	reports, skips, err := CollectSeasonReports(root, Options{Runs: 1, Validate: rv.fn, CountSco: okCount})
 	if err != nil {
 		t.Fatalf("CollectSeasonReports: %v", err)
 	}
@@ -123,10 +158,10 @@ func TestCollectSeasonReports_RegularPerSeason(t *testing.T) {
 
 // Row (negative): a season with no regular-type snapshot is skipped.
 func TestCollectSeasonReports_NoRegularSnapshotSkips(t *testing.T) {
-	seasons := []season{{name: "x", regularZip: ""}}
+	seasons := []season{{name: "x", regularCandidates: nil}}
 	rvReg := &recordingValidate{t: t}
 	rvPof := &recordingValidate{t: t}
-	reports, skips := collectSeasonReports(seasons, Options{Runs: 1}, rvReg.fn, rvPof.fn)
+	reports, skips := collectSeasonReports(seasons, Options{Runs: 1}, rvReg.fn, rvPof.fn, okCount)
 	if len(reports) != 0 || rvReg.calls != 0 || rvPof.calls != 0 || len(skips) != 1 {
 		t.Fatalf("want zero reports/calls and one skip; reports=%d reg=%d pof=%d skips=%v",
 			len(reports), rvReg.calls, rvPof.calls, skips)
@@ -144,7 +179,7 @@ func TestCollectSeasonReports_RegularAndPlayoffBuckets(t *testing.T) {
 	rvReg := &recordingValidate{t: t}
 	rvPof := &recordingValidate{t: t}
 	reports, skips, err := CollectSeasonReports(root, Options{
-		Runs: 1, Validate: rvReg.fn, ValidateUnscheduled: rvPof.fn,
+		Runs: 1, Validate: rvReg.fn, ValidateUnscheduled: rvPof.fn, CountSco: okCount,
 	})
 	if err != nil {
 		t.Fatalf("CollectSeasonReports: %v", err)
@@ -177,7 +212,7 @@ func TestCollectSeasonReports_NoFinalsEmitsOnlyRegular(t *testing.T) {
 	rvReg := &recordingValidate{t: t}
 	rvPof := &recordingValidate{t: t}
 	reports, skips, err := CollectSeasonReports(root, Options{
-		Runs: 1, Validate: rvReg.fn, ValidateUnscheduled: rvPof.fn,
+		Runs: 1, Validate: rvReg.fn, ValidateUnscheduled: rvPof.fn, CountSco: okCount,
 	})
 	if err != nil {
 		t.Fatalf("CollectSeasonReports: %v", err)
@@ -195,7 +230,7 @@ func TestCollectSeasonReports_SampleStride(t *testing.T) {
 		makeZip(t, filepath.Join(root, n, n+"_reg-sim.zip"), fullTriple())
 	}
 	rv := &recordingValidate{t: t}
-	reports, _, err := CollectSeasonReports(root, Options{Runs: 1, SampleStride: 2, Validate: rv.fn})
+	reports, _, err := CollectSeasonReports(root, Options{Runs: 1, SampleStride: 2, Validate: rv.fn, CountSco: okCount})
 	if err != nil {
 		t.Fatalf("CollectSeasonReports: %v", err)
 	}
@@ -214,7 +249,7 @@ func TestCollectSeasonReports_StampsLabel(t *testing.T) {
 	rvReg := &recordingValidate{t: t}
 	rvPof := &recordingValidate{t: t}
 	reports, _, err := CollectSeasonReports(root, Options{
-		Runs: 1, Validate: rvReg.fn, ValidateUnscheduled: rvPof.fn,
+		Runs: 1, Validate: rvReg.fn, ValidateUnscheduled: rvPof.fn, CountSco: okCount,
 	})
 	if err != nil {
 		t.Fatalf("CollectSeasonReports: %v", err)
@@ -227,5 +262,51 @@ func TestCollectSeasonReports_StampsLabel(t *testing.T) {
 	}
 	if reports[1].Label != "02-03 (playoffs)" {
 		t.Errorf("playoff label = %q, want %q", reports[1].Label, "02-03 (playoffs)")
+	}
+}
+
+// Rows #3 & #4: the medGP sanity floor. A season whose best regular candidate has
+// proxy medGP (2*games/teams) below minSeasonMedianGP (70) is skipped with a Skip
+// and produces NO report; a complete season (medGP≈82) is kept. The boundary is
+// exact: 70.0 is kept (not < 70), 69.9 is skipped.
+func TestCollectSeasonReports_MedGPFloor(t *testing.T) {
+	cases := []struct {
+		name       string
+		games      int
+		teams      int
+		wantReport bool
+	}{
+		{"below-floor", 49, 28, false},          // medGP 3.5  — row #3 (49 games / 28 teams)
+		{"just-below-boundary", 979, 28, false}, // medGP 69.93 — just under the floor
+		{"at-boundary", 980, 28, true},          // medGP 70.0  — exactly at the floor (kept)
+		{"above-floor", 1148, 28, true},         // medGP 82    — row #4 (complete season)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := neutralTempDir(t)
+			zipPath := filepath.Join(root, "06-07", "06-07_50_reg-sim40.zip")
+			makeZip(t, zipPath, fullTriple())
+			seasons := []season{{name: "06-07", regularCandidates: []string{zipPath}}}
+
+			rvReg := &recordingValidate{t: t}
+			rvPof := &recordingValidate{t: t}
+			reports, skips := collectSeasonReports(
+				seasons, Options{Runs: 1}, rvReg.fn, rvPof.fn,
+				countMap(map[string][2]int{zipPath: {tc.games, tc.teams}}),
+			)
+			if tc.wantReport {
+				if len(reports) != 1 || rvReg.calls != 1 {
+					t.Fatalf("reports=%d calls=%d, want 1/1 (medGP above floor) skips=%v", len(reports), rvReg.calls, skips)
+				}
+				return
+			}
+			// Below the floor: no report, no validate call, and a Skip naming the season.
+			if len(reports) != 0 || rvReg.calls != 0 {
+				t.Fatalf("reports=%d calls=%d, want 0/0 (medGP below floor)", len(reports), rvReg.calls)
+			}
+			if len(skips) != 1 || skips[0].Path != "06-07" || !strings.Contains(skips[0].Reason, "incomplete") {
+				t.Fatalf("want one incomplete-season skip for 06-07, got %v", skips)
+			}
+		})
 	}
 }

--- a/engine/internal/calibrate/season_test.go
+++ b/engine/internal/calibrate/season_test.go
@@ -56,6 +56,33 @@ func TestGroupSeasons_SelectsLastRegular(t *testing.T) {
 	}
 }
 
+// Row #1 (characterization, pre-impl): the CURRENT collector selects the
+// regular bucket purely by LEXICAL order — the lexically-greatest regular-type
+// snapshot wins, with no awareness of how many games its .sco actually holds.
+// This locks the bug before the fix: on the real archive (06-07, 90-91, …) the
+// lexically-last regular snapshot is a PARTIAL mid-season backup, yet it is
+// selected over an earlier, more-complete one. Here reg-sim85 sorts last and is
+// chosen even though (in reality) reg-sim15 is the complete cumulative snapshot.
+func TestGroupSeasons_LexicalLastSelection_Characterization(t *testing.T) {
+	root := "/b"
+	zips := []string{
+		"/b/06-07/06-07_25_reg-sim15.zip", // earlier; the complete cumulative snapshot in reality
+		"/b/06-07/06-07_95_reg-sim85.zip", // lexically last; a partial mid-season backup in reality
+	}
+	seasons, skips := groupSeasons(zips, root)
+	if len(skips) != 0 {
+		t.Fatalf("unexpected skips: %v", skips)
+	}
+	if len(seasons) != 1 {
+		t.Fatalf("seasons = %d, want 1", len(seasons))
+	}
+	// Current behavior: lexically-last regular snapshot is the regular bucket,
+	// regardless of completeness.
+	if s := seasons[0]; s.regularZip != "/b/06-07/06-07_95_reg-sim85.zip" {
+		t.Errorf("regularZip = %q, want lexically-last %q", s.regularZip, "/b/06-07/06-07_95_reg-sim85.zip")
+	}
+}
+
 // Row (negative): Olympics snapshots are flagged and recorded as Skips (not yet
 // supported — national-team rosters), never selected as a regular/finals snapshot.
 func TestGroupSeasons_OlympicsSkipped(t *testing.T) {

--- a/engine/internal/calibrate/walk.go
+++ b/engine/internal/calibrate/walk.go
@@ -2,6 +2,7 @@ package calibrate
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/a-jay85/IBL5/engine/internal/backup"
 	"github.com/a-jay85/IBL5/engine/internal/bundle"
 	"github.com/a-jay85/IBL5/engine/internal/validate"
 )
@@ -39,6 +41,12 @@ var requiredMembers = []string{"IBL5.plr", "IBL5.sch", "IBL5.sco"}
 // engine. A nil Options.Validate defaults to validate.ValidateCorpus.
 type ValidateFunc func(dir string, runs int, seed uint64, gt bundle.GameType) (validate.Report, error)
 
+// CountScoFunc is the seam to countScoGames, injected (via Options.CountSco) so
+// the season collector's max-games selection and medGP floor are unit-testable
+// without building multi-megabyte .sco fixtures. A nil Options.CountSco defaults
+// to countScoGames.
+type CountScoFunc func(zipPath string) (games, teams int, err error)
+
 // Options configures an archive walk.
 type Options struct {
 	Runs                int          // seeded engine runs per corpus game
@@ -47,6 +55,7 @@ type Options struct {
 	IncludeOlympics     bool         // include olympics/ snapshots (game-type 6)
 	Validate            ValidateFunc // nil -> validate.ValidateCorpus (regular/scheduled bucket)
 	ValidateUnscheduled ValidateFunc // nil -> validate.ValidateUnscheduled (playoff bucket)
+	CountSco            CountScoFunc // nil -> countScoGames (season: .sco game/team counter)
 	Progress            io.Writer    // nil -> io.Discard; one line per processed snapshot
 }
 
@@ -191,6 +200,47 @@ func extractOne(f *zip.File, dest string) error {
 		return err
 	}
 	return out.Close()
+}
+
+// countScoGames opens zipPath, extracts ONLY its IBL5.sco member (matched by
+// basename, case-insensitively, like extractTriple), parses it with
+// backup.ReadSco, and returns the cumulative game count and the number of
+// distinct team IDs (the union of every game's visitor and home team). It is the
+// cheap pre-sim completeness probe the season collector uses to pick the
+// most-complete regular snapshot and to floor out partial seasons: a snapshot's
+// .sco is CUMULATIVE, so its game count is the season-to-date total. The .sco
+// stream is bounded by maxEntryBytes (zip-bomb safe even for a trusted archive).
+// A zip with no IBL5.sco, or a malformed .sco, yields an error — never a panic.
+// Errors are returned unprefixed; the caller (selectMostComplete) stamps the
+// failing path onto the Skip, so the path appears exactly once in CLI output.
+func countScoGames(zipPath string) (games, teams int, err error) {
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func() { _ = zr.Close() }()
+
+	for _, f := range zr.File {
+		if !strings.EqualFold(filepath.Base(f.Name), "IBL5.sco") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return 0, 0, err
+		}
+		scoGames, err := backup.ReadSco(io.LimitReader(rc, maxEntryBytes))
+		_ = rc.Close()
+		if err != nil {
+			return 0, 0, err
+		}
+		seen := map[int]struct{}{}
+		for _, g := range scoGames {
+			seen[g.VisitorTeamID] = struct{}{}
+			seen[g.HomeTeamID] = struct{}{}
+		}
+		return len(scoGames), len(seen), nil
+	}
+	return 0, 0, errors.New("no IBL5.sco member")
 }
 
 // listArchiveZips walks root and returns every *.zip path in deterministic

--- a/engine/internal/calibrate/walk_test.go
+++ b/engine/internal/calibrate/walk_test.go
@@ -2,6 +2,7 @@ package calibrate
 
 import (
 	"archive/zip"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -263,4 +264,69 @@ func equalStrings(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// buildScoBytes builds a minimal but valid .sco byte stream: the 1,000,000-byte
+// metadata header (skipped by ReadSco) followed by one 2,000-byte record per
+// game. Each record carries the given RAW visitor/home team IDs in its game-info
+// header (ReadSco adds 1, so the decoded IDs are raw+1) and a single non-empty
+// player slot so the record is decoded rather than skipped as padding. Mirrors
+// the .sco offsets in internal/backup/sco.go (header 1,000,000; record 2,000;
+// game-info 58; visitor/home raw TID at game-info offsets 6/8; slot 0 name at
+// game-info-end + 0).
+func buildScoBytes(games [][2]int) []byte {
+	const (
+		header     = 1_000_000
+		recordSize = 2000
+		giVisitor  = 6  // raw visitor TID, width 2
+		giHome     = 8  // raw home TID, width 2
+		slot0Name  = 58 // first player slot begins right after the 58-byte game info
+	)
+	buf := make([]byte, header+len(games)*recordSize)
+	for i := range buf {
+		buf[i] = ' '
+	}
+	for i, g := range games {
+		rec := header + i*recordSize
+		copy(buf[rec+giVisitor:], fmt.Sprintf("%2d", g[0]))
+		copy(buf[rec+giHome:], fmt.Sprintf("%2d", g[1]))
+		copy(buf[rec+slot0Name:], "Player") // non-empty name -> record is a real game
+	}
+	return buf
+}
+
+// Row #5: countScoGames returns the game count and the distinct-team count for a
+// fixture .sco, and surfaces a parse error (not a panic) on a malformed .sco or
+// a zip with no .sco member.
+func TestCountScoGames(t *testing.T) {
+	root := t.TempDir()
+
+	// (a) valid .sco: 3 games over 4 distinct teams. Raw pairs {0,1},{2,3},{0,2}
+	// decode (raw+1) to {1,2},{3,4},{1,3} -> distinct teams {1,2,3,4} = 4.
+	good := filepath.Join(root, "good_reg-sim.zip")
+	makeZip(t, good, map[string]string{
+		"IBL5.plr": "p", "IBL5.sch": "s",
+		"IBL5.sco": string(buildScoBytes([][2]int{{0, 1}, {2, 3}, {0, 2}})),
+	})
+	games, teams, err := countScoGames(good)
+	if err != nil {
+		t.Fatalf("countScoGames(good): %v", err)
+	}
+	if games != 3 || teams != 4 {
+		t.Errorf("games=%d teams=%d, want 3 / 4", games, teams)
+	}
+
+	// (b) malformed .sco (shorter than the header): a parse error, not a panic.
+	bad := filepath.Join(root, "bad_reg-sim.zip")
+	makeZip(t, bad, map[string]string{"IBL5.sco": "too-short"})
+	if _, _, err := countScoGames(bad); err == nil {
+		t.Error("countScoGames(malformed) = nil error, want a parse error")
+	}
+
+	// (c) zip with no .sco member: an error, not a silent zero count.
+	none := filepath.Join(root, "none_reg-sim.zip")
+	makeZip(t, none, map[string]string{"IBL5.plr": "p"})
+	if _, _, err := countScoGames(none); err == nil {
+		t.Error("countScoGames(no .sco) = nil error, want a missing-member error")
+	}
 }


### PR DESCRIPTION
## Summary

The calibrate season collector was choosing each season's regular bucket as the lexically-last regular-type snapshot, assuming last == most-complete. The full-archive run falsified this for 5 of 19 regular seasons (07-08 preseason-only; 06-07/90-91/91-92/92-93 truncated mid-season), whose partial snapshots contaminated season-aggregate residuals.

### Two guards added:

**Max-games selection:** Among a season's regular candidates, pick the one whose .sco holds the most games (true completeness signal), not the lexically-greatest path. `groupSeasons` now collects every regular-type candidate; `collectSeasonReports` picks the max via the new `countScoGames` (single-member .sco extraction + `backup.ReadSco`, bounded/zip-slip-safe).

**medGP sanity floor:** `proxyMedGP = 2*games/distinctTeams`, computed pre-sim from the chosen .sco; below `minSeasonMedianGP` (70) the season is skipped with a warning rather than reported as if complete. Every complete season is medGP~82 regardless of era, so 70 drops the 5 partials and none others.

The playoff guard now forms a bucket only when `finalsZip` is playoff-typed (not merely != the chosen regular snapshot), since max-games selection can decouple the chosen regular snapshot from the lexically-last one.

`countScoGames` is injected via `Options.CountSco` (mirroring `Validate`/`ValidateUnscheduled`) so selection and the floor are unit-testable without multi-megabyte .sco fixtures.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.