### PR TITLE
feat(navigation): add admin-only Voting Results link to My Team menu

### DIFF
--- a/ibl5/classes/Navigation/NavigationConfig.php
+++ b/ibl5/classes/Navigation/NavigationConfig.php
@@ -33,6 +33,7 @@ final class NavigationConfig
         public readonly ?string $requestUri = null,
         public readonly bool $isDraftOrderFinalized = false,
         public readonly bool $isDebugAdmin = false,
+        public readonly bool $isAdmin = false,
         public readonly bool $debugViewAllExtensions = false,
     ) {
         $this->teamsData = $teamsData;

--- a/ibl5/classes/Navigation/NavigationMenuBuilder.php
+++ b/ibl5/classes/Navigation/NavigationMenuBuilder.php
@@ -208,8 +208,13 @@ class NavigationMenuBuilder implements NavigationMenuBuilderInterface
             ['label' => 'Depth Chart Entry', 'url' => 'modules.php?name=DepthChartEntry'],
             ['label' => 'Trading', 'url' => 'modules.php?name=Trading&op=reviewtrade'],
             ['label' => 'Voting', 'url' => 'modules.php?name=Voting'],
-            ['label' => 'Draft History', 'url' => 'modules.php?name=DraftHistory&teamid=' . $teamId],
         ];
+
+        if ($this->config->isAdmin) {
+            $links[] = ['label' => 'Voting Results', 'url' => 'modules.php?name=VotingResults'];
+        }
+
+        $links[] = ['label' => 'Draft History', 'url' => 'modules.php?name=DraftHistory&teamid=' . $teamId];
 
         if ($this->areWaiversAllowed()) {
             $links[] = ['rawHtml' => 'Waivers: <a href="modules.php?name=Waivers&amp;action=add">Add</a> | <a href="modules.php?name=Waivers&amp;action=waive">Waive</a>'];

--- a/ibl5/tests/Navigation/NavigationConfigTest.php
+++ b/ibl5/tests/Navigation/NavigationConfigTest.php
@@ -30,6 +30,7 @@ class NavigationConfigTest extends TestCase
             showDraftLink: 'On',
             serverName: 'localhost',
             requestUri: '/ibl5/index.php',
+            isAdmin: true,
         );
 
         $this->assertTrue($config->isLoggedIn);
@@ -42,6 +43,7 @@ class NavigationConfigTest extends TestCase
         $this->assertSame('On', $config->showDraftLink);
         $this->assertSame('localhost', $config->serverName);
         $this->assertSame('/ibl5/index.php', $config->requestUri);
+        $this->assertTrue($config->isAdmin);
     }
 
     public function testMinimalDefaults(): void
@@ -62,6 +64,7 @@ class NavigationConfigTest extends TestCase
         $this->assertSame('', $config->showDraftLink);
         $this->assertNull($config->serverName);
         $this->assertNull($config->requestUri);
+        $this->assertFalse($config->isAdmin);
     }
 
     public function testReadonlyProperties(): void

--- a/ibl5/tests/Navigation/NavigationMenuBuilderTest.php
+++ b/ibl5/tests/Navigation/NavigationMenuBuilderTest.php
@@ -19,6 +19,7 @@ class NavigationMenuBuilderTest extends TestCase
         string $allowWaivers = 'No',
         string $showDraftLink = 'Off',
         bool $isDraftOrderFinalized = false,
+        bool $isAdmin = false,
     ): NavigationConfig {
         return new NavigationConfig(
             isLoggedIn: $isLoggedIn,
@@ -29,6 +30,7 @@ class NavigationMenuBuilderTest extends TestCase
             allowWaivers: $allowWaivers,
             showDraftLink: $showDraftLink,
             isDraftOrderFinalized: $isDraftOrderFinalized,
+            isAdmin: $isAdmin,
         );
     }
 
@@ -96,6 +98,69 @@ class NavigationMenuBuilderTest extends TestCase
     {
         $builder = new NavigationMenuBuilder($this->createConfig(isLoggedIn: true, teamId: null));
         $this->assertNull($builder->getMyTeamMenu());
+    }
+
+    public function testVotingResultsLinkVisibleForAdminAndPositionedAfterVoting(): void
+    {
+        $builder = new NavigationMenuBuilder($this->createConfig(isLoggedIn: true, teamId: 5, isAdmin: true));
+        $menu = $builder->getMyTeamMenu();
+        $this->assertNotNull($menu);
+
+        $labels = array_map(
+            static fn (array $link): string => $link['label'] ?? '',
+            $menu['links']
+        );
+
+        $votingResults = array_filter(
+            $menu['links'],
+            static fn (array $link): bool => ($link['label'] ?? '') === 'Voting Results'
+        );
+        $this->assertCount(1, $votingResults, 'Voting Results link should be present for admins');
+        $this->assertSame(
+            'modules.php?name=VotingResults',
+            array_values($votingResults)[0]['url'] ?? null
+        );
+
+        // Relative-position assertion: the Draft/Free Agency branches array_unshift()
+        // (prepend), so absolute indices shift — only the relative ordering is invariant.
+        $votingIdx = array_search('Voting', $labels, true);
+        $votingResultsIdx = array_search('Voting Results', $labels, true);
+        $draftHistoryIdx = array_search('Draft History', $labels, true);
+        $this->assertIsInt($votingIdx);
+        $this->assertIsInt($votingResultsIdx);
+        $this->assertIsInt($draftHistoryIdx);
+        $this->assertSame($votingIdx + 1, $votingResultsIdx, 'Voting Results should sit directly after Voting');
+        $this->assertSame($votingResultsIdx + 1, $draftHistoryIdx, 'Voting Results should sit directly before Draft History');
+    }
+
+    public function testVotingResultsLinkHiddenForNonAdmin(): void
+    {
+        $builder = new NavigationMenuBuilder($this->createConfig(isLoggedIn: true, teamId: 5, isAdmin: false));
+        $menu = $builder->getMyTeamMenu();
+        $this->assertNotNull($menu);
+
+        $labels = array_map(
+            static fn (array $link): string => $link['label'] ?? '',
+            $menu['links']
+        );
+
+        // The menu still renders (Voting present); only the admin-gated link is hidden.
+        $this->assertContains('Voting', $labels);
+        $this->assertNotContains('Voting Results', $labels);
+    }
+
+    public function testVotingResultsLinkAbsentInOlympicsTeamMenuForAdmin(): void
+    {
+        $builder = new NavigationMenuBuilder($this->createConfig(currentLeague: 'olympics', isAdmin: true));
+        $menu = $builder->getMyTeamMenu();
+        $this->assertNotNull($menu);
+
+        $labels = array_map(
+            static fn (array $link): string => $link['label'] ?? '',
+            $menu['links']
+        );
+
+        $this->assertNotContains('Voting Results', $labels);
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('draftLinkProvider')]

--- a/ibl5/tests/e2e/flows/navigation.spec.ts
+++ b/ibl5/tests/e2e/flows/navigation.spec.ts
@@ -32,6 +32,25 @@ test.describe('Navigation bar (authenticated, desktop)', () => {
     await expect(teamPageLink).toBeVisible();
   });
 
+  test('my team dropdown shows admin-only Voting Results link', async ({ page }) => {
+    // The default auth fixture is the CI main user: roles_mask=1 (ADMIN,
+    // setup-docker-e2e action.yml ~L128) and gm_username on team Metros
+    // (action.yml ~L133). So isLoggedIn && teamId !== null && isAdmin all
+    // hold — the My Team menu renders AND the admin-gated link appears.
+    await page.goto('index.php');
+    const nav = desktopNav(page);
+    await nav.getByRole('button', { name: 'My Team' }).click();
+
+    const votingResultsLink = nav.locator('.nav-dropdown-item', {
+      hasText: 'Voting Results',
+    }).first();
+    await expect(votingResultsLink).toBeVisible();
+    await expect(votingResultsLink).toHaveAttribute(
+      'href',
+      /modules\.php\?name=VotingResults/,
+    );
+  });
+
   test('my team dropdown shows logout footer', async ({ page }) => {
     await page.goto('index.php');
     const nav = desktopNav(page);

--- a/ibl5/tests/e2e/flows/role-gating-non-admin.spec.ts
+++ b/ibl5/tests/e2e/flows/role-gating-non-admin.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures/auth-regular';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { desktopNav } from '../helpers/navigation';
 
 /**
  * Tier 2 role-gating coverage: exercises the production gate paths that
@@ -245,5 +246,24 @@ test.describe('GM-only pages: non-admin / no-team behavior', () => {
     const response = await page.goto('modules.php?name=DepthChartEntry');
     expect(response?.status()).toBe(200);
     await assertNoPhpErrors(page, 'on DepthChartEntry as non-admin');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block G — nav: admin-only "Voting Results" link is never shown to a non-admin
+//
+// The auth-regular user is roles_mask=0 with no ibl_team_info row
+// (ci-seed.sql:1929), so getMyTeamMenu() returns null and the My Team menu
+// does not render at all — the link is absent because no admin session ever
+// emits it. The precise "menu present, Voting shown, Voting Results hidden"
+// isolation is carried by NavigationMenuBuilderTest (admin=false + teamId set).
+// ---------------------------------------------------------------------------
+
+test.describe('Nav: Voting Results link hidden for non-admin', () => {
+  test('rendered desktop nav has no Voting Results link', async ({ page }) => {
+    await page.goto('index.php');
+    await expect(
+      desktopNav(page).getByRole('link', { name: 'Voting Results' }),
+    ).toHaveCount(0);
   });
 });

--- a/ibl5/themes/IBL/theme.php
+++ b/ibl5/themes/IBL/theme.php
@@ -108,6 +108,7 @@ function themeheader()
         requestUri: $_SERVER['REQUEST_URI'] ?? null,
         isDraftOrderFinalized: $isDraftOrderFinalized,
         isDebugAdmin: $debugSession->isDebugAdmin(),
+        isAdmin: is_admin() === 1,
         debugViewAllExtensions: $debugSession->isViewAllExtensionsEnabled(),
     );
 


### PR DESCRIPTION
## Summary

Adds a **Voting Results** link directly under **Voting** in the My Team dropdown menu, visible only to admins (Role::ADMIN). Gated by a new `NavigationConfig::$isAdmin` flag wired from `is_admin()` in `themeheader()` — same production gate as `leagueControlPanel.php`.

- No new endpoint or access-control change; visibility-only
- Link uses relative `modules.php?name=VotingResults`
- Olympics team menu is untouched

## Changes

- `NavigationConfig.php`: new `$isAdmin = false` constructor param (defaulted, named-arg safe)
- `NavigationMenuBuilder.php`: inserts gated Voting Results link between Voting and Draft History in `getIblTeamMenu()`
- `theme.php`: passes `isAdmin: is_admin() === 1` to NavigationConfig
- `NavigationConfigTest.php`: default/value/readonly assertions for new flag
- `NavigationMenuBuilderTest.php`: admin+team→present+positioned, non-admin→absent, Olympics+admin→absent
- `navigation.spec.ts`: E2E admin-sees-it (CI main user, Metros team, roles_mask=1)
- `role-gating-non-admin.spec.ts`: E2E non-admin-does-not (auth-regular, roles_mask=0)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.