### PR TITLE
phpstan: add scanDirectories: [classes] to test config

### DIFF
--- a/ibl5/phpstan-tests.neon
+++ b/ibl5/phpstan-tests.neon
@@ -6,6 +6,15 @@ parameters:
     level: 6
     paths:
         - tests
+    # Resolve classes/ symbols from THIS checkout's source, not the autoloader.
+    # In a worktree, vendor/ is a symlink to the main checkout, so autoload-
+    # reflection would otherwise resolve classes/ to the main repo and report
+    # false "wrong arity" / "undefined method" / class.notFound cascades for any
+    # classes/ signature this branch adds or changes. Mirrors phpstan.neon, which
+    # lists classes/ under paths and is already immune. scanDirectories is read
+    # for reflection only (not analysed), so it surfaces no new errors.
+    scanDirectories:
+        - classes
     excludePaths:
         - tests/TeamOffDefStats/TeamOffDefStatsRepositoryTest.php
         # Rule-test fixtures are deliberately-broken inputs to RuleTestCase


### PR DESCRIPTION
## Summary

Add `scanDirectories: [classes]` to `phpstan-tests.neon` so that `composer run analyse:tests`, when run inside a git worktree, resolves `classes/` symbols from the **worktree's own source files** instead of falling through the composer autoloader to the symlinked `vendor/` (which points at the main checkout).

This eliminates a whole family of worktree-only false positives — wrong-arity errors, `staticMethod.notFound` / "undefined method", and `class.notFound` cascades — that appear when a PR adds or changes a `classes/` signature. The masking variant is also fixed: previously an unresolvable class degraded analysis silently; now every `classes/` symbol resolves locally.

Mirrors the existing `paths: [classes]` entry in `phpstan.neon` (production config), which is already immune. `scanDirectories` is read for reflection only — not analysed — so it surfaces no new errors on a clean checkout.

## Manual Testing

No manual testing needed — all changes are covered by automated tests.
