### PR TITLE
feat(plan): delegation packets + exact edit-anchor conventions

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -68,6 +68,7 @@ The Plan agent MUST produce:
 - A full Verification Matrix in the exact format specified by `$VERIFICATION_RULE`
 - File paths for every test to be written or modified
 - A **Reuse** note in each implementation step that should call existing code: name the exact helper/service/repository method to use (from Step 2 findings) so the impl agent reuses rather than reinvents. Omit only when the step genuinely introduces new infrastructure.
+- An **exact edit anchor** for every step that modifies an existing file: quote the unique surrounding snippet (the exact line(s) the edit lands on or next to) so the impl agent's first `Edit` matches unambiguously. This is a **correctness / disambiguation** aid — it secures a first-try Edit match and avoids a failed-edit→re-read retry. It is **not** a token optimization and must not be presented as one: the impl agent already greps-then-slices and never reads a whole file to locate an edit, so anchors reduce ambiguity, not tokens.
 - For every behavior-changing step, at least one **negative-path, boundary, or failure-case** matrix row — not only the happy path (e.g. "rejects over-cap trade", "returns null for unknown player", "empty roster"). Happy-path-only coverage is insufficient.
 - When the plan emits a `## Critical Files` section, **mark every entry that will NOT be changed** (references, templates, files read for context) with an explicit reference marker — use `` `path` (reference) `` or `` `path` (read-only reference) ``. post-plan's Phase 5.0 file-conformance check treats every Critical File as a **must-appear** change target *by default* and blocks auto-merge if it never lands in the diff — it exempts an entry **only** when the annotation carries a reference marker (`reference`/`read-only`/`verify`/`template`/etc.). A bare path OR a path you annotate with a change-*description* (e.g. `` `path` — add the foo helper ``) is still checked, so describing your change-targets is safe; only the reference marker exempts. Mark the non-changed entries and the gate stays false-positive-free.
 
@@ -96,6 +97,21 @@ This guidance was relocated from `agent-tiering.md` (it is plan-authoring-only).
 > - Per-module sweeps with an explicit old→new mapping and no ambiguity → Haiku.
 > - Running tests, migrations, schema verification → direct Bash (short output); Haiku only if multi-step or output is unpredictably large.
 > - Interpreting failing tests, deciding when to update baselines → Opus (self).
+
+#### Delegation packets for verbose phases
+
+For a phase that is **genuinely verbose or parallelizable** — a multi-step run→inspect→fix→regen loop, or a bulk sweep of roughly **three or more** file-edits — emit a self-contained **delegation packet** the impl agent hands to a single sub-agent. Delegate the **whole phase loop including its own verify/regen/fixup** (not just the edits): the sub-agent's tool output then accumulates in *its* context and returns as one summary, keeping the orchestrator's per-turn context flat. The win is **context localization** (the orchestrator stops re-reading a growing transcript every turn) — not a flat cost-percentage. Reserve packets for phases whose moved work clearly exceeds a sub-agent's fixed startup (~15K tokens); a packet for one tiny edit costs more than it saves, so keep small phases inline.
+
+Format each packet as a fenced block within the plan:
+
+````
+### Delegate — <phase name>
+- **Tier:** Haiku | Sonnet  (per the agent-tiering guidance above)
+- **Scope:** which files, what change
+- **Recipe:** the exact commands / edits to run
+- **Self-verify:** the command the sub-agent runs *before returning* (e.g. `composer run analyse`, expected test count, green-green) — the packet owns its own verification
+- **Report back:** a one-line summary only
+````
 
 ## Step 4: Validate the matrix
 

--- a/bin/nightly-prompt-impl
+++ b/bin/nightly-prompt-impl
@@ -156,6 +156,8 @@ git log --oneline origin/master..HEAD
 
 Work in worktrees/<slug>/ibl5/. CLAUDE.md is auto-loaded — follow all project rules. Follow the plan step by step.
 
+When a plan phase carries a `### Delegate` packet, do NOT implement that phase inline: fire **one** Agent/Task call per packet at the packet's declared tier (Haiku or Sonnet), pass the packet **verbatim** as the sub-agent prompt, and absorb only the sub-agent's one-line summary. The packet is self-verifying — the sub-agent runs the packet's self-verify command before returning — and CI plus post-plan review remain the backstop. This keeps your own context flat across the run; inlining a verbose packet's tool output defeats its purpose.
+
 ### Incremental Commits
 
 Commit and push after each major milestone to checkpoint progress. This ensures work survives if the session ends unexpectedly. Use conventional commit messages — squash-merge erases the history anyway.


### PR DESCRIPTION
Part 2 of token-efficiency series. Adds delegation packet conventions and exact edit-anchor guidance to the plan command.

Rebased onto master (standalone, not stacked).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.