### PR TITLE
refactor(cache): move DatabaseCache onto BaseMysqliRepository + add failure-path logging

### DIFF
--- a/ibl5/classes/Cache/DatabaseCache.php
+++ b/ibl5/classes/Cache/DatabaseCache.php
@@ -11,13 +11,15 @@ use Cache\Contracts\DatabaseCacheInterface;
  *
  * Extracted from the pattern in CachedRecordHoldersService for reuse across modules.
  */
-class DatabaseCache implements DatabaseCacheInterface
+class DatabaseCache extends \BaseMysqliRepository implements DatabaseCacheInterface
 {
-    private \mysqli $db;
+    /** PSR-3 logger for cache-layer failure logging; defaults to the 'db' channel. */
+    private \Psr\Log\LoggerInterface $channelLogger;
 
-    public function __construct(\mysqli $db)
+    public function __construct(\mysqli $db, ?\Psr\Log\LoggerInterface $logger = null)
     {
-        $this->db = $db;
+        parent::__construct($db);
+        $this->channelLogger = $logger ?? \Logging\LoggerFactory::getChannel('db');
     }
 
     /**
@@ -27,39 +29,35 @@ class DatabaseCache implements DatabaseCacheInterface
      */
     public function get(string $key): ?array
     {
-        $stmt = $this->db->prepare("SELECT `value`, `expiration` FROM `cache` WHERE `cache_key` = ?");
-        if ($stmt === false) {
+        try {
+            $row = $this->fetchOne(
+                "SELECT `value`, `expiration` FROM `cache` WHERE `cache_key` = ?",
+                's',
+                $key
+            );
+        } catch (\RuntimeException $e) {
+            $this->channelLogger->error('cache_get_failed', ['cache_key' => $key, 'error' => $e->getMessage()]);
             return null;
         }
 
-        $stmt->bind_param('s', $key);
-        $stmt->execute();
-        $result = $stmt->get_result();
-
-        if ($result === false) {
-            $stmt->close();
-            return null;
-        }
-
-        $row = $result->fetch_assoc();
-        $stmt->close();
-
-        if (!is_array($row) || $row === []) {
-            return null;
+        if ($row === null) {
+            return null; // cache miss — NOT an error, do not log
         }
 
         /** @var array{value: string, expiration: int} $row */
         if ($row['expiration'] < time()) {
-            return null;
+            return null; // expired — not an error
         }
 
         try {
             /** @var mixed $decoded */
             $decoded = json_decode($row['value'], true, 512, JSON_THROW_ON_ERROR);
-        } catch (\JsonException) {
+        } catch (\JsonException $e) {
+            $this->channelLogger->warning('cache_corrupt_json', ['cache_key' => $key, 'error' => $e->getMessage()]);
             return null;
         }
         if (!is_array($decoded)) {
+            $this->channelLogger->warning('cache_corrupt_json', ['cache_key' => $key, 'error' => 'decoded value is not an array']);
             return null;
         }
 
@@ -76,18 +74,22 @@ class DatabaseCache implements DatabaseCacheInterface
     {
         $encoded = json_encode($data);
         if ($encoded === false) {
-            return;
-        }
-
-        $stmt = $this->db->prepare("REPLACE INTO `cache` (`cache_key`, `value`, `expiration`) VALUES (?, ?, ?)");
-        if ($stmt === false) {
+            $this->channelLogger->warning('cache_set_encode_failed', ['cache_key' => $key, 'error' => json_last_error_msg()]);
             return;
         }
 
         $expiration = time() + $ttlSeconds;
-        $stmt->bind_param('ssi', $key, $encoded, $expiration);
-        $stmt->execute();
-        $stmt->close();
+        try {
+            $this->execute(
+                "REPLACE INTO `cache` (`cache_key`, `value`, `expiration`) VALUES (?, ?, ?)",
+                'ssi',
+                $key,
+                $encoded,
+                $expiration
+            );
+        } catch (\RuntimeException $e) {
+            $this->channelLogger->error('cache_set_failed', ['cache_key' => $key, 'error' => $e->getMessage()]);
+        }
     }
 
     /**
@@ -95,13 +97,10 @@ class DatabaseCache implements DatabaseCacheInterface
      */
     public function delete(string $key): void
     {
-        $stmt = $this->db->prepare("DELETE FROM `cache` WHERE `cache_key` = ?");
-        if ($stmt === false) {
-            return;
+        try {
+            $this->execute("DELETE FROM `cache` WHERE `cache_key` = ?", 's', $key);
+        } catch (\RuntimeException $e) {
+            $this->channelLogger->error('cache_delete_failed', ['cache_key' => $key, 'error' => $e->getMessage()]);
         }
-
-        $stmt->bind_param('s', $key);
-        $stmt->execute();
-        $stmt->close();
     }
 }

--- a/ibl5/tests/Cache/DatabaseCacheTest.php
+++ b/ibl5/tests/Cache/DatabaseCacheTest.php
@@ -151,6 +151,113 @@ final class DatabaseCacheTest extends TestCase
 
         $this->assertSame($data, $result);
     }
+
+    public function testGetLogsErrorOnPrepareFailure(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with('cache_get_failed', \PHPUnit\Framework\Assert::anything());
+        $cache = new DatabaseCache($mockDb, $logger);
+
+        $mockDb->setPrepareShouldFail(true);
+        $result = $cache->get('any_key');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetLogsWarningOnCorruptJson(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('warning')->with('cache_corrupt_json', \PHPUnit\Framework\Assert::anything());
+        $cache = new DatabaseCache($mockDb, $logger);
+
+        $mockDb->setCacheData('corrupt_key', '{invalid json!!!', time() + 3600);
+        $result = $cache->get('corrupt_key');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetDoesNotLogOnCacheMiss(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+        $logger->expects($this->never())->method('warning');
+        $cache = new DatabaseCache($mockDb, $logger);
+
+        $result = $cache->get('nonexistent');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetDoesNotLogOnExpiredEntry(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+        $logger->expects($this->never())->method('warning');
+        $cache = new DatabaseCache($mockDb, $logger);
+
+        $mockDb->setCacheData('expired_key', (string) json_encode(['x' => 1]), time() - 100);
+        $result = $cache->get('expired_key');
+
+        $this->assertNull($result);
+    }
+
+    public function testSetLogsErrorOnPrepareFailure(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with('cache_set_failed', \PHPUnit\Framework\Assert::anything());
+        $cache = new DatabaseCache($mockDb, $logger);
+
+        $mockDb->setPrepareShouldFail(true);
+        $cache->set('key', [['pid' => 1]], 3600);
+
+        $this->assertFalse($mockDb->wasWriteCalled());
+    }
+
+    public function testDeleteLogsErrorOnPrepareFailure(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with('cache_delete_failed', \PHPUnit\Framework\Assert::anything());
+        $cache = new DatabaseCache($mockDb, $logger);
+
+        $mockDb->setPrepareShouldFail(true);
+        $cache->delete('any_key');
+
+        $this->assertFalse($mockDb->wasDeleteCalled());
+    }
+
+    public function testConstructsWithoutLoggerArg(): void
+    {
+        $mockDb = new MockCacheDb();
+        $cache = new DatabaseCache($mockDb);
+
+        // Un-injected production call shape: fallback logger fires, no TypeError
+        $data = [['pid' => 1]];
+        $cache->set('noarg_key', $data, 3600);
+        $result = $cache->get('noarg_key');
+        $this->assertSame($data, $result);
+
+        $cache->delete('noarg_key');
+        $this->assertNull($cache->get('noarg_key'));
+    }
+
+    public function testSetLogsOnEncodeFailure(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('warning')->with('cache_set_encode_failed', \PHPUnit\Framework\Assert::anything());
+        $cache = new DatabaseCache($mockDb, $logger);
+
+        // NAN is not JSON-encodable
+        $cache->set('encode_fail_key', ['x' => NAN], 3600);
+
+        $this->assertFalse($mockDb->wasWriteCalled());
+    }
 }
 
 /**
@@ -248,6 +355,7 @@ class MockCacheDb extends \mysqli
 
 class MockCacheStmt
 {
+    public int $affected_rows = 1;
     private MockCacheDb $db;
     private string $query;
     private string $boundKey = '';


### PR DESCRIPTION
## Summary

Moves `DatabaseCache` off its hand-rolled `mysqli_prepare`/`mysqli_bind_param` calls and onto `BaseMysqliRepository::fetchOne()` / `execute()`, catching `RuntimeException` silently (preserving null/void degradation contract). Adds an injected `LoggerInterface $channelLogger` (falls back to `getChannel('db')`) to emit structured `cache_*_failed` / `cache_corrupt_json` / `cache_set_encode_failed` log entries on failure paths — the first observable signal when the cache table develops problems.

Backlog item 7.5 / chunk C10b.

## Changes

- `classes/Cache/DatabaseCache.php` — re-parented onto `\BaseMysqliRepository`; `get`/`set`/`delete` rewritten to use `fetchOne`/`execute` inside `try/catch(\RuntimeException)`; own `$channelLogger` added with failure-path log calls.
- `tests/Cache/DatabaseCacheTest.php` — adds ~8 logging-spy + boundary tests; 13 existing test assertions unchanged (green-green characterization).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

Generated with [Claude Code](https://claude.ai/code)