### PR TITLE
feat(nightly): per-plan impl_model selection for the implementation agent

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -119,6 +119,7 @@ After receiving the Plan agent's output, check these gates yourself — do NOT d
 10. **Hot-file extraction** — if any step adds > 100 LOC to a file `bin/check-hot-files` lists as hot (> 500 LOC under `classes/`), the plan must either propose an extraction step or carry an inline justification (per `_plan-verification.md` § Hot-file thresholds). If neither is present, add one.
 11. **Refactor characterization** — if any step under `ibl5/classes/**` carries a refactor signal (file rename, method signature change, visibility narrowing, class removal, or > 30-line deletion per `refactor-flag.md`), the matrix must include a pre-impl characterization row for the affected code. If missing, add it.
 12. **Security surface resolved** — if Step 2 flagged a touched security surface, the plan contains a Security section with a defense step and matching matrix row for each. If a flagged surface has no resolution, add it.
+13. **impl_model criterion** — if the plan declares `impl_model: sonnet` frontmatter (see Step 5), scan the Verification Matrix; if ANY row is classified `Truly-manual`, strip the marker so the plan runs at the Opus default. Sonnet may drive a plan only when every behavior-changing step has an objectively machine-checkable row that fails on a wrong edit.
 
 If validation fails on any gate, fix the matrix yourself rather than re-running the Plan agent.
 
@@ -133,6 +134,18 @@ PLAN_PATH="$HOME/.claude/plans/<slug>.md"
 If a plan file already exists at that path, create a new one with a numeric suffix rather than overwriting.
 
 Write the validated plan (with corrected matrix if Step 4 required fixes) to the plan file. When the work was split into multiple PRs, give each plan a distinct slug (e.g. `<base-slug>-1-<unit>`, `<base-slug>-2-<unit>`) so they sort in dependency order, and write one file per unit.
+
+### Declaring the implementation model (optional)
+
+The nightly implementation agent's model is selectable per-plan via a line-1 YAML frontmatter field. When **every** behavior-changing step has at least one Verification-Matrix row that is objectively machine-checkable and fails on a wrong edit (PHPStan green, PHPUnit/CLI assertion, baseline regen, identical test count, green-green characterization), prepend this block as the **very first lines** of the plan file:
+
+```
+---
+impl_model: sonnet
+---
+```
+
+The implementation then runs at Sonnet (cheaper, verified-equivalent quality on uniformly-mechanical plans — parsed by `bin/lib/plan-impl-model`). Omit the marker for any plan carrying a `Truly-manual` or subjective row — absence defaults to Opus. Only the first frontmatter block is parsed, so documenting this syntax inside a plan body never mis-selects a model. Failure modes are bounded: an absent or garbled marker → Opus (safe); a wrongly-applied `sonnet` marker → the plan's objective matrix goes red under Sonnet → caught by CI / post-plan.
 
 ## Step 6: Report
 

--- a/.claude/rules/nightly-workflow.md
+++ b/.claude/rules/nightly-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: Nightly autonomous workflow — launchd fires claude -p at 00:03 and 05:03 daily, running two context-isolated agents per plan (implementation + post-plan) with time guards and incremental checkpoints.
-last_verified: 2026-05-28
+last_verified: 2026-06-07
 paths: "bin/nightly-*"
 ---
 
@@ -42,7 +42,7 @@ A headless `claude -p` process runs twice daily via macOS `launchd`. It loops th
 1. **Daytime:** Work with Claude in plan mode. After approval, queue the plan: `bin/nightly-queue <slug>`
 2. **00:03 and 05:03:** `launchd` fires `bin/nightly-run`
 3. **Loop:** For each queued plan (oldest first), `nightly-run` fires two `claude -p` invocations sequentially:
-   - **Implementation agent** (`bin/nightly-prompt-impl`): creates worktree, implements the plan, makes checkpoint commits, writes a handoff file
+   - **Implementation agent** (`bin/nightly-prompt-impl`): creates worktree, implements the plan, makes checkpoint commits, writes a handoff file. Its model is selectable per-plan via a line-1 `impl_model:` frontmatter field (`sonnet` → Sonnet, `haiku` → Haiku, absent or anything else → the Opus default), resolved by `bin/lib/plan-impl-model`; declare `sonnet` only for uniformly-mechanical plans whose every verification row is objectively machine-checkable. The post-plan agent is always Sonnet.
    - **Post-plan agent** (`bin/nightly-prompt-postplan`): reads the handoff file, runs `/post-plan` (code review, security audit, PR, CI monitoring, auto-merge), writes the completion report
 4. **Guards:** The loop stops when the queue is empty or ~4h45m have elapsed. Plans that fail 3 times are moved to `skipped/` as poison pills.
 5. **Morning:** Check `gh pr list` for new PRs, read reports for details

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -433,6 +433,17 @@ jobs:
 
           echo "OK: no host mariadb invocations found outside bin/db-query."
 
+  nightly-impl-model-test:
+    name: Nightly impl-model parser test
+    needs: [changes]
+    if: needs.changes.outputs.shell == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Run nightly impl-model parser regression test
+        run: bin/test-nightly-impl-model
+
   update-baselines:
     name: Update coverage & PHPStan baselines
     needs: [test, phpstan]
@@ -543,7 +554,7 @@ jobs:
   gate:
     name: Tests and Analysis
     if: always()
-    needs: [changes, test, audit-php, audit-js, ibl6-checks, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, update-baselines, infection-excludes, harness-tests]
+    needs: [changes, test, audit-php, audit-js, ibl6-checks, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, nightly-impl-model-test, update-baselines, infection-excludes, harness-tests]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1

--- a/bin/lib/plan-impl-model
+++ b/bin/lib/plan-impl-model
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/lib/plan-impl-model — resolve the nightly impl-agent model for a plan file.
+#
+# Reads a positionally-constrained `impl_model:` field from the plan's FIRST
+# YAML frontmatter block (anchored to line 1) and echoes the model id that
+# bin/nightly-run passes to `claude -p --model`. The body is never scanned, so
+# a plan that merely *documents* the syntax cannot self-select a model. Any
+# missing, unknown, or `opus` value falls through to the safe Opus default.
+#
+# Usage: bin/lib/plan-impl-model <plan-file>   # echoes exactly one model id
+
+set -u
+
+PLAN_FILE="${1:?Usage: plan-impl-model <plan-file>}"
+
+# Line-1-anchored: only a `---` on line 1 opens the frontmatter block; read
+# impl_model inside that block, then stop at its closing `---`. A body example
+# (no line-1 frontmatter, or after the block closes) is never matched.
+RAW=$(awk '
+  NR==1 && /^---[[:space:]]*$/ {infm=1; next}
+  infm && /^---[[:space:]]*$/ {infm=0; exit}
+  infm && /^impl_model:[[:space:]]*/ {sub(/^impl_model:[[:space:]]*/,""); gsub(/[[:space:]]/,""); print; exit}
+' "$PLAN_FILE" 2>/dev/null)
+
+case "$RAW" in
+  sonnet) echo "claude-sonnet-4-6" ;;
+  haiku)  echo "claude-haiku-4-5"  ;;
+  *)      echo "claude-opus-4-8"   ;;   # opus, empty, garbled, or unknown → safe default
+esac

--- a/bin/nightly-run
+++ b/bin/nightly-run
@@ -353,13 +353,17 @@ while true; do
         WATCHER_PID=$!
 
         IMPL_STATUS=0
+        # Per-plan model selection: a plan may declare `impl_model:` in its
+        # first frontmatter block; absent/unknown → Opus default.
+        IMPL_MODEL=$(bin/lib/plan-impl-model "$NEXT_PLAN")
+        echo "[$(date +%H:%M:%S)] impl model: $IMPL_MODEL for $PLAN_NAME" >> "$LOG"
         NIGHTLY_CMDPID_FILE="$CMDPID_FILE" \
         timeout "$REMAINING_SECS" \
             claude -p "$(cat bin/nightly-prompt-impl)
 
 PLAN_FILE=$PLAN_NAME" \
                 --dangerously-skip-permissions \
-                --model claude-opus-4-8 \
+                --model "$IMPL_MODEL" \
                 --output-format stream-json \
                 --verbose \
                 --name "nightly-impl-$(date +%Y-%m-%d-%H%M)" \

--- a/bin/test-nightly-impl-model
+++ b/bin/test-nightly-impl-model
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-nightly-impl-model — regression test for bin/lib/plan-impl-model.
+#
+# The helper selects the nightly impl-agent model from a plan's FIRST YAML
+# frontmatter block only (anchored to line 1). This pins:
+#   - sonnet / explicit-opus frontmatter selects the right model
+#   - the FOOTGUN (load-bearing negative): a plan with NO frontmatter that
+#     merely documents an impl_model example in its body must NOT self-select
+#     (→ Opus default). PR2's own plan documents the syntax this way.
+#   - frontmatter present but without impl_model → Opus default
+#   - leading/trailing whitespace tolerance
+# Without the footgun cases, a body-greedy parser could silently downgrade a
+# plan that only documents the syntax.
+#
+# Run: bin/test-nightly-impl-model  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$SCRIPT_DIR/lib/plan-impl-model"
+TMP="$(mktemp -d)"
+trap 'rm -f "$TMP"/*.md 2>/dev/null; rmdir "$TMP" 2>/dev/null' EXIT
+
+FAILED=0
+
+# assert <name> <expected-model> <plan-body>
+assert() {
+    name="$1"; want="$2"; body="$3"
+    f="$TMP/$name.md"
+    printf '%s\n' "$body" > "$f"
+    got=$("$HELPER" "$f")
+    if [ "$got" != "$want" ]; then
+        echo "FAIL: $name — expected '$want', got '$got'"
+        FAILED=1
+    else
+        echo "ok: $name ($got)"
+    fi
+}
+
+# c1 — line-1 frontmatter selects sonnet
+assert "c1-sonnet" "claude-sonnet-4-6" '---
+impl_model: sonnet
+---
+# Plan
+body'
+
+# c2 (FOOTGUN, negative) — no frontmatter; an impl_model example in the BODY is ignored
+assert "c2-footgun-body-example" "claude-opus-4-8" '# Plan
+Documenting the syntax:
+```
+---
+impl_model: haiku
+---
+```
+more body'
+
+# c3 (negative) — real frontmatter without impl_model; trailing body example ignored
+assert "c3-no-field" "claude-opus-4-8" '---
+description: x
+---
+# Plan
+---
+impl_model: haiku
+---'
+
+# c4 (negative) — explicit opus falls through to the default
+assert "c4-explicit-opus" "claude-opus-4-8" '---
+impl_model: opus
+---
+# Plan'
+
+# c5 — leading/trailing whitespace around the value is tolerated
+assert "c5-whitespace" "claude-sonnet-4-6" '---
+impl_model:   sonnet
+---
+# Plan'
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
## Summary

Lets a plan author declare the model the nightly **implementation** agent runs at via a positionally-constrained YAML frontmatter field `impl_model:` in the plan file. Parses with a line-1-anchored awk helper so a plan that *documents* the syntax (PR2) can never self-trigger. Missing/garbled/`opus`/unknown → Opus default; all 231 existing frontmatter-less plans parse unchanged.

**Efficacy already proven:** `/tmp/anchortest/FINDINGS.md` Lever 1 — same task, 5 reps/model, identical turn counts, 5/5 quality, 0 decoys, −37% cost (Sonnet $0.0588 vs Opus $0.0930 avg). This PR only wires the lever.

## Changes

- `bin/lib/plan-impl-model` — new parse-and-map helper (verified awk + case default)
- `bin/test-nightly-impl-model` — new regression test (c1–c5 fixtures including footgun negative)
- `bin/nightly-run` — replace hardcoded `--model claude-opus-4-8` (line 407 impl invocation) with `--model "$IMPL_MODEL"`; post-plan sonnet literal unchanged
- `.github/workflows/tests.yml` — new `nightly-impl-model-test` job + added to `gate` needs
- `.claude/commands/plan.md` — emit criterion + Step-4 strip gate + last_verified bump
- `.claude/rules/nightly-workflow.md` — document the lever + last_verified bump

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: enforces existing nightly model-selection + bin/test regression convention, no new architectural decision -->
<!-- no-adr: enforces existing nightly model-selection + bin/test regression convention, no new architectural decision -->