### PR TITLE
PR 7 — Inject hard-wired constructor dependencies

### DIFF
--- a/ibl5/classes/Injuries/Contracts/InjuriesRepositoryInterface.php
+++ b/ibl5/classes/Injuries/Contracts/InjuriesRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Injuries\Contracts;
+
+/**
+ * Repository interface for retrieving injured-player rows.
+ *
+ * Wraps the league-wide injured-players query so the Injuries service can be
+ * unit-tested with an injected double instead of a live database connection.
+ *
+ * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
+ */
+interface InjuriesRepositoryInterface
+{
+    /**
+     * Get all currently injured, non-retired players ordered by ordinal.
+     *
+     * @return list<PlayerRow> Injured player rows
+     */
+    public function getInjuredPlayers(): array;
+}

--- a/ibl5/classes/Injuries/InjuriesRepository.php
+++ b/ibl5/classes/Injuries/InjuriesRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Injuries;
+
+use Injuries\Contracts\InjuriesRepositoryInterface;
+use League\League;
+
+/**
+ * League-backed implementation of {@see InjuriesRepositoryInterface}.
+ *
+ * Delegates to {@see League::getInjuredPlayersResult()} so the underlying query
+ * stays in one place while {@see InjuriesService} depends only on the interface.
+ *
+ * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
+ */
+class InjuriesRepository implements InjuriesRepositoryInterface
+{
+    private League $league;
+
+    public function __construct(\mysqli $db, ?League $league = null)
+    {
+        $this->league = $league ?? new League($db);
+    }
+
+    /**
+     * @see InjuriesRepositoryInterface::getInjuredPlayers()
+     *
+     * @return list<PlayerRow>
+     */
+    public function getInjuredPlayers(): array
+    {
+        return $this->league->getInjuredPlayersResult();
+    }
+}

--- a/ibl5/classes/Injuries/InjuriesService.php
+++ b/ibl5/classes/Injuries/InjuriesService.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Injuries;
 
+use Injuries\Contracts\InjuriesRepositoryInterface;
 use Injuries\Contracts\InjuriesServiceInterface;
-use League\League;
 use Player\Player;
 use Team\Team;
 use Season\Season;
@@ -17,16 +17,17 @@ use Season\Season;
  */
 class InjuriesService implements InjuriesServiceInterface
 {
-    private League $league;
     private \mysqli $db;
+    private InjuriesRepositoryInterface $injuriesRepository;
 
     /**
-     * @param \mysqli $db Database connection
+     * @param \mysqli $db Database connection (still required for Player/Team/Season hydration)
+     * @param InjuriesRepositoryInterface|null $injuriesRepository Source of injured-player rows; defaults to the League-backed repository
      */
-    public function __construct(\mysqli $db)
+    public function __construct(\mysqli $db, ?InjuriesRepositoryInterface $injuriesRepository = null)
     {
         $this->db = $db;
-        $this->league = new League($db);
+        $this->injuriesRepository = $injuriesRepository ?? new InjuriesRepository($db);
     }
 
     /**
@@ -37,7 +38,7 @@ class InjuriesService implements InjuriesServiceInterface
         $season = new Season($this->db);
         $injuredPlayers = [];
 
-        $injuredRows = $this->league->getInjuredPlayersResult();
+        $injuredRows = $this->injuriesRepository->getInjuredPlayers();
 
         foreach ($injuredRows as $injuredPlayerRow) {
             $player = Player::withPlrRow($this->db, $injuredPlayerRow);

--- a/ibl5/classes/Team/Contracts/TeamQueryRepositoryInterface.php
+++ b/ibl5/classes/Team/Contracts/TeamQueryRepositoryInterface.php
@@ -153,9 +153,10 @@ interface TeamQueryRepositoryInterface
      * Check if team can add buyout without exceeding buyout limit
      *
      * @param int $buyoutValue Buyout value to add
+     * @param Season $season Current season (used to determine contract-year rollover)
      * @return bool True if under buyout limit, false otherwise
      */
-    public function canAddBuyoutWithoutExceedingBuyoutLimit(int $teamId, int $buyoutValue): bool;
+    public function canAddBuyoutWithoutExceedingBuyoutLimit(int $teamId, int $buyoutValue, Season $season): bool;
 
     /**
      * Convert player result array into Player objects

--- a/ibl5/classes/Team/TeamQueryRepository.php
+++ b/ibl5/classes/Team/TeamQueryRepository.php
@@ -417,9 +417,8 @@ class TeamQueryRepository extends \BaseMysqliRepository implements TeamQueryRepo
     /**
      * @see TeamQueryRepositoryInterface::canAddBuyoutWithoutExceedingBuyoutLimit()
      */
-    public function canAddBuyoutWithoutExceedingBuyoutLimit(int $teamId, int $buyoutValue): bool
+    public function canAddBuyoutWithoutExceedingBuyoutLimit(int $teamId, int $buyoutValue, Season $season): bool
     {
-        $season = new Season($this->db);
         $buyoutsResult = $this->getBuyouts($teamId);
         $totalCurrentSeasonBuyouts = BuyoutLedgerRepository::sumCurrentSeasonSalaryFromRows(
             $buyoutsResult,

--- a/ibl5/classes/Team/TeamService.php
+++ b/ibl5/classes/Team/TeamService.php
@@ -7,6 +7,7 @@ namespace Team;
 use League\League;
 use Team\Contracts\TeamServiceInterface;
 use Team\Contracts\TeamRepositoryInterface;
+use Team\Contracts\TeamQueryRepositoryInterface;
 use Team\Views\AwardsView;
 use Team\Views\BannersView;
 use Team\Views\CurrentSeasonView;
@@ -37,12 +38,21 @@ class TeamService implements TeamServiceInterface
     private \mysqli $db;
     private TeamRepositoryInterface $repository;
     private \League\LeagueContext $leagueContext;
+    private TeamQueryRepositoryInterface $teamQueryRepository;
+    private League $league;
 
-    public function __construct(\mysqli $db, TeamRepositoryInterface $repository, \League\LeagueContext $leagueContext)
-    {
+    public function __construct(
+        \mysqli $db,
+        TeamRepositoryInterface $repository,
+        \League\LeagueContext $leagueContext,
+        ?TeamQueryRepositoryInterface $teamQueryRepository = null,
+        ?League $league = null
+    ) {
         $this->db = $db;
         $this->repository = $repository;
         $this->leagueContext = $leagueContext;
+        $this->teamQueryRepository = $teamQueryRepository ?? new TeamQueryRepository($db);
+        $this->league = $league ?? new League($db);
     }
 
     /**
@@ -456,11 +466,9 @@ class TeamService implements TeamServiceInterface
      */
     private function prepareDraftPicksData(Team $team): array
     {
-        $teamQueryRepo = new TeamQueryRepository($this->db);
-        $resultPicks = $teamQueryRepo->getDraftPicks($team->teamid);
+        $resultPicks = $this->teamQueryRepository->getDraftPicks($team->teamid);
 
-        $league = new League($this->db);
-        $allTeamsResult = $league->getAllTeamsResult();
+        $allTeamsResult = $this->league->getAllTeamsResult();
 
         /** @var array<string, Team> $teamsArray */
         $teamsArray = [];

--- a/ibl5/classes/Trading/TradeOffer.php
+++ b/ibl5/classes/Trading/TradeOffer.php
@@ -44,17 +44,21 @@ class TradeOffer implements TradeOfferInterface
         TeamIdentityRepositoryInterface $commonRepository,
         string $serverName = '',
         ?TradeOfferRepositoryInterface $offerRepository = null,
-        ?TradeAssetRepositoryInterface $assetRepository = null
+        ?TradeAssetRepositoryInterface $assetRepository = null,
+        ?TradeCashRepositoryInterface $cashRepository = null,
+        ?BuyoutLedgerRepositoryInterface $cashConsiderationRepository = null,
+        ?Season $season = null,
+        ?TradeValidator $validator = null
     ) {
         $this->db = $db;
         $this->commonRepository = $commonRepository;
         $this->offerRepository = $offerRepository ?? new TradeOfferRepository($db, $serverName);
         $this->assetRepository = $assetRepository ?? new TradeAssetRepository($db);
-        $this->cashRepository = new TradeCashRepository($db);
-        $this->cashConsiderationRepository = new BuyoutLedgerRepository($db);
-        $this->season = new Season($db);
+        $this->cashRepository = $cashRepository ?? new TradeCashRepository($db);
+        $this->cashConsiderationRepository = $cashConsiderationRepository ?? new BuyoutLedgerRepository($db);
+        $this->season = $season ?? new Season($db);
         $this->cashHandler = new CashTransactionHandler($db, $this->commonRepository, $this->cashConsiderationRepository, $this->cashRepository);
-        $this->validator = new TradeValidator($db);
+        $this->validator = $validator ?? new TradeValidator($db);
 
         // Initialize Discord with error handling (may fail if column doesn't exist)
         try {

--- a/ibl5/classes/Trading/TradeProcessor.php
+++ b/ibl5/classes/Trading/TradeProcessor.php
@@ -46,17 +46,21 @@ class TradeProcessor implements TradeProcessorInterface
         TeamIdentityRepositoryInterface $commonRepository,
         string $serverName = '',
         ?TradeOfferRepositoryInterface $offerRepository = null,
-        ?TradeAssetRepositoryInterface $assetRepository = null
+        ?TradeAssetRepositoryInterface $assetRepository = null,
+        ?TradeCashRepositoryInterface $cashRepository = null,
+        ?BuyoutLedgerRepositoryInterface $cashConsiderationRepository = null,
+        ?TradeExecutionRepositoryInterface $executionRepository = null,
+        ?Season $season = null
     ) {
         $this->db = $db;
         $this->commonRepository = $commonRepository;
         $this->serverName = $serverName;
         $this->offerRepository = $offerRepository ?? new TradeOfferRepository($db, $serverName);
         $this->assetRepository = $assetRepository ?? new TradeAssetRepository($db);
-        $this->cashRepository = new TradeCashRepository($db);
-        $this->cashConsiderationRepository = new BuyoutLedgerRepository($db);
-        $this->executionRepository = new TradeExecutionRepository($db);
-        $this->season = new Season($db);
+        $this->cashRepository = $cashRepository ?? new TradeCashRepository($db);
+        $this->cashConsiderationRepository = $cashConsiderationRepository ?? new BuyoutLedgerRepository($db);
+        $this->executionRepository = $executionRepository ?? new TradeExecutionRepository($db);
+        $this->season = $season ?? new Season($db);
         $this->cashHandler = new CashTransactionHandler($db, $this->commonRepository, $this->cashConsiderationRepository, $this->cashRepository);
         $this->newsService = new \Topics\News\NewsRepository($db);
 

--- a/ibl5/tests/DatabaseIntegration/TeamQueryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TeamQueryRepositoryTest.php
@@ -380,13 +380,17 @@ class TeamQueryRepositoryTest extends DatabaseTestCase
 
     public function testCanAddBuyoutWithinLimitReturnsTrue(): void
     {
+        // Passing the Season the caller already holds reproduces the prior
+        // internal `new Season($this->db)` path exactly (same verdict).
+        $season = new Season($this->db);
         // Team 99999 has no players → buyout sum is 0, adding 0 is within limit
-        self::assertTrue($this->repo->canAddBuyoutWithoutExceedingBuyoutLimit(99999, 0));
+        self::assertTrue($this->repo->canAddBuyoutWithoutExceedingBuyoutLimit(99999, 0, $season));
     }
 
     public function testCanAddBuyoutExceedingLimitReturnsFalse(): void
     {
+        $season = new Season($this->db);
         // Adding the entire hard cap always exceeds the buyout percentage limit
-        self::assertFalse($this->repo->canAddBuyoutWithoutExceedingBuyoutLimit(99999, League::HARD_CAP_MAX));
+        self::assertFalse($this->repo->canAddBuyoutWithoutExceedingBuyoutLimit(99999, League::HARD_CAP_MAX, $season));
     }
 }

--- a/ibl5/tests/Injuries/InjuriesRepositoryTest.php
+++ b/ibl5/tests/Injuries/InjuriesRepositoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Injuries;
+
+use PHPUnit\Framework\TestCase;
+use Injuries\InjuriesRepository;
+use League\League;
+use Tests\WideUnit\Mocks\MockDatabase;
+
+/**
+ * InjuriesRepositoryTest - Tests for InjuriesRepository
+ *
+ * @covers \Injuries\InjuriesRepository
+ */
+class InjuriesRepositoryTest extends TestCase
+{
+    public function testGetInjuredPlayersDelegatesToLeague(): void
+    {
+        $rows = [
+            ['pid' => 1, 'name' => 'Player One'],
+            ['pid' => 2, 'name' => 'Player Two'],
+        ];
+
+        $league = $this->createMock(League::class);
+        $league->expects($this->once())
+            ->method('getInjuredPlayersResult')
+            ->willReturn($rows);
+
+        $repository = new InjuriesRepository(new MockDatabase(), $league);
+
+        $this->assertSame($rows, $repository->getInjuredPlayers());
+    }
+
+    public function testGetInjuredPlayersReturnsEmptyWhenLeagueReportsNone(): void
+    {
+        $league = $this->createMock(League::class);
+        $league->expects($this->once())
+            ->method('getInjuredPlayersResult')
+            ->willReturn([]);
+
+        $repository = new InjuriesRepository(new MockDatabase(), $league);
+
+        $this->assertSame([], $repository->getInjuredPlayers());
+    }
+}

--- a/ibl5/tests/Injuries/InjuriesServiceTest.php
+++ b/ibl5/tests/Injuries/InjuriesServiceTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Injuries;
 
 use PHPUnit\Framework\TestCase;
+use Injuries\Contracts\InjuriesRepositoryInterface;
 use Injuries\InjuriesService;
 use Tests\WideUnit\Mocks\MockDatabase;
+use Tests\WideUnit\Mocks\TestDataFactory;
 
 /**
  * InjuriesServiceTest - Tests for InjuriesService
@@ -27,13 +29,13 @@ class InjuriesServiceTest extends TestCase
     }
 
     // ============================================
-    // CONSTRUCTOR TESTS
+    // CONSTRUCTOR / DEFAULT-CONSTRUCTION CHARACTERIZATION
     // ============================================
 
-    // ============================================
-    // GET INJURED PLAYERS TESTS
-    // ============================================
-
+    /**
+     * Characterization: default (no injected repository) construction keeps the
+     * prior League-backed behavior — an empty injured-players query yields [].
+     */
     public function testGetInjuredPlayersWithTeamsReturnsEmptyArrayWhenNoInjuries(): void
     {
         $this->mockDb->setMockData([]);
@@ -43,6 +45,71 @@ class InjuriesServiceTest extends TestCase
 
         $this->assertIsArray($result);
         $this->assertEmpty($result);
+    }
+
+    // ============================================
+    // INJECTED REPOSITORY TESTS
+    // ============================================
+
+    /**
+     * Boundary: an injected repository that reports no injuries yields [] without
+     * touching the database for player/team hydration.
+     */
+    public function testGetInjuredPlayersWithTeamsReturnsEmptyWhenInjectedRepoIsEmpty(): void
+    {
+        $repository = $this->createMock(InjuriesRepositoryInterface::class);
+        $repository->expects($this->once())
+            ->method('getInjuredPlayers')
+            ->willReturn([]);
+
+        $service = new InjuriesService($this->mockDb, $repository);
+
+        $result = $service->getInjuredPlayersWithTeams();
+
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * The injected repository is the source of injured rows; each row is mapped
+     * into the player/team display shape.
+     */
+    public function testGetInjuredPlayersWithTeamsMapsRowsFromInjectedRepository(): void
+    {
+        $injuredRow = TestDataFactory::createPlayer([
+            'pid' => 7,
+            'name' => 'Injured Star',
+            'pos' => 'PG',
+            'teamid' => 3,
+            'injured' => 10,
+            'retired' => 0,
+        ]);
+
+        $repository = $this->createMock(InjuriesRepositoryInterface::class);
+        $repository->expects($this->once())
+            ->method('getInjuredPlayers')
+            ->willReturn([$injuredRow]);
+
+        // Team::initialize() resolves the player's team from ibl_team_info.
+        $this->mockDb->onQuery('ibl_team_info', [
+            TestDataFactory::createTeam([
+                'teamid' => 3,
+                'team_name' => 'Bulls',
+                'team_city' => 'Chicago',
+                'color1' => 'CE1141',
+                'color2' => '000000',
+            ]),
+        ]);
+
+        $service = new InjuriesService($this->mockDb, $repository);
+
+        $result = $service->getInjuredPlayersWithTeams();
+
+        $this->assertCount(1, $result);
+        $this->assertSame(7, $result[0]['playerID']);
+        $this->assertSame('Injured Star', $result[0]['name']);
+        $this->assertSame('PG', $result[0]['position']);
+        $this->assertSame('Chicago', $result[0]['teamCity']);
+        $this->assertSame('Bulls', $result[0]['teamName']);
     }
 
     // ============================================

--- a/ibl5/tests/Team/TeamServiceTest.php
+++ b/ibl5/tests/Team/TeamServiceTest.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Tests\Team;
 
 use PHPUnit\Framework\TestCase;
+use League\League;
 use Team\TeamService;
 use Team\Contracts\TeamServiceInterface;
+use Team\Contracts\TeamRepositoryInterface;
+use Team\Contracts\TeamQueryRepositoryInterface;
+use Tests\WideUnit\Mocks\MockDatabase;
+use Tests\WideUnit\Mocks\TestDataFactory;
 
 /**
  * Tests for TeamService
@@ -22,5 +27,42 @@ class TeamServiceTest extends TestCase
             TeamServiceInterface::class,
             $interfaces ? $interfaces : [],
         );
+    }
+
+    public function testGetTeamPageDataConsumesInjectedTeamQueryRepository(): void
+    {
+        $mockDb = new MockDatabase();
+        $mockDb->onQuery('ibl_team_info', [
+            TestDataFactory::createTeam([
+                'teamid' => 1,
+                'team_name' => 'Bulls',
+                'team_city' => 'Chicago',
+            ]),
+        ]);
+
+        $repository = self::createStub(TeamRepositoryInterface::class);
+        // No current-season power data → skip the current-season card branch.
+        $repository->method('getTeamPowerData')->willReturn(null);
+
+        $leagueContext = self::createStub(\League\LeagueContext::class);
+        $leagueContext->method('getConfig')->willReturn(['images_path' => '/images']);
+
+        $teamQueryRepository = $this->createMock(TeamQueryRepositoryInterface::class);
+        $teamQueryRepository->expects($this->once())
+            ->method('getDraftPicks')
+            ->with(1)
+            ->willReturn([]);
+
+        $league = self::createStub(League::class);
+        $league->method('getAllTeamsResult')->willReturn([]);
+
+        $service = new TeamService($mockDb, $repository, $leagueContext, $teamQueryRepository, $league);
+
+        $result = $service->getTeamPageData(1, null, 'ratings');
+
+        // getDraftPicks() expectation above proves the injected repository was
+        // consumed; the empty pick list renders the bare draft-picks container.
+        $this->assertTrue($result['isActualTeam']);
+        $this->assertStringContainsString('draft-picks-list', $result['draftPicksTable']);
     }
 }

--- a/ibl5/tests/Trading/TradeOfferTest.php
+++ b/ibl5/tests/Trading/TradeOfferTest.php
@@ -443,6 +443,49 @@ class TradeOfferTest extends TestCase
         $this->assertTrue($result['success']);
     }
 
+    // ── Constructor injection (real ctor, no anonymous subclass) ──
+
+    /**
+     * The real constructor accepts every collaborator as an injected double and
+     * wires them in place of its internal `new`s — provable without a live DB.
+     */
+    public function testConstructableWithInjectedCollaborators(): void
+    {
+        $offerRepository = $this->createMock(TradeOfferRepositoryInterface::class);
+        $offerRepository->expects($this->once())
+            ->method('generateNextTradeOfferId')
+            ->willReturn(99);
+
+        $assetRepository = self::createStub(TradeAssetRepositoryInterface::class);
+        $cashRepository = self::createStub(TradeCashRepositoryInterface::class);
+        $cashConsiderationRepository = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $season = self::createStub(Season::class);
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+
+        // Injected validator short-circuits createTradeOffer, proving it is the
+        // collaborator actually consulted (not an internally-constructed one).
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('validateMinimumCashAmounts')
+            ->willReturn(['valid' => false, 'error' => 'injected validator reached']);
+
+        $offer = new TradeOffer(
+            new MockDatabase(),
+            $commonRepo,
+            '',
+            $offerRepository,
+            $assetRepository,
+            $cashRepository,
+            $cashConsiderationRepository,
+            $season,
+            $validator,
+        );
+
+        $result = $offer->createTradeOffer($this->makeTradeData());
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('injected validator reached', $result['error']);
+    }
+
     public function testCreateTradeOfferNullDiscordSkipsNotification(): void
     {
         [$offerRepository, $assetRepository, $validator, $cashHandler, $commonRepo, $season] = $this->makeStubs();

--- a/ibl5/tests/Trading/TradeProcessorTest.php
+++ b/ibl5/tests/Trading/TradeProcessorTest.php
@@ -6,7 +6,13 @@ namespace Tests\Trading;
 
 use PHPUnit\Framework\TestCase;
 use Repositories\Contracts\TeamIdentityRepositoryInterface;
+use Trading\Contracts\TradeOfferRepositoryInterface;
+use Trading\Contracts\TradeAssetRepositoryInterface;
+use Trading\Contracts\TradeCashRepositoryInterface;
+use Trading\Contracts\TradeExecutionRepositoryInterface;
+use Trading\Contracts\BuyoutLedgerRepositoryInterface;
 use Trading\TradeProcessor;
+use Season\Season;
 use Tests\WideUnit\Mocks\MockDatabase;
 
 /**
@@ -30,6 +36,47 @@ class TradeProcessorTest extends TestCase
     public function testProcessTradeReturnsErrorWhenNoTradeDataFound(): void
     {
         $processor = new TradeProcessor($this->mockDb, $this->mockCommonRepo);
+
+        $result = $processor->processTrade(99999);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('No trade data found', $result['error']);
+    }
+
+    // ============================================
+    // CONSTRUCTOR INJECTION
+    // ============================================
+
+    /**
+     * The real constructor accepts every collaborator as an injected double and
+     * wires them in place of its internal `new`s — the injected offer repository
+     * is the one consulted by processTrade().
+     */
+    public function testConstructableWithInjectedCollaborators(): void
+    {
+        $offerRepository = $this->createMock(TradeOfferRepositoryInterface::class);
+        $offerRepository->expects($this->once())
+            ->method('getTradesByOfferIdForUpdate')
+            ->with(99999)
+            ->willReturn([]);
+
+        $assetRepository = self::createStub(TradeAssetRepositoryInterface::class);
+        $cashRepository = self::createStub(TradeCashRepositoryInterface::class);
+        $cashConsiderationRepository = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $executionRepository = self::createStub(TradeExecutionRepositoryInterface::class);
+        $season = self::createStub(Season::class);
+
+        $processor = new TradeProcessor(
+            $this->mockDb,
+            $this->mockCommonRepo,
+            '',
+            $offerRepository,
+            $assetRepository,
+            $cashRepository,
+            $cashConsiderationRepository,
+            $executionRepository,
+            $season,
+        );
 
         $result = $processor->processTrade(99999);
 


### PR DESCRIPTION
## Summary

Converts 5 classes from hard-wiring collaborators inside constructors to optional constructor parameters (`?Type $x = null`) with fallback `new`, following the existing nullable-default injection idiom already present in `TradeOffer.php`.

**Classes converted:**
- `InjuriesService` — new `InjuriesRepositoryInterface` + `InjuriesRepository` (League-backed); drops raw `mysqli`+internal `new League`
- `TeamService::prepareDraftPicksData` — injects `TeamQueryRepositoryInterface` + `League`
- `TeamQueryRepository::canAddBuyoutWithoutExceedingBuyoutLimit` — adds `Season` param (matching class pattern); no production callers outside DB-integration test
- `TradeOffer` + `TradeProcessor` — promotes `TradeCashRepository`, `BuyoutLedgerRepository`, `TradeExecutionRepository`, `TradeValidator`, and `Season` to optional ctor params

All new ctor params are appended after existing ones with `?Type=null` defaults; positional callers unchanged.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)