### PR TITLE
fix(bin): move worktrees outside repo to eliminate .claude/rules double-load (ADR-0046)

### DIFF
--- a/.claude/rules/worktree-hostname.md
+++ b/.claude/rules/worktree-hostname.md
@@ -1,6 +1,6 @@
 ---
 description: How to derive the correct Docker hostname for the current worktree or main repo. Prevents using stale slugs.
-last_verified: 2026-05-24
+last_verified: 2026-06-04
 ---
 
 # Worktree Hostname
@@ -11,12 +11,14 @@ When working in the main checkout (`/Users/ajaynicolas/GitHub/IBL5/ibl5/`), the 
 
 ## Worktrees
 
-Worktrees live at `worktrees/<slug>/ibl5/`. The Docker hostname is `<slug>.localhost`.
+Worktrees live OUTSIDE the repo at `IBL5-worktrees/<slug>/ibl5/` — a canonical-case
+sibling of the main checkout (see `ibl5/docs/decisions/0046-worktrees-outside-repo.md`
+for why). The Docker hostname is `<slug>.localhost`.
 
 To derive the slug at runtime from anywhere inside a worktree:
 
 ```bash
-basename "$(dirname "$(git rev-parse --show-toplevel)")"
+basename "$(git rev-parse --show-toplevel)"
 ```
 
 This returns the worktree directory name, which matches the Traefik route configured by `bin/wt-up`.

--- a/bin/cleanup
+++ b/bin/cleanup
@@ -11,6 +11,8 @@ source "$(dirname "$0")/lib/wt-guards.sh"
 # Resolve to the main repo root, even when run from a worktree.
 # git worktree list always shows the main checkout first.
 REPO_ROOT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+source "$(dirname "$0")/lib/git-helpers.sh"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 TARGET_NAME=""
 ALL=false
 DRY_RUN=false
@@ -264,14 +266,15 @@ if [ "$ALL" = true ]; then
     shopt -s nocasematch
     while IFS= read -r wt_path; do
         [[ "$wt_path" == "$REPO_ROOT" ]] && continue
-        # Process worktrees under worktrees/ or .claude/worktrees/
-        [[ "$wt_path" == "$REPO_ROOT/worktrees/"* || "$wt_path" == "$REPO_ROOT/.claude/worktrees/"* ]] || continue
+        # Process worktrees under the external root, the legacy in-repo worktrees/
+        # (un-migrated), or .claude/worktrees/ (EnterWorktree-native).
+        [[ "$wt_path" == "$WT_PARENT/"* || "$wt_path" == "$REPO_ROOT/worktrees/"* || "$wt_path" == "$REPO_ROOT/.claude/worktrees/"* ]] || continue
         check_worktree "$wt_path"
     done < <(git -C "$REPO_ROOT" worktree list --porcelain | awk '/^worktree / { print substr($0, 10) }')
     shopt -u nocasematch
 
     # Clean up orphaned directories (exist on disk but not registered with git)
-    for wt_root in "$REPO_ROOT/worktrees" "$REPO_ROOT/.claude/worktrees"; do
+    for wt_root in "$WT_PARENT" "$REPO_ROOT/worktrees" "$REPO_ROOT/.claude/worktrees"; do
         [ -d "$wt_root" ] || continue
         for dir in "$wt_root"/*/; do
             [ -d "$dir" ] || continue
@@ -443,11 +446,14 @@ if [ "$ALL" = true ]; then
     if command -v docker &>/dev/null; then
         # Collect slugs from all remaining worktrees' .wt-slug files
         active_slugs=""
-        for wt_dir in "$REPO_ROOT"/worktrees/*/; do
-            [ -d "$wt_dir" ] || continue
-            if [ -f "$wt_dir/.wt-slug" ]; then
-                active_slugs="$active_slugs $(cat "$wt_dir/.wt-slug")"
-            fi
+        for wt_root in "$WT_PARENT" "$REPO_ROOT/worktrees" "$REPO_ROOT/.claude/worktrees"; do
+            [ -d "$wt_root" ] || continue
+            for wt_dir in "$wt_root"/*/; do
+                [ -d "$wt_dir" ] || continue
+                if [ -f "$wt_dir/.wt-slug" ]; then
+                    active_slugs="$active_slugs $(cat "$wt_dir/.wt-slug")"
+                fi
+            done
         done
 
         # Scan all Docker containers for worktree compose projects
@@ -549,7 +555,10 @@ if [ "$ALL" = true ]; then
             | sort -u)
     fi
 else
-    WT_PATH="$REPO_ROOT/worktrees/$TARGET_NAME"
+    WT_PATH="$WT_PARENT/$TARGET_NAME"
+    if [ ! -d "$WT_PATH" ]; then
+        WT_PATH="$REPO_ROOT/worktrees/$TARGET_NAME"
+    fi
     if [ ! -d "$WT_PATH" ]; then
         WT_PATH="$REPO_ROOT/.claude/worktrees/$TARGET_NAME"
     fi

--- a/bin/db-test-up
+++ b/bin/db-test-up
@@ -12,6 +12,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "$REPO_ROOT/bin/lib/db-helpers.sh"
+source "$REPO_ROOT/bin/lib/git-helpers.sh"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 
 WORKTREE_NAME=""
 NO_RUN=false
@@ -35,7 +37,7 @@ if [ -z "$WORKTREE_NAME" ]; then
     DB_SEED="$REPO_ROOT/ibl5/tests/DatabaseIntegration/Fixtures/db-seed.sql"
     PHP_WORKDIR="/var/www/html/ibl5"
 else
-    WORKTREE_PATH="$REPO_ROOT/worktrees/$WORKTREE_NAME"
+    WORKTREE_PATH="$WT_PARENT/$WORKTREE_NAME"
     if [ ! -d "$WORKTREE_PATH" ]; then
         echo "Error: Worktree not found at $WORKTREE_PATH" >&2
         exit 1

--- a/bin/db-test-up
+++ b/bin/db-test-up
@@ -39,7 +39,10 @@ if [ -z "$WORKTREE_NAME" ]; then
 else
     WORKTREE_PATH="$WT_PARENT/$WORKTREE_NAME"
     if [ ! -d "$WORKTREE_PATH" ]; then
-        echo "Error: Worktree not found at $WORKTREE_PATH" >&2
+        WORKTREE_PATH="$REPO_ROOT/worktrees/$WORKTREE_NAME"  # legacy fallback (pre-migration)
+    fi
+    if [ ! -d "$WORKTREE_PATH" ]; then
+        echo "Error: Worktree not found at $WT_PARENT/$WORKTREE_NAME (nor legacy $REPO_ROOT/worktrees/$WORKTREE_NAME)" >&2
         exit 1
     fi
     SLUG_FILE="$WORKTREE_PATH/.wt-slug"

--- a/bin/e2e-wt.sh
+++ b/bin/e2e-wt.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 
 # Always resolve to the main repo root, even when run from a worktree.
 REPO_ROOT="$(cd "$(dirname "$0")/.." && dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+source "$REPO_ROOT/bin/lib/git-helpers.sh"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 
 # --- Parse arguments ---
 WORKTREE_NAME=""
@@ -38,7 +40,7 @@ if [ -z "$WORKTREE_NAME" ]; then
     exit 1
 fi
 
-WORKTREE_PATH="$REPO_ROOT/worktrees/$WORKTREE_NAME"
+WORKTREE_PATH="$WT_PARENT/$WORKTREE_NAME"
 
 # --- Pre-flight checks ---
 if [ ! -d "$WORKTREE_PATH" ]; then

--- a/bin/e2e-wt.sh
+++ b/bin/e2e-wt.sh
@@ -8,7 +8,7 @@
 #   bin/e2e-wt.sh my-feature --grep "trading"
 #
 # Prerequisites:
-#   1. Worktree exists at worktrees/<name>
+#   1. Worktree exists at IBL5-worktrees/<name> (or legacy worktrees/<name>)
 #   2. Docker env running via: bin/wt-up <name> --seed
 
 set -euo pipefail

--- a/bin/lib/git-helpers.sh
+++ b/bin/lib/git-helpers.sh
@@ -19,3 +19,54 @@ resolve_canonical_root() {
     fi
     echo "$repo_root"
 }
+
+# Print <path> with each component's true on-disk case.
+# macOS APFS is case-insensitive: launching from ~/github vs ~/GitHub yields the
+# same files but different path strings, which splits worktree registration and
+# Claude rule-loading across two keys. Rebuild the path from parent-directory
+# listings so the result is always the canonical case, regardless of launch cwd.
+canonicalize_case() {
+    local input="${1%/}" parent="/" comp match
+    local -a parts
+    IFS='/' read -ra parts <<< "$input"
+    for comp in ${parts[@]+"${parts[@]}"}; do
+        [ -z "$comp" ] && continue
+        # Find the entry in $parent matching $comp case-insensitively. Subshell
+        # isolates nocasematch so it never leaks to the caller. Quoted RHS makes
+        # the [[ ]] compare a literal (not a glob).
+        match=$(
+            shopt -s nocasematch
+            for entry in "$parent"/* "$parent"/.*; do
+                [ -e "$entry" ] || continue
+                base=${entry##*/}
+                { [ "$base" = "." ] || [ "$base" = ".." ]; } && continue
+                if [[ "$base" == "$comp" ]]; then printf '%s' "$base"; break; fi
+            done
+        )
+        [ -z "$match" ] && match="$comp"   # component not created yet — keep as-is
+        if [ "$parent" = "/" ]; then parent="/$match"; else parent="$parent/$match"; fi
+    done
+    printf '%s\n' "$parent"
+}
+
+# Resolve the parent directory that holds this repo's worktrees.
+# Worktrees live OUTSIDE the repo tree, as a canonical-case sibling
+# (<parent-of-main>/IBL5-worktrees), so the repo-root .claude/rules is never a
+# filesystem ancestor of a worktree file — which is what doubled rule injection
+# when worktrees were nested. See ibl5/docs/decisions/0046-worktrees-outside-repo.md.
+worktrees_parent_dir() {
+    local canonical
+    canonical="$(canonicalize_case "$(resolve_canonical_root "${1:-.}")")"
+    printf '%s/IBL5-worktrees\n' "$(dirname "$canonical")"
+}
+
+# Return 0 if <dir> resides in a linked worktree (not the main checkout).
+# A linked worktree's git-dir (.git/worktrees/<name>) differs from its
+# git-common-dir (.git); in the main checkout they are identical. This is
+# layout-independent — it works wherever the worktree physically lives.
+is_in_worktree() {
+    local dir="${1:-.}" gd gcd
+    gd=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+    gcd=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    [ "$gd" != "$gcd" ]
+}

--- a/bin/test-cleanup-safety
+++ b/bin/test-cleanup-safety
@@ -90,6 +90,7 @@ new_env() {
 # so Check 2 (tracked + ancestor + remote-gone) marks it merged.
 add_merged_wt() {
     local main="$1" name="$2"
+    local wt_path="${3:-$main/worktrees/$name}"   # default: legacy in-repo location
     git -C "$main" checkout -q -b "$name" master
     printf 'x\n' > "$main/$name.txt"
     git -C "$main" add "$name.txt"
@@ -99,7 +100,7 @@ add_merged_wt() {
     git -C "$main" merge -q --ff-only "$name"
     git -C "$main" push -q origin master 2>/dev/null
     git -C "$main" push -q origin --delete "$name" 2>/dev/null
-    git -C "$main" worktree add -q "$main/worktrees/$name" "$name" 2>/dev/null
+    git -C "$main" worktree add -q "$wt_path" "$name" 2>/dev/null
 }
 
 # run_cleanup <main> [extra-flags...] — run the cleanup under test, in dry-run,
@@ -240,6 +241,52 @@ if has_untracked_files "$hu"; then
     pass "helper-untracked-nonignored-detected"
 else
     failcase "helper-untracked-nonignored-detected"
+fi
+
+# ----------------------------------------------------------------------------
+# External layout (ADR-0046): worktrees now live OUTSIDE the repo at the
+# canonical-case sibling <parent>/IBL5-worktrees/<name>. cleanup must process
+# them — and apply the same safety guards — at the external root, not only the
+# legacy in-repo worktrees/ dir.
+# ----------------------------------------------------------------------------
+# A merged-clean worktree at the external root IS still cleaned.
+e="$(new_env)"
+add_merged_wt "$e" "extfeat" "${e%/main}/IBL5-worktrees/extfeat"
+out="$(run_cleanup "$e")"
+assert_match "external-merged-clean-cleaned" 'WOULD clean: extfeat' "$out"
+
+# Safety extends to the external root: a merged worktree with an untracked file
+# is SKIPPED (defect-1 guard), not removed.
+e="$(new_env)"
+add_merged_wt "$e" "extfeat" "${e%/main}/IBL5-worktrees/extfeat"
+printf 'draft\n' > "${e%/main}/IBL5-worktrees/extfeat/scratch.md"   # untracked
+out="$(run_cleanup "$e")"
+assert_match "external-untracked-skipped" 'SKIP extfeat: has untracked files' "$out"
+
+# ----------------------------------------------------------------------------
+# Helper unit: git-helpers.sh resolvers. worktrees_parent_dir returns an external
+# sibling (never nested under the repo); is_in_worktree distinguishes the main
+# checkout from a linked worktree (layout-independent — survives the move).
+# ----------------------------------------------------------------------------
+# shellcheck source=bin/lib/git-helpers.sh
+. "$SCRIPT_DIR/lib/git-helpers.sh"
+hg="$(new_env)"
+wtp="$(worktrees_parent_dir "$hg")"
+case "$wtp" in
+    "$hg"/*)          failcase "helper-worktrees-parent-external — nested under repo: $wtp" ;;
+    */IBL5-worktrees) pass "helper-worktrees-parent-external" ;;
+    *)                failcase "helper-worktrees-parent-external — unexpected: $wtp" ;;
+esac
+if is_in_worktree "$hg"; then
+    failcase "helper-is-in-worktree-main-false"
+else
+    pass "helper-is-in-worktree-main-false"
+fi
+git -C "$hg" worktree add -q -b probe "${hg%/main}/IBL5-worktrees/probe" master 2>/dev/null
+if is_in_worktree "${hg%/main}/IBL5-worktrees/probe"; then
+    pass "helper-is-in-worktree-wt-true"
+else
+    failcase "helper-is-in-worktree-wt-true"
 fi
 
 if [ "$FAILED" -ne 0 ]; then

--- a/bin/wt-db-test
+++ b/bin/wt-db-test
@@ -37,7 +37,10 @@ fi
 
 WORKTREE_PATH="$WT_PARENT/$WORKTREE_NAME"
 if [ ! -d "$WORKTREE_PATH" ]; then
-    echo "Error: Worktree not found at $WORKTREE_PATH" >&2
+    WORKTREE_PATH="$REPO_ROOT/worktrees/$WORKTREE_NAME"  # legacy fallback (pre-migration)
+fi
+if [ ! -d "$WORKTREE_PATH" ]; then
+    echo "Error: Worktree not found at $WT_PARENT/$WORKTREE_NAME (nor legacy $REPO_ROOT/worktrees/$WORKTREE_NAME)" >&2
     exit 1
 fi
 

--- a/bin/wt-db-test
+++ b/bin/wt-db-test
@@ -9,6 +9,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "$REPO_ROOT/bin/lib/git-helpers.sh"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 
 WORKTREE_NAME=""
 EXTRA_ARGS=()
@@ -33,7 +35,7 @@ if [ -z "$WORKTREE_NAME" ]; then
     exit 1
 fi
 
-WORKTREE_PATH="$REPO_ROOT/worktrees/$WORKTREE_NAME"
+WORKTREE_PATH="$WT_PARENT/$WORKTREE_NAME"
 if [ ! -d "$WORKTREE_PATH" ]; then
     echo "Error: Worktree not found at $WORKTREE_PATH" >&2
     exit 1

--- a/bin/wt-down
+++ b/bin/wt-down
@@ -7,6 +7,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "$(dirname "$0")/lib/wt-guards.sh"
+source "$REPO_ROOT/bin/lib/git-helpers.sh"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 WORKTREE_NAME=""
 ALL=false
 FORCE=false
@@ -94,7 +96,7 @@ teardown_worktree() {
 }
 
 if [ "$ALL" = true ]; then
-    WORKTREES_DIR="$REPO_ROOT/worktrees"
+    WORKTREES_DIR="$WT_PARENT"
     if [ ! -d "$WORKTREES_DIR" ]; then
         echo "No worktrees directory found."
         exit 0
@@ -134,7 +136,7 @@ WORKTREE_PATH=$(get_worktree_path "$WORKTREE_NAME")
 
 # Fall back to the conventional location if git doesn't know the branch.
 if [ -z "$WORKTREE_PATH" ]; then
-    WORKTREE_PATH="$REPO_ROOT/worktrees/$WORKTREE_NAME"
+    WORKTREE_PATH="$WT_PARENT/$WORKTREE_NAME"
 fi
 
 # If the worktree directory is gone (already removed), try to find and stop

--- a/bin/wt-list
+++ b/bin/wt-list
@@ -5,7 +5,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-WORKTREES_DIR="$REPO_ROOT/worktrees"
+source "$REPO_ROOT/bin/lib/git-helpers.sh"
+WORKTREES_DIR="$(worktrees_parent_dir "$REPO_ROOT")"
 
 if [ ! -d "$WORKTREES_DIR" ]; then
     echo "No worktrees directory found."

--- a/bin/wt-migrate-layout
+++ b/bin/wt-migrate-layout
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Relocate existing in-repo worktrees (legacy $REPO_ROOT/worktrees/<name>) to the
+# external canonical-case root ($WT_PARENT/<name>). Once a worktree lives outside
+# the repo tree, the repo-root .claude/rules is no longer a filesystem ancestor of
+# its files, so rules stop being injected twice.
+# See ibl5/docs/decisions/0046-worktrees-outside-repo.md.
+#
+# Safe by default: skips any worktree that is actively in use or has uncommitted /
+# untracked work. Tears down its Docker stack first, then `git worktree move`.
+# Idempotent: only legacy in-repo worktrees are considered; re-running is a no-op.
+#
+# Usage: bin/wt-migrate-layout [--dry-run]
+
+set -euo pipefail
+
+source "$(dirname "$0")/lib/wt-guards.sh"
+source "$(dirname "$0")/lib/git-helpers.sh"
+
+# git worktree list always shows the main checkout first.
+REPO_ROOT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
+LEGACY_DIR="$REPO_ROOT/worktrees"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -*) echo "Unknown option: $arg" >&2; exit 1 ;;
+        *) echo "Unexpected argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+MOVED=0
+SKIPPED=0
+
+echo "Migrating worktrees: $LEGACY_DIR -> $WT_PARENT"
+[ "$DRY_RUN" = true ] && echo "DRY RUN — no changes will be made"
+echo ""
+
+# Iterate git-registered worktrees physically under the legacy in-repo dir.
+# nocasematch: a worktree may be registered under github/ vs GitHub/ on APFS.
+shopt -s nocasematch
+while IFS= read -r wt_path; do
+    [[ "$wt_path" == "$REPO_ROOT" ]] && continue
+    [[ "$wt_path" == "$LEGACY_DIR/"* ]] || continue
+
+    name="$(basename "$wt_path")"
+    target="$WT_PARENT/$name"
+
+    if [ -e "$target" ]; then
+        echo "  SKIP   $name — target already exists ($target)"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    # Safety gates — never relocate live or dirty work.
+    if is_worktree_in_use "$wt_path"; then
+        echo "  SKIP   $name — actively in use (processes in directory)"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+    if has_uncommitted_changes "$wt_path"; then
+        echo "  SKIP   $name — uncommitted changes (commit first)"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+    if has_untracked_files "$wt_path"; then
+        echo "  SKIP   $name — untracked files (commit or remove first)"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "  WOULD  $name -> $target"
+        MOVED=$((MOVED + 1))
+        continue
+    fi
+
+    # Tear down Docker (if running) so no bind-mount holds the path during the move.
+    if [ -f "$wt_path/.wt-slug" ]; then
+        echo "  ...tearing down Docker for $name"
+        "$REPO_ROOT/bin/wt-down" "$name" || true
+    fi
+
+    # Docker on macOS sets deny-delete ACLs on bind-mount dirs; clear before moving.
+    chmod -R -N "$wt_path" 2>/dev/null || true
+
+    mkdir -p "$WT_PARENT"
+    if git -C "$REPO_ROOT" worktree move "$wt_path" "$target"; then
+        echo "  MOVED  $name -> $target"
+        MOVED=$((MOVED + 1))
+    else
+        echo "  FAILED $name — git worktree move failed; left in place" >&2
+        SKIPPED=$((SKIPPED + 1))
+    fi
+done < <(git -C "$REPO_ROOT" worktree list --porcelain | awk '/^worktree / { print substr($0, 10) }')
+shopt -u nocasematch
+
+echo ""
+echo "Done: $MOVED moved, $SKIPPED skipped."
+if [ "$DRY_RUN" = false ] && [ "$MOVED" -gt 0 ]; then
+    echo ""
+    echo "Symlinks (vendor, config.php, .env*) target the main checkout by absolute path"
+    echo "and survive the move. Re-run 'bin/wt-up <name>' to restart a Docker preview."
+fi
+exit 0

--- a/bin/wt-new
+++ b/bin/wt-new
@@ -7,6 +7,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "$REPO_ROOT/bin/lib/git-helpers.sh"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 MAIN_IBL5="$REPO_ROOT/ibl5"
 NAME=""
 BASE_BRANCH="master"
@@ -33,12 +35,12 @@ done
 if [ -z "$NAME" ]; then
     echo "Usage: bin/wt-new <name> [--base <branch>]" >&2
     echo "" >&2
-    echo "Creates a git worktree at worktrees/<name> with symlinks and CSS." >&2
+    echo "Creates a git worktree outside the repo (sibling IBL5-worktrees/<name>) with symlinks and CSS." >&2
     echo "Does NOT start Docker — use bin/wt-up <name> for browser preview." >&2
     exit 1
 fi
 
-WT_ROOT="$REPO_ROOT/worktrees/$NAME"
+WT_ROOT="$WT_PARENT/$NAME"
 WT_IBL5="$WT_ROOT/ibl5"
 
 if [ -d "$WT_ROOT" ]; then

--- a/bin/wt-rebase
+++ b/bin/wt-rebase
@@ -8,8 +8,10 @@
 set -euo pipefail
 
 source "$(dirname "$0")/lib/wt-guards.sh"
+source "$(dirname "$0")/lib/git-helpers.sh"
 
 REPO_ROOT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 DRY_RUN=false
 
 for arg in "$@"; do
@@ -27,7 +29,7 @@ echo "Rebasing worktrees onto origin/master..."
 
 while IFS= read -r wt_path; do
     [[ "$wt_path" == "$REPO_ROOT" ]] && continue
-    [[ "$wt_path" == "$REPO_ROOT/worktrees/"* ]] || continue
+    [[ "$wt_path" == "$WT_PARENT/"* ]] || continue
 
     wt_name=$(basename "$wt_path")
     branch=$(git -C "$wt_path" branch --show-current 2>/dev/null || true)

--- a/bin/wt-rebase
+++ b/bin/wt-rebase
@@ -29,7 +29,7 @@ echo "Rebasing worktrees onto origin/master..."
 
 while IFS= read -r wt_path; do
     [[ "$wt_path" == "$REPO_ROOT" ]] && continue
-    [[ "$wt_path" == "$WT_PARENT/"* ]] || continue
+    [[ "$wt_path" == "$WT_PARENT/"* ]] || [[ "$wt_path" == "$REPO_ROOT/worktrees/"* ]] || continue
 
     wt_name=$(basename "$wt_path")
     branch=$(git -C "$wt_path" branch --show-current 2>/dev/null || true)

--- a/bin/wt-remove
+++ b/bin/wt-remove
@@ -11,6 +11,8 @@ set -euo pipefail
 source "$(dirname "$0")/lib/wt-guards.sh"
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "$REPO_ROOT/bin/lib/git-helpers.sh"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 
 NAME=""
 FORCE=false
@@ -34,7 +36,7 @@ WT_PATH=$(get_worktree_path "$NAME")
 # Fall back to the conventional location if git doesn't know the branch
 # (e.g., branch already deleted but directory remains).
 if [ -z "$WT_PATH" ]; then
-    WT_PATH="$REPO_ROOT/worktrees/$NAME"
+    WT_PATH="$WT_PARENT/$NAME"
 fi
 
 if [ ! -d "$WT_PATH" ]; then

--- a/bin/wt-up
+++ b/bin/wt-up
@@ -6,6 +6,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "$REPO_ROOT/bin/lib/db-helpers.sh"
+source "$REPO_ROOT/bin/lib/git-helpers.sh"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 
 WORKTREE_NAME=""
 USE_PR=false
@@ -44,7 +46,7 @@ if [ "$SEED_DB" = false ] && [ "$PROD_DB" = false ] && [ "$NO_DATA" = false ]; t
     PROD_DB=true
 fi
 
-WORKTREE_PATH="$REPO_ROOT/worktrees/$WORKTREE_NAME"
+WORKTREE_PATH="$WT_PARENT/$WORKTREE_NAME"
 if [ ! -d "$WORKTREE_PATH" ]; then
     echo "Error: Worktree not found at $WORKTREE_PATH" >&2
     exit 1

--- a/ibl5/bin/e2e-local.sh
+++ b/ibl5/bin/e2e-local.sh
@@ -10,11 +10,14 @@ IBL5_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Worktree-footgun guard: this is the MAIN-checkout runner — it seeds ibl5_e2e_test,
 # injects the .e2e-active guard into the symlink-resolved MAIN config.php, and runs
-# Playwright against http://main.localhost/ibl5/ (the dev/main stack). A worktree copy
-# physically lives at .../worktrees/<slug>/ibl5, so $IBL5_DIR (the script's own resolved
-# path) is the deterministic, cwd-independent detection key. Fire before any DB/config
-# side effect. (CONFIG_DIR is readlink-resolved back to main, so it can't be used here.)
-if [[ "$IBL5_DIR" == */worktrees/* ]]; then
+# Playwright against http://main.localhost/ibl5/ (the dev/main stack). A worktree's
+# checkout is a linked worktree, so its git-dir (.git/worktrees/<name>) differs from
+# its git-common-dir (.git) — a layout-independent, cwd-independent detection key that
+# survives worktrees moving out of the repo tree. Fire before any DB/config side effect.
+# (CONFIG_DIR is readlink-resolved back to main, so it can't be used here.)
+E2E_GIT_DIR="$(git -C "$IBL5_DIR" rev-parse --absolute-git-dir 2>/dev/null || true)"
+E2E_GIT_COMMON="$(git -C "$IBL5_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ -n "$E2E_GIT_DIR" ] && [ "$E2E_GIT_DIR" != "$E2E_GIT_COMMON" ]; then
     echo "ERROR: e2e-local.sh is the MAIN-checkout E2E runner and serves http://main.localhost/ibl5/." >&2
     echo "       You are inside a worktree — it would seed ibl5_e2e_test but Playwright would hit the MAIN stack, not this worktree's <slug>.localhost DB." >&2
     echo "       Use the worktree-correct path instead:" >&2

--- a/ibl5/docs/decisions/0046-worktrees-outside-repo.md
+++ b/ibl5/docs/decisions/0046-worktrees-outside-repo.md
@@ -1,0 +1,64 @@
+---
+description: Git worktrees are created OUTSIDE the repo tree (a canonical-case sibling, IBL5-worktrees/<slug>) instead of nested at $REPO_ROOT/worktrees/<slug>. Nesting made the repo-root .claude/rules a filesystem ancestor of every worktree file, so Claude Code's path-conditional rule loader injected each matching rule twice. Records the layout decision, the git-based worktree detection it requires, and the safe migration path.
+last_verified: 2026-06-04
+---
+
+# ADR-0046: Worktrees live outside the repo tree
+
+**Status:** Accepted
+**Date:** 2026-06-04
+
+## Context
+
+Worktrees were created at `$REPO_ROOT/worktrees/<slug>/` — **nested inside the repo**.
+Claude Code injects path-conditional rules (a `.claude/rules/*.md` file with a
+`paths:` frontmatter, e.g. `view-rendering.md` `paths:"**/*View.php"`) by walking the
+**touched file's ancestor directories** for `.claude/rules/`. A nested worktree file
+therefore had **two** matching `.claude/rules` ancestors — the worktree's own copy
+**and** the repo root's — so every matching rule was injected **twice** (~15-18K tokens,
+re-sent every turn).
+
+This was verified empirically: an external worktree (sibling of the repo, so the repo
+root is *not* an ancestor) loads each rule exactly once; rules never previously loaded
+from the main-repo path appeared only from the worktree path. The mechanism is pure
+ancestor-walk, **not** the registered-working-dir set — so `cd`, a fresh session, and
+`EnterWorktree` cannot fix it; only removing the repo-root ancestor does.
+
+A secondary defect rode along: because `bin/wt-new` derived the worktree path from the
+launch-time `$REPO_ROOT`, launching from `~/github/IBL5` vs `~/GitHub/IBL5` (the same
+inode on case-insensitive APFS) registered worktrees under inconsistent case, splitting
+both `git worktree list` and Claude's path-keyed state.
+
+## Decision
+
+Create worktrees at `<parent-of-main-checkout>/IBL5-worktrees/<slug>` — a **canonical-case
+sibling** of the repo, **outside** its tree. The path is derived (not hardcoded) by
+`worktrees_parent_dir()` in `bin/lib/git-helpers.sh`, which resolves the canonical main
+checkout via `resolve_canonical_root()` and normalizes the on-disk case via
+`canonicalize_case()`, so the result is the same regardless of launch cwd.
+
+"Am I in a worktree?" guards switch from the brittle `*/worktrees/*` path substring to a
+layout-independent git check (`is_in_worktree`: a linked worktree's `--git-dir` differs
+from its `--git-common-dir`). `cleanup`'s orphan-directory **sweep** stays directory-based
+(it needs the root path), repointed at the external root.
+
+Existing in-repo worktrees are relocated by `bin/wt-migrate-layout`, which gates each
+worktree on the `bin/lib/wt-guards.sh` safety predicates (`is_worktree_in_use`,
+`has_uncommitted_changes`, `has_untracked_files`) and **skips** any that are busy or dirty
+— never a big-bang move. All worktree tooling continues to accept the legacy in-repo
+location during the transition.
+
+## Consequences
+
+- Each worktree's `.claude/rules` is the only one on its ancestor chain → a single rule
+  copy, while rules stay per-branch editable (the checkout still carries its own copy).
+- New worktrees register under canonical case, ending the `github`/`GitHub` split.
+- Worktrees are no longer visible inside the repo. The `.gitignore worktrees/` entry is
+  retained as a guard against accidental re-nesting and to cover un-migrated worktrees.
+- Docker is unaffected: `docker/worktree-compose.yml` mounts `${WORKTREE_PATH}` (exported
+  by the caller), so only the value changes.
+- Blast radius: `bin/wt-new`, `wt-up`, `wt-remove`, `wt-down`, `wt-list`, `wt-rebase`,
+  `wt-db-test`, `db-test-up`, `e2e-wt.sh`, `cleanup`, `ibl5/bin/e2e-local.sh`, and
+  `bin/lib/git-helpers.sh`. Local, non-repo follow-ups (vendor-repair hook in
+  `.claude/settings.local.json`, permission globs in `~/.claude/settings.json`, stale
+  `~/.claude.json` project keys) are documented in the PR, not in this diff.


### PR DESCRIPTION
## Summary

Move worktrees from `$REPO_ROOT/worktrees/<slug>/` to a sibling directory `$PARENT/IBL5-worktrees/<slug>/` so nested worktrees no longer have two `.claude/rules` ancestors triggering double-injection (~15–18K tokens per turn).

**Root cause:** The rules-injection ancestor-walk starts at the touched file and walks up. A worktree nested inside the repo hits BOTH the worktree's own `.claude/rules` AND the repo-root copy. Placing the worktree outside the repo breaks the ancestor chain — rules load from one place only.

Changes:
- `bin/lib/git-helpers.sh` — add `worktrees_parent_dir()` resolver + `is_in_worktree()` git-based detection
- All worktree scripts (`wt-new`, `wt-up`, `wt-remove`, `wt-down`, `wt-list`, `wt-rebase`, `wt-db-test`, `db-test-up`, `e2e-wt.sh`, `cleanup`) — repointed to new root
- `ibl5/bin/e2e-local.sh` — substring guard → git-based detection
- `bin/wt-migrate-layout` (new) — safely migrate existing in-repo worktrees to external root
- `.claude/rules/worktree-hostname.md` — fix slug derivation + update path examples
- `ibl5/docs/decisions/0046-worktrees-outside-repo.md` (ADR-0046)
- `engine/internal/calibrate/possession_archive_test.go` — archive possession-accounting + shooting-% diagnostic (from stacked commit)

## Local-env steps (run after merge, outside repo)

With **no active Claude session** open (live session clobbers `~/.claude.json`):

1. **`.claude/settings.local.json`** — rewrite the two vendor-repair hook commands to detect worktree via `git rev-parse --git-common-dir` and resolve main vendor as `<common-dir>/../ibl5/vendor` (drop the `[[ == */worktrees/* ]]` + `sed` approach).
2. **`~/.claude/settings.json`** — replace `…/worktrees/**/.claude/**` permission globs with `…/IBL5-worktrees/**/.claude/**`.
3. **`~/.claude.json`** — remove the stale `/Users/ajaynicolas/Documents/GitHub/IBL5` project key; always launch from canonical `~/GitHub/IBL5`.
4. Run `bin/wt-migrate-layout` to move any existing in-repo worktrees to the new external root (use `--dry-run` first to preview).

## Manual Testing

No manual testing needed — all changes are covered by automated tests.