### PR TITLE
chore(db): schema type alignment + migration idempotency (maintenance-27)

### DIFF
--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -2181,6 +2181,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Standardize career tables to `tinyint(1) NOT NULL DEFAULT 0`.
 **Est. effort:** S
 **Risk if untouched:** `=== 0` checks may fail silently.
+**Status:** Completed (maintenance-27, migration 135) — `retired` on `ibl_olympics_career_avgs`/`_totals` is now `tinyint(1) NOT NULL DEFAULT 0`.
 
 ### 15.5 `HasMLE` / `HasLLE` / `Used_Extension_*` Booleans Stored as `int(11)`
 **Location:** `ibl_team_info` lines 2351-2354
@@ -2188,6 +2189,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Downsize to `tinyint(1) NOT NULL DEFAULT 0`.
 **Est. effort:** S
 **Risk if untouched:** Storage inefficiency; cognitive overhead.
+**Status:** Completed (maintenance-27, migration 135) — `has_mle`, `has_lle`, `used_extension_this_chunk`, `used_extension_this_season` on `ibl_team_info` are now `tinyint(1)`; existing nullability preserved (`used_extension_this_season` stays nullable).
 
 ### 15.6 Awards Tables — Mixed Case in PK and Column Names
 **Location:** `ibl_awards.table_ID`, `Award`; `ibl_gm_awards.table_ID`, `Award`; `ibl_team_awards.Award`, `ID`
@@ -2216,6 +2218,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Add `FOREIGN KEY (tradeofferid) REFERENCES ibl_trade_offers (id) ON DELETE CASCADE ON UPDATE CASCADE`.
 **Est. effort:** S
 **Risk if untouched:** Orphaned line items after offer deletion; phantom trade history.
+**Status:** Completed (migration 067 `fk_trade_info_offer`) — verified 2026-06-05 against the migrated schema: `ibl_trade_info.tradeofferid` has an FK to `ibl_trade_offers.id`. No new work in maintenance-27.
 
 ### 15.10 `ibl_box_scores.teamID` Lacks FK
 **Location:** `ibl_box_scores.teamID` line 324
@@ -2293,6 +2296,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Convert to matching ENUM or add CHECK constraint.
 **Est. effort:** S
 **Risk if untouched:** Position data diverges from canonical player record; position breakdowns include garbage.
+**Status:** Completed (maintenance-27, migration 135) — `pos` on `ibl_box_scores` and `ibl_olympics_box_scores` (Olympics parity pair) is now `enum('PG','SG','SF','PF','C','G','F','GF','')`, matching `ibl_plr.pos`. Out-of-range values error under `STRICT_ALL_TABLES`.
 
 ### 15.21 `ibl_box_scores` Missing `(pid, game_type)` Composite Index
 **Location:** Indexes lines 325-342
@@ -2308,6 +2312,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Use `RENAME COLUMN IF EXISTS` (MariaDB 10.5.2+); conditional DELETEs; `ADD KEY IF NOT EXISTS`.
 **Est. effort:** S
 **Risk if untouched:** Re-seed scenarios fail fatally.
+**Status:** Completed (maintenance-27) — 113 & 117 rewritten to `RENAME COLUMN IF EXISTS` + guarded `MODIFY COLUMN IF EXISTS` (reproducing each original `CHANGE COLUMN` target); 125 to `ADD INDEX IF NOT EXISTS`. 122 was already idempotent (bare `DELETE` of absent rows). Equivalence to the originals proven by an information_schema diff of fresh-built DBs (only the 15.4/15.5/15.20 type deltas differ); double-apply confirmed error-free.
 
 ### 15.23 `ibl_gm_history.name` — Ambiguous (Username vs Display Name)
 **Location:** `ibl_gm_history.name varchar(50)` line 597 with comment "GM username"

--- a/ibl5/migrations/113_rename_reserved_word_rating_columns.sql
+++ b/ibl5/migrations/113_rename_reserved_word_rating_columns.sql
@@ -26,40 +26,73 @@
 -- PlayerDatabase, Updater/RefreshIblHistStep, Negotiation, plus any Service
 -- or View reading these columns. Enforced by SchemaValidator (config/
 -- schema-assertions.php) and a new PHPStan BanReservedWordColumnsRule.
+--
+-- made idempotent 2026-06-05 (maintenance-27, backlog 15.22): each pure rename
+-- is now `RENAME COLUMN IF EXISTS old TO new` followed by a guarded
+-- `MODIFY COLUMN IF EXISTS new ...` that reproduces the exact target definition
+-- (type / nullability / default / comment) the original `CHANGE COLUMN`
+-- produced. Re-running on an already-migrated DB is a no-op (the RENAME finds no
+-- old column; the MODIFY sets the type the column already has). Safe to edit
+-- this applied migration: the runner records it as run, so the body only
+-- matters on fresh installs / re-seeds.
 
 -- Tables where `to` (transition offense) and `do` (drive offense) are ratings
 ALTER TABLE `ibl_plr`
-  CHANGE COLUMN `to` `r_trans_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Transition offense rating',
-  CHANGE COLUMN `do` `r_drive_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Drive offense rating',
-  CHANGE COLUMN `r_to` `r_tvr` smallint(5) unsigned DEFAULT 0 COMMENT 'Turnover rating';
+  RENAME COLUMN IF EXISTS `to`   TO `r_trans_off`,
+  RENAME COLUMN IF EXISTS `do`   TO `r_drive_off`,
+  RENAME COLUMN IF EXISTS `r_to` TO `r_tvr`;
+ALTER TABLE `ibl_plr`
+  MODIFY COLUMN IF EXISTS `r_trans_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Transition offense rating',
+  MODIFY COLUMN IF EXISTS `r_drive_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Drive offense rating',
+  MODIFY COLUMN IF EXISTS `r_tvr` smallint(5) unsigned DEFAULT 0 COMMENT 'Turnover rating';
 
 ALTER TABLE `ibl_plr_snapshots`
-  CHANGE COLUMN `to` `r_trans_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Transition offense rating',
-  CHANGE COLUMN `do` `r_drive_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Drive offense rating',
-  CHANGE COLUMN `r_to` `r_tvr` smallint(6) DEFAULT 0 COMMENT 'Turnover rating';
+  RENAME COLUMN IF EXISTS `to`   TO `r_trans_off`,
+  RENAME COLUMN IF EXISTS `do`   TO `r_drive_off`,
+  RENAME COLUMN IF EXISTS `r_to` TO `r_tvr`;
+ALTER TABLE `ibl_plr_snapshots`
+  MODIFY COLUMN IF EXISTS `r_trans_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Transition offense rating',
+  MODIFY COLUMN IF EXISTS `r_drive_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Drive offense rating',
+  MODIFY COLUMN IF EXISTS `r_tvr` smallint(6) DEFAULT 0 COMMENT 'Turnover rating';
 
 ALTER TABLE `ibl_olympics_plr`
-  CHANGE COLUMN `to` `r_trans_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Transition offense rating',
-  CHANGE COLUMN `do` `r_drive_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Drive offense rating',
-  CHANGE COLUMN `r_to` `r_tvr` smallint(5) unsigned DEFAULT 0 COMMENT 'Turnover rating';
+  RENAME COLUMN IF EXISTS `to`   TO `r_trans_off`,
+  RENAME COLUMN IF EXISTS `do`   TO `r_drive_off`,
+  RENAME COLUMN IF EXISTS `r_to` TO `r_tvr`;
+ALTER TABLE `ibl_olympics_plr`
+  MODIFY COLUMN IF EXISTS `r_trans_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Transition offense rating',
+  MODIFY COLUMN IF EXISTS `r_drive_off` tinyint(3) unsigned DEFAULT 0 COMMENT 'Drive offense rating',
+  MODIFY COLUMN IF EXISTS `r_tvr` smallint(5) unsigned DEFAULT 0 COMMENT 'Turnover rating';
 
 ALTER TABLE `ibl_draft_class`
-  CHANGE COLUMN `to` `r_trans_off` tinyint(3) unsigned NOT NULL DEFAULT 0 COMMENT 'Transition offense rating',
-  CHANGE COLUMN `do` `r_drive_off` tinyint(3) unsigned NOT NULL DEFAULT 0 COMMENT 'Drive offense rating';
+  RENAME COLUMN IF EXISTS `to` TO `r_trans_off`,
+  RENAME COLUMN IF EXISTS `do` TO `r_drive_off`;
+ALTER TABLE `ibl_draft_class`
+  MODIFY COLUMN IF EXISTS `r_trans_off` tinyint(3) unsigned NOT NULL DEFAULT 0 COMMENT 'Transition offense rating',
+  MODIFY COLUMN IF EXISTS `r_drive_off` tinyint(3) unsigned NOT NULL DEFAULT 0 COMMENT 'Drive offense rating';
 
 -- Materialized history tables: r_to and r_do here are already ratings
 -- (populated from snap.`to` / snap.`do`). Rename for semantic uniformity
 -- with the live/snapshot tables above. This also removes the meaning-flip
 -- described above.
 ALTER TABLE `ibl_hist`
-  CHANGE COLUMN `r_to` `r_trans_off` int(11) NOT NULL DEFAULT 0 COMMENT 'Transition offense rating',
-  CHANGE COLUMN `r_do` `r_drive_off` int(11) NOT NULL DEFAULT 0 COMMENT 'Drive offense rating';
+  RENAME COLUMN IF EXISTS `r_to` TO `r_trans_off`,
+  RENAME COLUMN IF EXISTS `r_do` TO `r_drive_off`;
+ALTER TABLE `ibl_hist`
+  MODIFY COLUMN IF EXISTS `r_trans_off` int(11) NOT NULL DEFAULT 0 COMMENT 'Transition offense rating',
+  MODIFY COLUMN IF EXISTS `r_drive_off` int(11) NOT NULL DEFAULT 0 COMMENT 'Drive offense rating';
 
 ALTER TABLE `ibl_olympics_hist`
-  CHANGE COLUMN `r_to` `r_trans_off` int(11) NOT NULL DEFAULT 0 COMMENT 'Transition offense rating',
-  CHANGE COLUMN `r_do` `r_drive_off` int(11) NOT NULL DEFAULT 0 COMMENT 'Drive offense rating';
+  RENAME COLUMN IF EXISTS `r_to` TO `r_trans_off`,
+  RENAME COLUMN IF EXISTS `r_do` TO `r_drive_off`;
+ALTER TABLE `ibl_olympics_hist`
+  MODIFY COLUMN IF EXISTS `r_trans_off` int(11) NOT NULL DEFAULT 0 COMMENT 'Transition offense rating',
+  MODIFY COLUMN IF EXISTS `r_drive_off` int(11) NOT NULL DEFAULT 0 COMMENT 'Drive offense rating';
 
 -- Identifiers with spaces: ibl_sim_dates
 ALTER TABLE `ibl_sim_dates`
-  CHANGE COLUMN `Start Date` `start_date` date DEFAULT NULL COMMENT 'First date in sim range',
-  CHANGE COLUMN `End Date`   `end_date`   date DEFAULT NULL COMMENT 'Last date in sim range';
+  RENAME COLUMN IF EXISTS `Start Date` TO `start_date`,
+  RENAME COLUMN IF EXISTS `End Date`   TO `end_date`;
+ALTER TABLE `ibl_sim_dates`
+  MODIFY COLUMN IF EXISTS `start_date` date DEFAULT NULL COMMENT 'First date in sim range',
+  MODIFY COLUMN IF EXISTS `end_date`   date DEFAULT NULL COMMENT 'Last date in sim range';

--- a/ibl5/migrations/117_snake_case_team_info_columns.sql
+++ b/ibl5/migrations/117_snake_case_team_info_columns.sql
@@ -1,21 +1,46 @@
 -- Migration 117: Tier 3b — snake_case team-info columns.
 -- Renames 9 columns on ibl_team_info and 5 on ibl_olympics_team_info.
 -- No FK drops needed. No views/generated columns reference these columns.
+--
+-- made idempotent 2026-06-05 (maintenance-27, backlog 15.22): each pure rename
+-- is now `RENAME COLUMN IF EXISTS old TO new` followed by a guarded
+-- `MODIFY COLUMN IF EXISTS new ...` that reproduces the exact target definition
+-- (type / nullability / default / comment) the original `CHANGE COLUMN`
+-- produced. Re-running on an already-migrated DB is a no-op (the RENAME finds no
+-- old column; the MODIFY sets the type the column already has). Safe to edit
+-- this applied migration: the runner records it as run, so the body only
+-- matters on fresh installs / re-seeds.
 
 ALTER TABLE `ibl_team_info`
-  CHANGE COLUMN `discordID`                  `discord_id`                  bigint(20) unsigned DEFAULT NULL COMMENT 'GM Discord user ID',
-  CHANGE COLUMN `Contract_Wins`              `contract_wins`               int(11) NOT NULL DEFAULT 0 COMMENT 'Wins from last season for FA Play for Winner weight',
-  CHANGE COLUMN `Contract_Losses`            `contract_losses`             int(11) NOT NULL DEFAULT 0 COMMENT 'Losses from last season for FA Play for Winner weight',
-  CHANGE COLUMN `Contract_AvgW`              `contract_avg_w`              int(11) NOT NULL DEFAULT 0 COMMENT 'Avg wins from last five seasons for FA Tradition weight',
-  CHANGE COLUMN `Contract_AvgL`              `contract_avg_l`              int(11) NOT NULL DEFAULT 0 COMMENT 'Avg losses from last five seasons for FA Tradition weight',
-  CHANGE COLUMN `Used_Extension_This_Chunk`  `used_extension_this_chunk`   int(11) NOT NULL DEFAULT 0 COMMENT '1=used extension in current sim chunk',
-  CHANGE COLUMN `Used_Extension_This_Season` `used_extension_this_season`  int(11) DEFAULT 0 COMMENT '1=used extension this season',
-  CHANGE COLUMN `HasMLE`                     `has_mle`                     int(11) NOT NULL DEFAULT 0 COMMENT '1=Mid-Level Exception already used',
-  CHANGE COLUMN `HasLLE`                     `has_lle`                     int(11) NOT NULL DEFAULT 0 COMMENT '1=Lower-Level Exception already used';
+  RENAME COLUMN IF EXISTS `discordID`                  TO `discord_id`,
+  RENAME COLUMN IF EXISTS `Contract_Wins`              TO `contract_wins`,
+  RENAME COLUMN IF EXISTS `Contract_Losses`            TO `contract_losses`,
+  RENAME COLUMN IF EXISTS `Contract_AvgW`              TO `contract_avg_w`,
+  RENAME COLUMN IF EXISTS `Contract_AvgL`              TO `contract_avg_l`,
+  RENAME COLUMN IF EXISTS `Used_Extension_This_Chunk`  TO `used_extension_this_chunk`,
+  RENAME COLUMN IF EXISTS `Used_Extension_This_Season` TO `used_extension_this_season`,
+  RENAME COLUMN IF EXISTS `HasMLE`                     TO `has_mle`,
+  RENAME COLUMN IF EXISTS `HasLLE`                     TO `has_lle`;
+ALTER TABLE `ibl_team_info`
+  MODIFY COLUMN IF EXISTS `discord_id`                  bigint(20) unsigned DEFAULT NULL COMMENT 'GM Discord user ID',
+  MODIFY COLUMN IF EXISTS `contract_wins`               int(11) NOT NULL DEFAULT 0 COMMENT 'Wins from last season for FA Play for Winner weight',
+  MODIFY COLUMN IF EXISTS `contract_losses`             int(11) NOT NULL DEFAULT 0 COMMENT 'Losses from last season for FA Play for Winner weight',
+  MODIFY COLUMN IF EXISTS `contract_avg_w`              int(11) NOT NULL DEFAULT 0 COMMENT 'Avg wins from last five seasons for FA Tradition weight',
+  MODIFY COLUMN IF EXISTS `contract_avg_l`              int(11) NOT NULL DEFAULT 0 COMMENT 'Avg losses from last five seasons for FA Tradition weight',
+  MODIFY COLUMN IF EXISTS `used_extension_this_chunk`   int(11) NOT NULL DEFAULT 0 COMMENT '1=used extension in current sim chunk',
+  MODIFY COLUMN IF EXISTS `used_extension_this_season`  int(11) DEFAULT 0 COMMENT '1=used extension this season',
+  MODIFY COLUMN IF EXISTS `has_mle`                     int(11) NOT NULL DEFAULT 0 COMMENT '1=Mid-Level Exception already used',
+  MODIFY COLUMN IF EXISTS `has_lle`                     int(11) NOT NULL DEFAULT 0 COMMENT '1=Lower-Level Exception already used';
 
 ALTER TABLE `ibl_olympics_team_info`
-  CHANGE COLUMN `discordID`       `discord_id`       bigint(20) unsigned DEFAULT NULL COMMENT 'Discord user ID',
-  CHANGE COLUMN `Contract_Wins`   `contract_wins`    int(11) NOT NULL DEFAULT 0 COMMENT 'Contract performance tracking',
-  CHANGE COLUMN `Contract_Losses` `contract_losses`  int(11) NOT NULL DEFAULT 0 COMMENT 'Contract performance tracking',
-  CHANGE COLUMN `Contract_AvgW`   `contract_avg_w`   int(11) NOT NULL DEFAULT 0 COMMENT 'Average wins per contract',
-  CHANGE COLUMN `Contract_AvgL`   `contract_avg_l`   int(11) NOT NULL DEFAULT 0 COMMENT 'Average losses per contract';
+  RENAME COLUMN IF EXISTS `discordID`       TO `discord_id`,
+  RENAME COLUMN IF EXISTS `Contract_Wins`   TO `contract_wins`,
+  RENAME COLUMN IF EXISTS `Contract_Losses` TO `contract_losses`,
+  RENAME COLUMN IF EXISTS `Contract_AvgW`   TO `contract_avg_w`,
+  RENAME COLUMN IF EXISTS `Contract_AvgL`   TO `contract_avg_l`;
+ALTER TABLE `ibl_olympics_team_info`
+  MODIFY COLUMN IF EXISTS `discord_id`      bigint(20) unsigned DEFAULT NULL COMMENT 'Discord user ID',
+  MODIFY COLUMN IF EXISTS `contract_wins`   int(11) NOT NULL DEFAULT 0 COMMENT 'Contract performance tracking',
+  MODIFY COLUMN IF EXISTS `contract_losses` int(11) NOT NULL DEFAULT 0 COMMENT 'Contract performance tracking',
+  MODIFY COLUMN IF EXISTS `contract_avg_w`  int(11) NOT NULL DEFAULT 0 COMMENT 'Average wins per contract',
+  MODIFY COLUMN IF EXISTS `contract_avg_l`  int(11) NOT NULL DEFAULT 0 COMMENT 'Average losses per contract';

--- a/ibl5/migrations/125_add_franchise_seasons_composite_index.sql
+++ b/ibl5/migrations/125_add_franchise_seasons_composite_index.sql
@@ -3,5 +3,10 @@
 -- (franchise_id, season_ending_year). The existing unique key covers
 -- (franchise_id, season_year) — not season_ending_year — so the optimizer
 -- scans ~8 rows per join. The new index narrows that to a single-row lookup.
+--
+-- made idempotent 2026-06-05 (maintenance-27, backlog 15.22): `ADD INDEX IF NOT
+-- EXISTS` (MariaDB 10.5.2+) makes re-applying this migration a no-op when the
+-- index already exists. Safe to edit this applied migration: the runner records
+-- it as run, so the body only matters on fresh installs / re-seeds.
 ALTER TABLE ibl_franchise_seasons
-    ADD INDEX idx_franchise_ending_year (franchise_id, season_ending_year);
+    ADD INDEX IF NOT EXISTS idx_franchise_ending_year (franchise_id, season_ending_year);

--- a/ibl5/migrations/135_align_boolean_and_position_column_types.sql
+++ b/ibl5/migrations/135_align_boolean_and_position_column_types.sql
@@ -1,0 +1,56 @@
+-- Migration 135: Schema type alignment (maintenance-27 — backlog 15.4 / 15.5 / 15.20)
+--
+-- Non-breaking type narrowing. Every existing value already fits the target
+-- type (the boolean-intent columns hold only 0/1; pos holds valid position
+-- codes), so native-type reads return identical PHP values and NO PHP changes
+-- are required.
+--
+-- Fail-loud on dirty data: STRICT_ALL_TABLES guarantees the pos ENUM cast
+-- ERRORS (rather than silently truncating to '') if any out-of-range position
+-- value exists. MariaDB 10.11's default sql_mode already includes
+-- STRICT_TRANS_TABLES; widening it to STRICT_ALL_TABLES for this session makes
+-- the guarantee hold regardless of how the target server is configured.
+-- Pre-conversion audit (run against the seed before authoring this migration,
+-- and documented for prod-via-CI):
+--   SELECT DISTINCT pos FROM ibl_box_scores
+--     WHERE pos NOT IN ('PG','SG','SF','PF','C','G','F','GF','');          -- expect empty
+--   SELECT DISTINCT pos FROM ibl_olympics_box_scores
+--     WHERE pos NOT IN ('PG','SG','SF','PF','C','G','F','GF','');          -- expect empty
+--
+-- Idempotent: every statement is MODIFY COLUMN, which is naturally re-runnable
+-- (setting a column to the type it already has is a no-op, not an error).
+--
+-- DELIBERATE DEVIATION from the maintenance-27 plan's literal SQL: the plan
+-- listed `used_extension_this_season ... NOT NULL`, but migration 117 defines it
+-- nullable (`int(11) DEFAULT 0`). This migration preserves the existing
+-- nullability (no NOT NULL) so the change stays strictly type-only and
+-- non-breaking — adding NOT NULL would be an out-of-scope constraint change
+-- (and could itself error under STRICT_ALL_TABLES if any row held NULL).
+
+SET SESSION sql_mode = CONCAT(@@sql_mode, ',STRICT_ALL_TABLES');
+
+-- 15.4 — `retired`: int(11) -> tinyint(1) on the Olympics career aggregate
+-- tables, aligning them with ibl_plr/ibl_olympics_plr (tinyint). NOT NULL and
+-- comment preserved exactly.
+ALTER TABLE `ibl_olympics_career_avgs`
+  MODIFY COLUMN `retired` tinyint(1) NOT NULL DEFAULT 0 COMMENT '1=retired from league';
+ALTER TABLE `ibl_olympics_career_totals`
+  MODIFY COLUMN `retired` tinyint(1) NOT NULL DEFAULT 0 COMMENT '1=retired from league';
+
+-- 15.5 — boolean-intent flags: int(11) -> tinyint(1) on ibl_team_info.
+-- Nullability and comments preserved exactly as migration 117 defined them
+-- (used_extension_this_season is nullable; the other three are NOT NULL).
+ALTER TABLE `ibl_team_info`
+  MODIFY COLUMN `used_extension_this_chunk`  tinyint(1) NOT NULL DEFAULT 0 COMMENT '1=used extension in current sim chunk',
+  MODIFY COLUMN `used_extension_this_season` tinyint(1)          DEFAULT 0 COMMENT '1=used extension this season',
+  MODIFY COLUMN `has_mle`                     tinyint(1) NOT NULL DEFAULT 0 COMMENT '1=Mid-Level Exception already used',
+  MODIFY COLUMN `has_lle`                     tinyint(1) NOT NULL DEFAULT 0 COMMENT '1=Lower-Level Exception already used';
+
+-- 15.20 — `pos`: varchar(2) -> ENUM on BOTH box-score tables (the Olympics
+-- parity pair must move together). Collation, default, and nullability are
+-- preserved; out-of-range values ERROR under STRICT_ALL_TABLES rather than
+-- truncating to ''.
+ALTER TABLE `ibl_box_scores`
+  MODIFY COLUMN `pos` enum('PG','SG','SF','PF','C','G','F','GF','') COLLATE utf8mb4_unicode_ci DEFAULT '' COMMENT 'Player position at game time';
+ALTER TABLE `ibl_olympics_box_scores`
+  MODIFY COLUMN `pos` enum('PG','SG','SF','PF','C','G','F','GF','') COLLATE utf8mb4_unicode_ci DEFAULT '' COMMENT 'Position played';

--- a/ibl5/tests/DatabaseIntegration/SchemaTypeAlignmentTest.php
+++ b/ibl5/tests/DatabaseIntegration/SchemaTypeAlignmentTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Post-impl verification for maintenance-27 (backlog 15.4 / 15.5 / 15.20 / 15.22).
+ *
+ * Two concerns:
+ *  - Type alignment (migration 135): the boolean-intent columns are tinyint(1)
+ *    and the box-score `pos` columns are ENUM, matching the canonical player
+ *    tables.
+ *  - Idempotency (migrations 113 / 117 / 125): the rewritten migrations use
+ *    re-runnable constructs (RENAME COLUMN IF EXISTS / ADD INDEX IF NOT EXISTS)
+ *    and no bare CHANGE COLUMN / bare ADD INDEX. Asserted against the migration
+ *    source — re-running DDL inside the test transaction would auto-commit and
+ *    break isolation, so the source is the contract (same pattern as
+ *    EngineShadowSchemaTest::migrationUsesIfNotExistsForBothTables).
+ */
+#[Group('database')]
+final class SchemaTypeAlignmentTest extends DatabaseTestCase
+{
+    private const MIGRATIONS_DIR = __DIR__ . '/../../migrations';
+
+    /**
+     * Boolean-intent columns that must be tinyint(1) after migration 135.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function booleanColumnProvider(): array
+    {
+        return [
+            'career_avgs.retired'                 => ['ibl_olympics_career_avgs', 'retired'],
+            'career_totals.retired'               => ['ibl_olympics_career_totals', 'retired'],
+            'team_info.has_mle'                   => ['ibl_team_info', 'has_mle'],
+            'team_info.has_lle'                   => ['ibl_team_info', 'has_lle'],
+            'team_info.used_extension_this_chunk' => ['ibl_team_info', 'used_extension_this_chunk'],
+            'team_info.used_extension_this_season' => ['ibl_team_info', 'used_extension_this_season'],
+        ];
+    }
+
+    #[DataProvider('booleanColumnProvider')]
+    public function testBooleanColumnsAreTinyint1(string $table, string $column): void
+    {
+        self::assertSame(
+            'tinyint(1)',
+            $this->columnType($table, $column),
+            "$table.$column should be tinyint(1) after migration 135 (backlog 15.4/15.5)"
+        );
+    }
+
+    /**
+     * The box-score `pos` columns must be the same ENUM as ibl_plr.pos
+     * (backlog 15.20). Both halves of the Olympics parity pair move together.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function posTableProvider(): array
+    {
+        return [
+            'ibl_box_scores'          => ['ibl_box_scores'],
+            'ibl_olympics_box_scores' => ['ibl_olympics_box_scores'],
+        ];
+    }
+
+    #[DataProvider('posTableProvider')]
+    public function testBoxScorePosIsEnum(string $table): void
+    {
+        self::assertSame(
+            "enum('PG','SG','SF','PF','C','G','F','GF','')",
+            $this->columnType($table, 'pos'),
+            "$table.pos should be the canonical position ENUM after migration 135 (backlog 15.20)"
+        );
+    }
+
+    /**
+     * OlympicsSchemaParityTest already guards column-NAME parity; this asserts
+     * the dual ENUM ALTER kept both box-score tables' `pos` types in lockstep.
+     */
+    #[Test]
+    public function bothBoxScorePosColumnsShareTheSameType(): void
+    {
+        self::assertSame(
+            $this->columnType('ibl_box_scores', 'pos'),
+            $this->columnType('ibl_olympics_box_scores', 'pos'),
+            'pos type must match across the box_scores parity pair'
+        );
+    }
+
+    /**
+     * Migrations 113 and 117 must be re-runnable: pure renames expressed as
+     * RENAME COLUMN IF EXISTS, with no bare CHANGE COLUMN (which errors on the
+     * second apply because the old column no longer exists).
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function renameMigrationProvider(): array
+    {
+        return [
+            'migration_113' => ['113_rename_reserved_word_rating_columns.sql'],
+            'migration_117' => ['117_snake_case_team_info_columns.sql'],
+        ];
+    }
+
+    #[DataProvider('renameMigrationProvider')]
+    public function testRenameMigrationsAreIdempotent(string $file): void
+    {
+        $ddl = $this->migrationDdl($file);
+
+        self::assertStringContainsStringIgnoringCase(
+            'RENAME COLUMN IF EXISTS',
+            $ddl,
+            "$file must use RENAME COLUMN IF EXISTS for re-runnability"
+        );
+        self::assertStringNotContainsStringIgnoringCase(
+            'CHANGE COLUMN',
+            $ddl,
+            "$file must not use bare CHANGE COLUMN (fails on re-apply)"
+        );
+        // Every MODIFY that restores a post-rename type must be guarded with
+        // IF EXISTS, so a partial re-run cannot error on a missing column.
+        self::assertSame(
+            $this->countCi($ddl, 'MODIFY COLUMN'),
+            $this->countCi($ddl, 'MODIFY COLUMN IF EXISTS'),
+            "$file MODIFY clauses must all be guarded with IF EXISTS"
+        );
+    }
+
+    #[Test]
+    public function indexMigrationIsIdempotent(): void
+    {
+        $ddl = $this->migrationDdl('125_add_franchise_seasons_composite_index.sql');
+
+        self::assertStringContainsStringIgnoringCase(
+            'ADD INDEX IF NOT EXISTS',
+            $ddl,
+            '125 must use ADD INDEX IF NOT EXISTS for re-runnability'
+        );
+    }
+
+    #[Test]
+    public function typeAlignmentMigrationIsIdempotentAndFailsLoud(): void
+    {
+        $ddl = $this->migrationDdl('135_align_boolean_and_position_column_types.sql');
+
+        // MODIFY COLUMN is naturally re-runnable; CHANGE COLUMN would not be.
+        self::assertStringContainsStringIgnoringCase('MODIFY COLUMN', $ddl);
+        self::assertStringNotContainsStringIgnoringCase('CHANGE COLUMN', $ddl);
+        // STRICT_ALL_TABLES makes the pos ENUM cast error on dirty data instead
+        // of silently truncating an out-of-range position to ''.
+        self::assertStringContainsString('STRICT_ALL_TABLES', $ddl);
+    }
+
+    private function countCi(string $haystack, string $needle): int
+    {
+        return substr_count(strtoupper($haystack), strtoupper($needle));
+    }
+
+    private function columnType(string $table, string $column): string
+    {
+        $stmt = $this->db->prepare(
+            "SELECT COLUMN_TYPE FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?"
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('ss', $table, $column);
+        $stmt->execute();
+        /** @var array{COLUMN_TYPE: string}|null $row */
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        self::assertIsArray($row, "Column $table.$column not found");
+
+        return $row['COLUMN_TYPE'];
+    }
+
+    private function migrationSource(string $file): string
+    {
+        $path = self::MIGRATIONS_DIR . '/' . $file;
+        self::assertFileExists($path);
+
+        return (string) file_get_contents($path);
+    }
+
+    /**
+     * Migration source with `--` comment lines stripped, so DDL-pattern
+     * assertions are not fooled by prose that mentions the old constructs
+     * (e.g. a comment explaining the former `CHANGE COLUMN`).
+     */
+    private function migrationDdl(string $file): string
+    {
+        $split = preg_split('/\R/', $this->migrationSource($file));
+        $lines = $split === false ? [] : $split;
+        $ddl = array_filter(
+            $lines,
+            static fn (string $line): bool => !str_starts_with(ltrim($line), '--')
+        );
+
+        return implode("\n", $ddl);
+    }
+}


### PR DESCRIPTION
## Summary

Schema hygiene subset of Axis 15 — type alignments (no PHP changes, existing values already conform) and idempotency fixes for already-applied migrations.

**PR1 type alignments (15.4, 15.5, 15.20)** via new migration 135:
- `retired` int(11)→tinyint(1) on `ibl_olympics_career_avgs` and `ibl_olympics_career_totals` (15.4)
- `has_mle`, `has_lle`, `used_extension_this_chunk`, `used_extension_this_season` int(11)→tinyint(1) on `ibl_team_info` (15.5)
- `pos` varchar(2)→ENUM on both `ibl_box_scores` and `ibl_olympics_box_scores` (15.20, parity gate)

**PR2 idempotency rewrites (15.22)**:
- Migrations 113/117: bare `CHANGE COLUMN`→`RENAME COLUMN IF EXISTS` (MariaDB 10.11)
- Migration 125: bare `ADD INDEX`→`ADD INDEX IF NOT EXISTS`

Deliberate deviation: `used_extension_this_season` kept nullable (plan wrote NOT NULL) — strictly type-only/non-breaking.

Backlog items 15.4, 15.5, 15.9, 15.20, 15.22 marked Completed.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.