### PR TITLE
refactor: rename RookieOptionFormView → RookieOptionView (maintenance C8, finding 2.11)

### DIFF
--- a/ibl5/classes/RookieOption/Contracts/RookieOptionViewInterface.php
+++ b/ibl5/classes/RookieOption/Contracts/RookieOptionViewInterface.php
@@ -7,14 +7,14 @@ namespace RookieOption\Contracts;
 use Player\Player;
 
 /**
- * RookieOptionFormViewInterface - Contract for rookie option form rendering
+ * RookieOptionViewInterface - Contract for rookie option form rendering
  *
  * Defines the presentation layer for the rookie option eligibility form.
  * Renders the confirmation form with design system styling.
  *
  * @package RookieOption\Contracts
  */
-interface RookieOptionFormViewInterface
+interface RookieOptionViewInterface
 {
     /**
      * Renders the rookie option form for a player

--- a/ibl5/classes/RookieOption/RookieOptionView.php
+++ b/ibl5/classes/RookieOption/RookieOptionView.php
@@ -7,15 +7,15 @@ namespace RookieOption;
 use Player\Player;
 use Security\HtmlSanitizer;
 use Player\PlayerImageHelper;
-use RookieOption\Contracts\RookieOptionFormViewInterface;
+use RookieOption\Contracts\RookieOptionViewInterface;
 
 /**
- * @see RookieOptionFormViewInterface
+ * @see RookieOptionViewInterface
  */
-class RookieOptionFormView implements RookieOptionFormViewInterface
+class RookieOptionView implements RookieOptionViewInterface
 {
     /**
-     * @see RookieOptionFormViewInterface::renderForm()
+     * @see RookieOptionViewInterface::renderForm()
      */
     public function renderForm(Player $player, string $teamName, int $rookieOptionValue, ?string $error = null, ?string $result = null, ?string $from = null): string
     {

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -226,6 +226,7 @@ Effort scale:
 **Suggested direction:** Extract `InjuriesRepository extends BaseMysqliRepository`; add to Contracts/.
 **Est. effort:** S
 **Risk if untouched:** Injury queries un-traceable without reading service body.
+**Status:** Completed — InjuriesRepository already extracted and injected (PR #970, 2026-06-03); backlog was stale.
 
 ### 2.8 Search / Standings — No Service Layer
 **Location:** `classes/Search/`, `classes/Standings/`
@@ -233,6 +234,8 @@ Effort scale:
 **Suggested direction:** Wrap in a Service; for Search a pass-through maintains the pattern.
 **Est. effort:** S each
 **Risk if untouched:** Tiebreaker class has no obvious home; contributors may bypass it.
+**Status (Search):** Declined — pass-through Service is dead code; SearchRepository is the correct seam.
+**Status (Standings):** Declined — AggregateTiebreaker has a home (StandingsView + ProjectedDraftOrderService); no orchestration exists to wrap.
 
 ### 2.9 DraftHistory — No Service; ApiHandler Naming Ambiguous
 **Location:** `classes/DraftHistory/`
@@ -240,6 +243,7 @@ Effort scale:
 **Suggested direction:** Rename to Controller; add Service for sorting/grouping.
 **Est. effort:** S
 **Risk if untouched:** Wrong-namespace confusion; unclear where new actions go.
+**Status:** Declined — *ApiHandler is the established HTMX-fragment convention (9 handlers); rename would harm consistency. No Service target exists.
 
 ### 2.10 Extension — No View; Routed Through modules/Player
 **Location:** `classes/Extension/`, `modules/Player/extension.php`
@@ -254,6 +258,7 @@ Effort scale:
 **Suggested direction:** Add `RookieOptionService`; rename to `RookieOptionView`.
 **Est. effort:** S
 **Risk if untouched:** Service-level logic ends up in Controller/Validator; FormView name visible inconsistency.
+**Status:** Completed (2026-06-09) — renamed RookieOptionFormView → RookieOptionView / RookieOptionViewInterface. Service half declined as pass-through ceremony (RookieOptionController owns orchestration).
 
 ### 2.12 Negotiation — No Standalone Module; Six Non-Standard Role Names
 **Location:** `classes/Negotiation/`
@@ -740,6 +745,7 @@ Effort scale:
 **Suggested direction:** Extract `InjuriesRepository`; inject.
 **Est. effort:** S
 **Risk if untouched:** New injury DB logic lands as raw SQL in the Service.
+**Status:** Completed — InjuriesRepository already extracted and injected (PR #970, 2026-06-03); backlog was stale.
 
 ### 4.25 `Services/NewsService` Misplaced
 **Location:** `ibl5/classes/Topics/News/NewsRepository.php` (relocated and renamed)

--- a/ibl5/modules/Player/index.php
+++ b/ibl5/modules/Player/index.php
@@ -6,7 +6,7 @@ use Player\Player;
 use Player\PlayerPageController;
 use Player\PlayerRepository;
 use RookieOption\RookieOptionValidator;
-use RookieOption\RookieOptionFormView;
+use RookieOption\RookieOptionView;
 use RookieOption\RookieOptionController;
 use Repositories\TeamIdentityRepository;
 use Repositories\SalaryCapRepository;
@@ -100,7 +100,7 @@ function rookieoption($pid)
     // Initialize dependencies
     $season = new \Season\Season($mysqli_db);
     $validator = new RookieOptionValidator();
-    $formView = new RookieOptionFormView();
+    $formView = new RookieOptionView();
 
     // Load player
     $player = Player::withPlayerID($mysqli_db, (int) $pid);

--- a/ibl5/phpstan-rules/RequireEscapedOutputRule.php
+++ b/ibl5/phpstan-rules/RequireEscapedOutputRule.php
@@ -125,7 +125,7 @@ final class RequireEscapedOutputRule implements Rule
         'FranchiseRecordBook/FranchiseRecordBookView.php',
         'LeagueControlPanel/LeagueControlPanelView.php',
         'NextSim/NextSimView.php',
-        'RookieOption/RookieOptionFormView.php',
+        'RookieOption/RookieOptionView.php',
         'Standings/StandingsView.php',
         'Team/TeamView.php',
         'TransactionHistory/TransactionHistoryView.php',

--- a/ibl5/tests/RookieOption/RookieOptionViewTest.php
+++ b/ibl5/tests/RookieOption/RookieOptionViewTest.php
@@ -7,19 +7,19 @@ namespace Tests\RookieOption;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Player\Player;
-use RookieOption\RookieOptionFormView;
+use RookieOption\RookieOptionView;
 
 /**
- * Tests for RookieOptionFormView
+ * Tests for RookieOptionView
  */
 #[AllowMockObjectsWithoutExpectations]
-class RookieOptionFormViewTest extends TestCase
+class RookieOptionViewTest extends TestCase
 {
-    private RookieOptionFormView $view;
+    private RookieOptionView $view;
 
     protected function setUp(): void
     {
-        $this->view = new RookieOptionFormView();
+        $this->view = new RookieOptionView();
     }
 
     /**

--- a/ibl5/tests/RookieOption/RookieOptionViewXssTest.php
+++ b/ibl5/tests/RookieOption/RookieOptionViewXssTest.php
@@ -7,10 +7,10 @@ namespace Tests\RookieOption;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Player\Player;
-use RookieOption\RookieOptionFormView;
+use RookieOption\RookieOptionView;
 
 #[AllowMockObjectsWithoutExpectations]
-final class RookieOptionFormViewXssTest extends TestCase
+final class RookieOptionViewXssTest extends TestCase
 {
     public function testRenderFormEscapesXssInPlayerNamePositionAndTeamName(): void
     {
@@ -22,7 +22,7 @@ final class RookieOptionFormViewXssTest extends TestCase
         $player->method('getName')->willReturn($xss);
         $player->method('getPosition')->willReturn($xss);
 
-        $view = new RookieOptionFormView();
+        $view = new RookieOptionView();
         $output = $view->renderForm($player, $xss, 100);
 
         $this->assertStringContainsString($escaped, $output);


### PR DESCRIPTION
## Summary

Pure rename:  →  and  → . Finding 2.11 from maintenance C8 review.

The class was misnamed — canonical shape for a single-view module is `<Module>View` (cf. `InjuriesView`, `SearchView`, `StandingsView`). The `renderForm()` method name and body are byte-for-byte unchanged.

Also closes findings 2.7/4.24, 2.8 (Search), 2.8 (Standings), 2.9 (DraftHistory) in the backlog with their correct dispositions (already-done or ceremony).

## Changes

- `git mv` `RookieOptionFormView.php` → `RookieOptionView.php`
- `git mv` `RookieOptionFormViewInterface.php` → `RookieOptionViewInterface.php`
- Update sole consumer `modules/Player/index.php` (2 lines)
- `git mv` both test files; update references within
- Resolve 5 backlog findings in `docs/maintenance-backlog.md`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.