### PR TITLE
ci(lighthouse): extract shared setup composite + make lighthouse.yml PR-only

### DIFF
--- a/.github/actions/lighthouse-setup/action.yml
+++ b/.github/actions/lighthouse-setup/action.yml
@@ -1,0 +1,34 @@
+name: 'Lighthouse Setup'
+description: 'Shared Lighthouse CI prelude: Bun + dependency caching + install + Docker E2E stack'
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+
+    - name: Cache vendor directory
+      uses: actions/cache@v5
+      with:
+        path: ibl5/vendor
+        key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-vendor-
+
+    - name: Cache node_modules
+      uses: actions/cache@v5
+      with:
+        path: ibl5/node_modules
+        key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ibl5
+      run: |
+        composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
+        bun install
+
+    - uses: ./.github/actions/setup-docker-e2e
+      with:
+        build-css: 'true'

--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -22,34 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Cache vendor directory
-        uses: actions/cache@v5
-        with:
-          path: ibl5/vendor
-          key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-vendor-
-
-      - name: Cache node_modules
-        uses: actions/cache@v5
-        with:
-          path: ibl5/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        working-directory: ibl5
-        run: |
-          composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
-          bun install
-
-      - uses: ./.github/actions/setup-docker-e2e
-        with:
-          build-css: 'true'
+      - uses: ./.github/actions/lighthouse-setup
 
       - name: Generate URL list
         run: bin/lighthouse-audit-urls --json > /tmp/urls.json

--- a/.github/workflows/lighthouse-baseline.yml
+++ b/.github/workflows/lighthouse-baseline.yml
@@ -29,33 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Cache vendor directory
-        uses: actions/cache@v5
-        with:
-          path: ibl5/vendor
-          key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-vendor-
-
-      - name: Cache node_modules
-        uses: actions/cache@v5
-        with:
-          path: ibl5/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        working-directory: ibl5
-        run: |
-          composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
-          bun install
-
-      - uses: ./.github/actions/setup-docker-e2e
-        with:
-          build-css: 'true'
+      - uses: ./.github/actions/lighthouse-setup
 
       - name: Run Lighthouse
         working-directory: ibl5

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,18 +4,6 @@ on:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [master]
-    paths:
-      - '**.php'
-      - '**.css'
-      - '**.ts'
-      - '**.js'
-      - 'ibl5/design/**'
-      - 'ibl5/migrations/**.sql'
-      - 'Dockerfile'
-      - 'docker-compose*.yml'
-      - '.github/workflows/lighthouse.yml'
 
 permissions:
   contents: read
@@ -55,43 +43,14 @@ jobs:
     needs: [changes]
     if: |
       always() &&
-      (github.event_name == 'push' || needs.changes.outputs.src == 'true')
+      needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      # --- Dependency Caching ---
-      - name: Cache vendor directory
-        uses: actions/cache@v5
-        with:
-          path: ibl5/vendor
-          key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-vendor-
-
-      - name: Cache node_modules
-        uses: actions/cache@v5
-        with:
-          path: ibl5/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        working-directory: ibl5
-        run: |
-          composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
-          bun install
-
-      # --- Docker E2E Setup ---
-      - uses: ./.github/actions/setup-docker-e2e
-        with:
-          build-css: 'true'
+      - uses: ./.github/actions/lighthouse-setup
 
       # --- Lighthouse ---
       - name: Run Lighthouse CI
@@ -147,10 +106,6 @@ jobs:
         with:
           header: lighthouse-comment
           path: ibl5/.lighthouseci/comment.md
-
-      - name: Publish to job summary (master push)
-        if: always() && github.event_name == 'push' && hashFiles('ibl5/.lighthouseci/comment.md') != ''
-        run: cat ibl5/.lighthouseci/comment.md >> "$GITHUB_STEP_SUMMARY"
 
       # --- Cleanup ---
       - name: Teardown


### PR DESCRIPTION
## Summary

Three Lighthouse workflows share a byte-identical 27-line setup prelude (Setup Bun, vendor/node_modules cache, dep install, `setup-docker-e2e`). Any version bump drifts across all three. This PR extracts the prelude into a single parameterless composite action and removes the duplicate push run from `lighthouse.yml`.

**What changes:**
- New `.github/actions/lighthouse-setup/action.yml`: parameterless composite with the shared prelude. Nested `setup-docker-e2e` call preserved (no inlining).
- `lighthouse.yml`: `push:` trigger + dead push-summary step removed; job `if:` simplified to `always() && needs.changes.outputs.src == 'true'`; 27-line prelude → 1 `uses:` line.
- `lighthouse-baseline.yml` + `lighthouse-audit.yml`: same prelude swap; all downstream steps (autorun, manifest write, artifact upload, issue logic) untouched.

**What doesn't change:** artifact name (`lighthouse-baseline-manifest`), `manifest.json`/`links.json` shape, download step in `lighthouse.yml`, URL/threshold config in `.lighthouserc.json`, `changes` job and path filters, teardown step.

**ADR:** not required — no new `.github/workflows/*.yml` added; no URL/threshold changes.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.