### PR TITLE
feat(asg): ScoFileWriter encoder + patch CLI for 06-07 All-Star Weekend .sco records

### DIFF
--- a/ibl5/classes/JsbParser/Contracts/ScoFileWriterInterface.php
+++ b/ibl5/classes/JsbParser/Contracts/ScoFileWriterInterface.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser\Contracts;
+
+/**
+ * Interface for encoding JSB .sco (Box Score) binary records.
+ *
+ * Produces fixed-width records matching the format parsed by ScoFileParser /
+ * Boxscore::fillGameInfo / PlayerStats::fillBoxscoreStats.
+ *
+ * All numeric fields are right-justified and space-padded; name/position fields
+ * are left-justified and space-padded. Encoding validates field widths and rejects
+ * out-of-range or negative values with RuntimeException.
+ *
+ * Background: the two ASG records (bytes 0..3999) in 06-07_36_finals.zip's
+ * IBL5.sco are entirely blank. This interface encodes the known-good reconstructed
+ * stats (sourced from ibl5/scripts/reconstruct_2007_asg_boxscores.php) so a future
+ * archive-only reimport can natively reproduce the 48 DB rows without special-casing.
+ *
+ * @see \JsbParser\ScoFileParser
+ * @see \Boxscore\Boxscore::fillGameInfo()
+ * @see \Player\Stats\PlayerStats::fillBoxscoreStats()
+ * @see /docs/decisions/0051-reconstructed-2007-asg-boxscores-in-finals-sco.md
+ */
+interface ScoFileWriterInterface
+{
+    /**
+     * Build a 58-byte game-info header.
+     *
+     * Stored month/day/gameOfDay/teamid values are the raw JSB-encoded integers
+     * (before the +10/+1 parse-time transforms applied by Boxscore::fillGameInfo).
+     * They are overridden at import time by BoxscoreProcessor::overrideGameContext,
+     * so their exact values only need to be non-blank and within field width.
+     * Attendance, capacity, and quarter scores are read verbatim.
+     *
+     * @param int $monthStored      Raw stored month (JSB format, before +10)
+     * @param int $dayStored        Raw stored day (before +1)
+     * @param int $gameOfDayStored  Raw stored game-of-day (before +1)
+     * @param int $visitorTidStored Raw stored visitor team ID (before +1)
+     * @param int $homeTidStored    Raw stored home team ID (before +1)
+     * @param int $attendance       Actual attendance figure
+     * @param int $capacity         Venue capacity
+     * @param int $visitorWins      Visitor team wins before game
+     * @param int $visitorLosses    Visitor team losses before game
+     * @param int $homeWins         Home team wins before game
+     * @param int $homeLosses       Home team losses before game
+     * @param list<int> $visitorQ   [q1, q2, q3, q4, ot] points for visitor
+     * @param list<int> $homeQ      [q1, q2, q3, q4, ot] points for home
+     * @return string Exactly 58 bytes
+     */
+    public static function buildGameInfo(
+        int $monthStored,
+        int $dayStored,
+        int $gameOfDayStored,
+        int $visitorTidStored,
+        int $homeTidStored,
+        int $attendance,
+        int $capacity,
+        int $visitorWins,
+        int $visitorLosses,
+        int $homeWins,
+        int $homeLosses,
+        array $visitorQ,
+        array $homeQ,
+    ): string;
+
+    /**
+     * Build a 53-byte player slot.
+     *
+     * Stores two-pointer makes/attempts (game_2gm, game_2ga) — NOT total FGM/FGA.
+     * Stores defensive rebounds (game_drb) — NOT total rebounds.
+     * Caller must apply: twoGM = fgm − tpm, twoGA = fga − tpa, drb = reb − orb.
+     *
+     * @param string $name     Player name, max 16 bytes (left-justified, space-padded)
+     * @param string $pos      Position code, max 2 chars (left-justified)
+     * @param int    $playerID Player ID (0 for team-total slots)
+     * @param int    $min      Minutes played
+     * @param int    $twoGM    Two-pointer makes (fgm − tpm)
+     * @param int    $twoGA    Two-pointer attempts (fga − tpa)
+     * @param int    $ftm      Free throw makes
+     * @param int    $fta      Free throw attempts
+     * @param int    $threeGM  Three-pointer makes
+     * @param int    $threeGA  Three-pointer attempts
+     * @param int    $orb      Offensive rebounds
+     * @param int    $drb      Defensive rebounds (reb − orb)
+     * @param int    $ast      Assists
+     * @param int    $stl      Steals
+     * @param int    $tov      Turnovers
+     * @param int    $blk      Blocks
+     * @param int    $pf       Personal fouls
+     * @return string Exactly 53 bytes
+     */
+    public static function buildPlayerSlot(
+        string $name,
+        string $pos,
+        int $playerID,
+        int $min,
+        int $twoGM,
+        int $twoGA,
+        int $ftm,
+        int $fta,
+        int $threeGM,
+        int $threeGA,
+        int $orb,
+        int $drb,
+        int $ast,
+        int $stl,
+        int $tov,
+        int $blk,
+        int $pf,
+    ): string;
+
+    /**
+     * Build a 53-byte team-total slot (playerID forced to 0, min forced to 0).
+     *
+     * @param string $name   Team name, max 16 bytes (left-justified, space-padded)
+     * @param int    $twoGM  Two-pointer makes (fgm − tpm)
+     * @param int    $twoGA  Two-pointer attempts (fga − tpa)
+     * @param int    $ftm    Free throw makes
+     * @param int    $fta    Free throw attempts
+     * @param int    $threeGM Three-pointer makes
+     * @param int    $threeGA Three-pointer attempts
+     * @param int    $orb    Offensive rebounds
+     * @param int    $drb    Defensive rebounds (reb − orb)
+     * @param int    $ast    Assists
+     * @param int    $stl    Steals
+     * @param int    $tov    Turnovers
+     * @param int    $blk    Blocks
+     * @param int    $pf     Personal fouls
+     * @return string Exactly 53 bytes
+     */
+    public static function buildTeamTotalSlot(
+        string $name,
+        int $twoGM,
+        int $twoGA,
+        int $ftm,
+        int $fta,
+        int $threeGM,
+        int $threeGA,
+        int $orb,
+        int $drb,
+        int $ast,
+        int $stl,
+        int $tov,
+        int $blk,
+        int $pf,
+    ): string;
+
+    /**
+     * Assemble a 2000-byte record from a 58-byte game-info and up to 30 player slots.
+     *
+     * Slots are placed at byte 58 + (i * 53). Any unfilled slot positions and the
+     * trailing bytes 1648..1999 are space-padded.
+     *
+     * @param string       $gameInfo    58-byte game-info header
+     * @param list<string> $playerSlots Up to 30 53-byte slot strings
+     * @return string Exactly 2000 bytes
+     */
+    public static function buildRecord(string $gameInfo, array $playerSlots): string;
+
+    /**
+     * Build the 4000-byte All-Star Weekend header block (record 0 ‖ record 1).
+     *
+     * Encodes the Rising Stars Game (record 0) and All-Star Game (record 1).
+     * Each game array carries resolved player names and pre-derived stat values
+     * (twoGM = fgm − tpm, twoGA = fga − tpa, drb = reb − orb).
+     *
+     * Layout per record:
+     * - Visitor player slots 0..N-1 (N = count of visitor_players)
+     * - Blank filler slots N..13
+     * - Visitor team-total at slot 14
+     * - Home player slots 15..15+M-1 (M = count of home_players)
+     * - Blank filler slots 15+M..28
+     * - Home team-total at slot 29
+     *
+     * @param array{
+     *     visitor_name: string,
+     *     home_name: string,
+     *     visitor_q: list<int>,
+     *     home_q: list<int>,
+     *     visitor_teamid: int,
+     *     home_teamid: int,
+     *     attendance: int,
+     *     capacity: int,
+     *     visitor_team: array{twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int},
+     *     home_team: array{twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int},
+     *     visitor_players: list<array{name: string, pos: string, pid: int, min: int, twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int}>,
+     *     home_players: list<array{name: string, pos: string, pid: int, min: int, twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int}>,
+     * } $risingStars
+     * @param array{
+     *     visitor_name: string,
+     *     home_name: string,
+     *     visitor_q: list<int>,
+     *     home_q: list<int>,
+     *     visitor_teamid: int,
+     *     home_teamid: int,
+     *     attendance: int,
+     *     capacity: int,
+     *     visitor_team: array{twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int},
+     *     home_team: array{twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int},
+     *     visitor_players: list<array{name: string, pos: string, pid: int, min: int, twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int}>,
+     *     home_players: list<array{name: string, pos: string, pid: int, min: int, twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int}>,
+     * } $allStar
+     * @return string Exactly 4000 bytes
+     */
+    public static function buildAllStarHeaderBlock(array $risingStars, array $allStar): string;
+
+    /**
+     * Splice the 4000-byte All-Star block into a .sco file, replacing bytes 0..3999.
+     *
+     * Guards (throws RuntimeException on violation):
+     * - $block must be exactly 4000 bytes
+     * - $sco must be exactly 12,781,648 bytes
+     * - Bytes 0..3999 of $sco must be entirely spaces (blank precondition)
+     * - After splice: total length unchanged AND bytes 1,000,000..EOF byte-identical to original
+     *
+     * @param string $sco   Full .sco file contents (12,781,648 bytes)
+     * @param string $block Encoded 4000-byte block
+     * @return string Patched .sco contents (12,781,648 bytes)
+     * @throws \RuntimeException on any guard violation
+     */
+    public static function spliceAllStarBlock(string $sco, string $block): string;
+}

--- a/ibl5/classes/JsbParser/ScoFileWriter.php
+++ b/ibl5/classes/JsbParser/ScoFileWriter.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsbParser;
+
+use JsbParser\Contracts\ScoFileWriterInterface;
+
+/**
+ * Encodes JSB .sco (Box Score) binary records from structured PHP data.
+ *
+ * Produces fixed-width records that round-trip through ScoFileParser /
+ * Boxscore::fillGameInfo / PlayerStats::fillBoxscoreStats with byte-exact equality.
+ *
+ * Background: the two ASG records (bytes 0..3999) in 06-07_36_finals.zip's
+ * IBL5.sco are entirely blank. This class encodes the known-good reconstructed
+ * stats (sourced from ibl5/scripts/reconstruct_2007_asg_boxscores.php) so a
+ * future archive-only reimport reproduces the 48 DB rows natively.
+ * The patch CLI that applies the block is ibl5/scripts/patch_2007_asg_sco.php.
+ *
+ * @see \JsbParser\ScoFileParser   Paired reader
+ * @see \JsbParser\TrnFileWriter   Pattern reference
+ * @see /docs/decisions/0051-reconstructed-2007-asg-boxscores-in-finals-sco.md
+ */
+class ScoFileWriter implements ScoFileWriterInterface
+{
+    // ── Game-info offsets and widths (mirrors Boxscore::fillGameInfo) ─────────
+    public const OFF_MONTH         = 0;  public const W_MONTH         = 2;
+    public const OFF_DAY           = 2;  public const W_DAY           = 2;
+    public const OFF_GAME_OF_DAY   = 4;  public const W_GAME_OF_DAY   = 2;
+    public const OFF_VISITOR_TID   = 6;  public const W_VISITOR_TID   = 2;
+    public const OFF_HOME_TID      = 8;  public const W_HOME_TID      = 2;
+    public const OFF_ATTENDANCE    = 10; public const W_ATTENDANCE    = 5;
+    public const OFF_CAPACITY      = 15; public const W_CAPACITY      = 5;
+    public const OFF_VISITOR_WINS  = 20; public const W_VISITOR_WINS  = 2;
+    public const OFF_VISITOR_LOSSES = 22; public const W_VISITOR_LOSSES = 2;
+    public const OFF_HOME_WINS     = 24; public const W_HOME_WINS     = 2;
+    public const OFF_HOME_LOSSES   = 26; public const W_HOME_LOSSES   = 2;
+    public const OFF_VISITOR_Q1    = 28; public const W_Q             = 3;
+    public const OFF_VISITOR_Q2    = 31;
+    public const OFF_VISITOR_Q3    = 34;
+    public const OFF_VISITOR_Q4    = 37;
+    public const OFF_VISITOR_OT    = 40;
+    public const OFF_HOME_Q1       = 43;
+    public const OFF_HOME_Q2       = 46;
+    public const OFF_HOME_Q3       = 49;
+    public const OFF_HOME_Q4       = 52;
+    public const OFF_HOME_OT       = 55;
+
+    // ── Player-slot offsets and widths (mirrors PlayerStats::fillBoxscoreStats) ─
+    public const OFF_NAME   = 0;  public const W_NAME   = 16;
+    public const OFF_POS    = 16; public const W_POS    = 2;
+    public const OFF_PID    = 18; public const W_PID    = 6;
+    public const OFF_MIN    = 24; public const W_MIN    = 2;
+    public const OFF_2GM    = 26; public const W_2GM    = 2;
+    public const OFF_2GA    = 28; public const W_2GA    = 3;
+    public const OFF_FTM    = 31; public const W_FTM    = 2;
+    public const OFF_FTA    = 33; public const W_FTA    = 2;
+    public const OFF_3GM    = 35; public const W_3GM    = 2;
+    public const OFF_3GA    = 37; public const W_3GA    = 2;
+    public const OFF_ORB    = 39; public const W_ORB    = 2;
+    public const OFF_DRB    = 41; public const W_DRB    = 2;
+    public const OFF_AST    = 43; public const W_AST    = 2;
+    public const OFF_STL    = 45; public const W_STL    = 2;
+    public const OFF_TOV    = 47; public const W_TOV    = 2;
+    public const OFF_BLK    = 49; public const W_BLK    = 2;
+    public const OFF_PF     = 51; public const W_PF     = 2;
+
+    public const SCO_FILE_SIZE = 12781648;
+
+    /**
+     * @see ScoFileWriterInterface::buildGameInfo()
+     */
+    public static function buildGameInfo(
+        int $monthStored,
+        int $dayStored,
+        int $gameOfDayStored,
+        int $visitorTidStored,
+        int $homeTidStored,
+        int $attendance,
+        int $capacity,
+        int $visitorWins,
+        int $visitorLosses,
+        int $homeWins,
+        int $homeLosses,
+        array $visitorQ,
+        array $homeQ,
+    ): string {
+        $record = str_repeat(' ', ScoFileParser::GAME_INFO_SIZE);
+
+        $record = self::writeInt($record, self::OFF_MONTH,          self::W_MONTH,          $monthStored);
+        $record = self::writeInt($record, self::OFF_DAY,            self::W_DAY,            $dayStored);
+        $record = self::writeInt($record, self::OFF_GAME_OF_DAY,    self::W_GAME_OF_DAY,    $gameOfDayStored);
+        $record = self::writeInt($record, self::OFF_VISITOR_TID,    self::W_VISITOR_TID,    $visitorTidStored);
+        $record = self::writeInt($record, self::OFF_HOME_TID,       self::W_HOME_TID,       $homeTidStored);
+        $record = self::writeInt($record, self::OFF_ATTENDANCE,     self::W_ATTENDANCE,     $attendance);
+        $record = self::writeInt($record, self::OFF_CAPACITY,       self::W_CAPACITY,       $capacity);
+        $record = self::writeInt($record, self::OFF_VISITOR_WINS,   self::W_VISITOR_WINS,   $visitorWins);
+        $record = self::writeInt($record, self::OFF_VISITOR_LOSSES, self::W_VISITOR_LOSSES, $visitorLosses);
+        $record = self::writeInt($record, self::OFF_HOME_WINS,      self::W_HOME_WINS,      $homeWins);
+        $record = self::writeInt($record, self::OFF_HOME_LOSSES,    self::W_HOME_LOSSES,    $homeLosses);
+
+        $vOffsets = [self::OFF_VISITOR_Q1, self::OFF_VISITOR_Q2, self::OFF_VISITOR_Q3, self::OFF_VISITOR_Q4, self::OFF_VISITOR_OT];
+        $hOffsets = [self::OFF_HOME_Q1,    self::OFF_HOME_Q2,    self::OFF_HOME_Q3,    self::OFF_HOME_Q4,    self::OFF_HOME_OT];
+
+        for ($i = 0; $i < 5; $i++) {
+            $record = self::writeInt($record, $vOffsets[$i], self::W_Q, $visitorQ[$i]);
+            $record = self::writeInt($record, $hOffsets[$i], self::W_Q, $homeQ[$i]);
+        }
+
+        return $record;
+    }
+
+    /**
+     * @see ScoFileWriterInterface::buildPlayerSlot()
+     */
+    public static function buildPlayerSlot(
+        string $name,
+        string $pos,
+        int $playerID,
+        int $min,
+        int $twoGM,
+        int $twoGA,
+        int $ftm,
+        int $fta,
+        int $threeGM,
+        int $threeGA,
+        int $orb,
+        int $drb,
+        int $ast,
+        int $stl,
+        int $tov,
+        int $blk,
+        int $pf,
+    ): string {
+        $record = str_repeat(' ', ScoFileParser::PLAYER_SLOT_SIZE);
+
+        $record = self::writeName($record, self::OFF_NAME, self::W_NAME, $name);
+        $record = self::writeName($record, self::OFF_POS,  self::W_POS,  $pos);
+        $record = self::writeInt($record, self::OFF_PID,   self::W_PID,   $playerID);
+        $record = self::writeInt($record, self::OFF_MIN,   self::W_MIN,   $min);
+        $record = self::writeInt($record, self::OFF_2GM,   self::W_2GM,   $twoGM);
+        $record = self::writeInt($record, self::OFF_2GA,   self::W_2GA,   $twoGA);
+        $record = self::writeInt($record, self::OFF_FTM,   self::W_FTM,   $ftm);
+        $record = self::writeInt($record, self::OFF_FTA,   self::W_FTA,   $fta);
+        $record = self::writeInt($record, self::OFF_3GM,   self::W_3GM,   $threeGM);
+        $record = self::writeInt($record, self::OFF_3GA,   self::W_3GA,   $threeGA);
+        $record = self::writeInt($record, self::OFF_ORB,   self::W_ORB,   $orb);
+        $record = self::writeInt($record, self::OFF_DRB,   self::W_DRB,   $drb);
+        $record = self::writeInt($record, self::OFF_AST,   self::W_AST,   $ast);
+        $record = self::writeInt($record, self::OFF_STL,   self::W_STL,   $stl);
+        $record = self::writeInt($record, self::OFF_TOV,   self::W_TOV,   $tov);
+        $record = self::writeInt($record, self::OFF_BLK,   self::W_BLK,   $blk);
+        $record = self::writeInt($record, self::OFF_PF,    self::W_PF,    $pf);
+
+        return $record;
+    }
+
+    /**
+     * @see ScoFileWriterInterface::buildTeamTotalSlot()
+     */
+    public static function buildTeamTotalSlot(
+        string $name,
+        int $twoGM,
+        int $twoGA,
+        int $ftm,
+        int $fta,
+        int $threeGM,
+        int $threeGA,
+        int $orb,
+        int $drb,
+        int $ast,
+        int $stl,
+        int $tov,
+        int $blk,
+        int $pf,
+    ): string {
+        return self::buildPlayerSlot($name, '', 0, 0, $twoGM, $twoGA, $ftm, $fta, $threeGM, $threeGA, $orb, $drb, $ast, $stl, $tov, $blk, $pf);
+    }
+
+    /**
+     * @see ScoFileWriterInterface::buildRecord()
+     */
+    public static function buildRecord(string $gameInfo, array $playerSlots): string
+    {
+        if (strlen($gameInfo) !== ScoFileParser::GAME_INFO_SIZE) {
+            throw new \RuntimeException('gameInfo must be ' . ScoFileParser::GAME_INFO_SIZE . ' bytes, got ' . strlen($gameInfo));
+        }
+
+        $record = str_repeat(' ', ScoFileParser::RECORD_SIZE);
+        $record = substr_replace($record, $gameInfo, 0, ScoFileParser::GAME_INFO_SIZE);
+
+        foreach ($playerSlots as $i => $slot) {
+            if (strlen($slot) !== ScoFileParser::PLAYER_SLOT_SIZE) {
+                throw new \RuntimeException('Slot ' . $i . ' must be ' . ScoFileParser::PLAYER_SLOT_SIZE . ' bytes, got ' . strlen($slot));
+            }
+            $offset = ScoFileParser::GAME_INFO_SIZE + ($i * ScoFileParser::PLAYER_SLOT_SIZE);
+            $record = substr_replace($record, $slot, $offset, ScoFileParser::PLAYER_SLOT_SIZE);
+        }
+
+        if (strlen($record) !== ScoFileParser::RECORD_SIZE) {
+            throw new \RuntimeException('Record must be ' . ScoFileParser::RECORD_SIZE . ' bytes');
+        }
+
+        return $record;
+    }
+
+    /**
+     * @see ScoFileWriterInterface::buildAllStarHeaderBlock()
+     */
+    public static function buildAllStarHeaderBlock(array $risingStars, array $allStar): string
+    {
+        $block = self::buildGameRecord($risingStars) . self::buildGameRecord($allStar);
+
+        if (strlen($block) !== ScoFileParser::RECORD_SIZE * 2) {
+            throw new \RuntimeException('Block must be ' . (ScoFileParser::RECORD_SIZE * 2) . ' bytes');
+        }
+
+        return $block;
+    }
+
+    /**
+     * @see ScoFileWriterInterface::spliceAllStarBlock()
+     */
+    public static function spliceAllStarBlock(string $sco, string $block): string
+    {
+        if (strlen($block) !== 4000) {
+            throw new \RuntimeException('block must be exactly 4000 bytes, got ' . strlen($block));
+        }
+
+        if (strlen($sco) !== self::SCO_FILE_SIZE) {
+            throw new \RuntimeException('sco must be exactly ' . self::SCO_FILE_SIZE . ' bytes, got ' . strlen($sco));
+        }
+
+        if (trim(substr($sco, 0, 4000)) !== '') {
+            throw new \RuntimeException('sco bytes 0..3999 must be entirely spaces (blank precondition)');
+        }
+
+        $originalTailHash = hash('sha256', substr($sco, ScoFileParser::HEADER_OFFSET_BYTES));
+
+        $patched = substr_replace($sco, $block, 0, 4000);
+
+        if (strlen($patched) !== self::SCO_FILE_SIZE) {
+            throw new \RuntimeException('splice changed file length: expected ' . self::SCO_FILE_SIZE . ', got ' . strlen($patched));
+        }
+
+        $patchedTailHash = hash('sha256', substr($patched, ScoFileParser::HEADER_OFFSET_BYTES));
+        if ($patchedTailHash !== $originalTailHash) {
+            throw new \RuntimeException('splice mutated tail (bytes >= 1,000,000)');
+        }
+
+        return $patched;
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Build a 2000-byte record from one game's data array.
+     *
+     * @param array{
+     *     visitor_name: string,
+     *     home_name: string,
+     *     visitor_q: list<int>,
+     *     home_q: list<int>,
+     *     visitor_teamid: int,
+     *     home_teamid: int,
+     *     attendance: int,
+     *     capacity: int,
+     *     visitor_team: array{twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int},
+     *     home_team: array{twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int},
+     *     visitor_players: list<array{name: string, pos: string, pid: int, min: int, twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int}>,
+     *     home_players: list<array{name: string, pos: string, pid: int, min: int, twoGM: int, twoGA: int, ftm: int, fta: int, threeGM: int, threeGA: int, orb: int, drb: int, ast: int, stl: int, tov: int, blk: int, pf: int}>,
+     * } $game
+     */
+    private static function buildGameRecord(array $game): string
+    {
+        $gameInfo = self::buildGameInfo(
+            1, // monthStored — overridden at import by overrideGameContext
+            1, // dayStored   — overridden at import
+            0, // gameOfDayStored — overridden
+            $game['visitor_teamid'] - 1,
+            $game['home_teamid'] - 1,
+            $game['attendance'],
+            $game['capacity'],
+            0, 0, 0, 0, // W/L unrecoverable
+            $game['visitor_q'],
+            $game['home_q'],
+        );
+
+        // Slot layout: visitor players (0..N-1), blanks (N..13), visitor total (14),
+        //              home players (15..15+M-1), blanks (15+M..28), home total (29).
+        $slots = [];
+
+        // Visitor players
+        foreach ($game['visitor_players'] as $p) {
+            $slots[] = self::buildPlayerSlot(
+                $p['name'], $p['pos'], $p['pid'], $p['min'],
+                $p['twoGM'], $p['twoGA'], $p['ftm'], $p['fta'],
+                $p['threeGM'], $p['threeGA'], $p['orb'], $p['drb'],
+                $p['ast'], $p['stl'], $p['tov'], $p['blk'], $p['pf'],
+            );
+        }
+
+        // Blank filler: fill up to slot 13 (index 13) with space-only slots
+        while (count($slots) < 14) {
+            $slots[] = str_repeat(' ', ScoFileParser::PLAYER_SLOT_SIZE);
+        }
+
+        // Visitor team total at slot 14
+        $vt = $game['visitor_team'];
+        $slots[] = self::buildTeamTotalSlot(
+            $game['visitor_name'],
+            $vt['twoGM'], $vt['twoGA'], $vt['ftm'], $vt['fta'],
+            $vt['threeGM'], $vt['threeGA'], $vt['orb'], $vt['drb'],
+            $vt['ast'], $vt['stl'], $vt['tov'], $vt['blk'], $vt['pf'],
+        );
+
+        // Home players (slots 15+)
+        foreach ($game['home_players'] as $p) {
+            $slots[] = self::buildPlayerSlot(
+                $p['name'], $p['pos'], $p['pid'], $p['min'],
+                $p['twoGM'], $p['twoGA'], $p['ftm'], $p['fta'],
+                $p['threeGM'], $p['threeGA'], $p['orb'], $p['drb'],
+                $p['ast'], $p['stl'], $p['tov'], $p['blk'], $p['pf'],
+            );
+        }
+
+        // Blank filler: fill up to slot 28 (index 28) with space-only slots
+        while (count($slots) < 29) {
+            $slots[] = str_repeat(' ', ScoFileParser::PLAYER_SLOT_SIZE);
+        }
+
+        // Home team total at slot 29
+        $ht = $game['home_team'];
+        $slots[] = self::buildTeamTotalSlot(
+            $game['home_name'],
+            $ht['twoGM'], $ht['twoGA'], $ht['ftm'], $ht['fta'],
+            $ht['threeGM'], $ht['threeGA'], $ht['orb'], $ht['drb'],
+            $ht['ast'], $ht['stl'], $ht['tov'], $ht['blk'], $ht['pf'],
+        );
+
+        return self::buildRecord($gameInfo, $slots);
+    }
+
+    /**
+     * Write a right-justified, space-padded integer into a fixed-width field.
+     */
+    private static function writeInt(string $record, int $offset, int $width, int $value): string
+    {
+        if ($value < 0) {
+            throw new \RuntimeException("Negative value {$value} not allowed at offset {$offset}");
+        }
+        $str = (string) $value;
+        if (strlen($str) > $width) {
+            throw new \RuntimeException("Value {$value} overflows field width {$width} at offset {$offset}");
+        }
+        return substr_replace($record, str_pad($str, $width, ' ', STR_PAD_LEFT), $offset, $width);
+    }
+
+    /**
+     * Write a left-justified, space-padded string into a fixed-width field.
+     */
+    private static function writeName(string $record, int $offset, int $width, string $value): string
+    {
+        if (strlen($value) > $width) {
+            throw new \RuntimeException("Name '{$value}' exceeds field width {$width} at offset {$offset}");
+        }
+        return substr_replace($record, str_pad($value, $width), $offset, $width);
+    }
+}

--- a/ibl5/docs/decisions/0051-reconstructed-2007-asg-boxscores-in-finals-sco.md
+++ b/ibl5/docs/decisions/0051-reconstructed-2007-asg-boxscores-in-finals-sco.md
@@ -1,0 +1,114 @@
+---
+description: >
+  Why and how the 2006-07 All-Star Weekend box-score records were reconstructed
+  and patched into 06-07_36_finals.zip's IBL5.sco binary.
+last_verified: 2026-06-08
+---
+
+# 0051 — Reconstructed 2006-07 All-Star Weekend Box Scores in Finals SCO
+
+## Status
+
+Accepted
+
+## Context
+
+The 2006-07 season archive (`backups/06-07/06-07_36_finals.zip`) contains an
+`IBL5.sco` binary file (12,781,648 bytes). A `.sco` file stores game records as
+a 1,000,000-byte header followed by 2,000-byte per-game records. Records 0 and 1
+correspond to the Rising Stars Game (2007-02-02) and All-Star Game (2007-02-03).
+
+Both records were entirely blank (all `0x20` / space bytes). The JSB bulk importer
+skips any record where `trim(gameInfo) === ''`, so these two games were silently
+omitted from every archive-import run. The 48 player box-score rows and 4 team rows
+that should have existed in the database were never produced by the importer.
+
+The original blank state was discovered when auditing why the ASG break-season gate
+(which depends on `Season::getLastBoxScoreDate()`) returned stale dates. The root
+cause is that the sim software failed to write the All-Star Weekend records into the
+file at export time; this is unrecoverable from the archive alone.
+
+### What was reconstructed
+
+Stats were transcribed from the HTML box-score pages preserved on the IBL5 website
+and stored in `ibl5/scripts/reconstruct_2007_asg_boxscores.php` (the stat source of
+truth). Reconstructed fields per player:
+
+| Reconstructable | Not reconstructable |
+|-----------------|---------------------|
+| All counting stats (pts, reb, ast, stl, blk, tov, pf, min) | W-L record (stored as 0-0) |
+| Quarter scores | Exact attendance/capacity (approximated) |
+| Player positions | |
+| Team totals | |
+
+The W-L records stored in the `.sco` header are treated as don't-care: they are
+overridden at import time by `BoxscoreProcessor::overrideGameContext`, which derives
+the correct team context from the season gate and game-date sentinel rows.
+
+## Decision
+
+Apply two complementary fixes:
+
+### Fix A — Direct DB write (`reconstruct_2007_asg_boxscores.php`)
+
+`ibl5/scripts/reconstruct_2007_asg_boxscores.php` inserts the reconstructed rows
+directly into the live database. This is the fast path for the currently-deployed
+environment. It must be run once against production.
+
+### Fix B — Archive patch (`patch_2007_asg_sco.php` + `ScoFileWriter`)
+
+`ibl5/scripts/patch_2007_asg_sco.php` encodes the same stats into bytes 0..3999 of
+`IBL5.sco` inside `06-07_36_finals.zip`, making the archive self-sufficient. A future
+full reimport (without Fix A) will now produce the correct rows natively, without any
+special-case logic in the importer.
+
+The binary patch is not committed to git (the archive is gitignored at 158 MB); only
+the encoding code and this ADR are in the repository.
+
+### Encoding implementation (`ScoFileWriter`)
+
+`classes/JsbParser/ScoFileWriter` mirrors the `TrnFileWriter` pattern: a pure
+stateless encoder behind `ScoFileWriterInterface`, with no I/O. Key encoding rules
+derived from reading `Boxscore::fillGameInfo` and `PlayerStats::fillBoxscoreStats`:
+
+- Names: left-justified, space-padded to field width
+- Numerics: right-justified, space-padded to field width
+- The `.sco` stores **two-pointer** makes/attempts (`game_2gm`, `game_2ga`), not total
+  FGM/FGA. Caller must derive: `twoGM = fgm − tpm`, `twoGA = fga − tpa`
+- The `.sco` stores **defensive** rebounds (`game_drb`), not total rebounds. Caller
+  must derive: `drb = reb − orb`
+- Team-total slot is at position 14 (visitor) and 29 (home); player ID = 0
+- Blank filler slots occupy positions visitor_count..13 and 15+home_count..28
+- Stored month/day/gameOfDay/teamid values undergo `+10`/`+1`/`+1`/`+1` transforms at
+  parse time; the patch uses sentinel values (1, 1, 0, teamid-1) that decode correctly
+
+### Integrity guards in `spliceAllStarBlock`
+
+Before any write:
+1. `IBL5.sco` must be exactly 12,781,648 bytes
+2. Bytes 0..3999 must be entirely spaces (blank precondition — abort if already patched)
+3. SHA-256 hashes of all 30 archive members recorded before write
+4. After write: `IBL5.sco` tail bytes (1,000,000..EOF) hash-identical to pre-write
+5. After write: all other members hash-identical to pre-write
+
+## Consequences
+
+- Future full reimports of the 2006-07 archive will produce the correct 48 player
+  rows and 4 team rows for All-Star Weekend without any special-case importer logic.
+- The `ASG break-season gate` (`IBL_ALL_STAR_BREAK_END_DAY`) is no longer affected
+  by missing box-score rows for this season.
+- `ScoFileWriter` + `ScoFileWriterInterface` are available for encoding other blank
+  or corrupt `.sco` records if the same issue is discovered in other season archives.
+- W-L records remain 0-0 in the patched binary; this is acceptable because the
+  importer overrides them from context and they are not surfaced in the UI.
+
+## Related
+
+- `ibl5/scripts/reconstruct_2007_asg_boxscores.php` — stat source of truth (Fix A)
+- `ibl5/scripts/patch_2007_asg_sco.php` — archive patch CLI (Fix B)
+- `classes/JsbParser/ScoFileWriter.php` — pure encoder
+- `classes/JsbParser/Contracts/ScoFileWriterInterface.php` — interface
+- `tests/JsbParser/ScoFileWriterTest.php` — unit tests
+- `tests/DatabaseIntegration/AllStarScoReconstructionTest.php` — DB acceptance tests
+- `classes/JsbParser/ScoFileParser.php` — parser constants and slot extraction
+- `classes/Boxscore/BoxscoreProcessor.php` — importer (overrideGameContext, season gate)

--- a/ibl5/scripts/patch_2007_asg_sco.php
+++ b/ibl5/scripts/patch_2007_asg_sco.php
@@ -1,0 +1,439 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Patch the blank 2006-07 All-Star Weekend records into 06-07_36_finals.zip's IBL5.sco.
+ *
+ * The two ASG records (bytes 0..3999) in that archive are entirely blank (all 0x20),
+ * which causes the bulk importer to silently skip them. This script encodes the
+ * known-good reconstructed stats (transcribed from the HTML box scores and stored in
+ * reconstruct_2007_asg_boxscores.php) into those bytes so a future archive-only
+ * reimport reproduces the 48 DB rows with zero special-casing.
+ *
+ * This script is COMPLEMENTARY to reconstruct_2007_asg_boxscores.php:
+ *   - reconstruct_2007_asg_boxscores.php  — writes rows into the LIVE DB now
+ *   - this script                         — makes the ARCHIVE self-sufficient
+ *
+ * The stat source of truth is the $games array in reconstruct_2007_asg_boxscores.php.
+ * Do not re-transcribe stats here — copy them verbatim from that file.
+ *
+ * Integrity guards (abort on violation before any write):
+ *   1. IBL5.sco must be exactly 12,781,648 bytes.
+ *   2. Bytes 0..3999 of IBL5.sco must be entirely spaces (blank precondition).
+ *   3. All 30 zip members' decompressed SHA-256 hashes are recorded before write.
+ *   4. After write: IBL5.sco tail (bytes 1,000,000..EOF) hash identical to pre-write.
+ *   5. After write: every member except IBL5.sco hash-identical to pre-write.
+ *
+ * @see /docs/decisions/0051-reconstructed-2007-asg-boxscores-in-finals-sco.md
+ * @see ibl5/scripts/reconstruct_2007_asg_boxscores.php (stat source of truth)
+ *
+ * Usage:
+ *   php patch_2007_asg_sco.php           # dry-run (no writes)
+ *   php patch_2007_asg_sco.php --apply   # patch the archive in place
+ */
+
+use JsbParser\ScoFileParser;
+use JsbParser\ScoFileWriter;
+
+if (PHP_SAPI !== 'cli') {
+    echo 'This script must be run from the command line.';
+    exit(1);
+}
+
+// ── Minimal bootstrap (mirrors reconstruct_2007_asg_boxscores.php) ───────────
+$_SERVER['PHP_SELF'] = 'patch_2007_asg_sco.php';
+$_SERVER['SERVER_NAME'] = 'localhost';
+$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$localClassesDir = realpath(__DIR__ . '/../classes');
+if ($localClassesDir !== false) {
+    spl_autoload_register(static function (string $class) use ($localClassesDir): void {
+        $path = $localClassesDir . '/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($path)) {
+            require_once $path;
+        }
+    });
+}
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../db/db.php';
+
+/** @var \mysqli $mysqli_db */
+
+$apply = in_array('--apply', $argv, true);
+
+// ── Constants ────────────────────────────────────────────────────────────────
+const PATCH_ATTENDANCE = 5244;
+const PATCH_CAPACITY   = 20000;
+
+// ── Stat dataset (verbatim from reconstruct_2007_asg_boxscores.php) ───────────
+// Order: [pid, pos, min, fgm, fga, ftm, fta, tpm, tpa, orb, reb, ast, stl, tov, blk, pf]
+$games = [
+    'Rising Stars Game' => [
+        'date'         => '2007-02-02',
+        'visitor_teamid' => 40,
+        'home_teamid'    => 41,
+        'visitor_name'   => 'Rookies',
+        'home_name'      => 'Sophomores',
+        'visitor_q'      => [34, 39, 30, 31, 0],
+        'home_q'         => [34, 31, 39, 41, 0],
+        'visitor_team'   => [55, 119, 16, 21, 8, 21, 25, 66, 30, 11, 22, 8, 19],
+        'home_team'      => [64, 127, 5, 9, 12, 27, 24, 67, 34, 10, 21, 14, 21],
+        'visitor_players' => [
+            [5936, 'PG', 32, 7, 18, 5, 5, 0, 3, 3, 4, 7, 0, 3, 0, 3],
+            [5938, 'PG', 16, 2, 7, 0, 0, 1, 5, 1, 2, 1, 0, 2, 1, 0],
+            [5931, 'SG', 32, 10, 21, 3, 5, 2, 5, 4, 8, 0, 3, 1, 1, 2],
+            [5930, 'SG', 19, 3, 5, 2, 3, 2, 2, 1, 2, 2, 2, 1, 1, 1],
+            [5937, 'SF', 29, 6, 13, 0, 0, 1, 2, 0, 4, 11, 1, 5, 0, 2],
+            [5939, 'SF', 13, 6, 11, 1, 2, 0, 0, 1, 3, 4, 0, 3, 1, 4],
+            [5929, 'PF', 30, 9, 18, 2, 2, 2, 3, 3, 7, 2, 1, 2, 1, 1],
+            [5935, 'PF', 30, 7, 14, 3, 4, 0, 1, 6, 12, 2, 4, 3, 1, 3],
+            [5942, 'C', 14, 2, 5, 0, 0, 0, 0, 3, 7, 0, 0, 2, 1, 1],
+            [5964, 'C', 22, 3, 7, 0, 0, 0, 0, 1, 9, 1, 0, 0, 1, 2],
+        ],
+        'home_players'    => [
+            [5640, 'PG', 31, 13, 23, 0, 0, 0, 2, 4, 11, 12, 3, 6, 3, 1],
+            [5649, 'PG', 13, 2, 5, 3, 4, 1, 2, 0, 1, 5, 3, 2, 0, 0],
+            [5642, 'SG', 20, 11, 14, 1, 3, 1, 2, 1, 2, 6, 0, 3, 0, 2],
+            [5659, 'SG', 30, 10, 24, 0, 0, 6, 11, 0, 5, 5, 2, 3, 2, 2],
+            [5645, 'SF', 31, 9, 19, 1, 1, 2, 5, 0, 5, 1, 0, 0, 0, 4],
+            [5685, 'SF', 20, 3, 9, 0, 0, 2, 4, 0, 1, 2, 1, 0, 0, 2],
+            [5646, 'PF', 17, 3, 5, 0, 0, 0, 0, 2, 6, 0, 1, 2, 0, 5],
+            [5663, 'PF', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [5641, 'C', 31, 7, 17, 0, 0, 0, 1, 10, 16, 2, 0, 1, 4, 4],
+            [5644, 'C', 43, 6, 11, 0, 1, 0, 0, 6, 17, 1, 0, 4, 5, 1],
+        ],
+    ],
+    'All-Star Game' => [
+        'date'         => '2007-02-03',
+        'visitor_teamid' => 50,
+        'home_teamid'    => 51,
+        'visitor_name'   => 'Team Diep',
+        'home_name'      => 'Team Lilley',
+        'visitor_q'      => [43, 31, 44, 26, 0],
+        'home_q'         => [43, 48, 55, 36, 0],
+        'visitor_team'   => [53, 108, 33, 38, 5, 20, 11, 53, 23, 4, 20, 10, 23],
+        'home_team'      => [72, 132, 26, 29, 12, 30, 20, 67, 39, 16, 10, 9, 28],
+        'visitor_players' => [
+            [3852, 'PG', 13, 3, 8, 2, 2, 1, 4, 0, 2, 3, 0, 1, 0, 3],
+            [5640, 'PG', 17, 3, 4, 4, 4, 0, 0, 1, 3, 5, 0, 2, 0, 0],
+            [3851, 'PG', 28, 9, 14, 4, 4, 1, 3, 0, 3, 4, 2, 2, 0, 1],
+            [4148, 'PF', 21, 2, 4, 5, 5, 0, 0, 2, 7, 2, 0, 1, 0, 4],
+            [5258, 'SF', 25, 6, 13, 5, 6, 0, 1, 0, 5, 4, 1, 3, 0, 0],
+            [4500, 'C', 22, 9, 12, 7, 7, 2, 2, 3, 7, 0, 0, 0, 5, 2],
+            [3282, 'SG', 15, 0, 2, 2, 2, 0, 1, 0, 3, 3, 0, 2, 0, 4],
+            [3561, 'SG', 13, 3, 7, 0, 0, 1, 2, 0, 1, 0, 0, 3, 0, 0],
+            [2975, 'C', 25, 7, 15, 3, 6, 0, 0, 1, 9, 1, 1, 3, 4, 4],
+            [3277, 'SF', 15, 4, 13, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 2],
+            [5265, 'SG', 20, 5, 6, 0, 0, 0, 0, 0, 3, 0, 0, 1, 0, 0],
+            [4507, 'PF', 21, 2, 10, 1, 2, 0, 2, 1, 5, 1, 0, 2, 1, 3],
+        ],
+        'home_players'    => [
+            [4150, 'PG', 18, 6, 10, 0, 0, 1, 2, 1, 4, 3, 2, 2, 1, 1],
+            [3556, 'PG', 18, 7, 13, 4, 4, 0, 3, 1, 7, 5, 2, 1, 1, 1],
+            [3552, 'SG', 18, 6, 13, 0, 0, 2, 5, 0, 3, 4, 2, 0, 1, 3],
+            [5261, 'PF', 22, 4, 7, 7, 8, 1, 1, 1, 2, 2, 0, 0, 1, 1],
+            [3555, 'C', 12, 3, 6, 0, 0, 0, 0, 2, 7, 0, 0, 1, 0, 0],
+            [5259, 'SG', 27, 9, 23, 1, 2, 1, 4, 7, 8, 8, 1, 1, 1, 2],
+            [4490, 'C', 20, 8, 14, 3, 3, 3, 5, 1, 5, 1, 1, 1, 0, 3],
+            [4492, 'C', 20, 6, 11, 2, 2, 0, 0, 2, 9, 1, 0, 1, 1, 3],
+            [4494, 'SG', 16, 7, 9, 6, 6, 1, 2, 1, 3, 2, 3, 1, 0, 3],
+            [4502, 'PG', 11, 2, 3, 0, 0, 0, 1, 0, 3, 3, 0, 0, 0, 6],
+            [4824, 'C', 29, 8, 10, 3, 4, 0, 1, 2, 8, 0, 3, 2, 1, 5],
+            [4825, 'PG', 23, 6, 13, 0, 0, 3, 6, 1, 5, 10, 2, 0, 2, 0],
+        ],
+    ],
+];
+
+// ── Name resolution (same logic as reconstruct_2007_asg_boxscores.php) ────────
+$nameFor = static function (int $pid) use ($mysqli_db): string {
+    if ($pid === 5265) {
+        return 'Drazen Dalipagic';
+    }
+    $stmt = $mysqli_db->prepare('SELECT name FROM ibl_plr WHERE pid = ? LIMIT 1');
+    $stmt->bind_param('i', $pid);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    if ($row === null) {
+        throw new RuntimeException("pid {$pid} not found in ibl_plr");
+    }
+    return mb_substr((string) $row['name'], 0, 16);
+};
+
+// ── Build encoder-ready game arrays (apply 2gm/2ga/drb derivations) ──────────
+$buildGameArray = static function (array $g) use ($nameFor): array {
+    $derivePlayers = static function (array $players) use ($nameFor): array {
+        $result = [];
+        foreach ($players as $p) {
+            [$pid, $pos, $min, $fgm, $fga, $ftm, $fta, $tpm, $tpa, $orb, $reb, $ast, $stl, $tov, $blk, $pf] = $p;
+            $result[] = [
+                'name'    => $nameFor($pid),
+                'pos'     => $pos,
+                'pid'     => $pid,
+                'min'     => $min,
+                'twoGM'   => $fgm - $tpm,
+                'twoGA'   => $fga - $tpa,
+                'ftm'     => $ftm,
+                'fta'     => $fta,
+                'threeGM' => $tpm,
+                'threeGA' => $tpa,
+                'orb'     => $orb,
+                'drb'     => $reb - $orb,
+                'ast'     => $ast,
+                'stl'     => $stl,
+                'tov'     => $tov,
+                'blk'     => $blk,
+                'pf'      => $pf,
+            ];
+        }
+        return $result;
+    };
+
+    [$fgm, $fga, $ftm, $fta, $tpm, $tpa, $orb, $reb, $ast, $stl, $tov, $blk, $pf] = $g['visitor_team'];
+    $vTeam = [
+        'twoGM' => $fgm - $tpm, 'twoGA' => $fga - $tpa,
+        'ftm' => $ftm, 'fta' => $fta,
+        'threeGM' => $tpm, 'threeGA' => $tpa,
+        'orb' => $orb, 'drb' => $reb - $orb,
+        'ast' => $ast, 'stl' => $stl, 'tov' => $tov, 'blk' => $blk, 'pf' => $pf,
+    ];
+
+    [$fgm, $fga, $ftm, $fta, $tpm, $tpa, $orb, $reb, $ast, $stl, $tov, $blk, $pf] = $g['home_team'];
+    $hTeam = [
+        'twoGM' => $fgm - $tpm, 'twoGA' => $fga - $tpa,
+        'ftm' => $ftm, 'fta' => $fta,
+        'threeGM' => $tpm, 'threeGA' => $tpa,
+        'orb' => $orb, 'drb' => $reb - $orb,
+        'ast' => $ast, 'stl' => $stl, 'tov' => $tov, 'blk' => $blk, 'pf' => $pf,
+    ];
+
+    return [
+        'visitor_name'    => $g['visitor_name'],
+        'home_name'       => $g['home_name'],
+        'visitor_q'       => $g['visitor_q'],
+        'home_q'          => $g['home_q'],
+        'visitor_teamid'  => $g['visitor_teamid'],
+        'home_teamid'     => $g['home_teamid'],
+        'attendance'      => PATCH_ATTENDANCE,
+        'capacity'        => PATCH_CAPACITY,
+        'visitor_team'    => $vTeam,
+        'home_team'       => $hTeam,
+        'visitor_players' => $derivePlayers($g['visitor_players']),
+        'home_players'    => $derivePlayers($g['home_players']),
+    ];
+};
+
+echo $apply ? "APPLYING patch...\n\n" : "DRY RUN (pass --apply to write)\n\n";
+
+try {
+    // ── Step 1: Open archive ──────────────────────────────────────────────────
+    $archivePath = realpath(__DIR__ . '/../backups/06-07/06-07_36_finals.zip');
+    if ($archivePath === false) {
+        throw new RuntimeException('Archive not found at ' . __DIR__ . '/../backups/06-07/06-07_36_finals.zip');
+    }
+
+    $zip = new ZipArchive();
+    if ($zip->open($archivePath) !== true) {
+        throw new RuntimeException("Cannot open {$archivePath}");
+    }
+
+    $sco = $zip->getFromName('IBL5.sco');
+    if ($sco === false) {
+        throw new RuntimeException('IBL5.sco not found in archive');
+    }
+
+    // ── Step 2: File-length guard ─────────────────────────────────────────────
+    if (strlen($sco) !== ScoFileWriter::SCO_FILE_SIZE) {
+        throw new RuntimeException(sprintf(
+            'IBL5.sco is %d bytes, expected %d',
+            strlen($sco),
+            ScoFileWriter::SCO_FILE_SIZE,
+        ));
+    }
+    echo sprintf("IBL5.sco: %d bytes ✓\n", strlen($sco));
+
+    // ── Step 3: Blank-target guard ────────────────────────────────────────────
+    if (trim(substr($sco, 0, 4000)) !== '') {
+        throw new RuntimeException('IBL5.sco bytes 0..3999 are NOT entirely spaces — archive may already be patched or corrupt');
+    }
+    echo "Bytes 0..3999: entirely spaces (blank precondition) ✓\n";
+
+    // ── Step 4: Offset guard — read real record at 1,000,000 ─────────────────
+    $realRecord = substr($sco, ScoFileParser::HEADER_OFFSET_BYTES, ScoFileParser::RECORD_SIZE);
+    // Find first non-blank record for sanity check
+    $numRecords = intdiv(strlen($sco) - ScoFileParser::HEADER_OFFSET_BYTES, ScoFileParser::RECORD_SIZE);
+    $firstNonBlankIdx = null;
+    for ($i = 0; $i < min($numRecords, 2000); $i++) {
+        $rec = substr($sco, ScoFileParser::HEADER_OFFSET_BYTES + $i * ScoFileParser::RECORD_SIZE, ScoFileParser::RECORD_SIZE);
+        if (trim($rec) !== '') {
+            $firstNonBlankIdx = $i;
+            $realRecord = $rec;
+            break;
+        }
+    }
+    if ($firstNonBlankIdx === null) {
+        throw new RuntimeException('No non-blank records found after offset 1,000,000 — cannot verify layout');
+    }
+    $slot0 = ScoFileParser::extractPlayerSlot($realRecord, 0);
+    $slotName = trim(substr($slot0, 0, 16));
+    if ($slotName === '') {
+        throw new RuntimeException("First slot of real record #{$firstNonBlankIdx} has empty name — unexpected layout");
+    }
+    echo "Offset guard: real record #{$firstNonBlankIdx} found, slot-0 name=[{$slotName}] ✓\n";
+
+    // ── Step 5: Baseline hash all 30 members ─────────────────────────────────
+    $memberCount = $zip->numFiles;
+    echo "Archive has {$memberCount} members\n";
+
+    $baselineHashes = [];
+    for ($i = 0; $i < $memberCount; $i++) {
+        $stat = $zip->statIndex($i);
+        if ($stat === false) {
+            throw new RuntimeException("Cannot stat member {$i}");
+        }
+        $content = $zip->getFromIndex($i);
+        if ($content === false) {
+            throw new RuntimeException("Cannot read member {$stat['name']}");
+        }
+        $baselineHashes[$stat['name']] = hash('sha256', $content);
+    }
+    echo sprintf("Baseline: %d member hashes recorded ✓\n", count($baselineHashes));
+
+    $zip->close();
+
+    // ── Step 6: Resolve names from ibl_plr ────────────────────────────────────
+    echo "\nResolving player names from ibl_plr...\n";
+
+    $risingStarsArray = $buildGameArray($games['Rising Stars Game']);
+    $allStarArray     = $buildGameArray($games['All-Star Game']);
+
+    echo "Names resolved ✓\n";
+
+    // ── Step 7: Build 4000-byte block ─────────────────────────────────────────
+    $block = ScoFileWriter::buildAllStarHeaderBlock($risingStarsArray, $allStarArray);
+    echo sprintf("Block: %d bytes ✓\n", strlen($block));
+
+    // ── Step 8: Splice with integrity guards ──────────────────────────────────
+    $patched = ScoFileWriter::spliceAllStarBlock($sco, $block);
+    echo sprintf("Splice: length %d, tail hash preserved ✓\n", strlen($patched));
+
+    // ── Step 9: Report proposed change ───────────────────────────────────────
+    $oldHash = hash('sha256', substr($sco, 0, 4000));
+    $newHash = hash('sha256', substr($patched, 0, 4000));
+    echo "\nProposed change in IBL5.sco:\n";
+    echo "  bytes:    0..3999 (4000 bytes)\n";
+    echo "  before:   {$oldHash}\n";
+    echo "  after:    {$newHash}\n";
+
+    if (!$apply) {
+        echo "\nDry run complete — no files written.\n";
+        exit(0);
+    }
+
+    // ── Step 10: Write patched copy, verify, atomic-rename ───────────────────
+    $tempPath = $archivePath . '.patch_tmp_' . getmypid();
+
+    if (!copy($archivePath, $tempPath)) {
+        throw new RuntimeException("Cannot create temp copy at {$tempPath}");
+    }
+
+    $zipOut = new ZipArchive();
+    if ($zipOut->open($tempPath) !== true) {
+        throw new RuntimeException("Cannot open temp archive {$tempPath}");
+    }
+
+    if (!$zipOut->addFromString('IBL5.sco', $patched)) {
+        $zipOut->close();
+        unlink($tempPath);
+        throw new RuntimeException('addFromString failed for IBL5.sco');
+    }
+
+    $zipOut->close();
+
+    // Verify: re-open patched copy and check all members
+    $zipVerify = new ZipArchive();
+    if ($zipVerify->open($tempPath) !== true) {
+        unlink($tempPath);
+        throw new RuntimeException("Cannot re-open patched archive for verification");
+    }
+
+    $patchedSco = $zipVerify->getFromName('IBL5.sco');
+    if ($patchedSco === false) {
+        $zipVerify->close();
+        unlink($tempPath);
+        throw new RuntimeException('IBL5.sco missing from patched archive');
+    }
+
+    // Verify sco tail hash identical
+    $patchedTailHash = hash('sha256', substr($patchedSco, ScoFileParser::HEADER_OFFSET_BYTES));
+    $originalTailHash = hash('sha256', substr($sco, ScoFileParser::HEADER_OFFSET_BYTES));
+    if ($patchedTailHash !== $originalTailHash) {
+        $zipVerify->close();
+        unlink($tempPath);
+        throw new RuntimeException('Patched IBL5.sco tail hash mismatch');
+    }
+
+    // Verify all other members unchanged
+    $unchanged = 0;
+    for ($i = 0; $i < $zipVerify->numFiles; $i++) {
+        $stat = $zipVerify->statIndex($i);
+        if ($stat === false) {
+            continue;
+        }
+        if ($stat['name'] === 'IBL5.sco') {
+            continue;
+        }
+        $content = $zipVerify->getFromIndex($i);
+        if ($content === false) {
+            continue;
+        }
+        $actualHash = hash('sha256', $content);
+        $expectedHash = $baselineHashes[$stat['name']] ?? null;
+        if ($expectedHash === null || $actualHash !== $expectedHash) {
+            $zipVerify->close();
+            unlink($tempPath);
+            throw new RuntimeException("Member {$stat['name']} hash changed unexpectedly after patch");
+        }
+        $unchanged++;
+    }
+    $zipVerify->close();
+
+    echo "\nVerification:\n";
+    echo "  IBL5.sco tail hash: identical ✓\n";
+    echo "  Other members unchanged: {$unchanged} ✓\n";
+
+    // Atomic rename
+    if (!rename($tempPath, $archivePath)) {
+        throw new RuntimeException("Cannot rename {$tempPath} → {$archivePath}");
+    }
+
+    echo "\nPatched archive written to: {$archivePath}\n";
+
+    // Emit sidecar note (gitignored; informational only)
+    $sidecar = dirname($archivePath) . '/06-07_36_finals.README.txt';
+    file_put_contents($sidecar, implode("\n", [
+        '06-07_36_finals.zip — patch notes',
+        '',
+        'IBL5.sco bytes 0..3999 were blank (all 0x20) in the original sim archive.',
+        'They have been patched with reconstructed 2006-07 All-Star Weekend stats.',
+        '',
+        'Source: ibl5/scripts/patch_2007_asg_sco.php',
+        'Stats:  ibl5/scripts/reconstruct_2007_asg_boxscores.php',
+        'ADR:    ibl5/docs/decisions/0051-reconstructed-2007-asg-boxscores-in-finals-sco.md',
+        '',
+        sprintf('Patched: %s', date('Y-m-d H:i:s')),
+        '',
+        'Do not commit this file or the zip to git.',
+    ]) . "\n");
+
+    echo "Sidecar note: {$sidecar}\n";
+    echo "\nDone.\n";
+
+} catch (Throwable $e) {
+    fwrite(STDERR, 'ERROR: ' . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
+++ b/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
@@ -142,6 +142,23 @@ class AllStarScoReconstructionTest extends DatabaseTestCase
         $this->repo->deleteTeamBoxscoresByGame(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID, 1);
         $this->repo->deletePlayerBoxscoresByGame(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
 
+        // Seed ibl_plr rows for every PID that will be inserted into ibl_box_scores.
+        // The fk_boxscore_player FK requires these to exist before any boxscore insert.
+        foreach ([
+            // RSG visitor
+            5936, 5938, 5931, 5930, 5937, 5939, 5929, 5935, 5942, 5964,
+            // RSG home
+            5640, 5649, 5642, 5659, 5645, 5685, 5646, 5663, 5641, 5644,
+            // ASG visitor (5640 already seeded above)
+            3852, 3851, 4148, 5258, 4500, 3282, 3561, 2975, 3277, 5265, 4507,
+            // ASG home
+            4150, 3556, 3552, 5261, 3555, 5259, 4490, 4492, 4494, 4502, 4824, 4825,
+            // sentinel
+            99999,
+        ] as $pid) {
+            $this->insertTestPlayer($pid, "Player {$pid}");
+        }
+
         // Season::getLastBoxScoreDate() queries ibl_box_scores — insert sentinel there
         $this->insertPlayerBoxscoreRow(self::SENTINEL_DATE, 99999, 'Sentinel Player', 'PG', 1, 2, 1);
     }

--- a/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
+++ b/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
@@ -174,7 +174,11 @@ class AllStarScoReconstructionTest extends DatabaseTestCase
         return (int) ($row['cnt'] ?? 0);
     }
 
-    /** Fetch a single team row by name (ibl_box_scores_teams has no teamid column). */
+    /**
+     * Fetch a single team row by name (ibl_box_scores_teams has no teamid column).
+     *
+     * @return array<string, mixed>
+     */
     private function fetchTeamRowByName(string $date, int $visitorTid, int $homeTid, string $name): array
     {
         $stmt = $this->db->prepare(
@@ -193,7 +197,11 @@ class AllStarScoReconstructionTest extends DatabaseTestCase
         return $row;
     }
 
-    /** Sum player stats for a given teamid in ibl_box_scores. */
+    /**
+     * Sum player stats for a given teamid in ibl_box_scores.
+     *
+     * @return array<string, mixed>
+     */
     private function fetchPlayerSumsForTeamId(string $date, int $visitorTid, int $homeTid, int $teamid): array
     {
         $stmt = $this->db->prepare(

--- a/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
+++ b/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
@@ -1,0 +1,481 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use Boxscore\BoxscoreProcessor;
+use Boxscore\BoxscoreRepository;
+use JsbParser\ScoFileWriter;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Acceptance test: ScoFileWriter-encoded block → BoxscoreProcessor → 48 correct DB rows.
+ *
+ * Verifies that the 4000-byte All-Star header block produced by ScoFileWriter,
+ * when fed through the real processAllStarGamesData path, yields exactly the
+ * 48 rows expected for the 2006-07 All-Star Weekend (10+10 RSG + 12+12 ASG
+ * player rows, plus 4 team-total rows).
+ *
+ * @covers \JsbParser\ScoFileWriter
+ * @covers \Boxscore\BoxscoreProcessor
+ */
+#[Group('database')]
+class AllStarScoReconstructionTest extends DatabaseTestCase
+{
+    private const RSG_DATE         = '2007-02-02';
+    private const RSG_VISITOR_TID  = 40;
+    private const RSG_HOME_TID     = 41;
+    private const RSG_VISITOR_NAME = 'Rookies';
+    private const RSG_HOME_NAME    = 'Sophomores';
+
+    private const ASG_DATE         = '2007-02-03';
+    private const ASG_VISITOR_TID  = 50;
+    private const ASG_HOME_TID     = 51;
+    // ASG uses BoxscoreProcessor defaults (Outcome C — first import)
+    private const ASG_VISITOR_NAME = BoxscoreProcessor::DEFAULT_AWAY_NAME;
+    private const ASG_HOME_NAME    = BoxscoreProcessor::DEFAULT_HOME_NAME;
+
+    // Sentinel player row date: > IBL_ALL_STAR_BREAK_END_DAY (Feb 4)
+    private const SENTINEL_DATE    = '2007-02-15';
+
+    private BoxscoreRepository $repo;
+    private BoxscoreProcessor $processor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo      = new BoxscoreRepository($this->db);
+        $this->processor = new BoxscoreProcessor($this->db);
+    }
+
+    // ── Dataset builder ───────────────────────────────────────────────────────
+
+    private function buildBlock(): string
+    {
+        $risingStars = [
+            'visitor_name'    => self::RSG_VISITOR_NAME,
+            'home_name'       => self::RSG_HOME_NAME,
+            'visitor_q'       => [34, 39, 30, 31, 0],
+            'home_q'          => [34, 31, 39, 41, 0],
+            'visitor_teamid'  => self::RSG_VISITOR_TID,
+            'home_teamid'     => self::RSG_HOME_TID,
+            'attendance'      => 5244,
+            'capacity'        => 20000,
+            'visitor_team'    => ['twoGM' => 47, 'twoGA' => 98,  'ftm' => 16, 'fta' => 21, 'threeGM' => 8,  'threeGA' => 21, 'orb' => 25, 'drb' => 41, 'ast' => 30, 'stl' => 11, 'tov' => 22, 'blk' => 8,  'pf' => 19],
+            'home_team'       => ['twoGM' => 52, 'twoGA' => 100, 'ftm' => 5,  'fta' => 9,  'threeGM' => 12, 'threeGA' => 27, 'orb' => 24, 'drb' => 43, 'ast' => 34, 'stl' => 10, 'tov' => 21, 'blk' => 14, 'pf' => 21],
+            'visitor_players' => [
+                ['name' => 'Player V1',  'pos' => 'PG', 'pid' => 5936, 'min' => 32, 'twoGM' => 7,  'twoGA' => 15, 'ftm' => 5, 'fta' => 5, 'threeGM' => 0, 'threeGA' => 3, 'orb' => 3, 'drb' => 1,  'ast' => 7,  'stl' => 0, 'tov' => 3, 'blk' => 0, 'pf' => 3],
+                ['name' => 'Player V2',  'pos' => 'PG', 'pid' => 5938, 'min' => 16, 'twoGM' => 1,  'twoGA' => 2,  'ftm' => 0, 'fta' => 0, 'threeGM' => 1, 'threeGA' => 5, 'orb' => 1, 'drb' => 0,  'ast' => 1,  'stl' => 0, 'tov' => 2, 'blk' => 1, 'pf' => 0],
+                ['name' => 'Player V3',  'pos' => 'SG', 'pid' => 5931, 'min' => 32, 'twoGM' => 8,  'twoGA' => 16, 'ftm' => 3, 'fta' => 5, 'threeGM' => 2, 'threeGA' => 5, 'orb' => 4, 'drb' => 4,  'ast' => 0,  'stl' => 3, 'tov' => 1, 'blk' => 1, 'pf' => 2],
+                ['name' => 'Player V4',  'pos' => 'SG', 'pid' => 5930, 'min' => 19, 'twoGM' => 1,  'twoGA' => 3,  'ftm' => 2, 'fta' => 3, 'threeGM' => 2, 'threeGA' => 2, 'orb' => 1, 'drb' => 1,  'ast' => 2,  'stl' => 2, 'tov' => 1, 'blk' => 1, 'pf' => 1],
+                ['name' => 'Player V5',  'pos' => 'SF', 'pid' => 5937, 'min' => 29, 'twoGM' => 5,  'twoGA' => 11, 'ftm' => 0, 'fta' => 0, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 0, 'drb' => 4,  'ast' => 11, 'stl' => 1, 'tov' => 5, 'blk' => 0, 'pf' => 2],
+                ['name' => 'Player V6',  'pos' => 'SF', 'pid' => 5939, 'min' => 13, 'twoGM' => 6,  'twoGA' => 11, 'ftm' => 1, 'fta' => 2, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 1, 'drb' => 3,  'ast' => 4,  'stl' => 0, 'tov' => 3, 'blk' => 1, 'pf' => 4],
+                ['name' => 'Player V7',  'pos' => 'PF', 'pid' => 5929, 'min' => 30, 'twoGM' => 7,  'twoGA' => 15, 'ftm' => 2, 'fta' => 2, 'threeGM' => 2, 'threeGA' => 3, 'orb' => 3, 'drb' => 4,  'ast' => 2,  'stl' => 1, 'tov' => 2, 'blk' => 1, 'pf' => 1],
+                ['name' => 'Player V8',  'pos' => 'PF', 'pid' => 5935, 'min' => 30, 'twoGM' => 7,  'twoGA' => 13, 'ftm' => 3, 'fta' => 4, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 6, 'drb' => 6,  'ast' => 2,  'stl' => 4, 'tov' => 3, 'blk' => 1, 'pf' => 3],
+                ['name' => 'Player V9',  'pos' => 'C',  'pid' => 5942, 'min' => 14, 'twoGM' => 2,  'twoGA' => 5,  'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 3, 'drb' => 4,  'ast' => 0,  'stl' => 0, 'tov' => 2, 'blk' => 1, 'pf' => 1],
+                ['name' => 'Player V10', 'pos' => 'C',  'pid' => 5964, 'min' => 22, 'twoGM' => 3,  'twoGA' => 7,  'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 1, 'drb' => 8,  'ast' => 1,  'stl' => 0, 'tov' => 0, 'blk' => 1, 'pf' => 2],
+            ],
+            'home_players'    => [
+                ['name' => 'Player H1',  'pos' => 'PG', 'pid' => 5640, 'min' => 31, 'twoGM' => 13, 'twoGA' => 21, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 2,  'orb' => 4,  'drb' => 7,  'ast' => 12, 'stl' => 3, 'tov' => 6, 'blk' => 3, 'pf' => 1],
+                ['name' => 'Player H2',  'pos' => 'PG', 'pid' => 5649, 'min' => 13, 'twoGM' => 1,  'twoGA' => 3,  'ftm' => 3, 'fta' => 4, 'threeGM' => 1, 'threeGA' => 2,  'orb' => 0,  'drb' => 1,  'ast' => 5,  'stl' => 3, 'tov' => 2, 'blk' => 0, 'pf' => 0],
+                ['name' => 'Player H3',  'pos' => 'SG', 'pid' => 5642, 'min' => 20, 'twoGM' => 10, 'twoGA' => 12, 'ftm' => 1, 'fta' => 3, 'threeGM' => 1, 'threeGA' => 2,  'orb' => 1,  'drb' => 1,  'ast' => 6,  'stl' => 0, 'tov' => 3, 'blk' => 0, 'pf' => 2],
+                ['name' => 'Player H4',  'pos' => 'SG', 'pid' => 5659, 'min' => 30, 'twoGM' => 4,  'twoGA' => 13, 'ftm' => 0, 'fta' => 0, 'threeGM' => 6, 'threeGA' => 11, 'orb' => 0,  'drb' => 5,  'ast' => 5,  'stl' => 2, 'tov' => 3, 'blk' => 2, 'pf' => 2],
+                ['name' => 'Player H5',  'pos' => 'SF', 'pid' => 5645, 'min' => 31, 'twoGM' => 7,  'twoGA' => 14, 'ftm' => 1, 'fta' => 1, 'threeGM' => 2, 'threeGA' => 5,  'orb' => 0,  'drb' => 5,  'ast' => 1,  'stl' => 0, 'tov' => 0, 'blk' => 0, 'pf' => 4],
+                ['name' => 'Player H6',  'pos' => 'SF', 'pid' => 5685, 'min' => 20, 'twoGM' => 1,  'twoGA' => 5,  'ftm' => 0, 'fta' => 0, 'threeGM' => 2, 'threeGA' => 4,  'orb' => 0,  'drb' => 1,  'ast' => 2,  'stl' => 1, 'tov' => 0, 'blk' => 0, 'pf' => 2],
+                ['name' => 'Player H7',  'pos' => 'PF', 'pid' => 5646, 'min' => 17, 'twoGM' => 3,  'twoGA' => 5,  'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0,  'orb' => 2,  'drb' => 4,  'ast' => 0,  'stl' => 1, 'tov' => 2, 'blk' => 0, 'pf' => 5],
+                ['name' => 'DNP Player', 'pos' => 'PF', 'pid' => 5663, 'min' => 0,  'twoGM' => 0,  'twoGA' => 0,  'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0,  'orb' => 0,  'drb' => 0,  'ast' => 0,  'stl' => 0, 'tov' => 0, 'blk' => 0, 'pf' => 0],
+                ['name' => 'Player H9',  'pos' => 'C',  'pid' => 5641, 'min' => 31, 'twoGM' => 7,  'twoGA' => 16, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 1,  'orb' => 10, 'drb' => 6,  'ast' => 2,  'stl' => 0, 'tov' => 1, 'blk' => 4, 'pf' => 4],
+                ['name' => 'Player H10', 'pos' => 'C',  'pid' => 5644, 'min' => 43, 'twoGM' => 6,  'twoGA' => 11, 'ftm' => 0, 'fta' => 1, 'threeGM' => 0, 'threeGA' => 0,  'orb' => 6,  'drb' => 11, 'ast' => 1,  'stl' => 0, 'tov' => 4, 'blk' => 5, 'pf' => 1],
+            ],
+        ];
+
+        $allStar = [
+            'visitor_name'    => self::ASG_VISITOR_NAME,
+            'home_name'       => self::ASG_HOME_NAME,
+            'visitor_q'       => [43, 31, 44, 26, 0],
+            'home_q'          => [43, 48, 55, 36, 0],
+            'visitor_teamid'  => self::ASG_VISITOR_TID,
+            'home_teamid'     => self::ASG_HOME_TID,
+            'attendance'      => 5244,
+            'capacity'        => 20000,
+            'visitor_team'    => ['twoGM' => 48, 'twoGA' => 88,  'ftm' => 33, 'fta' => 38, 'threeGM' => 5,  'threeGA' => 20, 'orb' => 11, 'drb' => 42, 'ast' => 23, 'stl' => 4,  'tov' => 20, 'blk' => 10, 'pf' => 23],
+            'home_team'       => ['twoGM' => 60, 'twoGA' => 102, 'ftm' => 26, 'fta' => 29, 'threeGM' => 12, 'threeGA' => 30, 'orb' => 20, 'drb' => 47, 'ast' => 39, 'stl' => 16, 'tov' => 10, 'blk' => 9,  'pf' => 28],
+            'visitor_players' => [
+                ['name' => 'ASG V01', 'pos' => 'PG', 'pid' => 3852, 'min' => 13, 'twoGM' => 2, 'twoGA' => 4,  'ftm' => 2, 'fta' => 2, 'threeGM' => 1, 'threeGA' => 4, 'orb' => 0, 'drb' => 2, 'ast' => 3, 'stl' => 0, 'tov' => 1, 'blk' => 0, 'pf' => 3],
+                ['name' => 'ASG V02', 'pos' => 'PG', 'pid' => 5640, 'min' => 17, 'twoGM' => 3, 'twoGA' => 4,  'ftm' => 4, 'fta' => 4, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 1, 'drb' => 2, 'ast' => 5, 'stl' => 0, 'tov' => 2, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG V03', 'pos' => 'PG', 'pid' => 3851, 'min' => 28, 'twoGM' => 8, 'twoGA' => 11, 'ftm' => 4, 'fta' => 4, 'threeGM' => 1, 'threeGA' => 3, 'orb' => 0, 'drb' => 3, 'ast' => 4, 'stl' => 2, 'tov' => 2, 'blk' => 0, 'pf' => 1],
+                ['name' => 'ASG V04', 'pos' => 'PF', 'pid' => 4148, 'min' => 21, 'twoGM' => 2, 'twoGA' => 4,  'ftm' => 5, 'fta' => 5, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 2, 'drb' => 5, 'ast' => 2, 'stl' => 0, 'tov' => 1, 'blk' => 0, 'pf' => 4],
+                ['name' => 'ASG V05', 'pos' => 'SF', 'pid' => 5258, 'min' => 25, 'twoGM' => 6, 'twoGA' => 12, 'ftm' => 5, 'fta' => 6, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 0, 'drb' => 5, 'ast' => 4, 'stl' => 1, 'tov' => 3, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG V06', 'pos' => 'C',  'pid' => 4500, 'min' => 22, 'twoGM' => 7, 'twoGA' => 10, 'ftm' => 7, 'fta' => 7, 'threeGM' => 2, 'threeGA' => 2, 'orb' => 3, 'drb' => 4, 'ast' => 0, 'stl' => 0, 'tov' => 0, 'blk' => 5, 'pf' => 2],
+                ['name' => 'ASG V07', 'pos' => 'SG', 'pid' => 3282, 'min' => 15, 'twoGM' => 0, 'twoGA' => 1,  'ftm' => 2, 'fta' => 2, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 0, 'drb' => 3, 'ast' => 3, 'stl' => 0, 'tov' => 2, 'blk' => 0, 'pf' => 4],
+                ['name' => 'ASG V08', 'pos' => 'SG', 'pid' => 3561, 'min' => 13, 'twoGM' => 2, 'twoGA' => 5,  'ftm' => 0, 'fta' => 0, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 0, 'drb' => 1, 'ast' => 0, 'stl' => 0, 'tov' => 3, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG V09', 'pos' => 'C',  'pid' => 2975, 'min' => 25, 'twoGM' => 7, 'twoGA' => 15, 'ftm' => 3, 'fta' => 6, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 1, 'drb' => 8, 'ast' => 1, 'stl' => 1, 'tov' => 3, 'blk' => 4, 'pf' => 4],
+                ['name' => 'ASG V10', 'pos' => 'SF', 'pid' => 3277, 'min' => 15, 'twoGM' => 4, 'twoGA' => 8,  'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 5, 'orb' => 0, 'drb' => 0, 'ast' => 0, 'stl' => 0, 'tov' => 0, 'blk' => 0, 'pf' => 2],
+                ['name' => 'ASG V11', 'pos' => 'SG', 'pid' => 5265, 'min' => 20, 'twoGM' => 5, 'twoGA' => 6,  'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 0, 'drb' => 3, 'ast' => 0, 'stl' => 0, 'tov' => 1, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG V12', 'pos' => 'PF', 'pid' => 4507, 'min' => 21, 'twoGM' => 2, 'twoGA' => 8,  'ftm' => 1, 'fta' => 2, 'threeGM' => 0, 'threeGA' => 2, 'orb' => 1, 'drb' => 4, 'ast' => 1, 'stl' => 0, 'tov' => 2, 'blk' => 1, 'pf' => 3],
+            ],
+            'home_players'    => [
+                ['name' => 'ASG H01', 'pos' => 'PG', 'pid' => 4150, 'min' => 18, 'twoGM' => 5, 'twoGA' => 8,  'ftm' => 0, 'fta' => 0, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 1, 'drb' => 3, 'ast' => 3,  'stl' => 2, 'tov' => 2, 'blk' => 1, 'pf' => 1],
+                ['name' => 'ASG H02', 'pos' => 'PG', 'pid' => 3556, 'min' => 18, 'twoGM' => 7, 'twoGA' => 10, 'ftm' => 4, 'fta' => 4, 'threeGM' => 0, 'threeGA' => 3, 'orb' => 1, 'drb' => 6, 'ast' => 5,  'stl' => 2, 'tov' => 1, 'blk' => 1, 'pf' => 1],
+                ['name' => 'ASG H03', 'pos' => 'SG', 'pid' => 3552, 'min' => 18, 'twoGM' => 4, 'twoGA' => 8,  'ftm' => 0, 'fta' => 0, 'threeGM' => 2, 'threeGA' => 5, 'orb' => 0, 'drb' => 3, 'ast' => 4,  'stl' => 2, 'tov' => 0, 'blk' => 1, 'pf' => 3],
+                ['name' => 'ASG H04', 'pos' => 'PF', 'pid' => 5261, 'min' => 22, 'twoGM' => 3, 'twoGA' => 6,  'ftm' => 7, 'fta' => 8, 'threeGM' => 1, 'threeGA' => 1, 'orb' => 1, 'drb' => 1, 'ast' => 2,  'stl' => 0, 'tov' => 0, 'blk' => 1, 'pf' => 1],
+                ['name' => 'ASG H05', 'pos' => 'C',  'pid' => 3555, 'min' => 12, 'twoGM' => 3, 'twoGA' => 6,  'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 2, 'drb' => 5, 'ast' => 0,  'stl' => 0, 'tov' => 1, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG H06', 'pos' => 'SG', 'pid' => 5259, 'min' => 27, 'twoGM' => 8, 'twoGA' => 19, 'ftm' => 1, 'fta' => 2, 'threeGM' => 1, 'threeGA' => 4, 'orb' => 7, 'drb' => 1, 'ast' => 8,  'stl' => 1, 'tov' => 1, 'blk' => 1, 'pf' => 2],
+                ['name' => 'ASG H07', 'pos' => 'C',  'pid' => 4490, 'min' => 20, 'twoGM' => 5, 'twoGA' => 9,  'ftm' => 3, 'fta' => 3, 'threeGM' => 3, 'threeGA' => 5, 'orb' => 1, 'drb' => 4, 'ast' => 1,  'stl' => 1, 'tov' => 1, 'blk' => 0, 'pf' => 3],
+                ['name' => 'ASG H08', 'pos' => 'C',  'pid' => 4492, 'min' => 20, 'twoGM' => 6, 'twoGA' => 11, 'ftm' => 2, 'fta' => 2, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 2, 'drb' => 7, 'ast' => 1,  'stl' => 0, 'tov' => 1, 'blk' => 1, 'pf' => 3],
+                ['name' => 'ASG H09', 'pos' => 'SG', 'pid' => 4494, 'min' => 16, 'twoGM' => 6, 'twoGA' => 7,  'ftm' => 6, 'fta' => 6, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 1, 'drb' => 2, 'ast' => 2,  'stl' => 3, 'tov' => 1, 'blk' => 0, 'pf' => 3],
+                ['name' => 'ASG H10', 'pos' => 'PG', 'pid' => 4502, 'min' => 11, 'twoGM' => 2, 'twoGA' => 2,  'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 0, 'drb' => 3, 'ast' => 3,  'stl' => 0, 'tov' => 0, 'blk' => 0, 'pf' => 6],
+                ['name' => 'ASG H11', 'pos' => 'C',  'pid' => 4824, 'min' => 29, 'twoGM' => 8, 'twoGA' => 9,  'ftm' => 3, 'fta' => 4, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 2, 'drb' => 6, 'ast' => 0,  'stl' => 3, 'tov' => 2, 'blk' => 1, 'pf' => 5],
+                ['name' => 'ASG H12', 'pos' => 'PG', 'pid' => 4825, 'min' => 23, 'twoGM' => 3, 'twoGA' => 7,  'ftm' => 0, 'fta' => 0, 'threeGM' => 3, 'threeGA' => 6, 'orb' => 1, 'drb' => 4, 'ast' => 10, 'stl' => 2, 'tov' => 0, 'blk' => 2, 'pf' => 0],
+            ],
+        ];
+
+        return ScoFileWriter::buildAllStarHeaderBlock($risingStars, $allStar);
+    }
+
+    /** Delete ASG rows for both game keys and insert sentinel player row. */
+    private function setUpGameState(): void
+    {
+        $this->repo->deleteTeamBoxscoresByGame(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID, 1);
+        $this->repo->deletePlayerBoxscoresByGame(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID);
+        $this->repo->deleteTeamBoxscoresByGame(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID, 1);
+        $this->repo->deletePlayerBoxscoresByGame(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
+
+        // Season::getLastBoxScoreDate() queries ibl_box_scores — insert sentinel there
+        $this->insertPlayerBoxscoreRow(self::SENTINEL_DATE, 99999, 'Sentinel Player', 'PG', 1, 2, 1);
+    }
+
+    private function countPlayerRows(string $date, int $visitorTid, int $homeTid): int
+    {
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) AS cnt FROM ibl_box_scores WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ?'
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('sii', $date, $visitorTid, $homeTid);
+        $stmt->execute();
+        /** @var array{cnt: int} $row */
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return (int) ($row['cnt'] ?? 0);
+    }
+
+    private function countTeamRows(string $date, int $visitorTid, int $homeTid): int
+    {
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) AS cnt FROM ibl_box_scores_teams WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ?'
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('sii', $date, $visitorTid, $homeTid);
+        $stmt->execute();
+        /** @var array{cnt: int} $row */
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return (int) ($row['cnt'] ?? 0);
+    }
+
+    /** Fetch a single team row by name (ibl_box_scores_teams has no teamid column). */
+    private function fetchTeamRowByName(string $date, int $visitorTid, int $homeTid, string $name): array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT game_2gm, game_2ga, game_ftm, game_fta, game_3gm, game_3ga,
+                    game_orb, game_drb, game_ast, game_stl, game_tov, game_blk, game_pf,
+                    calc_points
+             FROM ibl_box_scores_teams
+             WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND name = ?'
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('siis', $date, $visitorTid, $homeTid, $name);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        self::assertNotNull($row, "Team row '{$name}' not found for {$date}");
+        return $row;
+    }
+
+    /** Sum player stats for a given teamid in ibl_box_scores. */
+    private function fetchPlayerSumsForTeamId(string $date, int $visitorTid, int $homeTid, int $teamid): array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT SUM(game_2gm) AS game_2gm, SUM(game_2ga) AS game_2ga,
+                    SUM(game_ftm) AS game_ftm, SUM(game_fta) AS game_fta,
+                    SUM(game_3gm) AS game_3gm, SUM(game_3ga) AS game_3ga,
+                    SUM(game_orb) AS game_orb, SUM(game_drb) AS game_drb,
+                    SUM(game_ast) AS game_ast, SUM(game_stl) AS game_stl,
+                    SUM(game_tov) AS game_tov, SUM(game_blk) AS game_blk,
+                    SUM(game_pf) AS game_pf
+             FROM ibl_box_scores
+             WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND teamid = ?'
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('siii', $date, $visitorTid, $homeTid, $teamid);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        self::assertNotNull($row);
+        return $row;
+    }
+
+    // ── V11: Row counts ──────────────────────────────────────────────────────
+
+    public function testRowCounts(): void
+    {
+        $this->setUpGameState();
+        $result = $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+
+        self::assertTrue($result['success']);
+        self::assertArrayNotHasKey('skipped', $result);
+
+        self::assertSame(20, $this->countPlayerRows(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID), 'RSG player rows (10+10)');
+        self::assertSame(24, $this->countPlayerRows(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID), 'ASG player rows (12+12)');
+
+        $totalPlayerRows = $this->countPlayerRows(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID)
+            + $this->countPlayerRows(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
+        self::assertSame(44, $totalPlayerRows, 'Total player rows');
+
+        $totalTeamRows = $this->countTeamRows(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID)
+            + $this->countTeamRows(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
+        self::assertSame(4, $totalTeamRows, 'Total team rows');
+    }
+
+    // ── V12: Per-player cross-foot — spot-check known expected points ─────────
+
+    public function testPerPlayerCrossfoot(): void
+    {
+        $this->setUpGameState();
+        $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+
+        $rsgDate = self::RSG_DATE;
+        $rsgVis  = self::RSG_VISITOR_TID;
+        $rsgHome = self::RSG_HOME_TID;
+
+        // pid 5663 (DNP): 0*2 + 0 + 0*3 = 0
+        $this->assertPlayerCalcPoints($rsgDate, $rsgVis, $rsgHome, 5663, 0, 'DNP');
+
+        // pid 5936 (RSG visitor, V1): 7*2 + 5 + 0*3 = 19
+        $this->assertPlayerCalcPoints($rsgDate, $rsgVis, $rsgHome, 5936, 19, 'RSG V1');
+
+        // pid 5640 (RSG home, H1): 13*2 + 0 + 0*3 = 26
+        $this->assertPlayerCalcPoints($rsgDate, $rsgVis, $rsgHome, 5640, 26, 'RSG H1');
+
+        $asgDate = self::ASG_DATE;
+        $asgVis  = self::ASG_VISITOR_TID;
+        $asgHome = self::ASG_HOME_TID;
+
+        // pid 4500 (ASG V06): 7*2 + 7 + 2*3 = 14 + 7 + 6 = 27
+        $this->assertPlayerCalcPoints($asgDate, $asgVis, $asgHome, 4500, 27, 'ASG V06');
+    }
+
+    private function assertPlayerCalcPoints(string $date, int $vTid, int $hTid, int $pid, int $expectedPts, string $label): void
+    {
+        $stmt = $this->db->prepare(
+            'SELECT calc_points FROM ibl_box_scores WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND pid = ?'
+        );
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('siii', $date, $vTid, $hTid, $pid);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        self::assertNotNull($row, "No row found for pid {$pid} ({$label})");
+        self::assertSame($expectedPts, (int) $row['calc_points'], "calc_points for {$label} (pid {$pid})");
+    }
+
+    // ── V13: Team-total calc_points = RSG 134/145, ASG 144/182 ───────────────
+
+    public function testTeamTotalPoints(): void
+    {
+        $this->setUpGameState();
+        $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+
+        $rsgVis = $this->fetchTeamRowByName(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID, self::RSG_VISITOR_NAME);
+        $rsgHome = $this->fetchTeamRowByName(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID, self::RSG_HOME_NAME);
+        $asgVis  = $this->fetchTeamRowByName(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID, self::ASG_VISITOR_NAME);
+        $asgHome = $this->fetchTeamRowByName(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID, self::ASG_HOME_NAME);
+
+        self::assertSame(134, (int) $rsgVis['calc_points'],  'RSG Rookies calc_points');
+        self::assertSame(145, (int) $rsgHome['calc_points'], 'RSG Sophomores calc_points');
+        self::assertSame(144, (int) $asgVis['calc_points'],  'ASG visitor calc_points');
+        self::assertSame(182, (int) $asgHome['calc_points'], 'ASG home calc_points');
+    }
+
+    // ── V14: Player-sum == team-total (counting stats) ────────────────────────
+
+    public function testPlayerSumEqualsTeamTotal(): void
+    {
+        $this->setUpGameState();
+        $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+
+        $games = [
+            [self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID, self::RSG_VISITOR_NAME, self::RSG_HOME_NAME],
+            [self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID, self::ASG_VISITOR_NAME, self::ASG_HOME_NAME],
+        ];
+
+        foreach ($games as [$date, $vTid, $hTid, $vName, $hName]) {
+            foreach ([[$vTid, $vName], [$hTid, $hName]] as [$teamid, $teamName]) {
+                $teamRow    = $this->fetchTeamRowByName($date, $vTid, $hTid, $teamName);
+                $playerSums = $this->fetchPlayerSumsForTeamId($date, $vTid, $hTid, $teamid);
+
+                foreach (['game_2gm', 'game_2ga', 'game_ftm', 'game_fta', 'game_3gm', 'game_3ga', 'game_ast', 'game_stl', 'game_tov', 'game_blk', 'game_pf'] as $col) {
+                    self::assertSame(
+                        (int) $teamRow[$col],
+                        (int) ($playerSums[$col] ?? 0),
+                        "V14 {$date} {$teamName} {$col}: player sum != team total"
+                    );
+                }
+            }
+        }
+    }
+
+    // ── V15: Player-sum ORB/DRB ≤ team total ─────────────────────────────────
+
+    public function testPlayerReboundSumsDoNotExceedTeamTotal(): void
+    {
+        $this->setUpGameState();
+        $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+
+        $games = [
+            [self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID, self::RSG_VISITOR_NAME, self::RSG_HOME_NAME],
+            [self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID, self::ASG_VISITOR_NAME, self::ASG_HOME_NAME],
+        ];
+
+        foreach ($games as [$date, $vTid, $hTid, $vName, $hName]) {
+            foreach ([[$vTid, $vName], [$hTid, $hName]] as [$teamid, $teamName]) {
+                $teamRow    = $this->fetchTeamRowByName($date, $vTid, $hTid, $teamName);
+                $playerSums = $this->fetchPlayerSumsForTeamId($date, $vTid, $hTid, $teamid);
+                self::assertLessThanOrEqual((int) $teamRow['game_orb'], (int) ($playerSums['game_orb'] ?? 0), "V15 ORB {$date} {$teamName}");
+                self::assertLessThanOrEqual((int) $teamRow['game_drb'], (int) ($playerSums['game_drb'] ?? 0), "V15 DRB {$date} {$teamName}");
+            }
+        }
+    }
+
+    // ── V16: game_type=1 and season_year=2007 ────────────────────────────────
+
+    public function testGeneratedColumnsGameTypeAndSeasonYear(): void
+    {
+        $this->setUpGameState();
+        $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) AS cnt FROM ibl_box_scores
+             WHERE (game_date = ? AND visitor_teamid = ? AND home_teamid = ?)
+                OR (game_date = ? AND visitor_teamid = ? AND home_teamid = ?)'
+        );
+        self::assertNotFalse($stmt);
+        $rsgDate = self::RSG_DATE; $rsgVis = self::RSG_VISITOR_TID; $rsgHome = self::RSG_HOME_TID;
+        $asgDate = self::ASG_DATE; $asgVis = self::ASG_VISITOR_TID; $asgHome = self::ASG_HOME_TID;
+        $stmt->bind_param('siisii', $rsgDate, $rsgVis, $rsgHome, $asgDate, $asgVis, $asgHome);
+        $stmt->execute();
+        /** @var array{cnt: int} $row */
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        $totalRows = (int) ($row['cnt'] ?? 0);
+        self::assertSame(44, $totalRows, 'All 44 player rows present');
+
+        // Query rows that DO NOT match game_type=1 and season_year=2007
+        $stmt2 = $this->db->prepare(
+            'SELECT COUNT(*) AS cnt FROM ibl_box_scores
+             WHERE ((game_date = ? AND visitor_teamid = ? AND home_teamid = ?)
+                 OR (game_date = ? AND visitor_teamid = ? AND home_teamid = ?))
+               AND NOT (game_type = 1 AND season_year = 2007)'
+        );
+        self::assertNotFalse($stmt2);
+        $stmt2->bind_param('siisii', $rsgDate, $rsgVis, $rsgHome, $asgDate, $asgVis, $asgHome);
+        $stmt2->execute();
+        /** @var array{cnt: int} $row2 */
+        $row2 = $stmt2->get_result()->fetch_assoc();
+        $stmt2->close();
+        self::assertSame(0, (int) ($row2['cnt'] ?? 0), 'All rows have game_type=1 and season_year=2007');
+    }
+
+    // ── V17: Exactly 1 DNP (pid 5663) ────────────────────────────────────────
+
+    public function testExactlyOneDnpPlayer(): void
+    {
+        $this->setUpGameState();
+        $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+
+        $stmt = $this->db->prepare(
+            'SELECT pid, game_min, calc_points FROM ibl_box_scores
+             WHERE game_date = ? AND visitor_teamid = ? AND home_teamid = ? AND game_min = 0'
+        );
+        self::assertNotFalse($stmt);
+        $rsgDate = self::RSG_DATE;
+        $rsgVis  = self::RSG_VISITOR_TID;
+        $rsgHome = self::RSG_HOME_TID;
+        $stmt->bind_param('sii', $rsgDate, $rsgVis, $rsgHome);
+        $stmt->execute();
+        $dnpRows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+
+        self::assertCount(1, $dnpRows, 'Exactly 1 DNP row in RSG');
+        self::assertSame(5663, (int) $dnpRows[0]['pid'], 'DNP pid is 5663');
+        self::assertSame(0, (int) $dnpRows[0]['game_min']);
+        self::assertSame(0, (int) $dnpRows[0]['calc_points']);
+    }
+
+    // ── V18: Zero NULL pid/teamid ─────────────────────────────────────────────
+
+    public function testNoPidOrTeamidNulls(): void
+    {
+        $this->setUpGameState();
+        $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) AS cnt FROM ibl_box_scores
+             WHERE ((game_date = ? AND visitor_teamid = ? AND home_teamid = ?)
+                 OR (game_date = ? AND visitor_teamid = ? AND home_teamid = ?))
+               AND (pid IS NULL OR teamid IS NULL)'
+        );
+        self::assertNotFalse($stmt);
+        $rsgDate = self::RSG_DATE; $rsgVis = self::RSG_VISITOR_TID; $rsgHome = self::RSG_HOME_TID;
+        $asgDate = self::ASG_DATE; $asgVis = self::ASG_VISITOR_TID; $asgHome = self::ASG_HOME_TID;
+        $stmt->bind_param('siisii', $rsgDate, $rsgVis, $rsgHome, $asgDate, $asgVis, $asgHome);
+        $stmt->execute();
+        /** @var array{cnt: int} $row */
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        self::assertSame(0, (int) ($row['cnt'] ?? 0), 'Zero NULL pid/teamid rows');
+    }
+
+    // ── V19: Season gate — no sentinel → skipped ─────────────────────────────
+
+    public function testSeasonGateSkipsWithoutSentinel(): void
+    {
+        $this->repo->deleteTeamBoxscoresByGame(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID, 1);
+        $this->repo->deletePlayerBoxscoresByGame(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID);
+        $this->repo->deleteTeamBoxscoresByGame(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID, 1);
+        $this->repo->deletePlayerBoxscoresByGame(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
+        // Do NOT insert sentinel — gate should fire
+
+        $result = $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+
+        self::assertTrue($result['success']);
+        self::assertSame('All-Star Weekend not yet reached', $result['skipped'] ?? null);
+
+        self::assertSame(0, $this->countPlayerRows(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID)
+            + $this->countPlayerRows(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID));
+    }
+
+    // ── V20: Idempotency ──────────────────────────────────────────────────────
+
+    public function testIdempotency(): void
+    {
+        $this->setUpGameState();
+        $block = $this->buildBlock();
+
+        $this->processor->processAllStarGamesData($block, 2007);
+        $playerAfterFirst = $this->countPlayerRows(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID)
+            + $this->countPlayerRows(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
+        $teamAfterFirst = $this->countTeamRows(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID)
+            + $this->countTeamRows(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
+
+        $this->processor->processAllStarGamesData($block, 2007);
+        $playerAfterSecond = $this->countPlayerRows(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID)
+            + $this->countPlayerRows(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
+        $teamAfterSecond = $this->countTeamRows(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID)
+            + $this->countTeamRows(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
+
+        self::assertSame($playerAfterFirst, $playerAfterSecond, 'Player count stable (V20)');
+        self::assertSame($teamAfterFirst, $teamAfterSecond, 'Team count stable (V20)');
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
+++ b/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
@@ -466,10 +466,11 @@ class AllStarScoReconstructionTest extends DatabaseTestCase
 
     public function testSeasonGateSkipsWithoutSentinel(): void
     {
-        $this->repo->deleteTeamBoxscoresByGame(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID, 1);
-        $this->repo->deletePlayerBoxscoresByGame(self::RSG_DATE, self::RSG_VISITOR_TID, self::RSG_HOME_TID);
-        $this->repo->deleteTeamBoxscoresByGame(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID, 1);
-        $this->repo->deletePlayerBoxscoresByGame(self::ASG_DATE, self::ASG_VISITOR_TID, self::ASG_HOME_TID);
+        // getLastBoxScoreDate() queries ibl_box_scores with no year filter.
+        // CI seed has modern games, so the 2007 all-star cutoff would always be exceeded
+        // unless we clear the table. DELETE is transactional (unlike TRUNCATE) so this
+        // rolls back in tearDown alongside all other mutations in this test.
+        $this->db->query('DELETE FROM ibl_box_scores');
         // Do NOT insert sentinel — gate should fire
 
         $result = $this->processor->processAllStarGamesData($this->buildBlock(), 2007);

--- a/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
+++ b/ibl5/tests/DatabaseIntegration/AllStarScoReconstructionTest.php
@@ -466,14 +466,15 @@ class AllStarScoReconstructionTest extends DatabaseTestCase
 
     public function testSeasonGateSkipsWithoutSentinel(): void
     {
-        // getLastBoxScoreDate() queries ibl_box_scores with no year filter.
-        // CI seed has modern games, so the 2007 all-star cutoff would always be exceeded
-        // unless we clear the table. DELETE is transactional (unlike TRUNCATE) so this
-        // rolls back in tearDown alongside all other mutations in this test.
-        $this->db->query('DELETE FROM ibl_box_scores');
-        // Do NOT insert sentinel — gate should fire
+        // Season::getLastBoxScoreDate() queries ibl_box_scores with no year filter.
+        // CI seed has modern games (dates >> 2007-02-04), so passing the real DB
+        // always makes the gate pass. Inject a Season stub that returns '' instead,
+        // so the gate fires correctly regardless of seed state.
+        $stubSeason = $this->createMock(\Season\Season::class);
+        $stubSeason->method('getLastBoxScoreDate')->willReturn('');
+        $processor = new BoxscoreProcessor($this->db, season: $stubSeason);
 
-        $result = $this->processor->processAllStarGamesData($this->buildBlock(), 2007);
+        $result = $processor->processAllStarGamesData($this->buildBlock(), 2007);
 
         self::assertTrue($result['success']);
         self::assertSame('All-Star Weekend not yet reached', $result['skipped'] ?? null);

--- a/ibl5/tests/JsbParser/ScoFileWriterTest.php
+++ b/ibl5/tests/JsbParser/ScoFileWriterTest.php
@@ -95,6 +95,7 @@ class ScoFileWriterTest extends TestCase
         );
 
         $stats = PlayerStats::withBoxscoreInfoLine($this->mockDb(), $slot);
+        self::assertInstanceOf(PlayerStats::class, $stats);
 
         // V4: every stat parses back equal (int-cast to handle space-padded strings)
         self::assertSame('Test Player', trim($stats->name));
@@ -122,6 +123,7 @@ class ScoFileWriterTest extends TestCase
     {
         $slot = ScoFileWriter::buildTeamTotalSlot('Rookies', 47, 98, 16, 21, 8, 21, 25, 41, 30, 11, 22, 8, 19);
         $stats = PlayerStats::withBoxscoreInfoLine($this->mockDb(), $slot);
+        self::assertInstanceOf(PlayerStats::class, $stats);
 
         self::assertSame(0, (int) $stats->playerID);
         self::assertSame('Rookies', trim($stats->name));

--- a/ibl5/tests/JsbParser/ScoFileWriterTest.php
+++ b/ibl5/tests/JsbParser/ScoFileWriterTest.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\JsbParser;
+
+use Boxscore\Boxscore;
+use JsbParser\ScoFileParser;
+use JsbParser\ScoFileWriter;
+use PHPUnit\Framework\TestCase;
+use Player\Stats\PlayerStats;
+
+/**
+ * @covers \JsbParser\ScoFileWriter
+ */
+class ScoFileWriterTest extends TestCase
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function mockDb(): \mysqli
+    {
+        return $this->createMock(\mysqli::class);
+    }
+
+    /** Build a minimal synthetic .sco of the correct size (all spaces). */
+    private function blankSco(): string
+    {
+        return str_repeat(' ', ScoFileWriter::SCO_FILE_SIZE);
+    }
+
+    /** Build a .sco with a non-blank tail so splice can verify tail preservation. */
+    private function syntheticSco(): string
+    {
+        return str_repeat(' ', 4000) . str_repeat('x', ScoFileWriter::SCO_FILE_SIZE - 4000);
+    }
+
+    /** Minimal valid 4000-byte block (all spaces except one non-space in game-info). */
+    private function minimalBlock(): string
+    {
+        $record = str_repeat(' ', ScoFileParser::RECORD_SIZE);
+        // Make game-info non-blank with a single digit so trim() !== '' passes
+        $record = substr_replace($record, '1', 0, 1);
+        return $record . str_repeat(' ', ScoFileParser::RECORD_SIZE);
+    }
+
+    // ── V3: Game-info round-trip ──────────────────────────────────────────────
+
+    public function testGameInfoRoundTrip(): void
+    {
+        $visitorQ = [34, 39, 30, 31, 0];
+        $homeQ    = [34, 31, 39, 41, 0];
+
+        $gameInfo = ScoFileWriter::buildGameInfo(
+            1, 1, 0, 39, 40,
+            5244, 20000,
+            0, 0, 0, 0,
+            $visitorQ, $homeQ,
+        );
+
+        $record = ScoFileWriter::buildRecord($gameInfo, []);
+        $boxscore = Boxscore::withGameInfoLine(ScoFileParser::extractGameInfo($record), 2007, 'Regular Season/Playoffs');
+
+        // Quarter scores and attendance/capacity are read verbatim — assert as ints (V3)
+        self::assertEquals(34, (int) $boxscore->visitor_q1_points);
+        self::assertEquals(39, (int) $boxscore->visitor_q2_points);
+        self::assertEquals(30, (int) $boxscore->visitor_q3_points);
+        self::assertEquals(31, (int) $boxscore->visitor_q4_points);
+        self::assertEquals(0,  (int) $boxscore->visitor_ot_points);
+        self::assertEquals(34, (int) $boxscore->home_q1_points);
+        self::assertEquals(31, (int) $boxscore->home_q2_points);
+        self::assertEquals(39, (int) $boxscore->home_q3_points);
+        self::assertEquals(41, (int) $boxscore->home_q4_points);
+        self::assertEquals(0,  (int) $boxscore->home_ot_points);
+        self::assertEquals(5244,  (int) $boxscore->attendance);
+        self::assertEquals(20000, (int) $boxscore->capacity);
+        self::assertEquals(0, (int) $boxscore->visitor_wins);
+        self::assertEquals(0, (int) $boxscore->visitor_losses);
+        self::assertEquals(0, (int) $boxscore->home_wins);
+        self::assertEquals(0, (int) $boxscore->home_losses);
+    }
+
+    // ── V4: Player slot round-trip ────────────────────────────────────────────
+
+    public function testPlayerSlotRoundTrip(): void
+    {
+        $slot = ScoFileWriter::buildPlayerSlot(
+            'Test Player',  // name (11 chars, fits W=16)
+            'PG',           // pos
+            5936,           // pid
+            32,             // min
+            7,              // twoGM
+            15,             // twoGA
+            5,              // ftm
+            5,              // fta
+            0,              // threeGM
+            3,              // threeGA
+            3,              // orb
+            1,              // drb
+            7,              // ast
+            0,              // stl
+            3,              // tov
+            0,              // blk
+            3,              // pf
+        );
+
+        $stats = PlayerStats::withBoxscoreInfoLine($this->mockDb(), $slot);
+
+        // V4: every stat parses back equal (int-cast to handle space-padded strings)
+        self::assertSame('Test Player', trim($stats->name));
+        self::assertSame('PG', trim($stats->position));
+        self::assertEquals(5936, (int) $stats->playerID);
+        self::assertEquals(32, (int) $stats->gameMinutesPlayed);
+        self::assertEquals(7,  (int) $stats->gameFieldGoalsMade);
+        self::assertEquals(15, (int) $stats->gameFieldGoalsAttempted);
+        self::assertEquals(5,  (int) $stats->gameFreeThrowsMade);
+        self::assertEquals(5,  (int) $stats->gameFreeThrowsAttempted);
+        self::assertEquals(0,  (int) $stats->gameThreePointersMade);
+        self::assertEquals(3,  (int) $stats->gameThreePointersAttempted);
+        self::assertEquals(3,  (int) $stats->gameOffensiveRebounds);
+        self::assertEquals(1,  (int) $stats->gameDefensiveRebounds);
+        self::assertEquals(7,  (int) $stats->gameAssists);
+        self::assertEquals(0,  (int) $stats->gameSteals);
+        self::assertEquals(3,  (int) $stats->gameTurnovers);
+        self::assertEquals(0,  (int) $stats->gameBlocks);
+        self::assertEquals(3,  (int) $stats->gamePersonalFouls);
+    }
+
+    // ── V5: Team-total slot has playerID 0 ───────────────────────────────────
+
+    public function testTeamTotalSlotHasZeroPlayerId(): void
+    {
+        $slot = ScoFileWriter::buildTeamTotalSlot('Rookies', 47, 98, 16, 21, 8, 21, 25, 41, 30, 11, 22, 8, 19);
+        $stats = PlayerStats::withBoxscoreInfoLine($this->mockDb(), $slot);
+
+        self::assertEquals(0, (int) $stats->playerID);
+        self::assertSame('Rookies', trim($stats->name));
+    }
+
+    // ── V6: Size assertions ───────────────────────────────────────────────────
+
+    public function testRecordIsExactly2000Bytes(): void
+    {
+        $gameInfo = str_repeat(' ', ScoFileParser::GAME_INFO_SIZE);
+        $record = ScoFileWriter::buildRecord($gameInfo, []);
+        self::assertSame(ScoFileParser::RECORD_SIZE, strlen($record));
+    }
+
+    public function testBlockIsExactly4000Bytes(): void
+    {
+        $block = $this->buildMinimalRsgAsgBlock();
+        self::assertSame(ScoFileParser::RECORD_SIZE * 2, strlen($block));
+    }
+
+    // ── V7: Both records' game-info non-blank (importer guard passes) ─────────
+
+    public function testGameInfoNonBlankSoImporterGuardPasses(): void
+    {
+        $block = $this->buildMinimalRsgAsgBlock();
+
+        $record0 = substr($block, 0, ScoFileParser::RECORD_SIZE);
+        $record1 = substr($block, ScoFileParser::RECORD_SIZE, ScoFileParser::RECORD_SIZE);
+
+        self::assertNotSame('', trim(ScoFileParser::extractGameInfo($record0)), 'record0 game-info must be non-blank');
+        self::assertNotSame('', trim(ScoFileParser::extractGameInfo($record1)), 'record1 game-info must be non-blank');
+    }
+
+    // ── V8: Encoder rejects overlong name ────────────────────────────────────
+
+    public function testRejectsOverlongName(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        ScoFileWriter::buildPlayerSlot('12345678901234567', 'PG', 1, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    // ── V9: Encoder rejects out-of-range stat (quarter value ≥ 1000) ──────────
+
+    public function testRejectsOutOfRangeStat(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        ScoFileWriter::buildGameInfo(
+            1, 1, 0, 39, 40,
+            5244, 20000,
+            0, 0, 0, 0,
+            [1000, 0, 0, 0, 0], // 1000 overflows W=3
+            [0, 0, 0, 0, 0],
+        );
+    }
+
+    // ── V10: Encoder rejects negative stat ───────────────────────────────────
+
+    public function testRejectsNegativeStat(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        ScoFileWriter::buildPlayerSlot('Test Player', 'PG', 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    // ── V23a: Splice guard rejects non-blank target ───────────────────────────
+
+    public function testSpliceRejectsNonBlankTarget(): void
+    {
+        $sco = str_repeat(' ', ScoFileWriter::SCO_FILE_SIZE);
+        // Dirty byte 0
+        $sco = substr_replace($sco, 'X', 0, 1);
+
+        $this->expectException(\RuntimeException::class);
+        ScoFileWriter::spliceAllStarBlock($sco, str_repeat('A', 4000));
+    }
+
+    // ── V23b: Splice guard rejects wrong-size inputs ──────────────────────────
+
+    public function testSpliceRejectsWrongBlockSize(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        ScoFileWriter::spliceAllStarBlock($this->blankSco(), str_repeat('A', 3999));
+    }
+
+    public function testSpliceRejectsWrongScoSize(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        ScoFileWriter::spliceAllStarBlock(str_repeat(' ', 100), str_repeat('A', 4000));
+    }
+
+    // ── V23c: Splice happy path ───────────────────────────────────────────────
+
+    public function testSplicePreservesTailAndLength(): void
+    {
+        $sco = $this->syntheticSco();
+        $block = str_repeat('B', 4000);
+
+        $patched = ScoFileWriter::spliceAllStarBlock($sco, $block);
+
+        // Total length preserved
+        self::assertSame(ScoFileWriter::SCO_FILE_SIZE, strlen($patched));
+
+        // First 4000 bytes replaced
+        self::assertSame($block, substr($patched, 0, 4000));
+
+        // Tail (bytes 1,000,000..EOF) hash identical
+        $originalTail = substr($sco, ScoFileParser::HEADER_OFFSET_BYTES);
+        $patchedTail  = substr($patched, ScoFileParser::HEADER_OFFSET_BYTES);
+        self::assertSame(hash('sha256', $originalTail), hash('sha256', $patchedTail));
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Build a valid 4000-byte block using actual RSG/ASG data from the dataset.
+     * Uses minimal but real stats so V7 (non-blank game-info) and V6 (sizes) pass.
+     */
+    private function buildMinimalRsgAsgBlock(): string
+    {
+        $risingStars = [
+            'visitor_name'    => 'Rookies',
+            'home_name'       => 'Sophomores',
+            'visitor_q'       => [34, 39, 30, 31, 0],
+            'home_q'          => [34, 31, 39, 41, 0],
+            'visitor_teamid'  => 40,
+            'home_teamid'     => 41,
+            'attendance'      => 5244,
+            'capacity'        => 20000,
+            'visitor_team'    => ['twoGM' => 47, 'twoGA' => 98, 'ftm' => 16, 'fta' => 21, 'threeGM' => 8, 'threeGA' => 21, 'orb' => 25, 'drb' => 41, 'ast' => 30, 'stl' => 11, 'tov' => 22, 'blk' => 8, 'pf' => 19],
+            'home_team'       => ['twoGM' => 52, 'twoGA' => 100, 'ftm' => 5, 'fta' => 9, 'threeGM' => 12, 'threeGA' => 27, 'orb' => 24, 'drb' => 43, 'ast' => 34, 'stl' => 10, 'tov' => 21, 'blk' => 14, 'pf' => 21],
+            'visitor_players' => [
+                ['name' => 'Player A',         'pos' => 'PG', 'pid' => 5936, 'min' => 32, 'twoGM' => 7, 'twoGA' => 15, 'ftm' => 5, 'fta' => 5, 'threeGM' => 0, 'threeGA' => 3, 'orb' => 3, 'drb' => 1, 'ast' => 7, 'stl' => 0, 'tov' => 3, 'blk' => 0, 'pf' => 3],
+                ['name' => 'Player B',         'pos' => 'PG', 'pid' => 5938, 'min' => 16, 'twoGM' => 1, 'twoGA' => 2, 'ftm' => 0, 'fta' => 0, 'threeGM' => 1, 'threeGA' => 5, 'orb' => 1, 'drb' => 0, 'ast' => 1, 'stl' => 0, 'tov' => 2, 'blk' => 1, 'pf' => 0],
+                ['name' => 'Player C',         'pos' => 'SG', 'pid' => 5931, 'min' => 32, 'twoGM' => 8, 'twoGA' => 16, 'ftm' => 3, 'fta' => 5, 'threeGM' => 2, 'threeGA' => 5, 'orb' => 4, 'drb' => 4, 'ast' => 0, 'stl' => 3, 'tov' => 1, 'blk' => 1, 'pf' => 2],
+                ['name' => 'Player D',         'pos' => 'SG', 'pid' => 5930, 'min' => 19, 'twoGM' => 1, 'twoGA' => 3, 'ftm' => 2, 'fta' => 3, 'threeGM' => 2, 'threeGA' => 2, 'orb' => 1, 'drb' => 1, 'ast' => 2, 'stl' => 2, 'tov' => 1, 'blk' => 1, 'pf' => 1],
+                ['name' => 'Player E',         'pos' => 'SF', 'pid' => 5937, 'min' => 29, 'twoGM' => 5, 'twoGA' => 11, 'ftm' => 0, 'fta' => 0, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 0, 'drb' => 4, 'ast' => 11, 'stl' => 1, 'tov' => 5, 'blk' => 0, 'pf' => 2],
+                ['name' => 'Player F',         'pos' => 'SF', 'pid' => 5939, 'min' => 13, 'twoGM' => 6, 'twoGA' => 11, 'ftm' => 1, 'fta' => 2, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 1, 'drb' => 3, 'ast' => 4, 'stl' => 0, 'tov' => 3, 'blk' => 1, 'pf' => 4],
+                ['name' => 'Player G',         'pos' => 'PF', 'pid' => 5929, 'min' => 30, 'twoGM' => 7, 'twoGA' => 15, 'ftm' => 2, 'fta' => 2, 'threeGM' => 2, 'threeGA' => 3, 'orb' => 3, 'drb' => 4, 'ast' => 2, 'stl' => 1, 'tov' => 2, 'blk' => 1, 'pf' => 1],
+                ['name' => 'Player H',         'pos' => 'PF', 'pid' => 5935, 'min' => 30, 'twoGM' => 7, 'twoGA' => 13, 'ftm' => 3, 'fta' => 4, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 6, 'drb' => 6, 'ast' => 2, 'stl' => 4, 'tov' => 3, 'blk' => 1, 'pf' => 3],
+                ['name' => 'Player I',         'pos' => 'C',  'pid' => 5942, 'min' => 14, 'twoGM' => 2, 'twoGA' => 5, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 3, 'drb' => 4, 'ast' => 0, 'stl' => 0, 'tov' => 2, 'blk' => 1, 'pf' => 1],
+                ['name' => 'Player J',         'pos' => 'C',  'pid' => 5964, 'min' => 22, 'twoGM' => 3, 'twoGA' => 7, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 1, 'drb' => 8, 'ast' => 1, 'stl' => 0, 'tov' => 0, 'blk' => 1, 'pf' => 2],
+            ],
+            'home_players'    => [
+                ['name' => 'Home A',           'pos' => 'PG', 'pid' => 5640, 'min' => 31, 'twoGM' => 13, 'twoGA' => 21, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 2, 'orb' => 4, 'drb' => 7, 'ast' => 12, 'stl' => 3, 'tov' => 6, 'blk' => 3, 'pf' => 1],
+                ['name' => 'Home B',           'pos' => 'PG', 'pid' => 5649, 'min' => 13, 'twoGM' => 1, 'twoGA' => 3, 'ftm' => 3, 'fta' => 4, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 0, 'drb' => 1, 'ast' => 5, 'stl' => 3, 'tov' => 2, 'blk' => 0, 'pf' => 0],
+                ['name' => 'Home C',           'pos' => 'SG', 'pid' => 5642, 'min' => 20, 'twoGM' => 10, 'twoGA' => 12, 'ftm' => 1, 'fta' => 3, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 1, 'drb' => 1, 'ast' => 6, 'stl' => 0, 'tov' => 3, 'blk' => 0, 'pf' => 2],
+                ['name' => 'Home D',           'pos' => 'SG', 'pid' => 5659, 'min' => 30, 'twoGM' => 4, 'twoGA' => 13, 'ftm' => 0, 'fta' => 0, 'threeGM' => 6, 'threeGA' => 11, 'orb' => 0, 'drb' => 5, 'ast' => 5, 'stl' => 2, 'tov' => 3, 'blk' => 2, 'pf' => 2],
+                ['name' => 'Home E',           'pos' => 'SF', 'pid' => 5645, 'min' => 31, 'twoGM' => 7, 'twoGA' => 14, 'ftm' => 1, 'fta' => 1, 'threeGM' => 2, 'threeGA' => 5, 'orb' => 0, 'drb' => 5, 'ast' => 1, 'stl' => 0, 'tov' => 0, 'blk' => 0, 'pf' => 4],
+                ['name' => 'Home F',           'pos' => 'SF', 'pid' => 5685, 'min' => 20, 'twoGM' => 1, 'twoGA' => 5, 'ftm' => 0, 'fta' => 0, 'threeGM' => 2, 'threeGA' => 4, 'orb' => 0, 'drb' => 1, 'ast' => 2, 'stl' => 1, 'tov' => 0, 'blk' => 0, 'pf' => 2],
+                ['name' => 'Home G',           'pos' => 'PF', 'pid' => 5646, 'min' => 17, 'twoGM' => 3, 'twoGA' => 5, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 2, 'drb' => 4, 'ast' => 0, 'stl' => 1, 'tov' => 2, 'blk' => 0, 'pf' => 5],
+                ['name' => 'Home H (DNP)',     'pos' => 'PF', 'pid' => 5663, 'min' => 0,  'twoGM' => 0, 'twoGA' => 0, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 0, 'drb' => 0, 'ast' => 0, 'stl' => 0, 'tov' => 0, 'blk' => 0, 'pf' => 0],
+                ['name' => 'Home I',           'pos' => 'C',  'pid' => 5641, 'min' => 31, 'twoGM' => 7, 'twoGA' => 16, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 10, 'drb' => 6, 'ast' => 2, 'stl' => 0, 'tov' => 1, 'blk' => 4, 'pf' => 4],
+                ['name' => 'Home J',           'pos' => 'C',  'pid' => 5644, 'min' => 43, 'twoGM' => 6, 'twoGA' => 11, 'ftm' => 0, 'fta' => 1, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 6, 'drb' => 11, 'ast' => 1, 'stl' => 0, 'tov' => 4, 'blk' => 5, 'pf' => 1],
+            ],
+        ];
+
+        $allStar = [
+            'visitor_name'    => 'Team Away',
+            'home_name'       => 'Team Home',
+            'visitor_q'       => [43, 31, 44, 26, 0],
+            'home_q'          => [43, 48, 55, 36, 0],
+            'visitor_teamid'  => 50,
+            'home_teamid'     => 51,
+            'attendance'      => 5244,
+            'capacity'        => 20000,
+            'visitor_team'    => ['twoGM' => 48, 'twoGA' => 88, 'ftm' => 33, 'fta' => 38, 'threeGM' => 5, 'threeGA' => 20, 'orb' => 11, 'drb' => 42, 'ast' => 23, 'stl' => 4, 'tov' => 20, 'blk' => 10, 'pf' => 23],
+            'home_team'       => ['twoGM' => 60, 'twoGA' => 102, 'ftm' => 26, 'fta' => 29, 'threeGM' => 12, 'threeGA' => 30, 'orb' => 20, 'drb' => 47, 'ast' => 39, 'stl' => 16, 'tov' => 10, 'blk' => 9, 'pf' => 28],
+            'visitor_players' => [
+                ['name' => 'ASG Vis A', 'pos' => 'PG', 'pid' => 3852, 'min' => 13, 'twoGM' => 2, 'twoGA' => 4, 'ftm' => 2, 'fta' => 2, 'threeGM' => 1, 'threeGA' => 4, 'orb' => 0, 'drb' => 2, 'ast' => 3, 'stl' => 0, 'tov' => 1, 'blk' => 0, 'pf' => 3],
+                ['name' => 'ASG Vis B', 'pos' => 'PG', 'pid' => 5640, 'min' => 17, 'twoGM' => 3, 'twoGA' => 4, 'ftm' => 4, 'fta' => 4, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 1, 'drb' => 2, 'ast' => 5, 'stl' => 0, 'tov' => 2, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG Vis C', 'pos' => 'PG', 'pid' => 3851, 'min' => 28, 'twoGM' => 8, 'twoGA' => 11, 'ftm' => 4, 'fta' => 4, 'threeGM' => 1, 'threeGA' => 3, 'orb' => 0, 'drb' => 3, 'ast' => 4, 'stl' => 2, 'tov' => 2, 'blk' => 0, 'pf' => 1],
+                ['name' => 'ASG Vis D', 'pos' => 'PF', 'pid' => 4148, 'min' => 21, 'twoGM' => 2, 'twoGA' => 4, 'ftm' => 5, 'fta' => 5, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 2, 'drb' => 5, 'ast' => 2, 'stl' => 0, 'tov' => 1, 'blk' => 0, 'pf' => 4],
+                ['name' => 'ASG Vis E', 'pos' => 'SF', 'pid' => 5258, 'min' => 25, 'twoGM' => 6, 'twoGA' => 12, 'ftm' => 5, 'fta' => 6, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 0, 'drb' => 5, 'ast' => 4, 'stl' => 1, 'tov' => 3, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG Vis F', 'pos' => 'C',  'pid' => 4500, 'min' => 22, 'twoGM' => 7, 'twoGA' => 10, 'ftm' => 7, 'fta' => 7, 'threeGM' => 2, 'threeGA' => 2, 'orb' => 3, 'drb' => 4, 'ast' => 0, 'stl' => 0, 'tov' => 0, 'blk' => 5, 'pf' => 2],
+                ['name' => 'ASG Vis G', 'pos' => 'SG', 'pid' => 3282, 'min' => 15, 'twoGM' => 0, 'twoGA' => 1, 'ftm' => 2, 'fta' => 2, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 0, 'drb' => 3, 'ast' => 3, 'stl' => 0, 'tov' => 2, 'blk' => 0, 'pf' => 4],
+                ['name' => 'ASG Vis H', 'pos' => 'SG', 'pid' => 3561, 'min' => 13, 'twoGM' => 2, 'twoGA' => 5, 'ftm' => 0, 'fta' => 0, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 0, 'drb' => 1, 'ast' => 0, 'stl' => 0, 'tov' => 3, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG Vis I', 'pos' => 'C',  'pid' => 2975, 'min' => 25, 'twoGM' => 7, 'twoGA' => 15, 'ftm' => 3, 'fta' => 6, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 1, 'drb' => 8, 'ast' => 1, 'stl' => 1, 'tov' => 3, 'blk' => 4, 'pf' => 4],
+                ['name' => 'ASG Vis J', 'pos' => 'SF', 'pid' => 3277, 'min' => 15, 'twoGM' => 4, 'twoGA' => 8, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 5, 'orb' => 0, 'drb' => 0, 'ast' => 0, 'stl' => 0, 'tov' => 0, 'blk' => 0, 'pf' => 2],
+                ['name' => 'Drazen Dalipagic', 'pos' => 'SG', 'pid' => 5265, 'min' => 20, 'twoGM' => 5, 'twoGA' => 6, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 0, 'drb' => 3, 'ast' => 0, 'stl' => 0, 'tov' => 1, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG Vis L', 'pos' => 'PF', 'pid' => 4507, 'min' => 21, 'twoGM' => 2, 'twoGA' => 8, 'ftm' => 1, 'fta' => 2, 'threeGM' => 0, 'threeGA' => 2, 'orb' => 1, 'drb' => 4, 'ast' => 1, 'stl' => 0, 'tov' => 2, 'blk' => 1, 'pf' => 3],
+            ],
+            'home_players'    => [
+                ['name' => 'ASG Home A', 'pos' => 'PG', 'pid' => 4150, 'min' => 18, 'twoGM' => 5, 'twoGA' => 8, 'ftm' => 0, 'fta' => 0, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 1, 'drb' => 3, 'ast' => 3, 'stl' => 2, 'tov' => 2, 'blk' => 1, 'pf' => 1],
+                ['name' => 'ASG Home B', 'pos' => 'PG', 'pid' => 3556, 'min' => 18, 'twoGM' => 7, 'twoGA' => 10, 'ftm' => 4, 'fta' => 4, 'threeGM' => 0, 'threeGA' => 3, 'orb' => 1, 'drb' => 6, 'ast' => 5, 'stl' => 2, 'tov' => 1, 'blk' => 1, 'pf' => 1],
+                ['name' => 'ASG Home C', 'pos' => 'SG', 'pid' => 3552, 'min' => 18, 'twoGM' => 4, 'twoGA' => 8, 'ftm' => 0, 'fta' => 0, 'threeGM' => 2, 'threeGA' => 5, 'orb' => 0, 'drb' => 3, 'ast' => 4, 'stl' => 2, 'tov' => 0, 'blk' => 1, 'pf' => 3],
+                ['name' => 'ASG Home D', 'pos' => 'PF', 'pid' => 5261, 'min' => 22, 'twoGM' => 3, 'twoGA' => 6, 'ftm' => 7, 'fta' => 8, 'threeGM' => 1, 'threeGA' => 1, 'orb' => 1, 'drb' => 1, 'ast' => 2, 'stl' => 0, 'tov' => 0, 'blk' => 1, 'pf' => 1],
+                ['name' => 'ASG Home E', 'pos' => 'C',  'pid' => 3555, 'min' => 12, 'twoGM' => 3, 'twoGA' => 6, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 2, 'drb' => 5, 'ast' => 0, 'stl' => 0, 'tov' => 1, 'blk' => 0, 'pf' => 0],
+                ['name' => 'ASG Home F', 'pos' => 'SG', 'pid' => 5259, 'min' => 27, 'twoGM' => 8, 'twoGA' => 19, 'ftm' => 1, 'fta' => 2, 'threeGM' => 1, 'threeGA' => 4, 'orb' => 7, 'drb' => 1, 'ast' => 8, 'stl' => 1, 'tov' => 1, 'blk' => 1, 'pf' => 2],
+                ['name' => 'ASG Home G', 'pos' => 'C',  'pid' => 4490, 'min' => 20, 'twoGM' => 5, 'twoGA' => 9, 'ftm' => 3, 'fta' => 3, 'threeGM' => 3, 'threeGA' => 5, 'orb' => 1, 'drb' => 4, 'ast' => 1, 'stl' => 1, 'tov' => 1, 'blk' => 0, 'pf' => 3],
+                ['name' => 'ASG Home H', 'pos' => 'C',  'pid' => 4492, 'min' => 20, 'twoGM' => 6, 'twoGA' => 11, 'ftm' => 2, 'fta' => 2, 'threeGM' => 0, 'threeGA' => 0, 'orb' => 2, 'drb' => 7, 'ast' => 1, 'stl' => 0, 'tov' => 1, 'blk' => 1, 'pf' => 3],
+                ['name' => 'ASG Home I', 'pos' => 'SG', 'pid' => 4494, 'min' => 16, 'twoGM' => 6, 'twoGA' => 7, 'ftm' => 6, 'fta' => 6, 'threeGM' => 1, 'threeGA' => 2, 'orb' => 1, 'drb' => 2, 'ast' => 2, 'stl' => 3, 'tov' => 1, 'blk' => 0, 'pf' => 3],
+                ['name' => 'ASG Home J', 'pos' => 'PG', 'pid' => 4502, 'min' => 11, 'twoGM' => 2, 'twoGA' => 2, 'ftm' => 0, 'fta' => 0, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 0, 'drb' => 3, 'ast' => 3, 'stl' => 0, 'tov' => 0, 'blk' => 0, 'pf' => 6],
+                ['name' => 'ASG Home K', 'pos' => 'C',  'pid' => 4824, 'min' => 29, 'twoGM' => 8, 'twoGA' => 9, 'ftm' => 3, 'fta' => 4, 'threeGM' => 0, 'threeGA' => 1, 'orb' => 2, 'drb' => 6, 'ast' => 0, 'stl' => 3, 'tov' => 2, 'blk' => 1, 'pf' => 5],
+                ['name' => 'ASG Home L', 'pos' => 'PG', 'pid' => 4825, 'min' => 23, 'twoGM' => 3, 'twoGA' => 7, 'ftm' => 0, 'fta' => 0, 'threeGM' => 3, 'threeGA' => 6, 'orb' => 1, 'drb' => 4, 'ast' => 10, 'stl' => 2, 'tov' => 0, 'blk' => 2, 'pf' => 0],
+            ],
+        ];
+
+        return ScoFileWriter::buildAllStarHeaderBlock($risingStars, $allStar);
+    }
+}

--- a/ibl5/tests/JsbParser/ScoFileWriterTest.php
+++ b/ibl5/tests/JsbParser/ScoFileWriterTest.php
@@ -34,15 +34,6 @@ class ScoFileWriterTest extends TestCase
         return str_repeat(' ', 4000) . str_repeat('x', ScoFileWriter::SCO_FILE_SIZE - 4000);
     }
 
-    /** Minimal valid 4000-byte block (all spaces except one non-space in game-info). */
-    private function minimalBlock(): string
-    {
-        $record = str_repeat(' ', ScoFileParser::RECORD_SIZE);
-        // Make game-info non-blank with a single digit so trim() !== '' passes
-        $record = substr_replace($record, '1', 0, 1);
-        return $record . str_repeat(' ', ScoFileParser::RECORD_SIZE);
-    }
-
     // ── V3: Game-info round-trip ──────────────────────────────────────────────
 
     public function testGameInfoRoundTrip(): void
@@ -61,22 +52,22 @@ class ScoFileWriterTest extends TestCase
         $boxscore = Boxscore::withGameInfoLine(ScoFileParser::extractGameInfo($record), 2007, 'Regular Season/Playoffs');
 
         // Quarter scores and attendance/capacity are read verbatim — assert as ints (V3)
-        self::assertEquals(34, (int) $boxscore->visitor_q1_points);
-        self::assertEquals(39, (int) $boxscore->visitor_q2_points);
-        self::assertEquals(30, (int) $boxscore->visitor_q3_points);
-        self::assertEquals(31, (int) $boxscore->visitor_q4_points);
-        self::assertEquals(0,  (int) $boxscore->visitor_ot_points);
-        self::assertEquals(34, (int) $boxscore->home_q1_points);
-        self::assertEquals(31, (int) $boxscore->home_q2_points);
-        self::assertEquals(39, (int) $boxscore->home_q3_points);
-        self::assertEquals(41, (int) $boxscore->home_q4_points);
-        self::assertEquals(0,  (int) $boxscore->home_ot_points);
-        self::assertEquals(5244,  (int) $boxscore->attendance);
-        self::assertEquals(20000, (int) $boxscore->capacity);
-        self::assertEquals(0, (int) $boxscore->visitor_wins);
-        self::assertEquals(0, (int) $boxscore->visitor_losses);
-        self::assertEquals(0, (int) $boxscore->home_wins);
-        self::assertEquals(0, (int) $boxscore->home_losses);
+        self::assertSame(34, (int) $boxscore->visitor_q1_points);
+        self::assertSame(39, (int) $boxscore->visitor_q2_points);
+        self::assertSame(30, (int) $boxscore->visitor_q3_points);
+        self::assertSame(31, (int) $boxscore->visitor_q4_points);
+        self::assertSame(0,  (int) $boxscore->visitor_ot_points);
+        self::assertSame(34, (int) $boxscore->home_q1_points);
+        self::assertSame(31, (int) $boxscore->home_q2_points);
+        self::assertSame(39, (int) $boxscore->home_q3_points);
+        self::assertSame(41, (int) $boxscore->home_q4_points);
+        self::assertSame(0,  (int) $boxscore->home_ot_points);
+        self::assertSame(5244,  (int) $boxscore->attendance);
+        self::assertSame(20000, (int) $boxscore->capacity);
+        self::assertSame(0, (int) $boxscore->visitor_wins);
+        self::assertSame(0, (int) $boxscore->visitor_losses);
+        self::assertSame(0, (int) $boxscore->home_wins);
+        self::assertSame(0, (int) $boxscore->home_losses);
     }
 
     // ── V4: Player slot round-trip ────────────────────────────────────────────
@@ -108,21 +99,21 @@ class ScoFileWriterTest extends TestCase
         // V4: every stat parses back equal (int-cast to handle space-padded strings)
         self::assertSame('Test Player', trim($stats->name));
         self::assertSame('PG', trim($stats->position));
-        self::assertEquals(5936, (int) $stats->playerID);
-        self::assertEquals(32, (int) $stats->gameMinutesPlayed);
-        self::assertEquals(7,  (int) $stats->gameFieldGoalsMade);
-        self::assertEquals(15, (int) $stats->gameFieldGoalsAttempted);
-        self::assertEquals(5,  (int) $stats->gameFreeThrowsMade);
-        self::assertEquals(5,  (int) $stats->gameFreeThrowsAttempted);
-        self::assertEquals(0,  (int) $stats->gameThreePointersMade);
-        self::assertEquals(3,  (int) $stats->gameThreePointersAttempted);
-        self::assertEquals(3,  (int) $stats->gameOffensiveRebounds);
-        self::assertEquals(1,  (int) $stats->gameDefensiveRebounds);
-        self::assertEquals(7,  (int) $stats->gameAssists);
-        self::assertEquals(0,  (int) $stats->gameSteals);
-        self::assertEquals(3,  (int) $stats->gameTurnovers);
-        self::assertEquals(0,  (int) $stats->gameBlocks);
-        self::assertEquals(3,  (int) $stats->gamePersonalFouls);
+        self::assertSame(5936, (int) $stats->playerID);
+        self::assertSame(32, (int) $stats->gameMinutesPlayed);
+        self::assertSame(7,  (int) $stats->gameFieldGoalsMade);
+        self::assertSame(15, (int) $stats->gameFieldGoalsAttempted);
+        self::assertSame(5,  (int) $stats->gameFreeThrowsMade);
+        self::assertSame(5,  (int) $stats->gameFreeThrowsAttempted);
+        self::assertSame(0,  (int) $stats->gameThreePointersMade);
+        self::assertSame(3,  (int) $stats->gameThreePointersAttempted);
+        self::assertSame(3,  (int) $stats->gameOffensiveRebounds);
+        self::assertSame(1,  (int) $stats->gameDefensiveRebounds);
+        self::assertSame(7,  (int) $stats->gameAssists);
+        self::assertSame(0,  (int) $stats->gameSteals);
+        self::assertSame(3,  (int) $stats->gameTurnovers);
+        self::assertSame(0,  (int) $stats->gameBlocks);
+        self::assertSame(3,  (int) $stats->gamePersonalFouls);
     }
 
     // ── V5: Team-total slot has playerID 0 ───────────────────────────────────
@@ -132,7 +123,7 @@ class ScoFileWriterTest extends TestCase
         $slot = ScoFileWriter::buildTeamTotalSlot('Rookies', 47, 98, 16, 21, 8, 21, 25, 41, 30, 11, 22, 8, 19);
         $stats = PlayerStats::withBoxscoreInfoLine($this->mockDb(), $slot);
 
-        self::assertEquals(0, (int) $stats->playerID);
+        self::assertSame(0, (int) $stats->playerID);
         self::assertSame('Rookies', trim($stats->name));
     }
 


### PR DESCRIPTION
## Summary

Blank records 0–1 in `06-07_36_finals.zip`'s `IBL5.sco` prevent the bulk importer from natively reconstructing the 48 All-Star Weekend box-score rows on a truncate+reimport. This PR adds the code-only half of the fix (the binary patch is an operator-run step, per plan).

**Added:**
- `JsbParser/ScoFileWriter` (+ `ScoFileWriterInterface`) — pure 2000-byte record encoder mirroring the `TrnFileWriter` const/`substr_replace` idiom. `buildAllStarHeaderBlock()` → 4000-byte block; `spliceAllStarBlock()` enforces blank-target, length, and tail-hash integrity guards.
- `scripts/patch_2007_asg_sco.php` — operator CLI that resolves names from `ibl_plr`, builds the block, dry-runs by default, writes on `--apply`, hash-verifies all 30 zip members post-write.
- `ScoFileWriterTest` — round-trip, size, importer-guard, rejection (overlong/overflow/negative), and splice-guard tests (V3–V10, V23a–c).
- `AllStarScoReconstructionTest` (`#[Group('database')]`) — acceptance: block → `processAllStarGamesData` → 48 rows with cross-foot, DNP, season gate, idempotency (V11–V20).
- `docs/decisions/0051` — tracked provenance for the reconstructed archive.

Stat source: `$games` array from `reconstruct_2007_asg_boxscores.php` (unchanged). That script remains the prod-DB path; this is the archive-parity path.

## Manual Testing

No manual testing needed — all changes are covered by unit and integration tests.