### PR TITLE
feat(trade-block): Trade Block / Availability Board

### DIFF
--- a/ibl5/classes/Module/ModuleRegistry.php
+++ b/ibl5/classes/Module/ModuleRegistry.php
@@ -47,6 +47,7 @@ final class ModuleRegistry
         'Team',
         'TeamOffDefStats',
         'Topics',
+        'TradeBlock',
         'Trading',
         'TrainingCampRatingsDiff',
         'TransactionHistory',

--- a/ibl5/classes/Navigation/NavigationMenuBuilder.php
+++ b/ibl5/classes/Navigation/NavigationMenuBuilder.php
@@ -112,6 +112,7 @@ class NavigationMenuBuilder implements NavigationMenuBuilderInterface
                     ['label' => 'Prime Time Football', 'url' => 'http://www.thakfu.com/ptf/index.php', 'external' => true],
                     ['label' => 'Activity Tracker', 'url' => 'modules.php?name=ActivityTracker'],
                     ['label' => 'Topics (News)', 'url' => 'modules.php?name=Topics'],
+                    ['label' => 'Trade Block', 'url' => 'modules.php?name=TradeBlock'],
                     $this->config->isLoggedIn && $this->config->teamId !== null
                         ? ['label' => 'GM Contact List', 'url' => 'modules.php?name=GMContactList']
                         : null,
@@ -207,6 +208,7 @@ class NavigationMenuBuilder implements NavigationMenuBuilderInterface
             ['label' => 'Next Sim', 'url' => 'modules.php?name=NextSim'],
             ['label' => 'Depth Chart Entry', 'url' => 'modules.php?name=DepthChartEntry'],
             ['label' => 'Trading', 'url' => 'modules.php?name=Trading&op=reviewtrade'],
+            ['label' => 'Trade Block', 'url' => 'modules.php?name=TradeBlock&op=edit'],
             ['label' => 'Voting', 'url' => 'modules.php?name=Voting'],
         ];
 

--- a/ibl5/classes/TradeBlock/Contracts/TradeBlockControllerInterface.php
+++ b/ibl5/classes/TradeBlock/Contracts/TradeBlockControllerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock\Contracts;
+
+/**
+ * TradeBlockControllerInterface - Entry point + op routing for the trade block.
+ */
+interface TradeBlockControllerInterface
+{
+    /**
+     * Route a request to the browse board or the owner's edit form.
+     *
+     * @param mixed $user Current user object (from PHP-Nuke authentication)
+     * @param string $op 'browse' (default, public board) or 'edit' (owner form)
+     *
+     * **Behaviors:**
+     * - Renders login form if user is not authenticated
+     * - On POST (Action=save): validates CSRF, resolves the owner team server-side,
+     *   reconciles the submitted set against the roster, then PRG-redirects
+     * - On GET op=edit: renders the owner's bulk edit form
+     * - On GET op=browse (default): renders the league-wide read-only board
+     */
+    public function handleRequest($user, string $op): void;
+}

--- a/ibl5/classes/TradeBlock/Contracts/TradeBlockProcessorInterface.php
+++ b/ibl5/classes/TradeBlock/Contracts/TradeBlockProcessorInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock\Contracts;
+
+/**
+ * TradeBlockProcessorInterface - Write-path orchestration for the edit form.
+ *
+ * Owns the IDOR defense: the submitted checkbox set is reconciled against the
+ * GM's OWN current roster (resolved server-side), so a forged pid belonging to
+ * another team never reaches a write.
+ */
+interface TradeBlockProcessorInterface
+{
+    /**
+     * Reconcile the submitted on-block set against the resolved team's roster
+     * and persist the seeking note.
+     *
+     * @param list<int> $postedPids       checkbox pids submitted by the client
+     * @param array<int, string> $postedNotes pid => per-player note
+     * @param string $seekingNote         team free-text seeking note
+     * @return array{success: bool, result?: string, error?: string}
+     */
+    public function processEdit(int $resolvedTeamId, array $postedPids, array $postedNotes, string $seekingNote): array;
+}

--- a/ibl5/classes/TradeBlock/Contracts/TradeBlockRepositoryInterface.php
+++ b/ibl5/classes/TradeBlock/Contracts/TradeBlockRepositoryInterface.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock\Contracts;
+
+/**
+ * TradeBlockRepositoryInterface - Contract for trade-block data access.
+ *
+ * Reads derive the current team at read time by JOINing gm_trade_block.pid to
+ * ibl_plr (live teamid/name), so a traded/waived player self-corrects and no
+ * redundant teamid is stored. All writes go through prepared statements.
+ *
+ * @phpstan-type AvailablePlayerRow array{
+ *     pid: int,
+ *     note: string,
+ *     name: string,
+ *     teamid: int,
+ *     team_name: string,
+ *     team_city: string,
+ *     color1: string,
+ *     color2: string
+ * }
+ */
+interface TradeBlockRepositoryInterface
+{
+    /**
+     * Browse query: every on-block player whose live row is active, with the
+     * current owning team derived via JOIN (not stored).
+     *
+     * @return list<AvailablePlayerRow>
+     */
+    public function getAllAvailable(): array;
+
+    /**
+     * pid => note map of on-block players currently rostered by $teamId
+     * (live teamid, retired = 0) — backs the edit form's checkbox pre-check.
+     *
+     * @return array<int, string>
+     */
+    public function getBlockPidsForTeam(int $teamId): array;
+
+    /**
+     * teamid => seeking_note map for every team that has set a note.
+     *
+     * @return array<int, string>
+     */
+    public function getSeekingNotesByTeam(): array;
+
+    /**
+     * The seeking note for one team, or '' when none set.
+     */
+    public function getSeekingNoteForTeam(int $teamId): string;
+
+    /**
+     * Mark a player on the block (upsert the note).
+     */
+    public function setOnBlock(int $pid, string $note): bool;
+
+    /**
+     * Remove a player from the block.
+     */
+    public function removeFromBlock(int $pid): bool;
+
+    /**
+     * Upsert a team's free-text seeking note.
+     */
+    public function upsertSeekingNote(int $teamId, string $note): bool;
+}

--- a/ibl5/classes/TradeBlock/Contracts/TradeBlockServiceInterface.php
+++ b/ibl5/classes/TradeBlock/Contracts/TradeBlockServiceInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock\Contracts;
+
+/**
+ * TradeBlockServiceInterface - Read-path orchestration for the trade block.
+ *
+ * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
+ *
+ * @phpstan-type BrowseTeamGroup array{
+ *     teamid: int,
+ *     team_name: string,
+ *     team_city: string,
+ *     color1: string,
+ *     color2: string,
+ *     players: list<array{pid: int, name: string, note: string}>,
+ *     seekingNote: string
+ * }
+ * @phpstan-type BrowseData array{teams: list<BrowseTeamGroup>}
+ * @phpstan-type EditFormData array{
+ *     team: \Team\Team,
+ *     roster: list<PlayerRow>,
+ *     blockPids: array<int, string>,
+ *     seekingNote: string
+ * }
+ */
+interface TradeBlockServiceInterface
+{
+    /**
+     * League-wide read-only board data, grouped by current owning team.
+     *
+     * @return BrowseData
+     */
+    public function getBrowseData(): array;
+
+    /**
+     * Everything the owner's bulk edit form needs.
+     *
+     * @return EditFormData
+     */
+    public function getEditFormData(int $teamId): array;
+}

--- a/ibl5/classes/TradeBlock/Contracts/TradeBlockValidatorInterface.php
+++ b/ibl5/classes/TradeBlock/Contracts/TradeBlockValidatorInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock\Contracts;
+
+/**
+ * TradeBlockValidatorInterface - Sanitizes raw POST input for the edit form.
+ *
+ * Coerces the checkbox list to ints, length-caps free-text notes to the
+ * VARCHAR(255) column width, and tolerates malformed input (non-array
+ * on_block) without crashing. Ownership/IDOR enforcement is the Processor's
+ * job (reconcile against the resolved roster) — the validator only shapes data.
+ *
+ * @phpstan-type SanitizedEdit array{
+ *     pids: list<int>,
+ *     notes: array<int, string>,
+ *     seekingNote: string
+ * }
+ */
+interface TradeBlockValidatorInterface
+{
+    public const NOTE_MAX_LENGTH = 255;
+
+    /**
+     * @param array<string, mixed> $post
+     * @return SanitizedEdit
+     */
+    public function sanitizeEdit(array $post): array;
+}

--- a/ibl5/classes/TradeBlock/Contracts/TradeBlockViewInterface.php
+++ b/ibl5/classes/TradeBlock/Contracts/TradeBlockViewInterface.php
@@ -14,7 +14,6 @@ use Team\Team;
  * CsrfGuard::generateToken('tradeblock').
  *
  * @phpstan-import-type BrowseData from TradeBlockServiceInterface
- * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
  */
 interface TradeBlockViewInterface
 {
@@ -26,9 +25,10 @@ interface TradeBlockViewInterface
     public function renderBrowse(array $data): string;
 
     /**
-     * Owner's bulk edit form.
+     * Owner's bulk edit form. The view consumes only `pid` and `name` from each
+     * roster row (the Service passes full player rows, which satisfy this shape).
      *
-     * @param list<PlayerRow> $roster
+     * @param list<array{pid: int, name: string, ...<string, mixed>}> $roster
      * @param array<int, string> $blockPids pid => note for already-on-block players
      */
     public function renderEditForm(

--- a/ibl5/classes/TradeBlock/Contracts/TradeBlockViewInterface.php
+++ b/ibl5/classes/TradeBlock/Contracts/TradeBlockViewInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock\Contracts;
+
+use Team\Team;
+
+/**
+ * TradeBlockViewInterface - HTML rendering for the trade block.
+ *
+ * All dynamic output is escaped via \Security\HtmlSanitizer::e(); the browse
+ * board contains NO <form> elements; the edit form emits exactly one
+ * CsrfGuard::generateToken('tradeblock').
+ *
+ * @phpstan-import-type BrowseData from TradeBlockServiceInterface
+ * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
+ */
+interface TradeBlockViewInterface
+{
+    /**
+     * Read-only league board.
+     *
+     * @param BrowseData $data
+     */
+    public function renderBrowse(array $data): string;
+
+    /**
+     * Owner's bulk edit form.
+     *
+     * @param list<PlayerRow> $roster
+     * @param array<int, string> $blockPids pid => note for already-on-block players
+     */
+    public function renderEditForm(
+        Team $team,
+        array $roster,
+        array $blockPids,
+        string $seekingNote,
+        ?string $result = null,
+        ?string $error = null
+    ): string;
+}

--- a/ibl5/classes/TradeBlock/TradeBlockController.php
+++ b/ibl5/classes/TradeBlock/TradeBlockController.php
@@ -50,8 +50,10 @@ class TradeBlockController implements TradeBlockControllerInterface
             return;
         }
 
-        $cookie = $this->nukeCompat->cookieDecode($user);
-        $username = is_string($cookie[1] ?? null) ? $cookie[1] : '';
+        // Decoded return of cookieDecode($user) — a local, not the header-populated
+        // $cookie superglobal, so it is safe to read before PageLayout::header().
+        $decodedCookie = $this->nukeCompat->cookieDecode($user);
+        $username = is_string($decodedCookie[1] ?? null) ? $decodedCookie[1] : '';
 
         // PRG: process the bulk edit submission, then redirect.
         if (isset($_POST['Action']) && $_POST['Action'] === 'save') {
@@ -98,11 +100,13 @@ class TradeBlockController implements TradeBlockControllerInterface
             $result = ['success' => false, 'error' => 'An unexpected error occurred. Please try again.'];
         }
 
-        if (($result['success'] ?? false) === true) {
-            \Utilities\HtmxHelper::redirect('modules.php?name=TradeBlock&op=edit&result=' . rawurlencode($result['result'] ?? ''));
+        if ($result['success'] === true) {
+            $resultParam = $result['result'] ?? '';
+            \Utilities\HtmxHelper::redirect('modules.php?name=TradeBlock&op=edit&result=' . rawurlencode($resultParam));
+        } else {
+            $errorParam = $result['error'] ?? '';
+            \Utilities\HtmxHelper::redirect('modules.php?name=TradeBlock&op=edit&error=' . rawurlencode($errorParam));
         }
-
-        \Utilities\HtmxHelper::redirect('modules.php?name=TradeBlock&op=edit&error=' . rawurlencode($result['error'] ?? ''));
     }
 
     private function displayEditForm(string $username): void

--- a/ibl5/classes/TradeBlock/TradeBlockController.php
+++ b/ibl5/classes/TradeBlock/TradeBlockController.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock;
+
+use TradeBlock\Contracts\TradeBlockControllerInterface;
+use TradeBlock\Contracts\TradeBlockProcessorInterface;
+use TradeBlock\Contracts\TradeBlockServiceInterface;
+use TradeBlock\Contracts\TradeBlockValidatorInterface;
+use TradeBlock\Contracts\TradeBlockViewInterface;
+
+/**
+ * @see TradeBlockControllerInterface
+ *
+ * @phpstan-import-type UserRow from \Repositories\Contracts\TeamIdentityRepositoryInterface
+ */
+class TradeBlockController implements TradeBlockControllerInterface
+{
+    private TradeBlockServiceInterface $service;
+    private TradeBlockProcessorInterface $processor;
+    private TradeBlockViewInterface $view;
+    private TradeBlockValidatorInterface $validator;
+    private \Repositories\Contracts\TeamIdentityRepositoryInterface $teamIdentityRepo;
+    private \Utilities\NukeCompat $nukeCompat;
+
+    public function __construct(
+        TradeBlockServiceInterface $service,
+        TradeBlockProcessorInterface $processor,
+        TradeBlockViewInterface $view,
+        TradeBlockValidatorInterface $validator,
+        \Repositories\Contracts\TeamIdentityRepositoryInterface $teamIdentityRepo,
+        \Utilities\NukeCompat $nukeCompat
+    ) {
+        $this->service = $service;
+        $this->processor = $processor;
+        $this->view = $view;
+        $this->validator = $validator;
+        $this->teamIdentityRepo = $teamIdentityRepo;
+        $this->nukeCompat = $nukeCompat;
+    }
+
+    /**
+     * @see TradeBlockControllerInterface::handleRequest()
+     */
+    public function handleRequest($user, string $op): void
+    {
+        if (!$this->nukeCompat->isUser($user)) {
+            $this->nukeCompat->loginBox();
+            return;
+        }
+
+        $cookie = $this->nukeCompat->cookieDecode($user);
+        $username = is_string($cookie[1] ?? null) ? $cookie[1] : '';
+
+        // PRG: process the bulk edit submission, then redirect.
+        if (isset($_POST['Action']) && $_POST['Action'] === 'save') {
+            $this->handleSave($username);
+            return;
+        }
+
+        if ($op === 'edit') {
+            $this->displayEditForm($username);
+            return;
+        }
+
+        $this->displayBrowse();
+    }
+
+    private function handleSave(string $username): void
+    {
+        if (!\Security\CsrfGuard::validateSubmittedToken('tradeblock')) {
+            \Utilities\HtmxHelper::redirect('modules.php?name=TradeBlock&op=edit&error=' . rawurlencode('Invalid or expired form submission. Please try again.'));
+        }
+
+        $teamId = $this->resolveTeamId($username);
+        if ($teamId === null) {
+            $this->nukeCompat->loginBox();
+            return;
+        }
+
+        try {
+            /** @var array<string, mixed> $post */
+            $post = $_POST;
+            $sanitized = $this->validator->sanitizeEdit($post);
+            $result = $this->processor->processEdit(
+                $teamId,
+                $sanitized['pids'],
+                $sanitized['notes'],
+                $sanitized['seekingNote']
+            );
+        } catch (\Throwable $e) {
+            \Logging\LoggerFactory::getChannel('audit')->error('trade_block_submission_error', [
+                'error' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+            $result = ['success' => false, 'error' => 'An unexpected error occurred. Please try again.'];
+        }
+
+        if (($result['success'] ?? false) === true) {
+            \Utilities\HtmxHelper::redirect('modules.php?name=TradeBlock&op=edit&result=' . rawurlencode($result['result'] ?? ''));
+        }
+
+        \Utilities\HtmxHelper::redirect('modules.php?name=TradeBlock&op=edit&error=' . rawurlencode($result['error'] ?? ''));
+    }
+
+    private function displayEditForm(string $username): void
+    {
+        $teamId = $this->resolveTeamId($username);
+        if ($teamId === null) {
+            $this->nukeCompat->loginBox();
+            return;
+        }
+
+        $resultParam = isset($_GET['result']) && is_string($_GET['result']) ? $_GET['result'] : null;
+        $errorParam = isset($_GET['error']) && is_string($_GET['error']) ? $_GET['error'] : null;
+
+        $formData = $this->service->getEditFormData($teamId);
+
+        \PageLayout\PageLayout::header();
+        $responder = new \Api\Response\HtmlResponder();
+        $responder->html($this->view->renderEditForm(
+            $formData['team'],
+            $formData['roster'],
+            $formData['blockPids'],
+            $formData['seekingNote'],
+            $resultParam,
+            $errorParam
+        ));
+        \PageLayout\PageLayout::footer();
+    }
+
+    private function displayBrowse(): void
+    {
+        $browseData = $this->service->getBrowseData();
+
+        \PageLayout\PageLayout::header();
+        $responder = new \Api\Response\HtmlResponder();
+        $responder->html($this->view->renderBrowse($browseData));
+        \PageLayout\PageLayout::footer();
+    }
+
+    /**
+     * Resolve the authoritative team id for the logged-in user from the session.
+     * Never trusts POST input for ownership.
+     */
+    private function resolveTeamId(string $username): ?int
+    {
+        $userInfo = $this->teamIdentityRepo->getUserByUsername($username);
+        if ($userInfo === null) {
+            return null;
+        }
+
+        $teamName = $this->teamIdentityRepo->getTeamnameFromUsername($username);
+        if ($teamName === null || $teamName === '') {
+            return null;
+        }
+
+        return $this->teamIdentityRepo->getTidFromTeamname($teamName);
+    }
+}

--- a/ibl5/classes/TradeBlock/TradeBlockProcessor.php
+++ b/ibl5/classes/TradeBlock/TradeBlockProcessor.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock;
+
+use Team\Contracts\TeamQueryRepositoryInterface;
+use TradeBlock\Contracts\TradeBlockProcessorInterface;
+use TradeBlock\Contracts\TradeBlockRepositoryInterface;
+
+/**
+ * @see TradeBlockProcessorInterface
+ *
+ * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
+ */
+class TradeBlockProcessor implements TradeBlockProcessorInterface
+{
+    private TradeBlockRepositoryInterface $repo;
+    private TeamQueryRepositoryInterface $teamQueryRepo;
+
+    public function __construct(
+        TradeBlockRepositoryInterface $repo,
+        TeamQueryRepositoryInterface $teamQueryRepo
+    ) {
+        $this->repo = $repo;
+        $this->teamQueryRepo = $teamQueryRepo;
+    }
+
+    /**
+     * @see TradeBlockProcessorInterface::processEdit()
+     *
+     * @param list<int> $postedPids
+     * @param array<int, string> $postedNotes
+     * @return array{success: bool, result?: string, error?: string}
+     */
+    public function processEdit(int $resolvedTeamId, array $postedPids, array $postedNotes, string $seekingNote): array
+    {
+        // Authoritative roster for the team resolved server-side from the session.
+        $roster = $this->teamQueryRepo->getRosterUnderContractOrderedByName($resolvedTeamId);
+
+        /** @var list<int> $rosterPids */
+        $rosterPids = [];
+        foreach ($roster as $player) {
+            /** @var PlayerRow $player */
+            $rosterPids[] = (int) $player['pid'];
+        }
+
+        // IDOR defense: keep only submitted pids that are actually on this
+        // team's roster. Forged cross-team pids never reach a write.
+        $submitted = array_intersect($postedPids, $rosterPids);
+
+        // Only ever touch block rows whose pid is on THIS team's roster.
+        foreach ($rosterPids as $pid) {
+            if (in_array($pid, $submitted, true)) {
+                $note = $postedNotes[$pid] ?? '';
+                $this->repo->setOnBlock($pid, $note);
+            } else {
+                $this->repo->removeFromBlock($pid);
+            }
+        }
+
+        $this->repo->upsertSeekingNote($resolvedTeamId, $seekingNote);
+
+        return ['success' => true, 'result' => 'block_updated'];
+    }
+}

--- a/ibl5/classes/TradeBlock/TradeBlockRepository.php
+++ b/ibl5/classes/TradeBlock/TradeBlockRepository.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock;
+
+use BaseMysqliRepository;
+use TradeBlock\Contracts\TradeBlockRepositoryInterface;
+
+/**
+ * @see TradeBlockRepositoryInterface
+ *
+ * @phpstan-import-type AvailablePlayerRow from TradeBlockRepositoryInterface
+ */
+class TradeBlockRepository extends BaseMysqliRepository implements TradeBlockRepositoryInterface
+{
+    public function __construct(\mysqli $db)
+    {
+        parent::__construct($db);
+    }
+
+    /**
+     * @see TradeBlockRepositoryInterface::getAllAvailable()
+     *
+     * @return list<AvailablePlayerRow>
+     */
+    public function getAllAvailable(): array
+    {
+        /** @var list<AvailablePlayerRow> */
+        return $this->fetchAll(
+            "SELECT b.pid, b.note, p.name, p.teamid, t.team_name, t.team_city, t.color1, t.color2
+             FROM `gm_trade_block` b
+             JOIN `ibl_plr` p ON b.pid = p.pid
+             JOIN `ibl_team_info` t ON p.teamid = t.teamid
+             WHERE p.retired = 0
+             ORDER BY t.team_name ASC, p.name ASC"
+        );
+    }
+
+    /**
+     * @see TradeBlockRepositoryInterface::getBlockPidsForTeam()
+     *
+     * @return array<int, string>
+     */
+    public function getBlockPidsForTeam(int $teamId): array
+    {
+        $rows = $this->fetchAll(
+            "SELECT b.pid, b.note
+             FROM `gm_trade_block` b
+             JOIN `ibl_plr` p ON b.pid = p.pid
+             WHERE p.teamid = ?
+               AND p.retired = 0",
+            "i",
+            $teamId
+        );
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[(int) $row['pid']] = (string) $row['note'];
+        }
+
+        return $map;
+    }
+
+    /**
+     * @see TradeBlockRepositoryInterface::getSeekingNotesByTeam()
+     *
+     * @return array<int, string>
+     */
+    public function getSeekingNotesByTeam(): array
+    {
+        $rows = $this->fetchAll(
+            "SELECT teamid, seeking_note FROM `gm_trade_seeking`"
+        );
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[(int) $row['teamid']] = (string) $row['seeking_note'];
+        }
+
+        return $map;
+    }
+
+    /**
+     * @see TradeBlockRepositoryInterface::getSeekingNoteForTeam()
+     */
+    public function getSeekingNoteForTeam(int $teamId): string
+    {
+        $row = $this->fetchOne(
+            "SELECT seeking_note FROM `gm_trade_seeking` WHERE teamid = ? LIMIT 1",
+            "i",
+            $teamId
+        );
+
+        return $row !== null ? (string) $row['seeking_note'] : '';
+    }
+
+    /**
+     * @see TradeBlockRepositoryInterface::setOnBlock()
+     */
+    public function setOnBlock(int $pid, string $note): bool
+    {
+        try {
+            $this->execute(
+                "INSERT INTO `gm_trade_block` (pid, note) VALUES (?, ?)
+                 ON DUPLICATE KEY UPDATE note = VALUES(note)",
+                "is",
+                $pid,
+                $note
+            );
+            return true;
+        } catch (\RuntimeException $e) {
+            \Logging\LoggerFactory::getChannel('db')->error('Failed to set player on trade block', ['error' => $e->getMessage()]);
+            return false;
+        }
+    }
+
+    /**
+     * @see TradeBlockRepositoryInterface::removeFromBlock()
+     */
+    public function removeFromBlock(int $pid): bool
+    {
+        try {
+            $this->execute(
+                "DELETE FROM `gm_trade_block` WHERE pid = ?",
+                "i",
+                $pid
+            );
+            return true;
+        } catch (\RuntimeException $e) {
+            \Logging\LoggerFactory::getChannel('db')->error('Failed to remove player from trade block', ['error' => $e->getMessage()]);
+            return false;
+        }
+    }
+
+    /**
+     * @see TradeBlockRepositoryInterface::upsertSeekingNote()
+     */
+    public function upsertSeekingNote(int $teamId, string $note): bool
+    {
+        try {
+            $this->execute(
+                "INSERT INTO `gm_trade_seeking` (teamid, seeking_note) VALUES (?, ?)
+                 ON DUPLICATE KEY UPDATE seeking_note = VALUES(seeking_note)",
+                "is",
+                $teamId,
+                $note
+            );
+            return true;
+        } catch (\RuntimeException $e) {
+            \Logging\LoggerFactory::getChannel('db')->error('Failed to upsert seeking note', ['error' => $e->getMessage()]);
+            return false;
+        }
+    }
+}

--- a/ibl5/classes/TradeBlock/TradeBlockRepository.php
+++ b/ibl5/classes/TradeBlock/TradeBlockRepository.php
@@ -44,6 +44,7 @@ class TradeBlockRepository extends BaseMysqliRepository implements TradeBlockRep
      */
     public function getBlockPidsForTeam(int $teamId): array
     {
+        /** @var list<array{pid: int, note: string}> $rows */
         $rows = $this->fetchAll(
             "SELECT b.pid, b.note
              FROM `gm_trade_block` b
@@ -56,7 +57,7 @@ class TradeBlockRepository extends BaseMysqliRepository implements TradeBlockRep
 
         $map = [];
         foreach ($rows as $row) {
-            $map[(int) $row['pid']] = (string) $row['note'];
+            $map[$row['pid']] = $row['note'];
         }
 
         return $map;
@@ -69,13 +70,14 @@ class TradeBlockRepository extends BaseMysqliRepository implements TradeBlockRep
      */
     public function getSeekingNotesByTeam(): array
     {
+        /** @var list<array{teamid: int, seeking_note: string}> $rows */
         $rows = $this->fetchAll(
             "SELECT teamid, seeking_note FROM `gm_trade_seeking`"
         );
 
         $map = [];
         foreach ($rows as $row) {
-            $map[(int) $row['teamid']] = (string) $row['seeking_note'];
+            $map[$row['teamid']] = $row['seeking_note'];
         }
 
         return $map;
@@ -86,13 +88,14 @@ class TradeBlockRepository extends BaseMysqliRepository implements TradeBlockRep
      */
     public function getSeekingNoteForTeam(int $teamId): string
     {
+        /** @var array{seeking_note: string}|null $row */
         $row = $this->fetchOne(
             "SELECT seeking_note FROM `gm_trade_seeking` WHERE teamid = ? LIMIT 1",
             "i",
             $teamId
         );
 
-        return $row !== null ? (string) $row['seeking_note'] : '';
+        return $row !== null ? $row['seeking_note'] : '';
     }
 
     /**

--- a/ibl5/classes/TradeBlock/TradeBlockService.php
+++ b/ibl5/classes/TradeBlock/TradeBlockService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock;
+
+use Team\Contracts\TeamQueryRepositoryInterface;
+use Team\Team;
+use TradeBlock\Contracts\TradeBlockRepositoryInterface;
+use TradeBlock\Contracts\TradeBlockServiceInterface;
+
+/**
+ * @see TradeBlockServiceInterface
+ *
+ * @phpstan-import-type BrowseData from TradeBlockServiceInterface
+ * @phpstan-import-type EditFormData from TradeBlockServiceInterface
+ * @phpstan-import-type AvailablePlayerRow from TradeBlockRepositoryInterface
+ */
+class TradeBlockService implements TradeBlockServiceInterface
+{
+    private TradeBlockRepositoryInterface $repo;
+    private TeamQueryRepositoryInterface $teamQueryRepo;
+    private \mysqli $db;
+
+    public function __construct(
+        TradeBlockRepositoryInterface $repo,
+        TeamQueryRepositoryInterface $teamQueryRepo,
+        \mysqli $db
+    ) {
+        $this->repo = $repo;
+        $this->teamQueryRepo = $teamQueryRepo;
+        $this->db = $db;
+    }
+
+    /**
+     * @see TradeBlockServiceInterface::getBrowseData()
+     *
+     * @return BrowseData
+     */
+    public function getBrowseData(): array
+    {
+        $available = $this->repo->getAllAvailable();
+        $seekingByTeam = $this->repo->getSeekingNotesByTeam();
+
+        /** @var array<int, array{teamid: int, team_name: string, team_city: string, color1: string, color2: string, players: list<array{pid: int, name: string, note: string}>, seekingNote: string}> $groups */
+        $groups = [];
+        foreach ($available as $row) {
+            $teamid = (int) $row['teamid'];
+            if (!isset($groups[$teamid])) {
+                $groups[$teamid] = [
+                    'teamid' => $teamid,
+                    'team_name' => (string) $row['team_name'],
+                    'team_city' => (string) $row['team_city'],
+                    'color1' => (string) $row['color1'],
+                    'color2' => (string) $row['color2'],
+                    'players' => [],
+                    'seekingNote' => $seekingByTeam[$teamid] ?? '',
+                ];
+            }
+            $groups[$teamid]['players'][] = [
+                'pid' => (int) $row['pid'],
+                'name' => (string) $row['name'],
+                'note' => (string) $row['note'],
+            ];
+        }
+
+        return ['teams' => array_values($groups)];
+    }
+
+    /**
+     * @see TradeBlockServiceInterface::getEditFormData()
+     *
+     * @return EditFormData
+     */
+    public function getEditFormData(int $teamId): array
+    {
+        return [
+            'team' => Team::initialize($this->db, $teamId),
+            'roster' => $this->teamQueryRepo->getRosterUnderContractOrderedByName($teamId),
+            'blockPids' => $this->repo->getBlockPidsForTeam($teamId),
+            'seekingNote' => $this->repo->getSeekingNoteForTeam($teamId),
+        ];
+    }
+}

--- a/ibl5/classes/TradeBlock/TradeBlockValidator.php
+++ b/ibl5/classes/TradeBlock/TradeBlockValidator.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock;
+
+use TradeBlock\Contracts\TradeBlockValidatorInterface;
+
+/**
+ * @see TradeBlockValidatorInterface
+ *
+ * @phpstan-import-type SanitizedEdit from TradeBlockValidatorInterface
+ */
+class TradeBlockValidator implements TradeBlockValidatorInterface
+{
+    /**
+     * @see TradeBlockValidatorInterface::sanitizeEdit()
+     *
+     * @param array<string, mixed> $post
+     * @return SanitizedEdit
+     */
+    public function sanitizeEdit(array $post): array
+    {
+        $pids = [];
+        $rawOnBlock = $post['on_block'] ?? null;
+        if (is_array($rawOnBlock)) {
+            foreach ($rawOnBlock as $value) {
+                if (is_scalar($value)) {
+                    $pid = (int) $value;
+                    if ($pid > 0) {
+                        $pids[] = $pid;
+                    }
+                }
+            }
+        }
+        // Drop duplicates while preserving order.
+        $pids = array_values(array_unique($pids));
+
+        $notes = [];
+        $rawNotes = $post['note'] ?? null;
+        if (is_array($rawNotes)) {
+            foreach ($rawNotes as $pid => $note) {
+                if (!is_scalar($note)) {
+                    continue;
+                }
+                $intPid = (int) $pid;
+                if ($intPid > 0) {
+                    $notes[$intPid] = $this->cap((string) $note);
+                }
+            }
+        }
+
+        $rawSeeking = $post['seeking_note'] ?? '';
+        $seekingNote = is_scalar($rawSeeking) ? $this->cap((string) $rawSeeking) : '';
+
+        return [
+            'pids' => $pids,
+            'notes' => $notes,
+            'seekingNote' => $seekingNote,
+        ];
+    }
+
+    private function cap(string $value): string
+    {
+        $trimmed = trim($value);
+        return mb_substr($trimmed, 0, self::NOTE_MAX_LENGTH);
+    }
+}

--- a/ibl5/classes/TradeBlock/TradeBlockView.php
+++ b/ibl5/classes/TradeBlock/TradeBlockView.php
@@ -11,7 +11,6 @@ use TradeBlock\Contracts\TradeBlockViewInterface;
  * @see TradeBlockViewInterface
  *
  * @phpstan-import-type BrowseData from \TradeBlock\Contracts\TradeBlockServiceInterface
- * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
  */
 class TradeBlockView implements TradeBlockViewInterface
 {
@@ -79,7 +78,7 @@ class TradeBlockView implements TradeBlockViewInterface
     /**
      * @see TradeBlockViewInterface::renderEditForm()
      *
-     * @param list<PlayerRow> $roster
+     * @param list<array{pid: int, name: string, ...<string, mixed>}> $roster
      * @param array<int, string> $blockPids
      */
     public function renderEditForm(

--- a/ibl5/classes/TradeBlock/TradeBlockView.php
+++ b/ibl5/classes/TradeBlock/TradeBlockView.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TradeBlock;
+
+use Team\Team;
+use TradeBlock\Contracts\TradeBlockViewInterface;
+
+/**
+ * @see TradeBlockViewInterface
+ *
+ * @phpstan-import-type BrowseData from \TradeBlock\Contracts\TradeBlockServiceInterface
+ * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
+ */
+class TradeBlockView implements TradeBlockViewInterface
+{
+    /**
+     * @see TradeBlockViewInterface::renderBrowse()
+     *
+     * @param BrowseData $data
+     */
+    public function renderBrowse(array $data): string
+    {
+        $teams = $data['teams'];
+
+        if ($teams === []) {
+            return $this->renderEmptyBrowse();
+        }
+
+        ob_start();
+        ?>
+        <div class="trade-block-page">
+            <h2 class="ibl-title">Trade Block</h2>
+            <p class="text-center">
+                <a href="modules.php?name=TradeBlock&amp;op=edit">Edit your team's trade block &raquo;</a>
+            </p>
+            <?php foreach ($teams as $team): ?>
+            <div class="ibl-card">
+                <div class="ibl-card__header">
+                    <h2 class="ibl-card__title">
+                        <?= \Security\HtmlSanitizer::e($team['team_city']) ?> <?= \Security\HtmlSanitizer::e($team['team_name']) ?>
+                    </h2>
+                </div>
+                <div class="ibl-card__body">
+                    <?php if ($team['seekingNote'] !== ''): ?>
+                    <p class="trade-block-seeking"><strong>Seeking:</strong> <?= \Security\HtmlSanitizer::e($team['seekingNote']) ?></p>
+                    <?php endif; ?>
+                    <table class="ibl-data-table">
+                        <thead>
+                            <tr><th>Available Player</th><th>Note</th></tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($team['players'] as $player): ?>
+                            <tr>
+                                <td><?= \Security\HtmlSanitizer::e($player['name']) ?></td>
+                                <td><?= \Security\HtmlSanitizer::e($player['note']) ?></td>
+                            </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <?php endforeach; ?>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    private function renderEmptyBrowse(): string
+    {
+        return '<div class="trade-block-page">'
+            . '<h2 class="ibl-title">Trade Block</h2>'
+            . '<p class="text-center"><a href="modules.php?name=TradeBlock&amp;op=edit">Edit your team\'s trade block &raquo;</a></p>'
+            . '<p>No players are currently on the trade block.</p>'
+            . '</div>';
+    }
+
+    /**
+     * @see TradeBlockViewInterface::renderEditForm()
+     *
+     * @param list<PlayerRow> $roster
+     * @param array<int, string> $blockPids
+     */
+    public function renderEditForm(
+        Team $team,
+        array $roster,
+        array $blockPids,
+        string $seekingNote,
+        ?string $result = null,
+        ?string $error = null
+    ): string {
+        ob_start();
+        ?>
+        <div class="trade-block-page">
+            <h2 class="ibl-title">My Trade Block</h2>
+            <?= \UI\AlertRenderer::fromCode($result, [
+                'block_updated' => ['class' => 'ibl-alert--success', 'message' => 'Your trade block has been updated.'],
+            ], $error) ?>
+            <form name="Trade_Block" method="post" action="" class="ibl-form-container">
+                <?= \Security\CsrfGuard::generateToken('tradeblock') ?>
+                <input type="hidden" name="op" value="edit">
+                <input type="hidden" name="Action" value="save">
+                <div class="text-center">
+                    <img src="images/logo/<?= \Security\HtmlSanitizer::e($team->teamid) ?>.jpg" alt="Team Logo" class="team-logo-banner">
+                    <div class="ibl-card">
+                        <div class="ibl-card__header">
+                            <h2 class="ibl-card__title"><?= \Security\HtmlSanitizer::e($team->city) ?> <?= \Security\HtmlSanitizer::e($team->name) ?></h2>
+                        </div>
+                        <div class="ibl-card__body">
+                            <?php if ($roster === []): ?>
+                            <p>You have no rostered players to make available.</p>
+                            <?php else: ?>
+                            <table class="ibl-data-table">
+                                <thead>
+                                    <tr><th>On Block</th><th>Player</th><th>Note</th></tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($roster as $player): ?>
+                                    <?php
+                                    $pid = (int) ($player['pid'] ?? 0);
+                                    $name = is_scalar($player['name'] ?? null) ? (string) $player['name'] : '';
+                                    $checked = array_key_exists($pid, $blockPids);
+                                    $note = $blockPids[$pid] ?? '';
+                                    ?>
+                                    <tr>
+                                        <td>
+                                            <input type="checkbox" name="on_block[]" value="<?= \Security\HtmlSanitizer::e($pid) ?>"<?= $checked ? ' checked' : '' ?>>
+                                        </td>
+                                        <td><?= \Security\HtmlSanitizer::e($name) ?></td>
+                                        <td>
+                                            <input type="text" name="note[<?= \Security\HtmlSanitizer::e($pid) ?>]" value="<?= \Security\HtmlSanitizer::e($note) ?>" maxlength="255" class="ibl-input">
+                                        </td>
+                                    </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                            <?php endif; ?>
+                            <div class="ibl-form-group">
+                                <label for="seeking_note">What are you seeking?</label>
+                                <textarea name="seeking_note" id="seeking_note" maxlength="255" class="ibl-input" rows="3"><?= \Security\HtmlSanitizer::e($seekingNote) ?></textarea>
+                            </div>
+                            <button type="submit" class="ibl-btn ibl-btn--primary ibl-btn--block">Save Trade Block</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/ibl5/migrations/146_create_trade_block.sql
+++ b/ibl5/migrations/146_create_trade_block.sql
@@ -1,0 +1,30 @@
+-- Migration 146: Trade Block / availability board.
+-- gm_trade_block: per-player availability (pid PK), team derived at read time via JOIN to ibl_plr.
+-- gm_trade_seeking: per-team free-text "seeking" note (teamid PK, 0..1 per team).
+-- Signedness matches FK targets: ibl_plr.pid int(11) signed, ibl_team_info.teamid int(11) signed.
+-- note is NOT NULL DEFAULT '' (matches setOnBlock(int, string) — always a string, no nullable-bind footgun).
+-- adr-check: plain CREATE TABLE, not destructive.
+
+CREATE TABLE IF NOT EXISTS `gm_trade_block` (
+  `pid` int(11) NOT NULL,
+  `note` varchar(255) NOT NULL DEFAULT '',
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`pid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `gm_trade_block` DROP FOREIGN KEY IF EXISTS `fk_trade_block_player`;
+ALTER TABLE `gm_trade_block`
+  ADD CONSTRAINT `fk_trade_block_player` FOREIGN KEY (`pid`)
+    REFERENCES `ibl_plr` (`pid`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TABLE IF NOT EXISTS `gm_trade_seeking` (
+  `teamid` int(11) NOT NULL,
+  `seeking_note` varchar(255) NOT NULL DEFAULT '',
+  `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`teamid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `gm_trade_seeking` DROP FOREIGN KEY IF EXISTS `fk_trade_seeking_team`;
+ALTER TABLE `gm_trade_seeking`
+  ADD CONSTRAINT `fk_trade_seeking_team` FOREIGN KEY (`teamid`)
+    REFERENCES `ibl_team_info` (`teamid`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/ibl5/modules/TradeBlock/index.php
+++ b/ibl5/modules/TradeBlock/index.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+if (!defined('MODULE_FILE')) {
+    die("You can't access this file directly...");
+}
+
+$module_name = basename(dirname(__FILE__));
+get_lang($module_name);
+
+// Module inputs are read from $_REQUEST explicitly (ConfigBootstrap no longer
+// extracts request keys to globals). Leave $op null so the handleRequest()
+// 'browse' fallback applies for the bare module URL.
+$op = (is_string($_REQUEST['op'] ?? null) && $_REQUEST['op'] !== '') ? $_REQUEST['op'] : null;
+
+$pagetitle = "- Trade Block";
+
+/**
+ * Main entry point for the Trade Block module.
+ *
+ * @param mixed $user Current user
+ */
+function tradeBlock($user)
+{
+    global $mysqli_db, $op;
+
+    cookiedecode($user);
+
+    $repo = new TradeBlock\TradeBlockRepository($mysqli_db);
+    $teamIdentityRepo = new Repositories\TeamIdentityRepository($mysqli_db);
+    $teamQueryRepo = new Team\TeamQueryRepository($mysqli_db);
+    $validator = new TradeBlock\TradeBlockValidator();
+    $processor = new TradeBlock\TradeBlockProcessor($repo, $teamQueryRepo);
+    $view = new TradeBlock\TradeBlockView();
+    $service = new TradeBlock\TradeBlockService($repo, $teamQueryRepo, $mysqli_db);
+    $nukeCompat = new Utilities\NukeCompat();
+    $controller = new TradeBlock\TradeBlockController(
+        $service,
+        $processor,
+        $view,
+        $validator,
+        $teamIdentityRepo,
+        $nukeCompat
+    );
+    $controller->handleRequest($user, $op ?? 'browse');
+}
+
+tradeBlock($user);

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -31,6 +31,9 @@
         <testsuite name="Waivers Module Tests">
             <directory>tests/Waivers</directory>
         </testsuite>
+        <testsuite name="TradeBlock Module Tests">
+            <directory>tests/TradeBlock</directory>
+        </testsuite>
         <testsuite name="TrainingCampRatingsDiff Module Tests">
             <directory>tests/TrainingCampRatingsDiff</directory>
         </testsuite>

--- a/ibl5/test-state.php
+++ b/ibl5/test-state.php
@@ -607,6 +607,20 @@ if ($method === 'DELETE' && $action === 'reset-waiver-player') {
     exit;
 }
 
+// DELETE ?action=reset-trade-block — undo the trade-block toggle tests. Deletes
+// every gm_trade_block row whose pid belongs to a Metros (teamid=1) player and
+// clears Metros' seeking note. Scoped to teamid=1 so the seeded cross-team
+// fixture (Cougars pid=23 / teamid=3 seeking note) survives for the browse spec.
+if ($method === 'DELETE' && $action === 'reset-trade-block') {
+    $db->query("DELETE b FROM gm_trade_block b JOIN ibl_plr p ON b.pid = p.pid WHERE p.teamid = 1");
+    $blockDeleted = $db->affected_rows;
+    $db->query("DELETE FROM gm_trade_seeking WHERE teamid = 1");
+    $seekingDeleted = $db->affected_rows;
+    echo json_encode(['block_deleted' => $blockDeleted, 'seeking_deleted' => $seekingDeleted]);
+    $db->close();
+    exit;
+}
+
 // DELETE ?action=reset-rookie-option&pid=N — restore the rookie-option player's
 // contract after a successful option exercise. RookieOptionRepository writes
 // salary_yr4 (round 1) for this round-1 fixture; restore salary_yr3=500 (final

--- a/ibl5/tests/DatabaseIntegration/TradeBlockRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/TradeBlockRepositoryTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration;
+
+use PHPUnit\Framework\Attributes\Group;
+use TradeBlock\TradeBlockRepository;
+
+/**
+ * Migration 146 (gm-02): gm_trade_block (pid PK, FK -> ibl_plr ON DELETE CASCADE)
+ * and gm_trade_seeking (teamid PK, FK -> ibl_team_info ON DELETE CASCADE).
+ *
+ * Proves: tables/columns exist; setOnBlock -> getAllAvailable derives the live
+ * team at read time; a traded player self-corrects to the new team; a retired
+ * player is excluded; the pid FK cascades on player delete; the seeking note
+ * upserts to a single row.
+ */
+#[Group('database')]
+class TradeBlockRepositoryTest extends DatabaseTestCase
+{
+    private const PID = 200000910;
+
+    private function repo(): TradeBlockRepository
+    {
+        return new TradeBlockRepository($this->db);
+    }
+
+    public function testTradeBlockTablesExistWithExpectedColumns(): void
+    {
+        $blockCols = $this->columnNames('gm_trade_block');
+        self::assertContains('pid', $blockCols);
+        self::assertContains('note', $blockCols);
+        self::assertContains('created_at', $blockCols);
+
+        $seekingCols = $this->columnNames('gm_trade_seeking');
+        self::assertContains('teamid', $seekingCols);
+        self::assertContains('seeking_note', $seekingCols);
+        self::assertContains('updated_at', $seekingCols);
+    }
+
+    public function testSetOnBlockThenGetAllAvailableDerivesTeamName(): void
+    {
+        $this->insertTestPlayer(self::PID, 'Block Tester', ['teamid' => 1]);
+
+        self::assertTrue($this->repo()->setOnBlock(self::PID, 'available'));
+
+        $row = $this->findAvailable(self::PID);
+        self::assertNotNull($row, 'player should appear on the board');
+        self::assertSame('available', $row['note']);
+        self::assertNotSame('', (string) $row['team_name'], 'team_name is derived via JOIN');
+    }
+
+    public function testTradedPlayerAppearsUnderNewTeam(): void
+    {
+        $this->insertTestPlayer(self::PID, 'Trade Tester', ['teamid' => 1]);
+        $this->repo()->setOnBlock(self::PID, '');
+
+        $before = $this->findAvailable(self::PID);
+        self::assertNotNull($before);
+        $teamBefore = (int) $before['teamid'];
+
+        // Trade the player to a different team — no stored teamid to go stale.
+        $newTeam = $teamBefore === 3 ? 2 : 3;
+        $this->db->query("UPDATE ibl_plr SET teamid = {$newTeam} WHERE pid = " . self::PID);
+
+        $after = $this->findAvailable(self::PID);
+        self::assertNotNull($after);
+        self::assertSame($newTeam, (int) $after['teamid'], 'derived team self-corrects after a trade');
+    }
+
+    public function testRetiredPlayerIsExcluded(): void
+    {
+        $this->insertTestPlayer(self::PID, 'Retire Tester', ['teamid' => 1]);
+        $this->repo()->setOnBlock(self::PID, '');
+        self::assertNotNull($this->findAvailable(self::PID));
+
+        $this->db->query('UPDATE ibl_plr SET retired = 1 WHERE pid = ' . self::PID);
+
+        self::assertNull($this->findAvailable(self::PID), 'retired player must drop off the board');
+    }
+
+    public function testRemoveFromBlock(): void
+    {
+        $this->insertTestPlayer(self::PID, 'Remove Tester', ['teamid' => 1]);
+        $this->repo()->setOnBlock(self::PID, '');
+        self::assertNotNull($this->findAvailable(self::PID));
+
+        self::assertTrue($this->repo()->removeFromBlock(self::PID));
+        self::assertNull($this->findAvailable(self::PID));
+    }
+
+    public function testDeletingPlayerCascadesBlockRow(): void
+    {
+        $this->insertTestPlayer(self::PID, 'Cascade Tester', ['teamid' => 1]);
+        $this->repo()->setOnBlock(self::PID, '');
+
+        $this->db->query('DELETE FROM ibl_plr WHERE pid = ' . self::PID);
+
+        $row = $this->db->query('SELECT COUNT(*) AS c FROM gm_trade_block WHERE pid = ' . self::PID)->fetch_assoc();
+        self::assertNotNull($row);
+        self::assertSame(0, (int) $row['c'], 'deleting the player must cascade-delete its block row');
+    }
+
+    public function testOrphanPidInsertIsRejected(): void
+    {
+        try {
+            $this->db->query('INSERT INTO gm_trade_block (pid, note) VALUES (999999000, \'\')');
+            self::fail('orphan-pid block insert was not rejected');
+        } catch (\mysqli_sql_exception $e) {
+            self::assertSame(1452, $e->getCode(), 'expected FK violation errno 1452');
+        }
+    }
+
+    public function testUpsertSeekingNoteUpdatesSingleRow(): void
+    {
+        $repo = $this->repo();
+
+        self::assertTrue($repo->upsertSeekingNote(1, 'first'));
+        self::assertSame('first', $repo->getSeekingNoteForTeam(1));
+
+        self::assertTrue($repo->upsertSeekingNote(1, 'second'));
+        self::assertSame('second', $repo->getSeekingNoteForTeam(1));
+
+        $row = $this->db->query('SELECT COUNT(*) AS c FROM gm_trade_seeking WHERE teamid = 1')->fetch_assoc();
+        self::assertNotNull($row);
+        self::assertSame(1, (int) $row['c'], 'upsert must keep exactly one row per team');
+    }
+
+    public function testGetSeekingNoteForTeamDefaultsToEmpty(): void
+    {
+        self::assertSame('', $this->repo()->getSeekingNoteForTeam(999999));
+    }
+
+    public function testGetBlockPidsForTeamReturnsNoteMap(): void
+    {
+        $this->insertTestPlayer(self::PID, 'Map Tester', ['teamid' => 1]);
+        $this->repo()->setOnBlock(self::PID, 'trade me');
+
+        $map = $this->repo()->getBlockPidsForTeam(1);
+        self::assertArrayHasKey(self::PID, $map);
+        self::assertSame('trade me', $map[self::PID]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function findAvailable(int $pid): ?array
+    {
+        foreach ($this->repo()->getAllAvailable() as $row) {
+            if ((int) $row['pid'] === $pid) {
+                return $row;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function columnNames(string $table): array
+    {
+        $result = $this->db->query("SHOW COLUMNS FROM `{$table}`");
+        self::assertInstanceOf(\mysqli_result::class, $result);
+
+        $names = [];
+        while (true) {
+            $row = $result->fetch_assoc();
+            if (!is_array($row)) {
+                break;
+            }
+            $names[] = (string) $row['Field'];
+        }
+        $result->free();
+
+        return $names;
+    }
+}

--- a/ibl5/tests/Module/ModuleRegistryTest.php
+++ b/ibl5/tests/Module/ModuleRegistryTest.php
@@ -16,6 +16,11 @@ final class ModuleRegistryTest extends TestCase
         self::assertTrue(ModuleRegistry::isValid('YourAccount'));
     }
 
+    public function testTradeBlockModuleIsValid(): void
+    {
+        self::assertTrue(ModuleRegistry::isValid('TradeBlock'));
+    }
+
     public function testUnknownModuleIsInvalid(): void
     {
         self::assertFalse(ModuleRegistry::isValid('NotAModule'));

--- a/ibl5/tests/TradeBlock/TradeBlockControllerTest.php
+++ b/ibl5/tests/TradeBlock/TradeBlockControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TradeBlock;
+
+use PHPUnit\Framework\TestCase;
+use Repositories\Contracts\TeamIdentityRepositoryInterface;
+use TradeBlock\Contracts\TradeBlockProcessorInterface;
+use TradeBlock\Contracts\TradeBlockServiceInterface;
+use TradeBlock\Contracts\TradeBlockValidatorInterface;
+use TradeBlock\Contracts\TradeBlockViewInterface;
+use TradeBlock\TradeBlockController;
+
+/**
+ * Structural coverage only: the POST/CSRF/PRG paths call HtmxHelper::redirect(),
+ * which is typed `: never` and hard-`exit`s, so they cannot be driven from a unit
+ * test without terminating the runner. The CSRF-reject and IDOR behaviors are
+ * covered at the API level in tests/e2e/flows/trade-block-submission.spec.ts, and
+ * the reconcile/IDOR logic is unit-tested in TradeBlockProcessorTest.
+ */
+class TradeBlockControllerTest extends TestCase
+{
+    private TradeBlockController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = new TradeBlockController(
+            self::createStub(TradeBlockServiceInterface::class),
+            self::createStub(TradeBlockProcessorInterface::class),
+            self::createStub(TradeBlockViewInterface::class),
+            self::createStub(TradeBlockValidatorInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
+            self::createStub(\Utilities\NukeCompat::class),
+        );
+    }
+
+    public function testControllerConstructsWithAllDependencies(): void
+    {
+        $reflection = new \ReflectionClass($this->controller);
+        self::assertTrue($reflection->hasMethod('handleRequest'));
+    }
+
+    public function testUnauthenticatedUserGetsLoginBox(): void
+    {
+        $nukeCompat = $this->createMock(\Utilities\NukeCompat::class);
+        $nukeCompat->method('isUser')->willReturn(false);
+        $nukeCompat->expects(self::once())->method('loginBox');
+
+        $serviceMock = $this->createMock(TradeBlockServiceInterface::class);
+        $serviceMock->expects(self::never())->method('getBrowseData');
+
+        $controller = new TradeBlockController(
+            $serviceMock,
+            self::createStub(TradeBlockProcessorInterface::class),
+            self::createStub(TradeBlockViewInterface::class),
+            self::createStub(TradeBlockValidatorInterface::class),
+            self::createStub(TeamIdentityRepositoryInterface::class),
+            $nukeCompat,
+        );
+
+        $controller->handleRequest('not-a-user', 'browse');
+    }
+}

--- a/ibl5/tests/TradeBlock/TradeBlockProcessorTest.php
+++ b/ibl5/tests/TradeBlock/TradeBlockProcessorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TradeBlock;
+
+use PHPUnit\Framework\TestCase;
+use Team\Contracts\TeamQueryRepositoryInterface;
+use TradeBlock\Contracts\TradeBlockRepositoryInterface;
+use TradeBlock\TradeBlockProcessor;
+
+class TradeBlockProcessorTest extends TestCase
+{
+    /** @var list<int> */
+    private array $setOnBlockCalls = [];
+    /** @var list<int> */
+    private array $removeFromBlockCalls = [];
+    /** @var list<array{teamId: int, note: string}> */
+    private array $seekingCalls = [];
+
+    /** @var TradeBlockRepositoryInterface&\PHPUnit\Framework\MockObject\Stub */
+    private TradeBlockRepositoryInterface $repoStub;
+    /** @var TeamQueryRepositoryInterface&\PHPUnit\Framework\MockObject\Stub */
+    private TeamQueryRepositoryInterface $teamQueryRepoStub;
+
+    protected function setUp(): void
+    {
+        $this->setOnBlockCalls = [];
+        $this->removeFromBlockCalls = [];
+        $this->seekingCalls = [];
+
+        $this->repoStub = self::createStub(TradeBlockRepositoryInterface::class);
+        $this->repoStub->method('setOnBlock')->willReturnCallback(function (int $pid, string $note): bool {
+            $this->setOnBlockCalls[] = $pid;
+            return true;
+        });
+        $this->repoStub->method('removeFromBlock')->willReturnCallback(function (int $pid): bool {
+            $this->removeFromBlockCalls[] = $pid;
+            return true;
+        });
+        $this->repoStub->method('upsertSeekingNote')->willReturnCallback(function (int $teamId, string $note): bool {
+            $this->seekingCalls[] = ['teamId' => $teamId, 'note' => $note];
+            return true;
+        });
+
+        $this->teamQueryRepoStub = self::createStub(TeamQueryRepositoryInterface::class);
+    }
+
+    /**
+     * @param list<int> $pids
+     */
+    private function stubRoster(array $pids): void
+    {
+        $rows = array_map(static fn (int $pid): array => ['pid' => $pid, 'name' => "P{$pid}"], $pids);
+        $this->teamQueryRepoStub->method('getRosterUnderContractOrderedByName')->willReturn($rows);
+    }
+
+    private function makeProcessor(): TradeBlockProcessor
+    {
+        return new TradeBlockProcessor($this->repoStub, $this->teamQueryRepoStub);
+    }
+
+    public function testCheckedPlayerIsSetAndUncheckedIsRemoved(): void
+    {
+        $this->stubRoster([10, 11]);
+
+        $result = $this->makeProcessor()->processEdit(1, [10], [10 => 'note'], '');
+
+        self::assertContains(10, $this->setOnBlockCalls);
+        self::assertContains(11, $this->removeFromBlockCalls);
+        self::assertNotContains(11, $this->setOnBlockCalls);
+        self::assertTrue($result['success']);
+        self::assertSame('block_updated', $result['result'] ?? '');
+    }
+
+    public function testForgedCrossTeamPidNeverReachesAWrite(): void
+    {
+        // Roster is [10, 11]; pid 999 belongs to another team.
+        $this->stubRoster([10, 11]);
+
+        $this->makeProcessor()->processEdit(1, [999], [], '');
+
+        self::assertNotContains(999, $this->setOnBlockCalls, 'forged pid must never be set on block');
+        self::assertNotContains(999, $this->removeFromBlockCalls, 'forged pid must never be touched');
+        // The roster pids are still reconciled (both unchecked => removed).
+        self::assertContains(10, $this->removeFromBlockCalls);
+        self::assertContains(11, $this->removeFromBlockCalls);
+    }
+
+    public function testEmptySeekingNoteStillUpserts(): void
+    {
+        $this->stubRoster([10]);
+
+        $this->makeProcessor()->processEdit(7, [], [], '');
+
+        self::assertCount(1, $this->seekingCalls);
+        self::assertSame(7, $this->seekingCalls[0]['teamId']);
+        self::assertSame('', $this->seekingCalls[0]['note']);
+    }
+}

--- a/ibl5/tests/TradeBlock/TradeBlockRepositoryTest.php
+++ b/ibl5/tests/TradeBlock/TradeBlockRepositoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TradeBlock;
+
+use PHPUnit\Framework\TestCase;
+use Tests\WideUnit\Mocks\MockDatabase;
+use TradeBlock\TradeBlockRepository;
+
+class TradeBlockRepositoryTest extends TestCase
+{
+    private MockDatabase $mockDb;
+    private TradeBlockRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->mockDb = new MockDatabase();
+        $this->repository = new TradeBlockRepository($this->mockDb);
+    }
+
+    public function testSetOnBlockExecutesParameterizedUpsert(): void
+    {
+        $this->mockDb->setReturnTrue(true);
+
+        $result = $this->repository->setOnBlock(23, 'on the block');
+
+        self::assertTrue($result);
+
+        $queries = $this->mockDb->getExecutedQueries();
+        self::assertCount(1, $queries);
+        self::assertStringContainsString('INSERT INTO gm_trade_block', $queries[0]);
+        self::assertStringContainsString('ON DUPLICATE KEY UPDATE', $queries[0]);
+        // Bound pid value appears (parameterization, not string interpolation of raw input).
+        self::assertStringContainsString('(23,', $queries[0]);
+        self::assertStringContainsString("'on the block'", $queries[0]);
+    }
+
+    public function testRemoveFromBlockExecutesParameterizedDelete(): void
+    {
+        $this->mockDb->setReturnTrue(true);
+
+        $result = $this->repository->removeFromBlock(23);
+
+        self::assertTrue($result);
+
+        $queries = $this->mockDb->getExecutedQueries();
+        self::assertCount(1, $queries);
+        self::assertStringContainsString('DELETE FROM gm_trade_block', $queries[0]);
+        self::assertStringContainsString('WHERE pid = 23', $queries[0]);
+    }
+
+    public function testUpsertSeekingNoteExecutesParameterizedUpsert(): void
+    {
+        $this->mockDb->setReturnTrue(true);
+
+        $result = $this->repository->upsertSeekingNote(3, 'seeking shooting');
+
+        self::assertTrue($result);
+
+        $queries = $this->mockDb->getExecutedQueries();
+        self::assertCount(1, $queries);
+        self::assertStringContainsString('INSERT INTO gm_trade_seeking', $queries[0]);
+        self::assertStringContainsString('ON DUPLICATE KEY UPDATE', $queries[0]);
+        self::assertStringContainsString('(3,', $queries[0]);
+        self::assertStringContainsString("'seeking shooting'", $queries[0]);
+    }
+
+    public function testUpsertSeekingNoteAcceptsEmptyString(): void
+    {
+        $this->mockDb->setReturnTrue(true);
+
+        $result = $this->repository->upsertSeekingNote(3, '');
+
+        self::assertTrue($result);
+
+        $queries = $this->mockDb->getExecutedQueries();
+        self::assertStringContainsString('INSERT INTO gm_trade_seeking', $queries[0]);
+    }
+}

--- a/ibl5/tests/TradeBlock/TradeBlockValidatorTest.php
+++ b/ibl5/tests/TradeBlock/TradeBlockValidatorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TradeBlock;
+
+use PHPUnit\Framework\TestCase;
+use TradeBlock\TradeBlockValidator;
+
+class TradeBlockValidatorTest extends TestCase
+{
+    private TradeBlockValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new TradeBlockValidator();
+    }
+
+    public function testCoercesCheckboxListToInts(): void
+    {
+        $result = $this->validator->sanitizeEdit([
+            'on_block' => ['10', '11', '12'],
+        ]);
+
+        self::assertSame([10, 11, 12], $result['pids']);
+    }
+
+    public function testDropsNonPositivePids(): void
+    {
+        $result = $this->validator->sanitizeEdit([
+            'on_block' => ['0', '-5', '7'],
+        ]);
+
+        self::assertSame([7], $result['pids']);
+    }
+
+    public function testDeduplicatesPids(): void
+    {
+        $result = $this->validator->sanitizeEdit([
+            'on_block' => ['10', '10', '11'],
+        ]);
+
+        self::assertSame([10, 11], $result['pids']);
+    }
+
+    public function testTruncatesSeekingNoteTo255Chars(): void
+    {
+        $longNote = str_repeat('a', 300);
+
+        $result = $this->validator->sanitizeEdit([
+            'seeking_note' => $longNote,
+        ]);
+
+        self::assertSame(255, mb_strlen($result['seekingNote']));
+    }
+
+    public function testTruncatesPerPlayerNoteTo255Chars(): void
+    {
+        $longNote = str_repeat('b', 300);
+
+        $result = $this->validator->sanitizeEdit([
+            'note' => [10 => $longNote],
+        ]);
+
+        self::assertSame(255, mb_strlen($result['notes'][10]));
+    }
+
+    public function testTrimsNotes(): void
+    {
+        $result = $this->validator->sanitizeEdit([
+            'seeking_note' => '   hello   ',
+        ]);
+
+        self::assertSame('hello', $result['seekingNote']);
+    }
+
+    public function testOnBlockAsStringIsRejectedWithoutCrash(): void
+    {
+        $result = $this->validator->sanitizeEdit([
+            'on_block' => 'not-an-array',
+        ]);
+
+        self::assertSame([], $result['pids']);
+    }
+
+    public function testMissingKeysDefaultSafely(): void
+    {
+        $result = $this->validator->sanitizeEdit([]);
+
+        self::assertSame([], $result['pids']);
+        self::assertSame([], $result['notes']);
+        self::assertSame('', $result['seekingNote']);
+    }
+
+    public function testEmptySeekingNoteStaysEmptyString(): void
+    {
+        $result = $this->validator->sanitizeEdit([
+            'seeking_note' => '',
+        ]);
+
+        self::assertSame('', $result['seekingNote']);
+    }
+}

--- a/ibl5/tests/TradeBlock/TradeBlockViewXssTest.php
+++ b/ibl5/tests/TradeBlock/TradeBlockViewXssTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TradeBlock;
+
+use PHPUnit\Framework\TestCase;
+use Team\Team;
+use Tests\WideUnit\Mocks\MockDatabase;
+use TradeBlock\TradeBlockView;
+
+class TradeBlockViewXssTest extends TestCase
+{
+    private TradeBlockView $view;
+
+    protected function setUp(): void
+    {
+        $this->view = new TradeBlockView();
+    }
+
+    private function makeTeam(): Team
+    {
+        $team = new Team(new MockDatabase());
+        $team->teamid = 1;
+        $team->city = 'New York';
+        $team->name = 'Metros';
+        $team->color1 = '000000';
+        $team->color2 = 'FFFFFF';
+
+        return $team;
+    }
+
+    public function testBrowseEscapesPlayerName(): void
+    {
+        $xss = '<script>alert("xss")</script>';
+
+        $html = $this->view->renderBrowse([
+            'teams' => [[
+                'teamid' => 3,
+                'team_name' => 'Cougars',
+                'team_city' => 'Carolina',
+                'color1' => '000000',
+                'color2' => 'FFFFFF',
+                'players' => [['pid' => 23, 'name' => $xss, 'note' => '']],
+                'seekingNote' => '',
+            ]],
+        ]);
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testBrowseEscapesSeekingNote(): void
+    {
+        $xss = '<script>alert("seeking")</script>';
+
+        $html = $this->view->renderBrowse([
+            'teams' => [[
+                'teamid' => 3,
+                'team_name' => 'Cougars',
+                'team_city' => 'Carolina',
+                'color1' => '000000',
+                'color2' => 'FFFFFF',
+                'players' => [['pid' => 23, 'name' => 'Safe Player', 'note' => '']],
+                'seekingNote' => $xss,
+            ]],
+        ]);
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testBrowseEscapesPerPlayerNote(): void
+    {
+        $xss = '<img src=x onerror=alert(1)>';
+
+        $html = $this->view->renderBrowse([
+            'teams' => [[
+                'teamid' => 3,
+                'team_name' => 'Cougars',
+                'team_city' => 'Carolina',
+                'color1' => '000000',
+                'color2' => 'FFFFFF',
+                'players' => [['pid' => 23, 'name' => 'Safe Player', 'note' => $xss]],
+                'seekingNote' => '',
+            ]],
+        ]);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img', $html);
+    }
+
+    public function testEditEscapesPlayerName(): void
+    {
+        $xss = '<script>alert("xss")</script>';
+
+        $html = $this->view->renderEditForm(
+            $this->makeTeam(),
+            [['pid' => 10, 'name' => $xss]],
+            [],
+            ''
+        );
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testEditEscapesSeekingNotePrefill(): void
+    {
+        $xss = '<script>alert("seeking")</script>';
+
+        $html = $this->view->renderEditForm(
+            $this->makeTeam(),
+            [['pid' => 10, 'name' => 'Safe Player']],
+            [],
+            $xss
+        );
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testEditEscapesPerPlayerNotePrefill(): void
+    {
+        $xss = '<script>alert("note")</script>';
+
+        $html = $this->view->renderEditForm(
+            $this->makeTeam(),
+            [['pid' => 10, 'name' => 'Safe Player']],
+            [10 => $xss],
+            ''
+        );
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testEditFormHasExactlyOneCsrfToken(): void
+    {
+        $html = $this->view->renderEditForm(
+            $this->makeTeam(),
+            [['pid' => 10, 'name' => 'Safe Player']],
+            [],
+            ''
+        );
+
+        self::assertSame(1, substr_count($html, 'name="_csrf_token"'));
+    }
+
+    public function testBrowseContainsNoFormElements(): void
+    {
+        $html = $this->view->renderBrowse([
+            'teams' => [[
+                'teamid' => 3,
+                'team_name' => 'Cougars',
+                'team_city' => 'Carolina',
+                'color1' => '000000',
+                'color2' => 'FFFFFF',
+                'players' => [['pid' => 23, 'name' => 'Safe Player', 'note' => '']],
+                'seekingNote' => 'Seeking help',
+            ]],
+        ]);
+
+        self::assertStringNotContainsString('<form', $html);
+    }
+}

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -408,20 +408,6 @@ INSERT INTO ibl_plr (
    65, 22, 88,
    'a0000000-0000-0000-0000-000000200032');
 
--- ============================================================
--- Trade Block fixtures (trade-block.spec.ts browse board).
--- Cross-team data independent of test ordering: pid=23 "Cougars Guard"
--- (teamid=3, retired=0) is seeded onto the block, and the Cougars get a
--- seeking note. The team-1 (Metros) toggle E2E mutates its own listing and
--- cleans up via afterAll, so it must NOT collide with this row. The IDOR
--- negative test forges pid=24 "Cougars Forward" (team 3, NOT on the block),
--- so 23 (seeded) and 24 (forged) stay distinct.
--- ============================================================
-INSERT INTO gm_trade_block (pid, note) VALUES
-  (23, 'Looking for a wing defender');
-INSERT INTO gm_trade_seeking (teamid, seeking_note) VALUES
-  (3, 'Seeking shooting and a backup big');
-
 -- Cash consideration record for Free Agency placeholder filtering tests.
 -- Cash entries live in ibl_cash_considerations (not ibl_plr) since migration 095.
 -- Tests verify that cash rows appear in "Under Contract" and do NOT appear
@@ -600,6 +586,22 @@ INSERT INTO ibl_plr (
    30, 90, 50, 140, 95, 30,
    55, 35, 85,
    'a0000000-0000-0000-0000-000000000029');
+
+-- ============================================================
+-- Trade Block fixtures (trade-block.spec.ts browse board).
+-- MUST come after the pid 23/24 ibl_plr inserts above — gm_trade_block.pid has
+-- an FK to ibl_plr(pid), so the player rows must exist first.
+-- Cross-team data independent of test ordering: pid=23 "Cougars Guard"
+-- (teamid=3, retired=0) is seeded onto the block, and the Cougars get a seeking
+-- note. The team-1 (Metros) toggle E2E mutates its own listing and cleans up via
+-- afterAll, so it never collides with this row. The IDOR negative test forges
+-- pid=24 "Cougars Forward" (team 3, NOT on the block), so 23 (seeded) and 24
+-- (forged) stay distinct.
+-- ============================================================
+INSERT INTO gm_trade_block (pid, note) VALUES
+  (23, 'Looking for a wing defender');
+INSERT INTO gm_trade_seeking (teamid, seeking_note) VALUES
+  (3, 'Seeking shooting and a backup big');
 
 -- ============================================================
 -- Placeholder player for LeagueStarters module

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -408,6 +408,20 @@ INSERT INTO ibl_plr (
    65, 22, 88,
    'a0000000-0000-0000-0000-000000200032');
 
+-- ============================================================
+-- Trade Block fixtures (trade-block.spec.ts browse board).
+-- Cross-team data independent of test ordering: pid=23 "Cougars Guard"
+-- (teamid=3, retired=0) is seeded onto the block, and the Cougars get a
+-- seeking note. The team-1 (Metros) toggle E2E mutates its own listing and
+-- cleans up via afterAll, so it must NOT collide with this row. The IDOR
+-- negative test forges pid=24 "Cougars Forward" (team 3, NOT on the block),
+-- so 23 (seeded) and 24 (forged) stay distinct.
+-- ============================================================
+INSERT INTO gm_trade_block (pid, note) VALUES
+  (23, 'Looking for a wing defender');
+INSERT INTO gm_trade_seeking (teamid, seeking_note) VALUES
+  (3, 'Seeking shooting and a backup big');
+
 -- Cash consideration record for Free Agency placeholder filtering tests.
 -- Cash entries live in ibl_cash_considerations (not ibl_plr) since migration 095.
 -- Tests verify that cash rows appear in "Under Contract" and do NOT appear

--- a/ibl5/tests/e2e/flows/trade-block-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/trade-block-submission.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '../fixtures/auth';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+import { resetTradeBlock } from '../helpers/cleanup';
+
+// Trade Block submission flow — mutates Metros' (teamid=1) block rows.
+// Serial: toggle ON/OFF + seeking note share team-1 state.
+test.describe.configure({ mode: 'serial' });
+
+// A known Metros (teamid=1) roster player seeded in ci-seed.sql.
+const METROS_PID = '20';
+const METROS_PLAYER_NAME = 'Metros PG';
+
+async function submitEditForm(page: import('@playwright/test').Page): Promise<void> {
+  const form = page.locator('form[name="Trade_Block"]');
+  const responsePromise = page.waitForResponse(
+    resp => resp.url().includes('modules.php') && resp.request().method() === 'POST',
+  );
+  await form.locator('button[type="submit"]').first().click();
+  const response = await responsePromise;
+  await page.waitForLoadState('networkidle');
+  expect(page.url(), `POST status=${response.status()}`).toContain('result=block_updated');
+}
+
+test.describe('Trade Block: toggle on/off', () => {
+  test('toggle ON: player appears on the browse board under Metros', async ({ page }) => {
+    await page.goto('modules.php?name=TradeBlock&op=edit');
+
+    const form = page.locator('form[name="Trade_Block"]');
+    await expect(form).toBeVisible();
+
+    await form.locator(`input[name="on_block[]"][value="${METROS_PID}"]`).check();
+    await form.locator(`input[name="note[${METROS_PID}]"]`).fill('Available for the right deal');
+
+    await submitEditForm(page);
+    await expect(page.locator('.ibl-alert--success')).toBeVisible();
+    await assertNoPhpErrors(page, 'after trade-block toggle ON');
+
+    // Browse readback: the player now shows under Metros.
+    await page.goto('modules.php?name=TradeBlock');
+    await expect(page.locator('body')).toContainText(METROS_PLAYER_NAME);
+  });
+
+  test('toggle OFF: player no longer appears on the browse board', async ({ page }) => {
+    await page.goto('modules.php?name=TradeBlock&op=edit');
+
+    const form = page.locator('form[name="Trade_Block"]');
+    await expect(form).toBeVisible();
+
+    await form.locator(`input[name="on_block[]"][value="${METROS_PID}"]`).uncheck();
+    await submitEditForm(page);
+
+    // Browse readback: the player is gone (reconcile removed the block row).
+    await page.goto('modules.php?name=TradeBlock');
+    await expect(page.locator('body')).not.toContainText(METROS_PLAYER_NAME);
+  });
+});
+
+test.describe('Trade Block: seeking note persists', () => {
+  test('submitted seeking note is retained on reload', async ({ page }) => {
+    const note = 'Seeking a stretch four and draft picks';
+
+    await page.goto('modules.php?name=TradeBlock&op=edit');
+    const form = page.locator('form[name="Trade_Block"]');
+    await expect(form).toBeVisible();
+
+    await form.locator('textarea[name="seeking_note"]').fill(note);
+    await submitEditForm(page);
+
+    // Reload the edit form — the textarea retains the saved value.
+    await page.goto('modules.php?name=TradeBlock&op=edit');
+    await expect(page.locator('textarea[name="seeking_note"]')).toHaveValue(note);
+  });
+});
+
+test.describe('Trade Block: CSRF rejection', () => {
+  test('POST without a valid CSRF token is rejected and writes nothing', async ({ page }) => {
+    const response = await page.request.post('/ibl5/modules.php?name=TradeBlock', {
+      form: {
+        op: 'edit',
+        Action: 'save',
+        'on_block[]': METROS_PID,
+        _csrf_token: 'garbage-token',
+      },
+      maxRedirects: 0,
+    });
+
+    const location = response.headers()['location'] ?? '';
+    expect(location, 'Expected error redirect').toContain('error=');
+    expect(location, 'Must not report success').not.toContain('result=block_updated');
+
+    // Readback: the player was not added to the board.
+    await page.goto('modules.php?name=TradeBlock');
+    await expect(page.locator('body')).not.toContainText(METROS_PLAYER_NAME);
+  });
+});
+
+test.describe('Trade Block: cross-team IDOR rejection', () => {
+  test('forged pid for another team creates no block row', async ({ page }) => {
+    // Read a valid CSRF token from A-Jay's (team 1) own edit form.
+    await page.goto('modules.php?name=TradeBlock&op=edit');
+    const csrfToken = await page
+      .locator('form[name="Trade_Block"] input[name="_csrf_token"]')
+      .inputValue();
+
+    // Forge pid=24 "Cougars Forward" (teamid=3) — not on Metros' roster.
+    const response = await page.request.post('/ibl5/modules.php?name=TradeBlock', {
+      form: {
+        op: 'edit',
+        Action: 'save',
+        'on_block[]': '24',
+        _csrf_token: csrfToken,
+      },
+      maxRedirects: 0,
+    });
+
+    // The submission itself succeeds (own-roster reconcile), but the forged pid
+    // is silently dropped — it is not on the resolved Metros roster.
+    const location = response.headers()['location'] ?? '';
+    expect(location).toContain('result=block_updated');
+
+    // Readback: the forged Cougars player is NOT on the board.
+    await page.goto('modules.php?name=TradeBlock');
+    await expect(page.locator('body')).not.toContainText('Cougars Forward');
+  });
+
+  test.afterAll(async ({ request }) => {
+    await resetTradeBlock(request);
+  });
+});

--- a/ibl5/tests/e2e/flows/trade-block.spec.ts
+++ b/ibl5/tests/e2e/flows/trade-block.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '../fixtures/auth';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+
+// Trade Block — read-only browse board + navigation. No mutations here; the
+// toggle/submit flow lives in trade-block-submission.spec.ts.
+
+test.describe('Trade Block: browse board', () => {
+  test('browse page loads without PHP errors', async ({ page }) => {
+    await page.goto('modules.php?name=TradeBlock');
+    await assertNoPhpErrors(page, 'on Trade Block browse page');
+  });
+
+  test('lists the seeded cross-team available player and seeking note', async ({ page }) => {
+    await page.goto('modules.php?name=TradeBlock');
+
+    // ci-seed.sql seeds pid=23 "Cougars Guard" (teamid=3) onto the block and a
+    // Cougars seeking note — present regardless of test ordering.
+    await expect(page.locator('body')).toContainText('Cougars Guard');
+    await expect(page.locator('body')).toContainText('Seeking shooting and a backup big');
+  });
+
+  test('browse board contains no form elements', async ({ page }) => {
+    await page.goto('modules.php?name=TradeBlock');
+    await expect(page.locator('.trade-block-page form')).toHaveCount(0);
+  });
+});
+
+test.describe('Trade Block: navigation', () => {
+  test('Community browse link and My-Team edit link are present', async ({ page }) => {
+    await page.goto('modules.php?name=TradeBlock');
+
+    // Browse anchor (Community menu): bare module URL.
+    await expect(
+      page.locator('a[href="modules.php?name=TradeBlock"]').first(),
+    ).toBeAttached();
+
+    // Edit anchor (IBL My-Team menu): op=edit.
+    await expect(
+      page.locator('a[href="modules.php?name=TradeBlock&op=edit"]').first(),
+    ).toBeAttached();
+  });
+});
+
+test.describe('Trade Block: edit form loads', () => {
+  test('edit form has one CSRF token and a checkbox per roster player', async ({ page }) => {
+    await page.goto('modules.php?name=TradeBlock&op=edit');
+
+    const form = page.locator('form[name="Trade_Block"]');
+    await expect(form).toBeVisible();
+
+    // Exactly one CSRF token (bulk single-form design, well under MAX_TOKENS).
+    await expect(form.locator('input[name="_csrf_token"]')).toHaveCount(1);
+
+    // At least one roster checkbox + the seeking textarea.
+    expect(await form.locator('input[name="on_block[]"]').count()).toBeGreaterThanOrEqual(1);
+    await expect(form.locator('textarea[name="seeking_note"]')).toBeVisible();
+
+    await assertNoPhpErrors(page, 'on Trade Block edit page');
+  });
+});

--- a/ibl5/tests/e2e/helpers/cleanup.ts
+++ b/ibl5/tests/e2e/helpers/cleanup.ts
@@ -195,6 +195,24 @@ export async function resetTradeOffers(
 }
 
 /**
+ * Undo the trade-block toggle tests: delete every gm_trade_block row owned by a
+ * Metros (teamid=1) player and clear Metros' seeking note. Scoped to teamid=1 so
+ * the seeded cross-team fixture (Cougars pid=23 / teamid=3) survives.
+ */
+export async function resetTradeBlock(
+  request: APIRequestContext,
+): Promise<void> {
+  const response = await request.delete(
+    'test-state.php?action=reset-trade-block',
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `reset-trade-block failed: ${response.status()} ${await response.text()}`,
+    );
+  }
+}
+
+/**
  * Restore state after a block.php assign_free_agents test: returns the three FA
  * players (pids 10/11/12) to their pre-signing seed, restores Metros' MLE/LLE,
  * deletes the assign news story, and re-seeds ibl_fa_offers.


### PR DESCRIPTION
## Summary

Implements the **Trade Block / Availability Board** (GM module #2). GMs can mark players on their roster as available for trade (with an optional note), and the browse board shows all available players league-wide. A separate seeking note lets each team advertise what they're looking for.

**Key design decisions:**
-  +  tables; no stored teamid in trade_block (read-time derivation via  prevents stale-team listings)
- Reconcile-on-save: Controller resolves GMs own roster server-side; any forged pid is silently dropped (IDOR prevention)
- CSRF-protected PRG pattern (same template as Waivers)
- XSS: all output via `htmlspecialchars()` enforced by PHPStan `RequireEscapedOutputRule`

**Files added:** migration 146, `TradeBlock` module + 5 classes + 6 interfaces, unit/DB-integration/E2E tests.

**Files changed:** ModuleRegistry, NavigationMenuBuilder, phpunit.xml, ci-seed.sql.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.