### PR TITLE
chore: fix stale worktree paths (worktrees/ → IBL5-worktrees/)

### DIFF
--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -17,7 +17,7 @@ Before implementation, create a worktree unless one already exists for this task
 bin/wt-new <slug>   # slug = kebab-case branch name derived from the plan
 ```
 
-Use `--base <branch>` for stacked PRs. Work in `worktrees/<slug>/ibl5/`. Skip if already inside a worktree or the plan specifies an existing one.
+Use `--base <branch>` for stacked PRs. Work in `IBL5-worktrees/<slug>/ibl5/` (worktrees live outside the repo — ADR-0046). Skip if already inside a worktree or the plan specifies an existing one.
 
 ## Post-Plan
 

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -126,7 +126,7 @@ COUNT_LOCK=$(echo "$FILES" | grep -cE '(composer|package|bun)\.lock$' || true)
 COUNT_SNAPSHOT=$(echo "$FILES" | grep -cE '__snapshots__/|\.snap$' || true)
 COUNT_NON_CODE=$(( COUNT_MD + COUNT_LOCK + COUNT_SNAPSHOT ))
 # Go engine (repo-root engine/, NOT under ibl5/). Anchored at ^engine/ so other
-# worktree checkouts under worktrees/<slug>/engine/*.go never false-positive —
+# worktree checkouts under IBL5-worktrees/<slug>/engine/*.go never false-positive —
 # PR file lists are repo-root-relative.
 COUNT_GO=$(echo "$FILES" | grep -cE '^engine/.*\.go$' || true)
 COUNT_IBL5=$(echo "$FILES" | grep -cE '^ibl5/' || true)

--- a/bin/db-sync-prod
+++ b/bin/db-sync-prod
@@ -9,9 +9,13 @@
 # Usage: bin/db-sync-prod [worktree-name]
 #
 # Target resolution (in order):
-#   1. <worktree-name> argument → worktrees/<name>/.wt-slug
-#   2. CWD inside worktrees/<name>/... → that worktree
+#   1. <worktree-name> argument → <WT_PARENT>/<name>/.wt-slug
+#   2. CWD inside <WT_PARENT>/<name>/... → that worktree
 #   3. No argument, not in worktree → main ibl5-mariadb container
+#
+# Worktrees live OUTSIDE the repo (ADR-0046); WT_PARENT is resolved via the
+# worktrees_parent_dir helper. A legacy in-repo path is kept as a fallback for
+# pre-migration worktrees, mirroring bin/db-test-up.
 #
 # Prereqs: .env with REMOTE_* creds; target container already running.
 
@@ -19,6 +23,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "$REPO_ROOT/bin/lib/db-helpers.sh"
+source "$REPO_ROOT/bin/lib/git-helpers.sh"
+WT_PARENT="$(worktrees_parent_dir "$REPO_ROOT")"
 
 WORKTREE_ARG="${1:-}"
 
@@ -55,25 +61,33 @@ WORKTREE_PATH=""
 
 resolve_from_wt_name() {
     local name="$1"
-    local slug_file="$REPO_ROOT/worktrees/$name/.wt-slug"
+    local wt_path="$WT_PARENT/$name"
+    if [ ! -d "$wt_path" ]; then
+        wt_path="$REPO_ROOT/worktrees/$name"  # legacy fallback (pre-migration)
+    fi
+    local slug_file="$wt_path/.wt-slug"
     if [ ! -f "$slug_file" ]; then
         return 1
     fi
     SLUG="$(cat "$slug_file")"
-    WORKTREE_PATH="$REPO_ROOT/worktrees/$name"
+    WORKTREE_PATH="$wt_path"
 }
 
 if [ -n "$WORKTREE_ARG" ]; then
     if ! resolve_from_wt_name "$WORKTREE_ARG"; then
-        echo "Error: No worktree named '$WORKTREE_ARG' (missing $REPO_ROOT/worktrees/$WORKTREE_ARG/.wt-slug)." >&2
+        echo "Error: No worktree named '$WORKTREE_ARG' (missing $WT_PARENT/$WORKTREE_ARG/.wt-slug)." >&2
         echo "Start it first: bin/wt-up $WORKTREE_ARG" >&2
         exit 1
     fi
-elif [[ "$PWD" == "$REPO_ROOT/worktrees/"* ]]; then
-    wt_rel="${PWD#"$REPO_ROOT/worktrees/"}"
+elif [[ "$PWD" == "$WT_PARENT/"* || "$PWD" == "$REPO_ROOT/worktrees/"* ]]; then
+    if [[ "$PWD" == "$WT_PARENT/"* ]]; then
+        wt_rel="${PWD#"$WT_PARENT/"}"
+    else
+        wt_rel="${PWD#"$REPO_ROOT/worktrees/"}"  # legacy fallback (pre-migration)
+    fi
     wt_name="${wt_rel%%/*}"
     if ! resolve_from_wt_name "$wt_name"; then
-        echo "Error: CWD is in worktrees/$wt_name but .wt-slug is missing. Start it: bin/wt-up $wt_name" >&2
+        echo "Error: CWD is in worktree '$wt_name' but .wt-slug is missing. Start it: bin/wt-up $wt_name" >&2
         exit 1
     fi
 else

--- a/bin/nightly-prompt-impl
+++ b/bin/nightly-prompt-impl
@@ -120,7 +120,7 @@ First, check if a worktree already exists for this slug:
 
 ```bash
 SLUG=<slug>
-WORKTREE_DIR="/Users/ajaynicolas/GitHub/IBL5/worktrees/$SLUG"
+WORKTREE_DIR="/Users/ajaynicolas/GitHub/IBL5-worktrees/$SLUG"
 if [ -d "$WORKTREE_DIR" ]; then
     echo "RESUME: worktree exists"
 else
@@ -144,7 +144,7 @@ If bin/wt-new fails, write an error report to $NIGHTLY_DIR/reports/YYYY-MM-DD-er
 The worktree may exist from a previous interrupted run. Check its state:
 
 ```bash
-cd /Users/ajaynicolas/GitHub/IBL5/worktrees/<slug>
+cd /Users/ajaynicolas/GitHub/IBL5-worktrees/<slug>
 git log --oneline origin/master..HEAD
 ```
 
@@ -154,7 +154,7 @@ git log --oneline origin/master..HEAD
 
 ## Step 6: Implement the Plan
 
-Work in worktrees/<slug>/ibl5/. CLAUDE.md is auto-loaded — follow all project rules. Follow the plan step by step.
+Work in /Users/ajaynicolas/GitHub/IBL5-worktrees/<slug>/ibl5/. CLAUDE.md is auto-loaded — follow all project rules. Follow the plan step by step.
 
 When a plan phase carries a `### Delegate` packet, do NOT implement that phase inline: fire **one** Agent/Task call per packet at the packet's declared tier (Haiku or Sonnet), pass the packet **verbatim** as the sub-agent prompt, and absorb only the sub-agent's one-line summary. The packet is self-verifying — the sub-agent runs the packet's self-verify command before returning — and CI plus post-plan review remain the backstop. This keeps your own context flat across the run; inlining a verbose packet's tool output defeats its purpose.
 
@@ -170,7 +170,7 @@ Checkpoint after each of these (when applicable):
 5. Seed/fixture updates complete
 
 ```bash
-cd /Users/ajaynicolas/GitHub/IBL5/worktrees/<slug>
+cd /Users/ajaynicolas/GitHub/IBL5-worktrees/<slug>
 git add -A
 git commit -m "<type>: <what this checkpoint covers>"
 git push origin <slug>
@@ -183,7 +183,7 @@ If implementation requires information you do not have — external resources, u
 This is the certain, zero-cost backstop to the Step 2.6 heuristic. If implementing the plan produced **no net change** vs master, the work was already merged and the Step 2.6 title search missed it (squash-rename, title drift). Do not write a handoff for an empty branch — an empty branch must never reach the post-plan agent.
 
 ```bash
-cd /Users/ajaynicolas/GitHub/IBL5/worktrees/<slug>
+cd /Users/ajaynicolas/GitHub/IBL5-worktrees/<slug>
 git fetch origin master
 AHEAD=$(git rev-list origin/master..HEAD)
 DIRTY=$(git status --porcelain)
@@ -210,7 +210,7 @@ mkdir -p "$NIGHTLY_DIR/handoff"
 cat <<'HANDOFF_EOF' > "$NIGHTLY_DIR/handoff/<plan-filename>.json"
 {
   "slug": "<slug>",
-  "worktree": "/Users/ajaynicolas/GitHub/IBL5/worktrees/<slug>",
+  "worktree": "/Users/ajaynicolas/GitHub/IBL5-worktrees/<slug>",
   "branch": "<slug>",
   "plan_file": "<plan-filename>",
   "plan_title": "<title from the plan>",


### PR DESCRIPTION
## Summary

Updates stale in-repo worktree path references (`worktrees/<slug>`) to the canonical outside-repo location (`IBL5-worktrees/<slug>`) per ADR-0046.

### Files changed
- `.claude/rules/workflow-continuity.md` — prose path updated
- `.claude/skills/post-plan/SKILL.md` — comment in Go engine path guard updated
- `bin/db-sync-prod` — resolves worktree via `worktrees_parent_dir` helper; legacy in-repo path kept as fallback
- `bin/nightly-prompt-impl` — hardcoded prompt paths updated

## Manual Testing

No manual testing needed — all changes are covered by automated tests.