### PR TITLE
fix: stabilise flaky E2E tests — trade CSRF overflow + LCP serial + schedule-contrast retry

### DIFF
--- a/ibl5/classes/Trading/TradingView.php
+++ b/ibl5/classes/Trading/TradingView.php
@@ -238,7 +238,17 @@ $tradeConfig = [
 </div>
 <div class="trading-review-wrapper">
     <div class="trading-review-offers">
-<?php if ($tradeOffers !== []): ?>
+<?php if ($tradeOffers !== []):
+    // One CSRF token per action shared by every offer card's accept/reject form
+    // on this render. Generating a token per card overflowed CsrfGuard's
+    // per-action MAX_TOKENS=10 cap once many offers accumulated (or concurrent
+    // renders piled onto the shared E2E session), evicting the oldest card's
+    // token before it could be submitted ("Invalid or expired form submission").
+    // Sharing keeps token usage flat regardless of offer count; tokens are
+    // single-use and each action PRG-reloads to mint a fresh pair.
+    $acceptToken = \Security\CsrfGuard::generateRawToken('trade_accept');
+    $rejectToken = \Security\CsrfGuard::generateRawToken('trade_reject');
+?>
     <?php foreach ($tradeOffers as $offerId => $offer):
         $preview = $offer['previewData'];
         $reviewConfigs[(int) $offerId] = [
@@ -259,7 +269,7 @@ $tradeConfig = [
             'userTeamId' => $userTeamId,
         ];
     ?>
-        <?= HtmlSanitizer::trusted($this->renderTradeOfferCard((int) $offerId, $offer, $userTeam, $userTeamId)) ?>
+        <?= HtmlSanitizer::trusted($this->renderTradeOfferCard((int) $offerId, $offer, $userTeam, $userTeamId, $acceptToken, $rejectToken)) ?>
     <?php endforeach; ?>
 <?php endif; ?>
     </div>
@@ -498,8 +508,10 @@ $tradeConfig = [
      * Render a single trade offer card with items, action buttons, and preview panel
      *
      * @param array{from: string, to: string, approval: string, oppositeTeam: string, hasHammer: bool, items: list<array{type: string, description: string, notes: string|null, from: string, to: string}>, previewData: array{fromPids: list<int>, toPids: list<int>, fromTeamId: int, toTeamId: int, fromColor1: string, toColor1: string, fromCash: array<int, int>, toCash: array<int, int>, cashStartYear: int, cashEndYear: int, seasonEndingYear: int}} $offer
+     * @param string $acceptToken Shared per-render CSRF token for the accept form (see renderReview)
+     * @param string $rejectToken Shared per-render CSRF token for the reject form (see renderReview)
      */
-    private function renderTradeOfferCard(int $offerId, array $offer, string $userTeam, int $userTeamId): string
+    private function renderTradeOfferCard(int $offerId, array $offer, string $userTeam, int $userTeamId, string $acceptToken, string $rejectToken): string
     {
         $oppositeTeam = HtmlSanitizer::safeHtmlOutput($offer['oppositeTeam']);
 
@@ -512,7 +524,7 @@ $tradeConfig = [
     <div class="trade-offer-card__actions">
 <?php if ($offer['hasHammer']): ?>
         <form name="tradeaccept" method="post" action="/ibl5/modules/Trading/accepttradeoffer.php" class="trade-offer-card__form">
-            <?= \Security\CsrfGuard::generateToken('trade_accept') ?>
+            <input type="hidden" name="_csrf_token" value="<?= HtmlSanitizer::e($acceptToken) ?>">
             <input type="hidden" name="offer" value="<?= HtmlSanitizer::e($offerId) ?>">
             <button type="submit" class="ibl-btn ibl-btn--success">Accept</button>
         </form>
@@ -520,7 +532,7 @@ $tradeConfig = [
         <span class="trade-offer-card__awaiting">Awaiting Approval</span>
 <?php endif; ?>
         <form name="tradereject" method="post" action="/ibl5/modules/Trading/rejecttradeoffer.php" class="trade-offer-card__form">
-            <?= \Security\CsrfGuard::generateToken('trade_reject') ?>
+            <input type="hidden" name="_csrf_token" value="<?= HtmlSanitizer::e($rejectToken) ?>">
             <input type="hidden" name="offer" value="<?= HtmlSanitizer::e($offerId) ?>">
             <input type="hidden" name="teamRejecting" value="<?= HtmlSanitizer::trusted($userTeam) ?>">
             <input type="hidden" name="teamReceiving" value="<?= HtmlSanitizer::trusted($oppositeTeam) ?>">

--- a/ibl5/tests/e2e/flows/league-control-panel.spec.ts
+++ b/ibl5/tests/e2e/flows/league-control-panel.spec.ts
@@ -13,6 +13,18 @@ import { setAward } from '../helpers/test-state';
 
 const SEASON_YEAR = 2026; // CI seed 'Current Season Ending Year'
 
+// File-level serial: every describe below submits the LCP "Set Season Phase"
+// form, which writes the GLOBAL `Current Season Phase` DB row (the LCP reads
+// phase from the DB, not a per-request cookie override). Under fullyParallel the
+// three describes land on different workers and stomp each other's phase — e.g.
+// "Update Tradition" sets Free Agency while "Generate Season Awards" expects
+// Playoffs, surfacing "Season awards can only be generated during Playoffs or
+// Draft phase." instead of the asserted Leaders.htm error. Serializing the whole
+// file pins them to one worker so the phase row is single-owner within this spec.
+// (The remaining cross-file race with updater-awards.spec.ts — also a DB-phase
+// mutator — needs the dedicated non-sharded updater job tracked in #910.)
+test.describe.configure({ mode: 'serial' });
+
 test.describe('LeagueControlPanel — Finals MVP flow', () => {
   test.describe.configure({ mode: 'serial' });
 

--- a/ibl5/tests/e2e/smoke/schedule-contrast.spec.ts
+++ b/ibl5/tests/e2e/smoke/schedule-contrast.spec.ts
@@ -1,12 +1,22 @@
 import { test, expect } from '../fixtures/public';
 import { assertNoA11yViolations } from '../helpers/accessibility';
+import { gotoWithRetry } from '../helpers/navigation';
+
+// NOTE: the historically-reported flake here could not be reproduced or traced
+// (the failing CI artifacts had expired and the test passed in every surviving
+// run). The hardening below is deliberately NON-MASKING: gotoWithRetry plus an
+// explicit `.schedule-container` visibility gate before axe only make a
+// blank/partial-render page fail louder — they cannot turn a real color-contrast
+// violation into a silent pass. If it still flakes, capture the trace before
+// touching the axe assertion itself.
 
 const PHP_ERROR_STRINGS = ['Fatal error', 'Warning:', 'Parse error', 'Uncaught', 'Stack trace:'];
 
 test.describe('Schedule color-contrast (issue #908)', () => {
   test('default phase — no color-contrast violations in .schedule-container', async ({ page, appState }) => {
     await appState({ 'Trivia Mode': 'Off', 'Current Season Ending Year': '2026' });
-    await page.goto('modules.php?name=Schedule');
+    await gotoWithRetry(page, 'modules.php?name=Schedule');
+    await expect(page.locator('.schedule-container')).toBeVisible();
     await assertNoA11yViolations(page, 'on Schedule (.schedule-container, color-contrast)', {
       include: '.schedule-container',
       onlyRules: ['color-contrast'],
@@ -15,7 +25,8 @@ test.describe('Schedule color-contrast (issue #908)', () => {
 
   test('playoff phase — no color-contrast violations in .schedule-container', async ({ page, appState }) => {
     await appState({ 'Trivia Mode': 'Off', 'Current Season Phase': 'Playoffs', 'Current Season Ending Year': '2026' });
-    await page.goto('modules.php?name=Schedule');
+    await gotoWithRetry(page, 'modules.php?name=Schedule');
+    await expect(page.locator('.schedule-container')).toBeVisible();
     await assertNoA11yViolations(page, 'on Schedule (.schedule-container, color-contrast) — playoffs header', {
       include: '.schedule-container',
       onlyRules: ['color-contrast'],


### PR DESCRIPTION
## Summary

Three independent flake sources addressed:

### 1. Trade LCP — CSRF token overflow (CsrfGuard MAX_TOKENS=10)

`TradingView::renderReview` was calling `CsrfGuard::generateToken()` inside `foreach ($tradeOffers)`, minting a fresh accept *and* reject token per offer card. With many open offers — or concurrent E2E workers rendering the page in the same session — this exceeded the per-action cap of 10, evicting the oldest card's token before it could be submitted, producing "Invalid or expired form submission".

**Fix:** generate one token per action at the top of the `if ($tradeOffers !== [])` block and pass them into `renderTradeOfferCard()`. Token count is now flat regardless of offer count.

### 2. league-control-panel.spec.ts — DB phase stomping

The three `test.describe` blocks all submit the LCP "Set Season Phase" form, writing the global `Current Season Phase` DB row. Under `fullyParallel`, they land on different workers and stomp each other's phase (e.g. "Update Tradition" sets Free Agency while "Generate Season Awards" expects Playoffs). Added `test.describe.configure({ mode: 'serial' })` at file level to pin all describes to one worker.

### 3. schedule-contrast.spec.ts — blank/partial-render hardening

Replaced bare `page.goto` with `gotoWithRetry` and added an explicit `.schedule-container` visibility assertion before axe scans. This makes a blank/partial render fail loudly (timeout on the visibility check) rather than silently passing an empty axe run.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-refactor-tests: renderTradeOfferCard is a private method with a single call site updated in the same diff; renderTradeReview public API is covered by existing TradingViewTest -->
