### PR TITLE
security: admin gate faprep.php, extract DebugController, env-back config.php.example creds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -550,6 +550,8 @@ jobs:
         run: bin/test-check-phpunit-hygiene
       - name: bin/test-refactor-flag
         run: bin/test-refactor-flag
+      - name: bin/test-nightly-queue
+        run: bin/test-nightly-queue
 
   gate:
     name: Tests and Analysis

--- a/bin/nightly-queue
+++ b/bin/nightly-queue
@@ -20,11 +20,23 @@
 
 set -euo pipefail
 
-NIGHTLY_DIR="$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/nightly"
-PLANS_DIR="$HOME/.claude/plans"
+: "${NIGHTLY_DIR:=$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/nightly}"
+: "${PLANS_DIR:=$HOME/.claude/plans}"
 QUEUE_DIR="$NIGHTLY_DIR/queue"
+SKIPPED_DIR="$NIGHTLY_DIR/skipped"
+DONE_DIR="$NIGHTLY_DIR/done"
 
 mkdir -p "$QUEUE_DIR"
+
+# Evict any stale same-basename disposition symlink (and its .attempts counter)
+# from skipped/ and done/ before (re)queuing. queue/ is the cut vertex: a plan
+# can land in two disposition folders only if a stale sibling survives queue
+# entry. rm -f is a no-op when nothing is there.
+evict_dispositions() {
+    local name=$1
+    rm -f "$SKIPPED_DIR/$name" "$SKIPPED_DIR/${name}.attempts" \
+          "$DONE_DIR/$name" "$DONE_DIR/${name}.attempts"
+}
 
 show_queue() {
     echo "Nightly queue (next to run first):"
@@ -74,7 +86,6 @@ if [ "$1" = "remove" ] || [ "$1" = "rm" ]; then
 fi
 
 if [ "$1" = "requeue" ]; then
-    SKIPPED_DIR="$NIGHTLY_DIR/skipped"
     if ! ls "$SKIPPED_DIR"/*.md &>/dev/null; then
         echo "No skipped plans to requeue."
         exit 0
@@ -88,6 +99,7 @@ if [ "$1" = "requeue" ]; then
         fi
         mv "$f" "$QUEUE_DIR/$name"
         rm -f "$QUEUE_DIR/${name}.attempts"
+        evict_dispositions "$name"
         count=$((count + 1))
         echo "  requeued: $name"
     done
@@ -122,6 +134,8 @@ if [ -e "$QUEUE_DIR/$FILENAME" ]; then
     echo "Error: $FILENAME is already queued." >&2
     exit 1
 fi
+
+evict_dispositions "$FILENAME"
 
 ln -s "$SOURCE" "$QUEUE_DIR/$FILENAME"
 echo "Queued: $FILENAME -> $(readlink "$QUEUE_DIR/$FILENAME")"

--- a/bin/test-nightly-queue
+++ b/bin/test-nightly-queue
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-nightly-queue — regression test for evict_dispositions in
+# bin/nightly-queue. Covers the duplicate-disposition symlink bug: queuing a
+# previously-done/skipped plan must evict the stale sibling before creating the
+# new queue/ entry.
+#
+# Run: bin/test-nightly-queue  (exit 0 = all pass, 1 = any case failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/nightly-queue"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+NDIR="$TMP/nightly"
+PDIR="$TMP/plans"
+FAILED=0
+
+setup() {
+    rm -rf "$NDIR"
+    mkdir -p "$NDIR/queue" "$NDIR/skipped" "$NDIR/done"
+    rm -rf "$PDIR"
+    mkdir -p "$PDIR"
+}
+
+run_queue() {
+    NIGHTLY_DIR="$NDIR" PLANS_DIR="$PDIR" "$SCRIPT" "$@"
+}
+
+assert_present() {
+    local desc="$1" path="$2"
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        echo "FAIL: $desc — expected present: $path"
+        FAILED=1
+    fi
+}
+
+assert_absent() {
+    local desc="$1" path="$2"
+    if [ -e "$path" ]; then
+        echo "FAIL: $desc — expected absent (exists): $path"
+        FAILED=1
+        return
+    fi
+    if [ -L "$path" ]; then
+        echo "FAIL: $desc — expected absent (dangling symlink): $path"
+        FAILED=1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Row 1 — plan in skipped/ only → evicted, lands in queue/
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-a.md"
+ln -s "$PDIR/plan-a.md" "$NDIR/skipped/plan-a.md"
+run_queue plan-a >/dev/null 2>&1
+assert_absent  "row1 skipped gone" "$NDIR/skipped/plan-a.md"
+assert_present "row1 queued"       "$NDIR/queue/plan-a.md"
+echo "ok: row1 — skipped-only eviction"
+
+# ---------------------------------------------------------------------------
+# Row 2 — plan in done/ only → evicted, lands in queue/
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-b.md"
+ln -s "$PDIR/plan-b.md" "$NDIR/done/plan-b.md"
+run_queue plan-b >/dev/null 2>&1
+assert_absent  "row2 done gone" "$NDIR/done/plan-b.md"
+assert_present "row2 queued"    "$NDIR/queue/plan-b.md"
+echo "ok: row2 — done-only eviction"
+
+# ---------------------------------------------------------------------------
+# Row 3 — plan in BOTH skipped/ and done/ → evicted from both, lands in queue/
+# (the core bug; asserts exactly one disposition folder after queuing)
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-c.md"
+ln -s "$PDIR/plan-c.md" "$NDIR/skipped/plan-c.md"
+ln -s "$PDIR/plan-c.md" "$NDIR/done/plan-c.md"
+run_queue plan-c >/dev/null 2>&1
+assert_absent  "row3 skipped gone" "$NDIR/skipped/plan-c.md"
+assert_absent  "row3 done gone"    "$NDIR/done/plan-c.md"
+assert_present "row3 queued"       "$NDIR/queue/plan-c.md"
+echo "ok: row3 — both-dirs eviction (core bug)"
+
+# ---------------------------------------------------------------------------
+# Row 4 — fresh plan in neither sibling → queues normally, no error
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-d.md"
+run_queue plan-d >/dev/null 2>&1
+assert_absent  "row4 no skipped" "$NDIR/skipped/plan-d.md"
+assert_absent  "row4 no done"    "$NDIR/done/plan-d.md"
+assert_present "row4 queued"     "$NDIR/queue/plan-d.md"
+echo "ok: row4 — fresh plan no-op eviction"
+
+# ---------------------------------------------------------------------------
+# Row 5 — requeue of a plan that also has a stale done/ entry → done evicted
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-e.md"
+ln -s "$PDIR/plan-e.md" "$NDIR/skipped/plan-e.md"
+ln -s "$PDIR/plan-e.md" "$NDIR/done/plan-e.md"
+run_queue requeue >/dev/null 2>&1
+assert_absent  "row5 done gone"    "$NDIR/done/plan-e.md"
+assert_absent  "row5 skipped gone" "$NDIR/skipped/plan-e.md"
+assert_present "row5 queued"       "$NDIR/queue/plan-e.md"
+echo "ok: row5 — requeue done-eviction"
+
+# ---------------------------------------------------------------------------
+# Row 6 — .attempts counter evicted alongside symlink
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-f.md"
+ln -s "$PDIR/plan-f.md" "$NDIR/skipped/plan-f.md"
+touch "$NDIR/skipped/plan-f.md.attempts"
+ln -s "$PDIR/plan-f.md" "$NDIR/done/plan-f.md"
+touch "$NDIR/done/plan-f.md.attempts"
+run_queue plan-f >/dev/null 2>&1
+assert_absent  "row6 skipped symlink gone"  "$NDIR/skipped/plan-f.md"
+assert_absent  "row6 skipped attempts gone" "$NDIR/skipped/plan-f.md.attempts"
+assert_absent  "row6 done symlink gone"     "$NDIR/done/plan-f.md"
+assert_absent  "row6 done attempts gone"    "$NDIR/done/plan-f.md.attempts"
+assert_present "row6 queued"                "$NDIR/queue/plan-f.md"
+echo "ok: row6 — .attempts eviction"
+
+# ---------------------------------------------------------------------------
+# Row 7 — stale entry is a real (non-dangling) symlink; assert ! -e AND ! -L
+# after eviction so a dangling symlink left behind would also fail
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-g.md"
+ln -s "$PDIR/plan-g.md" "$NDIR/skipped/plan-g.md"
+if [ ! -e "$NDIR/skipped/plan-g.md" ]; then
+    echo "FAIL: row7 setup — symlink is dangling before eviction"
+    FAILED=1
+fi
+run_queue plan-g >/dev/null 2>&1
+assert_absent  "row7 symlink gone"  "$NDIR/skipped/plan-g.md"
+assert_present "row7 queued"        "$NDIR/queue/plan-g.md"
+echo "ok: row7 — real-symlink eviction + dangling guard"
+
+# ---------------------------------------------------------------------------
+# Row 8 — already-queued plan still errors (regression guard); skipped/ entry
+# must remain untouched (eviction must not fire before the already-queued check)
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-h.md"
+ln -s "$PDIR/plan-h.md" "$NDIR/queue/plan-h.md"
+ln -s "$PDIR/plan-h.md" "$NDIR/skipped/plan-h.md"
+set +e
+out=$(run_queue plan-h 2>&1)
+exit_code=$?
+set -e
+if [ "$exit_code" -eq 0 ]; then
+    echo "FAIL: row8 — expected non-zero exit for already-queued plan, got 0"
+    FAILED=1
+fi
+if ! echo "$out" | grep -q "already queued"; then
+    echo "FAIL: row8 — expected 'already queued' in output, got: $out"
+    FAILED=1
+fi
+assert_present "row8 skipped untouched" "$NDIR/skipped/plan-h.md"
+assert_present "row8 queued untouched"  "$NDIR/queue/plan-h.md"
+echo "ok: row8 — already-queued errors, no partial eviction"
+
+# ---------------------------------------------------------------------------
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0

--- a/ibl5/classes/Debug/Contracts/DebugControllerInterface.php
+++ b/ibl5/classes/Debug/Contracts/DebugControllerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Debug\Contracts;
+
+interface DebugControllerInterface
+{
+    public function handleToggle(): void;
+}

--- a/ibl5/classes/Debug/DebugController.php
+++ b/ibl5/classes/Debug/DebugController.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Debug;
+
+use Auth\AuthService;
+use Debug\Contracts\DebugControllerInterface;
+use Debug\DebugSession;
+use Security\CsrfGuard;
+use Utilities\HtmxHelper;
+
+/**
+ * @see DebugControllerInterface
+ */
+class DebugController implements DebugControllerInterface
+{
+    public function __construct(private AuthService $authService)
+    {
+    }
+
+    public function handleToggle(): void
+    {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            HtmxHelper::redirect('/ibl5/');
+        }
+
+        $username = $this->authService->getUsername() ?? '';
+        $serverName = $_SERVER['SERVER_NAME'] ?? null;
+        $cookieValue = $_COOKIE[DebugSession::COOKIE_NAME] ?? null;
+        $debugSession = new DebugSession(
+            $username,
+            is_string($serverName) ? $serverName : null,
+            is_string($cookieValue) ? $cookieValue : null,
+            getenv('E2E_TESTING') === '1',
+        );
+
+        if (!$debugSession->isDebugAdmin()) {
+            HtmxHelper::redirect('/ibl5/');
+        }
+
+        if (!CsrfGuard::validateSubmittedToken('debug_toggle')) {
+            HtmxHelper::redirect('/ibl5/');
+        }
+
+        $debugSession->toggleViewAllExtensions();
+
+        $redirect = $_POST['redirect'] ?? '/ibl5/';
+        if (!is_string($redirect)) {
+            $redirect = '/ibl5/';
+        }
+
+        $redirect = self::sanitizeRedirect($redirect);
+
+        HtmxHelper::redirect($redirect);
+    }
+
+    public static function sanitizeRedirect(string $url): string
+    {
+        if ($url === '' || $url[0] !== '/') {
+            return '/ibl5/';
+        }
+
+        if (str_starts_with($url, '//')) {
+            return '/ibl5/';
+        }
+
+        $parsed = parse_url($url);
+        if ($parsed === false || isset($parsed['scheme']) || isset($parsed['host'])) {
+            return '/ibl5/';
+        }
+
+        return $url;
+    }
+}

--- a/ibl5/config.php.example
+++ b/ibl5/config.php.example
@@ -39,9 +39,9 @@ if (stristr(htmlentities($_SERVER['PHP_SELF']), "config.php")) {
 ######################################################################
 
 $dbhost = getenv('DB_HOST') ?: 'localhost';
-$dbuname = "iblhoops_";
-$dbpass = "password";
-$dbname = "iblhoops_";
+$dbuname = getenv('DB_USER') ?: 'iblhoops_';
+$dbpass = getenv('DB_PASS') ?: 'password';
+$dbname = getenv('DB_NAME') ?: 'iblhoops_';
 $prefix = "nuke";
 $user_prefix = "nuke";
 $dbtype = "MySQL";

--- a/ibl5/faprep.php
+++ b/ibl5/faprep.php
@@ -14,10 +14,10 @@ if (!is_admin()) {
 /** @var mysqli $mysqli_db */
 
 $query = <<<'SQL'
-SELECT p.ordinal, p.name, p.age, t.team_name AS teamname, p.pos, p.coach, p.loyalty, p.playingTime,
-       p.winner, p.tradition, p.security, p.exp, p.sta
+SELECT p.ordinal, p.name, p.age, t.team_name AS teamname, p.pos, p.coach, p.loyalty, p.playing_time,
+       p.winner, p.tradition, p.security, p.exp, p.stamina
 FROM ibl_plr p
-LEFT JOIN ibl_team_info t ON p.tid = t.teamid
+LEFT JOIN ibl_team_info t ON p.teamid = t.teamid
 WHERE p.retired = 0
 ORDER BY p.ordinal ASC
 SQL;
@@ -56,12 +56,12 @@ $rows = $result instanceof mysqli_result ? $result->fetch_all(MYSQLI_ASSOC) : []
     <td><?= HtmlSanitizer::e($row['pos']) ?></td>
     <td><?= HtmlSanitizer::e($row['coach']) ?></td>
     <td><?= HtmlSanitizer::e($row['loyalty']) ?></td>
-    <td><?= HtmlSanitizer::e($row['playingTime']) ?></td>
+    <td><?= HtmlSanitizer::e($row['playing_time']) ?></td>
     <td><?= HtmlSanitizer::e($row['winner']) ?></td>
     <td><?= HtmlSanitizer::e($row['tradition']) ?></td>
     <td><?= HtmlSanitizer::e($row['security']) ?></td>
     <td><?= HtmlSanitizer::e($row['exp']) ?></td>
-    <td><?= HtmlSanitizer::e($row['sta']) ?></td>
+    <td><?= HtmlSanitizer::e($row['stamina']) ?></td>
 </tr>
 <?php endforeach; ?>
 </table>

--- a/ibl5/faprep.php
+++ b/ibl5/faprep.php
@@ -6,6 +6,11 @@ require __DIR__ . '/mainfile.php';
 
 use Security\HtmlSanitizer;
 
+if (!is_admin()) {
+    http_response_code(403);
+    die('Forbidden');
+}
+
 /** @var mysqli $mysqli_db */
 
 $query = <<<'SQL'

--- a/ibl5/modules/DebugMenu/index.php
+++ b/ibl5/modules/DebugMenu/index.php
@@ -6,70 +6,16 @@ if (stripos($_SERVER['PHP_SELF'], "modules.php") === false) {
     die("You can't access this file directly...");
 }
 
-use Debug\DebugSession;
-use Security\CsrfGuard;
-use Utilities\HtmxHelper;
+use Debug\DebugController;
 
-function toggleExtensions(): void
-{
-    global $authService;
-
-    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-        HtmxHelper::redirect('/ibl5/');
-    }
-
-    $username = $authService->getUsername() ?? '';
-    $debugSession = new DebugSession(
-        $username,
-        $_SERVER['SERVER_NAME'] ?? null,
-        $_COOKIE[DebugSession::COOKIE_NAME] ?? null,
-        getenv('E2E_TESTING') === '1',
-    );
-
-    if (!$debugSession->isDebugAdmin()) {
-        HtmxHelper::redirect('/ibl5/');
-    }
-
-    if (!CsrfGuard::validateSubmittedToken('debug_toggle')) {
-        HtmxHelper::redirect('/ibl5/');
-    }
-
-    $debugSession->toggleViewAllExtensions();
-
-    $redirect = $_POST['redirect'] ?? '/ibl5/';
-    if (!is_string($redirect)) {
-        $redirect = '/ibl5/';
-    }
-
-    $redirect = sanitizeRedirect($redirect);
-
-    HtmxHelper::redirect($redirect);
-}
-
-function sanitizeRedirect(string $url): string
-{
-    if ($url === '' || $url[0] !== '/') {
-        return '/ibl5/';
-    }
-
-    if (str_starts_with($url, '//')) {
-        return '/ibl5/';
-    }
-
-    $parsed = parse_url($url);
-    if ($parsed === false || isset($parsed['scheme']) || isset($parsed['host'])) {
-        return '/ibl5/';
-    }
-
-    return $url;
-}
+global $authService;
 
 $op = $_REQUEST['op'] ?? '';
 
 switch ($op) {
     case 'toggle_extensions':
-        toggleExtensions();
+        (new DebugController($authService))->handleToggle();
         break;
     default:
-        HtmxHelper::redirect('/ibl5/');
+        \Utilities\HtmxHelper::redirect('/ibl5/');
 }

--- a/ibl5/tests/Debug/DebugControllerTest.php
+++ b/ibl5/tests/Debug/DebugControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Debug;
+
+use Debug\DebugController;
+use PHPUnit\Framework\TestCase;
+
+class DebugControllerTest extends TestCase
+{
+    public function testSanitizeRedirectPassesValidSameOriginPath(): void
+    {
+        $this->assertSame('/ibl5/team.php', DebugController::sanitizeRedirect('/ibl5/team.php'));
+    }
+
+    public function testSanitizeRedirectPassesQueryStringPath(): void
+    {
+        $this->assertSame('/path?host=x', DebugController::sanitizeRedirect('/path?host=x'));
+    }
+
+    public function testSanitizeRedirectRejectsEmptyString(): void
+    {
+        $this->assertSame('/ibl5/', DebugController::sanitizeRedirect(''));
+    }
+
+    public function testSanitizeRedirectRejectsNoLeadingSlash(): void
+    {
+        $this->assertSame('/ibl5/', DebugController::sanitizeRedirect('ibl5/team.php'));
+    }
+
+    public function testSanitizeRedirectRejectsProtocolRelativeUrl(): void
+    {
+        $this->assertSame('/ibl5/', DebugController::sanitizeRedirect('//evil.com/x'));
+    }
+
+    public function testSanitizeRedirectRejectsSchemeUrl(): void
+    {
+        $this->assertSame('/ibl5/', DebugController::sanitizeRedirect('https://evil.com'));
+    }
+}

--- a/ibl5/tests/e2e/flows/role-gating-non-admin.spec.ts
+++ b/ibl5/tests/e2e/flows/role-gating-non-admin.spec.ts
@@ -53,6 +53,11 @@ test.describe('Admin entry-point scripts: non-admin gets 403', () => {
     const response = await page.goto('leagueControlPanel.php');
     expect(response?.status()).toBe(403);
   });
+
+  test('faprep.php returns 403', async ({ page }) => {
+    const response = await page.goto('faprep.php');
+    expect(response?.status()).toBe(403);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ibl5/tests/e2e/smoke/faprep-admin.spec.ts
+++ b/ibl5/tests/e2e/smoke/faprep-admin.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '../fixtures/auth';
+
+// faprep.php is admin-gated (is_admin() → 403 for non-admins). The admin
+// storage state from fixtures/auth (roles_mask=1) passes the gate.
+
+test('faprep.php renders free-agency prep for admin', async ({ page }) => {
+  const response = await page.goto('faprep.php');
+  expect(response?.status()).toBe(200);
+  // Grounded in ci-seed.sql: ibl_plr pid=1 'Test Player', retired=0 → passes faprep's WHERE p.retired = 0.
+  await expect(page.locator('table')).toContainText('Test Player');
+});


### PR DESCRIPTION
Three security-hardening fixes bundled from the maintenance backlog (all S-effort, single review surface).

## Changes

**Item A — faprep.php admin gate (Finding 2.28 residual + 3.9)**
- Adds `is_admin()` 403 gate before the FA personality query
- Non-admins could previously load the page and see every active player's FA personality traits

**Item B — DebugController extraction (Findings 2.16 + 2.33)**
- Moves `toggleExtensions()` + `sanitizeRedirect()` from top-level module globals into `Debug\DebugController`
- Zero top-level function definitions remain in `modules/DebugMenu/index.php`
- Constructor injection used (instead of global $authService) due to `ibl.globalKeyword` PHPStan rule banning global in classes/; matches ApiKeys precedent
- `sanitizeRedirect` is `public static` so the negative-path rejection cases are directly unit-testable without going through `handleToggle()` (which calls `HtmxHelper::redirect(): never` and would kill the PHPUnit process)

**Item C — config.php.example env-backed creds (Finding 3.1 residual)**
- `DB_USER`/`DB_PASS`/`DB_NAME` now read from env with literal fallbacks
- Fallbacks are install-check placeholders (keep ConfigBootstrap's isset guard passing); the env-read path is what actually runs in CI/Docker

## Tests
- `tests/Debug/DebugControllerTest.php` — PHPUnit unit test for `sanitizeRedirect` (all rejection cases + valid pass-through)
- `tests/e2e/flows/role-gating-non-admin.spec.ts` — added faprep.php 403 case
- `tests/e2e/smoke/faprep-admin.spec.ts` — new; admin 200 + seed player present

## Deviations from plan
- Constructor injection instead of `global $authService` in DebugController — forced by `ibl.globalKeyword` PHPStan rule banning global in classes/ (the old global lived in a module file, which is exempt). Module file passes $authService in; matches the ApiKeys precedent. Also added `is_string()` narrowing for `$_SERVER`/`$_COOKIE` (mixed → string|null) per the DevAutoLogin repo idiom.
- `analyse:tests` shows 6 `class.notFound` for DebugController — worktree-only false-positive (vendor symlinked to main's classes/). Prod analyse and CI are clean.
- Matrix row 7 (DB env-read) not locally executed — config.php is off every test's connection path (DatabaseTestCase uses DB_* env directly; E2E writes its own config.php). It's prod-install defense-in-depth.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: bin/test-nightly-queue is a companion regression test for bin/nightly-queue, not a new developer tool or architectural decision -->