### PR TITLE
feat(engine): source real per-48-minute volume rates for the 2pt-bucket composite (ADR-0040 A)

### DIFF
--- a/engine/internal/backup/assemble.go
+++ b/engine/internal/backup/assemble.go
@@ -44,6 +44,12 @@ type AssembleOptions struct {
 //   - dc_minutes — the GM depth-chart minutes, sourced from the snapshot's .plb
 //     file via opts.Minutes (keyed by player Ordinal). A nil map -> 0 (no .plb).
 //
+// The real-life / previous-season counting-stat sums (RealLifeMIN/FGA/FTA/ORB) ARE
+// per-player .plr fields (static block at offsets 52-111, parsed by ReadPlr) and
+// are mapped straight through; they feed the engine's per-48-minute shot-volume
+// rate composite (sim/bucketweights.go). On the PHP production path the same bundle
+// fields come from PlrParserService's rl_* columns (a follow-on PR).
+//
 // Still zeroed (correct, not a gap):
 //   - r_foul — no foul rating in the .plr ratings block.
 //   - dc_of/df/oi/di/bh — dead on IBL5 data; the engine deliberately never reads
@@ -139,6 +145,12 @@ func toBundlePlayer(p PlrPlayer, minutes map[int]int) bundle.Player {
 		TVR: p.RatingTVR,
 		BLK: p.RatingBLK,
 		// Foul: no .plr source -> 0.
+
+		// Real-life / previous-season sums -> the per-48-minute rate composite inputs.
+		RealLifeMIN: p.RealLifeMIN,
+		RealLifeFGA: p.RealLifeFGA,
+		RealLifeFTA: p.RealLifeFTA,
+		RealLifeORB: p.RealLifeORB,
 
 		Age:         p.Age,
 		Clutch:      p.Clutch,

--- a/engine/internal/backup/assemble_test.go
+++ b/engine/internal/backup/assemble_test.go
@@ -113,6 +113,51 @@ func TestToBundle_RoundTripAndSimulate(t *testing.T) {
 	}
 }
 
+// Row 5 (characterization): a PlrPlayer with no real-life sums assembles to bundle
+// RealLife*==0 — locks the zero mapping across the struct change (the no-reference
+// case the engine falls back to the rating stand-in for).
+func TestToBundle_NoRealLife_Zero(t *testing.T) {
+	players := append(teamRoster(1), teamRoster(2)...) // makePlayer sets no real-life sums
+	sched := []SchGame{{VisitorTeamID: 1, HomeTeamID: 2, Month: 11, Day: 2, Played: true}}
+
+	b, err := ToBundle(players, sched, AssembleOptions{})
+	if err != nil {
+		t.Fatalf("ToBundle: %v", err)
+	}
+	for _, p := range b.Players {
+		if p.RealLifeMIN != 0 || p.RealLifeFGA != 0 || p.RealLifeFTA != 0 || p.RealLifeORB != 0 {
+			t.Fatalf("player %d real-life not zero: %+v", p.PID, p)
+		}
+	}
+}
+
+// Row 6: populated real-life sums on the PlrPlayer map straight through to
+// bundle.Player.RealLife* by field.
+func TestToBundle_RealLifeWired(t *testing.T) {
+	roster := teamRoster(1)
+	roster[0].RealLifeMIN = 2520
+	roster[0].RealLifeFGA = 1400
+	roster[0].RealLifeFTA = 360
+	roster[0].RealLifeORB = 120
+	players := append(roster, teamRoster(2)...)
+	sched := []SchGame{{VisitorTeamID: 1, HomeTeamID: 2, Month: 11, Day: 2, Played: true}}
+
+	b, err := ToBundle(players, sched, AssembleOptions{})
+	if err != nil {
+		t.Fatalf("ToBundle: %v", err)
+	}
+	var got bundle.Player
+	for _, p := range b.Players {
+		if p.PID == roster[0].PID {
+			got = p
+		}
+	}
+	if got.RealLifeMIN != 2520 || got.RealLifeFGA != 1400 || got.RealLifeFTA != 360 || got.RealLifeORB != 120 {
+		t.Errorf("wired real-life = MIN%d FGA%d FTA%d ORB%d, want 2520/1400/360/120",
+			got.RealLifeMIN, got.RealLifeFGA, got.RealLifeFTA, got.RealLifeORB)
+	}
+}
+
 // Row #12: an unknown team and empty inputs are typed errors, not silent empty
 // bundles.
 func TestToBundle_Errors(t *testing.T) {

--- a/engine/internal/backup/plr.go
+++ b/engine/internal/backup/plr.go
@@ -54,6 +54,33 @@ const (
 	offPeak    = 46 // width 4
 	offPos     = 50 // width 2 — PG/SG/SF/PF/" C"
 
+	// Real-life / previous-season counting-stat sums (width 4 each), the engine's
+	// per-48-MINUTE shot-volume rate inputs (D88/DB8/D70 in sim/bucketweights.go).
+	// Offsets transcribed from PlrLineParser.php 42-55. This is the STATIC reference
+	// block JSB reads for "real-life tendencies" (ibl5/docs/JSB_FILE_FORMATS.md, the
+	// 52-111 block), distinct from the in-game season totals (144-207).
+	//
+	// The rate is (stat / divisor) × 48 — the per-48 convention (_DAT_00669ed0 = 48.0).
+	// The divisor is season MINUTES (offRealLifeMIN), established by elimination, not by
+	// a clean decompile trace: a games-magnitude divisor (GP +0x144 or GS +0x148, both
+	// ≈ 75-82) drives the 2pt bucket to O(100s) and collapses the foul/FTA play-outcome
+	// mix to ~0, while a minutes-magnitude divisor (≈ 2500) reproduces jumpshot 5.60's
+	// FTA/PF against the .sco corpus (5.60's own output) — and MIN (+0x14C) is the only
+	// minutes-magnitude field in the stat block. COMPOSITE_DOUBLES_TRACE.md §1 labels
+	// the divisor "ΣGP" and its §2 stat-offset map is flagged PARTIAL; the divisor
+	// temporary is reused across blocks, so the exact accumulator identity is NOT
+	// cleanly pinned — but games-scale is empirically excluded, leaving minutes.
+	//
+	// offRealLifeFGA is TOTAL field-goal attempts (incl. 3PA, standard FG naming;
+	// verified FGA>=3GA across all 657 records of a real .plr) — it IS the decompile's
+	// FGA_total, so D88 reads it directly. Only the four fields the 2pt-bucket
+	// composite consumes are mapped; the Branch-B usage-shrink's team DRB/AST rates
+	// (offsets 88/92) are a separate follow-on input and are not parsed here.
+	offRealLifeMIN = 56 // width 4 — minutes played (the per-48 rate divisor)
+	offRealLifeFGA = 64 // width 4 — total FG attempts (D88)
+	offRealLifeFTA = 72 // width 4 — FT attempts (D70 per-player part)
+	offRealLifeORB = 84 // width 4 — offensive rebounds (DB8)
+
 	// Clutch / consistency / depth chart.
 	offClutch        = 128 // width 2
 	offConsistency   = 130 // width 2
@@ -131,6 +158,15 @@ type PlrPlayer struct {
 	PFDepth int
 	CDepth  int
 
+	// Real-life / previous-season counting-stat sums — the per-48-MINUTE rate inputs
+	// the 2pt-bucket composite reads ((stat/MIN)×48; RealLifeFGA is total FG attempts
+	// incl. 3PA). Zero MINUTES means no prior-season reference (e.g. a rookie); the
+	// engine falls back to the rating stand-in (sim/bucketweights.go twoPtBucketWeight).
+	RealLifeMIN int
+	RealLifeFGA int
+	RealLifeFTA int
+	RealLifeORB int
+
 	// Main ratings (0-99).
 	RatingFGA int
 	RatingFGP int
@@ -202,6 +238,8 @@ func ReadPlr(r io.Reader) ([]PlrPlayer, error) {
 			{&p.CanPlayInGame, offCanPlayInGame, 1},
 			{&p.PGDepth, offPGDepth, 1}, {&p.SGDepth, offSGDepth, 1}, {&p.SFDepth, offSFDepth, 1},
 			{&p.PFDepth, offPFDepth, 1}, {&p.CDepth, offCDepth, 1},
+			{&p.RealLifeMIN, offRealLifeMIN, 4}, {&p.RealLifeFGA, offRealLifeFGA, 4},
+			{&p.RealLifeFTA, offRealLifeFTA, 4}, {&p.RealLifeORB, offRealLifeORB, 4},
 			{&p.RatingFGA, offRating2GA, 3}, {&p.RatingFGP, offRating2GP, 3},
 			{&p.RatingFTA, offRatingFTA, 3}, {&p.RatingFTP, offRatingFTP, 3},
 			{&p.Rating3GA, offRating3GA, 3}, {&p.Rating3GP, offRating3GP, 3},

--- a/engine/internal/backup/plr_test.go
+++ b/engine/internal/backup/plr_test.go
@@ -142,3 +142,40 @@ func TestReadPlr_EmptyAndBlank(t *testing.T) {
 		}
 	}
 }
+
+// Row 2: ReadPlr parses the static real-life / previous-season block into
+// RealLifeMIN/FGA/FTA/ORB. Offsets restated literally (56/64/72/84) so the test
+// cross-checks the map rather than echoing plr.go's constants.
+func TestReadPlr_RealLifeBlock(t *testing.T) {
+	buf := []byte(newPlrRecord(1, 100, 1, 25, "Volume Shooter", "SG", 75, 6, 5))
+	plrField(buf, 56, itoaPad(2520, 4)) // realLifeMIN (the per-48 rate divisor)
+	plrField(buf, 64, itoaPad(1400, 4)) // realLifeFGA (total FG attempts)
+	plrField(buf, 72, itoaPad(360, 4))  // realLifeFTA
+	plrField(buf, 84, itoaPad(120, 4))  // realLifeORB
+
+	players, err := ReadPlr(strings.NewReader(string(buf) + "\r\n"))
+	if err != nil {
+		t.Fatalf("ReadPlr: %v", err)
+	}
+	p := players[0]
+	if p.RealLifeMIN != 2520 || p.RealLifeFGA != 1400 || p.RealLifeFTA != 360 || p.RealLifeORB != 120 {
+		t.Errorf("real-life block = MIN%d FGA%d FTA%d ORB%d, want 2520/1400/360/120",
+			p.RealLifeMIN, p.RealLifeFGA, p.RealLifeFTA, p.RealLifeORB)
+	}
+}
+
+// Row 3: a non-numeric real-life field yields ErrBadField naming the offset
+// (boundary — the same guard every numeric field uses, now over the new block).
+func TestReadPlr_RealLifeBadField(t *testing.T) {
+	buf := []byte(newPlrRecord(1, 100, 1, 25, "Bad RL", "PG", 70, 5, 5))
+	plrField(buf, 56, itoaPad(2520, 4))
+	copy(buf[64:68], "XXXX") // realLifeFGA non-numeric
+
+	_, err := ReadPlr(strings.NewReader(string(buf) + "\r\n"))
+	if !errors.Is(err, ErrBadField) {
+		t.Fatalf("err = %v, want ErrBadField", err)
+	}
+	if !strings.Contains(err.Error(), "64") {
+		t.Errorf("error should name offset 64: %v", err)
+	}
+}

--- a/engine/internal/bundle/bundle.go
+++ b/engine/internal/bundle/bundle.go
@@ -87,6 +87,19 @@ type Player struct {
 	BLK  int `json:"r_blk"`
 	Foul int `json:"r_foul"`
 
+	// Real-life / previous-season counting-stat sums — the engine's per-48-MINUTE
+	// shot-volume rate inputs (D88/DB8/D70 = (stat/MIN)×48) for the 2pt-bucket
+	// composite. JSON tags match the PHP PlrParserService rl_* derived columns so the
+	// production bundle-builder (a follow-on PR) maps 1:1. The Go backup assembler
+	// populates them from the static real-life .plr block (offsets 52-111). Absent/
+	// zero MINUTES — a player with no prior-season reference, or a production bundle
+	// not yet wired — falls back to the rating stand-in (sim/bucketweights.go).
+	// RealLifeFGA is total FG attempts (incl. 3PA).
+	RealLifeMIN int `json:"rl_min"`
+	RealLifeFGA int `json:"rl_fga"`
+	RealLifeFTA int `json:"rl_fta"`
+	RealLifeORB int `json:"rl_orb"`
+
 	// Attributes.
 	Age         int `json:"age"`
 	Stamina     int `json:"stamina"`

--- a/engine/internal/bundle/bundle_test.go
+++ b/engine/internal/bundle/bundle_test.go
@@ -67,6 +67,32 @@ func TestDecode_RoundTripPopulatesAllFields(t *testing.T) {
 	}
 }
 
+// Row 4 (boundary) — a bundle whose player omits the rl_* keys decodes with
+// RealLife*==0 (production-omission tolerated → the engine falls back to the
+// rating stand-in); when the keys ARE present they bind by tag.
+func TestDecode_RealLifeAbsentZero(t *testing.T) {
+	// validBundleJSON carries no rl_* keys.
+	b, err := Decode([]byte(validBundleJSON))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if p := b.Players[0]; p.RealLifeMIN != 0 || p.RealLifeFGA != 0 || p.RealLifeFTA != 0 || p.RealLifeORB != 0 {
+		t.Errorf("absent rl_* should default to 0, got MIN=%d FGA=%d FTA=%d ORB=%d",
+			p.RealLifeMIN, p.RealLifeFGA, p.RealLifeFTA, p.RealLifeORB)
+	}
+
+	withRL := `{"seed":1,"players":[{"pid":1,"teamid":3,"rl_min":2520,"rl_fga":1400,"rl_fta":360,"rl_orb":120}],` +
+		`"schedule":[{"home_team_id":3,"visitor_team_id":7,"date":"d","game_type":2}]}`
+	b2, err := Decode([]byte(withRL))
+	if err != nil {
+		t.Fatalf("Decode withRL: %v", err)
+	}
+	if p := b2.Players[0]; p.RealLifeMIN != 2520 || p.RealLifeFGA != 1400 || p.RealLifeFTA != 360 || p.RealLifeORB != 120 {
+		t.Errorf("rl_* decode = MIN%d FGA%d FTA%d ORB%d, want 2520/1400/360/120",
+			p.RealLifeMIN, p.RealLifeFGA, p.RealLifeFTA, p.RealLifeORB)
+	}
+}
+
 // #3 (boundary) — an unknown game_type value is rejected at decode time.
 func TestDecode_RejectsUnknownGameType(t *testing.T) {
 	for _, gt := range []int{0, 1, 7, 99} {

--- a/engine/internal/sim/bucketweights.go
+++ b/engine/internal/sim/bucketweights.go
@@ -50,15 +50,29 @@ package sim
 // SIGN, the invariant PR7a got wrong.
 
 const (
-	// +0xD90 Branch-A per-48 rate stand-ins (COMPOSITE_DOUBLES_TRACE.md §1, §4).
-	// Each maps a 0-99 rating to a per-48 rate analog; the bundle has no season
-	// GP/FGA sums so these are documented stand-ins for the recovered season-rate
-	// doubles. fgaRateScale: r_fga 60 → ~18 FGA/48; orbRateScale: r_orb 20 → ~3
-	// ORB/48; ftaRateScale: the team-relative FTA-weighted D70 stand-in, r_fta 20 →
-	// ~6 (the real D70 reads CEngine team/league aggregates absent from the bundle).
+	// +0xD90 Branch-A per-48 rate FALLBACK stand-ins (COMPOSITE_DOUBLES_TRACE.md
+	// §1, §4). Used only when the bundle carries no real-life minutes
+	// (RealLifeMIN == 0): a player with no prior-season reference, or a production
+	// bundle whose PHP builder is not yet wired. Each maps a 0-99 rating to a per-48
+	// rate analog: fgaRateScale r_fga 60 → ~18 FGA/48; orbRateScale r_orb 20 → ~3
+	// ORB/48; ftaRateScale r_fta 20 → ~6. The PRIMARY path now computes the real
+	// per-48-MINUTE rates (stat/MIN)×48 from the bundle's real-life sums — see
+	// twoPtBucketWeight. The compressed-rating stand-in is why team offense did not
+	// disperse (ADR-0040); these constants survive only as the no-reference fallback.
+	// (The stand-in scales target this same ~18-FGA/48 O(10s) magnitude, which is why
+	// the real rate must be per-48-MINUTES — per-48-GAMES would be ~55× larger and
+	// collapse the foul/FTA mix; see twoPtBucketWeight.)
 	fgaRateScale = 0.30
 	orbRateScale = 0.15
 	ftaRateScale = 0.30
+
+	// d70LeagueScalar carries D70's league-relative factor
+	// ((C[+0x6938]×5 − C[+0x68D8]×0.5)/(C[+0x6728]×5), COMPOSITE_DOUBLES_TRACE.md §3),
+	// which reads runtime CEngine LEAGUE aggregates absent from the IBL data path
+	// (ADR-0040 negative finding 2 — the "loader-populated, not modeled" class, like
+	// league_baseline). It is a uniform league scalar, so it degrades to a documented
+	// calibrated constant: 1.0 (neutral) here, corpus-tunable on PR2's instrument.
+	d70LeagueScalar = 1.0
 
 	// +0xD90 Branch-A pinned constants (COMPOSITE_DOUBLES_TRACE.md §5): the 0.5
 	// (_DAT_00669ef0) and 0.25 (_DAT_00669f58) factors in the make-share weighting.
@@ -84,22 +98,52 @@ const (
 	andOneMadeRateScale = 0.0008
 )
 
+// per48Min is the per-48-MINUTE season rate (stat / minutes) × 48 (_DAT_00669ed0 =
+// 48.0). The divisor is season minutes by elimination — a games-scale divisor
+// collapses the play-outcome mix; see plr.go's offRealLifeMIN note for the .sco
+// evidence and the open decompile-identity caveat. Callers guard minutes > 0.
+func per48Min(stat, minutes int) float64 {
+	return float64(stat) / float64(minutes) * 48.0
+}
+
 // twoPtBucketWeight is the recovered +0xD90 Branch-A cold composite
 // (jsb560_decompiled.c:91078-91086, COMPOSITE_DOUBLES_TRACE.md §4):
 //
 //	D90 = D88 − (D88/(D70+D88)) × DB8 × ((D88/(DB8+D88)) × 0.5 + 0.25)
 //
-// where D88 = per-48 FGA rate, DB8 = per-48 ORB rate, D70 = the team-relative
-// FTA-weighted rate (documented stand-ins, see the rate-scale constants above).
+// where D88 = per-48 FGA rate, DB8 = per-48 ORB rate, D70 = the FTA-weighted rate.
+// The composite formula is unchanged; what changed (ADR-0040, candidate A) is its
+// INPUTS. When the bundle carries the real-life minutes (RealLifeMIN > 0) D88/DB8/
+// D70 are the FAITHFUL per-48-MINUTE rates (stat/MIN)×48 — the wide team-to-team
+// spread 5.60 disperses team offense on, in the same O(10s) magnitude as the
+// stand-in (a high-volume player ≈ 27 FGA/48). Absent them (rookie / unwired
+// production bundle) it falls back to the compressed rating stand-in (fgaRateScale
+// etc.), the behavior this PR preserves byte-for-byte for the no-reference case.
+// (Using minutes, not games, is load-bearing: per-48-GAMES would be ~55× larger,
+// driving the 2pt bucket to O(100s) and collapsing the foul/FTA play-outcome share
+// to ~0 — verified degenerate against the .sco corpus.)
+//
 // It is net-free: in JSB net enters only via shot_value, so the playoff ×1.25
 // multiplier never amplifies this bucket. The composite is O(10s), keeping the
 // 0.6-floored foul bucket a realistic minority share and field-goal attempts the
 // majority path.
 func twoPtBucketWeight(p onCourt) float64 {
-	d88 := floor1(p.FGA) * fgaRateScale
-	db8 := floor1(p.ORB) * orbRateScale
-	d70 := floor1(p.FTA) * ftaRateScale
-	if d70+d88 <= 0 {
+	var d88, db8, d70 float64
+	if p.RealLifeMIN > 0 {
+		d88 = per48Min(p.RealLifeFGA, p.RealLifeMIN)
+		db8 = per48Min(p.RealLifeORB, p.RealLifeMIN)
+		d70 = per48Min(p.RealLifeFTA, p.RealLifeMIN) * d70LeagueScalar
+	} else {
+		d88 = floor1(p.FGA) * fgaRateScale
+		db8 = floor1(p.ORB) * orbRateScale
+		d70 = floor1(p.FTA) * ftaRateScale
+	}
+	// Guard both composite divisions. The real-rate path can yield d88 == 0 (a
+	// player who took no FGs) where the stand-in's floor1 always made d88 > 0; with
+	// d88 == 0 the faithful composite limit is d88 (the subtracted term carries d88
+	// as a factor), and without this guard makeShare's d88/(db8+d88) is 0/0 = NaN
+	// when db8 is also 0 — a NaN that would silently poison the weighted pick.
+	if d88 <= 0 || d70+d88 <= 0 {
 		return d88
 	}
 	makeShare := (d88/(db8+d88))*d90MakeShareHalf + d90MakeShareQuarter

--- a/engine/internal/sim/bucketweights_test.go
+++ b/engine/internal/sim/bucketweights_test.go
@@ -163,3 +163,94 @@ func TestBucketWeights_FoulEVExceedsTwoPt(t *testing.T) {
 	}
 	t.Logf("EV(foul)=%.3f EV(2pt)=%.3f — foul is the higher-EV path (locks HCA directionality)", evFoul, ev2pt)
 }
+
+// --- ADR-0040 (A): real per-48 volume rates replace the rating stand-ins -------
+
+// Row 8 (characterization): with no real-life minutes (RealLifeMIN==0) the bucket
+// equals the current stand-in composite, byte-for-byte — the no-reference fallback
+// the change preserves. Setting the sums but leaving MIN==0 must NOT engage the real
+// path (MIN is the gate and divisor).
+func TestBucketWeights_RealLifeFallbackUnchanged(t *testing.T) {
+	p := oc(slotPG, mkPlayer(1, 3, slotPG, 48)) // RealLifeMIN==0 → fallback
+
+	d88 := floor1(p.FGA) * fgaRateScale
+	db8 := floor1(p.ORB) * orbRateScale
+	d70 := floor1(p.FTA) * ftaRateScale
+	makeShare := (d88/(db8+d88))*d90MakeShareHalf + d90MakeShareQuarter
+	want := d88 - (d88/(d70+d88))*db8*makeShare
+
+	if got := twoPtBucketWeight(p); math.Abs(got-want) > 1e-9 {
+		t.Errorf("fallback weight = %.6f, want stand-in composite = %.6f", got, want)
+	}
+
+	// Sums present but MIN==0 → still the fallback (MIN gates the real path).
+	p2 := p
+	p2.RealLifeFGA = 9999
+	if got := twoPtBucketWeight(p2); math.Abs(got-want) > 1e-9 {
+		t.Errorf("MIN==0 with sums set engaged the real path: got %.6f, want %.6f", got, want)
+	}
+}
+
+// Row 9: with real-life minutes the bucket equals the hand-computed +0xD90 over the
+// faithful per-48-MINUTE rates (stat/MIN)×48 (D70 scaled by d70LeagueScalar). The
+// magnitude lands in the O(10s) stand-in regime (d88 ≈ 25.6), not the O(100s) the
+// per-48-games divisor would give.
+func TestBucketWeights_RealLifeComposite(t *testing.T) {
+	pl := mkPlayer(1, 3, slotPG, 48)
+	pl.RealLifeMIN = 2400 // ~34 min/game over 70 games
+	pl.RealLifeFGA = 1280 // d88 = 1280/2400*48 = 25.6
+	pl.RealLifeORB = 160  // db8 = 160/2400*48  = 3.2
+	pl.RealLifeFTA = 320  // d70 = 320/2400*48  = 6.4 (×1.0)
+	p := oc(slotPG, pl)
+
+	d88 := per48Min(1280, 2400)
+	db8 := per48Min(160, 2400)
+	d70 := per48Min(320, 2400) * d70LeagueScalar
+	makeShare := (d88/(db8+d88))*d90MakeShareHalf + d90MakeShareQuarter
+	want := d88 - (d88/(d70+d88))*db8*makeShare
+
+	if got := twoPtBucketWeight(p); math.Abs(got-want) > 1e-9 {
+		t.Errorf("real-rate composite = %.6f, want %.6f", got, want)
+	}
+	if want > 50 {
+		t.Errorf("real-rate 2pt bucket = %.2f is O(100s) — the per-48-minute scale must stay O(10s)", want)
+	}
+}
+
+// Row 10: two players with IDENTICAL FGA ratings but DIFFERENT real-life FGA rates
+// produce different 2pt weights — the volume signal the compressed rating stand-in
+// flattened away (the dispersion mechanism, ADR-0040). Both also differ from the
+// rating-only stand-in.
+func TestBucketWeights_RealRateDisperses(t *testing.T) {
+	lo := mkPlayer(1, 3, slotPG, 48) // FGA rating 60
+	lo.RealLifeMIN, lo.RealLifeFGA, lo.RealLifeFTA, lo.RealLifeORB = 2400, 800, 200, 80
+	hi := mkPlayer(2, 3, slotPG, 48) // SAME FGA rating 60
+	hi.RealLifeMIN, hi.RealLifeFGA, hi.RealLifeFTA, hi.RealLifeORB = 2400, 1600, 200, 80
+
+	wLo := twoPtBucketWeight(oc(slotPG, lo))
+	wHi := twoPtBucketWeight(oc(slotPG, hi))
+	if !(wHi > wLo) {
+		t.Errorf("higher real FGA rate should give a larger 2pt weight: hi=%.4f lo=%.4f", wHi, wLo)
+	}
+
+	standin := twoPtBucketWeight(oc(slotPG, mkPlayer(3, 3, slotPG, 48))) // RealLifeMIN==0
+	if math.Abs(wLo-standin) < 1e-9 {
+		t.Errorf("real-rate weight %.4f indistinguishable from compressed stand-in %.4f", wLo, standin)
+	}
+}
+
+// Row 11 (boundary): RealLifeMIN>0 with FGA==0 ∧ ORB==0 (played, only ever shot FTs)
+// must yield a finite weight, not the 0/0 NaN the real-rate path reopens (the guard).
+// The faithful limiting value is d88 == 0.
+func TestBucketWeights_RealLifeZeroFGA(t *testing.T) {
+	pl := mkPlayer(1, 3, slotPG, 48)
+	pl.RealLifeMIN, pl.RealLifeFGA, pl.RealLifeORB, pl.RealLifeFTA = 1200, 0, 0, 300
+	got := twoPtBucketWeight(oc(slotPG, pl))
+
+	if math.IsNaN(got) || math.IsInf(got, 0) {
+		t.Fatalf("FGA==0 ∧ ORB==0 produced a non-finite weight: %v", got)
+	}
+	if got != 0 {
+		t.Errorf("zero-FGA limit = %v, want 0 (d88)", got)
+	}
+}

--- a/ibl5/docs/JSB_FILE_FORMATS.md
+++ b/ibl5/docs/JSB_FILE_FORMATS.md
@@ -1,6 +1,6 @@
 ---
 description: Jump Shot Basketball binary file format specifications.
-last_verified: 2026-06-02
+last_verified: 2026-06-03
 ---
 
 # Jump Shot Basketball (JSB) Engine File Format Specifications
@@ -122,6 +122,8 @@ Field offsets and widths below are the authoritative spec used by `classes/PlrPa
 #### Real-Life / Previous Season Stats (52-111)
 
 Backing for the JSB simulation engine's "real-life" tendencies — these are the reference stats used by the engine when simulating games, independent of the in-game season totals.
+
+**Live engine input (native Go engine).** The +0xD90 2pt-bucket composite (`engine/internal/sim/bucketweights.go`) reads `realLifeMIN/FGA/FTA/ORB` as its per-48-**minute** shot-volume rates `(stat/MIN)×48` (D88/DB8/D70) — the faithful basis on which JSB disperses team offense (ADR-0040). `realLifeMIN` (offset 56) is the divisor: per-48-**minutes**, not per-48-games — the latter is ~55× larger and collapses the foul/FTA play-outcome mix (verified against the `.sco` corpus, jumpshot 5.60's own output). `realLifeFGA` is **total** FG attempts (incl. 3PA; `realLife3GA` is the 3PA subset). The Go reader is `engine/internal/backup/plr.go` (offsets transcribed from `classes/PlrParser/PlrLineParser.php`); on the production path the same values arrive as PlrParserService's `rl_*` columns. A player with zero real-life minutes (e.g. a rookie) makes the engine fall back to a compressed rating stand-in.
 
 | Offset | Width | Field |
 |--------|-------|-------|


### PR DESCRIPTION
Replace the compressed 0-99 rating stand-ins feeding the +0xD90 Branch-A 2pt-bucket composite with the faithful per-48-minute season-volume rates (stat/MIN)×48 — the basis on which JSB 5.60 disperses team offense. The composite formula is unchanged; only its INPUTS change.

## Changes

- **plr.go**: parse the static real-life block (offsets 56/64/72/84) into RealLifeMIN/FGA/FTA/ORB. `realLifeFGA` is total FG attempts (incl. 3PA; verified FGA>=3GA across all 657 records of a real .plr) = the decompile's FGA_total, so D88 reads it directly. Branch-B's DRB/AST (88/92) deferred.
- **bundle.go**: carry the sums (`rl_*` JSON tags, 1:1 with PlrParserService for the follow-on PHP builder); auto-promoted onto onCourt via the embed.
- **assemble.go**: wire them through `toBundlePlayer` (backup/validation path).
- **bucketweights.go**: `twoPtBucketWeight` uses real rates when `RealLifeMIN>0`, else the rating stand-in (cold-start / unwired-production fallback, byte-identical to today). `d70LeagueScalar` carries D70's runtime league factor as a calibrated constant (ADR-0040 negative finding 2). NaN guard (d88<=0) for the played-but-no-FG case the real-rate path reopens.
- **JSB_FILE_FORMATS.md**: document the real-life static block offsets.

Divisor is season MINUTES, by elimination: a games-scale divisor (~75-82) drives the 2pt bucket to O(100s) and collapses the foul/FTA play-outcome mix to ~0 (verified degenerate against the .sco corpus — 5.60's own output); only a minutes-scale divisor (~2500) restores FTA/PF, and MIN (+0x14C) is the only minutes-magnitude field.

Scope: Go backup/validation path only (what PR2's calibrate instrument measures). PHP production population, Branch-B, and d70LeagueScalar corpus tuning are follow-ons.

## Tests

11 new tests: parse, decode-absent/present, wire, fallback==today, real-rate composite + O(10s) magnitude guard, dispersion, zero-FGA NaN guard. Full suite + lint green, coverage 92.6% (changed funcs 100%).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.