### PR TITLE
refactor(trading): dedup contract-advancement phase predicate onto Season::advancesContractYears()

### DIFF
--- a/ibl5/classes/Season/Season.php
+++ b/ibl5/classes/Season/Season.php
@@ -172,10 +172,33 @@ class Season
      *
      * During offseason phases, salary/roster displays shift to show next season's
      * contracts instead of the current (now-expired) season's contracts.
+     *
+     * NOTE: This is a narrower set than {@see advancesContractYears()} — it
+     * deliberately EXCLUDES Playoffs. The two concepts are distinct; do not
+     * conflate them.
      */
     public function isOffseasonPhase(): bool
     {
         return $this->phase === 'Draft' || $this->phase === 'Free Agency';
+    }
+
+    /**
+     * Check if the current phase advances contract years for trade cap math.
+     *
+     * During Playoffs, Draft, and Free Agency the contract years have
+     * effectively rolled over, so trade-related calculations (roster counting,
+     * queueing, cash considerations, cash-record sums) shift to the next
+     * season's contracts.
+     *
+     * NOTE: This is a wider set than {@see isOffseasonPhase()} — it INCLUDES
+     * Playoffs, which `isOffseasonPhase()` excludes. Reusing `isOffseasonPhase()`
+     * here would silently drop Playoffs from trade cap math.
+     */
+    public function advancesContractYears(): bool
+    {
+        return $this->phase === 'Playoffs'
+            || $this->phase === 'Draft'
+            || $this->phase === 'Free Agency';
     }
 
     /**

--- a/ibl5/classes/Trading/TradeOffer.php
+++ b/ibl5/classes/Trading/TradeOffer.php
@@ -251,9 +251,7 @@ class TradeOffer implements TradeOfferInterface
 
         // Playoffs counts as offseason for trade cap math (contract years have
         // effectively rolled over), unlike the FA cap calculation.
-        $isOffseason = $this->season->phase === 'Playoffs'
-            || $this->season->phase === 'Draft'
-            || $this->season->phase === 'Free Agency';
+        $isOffseason = $this->season->advancesContractYears();
 
         return BuyoutLedgerRepository::sumCurrentSeasonSalaryFromRows($cashRecords, $isOffseason);
     }

--- a/ibl5/classes/Trading/TradeProcessor.php
+++ b/ibl5/classes/Trading/TradeProcessor.php
@@ -280,9 +280,7 @@ class TradeProcessor implements TradeProcessorInterface
      */
     protected function shouldQueueTrades(): bool
     {
-        return $this->season->phase === "Playoffs"
-            || $this->season->phase === "Draft"
-            || $this->season->phase === "Free Agency";
+        return $this->season->advancesContractYears();
     }
 
     /**

--- a/ibl5/classes/Trading/TradeValidator.php
+++ b/ibl5/classes/Trading/TradeValidator.php
@@ -99,9 +99,7 @@ class TradeValidator implements TradeValidatorInterface
         int $userPlayersSent,
         int $partnerPlayersSent
     ): array {
-        $isOffseason = $this->season->phase === "Playoffs"
-            || $this->season->phase === "Draft"
-            || $this->season->phase === "Free Agency";
+        $isOffseason = $this->season->advancesContractYears();
 
         $userCurrentRoster = $this->formRepository->getTeamPlayerCount($userTeamId, $isOffseason);
         $partnerCurrentRoster = $this->formRepository->getTeamPlayerCount($partnerTeamId, $isOffseason);
@@ -150,11 +148,7 @@ class TradeValidator implements TradeValidatorInterface
     public function getCurrentSeasonCashConsiderations(array $userSendsCash, array $partnerSendsCash): array
     {
         // If the current season phase shifts cap situations to next season, evaluate next season's cap limits.
-        if (
-            $this->season->phase === "Playoffs"
-            || $this->season->phase === "Draft"
-            || $this->season->phase === "Free Agency"
-        ) {
+        if ($this->season->advancesContractYears()) {
             $cashSentToThemThisSeason = $userSendsCash[2] ?? 0;
             $cashSentToMeThisSeason = $partnerSendsCash[2] ?? 0;
         } else {

--- a/ibl5/classes/Trading/TradingService.php
+++ b/ibl5/classes/Trading/TradingService.php
@@ -83,7 +83,7 @@ class TradingService implements TradingServiceInterface
         // Calculate cash exchange year range
         $currentSeasonEndingYear = $season->endingYear;
         $cashStartYear = 1;
-        if ($this->isOffseasonPhase($season->phase)) {
+        if ($season->advancesContractYears()) {
             $cashStartYear = 2;
         }
 
@@ -159,7 +159,7 @@ class TradingService implements TradingServiceInterface
             $contractYear = is_int($contractYearRaw) ? $contractYearRaw : 0;
 
             // Adjust contract year based on season phase
-            if ($this->isOffseasonPhase($season->phase)) {
+            if ($season->advancesContractYears()) {
                 $contractYear++;
             }
             if ($contractYear === 0) {
@@ -358,16 +358,6 @@ class TradingService implements TradingServiceInterface
     }
 
     /**
-     * Check if the season is in an offseason phase where contract years advance
-     */
-    private function isOffseasonPhase(string $phase): bool
-    {
-        return $phase === 'Playoffs'
-            || $phase === 'Draft'
-            || $phase === 'Free Agency';
-    }
-
-    /**
      * Enrich trade offers with preview data (team IDs, colors, cash amounts)
      *
      * @param array<int, array{from: string, to: string, approval: string, oppositeTeam: string, hasHammer: bool, items: list<array{type: string, description: string, notes: string|null, from: string, to: string}>, previewData: array{fromPids: list<int>, toPids: list<int>}}> $tradeOffers
@@ -386,7 +376,7 @@ class TradingService implements TradingServiceInterface
         }
 
         $cashStartYear = 1;
-        if ($this->isOffseasonPhase($season->phase)) {
+        if ($season->advancesContractYears()) {
             $cashStartYear = 2;
         }
 

--- a/ibl5/tests/SeasonTest.php
+++ b/ibl5/tests/SeasonTest.php
@@ -237,4 +237,61 @@ class SeasonTest extends \PHPUnit\Framework\TestCase
             'playoffs always blocked with No setting' => ['Playoffs', 'No', false],
         ];
     }
+
+    // --- advancesContractYears() (trade contract-advancement predicate) ---
+
+    /**
+     * The contract-advancement predicate is true for Playoffs, Draft, and Free
+     * Agency, and false for every other phase. Locks the {Playoffs, Draft, Free
+     * Agency} set — including Playoffs — for trade cap math.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('advancesContractYearsProvider')]
+    public function testAdvancesContractYears(string $phase, bool $expected): void
+    {
+        $season = new \Tests\WideUnit\Mocks\Season(self::createStub(\mysqli::class));
+        $season->phase = $phase;
+
+        $this->assertSame($expected, $season->advancesContractYears());
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function advancesContractYearsProvider(): array
+    {
+        return [
+            // Contract years advance (next-season cap math)
+            'Playoffs advances' => ['Playoffs', true],
+            'Draft advances' => ['Draft', true],
+            'Free Agency advances' => ['Free Agency', true],
+            // Negative/boundary: these phases do NOT advance contract years
+            'Preseason does not advance' => ['Preseason', false],
+            'Regular Season does not advance' => ['Regular Season', false],
+            'HEAT does not advance' => ['HEAT', false],
+        ];
+    }
+
+    /**
+     * Regression guard: advancesContractYears() must differ from
+     * isOffseasonPhase() during Playoffs. Reusing isOffseasonPhase() for trade
+     * cap math would silently drop Playoffs — the exact bug this dedup avoids.
+     */
+    public function testAdvancesContractYearsIncludesPlayoffsUnlikeIsOffseasonPhase(): void
+    {
+        $season = new \Tests\WideUnit\Mocks\Season(self::createStub(\mysqli::class));
+        $season->phase = 'Playoffs';
+
+        // Playoffs: the two predicates DISAGREE — this is the whole point.
+        $this->assertTrue($season->advancesContractYears(), 'Playoffs advances contract years');
+        $this->assertFalse($season->isOffseasonPhase(), 'Playoffs is NOT an offseason phase');
+
+        // Draft / Free Agency: the two predicates AGREE (both true).
+        $season->phase = 'Draft';
+        $this->assertTrue($season->advancesContractYears());
+        $this->assertTrue($season->isOffseasonPhase());
+
+        $season->phase = 'Free Agency';
+        $this->assertTrue($season->advancesContractYears());
+        $this->assertTrue($season->isOffseasonPhase());
+    }
 }

--- a/ibl5/tests/Trading/TradingServiceTest.php
+++ b/ibl5/tests/Trading/TradingServiceTest.php
@@ -589,7 +589,10 @@ class TradingServiceTest extends TestCase
 
     private function createSeasonStub(string $phase): Season
     {
-        $season = self::createStub(Season::class);
+        // Use the real mock Season (not a PHPUnit stub) so its phase-derived
+        // methods — e.g. advancesContractYears() — return correct values for the
+        // configured phase without re-encoding the phase set in test config.
+        $season = new \Tests\WideUnit\Mocks\Season($this->mockDb);
         $season->phase = $phase;
         $season->endingYear = 2025;
         $season->beginningYear = 2024;

--- a/ibl5/tests/WideUnit/Mocks/Season.php
+++ b/ibl5/tests/WideUnit/Mocks/Season.php
@@ -86,6 +86,18 @@ class Season
     }
 
     /**
+     * Check if the current phase advances contract years (mock implementation)
+     *
+     * @see Season::advancesContractYears()
+     */
+    public function advancesContractYears(): bool
+    {
+        return $this->phase === 'Playoffs'
+            || $this->phase === 'Draft'
+            || $this->phase === 'Free Agency';
+    }
+
+    /**
      * Check if trades are currently allowed (mock implementation)
      *
      * @see Season::areTradesAllowed()


### PR DESCRIPTION
## Summary

Introduces `Season::advancesContractYears(): bool` as the single source of truth for the `{Playoffs, Draft, Free Agency}` predicate. Removes 4 copies of inline 3-phase literal checks across `TradeValidator`, `TradeProcessor`, `TradeOffer`, and `TradingService`, plus deletes the now-redundant private `TradingService::isOffseasonPhase()` helper.

**Key semantic distinction preserved:** `advancesContractYears()` includes Playoffs; `isOffseasonPhase()` does not. The two methods have cross-referenced docblocks to prevent future conflation.

## Changes
- `classes/Season/Season.php` — adds `advancesContractYears()` beside `isOffseasonPhase()`
- `classes/Trading/TradeValidator.php` — routes roster-limit and cash-consideration paths to new method
- `classes/Trading/TradeProcessor.php` — routes queue-trades path to new method
- `classes/Trading/TradeOffer.php` — routes sum-cash-records path to new method
- `classes/Trading/TradingService.php` — deletes `isOffseasonPhase()`, routes all 3 call sites to Season method
- `tests/SeasonTest.php` — characterization + regression tests for new predicate
- `tests/Trading/TradingServiceTest.php` — updated to use real mock Season instance
- `tests/WideUnit/Mocks/Season.php` — adds `advancesContractYears()` to mock

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)
<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>