### PR TITLE
feat(dashboard): GM Dashboard — owner-scoped landing page aggregating 6 read-only data sources

### DIFF
--- a/ibl5/classes/Dashboard/Contracts/DashboardServiceInterface.php
+++ b/ibl5/classes/Dashboard/Contracts/DashboardServiceInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dashboard\Contracts;
+
+use Season\Season;
+
+/**
+ * Service interface for the GM Dashboard module.
+ *
+ * Aggregates six existing read-only data sources for the logged-in GM's own
+ * team. Every team-scoped section is filtered server-side to the owner's
+ * teamid; the news section is league-wide by design.
+ *
+ * @phpstan-type DashboardTradeOffer array{oppositeTeam: string, approval: string, hasHammer: bool}
+ * @phpstan-type DashboardPendingTrades array{count: int, offers: list<DashboardTradeOffer>}
+ * @phpstan-type DashboardNextSim array{opponent: string, location: string, tier: string, date: string}
+ * @phpstan-type DashboardCap array{headroom: int}
+ * @phpstan-type DashboardFreeAgent array{pid: int, name: string, pos: string, teamid: int}
+ * @phpstan-type DashboardInjury array{playerID: int, name: string, position: string, daysRemaining: int, teamid: int}
+ * @phpstan-type DashboardNewsItem array{sid: int, title: string, catTitle: string}
+ * @phpstan-type DashboardData array{
+ *     teamId: int,
+ *     teamName: string,
+ *     pendingTrades: DashboardPendingTrades,
+ *     nextSim: DashboardNextSim|null,
+ *     cap: DashboardCap,
+ *     upcomingFreeAgents: list<DashboardFreeAgent>,
+ *     injuries: list<DashboardInjury>,
+ *     news: list<DashboardNewsItem>
+ * }
+ */
+interface DashboardServiceInterface
+{
+    /**
+     * Aggregate the dashboard data for a single owner's team.
+     *
+     * @param int $ownerTeamId Resolved server-side from the session; never a request param.
+     * @param string $ownerTeamName Resolved server-side from the session.
+     * @param string $ownerUsername Resolved server-side from the session.
+     * @param Season $season Current season.
+     * @return DashboardData Aggregated, owner-scoped dashboard sections.
+     */
+    public function getDashboardData(int $ownerTeamId, string $ownerTeamName, string $ownerUsername, Season $season): array;
+}

--- a/ibl5/classes/Dashboard/Contracts/DashboardViewInterface.php
+++ b/ibl5/classes/Dashboard/Contracts/DashboardViewInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dashboard\Contracts;
+
+/**
+ * View interface for the GM Dashboard module.
+ *
+ * Renders the aggregated dashboard data as compact, escaped section cards.
+ *
+ * @phpstan-import-type DashboardData from DashboardServiceInterface
+ */
+interface DashboardViewInterface
+{
+    /**
+     * Render the dashboard as an HTML string.
+     *
+     * @param DashboardData $dashboardData Aggregated, owner-scoped dashboard sections.
+     * @return string Rendered HTML.
+     */
+    public function render(array $dashboardData): string;
+}

--- a/ibl5/classes/Dashboard/DashboardService.php
+++ b/ibl5/classes/Dashboard/DashboardService.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dashboard;
+
+use CapSpace\CapSpaceService;
+use Dashboard\Contracts\DashboardServiceInterface;
+use FreeAgencyPreview\Contracts\FreeAgencyPreviewServiceInterface;
+use Injuries\Contracts\InjuriesServiceInterface;
+use NextSim\Contracts\NextSimServiceInterface;
+use Season\Season;
+use Topics\Contracts\TopicsServiceInterface;
+use Trading\Contracts\TradingServiceInterface;
+
+/**
+ * DashboardService - Aggregator for the GM Dashboard module.
+ *
+ * Delegates to six read-only collaborators and composes owner-scoped data
+ * into the DashboardData DTO. Writes no SQL and touches no database directly.
+ *
+ * @phpstan-import-type DashboardData from DashboardServiceInterface
+ */
+final class DashboardService implements DashboardServiceInterface
+{
+    public function __construct(
+        private readonly TradingServiceInterface $tradingService,
+        private readonly NextSimServiceInterface $nextSimService,
+        private readonly CapSpaceService $capSpaceService,
+        private readonly FreeAgencyPreviewServiceInterface $freeAgencyPreviewService,
+        private readonly InjuriesServiceInterface $injuriesService,
+        private readonly TopicsServiceInterface $topicsService,
+    ) {
+    }
+
+    /**
+     * @return DashboardData
+     */
+    public function getDashboardData(
+        int $ownerTeamId,
+        string $ownerTeamName,
+        string $ownerUsername,
+        Season $season,
+    ): array {
+        return [
+            'teamId'              => $ownerTeamId,
+            'teamName'            => $ownerTeamName,
+            'pendingTrades'       => $this->buildPendingTrades($ownerUsername),
+            'nextSim'             => $this->buildNextSim($ownerTeamId, $season),
+            'cap'                 => $this->buildCap($ownerTeamId, $season),
+            'upcomingFreeAgents'  => $this->buildUpcomingFreeAgents($ownerTeamId, $season),
+            'injuries'            => $this->buildInjuries($ownerTeamId),
+            'news'                => $this->buildNews(),
+        ];
+    }
+
+    /**
+     * @return array{count: int, offers: list<array{oppositeTeam: string, approval: string, hasHammer: bool}>}
+     */
+    private function buildPendingTrades(string $ownerUsername): array
+    {
+        $offers = $this->tradingService->getTradeReviewPageData($ownerUsername)['tradeOffers'];
+        $summary = array_map(
+            static fn(array $offer): array => [
+                'oppositeTeam' => $offer['oppositeTeam'],
+                'approval'     => $offer['approval'],
+                'hasHammer'    => $offer['hasHammer'],
+            ],
+            $offers,
+        );
+
+        return [
+            'count'  => count($offers),
+            'offers' => array_values($summary),
+        ];
+    }
+
+    /**
+     * @return array{opponent: string, location: string, tier: string, date: string}|null
+     */
+    private function buildNextSim(int $ownerTeamId, Season $season): array|null
+    {
+        $games = $this->nextSimService->getNextSimGames($ownerTeamId, $season);
+        if ($games === []) {
+            return null;
+        }
+
+        $first = $games[array_key_first($games)];
+
+        return [
+            'opponent' => $first['opposingTeam']->name,
+            'location' => $first['locationPrefix'],
+            'tier'     => $first['opponentTier'],
+            'date'     => $first['date']->format('Y-m-d'),
+        ];
+    }
+
+    /**
+     * @return array{headroom: int}
+     */
+    private function buildCap(int $ownerTeamId, Season $season): array
+    {
+        $rows = $this->capSpaceService->getTeamsCapData($season);
+        foreach ($rows as $row) {
+            if ($row['teamId'] === $ownerTeamId) {
+                return ['headroom' => $row['availableSalary']['year1']];
+            }
+        }
+
+        return ['headroom' => 0];
+    }
+
+    /**
+     * @return list<array{pid: int, name: string, pos: string, teamid: int}>
+     */
+    private function buildUpcomingFreeAgents(int $ownerTeamId, Season $season): array
+    {
+        $all = $this->freeAgencyPreviewService->getUpcomingFreeAgents($season->endingYear);
+        $filtered = array_filter(
+            $all,
+            static fn(array $p): bool => $p['teamid'] === $ownerTeamId,
+        );
+
+        return array_values(array_map(
+            static fn(array $p): array => [
+                'pid'    => $p['pid'],
+                'name'   => $p['name'],
+                'pos'    => $p['pos'],
+                'teamid' => $p['teamid'],
+            ],
+            $filtered,
+        ));
+    }
+
+    /**
+     * @return list<array{playerID: int, name: string, position: string, daysRemaining: int, teamid: int}>
+     */
+    private function buildInjuries(int $ownerTeamId): array
+    {
+        $all = $this->injuriesService->getInjuredPlayersWithTeams();
+        $filtered = array_filter(
+            $all,
+            static fn(array $p): bool => $p['teamid'] === $ownerTeamId,
+        );
+
+        return array_values(array_map(
+            static fn(array $p): array => [
+                'playerID'      => $p['playerID'],
+                'name'          => $p['name'],
+                'position'      => $p['position'],
+                'daysRemaining' => $p['daysRemaining'],
+                'teamid'        => $p['teamid'],
+            ],
+            $filtered,
+        ));
+    }
+
+    /**
+     * @return list<array{sid: int, title: string, catTitle: string}>
+     */
+    private function buildNews(): array
+    {
+        $topics = $this->topicsService->getPageData(false)['topics'];
+
+        /** @var list<array{sid: int, title: string, catTitle: string}> $articles */
+        $articles = [];
+        foreach ($topics as $topic) {
+            foreach ($topic['recentArticles'] as $article) {
+                $articles[] = [
+                    'sid'      => $article['sid'],
+                    'title'    => $article['title'],
+                    'catTitle' => $article['catTitle'],
+                ];
+            }
+        }
+
+        usort($articles, static fn(array $a, array $b): int => $b['sid'] <=> $a['sid']);
+
+        return array_values(array_slice($articles, 0, 5));
+    }
+}

--- a/ibl5/classes/Dashboard/DashboardView.php
+++ b/ibl5/classes/Dashboard/DashboardView.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dashboard;
+
+use Dashboard\Contracts\DashboardViewInterface;
+use Security\HtmlSanitizer;
+
+/**
+ * Renders the GM Dashboard as compact, escaped section cards.
+ *
+ * Every interpolated player/team name and headline is escaped through
+ * {@see HtmlSanitizer::e()}. Each card links to the existing full module page.
+ *
+ * @phpstan-import-type DashboardData from \Dashboard\Contracts\DashboardServiceInterface
+ *
+ * @see DashboardViewInterface
+ */
+class DashboardView implements DashboardViewInterface
+{
+    /**
+     * @see DashboardViewInterface::render()
+     */
+    public function render(array $dashboardData): string
+    {
+        $teamName = HtmlSanitizer::e($dashboardData['teamName']);
+
+        $output = "<h1 class=\"ibl-title\">{$teamName} Dashboard</h1>";
+        $output .= '<div class="gm-dashboard-grid">';
+        $output .= $this->renderPendingTrades($dashboardData['pendingTrades']);
+        $output .= $this->renderNextSim($dashboardData['nextSim']);
+        $output .= $this->renderCap($dashboardData['cap']);
+        $output .= $this->renderUpcomingFreeAgents($dashboardData['upcomingFreeAgents']);
+        $output .= $this->renderInjuries($dashboardData['injuries']);
+        $output .= $this->renderNews($dashboardData['news']);
+        $output .= '</div>';
+
+        return $output;
+    }
+
+    /**
+     * Render one section card wrapper.
+     *
+     * @param string $heading Plain heading text (rendered as-is — caller controls it).
+     * @param string $body Pre-built, already-escaped inner HTML.
+     * @param string $fullPageUrl Link to the full module page.
+     */
+    private function card(string $heading, string $body, string $fullPageUrl): string
+    {
+        $url = HtmlSanitizer::e($fullPageUrl);
+
+        return '<section class="gm-dashboard-card">'
+            . "<h2 class=\"ibl-title\">{$heading}</h2>"
+            . $body
+            . "<p class=\"gm-dashboard-link\"><a href=\"{$url}\">View full page &rarr;</a></p>"
+            . '</section>';
+    }
+
+    /**
+     * @param array{count: int, offers: list<array{oppositeTeam: string, approval: string, hasHammer: bool}>} $pendingTrades
+     */
+    private function renderPendingTrades(array $pendingTrades): string
+    {
+        if ($pendingTrades['count'] === 0) {
+            $body = '<p class="gm-dashboard-empty">No pending trade offers.</p>';
+
+            return $this->card('Pending Trades', $body, 'modules.php?name=Trading&op=reviewtrade');
+        }
+
+        $rows = '';
+        foreach ($pendingTrades['offers'] as $offer) {
+            $oppositeTeam = HtmlSanitizer::e($offer['oppositeTeam']);
+            $approval = HtmlSanitizer::e($offer['approval']);
+            $hammer = $offer['hasHammer'] ? ' &#9794;' : '';
+            $rows .= "<li>{$oppositeTeam} &mdash; {$approval}{$hammer}</li>";
+        }
+        $count = (string) $pendingTrades['count'];
+        $body = "<p>{$count} pending offer(s):</p><ul class=\"gm-dashboard-list\">{$rows}</ul>";
+
+        return $this->card('Pending Trades', $body, 'modules.php?name=Trading&op=reviewtrade');
+    }
+
+    /**
+     * @param array{opponent: string, location: string, tier: string, date: string}|null $nextSim
+     */
+    private function renderNextSim(?array $nextSim): string
+    {
+        if ($nextSim === null) {
+            $body = '<p class="gm-dashboard-empty">No upcoming game scheduled.</p>';
+
+            return $this->card('Next Sim', $body, 'modules.php?name=NextSim');
+        }
+
+        $opponent = HtmlSanitizer::e($nextSim['opponent']);
+        $location = HtmlSanitizer::e($nextSim['location']);
+        $tier = HtmlSanitizer::e($nextSim['tier']);
+        $date = HtmlSanitizer::e($nextSim['date']);
+        $body = "<p>{$location} <strong>{$opponent}</strong></p>"
+            . "<p>Tier: {$tier}</p>"
+            . "<p>Date: {$date}</p>";
+
+        return $this->card('Next Sim', $body, 'modules.php?name=NextSim');
+    }
+
+    /**
+     * @param array{headroom: int} $cap
+     */
+    private function renderCap(array $cap): string
+    {
+        $headroom = HtmlSanitizer::e(number_format($cap['headroom']));
+        $body = "<p class=\"gm-dashboard-stat\">Cap headroom: <strong>{$headroom}</strong></p>";
+
+        return $this->card('Cap Space', $body, 'modules.php?name=CapSpace');
+    }
+
+    /**
+     * @param list<array{pid: int, name: string, pos: string, teamid: int}> $freeAgents
+     */
+    private function renderUpcomingFreeAgents(array $freeAgents): string
+    {
+        if ($freeAgents === []) {
+            $body = '<p class="gm-dashboard-empty">No upcoming free agents on your roster.</p>';
+
+            return $this->card('Upcoming Free Agents', $body, 'modules.php?name=FreeAgencyPreview');
+        }
+
+        $rows = '';
+        foreach ($freeAgents as $player) {
+            $name = HtmlSanitizer::e($player['name']);
+            $pos = HtmlSanitizer::e($player['pos']);
+            $rows .= "<li>{$pos} {$name}</li>";
+        }
+        $body = "<ul class=\"gm-dashboard-list\">{$rows}</ul>";
+
+        return $this->card('Upcoming Free Agents', $body, 'modules.php?name=FreeAgencyPreview');
+    }
+
+    /**
+     * @param list<array{playerID: int, name: string, position: string, daysRemaining: int, teamid: int}> $injuries
+     */
+    private function renderInjuries(array $injuries): string
+    {
+        if ($injuries === []) {
+            $body = '<p class="gm-dashboard-empty">No injured players on your roster.</p>';
+
+            return $this->card('Injuries', $body, 'modules.php?name=Injuries');
+        }
+
+        $rows = '';
+        foreach ($injuries as $player) {
+            $name = HtmlSanitizer::e($player['name']);
+            $position = HtmlSanitizer::e($player['position']);
+            $days = (string) $player['daysRemaining'];
+            $rows .= "<li>{$position} {$name} &mdash; {$days} day(s)</li>";
+        }
+        $body = "<ul class=\"gm-dashboard-list\">{$rows}</ul>";
+
+        return $this->card('Injuries', $body, 'modules.php?name=Injuries');
+    }
+
+    /**
+     * @param list<array{sid: int, title: string, catTitle: string}> $news
+     */
+    private function renderNews(array $news): string
+    {
+        if ($news === []) {
+            $body = '<p class="gm-dashboard-empty">No recent league news.</p>';
+
+            return $this->card('League News', $body, 'modules.php?name=Topics');
+        }
+
+        $rows = '';
+        foreach ($news as $item) {
+            $title = HtmlSanitizer::e($item['title']);
+            $catTitle = HtmlSanitizer::e($item['catTitle']);
+            $rows .= "<li>{$title} <span class=\"gm-dashboard-cat\">({$catTitle})</span></li>";
+        }
+        $body = "<ul class=\"gm-dashboard-list\">{$rows}</ul>";
+
+        return $this->card('League News', $body, 'modules.php?name=Topics');
+    }
+}

--- a/ibl5/classes/Dashboard/DashboardView.php
+++ b/ibl5/classes/Dashboard/DashboardView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dashboard;
 
+use BasketballStats\StatsFormatter;
 use Dashboard\Contracts\DashboardViewInterface;
 use Security\HtmlSanitizer;
 
@@ -108,7 +109,7 @@ class DashboardView implements DashboardViewInterface
      */
     private function renderCap(array $cap): string
     {
-        $headroom = HtmlSanitizer::e(number_format($cap['headroom']));
+        $headroom = HtmlSanitizer::e(StatsFormatter::formatTotal($cap['headroom']));
         $body = "<p class=\"gm-dashboard-stat\">Cap headroom: <strong>{$headroom}</strong></p>";
 
         return $this->card('Cap Space', $body, 'modules.php?name=CapSpace');

--- a/ibl5/classes/Module/ModuleRegistry.php
+++ b/ibl5/classes/Module/ModuleRegistry.php
@@ -26,6 +26,7 @@ final class ModuleRegistry
         'FreeAgency',
         'FreeAgencyPreview',
         'GMContactList',
+        'GMDashboard',
         'Injuries',
         'LeagueStarters',
         'News',

--- a/ibl5/classes/Navigation/NavigationMenuBuilder.php
+++ b/ibl5/classes/Navigation/NavigationMenuBuilder.php
@@ -202,6 +202,7 @@ class NavigationMenuBuilder implements NavigationMenuBuilderInterface
         $teamId = $this->config->teamId;
         /** @var list<NavLink> $links */
         $links = [
+            ['label' => 'My Dashboard', 'url' => 'modules.php?name=GMDashboard'],
             ['label' => 'Team Page', 'url' => 'modules.php?name=Team&op=team&teamid=' . $teamId],
             ['label' => 'Schedule', 'url' => 'modules.php?name=Schedule&teamid=' . $teamId],
             ['label' => 'Next Sim', 'url' => 'modules.php?name=NextSim'],

--- a/ibl5/modules/GMDashboard/index.php
+++ b/ibl5/modules/GMDashboard/index.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * GMDashboard Module - Owner-scoped landing page aggregating six read-only data sources.
+ *
+ * Read-only. No write surface, no new table, no schema change. Every team-scoped
+ * section is filtered server-side to the session owner's teamid; the owner identity
+ * is resolved from $user and NEVER from a ?teamid= request parameter.
+ *
+ * @see Dashboard\DashboardService For aggregation
+ * @see Dashboard\DashboardView For HTML rendering
+ */
+
+if (!defined('MODULE_FILE')) {
+    die("You can't access this file directly...");
+}
+
+use CapSpace\CapSpaceRepository;
+use CapSpace\CapSpaceService;
+use Dashboard\DashboardService;
+use Dashboard\DashboardView;
+use FreeAgencyPreview\FreeAgencyPreviewRepository;
+use FreeAgencyPreview\FreeAgencyPreviewService;
+use Injuries\InjuriesService;
+use League\League;
+use NextSim\NextSimService;
+use Standings\StandingsRepository;
+use Topics\TopicsService;
+use TeamSchedule\TeamScheduleRepository;
+use Trading\TradeAssetRepository;
+use Trading\TradeFormRepository;
+use Trading\TradeOfferRepository;
+use Trading\TradingService;
+
+global $db, $cookie, $user, $mysqli_db;
+
+if (!is_user($user)) {
+    loginbox();
+} else {
+    $commonRepository = new Repositories\TeamIdentityRepository($mysqli_db);
+    $season = new \Season\Season($mysqli_db);
+
+    // Load power rankings for the Next Sim SOS tier indicator.
+    $standingsRepo = new StandingsRepository($mysqli_db);
+    $allStreakData = $standingsRepo->getAllStreakData();
+    /** @var array<int, float> $teamPowerRankings */
+    $teamPowerRankings = [];
+    foreach ($allStreakData as $teamid => $data) {
+        $teamPowerRankings[$teamid] = (float) $data['ranking'];
+    }
+
+    // Render header first (populates $cookie via cookiedecode()).
+    PageLayout\PageLayout::header();
+
+    // Owner identity is resolved server-side from the session — never a request param.
+    $username = strval($cookie[1] ?? '');
+    $ownerTeamName = $commonRepository->getTeamnameFromUsername($username) ?? '';
+    $ownerTeamId = $commonRepository->getTidFromTeamname($ownerTeamName) ?? League::FREE_AGENTS_TEAMID;
+
+    if ($ownerTeamName === '' || $ownerTeamName === League::FREE_AGENTS_TEAM_NAME || $ownerTeamId === League::FREE_AGENTS_TEAMID) {
+        echo '<h1 class="ibl-title">My Dashboard</h1>';
+        echo '<p>Your account is not associated with a team, so there is no dashboard to display.</p>';
+        PageLayout\PageLayout::footer();
+
+        return;
+    }
+
+    // Wire the six source services (mirrors each module's own entry point).
+    $serverName = strval($_SERVER['SERVER_NAME'] ?? '');
+    $tradingService = new TradingService(
+        new TradeOfferRepository($mysqli_db, $serverName),
+        new TradeAssetRepository($mysqli_db),
+        new TradeFormRepository($mysqli_db),
+        $commonRepository,
+        $mysqli_db
+    );
+    $nextSimService = new NextSimService($mysqli_db, new TeamScheduleRepository($mysqli_db), $teamPowerRankings);
+    $capSpaceService = new CapSpaceService(new CapSpaceRepository($mysqli_db), $mysqli_db);
+    $freeAgencyPreviewService = new FreeAgencyPreviewService(new FreeAgencyPreviewRepository($mysqli_db));
+    $injuriesService = new InjuriesService($mysqli_db);
+    $topicsService = new TopicsService($mysqli_db);
+
+    $dashboardService = new DashboardService(
+        $tradingService,
+        $nextSimService,
+        $capSpaceService,
+        $freeAgencyPreviewService,
+        $injuriesService,
+        $topicsService
+    );
+    $view = new DashboardView();
+
+    echo $view->render($dashboardService->getDashboardData($ownerTeamId, $ownerTeamName, $username, $season));
+
+    PageLayout\PageLayout::footer();
+}

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -7,6 +7,9 @@
         <testsuite name="Auth Module Tests">
             <directory>tests/Auth</directory>
         </testsuite>
+        <testsuite name="Dashboard Module Tests">
+            <directory>tests/Dashboard</directory>
+        </testsuite>
         <testsuite name="Validation Module Tests">
             <directory>tests/Validation</directory>
         </testsuite>

--- a/ibl5/tests/Dashboard/DashboardServiceTest.php
+++ b/ibl5/tests/Dashboard/DashboardServiceTest.php
@@ -1,0 +1,410 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Dashboard;
+
+use CapSpace\CapSpaceService;
+use Dashboard\DashboardService;
+use FreeAgencyPreview\Contracts\FreeAgencyPreviewServiceInterface;
+use Injuries\Contracts\InjuriesServiceInterface;
+use LeagueSchedule\Game;
+use NextSim\Contracts\NextSimServiceInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Season\Season;
+use Team\Team;
+use Topics\Contracts\TopicsServiceInterface;
+use Trading\Contracts\TradingServiceInterface;
+
+/**
+ * DashboardServiceTest - Unit tests for DashboardService aggregator.
+ *
+ * @covers \Dashboard\DashboardService
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class DashboardServiceTest extends TestCase
+{
+    /** @var TradingServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private TradingServiceInterface $tradingService;
+
+    /** @var NextSimServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private NextSimServiceInterface $nextSimService;
+
+    /** @var CapSpaceService&\PHPUnit\Framework\MockObject\MockObject */
+    private CapSpaceService $capSpaceService;
+
+    /** @var FreeAgencyPreviewServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private FreeAgencyPreviewServiceInterface $freeAgencyPreviewService;
+
+    /** @var InjuriesServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private InjuriesServiceInterface $injuriesService;
+
+    /** @var TopicsServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private TopicsServiceInterface $topicsService;
+
+    private DashboardService $service;
+
+    /** @var Season&\PHPUnit\Framework\MockObject\MockObject */
+    private Season $season;
+
+    protected function setUp(): void
+    {
+        $this->tradingService = $this->createMock(TradingServiceInterface::class);
+        $this->nextSimService = $this->createMock(NextSimServiceInterface::class);
+        $this->capSpaceService = $this->createMock(CapSpaceService::class);
+        $this->freeAgencyPreviewService = $this->createMock(FreeAgencyPreviewServiceInterface::class);
+        $this->injuriesService = $this->createMock(InjuriesServiceInterface::class);
+        $this->topicsService = $this->createMock(TopicsServiceInterface::class);
+
+        $this->service = new DashboardService(
+            $this->tradingService,
+            $this->nextSimService,
+            $this->capSpaceService,
+            $this->freeAgencyPreviewService,
+            $this->injuriesService,
+            $this->topicsService,
+        );
+
+        $this->season = $this->createMock(Season::class);
+        $this->season->endingYear = 2026;
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers — stub the collaborators that are not under test in each case
+    // -----------------------------------------------------------------------
+
+    private function stubEmptyTrades(): void
+    {
+        $this->tradingService->method('getTradeReviewPageData')->willReturn([
+            'userTeam'    => 'Metros',
+            'userTeamId'  => 1,
+            'tradeOffers' => [],
+            'teams'       => [],
+        ]);
+    }
+
+    private function stubNoNextSim(): void
+    {
+        $this->nextSimService->method('getNextSimGames')->willReturn([]);
+    }
+
+    private function stubCapRow(int $teamId, int $headroom): void
+    {
+        $this->capSpaceService->method('getTeamsCapData')->willReturn([
+            [
+                'team'            => $this->createMock(Team::class),
+                'teamId'          => $teamId,
+                'teamName'        => 'Metros',
+                'teamCity'        => 'Metro City',
+                'color1'          => '000000',
+                'color2'          => 'FFFFFF',
+                'availableSalary' => ['year1' => $headroom, 'year2' => 0, 'year3' => 0, 'year4' => 0, 'year5' => 0, 'year6' => 0],
+                'positionSalaries' => [],
+                'freeAgencySlots'  => 10,
+                'has_mle'          => false,
+                'has_lle'          => false,
+            ],
+        ]);
+    }
+
+    private function stubNoFreeAgents(): void
+    {
+        $this->freeAgencyPreviewService->method('getUpcomingFreeAgents')->willReturn([]);
+    }
+
+    private function stubNoInjuries(): void
+    {
+        $this->injuriesService->method('getInjuredPlayersWithTeams')->willReturn([]);
+    }
+
+    private function stubEmptyNews(): void
+    {
+        $this->topicsService->method('getPageData')->willReturn([
+            'topics'        => [],
+            'searchFilters' => ['topics' => [], 'categories' => [], 'authors' => [], 'articleComm' => false],
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    public function testPendingTradesReturnsOwnerOffers(): void
+    {
+        $this->tradingService->method('getTradeReviewPageData')->willReturn([
+            'userTeam'    => 'Metros',
+            'userTeamId'  => 1,
+            'tradeOffers' => [
+                10 => ['oppositeTeam' => 'Stars', 'approval' => 'Pending', 'hasHammer' => true,  'from' => 'Metros', 'to' => 'Stars', 'items' => [], 'previewData' => []],
+                11 => ['oppositeTeam' => 'Hawks', 'approval' => 'Rejected', 'hasHammer' => false, 'from' => 'Hawks', 'to' => 'Metros', 'items' => [], 'previewData' => []],
+            ],
+            'teams' => [],
+        ]);
+        $this->stubNoNextSim();
+        $this->stubCapRow(1, 5000);
+        $this->stubNoFreeAgents();
+        $this->stubNoInjuries();
+        $this->stubEmptyNews();
+
+        $result = $this->service->getDashboardData(1, 'Metros', 'metrosgm', $this->season);
+
+        $this->assertSame(2, $result['pendingTrades']['count']);
+        $this->assertCount(2, $result['pendingTrades']['offers']);
+        $this->assertSame('Stars', $result['pendingTrades']['offers'][0]['oppositeTeam']);
+        $this->assertSame('Hawks', $result['pendingTrades']['offers'][1]['oppositeTeam']);
+        $this->assertTrue($result['pendingTrades']['offers'][0]['hasHammer']);
+    }
+
+    public function testNextSimReturnsOwnerOpponent(): void
+    {
+        $this->stubEmptyTrades();
+        $this->stubCapRow(1, 5000);
+        $this->stubNoFreeAgents();
+        $this->stubNoInjuries();
+        $this->stubEmptyNews();
+
+        $team = $this->createMock(Team::class);
+        $team->name = 'Stars';
+
+        $game = $this->createMock(Game::class);
+
+        $this->nextSimService->method('getNextSimGames')->willReturn([
+            42 => [
+                'game'               => $game,
+                'date'               => new \DateTime('2026-01-15'),
+                'dayNumber'          => 42,
+                'opposingTeam'       => $team,
+                'locationPrefix'     => 'vs',
+                'opposingStarters'   => [],
+                'opponentTier'       => 'Elite',
+                'opponentPowerRanking' => 1.5,
+            ],
+        ]);
+
+        $result = $this->service->getDashboardData(1, 'Metros', 'metrosgm', $this->season);
+
+        $this->assertNotNull($result['nextSim']);
+        $this->assertSame('Stars', $result['nextSim']['opponent']);
+        $this->assertSame('vs', $result['nextSim']['location']);
+        $this->assertSame('Elite', $result['nextSim']['tier']);
+        $this->assertSame('2026-01-15', $result['nextSim']['date']);
+    }
+
+    public function testNextSimReturnsNullWhenNoGames(): void
+    {
+        $this->stubEmptyTrades();
+        $this->stubNoNextSim();
+        $this->stubCapRow(1, 5000);
+        $this->stubNoFreeAgents();
+        $this->stubNoInjuries();
+        $this->stubEmptyNews();
+
+        $result = $this->service->getDashboardData(1, 'Metros', 'metrosgm', $this->season);
+
+        $this->assertNull($result['nextSim']);
+    }
+
+    public function testCapHeadroomMatchesCapSpaceService(): void
+    {
+        $this->stubEmptyTrades();
+        $this->stubNoNextSim();
+        $this->stubNoFreeAgents();
+        $this->stubNoInjuries();
+        $this->stubEmptyNews();
+
+        $this->capSpaceService->method('getTeamsCapData')->willReturn([
+            [
+                'team'             => $this->createMock(Team::class),
+                'teamId'           => 1,
+                'teamName'         => 'Metros',
+                'teamCity'         => 'Metro City',
+                'color1'           => '000000',
+                'color2'           => 'FFFFFF',
+                'availableSalary'  => ['year1' => 3500, 'year2' => 0, 'year3' => 0, 'year4' => 0, 'year5' => 0, 'year6' => 0],
+                'positionSalaries' => [],
+                'freeAgencySlots'  => 10,
+                'has_mle'          => false,
+                'has_lle'          => false,
+            ],
+            [
+                'team'             => $this->createMock(Team::class),
+                'teamId'           => 2,
+                'teamName'         => 'Hawks',
+                'teamCity'         => 'Hawk City',
+                'color1'           => 'FF0000',
+                'color2'           => '0000FF',
+                'availableSalary'  => ['year1' => 9999, 'year2' => 0, 'year3' => 0, 'year4' => 0, 'year5' => 0, 'year6' => 0],
+                'positionSalaries' => [],
+                'freeAgencySlots'  => 5,
+                'has_mle'          => true,
+                'has_lle'          => false,
+            ],
+        ]);
+
+        $result = $this->service->getDashboardData(1, 'Metros', 'metrosgm', $this->season);
+
+        $this->assertSame(3500, $result['cap']['headroom']);
+    }
+
+    public function testUpcomingFreeAgentsFilteredToOwner(): void
+    {
+        $this->stubEmptyTrades();
+        $this->stubNoNextSim();
+        $this->stubCapRow(1, 5000);
+        $this->stubNoInjuries();
+        $this->stubEmptyNews();
+
+        $this->freeAgencyPreviewService->method('getUpcomingFreeAgents')->willReturn([
+            $this->makeFreeAgent(101, 1, 'Alice', 'PG'),
+            $this->makeFreeAgent(102, 0, 'Bob',   'SG'),   // Free agent (teamid=0) — excluded
+            $this->makeFreeAgent(103, 2, 'Carol', 'SF'),   // Other team — excluded
+        ]);
+
+        $result = $this->service->getDashboardData(1, 'Metros', 'metrosgm', $this->season);
+
+        $this->assertCount(1, $result['upcomingFreeAgents']);
+        $this->assertSame(101, $result['upcomingFreeAgents'][0]['pid']);
+        $this->assertSame('Alice', $result['upcomingFreeAgents'][0]['name']);
+
+        // Negative: teamid=2 must not appear
+        $pids = array_column($result['upcomingFreeAgents'], 'pid');
+        $this->assertNotContains(103, $pids);
+    }
+
+    public function testInjuriesFilteredToOwner(): void
+    {
+        $this->stubEmptyTrades();
+        $this->stubNoNextSim();
+        $this->stubCapRow(1, 5000);
+        $this->stubNoFreeAgents();
+        $this->stubEmptyNews();
+
+        $this->injuriesService->method('getInjuredPlayersWithTeams')->willReturn([
+            1 => $this->makeInjury(201, 'Dave',  'PG', 5,  1),
+            2 => $this->makeInjury(202, 'Eve',   'SG', 10, 2),   // Other team — excluded
+            3 => $this->makeInjury(203, 'Frank', 'SF', 3,  14),  // Other team — excluded
+        ]);
+
+        $result = $this->service->getDashboardData(1, 'Metros', 'metrosgm', $this->season);
+
+        $this->assertCount(1, $result['injuries']);
+        $this->assertSame(201, $result['injuries'][0]['playerID']);
+
+        // Negative: teamid=2 and teamid=14 must not appear
+        $ids = array_column($result['injuries'], 'playerID');
+        $this->assertNotContains(202, $ids);
+        $this->assertNotContains(203, $ids);
+    }
+
+    public function testInjuriesEmptyWhenNoOwnerPlayers(): void
+    {
+        $this->stubEmptyTrades();
+        $this->stubNoNextSim();
+        $this->stubCapRow(1, 5000);
+        $this->stubNoFreeAgents();
+        $this->stubEmptyNews();
+
+        $this->injuriesService->method('getInjuredPlayersWithTeams')->willReturn([
+            1 => $this->makeInjury(301, 'Grace', 'C', 7, 2),
+            2 => $this->makeInjury(302, 'Heidi', 'PF', 2, 3),
+        ]);
+
+        $result = $this->service->getDashboardData(1, 'Metros', 'metrosgm', $this->season);
+
+        $this->assertSame([], $result['injuries']);
+    }
+
+    public function testNewsIsLeagueWideNotFiltered(): void
+    {
+        $this->stubEmptyTrades();
+        $this->stubNoNextSim();
+        $this->stubCapRow(1, 5000);
+        $this->stubNoFreeAgents();
+        $this->stubNoInjuries();
+
+        // Articles from two different topics — teamids not involved; league-wide
+        $this->topicsService->method('getPageData')->willReturn([
+            'topics' => [
+                1 => [
+                    'topicId'        => 1,
+                    'topicName'      => 'Trades',
+                    'topicImage'     => '',
+                    'topicText'      => '',
+                    'storyCount'     => 3,
+                    'totalReads'     => 0,
+                    'recentArticles' => [
+                        ['sid' => 10, 'title' => 'Big Trade Incoming', 'catId' => 1, 'catTitle' => 'Trades'],
+                        ['sid' => 8,  'title' => 'Counter Offer Made', 'catId' => 1, 'catTitle' => 'Trades'],
+                    ],
+                ],
+                2 => [
+                    'topicId'        => 2,
+                    'topicName'      => 'Injuries',
+                    'topicImage'     => '',
+                    'topicText'      => '',
+                    'storyCount'     => 2,
+                    'totalReads'     => 0,
+                    'recentArticles' => [
+                        ['sid' => 9, 'title' => 'Star Player Out', 'catId' => 2, 'catTitle' => 'Injuries'],
+                    ],
+                ],
+            ],
+            'searchFilters' => ['topics' => [], 'categories' => [], 'authors' => [], 'articleComm' => false],
+        ]);
+
+        $result = $this->service->getDashboardData(1, 'Metros', 'metrosgm', $this->season);
+
+        // Should contain articles from both topics (league-wide), sorted by sid DESC, max 5
+        $this->assertGreaterThan(0, count($result['news']));
+        $titles = array_column($result['news'], 'title');
+        $this->assertContains('Big Trade Incoming', $titles);
+        $this->assertContains('Star Player Out', $titles);
+        $this->assertContains('Counter Offer Made', $titles);
+
+        // Sorted by sid DESC: 10, 9, 8
+        $this->assertSame(10, $result['news'][0]['sid']);
+        $this->assertSame(9,  $result['news'][1]['sid']);
+        $this->assertSame(8,  $result['news'][2]['sid']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Private factory helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * @return array{pid: int, teamid: int, name: string, teamname: string, team_city: string, color1: string, color2: string, pos: string, age: int, r_fga: int, r_fgp: int, r_fta: int, r_ftp: int, r_3ga: int, r_3gp: int, r_orb: int, r_drb: int, r_ast: int, r_stl: int, r_blk: int, r_tvr: int, r_foul: int, oo: int, r_drive_off: int, po: int, r_trans_off: int, od: int, dd: int, pd: int, td: int, loyalty: int, winner: int, playing_time: int, security: int, tradition: int}
+     */
+    private function makeFreeAgent(int $pid, int $teamid, string $name, string $pos): array
+    {
+        return [
+            'pid' => $pid, 'teamid' => $teamid, 'name' => $name, 'teamname' => 'Team',
+            'team_city' => 'City', 'color1' => '000000', 'color2' => 'FFFFFF',
+            'pos' => $pos, 'age' => 25, 'r_fga' => 0, 'r_fgp' => 0, 'r_fta' => 0,
+            'r_ftp' => 0, 'r_3ga' => 0, 'r_3gp' => 0, 'r_orb' => 0, 'r_drb' => 0,
+            'r_ast' => 0, 'r_stl' => 0, 'r_blk' => 0, 'r_tvr' => 0, 'r_foul' => 0,
+            'oo' => 0, 'r_drive_off' => 0, 'po' => 0, 'r_trans_off' => 0,
+            'od' => 0, 'dd' => 0, 'pd' => 0, 'td' => 0, 'loyalty' => 0,
+            'winner' => 0, 'playing_time' => 0, 'security' => 0, 'tradition' => 0,
+        ];
+    }
+
+    /**
+     * @return array{playerID: int, name: string, position: string, daysRemaining: int, returnDate: string, teamid: int, teamCity: string, teamName: string, teamColor1: string, teamColor2: string}
+     */
+    private function makeInjury(int $playerID, string $name, string $position, int $daysRemaining, int $teamid): array
+    {
+        return [
+            'playerID'      => $playerID,
+            'name'          => $name,
+            'position'      => $position,
+            'daysRemaining' => $daysRemaining,
+            'returnDate'    => '2026-02-01',
+            'teamid'        => $teamid,
+            'teamCity'      => 'City',
+            'teamName'      => 'Team',
+            'teamColor1'    => '000000',
+            'teamColor2'    => 'FFFFFF',
+        ];
+    }
+}

--- a/ibl5/tests/Dashboard/DashboardViewTest.php
+++ b/ibl5/tests/Dashboard/DashboardViewTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Dashboard;
+
+use Dashboard\DashboardView;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Dashboard\DashboardView
+ */
+class DashboardViewTest extends TestCase
+{
+    /**
+     * Build a fully-populated dashboard data array, overlaying any overrides.
+     *
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function dashboardData(array $overrides = []): array
+    {
+        $base = [
+            'teamId' => 1,
+            'teamName' => 'Metros',
+            'pendingTrades' => ['count' => 1, 'offers' => [
+                ['oppositeTeam' => 'Stars', 'approval' => 'Pending', 'hasHammer' => true],
+            ]],
+            'nextSim' => ['opponent' => 'Stars', 'location' => 'vs', 'tier' => 'Contender', 'date' => '2026-01-15'],
+            'cap' => ['headroom' => 3500],
+            'upcomingFreeAgents' => [
+                ['pid' => 10, 'name' => 'FA Guard', 'pos' => 'PG', 'teamid' => 1],
+            ],
+            'injuries' => [
+                ['playerID' => 5, 'name' => 'Hurt Forward', 'position' => 'SF', 'daysRemaining' => 7, 'teamid' => 1],
+            ],
+            'news' => [
+                ['sid' => 6, 'title' => 'Big Trade Shakes League', 'catTitle' => 'News'],
+            ],
+        ];
+
+        return array_merge($base, $overrides);
+    }
+
+    public function testRendersAllSectionHeadings(): void
+    {
+        $view = new DashboardView();
+        /** @phpstan-ignore argument.type */
+        $html = $view->render($this->dashboardData());
+
+        foreach (['Pending Trades', 'Next Sim', 'Cap Space', 'Upcoming Free Agents', 'Injuries', 'League News'] as $heading) {
+            $this->assertStringContainsString($heading, $html, "Missing section heading: {$heading}");
+        }
+    }
+
+    public function testEscapesPlayerNames(): void
+    {
+        $view = new DashboardView();
+        /** @phpstan-ignore argument.type */
+        $html = $view->render($this->dashboardData([
+            'injuries' => [
+                ['playerID' => 5, 'name' => '<script>x</script>', 'position' => 'SF', 'daysRemaining' => 7, 'teamid' => 1],
+            ],
+        ]));
+
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+        $this->assertStringNotContainsString('<script>x</script>', $html);
+    }
+
+    public function testRendersEmptyStateForInjuries(): void
+    {
+        $view = new DashboardView();
+        /** @phpstan-ignore argument.type */
+        $html = $view->render($this->dashboardData(['injuries' => []]));
+
+        $this->assertStringContainsString('No injured players on your roster.', $html);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/GMDashboardEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/GMDashboardEntryPointTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * GMDashboard/index.php uses is_user() with a static cache and loginbox() → die()
+ * for unauthenticated access, so each test runs in a separate process.
+ *
+ * The dashboard wires six real read-only services against the MockDatabase; with
+ * empty mock data every section renders its empty-state, so the page still renders.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class GMDashboardEntryPointTest extends ModuleEntryPointTestCase
+{
+    private function seedSeasonMocks(): void
+    {
+        $this->mockDb->onQuery('ibl_settings', [
+            ['name' => 'Current Season Phase', 'value' => 'Regular Season'],
+            ['name' => 'Current Season Ending Year', 'value' => '2026'],
+            ['name' => 'Allow Trades', 'value' => 'Yes'],
+            ['name' => 'Allow Waiver Moves', 'value' => 'Yes'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', [
+            ['sim' => 1, 'start_date' => '2025-11-01', 'end_date' => '2025-11-07'],
+        ]);
+    }
+
+    /**
+     * The owner team row, enriched with the contract/salary columns that
+     * player+team JOIN queries (CapSpace cap calc, FreeAgencyPreview) read.
+     * The MockDatabase routes every query containing `ibl_team_info` to this
+     * row, so it must carry every key any of the six services touches — a full
+     * contract span (cy=1, cyt=6, salary_yr1..6) keeps both services warning-free.
+     *
+     * @return array<string, mixed>
+     */
+    private function ownerTeamRow(): array
+    {
+        return self::fullTeamData([
+            'cy' => 1,
+            'cyt' => 6,
+            'salary_yr1' => 100,
+            'salary_yr2' => 100,
+            'salary_yr3' => 100,
+            'salary_yr4' => 100,
+            'salary_yr5' => 100,
+            'salary_yr6' => 100,
+        ]);
+    }
+
+    public function testRendersDashboardForAuthenticatedOwner(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockTeamData([$this->ownerTeamRow()]);
+        $this->mockDb->setMockData([]);
+
+        $output = $this->runModule('GMDashboard', [], [], [
+            'user' => $GLOBALS['user'],
+        ]);
+
+        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('Test Team Dashboard', $output);
+        $this->assertStringContainsString('Pending Trades', $output);
+    }
+
+    public function testIgnoresTeamidRequestParam(): void
+    {
+        $this->authenticateAs('testgm');
+        $this->seedSeasonMocks();
+        $this->mockDb->setMockTeamData([$this->ownerTeamRow()]);
+        $this->mockDb->setMockData([]);
+
+        // A ?teamid=2 injection must be ignored — output still reflects the
+        // authenticated owner (Test Team), never team 2.
+        $output = $this->runModule('GMDashboard', ['teamid' => '2'], [], [
+            'user' => $GLOBALS['user'],
+        ]);
+
+        $this->assertStringContainsString('Test Team Dashboard', $output);
+    }
+}

--- a/ibl5/tests/Navigation/NavigationMenuBuilderTest.php
+++ b/ibl5/tests/Navigation/NavigationMenuBuilderTest.php
@@ -163,6 +163,39 @@ class NavigationMenuBuilderTest extends TestCase
         $this->assertNotContains('Voting Results', $labels);
     }
 
+    public function testIblTeamMenuIncludesMyDashboard(): void
+    {
+        $builder = new NavigationMenuBuilder($this->createConfig(isLoggedIn: true, teamId: 1));
+        $menu = $builder->getMyTeamMenu();
+        $this->assertNotNull($menu);
+
+        $dashboardLinks = array_filter(
+            $menu['links'],
+            static fn (array $link): bool => ($link['url'] ?? '') === 'modules.php?name=GMDashboard'
+        );
+        $this->assertCount(1, $dashboardLinks, 'My Dashboard link should be present in the IBL team menu');
+        $this->assertSame('My Dashboard', array_values($dashboardLinks)[0]['label'] ?? null);
+    }
+
+    public function testMyDashboardAbsentFromOlympicsTeamMenu(): void
+    {
+        $builder = new NavigationMenuBuilder($this->createConfig(currentLeague: 'olympics'));
+        $menu = $builder->getMyTeamMenu();
+        $this->assertNotNull($menu);
+
+        $urls = array_map(
+            static fn (array $link): string => $link['url'] ?? '',
+            $menu['links']
+        );
+        $this->assertNotContains('modules.php?name=GMDashboard', $urls);
+    }
+
+    public function testMyDashboardAbsentWhenLoggedOut(): void
+    {
+        $builder = new NavigationMenuBuilder($this->createConfig(isLoggedIn: false, username: null, teamId: null));
+        $this->assertNull($builder->getMyTeamMenu());
+    }
+
     #[\PHPUnit\Framework\Attributes\DataProvider('draftLinkProvider')]
     public function testDraftLinkBehavior(string $seasonPhase, string $showDraftLink, bool $expectDraftLink, ?string $expectedBadge): void
     {

--- a/ibl5/tests/e2e/flows/gm-dashboard.spec.ts
+++ b/ibl5/tests/e2e/flows/gm-dashboard.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * GM Dashboard E2E flow spec.
+ *
+ * Owner-scoped module: the CI auth user maps to Metros (teamid=1) via
+ * getTeamnameFromUsername(). The module resolves owner from the session
+ * cookie — never from a ?teamid= request param.
+ *
+ * ci-seed.sql grounding:
+ *   - line 71:  tid=1, team_name='Metros'
+ *   - line 294: pid=10 'FA Guard', teamid=1, pos='SG', cy=0, salary_yr1=0
+ *               → nextYearSalary = salary_yr[cy+1] = salary_yr1 = 0 → upcoming FA
+ *   - lines 1459-1460: only pid=5 (Stars tid=2) and pid=7 (Phoenixes tid=14) injured;
+ *                      no Metros player has injured > 0 → injuries card renders empty-state
+ *   - lines 2159-2161: 'All-Star Game recap' is the last-inserted nuke_stories row (highest
+ *                      auto-increment sid); buildNews() sorts by sid DESC and slices to 5,
+ *                      so this title is always first in the League News list
+ *   - lines 893-914: trade offers 1-6 involve Metros but are consumed by parallel
+ *                    trading-submission specs → no count assertion, only assert section renders
+ */
+import { test, expect } from '../fixtures/auth';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+import { publicStorageState } from '../helpers/public-storage-state';
+
+const MODULE_URL = 'modules.php?name=GMDashboard';
+
+// All authenticated tests use the stored auth session (CI user = Metros, tid=1).
+// Pin the season phase to avoid flakiness from concurrent phase-mutating tests.
+test.describe('GM Dashboard — authenticated (Metros tid=1)', () => {
+  test.beforeEach(async ({ page, appState }) => {
+    // Pin phase so NextSim and Cap Space resolve the same season as the seed.
+    await appState({ 'Current Season Phase': 'Regular Season', 'Current Season Ending Year': '2026' });
+    await page.goto(MODULE_URL);
+  });
+
+  // Matrix #13: route renders + no PHP errors
+  test('page renders Metros Dashboard title without PHP errors', async ({ page }) => {
+    // ci-seed.sql line 71: team_name = 'Metros' for tid=1
+    await expect(page.locator('h1.ibl-title')).toContainText('Metros Dashboard');
+    await assertNoPhpErrors(page, 'on GMDashboard');
+  });
+
+  // Matrix #14: trades section heading renders
+  // Offers 1-6 involve Metros (ci-seed lines 893-914) but are consumed by parallel
+  // trading-submission specs — assert only the card heading and link, not the count.
+  test('Pending Trades section heading and link render', async ({ page }) => {
+    const card = page.locator('section.gm-dashboard-card').filter({
+      has: page.locator('h2.ibl-title', { hasText: 'Pending Trades' }),
+    });
+    await expect(card.locator('h2.ibl-title')).toBeVisible();
+    await expect(card.locator('.gm-dashboard-link a')).toBeVisible();
+  });
+
+  // Matrix #15: next-sim section heading renders
+  // Whether a game is scheduled is not verified by seed → assert heading only.
+  test('Next Sim section heading and link render', async ({ page }) => {
+    const card = page.locator('section.gm-dashboard-card').filter({
+      has: page.locator('h2.ibl-title', { hasText: 'Next Sim' }),
+    });
+    await expect(card.locator('h2.ibl-title')).toBeVisible();
+    await expect(card.locator('.gm-dashboard-link a')).toBeVisible();
+  });
+
+  // Matrix #16: cap headroom numeric strong renders
+  // Value depends on seed salaries and cap ceiling — only assert label + numeric content.
+  test('Cap Space section shows cap headroom label and a number', async ({ page }) => {
+    const card = page.locator('section.gm-dashboard-card').filter({
+      has: page.locator('h2.ibl-title', { hasText: 'Cap Space' }),
+    });
+    await expect(card.locator('.gm-dashboard-stat')).toContainText('Cap headroom:');
+    await expect(card.locator('.gm-dashboard-stat strong')).toBeVisible();
+  });
+
+  // Matrix #17: FA section lists "FA Guard"
+  // ci-seed line 294: pid=10, name='FA Guard', teamid=1, pos='SG', cy=0, salary_yr1=0
+  // FreeAgencyPreviewService: nextYearSalary = salary_yr[cy+1] = salary_yr1 = 0 → upcoming FA.
+  // DashboardView renders each FA as "<li>{pos} {name}</li>" → "SG FA Guard".
+  test('Upcoming Free Agents section lists FA Guard for Metros', async ({ page }) => {
+    const card = page.locator('section.gm-dashboard-card').filter({
+      has: page.locator('h2.ibl-title', { hasText: 'Upcoming Free Agents' }),
+    });
+    await expect(card.locator('.gm-dashboard-list li', { hasText: 'FA Guard' })).toBeVisible();
+  });
+
+  // Matrix #18: injuries empty-state
+  // ci-seed lines 1459-1460: only pid=5 (Stars tid=2, injured=5) and pid=7
+  // (Phoenixes tid=14, injured=3) are injured; no Metros player has injured > 0.
+  test('Injuries section shows empty-state because no Metros players are injured', async ({ page }) => {
+    await expect(page.getByText('No injured players on your roster.')).toBeVisible();
+  });
+
+  // Matrix #19: news section shows the highest-sid headline
+  // buildNews() flattens nuke_stories by topic, sorts by sid DESC, slices to 5.
+  // ci-seed lines 2159-2161: 'All-Star Game recap' is inserted last → highest sid → first item.
+  test('League News section shows All-Star Game recap as first headline', async ({ page }) => {
+    const card = page.locator('section.gm-dashboard-card').filter({
+      has: page.locator('h2.ibl-title', { hasText: 'League News' }),
+    });
+    await expect(card.locator('.gm-dashboard-list li').first()).toContainText('All-Star Game recap');
+  });
+
+  // Matrix #20: ?teamid=2 param is ignored — still resolves Metros from session
+  test('teamid query param is ignored — still renders Metros Dashboard', async ({ page }) => {
+    await page.goto(`${MODULE_URL}&teamid=2`);
+    // Owner identity comes from the session cookie, never from request params.
+    // ci-seed line 71: tid=1 is Metros; tid=2 is Stars.
+    await expect(page.locator('h1.ibl-title')).toContainText('Metros Dashboard');
+  });
+});
+
+// Matrix #21: unauthenticated → JS redirect to login page
+// loginbox() emits: window.location.href = "modules.php?name=YourAccount"
+test.describe('GM Dashboard — unauthenticated', () => {
+  test.use({ storageState: publicStorageState() });
+
+  test('unauthenticated request redirects to YourAccount login', async ({ page }) => {
+    await page.goto(MODULE_URL);
+    // Same pattern as smoke/auth-redirect.spec.ts — loginbox() is a JS redirect.
+    await page.waitForURL(/name=YourAccount/, { timeout: 10_000 });
+    await expect(page.locator('#login-username')).toBeVisible();
+  });
+});

--- a/ibl5/tests/e2e/vr-manifest.ts
+++ b/ibl5/tests/e2e/vr-manifest.ts
@@ -215,6 +215,9 @@ export const VR_MANIFEST: VrRow[] = [
       { name: 'empty', appState: { 'Allow Waiver Moves': 'No' } },
     ],
     dataDriven: true },
+  { name: 'gm-dashboard', auth: 'auth', url: 'modules.php?name=GMDashboard',
+    anchor: '.gm-dashboard-grid', viewports: ['desktop', 'mobile'],
+    notes: 'Owner-scoped; CI user resolves to Metros (tid=1). Renders six section cards.' },
 
   // ── Auth-regular modules ────────────────────────────────────
   { name: 'team-non-admin', auth: 'auth-regular', url: 'modules.php?name=Team&op=team&teamid=1',


### PR DESCRIPTION
## Summary

Add a new read-only **GM Dashboard** at `modules.php?name=GMDashboard` that stitches together six existing data sources for the logged-in GM's own team: pending trade offers, next sim opponent + matchup, cap headroom, upcoming free agents / expiring contracts, current injuries, and recent league news.

No write surface, no new table, no schema change — every section delegates to an existing service/repository.

## Changes

- New `Dashboard` module (`classes/Dashboard/` — `DashboardService`, `DashboardView`, contracts)
- New entry point (`modules/GMDashboard/index.php`)
- `ModuleRegistry` allowlist entry for `GMDashboard`
- Nav link "My Dashboard" under My Team
- Full test suite: 12 PHPUnit tests + E2E spec + VR manifest entry

## Manual Testing

24. **Overall aggregated layout reads well / sections legible at a glance** (subjective new-UI judgment only)
    - Navigate to `modules.php?name=GMDashboard` as an authenticated IBL GM
    - Verify the six sections (pending trades, next sim, cap headroom, upcoming FAs, injuries, news) are legible and the layout reads naturally at a glance
    - All data assertions are automated (rows 1–21, grounded in ci-seed.sql); this is ONLY the subjective "does the new aggregated layout read well" judgment

Generated with [Claude Code](https://claude.ai/code)