### PR TITLE
chore(tooling): jsb-verdict + jsb-ref RE token-efficiency helpers

### DIFF
--- a/bin/jsb-ref
+++ b/bin/jsb-ref
@@ -1,0 +1,30 @@
+#!/bin/bash
+# jsb-ref — locate a JSB symbol / address / topic in the master reference and the
+# decompile, printing only excerpts (ref) and match line-numbers (the 10MB .c), so you
+# avoid full-reading 00_MASTER_REFERENCE.md (287K) or jsb560_decompiled.c (10.4M).
+# Workflow: jsb-ref FUN_004e1ba0  → then Read ±ctx at the decompile line it reports.
+# Usage: bin/jsb-ref <pattern> [context-lines]   (env: JSB_DECOMPILE_DIR)
+set -uo pipefail
+
+pat="${1:-}"
+[ -n "$pat" ] || { echo "usage: bin/jsb-ref <pattern> [context-lines]" >&2; exit 2; }
+ctx="${2:-12}"
+dir="${JSB_DECOMPILE_DIR:-$HOME/Downloads/jsb_560/decompiled}"
+ref="$dir/00_MASTER_REFERENCE.md"
+dec="$dir/jsb560_decompiled.c"
+[ -d "$dir" ] || { echo "decompile dir not found: $dir (set JSB_DECOMPILE_DIR)" >&2; exit 1; }
+
+echo "=== 00_MASTER_REFERENCE.md  (±$ctx lines, capped at 120) ==="
+if [ -f "$ref" ] && grep -q -i -- "$pat" "$ref"; then
+  grep -n -i -C "$ctx" -- "$pat" "$ref" | head -120
+else
+  echo "(no match in master ref)"
+fi
+
+echo ""
+echo "=== jsb560_decompiled.c  (match line numbers — Read ±$ctx at these, capped at 40) ==="
+if [ -f "$dec" ] && grep -q -i -- "$pat" "$dec"; then
+  grep -n -i -- "$pat" "$dec" | head -40
+else
+  echo "(no match in decompile)"
+fi

--- a/bin/jsb-verdict
+++ b/bin/jsb-verdict
@@ -1,0 +1,33 @@
+#!/bin/bash
+# jsb-verdict — collapse a JSB calibration JSON (up to ~400KB) to its verdict metrics
+# WITHOUT full-reading it. Array indices are collapsed to [] and numeric leaves
+# aggregated (n/min/max/mean), so per-row arrays become one summary line.
+# A ~100K-token Read becomes ~40 lines. Usage: bin/jsb-verdict <artifact.json> [key-regex]
+set -uo pipefail
+
+f="${1:-}"
+[ -n "$f" ] || { echo "usage: bin/jsb-verdict <artifact.json> [key-regex]" >&2; exit 2; }
+[ -f "$f" ] || { echo "no such file: $f" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq not installed" >&2; exit 1; }
+re="${2:-.}"
+
+echo "=== shape ==="
+jq -r 'to_entries[]
+  | "\(.key): \(.value | if type=="array" then "array[\(length)]"
+                        elif type=="object" then "object{\(keys|length)}"
+                        else tostring end)"' "$f"
+
+echo ""
+echo "=== metrics (array indices collapsed to [], numeric leaves aggregated) ==="
+jq -r --arg re "$re" '
+  [ paths(scalars) as $p
+    | {k: ($p | map(if type=="number" then "[]" else tostring end) | join(".")),
+       v: getpath($p)} ]
+  | group_by(.k)
+  | map({k: .[0].k, n: length, vals: [.[].v]})
+  | .[]
+  | select(.k | test($re; "i"))
+  | if (.n > 1) and (.vals | all(type == "number"))
+    then "\(.k)  [n=\(.n)] min=\(.vals|min) max=\(.vals|max) mean=\(((.vals|add)/.n*1000|round)/1000)"
+    else "\(.k) = \(.vals[0])\(if .n > 1 then "  …(+\(.n-1) more)" else "" end)"
+    end' "$f"


### PR DESCRIPTION
Two small dev helpers for JSB native-engine reverse-engineering, to stop full-reading huge files into context.

- **`bin/jsb-verdict <artifact.json> [key-regex]`** — collapses a calibration JSON (up to ~400K) to its verdict metrics: array indices collapsed to `[]`, numeric leaves aggregated (n/min/max/mean). A ~100K-token full Read becomes ~40 lines. Shape-robust (handles season-aggregate *and* freeze-attribution layouts).
- **`bin/jsb-ref <addr|topic> [ctx]`** — greps `00_MASTER_REFERENCE.md` (windowed excerpts) + `jsb560_decompiled.c` (match line-numbers, for a targeted Read), avoiding full-reads of the 287K ref / 10.4M decompile. Decompile dir via `$JSB_DECOMPILE_DIR` (default `~/Downloads/jsb_560/decompiled`).

Both: bash-3.2 safe (shellcheck clean), <50 LOC (no adr-check trigger), no app/CI surface touched.

## Manual Testing

No manual testing needed — purely developer CLI helpers with no UI/UX or app surface.