### PR TITLE
security: replace updateAllTheThings GET link with CSRF-validated POST button

### DIFF
--- a/ibl5/classes/LeagueControlPanel/LeagueControlPanelView.php
+++ b/ibl5/classes/LeagueControlPanel/LeagueControlPanelView.php
@@ -39,6 +39,10 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
 
     <form action="leagueControlPanel.php" method="POST">
         <input type="hidden" name="current_phase" value="<?= HtmlSanitizer::e($panelData['phase']) ?>">
+        <?= \Security\CsrfGuard::generateToken('lcp_update_all') ?>
+<?php if ($currentLeague !== 'ibl'): ?>
+        <input type="hidden" name="league" value="olympics">
+<?php endif; ?>
 
         <?= HtmlSanitizer::trusted($this->renderSeasonPhaseControls($currentLeague, $panelData)) ?>
         <?= HtmlSanitizer::trusted($this->renderPhaseControls($currentLeague, $panelData)) ?>
@@ -146,6 +150,17 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
         };
     }
 
+    private function renderUpdateAllButton(): string
+    {
+        ob_start();
+        ?>
+<div class="lcp-control-row">
+    <button type="submit" formaction="/ibl5/scripts/updateAllTheThings.php" formmethod="post" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Update All The Things</button>
+</div>
+        <?php
+        return (string) ob_get_clean();
+    }
+
     /**
      * @param array{phase: string, allowTrades: string, allowWaivers: string, showDraftLink: string, freeAgencyNotifications: string, triviaMode: string, simLengthInDays: int, seasonEndingYear: int, hasFinalsMvp: bool} $panelData
      */
@@ -155,12 +170,10 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
         ?>
 <section class="updater-section">
     <div class="updater-section__label">Preseason Operations</div>
-    <div class="lcp-control-row">
-        <a href="/ibl5/scripts/updateAllTheThings.php">Update All The Things</a>
-    </div>
+    <?= HtmlSanitizer::trusted($this->renderUpdateAllButton()) ?>
     <div class="lcp-note">Upload sim backup to <strong>backups/</strong> before running</div>
     <div class="lcp-control-row">
-        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" class="ibl-input ibl-input--sm w-20">
+        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
         <button type="submit" name="action" value="set_sim_length" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Set Sim Length in Days</button>
     </div>
     <div class="lcp-note">You must click the button — pressing Enter will not work</div>
@@ -193,12 +206,10 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
         ?>
 <section class="updater-section">
     <div class="updater-section__label">HEAT Operations</div>
-    <div class="lcp-control-row">
-        <a href="/ibl5/scripts/updateAllTheThings.php">Update All The Things</a>
-    </div>
+    <?= HtmlSanitizer::trusted($this->renderUpdateAllButton()) ?>
     <div class="lcp-note">Upload sim backup to <strong>backups/</strong> before running</div>
     <div class="lcp-control-row">
-        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" class="ibl-input ibl-input--sm w-20">
+        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
         <button type="submit" name="action" value="set_sim_length" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Set Sim Length in Days</button>
     </div>
     <div class="lcp-note">You must click the button — pressing Enter will not work</div>
@@ -216,12 +227,10 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
         ?>
 <section class="updater-section">
     <div class="updater-section__label">Regular Season Operations</div>
-    <div class="lcp-control-row">
-        <a href="/ibl5/scripts/updateAllTheThings.php">Update All The Things</a>
-    </div>
+    <?= HtmlSanitizer::trusted($this->renderUpdateAllButton()) ?>
     <div class="lcp-note">Upload sim backup to <strong>backups/</strong> before running</div>
     <div class="lcp-control-row">
-        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" class="ibl-input ibl-input--sm w-20">
+        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
         <button type="submit" name="action" value="set_sim_length" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Set Sim Length in Days</button>
     </div>
     <div class="lcp-note">You must click the button — pressing Enter will not work</div>
@@ -249,12 +258,10 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
         ?>
 <section class="updater-section">
     <div class="updater-section__label">Playoffs Operations</div>
-    <div class="lcp-control-row">
-        <a href="/ibl5/scripts/updateAllTheThings.php">Update All The Things</a>
-    </div>
+    <?= HtmlSanitizer::trusted($this->renderUpdateAllButton()) ?>
     <div class="lcp-note">Upload sim backup to <strong>backups/</strong> before running</div>
     <div class="lcp-control-row">
-        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" class="ibl-input ibl-input--sm w-20">
+        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
         <button type="submit" name="action" value="set_sim_length" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Set Sim Length in Days</button>
     </div>
     <div class="lcp-note">You must click the button — pressing Enter will not work</div>

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Long-running backlog of maintenance-cost reduction opportunities, organized by axis. Each item is a candidate for a future plan.
-last_verified: 2026-06-09
+last_verified: 2026-06-10
 ---
 
 # Maintenance-Cost Reduction Backlog
@@ -1291,7 +1291,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Audit auth; move to authenticated POST endpoints.
 **Est. effort:** M
 **Risk if untouched:** Unauthorized script execution; accidental data corruption.
-**Status:** Tradition half resolved (2026-06-09) — unauthenticated `scripts/tradition.php` deleted; mutation now runs only via the `is_admin()`-guarded `update_tradition` POST action in the LCP. `updateAllTheThings.php` audit still open.
+**Status:** Resolved (2026-06-09). Tradition half — unauthenticated `scripts/tradition.php` deleted; mutation now runs only via the `is_admin()`-guarded `update_tradition` POST action in the LCP. `updateAllTheThings.php` half — the unauthenticated-CSRF GET link was replaced by an `is_admin()`-guarded, CSRF-validated POST button in the LCP; the script is now POST-only (`is_admin()` 403 before the method check; `CsrfGuard::validateToken(..., 'lcp_update_all')` on the POST), so a cross-site GET can no longer fire the full-league mutation.
 
 ### 8.14 Mixed PHP Bootstrap Styles in Scripts
 **Location:** `ibl5/scripts/`

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -10,7 +10,7 @@ require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/mainfile.php';
 
 // SECURITY: Redirect logged-out users to login
 if (!function_exists('is_user') || !is_user($user ?? '')) {
-    $_SESSION['redirect_after_login_path'] = 'scripts/updateAllTheThings.php'
+    $_SESSION['redirect_after_login_path'] = 'leagueControlPanel.php'
         . (isset($_GET['league']) && $_GET['league'] === League\LeagueContext::LEAGUE_OLYMPICS ? '?league=olympics' : '');
     header('Location: ../modules.php?name=YourAccount');
     exit;
@@ -20,6 +20,21 @@ if (!function_exists('is_user') || !is_user($user ?? '')) {
 if (!is_admin()) {
     http_response_code(403);
     die('Access denied. This script requires administrator privileges.');
+}
+
+// SECURITY: This is a destructive full-league mutation — POST-only closes the
+// GET-based CSRF vector (e.g. <img src=".../updateAllTheThings.php">). A GET
+// from a stale link/bookmark bounces back to the control panel.
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: ../leagueControlPanel.php');
+    exit;
+}
+
+// SECURITY: Validate CSRF token (form name must match the LCP View's generateToken call)
+$csrfToken = isset($_POST['_csrf_token']) && is_string($_POST['_csrf_token']) ? $_POST['_csrf_token'] : '';
+if (!\Security\CsrfGuard::validateToken($csrfToken, 'lcp_update_all')) {
+    http_response_code(403);
+    die('Invalid CSRF token.');
 }
 
 // Allow up to 5 minutes for the full update (production shared hosting has 30s default)
@@ -51,8 +66,9 @@ if (!headers_sent()) {
 
 global $mysqli_db;
 
-// Determine league context from explicit URL parameter only (not cookie/session)
-$leagueParam = isset($_GET['league']) && is_string($_GET['league']) ? $_GET['league'] : null;
+// Determine league context from the explicit POST parameter only (not cookie/session);
+// the LCP's conditional `league=olympics` hidden input rides the CSRF-validated POST.
+$leagueParam = isset($_POST['league']) && is_string($_POST['league']) ? $_POST['league'] : null;
 $leagueContext = $leagueParam === League\LeagueContext::LEAGUE_OLYMPICS ? new League\LeagueContext() : null;
 $isOlympics = $leagueContext !== null;
 if ($leagueContext !== null) {
@@ -107,8 +123,8 @@ try {
     $season = new \Season\Season($mysqli_db);
 
     // Season year override for historical imports (e.g., Olympics 2003)
-    $seasonYearOverride = isset($_GET['season_year']) && is_string($_GET['season_year'])
-        ? (int) $_GET['season_year'] : null;
+    $seasonYearOverride = isset($_POST['season_year']) && is_string($_POST['season_year'])
+        ? (int) $_POST['season_year'] : null;
     if ($seasonYearOverride !== null && $seasonYearOverride > 1900 && $seasonYearOverride < 2100) {
         $season->endingYear = $seasonYearOverride;
         $season->beginningYear = $seasonYearOverride - 1;
@@ -161,8 +177,8 @@ try {
     ));
 
     if ($isOlympics) {
-        $realTeamCountParam = isset($_GET['real_team_count']) && is_string($_GET['real_team_count'])
-            ? (int) $_GET['real_team_count'] : null;
+        $realTeamCountParam = isset($_POST['real_team_count']) && is_string($_POST['real_team_count'])
+            ? (int) $_POST['real_team_count'] : null;
         $updaterService->addStep(new Updater\Steps\AutoSeedOlympicsTeamInfoStep(
             $mysqli_db, $season->endingYear, $realTeamCountParam,
         ));

--- a/ibl5/tests/JsbParser/ScoFileWriterTest.php
+++ b/ibl5/tests/JsbParser/ScoFileWriterTest.php
@@ -19,7 +19,7 @@ class ScoFileWriterTest extends TestCase
 
     private function mockDb(): \mysqli
     {
-        return $this->createMock(\mysqli::class);
+        return $this->createStub(\mysqli::class); // @phpstan-ignore staticMethod.dynamicCall
     }
 
     /** Build a minimal synthetic .sco of the correct size (all spaces). */

--- a/ibl5/tests/LeagueControlPanel/LeagueControlPanelViewTest.php
+++ b/ibl5/tests/LeagueControlPanel/LeagueControlPanelViewTest.php
@@ -92,6 +92,10 @@ class LeagueControlPanelViewTest extends TestCase
         ]);
 
         $this->assertStringContainsString('Update All The Things', $html);
+        $this->assertStringContainsString('formaction="/ibl5/scripts/updateAllTheThings.php"', $html);
+        $this->assertStringContainsString('formmethod="post"', $html);
+        // Regression lock: the unauthenticated-CSRF GET link must be gone.
+        $this->assertStringNotContainsString('href="/ibl5/scripts/updateAllTheThings.php"', $html);
         $this->assertStringContainsString('value="set_allow_waivers"', $html);
         $this->assertStringContainsString('value="set_waivers_to_free_agents"', $html);
         $this->assertStringContainsString('value="reset_contract_extensions"', $html);
@@ -371,7 +375,51 @@ class LeagueControlPanelViewTest extends TestCase
         $this->assertStringNotContainsString('value="set_waivers_to_free_agents"', $html);
         $this->assertStringNotContainsString('value="reset_contract_extensions"', $html);
         $this->assertStringNotContainsString('value="reset_mles_lles"', $html);
-        $this->assertStringContainsString('updateAllTheThings', $html);
+        $this->assertStringContainsString('formaction="/ibl5/scripts/updateAllTheThings.php"', $html);
+        $this->assertStringContainsString('formmethod="post"', $html);
+        $this->assertStringNotContainsString('href="/ibl5/scripts/updateAllTheThings.php"', $html);
+    }
+
+    public function testRenderContainsCsrfTokenInPanelForm(): void
+    {
+        $html = $this->renderWithDefaults();
+
+        $this->assertStringContainsString('name="_csrf_token"', $html);
+    }
+
+    public function testOlympicsRenderContainsLeagueHiddenInput(): void
+    {
+        $html = $this->renderWithDefaults([
+            'currentLeague' => 'olympics',
+            'panelData' => self::createPanelData(['phase' => 'Regular Season']),
+        ]);
+
+        $this->assertStringContainsString('name="league"', $html);
+        $this->assertStringContainsString('value="olympics"', $html);
+    }
+
+    public function testIblRenderOmitsLeagueHiddenInput(): void
+    {
+        $html = $this->renderWithDefaults(['currentLeague' => 'ibl']);
+
+        $this->assertStringNotContainsString('name="league"', $html);
+    }
+
+    public function testSimLengthInputSuppressesEnterSubmit(): void
+    {
+        // On the Olympics panel there is no "Set Season Phase" button, so the
+        // destructive "Update All The Things" submit would otherwise be the form's
+        // implicit default — Enter in the sim-length field could fire the full
+        // updater. The number input must suppress Enter to block that.
+        $html = $this->renderWithDefaults([
+            'currentLeague' => 'olympics',
+            'panelData' => self::createPanelData(['phase' => 'Preseason']),
+        ]);
+
+        $this->assertMatchesRegularExpression(
+            '/name="SimLengthInDays"[^>]*onkeydown="if\(event\.key===\'Enter\'\)event\.preventDefault\(\)"/',
+            $html,
+        );
     }
 
     public function testRenderContainsHiddenCurrentPhase(): void

--- a/ibl5/tests/e2e/flows/engine-shadow-spawn-on-update.spec.ts
+++ b/ibl5/tests/e2e/flows/engine-shadow-spawn-on-update.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures/auth';
 import type { APIRequestContext } from '@playwright/test';
+import { triggerUpdater } from '../helpers/updater';
 
 /**
  * Engine shadow sim runs OUT-OF-BAND (ADR-0037): hitting the admin
@@ -36,7 +37,6 @@ async function countShadowRows(request: APIRequestContext): Promise<ShadowCounts
 
 test.describe('Engine shadow: out-of-band spawn on admin update', () => {
   test('hitting updateAllTheThings spawns the detached run and shadow rows land', async ({
-    page,
     request,
   }) => {
     // Skip fast when the engine binary is not installed in this image.
@@ -48,10 +48,13 @@ test.describe('Engine shadow: out-of-band spawn on admin update', () => {
 
     const before = await countShadowRows(request);
 
-    // Trigger the admin update — runs the pipeline on GET and fires the detached
-    // shadow spawn (ENGINE_SHADOW_ENABLED=1 on the CI php service).
-    const response = await page.goto('scripts/updateAllTheThings.php');
-    expect(response?.status()).toBe(200);
+    // Trigger the admin update via a CSRF-validated POST (token fetched from the
+    // LCP form, which renders it at any phase) and fire the detached shadow spawn
+    // (ENGINE_SHADOW_ENABLED=1 on the CI php service). We POST rather than click
+    // the phase-gated button so this spec never mutates the shared season-phase
+    // row — updater-awards.spec.ts stays its sole writer. The POST resolves only
+    // after the streamed pipeline completes, replacing the old GET status check.
+    await triggerUpdater(request);
 
     // Poll for asynchronously-written shadow rows (the run is fire-and-forget).
     const deadline = Date.now() + 60_000;

--- a/ibl5/tests/e2e/helpers/updater.ts
+++ b/ibl5/tests/e2e/helpers/updater.ts
@@ -1,0 +1,75 @@
+import type { Page, APIRequestContext } from '@playwright/test';
+
+/**
+ * Trigger the full-season updater the way an admin does: by clicking the League
+ * Control Panel's CSRF-tokened POST button (formaction → updateAllTheThings.php).
+ *
+ * The script is now POST-only + CSRF-validated, so a bare `page.goto()` GET no
+ * longer runs the pipeline. The button is also phase-gated — it only renders in
+ * Preseason / HEAT / Regular Season / Playoffs. Callers MUST set a button-rendering
+ * phase (Regular Season is safe for both leagues) via setState BEFORE calling,
+ * because the CI seed default phase (IBL = Free Agency) renders no button. The LCP
+ * reads the phase from the DB directly, so the cookie-based appState fixture does
+ * NOT affect button rendering — use DB-level setState.
+ *
+ * The script streams progressive HTML (flush() after each step), so we wait for the
+ * full `load` event before returning.
+ */
+export async function runUpdater(
+  page: Page,
+  options: { league?: 'ibl' | 'olympics' } = {},
+): Promise<void> {
+  const path =
+    options.league === 'olympics'
+      ? 'leagueControlPanel.php?league=olympics'
+      : 'leagueControlPanel.php';
+  await page.goto(path);
+  await Promise.all([
+    page.waitForLoadState('load'),
+    page.getByRole('button', { name: 'Update All The Things' }).click(),
+  ]);
+}
+
+/**
+ * Trigger the updater via a CSRF-validated POST WITHOUT mutating the season phase.
+ *
+ * Use this when a test only needs the pipeline to fire (not a phase-dependent
+ * outcome). The LCP renders the `_csrf_token` in its form unconditionally — at
+ * ANY phase — so this fetches the token from the LCP and POSTs it directly to the
+ * script. That avoids the DB-level `setState('Current Season Phase')` that the
+ * click path requires (the button is phase-gated), keeping `updater-awards` the
+ * sole writer of the shared phase row and avoiding a cross-worker race under
+ * Playwright's parallel execution (cf. PR #884/#886 shared-table flakes).
+ *
+ * Returns the streamed response body text for assertion.
+ */
+export async function triggerUpdater(
+  request: APIRequestContext,
+  options: { league?: 'ibl' | 'olympics' } = {},
+): Promise<string> {
+  const lcpPath =
+    options.league === 'olympics'
+      ? 'leagueControlPanel.php?league=olympics'
+      : 'leagueControlPanel.php';
+
+  const lcpResp = await request.get(lcpPath);
+  if (!lcpResp.ok()) {
+    throw new Error(`LCP GET failed: ${lcpResp.status()} ${await lcpResp.text()}`);
+  }
+  const html = await lcpResp.text();
+  const match = html.match(/name="_csrf_token" value="([0-9a-f]+)"/);
+  if (match === null) {
+    throw new Error('No _csrf_token found in the League Control Panel form');
+  }
+
+  const form: Record<string, string> = { _csrf_token: match[1] };
+  if (options.league === 'olympics') {
+    form.league = 'olympics';
+  }
+
+  const resp = await request.post('scripts/updateAllTheThings.php', { form });
+  if (!resp.ok()) {
+    throw new Error(`updateAllTheThings POST failed: ${resp.status()} ${await resp.text()}`);
+  }
+  return resp.text();
+}

--- a/ibl5/tests/e2e/smoke/admin-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/admin-pages.spec.ts
@@ -1,35 +1,36 @@
 import { test, expect } from '../fixtures/auth';
-import { assertNoPhpErrors } from '../helpers/php-errors';
+import { assertNoPhpErrors, PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { triggerUpdater } from '../helpers/updater';
 
 // Admin-only page smoke tests — require roles_mask = 1 (ADMIN) on the test user.
 
 test.describe('Admin page smoke tests', () => {
-  test('updateAllTheThings page loads for admin', async ({ page }) => {
-    const response = await page.goto('scripts/updateAllTheThings.php', {
-      timeout: 60_000,
-    });
-    const status = response?.status() ?? 0;
+  // The updater is now POST-only + CSRF-validated. These tests only need the
+  // pipeline to fire (not a phase-dependent outcome), so they trigger it via a
+  // CSRF-token POST (token renders in the LCP form at any phase) rather than
+  // clicking the phase-gated button — that avoids mutating the shared season-phase
+  // row, leaving updater-awards.spec.ts the sole writer (no cross-worker race).
+  // The genuine button click→POST→pipeline path is covered by olympics-admin.spec.ts.
+  test('updateAllTheThings pipeline runs for admin (CSRF POST)', async ({ request }) => {
+    const body = await triggerUpdater(request);
 
-    expect(status, 'Test user must have admin privileges — ensure roles_mask=1').not.toBe(403);
-    await assertNoPhpErrors(page, 'on scripts/updateAllTheThings.php');
-
-    // The page renders an Initialization section on success
-    await expect(page.getByText('Initialization')).toBeVisible();
+    for (const pattern of PHP_ERROR_PATTERNS) {
+      expect(body, `PHP error "${pattern}" in updater output`).not.toContain(pattern);
+    }
+    // The page renders an Initialization section and a completion summary.
+    expect(body).toContain('Initialization');
+    expect(body).toMatch(/\d+\s+(steps?\s+completed|succeeded)/i);
   });
 
-  test('updateAllTheThings pipeline renders summary', async ({ page }) => {
-    const response = await page.goto('scripts/updateAllTheThings.php', {
-      timeout: 60_000,
-    });
-    const status = response?.status() ?? 0;
+  test('admin GET to updateAllTheThings redirects to LCP without running pipeline', async ({
+    page,
+  }) => {
+    // Security proof: the CSRF fix makes a GET inert — it 302s back to the LCP
+    // (where the real tokened POST button lives) instead of mutating the league.
+    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
 
-    expect(status, 'Test user must have admin privileges — ensure roles_mask=1').not.toBe(403);
-    await assertNoPhpErrors(page, 'on scripts/updateAllTheThings.php');
-
-    // Pipeline renders a summary: "X steps completed" or "X succeeded"
-    await expect(
-      page.getByText(/\d+\s+(steps?\s+completed|succeeded)/i),
-    ).toBeVisible({ timeout: 60_000 });
+    await expect(page).toHaveURL(/leagueControlPanel\.php/);
+    await expect(page.getByText('Initialization')).not.toBeVisible();
   });
 
   test('block.php loads for admin', async ({ page }) => {

--- a/ibl5/tests/e2e/smoke/olympics-admin.spec.ts
+++ b/ibl5/tests/e2e/smoke/olympics-admin.spec.ts
@@ -1,10 +1,15 @@
 import { test, expect } from '../fixtures/auth';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { runUpdater } from '../helpers/updater';
 
 // Olympics admin page — verify pipeline loads in Olympics context.
 test.describe('Olympics admin smoke tests', () => {
-  test('updateAllTheThings loads in Olympics context', async ({ page }) => {
-    await page.goto('scripts/updateAllTheThings.php?league=olympics');
+  test('updateAllTheThings runs in Olympics context via LCP button', async ({ page }) => {
+    // The Olympics LCP carries a `league=olympics` hidden input, so clicking the
+    // CSRF-tokened "Update All The Things" button POSTs the Olympics context to
+    // the script. The Olympics seed phase (Preseason) renders the button, so no
+    // phase mutation is needed.
+    await runUpdater(page, { league: 'olympics' });
     await expect(page.locator('body')).toContainText('Olympics');
     await assertNoPhpErrors(page, 'on Olympics pipeline');
   });

--- a/ibl5/tests/e2e/smoke/updater-awards.spec.ts
+++ b/ibl5/tests/e2e/smoke/updater-awards.spec.ts
@@ -6,17 +6,25 @@ import {
   setChampion,
   setAward,
 } from '../helpers/test-state';
+import { runUpdater } from '../helpers/updater';
 
 // E2E tests for the updater awards steps:
 //   - GenerateSeasonAwardsStep (Season awards card)
 //   - EndOfSeasonImportStep Finals MVP card
 //
+// The updater is now POST-only + CSRF-validated: it runs when the admin clicks
+// the LCP "Update All The Things" button (carrying a valid token). runUpdater()
+// navigates to the LCP and clicks that button. The button is phase-gated, so
+// every test sets a button-rendering phase (Regular Season or Playoffs) via
+// DB-level setState before triggering — the CI seed phase ('Free Agency')
+// renders no button.
+//
 // The updater script queries ibl_settings via $lcpRepo->getSetting()
-// (direct DB read), so cookie-based appState overrides don't work here.
-// All state mutations use setState() (DB-level) with afterEach cleanup.
+// (direct DB read), so cookie-based appState overrides don't work here — and
+// the LCP reads the phase the same way, so setState (DB-level) is required.
 //
 // The CI seed has:
-//   - Phase = 'Free Agency' (non-Playoffs), so the Playoffs skip is the default
+//   - Phase = 'Free Agency' (non-Playoffs, renders no Update-All button)
 //   - No ibl_jsb_history rows with won_championship=1 for year 2026,
 //     so EndOfSeasonImportStep is skipped ("No champion determined yet")
 //   - No Leaders.htm at $basePath/Leaders.htm, so the Generate button
@@ -41,9 +49,12 @@ test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
 
   test('phase not Playoffs: shows "Only available during Playoffs phase"', async ({
     page,
+    request,
   }) => {
-    // Seed default is 'Regular Season' — no setup needed
-    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+    // Regular Season is a non-Playoffs phase that still renders the Update-All
+    // button, so the "Only available during Playoffs phase" skip holds.
+    await setState(request, { 'Current Season Phase': 'Regular Season' });
+    await runUpdater(page);
 
     await expect(
       page.getByText('Only available during Playoffs phase'),
@@ -56,7 +67,7 @@ test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
   }) => {
     await setState(request, { 'Current Season Phase': 'Playoffs' });
     await setEoyVotes(request, 15);
-    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+    await runUpdater(page);
 
     await expect(
       page.getByText(/Voting not yet complete/),
@@ -72,7 +83,7 @@ test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
     // of the Generate button.
     await setState(request, { 'Current Season Phase': 'Playoffs' });
     await setEoyVotes(request, 21);
-    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+    await runUpdater(page);
 
     await expect(
       page.getByText('Leaders.htm not found'),
@@ -86,7 +97,7 @@ test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
     await setState(request, { 'Current Season Phase': 'Playoffs' });
     await setEoyVotes(request, 21);
     await setLeadersHtm(request, true);
-    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+    await runUpdater(page);
 
     const card = page.locator('.ibl-card', { hasText: 'Season Awards' });
     await expect(card).toBeVisible({ timeout: 60_000 });
@@ -100,8 +111,11 @@ test.describe('Updater awards — GenerateSeasonAwardsStep', () => {
     page,
     request,
   }) => {
+    // The already-generated short-circuit fires before the phase gate, so the
+    // message holds at any phase; Regular Season just renders the trigger button.
+    await setState(request, { 'Current Season Phase': 'Regular Season' });
     await setAward(request, SEASON_YEAR, 'Most Valuable Player (1st)', true);
-    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+    await runUpdater(page);
 
     await expect(
       page.getByText(`Season awards already generated for ${SEASON_YEAR}`),
@@ -123,7 +137,7 @@ test.describe('Updater awards — EndOfSeasonImportStep', () => {
     // CI seed has no won_championship=1 row for season year 2026, so
     // EndOfSeasonImportStep returns skipped and "IBL Finals MVP" is never rendered.
     await setState(request, { 'Current Season Phase': 'Playoffs' });
-    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+    await runUpdater(page);
 
     // Anchor: confirm the pipeline ran to completion before checking negative
     await expect(
@@ -139,7 +153,7 @@ test.describe('Updater awards — EndOfSeasonImportStep', () => {
   }) => {
     await setState(request, { 'Current Season Phase': 'Playoffs' });
     await setChampion(request, SEASON_YEAR, true);
-    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+    await runUpdater(page);
 
     const card = page.locator('.ibl-card', { hasText: 'IBL Finals MVP' });
     await expect(card).toBeVisible({ timeout: 60_000 });
@@ -158,7 +172,7 @@ test.describe('Updater awards — EndOfSeasonImportStep', () => {
     await setState(request, { 'Current Season Phase': 'Playoffs' });
     await setChampion(request, SEASON_YEAR, true);
     await setAward(request, SEASON_YEAR, 'IBL Finals MVP', true);
-    await page.goto('scripts/updateAllTheThings.php', { timeout: 60_000 });
+    await runUpdater(page);
 
     const card = page.locator('.ibl-card', { hasText: 'IBL Finals MVP' });
     await expect(card).toBeVisible({ timeout: 60_000 });


### PR DESCRIPTION
## Summary

Closes the unauthenticated-CSRF GET vector on `updateAllTheThings.php` (maintenance-backlog §8.13).

**Before:** The LCP rendered an `<a href="/ibl5/scripts/updateAllTheThings.php">` link. A cross-site GET (img tag, prefetch, bookmarked link by a non-admin admin-impersonator) could trigger the full-league mutation. The script also accepted `league`, `season_year`, and `real_team_count` from `$_GET`.

**After:**
- LCP renders a `<button formaction=".../updateAllTheThings.php" formmethod="post">` inside the existing outer form, which already carries `CsrfGuard::generateToken('lcp_update_all')`.
- The Olympics panel gets a `<input type="hidden" name="league" value="olympics">` (IBL panel omits it).
- The `SimLengthInDays` number input gains `onkeydown="if(event.key==='Enter')event.preventDefault()"` — on the Olympics Preseason/HEAT panels there is no Set Season Phase button, making the Update All The Things button the form's implicit submit default; Enter in that field would have fired the 5-min pipeline.
- `updateAllTheThings.php`: POST-only (GET → 302 to LCP, admin check fires first so non-admin GET → 403 before the method redirect); `CsrfGuard::validateToken($_POST['_csrf_token'], 'lcp_update_all')` on the POST; all three params read from `$_POST`.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---

Generated with [Claude Code](https://claude.ai/code)
<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>