### PR TITLE
feat(doc-freshness): split staleness from PR gate onto nightly audit workflow

### DIFF
--- a/.github/workflows/doc-freshness-audit.yml
+++ b/.github/workflows/doc-freshness-audit.yml
@@ -1,0 +1,131 @@
+name: Doc Freshness Audit
+
+on:
+  # Nightly. Offset minute (not :00) per the log-review.yml convention.
+  schedule:
+    - cron: '43 11 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: doc-freshness-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Repo-wide staleness audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Generate staleness report
+        id: report
+        run: |
+          bin/check-docs --staleness-report > /tmp/stale.json
+          COUNT=$(jq 'length' /tmp/stale.json)
+          SIG=$(jq -r '.[].path' /tmp/stale.json | sort | paste -sd, -)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "sig=$SIG" >> "$GITHUB_OUTPUT"
+          echo "Stale docs: $COUNT"
+
+      - name: Build issue body
+        run: |
+          {
+            echo "Repo-wide doc staleness audit ($(date -u +%Y-%m-%d))."
+            echo ""
+            echo "These in-scope docs have a \`last_verified\` older than the 60-day window."
+            echo ""
+            echo "| Doc | last_verified | Age (days) | Days over |"
+            echo "|-----|---------------|------------|-----------|"
+            jq -r '.[] | "| `\(.path)` | \(.last_verified) | \(.age_days) | \(.days_over) |"' /tmp/stale.json
+            echo ""
+            echo "**Remediation:** re-verify each doc against reality, then bump its \`last_verified\` to today and commit (on a branch that touches the doc, \`bin/check-docs --fix-dates --since=master\` bumps the changed-but-unbumped ones)."
+            echo ""
+            echo "<!-- stale-set: ${{ steps.report.outputs.sig }} -->"
+          } > /tmp/issue-body.md
+
+      - name: Ensure stale-docs label exists
+        run: gh label create stale-docs --color 0075ca --force 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: File or update the stale-docs issue (idempotent)
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COUNT: ${{ steps.report.outputs.count }}
+          CUR_SIG: ${{ steps.report.outputs.sig }}
+        run: |
+          NUM=$(gh issue list --label stale-docs --state open --json number --jq '.[0].number // empty')
+          PREV_SIG=""
+          if [ -n "$NUM" ]; then
+            PREV_SIG=$(gh issue view "$NUM" --json body --jq '.body' \
+              | tr -d '\r' | sed -n 's/.*<!-- stale-set: \(.*\) -->.*/\1/p')
+          fi
+
+          if [ "$COUNT" -eq 0 ]; then
+            # Everything is fresh again — close the open issue, stay silent.
+            if [ -n "$NUM" ]; then
+              gh issue close "$NUM" --comment "All previously-stale docs are now fresh. Closing automatically."
+            fi
+            echo "notify=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$NUM" ]; then
+            gh issue create \
+              --title "Stale docs: $COUNT over the 60-day window" \
+              --body-file /tmp/issue-body.md \
+              --label stale-docs
+            echo "notify=true" >> "$GITHUB_OUTPUT"
+          elif [ "$CUR_SIG" = "$PREV_SIG" ]; then
+            # Same set of stale docs as the open issue — leave it, no ping.
+            echo "Stale set unchanged; leaving issue #$NUM as-is."
+            echo "notify=false" >> "$GITHUB_OUTPUT"
+          else
+            gh issue edit "$NUM" --body-file /tmp/issue-body.md
+            echo "notify=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to job summary
+        run: |
+          if [ "${{ steps.report.outputs.count }}" -gt 0 ]; then
+            cat /tmp/issue-body.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No stale docs — all in-scope docs are within the 60-day window." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Setup SSH
+        if: steps.issue.outputs.notify == 'true'
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+        env:
+          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Send Discord DM
+        if: steps.issue.outputs.notify == 'true'
+        env:
+          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
+          COUNT: ${{ steps.report.outputs.count }}
+        run: |
+          MSG=$(printf 'Doc Freshness Audit: %s doc(s) past the 60-day staleness window.\nIssue + details: https://github.com/%s/actions/runs/%s' \
+            "$COUNT" "${{ github.repository }}" "${{ github.run_id }}")
+
+          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
+            '{content: {receivingUserDiscordID: $id, message: $msg}}')
+
+          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
+            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
+            || echo "::warning::IBLbot notification failed (bot may be down)"

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -30,8 +30,12 @@ jobs:
           php-version: '8.5'
           coverage: none
 
-      - name: Run bin/check-docs
-        run: bin/check-docs
+      - name: Run bin/check-docs (frontmatter, dead-refs, ADR transitions)
+        # Staleness is deliberately suppressed here: an untouched stale doc must
+        # not block an unrelated PR. Repo-wide staleness is owned by the nightly
+        # doc-freshness-audit workflow; on-touch staleness is still enforced by
+        # the --since step below.
+        run: bin/check-docs --no-staleness
 
       - name: Run bin/check-docs (on-touch / changed-files)
         if: github.event_name == 'pull_request'

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -69,6 +69,15 @@ Options:
                      changed file is also run through the full-scan checks
                      (future-date, staleness, dead-ref). Pure base-vs-head
                      value comparison — never date-equality-to-today.
+  --no-staleness     Full-scan only: suppress the 60-day staleness rule while
+                     still failing on frontmatter, future-date, dead-ref, and
+                     ADR-transition issues. Used by the PR/push gate so an
+                     untouched stale doc never blocks an unrelated change; the
+                     nightly audit owns repo-wide staleness instead.
+  --staleness-report Full-scan only: emit a JSON array of stale docs
+                     ([{path, last_verified, age_days, days_over}]) and exit 0
+                     regardless of whether any doc is stale. A report, not a
+                     gate. Consumed by the doc-freshness-audit workflow.
   --verbose, -v      Show passing files too.
   --help, -h         Show this message.
 
@@ -243,8 +252,29 @@ function scanReferences(string $content, string $repoRoot): array
     return array_values(array_unique($issues));
 }
 
+/**
+ * Age in days of a valid, non-future, past ISO last_verified value.
+ *
+ * Returns null when the value is missing, not an ISO date, unparseable, or in
+ * the future — those are the gate's job (checkFile emits them as failures) and
+ * must never appear in the staleness report. Both the gate's staleness check
+ * and the staleness report derive age from this single helper so they cannot
+ * disagree about what "stale" means.
+ */
+function stalenessAgeDays(?string $lv, \DateTimeImmutable $today): ?int
+{
+    if ($lv === null || preg_match('/^\d{4}-\d{2}-\d{2}$/', $lv) !== 1) {
+        return null;
+    }
+    $verified = \DateTimeImmutable::createFromFormat('!Y-m-d', $lv);
+    if ($verified === false || $verified > $today) {
+        return null;
+    }
+    return (int) $today->diff($verified)->days;
+}
+
 /** @return list<string> */
-function checkFile(string $path, string $repoRoot, \DateTimeImmutable $today): array
+function checkFile(string $path, string $repoRoot, \DateTimeImmutable $today, bool $enforceStaleness = true): array
 {
     if (!is_file($path)) {
         return ['broken symlink or missing file'];
@@ -276,7 +306,7 @@ function checkFile(string $path, string $repoRoot, \DateTimeImmutable $today): a
             } else {
                 $diff = $today->diff($verified);
                 $age = (int) $diff->days;
-                if ($age > STALENESS_DAYS) {
+                if ($enforceStaleness && $age > STALENESS_DAYS) {
                     $issues[] = sprintf('stale: last_verified %s is %d days old (max %d)', $lv, $age, STALENESS_DAYS);
                 }
             }
@@ -288,6 +318,48 @@ function checkFile(string $path, string $repoRoot, \DateTimeImmutable $today): a
     }
 
     return $issues;
+}
+
+/**
+ * Repo-wide staleness report: one entry per in-scope doc whose last_verified is
+ * a valid past ISO date older than STALENESS_DAYS. Missing/invalid/future dates
+ * are excluded — the gate (checkFile) owns those; the report only lists docs
+ * that are genuinely stale. Pure read; never fails.
+ *
+ * @return list<array{path: string, last_verified: string, age_days: int, days_over: int}>
+ */
+function stalenessReport(string $repoRoot, \DateTimeImmutable $today): array
+{
+    $files = collectFiles($repoRoot, false);
+    sort($files);
+
+    $report = [];
+    foreach ($files as $path) {
+        if (!is_file($path)) {
+            continue;
+        }
+        $content = file_get_contents($path);
+        if ($content === false) {
+            continue;
+        }
+        $fm = parseFrontmatter($content);
+        if ($fm === null || !isset($fm['last_verified'])) {
+            continue;
+        }
+        $lv = $fm['last_verified'];
+        $age = stalenessAgeDays($lv, $today);
+        if ($age === null || $age <= STALENESS_DAYS) {
+            continue;
+        }
+        $report[] = [
+            'path' => substr($path, strlen($repoRoot) + 1),
+            'last_verified' => $lv,
+            'age_days' => $age,
+            'days_over' => $age - STALENESS_DAYS,
+        ];
+    }
+
+    return $report;
 }
 
 /**
@@ -576,7 +648,7 @@ function iterChangedDocs(string $base, string $repoRoot): array
 
 // --- main ---
 
-$opts = ['fix_dates' => false, 'include_memory' => false, 'verbose' => false, 'since' => null];
+$opts = ['fix_dates' => false, 'include_memory' => false, 'verbose' => false, 'since' => null, 'no_staleness' => false, 'staleness_report' => false];
 foreach (array_slice($argv, 1) as $arg) {
     if (str_starts_with($arg, '--since=')) {
         $opts['since'] = substr($arg, strlen('--since='));
@@ -598,6 +670,12 @@ foreach (array_slice($argv, 1) as $arg) {
         case '-v':
             $opts['verbose'] = true;
             break;
+        case '--no-staleness':
+            $opts['no_staleness'] = true;
+            break;
+        case '--staleness-report':
+            $opts['staleness_report'] = true;
+            break;
         case '--help':
         case '-h':
             echo usage();
@@ -611,6 +689,14 @@ foreach (array_slice($argv, 1) as $arg) {
 
 $root = repoRoot();
 $today = new \DateTimeImmutable('today');
+
+// Report mode short-circuits: emit the stale-doc list as JSON and exit 0
+// regardless of whether any doc is stale. It is a report, not a gate — the
+// nightly audit workflow decides what to do with the list.
+if ($opts['staleness_report']) {
+    echo json_encode(stalenessReport($root, $today), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
+    exit(0);
+}
 
 if ($opts['since'] !== null) {
     // --fix-dates is scoped to the changed-but-unbumped set (the exact files
@@ -654,7 +740,7 @@ $failures = 0;
 $passed = 0;
 foreach ($files as $path) {
     $rel = substr($path, strlen($root) + 1);
-    $issues = checkFile($path, $root, $today);
+    $issues = checkFile($path, $root, $today, !$opts['no_staleness']);
     if ($issues === []) {
         $passed++;
         if ($opts['verbose']) {

--- a/ibl5/tests/Cli/CheckDocsCliTest.php
+++ b/ibl5/tests/Cli/CheckDocsCliTest.php
@@ -270,4 +270,96 @@ final class CheckDocsCliTest extends TestCase
         $this->assertSame(2, $code, $output);
         $this->assertStringContainsString('requires a base ref', $output);
     }
+
+    // --- Phase 3: --no-staleness (PR/push gate de-fang) ---
+
+    #[Test]
+    public function noStalenessStaleButValidDocExitsZero(): void
+    {
+        // Same fixture as fullScanWithStaleDocExitsOne, but the flag suppresses
+        // the staleness failure so an untouched stale doc no longer blocks.
+        $this->commitFile('ibl5/docs/sample.md', $this->doc('2026-01-01'), 'add stale doc');
+
+        [$code, $output] = $this->runScript('--no-staleness');
+        $this->assertSame(0, $code, $output);
+        $this->assertStringContainsString('docs verified', $output);
+        $this->assertStringNotContainsString('stale', $output);
+    }
+
+    #[Test]
+    public function noStalenessStillFailsOnDeadReference(): void
+    {
+        // A doc that is BOTH stale AND has a dead repo-path reference: the flag
+        // suppresses staleness, but the dead-ref failure must still fail the run.
+        $body = "References `ibl5/classes/DoesNotExist.php` which is not real.";
+        $this->commitFile('ibl5/docs/sample.md', $this->doc('2026-01-01', $body), 'stale + dead ref');
+
+        [$code, $output] = $this->runScript('--no-staleness');
+        $this->assertSame(1, $code, $output);
+        $this->assertStringContainsString('dead reference', $output);
+        $this->assertStringNotContainsString('stale', $output);
+    }
+
+    #[Test]
+    public function noStalenessStillFailsOnMissingFrontmatter(): void
+    {
+        // A second non-staleness failure class (missing frontmatter) survives the flag.
+        $this->commitFile('ibl5/docs/sample.md', "no frontmatter here\n", 'no frontmatter');
+
+        [$code, $output] = $this->runScript('--no-staleness');
+        $this->assertSame(1, $code, $output);
+        $this->assertStringContainsString('missing frontmatter block', $output);
+    }
+
+    // --- Phase 4: --staleness-report (nightly audit data source) ---
+
+    #[Test]
+    public function stalenessReportStaleDocExitsZeroWithJson(): void
+    {
+        $this->commitFile('ibl5/docs/sample.md', $this->doc('2026-01-01'), 'add stale doc');
+
+        [$code, $output] = $this->runScript('--staleness-report');
+        $this->assertSame(0, $code, $output);
+
+        $report = json_decode($output, true);
+        $this->assertIsArray($report, $output);
+        $this->assertCount(1, $report);
+        $entry = $report[0];
+        $this->assertSame('ibl5/docs/sample.md', $entry['path']);
+        $this->assertSame('2026-01-01', $entry['last_verified']);
+        $this->assertArrayHasKey('age_days', $entry);
+        $this->assertArrayHasKey('days_over', $entry);
+        $this->assertGreaterThan(60, $entry['age_days']);
+        $this->assertSame($entry['age_days'] - 60, $entry['days_over']);
+    }
+
+    #[Test]
+    public function stalenessReportAllFreshExitsZeroEmptyList(): void
+    {
+        // Zero-stale must be a valid empty JSON array, not an empty string —
+        // the nightly workflow's `jq 'length'` depends on it.
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($this->freshDate()), 'add fresh doc');
+
+        [$code, $output] = $this->runScript('--staleness-report');
+        $this->assertSame(0, $code, $output);
+
+        $report = json_decode($output, true);
+        $this->assertIsArray($report, $output);
+        $this->assertCount(0, $report);
+    }
+
+    #[Test]
+    public function stalenessReportExcludesMissingDateFromReport(): void
+    {
+        // Missing last_verified is the gate's job, never the staleness report's.
+        $noDate = "---\ndescription: No date here.\n---\n\n# Sample\n\nBody.\n";
+        $this->commitFile('ibl5/docs/sample.md', $noDate, 'add doc without date');
+
+        [$code, $output] = $this->runScript('--staleness-report');
+        $this->assertSame(0, $code, $output);
+
+        $report = json_decode($output, true);
+        $this->assertIsArray($report, $output);
+        $this->assertCount(0, $report);
+    }
 }


### PR DESCRIPTION
## Summary

Separates **staleness enforcement** from the rest of doc-freshness validation. The PR/push gate keeps blocking on frontmatter validity, dead-reference integrity, and ADR-transition integrity, but stops failing on the 60-day `last_verified` rule for untouched docs. A new nightly workflow becomes the single surface for repo-wide staleness: it files/updates one GitHub issue and pings Discord only when the stale set changes.

### Changes

- `bin/check-docs`: new `--no-staleness` flag (full-scan only; suppresses staleness while keeping all other checks) and `--staleness-report` mode (emits JSON array of stale docs, always exits 0). Shared `stalenessAgeDays()` helper ensures gate and report agree on staleness age.
- `.github/workflows/doc-freshness.yml`: repo-wide step uses `--no-staleness` on both push and PR triggers; on-touch `--since` step unchanged.
- `.github/workflows/doc-freshness-audit.yml`: new nightly workflow; files/updates a `stale-docs` GitHub issue idempotent by path-set signature; pings Discord only when the stale set changes.
- `ibl5/tests/Cli/CheckDocsCliTest.php`: 6 new PHPUnit CLI tests covering all flag paths including negative/boundary cases.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: relocates existing doc-freshness staleness enforcement from PR gate to nightly audit; no new architectural constraint -->