### PR TITLE
feat: add ibl_box_scores.teamid FK (migration 142, backlog 15.10)

### DIFF
--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -2199,6 +2199,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Add `CHANGE COLUMN teamID team_id` to migration 121 + view updates.
 **Est. effort:** S
 **Risk if untouched:** Visual anomaly; future queries use the wrong name.
+**Status:** Completed — migration 114 already renamed teamID→teamid on ibl_box_scores and ibl_olympics_box_scores; the unified standard is single-token teamid (config/schema-assertions.php), not team_id. No further rename. Views already use bs.teamid (migration 121).
 
 ### 15.3 `cy1`-`cy6` / `dem1`-`dem6` / `offer1`-`offer6` — 1NF Violations
 **Location:** `ibl_plr`, `ibl_olympics_plr`, `ibl_trade_cash` (cy1-cy6); `ibl_demands` (dem1-dem6); `ibl_fa_offers` (offer1-offer6)
@@ -2259,6 +2260,7 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Suggested direction:** Add FK alongside migration-121 rename; ensure All-Star team IDs (50/51) are in `ibl_team_info`.
 **Est. effort:** S
 **Risk if untouched:** Invalid team IDs writable; stat views silently wrong.
+**Status:** Completed (maintenance-41, migration 142) — fk_boxscore_team on ibl_box_scores.teamid → ibl_team_info.teamid (ON UPDATE CASCADE), plus parity fk_olympics_boxscore_team. Special teams 0/40/41/50/51 confirmed present in ibl_team_info; zero orphans. Signedness matches (int(11) both sides).
 
 ### 15.11 Migration Numbering Gaps — 018-023, 111
 **Location:** `ibl5/migrations/`

--- a/ibl5/migrations/142_box_scores_teamid_fk.sql
+++ b/ibl5/migrations/142_box_scores_teamid_fk.sql
@@ -1,0 +1,44 @@
+-- Migration 142: ibl_box_scores.teamid foreign key (+ Olympics parity)
+-- (maintenance-41 — backlog 15.10; finding 15.2 already done by migration 114)
+--
+-- ibl_box_scores.teamid referenced ibl_team_info.teamid by value only, with no
+-- FK constraint. This adds:
+--   1. fk_boxscore_team          on ibl_box_scores.teamid          -> ibl_team_info.teamid
+--   2. fk_olympics_boxscore_team on ibl_olympics_box_scores.teamid -> ibl_olympics_team_info.teamid (parity)
+--
+-- Column already exists with the correct name (single-token `teamid`, per
+-- migration 114 and config/schema-assertions.php), signedness, and a covering
+-- index (`idx_team_id`) — so this is an FK-add only: no rename, no index add,
+-- no expand-contract. Mirrors migration 140 (idempotent DROP FK IF EXISTS -> ADD).
+--
+-- Signedness matches: ibl_box_scores.teamid int(11) (signed) <-> ibl_team_info.teamid
+-- int(11) NOT NULL (signed). Constraint is valid.
+--
+-- Delete semantics: ON UPDATE CASCADE only (default RESTRICT on delete), mirroring
+-- the existing sibling team FKs fk_boxscore_home / fk_boxscore_visitor. Franchises
+-- are renamed (CASCADE keeps box-score teamids correct) but effectively never
+-- deleted. Column stays nullable (no change) — legacy rows may carry NULL.
+--
+-- FK is safe — verified empirically, not assumed. Special teams are real rows in
+-- ibl_team_info: 0 Free Agents, 1-28 franchises, 40 Rookies, 41 Sophomores,
+-- 50 All-Star Away, 51 All-Star Home (League constants FREE_AGENTS_TEAMID(0),
+-- ROOKIES_TEAMID(40), SOPHOMORES_TEAMID(41), ALL_STAR_AWAY_TEAMID(50),
+-- ALL_STAR_HOME_TEAMID(51)). LEFT JOIN orphan check returned zero orphans on both
+-- ibl_box_scores and ibl_olympics_box_scores. If prod held an orphan, ADD CONSTRAINT
+-- fails loudly (fail-closed) rather than silently corrupting.
+--
+-- Idempotent: each FK is DROP IF EXISTS then ADD, so re-running is a no-op.
+--
+-- Pre-flight (run on prod before deploy if paranoid):
+-- SELECT DISTINCT bs.teamid FROM ibl_box_scores bs LEFT JOIN ibl_team_info ti ON bs.teamid = ti.teamid WHERE ti.teamid IS NULL AND bs.teamid IS NOT NULL; -- expect empty
+-- SELECT DISTINCT bs.teamid FROM ibl_olympics_box_scores bs LEFT JOIN ibl_olympics_team_info ti ON bs.teamid = ti.teamid WHERE ti.teamid IS NULL AND bs.teamid IS NOT NULL; -- expect empty
+
+ALTER TABLE `ibl_box_scores` DROP FOREIGN KEY IF EXISTS `fk_boxscore_team`;
+ALTER TABLE `ibl_box_scores`
+  ADD CONSTRAINT `fk_boxscore_team` FOREIGN KEY (`teamid`)
+    REFERENCES `ibl_team_info` (`teamid`) ON UPDATE CASCADE;
+
+ALTER TABLE `ibl_olympics_box_scores` DROP FOREIGN KEY IF EXISTS `fk_olympics_boxscore_team`;
+ALTER TABLE `ibl_olympics_box_scores`
+  ADD CONSTRAINT `fk_olympics_boxscore_team` FOREIGN KEY (`teamid`)
+    REFERENCES `ibl_olympics_team_info` (`teamid`) ON UPDATE CASCADE;

--- a/ibl5/tests/DatabaseIntegration/BoxScoresTeamidFkTest.php
+++ b/ibl5/tests/DatabaseIntegration/BoxScoresTeamidFkTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Migration 142 (maintenance-41 — backlog 15.10): ibl_box_scores.teamid gains a
+ * foreign key fk_boxscore_team -> ibl_team_info.teamid (ON UPDATE CASCADE), mirroring
+ * the sibling fk_boxscore_home / fk_boxscore_visitor. The column already exists with
+ * the correct name/signedness (migration 114), so this is an FK-add only — no rename.
+ */
+#[Group('database')]
+class BoxScoresTeamidFkTest extends DatabaseTestCase
+{
+    public function testForeignKeyPresentOnTeamid(): void
+    {
+        $result = $this->db->query(
+            "SELECT rc.CONSTRAINT_NAME, rc.UPDATE_RULE, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME
+             FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+             JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+               ON kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+              AND kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+             WHERE rc.CONSTRAINT_SCHEMA = DATABASE()
+               AND rc.TABLE_NAME = 'ibl_box_scores'
+               AND kcu.COLUMN_NAME = 'teamid'"
+        );
+        self::assertNotFalse($result);
+
+        $row = $result->fetch_assoc();
+        self::assertNotNull($row, 'No FK found on ibl_box_scores.teamid');
+        self::assertSame('ibl_team_info', $row['REFERENCED_TABLE_NAME']);
+        self::assertSame('teamid', $row['REFERENCED_COLUMN_NAME']);
+        self::assertSame('CASCADE', $row['UPDATE_RULE'], 'teamid FK must be ON UPDATE CASCADE');
+    }
+
+    public function testTeamidSignednessMatchesReferencedColumn(): void
+    {
+        $types = [];
+        foreach ([['ibl_box_scores', 'teamid'], ['ibl_team_info', 'teamid']] as [$table, $col]) {
+            $stmt = $this->db->prepare(
+                "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?"
+            );
+            self::assertNotFalse($stmt);
+            $stmt->bind_param('ss', $table, $col);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+
+            self::assertNotNull($row, "$table.$col not found");
+            $types["$table.$col"] = strtolower((string) $row['COLUMN_TYPE']);
+        }
+
+        foreach ($types as $key => $type) {
+            self::assertStringContainsString('int(11)', $type, "$key must be int(11)");
+            self::assertStringNotContainsString('unsigned', $type, "$key must be signed (FK signedness must match)");
+        }
+    }
+
+    public function testValidTeamidAccepted(): void
+    {
+        $row = $this->db->query('SELECT teamid FROM ibl_team_info ORDER BY teamid LIMIT 1')->fetch_assoc();
+        self::assertNotNull($row, 'seed has no ibl_team_info rows');
+        $teamid = (int) $row['teamid'];
+
+        $pid = 200420001;
+        $this->insertTestPlayer($pid, 'BS FK Valid', ['teamid' => $teamid]);
+
+        $id = $this->insertPlayerBoxscoreRow('2025-04-02', $pid, 'BS FK Valid', 'PG', 2, 1, $teamid);
+
+        $check = $this->db->query("SELECT teamid FROM ibl_box_scores WHERE id = $id")->fetch_assoc();
+        self::assertNotNull($check);
+        self::assertSame($teamid, (int) $check['teamid']);
+    }
+
+    public function testInvalidTeamidRejectedByForeignKey(): void
+    {
+        $pid = 200420002;
+        $this->insertTestPlayer($pid, 'BS FK Invalid');
+
+        $this->expectException(\mysqli_sql_exception::class);
+        // visitor/home teamids are valid seed rows, so the ONLY violated constraint
+        // is the new fk_boxscore_team on teamid.
+        $this->insertPlayerBoxscoreRow('2025-04-02', $pid, 'BS FK Invalid', 'PG', 2, 1, 2147483647);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/SchemaInvariantTest.php
+++ b/ibl5/tests/DatabaseIntegration/SchemaInvariantTest.php
@@ -130,7 +130,6 @@ class SchemaInvariantTest extends DatabaseTestCase
      * @var array<string, string>
      */
     private const KNOWN_COLUMNS_WITHOUT_FK = [
-        'ibl_box_scores.teamid' => 'denormalized per-row team marker; home_teamid/visitor_teamid carry the team FKs',
         'ibl_box_scores_engine_shadow.home_teamid' => 'engine debug shadow table; transient sim output, not referentially constrained',
         'ibl_box_scores_engine_shadow.pid' => 'engine debug shadow table; transient sim output, not referentially constrained',
         'ibl_box_scores_engine_shadow.teamid' => 'engine debug shadow table; transient sim output, not referentially constrained',
@@ -151,7 +150,6 @@ class SchemaInvariantTest extends DatabaseTestCase
         'ibl_jsb_transactions.from_teamid' => 'JSB transaction log; historical team marker, no cascade',
         'ibl_jsb_transactions.pid' => 'JSB transaction log; historical player marker, no cascade',
         'ibl_jsb_transactions.to_teamid' => 'JSB transaction log; historical team marker, no cascade',
-        'ibl_olympics_box_scores.teamid' => 'denormalized per-row team marker; home_teamid/visitor_teamid carry the team FKs',
         'ibl_olympics_career_avgs.pid' => 'denormalized Olympics career aggregate; rebuilt from box scores',
         'ibl_olympics_career_totals.pid' => 'denormalized Olympics career aggregate; rebuilt from box scores',
         'ibl_olympics_hist.pid' => 'Olympics append-only transaction log; retains rows for archived players',


### PR DESCRIPTION
<!-- no-adr: FK add only; covered by ADR-0009 unify-cross-table-column-names; no DROP TABLE/COLUMN/INDEX, mirrors migration 140 -->

## Summary

Adds missing foreign-key constraint on `ibl_box_scores.teamid` → `ibl_team_info.teamid` (backlog 15.10), plus parity FK on `ibl_olympics_box_scores.teamid` → `ibl_olympics_team_info.teamid`. Migration 142, ON UPDATE CASCADE only (mirrors sibling FKs `fk_boxscore_home`/`fk_boxscore_visitor`).

**Finding 15.2 (rename teamID→snake_case) is already done** — migration 114 executed it; annotated in backlog.

## Changes

- `migrations/142_box_scores_teamid_fk.sql` — idempotent FK-add (DROP IF EXISTS → ADD CONSTRAINT) on both tables
- `tests/DatabaseIntegration/BoxScoresTeamidFkTest.php` — FK existence, signedness match, happy-path insert, negative-path rejection
- `docs/maintenance-backlog.md` — annotate 15.2 (done) and 15.10 (done, migration 142)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.