### PR TITLE
rules: all work happens in a worktree; main checkout is reference-only

### DIFF
--- a/.claude/rules/auto-commit.md
+++ b/.claude/rules/auto-commit.md
@@ -1,11 +1,15 @@
 ---
-description: Commit after a unit of work (Stop hook reminds you); amend when fixing unpushed work
-last_verified: 2026-06-04
+description: Commit/PR work from the worktree; the Stop hook warns if the main checkout is dirty (work landed in the wrong place); amend when fixing unpushed work
+last_verified: 2026-06-13
 ---
 
 # Auto-Commit
 
-The `$HOME/.claude/hooks/auto-commit-reminder.sh` Stop hook delivers the "commit when done" reminder at runtime: it fires at turn-end when the main checkout has uncommitted changes and no plan workflow is active, and stays silent in worktrees and during `/post-plan` (those hand off / commit internally). When reminded — or whenever a prompt finishes a unit of work (impl, fix, refactor, config, docs) — invoke `/commit-commands:commit`. Skip it when mid-task or when the user is only exploring.
+All work happens in a worktree, never the main checkout (ADR-0062, `workflow-continuity.md`). Worktree work is committed by `/post-plan` (auto-fired) or `/commit-commands:commit-push-pr` — not by this hook.
+
+The `$HOME/.claude/hooks/auto-commit-reminder.sh` Stop hook is now a **misplaced-work warning**, not a commit reminder: it fires at turn-end when the **main checkout** has uncommitted changes (and no plan workflow is active), telling you the work landed in the wrong place and to move it into a worktree (`bin/wt-new`). It stays silent in worktrees and during `/post-plan`. It is a warning, not a hard block — heed it unless you have a deliberate reason to be touching the main checkout.
+
+When you finish a unit of work in a worktree (impl, fix, refactor, config, docs) and are not using the `/post-plan` auto-fire handoff, invoke `/commit-commands:commit` (or `commit-push-pr`). Skip it when mid-task or when the user is only exploring.
 
 ## Amend vs new commit
 

--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -1,9 +1,15 @@
 ---
-description: Worktree setup and the implementation→/post-plan handoff (auto-fired in a detached fresh session) for multi-step work.
-last_verified: 2026-06-11
+description: All work happens in a worktree (never the main checkout); worktree setup and the implementation→/post-plan handoff (auto-fired in a detached fresh session) for multi-step work.
+last_verified: 2026-06-13
 ---
 
 # Workflow Continuity Rule
+
+## All work happens in a worktree
+
+**Never edit the main checkout (`/Users/ajaynicolas/GitHub/IBL5`, branch `master`) directly** — not code, not migrations, not docs, not `.claude/rules`, not config, not ADRs. No size or category exception (ADR-0062). The main checkout is reference/read-only: it holds canonical `master`, is the base for `bin/wt-new`, and runs main-stack Docker/DB tooling.
+
+The only files exempt are those that physically live **outside** the repo tree and cannot go in a worktree: the Claude hooks (`~/.claude/hooks/`), per-project memory (`~/.claude/projects/.../memory/`), and `~/.claude/settings*.json`. Edit those in place as usual.
 
 ## Planning
 
@@ -11,13 +17,13 @@ Use `/plan <task description>` for implementation planning.
 
 ## Worktree Setup
 
-Before implementation, create a worktree unless one already exists for this task:
+Before touching any repo file, make sure you are in a worktree. Create one unless it already exists for this task:
 
 ```bash
 bin/wt-new <slug>   # slug = kebab-case branch name derived from the plan
 ```
 
-Use `--base <branch>` for stacked PRs. Work in `IBL5-worktrees/<slug>/ibl5/` (worktrees live outside the repo — ADR-0046). Skip if already inside a worktree or the plan specifies an existing one.
+Use `--base <branch>` for stacked PRs. Work in `IBL5-worktrees/<slug>/ibl5/` (worktrees live outside the repo — ADR-0046). The only reason to skip creation is that the worktree for this task already exists (or the plan names an existing one) — never because "this edit is small enough to do on master."
 
 ## Post-Plan
 

--- a/.claude/rules/worktree-hostname.md
+++ b/.claude/rules/worktree-hostname.md
@@ -1,13 +1,13 @@
 ---
 description: How to derive the correct Docker hostname for the current worktree or main repo. Prevents using stale slugs.
-last_verified: 2026-06-04
+last_verified: 2026-06-13
 ---
 
 # Worktree Hostname
 
 ## Main repo
 
-When working in the main checkout (`/Users/ajaynicolas/GitHub/IBL5/ibl5/`), the Docker hostname is `main.localhost`.
+The main checkout (`/Users/ajaynicolas/GitHub/IBL5/ibl5/`) is reference/read-only — you do not edit files there (ADR-0062); all work happens in a worktree. Its Docker hostname is `main.localhost`, used for reading/serving the canonical `master` stack and main-stack DB tooling, not for developing a change.
 
 ## Worktrees
 

--- a/ibl5/docs/decisions/0062-all-work-in-worktrees.md
+++ b/ibl5/docs/decisions/0062-all-work-in-worktrees.md
@@ -1,0 +1,64 @@
+---
+description: All work happens in a git worktree; the main checkout (master) is reference/read-only and is never edited directly. Generalizes the nightly agent's "never modify files on master" rule to every session — interactive and headless, code and repo-meta (rules, docs, config, ADRs). Records why and the enforcement surfaces (auto-commit Stop hook flips to a warning in the main checkout).
+last_verified: 2026-06-13
+---
+
+# ADR-0062: All work happens in a worktree; the main checkout is reference-only
+
+**Status:** Accepted
+**Date:** 2026-06-13
+
+## Context
+
+Worktrees were already the norm for plan-driven implementation
+(`workflow-continuity.md` told you to `bin/wt-new` *before* implementation), but the
+prohibition on editing the main checkout directly only existed in one place: the
+nightly agent's prompt (`bin/nightly-prompt-impl`: "Work only in worktrees, never
+modify files on the master branch directly"). Interactive sessions had no such rule.
+
+In practice this left the main checkout (`/Users/ajaynicolas/GitHub/IBL5`, branch
+`master`) treated as a valid place for "small" work — config tweaks, doc edits,
+`.claude/rules` changes. The `auto-commit-reminder.sh` Stop hook reinforced this: it
+*reminded you to commit* uncommitted changes in the main checkout. That is exactly
+the behavior we no longer want.
+
+Working on `master` directly is a footgun: commits land on the integration branch with
+no PR, no CI gate, no review, and no isolation from a concurrent Claude instance (see
+the `feedback_concurrent_instance_use_worktree` memory — main-checkout HEAD churn is a
+known failure mode). The "it's just a one-line config change" exception is where the
+discipline erodes.
+
+## Decision
+
+**All work happens in a worktree. The main checkout is reference/read-only and is never
+edited directly — not code, not migrations, not docs, not `.claude/rules`, not config,
+not ADRs.** No size or category exception.
+
+- Every session that will edit a repo file first ensures it is in a worktree
+  (`bin/wt-new <slug>`); the only reason to skip creation is that the worktree for this
+  task already exists.
+- The main checkout exists to: hold the canonical `master`, serve as the base for
+  `bin/wt-new`, run main-stack Docker/DB tooling, and be read for reference. It is not
+  an editing surface.
+- The `auto-commit-reminder.sh` Stop hook **flips**: instead of reminding you to commit
+  uncommitted changes in the main checkout, it now **warns** that work is happening in
+  the wrong place and tells you to move it to a worktree. It is a warning, not a hard
+  block (a human may have legitimate reasons to touch the main checkout briefly), per
+  the user's explicit choice.
+
+Files that physically live outside the repo tree — the Stop hook itself
+(`~/.claude/hooks/`), Claude's per-project memory (`~/.claude/projects/.../memory/`),
+and `~/.claude/settings*.json` — cannot be placed in a worktree and are edited directly
+as before. This ADR governs **repo files only**.
+
+## Consequences
+
+- Every repo change flows through a worktree → branch → PR → CI, with no master-direct
+  escape hatch. Review and CI gates apply uniformly.
+- A trivial one-line repo-meta edit now carries worktree ceremony. Accepted: the cost is
+  small (`bin/wt-new` needs no Docker for a markdown/config edit) and the eroded-discipline
+  failure mode it prevents is worse.
+- The auto-commit Stop hook no longer nudges-to-commit in the main checkout; an
+  uncommitted main checkout is now a signal that work landed in the wrong place.
+- Lineage: generalizes the nightly-only rule in `bin/nightly-prompt-impl` to all sessions;
+  builds on ADR-0046 (worktree layout) and the `workflow-continuity.md` rule.


### PR DESCRIPTION
## What

Workflow change: **all work happens in a git worktree; the main checkout (`master`) is reference/read-only and is never edited directly** — no size or category exception. Generalizes the nightly-agent-only "never modify files on master" rule to every session.

## Changes (in-repo)

- **ADR-0062** — records the decision, rationale, and enforcement surfaces.
- **`workflow-continuity.md`** — adds the explicit prohibition; rewords the worktree-skip condition (skip creation only when the worktree already exists, never because an edit is "small").
- **`auto-commit.md`** — reframed: the Stop hook is now a misplaced-work warning, not a commit reminder.
- **`worktree-hostname.md`** — main checkout framed as reference-only.

## Out-of-repo (already applied, can't live in a worktree)

- `~/.claude/hooks/auto-commit-reminder.sh` — flips from "commit your changes" to a **WARNING** that the main checkout is dirty + move work to `bin/wt-new`. Warning, not a hard block.
- Claude per-project memory — added `feedback_all_work_in_worktree`, indexed it, and strengthened `feedback_concurrent_instance_use_worktree`.

## Note

Rule files only go live in the main checkout after this merges; the hook + memory take effect immediately.
