### PR TITLE
fix(check-docs): allow same-UTC-day re-edit via commit-date escape

### DIFF
--- a/.claude/rules/doc-freshness.md
+++ b/.claude/rules/doc-freshness.md
@@ -1,6 +1,6 @@
 ---
 description: Frontmatter schema, 60-day staleness policy, on-touch verification rule, and dead-reference rules enforced by bin/check-docs
-last_verified: 2026-05-31
+last_verified: 2026-06-04
 paths: "**/*.md"
 ---
 
@@ -25,7 +25,7 @@ paths: "glob-or-list"  # only meaningful for .claude/rules/*
 
 When editing any in-scope `.md` file, verify its content still matches reality, confirm the `description` field accurately reflects the content, and bump `last_verified` to today — all in the same edit.
 
-This is enforced in CI by `bin/check-docs --since=<base-ref>`, which fails any PR that changes an in-scope `.md` body without bumping `last_verified` (a base-vs-head value comparison, never date-equality-to-today, so a PR opened one day and merged later does not false-fail).
+This is enforced in CI by `bin/check-docs --since=<base-ref>`, which fails any PR that changes an in-scope `.md` body without bumping `last_verified` (a base-vs-head value comparison, never date-equality-to-today, so a PR opened one day and merged later does not false-fail). Exception: if the doc was already verified earlier the **same day**, the value cannot bump higher without going into the future — so an unchanged value still passes when it equals the edit's git commit date. That escape keys off the immutable commit date, not the CI clock, so it does not reintroduce a midnight false-fail. The practical effect: a same-UTC-day re-edit of a doc verified earlier that day does not have to wait for UTC rollover. Trade-off: at one-day granularity the escape cannot tell a genuine same-day re-verification from a same-day edit that skipped re-checking — an accepted loosening, since the alternative (a hard same-day deadlock) was worse.
 
 ## Dead-Reference Rule
 

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -418,6 +418,39 @@ function fixDates(array $files, \DateTimeImmutable $today): int
 }
 
 /**
+ * Default-tz calendar date (Y-m-d) of the most recent commit in $base..HEAD that
+ * touched $rel — the date the change was committed. Read from the author
+ * timestamp (%at), an absolute instant, then formatted in the same default
+ * timezone as $today so the two share one frame.
+ *
+ * Immutable per commit, so comparing last_verified against it is independent of
+ * when CI runs: a same-day re-edit of a doc already verified today passes without
+ * waiting for UTC rollover, and a PR spanning midnight never false-fails (the trap
+ * equality-to-today would create). Returns null when the date can't be read, so
+ * the caller falls back to the strict value comparison (fail-closed).
+ */
+function editCommitDate(string $repoRoot, string $base, string $rel): ?string
+{
+    $cmd = sprintf(
+        'git -C %s log -1 --format=%%at %s..HEAD -- %s 2>/dev/null',
+        escapeshellarg($repoRoot),
+        escapeshellarg($base),
+        escapeshellarg($rel)
+    );
+    $out = [];
+    $code = 0;
+    exec($cmd, $out, $code);
+    $ts = trim(implode('', $out));
+    if ($code !== 0 || $ts === '' || ctype_digit($ts) === false) {
+        return null;
+    }
+
+    return (new \DateTimeImmutable('@' . $ts))
+        ->setTimezone(new \DateTimeZone(date_default_timezone_get()))
+        ->format('Y-m-d');
+}
+
+/**
  * Changed-files (PR) mode. For each in-scope .md that changed between $base and
  * HEAD, fail when its body changed but the parsed `last_verified` value did NOT
  * change (the On-Touch Rule), and additionally run the full-scan checkFile()
@@ -426,10 +459,16 @@ function fixDates(array $files, \DateTimeImmutable $today): int
  * The bump check compares the parsed frontmatter VALUE base-vs-head — never
  * date-equality-to-today — so a PR opened Monday and merged Wednesday does not
  * false-fail, and body text that literally contains `last_verified:` (e.g. inside
- * a code fence) cannot trip the check. The value comparison subsumes every case:
- * body-changed-not-bumped fails (values equal), date-bumped passes (values
- * differ), newly-added-with-date passes (base null != date), added-without-date
- * fails (null === null).
+ * a code fence) cannot trip the check. One escape sits on top of the value
+ * compare: when head and base values are EQUAL, the file still passes if that
+ * value equals the edit's commit date (editCommitDate) — a same-day re-edit of a
+ * doc already verified today, which cannot bump higher without becoming a future
+ * date. The escape keys off the immutable commit date, not the CI wall clock, so
+ * it does not reintroduce the midnight false-fail. Cases: body-changed-not-bumped
+ * fails (values equal AND lv predates the edit), date-bumped passes (values
+ * differ), same-day re-edit passes (value == commit date), newly-added-with-date
+ * passes (base null != date), added-without-date fails (null === null, null !=
+ * commit date).
  *
  * @return list<string> diagnostic lines, each prefixed with the repo-relative path.
  */
@@ -483,7 +522,12 @@ function checkChanged(string $base, string $repoRoot, \DateTimeImmutable $today)
         $headLv = $headFm['last_verified'] ?? null;
         $baseLv = $baseFm['last_verified'] ?? null;
 
-        if ($headLv === $baseLv) {
+        // Body changed but the date did not move from base. Allow it only when
+        // the kept date is itself the commit date of this edit — a same-day
+        // re-verify of a doc already verified today, which cannot bump higher
+        // without going into the future. Otherwise it is an un-bumped stale date.
+        $verifiedAtEdit = $headLv !== null && $headLv === editCommitDate($repoRoot, $base, $rel);
+        if ($headLv === $baseLv && !$verifiedAtEdit) {
             $issues[] = sprintf(
                 '%s: body changed but last_verified not bumped (still %s)',
                 $rel,

--- a/ibl5/tests/Cli/CheckDocsCliTest.php
+++ b/ibl5/tests/Cli/CheckDocsCliTest.php
@@ -186,6 +186,22 @@ final class CheckDocsCliTest extends TestCase
     }
 
     #[Test]
+    public function sinceBodyChangedSameDayAsVerifiedExitsZero(): void
+    {
+        // A doc already verified today (e.g. by an earlier same-day merge) whose
+        // body is edited again the same day. last_verified cannot be bumped higher
+        // without becoming a future date, so the commit-date escape must pass it —
+        // no waiting for UTC rollover. The kept date equals the edit's commit date.
+        $today = (new \DateTimeImmutable('today'))->format('Y-m-d');
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($today, 'Original body.'), 'base verified today');
+        $base = $this->currentSha();
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($today, 'Edited body, same day.'), 'edit body same day');
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(0, $code, $output);
+    }
+
+    #[Test]
     public function sinceOutOfScopeChangeExitsZero(): void
     {
         $date = $this->freshDate();


### PR DESCRIPTION
## Problem

`bin/check-docs --since` failed any in-scope `.md` body edit whose `last_verified` already equaled the base value. When a doc was verified earlier the **same UTC day** (e.g. a prior same-day merge — exactly what happened to ADR-0045 after #980), a same-day body edit could not bump the date higher without it becoming a *future* date (caught by the future-date guard). A hard deadlock that forced waiting for UTC rollover.

## Fix

Adds `editCommitDate()`: when head == base `last_verified`, the file still passes if the kept date equals the **edit's git commit date** (author `%at`, formatted in the same default tz as `$today`). The escape keys off the immutable commit date — not the CI wall clock — so it does **not** reintroduce the midnight false-fail that `date-equality-to-today` would. Fail-closed when the commit date cannot be read.

The change **only ever loosens** the gate, so no in-flight doc PR can flip red from it.

## Tests

- `CheckDocsCliTest`: adds `sinceBodyChangedSameDayAsVerifiedExitsZero`; all 12 existing cases stay green (13/13, 35 assertions).
- `analyse:tests` clean; `php -l` clean; dogfooded `bin/check-docs --since=master` on this branch (passes).

## Docs

`.claude/rules/doc-freshness.md` documents the exception and the honest date-granularity trade-off (the escape cannot distinguish a genuine same-day re-verify from a same-day edit that skipped re-checking — accepted, since the deadlock was worse).
