### PR TITLE
refactor: add TeamOrderBy enum, enumify fetchAllRealTeams, promote WaiversRepositoryInterface shapes (maintenance C10 7.10+7.12)

### DIFF
--- a/ibl5/classes/BaseMysqliRepository.php
+++ b/ibl5/classes/BaseMysqliRepository.php
@@ -411,21 +411,13 @@ abstract class BaseMysqliRepository
     /**
      * Fetch all real teams from `ibl_team_info` (excludes Free Agents, All-Star, etc.)
      *
-     * @param string $orderBy One of 'team_name ASC', 'teamid ASC', or 'team_city ASC'
      * @return list<array<string, mixed>>
      */
-    protected function fetchAllRealTeams(string $orderBy = 'team_name ASC'): array
+    protected function fetchAllRealTeams(\TeamOrderBy $orderBy = \TeamOrderBy::TeamName): array
     {
-        $allowedOrderBy = [
-            'team_name ASC' => 'team_name ASC',
-            'teamid ASC' => 'teamid ASC',
-            'team_city ASC' => 'team_city ASC',
-        ];
-        $safeOrderBy = $allowedOrderBy[$orderBy] ?? 'team_name ASC';
-
         /** @var list<array<string, mixed>> */
         return $this->fetchAll(
-            "SELECT * FROM `ibl_team_info` WHERE teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . " ORDER BY $safeOrderBy"
+            "SELECT * FROM `ibl_team_info` WHERE teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . " ORDER BY " . $orderBy->value
         );
     }
 

--- a/ibl5/classes/CapSpace/CapSpaceRepository.php
+++ b/ibl5/classes/CapSpace/CapSpaceRepository.php
@@ -27,7 +27,7 @@ class CapSpaceRepository extends \BaseMysqliRepository implements CapSpaceReposi
     public function getAllTeams(): array
     {
         /** @var list<TeamInfoRow> */
-        return $this->fetchAllRealTeams('teamid ASC');
+        return $this->fetchAllRealTeams(\TeamOrderBy::TeamId);
     }
 
     /**

--- a/ibl5/classes/DraftPickLocator/DraftPickLocatorRepository.php
+++ b/ibl5/classes/DraftPickLocator/DraftPickLocatorRepository.php
@@ -24,7 +24,7 @@ class DraftPickLocatorRepository extends \BaseMysqliRepository implements DraftP
     public function getAllTeams(): array
     {
         /** @var list<array{teamid: int, team_city: string, team_name: string, color1: string, color2: string}> */
-        return $this->fetchAllRealTeams('teamid ASC');
+        return $this->fetchAllRealTeams(\TeamOrderBy::TeamId);
     }
 
     /**

--- a/ibl5/classes/FranchiseRecordBook/FranchiseRecordBookRepository.php
+++ b/ibl5/classes/FranchiseRecordBook/FranchiseRecordBookRepository.php
@@ -117,7 +117,7 @@ class FranchiseRecordBookRepository extends \BaseMysqliRepository implements Fra
     public function getAllTeams(): array
     {
         /** @var list<TeamInfo> */
-        return $this->fetchAllRealTeams('team_name ASC');
+        return $this->fetchAllRealTeams(\TeamOrderBy::TeamName);
     }
 
     /**

--- a/ibl5/classes/Repositories/TeamIdentityRepository.php
+++ b/ibl5/classes/Repositories/TeamIdentityRepository.php
@@ -125,7 +125,13 @@ class TeamIdentityRepository extends \BaseMysqliRepository implements TeamIdenti
      */
     public function getAllRealTeams(string $orderBy = 'team_name ASC'): array
     {
+        $teamOrderBy = \TeamOrderBy::tryFrom($orderBy);
+        if ($teamOrderBy === null) {
+            throw new \InvalidArgumentException(
+                "Invalid orderBy '{$orderBy}'. Allowed: 'team_name ASC', 'teamid ASC', 'team_city ASC'."
+            );
+        }
         /** @var list<TeamInfoRow> */
-        return $this->fetchAllRealTeams($orderBy);
+        return $this->fetchAllRealTeams($teamOrderBy);
     }
 }

--- a/ibl5/classes/SeasonArchive/SeasonArchiveRepository.php
+++ b/ibl5/classes/SeasonArchive/SeasonArchiveRepository.php
@@ -219,7 +219,7 @@ class SeasonArchiveRepository extends BaseMysqliRepository implements SeasonArch
      */
     public function getTeamColors(): array
     {
-        $rows = $this->fetchAllRealTeams('teamid ASC');
+        $rows = $this->fetchAllRealTeams(\TeamOrderBy::TeamId);
 
         $colors = [];
         foreach ($rows as $row) {

--- a/ibl5/classes/SeriesRecords/SeriesRecordsRepository.php
+++ b/ibl5/classes/SeriesRecords/SeriesRecordsRepository.php
@@ -29,7 +29,7 @@ class SeriesRecordsRepository extends \BaseMysqliRepository implements SeriesRec
     public function getTeamsForSeriesRecords(): array
     {
         /** @var list<array{teamid: int, team_city: string, team_name: string, color1: string, color2: string}> */
-        return $this->fetchAllRealTeams('teamid ASC');
+        return $this->fetchAllRealTeams(\TeamOrderBy::TeamId);
     }
 
     /**

--- a/ibl5/classes/Team/TeamRepository.php
+++ b/ibl5/classes/Team/TeamRepository.php
@@ -412,6 +412,6 @@ class TeamRepository extends \BaseMysqliRepository implements TeamRepositoryInte
     public function getAllTeams(): array
     {
         /** @var list<array{teamid: int, team_name: string}> */
-        return $this->fetchAllRealTeams('team_name ASC');
+        return $this->fetchAllRealTeams(\TeamOrderBy::TeamName);
     }
 }

--- a/ibl5/classes/TeamOrderBy.php
+++ b/ibl5/classes/TeamOrderBy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Whitelisted ORDER BY fragments for fetchAllRealTeams().
+ * The enum is the whitelist: the backing string value is the literal SQL
+ * `ORDER BY` fragment, so no value reaching the query can be unsafe.
+ */
+enum TeamOrderBy: string
+{
+    case TeamName = 'team_name ASC';
+    case TeamId = 'teamid ASC';
+    case TeamCity = 'team_city ASC';
+}

--- a/ibl5/classes/Trading/TradeFormRepository.php
+++ b/ibl5/classes/Trading/TradeFormRepository.php
@@ -72,7 +72,7 @@ class TradeFormRepository extends BaseMysqliRepository implements TradeFormRepos
     public function getAllTeamsWithCity(): array
     {
         /** @var list<TeamWithCityRow> */
-        return $this->fetchAllRealTeams('team_city ASC');
+        return $this->fetchAllRealTeams(\TeamOrderBy::TeamCity);
     }
 
     /**

--- a/ibl5/classes/Waivers/Contracts/WaiversRepositoryInterface.php
+++ b/ibl5/classes/Waivers/Contracts/WaiversRepositoryInterface.php
@@ -6,12 +6,15 @@ namespace Waivers\Contracts;
 
 /**
  * WaiversRepositoryInterface - Contract for waiver wire database operations
- * 
+ *
  * Defines the data access layer for waiver wire transactions. Handles all
  * database operations related to dropping players to waivers and signing
  * players from the waiver pool.
- * 
+ *
  * @package Waivers\Contracts
+ *
+ * @phpstan-type WaiverTeamRow array{team_name: string, teamid: int, ...<string, mixed>}
+ * @phpstan-type WaiverContractData array{hasExistingContract: bool, salary: int}
  */
 interface WaiversRepositoryInterface
 {
@@ -45,10 +48,10 @@ interface WaiversRepositoryInterface
      * with existing contracts and free agents who need veteran minimum contracts.
      * 
      * @param int $playerID Player ID to sign (must be positive integer)
-     * @param array{team_name: string, teamid: int, ...<string, mixed>} $team Team data array with keys:
+     * @param WaiverTeamRow $team Team data array with keys:
      *   - 'team_name': string - Full team name
      *   - 'teamid': int - Team ID for foreign key relationship
-     * @param array{hasExistingContract: bool, salary: int} $contractData Contract information with keys:
+     * @param WaiverContractData $contractData Contract information with keys:
      *   - 'hasExistingContract': bool - Whether player has existing contract
      *   - 'salary': int - Salary amount (used only if no existing contract)
      * @return bool True if update succeeded, false on database error

--- a/ibl5/classes/Waivers/WaiversRepository.php
+++ b/ibl5/classes/Waivers/WaiversRepository.php
@@ -10,6 +10,8 @@ use Waivers\Contracts\WaiversRepositoryInterface;
 
 /**
  * @see WaiversRepositoryInterface
+ * @phpstan-import-type WaiverTeamRow from \Waivers\Contracts\WaiversRepositoryInterface
+ * @phpstan-import-type WaiverContractData from \Waivers\Contracts\WaiversRepositoryInterface
  */
 class WaiversRepository extends BaseMysqliRepository implements WaiversRepositoryInterface
 {
@@ -45,8 +47,8 @@ class WaiversRepository extends BaseMysqliRepository implements WaiversRepositor
     /**
      * @see WaiversRepositoryInterface::signPlayerFromWaivers()
      *
-     * @param array{team_name: string, teamid: int, ...<string, mixed>} $team
-     * @param array{hasExistingContract: bool, salary: int} $contractData
+     * @param WaiverTeamRow $team
+     * @param WaiverContractData $contractData
      */
     public function signPlayerFromWaivers(int $playerID, array $team, array $contractData): bool
     {

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -34,12 +34,6 @@ parameters:
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringInterpolation
 			count: 1
-			path: classes/BaseMysqliRepository.php
-
-		-
-			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
-			identifier: ibl.sqlStringInterpolation
-			count: 1
 			path: classes/BasketballStats/Tables/PeriodAverages.php
 
 		-

--- a/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BaseMysqliRepositoryTest.php
@@ -160,7 +160,7 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
 
     public function testFetchAllRealTeamsOrderByTeamid(): void
     {
-        $teams = $this->repo->callFetchAllRealTeams('teamid ASC');
+        $teams = $this->repo->callFetchAllRealTeams(\TeamOrderBy::TeamId);
         self::assertNotEmpty($teams);
 
         $ids = array_column($teams, 'teamid');
@@ -169,15 +169,26 @@ class BaseMysqliRepositoryTest extends DatabaseTestCase
         self::assertSame($sorted, $ids);
     }
 
-    public function testFetchAllRealTeamsInvalidOrderFallsBackToDefault(): void
+    public function testGetAllRealTeamsRejectsNonWhitelistedOrderBy(): void
     {
-        $teams = $this->repo->callFetchAllRealTeams('DROP TABLE');
-        self::assertNotEmpty($teams);
+        $repo = new \Repositories\TeamIdentityRepository($this->db);
 
-        $names = array_column($teams, 'team_name');
-        $sorted = $names;
-        sort($sorted);
-        self::assertSame($sorted, $names);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid orderBy 'team_city DESC'");
+
+        $repo->getAllRealTeams('team_city DESC');
+    }
+
+    public function testGetAllRealTeamsAcceptsWhitelistedOrderBy(): void
+    {
+        $repo = new \Repositories\TeamIdentityRepository($this->db);
+        $teams = $repo->getAllRealTeams('teamid ASC');
+
+        self::assertNotEmpty($teams);
+        $ids = array_column($teams, 'teamid');
+        $sorted = $ids;
+        sort($sorted, SORT_NUMERIC);
+        self::assertSame($sorted, $ids);
     }
 
     // ==================== getLastInsertId ====================
@@ -571,7 +582,7 @@ class TestableBaseMysqliRepository extends \BaseMysqliRepository
     }
 
     /** @return list<array<string, mixed>> */
-    public function callFetchAllRealTeams(string $orderBy = 'team_name ASC'): array
+    public function callFetchAllRealTeams(\TeamOrderBy $orderBy = \TeamOrderBy::TeamName): array
     {
         return $this->fetchAllRealTeams($orderBy);
     }


### PR DESCRIPTION
## Summary

Repository Contract Cleanup — Maintenance Backlog Chunk C10 (findings 7.10 and 7.12).

**7.12 — Enumify `fetchAllRealTeams` orderBy parameter:**
- New `TeamOrderBy` enum where the backing string value IS the safe SQL `ORDER BY` fragment
- Converts the silent-fallback whitelist map to a fail-fast type contract
- Updates all 8 call sites (7 protected + 1 public boundary with `tryFrom` + throw)
- Rewrites the fallback test as a negative-path throw test, adds positive companion

**7.10 — Promote inline array shapes to named `@phpstan-type` aliases on `WaiversRepositoryInterface`:**
- Adds `WaiverTeamRow` and `WaiverContractData` phpstan-type aliases to the interface
- Imports and consumes them in `WaiversRepository` via `@phpstan-import-type`

**Scope:** 7.6 closed (no mechanical migration remains), 7.7 closed (already done), 7.5 deferred to C10b.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---

Generated with [Claude Code](https://claude.ai/code)