### PR TITLE
fix: PHPStan baseline hygiene — clear 2 setMockData argument.type entries (maintenance C5)

### DIFF
--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -8,6 +8,6 @@
         "ibl.sqlStringInterpolation": 32
     },
     "phpstan-tests-baseline.neon": {
-        "argument.type": 77
+        "argument.type": 75
     }
 }

--- a/ibl5/phpstan-tests-baseline.neon
+++ b/ibl5/phpstan-tests-baseline.neon
@@ -450,15 +450,4 @@ parameters:
 			count: 3
 			path: tests/WideUnit/Schedule/ScheduleWideUnitTest.php
 
-		-
-			rawMessage: 'Parameter #1 $data of method Tests\WideUnit\Mocks\MockDatabase::setMockData() expects list<array<string, mixed>>, array{array{salary_yr1: 1000, salary_yr2: 1500, salary_yr3: 0, salary_yr4: 0, salary_yr5: 0, salary_yr6: 0, 0: 1000, 1: 1500, ...}} given.'
-			identifier: argument.type
-			count: 1
-			path: tests/WideUnit/Trading/TradeWideUnitTest.php
-
-		-
-			rawMessage: 'Parameter #1 $data of method Tests\WideUnit\Mocks\MockDatabase::setMockData() expects list<array<string, mixed>>, array{array{salary_yr1: 500, salary_yr2: 0, salary_yr3: 0, salary_yr4: 0, salary_yr5: 0, salary_yr6: 0, 0: 500, 1: 0, ...}} given.'
-			identifier: argument.type
-			count: 1
-			path: tests/WideUnit/Trading/TradeWideUnitTest.php
 

--- a/ibl5/tests/WideUnit/Trading/TradeWideUnitTest.php
+++ b/ibl5/tests/WideUnit/Trading/TradeWideUnitTest.php
@@ -205,13 +205,7 @@ class TradeWideUnitTest extends WideUnitTestCase
                 'salary_yr3' => 0,
                 'salary_yr4' => 0,
                 'salary_yr5' => 0,
-                'salary_yr6' => 0,
-                0 => 1000,
-                1 => 1500,
-                2 => 0,
-                3 => 0,
-                4 => 0,
-                5 => 0
+                'salary_yr6' => 0
             ]
         ]);
 
@@ -496,13 +490,7 @@ class TradeWideUnitTest extends WideUnitTestCase
                 'salary_yr3' => 0,
                 'salary_yr4' => 0,
                 'salary_yr5' => 0,
-                'salary_yr6' => 0,
-                0 => 500,
-                1 => 0,
-                2 => 0,
-                3 => 0,
-                4 => 0,
-                5 => 0
+                'salary_yr6' => 0
             ]
         ]);
 


### PR DESCRIPTION
## Summary

Fixes findings 10.1, 10.25, and 5.4 from the maintenance backlog (chunk C5).

**Background:** The backlog's premise was largely already satisfied:
- 10.1/10.25 (snapshot drift) — already remediated; `bin/check-baseline-drift` passes, all five cited identifiers are genuinely 0.
- 5.4 (46 cascade errors) — mocks are already fully typed; only 2 residual `argument.type` entries remained.

**Changes:**
1. Fix `ScoFileWriterTest` base-breaker: `$this->createStub` → `self::createStub` (unblocks `analyse:tests` green gate; already applied by fast-follow, confirmed no-op).
2. Delete 12 redundant integer keys from 2 test rows in `TradeWideUnitTest.php` — mock re-synthesizes positional keys on demand via `fetchRow()`, so behavior is preserved.
3. Remove the 2 now-unmatched `argument.type` baseline entries from `phpstan-tests-baseline.neon`.
4. Decrement `phpstan-baseline-counts.json` snapshot `argument.type` count 77 → 75.

**Not widening the mock signature** — the fix lands in test data only, preserving `setMockData(list<array<string, mixed>>)` contract for all ~40 consumers.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)