### PR TITLE
workflow: auto-fire /post-plan in fresh detached Sonnet session on impl completion

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -3,7 +3,7 @@ description: "Plan an implementation task: enforces a verification matrix, direc
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
-last_verified: 2026-06-07
+last_verified: 2026-06-11
 
 ---
 
@@ -136,6 +136,7 @@ After receiving the Plan agent's output, check these gates yourself — do NOT d
 11. **Refactor characterization** — if any step under `ibl5/classes/**` carries a refactor signal (file rename, method signature change, visibility narrowing, class removal, or > 30-line deletion per `refactor-flag.md`), the matrix must include a pre-impl characterization row for the affected code. If missing, add it.
 12. **Security surface resolved** — if Step 2 flagged a touched security surface, the plan contains a Security section with a defense step and matching matrix row for each. If a flagged surface has no resolution, add it.
 13. **impl_model criterion** — if the plan declares `impl_model: sonnet` frontmatter (see Step 5), scan the Verification Matrix; if ANY row is classified `Truly-manual`, strip the marker so the plan runs at the Opus default. Sonnet may drive a plan only when every behavior-changing step has an objectively machine-checkable row that fails on a wrong edit.
+14. **auto-fire risk criterion** — by default an implementation session auto-fires `/post-plan` the moment it verifies complete (no human eyeball before the PR opens and auto-merge arms). Decide yourself — do NOT delegate — whether this plan is risky enough to want that eyeball, and if so declare `auto_postplan: false` (see Step 5). Disable auto-fire when **any** hold: (a) the Verification Matrix carries a `Truly-manual` (or otherwise subjective) row — post-plan's machine gates can't validate it; (b) Step 2 flagged a touched security surface; (c) the plan is a high-blast-radius data/schema change — a destructive migration (DROP/backfill/data mutation), a column-rename sweep, or an FK-ordering migration. Otherwise omit the marker (default = auto-fire). This composes with gate 13: a `Truly-manual` row both strips `impl_model: sonnet` **and** sets `auto_postplan: false`.
 
 If validation fails on any gate, fix the matrix yourself rather than re-running the Plan agent.
 
@@ -163,11 +164,25 @@ impl_model: sonnet
 
 The implementation then runs at Sonnet (cheaper, verified-equivalent quality on uniformly-mechanical plans — parsed by `bin/lib/plan-impl-model`). Omit the marker for any plan carrying a `Truly-manual` or subjective row — absence defaults to Opus. Only the first frontmatter block is parsed, so documenting this syntax inside a plan body never mis-selects a model. Failure modes are bounded: an absent or garbled marker → Opus (safe); a wrongly-applied `sonnet` marker → the plan's objective matrix goes red under Sonnet → caught by CI / post-plan.
 
+### Disabling auto-fired post-plan (optional)
+
+By default an interactive implementation session, once it verifies complete, auto-fires a detached `/post-plan` via `bin/post-plan-now --auto` — opening the PR and arming auto-merge with no human eyeball at the trigger. For a plan judged risky by Step 4 gate 14, add `auto_postplan: false` to the **same** line-1 frontmatter block so the auto-fire skips (the work waits for a reviewed, manual `bin/post-plan-now`):
+
+```
+---
+impl_model: sonnet
+auto_postplan: false
+---
+```
+
+Either field may appear alone; the block above shows both (a mechanical column-rename sweep, e.g., can be Sonnet-eligible **and** high-blast-radius). Absence of `auto_postplan` defaults to auto-fire. Only the line-1 block is parsed (`bin/post-plan-now`), so a body that documents the syntax can't opt a plan out. Failure modes are bounded: absent/garbled → auto-fire (post-plan's own gates — code review, security audit, CI-green-required, headless golden-snapshot block — still apply); a wrongly-applied `false` → the plan just waits for a manual ship.
+
 ## Step 6: Report
 
 Tell the user:
 - The plan file path — **all of them** when the work was split into multiple PRs
 - A one-line matrix summary per plan (e.g., "12 items: 7 PHPUnit, 3 E2E, 2 CLI-executable, 0 truly-manual")
 - Whether any security surface was flagged and how each is defended (or "no security surface touched")
+- Whether post-plan auto-fires on completion (default) or is held for review (`auto_postplan: false`, per Step 4 gate 14) — and why, if held
 - For a multi-PR split: the PR sequence and dependency order (which lands first, what each stacks on)
 - Whether each plan is ready for implementation or has open questions

--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -1,6 +1,6 @@
 ---
-description: Worktree setup and the implementation→/post-plan handoff (run separately) for multi-step work.
-last_verified: 2026-06-08
+description: Worktree setup and the implementation→/post-plan handoff (auto-fired in a detached fresh session) for multi-step work.
+last_verified: 2026-06-11
 ---
 
 # Workflow Continuity Rule
@@ -21,10 +21,20 @@ Use `--base <branch>` for stacked PRs. Work in `IBL5-worktrees/<slug>/ibl5/` (wo
 
 ## Post-Plan
 
-After implementation, **STOP** — do **NOT** invoke `/post-plan` in this session. Leave the worktree with **uncommitted** changes and hand off; do not commit.
+Never run `/post-plan` **inline** in this session — it re-reads the full implementation context on every phase, so an inline run after a long implementation session (especially on Opus) costs several times a fresh run. It must run in a **fresh** session, with **cwd = this worktree**.
 
-`/post-plan` is run **separately**, in a **fresh** session (typically Sonnet), with **cwd = this worktree** so it sees the uncommitted working tree. Run it from a fresh session in the worktree as the model handing off, or hand the branch to a teammate.
+### Interactive sessions — auto-fire the handoff
 
-Why separate: `/post-plan` re-reads the full implementation context on every phase, so running it inline after a long implementation session — especially on Opus — costs several times a fresh run.
+When implementation is **verified complete**, your **final action** is:
 
-`/post-plan` auto-resolves the plan from the branch slug, fetches the diff itself, and commits the uncommitted working tree in its Phase 2.
+```bash
+bin/post-plan-now --auto
+```
+
+This spawns a detached, fresh **Sonnet 4.6** `/post-plan` on this branch (supervised by launchd, so it survives you closing Claude Code). It removes the manual "open a new session and hand off" step. Notes:
+
+- **Do NOT commit first.** Leave the worktree **dirty** — `/post-plan` commits the uncommitted tree in its Phase 2 and opens the PR. Committing here would change what it ships.
+- **Only fire when verification passed.** If implementation did **not** verify clean (failing tests, unresolved blocker, you stopped to ask the user something), do **not** run it — leave the worktree dirty and hand off in prose instead. Turn-end ≠ done; that judgment is yours.
+- **No deadlock.** `/post-plan` resolves the plan from the branch slug (no handoff file needed); the detached child is reparented under launchd, so it clears its own plan-gate independently of this session.
+
+`--auto` adds two safety gates (a bare `bin/post-plan-now` skips them — running it by hand IS the decision to ship): it **skips** when already inside a headless/nightly run (the nightly runner fires post-plan itself), and it **honors** a plan that declares `auto_postplan: false` — a plan judged risky enough (see `/plan` Step 4) to want a human eyeball before the PR opens and auto-merge arms. A skipped risky plan is shipped later with a reviewed bare `bin/post-plan-now`.

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# bin/post-plan-now — fire a fresh, detached Sonnet 4.6 /post-plan session on the
+# current worktree's branch, replacing the manual "open a new session and hand
+# off" step. The run is supervised by launchd (RunAtLoad one-shot), so it
+# survives closing Claude Code or the terminal — a plain `nohup … &` launched
+# from Claude Code's Bash tool shares the tool-shell's process group and dies
+# with it, so launchd is the load-bearing detach mechanism (same reason
+# bin/nightly-run uses launchd).
+#
+# The plan is resolved from the branch slug by /post-plan Phase 1 — no handoff
+# file is needed (that machinery is nightly-only).
+#
+# Usage:
+#   bin/post-plan-now           # you decided to ship: fire unconditionally
+#   bin/post-plan-now --auto    # impl agent's closing action: honor the plan's
+#                               #   `auto_postplan: false` opt-out and skip when
+#                               #   already inside a headless/nightly run
+#
+# Run from anywhere inside the target worktree.
+
+set -euo pipefail
+
+AUTO=0
+[ "${1:-}" = "--auto" ] && AUTO=1
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
+    || { echo "post-plan-now: not inside a git repo." >&2; exit 1; }
+cd "$ROOT"
+SLUG=$(git rev-parse --abbrev-ref HEAD)
+
+case "$SLUG" in
+    master|main|HEAD)
+        echo "post-plan-now: refusing to run on '$SLUG' — switch to the feature branch." >&2
+        exit 1 ;;
+esac
+
+PLAN_FILE="$HOME/.claude/plans/$SLUG.md"
+
+# --auto is the impl agent's automatic closing action. Two gates apply only here;
+# a bare (human) invocation always fires, because running it by hand IS the
+# decision to ship.
+if [ "$AUTO" -eq 1 ]; then
+    # (1) We're already inside a headless/nightly run — the nightly runner fires
+    #     post-plan itself, so an auto-fire here would double-run. The
+    #     workflow-continuity rule that tells the impl agent to call this is
+    #     globally loaded, so the nightly impl agent sees it too; this is the
+    #     belt-and-suspenders guard against that.
+    if [ "${CLAUDE_HEADLESS:-}" = "1" ]; then
+        echo "post-plan-now: CLAUDE_HEADLESS=1 — nightly/headless run owns post-plan; skipping auto-fire."
+        exit 0
+    fi
+    # (2) The plan opted out of auto-fire (judged risky enough to want a human
+    #     eyeball before the PR opens / auto-merge arms). Parse the line-1 YAML
+    #     frontmatter only — a body that documents the syntax can't self-select.
+    if [ -f "$PLAN_FILE" ]; then
+        AUTO_PP=$(awk '
+            NR==1 && /^---[[:space:]]*$/ {infm=1; next}
+            infm && /^---[[:space:]]*$/ {infm=0; exit}
+            infm && /^auto_postplan:[[:space:]]*/ {
+                sub(/^auto_postplan:[[:space:]]*/,""); gsub(/[[:space:]]/,""); print; exit
+            }
+        ' "$PLAN_FILE" 2>/dev/null)
+        if [ "$AUTO_PP" = "false" ]; then
+            echo "post-plan-now: plan declares 'auto_postplan: false' — judged risky; not auto-firing."
+            echo "  Review the worktree, then ship when ready:  bin/post-plan-now"
+            exit 0
+        fi
+    fi
+fi
+
+# Nothing to ship? Clean tree AND no commits ahead of origin/master.
+if git diff --quiet && git diff --cached --quiet \
+   && [ -z "$(git log --oneline origin/master..HEAD 2>/dev/null)" ]; then
+    echo "post-plan-now: nothing to do — clean tree and no commits ahead of master." >&2
+    exit 1
+fi
+
+[ -f "$PLAN_FILE" ] \
+    || echo "post-plan-now: warn — no plan at $PLAN_FILE; /post-plan will run plan-blind." >&2
+
+TS=$(date +%Y%m%d-%H%M%S)
+LOG="/tmp/post-plan-now-$SLUG-$TS.log"
+LABEL="com.ibl5.postplan-now-$SLUG-$TS"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+PROMPT="Invoke the /post-plan skill now on the current git branch. Resolve the plan from the branch slug per the skill Phase 1, then execute every phase. No human is present: never ask questions or wait for input — make the safe choice and continue."
+
+# launchd runs with a minimal env, so prepend the same PATH bin/nightly-run uses
+# (proven to find claude/gh/docker/node for full post-plan runs). CLAUDE_HEADLESS=1
+# marks the detached run unattended: /post-plan skips the Phase 10 preview rebuild
+# and BLOCKS auto-merge on a golden-snapshot change instead of merely warning.
+# caffeinate -s keeps the Mac awake on AC for the run's duration.
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>$LABEL</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-lc</string>
+		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>WorkingDirectory</key>
+	<string>$ROOT</string>
+	<key>StandardOutPath</key>
+	<string>$LOG</string>
+	<key>StandardErrorPath</key>
+	<string>$LOG</string>
+</dict>
+</plist>
+PLIST_EOF
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+
+echo "post-plan-now: fired a detached Sonnet 4.6 /post-plan on branch '$SLUG'."
+echo "  supervised by launchd — survives closing Claude Code / the terminal"
+echo "  log:    tail -f $LOG"
+echo "  label:  $LABEL   (self-removes when post-plan finishes)"
+echo "  PR / code review / CI / auto-merge progress appears on the PR."
+echo "  Leave this worktree alone — /post-plan rebuilds its Docker stack for E2E."


### PR DESCRIPTION
## Summary

Eliminates the manual "open a new session and hand off" step after implementation.

**Before:** impl agent would stop, leave the worktree dirty, and instruct the user to open a fresh session and run `/post-plan`.

**After:** impl agent's final action is `bin/post-plan-now --auto`, which spawns a detached Sonnet 4.6 `/post-plan` session supervised by launchd — it survives closing Claude Code or the terminal.

## Changes

- **`bin/post-plan-now`** (new): fires the detached session. Two auto-fire safety gates (`--auto` mode only):
  1. Skips if `CLAUDE_HEADLESS=1` — nightly runner owns post-plan itself
  2. Skips if the plan declares `auto_postplan: false` (risky plan opted out of unattended ship)
- **`workflow-continuity.md`**: replaces manual handoff prose with auto-fire instructions; impl agent fires `bin/post-plan-now --auto` when verified complete, leaves the worktree dirty
- **`plan.md`**: adds gate 14 (auto-fire risk criterion) and `auto_postplan` frontmatter field; documents when to opt out (truly-manual rows, security surfaces, high-blast-radius schema changes); composes with gate 13 (`impl_model: sonnet`)

## Manual Testing

No manual testing needed — all changes are workflow tooling (script, docs, rules) with no UI/UX to evaluate subjectively.

---
Generated with [Claude Code](https://claude.ai/code)
<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>
