### PR TITLE
e2e: isolate destructive mutator specs into dedicated non-sharded CI job (#910)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -355,6 +355,7 @@ jobs:
             -e "HOME=/tmp" \
             mcr.microsoft.com/playwright:v1.60.0-jammy \
             npx playwright test \
+              --project=chromium \
               --shard=${{ matrix.shard-index }}/${{ matrix.total-shards }} \
               --reporter=blob
 
@@ -371,6 +372,108 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-results-shard-${{ matrix.shard-index }}
+          path: ibl5/test-results/
+          retention-days: 1
+
+      - name: Dump PHP error log
+        if: failure()
+        run: |
+          echo "=== PHP error log ==="
+          docker compose -f docker-compose.ci.yml exec -T php cat /tmp/php_errors.log 2>/dev/null || echo "(no php_errors.log)"
+          echo ""
+          echo "=== Application log (last 30 lines) ==="
+          docker compose -f docker-compose.ci.yml exec -T php sh -c 'tail -30 /var/www/html/ibl5/logs/*.log 2>/dev/null' || echo "(no app logs)"
+
+      - name: Stop Docker containers
+        if: always()
+        run: docker compose -f docker-compose.ci.yml down
+
+  e2e-mutators:
+    name: E2E Mutators (non-sharded, dedicated DB)
+    needs: [changes]
+    if: needs.changes.outputs.src == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      # --- Dependency Caching ---
+      - name: Cache vendor directory
+        uses: actions/cache@v5
+        with:
+          path: ibl5/vendor
+          key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-vendor-
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: ibl5/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install JS dependencies
+        working-directory: ibl5
+        run: bun install
+
+      - name: Install Composer dependencies
+        working-directory: ibl5
+        run: composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
+
+      # --- Docker E2E Setup (fresh, dedicated DB for this job) ---
+      - uses: ./.github/actions/setup-docker-e2e
+        with:
+          build-css: 'true'
+          with-playwright: 'true'
+          test-user: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
+          test-pass: ${{ secrets.IBL_TEST_PASS || 'ci-e2e-pass-not-secret' }}
+          test-user-regular: ${{ secrets.IBL_TEST_USER_REGULAR || 'ci-e2e-regular' }}
+          test-pass-regular: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
+
+      # --- Run the destructive mutator specs, serially, against this job's own DB ---
+      - name: Run E2E mutator tests
+        env:
+          IBL_TEST_USER: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
+          IBL_TEST_PASS: ${{ secrets.IBL_TEST_PASS || 'ci-e2e-pass-not-secret' }}
+          IBL_TEST_USER_REGULAR: ${{ secrets.IBL_TEST_USER_REGULAR || 'ci-e2e-regular' }}
+          IBL_TEST_PASS_REGULAR: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
+        run: |
+          docker run --rm \
+            --network ibl5-e2e \
+            --user "$(id -u):$(id -g)" \
+            -v "${{ github.workspace }}/ibl5:/ibl5" \
+            -w /ibl5 \
+            -e "BASE_URL=http://php/ibl5/" \
+            -e "IBL_TEST_USER=$IBL_TEST_USER" \
+            -e "IBL_TEST_PASS=$IBL_TEST_PASS" \
+            -e "IBL_TEST_USER_REGULAR=$IBL_TEST_USER_REGULAR" \
+            -e "IBL_TEST_PASS_REGULAR=$IBL_TEST_PASS_REGULAR" \
+            -e "HOME=/tmp" \
+            mcr.microsoft.com/playwright:v1.60.0-jammy \
+            npx playwright test \
+              --project=mutators \
+              --workers=1 \
+              --reporter=blob
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: blob-report-mutators
+          path: ibl5/blob-report/
+          retention-days: 1
+
+      - name: Upload mutator test results
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-mutators
           path: ibl5/test-results/
           retention-days: 1
 
@@ -539,7 +642,7 @@ jobs:
 
   merge-reports:
     name: Merge E2E Reports
-    needs: [changes, e2e, e2e-shards, api-e2e, ibl6-visual, ibl6-e2e]
+    needs: [changes, e2e, e2e-shards, e2e-mutators, api-e2e, ibl6-visual, ibl6-e2e]
     if: always() && needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -631,7 +734,7 @@ jobs:
   gate:
     name: E2E Tests
     if: always()
-    needs: [changes, e2e, api-e2e, e2e-shards, ibl6-visual, ibl6-e2e]
+    needs: [changes, e2e, api-e2e, e2e-shards, e2e-mutators, ibl6-visual, ibl6-e2e]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1

--- a/ibl5/docs/decisions/0052-non-sharded-mutator-isolation-job.md
+++ b/ibl5/docs/decisions/0052-non-sharded-mutator-isolation-job.md
@@ -1,0 +1,42 @@
+---
+description: Isolate destructive global-state E2E specs into a dedicated non-sharded Playwright project and CI job to prevent cross-shard reader/mutator collisions.
+last_verified: 2026-06-09
+---
+
+# ADR-0052: Non-sharded mutator isolation job for destructive global-state E2E specs
+
+**Status:** Accepted
+**Date:** 2026-06-09
+
+## Context
+
+Two E2E specs — `ibl5/tests/e2e/smoke/updater-awards.spec.ts` and `ibl5/tests/e2e/flows/league-control-panel.spec.ts` — drive the full-season updater and mutate **global** DB rows (schedules, standings, sims, awards, season phase) that every other spec treats as read-only. In CI these specs pass only because the four shards each run against an isolated DB and the two files happen to land on different shards — a latent reshuffle-race identical to the #884/#886 class documented in ADR-0033. A single-DB local full-suite run reproducibly collides: a reader shard sees an in-flight mutator's torn state and fails. The fix must partition the test graph at the job level so the mutators never share a DB with the readers.
+
+## Decision
+
+Add a dedicated Playwright project named `mutators` in `ibl5/playwright.config.ts` whose `testMatch` captures exactly those two spec files. Exclude both files from the `chromium` project's `testIgnore` so the sharded run is strictly reader-only. Add a CI job `e2e-mutators` in `.github/workflows/e2e-tests.yml` that runs `--project=mutators --workers=1` with its own fresh Docker DB (via the existing `.github/actions/setup-docker-e2e` composite action). Wire `e2e-mutators` into both `gate.needs` and `merge-reports.needs` so a red mutators job blocks merge and its blob artifact is included in the merged HTML report. All future destructive global-state specs must be added to the `mutators` project, not `chromium`.
+
+## Alternatives Considered
+
+- **Config project ordering / `fullyParallel: false`** — orders tests only within a single file; does not prevent cross-shard co-location of a reader and a mutator. Rejected.
+- **Mutators-as-`dependency` of chromium** — Playwright runs dependency projects before dependents, which would rewrite the seeded DB that the readers consume before they run. Rejected.
+- **chromium-as-`dependency` of mutators** — Playwright would rerun the entire ~1 000-test chromium project as a prerequisite on every shard before running the mutators, multiplying wall-clock time 4×. Rejected.
+- **Per-spec `test.describe.serial` annotations only** — serialises tests within one file but does not prevent the sharded runner from co-locating a reader shard with a mutator shard on a shared DB. Rejected.
+
+## Consequences
+
+- Positive: the sharded `chromium` run is strictly reader-only; reshuffle no longer risks a reader/mutator collision.
+- Positive: the mutators run serially (`--workers=1`) in one job against a fresh DB, mirroring the isolation contract that applies to all global-state specs.
+- Positive: a red mutators job blocks merge via `gate.needs`; its results appear in the merged HTML report via `merge-reports.needs`.
+- Negative: one additional CI job per PR (~one updater run's wall-clock time, not 9× across shards).
+- Negative: a bare local `bin/e2e-wt.sh` (no `--project`) still runs both projects against one DB and will collide; developers must use the two-run protocol (chromium-only on fresh seed, then mutators-only on fresh seed) to reproduce CI conditions locally.
+
+## References
+
+- `ibl5/playwright.config.ts` — `mutators` project definition; `chromium` `testIgnore` extension.
+- `.github/workflows/e2e-tests.yml` — `e2e-mutators` job; `gate.needs` and `merge-reports.needs` wiring; `--project=chromium` pin on the shard run.
+- `ibl5/tests/e2e/smoke/updater-awards.spec.ts` — mutator spec (destructive updater runs).
+- `ibl5/tests/e2e/flows/league-control-panel.spec.ts` — mutator spec (Finals MVP insert + season-phase flip).
+- `bin/e2e-wt.sh` — local full-suite runner; runs all projects against one DB unless `--project` is passed.
+- `ibl5/docs/decisions/0033-non-destructive-sibling-test-database.md` — DB-level sibling isolation for PHPUnit (the #884/#886 reshuffle-race precedent; different layer from this ADR).
+- `ibl5/docs/decisions/0043-empty-fga-source-isolation.md` — engine-instrument isolation (related by name only; different constraint).

--- a/ibl5/playwright.config.ts
+++ b/ibl5/playwright.config.ts
@@ -58,7 +58,21 @@ export default defineConfig({
         storageState: 'playwright/.auth/user.json',
       },
       dependencies: ['setup'],
-      testIgnore: [/auth\.setup\.ts/, /auth-regular\.setup\.ts/, /visual-regression/],
+      testIgnore: [/auth\.setup\.ts/, /auth-regular\.setup\.ts/, /visual-regression/, /updater-awards\.spec\.ts$/, /league-control-panel\.spec\.ts$/],
+    },
+    {
+      // Destructive full-season updater specs mutate GLOBAL DB rows (schedules,
+      // standings, sims, awards, season phase) that other specs read. Isolated
+      // into their own project so CI can run them in a dedicated, NON-sharded
+      // job against a fresh DB — see ADR-0052. They are excluded from chromium's
+      // testIgnore above so the sharded run never touches them.
+      name: 'mutators',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+      testMatch: [/updater-awards\.spec\.ts$/, /league-control-panel\.spec\.ts$/],
     },
   ],
 });


### PR DESCRIPTION
## Summary

Two E2E specs — `updater-awards.spec.ts` and `league-control-panel.spec.ts` — mutate global DB state (schedules, standings, sims, awards, season phase) that every other spec treats as read-only. In CI they pass only because shards run against isolated DBs; a local full-suite run reproducibly collides (reshuffle-race identical to #884/#886).

**Changes:**
- `playwright.config.ts`: add `mutators` project with `testMatch` for the two specs; extend `chromium` `testIgnore` to exclude both — sharded run is now strictly reader-only
- `.github/workflows/e2e-tests.yml`: add `e2e-mutators` job (`--project=mutators --workers=1`, dedicated DB via `setup-docker-e2e`); pin shard run to `--project=chromium`; wire `e2e-mutators` into `gate.needs` and `merge-reports.needs`
- `docs/decisions/0052-non-sharded-mutator-isolation-job.md`: ADR documenting decision + alternatives considered

Closes #910

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.