### PR TITLE
PR 6 — Centralize stat-formula & RecordHolders registry duplication

### DIFF
--- a/ibl5/classes/ComparePlayers/ComparePlayersView.php
+++ b/ibl5/classes/ComparePlayers/ComparePlayersView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ComparePlayers;
 
+use BasketballStats\StatsFormatter;
 use ComparePlayers\Contracts\ComparePlayersViewInterface;
 use Player\PlayerImageHelper;
 use UI\TeamCellHelper;
@@ -196,7 +197,7 @@ class ComparePlayersView implements ComparePlayersViewInterface
         $fgm = (int)$player['stats_fgm'];
         $ftm = (int)$player['stats_ftm'];
         $tgm = (int)$player['stats_3gm'];
-        $pts = 2 * $fgm + $ftm + $tgm;
+        $pts = StatsFormatter::calculatePoints($fgm, $ftm, $tgm);
 
         $posSafe = HtmlSanitizer::safeHtmlOutput($player['pos']);
         $output = '<tr>';

--- a/ibl5/classes/RecordHolders/RecordBreakingDetector.php
+++ b/ibl5/classes/RecordHolders/RecordBreakingDetector.php
@@ -25,40 +25,6 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
     private const SITE_BASE_URL = 'https://iblhoops.net';
 
     /**
-     * Player single-game stat expressions and labels.
-     *
-     * @var array<string, array{expression: string, unit: string}>
-     */
-    private const PLAYER_STATS = [
-        'points' => ['expression' => 'bs.calc_points', 'unit' => 'points'],
-        'rebounds' => ['expression' => 'bs.calc_rebounds', 'unit' => 'rebounds'],
-        'assists' => ['expression' => 'bs.game_ast', 'unit' => 'assists'],
-        'steals' => ['expression' => 'bs.game_stl', 'unit' => 'steals'],
-        'blocks' => ['expression' => 'bs.game_blk', 'unit' => 'blocks'],
-        'turnovers' => ['expression' => 'bs.game_tov', 'unit' => 'turnovers'],
-        'fg_made' => ['expression' => 'bs.calc_fg_made', 'unit' => 'field goals'],
-        'ft_made' => ['expression' => 'bs.game_ftm', 'unit' => 'free throws'],
-        '3pt_made' => ['expression' => 'bs.game_3gm', 'unit' => 'three pointers'],
-    ];
-
-    /**
-     * Team single-game stat expressions, labels, and sort directions.
-     *
-     * @var array<string, array{expression: string, unit: string, order: string}>
-     */
-    private const TEAM_STATS = [
-        'team_points' => ['expression' => 'bs.calc_points', 'unit' => 'points', 'order' => 'DESC'],
-        'team_rebounds' => ['expression' => 'bs.calc_rebounds', 'unit' => 'rebounds', 'order' => 'DESC'],
-        'team_assists' => ['expression' => 'bs.game_ast', 'unit' => 'assists', 'order' => 'DESC'],
-        'team_steals' => ['expression' => 'bs.game_stl', 'unit' => 'steals', 'order' => 'DESC'],
-        'team_blocks' => ['expression' => 'bs.game_blk', 'unit' => 'blocks', 'order' => 'DESC'],
-        'team_fg_made' => ['expression' => 'bs.calc_fg_made', 'unit' => 'field goals', 'order' => 'DESC'],
-        'team_ft_made' => ['expression' => 'bs.game_ftm', 'unit' => 'free throws', 'order' => 'DESC'],
-        'team_3pt_made' => ['expression' => 'bs.game_3gm', 'unit' => 'three pointers', 'order' => 'DESC'],
-        'team_fewest_points' => ['expression' => 'bs.calc_points', 'unit' => 'points', 'order' => 'ASC'],
-    ];
-
-    /**
      * @var array<string, string>
      */
     private const GAME_TYPE_LABELS = [
@@ -94,33 +60,56 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
             $dateFilter = $this->getDateFilterForType($gameType);
             $gameTypeLabel = self::GAME_TYPE_LABELS[$gameType] ?? 'regular season';
 
-            // Player single-game records
+            // Player single-game records — one query for all stats in the
+            // canonical registry, keyed by stat key.
             $expressions = [];
-            foreach (self::PLAYER_STATS as $key => $stat) {
-                $expressions[$key] = $stat['expression'];
+            foreach (RecordStatDefinitions::STATS as $key => $def) {
+                $expressions[$key] = $def['expression'];
             }
             $allPlayerRecords = $this->repository->getTopPlayerSingleGameBatch($expressions, $dateFilter);
 
-            foreach (self::PLAYER_STATS as $key => $stat) {
+            foreach (RecordStatDefinitions::STATS as $key => $def) {
                 $topRecords = $allPlayerRecords[$key] ?? [];
-                $newAnnouncements = $this->detectPlayerRecords($topRecords, $targetDates, $stat['unit'], $gameTypeLabel);
+                $newAnnouncements = $this->detectPlayerRecords($topRecords, $targetDates, $def['unit'], $gameTypeLabel);
                 array_push($announcements, ...$newAnnouncements);
             }
 
-            // Team single-game records
+            // Team single-game records — the 8 team stats (DESC) plus a synthetic
+            // "fewest points" (ASC) that reuses the points expression.
             /** @var array<string, array{expression: string, order: string}> $teamBatchConfig */
             $teamBatchConfig = [];
-            foreach (self::TEAM_STATS as $key => $stat) {
-                $teamBatchConfig[$key] = ['expression' => $stat['expression'], 'order' => $stat['order']];
+            foreach (RecordStatDefinitions::STATS as $def) {
+                $teamKey = $def['teamKey'];
+                if ($teamKey === null) {
+                    continue;
+                }
+                $teamBatchConfig[$teamKey] = ['expression' => $def['expression'], 'order' => 'DESC'];
             }
+            $teamBatchConfig['team_fewest_points'] = [
+                'expression' => RecordStatDefinitions::STATS['points']['expression'],
+                'order' => 'ASC',
+            ];
             $allTeamRecords = $this->repository->getTopTeamSingleGameBatch($teamBatchConfig, $dateFilter);
 
-            foreach (self::TEAM_STATS as $key => $stat) {
-                $topRecords = $allTeamRecords[$key] ?? [];
-                $isAscending = $stat['order'] === 'ASC';
-                $newAnnouncements = $this->detectTeamRecords($topRecords, $targetDates, $stat['unit'], $gameTypeLabel, $isAscending);
+            foreach (RecordStatDefinitions::STATS as $def) {
+                $teamKey = $def['teamKey'];
+                if ($teamKey === null) {
+                    continue;
+                }
+                $topRecords = $allTeamRecords[$teamKey] ?? [];
+                $newAnnouncements = $this->detectTeamRecords($topRecords, $targetDates, $def['unit'], $gameTypeLabel, false);
                 array_push($announcements, ...$newAnnouncements);
             }
+
+            $fewestRecords = $allTeamRecords['team_fewest_points'] ?? [];
+            $fewestAnnouncements = $this->detectTeamRecords(
+                $fewestRecords,
+                $targetDates,
+                RecordStatDefinitions::STATS['points']['unit'],
+                $gameTypeLabel,
+                true
+            );
+            array_push($announcements, ...$fewestAnnouncements);
         }
 
         // Quadruple doubles (not filtered by game type)
@@ -438,12 +427,7 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
      */
     private function getDateFilterForType(string $gameType): string
     {
-        $filters = [
-            'regularSeason' => 'bs.game_type = 1',
-            'playoffs' => 'bs.game_type = 2',
-            'heat' => 'bs.game_type = 3',
-        ];
-
-        return $filters[$gameType] ?? $filters['regularSeason'];
+        return RecordStatDefinitions::DATE_FILTERS[$gameType]
+            ?? RecordStatDefinitions::DATE_FILTERS['regularSeason'];
     }
 }

--- a/ibl5/classes/RecordHolders/RecordHoldersService.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersService.php
@@ -66,39 +66,6 @@ class RecordHoldersService implements RecordHoldersServiceInterface
     ];
 
     /**
-     * Stat SQL expressions for player single-game records.
-     *
-     * @var array<string, string>
-     */
-    private const PLAYER_STAT_EXPRESSIONS = [
-        'Most Points in a Single Game' => 'bs.calc_points',
-        'Most Rebounds in a Single Game' => 'bs.calc_rebounds',
-        'Most Assists in a Single Game' => 'bs.game_ast',
-        'Most Steals in a Single Game' => 'bs.game_stl',
-        'Most Blocks in a Single Game' => 'bs.game_blk',
-        'Most Turnovers in a Single Game' => 'bs.game_tov',
-        'Most Field Goals in a Single Game' => 'bs.calc_fg_made',
-        'Most Free Throws in a Single Game' => 'bs.game_ftm',
-        'Most Three Pointers in a Single Game' => 'bs.game_3gm',
-    ];
-
-    /**
-     * Stat SQL expressions for team single-game records.
-     *
-     * @var array<string, string>
-     */
-    private const TEAM_STAT_EXPRESSIONS = [
-        'Most Points in a Single Game' => 'bs.calc_points',
-        'Most Rebounds in a Single Game' => 'bs.calc_rebounds',
-        'Most Assists in a Single Game' => 'bs.game_ast',
-        'Most Steals in a Single Game' => 'bs.game_stl',
-        'Most Blocks in a Single Game' => 'bs.game_blk',
-        'Most Field Goals in a Single Game' => 'bs.calc_fg_made',
-        'Most Free Throws in a Single Game' => 'bs.game_ftm',
-        'Most Three Pointers in a Single Game' => 'bs.game_3gm',
-    ];
-
-    /**
      * Full-season stat columns in ibl_hist and the games column to divide by.
      *
      * @var array<string, array{statColumn: string, gamesColumn: string}>
@@ -109,21 +76,6 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         'Highest Assist Average in a Regular Season' => ['statColumn' => 'ast', 'gamesColumn' => 'games'],
         'Highest Steals Average in a Regular Season' => ['statColumn' => 'stl', 'gamesColumn' => 'games'],
         'Highest Blocks Average in a Regular Season' => ['statColumn' => 'blk', 'gamesColumn' => 'games'],
-    ];
-
-    /**
-     * Date filters for game types.
-     *
-     * Regular season: Nov-May (months 11,12,1,2,3,4,5)
-     * Playoffs: June (month 6)
-     * HEAT: October (month 10)
-     *
-     * @var array<string, string>
-     */
-    private const DATE_FILTERS = [
-        'regularSeason' => 'bs.game_type = 1',
-        'playoffs' => 'bs.game_type = 2',
-        'heat' => 'bs.game_type = 3',
     ];
 
     public function __construct(RecordHoldersRepositoryInterface $repository)
@@ -161,9 +113,9 @@ class RecordHoldersService implements RecordHoldersServiceInterface
      */
     private function getPlayerSingleGameRecords(string $gameType): array
     {
-        $dateFilter = self::DATE_FILTERS[$gameType] ?? self::DATE_FILTERS['regularSeason'];
+        $dateFilter = RecordStatDefinitions::DATE_FILTERS[$gameType] ?? RecordStatDefinitions::DATE_FILTERS['regularSeason'];
 
-        $batchResults = $this->repository->getTopPlayerSingleGameBatch(self::PLAYER_STAT_EXPRESSIONS, $dateFilter);
+        $batchResults = $this->repository->getTopPlayerSingleGameBatch(self::playerStatExpressions(), $dateFilter);
 
         $records = [];
         foreach ($batchResults as $category => $dbRecords) {
@@ -318,12 +270,12 @@ class RecordHoldersService implements RecordHoldersServiceInterface
     private function getTeamGameRecords(): array
     {
         $records = [];
-        $dateFilter = self::DATE_FILTERS['regularSeason'];
+        $dateFilter = RecordStatDefinitions::DATE_FILTERS['regularSeason'];
 
         // Build batch config for all team stats (8 DESC + 1 ASC = 9 queries → 1)
         /** @var array<string, array{expression: string, order: string}> $batchConfig */
         $batchConfig = [];
-        foreach (self::TEAM_STAT_EXPRESSIONS as $category => $expression) {
+        foreach (self::teamStatExpressions() as $category => $expression) {
             $batchConfig[$category] = ['expression' => $expression, 'order' => 'DESC'];
         }
         $batchConfig['Fewest Points in a Single Game'] = [
@@ -610,6 +562,42 @@ class RecordHoldersService implements RecordHoldersServiceInterface
     private static function teamAbbreviationByName(string $teamName): string
     {
         return self::teamAbbreviation(self::teamIdByName($teamName));
+    }
+
+    /**
+     * Player single-game stat expressions, keyed by record label (all 9 stats).
+     *
+     * Mapped from the canonical RecordStatDefinitions registry.
+     *
+     * @return array<string, string>
+     */
+    private static function playerStatExpressions(): array
+    {
+        $map = [];
+        foreach (RecordStatDefinitions::STATS as $def) {
+            $map[$def['recordLabel']] = $def['expression'];
+        }
+        return $map;
+    }
+
+    /**
+     * Team single-game stat expressions, keyed by record label (the 8-stat team
+     * subset — turnovers excluded).
+     *
+     * Mapped from the canonical RecordStatDefinitions registry.
+     *
+     * @return array<string, string>
+     */
+    private static function teamStatExpressions(): array
+    {
+        $map = [];
+        foreach (RecordStatDefinitions::STATS as $def) {
+            if ($def['teamKey'] === null) {
+                continue;
+            }
+            $map[$def['recordLabel']] = $def['expression'];
+        }
+        return $map;
     }
 
     /**

--- a/ibl5/classes/RecordHolders/RecordStatDefinitions.php
+++ b/ibl5/classes/RecordHolders/RecordStatDefinitions.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RecordHolders;
+
+/**
+ * RecordStatDefinitions - Canonical source for record-holder stat definitions.
+ *
+ * Both RecordHoldersService and RecordBreakingDetector previously declared the
+ * same player/team single-game SQL stat expressions and the same
+ * {regularSeason, playoffs, heat} → game_type date filters, in different shapes
+ * (RecordHoldersService uses `recordLabel => expression`; RecordBreakingDetector
+ * uses `key => [expression, unit, ...]`). This class is the single definition
+ * both consumers map from, so the SQL expressions, display units, record labels,
+ * and date filters live in exactly one place.
+ *
+ * The two consumers keep their distinct array shapes — only the source of the
+ * literals is centralized.
+ */
+final class RecordStatDefinitions
+{
+    /**
+     * Ordered canonical stat definitions, keyed by the RecordBreakingDetector
+     * player-stat key. Iteration order is significant: both consumers rely on it
+     * to reproduce their existing array ordering.
+     *
+     * Per-entry fields:
+     * - `teamKey`:     RecordBreakingDetector team-stat key, or null for a
+     *                  player-only stat (turnovers). A non-null `teamKey` also
+     *                  marks membership in the 8-stat team subset.
+     * - `expression`:  SQL expression (a box-score column or a precomputed
+     *                  `bs.calc_*` value).
+     * - `unit`:        plural display noun used in record announcements.
+     * - `recordLabel`: RecordHoldersService category label.
+     */
+    public const STATS = [
+        'points'    => ['teamKey' => 'team_points',   'expression' => 'bs.calc_points',   'unit' => 'points',         'recordLabel' => 'Most Points in a Single Game'],
+        'rebounds'  => ['teamKey' => 'team_rebounds', 'expression' => 'bs.calc_rebounds', 'unit' => 'rebounds',       'recordLabel' => 'Most Rebounds in a Single Game'],
+        'assists'   => ['teamKey' => 'team_assists',  'expression' => 'bs.game_ast',      'unit' => 'assists',        'recordLabel' => 'Most Assists in a Single Game'],
+        'steals'    => ['teamKey' => 'team_steals',   'expression' => 'bs.game_stl',      'unit' => 'steals',         'recordLabel' => 'Most Steals in a Single Game'],
+        'blocks'    => ['teamKey' => 'team_blocks',   'expression' => 'bs.game_blk',      'unit' => 'blocks',         'recordLabel' => 'Most Blocks in a Single Game'],
+        'turnovers' => ['teamKey' => null,            'expression' => 'bs.game_tov',      'unit' => 'turnovers',      'recordLabel' => 'Most Turnovers in a Single Game'],
+        'fg_made'   => ['teamKey' => 'team_fg_made',  'expression' => 'bs.calc_fg_made',  'unit' => 'field goals',    'recordLabel' => 'Most Field Goals in a Single Game'],
+        'ft_made'   => ['teamKey' => 'team_ft_made',  'expression' => 'bs.game_ftm',      'unit' => 'free throws',    'recordLabel' => 'Most Free Throws in a Single Game'],
+        '3pt_made'  => ['teamKey' => 'team_3pt_made', 'expression' => 'bs.game_3gm',      'unit' => 'three pointers', 'recordLabel' => 'Most Three Pointers in a Single Game'],
+    ];
+
+    /**
+     * SQL WHERE-clause fragments selecting each game type by box-score game_type.
+     *
+     * Regular season = 1, Playoffs = 2, HEAT = 3.
+     */
+    public const DATE_FILTERS = [
+        'regularSeason' => 'bs.game_type = 1',
+        'playoffs'      => 'bs.game_type = 2',
+        'heat'          => 'bs.game_type = 3',
+    ];
+}

--- a/ibl5/classes/SeasonHighs/SeasonHighsService.php
+++ b/ibl5/classes/SeasonHighs/SeasonHighsService.php
@@ -27,6 +27,12 @@ class SeasonHighsService implements SeasonHighsServiceInterface
     /**
      * Stat definitions with SQL expressions and display names.
      *
+     * The POINTS expression computes the same total-points quantity as the
+     * canonical PHP helper BasketballStats\StatsFormatter::calculatePoints();
+     * it is decomposed here as 2*2gm + ftm + 3*3gm because the box-score columns
+     * split 2-pointers (`game_2gm`) and 3-pointers (`game_3gm`). SQL-side copy —
+     * keep in sync with the canonical definition.
+     *
      * @var array<string, string>
      */
     private const STATS = [
@@ -43,6 +49,9 @@ class SeasonHighsService implements SeasonHighsServiceInterface
 
     /**
      * Stats used for home/away highs (no TURNOVERS — RCB doesn't track it).
+     *
+     * POINTS mirrors BasketballStats\StatsFormatter::calculatePoints() (SQL-side
+     * copy; see the STATS docblock above for the 2pt/3pt decomposition rationale).
      *
      * @var array<string, string>
      */

--- a/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsRepository.php
+++ b/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsRepository.php
@@ -110,6 +110,10 @@ class SeasonLeaderboardsRepository extends \BaseMysqliRepository implements Seas
      */
     private function getSortColumn(string $sortBy): string
     {
+        // The points sub-expression `2*fgm+ftm+tgm` (PPG and QA below) mirrors the
+        // canonical PHP definition in BasketballStats\StatsFormatter::calculatePoints().
+        // It is duplicated here only because ORDER BY runs SQL-side, where that PHP
+        // helper cannot be called; keep the two in sync.
         $sortMap = [
             'PPG' => '((2*`fgm`+`ftm`+`tgm`)/`games`)',
             'REB' => '((`reb`)/`games`)',

--- a/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsService.php
+++ b/ibl5/classes/SeasonLeaderboards/SeasonLeaderboardsService.php
@@ -254,7 +254,7 @@ class SeasonLeaderboardsService implements SeasonLeaderboardsServiceInterface
         $tga = $row['tga'];
 
         return match ($sortBy) {
-            'PPG' => (2 * $fgm + $ftm + $tgm) / $games,
+            'PPG' => StatsFormatter::calculatePoints($fgm, $ftm, $tgm) / $games,
             'REB' => $row['reb'] / $games,
             'OREB' => $row['orb'] / $games,
             'DREB' => ($row['reb'] - $row['orb']) / $games,
@@ -275,7 +275,7 @@ class SeasonLeaderboardsService implements SeasonLeaderboardsServiceInterface
             'TGP' => $tga > 0 ? $tgm / $tga : 0.0,
             'GAMES' => $games,
             'MIN' => $row['minutes'] / $games,
-            default => (2 * $fgm + $ftm + $tgm) / $games,
+            default => StatsFormatter::calculatePoints($fgm, $ftm, $tgm) / $games,
         };
     }
 
@@ -290,7 +290,7 @@ class SeasonLeaderboardsService implements SeasonLeaderboardsServiceInterface
         $fta = $row['fta'];
         $tgm = $row['tgm'];
 
-        $pts = 2 * $fgm + $ftm + $tgm;
+        $pts = StatsFormatter::calculatePoints($fgm, $ftm, $tgm);
         $positive = $pts + $row['reb'] + (2 * $row['ast']) + (2 * $row['stl']) + (2 * $row['blk']);
         $negative = ($fga - $fgm) + ($fta - $ftm) + $row['tvr'] + $row['pf'];
 

--- a/ibl5/tests/BasketballStats/StatsFormatterTest.php
+++ b/ibl5/tests/BasketballStats/StatsFormatterTest.php
@@ -93,10 +93,14 @@ final class StatsFormatterTest extends TestCase
         
         // Test with zeros
         $this->assertSame(0, StatsFormatter::calculatePoints(0, 0, 0));
-        
+
         // Test with nulls
         $this->assertSame(20, StatsFormatter::calculatePoints(10, null, null));
         $this->assertSame(5, StatsFormatter::calculatePoints(null, 5, null));
+
+        // Boundary: a fully null/empty stat line yields 0 points — this is the
+        // behavior the inlined `2*fgm+ftm+tgm` copies relied on (null-coalesced).
+        $this->assertSame(0, StatsFormatter::calculatePoints(null, null, null));
     }
 
     public function testSafeDivide(): void

--- a/ibl5/tests/RecordHolders/RecordBreakingDetectorTest.php
+++ b/ibl5/tests/RecordHolders/RecordBreakingDetectorTest.php
@@ -328,6 +328,96 @@ final class RecordBreakingDetectorTest extends TestCase
         $this->assertEmpty($result);
     }
 
+    // --- Canonical stat-definition characterization ---
+
+    /**
+     * Characterization (single-source guard): the exact player stat-expression
+     * map and the per-game-type date filters this detector hands to the
+     * repository. Captures live arguments so the assertion is byte-identical to
+     * what the SQL layer receives — the values the RecordStatDefinitions
+     * refactor must preserve.
+     */
+    public function testProducesCanonicalPlayerExpressionsAndDateFilters(): void
+    {
+        /** @var list<array<string, string>> $playerExpressionCalls */
+        $playerExpressionCalls = [];
+        /** @var list<string> $playerDateFilters */
+        $playerDateFilters = [];
+
+        $this->mockRepository->method('getTopPlayerSingleGameBatch')
+            ->willReturnCallback(
+                function (array $expressions, string $dateFilter) use (&$playerExpressionCalls, &$playerDateFilters): array {
+                    $playerExpressionCalls[] = $expressions;
+                    $playerDateFilters[] = $dateFilter;
+                    return $this->buildPlayerBatchResult([]);
+                }
+            );
+        $this->mockRepository->method('getTopTeamSingleGameBatch')->willReturn($this->buildTeamBatchResult([]));
+        $this->mockRepository->method('getQuadrupleDoubles')->willReturn([]);
+
+        // One date per game type: regular season (Jan), playoffs (Jun), HEAT (Oct).
+        $this->detector->detectAndAnnounce(['2007-01-15', '2007-06-15', '2006-10-10']);
+
+        $expectedExpressions = [
+            'points' => 'bs.calc_points',
+            'rebounds' => 'bs.calc_rebounds',
+            'assists' => 'bs.game_ast',
+            'steals' => 'bs.game_stl',
+            'blocks' => 'bs.game_blk',
+            'turnovers' => 'bs.game_tov',
+            'fg_made' => 'bs.calc_fg_made',
+            'ft_made' => 'bs.game_ftm',
+            '3pt_made' => 'bs.game_3gm',
+        ];
+
+        $this->assertCount(3, $playerExpressionCalls);
+        foreach ($playerExpressionCalls as $expressions) {
+            $this->assertSame($expectedExpressions, $expressions);
+        }
+
+        $uniqueFilters = array_values(array_unique($playerDateFilters));
+        sort($uniqueFilters);
+        $this->assertSame(['bs.game_type = 1', 'bs.game_type = 2', 'bs.game_type = 3'], $uniqueFilters);
+    }
+
+    /**
+     * Characterization (single-source guard): the exact team batch config
+     * (8 DESC stats + ASC "team_fewest_points") this detector hands to the
+     * repository, including sort order per stat.
+     */
+    public function testProducesCanonicalTeamBatchConfig(): void
+    {
+        /** @var list<array<string, array{expression: string, order: string}>> $teamConfigs */
+        $teamConfigs = [];
+
+        $this->mockRepository->method('getTopTeamSingleGameBatch')
+            ->willReturnCallback(
+                function (array $config, string $dateFilter) use (&$teamConfigs): array {
+                    $teamConfigs[] = $config;
+                    return $this->buildTeamBatchResult([]);
+                }
+            );
+        $this->mockRepository->method('getTopPlayerSingleGameBatch')->willReturn($this->buildPlayerBatchResult([]));
+        $this->mockRepository->method('getQuadrupleDoubles')->willReturn([]);
+
+        $this->detector->detectAndAnnounce(['2007-01-15']);
+
+        $expectedConfig = [
+            'team_points' => ['expression' => 'bs.calc_points', 'order' => 'DESC'],
+            'team_rebounds' => ['expression' => 'bs.calc_rebounds', 'order' => 'DESC'],
+            'team_assists' => ['expression' => 'bs.game_ast', 'order' => 'DESC'],
+            'team_steals' => ['expression' => 'bs.game_stl', 'order' => 'DESC'],
+            'team_blocks' => ['expression' => 'bs.game_blk', 'order' => 'DESC'],
+            'team_fg_made' => ['expression' => 'bs.calc_fg_made', 'order' => 'DESC'],
+            'team_ft_made' => ['expression' => 'bs.game_ftm', 'order' => 'DESC'],
+            'team_3pt_made' => ['expression' => 'bs.game_3gm', 'order' => 'DESC'],
+            'team_fewest_points' => ['expression' => 'bs.calc_points', 'order' => 'ASC'],
+        ];
+
+        $this->assertCount(1, $teamConfigs);
+        $this->assertSame($expectedConfig, $teamConfigs[0]);
+    }
+
     // --- Helper methods ---
 
     /**

--- a/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
+++ b/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
@@ -50,6 +50,102 @@ final class RecordHoldersServiceTest extends TestCase
         $this->assertCount(9, $regSeason);
     }
 
+    /**
+     * Characterization (single-source guard): the exact player stat-expression
+     * map and the per-game-type date filters this service hands to the
+     * repository. Captures the live arguments so the assertion is byte-identical
+     * to what the SQL layer receives — the values the RecordStatDefinitions
+     * refactor must preserve.
+     */
+    public function testProducesCanonicalPlayerExpressionsAndDateFilters(): void
+    {
+        /** @var list<array<string, string>> $playerExpressionCalls */
+        $playerExpressionCalls = [];
+        /** @var list<string> $playerDateFilters */
+        $playerDateFilters = [];
+
+        $this->mockRepository->method('getTopPlayerSingleGameBatch')
+            ->willReturnCallback(
+                function (array $expressions, string $dateFilter) use (&$playerExpressionCalls, &$playerDateFilters): array {
+                    $playerExpressionCalls[] = $expressions;
+                    $playerDateFilters[] = $dateFilter;
+                    return $this->buildBatchPlayerResult([]);
+                }
+            );
+        $this->configureOtherMocksEmpty();
+
+        $this->service->getAllRecords();
+
+        $expectedExpressions = [
+            'Most Points in a Single Game' => 'bs.calc_points',
+            'Most Rebounds in a Single Game' => 'bs.calc_rebounds',
+            'Most Assists in a Single Game' => 'bs.game_ast',
+            'Most Steals in a Single Game' => 'bs.game_stl',
+            'Most Blocks in a Single Game' => 'bs.game_blk',
+            'Most Turnovers in a Single Game' => 'bs.game_tov',
+            'Most Field Goals in a Single Game' => 'bs.calc_fg_made',
+            'Most Free Throws in a Single Game' => 'bs.game_ftm',
+            'Most Three Pointers in a Single Game' => 'bs.game_3gm',
+        ];
+
+        // Called once per game type: regularSeason, playoffs, heat (in that order).
+        $this->assertCount(3, $playerExpressionCalls);
+        foreach ($playerExpressionCalls as $expressions) {
+            $this->assertSame($expectedExpressions, $expressions);
+        }
+        $this->assertSame(['bs.game_type = 1', 'bs.game_type = 2', 'bs.game_type = 3'], $playerDateFilters);
+    }
+
+    /**
+     * Characterization (single-source guard): the exact team batch config
+     * (8 DESC stats + inline ASC "Fewest Points") and the regular-season date
+     * filter the service hands to the repository.
+     */
+    public function testProducesCanonicalTeamBatchConfig(): void
+    {
+        /** @var array<string, array{expression: string, order: string}>|null $teamConfig */
+        $teamConfig = null;
+        /** @var string|null $teamDateFilter */
+        $teamDateFilter = null;
+
+        $this->mockRepository->method('getTopTeamSingleGameBatch')
+            ->willReturnCallback(
+                function (array $config, string $dateFilter) use (&$teamConfig, &$teamDateFilter): array {
+                    $teamConfig = $config;
+                    $teamDateFilter = $dateFilter;
+                    return $this->buildBatchTeamResult([]);
+                }
+            );
+        $this->mockRepository->method('getTopPlayerSingleGameBatch')->willReturn($this->buildBatchPlayerResult([]));
+        $this->mockRepository->method('getTopSeasonAverageBatch')->willReturn($this->buildBatchSeasonResult([]));
+        $this->mockRepository->method('getQuadrupleDoubles')->willReturn([]);
+        $this->mockRepository->method('getMostAllStarAppearances')->willReturn([]);
+        $this->mockRepository->method('getTopTeamHalfScore')->willReturn([]);
+        $this->mockRepository->method('getLargestMarginOfVictory')->willReturn([]);
+        $this->mockRepository->method('getBestWorstSeasonRecord')->willReturn([]);
+        $this->mockRepository->method('getLongestStreak')->willReturn([]);
+        $this->mockRepository->method('getBestWorstSeasonStart')->willReturn([]);
+        $this->mockRepository->method('getMostPlayoffAppearances')->willReturn([]);
+        $this->mockRepository->method('getMostTitlesByType')->willReturn([]);
+
+        $this->service->getAllRecords();
+
+        $expectedConfig = [
+            'Most Points in a Single Game' => ['expression' => 'bs.calc_points', 'order' => 'DESC'],
+            'Most Rebounds in a Single Game' => ['expression' => 'bs.calc_rebounds', 'order' => 'DESC'],
+            'Most Assists in a Single Game' => ['expression' => 'bs.game_ast', 'order' => 'DESC'],
+            'Most Steals in a Single Game' => ['expression' => 'bs.game_stl', 'order' => 'DESC'],
+            'Most Blocks in a Single Game' => ['expression' => 'bs.game_blk', 'order' => 'DESC'],
+            'Most Field Goals in a Single Game' => ['expression' => 'bs.calc_fg_made', 'order' => 'DESC'],
+            'Most Free Throws in a Single Game' => ['expression' => 'bs.game_ftm', 'order' => 'DESC'],
+            'Most Three Pointers in a Single Game' => ['expression' => 'bs.game_3gm', 'order' => 'DESC'],
+            'Fewest Points in a Single Game' => ['expression' => 'bs.calc_points', 'order' => 'ASC'],
+        ];
+
+        $this->assertSame($expectedConfig, $teamConfig);
+        $this->assertSame('bs.game_type = 1', $teamDateFilter);
+    }
+
     public function testFormatsPlayerRecordCorrectly(): void
     {
         $playerRecord = [

--- a/ibl5/tests/RecordHolders/RecordStatDefinitionsTest.php
+++ b/ibl5/tests/RecordHolders/RecordStatDefinitionsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\RecordHolders;
+
+use PHPUnit\Framework\TestCase;
+use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
+use RecordHolders\RecordBreakingDetector;
+use RecordHolders\RecordHoldersService;
+use RecordHolders\RecordStatDefinitions;
+
+final class RecordStatDefinitionsTest extends TestCase
+{
+    /**
+     * Locks the canonical registry exactly — every field (teamKey, expression,
+     * unit, recordLabel) and the iteration order both consumers depend on.
+     */
+    public function testStatsRegistryIsTheCanonicalDefinition(): void
+    {
+        $expected = [
+            'points'    => ['teamKey' => 'team_points',   'expression' => 'bs.calc_points',   'unit' => 'points',         'recordLabel' => 'Most Points in a Single Game'],
+            'rebounds'  => ['teamKey' => 'team_rebounds', 'expression' => 'bs.calc_rebounds', 'unit' => 'rebounds',       'recordLabel' => 'Most Rebounds in a Single Game'],
+            'assists'   => ['teamKey' => 'team_assists',  'expression' => 'bs.game_ast',      'unit' => 'assists',        'recordLabel' => 'Most Assists in a Single Game'],
+            'steals'    => ['teamKey' => 'team_steals',   'expression' => 'bs.game_stl',      'unit' => 'steals',         'recordLabel' => 'Most Steals in a Single Game'],
+            'blocks'    => ['teamKey' => 'team_blocks',   'expression' => 'bs.game_blk',      'unit' => 'blocks',         'recordLabel' => 'Most Blocks in a Single Game'],
+            'turnovers' => ['teamKey' => null,            'expression' => 'bs.game_tov',      'unit' => 'turnovers',      'recordLabel' => 'Most Turnovers in a Single Game'],
+            'fg_made'   => ['teamKey' => 'team_fg_made',  'expression' => 'bs.calc_fg_made',  'unit' => 'field goals',    'recordLabel' => 'Most Field Goals in a Single Game'],
+            'ft_made'   => ['teamKey' => 'team_ft_made',  'expression' => 'bs.game_ftm',      'unit' => 'free throws',    'recordLabel' => 'Most Free Throws in a Single Game'],
+            '3pt_made'  => ['teamKey' => 'team_3pt_made', 'expression' => 'bs.game_3gm',      'unit' => 'three pointers', 'recordLabel' => 'Most Three Pointers in a Single Game'],
+        ];
+
+        $this->assertSame($expected, RecordStatDefinitions::STATS);
+    }
+
+    public function testTurnoversIsTheOnlyPlayerOnlyStat(): void
+    {
+        $playerOnly = array_keys(array_filter(
+            RecordStatDefinitions::STATS,
+            static fn (array $def): bool => $def['teamKey'] === null
+        ));
+
+        $this->assertSame(['turnovers'], $playerOnly);
+    }
+
+    public function testDateFiltersMapGameTypesToBoxScoreGameType(): void
+    {
+        $this->assertSame([
+            'regularSeason' => 'bs.game_type = 1',
+            'playoffs'      => 'bs.game_type = 2',
+            'heat'          => 'bs.game_type = 3',
+        ], RecordStatDefinitions::DATE_FILTERS);
+    }
+
+    // --- Single-source propagation guards ---
+    //
+    // Expected maps are DERIVED from RecordStatDefinitions::STATS, not
+    // re-hardcoded. If a registry expression changes, the derived expectation
+    // changes with it — and these tests fail unless the consumer also tracks the
+    // registry. That is what proves both consumers share one source.
+
+    public function testServiceDerivesPlayerExpressionsFromRegistry(): void
+    {
+        $expected = [];
+        foreach (RecordStatDefinitions::STATS as $def) {
+            $expected[$def['recordLabel']] = $def['expression'];
+        }
+
+        /** @var array<string, string>|null $captured */
+        $captured = null;
+        $repo = self::createStub(RecordHoldersRepositoryInterface::class);
+        $repo->method('getTopPlayerSingleGameBatch')
+            ->willReturnCallback(function (array $expressions) use (&$captured): array {
+                $captured ??= $expressions;
+                return [];
+            });
+        $service = new RecordHoldersService($repo);
+
+        $service->getAllRecords();
+
+        $this->assertSame($expected, $captured);
+    }
+
+    public function testDetectorDerivesPlayerExpressionsFromRegistry(): void
+    {
+        $expected = [];
+        foreach (RecordStatDefinitions::STATS as $key => $def) {
+            $expected[$key] = $def['expression'];
+        }
+
+        /** @var array<string, string>|null $captured */
+        $captured = null;
+        $repo = self::createStub(RecordHoldersRepositoryInterface::class);
+        $repo->method('getTopPlayerSingleGameBatch')
+            ->willReturnCallback(function (array $expressions) use (&$captured): array {
+                $captured ??= $expressions;
+                return [];
+            });
+        $detector = new RecordBreakingDetector($repo);
+
+        $detector->detectAndAnnounce(['2007-01-15']);
+
+        $this->assertSame($expected, $captured);
+    }
+}

--- a/ibl5/tests/RecordHolders/RecordStatDefinitionsTest.php
+++ b/ibl5/tests/RecordHolders/RecordStatDefinitionsTest.php
@@ -30,6 +30,7 @@ final class RecordStatDefinitionsTest extends TestCase
             '3pt_made'  => ['teamKey' => 'team_3pt_made', 'expression' => 'bs.game_3gm',      'unit' => 'three pointers', 'recordLabel' => 'Most Three Pointers in a Single Game'],
         ];
 
+        // @phpstan-ignore method.alreadyNarrowedType (const value is statically known; assertion still guards against future edits)
         $this->assertSame($expected, RecordStatDefinitions::STATS);
     }
 
@@ -45,6 +46,7 @@ final class RecordStatDefinitionsTest extends TestCase
 
     public function testDateFiltersMapGameTypesToBoxScoreGameType(): void
     {
+        // @phpstan-ignore method.alreadyNarrowedType (const value is statically known; assertion still guards against future edits)
         $this->assertSame([
             'regularSeason' => 'bs.game_type = 1',
             'playoffs'      => 'bs.game_type = 2',

--- a/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsServiceTest.php
+++ b/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsServiceTest.php
@@ -177,16 +177,43 @@ final class SeasonLeaderboardsServiceTest extends TestCase
     }
 
     /**
+     * Characterization: PPG sorts by points-PER-GAME, not raw points. Games
+     * differ per player so the ordering distinguishes pts/games from any other
+     * combination of the two operands (guards the division in the PPG arm).
+     */
+    public function testSortsByPpgPerGameWithVaryingGames(): void
+    {
+        $service = $this->buildServiceWithRows([
+            // pts=1000, games=100 -> 10.0 ppg
+            $this->createRow(1, 'Volume', 2024, 1, 100, 1000, fgm: 500),
+            // pts=600,  games=20  -> 30.0 ppg (fewest points, fewest games, best rate)
+            $this->createRow(2, 'Efficient', 2024, 2, 20, 200, fgm: 300),
+            // pts=800,  games=40  -> 20.0 ppg
+            $this->createRow(3, 'Middle', 2024, 3, 40, 400, fgm: 400),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'PPG']);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(3, $result['results'][1]['pid']);
+        $this->assertSame(1, $result['results'][2]['pid']);
+    }
+
+    /**
      * Characterization: an unrecognized sort key falls through the match's
-     * default arm, which sorts by the inline points-per-game formula
-     * (2*fgm + ftm + tgm) / games — identical to PPG.
+     * default arm, which sorts by the points-per-game formula
+     * calculatePoints(fgm, ftm, tgm) / games — identical to PPG. Games differ
+     * per player so the assertion pins the division (not raw points).
      */
     public function testUnknownSortKeyFallsBackToPpgFormula(): void
     {
         $service = $this->buildServiceWithRows([
-            $this->createRow(1, 'Low', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
-            $this->createRow(2, 'High', 2024, 2, 80, 800, fgm: 500, ftm: 200, tgm: 100),
-            $this->createRow(3, 'Mid', 2024, 3, 80, 800, fgm: 350, ftm: 150, tgm: 75),
+            // pts=1000, games=100 -> 10.0 ppg
+            $this->createRow(1, 'Volume', 2024, 1, 100, 1000, fgm: 500),
+            // pts=600,  games=20  -> 30.0 ppg
+            $this->createRow(2, 'Efficient', 2024, 2, 20, 200, fgm: 300),
+            // pts=800,  games=40  -> 20.0 ppg
+            $this->createRow(3, 'Middle', 2024, 3, 40, 400, fgm: 400),
         ]);
 
         $result = $service->getFilteredLeaderboard(['sortby' => 'NOT_A_REAL_STAT']);

--- a/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsServiceTest.php
+++ b/ibl5/tests/SeasonLeaderboards/SeasonLeaderboardsServiceTest.php
@@ -155,6 +155,47 @@ final class SeasonLeaderboardsServiceTest extends TestCase
         $this->assertSame(2, $result['results'][0]['pid']);
     }
 
+    /**
+     * Characterization: QA sort order is driven by the inline points term
+     * (2*fgm + ftm + tgm) inside the QA-per-game computation. Negative/positive
+     * QA terms are neutralized (fga=fgm, fta=ftm, all other counting stats 0)
+     * so ordering reflects the points formula alone.
+     */
+    public function testSortsByQualityAssessmentDesc(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Low QA', 2024, 1, 80, 800, fgm: 200, fga: 200, ftm: 100, fta: 100, tgm: 50),
+            $this->createRow(2, 'High QA', 2024, 2, 80, 800, fgm: 500, fga: 500, ftm: 200, fta: 200, tgm: 100),
+            $this->createRow(3, 'Mid QA', 2024, 3, 80, 800, fgm: 350, fga: 350, ftm: 150, fta: 150, tgm: 75),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'QA']);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(3, $result['results'][1]['pid']);
+        $this->assertSame(1, $result['results'][2]['pid']);
+    }
+
+    /**
+     * Characterization: an unrecognized sort key falls through the match's
+     * default arm, which sorts by the inline points-per-game formula
+     * (2*fgm + ftm + tgm) / games — identical to PPG.
+     */
+    public function testUnknownSortKeyFallsBackToPpgFormula(): void
+    {
+        $service = $this->buildServiceWithRows([
+            $this->createRow(1, 'Low', 2024, 1, 80, 800, fgm: 200, ftm: 100, tgm: 50),
+            $this->createRow(2, 'High', 2024, 2, 80, 800, fgm: 500, ftm: 200, tgm: 100),
+            $this->createRow(3, 'Mid', 2024, 3, 80, 800, fgm: 350, ftm: 150, tgm: 75),
+        ]);
+
+        $result = $service->getFilteredLeaderboard(['sortby' => 'NOT_A_REAL_STAT']);
+
+        $this->assertSame(2, $result['results'][0]['pid']);
+        $this->assertSame(3, $result['results'][1]['pid']);
+        $this->assertSame(1, $result['results'][2]['pid']);
+    }
+
     // --- getFilteredLeaderboard: limit tests ---
 
     public function testLimitRestrictsResultCount(): void

--- a/ibl5/tests/e2e/flows/record-holders.spec.ts
+++ b/ibl5/tests/e2e/flows/record-holders.spec.ts
@@ -35,4 +35,23 @@ test.describe('Record Holders flow', () => {
   test('no PHP errors', async ({ page }) => {
     await assertNoPhpErrors(page, 'on Record Holders page');
   });
+
+  // The five record sections render unconditionally (the card titles are emitted
+  // before any data loop in RecordHoldersView), so these assertions are
+  // independent of how sparse the CI seed's box-score data is. This confirms the
+  // page still composes after the RecordStatDefinitions query-source refactor.
+  test('all five record sections render', async ({ page }) => {
+    const sectionTitles = [
+      'Player, Regular Season (Single Game)',
+      'Player, Regular Season (Full Season) [minimum 50 games]',
+      'Player, Playoffs',
+      'Player, H.E.A.T.',
+      'Team Records',
+    ];
+    for (const title of sectionTitles) {
+      await expect(
+        page.locator('.ibl-card__title', { hasText: title }),
+      ).toBeVisible();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Two deduplication centralizations from the classes refactor audit (Tier 1 §1.5 + Tier 2 §2.4):

**(a) Points formula** — `2·fgm + ftm + 3·tgm` was inlined at 4 PHP sites in `SeasonLeaderboardsService` and `ComparePlayersView`. All are now routed through the existing `StatsFormatter::calculatePoints()`. SQL-side copies (in `SeasonLeaderboardsRepository` and `SeasonHighsService`) cannot share a PHP function; they retain inline SQL with a cross-reference docblock added.

**(b) RecordHolders registry** — `RecordHoldersService` and `RecordBreakingDetector` each declared identical 9-player + 8-team stat-expression maps and a `game_type` filter map. Extracted into `RecordStatDefinitions` value object; both consumers now build their own-shaped arrays from one source. No SQL string changes.

## Changes
- `classes/BasketballStats/StatsFormatter.php` — no change (already had `calculatePoints`)
- `classes/SeasonLeaderboards/SeasonLeaderboardsService.php` — inline points at :257, :278, :293 → `StatsFormatter::calculatePoints()`
- `classes/ComparePlayers/Views/ComparePlayersView.php` — inline points at :199 → `StatsFormatter::calculatePoints()`
- `classes/SeasonLeaderboards/SeasonLeaderboardsRepository.php` — docblock added at SQL copy
- `classes/SeasonHighs/SeasonHighsService.php` — docblock added at SQL copies
- `classes/RecordHolders/RecordStatDefinitions.php` — new value object (canonical stat maps)
- `classes/RecordHolders/RecordHoldersService.php` — maps built from `RecordStatDefinitions`
- `classes/RecordHolders/RecordBreakingDetector.php` — maps built from `RecordStatDefinitions`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.