### PR TITLE
test(engine): relax archive Control-B to a residual-frac band (ADR-0045 second-seed settle)

### DIFF
--- a/engine/internal/calibrate/freeze_archive_test.go
+++ b/engine/internal/calibrate/freeze_archive_test.go
@@ -79,14 +79,20 @@ func TestRealArchive_FreezeLatticeAttribution(t *testing.T) {
 		t.Errorf("Control A: baseline |Cov| = %.6f outside the ~1e-3 sanity band [1e-5, 5e-2]", ab)
 	}
 
-	// --- Control B: freezing ALL four arms reduces |Cov| relative to baseline (the
-	// arms collectively remove covariance, never add it). The RESIDUAL that survives
-	// is the non-arm (pace / shot-mix / FT / rebound-count) covariance — REPORTED,
-	// not asserted to zero. A large residual is itself a verdict (defect outside the
-	// four arms → the "no single dominant lever" terminal branch).
+	// --- Control B (RELAXED to a band — ADR-0045 second-seed settle, 2026-06-04):
+	// freezing ALL four arms leaves |Cov| at ~baseline. Two full-precision seeds
+	// (20240601 / 20240602) put residual-frac at 1.028 / 1.023 — a STRUCTURAL ~2–3%
+	// excess above baseline, NOT noise: post-ADR-0045 the steal-driven TVR arm
+	// genuinely ADDS positive cov, so freezing it RAISES |Cov|. The arms therefore do
+	// not strictly remove covariance; the surviving residual (≈ baseline) is the
+	// non-arm (pace / shot-mix / FT / rebound-count) coupling — REPORTED, the real
+	// verdict. Band the UPPER edge only: arms adding FAR more cov than the structural
+	// TVR excess is a real defect. Do NOT invert — a lower residual-frac (arms
+	// removing more cov) was the control's original pass direction and stays fine.
+	const controlBCeiling = 1.05 // headroom over the 1.023–1.028 two-seed settle
 	allFrozen := rep.AllFrozenCovLnFGALnPPS
-	if math.Abs(allFrozen) > math.Abs(base)+1e-9 {
-		t.Errorf("Control B: all-frozen |Cov| = %.6f exceeds baseline |Cov| = %.6f (arms must not ADD covariance)", math.Abs(allFrozen), math.Abs(base))
+	if rep.ResidualFracOfBaseline > controlBCeiling {
+		t.Errorf("Control B: residual-frac of baseline = %.3f exceeds the structural-settle ceiling %.2f (all-frozen |Cov|=%.6f vs baseline |Cov|=%.6f — arms adding far more covariance than the ADR-0045 TVR-arm structural excess)", rep.ResidualFracOfBaseline, controlBCeiling, math.Abs(allFrozen), math.Abs(base))
 	}
 	t.Logf("CONTROLS: baseline Cov=%.6f all-frozen Cov=%.6f residual frac of baseline=%.3f",
 		base, allFrozen, rep.ResidualFracOfBaseline)

--- a/engine/internal/validate/testdata/calibration-5.60-20260604-freeze-attribution-seed20240602.json
+++ b/engine/internal/validate/testdata/calibration-5.60-20260604-freeze-attribution-seed20240602.json
@@ -1,0 +1,269 @@
+{
+  "game_type": 2,
+  "num_seasons": 18,
+  "runs": 20,
+  "configs": [
+    {
+      "mask": 0,
+      "frozen": null,
+      "var_ln_pf": 0.0009357830200786401,
+      "var_ln_fga": 0.0017940617137510708,
+      "var_ln_pps": 0.0015767477649980292,
+      "cov_ln_fga_ln_pps": -0.0012175132293352313,
+      "cov_ln_fga_ln_pf": 0.0005765484844158396,
+      "num_rows": 484
+    },
+    {
+      "mask": 1,
+      "frozen": [
+        "ORB"
+      ],
+      "var_ln_pf": 0.0009346786782565495,
+      "var_ln_fga": 0.0019567573882415443,
+      "var_ln_pps": 0.0015648793346140309,
+      "cov_ln_fga_ln_pps": -0.0012934790222995129,
+      "cov_ln_fga_ln_pf": 0.0006632783659420315,
+      "num_rows": 484
+    },
+    {
+      "mask": 2,
+      "frozen": [
+        "TVR"
+      ],
+      "var_ln_pf": 0.0006392406041430053,
+      "var_ln_fga": 0.0019778515238657196,
+      "var_ln_pps": 0.001542710293404244,
+      "cov_ln_fga_ln_pps": -0.0014406606065634799,
+      "cov_ln_fga_ln_pf": 0.0005371909173022397,
+      "num_rows": 484
+    },
+    {
+      "mask": 3,
+      "frozen": [
+        "ORB",
+        "TVR"
+      ],
+      "var_ln_pf": 0.0005801773052543956,
+      "var_ln_fga": 0.002059709544160969,
+      "var_ln_pps": 0.001516174064314739,
+      "cov_ln_fga_ln_pps": -0.001497853151610657,
+      "cov_ln_fga_ln_pf": 0.0005618563925503123,
+      "num_rows": 484
+    },
+    {
+      "mask": 4,
+      "frozen": [
+        "Foul"
+      ],
+      "var_ln_pf": 0.0009498624304152791,
+      "var_ln_fga": 0.001659683367446137,
+      "var_ln_pps": 0.0014424942300088805,
+      "cov_ln_fga_ln_pps": -0.0010761575835198684,
+      "cov_ln_fga_ln_pf": 0.0005835257839262686,
+      "num_rows": 484
+    },
+    {
+      "mask": 5,
+      "frozen": [
+        "ORB",
+        "Foul"
+      ],
+      "var_ln_pf": 0.0009769483578521139,
+      "var_ln_fga": 0.0017795868641288291,
+      "var_ln_pps": 0.0014587946433194164,
+      "cov_ln_fga_ln_pps": -0.0011307165747980663,
+      "cov_ln_fga_ln_pf": 0.0006488702893307629,
+      "num_rows": 484
+    },
+    {
+      "mask": 6,
+      "frozen": [
+        "TVR",
+        "Foul"
+      ],
+      "var_ln_pf": 0.0006576590846092619,
+      "var_ln_fga": 0.0018251259762858787,
+      "var_ln_pps": 0.001395932263512645,
+      "cov_ln_fga_ln_pps": -0.001281699577594631,
+      "cov_ln_fga_ln_pf": 0.0005434263986912476,
+      "num_rows": 484
+    },
+    {
+      "mask": 7,
+      "frozen": [
+        "ORB",
+        "TVR",
+        "Foul"
+      ],
+      "var_ln_pf": 0.0006040262842709617,
+      "var_ln_fga": 0.001878910123879447,
+      "var_ln_pps": 0.0013987439535277345,
+      "cov_ln_fga_ln_pps": -0.0013368138965681095,
+      "cov_ln_fga_ln_pf": 0.0005420962273113374,
+      "num_rows": 484
+    },
+    {
+      "mask": 8,
+      "frozen": [
+        "Make"
+      ],
+      "var_ln_pf": 0.0007429163663318956,
+      "var_ln_fga": 0.0018091518772106964,
+      "var_ln_pps": 0.0014059135225350096,
+      "cov_ln_fga_ln_pps": -0.001236074516706907,
+      "cov_ln_fga_ln_pf": 0.0005730773605037893,
+      "num_rows": 484
+    },
+    {
+      "mask": 9,
+      "frozen": [
+        "ORB",
+        "Make"
+      ],
+      "var_ln_pf": 0.0007885513755647525,
+      "var_ln_fga": 0.0019475710945260432,
+      "var_ln_pps": 0.0014060046637456617,
+      "cov_ln_fga_ln_pps": -0.0012825121913534738,
+      "cov_ln_fga_ln_pf": 0.0006650589031725693,
+      "num_rows": 484
+    },
+    {
+      "mask": 10,
+      "frozen": [
+        "TVR",
+        "Make"
+      ],
+      "var_ln_pf": 0.0004497926240733483,
+      "var_ln_fga": 0.001993837531248967,
+      "var_ln_pps": 0.001370882239929234,
+      "cov_ln_fga_ln_pps": -0.0014574635735524275,
+      "cov_ln_fga_ln_pf": 0.0005363739576965396,
+      "num_rows": 484
+    },
+    {
+      "mask": 11,
+      "frozen": [
+        "ORB",
+        "TVR",
+        "Make"
+      ],
+      "var_ln_pf": 0.00044297575286088287,
+      "var_ln_fga": 0.0020863178550865,
+      "var_ln_pps": 0.0013757511099950334,
+      "cov_ln_fga_ln_pps": -0.0015095466061103263,
+      "cov_ln_fga_ln_pf": 0.0005767712489761739,
+      "num_rows": 484
+    },
+    {
+      "mask": 12,
+      "frozen": [
+        "Foul",
+        "Make"
+      ],
+      "var_ln_pf": 0.000755581584832472,
+      "var_ln_fga": 0.0016724643541873167,
+      "var_ln_pps": 0.0011652079376232819,
+      "cov_ln_fga_ln_pps": -0.0010410453534890629,
+      "cov_ln_fga_ln_pf": 0.0006314190006982538,
+      "num_rows": 484
+    },
+    {
+      "mask": 13,
+      "frozen": [
+        "ORB",
+        "Foul",
+        "Make"
+      ],
+      "var_ln_pf": 0.0008163434342808335,
+      "var_ln_fga": 0.0017371498725972131,
+      "var_ln_pps": 0.0011560495239362647,
+      "cov_ln_fga_ln_pps": -0.0010384279811263219,
+      "cov_ln_fga_ln_pf": 0.0006987218914708913,
+      "num_rows": 484
+    },
+    {
+      "mask": 14,
+      "frozen": [
+        "TVR",
+        "Foul",
+        "Make"
+      ],
+      "var_ln_pf": 0.00046412187178927663,
+      "var_ln_fga": 0.0018280764134613312,
+      "var_ln_pps": 0.0011322262556181816,
+      "cov_ln_fga_ln_pps": -0.001248090398645117,
+      "cov_ln_fga_ln_pf": 0.0005799860148162142,
+      "num_rows": 484
+    },
+    {
+      "mask": 15,
+      "frozen": [
+        "ORB",
+        "TVR",
+        "Foul",
+        "Make"
+      ],
+      "var_ln_pf": 0.0004728011932251419,
+      "var_ln_fga": 0.0018435997064120493,
+      "var_ln_pps": 0.0011210335922858228,
+      "cov_ln_fga_ln_pps": -0.001245916052736365,
+      "cov_ln_fga_ln_pf": 0.0005976836536756842,
+      "num_rows": 484
+    }
+  ],
+  "arms": [
+    {
+      "arm": "ORB",
+      "d_var_ln_fga": 0.00009048230220482175,
+      "d_cov_ln_fga_ln_pf": 0.00005013700792922451,
+      "d_cov_ln_fga_ln_pps": -0.000040345294275597245,
+      "cov_pps_collapse_frac": -0.03313745863576857
+    },
+    {
+      "arm": "TVR",
+      "d_var_ln_fga": 0.00014312345251424845,
+      "d_cov_ln_fga_ln_pf": -0.00007049223985485592,
+      "d_cov_ln_fga_ln_pps": -0.00021361569236910436,
+      "cov_pps_collapse_frac": -0.17545246098536413
+    },
+    {
+      "arm": "Foul",
+      "d_var_ln_fga": -0.00017957123663767317,
+      "d_cov_ln_fga_ln_pf": 0.000015946086481753643,
+      "d_cov_ln_fga_ln_pps": 0.0001955173231194268,
+      "cov_pps_collapse_frac": 0.16058743215971485
+    },
+    {
+      "arm": "Make",
+      "d_var_ln_fga": -0.000004496525420418554,
+      "d_cov_ln_fga_ln_pf": 0.000025544314703722437,
+      "d_cov_ln_fga_ln_pps": 0.000030040840124140994,
+      "cov_pps_collapse_frac": 0.024673933227438896
+    }
+  ],
+  "mech_panel": [
+    {
+      "mech": "turnover",
+      "cov_with_ln_fga": -0.000040845840491582866,
+      "cov_with_ln_pps": -0.0002599186932318318
+    },
+    {
+      "mech": "oreb_continuation",
+      "cov_with_ln_fga": 0.0002525887449424141,
+      "cov_with_ln_pps": -0.00019698422645224572
+    },
+    {
+      "mech": "foul_only",
+      "cov_with_ln_fga": -0.0009243623039522817,
+      "cov_with_ln_pps": 0.0009274185137727064
+    },
+    {
+      "mech": "miss",
+      "cov_with_ln_fga": 0.00005935537259211022,
+      "cov_with_ln_pps": -0.00021655326358848667
+    }
+  ],
+  "baseline_cov_ln_fga_ln_pps": -0.0012175132293352313,
+  "all_frozen_cov_ln_fga_ln_pps": -0.001245916052736365,
+  "residual_frac_of_baseline": 1.023328554233979
+}

--- a/ibl5/docs/decisions/0045-turnover-model-fidelity.md
+++ b/ibl5/docs/decisions/0045-turnover-model-fidelity.md
@@ -1,5 +1,5 @@
 ---
-description: Replaces the mis-ported independent-turnover check (which jammed (TVR×5.8)² into the [2,5] energy slot, firing ~24%/poss) with the faithful JSB two-part model — a negligible [2,5]-energy independent check plus a dominant steal-driven turnover tied to offensive carelessness × defensive STL — and recalibrates the 2pt make-value. Closes the season scoring-level deficit; records the Cov re-run, with a full-precision (18-season/20-run) addendum confirming the Cov null (no flip; wrong sign lives in the non-arm residual; Control-B structural-vs-noise left to a 2nd seed).
+description: Replaces the mis-ported independent-turnover check (which jammed (TVR×5.8)² into the [2,5] energy slot, firing ~24%/poss) with the faithful JSB two-part model — a negligible [2,5]-energy independent check plus a dominant steal-driven turnover tied to offensive carelessness × defensive STL — and recalibrates the 2pt make-value. Closes the season scoring-level deficit; records the Cov re-run, with a full-precision (18-season/20-run) addendum confirming the Cov null (no flip; wrong sign lives in the non-arm residual). A second-seed addendum settles Control-B as STRUCTURAL (residual-frac 1.023 vs 1.028) and relaxes the archive control to a residual-frac band (≤ 1.05).
 last_verified: 2026-06-04
 ---
 
@@ -193,8 +193,37 @@ forbids loosening a control on one-seed evidence.
 
 **Net settle.** The Cov flip is a confirmed null at full precision; ADR-0045's
 steal-driven turnover behaves as designed (a genuine positive-cov arm) but is not the
-missing coupling; the next lever lives in the non-arm residual. The only open thread
-is the 2.8% Control-B excess, which one additional seed resolves.
+missing coupling; the next lever lives in the non-arm residual. The one remaining
+thread — the 2.8% Control-B excess — is resolved by the **Second-seed settle**
+addendum below (structural).
+
+### Second-seed settle — Control B is STRUCTURAL (2026-06-04 addendum)
+
+The pre-registered discriminator is resolved. A second full-precision seed
+(`JSB_ARCHIVE_SEED=20240602`, `RUNS=20 STRIDE=1`, 18 seasons, ~106 min) gives
+residual-frac **1.023**, against seed `20240601`'s **1.028** — two independent seeds
+clustered tightly just above 1.0, **not** scattered across it. By the rule set in the
+prior addendum this is **structural, not noise**: the arms reproduce (TVR −0.175, Foul
++0.161, ORB −0.033, Make +0.025), baseline `Cov(lnFGA,lnPPS) = −0.001218` (Control A
+holds), and the post-ADR-0045 steal-driven TVR arm genuinely **adds** positive cov, so
+freezing all four legitimately leaves `|Cov|` ~2–3% above baseline. The harness pools
+all rows into one covariance, so the cross-seed agreement (1.023 vs 1.028) is the
+discriminator — not a per-run σ, which the artifact does not store.
+
+**Action (per the pre-registered "relax to a band, do not invert").** The
+`freeze_archive_test.go` Control-B assertion is relaxed from the strict
+`|all-frozen| ≤ |baseline|` to a residual-frac band capped at **1.05** — headroom over
+the 1.023–1.028 settle, still flagging a real defect (arms adding *far* more
+covariance than the structural TVR excess). The control is **not** inverted: a *lower*
+residual-frac (arms removing more cov) was the control's original pass direction and
+remains fine. ADR-0041's anti-metric-gaming discipline is satisfied — the loosening
+rests on two seeds, not one, and the band is justified by a named structural mechanism
+(the TVR positive-cov arm), not fitted to make a red test pass.
+
+This closes the only open thread. The validation roadmap now moves to the **non-arm
+lever hunt**: the missing *positive* volume→PPS coupling lives in the non-arm residual
+(pace / shot-mix / FT / rebound-count), ~48% of |Cov| per ADR-0043, with the four
+instrumented arms now exhausted.
 
 ## Alternatives Considered
 

--- a/ibl5/docs/decisions/0045-turnover-model-fidelity.md
+++ b/ibl5/docs/decisions/0045-turnover-model-fidelity.md
@@ -1,6 +1,6 @@
 ---
 description: Replaces the mis-ported independent-turnover check (which jammed (TVR×5.8)² into the [2,5] energy slot, firing ~24%/poss) with the faithful JSB two-part model — a negligible [2,5]-energy independent check plus a dominant steal-driven turnover tied to offensive carelessness × defensive STL — and recalibrates the 2pt make-value. Closes the season scoring-level deficit; records the Cov re-run, with a full-precision (18-season/20-run) addendum confirming the Cov null (no flip; wrong sign lives in the non-arm residual). A second-seed addendum settles Control-B as STRUCTURAL (residual-frac 1.023 vs 1.028) and relaxes the archive control to a residual-frac band (≤ 1.05).
-last_verified: 2026-06-04
+last_verified: 2026-06-05
 ---
 
 # ADR-0045: Turnover-model fidelity + 2pt make-value calibration


### PR DESCRIPTION
## What

Relaxes the archive freeze-lattice **Control B** assertion from the strict
`|all-frozen Cov| <= |baseline Cov|` to a **residual-frac band capped at 1.05**,
and records the settling evidence in ADR-0045.

## Why

ADR-0045's full-precision addendum left exactly one open thread: was the ~2.8%
Control-B excess (residual-frac **1.028** at seed `20240601`) **structural** or
**noise**? The pre-registered discriminator was "one more full-precision seed."

That seed is now run -- `JSB_ARCHIVE_SEED=20240602 RUNS=20 STRIDE=1`, 18 seasons,
~106 min -> **residual-frac 1.023**. Two independent seeds (1.028 / 1.023)
cluster tightly just above 1.0 => **STRUCTURAL**, not noise. Mechanism:
post-ADR-0045 the steal-driven TVR arm genuinely *adds* positive cov, so freezing
all four arms legitimately leaves `|Cov|` ~2-3% above baseline. Arms reproduce
(TVR -0.175, Foul +0.161, ORB -0.033, Make +0.025); baseline `Cov(lnFGA,lnPPS)`
-0.001218 (Control A holds).

Per the pre-registered "relax to a band, do **not** invert," the upper edge is
set to **1.05** (headroom over the 1.023-1.028 settle); a *lower* residual-frac
(arms removing more cov) was the control's original pass direction and stays
fine. ADR-0041 anti-gaming discipline is satisfied -- the loosening rests on two
seeds, not one, and is justified by a named structural mechanism rather than
fitted to make a red test pass.

## Scope / testing

- `freeze_archive_test.go` is build-tag `archive` -- **manual-only, never run in
  CI**. Verified locally: `go vet -tags archive`, tagged compile, `gofmt` clean;
  the band trivially admits both measured residual-fracs (default seed 20240601
  -> 1.028 <= 1.05, so the canonical no-env invocation stays green).
- Seed-20240602 attribution artifact committed as durable evidence.
- No app / DB / web / E2E surface.

<!-- no-adr: extends existing ADR-0045 (executes its pre-registered action); introduces no new architectural constraint -->
