### PR TITLE
feat: introduce TopicsService + TopicsServiceInterface (backlog C7 Topics)

### DIFF
--- a/ibl5/classes/Topics/Contracts/TopicsServiceInterface.php
+++ b/ibl5/classes/Topics/Contracts/TopicsServiceInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Topics\Contracts;
+
+/**
+ * Service interface for Topics module operations.
+ *
+ * Assembles the page-data for the Topics route: topic rows from the
+ * repository plus search-filter options from the Search module.
+ */
+interface TopicsServiceInterface
+{
+    /**
+     * Assemble the full Topics page data.
+     *
+     * @param bool $articleComm Whether article comments are enabled
+     * @return array{
+     *     topics: array<int, array{
+     *         topicId: int,
+     *         topicName: string,
+     *         topicImage: string,
+     *         topicText: string,
+     *         storyCount: int,
+     *         totalReads: int,
+     *         recentArticles: array<int, array{sid: int, title: string, catId: int, catTitle: string}>
+     *     }>,
+     *     searchFilters: array{
+     *         topics: list<array{topicId: int, topicText: string}>,
+     *         categories: list<array{catId: int, title: string}>,
+     *         authors: array<int, string>,
+     *         articleComm: bool
+     *     }
+     * }
+     */
+    public function getPageData(bool $articleComm): array;
+}

--- a/ibl5/classes/Topics/TopicsService.php
+++ b/ibl5/classes/Topics/TopicsService.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Topics;
+
+use Search\Contracts\SearchRepositoryInterface;
+use Topics\Contracts\TopicsRepositoryInterface;
+use Topics\Contracts\TopicsServiceInterface;
+
+/**
+ * Service for assembling Topics page data.
+ *
+ * @see TopicsServiceInterface
+ */
+class TopicsService implements TopicsServiceInterface
+{
+    private TopicsRepositoryInterface $topicsRepository;
+    private SearchRepositoryInterface $searchRepository;
+
+    public function __construct(
+        \mysqli $db,
+        string $prefix = 'nuke',
+        ?TopicsRepositoryInterface $topicsRepository = null,
+        ?SearchRepositoryInterface $searchRepository = null,
+    ) {
+        $this->topicsRepository = $topicsRepository ?? new TopicsRepository($db, $prefix);
+        $this->searchRepository = $searchRepository ?? new \Search\SearchRepository($db, $prefix);
+    }
+
+    /**
+     * @see TopicsServiceInterface::getPageData()
+     */
+    public function getPageData(bool $articleComm): array
+    {
+        return [
+            'topics' => $this->topicsRepository->getTopicsWithArticles(),
+            'searchFilters' => [
+                'topics' => $this->searchRepository->getTopics(),
+                'categories' => $this->searchRepository->getCategories(),
+                'authors' => $this->searchRepository->getAuthors(),
+                'articleComm' => $articleComm,
+            ],
+        ];
+    }
+}

--- a/ibl5/modules/Topics/index.php
+++ b/ibl5/modules/Topics/index.php
@@ -18,8 +18,7 @@ if (!defined('MODULE_FILE')) {
     die("You can't access this file directly...");
 }
 
-use Search\SearchRepository;
-use Topics\TopicsRepository;
+use Topics\TopicsService;
 use Topics\TopicsView;
 
 $module_name = basename(dirname(__FILE__));
@@ -36,21 +35,14 @@ $themePath = (is_dir("themes/{$ThemeSel}/images/topics/"))
     ? "themes/{$ThemeSel}/images/topics/"
     : (string) $tipath;
 
-// Initialize services
-$service = new TopicsRepository($mysqli_db, $prefix);
-$searchRepo = new SearchRepository($mysqli_db, $prefix);
+// Initialize service (owns the Topics + Search repositories)
+$service = new TopicsService($mysqli_db, $prefix);
 $view = new TopicsView();
 
-// Get topics data
-$topics = $service->getTopicsWithArticles();
-
-// Get search filter data
-$searchFilters = [
-    'topics' => $searchRepo->getTopics(),
-    'categories' => $searchRepo->getCategories(),
-    'authors' => $searchRepo->getAuthors(),
-    'articleComm' => (bool) ($articlecomm ?? false),
-];
+// Assemble page data (topics + search filters)
+$pageData = $service->getPageData((bool) ($articlecomm ?? false));
+$topics = $pageData['topics'];
+$searchFilters = $pageData['searchFilters'];
 
 // Render page
 PageLayout\PageLayout::header();

--- a/ibl5/tests/Topics/TopicsServiceTest.php
+++ b/ibl5/tests/Topics/TopicsServiceTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Topics;
+
+use PHPUnit\Framework\TestCase;
+use Search\Contracts\SearchRepositoryInterface;
+use Topics\Contracts\TopicsRepositoryInterface;
+use Topics\TopicsService;
+
+class TopicsServiceTest extends TestCase
+{
+    // ============================================
+    // HAPPY PATH
+    // ============================================
+
+    public function testGetPageDataReturnsMappedShapeWithArticleCommTrue(): void
+    {
+        $topicRow = [
+            'topicId' => 1,
+            'topicName' => 'Basketball',
+            'topicImage' => 'bball.png',
+            'topicText' => 'Basketball News',
+            'storyCount' => 5,
+            'totalReads' => 100,
+            'recentArticles' => [
+                ['sid' => 10, 'title' => 'Big Game', 'catId' => 2, 'catTitle' => 'Sports'],
+            ],
+        ];
+        $topicFilterRow = ['topicId' => 1, 'topicText' => 'Basketball News'];
+        $categoryRow = ['catId' => 2, 'title' => 'Sports'];
+
+        $topicsRepo = self::createStub(TopicsRepositoryInterface::class);
+        $topicsRepo->method('getTopicsWithArticles')->willReturn([$topicRow]);
+
+        $searchRepo = self::createStub(SearchRepositoryInterface::class);
+        $searchRepo->method('getTopics')->willReturn([$topicFilterRow]);
+        $searchRepo->method('getCategories')->willReturn([$categoryRow]);
+        $searchRepo->method('getAuthors')->willReturn([1 => 'A. Reporter']);
+
+        $service = new TopicsService(
+            self::createStub(\mysqli::class),
+            'nuke',
+            $topicsRepo,
+            $searchRepo,
+        );
+
+        $result = $service->getPageData(true);
+
+        $this->assertArrayHasKey('topics', $result);
+        $this->assertArrayHasKey('searchFilters', $result);
+        $this->assertCount(1, $result['topics']);
+        $this->assertSame($topicRow, $result['topics'][0]);
+        $this->assertTrue($result['searchFilters']['articleComm']);
+        $this->assertSame([$topicFilterRow], $result['searchFilters']['topics']);
+        $this->assertSame([$categoryRow], $result['searchFilters']['categories']);
+        $this->assertSame([1 => 'A. Reporter'], $result['searchFilters']['authors']);
+    }
+
+    // ============================================
+    // NEGATIVE / EMPTY PATH
+    // ============================================
+
+    public function testGetPageDataReturnsWellShapedEmptyStructureWhenAllCollaboratorsEmpty(): void
+    {
+        $topicsRepo = self::createStub(TopicsRepositoryInterface::class);
+        $topicsRepo->method('getTopicsWithArticles')->willReturn([]);
+
+        $searchRepo = self::createStub(SearchRepositoryInterface::class);
+        $searchRepo->method('getTopics')->willReturn([]);
+        $searchRepo->method('getCategories')->willReturn([]);
+        $searchRepo->method('getAuthors')->willReturn([]);
+
+        $service = new TopicsService(
+            self::createStub(\mysqli::class),
+            'nuke',
+            $topicsRepo,
+            $searchRepo,
+        );
+
+        $result = $service->getPageData(false);
+
+        $this->assertSame([], $result['topics']);
+        $this->assertSame([], $result['searchFilters']['topics']);
+        $this->assertSame([], $result['searchFilters']['categories']);
+        $this->assertSame([], $result['searchFilters']['authors']);
+        $this->assertFalse($result['searchFilters']['articleComm']);
+    }
+
+    // ============================================
+    // DELEGATION: service calls the injected interface
+    // ============================================
+
+    public function testGetPageDataDelegatesFiltersToInjectedSearchRepository(): void
+    {
+        $topicsRepo = self::createStub(TopicsRepositoryInterface::class);
+        $topicsRepo->method('getTopicsWithArticles')->willReturn([]);
+
+        $searchRepo = $this->createMock(SearchRepositoryInterface::class);
+        $searchRepo->expects($this->once())->method('getTopics')->willReturn([]);
+        $searchRepo->expects($this->once())->method('getCategories')->willReturn([]);
+        $searchRepo->expects($this->once())->method('getAuthors')->willReturn([]);
+
+        $service = new TopicsService(
+            self::createStub(\mysqli::class),
+            'nuke',
+            $topicsRepo,
+            $searchRepo,
+        );
+
+        $service->getPageData(false);
+    }
+
+    public function testGetPageDataDelegatesTopicsToInjectedTopicsRepository(): void
+    {
+        $topicsRepo = $this->createMock(TopicsRepositoryInterface::class);
+        $topicsRepo->expects($this->once())->method('getTopicsWithArticles')->willReturn([]);
+
+        $searchRepo = self::createStub(SearchRepositoryInterface::class);
+        $searchRepo->method('getTopics')->willReturn([]);
+        $searchRepo->method('getCategories')->willReturn([]);
+        $searchRepo->method('getAuthors')->willReturn([]);
+
+        $service = new TopicsService(
+            self::createStub(\mysqli::class),
+            'nuke',
+            $topicsRepo,
+            $searchRepo,
+        );
+
+        $service->getPageData(true);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `TopicsService` and `TopicsServiceInterface` as part of backlog C7 (service-layer scaffolding). This PR resolves the cross-module coupling flagged in finding 2.4 by moving the `SearchRepository` filter-assembly out of `modules/Topics/index.php` into `TopicsService`, where it depends on `Search\Contracts\SearchRepositoryInterface` (a contract) rather than the concrete class.

**Changes:**
- `classes/Topics/Contracts/TopicsServiceInterface.php` — new interface with `getPageData(bool $articleComm): array`
- `classes/Topics/TopicsService.php` — new service implementing the interface; wraps `TopicsRepository` + `SearchRepositoryInterface`; mirrors `Injuries\InjuriesService` shape
- `modules/Topics/index.php` — rewired to use `TopicsService`; removes direct `SearchRepository` import; rendered output byte-identical
- `tests/Topics/TopicsServiceTest.php` — new unit tests (happy path, empty path, delegation test for contract injection)

**Behavior:** Preserved exactly. `TopicsRepository`, `SearchRepository`, and their tests are untouched. The `render()` call arguments are unchanged.

**Template module:** mirrors `Injuries\InjuriesService` shape (R + S + V + Contracts, constructor-injectable collaborators).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.