### PR TITLE
fix(bin): harden cleanup against destroying in-progress worktrees

### DIFF
--- a/bin/cleanup
+++ b/bin/cleanup
@@ -14,6 +14,7 @@ REPO_ROOT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
 TARGET_NAME=""
 ALL=false
 DRY_RUN=false
+DISCARD_GENERATED=false
 CLEANED=0
 SKIPPED=0
 
@@ -21,14 +22,15 @@ for arg in "$@"; do
     case "$arg" in
         --all) ALL=true ;;
         --dry-run) DRY_RUN=true ;;
+        --discard-generated) DISCARD_GENERATED=true ;;
         -*) echo "Unknown option: $arg" >&2; exit 1 ;;
         *) TARGET_NAME="$arg" ;;
     esac
 done
 
 if [ -z "$TARGET_NAME" ] && [ "$ALL" = false ]; then
-    echo "Usage: bin/wt-cleanup <worktree-name> [--dry-run]" >&2
-    echo "       bin/wt-cleanup --all [--dry-run]" >&2
+    echo "Usage: bin/wt-cleanup <worktree-name> [--dry-run] [--discard-generated]" >&2
+    echo "       bin/wt-cleanup --all [--dry-run] [--discard-generated]" >&2
     exit 1
 fi
 
@@ -154,15 +156,30 @@ check_worktree() {
         fi
     fi
 
-    # Check 3: Local-only (never pushed), ancestor of master, with unique commits.
-    # Catches agent worktrees whose work landed on master via another branch.
+    # Check 3: Local-only (never pushed) branch whose OWN commits landed on
+    # master via another branch. Catches agent worktrees whose work was
+    # cherry-picked/squashed onto master.
+    #
+    # The tip != master-tip test is NOT a valid "has merged work" signal: a
+    # fresh branch created from an older master commit (tip == fork point) is
+    # an ancestor of the now-advanced master with tip != master tip, yet has
+    # NO work of its own — it is in-progress, not merged. merge-master-to-prod
+    # advances master then runs `cleanup --all`, manufacturing exactly this
+    # state for every fresh worktree. Require the branch to have at least one
+    # commit beyond its fork-point instead; if the fork-point can't be resolved
+    # or the branch has zero own-commits, treat as NOT merged (conservative —
+    # genuinely-merged work is caught by Check 1's PR MERGED signal anyway).
     if [ "$is_merged" = false ]; then
         local local_tracking
         local_tracking=$(git -C "$REPO_ROOT" config "branch.$branch.remote" 2>/dev/null || true)
         if [ -z "$local_tracking" ] \
-           && git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" origin/master 2>/dev/null \
-           && [ "$(git -C "$REPO_ROOT" rev-parse "$branch")" != "$(git -C "$REPO_ROOT" rev-parse origin/master)" ]; then
-            is_merged=true
+           && git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" origin/master 2>/dev/null; then
+            local fork_point
+            fork_point=$(git -C "$REPO_ROOT" merge-base --fork-point origin/master "$branch" 2>/dev/null || true)
+            if [ -n "$fork_point" ] \
+               && git -C "$REPO_ROOT" rev-list "$fork_point..$branch" 2>/dev/null | grep -q .; then
+                is_merged=true
+            fi
         fi
     fi
 
@@ -183,9 +200,22 @@ check_worktree() {
             return
         fi
 
+        # Untracked files are real work product the diff-based checks never see
+        # (an untracked-only ADR draft, a new test file). NEVER discard or
+        # remove a worktree carrying them — reset --hard is a no-op on untracked
+        # anyway, so the only safe action is to leave it.
+        if has_untracked_files "$wt_path"; then
+            echo "  SKIP $wt_name: has untracked files"
+            SKIPPED=$((SKIPPED + 1))
+            return
+        fi
+
         if has_uncommitted_changes "$wt_path"; then
-            # On merged branches, discard changes to generated/worktree-local
-            # files that are never real work product.
+            # On merged branches, dirt confined to generated/worktree-local
+            # files (never real work product) MAY be discarded — but only when
+            # --discard-generated is passed. Auto-discarding is destructive if
+            # merged-detection is ever wrong, so it defaults OFF; that keeps
+            # merge-master-to-prod's `cleanup --all` (no flag) non-destructive.
             local dirty_files
             dirty_files=$(git -C "$wt_path" diff --name-only 2>/dev/null; \
                           git -C "$wt_path" diff --cached --name-only 2>/dev/null)
@@ -193,13 +223,17 @@ check_worktree() {
             local non_discardable
             non_discardable=$(echo "$dirty_files" \
                 | grep -v -E '^(CLAUDE\.md|ibl5/bun\.lock)$' || true)
-            if [ -z "$non_discardable" ]; then
+            if [ -n "$non_discardable" ]; then
+                echo "  SKIP $wt_name: has uncommitted changes"
+                SKIPPED=$((SKIPPED + 1))
+                return
+            elif [ "$DISCARD_GENERATED" = true ]; then
                 echo "  Discarding generated files: $dirty_files"
                 if [ "$DRY_RUN" = false ]; then
                     git -C "$wt_path" reset --hard HEAD 2>/dev/null || true
                 fi
             else
-                echo "  SKIP $wt_name: has uncommitted changes"
+                echo "  SKIP $wt_name: has discardable changes (pass --discard-generated to discard)"
                 SKIPPED=$((SKIPPED + 1))
                 return
             fi
@@ -244,7 +278,22 @@ if [ "$ALL" = true ]; then
             dir="${dir%/}"
             dir_name="$(basename "$dir")"
 
-            if git -C "$REPO_ROOT" worktree list --porcelain | grep -q "^worktree $dir$"; then
+            # Already handled by the registered-worktree pass above? Compare
+            # case-insensitively: git may register a worktree under a different-
+            # cased path (e.g. /Users/.../github/... vs REPO_ROOT's .../GitHub/...)
+            # on a case-insensitive FS. A case-sensitive grep would miss it and
+            # mis-process the live worktree down the orphan rm -rf branch.
+            registered=false
+            dir_lc=$(printf '%s' "$dir" | tr '[:upper:]' '[:lower:]')
+            while IFS= read -r reg_path; do
+                reg_lc=$(printf '%s' "$reg_path" | tr '[:upper:]' '[:lower:]')
+                if [ "$reg_lc" = "$dir_lc" ]; then
+                    registered=true
+                    break
+                fi
+            done < <(git -C "$REPO_ROOT" worktree list --porcelain \
+                | awk '/^worktree / { print substr($0, 10) }')
+            if [ "$registered" = true ]; then
                 continue  # registered with git, already handled above
             fi
 
@@ -258,11 +307,14 @@ if [ "$ALL" = true ]; then
                 continue
             fi
 
-            # Safety: skip if this is a real git worktree with uncommitted changes.
-            # Only trust git diff if the directory has its own .git file —
-            # without one, git walks up to the main repo and reports false positives.
-            if [ -e "$dir/.git" ] && has_uncommitted_changes "$dir"; then
-                echo "  SKIP orphan $dir_name: has uncommitted changes"
+            # Safety: skip if this is a real git worktree with uncommitted OR
+            # untracked work. Only trust git here if the directory has its own
+            # .git file — without one, git walks up to the main repo and reports
+            # false positives. has_untracked_files is checked too because git
+            # diff never sees untracked files (e.g. an untracked ADR draft).
+            if [ -e "$dir/.git" ] \
+               && { has_uncommitted_changes "$dir" || has_untracked_files "$dir"; }; then
+                echo "  SKIP orphan $dir_name: has uncommitted or untracked changes"
                 echo "           To remove: rm -rf $dir"
                 SKIPPED=$((SKIPPED + 1))
                 continue
@@ -351,18 +403,23 @@ if [ "$ALL" = true ]; then
             fi
         fi
 
-        # Check 3: Local-only branch fully merged into origin/master.
-        # Catches branches that were never pushed (no tracking config, no PR)
-        # but whose work landed on master via another branch or local merge.
-        # Requires strict ancestry (branch tip != master tip) to avoid nuking
-        # a freshly created branch used as a name reservation.
+        # Check 3: Local-only branch whose OWN commits landed on origin/master
+        # via another branch or local merge. Catches branches never pushed (no
+        # tracking config, no PR). The tip != master-tip test is NOT a valid
+        # signal — a freshly created branch (tip == fork point) off an older
+        # master is an ancestor of the advanced master with tip != master tip,
+        # yet has no work of its own. Require at least one commit beyond the
+        # fork-point; conservative when the fork-point can't be resolved.
         if [ "$should_delete" = false ]; then
             local_tracking=$(git -C "$REPO_ROOT" config "branch.$bare_branch.remote" 2>/dev/null || true)
             if [ -z "$local_tracking" ] \
-               && git -C "$REPO_ROOT" merge-base --is-ancestor "$bare_branch" origin/master 2>/dev/null \
-               && [ "$(git -C "$REPO_ROOT" rev-parse "$bare_branch")" != "$(git -C "$REPO_ROOT" rev-parse origin/master)" ]; then
-                should_delete=true
-                delete_reason="local-only, merged into master"
+               && git -C "$REPO_ROOT" merge-base --is-ancestor "$bare_branch" origin/master 2>/dev/null; then
+                bare_fork_point=$(git -C "$REPO_ROOT" merge-base --fork-point origin/master "$bare_branch" 2>/dev/null || true)
+                if [ -n "$bare_fork_point" ] \
+                   && git -C "$REPO_ROOT" rev-list "$bare_fork_point..$bare_branch" 2>/dev/null | grep -q .; then
+                    should_delete=true
+                    delete_reason="local-only, merged into master"
+                fi
             fi
         fi
 

--- a/bin/lib/wt-guards.sh
+++ b/bin/lib/wt-guards.sh
@@ -93,3 +93,18 @@ has_uncommitted_changes() {
     if [ "$rc" -eq 1 ]; then return 0; fi
     return 1
 }
+
+# Check if a directory has untracked (but not gitignored) files.
+# Returns 0 (has untracked work) or 1 (none / not a valid git repo).
+# has_uncommitted_changes is git-diff-based and NEVER sees untracked files;
+# callers that gate destructive actions on "is there work here?" must check
+# BOTH. --exclude-standard is load-bearing: without it gitignored build
+# artifacts/logs would trip the guard and falsely flag nearly every worktree.
+has_untracked_files() {
+    local dir="${1:-.}"
+    local out
+    # A broken/missing gitdir yields empty output (treated as "no untracked"),
+    # mirroring has_uncommitted_changes's exit-128 tolerance.
+    out=$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null)
+    [ -n "$out" ]
+}

--- a/bin/test-cleanup-safety
+++ b/bin/test-cleanup-safety
@@ -226,13 +226,10 @@ if has_untracked_files "$hu"; then
 else
     pass "helper-clean-tree-has-no-untracked"
 fi
-printf 'ignored\n' > "$hu/.gitignore"
-printf 'junk\n'    > "$hu/build.log"
+echo '*.log' > "$hu/.gitignore"     # ignore build.log via a real glob pattern
+printf 'junk\n' > "$hu/build.log"   # untracked but gitignored
 git -C "$hu" add .gitignore
 git -C "$hu" commit -qm gitignore
-echo "*.log" > "$hu/.gitignore"
-git -C "$hu" add .gitignore
-git -C "$hu" commit -qm ignore-logs
 if has_untracked_files "$hu"; then
     failcase "helper-gitignored-only-has-no-untracked"
 else

--- a/bin/test-cleanup-safety
+++ b/bin/test-cleanup-safety
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-cleanup-safety — regression test for bin/cleanup's safety guards.
+#
+# bin/cleanup is invoked (with --all) by bin/merge-master-to-prod, which
+# advances master and THEN sweeps worktrees — manufacturing the precondition
+# for cleanup's "merged" heuristics to misfire on fresh worktrees. This test
+# pins the four guards that keep that sweep from destroying in-progress work:
+#
+#   defect1  untracked files (invisible to git diff) are NEVER discarded/removed
+#   defect2  generated-file discard is OFF unless --discard-generated is passed
+#   defect3  a fresh local branch with no own-commits is NOT deemed "merged"
+#   defect4  orphan-dedupe matches a worktree registered under a different-cased
+#            path (case-insensitive FS only; skipped on case-sensitive FS)
+#
+# It also pins the POSITIVE case: a genuinely-merged clean worktree is STILL
+# cleaned, so the hardening did not neuter cleanup.
+#
+# Every assertion runs `bin/cleanup --all --dry-run` against a throwaway git
+# repo built under a mktemp dir, so nothing real is touched. A stub `gh` forces
+# Check 1 (PR-state) to no-op, making the merged-detection deterministic.
+#
+# Run: bin/test-cleanup-safety  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLEANUP="$SCRIPT_DIR/cleanup"
+TMP="$(mktemp -d)"
+trap 'chmod -R u+w "$TMP" 2>/dev/null; rm -rf "$TMP" 2>/dev/null' EXIT
+
+FAILED=0
+
+# A stub gh that always fails, so cleanup's `gh pr view` yields no PR state and
+# Check 1 is skipped. Keeps merged-detection on the deterministic Check 2/3.
+STUBBIN="$TMP/stubbin"
+mkdir -p "$STUBBIN"
+printf '#!/bin/sh\nexit 1\n' > "$STUBBIN/gh"
+chmod +x "$STUBBIN/gh"
+
+pass()     { echo "ok: $1"; }
+failcase() { echo "FAIL: $1"; FAILED=1; }
+
+# assert_match <name> <regex> <haystack>
+assert_match() {
+    if printf '%s' "$3" | grep -qE "$2"; then
+        pass "$1"
+    else
+        failcase "$1 — expected to match: $2"
+        printf '%s\n' "$3" | sed 's/^/    /'
+    fi
+}
+
+# assert_absent <name> <regex> <haystack>
+assert_absent() {
+    if printf '%s' "$3" | grep -qE "$2"; then
+        failcase "$1 — expected NOT to match: $2"
+        printf '%s\n' "$3" | sed 's/^/    /'
+    else
+        pass "$1"
+    fi
+}
+
+# new_env — build a unique <TMP>/env.XXXX/{origin.git,main}; echo the main path.
+# All git output is silenced so command substitution captures ONLY the path
+# (a stray git status line would otherwise corrupt the returned path). The
+# initial commit tracks README.md and CLAUDE.md (the latter is the allowlisted
+# "generated" file the discard logic targets).
+new_env() {
+    local base
+    base="$(mktemp -d "$TMP/env.XXXXXX")"
+    git init -q --bare "$base/origin.git" >/dev/null 2>&1
+    git clone -q "$base/origin.git" "$base/main" >/dev/null 2>&1
+    git -C "$base/main" config user.email t@example.com >/dev/null 2>&1
+    git -C "$base/main" config user.name tester >/dev/null 2>&1
+    git -C "$base/main" config commit.gpgsign false >/dev/null 2>&1
+    printf 'init\n'  > "$base/main/README.md"
+    printf 'rules\n' > "$base/main/CLAUDE.md"
+    git -C "$base/main" add README.md CLAUDE.md >/dev/null 2>&1
+    git -C "$base/main" commit -qm init >/dev/null 2>&1
+    git -C "$base/main" branch -q -M master >/dev/null 2>&1
+    git -C "$base/main" push -q -u origin master >/dev/null 2>&1
+    echo "$base/main"
+}
+
+# add_merged_wt <main> <name> — create a Check-2-merged worktree on branch
+# <name>: a real own-commit, pushed (sets upstream), ff-merged into master,
+# then its remote branch deleted. cleanup's fetch --prune drops origin/<name>,
+# so Check 2 (tracked + ancestor + remote-gone) marks it merged.
+add_merged_wt() {
+    local main="$1" name="$2"
+    git -C "$main" checkout -q -b "$name" master
+    printf 'x\n' > "$main/$name.txt"
+    git -C "$main" add "$name.txt"
+    git -C "$main" commit -qm "feat-$name"
+    git -C "$main" push -q -u origin "$name" 2>/dev/null
+    git -C "$main" checkout -q master
+    git -C "$main" merge -q --ff-only "$name"
+    git -C "$main" push -q origin master 2>/dev/null
+    git -C "$main" push -q origin --delete "$name" 2>/dev/null
+    git -C "$main" worktree add -q "$main/worktrees/$name" "$name" 2>/dev/null
+}
+
+# run_cleanup <main> [extra-flags...] — run the cleanup under test, in dry-run,
+# from inside <main> (so REPO_ROOT resolves to the scratch repo). Echoes output.
+run_cleanup() {
+    local main="$1"; shift
+    ( cd "$main" && PATH="$STUBBIN:$PATH" "$CLEANUP" --all --dry-run "$@" 2>&1 )
+}
+
+# ----------------------------------------------------------------------------
+# Positive (characterization): a genuinely-merged CLEAN worktree is STILL cleaned.
+# Must pass both before and after the hardening — proves cleanup is not neutered.
+# ----------------------------------------------------------------------------
+e="$(new_env)"
+add_merged_wt "$e" "feat"
+out="$(run_cleanup "$e")"
+assert_match "positive-merged-clean-still-cleaned" 'WOULD clean: feat' "$out"
+
+# ----------------------------------------------------------------------------
+# Check 3 is now CONSERVATIVE (the core defect-3 fix). A local-only branch whose
+# own commit landed on master via ff-merge (master then advanced past it) is an
+# ancestor of origin/master with NO commit distinguishable from master — the
+# EXACT same graph shape as a fresh never-committed branch (defect 3 / Case A).
+# Because the two are graph-indistinguishable, safety requires skipping BOTH:
+# this row asserts the ambiguous "merged-looking" shape is now SKIPPED, where
+# the OLD code aggressively cleaned it (the fresh-branch destruction path).
+# Genuinely-merged local work is reclaimed by Check 1 (PR MERGED) in real use —
+# we accept leaving a rare no-PR merged branch over risking in-progress work.
+# ----------------------------------------------------------------------------
+e="$(new_env)"
+git -C "$e" worktree add -q -b own "$e/worktrees/own" master 2>/dev/null
+printf 'own-work\n' > "$e/worktrees/own/own.txt"
+git -C "$e/worktrees/own" add own.txt
+git -C "$e/worktrees/own" commit -qm own-commit
+git -C "$e" merge -q --ff-only own          # master -> own's tip
+printf 'later\n' > "$e/after.txt"           # advance master PAST own
+git -C "$e" add after.txt
+git -C "$e" commit -qm after-own
+git -C "$e" push -q origin master 2>/dev/null
+out="$(run_cleanup "$e")"
+assert_match "check3-conservative-ambiguous-shape-skipped" \
+    "SKIP own: branch 'own' not merged to master" "$out"
+
+# ----------------------------------------------------------------------------
+# Defect 1: merged worktree whose only change is an UNTRACKED (non-ignored)
+# file is SKIPPED, not reset/removed.
+# ----------------------------------------------------------------------------
+e="$(new_env)"
+add_merged_wt "$e" "feat"
+printf 'draft\n' > "$e/worktrees/feat/docs-decision-0044.md"   # untracked
+out="$(run_cleanup "$e")"
+assert_match "defect1-untracked-skipped" 'SKIP feat: has untracked files' "$out"
+
+# ----------------------------------------------------------------------------
+# Defect 2: merged worktree with only an allowlisted CLAUDE.md diff is SKIPPED
+# WITHOUT --discard-generated, and cleaned WITH it. Same prepared env, two runs
+# (dry-run mutates nothing) — so the flag is the only difference.
+# ----------------------------------------------------------------------------
+e="$(new_env)"
+add_merged_wt "$e" "feat"
+printf 'rules-changed\n' > "$e/worktrees/feat/CLAUDE.md"        # tracked, allowlisted
+out="$(run_cleanup "$e")"
+assert_match "defect2-discardable-skipped-by-default" \
+    'SKIP feat: has discardable changes' "$out"
+out="$(run_cleanup "$e" --discard-generated)"
+assert_match "defect2-discardable-cleaned-with-flag" 'WOULD clean: feat' "$out"
+
+# ----------------------------------------------------------------------------
+# Defect 3: a fresh local-only branch (forked from master, master then advanced,
+# zero own-commits) is NOT deemed merged by Check 3 → SKIPPED as "not merged".
+# ----------------------------------------------------------------------------
+e="$(new_env)"
+git -C "$e" worktree add -q -b fresh "$e/worktrees/fresh" master 2>/dev/null
+printf 'c2\n' > "$e/advance.txt"
+git -C "$e" add advance.txt
+git -C "$e" commit -qm advance-master
+git -C "$e" push -q origin master 2>/dev/null
+out="$(run_cleanup "$e")"
+assert_match "defect3-fresh-branch-not-merged" \
+    "SKIP fresh: branch 'fresh' not merged to master" "$out"
+
+# ----------------------------------------------------------------------------
+# Defect 4 (env-gated): a worktree git-registered under a different-cased path
+# than REPO_ROOT must be recognized by the orphan-dedupe and NOT re-processed
+# down the orphan rm -rf branch. Only reproducible on a case-insensitive FS;
+# on a case-sensitive FS the differently-cased dir does not exist, so skip.
+# ----------------------------------------------------------------------------
+: > "$TMP/CaseProbe"
+if [ -e "$TMP/caseprobe" ]; then
+    rm -f "$TMP/CaseProbe"
+    e="$(new_env)"                                  # main at <base>/main (lowercase)
+    upper="${e%/main}/Main"                          # same dir on case-insensitive FS
+    git -C "$upper" worktree add -q -b orphancs "$upper/worktrees/orphancs" master 2>/dev/null
+    # Confirm the mismatch was actually recorded (git did not canonicalize casing).
+    reg="$(cd "$e" && git worktree list --porcelain | grep '/Main/worktrees/orphancs' || true)"
+    if [ -n "$reg" ]; then
+        out="$(run_cleanup "$e")"
+        assert_absent "defect4-cased-worktree-not-treated-as-orphan" \
+            'WOULD remove orphan: orphancs' "$out"
+    else
+        pass "defect4-cased-worktree-not-treated-as-orphan (skipped: FS canonicalized casing)"
+    fi
+else
+    rm -f "$TMP/CaseProbe"
+    pass "defect4-cased-worktree-not-treated-as-orphan (skipped: case-sensitive FS)"
+fi
+
+# ----------------------------------------------------------------------------
+# Helper unit: has_untracked_files sees an untracked non-ignored file, ignores
+# a clean tree, and respects .gitignore (--exclude-standard).
+# ----------------------------------------------------------------------------
+# shellcheck source=bin/lib/wt-guards.sh
+. "$SCRIPT_DIR/lib/wt-guards.sh"
+hu="$TMP/huf"
+git init -q "$hu"
+git -C "$hu" config user.email t@example.com
+git -C "$hu" config user.name tester
+git -C "$hu" config commit.gpgsign false
+printf 'seed\n' > "$hu/seed.txt"
+git -C "$hu" add seed.txt
+git -C "$hu" commit -qm seed
+if has_untracked_files "$hu"; then
+    failcase "helper-clean-tree-has-no-untracked"
+else
+    pass "helper-clean-tree-has-no-untracked"
+fi
+printf 'ignored\n' > "$hu/.gitignore"
+printf 'junk\n'    > "$hu/build.log"
+git -C "$hu" add .gitignore
+git -C "$hu" commit -qm gitignore
+echo "*.log" > "$hu/.gitignore"
+git -C "$hu" add .gitignore
+git -C "$hu" commit -qm ignore-logs
+if has_untracked_files "$hu"; then
+    failcase "helper-gitignored-only-has-no-untracked"
+else
+    pass "helper-gitignored-only-has-no-untracked"
+fi
+printf 'real\n' > "$hu/new-real-file.md"
+if has_untracked_files "$hu"; then
+    pass "helper-untracked-nonignored-detected"
+else
+    failcase "helper-untracked-nonignored-detected"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
## Problem

`bin/merge-master-to-prod` advances master (`git pull origin master`) and **then** runs `bin/cleanup --all` in the same script. That sequence manufactures the precondition for cleanup's "merged" heuristic to misfire on every fresh worktree, and the protect-guards were blind to untracked files — so an in-progress worktree could be `reset --hard`'d or removed.

This keeps the auto-cleanup-on-merge behavior (the user wants it) but makes it incapable of destroying in-progress work. It closes **four provable destroy-in-progress-work paths**. (It does not claim to reconstruct any specific past incident — only defect 4 had direct evidence it was touching a real worktree's orphan path.)

## Changes

1. **Untracked-blindness** — added `has_untracked_files()` to `bin/lib/wt-guards.sh` (additive; no existing caller changed). Both the `check_worktree` protect block **and** the orphan-loop guard now skip a worktree carrying untracked work (`git diff` never sees untracked files, e.g. an untracked ADR draft).
2. **Silent discard now opt-in** — the `git reset --hard HEAD` discard of allowlisted "generated" files (`CLAUDE.md`, `ibl5/bun.lock`) is gated behind a new `--discard-generated` flag, **default OFF**. `merge-master-to-prod` calls `cleanup --all` with no flag, so its sweep is non-destructive without editing that script.
3. **check-3 conservative** — replaced the `tip != master-tip` test with `merge-base --fork-point` + a real own-commit beyond the fork-point; an empty fork-point means **NOT merged**. Applied to the worktree check and the bare-branch sweep. A fresh never-committed branch and an own-commit ff-merged branch are **graph-indistinguishable** (both fully contained in master), so both are conservatively skipped. **Check 1 (PR MERGED via gh) is the authoritative merged-signal** in practice; we accept leaving a rare no-PR merged branch over risking in-progress work.
4. **Case-insensitive orphan dedupe** — git registers a worktree under whatever-cased path it was created through (`/Users/.../github/...` vs REPO_ROOT `/Users/.../GitHub/...`). The orphan-dedupe `grep -q "^worktree $dir$"` was case-sensitive → missed the live worktree → re-processed it down the orphan `rm -rf` branch. Now a `tr`-lowercase compare.

The orphan-loop untracked guard is a **defense-in-depth backstop** added without a dedicated test row: defect-4's fix makes registered worktrees skip the orphan loop entirely, and a genuinely-detached orphan typically has a broken `.git` where no git guard works.

## Tests

`bin/test-cleanup-safety` (new) builds throwaway git repos under `mktemp -d`, sets up each precondition, and asserts `bin/cleanup --all --dry-run` decisions (`WOULD clean` vs `SKIP`). 10 rows, all pass; **5 discriminate** (red against pre-fix `bin/cleanup`, green after — verified via `git stash`). Defect-4 row is FS-gated (reproduces on case-insensitive FS; skips on case-sensitive CI). shellcheck-clean (`--severity=warning --shell=bash`, bash 3.2).

## Manual Testing

No manual testing needed — all verification is automated (`bin/test-cleanup-safety` + shellcheck).

<!-- no-adr: regression test + hardening edits to existing bin/cleanup; no new architectural constraint -->

Generated with [Claude Code](https://claude.ai/code)