### PR TITLE
docs(adr): re-verify ADR-0006 (materialize ibl_hist), bump last_verified

### DIFF
--- a/ibl5/docs/decisions/0006-materialize-ibl-hist.md
+++ b/ibl5/docs/decisions/0006-materialize-ibl-hist.md
@@ -1,6 +1,6 @@
 ---
 description: Replace ibl_hist TEMPTABLE VIEW with a materialized table refreshed by the update pipeline
-last_verified: 2026-04-13
+last_verified: 2026-06-13
 ---
 
 # ADR-0006: Materialize ibl_hist VIEW


### PR DESCRIPTION
## What

`origin/master`'s ADR-0006 was 61 days stale (`last_verified: 2026-04-13`, max 60), failing the scheduled doc-freshness audit and the local pre-commit hook.

Re-verified the decision still matches reality and bumped `last_verified` to `2026-06-13`. **Content unchanged** — verification-only.

## Verification

Confirmed the symbols the ADR names still exist and are consistent:
- `classes/Updater/Steps/RefreshIblHistStep.php` + `SnapshotPlrStep.php` (+ their tests)
- `tests/DatabaseIntegration/DatabaseTestCase.php::insertHistRow`
- `migrations/109_materialize_ibl_hist.sql`, `vw_career_totals` recreated

`bin/check-docs` → 119 docs verified; `--since` (changed-files) passes.

## Note

A re-verify of this same ADR also exists as an **unpushed local-master commit** (`e2d6caeb4`, bundled with backlog edits). This PR is the clean, standalone version off `origin/master`; that local commit can be dropped/rebased to avoid duplication.