### PR TITLE
rules: decouple /post-plan from implementation (stop + hand off)

### DIFF
--- a/.claude/rules/auto-commit.md
+++ b/.claude/rules/auto-commit.md
@@ -1,6 +1,6 @@
 ---
 description: Auto-commit after completing changes; amend when fixing unpushed work
-last_verified: 2026-05-24
+last_verified: 2026-06-04
 ---
 
 # Auto-Commit
@@ -13,6 +13,7 @@ Do NOT auto-commit when:
 - You're mid-task with more phases to complete (commit at logical checkpoints instead)
 - The user is asking a question or exploring options (no files changed)
 - You're inside `/post-plan` (it handles commits internally)
+- You just finished implementing a `/plan` (the plan workflow is active, or you're in a plan worktree) — do NOT commit. STOP and hand off; the separate `/post-plan` session commits the working tree (its Phase 2) and ships.
 
 ## Amend vs new commit
 

--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -1,6 +1,6 @@
 ---
-description: Worktree setup and /post-plan workflow rules for multi-step implementation work.
-last_verified: 2026-05-27
+description: Worktree setup and the implementation→/post-plan handoff (run separately) for multi-step work.
+last_verified: 2026-06-04
 ---
 
 # Workflow Continuity Rule
@@ -21,4 +21,10 @@ Use `--base <branch>` for stacked PRs. Work in `worktrees/<slug>/ibl5/`. Skip if
 
 ## Post-Plan
 
-After implementation, invoke `/post-plan` and let it run to completion.
+After implementation, **STOP** — do **NOT** invoke `/post-plan` in this session. Leave the worktree with **uncommitted** changes and hand off; do not commit.
+
+`/post-plan` is run **separately**, in a **fresh** session (typically Sonnet), with **cwd = this worktree** so it sees the uncommitted working tree. Run it from a fresh session in the worktree as the model handing off, or hand the branch to a teammate.
+
+Why separate: `/post-plan` re-reads the full implementation context on every phase, so running it inline after a long implementation session — especially on Opus — costs several times a fresh run.
+
+`/post-plan` auto-resolves the plan from the branch slug, fetches the diff itself, and commits the uncommitted working tree in its Phase 2.


### PR DESCRIPTION
## Summary

Rewrites two agent-guidance rule files so the implementation session **stops and hands off** rather than auto-chaining into `/post-plan` in the same session.

- `workflow-continuity.md` § Post-Plan: replaces "invoke `/post-plan` and let it run to completion" with an explicit STOP + hand-off instruction; states the cwd requirement (fresh session must have cwd = the worktree) and the cost rationale.
- `auto-commit.md`: adds a plan-flow exclusion bullet to the "Do NOT auto-commit when" list — the load-bearing edit that prevents the auto-commit rule from firing and creating a commit→gate-block→re-nudge deadlock at handoff.

Three local-only files (post-verification-workflow.sh, plan-gate-commit.sh, settings.local.json) were hand-edited in place and are not in this PR — they are gitignored / outside the repo.

## Manual Testing

No manual testing needed — all changes are covered by automated tests.
