### PR TITLE
test: fix 49 undefined-key warnings + gate via failOnWarning

### DIFF
--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="tests/bootstrap.php"
          colors="true"
-         testdox="true">
+         testdox="true"
+         failOnWarning="true">
     <testsuites>
         <testsuite name="Auth Module Tests">
             <directory>tests/Auth</directory>

--- a/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
@@ -26,7 +26,10 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
     {
         $badDb = new \mysqli();
         try {
-            $badDb->real_connect('db', 'nonexistent_user_xyz', 'wrong', 'x');
+            // Deliberate bad connection: host 'db' is unresolvable on the CI
+            // runner (DB_HOST=127.0.0.1) and emits a real_connect() warning we
+            // expect — suppress it so failOnWarning gates only genuine warnings.
+            @$badDb->real_connect('db', 'nonexistent_user_xyz', 'wrong', 'x');
         } catch (\mysqli_sql_exception) {
             // connect_errno is now set
         }

--- a/ibl5/tests/FreeAgency/FreeAgencyServiceTest.php
+++ b/ibl5/tests/FreeAgency/FreeAgencyServiceTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
 use Team\Contracts\TeamQueryRepositoryInterface;
 use Team\Team;
 use Tests\WideUnit\Mocks\MockDatabase;
+use Tests\WideUnit\Mocks\TestDataFactory;
 
 /**
  * @covers \FreeAgency\FreeAgencyService
@@ -143,8 +144,8 @@ class FreeAgencyServiceTest extends TestCase
     public function testGetMainPageDataIncludesAllOtherPlayers(): void
     {
         $testPlayers = [
-            ['pid' => 1, 'name' => 'Player A'],
-            ['pid' => 2, 'name' => 'Player B'],
+            TestDataFactory::createPlayer(['pid' => 1, 'name' => 'Player A']),
+            TestDataFactory::createPlayer(['pid' => 2, 'name' => 'Player B']),
         ];
         $this->stubRepo->method('getAllPlayersExcludingTeam')->willReturn($testPlayers);
 


### PR DESCRIPTION
## Summary

Investigation of PHPUnit/PHPStan warnings on master found 49 `Undefined array key` warnings (all from one FreeAgency test) that CI never flagged because its phpunit invocation has no `--fail-on-warning`. This fixes the root cause and adds the gate so warnings can't accumulate silently again.

## Changes

- **`FreeAgencyServiceTest::testGetMainPageDataIncludesAllOtherPlayers`** — the fixture passed player rows with only `pid`/`name`, but `PlayerRepository::fillFromCurrentRow` reads ~24 keys directly (`ordinal`, `age`, `r_*`, …). Each missing key emitted a warning (49 total). Now hydrated via `TestDataFactory::createPlayer`, which supplies a complete `ibl_plr` row.
- **`phpunit.xml`** — `failOnWarning="true"`. Warnings are now build failures.
- **`BaseMysqliRepositoryTest::testConstructorThrowsOnInvalidConnection`** — this test deliberately calls `real_connect('db', …)` with bad creds. Host `'db'` is unresolvable on the CI runner (`DB_HOST=127.0.0.1`), so `real_connect` leaks a `getaddrinfo` warning that would redden the CI **database** job the moment `failOnWarning` shipped. Suppressed with `@` so the gate catches only genuine warnings.

## Verification

| Check | Result |
|---|---|
| Full suite (host, `failOnWarning`) | 5810 tests, 0 fail / **0 warn**, 1 skip |
| `--group database` (`failOnWarning`) | 871 tests, **0 warn** |
| `composer run analyse` | `[OK] No errors` |
| `composer run analyse:tests` | `[OK] No errors` |

## Out of scope (env-only, no code)

- `Cli/*` tests fail only when PHPUnit runs via `docker exec` (repo-root `bin/` isn't mounted). Run on the host, as CI does.
- A stray git-ignored `modules/SiteStatistics/` local dir tripped `ModuleRegistryTest` locally; deleted (no tracked change).

## Manual Testing

No manual testing needed — all changes are covered by automated tests (PHPUnit with `failOnWarning=true`).