### PR TITLE
docs(engine): ADR-0045 full-precision Cov re-run settle (addendum)

### DIFF
--- a/engine/internal/validate/testdata/calibration-5.60-20260604-freeze-attribution.json
+++ b/engine/internal/validate/testdata/calibration-5.60-20260604-freeze-attribution.json
@@ -1,0 +1,269 @@
+{
+  "game_type": 2,
+  "num_seasons": 18,
+  "runs": 20,
+  "configs": [
+    {
+      "mask": 0,
+      "frozen": null,
+      "var_ln_pf": 0.0009372317486814012,
+      "var_ln_fga": 0.0017927325664736323,
+      "var_ln_pps": 0.0015796859199587868,
+      "cov_ln_fga_ln_pps": -0.0012175933688755095,
+      "cov_ln_fga_ln_pf": 0.0005751391975981229,
+      "num_rows": 484
+    },
+    {
+      "mask": 1,
+      "frozen": [
+        "ORB"
+      ],
+      "var_ln_pf": 0.0009328450752701931,
+      "var_ln_fga": 0.0019562063241841923,
+      "var_ln_pps": 0.0015698375689162012,
+      "cov_ln_fga_ln_pps": -0.0012965994089150982,
+      "cov_ln_fga_ln_pf": 0.0006596069152690941,
+      "num_rows": 484
+    },
+    {
+      "mask": 2,
+      "frozen": [
+        "TVR"
+      ],
+      "var_ln_pf": 0.000643924010448585,
+      "var_ln_fga": 0.001980262501003117,
+      "var_ln_pps": 0.001547200686939078,
+      "cov_ln_fga_ln_pps": -0.0014417695887468046,
+      "cov_ln_fga_ln_pf": 0.0005384929122563124,
+      "num_rows": 484
+    },
+    {
+      "mask": 3,
+      "frozen": [
+        "ORB",
+        "TVR"
+      ],
+      "var_ln_pf": 0.0005798987517098695,
+      "var_ln_fga": 0.0020523342813507112,
+      "var_ln_pps": 0.0015137286944434632,
+      "cov_ln_fga_ln_pps": -0.0014930821120421544,
+      "cov_ln_fga_ln_pf": 0.0005592521693085569,
+      "num_rows": 484
+    },
+    {
+      "mask": 4,
+      "frozen": [
+        "Foul"
+      ],
+      "var_ln_pf": 0.0009630355696677405,
+      "var_ln_fga": 0.0016591608204818448,
+      "var_ln_pps": 0.0014480212308941442,
+      "cov_ln_fga_ln_pps": -0.001072073240854124,
+      "cov_ln_fga_ln_pf": 0.0005870875796277208,
+      "num_rows": 484
+    },
+    {
+      "mask": 5,
+      "frozen": [
+        "ORB",
+        "Foul"
+      ],
+      "var_ln_pf": 0.0009749235138057245,
+      "var_ln_fga": 0.001775391363316819,
+      "var_ln_pps": 0.0014496742846086767,
+      "cov_ln_fga_ln_pps": -0.001125071067059884,
+      "cov_ln_fga_ln_pf": 0.000650320296256935,
+      "num_rows": 484
+    },
+    {
+      "mask": 6,
+      "frozen": [
+        "TVR",
+        "Foul"
+      ],
+      "var_ln_pf": 0.000656632138105237,
+      "var_ln_fga": 0.0018324267137553615,
+      "var_ln_pps": 0.0013924091867180781,
+      "cov_ln_fga_ln_pps": -0.0012841018811841024,
+      "cov_ln_fga_ln_pf": 0.0005483248325712591,
+      "num_rows": 484
+    },
+    {
+      "mask": 7,
+      "frozen": [
+        "ORB",
+        "TVR",
+        "Foul"
+      ],
+      "var_ln_pf": 0.0006168177801642344,
+      "var_ln_fga": 0.001885593344468954,
+      "var_ln_pps": 0.0013902928610794066,
+      "cov_ln_fga_ln_pps": -0.0013295342126920645,
+      "cov_ln_fga_ln_pf": 0.0005560591317768896,
+      "num_rows": 484
+    },
+    {
+      "mask": 8,
+      "frozen": [
+        "Make"
+      ],
+      "var_ln_pf": 0.0007425704736450733,
+      "var_ln_fga": 0.0018087975625136479,
+      "var_ln_pps": 0.0014052895962869845,
+      "cov_ln_fga_ln_pps": -0.00123575834257778,
+      "cov_ln_fga_ln_pf": 0.0005730392199358679,
+      "num_rows": 484
+    },
+    {
+      "mask": 9,
+      "frozen": [
+        "ORB",
+        "Make"
+      ],
+      "var_ln_pf": 0.0007889814447366878,
+      "var_ln_fga": 0.0019461025655165894,
+      "var_ln_pps": 0.0014057793233776992,
+      "cov_ln_fga_ln_pps": -0.001281450222078802,
+      "cov_ln_fga_ln_pf": 0.0006646523434377875,
+      "num_rows": 484
+    },
+    {
+      "mask": 10,
+      "frozen": [
+        "TVR",
+        "Make"
+      ],
+      "var_ln_pf": 0.0004493386681792727,
+      "var_ln_fga": 0.001992502114786671,
+      "var_ln_pps": 0.0013703850594932005,
+      "cov_ln_fga_ln_pps": -0.0014567742530503,
+      "cov_ln_fga_ln_pf": 0.0005357278617363712,
+      "num_rows": 484
+    },
+    {
+      "mask": 11,
+      "frozen": [
+        "ORB",
+        "TVR",
+        "Make"
+      ],
+      "var_ln_pf": 0.0004375382025457683,
+      "var_ln_fga": 0.002088342280436177,
+      "var_ln_pps": 0.001385820674272559,
+      "cov_ln_fga_ln_pps": -0.0015183123760814836,
+      "cov_ln_fga_ln_pf": 0.0005700299043546932,
+      "num_rows": 484
+    },
+    {
+      "mask": 12,
+      "frozen": [
+        "Foul",
+        "Make"
+      ],
+      "var_ln_pf": 0.0007600882876097006,
+      "var_ln_fga": 0.0016724528623871734,
+      "var_ln_pps": 0.0011834879281266363,
+      "cov_ln_fga_ln_pps": -0.0010479262514520539,
+      "cov_ln_fga_ln_pf": 0.0006245266109351196,
+      "num_rows": 484
+    },
+    {
+      "mask": 13,
+      "frozen": [
+        "ORB",
+        "Foul",
+        "Make"
+      ],
+      "var_ln_pf": 0.0008236489706641603,
+      "var_ln_fga": 0.0017336556393599228,
+      "var_ln_pps": 0.0011515947569873404,
+      "cov_ln_fga_ln_pps": -0.0010308007128415515,
+      "cov_ln_fga_ln_pf": 0.0007028549265183713,
+      "num_rows": 484
+    },
+    {
+      "mask": 14,
+      "frozen": [
+        "TVR",
+        "Foul",
+        "Make"
+      ],
+      "var_ln_pf": 0.00046190933130175956,
+      "var_ln_fga": 0.0018322333984905747,
+      "var_ln_pps": 0.0011272895687401436,
+      "cov_ln_fga_ln_pps": -0.0012488068179644797,
+      "cov_ln_fga_ln_pf": 0.000583426580526095,
+      "num_rows": 484
+    },
+    {
+      "mask": 15,
+      "frozen": [
+        "ORB",
+        "TVR",
+        "Foul",
+        "Make"
+      ],
+      "var_ln_pf": 0.00046666008872706794,
+      "var_ln_fga": 0.0018529061879398344,
+      "var_ln_pps": 0.0011160604238562694,
+      "cov_ln_fga_ln_pps": -0.0012511532615345179,
+      "cov_ln_fga_ln_pf": 0.0006017529264053165,
+      "num_rows": 484
+    }
+  ],
+  "arms": [
+    {
+      "arm": "ORB",
+      "d_var_ln_fga": 0.00009068804508340139,
+      "d_cov_ln_fga_ln_pf": 0.000050362662103430035,
+      "d_cov_ln_fga_ln_pps": -0.000040325382979971335,
+      "cov_pps_collapse_frac": -0.033118924602236664
+    },
+    {
+      "arm": "TVR",
+      "d_var_ln_fga": 0.0001488051736846976,
+      "d_cov_ln_fga_ln_pf": -0.00006830477846277131,
+      "d_cov_ln_fga_ln_pps": -0.00021710995214746897,
+      "cov_pps_collapse_frac": -0.1783107215407864
+    },
+    {
+      "arm": "Foul",
+      "d_var_ln_fga": -0.00017595629525337612,
+      "d_cov_ln_fga_ln_pf": 0.000022146264073445275,
+      "d_cov_ln_fga_ln_pps": 0.0001981025593268214,
+      "cov_pps_collapse_frac": 0.16270009708559444
+    },
+    {
+      "arm": "Make",
+      "d_var_ln_fga": -0.00000336330204852084,
+      "d_cov_ln_fga_ln_pf": 0.000022409581093089623,
+      "d_cov_ln_fga_ln_pps": 0.000025772883141610463,
+      "cov_pps_collapse_frac": 0.021167069237090733
+    }
+  ],
+  "mech_panel": [
+    {
+      "mech": "turnover",
+      "cov_with_ln_fga": -0.00003982950555544941,
+      "cov_with_ln_pps": -0.00026071453123837295
+    },
+    {
+      "mech": "oreb_continuation",
+      "cov_with_ln_fga": 0.0002525839603519442,
+      "cov_with_ln_pps": -0.00019737127975333427
+    },
+    {
+      "mech": "foul_only",
+      "cov_with_ln_fga": -0.0009248680705500995,
+      "cov_with_ln_pps": 0.0009279527318546988
+    },
+    {
+      "mech": "miss",
+      "cov_with_ln_fga": 0.00005959012993220383,
+      "cov_with_ln_pps": -0.00021807942606153936
+    }
+  ],
+  "baseline_cov_ln_fga_ln_pps": -0.0012175933688755095,
+  "all_frozen_cov_ln_fga_ln_pps": -0.0012511532615345179,
+  "residual_frac_of_baseline": 1.0275624798203378
+}

--- a/ibl5/docs/decisions/0045-turnover-model-fidelity.md
+++ b/ibl5/docs/decisions/0045-turnover-model-fidelity.md
@@ -1,5 +1,5 @@
 ---
-description: Replaces the mis-ported independent-turnover check (which jammed (TVR×5.8)² into the [2,5] energy slot, firing ~24%/poss) with the faithful JSB two-part model — a negligible [2,5]-energy independent check plus a dominant steal-driven turnover tied to offensive carelessness × defensive STL — and recalibrates the 2pt make-value. Closes the season scoring-level deficit; records the Cov re-run.
+description: Replaces the mis-ported independent-turnover check (which jammed (TVR×5.8)² into the [2,5] energy slot, firing ~24%/poss) with the faithful JSB two-part model — a negligible [2,5]-energy independent check plus a dominant steal-driven turnover tied to offensive carelessness × defensive STL — and recalibrates the 2pt make-value. Closes the season scoring-level deficit; records the Cov re-run, with a full-precision (18-season/20-run) addendum confirming the Cov null (no flip; wrong sign lives in the non-arm residual; Control-B structural-vs-noise left to a 2nd seed).
 last_verified: 2026-06-04
 ---
 
@@ -141,13 +141,60 @@ non-arm residual — the steal-driven turnover participates but is not the missi
 lever. (At this reduced resolution the all-frozen ≤ baseline sanity, Control B, is
 tripped by a ~4% margin — a low-runs noise artifact and/or the turnover arm's new
 positive contribution, which the broken-engine premise did not anticipate; a
-full-precision run is the proper settle and is left as follow-up.)
+full-precision run is the proper settle — see the **Full-precision settle**
+addendum below.)
 
 A Cov flip toward + was the win condition, but a **null is a valid, publishable
 result** (it would say the volume-coupling lives elsewhere), and this PR does **not**
 block on a flip. Caveat: the repurposed TVR arm now conflates offense-carelessness
 and defense-STL variance in one frozen scalar, so a null could reflect low cross-team
 **input** variance rather than a wrong model.
+
+### Full-precision settle (2026-06-04 addendum)
+
+The reduced-scope re-run above left Control B's trip ("is the all-frozen `|Cov|` >
+baseline a low-runs artifact, or the turnover arm's new positive contribution?") for
+a full-precision settle. That run is now done: `JSB_ARCHIVE_RUNS=20
+JSB_ARCHIVE_STRIDE=1` over the full archive (18 seasons, N=484 pooled gt-2 team-rows),
+artifact `calibration-5.60-20260604-freeze-attribution.json`.
+
+**The NULL holds, and is now robust.** Baseline engine `Cov(lnFGA,lnPPS) = −0.00122`
+— still the ADR-0042 wrong (negative) sign, **no flip**, stable against the reduced
+run's −0.0013. Control A (baseline negative, in the ~1e-3 band) is solid. The
+marginals confirm and improve on the ADR-0044/0045 picture: `Var(lnPPS)` 0.00158 ≈
+real 0.00145 (fixed); `Var(lnFGA)` **narrowed further to 0.00179** (was 0.00269 at
+ADR-0044; real 0.00133 — the turnover fix pulled it from ~2.0× to ~1.35× too wide);
+`Var(lnPF)` 0.00094 still ~3.5× too narrow (real 0.00332) — the collapsed
+total-scoring spread is unchanged precisely because Cov did not flip.
+
+**The wrong sign still lives ~entirely outside the four instrumented arms.** Arm
+collapse fractions: TVR **−0.178** (freezing it *raises* `|Cov|` — the steal-driven
+turnover adds positive cov, as designed), Foul **+0.163** (adds negative cov), ORB
+−0.033, Make +0.021. The two large arms are opposite-signed and **nearly cancel**;
+all-four-frozen `Cov = −0.00125`, residual-frac **1.028** of baseline. So the four
+arms are **exhausted** — none is the missing lever — and the volume-coupling lever
+search (the ADR-0042 follow-on) is confirmed pointed at the **non-arm residual**
+(pace / shot-mix / FT / rebound-count), consistent with ADR-0043's ~48% non-arm share.
+
+**Control B (structural vs. noise) is NOT settled by one seed — left open,
+deliberately.** The trip shrank from ~4% (reduced) to **2.8%** (full-precision) — it
+converged *toward* 1.0, not away. residual-frac 1.028 is a small difference of two
+large opposite-signed arms (TVR −0.178, Foul +0.163): the noise-dominated regime,
+measured at a **single seed**. The harness pools all rows into one covariance and
+stores no per-run values, so a run-to-run σ is not recoverable from the artifact. A
+2.8% one-seed excess is therefore **not** sufficient to declare Control B's premise
+("freezing arms never ADDS covariance") stale — even though post-ADR-0045 the TVR arm
+genuinely does add positive cov, which *would* push residual-frac ≥ 1. The clean
+discriminator is **one more full-precision seed** (`JSB_ARCHIVE_SEED=…`): two seeds at
+~1.02–1.03 ⇒ structural (then relax Control B to a band, do **not** invert); scatter
+across 1.0 ⇒ noise. **Control B's assertion is left unchanged pending that second
+seed** — it is a pre-registered control, and ADR-0041's anti-metric-gaming discipline
+forbids loosening a control on one-seed evidence.
+
+**Net settle.** The Cov flip is a confirmed null at full precision; ADR-0045's
+steal-driven turnover behaves as designed (a genuine positive-cov arm) but is not the
+missing coupling; the next lever lives in the non-arm residual. The only open thread
+is the 2.8% Control-B excess, which one additional seed resolves.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
Records the full-precision Cov re-run settle that ADR-0045 (#980) deferred as follow-up.

## Result — null confirmed at full precision

Full-archive freeze-lattice re-run (18 seasons, 20 runs, stride 1; N=484 pooled gt-2 rows): baseline engine `Cov(lnFGA,lnPPS) = -0.00122` — still the ADR-0042 wrong (negative) sign, **no flip**, robust vs the reduced run's -0.0013 (Control A solid). The wrong sign lives ~entirely in the **non-arm residual**; the four instrumented arms net-cancel (TVR -0.178 adds positive cov *as designed*, Foul +0.163 adds negative). `Var(lnFGA)` narrowed further to 0.00179 (was 0.00269; real 0.00133).

→ The volume-coupling lever search (ADR-0042 follow-on) is confirmed pointed at the non-arm residual (pace / shot-mix / FT / rebound-count); no instrumented arm is the missing lever.

## Open thread (recorded, not resolved)

Control B's residual-frac excess shrank ~4% → 2.8% (one seed, a noisy difference of opposite-sign arms) — converging *toward* 1.0. Structural-vs-noise is left to a **second seed**; the pre-registered control assertion is **unchanged** (ADR-0041 anti-metric-gaming forbids loosening a control on one-seed evidence).

## Contents

- ADR-0045 "Full-precision settle" addendum; stale "left as follow-up" pointer + description frontmatter updated.
- Commits the run artifact `calibration-5.60-20260604-freeze-attribution.json` as the reference.

Unblocked by #984 (check-docs same-UTC-day commit-date escape): this doc was `last_verified` the same UTC day by #980. Verified locally that `bin/check-docs --since=origin/master` now passes via the escape.
