### PR TITLE
fix(stats): exclude DNP rows from playoff/HEAT career & per-season averages

### DIFF
--- a/ibl5/.gitignore
+++ b/ibl5/.gitignore
@@ -29,3 +29,8 @@ test-results.json
 
 # Page cache (generated at runtime)
 cache/page/
+
+# Security backlog — catalogs unpatched, reachable vulnerabilities (attacker roadmap).
+# Kept in-tree so Claude can read/track it, but MUST NOT be committed.
+docs/security-backlog.md
+docs/security-backlog-parts/

--- a/ibl5/classes/Player/Stats/PlayerStatsRepository.php
+++ b/ibl5/classes/Player/Stats/PlayerStatsRepository.php
@@ -92,7 +92,7 @@ class PlayerStatsRepository extends BaseMysqliRepository implements PlayerStatsR
     {
         /** @var list<array{year: int, pos: string, pid: int, name: string, team: string, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int}> */
         return $this->fetchAll(
-            self::buildPerSeasonStatsQuery(2),
+            $this->buildPerSeasonStatsQuery(2),
             "s",
             $playerName
         );
@@ -120,7 +120,7 @@ class PlayerStatsRepository extends BaseMysqliRepository implements PlayerStatsR
     {
         /** @var CareerAveragesRow|null */
         return $this->fetchOne(
-            self::buildCareerAveragesQuery(2, 'p.name = ?'),
+            $this->buildCareerAveragesQuery(2, 'p.name = ?'),
             "s",
             $playerName
         );
@@ -134,7 +134,7 @@ class PlayerStatsRepository extends BaseMysqliRepository implements PlayerStatsR
     {
         /** @var list<array{year: int, pos: string, pid: int, name: string, team: string, games: int, minutes: int, fgm: int, fga: int, ftm: int, fta: int, tgm: int, tga: int, orb: int, reb: int, ast: int, stl: int, tvr: int, blk: int, pf: int, pts: int}> */
         return $this->fetchAll(
-            self::buildPerSeasonStatsQuery(3),
+            $this->buildPerSeasonStatsQuery(3),
             "s",
             $playerName
         );
@@ -162,7 +162,7 @@ class PlayerStatsRepository extends BaseMysqliRepository implements PlayerStatsR
     {
         /** @var CareerAveragesRow|null */
         return $this->fetchOne(
-            self::buildCareerAveragesQuery(3, 'p.name = ?'),
+            $this->buildCareerAveragesQuery(3, 'p.name = ?'),
             "s",
             $playerName
         );
@@ -283,7 +283,7 @@ class PlayerStatsRepository extends BaseMysqliRepository implements PlayerStatsR
      * (game_type 2 and 3). Regular-season averages (game_type=1) use
      * buildHistCareerAveragesQuery() to avoid scanning 489K+ box-score rows.
      */
-    private static function buildCareerAveragesQuery(int $gameType, string $filterClause): string
+    private function buildCareerAveragesQuery(int $gameType, string $filterClause): string
     {
         return "SELECT bs.pid, p.name,
             CAST(COUNT(*) AS SIGNED) AS games,
@@ -314,7 +314,7 @@ class PlayerStatsRepository extends BaseMysqliRepository implements PlayerStatsR
             p.retired
         FROM `ibl_box_scores` bs
         JOIN `ibl_plr` p ON bs.pid = p.pid
-        WHERE bs.game_type = {$gameType} AND {$filterClause}
+        WHERE bs.game_type = {$gameType} AND " . $this->playedCondition('bs') . " AND {$filterClause}
         GROUP BY bs.pid, p.name, p.retired";
     }
 
@@ -323,7 +323,7 @@ class PlayerStatsRepository extends BaseMysqliRepository implements PlayerStatsR
      *
      * Replaces SELECT from `ibl_playoff_stats` / ibl_heat_stats views.
      */
-    private static function buildPerSeasonStatsQuery(int $gameType): string
+    private function buildPerSeasonStatsQuery(int $gameType): string
     {
         return "SELECT bs.season_year AS year, MIN(bs.pos) AS pos, bs.pid, p.name,
             fs.team_name AS team,
@@ -347,7 +347,7 @@ class PlayerStatsRepository extends BaseMysqliRepository implements PlayerStatsR
         JOIN `ibl_plr` p ON bs.pid = p.pid
         JOIN `ibl_franchise_seasons` fs ON bs.teamid = fs.franchise_id
             AND bs.season_year = fs.season_ending_year
-        WHERE bs.game_type = {$gameType} AND p.name = ?
+        WHERE bs.game_type = {$gameType} AND " . $this->playedCondition('bs') . " AND p.name = ?
         GROUP BY bs.pid, p.name, bs.season_year, fs.team_name
         ORDER BY year ASC";
     }

--- a/ibl5/tests/DatabaseIntegration/PlayerStatsRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/PlayerStatsRepositoryTest.php
@@ -338,4 +338,134 @@ class PlayerStatsRepositoryTest extends DatabaseTestCase
         }
         self::assertTrue($found, 'DNP row must be included in getBoxScoresBetweenDates (include-DNP site)');
     }
+
+    // ── DNP exclusion from career/per-season averages (maintenance-40b) ──
+    //
+    // Career per-game averages and games counts must exclude DNP rows
+    // (game_min = 0). A per-game average = total ÷ games-played, never
+    // ÷ total roster rows; DNP rows are bench appearances, not games played.
+    // The fix adds BaseMysqliRepository::playedCondition('bs') (game_min > 0)
+    // to buildCareerAveragesQuery() and buildPerSeasonStatsQuery().
+    //
+    // The CI seed has no game_min=0 rows, so these tests self-seed a
+    // 1-played + 1-DNP block (mirroring testGetBoxScoresBetweenDatesIncludesDnpRows).
+
+    public function testGetPlayoffCareerAveragesExcludeDnpRows(): void
+    {
+        $pid = 200000080;
+        $name = 'DB DNP Avg';
+        $this->insertTestPlayer($pid, $name);
+        $this->insertFranchiseSeasonRow(1, 2098, 'Metros');
+
+        // Played playoff game: 30 min, 8 pts (game_2gm 4 → 4·2), reb 6 (orb 2 + drb 4)
+        $this->insertPlayerBoxscoreRow(
+            '2098-06-10', $pid, $name, 'PG', 2, 1, 1,
+            minutes: 30, points2m: 4, points2a: 8,
+            ftm: 0, fta: 0, points3m: 0, points3a: 0,
+            orb: 2, drb: 4, ast: 0, stl: 0, tov: 0, blk: 0, pf: 0
+        );
+        // DNP playoff game: every stat 0
+        $this->insertPlayerBoxscoreRow(
+            '2098-06-12', $pid, $name, 'PG', 2, 1, 1,
+            minutes: 0, points2m: 0, points2a: 0,
+            ftm: 0, fta: 0, points3m: 0, points3a: 0,
+            orb: 0, drb: 0, ast: 0, stl: 0, tov: 0, blk: 0, pf: 0
+        );
+
+        $result = $this->repo->getPlayoffCareerAverages($name);
+
+        self::assertNotNull($result);
+        // DNP row excluded: games=1 (not 2), averages over the played game only.
+        // (Buggy pre-fix values were games=2, MIN=15.0, PTS=4.0, REB=3.0.)
+        self::assertSame(1, $result['games']);
+        self::assertSame(30.0, (float) $result['minutes']);
+        self::assertSame(8.0, (float) $result['pts']);
+        self::assertSame(6.0, (float) $result['reb']);
+    }
+
+    public function testGetPlayoffStatsExcludesDnpRowsFromGamesCount(): void
+    {
+        $pid = 200000081;
+        $name = 'DB DNP Szn';
+        $this->insertTestPlayer($pid, $name);
+        $this->insertFranchiseSeasonRow(1, 2098, 'Metros');
+
+        // One played + one DNP playoff game in the same season.
+        $this->insertPlayerBoxscoreRow(
+            '2098-06-10', $pid, $name, 'PG', 2, 1, 1,
+            minutes: 30, points2m: 4, points2a: 8,
+            ftm: 0, fta: 0, points3m: 0, points3a: 0,
+            orb: 2, drb: 4, ast: 0, stl: 0, tov: 0, blk: 0, pf: 0
+        );
+        $this->insertPlayerBoxscoreRow(
+            '2098-06-12', $pid, $name, 'PG', 2, 1, 1,
+            minutes: 0, points2m: 0, points2a: 0,
+            ftm: 0, fta: 0, points3m: 0, points3a: 0,
+            orb: 0, drb: 0, ast: 0, stl: 0, tov: 0, blk: 0, pf: 0
+        );
+
+        $result = $this->repo->getPlayoffStats($name);
+
+        self::assertCount(1, $result);
+        // SUM-based per-season row reflects only the played game (games=1, not 2).
+        self::assertSame(1, $result[0]['games']);
+        self::assertSame(30, $result[0]['minutes']);
+        self::assertSame(8, $result[0]['pts']);
+    }
+
+    public function testGetPlayoffCareerAveragesReturnsNullForAllDnpPlayer(): void
+    {
+        $pid = 200000082;
+        $name = 'DB All DNP';
+        $this->insertTestPlayer($pid, $name);
+        $this->insertFranchiseSeasonRow(1, 2098, 'Metros');
+
+        // Only DNP playoff rows — after the filter, no rows remain → no GROUP BY row.
+        $this->insertPlayerBoxscoreRow(
+            '2098-06-10', $pid, $name, 'PG', 2, 1, 1,
+            minutes: 0, points2m: 0, points2a: 0,
+            ftm: 0, fta: 0, points3m: 0, points3a: 0,
+            orb: 0, drb: 0, ast: 0, stl: 0, tov: 0, blk: 0, pf: 0
+        );
+        $this->insertPlayerBoxscoreRow(
+            '2098-06-12', $pid, $name, 'PG', 2, 1, 1,
+            minutes: 0, points2m: 0, points2a: 0,
+            ftm: 0, fta: 0, points3m: 0, points3a: 0,
+            orb: 0, drb: 0, ast: 0, stl: 0, tov: 0, blk: 0, pf: 0
+        );
+
+        // All rows filtered out → null (not a row with games=0 and zeroed averages).
+        self::assertNull($this->repo->getPlayoffCareerAverages($name));
+    }
+
+    public function testGetPlayoffCareerAveragesUnaffectedForPlayedOnlyPlayer(): void
+    {
+        $pid = 200000083;
+        $name = 'DB Played Only';
+        $this->insertTestPlayer($pid, $name);
+        $this->insertFranchiseSeasonRow(1, 2098, 'Metros');
+
+        // Two played playoff games, no DNP rows — the filter is a no-op here.
+        $this->insertPlayerBoxscoreRow(
+            '2098-06-10', $pid, $name, 'PG', 2, 1, 1,
+            minutes: 30, points2m: 4, points2a: 8,
+            ftm: 0, fta: 0, points3m: 0, points3a: 0,
+            orb: 2, drb: 4, ast: 0, stl: 0, tov: 0, blk: 0, pf: 0
+        );
+        $this->insertPlayerBoxscoreRow(
+            '2098-06-12', $pid, $name, 'PG', 2, 1, 1,
+            minutes: 20, points2m: 6, points2a: 10,
+            ftm: 0, fta: 0, points3m: 0, points3a: 0,
+            orb: 0, drb: 6, ast: 0, stl: 0, tov: 0, blk: 0, pf: 0
+        );
+
+        $result = $this->repo->getPlayoffCareerAverages($name);
+
+        self::assertNotNull($result);
+        // Both games count; averages over both: games=2, MIN=25, PTS=(8+12)/2=10, REB=(6+6)/2=6.
+        self::assertSame(2, $result['games']);
+        self::assertSame(25.0, (float) $result['minutes']);
+        self::assertSame(10.0, (float) $result['pts']);
+        self::assertSame(6.0, (float) $result['reb']);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a latent bug where `PlayerStatsRepository::buildCareerAveragesQuery()` and `buildPerSeasonStatsQuery()` counted DNP rows (`game_min = 0`) in `COUNT(*)` and `AVG()` denominators, halving per-game averages and inflating games counts for any player with DNP appearances.

PR #1033 added `BaseMysqliRepository::playedCondition()` (`game_min > 0`) and applied it to 3 consumers but missed these two career-average builders. This PR completes chunk C11 / backlog 13.13.

**Fix:** convert the two `private static` builders to `private function`, update 4 in-class callers (`self::` → `$this->`), and add `$this->playedCondition('bs')` to each WHERE clause. Single-file change; no base-class edit; no migration.

**Before/after (1 played + 1 DNP playoff game):**

| Metric | Buggy (before) | Correct (after) |
|--------|:--------------:|:---------------:|
| games  | 2 | 1 |
| minutes | 15.00 | 30.00 |
| pts | 4.00 | 8.00 |
| reb | 3.00 | 6.00 |

**Scope:** playoff and HEAT career averages (`getPlayoffCareerAverages`, `getHeatCareerAverages`) and per-season stats (`getPlayoffStats`, `getHeatStats`). Regular-season path (`buildHistCareerAveragesQuery` over `ibl_hist`) is already correct — left untouched.

**Known temporary divergence:** leaderboard DB views (`ibl_playoff_career_avgs` etc.) carry the same bug and are deferred — see follow-up slug `maintenance-40c-career-avgs-views-dnp`.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.