### PR TITLE
Add bin/check-plan: deterministic linter for /plan's mechanical Step-4 gates

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -3,7 +3,7 @@ description: "Plan an implementation task: enforces a verification matrix, direc
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
-last_verified: 2026-06-11
+last_verified: 2026-06-12
 
 ---
 
@@ -115,21 +115,17 @@ Format each packet as a fenced block within the plan:
 
 ## Step 4: Validate the matrix
 
-After receiving the Plan agent's output, check these gates yourself — do NOT delegate validation:
+After receiving the Plan agent's output, check these gates yourself — do NOT delegate validation.
 
-1. **Matrix exists** — the plan contains a table with columns: #, What to verify, Test type, Timing, Test file / location
-2. **No unclassified items** — every row has a test type from the allowed set (PHPUnit, API-test, E2E, Visual-regression, CLI-executable, Truly-manual)
-3. **No false manuals** — scan for "verify", "check that", "confirm", "ensure" in any row classified as Truly-manual. These verbs indicate an automatable assertion — reclassify the row
+**The deterministic gates are scripted, not hand-run.** `bin/check-plan` (invoked in Step 5, once the plan is on disk) mechanically enforces the false-positive-free subset: gate 1 (matrix exists), gate 3 (no false manuals), the `DECIDE`/`TBD`/`subject to validation`/`subject to review` tokens of gate 7, **and** reuse-target existence (a PHP `Class::method` named in a **Reuse** note whose class exists in `ibl5/` but whose method is absent — a likely typo). Do **not** hand-scan for those; fix whatever the script reports. The gates below are the ones that need judgment a script cannot do:
+
+1. *(scripted — see above)*
+2. **No unclassified items** — every row's test type is a real classification. *Not scripted on purpose:* the type column is open-ended in practice (`Go-archive-diagnostic`, `Documented (domain rule)`, `read-before-cut` are legitimate), so a closed-set check would false-positive — judge membership yourself.
+3. *(scripted — see above)*
 4. **Tests woven inline** — pre-impl tests appear before their implementation step, not collected in a bottom appendix
 5. **Production comparison classified correctly** — any "compare against production" or "match iblhoops.net" row must be Visual-regression, not Truly-manual
 6. **Test file paths present** — every PHPUnit/API-test/E2E/Visual-regression row names a concrete test file path, not just a category
-7. **No unresolved decisions** — scan all table rows (lines matching `^\s*\|`) for these tokens (case-insensitive):
-   - `DECIDE` (whole word)
-   - `TBD` (whole word)
-   - `(or ` (literal — indicates unresolved alternative, e.g., "STAY (or move)")
-   - `subject to validation`
-   - `subject to review`
-   If any match is found, resolve the decision in-place before saving the plan. The nightly agent cannot make judgment calls — every table cell must contain a concrete action, not a deferred question.
+7. **No unresolved decisions** — the literal tokens are scripted (see above). You still hand-resolve an unresolved **`(or `** fork (e.g. "STAY (or move)") — `bin/check-plan` skips that token because the corpus showed it is overwhelmingly a benign aside (`≤5 (or 0 ideally)`, `(or extend existing)`), and telling a real fork from an aside needs reading the alternative. Resolve any genuine fork in-place; the nightly agent cannot make judgment calls.
 8. **Decision-trigger pre-classified** — scan implementation phases for file additions matching `bin/adr-check` trigger patterns (listed in `_plan-verification.md` § Decision-trigger pre-classification). If any trigger fires, verify the plan includes a resolution step (ADR or bypass marker). If missing, add the appropriate resolution step and update the verification matrix.
 9. **Negative-path coverage** — every behavior-changing step has at least one matrix row asserting a failure, boundary, or rejection case, not only happy-path. If a step has only happy-path rows, add the missing negative-path row.
 10. **Hot-file extraction** — if any step adds > 100 LOC to a file `bin/check-hot-files` lists as hot (> 500 LOC under `classes/`), the plan must either propose an extraction step or carry an inline justification (per `_plan-verification.md` § Hot-file thresholds). If neither is present, add one.
@@ -151,6 +147,14 @@ PLAN_PATH="$HOME/.claude/plans/<slug>.md"
 If a plan file already exists at that path, create a new one with a numeric suffix rather than overwriting.
 
 Write the validated plan (with corrected matrix if Step 4 required fixes) to the plan file. When the work was split into multiple PRs, give each plan a distinct slug (e.g. `<base-slug>-1-<unit>`, `<base-slug>-2-<unit>`) so they sort in dependency order, and write one file per unit.
+
+Then run the mechanical linter on each plan file you wrote and fix anything it reports, in-place, until it exits clean:
+
+```bash
+bin/check-plan "$PLAN_PATH"
+```
+
+It enforces the deterministic gates from Step 4 (matrix present, no false manuals, no `DECIDE`/`TBD`/`subject to …` tokens, reuse targets resolve). A non-zero exit prints each violation prefixed by its gate (`[1]`/`[3]`/`[7]`/`[R]`); resolve each and re-run. Do not leave a plan written until `bin/check-plan` passes.
 
 ### Declaring the implementation model (optional)
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -566,6 +566,8 @@ jobs:
         run: bin/test-nightly-queue
       - name: bin/test-wt-status
         run: bin/test-wt-status
+      - name: bin/test-check-plan
+        run: bin/test-check-plan
 
   gate:
     name: Tests and Analysis

--- a/bin/README.md
+++ b/bin/README.md
@@ -11,7 +11,7 @@ container.
 |-------|---------|
 | Worktrees | `wt-new`, `wt-up`, `wt-down`, `wt-list`, `wt-rebase`, `wt-remove`, `wt-db-test`, `e2e-wt.sh` |
 | Nightly automation | `nightly-run`, `nightly-queue`, `nightly-prompt-impl`, `nightly-prompt-postplan` |
-| CI / quality gates | `adr-check`, `check-docs`, `check-hot-files`, `check-master-ci-green`, `check-plan-staleness`, `check-vr-coverage`, `check-e2e-hygiene`, `check-e2e-fa-offers-owner`, `check-destructive-migrations`, `refactor-flag` |
+| CI / quality gates | `adr-check`, `check-docs`, `check-hot-files`, `check-master-ci-green`, `check-plan`, `check-plan-staleness`, `check-vr-coverage`, `check-e2e-hygiene`, `check-e2e-fa-offers-owner`, `check-destructive-migrations`, `refactor-flag` |
 | Prod ops (SSH) | `db-sync-prod`, `log-fetch-prod`, `merge-master-to-prod`, `smoke-prod` |
 | Dev / Docker env | `dev-up`, `db-test-up`, `db-migrate` |
 | Scaffolding | `next-adr`, `next-migration`, `generate-codebase-map`, `sync-branches` |

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/check-plan — mechanical lint for /plan output (the Step-4 deterministic gates).
+#
+# Takes one argument: a plan file path. Runs the subset of /plan's Step-4
+# validation gates that are pure, false-positive-free lint — so /plan's prose can
+# collapse to "run bin/check-plan, fix what it reports" instead of having the
+# Opus orchestrator re-execute them by reading ~40 lines of instructions every
+# invocation. The JUDGMENT gates (negative-path coverage, hot-file extraction,
+# security-surface resolution, impl_model / auto_postplan risk) stay in /plan —
+# they need reasoning a script cannot do.
+#
+# Gates implemented (numbering mirrors .claude/commands/plan.md Step 4):
+#   1  Matrix exists        — the verification matrix header is present.
+#   3  No false manuals      — a Truly-manual row whose text uses an automatable
+#                              verb (verify / check that / confirm / ensure) is an
+#                              automatable assertion mislabeled manual.
+#   7  No unresolved decisions — any table row carrying DECIDE / TBD /
+#                              "subject to validation" / "subject to review" is a
+#                              deferred question the nightly agent cannot resolve.
+#
+# Two parts of /plan's Step 4 are DELIBERATELY left in /plan as Opus judgment,
+# because a sweep over the real plan corpus proved them not false-positive-free:
+#   - Gate 2 (test-type membership): the type column is effectively open-ended in
+#     practice — `Go-archive-diagnostic`, `Documented (domain rule)`,
+#     `read-before-cut (method)` are all legitimate author choices. A closed-set
+#     check flags them; whack-a-mole widening is a maintenance sink.
+#   - Gate 7's "(or " token: overwhelmingly benign asides (`≤5 (or 0 ideally)`,
+#     `(or extend existing)`, `(or equivalent)`). Telling a real unresolved fork
+#     ("STAY (or move)") from an aside needs reading the alternative — judgment.
+# Whole-word DECIDE/TBD and the "subject to …" phrases ARE FP-free, so they stay.
+#
+# Plus a NEW conservative check the gates describe but never enforced:
+#   R  Reuse-target exists   — a `Class::method` token named in a **Reuse** note
+#                              must resolve: if the class exists in ibl5/ but the
+#                              method name appears nowhere as a `function`, it is a
+#                              likely typo that would make the impl agent reinvent.
+#                              FP-guards: skip tokens whose class is absent from
+#                              ibl5/ (could be Go/engine/external/renamed) and skip
+#                              forward references the plan itself creates.
+#
+# Deliberately NOT linted (kept as /plan Opus judgment): tests-woven-inline,
+# production-comparison classification, test-file-path presence, negative-path
+# coverage, hot-file extraction, decision-trigger ADRs, security surface,
+# impl_model / auto_postplan risk. Edit-anchor snippets are not linted: the real
+# plan corpus quotes them as drifting descriptions ("the Options struct", with
+# file:line refs that go stale), not verbatim lines, so a grep-the-snippet check
+# would false-positive constantly.
+#
+# Exit codes: 0 = clean, 1 = one or more violations (printed, prefixed by gate),
+#             2 = usage error / plan file missing.
+#
+# Bash 3.2 / macOS compatible: no mapfile, no declare -A; temp files collect
+# state. `shell=bash` keeps shellcheck's SC3xxx (sh-dialect) warnings quiet on
+# the intentional bashisms.
+
+set -u
+
+# Force the C locale so every range/char-class glob and grep below is byte-wise
+# deterministic. Without this, macOS's default collation makes `[a-z]` (and
+# `[A-Z]`) also match the opposite case, which silently breaks the constant-vs-
+# method discrimination in the reuse check (a `Class::SCREAMING_CONST` token then
+# false-positives as a missing method).
+export LC_ALL=C
+
+usage() {
+    echo "Usage: bin/check-plan <plan-file>" >&2
+}
+
+PLAN_FILE="${1:-}"
+if [ -z "$PLAN_FILE" ] || [ ! -e "$PLAN_FILE" ]; then
+    usage
+    exit 2
+fi
+
+# Resolve the repo root from THIS SCRIPT's own location — never from the plan
+# file (which lives outside the repo under ~/.claude/plans/) or the cwd. Walk up
+# until a .git dir/file is found. Same load-bearing point as check-plan-staleness:
+# the reuse check searches $REPO_ROOT/ibl5, so a wrong root breaks it.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+while [ "$REPO_ROOT" != "/" ] && [ ! -e "$REPO_ROOT/.git" ]; do
+    REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+if [ "$REPO_ROOT" = "/" ]; then
+    echo "error: could not locate repo root" >&2
+    exit 2
+fi
+
+VIOL_FILE="$(mktemp)"
+MATRIX_FILE="$(mktemp)"
+SEEN_FILE="$(mktemp)"
+trap 'rm -f "$VIOL_FILE" "$MATRIX_FILE" "$SEEN_FILE"' EXIT
+
+viol() { printf '%s\n' "$1" >> "$VIOL_FILE"; }
+
+# ---------------------------------------------------------------------------
+# Gate 1: Matrix exists.
+# ---------------------------------------------------------------------------
+# The header survives a trailing `| PR |` column variant, so match on the
+# distinctive middle column rather than the full header.
+if ! grep -qiE '\|[[:space:]]*What to verify[[:space:]]*\|' "$PLAN_FILE"; then
+    viol "[1] no verification matrix found (expected a '| # | What to verify | Test type | Timing | ... |' header)"
+fi
+
+# ---------------------------------------------------------------------------
+# Isolate the matrix region for gate 3.
+# ---------------------------------------------------------------------------
+# Start at the header line; keep subsequent contiguous pipe-lines; stop at the
+# first non-pipe line. This bounds gate 3 to the actual matrix so other markdown
+# tables in the plan (e.g. a comparison table) cannot trip it.
+awk '
+    /\|[[:space:]]*[Ww]hat to verify[[:space:]]*\|/ { inm=1; next }
+    inm && /^[[:space:]]*\|/ { print; next }
+    inm && !/^[[:space:]]*\|/ { inm=0 }
+' "$PLAN_FILE" > "$MATRIX_FILE"
+
+while IFS= read -r row; do
+    low="$(printf '%s' "$row" | tr '[:upper:]' '[:lower:]')"
+    # Gate 3: a Truly-manual row using an automatable verb is mislabeled.
+    if printf '%s' "$low" | grep -qE 'truly[- ]manual'; then
+        if printf '%s' "$low" | grep -qE 'verify|check that|confirm|ensure'; then
+            viol "[3] truly-manual row uses an automatable verb (reclassify): ${row}"
+        fi
+    fi
+done < "$MATRIX_FILE"
+
+# ---------------------------------------------------------------------------
+# Gate 7: No unresolved decisions anywhere in any table row.
+# ---------------------------------------------------------------------------
+# Scans EVERY table row (not just the matrix) for deferred-question tokens. The
+# nightly agent cannot make judgment calls, so every cell must be concrete.
+#   DECIDE / TBD — whole word, case-insensitive.
+#   subject to validation / subject to review — literal.
+# ("(or " is intentionally NOT scanned here — see the header note; it lives in
+# /plan as Opus judgment because the corpus proved it overwhelmingly benign.)
+while IFS= read -r row; do
+    case "$row" in *\|*) : ;; *) continue ;; esac
+    low="$(printf '%s' "$row" | tr '[:upper:]' '[:lower:]')"
+    if printf '%s' "$low" | grep -qE '\bdecide\b|\btbd\b|subject to validation|subject to review'; then
+        viol "[7] unresolved decision token in table row: ${row}"
+    fi
+done < <(grep -E '^[[:space:]]*\|' "$PLAN_FILE")
+
+# ---------------------------------------------------------------------------
+# Reuse-target existence (new check). PHP Class::method only.
+# ---------------------------------------------------------------------------
+# Restrict to lines that mention "reuse" — that is where the gate's value lives
+# (directing the impl agent at existing code). A method named there that does not
+# resolve is the typo that makes the agent reinvent.
+while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    # De-duplicate.
+    if grep -qxF "$token" "$SEEN_FILE"; then continue; fi
+    printf '%s\n' "$token" >> "$SEEN_FILE"
+
+    class="${token%%::*}"
+    method="${token#*::}"
+
+    # Skip class CONSTANTS — `Class::SCREAMING_CASE` is a const reference, not a
+    # method, so a `function <name>` lookup would always (falsely) fail.
+    case "$method" in
+        *[a-z]*) : ;;             # has a lowercase letter → treat as a method
+        *) continue ;;           # all-caps / digits / underscore → constant
+    esac
+
+    # Forward-reference exemption: the plan creates this symbol itself.
+    if grep -F -- "$token" "$PLAN_FILE" \
+        | grep -qiE 'create|new (method|class|file)|add(s|ing)? (a )?new|introduce|rename|extract|scaffold'; then
+        continue
+    fi
+
+    # Is the class defined anywhere in ibl5/? If not, it may be Go/engine/external
+    # or renamed — do NOT flag (false-positive guard).
+    if ! grep -rqE "(class|interface|trait)[[:space:]]+${class}\b" "$REPO_ROOT/ibl5" --include='*.php' 2>/dev/null; then
+        continue
+    fi
+
+    # Class exists. Does a method with that name exist anywhere as a function? If
+    # not, it is a likely typo in the Reuse note.
+    if ! grep -rqE "function[[:space:]]+${method}\b" "$REPO_ROOT/ibl5" --include='*.php' 2>/dev/null; then
+        viol "[R] reuse target ${token}: class found in ibl5/ but no 'function ${method}' anywhere (typo?)"
+    fi
+done < <(grep -iE 'reuse' "$PLAN_FILE" \
+            | grep -oE '[A-Z][A-Za-z0-9_]*::[a-zA-Z_][A-Za-z0-9_]*')
+
+# ---------------------------------------------------------------------------
+# Report.
+# ---------------------------------------------------------------------------
+if [ -s "$VIOL_FILE" ]; then
+    echo "check-plan: violations in $PLAN_FILE" >&2
+    cat "$VIOL_FILE" >&2
+    exit 1
+fi
+
+echo "check-plan: OK ($PLAN_FILE)"
+exit 0

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-check-plan — regression test for bin/check-plan.
+#
+# Pins each gate's positive (clean plan passes) AND negative (a real violation
+# flags) case. The negative cases are load-bearing: a softened gate that stops
+# catching violations is worse than no gate, because /plan deleted its prose
+# copy of the check and now trusts this script.
+#
+# Run: bin/test-check-plan  (exit 0 = all pass, 1 = a case failed)
+#
+# shellcheck disable=SC2016  # backtick spans in the single-quoted plan fixtures
+# are literal markdown code spans, not command substitution — single quotes are
+# intentional so the fixture text reaches check-plan verbatim.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GUARD="$SCRIPT_DIR/check-plan"
+TMP="$(mktemp -d)"
+trap 'rm -f "$TMP"/*.md 2>/dev/null; rmdir "$TMP" 2>/dev/null' EXIT
+
+FAILED=0
+
+# assert <name> <expected-exit> <plan-body>
+assert() {
+    name="$1"; want="$2"; body="$3"
+    f="$TMP/$name.md"
+    printf '%s\n' "$body" > "$f"
+    "$GUARD" "$f" >/dev/null 2>&1
+    got=$?
+    if [ "$got" -ne "$want" ]; then
+        echo "FAIL: $name — expected exit $want, got $got"
+        FAILED=1
+    else
+        echo "ok: $name (exit $got)"
+    fi
+}
+
+# A minimal well-formed matrix passes (exit 0). Baseline / no false positives.
+assert "clean-minimal" 0 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | cap rejects over-cap trade | PHPUnit | pre-impl | `tests/Trade/TradeValidatorTest.php` |
+| 2 | form submits and redirects | E2E | post-impl | `tests/e2e/trade.spec.ts` |
+'
+
+# Gate 1: no matrix at all must flag (exit 1).
+assert "no-matrix" 1 'Implementation steps only. No verification table here.'
+
+# Gate 1: 6-column `| PR |` header variant is still recognized as a matrix —
+# combined with valid rows it passes (exit 0). Regression for header detection.
+assert "pr-column-header" 0 '
+| # | What to verify | Test type | Timing | Test file / location | PR |
+|---|---------------|-----------|--------|---------------------|----|
+| 1 | thing works | PHPUnit | post-impl | `tests/X.php` | 1 |
+'
+
+# Gate 2 (test-type membership) is intentionally NOT linted by check-plan — the
+# corpus proved the type column open-ended (Go-archive-diagnostic, Documented
+# (domain rule), read-before-cut). So a row with an unusual type must NOT flag
+# on type grounds (exit 0). Left as /plan Opus judgment.
+assert "open-type-not-flagged" 0 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | engine attribution | Go-archive-diagnostic | post-impl | `engine/x_test.go` |
+| 2 | domain invariant | Documented (domain rule) | post-impl | `walk.go comment` |
+'
+
+# Gate 3: a Truly-manual row using an automatable verb must flag (exit 1).
+assert "false-manual" 1 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | verify the redirect works | Truly-manual | post-impl | n/a |
+'
+
+# Gate 3: a legitimately subjective Truly-manual row (no automatable verb) must
+# NOT flag (exit 0).
+assert "real-manual-ok" 0 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | does the new dashboard feel polished | Truly-manual | post-impl | n/a |
+'
+
+# Gate 7: a DECIDE token in a table row must flag (exit 1).
+assert "unresolved-decide" 1 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | DECIDE which validator to call | PHPUnit | post-impl | `tests/X.php` |
+'
+
+# Gate 7: TBD token likewise (exit 1).
+assert "unresolved-tbd" 1 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | TBD which validator | PHPUnit | post-impl | `tests/X.php` |
+'
+
+# Gate 7: a benign "(or ...)" aside must NOT flag (exit 0). The corpus is full of
+# these (`≤5 (or 0 ideally)`, `(or extend existing)`); "(or " is left to /plan
+# judgment precisely so they do not false-positive here.
+assert "benign-or-aside-ok" 0 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | baseline count is ≤ 5 (or 0 ideally) | CLI-executable | post-impl | `grep -c X file` |
+| 2 | characterization captured | PHPUnit (or visual-regression) | pre-impl | `tests/Y.php` |
+'
+
+# Reuse: a Class::method whose class is absent from ibl5/ (could be Go/external)
+# must NOT flag — the false-positive guard (exit 0).
+assert "reuse-unknown-class-ok" 0 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | x | PHPUnit | post-impl | `tests/X.php` |
+
+**Reuse:** call `TotallyMadeUpClass::someMethod()` for the lookup.
+'
+
+# Reuse: a forward-referenced method the plan creates must NOT flag (exit 0),
+# even if it does not exist yet.
+assert "reuse-forward-ref-ok" 0 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | x | PHPUnit | post-impl | `tests/X.php` |
+
+Create a new method `TotallyMadeUpClass::brandNewMethod()` and **reuse** it later.
+'
+
+# Reuse: a `Class::SCREAMING_CASE` token is a class CONSTANT, not a method — it
+# must NOT be method-existence-checked (exit 0). Regression for the corpus false
+# positive on `EngineBundleService::DEFAULT_GAME_TYPE`.
+assert "reuse-constant-not-method" 0 '
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | x | PHPUnit | post-impl | `tests/X.php` |
+
+**Reuse:** the `TotallyMadeUpClass::SOME_CONSTANT` value for the default.
+'
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
## What

Replaces in-context, prose-interpreted validation of `/plan`'s false-positive-free Step-4 gates with a scripted check (`bin/check-plan`) the orchestrator runs in Step 5. The gains are **execution determinism** (a script can't be misread or skipped at validation time) and **bug-prevention** — not doc-token savings (`plan.md` is ~net-neutral in size).

## Scripted (proven FP-free)

- `[1]` matrix exists
- `[3]` no false manuals (Truly-manual row using an automatable verb)
- `[7]` `DECIDE` / `TBD` / `subject to validation|review` tokens
- `[R]` **new** reuse-target existence — a PHP `Class::method` named in a **Reuse** note whose class exists in `ibl5/` but whose method is absent (a likely typo that makes the impl agent reinvent instead of reuse)

## Deliberately left as `/plan` Opus judgment

A sweep over the 277-plan corpus proved these **not** FP-free:
- **gate 2** test-type membership — the column is open-ended in practice (`Go-archive-diagnostic`, `Documented (domain rule)`, `read-before-cut` are legitimate)
- **gate 7's `(or `** token — overwhelmingly benign asides (`≤5 (or 0 ideally)`, `(or extend existing)`)

## Evidence

- **FP sweep: 39 → 8 flags**, all true positives (real `TBD` deferrals, matrix-less docs) or one meta self-ref plan. Zero FP on real implementation plans.
- `LC_ALL=C` forces deterministic char-class globs (macOS collation made `[a-z]` match uppercase, which broke the constant-vs-method guard — caught a real bug).
- Consistent with the team's measured finding that edit anchors are a correctness aid, not a token lever (`plan-token-efficiency-FINDINGS`); the `[R]` check is in that spirit.

## Files

- `bin/check-plan` + `bin/test-check-plan` (12 regression cases pinning each gate's positive **and** negative)
- CI-gated: `bin/test-check-plan` added to `tests.yml`
- `plan.md` Step 4 defers the mechanical gates to the script (run in Step 5)
- `bin/README.md` gate table updated

## Note

The Step-5 `bin/check-plan` call is a prose instruction (like the rest of `/plan`), not hard-wired the way `nightly-prompt-impl` invokes `check-plan-staleness`. If the orchestrator forgets it, the gate is unprotected — a mild forget-risk, candidate follow-up.

<!-- no-adr: bin/check-plan mechanically scripts existing /plan Step-4 validation gates (decided in plan-decide-rejection-gate + the verification rule); the tests.yml edit only wires its regression test into CI. No new architectural constraint. -->
