### PR TITLE
refactor: extract StreakCalculator from RecordHoldersRepository (maintenance C9)

### DIFF
--- a/ibl5/classes/RecordHolders/Contracts/RecordHoldersRepositoryInterface.php
+++ b/ibl5/classes/RecordHolders/Contracts/RecordHoldersRepositoryInterface.php
@@ -166,6 +166,9 @@ interface RecordHoldersRepositoryInterface
     /**
      * Get the longest winning or losing streak.
      *
+     * Implementations are request-scoped and may memoize the underlying game rows;
+     * results are read-only and require no cache invalidation.
+     *
      * @param string $type Streak type ('winning' or 'losing')
      * @return list<StreakRecord>
      */
@@ -173,6 +176,9 @@ interface RecordHoldersRepositoryInterface
 
     /**
      * Get the best or worst season start.
+     *
+     * Implementations are request-scoped and may memoize the underlying game rows;
+     * results are read-only and require no cache invalidation.
      *
      * @param string $type Start type ('best' or 'worst')
      * @return list<SeasonStartRecord>

--- a/ibl5/classes/RecordHolders/RecordHoldersRepository.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersRepository.php
@@ -42,10 +42,23 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
      */
     private const SEASON_YEAR_EXPRESSION = 'bs.season_year';
 
-    /** @var list<array{game_date: string, visitor_teamid: int, home_teamid: int, visitorScore: int, homeScore: int}>|null */
+    /**
+     * Per-request memoization of regular-season game rows.
+     *
+     * Loaded once and reused by all four streak/season-start computations within a
+     * single request. The repository is instantiated per request (see
+     * modules/RecordHolders/index.php) and never reused across requests, so this
+     * cache cannot return stale data; no invalidation hook is required.
+     *
+     * @var list<array{game_date: string, visitor_teamid: int, home_teamid: int, visitorScore: int, homeScore: int}>|null
+     */
     private ?array $regularSeasonGamesCache = null;
 
-    /** @var array<int, string> Team ID → team name lookup cache */
+    /**
+     * Per-request memoization of team ID → team name lookups (request-scoped, see above).
+     *
+     * @var array<int, string>
+     */
     private array $teamNameCache = [];
 
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
@@ -377,176 +390,29 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
     /**
      * @see RecordHoldersRepositoryInterface::getLongestStreak()
      *
-     * Processes all games sequentially to find the longest winning or losing streak.
-     *
      * @return list<StreakRecord>
      */
     public function getLongestStreak(string $type): array
     {
-        $rows = $this->getRegularSeasonGames();
-
-        // Track streaks per team
-        /** @var array<int, array{current: int, start: string, team: int}> $streaks */
-        $streaks = [];
-        /** @var array<int, array{streak: int, start: string, end: string}> $bestStreaks */
-        $bestStreaks = [];
-
-        foreach ($rows as $row) {
-            /** @var array{game_date: string, visitor_teamid: int, home_teamid: int, visitorScore: int, homeScore: int} $row */
-            $date = $row['game_date'];
-            $visitorTid = $row['visitor_teamid'];
-            $homeTid = $row['home_teamid'];
-            $visitorScore = $row['visitorScore'];
-            $homeScore = $row['homeScore'];
-
-            $visitorWon = $visitorScore > $homeScore;
-
-            foreach ([$visitorTid, $homeTid] as $teamid) {
-                $teamWon = ($teamid === $visitorTid) ? $visitorWon : !$visitorWon;
-                $isStreakType = ($type === 'winning') ? $teamWon : !$teamWon;
-
-                if (!isset($streaks[$teamid])) {
-                    $streaks[$teamid] = ['current' => 0, 'start' => '', 'team' => $teamid];
-                    $bestStreaks[$teamid] = ['streak' => 0, 'start' => '', 'end' => ''];
-                }
-
-                if ($isStreakType) {
-                    if ($streaks[$teamid]['current'] === 0) {
-                        $streaks[$teamid]['start'] = $date;
-                    }
-                    $streaks[$teamid]['current']++;
-                    if ($streaks[$teamid]['current'] > $bestStreaks[$teamid]['streak']) {
-                        $bestStreaks[$teamid] = [
-                            'streak' => $streaks[$teamid]['current'],
-                            'start' => $streaks[$teamid]['start'],
-                            'end' => $date,
-                        ];
-                    }
-                } else {
-                    $streaks[$teamid]['current'] = 0;
-                }
-            }
-        }
-
-        // Find the overall best
-        $maxStreak = 0;
-        foreach ($bestStreaks as $data) {
-            if ($data['streak'] > $maxStreak) {
-                $maxStreak = $data['streak'];
-            }
-        }
-
-        // Collect all teams matching the max streak
-        /** @var list<StreakRecord> $records */
-        $records = [];
-        foreach ($bestStreaks as $teamid => $data) {
-            if ($data['streak'] === $maxStreak && $maxStreak > 0) {
-                $startYear = IblSeasonDateHelper::dateToSeasonEndingYear($data['start']);
-                $endYear = IblSeasonDateHelper::dateToSeasonEndingYear($data['end']);
-                $records[] = [
-                    'team_name' => $this->resolveTeamName($teamid),
-                    'streak' => $data['streak'],
-                    'start_date' => $data['start'],
-                    'end_date' => $data['end'],
-                    'start_year' => $startYear,
-                    'end_year' => $endYear,
-                ];
-            }
-        }
-
-        return $records;
+        return StreakCalculator::longestStreak(
+            $this->getRegularSeasonGames(),
+            $type,
+            fn (int $teamId): string => $this->resolveTeamName($teamId)
+        );
     }
 
     /**
      * @see RecordHoldersRepositoryInterface::getBestWorstSeasonStart()
      *
-     * Finds the team with the best/worst record at the START of any season.
-     * Best start = most consecutive wins from game 1; Worst start = most consecutive losses.
-     *
      * @return list<SeasonStartRecord>
      */
     public function getBestWorstSeasonStart(string $type): array
     {
-        $rows = $this->getRegularSeasonGames();
-
-        // Track season starts per team per season
-        /** @var array<string, array{wins: int, losses: int, streakBroken: bool}> $seasonStarts */
-        $seasonStarts = [];
-
-        foreach ($rows as $row) {
-            /** @var array{game_date: string, visitor_teamid: int, home_teamid: int, visitorScore: int, homeScore: int} $row */
-            $date = $row['game_date'];
-            $visitorTid = $row['visitor_teamid'];
-            $homeTid = $row['home_teamid'];
-            $visitorScore = $row['visitorScore'];
-            $homeScore = $row['homeScore'];
-            $visitorWon = $visitorScore > $homeScore;
-            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($date);
-
-            foreach ([$visitorTid, $homeTid] as $teamid) {
-                $key = $teamid . '-' . $seasonYear;
-                if (!isset($seasonStarts[$key])) {
-                    $seasonStarts[$key] = ['wins' => 0, 'losses' => 0, 'streakBroken' => false];
-                }
-
-                if ($seasonStarts[$key]['streakBroken']) {
-                    continue;
-                }
-
-                $teamWon = ($teamid === $visitorTid) ? $visitorWon : !$visitorWon;
-
-                if ($type === 'best') {
-                    if ($teamWon) {
-                        $seasonStarts[$key]['wins']++;
-                    } else {
-                        $seasonStarts[$key]['streakBroken'] = true;
-                    }
-                } else {
-                    if (!$teamWon) {
-                        $seasonStarts[$key]['losses']++;
-                    } else {
-                        $seasonStarts[$key]['streakBroken'] = true;
-                    }
-                }
-            }
-        }
-
-        // Find the record-holding start
-        $maxValue = 0;
-        foreach ($seasonStarts as $data) {
-            $value = $type === 'best' ? $data['wins'] : $data['losses'];
-            if ($value > $maxValue) {
-                $maxValue = $value;
-            }
-        }
-
-        /** @var list<SeasonStartRecord> $records */
-        $records = [];
-        foreach ($seasonStarts as $key => $data) {
-            $value = $type === 'best' ? $data['wins'] : $data['losses'];
-            if ($value === $maxValue && $maxValue > 0) {
-                [$tidStr, $yearStr] = explode('-', $key);
-                $teamid = (int) $tidStr;
-                $year = (int) $yearStr;
-                if ($type === 'best') {
-                    $records[] = [
-                        'team_name' => $this->resolveTeamName($teamid),
-                        'year' => $year,
-                        'wins' => $data['wins'],
-                        'losses' => 0,
-                    ];
-                } else {
-                    $records[] = [
-                        'team_name' => $this->resolveTeamName($teamid),
-                        'year' => $year,
-                        'wins' => 0,
-                        'losses' => $data['losses'],
-                    ];
-                }
-            }
-        }
-
-        return $records;
+        return StreakCalculator::bestWorstSeasonStart(
+            $this->getRegularSeasonGames(),
+            $type,
+            fn (int $teamId): string => $this->resolveTeamName($teamId)
+        );
     }
 
     /**

--- a/ibl5/classes/RecordHolders/StreakCalculator.php
+++ b/ibl5/classes/RecordHolders/StreakCalculator.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RecordHolders;
+
+use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
+
+/**
+ * Pure streak/season-start computation extracted from RecordHoldersRepository.
+ * No database dependency: operates on already-fetched game rows.
+ * @phpstan-import-type StreakRecord from RecordHoldersRepositoryInterface
+ * @phpstan-import-type SeasonStartRecord from RecordHoldersRepositoryInterface
+ */
+final class StreakCalculator
+{
+    /**
+     * @param list<array{game_date: string, visitor_teamid: int, home_teamid: int, visitorScore: int, homeScore: int}> $games
+     * @param callable(int): string $resolveTeamName
+     * @return list<StreakRecord>
+     */
+    public static function longestStreak(array $games, string $type, callable $resolveTeamName): array
+    {
+        // Track streaks per team
+        /** @var array<int, array{current: int, start: string, team: int}> $streaks */
+        $streaks = [];
+        /** @var array<int, array{streak: int, start: string, end: string}> $bestStreaks */
+        $bestStreaks = [];
+
+        foreach ($games as $row) {
+            /** @var array{game_date: string, visitor_teamid: int, home_teamid: int, visitorScore: int, homeScore: int} $row */
+            $date = $row['game_date'];
+            $visitorTid = $row['visitor_teamid'];
+            $homeTid = $row['home_teamid'];
+            $visitorScore = $row['visitorScore'];
+            $homeScore = $row['homeScore'];
+
+            $visitorWon = $visitorScore > $homeScore;
+
+            foreach ([$visitorTid, $homeTid] as $teamid) {
+                $teamWon = ($teamid === $visitorTid) ? $visitorWon : !$visitorWon;
+                $isStreakType = ($type === 'winning') ? $teamWon : !$teamWon;
+
+                if (!isset($streaks[$teamid])) {
+                    $streaks[$teamid] = ['current' => 0, 'start' => '', 'team' => $teamid];
+                    $bestStreaks[$teamid] = ['streak' => 0, 'start' => '', 'end' => ''];
+                }
+
+                if ($isStreakType) {
+                    if ($streaks[$teamid]['current'] === 0) {
+                        $streaks[$teamid]['start'] = $date;
+                    }
+                    $streaks[$teamid]['current']++;
+                    if ($streaks[$teamid]['current'] > $bestStreaks[$teamid]['streak']) {
+                        $bestStreaks[$teamid] = [
+                            'streak' => $streaks[$teamid]['current'],
+                            'start' => $streaks[$teamid]['start'],
+                            'end' => $date,
+                        ];
+                    }
+                } else {
+                    $streaks[$teamid]['current'] = 0;
+                }
+            }
+        }
+
+        // Find the overall best
+        $maxStreak = 0;
+        foreach ($bestStreaks as $data) {
+            if ($data['streak'] > $maxStreak) {
+                $maxStreak = $data['streak'];
+            }
+        }
+
+        // Collect all teams matching the max streak
+        /** @var list<StreakRecord> $records */
+        $records = [];
+        foreach ($bestStreaks as $teamid => $data) {
+            if ($data['streak'] === $maxStreak && $maxStreak > 0) {
+                $startYear = IblSeasonDateHelper::dateToSeasonEndingYear($data['start']);
+                $endYear = IblSeasonDateHelper::dateToSeasonEndingYear($data['end']);
+                $records[] = [
+                    'team_name' => $resolveTeamName($teamid),
+                    'streak' => $data['streak'],
+                    'start_date' => $data['start'],
+                    'end_date' => $data['end'],
+                    'start_year' => $startYear,
+                    'end_year' => $endYear,
+                ];
+            }
+        }
+
+        return $records;
+    }
+
+    /**
+     * @param list<array{game_date: string, visitor_teamid: int, home_teamid: int, visitorScore: int, homeScore: int}> $games
+     * @param callable(int): string $resolveTeamName
+     * @return list<SeasonStartRecord>
+     */
+    public static function bestWorstSeasonStart(array $games, string $type, callable $resolveTeamName): array
+    {
+        // Track season starts per team per season
+        /** @var array<string, array{wins: int, losses: int, streakBroken: bool}> $seasonStarts */
+        $seasonStarts = [];
+
+        foreach ($games as $row) {
+            /** @var array{game_date: string, visitor_teamid: int, home_teamid: int, visitorScore: int, homeScore: int} $row */
+            $date = $row['game_date'];
+            $visitorTid = $row['visitor_teamid'];
+            $homeTid = $row['home_teamid'];
+            $visitorScore = $row['visitorScore'];
+            $homeScore = $row['homeScore'];
+            $visitorWon = $visitorScore > $homeScore;
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($date);
+
+            foreach ([$visitorTid, $homeTid] as $teamid) {
+                $key = $teamid . '-' . $seasonYear;
+                if (!isset($seasonStarts[$key])) {
+                    $seasonStarts[$key] = ['wins' => 0, 'losses' => 0, 'streakBroken' => false];
+                }
+
+                if ($seasonStarts[$key]['streakBroken']) {
+                    continue;
+                }
+
+                $teamWon = ($teamid === $visitorTid) ? $visitorWon : !$visitorWon;
+
+                if ($type === 'best') {
+                    if ($teamWon) {
+                        $seasonStarts[$key]['wins']++;
+                    } else {
+                        $seasonStarts[$key]['streakBroken'] = true;
+                    }
+                } else {
+                    if (!$teamWon) {
+                        $seasonStarts[$key]['losses']++;
+                    } else {
+                        $seasonStarts[$key]['streakBroken'] = true;
+                    }
+                }
+            }
+        }
+
+        // Find the record-holding start
+        $maxValue = 0;
+        foreach ($seasonStarts as $data) {
+            $value = $type === 'best' ? $data['wins'] : $data['losses'];
+            if ($value > $maxValue) {
+                $maxValue = $value;
+            }
+        }
+
+        /** @var list<SeasonStartRecord> $records */
+        $records = [];
+        foreach ($seasonStarts as $key => $data) {
+            $value = $type === 'best' ? $data['wins'] : $data['losses'];
+            if ($value === $maxValue && $maxValue > 0) {
+                [$tidStr, $yearStr] = explode('-', $key);
+                $teamid = (int) $tidStr;
+                $year = (int) $yearStr;
+                if ($type === 'best') {
+                    $records[] = [
+                        'team_name' => $resolveTeamName($teamid),
+                        'year' => $year,
+                        'wins' => $data['wins'],
+                        'losses' => 0,
+                    ];
+                } else {
+                    $records[] = [
+                        'team_name' => $resolveTeamName($teamid),
+                        'year' => $year,
+                        'wins' => 0,
+                        'losses' => $data['losses'],
+                    ];
+                }
+            }
+        }
+
+        return $records;
+    }
+}

--- a/ibl5/tests/RecordHolders/StreakCalculatorTest.php
+++ b/ibl5/tests/RecordHolders/StreakCalculatorTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\RecordHolders;
+
+use PHPUnit\Framework\TestCase;
+use RecordHolders\StreakCalculator;
+
+class StreakCalculatorTest extends TestCase
+{
+    /** @var callable(int): string */
+    private $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = fn (int $tid): string => 'T' . $tid;
+    }
+
+    /**
+     * @return array{game_date: string, visitor_teamid: int, home_teamid: int, visitorScore: int, homeScore: int}
+     */
+    private function game(string $date, int $vis, int $home, int $visScore, int $homeScore): array
+    {
+        return [
+            'game_date'      => $date,
+            'visitor_teamid' => $vis,
+            'home_teamid'    => $home,
+            'visitorScore'   => $visScore,
+            'homeScore'      => $homeScore,
+        ];
+    }
+
+    // Test 1: empty input → []
+    public function testLongestStreakEmptyInput(): void
+    {
+        $result = StreakCalculator::longestStreak([], 'winning', $this->resolver);
+        $this->assertSame([], $result);
+    }
+
+    // Test 2: W W L W W W → streak 3, second run's start/end dates
+    public function testLongestStreakSecondRunDates(): void
+    {
+        $games = [
+            $this->game('2024-01-01', 1, 2, 100, 90), // T1 wins
+            $this->game('2024-01-02', 1, 2, 100, 90), // T1 wins
+            $this->game('2024-01-03', 1, 2, 90, 100),  // T2 wins (T1 loses, streak resets)
+            $this->game('2024-01-04', 1, 2, 100, 90), // T1 wins — second run starts
+            $this->game('2024-01-05', 1, 2, 100, 90), // T1 wins
+            $this->game('2024-01-06', 1, 2, 100, 90), // T1 wins
+        ];
+
+        $result = StreakCalculator::longestStreak($games, 'winning', $this->resolver);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('T1', $result[0]['team_name']);
+        $this->assertSame(3, $result[0]['streak']);
+        $this->assertSame('2024-01-04', $result[0]['start_date']);
+        $this->assertSame('2024-01-06', $result[0]['end_date']);
+    }
+
+    // Test 3: Two teams tied at max N → both returned (tie collection + maxStreak > 0)
+    public function testLongestStreakTwoTeamsTied(): void
+    {
+        $games = [];
+        // T3 beats T5 three times
+        for ($i = 1; $i <= 3; $i++) {
+            $games[] = $this->game('2024-02-0' . $i, 3, 5, 100, 90);
+        }
+        // T4 beats T6 three times — same max streak
+        for ($i = 1; $i <= 3; $i++) {
+            $games[] = $this->game('2024-02-0' . ($i + 3), 4, 6, 100, 90);
+        }
+
+        $result = StreakCalculator::longestStreak($games, 'winning', $this->resolver);
+
+        $teamNames = array_column($result, 'team_name');
+        $this->assertCount(2, $result);
+        $this->assertContains('T3', $teamNames);
+        $this->assertContains('T4', $teamNames);
+        $this->assertSame(3, $result[0]['streak']);
+    }
+
+    // Test 4: Streak crossing IBL season boundary → start_year !== end_year
+    public function testLongestStreakCrossesSeasonBoundary(): void
+    {
+        // Jan 2022 → IblSeasonDateHelper returns season year 2022
+        // Nov 2022 → IblSeasonDateHelper returns season year 2023
+        $games = [
+            $this->game('2022-01-15', 10, 11, 100, 90),
+            $this->game('2022-11-15', 10, 11, 100, 90),
+        ];
+
+        $result = StreakCalculator::longestStreak($games, 'winning', $this->resolver);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('T10', $result[0]['team_name']);
+        $this->assertSame(2, $result[0]['streak']);
+        $this->assertSame(2022, $result[0]['start_year']);
+        $this->assertSame(2023, $result[0]['end_year']);
+        $this->assertNotSame($result[0]['start_year'], $result[0]['end_year']);
+    }
+
+    // Test 5: losing type — T10 loses 3 consecutive games
+    public function testLongestStreakLosingType(): void
+    {
+        $games = [
+            $this->game('2024-01-01', 10, 12, 90, 100), // T10 loses
+            $this->game('2024-01-02', 10, 12, 90, 100), // T10 loses
+            $this->game('2024-01-03', 10, 12, 90, 100), // T10 loses
+            $this->game('2024-01-04', 10, 12, 100, 90), // T10 wins (breaks streak)
+        ];
+
+        $result = StreakCalculator::longestStreak($games, 'losing', $this->resolver);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('T10', $result[0]['team_name']);
+        $this->assertSame(3, $result[0]['streak']);
+        $this->assertSame('2024-01-01', $result[0]['start_date']);
+        $this->assertSame('2024-01-03', $result[0]['end_date']);
+    }
+
+    // Test 6: bestWorstSeasonStart empty input → []
+    public function testBestWorstSeasonStartEmptyInput(): void
+    {
+        $result = StreakCalculator::bestWorstSeasonStart([], 'best', $this->resolver);
+        $this->assertSame([], $result);
+    }
+
+    // Test 7: W W L for best → wins===2 (streakBroken halts count)
+    public function testBestSeasonStartWwl(): void
+    {
+        $games = [
+            $this->game('2024-01-01', 1, 2, 100, 90), // T1 wins, T2 loses → T2 streak broken
+            $this->game('2024-01-02', 1, 2, 100, 90), // T1 wins (wins=2)
+            $this->game('2024-01-03', 1, 2, 90, 100),  // T2 wins, T1 loses → T1 streak broken
+        ];
+
+        $result = StreakCalculator::bestWorstSeasonStart($games, 'best', $this->resolver);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('T1', $result[0]['team_name']);
+        $this->assertSame(2, $result[0]['wins']);
+    }
+
+    // Test 8: Team that loses game 1 (best) excluded; tied single-best survivor returned
+    public function testBestSeasonStartTeamLosingGame1Excluded(): void
+    {
+        $games = [
+            $this->game('2024-01-01', 1, 2, 90, 100),  // T2 wins, T1 loses → T1 streak broken immediately
+            $this->game('2024-01-02', 1, 2, 90, 100),  // T2 wins (wins=2), T1 skipped
+            $this->game('2024-01-03', 1, 2, 100, 90),  // T1 wins (skipped), T2 loses → T2 streak broken
+        ];
+
+        $result = StreakCalculator::bestWorstSeasonStart($games, 'best', $this->resolver);
+
+        $teamNames = array_column($result, 'team_name');
+        $this->assertNotContains('T1', $teamNames);
+        $this->assertContains('T2', $teamNames);
+        $this->assertSame(2, $result[0]['wins']);
+    }
+
+    // Test 9: Same team in two season-years counted independently per teamid-year key
+    public function testBestSeasonStartIndependentPerYear(): void
+    {
+        $games = [
+            // Jan 2022 → season year 2022
+            $this->game('2022-01-01', 1, 2, 100, 90),
+            $this->game('2022-01-02', 1, 2, 100, 90),
+            // Jan 2023 → season year 2023
+            $this->game('2023-01-01', 1, 2, 100, 90),
+            $this->game('2023-01-02', 1, 2, 100, 90),
+            $this->game('2023-01-03', 1, 2, 100, 90),
+        ];
+
+        $result = StreakCalculator::bestWorstSeasonStart($games, 'best', $this->resolver);
+
+        // T1 in 2022: wins=2; T1 in 2023: wins=3 → maxValue=3 → only 2023 entry returned
+        $this->assertCount(1, $result);
+        $this->assertSame('T1', $result[0]['team_name']);
+        $this->assertSame(2023, $result[0]['year']);
+        $this->assertSame(3, $result[0]['wins']);
+    }
+
+    // Test 10: worst type returns losses field
+    public function testWorstSeasonStartReturnsLosses(): void
+    {
+        $games = [
+            $this->game('2024-01-01', 1, 2, 90, 100),  // T1 loses (losses=1), T2 wins → T2 streak broken
+            $this->game('2024-01-02', 1, 2, 90, 100),  // T1 loses (losses=2), T2 skipped
+            $this->game('2024-01-03', 1, 2, 100, 90),  // T1 wins → T1 streak broken, T2 skipped
+        ];
+
+        $result = StreakCalculator::bestWorstSeasonStart($games, 'worst', $this->resolver);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('T1', $result[0]['team_name']);
+        $this->assertSame(2, $result[0]['losses']);
+        $this->assertSame(0, $result[0]['wins']);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the two pure state-machine loop bodies from `RecordHoldersRepository` into a new `RecordHolders\StreakCalculator` static helper class (maintenance backlog findings 1.2 + 7.16).

**What moved:** the streak/season-start computation loops from `getLongestStreak()` (lines 388–457) and `getBestWorstSeasonStart()` (lines 472–549) are extracted verbatim into `StreakCalculator::longestStreak()` and `StreakCalculator::bestWorstSeasonStart()`. The only semantic edit is `$this->resolveTeamName()` → the passed-in `callable $resolveTeamName`.

**Repository methods stay public and keep their signatures.** Each shrinks to fetch-and-delegate:
```php
return StreakCalculator::longestStreak(
    $this->getRegularSeasonGames(),
    $type,
    fn (int $teamId): string => $this->resolveTeamName($teamId)
);
```

**7.16 hidden caches resolved:** `$regularSeasonGamesCache` and `$teamNameCache` are now documented as per-request memoization in docblocks. Interface updated with a note that implementations are request-scoped.

**~165 net LOC removed** from the repository (still ~810 LOC total; HEAT-champion CTE extraction is deferred per plan — that requires a migration).

## Changed files

- `classes/RecordHolders/StreakCalculator.php` — **new** pure state-machine helper
- `classes/RecordHolders/RecordHoldersRepository.php` — methods delegate; cache docblocks updated
- `tests/RecordHolders/StreakCalculatorTest.php` — **new** value-pinned unit characterization (10 cases)
- `classes/RecordHolders/Contracts/RecordHoldersRepositoryInterface.php` — request-scoped memoization note

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.