### PR TITLE
refactor(franchise-history): extract assembly into FranchiseHistoryService (backlog 2.3 / C7b)

### DIFF
--- a/ibl5/classes/FranchiseHistory/Contracts/FranchiseHistoryRepositoryInterface.php
+++ b/ibl5/classes/FranchiseHistory/Contracts/FranchiseHistoryRepositoryInterface.php
@@ -7,19 +7,48 @@ namespace FranchiseHistory\Contracts;
 /**
  * FranchiseHistoryRepositoryInterface - Contract for franchise history data access
  *
- * Defines methods for retrieving franchise history data from the database.
+ * Defines methods for retrieving raw franchise history rows from the database.
+ * All cross-source merging and derived-field computation lives in
+ * {@see \FranchiseHistory\FranchiseHistoryService}; this contract returns only
+ * the raw rows the queries produce.
  *
- * @phpstan-type FranchiseRow array{teamid: int|string, team_name: string, color1: string, color2: string, totwins: int|string, totloss: int|string, winpct: string, five_season_wins: int|string, five_season_losses: int|string, five_season_winpct: string|null, totalgames: int|string, playoffs: int|string, playoff_total_wins: int, playoff_total_losses: int, playoff_winpct: string, heat_total_wins: int, heat_total_losses: int, heat_winpct: string, heat_titles: int, div_titles: int, conf_titles: int, ibl_titles: int, ...<string, mixed>}
+ * @phpstan-type SummaryRow array{teamid: int, team_name: string, color1: string, color2: string, totwins: int, totloss: int, winpct: string, playoffs: int, div_titles: int, conf_titles: int, ibl_titles: int, heat_titles: int}
+ * @phpstan-type WindowRow array{currentname: string, five_season_wins: int, five_season_losses: int}
+ * @phpstan-type PlayoffTotalRow array{team_name: string, total_wins: int, total_losses: int}
+ * @phpstan-type HeatTotalRow array{currentname: string, total_wins: int|null, total_losses: int|null}
  *
  * @see \FranchiseHistory\FranchiseHistoryRepository For the concrete implementation
  */
 interface FranchiseHistoryRepositoryInterface
 {
     /**
-     * Get all franchise history data with win/loss records
+     * Get all-time franchise summary rows (one per real team), ordered by teamid ASC.
      *
-     * @param int $currentEndingYear Current season ending year
-     * @return array<int, FranchiseRow> Array of franchise history data
+     * @param int $currentEndingYear Current season ending year (unused by the query today,
+     *                               kept for symmetry / future filtering)
+     * @return list<SummaryRow>
      */
-    public function getAllFranchiseHistory(int $currentEndingYear): array;
+    public function getFranchiseSummaryRows(int $currentEndingYear): array;
+
+    /**
+     * Get rolling 5-season window win/loss sums per team name (raw, ungrouped into a map).
+     *
+     * @param int $currentEndingYear Current season ending year (window is the 5 seasons ending here)
+     * @return list<WindowRow>
+     */
+    public function getFiveSeasonWindowRows(int $currentEndingYear): array;
+
+    /**
+     * Get aggregated playoff game wins/losses per team name (raw totals, no derived winpct).
+     *
+     * @return list<PlayoffTotalRow>
+     */
+    public function getRawPlayoffTotals(): array;
+
+    /**
+     * Get aggregated HEAT wins/losses per team name (raw totals, no derived winpct).
+     *
+     * @return list<HeatTotalRow>
+     */
+    public function getRawHeatTotals(): array;
 }

--- a/ibl5/classes/FranchiseHistory/Contracts/FranchiseHistoryServiceInterface.php
+++ b/ibl5/classes/FranchiseHistory/Contracts/FranchiseHistoryServiceInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FranchiseHistory\Contracts;
+
+/**
+ * FranchiseHistoryServiceInterface - Contract for franchise history business logic
+ *
+ * Owns the assembly of franchise history rows: merging the all-time summary,
+ * the rolling 5-season window, playoff totals, and HEAT totals into a single
+ * display row per team (with derived win percentages and absent-source defaults).
+ *
+ * @phpstan-type FranchiseRow array{teamid: int|string, team_name: string, color1: string, color2: string, totwins: int|string, totloss: int|string, winpct: string, five_season_wins: int|string, five_season_losses: int|string, five_season_winpct: string|null, totalgames: int|string, playoffs: int|string, playoff_total_wins: int, playoff_total_losses: int, playoff_winpct: string, heat_total_wins: int, heat_total_losses: int, heat_winpct: string, heat_titles: int, div_titles: int, conf_titles: int, ibl_titles: int, ...<string, mixed>}
+ *
+ * @see \FranchiseHistory\FranchiseHistoryService For the concrete implementation
+ */
+interface FranchiseHistoryServiceInterface
+{
+    /**
+     * Get all franchise history data with win/loss records
+     *
+     * @param int $currentEndingYear Current season ending year
+     * @return array<int, FranchiseRow> Array of franchise history data
+     */
+    public function getAllFranchiseHistory(int $currentEndingYear): array;
+}

--- a/ibl5/classes/FranchiseHistory/Contracts/FranchiseHistoryViewInterface.php
+++ b/ibl5/classes/FranchiseHistory/Contracts/FranchiseHistoryViewInterface.php
@@ -9,7 +9,7 @@ namespace FranchiseHistory\Contracts;
  *
  * Defines methods for generating HTML output for franchise history.
  *
- * @phpstan-import-type FranchiseRow from FranchiseHistoryRepositoryInterface
+ * @phpstan-import-type FranchiseRow from FranchiseHistoryServiceInterface
  *
  * @see \FranchiseHistory\FranchiseHistoryView For the concrete implementation
  */

--- a/ibl5/classes/FranchiseHistory/FranchiseHistoryRepository.php
+++ b/ibl5/classes/FranchiseHistory/FranchiseHistoryRepository.php
@@ -10,9 +10,14 @@ use League\League;
 /**
  * FranchiseHistoryRepository - Data access layer for franchise history
  *
- * Retrieves franchise history and win/loss records from the database.
+ * Retrieves raw franchise history rows from the database. All cross-source
+ * merging and derived-field computation lives in {@see FranchiseHistoryService};
+ * this class returns only the raw rows the queries produce.
  *
- * @phpstan-import-type FranchiseRow from \FranchiseHistory\Contracts\FranchiseHistoryRepositoryInterface
+ * @phpstan-import-type SummaryRow from \FranchiseHistory\Contracts\FranchiseHistoryRepositoryInterface
+ * @phpstan-import-type WindowRow from \FranchiseHistory\Contracts\FranchiseHistoryRepositoryInterface
+ * @phpstan-import-type PlayoffTotalRow from \FranchiseHistory\Contracts\FranchiseHistoryRepositoryInterface
+ * @phpstan-import-type HeatTotalRow from \FranchiseHistory\Contracts\FranchiseHistoryRepositoryInterface
  *
  * @see FranchiseHistoryRepositoryInterface For the interface contract
  * @see \BaseMysqliRepository For base class documentation
@@ -20,16 +25,14 @@ use League\League;
 class FranchiseHistoryRepository extends \BaseMysqliRepository implements FranchiseHistoryRepositoryInterface
 {
     /**
-     * @see FranchiseHistoryRepositoryInterface::getAllFranchiseHistory()
+     * @see FranchiseHistoryRepositoryInterface::getFranchiseSummaryRows()
      *
-     * @return array<int, FranchiseRow>
+     * @return list<SummaryRow>
      */
-    public function getAllFranchiseHistory(int $currentEndingYear): array
+    public function getFranchiseSummaryRows(int $currentEndingYear): array
     {
-        $fiveSeasonsAgoEndingYear = $currentEndingYear - 4;
-
-        // Query 1: All-time totals from vw_franchise_summary (no redundant ibl_team_win_loss JOIN)
-        /** @var list<array{teamid: int, team_name: string, color1: string, color2: string, totwins: int, totloss: int, winpct: string, playoffs: int, div_titles: int, conf_titles: int, ibl_titles: int, heat_titles: int}> $summaryRows */
+        // All-time totals from vw_franchise_summary (no redundant ibl_team_win_loss JOIN)
+        /** @var list<SummaryRow> $summaryRows */
         $summaryRows = $this->fetchAll(
             "SELECT ti.teamid, ti.team_name, ti.color1, ti.color2,
                     fs.totwins, fs.totloss, fs.winpct, fs.playoffs,
@@ -42,8 +45,20 @@ class FranchiseHistoryRepository extends \BaseMysqliRepository implements Franch
             League::FREE_AGENTS_TEAMID
         );
 
-        // Query 2: Rolling 5-season window from `ibl_team_win_loss` directly (avoids double materialization)
-        /** @var list<array{currentname: string, five_season_wins: int, five_season_losses: int}> $windowRows */
+        return $summaryRows;
+    }
+
+    /**
+     * @see FranchiseHistoryRepositoryInterface::getFiveSeasonWindowRows()
+     *
+     * @return list<WindowRow>
+     */
+    public function getFiveSeasonWindowRows(int $currentEndingYear): array
+    {
+        $fiveSeasonsAgoEndingYear = $currentEndingYear - 4;
+
+        // Rolling 5-season window from `ibl_team_win_loss` directly (avoids double materialization)
+        /** @var list<WindowRow> $windowRows */
         $windowRows = $this->fetchAll(
             "SELECT currentname,
                     CAST(SUM(wins) AS UNSIGNED) AS five_season_wins,
@@ -56,73 +71,22 @@ class FranchiseHistoryRepository extends \BaseMysqliRepository implements Franch
             $currentEndingYear
         );
 
-        /** @var array<string, array{five_season_wins: int, five_season_losses: int}> $windowByTeam */
-        $windowByTeam = [];
-        foreach ($windowRows as $row) {
-            $windowByTeam[$row['currentname']] = [
-                'five_season_wins' => $row['five_season_wins'],
-                'five_season_losses' => $row['five_season_losses'],
-            ];
-        }
-
-        // Bulk-fetch playoff totals and HEAT totals
-        $allPlayoffTotals = $this->getAllPlayoffTotals();
-        $allHeatTotals = $this->getAllHEATTotals();
-
-        /** @var array<int, FranchiseRow> $teams */
-        $teams = [];
-        foreach ($summaryRows as $summary) {
-            $teamName = $summary['team_name'];
-            $window = $windowByTeam[$teamName] ?? ['five_season_wins' => 0, 'five_season_losses' => 0];
-            $fiveWins = $window['five_season_wins'];
-            $fiveLosses = $window['five_season_losses'];
-            $totalGames = $fiveWins + $fiveLosses;
-            $fiveWinpct = $totalGames > 0
-                ? \BasketballStats\StatsFormatter::formatPercentage($fiveWins, $totalGames)
-                : null;
-
-            $playoffTotals = $allPlayoffTotals[$teamName] ?? ['wins' => 0, 'losses' => 0, 'winpct' => '.000'];
-            $heatTotals = $allHeatTotals[$teamName] ?? ['wins' => 0, 'losses' => 0, 'winpct' => '.000'];
-
-            $teams[] = [
-                'teamid' => $summary['teamid'],
-                'team_name' => $teamName,
-                'color1' => $summary['color1'],
-                'color2' => $summary['color2'],
-                'totwins' => $summary['totwins'],
-                'totloss' => $summary['totloss'],
-                'winpct' => $summary['winpct'],
-                'playoffs' => $summary['playoffs'],
-                'five_season_wins' => $fiveWins,
-                'five_season_losses' => $fiveLosses,
-                'totalgames' => $totalGames,
-                'five_season_winpct' => $fiveWinpct,
-                'playoff_total_wins' => $playoffTotals['wins'],
-                'playoff_total_losses' => $playoffTotals['losses'],
-                'playoff_winpct' => $playoffTotals['winpct'],
-                'heat_total_wins' => $heatTotals['wins'],
-                'heat_total_losses' => $heatTotals['losses'],
-                'heat_winpct' => $heatTotals['winpct'],
-                'heat_titles' => $summary['heat_titles'],
-                'div_titles' => $summary['div_titles'],
-                'conf_titles' => $summary['conf_titles'],
-                'ibl_titles' => $summary['ibl_titles'],
-            ];
-        }
-
-        return $teams;
+        return $windowRows;
     }
 
     /**
-     * Get aggregated playoff game wins and losses for all teams in bulk
+     * Get aggregated playoff game wins and losses for all teams in bulk (raw totals).
      *
      * Uses a single SELECT from vw_playoff_series_results with conditional aggregation
      * to compute both winner and loser game tallies without UNION ALL (avoids double materialization).
      *
-     * @return array<string, array{wins: int, losses: int, winpct: string}> Map of team name -> playoff totals
+     * @see FranchiseHistoryRepositoryInterface::getRawPlayoffTotals()
+     *
+     * @return list<PlayoffTotalRow>
      */
-    private function getAllPlayoffTotals(): array
+    public function getRawPlayoffTotals(): array
     {
+        /** @var list<PlayoffTotalRow> $rows */
         $rows = $this->fetchAll(
             "SELECT
                 team_name,
@@ -138,49 +102,25 @@ class FranchiseHistoryRepository extends \BaseMysqliRepository implements Franch
             GROUP BY team_name"
         );
 
-        /** @var array<string, array{wins: int, losses: int, winpct: string}> $result */
-        $result = [];
-        foreach ($rows as $row) {
-            /** @var array{team_name: string, total_wins: int, total_losses: int} $row */
-            $wins = $row['total_wins'];
-            $losses = $row['total_losses'];
-            $totalGames = $wins + $losses;
-            $winpct = $totalGames > 0
-                ? \BasketballStats\StatsFormatter::formatPercentage($wins, $totalGames)
-                : '.000';
-            $result[$row['team_name']] = ['wins' => $wins, 'losses' => $losses, 'winpct' => $winpct];
-        }
-
-        return $result;
+        return $rows;
     }
 
     /**
-     * Get aggregated HEAT wins and losses for all teams in bulk
+     * Get aggregated HEAT wins and losses for all teams in bulk (raw totals).
      *
-     * @return array<string, array{wins: int, losses: int, winpct: string}> Map of team name → HEAT totals
+     * @see FranchiseHistoryRepositoryInterface::getRawHeatTotals()
+     *
+     * @return list<HeatTotalRow>
      */
-    private function getAllHEATTotals(): array
+    public function getRawHeatTotals(): array
     {
+        /** @var list<HeatTotalRow> $rows */
         $rows = $this->fetchAll(
             "SELECT currentname, SUM(wins) AS total_wins, SUM(losses) AS total_losses
             FROM `ibl_heat_win_loss`
             GROUP BY currentname"
         );
 
-        /** @var array<string, array{wins: int, losses: int, winpct: string}> $result */
-        $result = [];
-        foreach ($rows as $row) {
-            /** @var array{currentname: string, total_wins: int|null, total_losses: int|null} $row */
-            $wins = $row['total_wins'] ?? 0;
-            $losses = $row['total_losses'] ?? 0;
-            $totalGames = $wins + $losses;
-            $winpct = $totalGames > 0
-                ? \BasketballStats\StatsFormatter::formatPercentage($wins, $totalGames)
-                : '.000';
-            $result[$row['currentname']] = ['wins' => $wins, 'losses' => $losses, 'winpct' => $winpct];
-        }
-
-        return $result;
+        return $rows;
     }
-
 }

--- a/ibl5/classes/FranchiseHistory/FranchiseHistoryService.php
+++ b/ibl5/classes/FranchiseHistory/FranchiseHistoryService.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FranchiseHistory;
+
+use FranchiseHistory\Contracts\FranchiseHistoryRepositoryInterface;
+use FranchiseHistory\Contracts\FranchiseHistoryServiceInterface;
+
+/**
+ * FranchiseHistoryService - Business logic for franchise history
+ *
+ * Owns the assembly that the Repository sheds: merges the all-time summary,
+ * the rolling 5-season window, playoff totals, and HEAT totals into one display
+ * row per team, deriving win percentages and applying absent-source defaults.
+ *
+ * @phpstan-import-type FranchiseRow from FranchiseHistoryServiceInterface
+ *
+ * @see FranchiseHistoryServiceInterface For the interface contract
+ */
+class FranchiseHistoryService implements FranchiseHistoryServiceInterface
+{
+    public function __construct(private FranchiseHistoryRepositoryInterface $repository)
+    {
+    }
+
+    /**
+     * @see FranchiseHistoryServiceInterface::getAllFranchiseHistory()
+     *
+     * @return array<int, FranchiseRow>
+     */
+    public function getAllFranchiseHistory(int $currentEndingYear): array
+    {
+        $summaryRows = $this->repository->getFranchiseSummaryRows($currentEndingYear);
+        $windowRows = $this->repository->getFiveSeasonWindowRows($currentEndingYear);
+
+        /** @var array<string, array{five_season_wins: int, five_season_losses: int}> $windowByTeam */
+        $windowByTeam = [];
+        foreach ($windowRows as $row) {
+            $windowByTeam[$row['currentname']] = [
+                'five_season_wins' => $row['five_season_wins'],
+                'five_season_losses' => $row['five_season_losses'],
+            ];
+        }
+
+        $allPlayoffTotals = $this->buildPlayoffTotals();
+        $allHeatTotals = $this->buildHeatTotals();
+
+        /** @var array<int, FranchiseRow> $teams */
+        $teams = [];
+        foreach ($summaryRows as $summary) {
+            $teamName = $summary['team_name'];
+            $window = $windowByTeam[$teamName] ?? ['five_season_wins' => 0, 'five_season_losses' => 0];
+            $fiveWins = $window['five_season_wins'];
+            $fiveLosses = $window['five_season_losses'];
+            $totalGames = $fiveWins + $fiveLosses;
+            $fiveWinpct = $totalGames > 0
+                ? \BasketballStats\StatsFormatter::formatPercentage($fiveWins, $totalGames)
+                : null;
+
+            $playoffTotals = $allPlayoffTotals[$teamName] ?? ['wins' => 0, 'losses' => 0, 'winpct' => '.000'];
+            $heatTotals = $allHeatTotals[$teamName] ?? ['wins' => 0, 'losses' => 0, 'winpct' => '.000'];
+
+            $teams[] = [
+                'teamid' => $summary['teamid'],
+                'team_name' => $teamName,
+                'color1' => $summary['color1'],
+                'color2' => $summary['color2'],
+                'totwins' => $summary['totwins'],
+                'totloss' => $summary['totloss'],
+                'winpct' => $summary['winpct'],
+                'playoffs' => $summary['playoffs'],
+                'five_season_wins' => $fiveWins,
+                'five_season_losses' => $fiveLosses,
+                'totalgames' => $totalGames,
+                'five_season_winpct' => $fiveWinpct,
+                'playoff_total_wins' => $playoffTotals['wins'],
+                'playoff_total_losses' => $playoffTotals['losses'],
+                'playoff_winpct' => $playoffTotals['winpct'],
+                'heat_total_wins' => $heatTotals['wins'],
+                'heat_total_losses' => $heatTotals['losses'],
+                'heat_winpct' => $heatTotals['winpct'],
+                'heat_titles' => $summary['heat_titles'],
+                'div_titles' => $summary['div_titles'],
+                'conf_titles' => $summary['conf_titles'],
+                'ibl_titles' => $summary['ibl_titles'],
+            ];
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build a team-name → playoff totals map with derived winpct from raw repository rows.
+     *
+     * @return array<string, array{wins: int, losses: int, winpct: string}>
+     */
+    private function buildPlayoffTotals(): array
+    {
+        $result = [];
+        foreach ($this->repository->getRawPlayoffTotals() as $row) {
+            $wins = $row['total_wins'];
+            $losses = $row['total_losses'];
+            $totalGames = $wins + $losses;
+            $winpct = $totalGames > 0
+                ? \BasketballStats\StatsFormatter::formatPercentage($wins, $totalGames)
+                : '.000';
+            $result[$row['team_name']] = ['wins' => $wins, 'losses' => $losses, 'winpct' => $winpct];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Build a team-name → HEAT totals map with derived winpct from raw repository rows.
+     *
+     * @return array<string, array{wins: int, losses: int, winpct: string}>
+     */
+    private function buildHeatTotals(): array
+    {
+        $result = [];
+        foreach ($this->repository->getRawHeatTotals() as $row) {
+            $wins = $row['total_wins'] ?? 0;
+            $losses = $row['total_losses'] ?? 0;
+            $totalGames = $wins + $losses;
+            $winpct = $totalGames > 0
+                ? \BasketballStats\StatsFormatter::formatPercentage($wins, $totalGames)
+                : '.000';
+            $result[$row['currentname']] = ['wins' => $wins, 'losses' => $losses, 'winpct' => $winpct];
+        }
+
+        return $result;
+    }
+}

--- a/ibl5/classes/FranchiseHistory/FranchiseHistoryView.php
+++ b/ibl5/classes/FranchiseHistory/FranchiseHistoryView.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FranchiseHistory;
 
-use FranchiseHistory\Contracts\FranchiseHistoryRepositoryInterface;
+use FranchiseHistory\Contracts\FranchiseHistoryServiceInterface;
 use FranchiseHistory\Contracts\FranchiseHistoryViewInterface;
 use UI\TeamCellHelper;
 use Security\HtmlSanitizer;
@@ -14,7 +14,7 @@ use Security\HtmlSanitizer;
  *
  * Generates sortable HTML table displaying franchise history data.
  *
- * @phpstan-import-type FranchiseRow from FranchiseHistoryRepositoryInterface
+ * @phpstan-import-type FranchiseRow from FranchiseHistoryServiceInterface
  *
  * @see FranchiseHistoryViewInterface For the interface contract
  */

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -199,6 +199,7 @@ Effort scale:
 **Suggested direction:** Add a Service even as a pass-through to maintain pattern consistency.
 **Est. effort:** S each
 **Risk if untouched:** Same as 2.2.
+**Status:** Split (C7b, maintenance-48b) — FranchiseHistory: Service built; `getAllFranchiseHistory()` assembly extracted from the Repository into `FranchiseHistoryService` (raw-fetch Repo + assembly Service), unblocking DB-free unit tests of the winpct/default/merge branches. PlayerMovement: Declined — `PlayerMovementRepository::getPlayerMovements()` is a single JOIN with zero PHP assembly; a Service would be pass-through ceremony (cf. 2.9/2.11).
 
 ### 2.4 GMContactList / Topics — No Service Layer; Topics Cross-Module Coupling
 **Location:** `classes/GMContactList/`, `classes/Topics/`

--- a/ibl5/modules/FranchiseHistory/index.php
+++ b/ibl5/modules/FranchiseHistory/index.php
@@ -18,6 +18,7 @@ if (!defined('MODULE_FILE')) {
 }
 
 use FranchiseHistory\FranchiseHistoryRepository;
+use FranchiseHistory\FranchiseHistoryService;
 use FranchiseHistory\FranchiseHistoryView;
 
 global $mysqli_db;
@@ -28,10 +29,11 @@ PageLayout\PageLayout::header();
 
 // Initialize services
 $repository = new FranchiseHistoryRepository($mysqli_db);
+$service = new FranchiseHistoryService($repository);
 $view = new FranchiseHistoryView();
 
 // Get franchise history data
-$franchiseData = $repository->getAllFranchiseHistory($season->endingYear);
+$franchiseData = $service->getAllFranchiseHistory($season->endingYear);
 
 // Render output
 echo $view->render($franchiseData);

--- a/ibl5/tests/DatabaseIntegration/FranchiseHistoryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/FranchiseHistoryRepositoryTest.php
@@ -7,10 +7,15 @@ namespace Tests\DatabaseIntegration;
 use PHPUnit\Framework\Attributes\Group;
 
 use FranchiseHistory\FranchiseHistoryRepository;
+use FranchiseHistory\FranchiseHistoryService;
 use League\League;
 
 /**
- * Database integration tests for FranchiseHistoryRepository.
+ * Database integration tests for franchise history assembly over the real DB.
+ *
+ * Exercises the FranchiseHistoryService composed over the real-DB-backed
+ * FranchiseHistoryRepository — the green-green anchor proving the assembly
+ * behavior is byte-identical after the Repository→Service extraction.
  *
  * Tests the VIEW chain: vw_franchise_summary → ibl_team_win_loss → ibl_box_scores_teams,
  * plus vw_playoff_series_results and ibl_heat_win_loss.
@@ -18,12 +23,12 @@ use League\League;
 #[Group('database')]
 class FranchiseHistoryRepositoryTest extends DatabaseTestCase
 {
-    private FranchiseHistoryRepository $repo;
+    private FranchiseHistoryService $repo;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repo = new FranchiseHistoryRepository($this->db);
+        $this->repo = new FranchiseHistoryService(new FranchiseHistoryRepository($this->db));
     }
 
     public function testReturnsArrayWithExpectedKeys(): void

--- a/ibl5/tests/FranchiseHistory/FranchiseHistoryRepositoryTest.php
+++ b/ibl5/tests/FranchiseHistory/FranchiseHistoryRepositoryTest.php
@@ -7,14 +7,16 @@ namespace Tests\FranchiseHistory;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use FranchiseHistory\FranchiseHistoryRepository;
-use FranchiseHistory\Contracts\FranchiseHistoryRepositoryInterface;
 
 /**
  * FranchiseHistoryRepositoryTest - Tests for FranchiseHistoryRepository
  *
- * Tests verify that title counts are sourced from vw_franchise_summary
- * (which internally derives them from vw_team_awards) and that playoff
- * records are derived from vw_playoff_series_results.
+ * The repository is now a thin raw-fetch layer: all cross-source merging and
+ * derived-field computation lives in FranchiseHistoryService (tested DB-free in
+ * FranchiseHistoryServiceTest). These tests assert only the repository's
+ * legitimate concern — that each raw-fetch method queries the expected
+ * view/table. Behavioral assembly assertions belong to the Service test;
+ * the live query chain is covered by the DB-integration suite.
  *
  * @covers \FranchiseHistory\FranchiseHistoryRepository
  */
@@ -31,93 +33,72 @@ class FranchiseHistoryRepositoryTest extends TestCase
         $this->repository = new FranchiseHistoryRepository($this->mockDb);
     }
 
-    /**
-     * Verify that titles are sourced from vw_franchise_summary
-     *
-     * vw_franchise_summary internally derives title counts from vw_team_awards,
-     * so querying it directly avoids redundant vw_team_awards materialization.
-     */
-    public function testTitlesSourcedFromFranchiseSummaryView(): void
+    public function testSummaryFetchQueriesFranchiseSummaryView(): void
     {
-        $reflectionClass = new \ReflectionClass($this->repository);
-        $fileName = $reflectionClass->getFileName();
-        $this->assertIsString($fileName);
-        $sourceCode = file_get_contents($fileName);
-        $this->assertIsString($sourceCode);
+        $sourceCode = $this->repositorySource();
 
-        // Verify the repository queries vw_franchise_summary (which contains title data)
+        // Summary rows come from vw_franchise_summary (which internally derives
+        // title counts from vw_team_awards), avoiding redundant materialization.
         $this->assertStringContainsString(
             'vw_franchise_summary',
             $sourceCode,
-            'Repository must query vw_franchise_summary to get title counts'
+            'Repository must query vw_franchise_summary for the all-time summary rows'
         );
 
-        // Verify title fields are selected from the summary
+        // Title columns are DB-supplied on the raw summary row.
+        foreach (['heat_titles', 'div_titles', 'conf_titles', 'ibl_titles'] as $titleColumn) {
+            $this->assertStringContainsString(
+                $titleColumn,
+                $sourceCode,
+                "Repository summary query must select $titleColumn from the franchise summary"
+            );
+        }
+    }
+
+    public function testFiveSeasonWindowFetchQueriesTeamWinLoss(): void
+    {
         $this->assertStringContainsString(
-            'heat_titles',
-            $sourceCode,
-            'Repository must include heat_titles from franchise summary'
-        );
-        $this->assertStringContainsString(
-            'div_titles',
-            $sourceCode,
-            'Repository must include div_titles from franchise summary'
-        );
-        $this->assertStringContainsString(
-            'conf_titles',
-            $sourceCode,
-            'Repository must include conf_titles from franchise summary'
-        );
-        $this->assertStringContainsString(
-            'ibl_titles',
-            $sourceCode,
-            'Repository must include ibl_titles from franchise summary'
+            'ibl_team_win_loss',
+            $this->repositorySource(),
+            'Repository must query ibl_team_win_loss for the rolling 5-season window'
         );
     }
 
-    /**
-     * Verify that getAllPlayoffTotals method exists and queries vw_playoff_series_results
-     *
-     * This test documents the expected behavior: playoff game records must be
-     * derived from series results in vw_playoff_series_results.
-     */
-    public function testRepositoryQueriesPlayoffSeriesResultsViewForPlayoffTotals(): void
+    public function testPlayoffFetchQueriesPlayoffSeriesResultsView(): void
     {
-        $reflectionClass = new \ReflectionClass($this->repository);
-
-        // Verify the private getAllPlayoffTotals method exists (bulk playoff calculation)
-        $this->assertTrue(
-            $reflectionClass->hasMethod('getAllPlayoffTotals'),
-            'Repository must have getAllPlayoffTotals method to calculate playoff records from vw_playoff_series_results'
-        );
-
-        $fileName = $reflectionClass->getFileName();
-        $this->assertIsString($fileName);
-        $sourceCode = file_get_contents($fileName);
-        $this->assertIsString($sourceCode);
-
-        // Verify that the repository queries vw_playoff_series_results view
         $this->assertStringContainsString(
             'vw_playoff_series_results',
-            $sourceCode,
-            'Repository must query vw_playoff_series_results view to calculate playoff records'
-        );
-
-        // Verify that playoff fields are present in the result array
-        $this->assertStringContainsString(
-            "'playoff_total_wins'",
-            $sourceCode,
-            'Repository must include playoff_total_wins in result'
+            $this->repositorySource(),
+            'Repository must query vw_playoff_series_results for raw playoff totals'
         );
     }
 
-    /**
-     * Regression test: Verify that title fields are populated in results
-     *
-     * This test documents that the repository MUST include title fields
-     * in the returned franchise data.
-     */
-    public function testTitleFieldsArePopulatedInResults(): void
+    public function testHeatFetchQueriesHeatWinLossTable(): void
+    {
+        $this->assertStringContainsString(
+            'ibl_heat_win_loss',
+            $this->repositorySource(),
+            'Repository must query ibl_heat_win_loss for raw HEAT totals'
+        );
+    }
+
+    public function testExposesRawFetchMethods(): void
+    {
+        // The repository sheds assembly: it exposes only raw-row fetches.
+        foreach ([
+            'getFranchiseSummaryRows',
+            'getFiveSeasonWindowRows',
+            'getRawPlayoffTotals',
+            'getRawHeatTotals',
+        ] as $method) {
+            $this->assertTrue(
+                method_exists($this->repository, $method),
+                "Repository must expose raw-fetch method $method"
+            );
+        }
+    }
+
+    private function repositorySource(): string
     {
         $reflectionClass = new \ReflectionClass($this->repository);
         $fileName = $reflectionClass->getFileName();
@@ -125,26 +106,6 @@ class FranchiseHistoryRepositoryTest extends TestCase
         $sourceCode = file_get_contents($fileName);
         $this->assertIsString($sourceCode);
 
-        // Verify that title fields are included in the result array
-        $this->assertStringContainsString(
-            "'heat_titles'",
-            $sourceCode,
-            'Repository result must include heat_titles field'
-        );
-        $this->assertStringContainsString(
-            "'div_titles'",
-            $sourceCode,
-            'Repository result must include div_titles field'
-        );
-        $this->assertStringContainsString(
-            "'conf_titles'",
-            $sourceCode,
-            'Repository result must include conf_titles field'
-        );
-        $this->assertStringContainsString(
-            "'ibl_titles'",
-            $sourceCode,
-            'Repository result must include ibl_titles field'
-        );
+        return $sourceCode;
     }
 }

--- a/ibl5/tests/FranchiseHistory/FranchiseHistoryServiceTest.php
+++ b/ibl5/tests/FranchiseHistory/FranchiseHistoryServiceTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FranchiseHistory;
+
+use FranchiseHistory\Contracts\FranchiseHistoryRepositoryInterface;
+use FranchiseHistory\FranchiseHistoryService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for FranchiseHistoryService.
+ *
+ * DB-free: the repository is a stub returning canned raw rows, so these tests
+ * exercise the assembly branches (windowByTeam merge, winpct derivation via
+ * StatsFormatter, absent-source defaults, FranchiseRow build) that previously
+ * lived welded to the live database inside the Repository.
+ *
+ * @covers \FranchiseHistory\FranchiseHistoryService
+ */
+class FranchiseHistoryServiceTest extends TestCase
+{
+    /** @var FranchiseHistoryRepositoryInterface&\PHPUnit\Framework\MockObject\Stub */
+    private FranchiseHistoryRepositoryInterface $repository;
+
+    private FranchiseHistoryService $service;
+
+    protected function setUp(): void
+    {
+        $this->repository = self::createStub(FranchiseHistoryRepositoryInterface::class);
+        $this->service = new FranchiseHistoryService($this->repository);
+    }
+
+    /**
+     * @param array{teamid?: int, team_name?: string, color1?: string, color2?: string, totwins?: int, totloss?: int, winpct?: string, playoffs?: int, div_titles?: int, conf_titles?: int, ibl_titles?: int, heat_titles?: int} $overrides
+     * @return array{teamid: int, team_name: string, color1: string, color2: string, totwins: int, totloss: int, winpct: string, playoffs: int, div_titles: int, conf_titles: int, ibl_titles: int, heat_titles: int}
+     */
+    private function summaryRow(array $overrides = []): array
+    {
+        return array_merge([
+            'teamid' => 1,
+            'team_name' => 'Metros',
+            'color1' => '#000000',
+            'color2' => '#FFFFFF',
+            'totwins' => 100,
+            'totloss' => 50,
+            'winpct' => '.667',
+            'playoffs' => 5,
+            'div_titles' => 2,
+            'conf_titles' => 1,
+            'ibl_titles' => 1,
+            'heat_titles' => 3,
+        ], $overrides);
+    }
+
+    /**
+     * @param list<array{teamid: int, team_name: string, color1: string, color2: string, totwins: int, totloss: int, winpct: string, playoffs: int, div_titles: int, conf_titles: int, ibl_titles: int, heat_titles: int}> $summaryRows
+     * @param list<array{currentname: string, five_season_wins: int, five_season_losses: int}> $windowRows
+     * @param list<array{team_name: string, total_wins: int, total_losses: int}> $playoffRows
+     * @param list<array{currentname: string, total_wins: int|null, total_losses: int|null}> $heatRows
+     */
+    private function stubRepo(
+        array $summaryRows = [],
+        array $windowRows = [],
+        array $playoffRows = [],
+        array $heatRows = [],
+    ): void {
+        $this->repository->method('getFranchiseSummaryRows')->willReturn($summaryRows);
+        $this->repository->method('getFiveSeasonWindowRows')->willReturn($windowRows);
+        $this->repository->method('getRawPlayoffTotals')->willReturn($playoffRows);
+        $this->repository->method('getRawHeatTotals')->willReturn($heatRows);
+    }
+
+    public function testAssemblesMergedRowWithDerivedWinpcts(): void
+    {
+        $this->stubRepo(
+            summaryRows: [$this->summaryRow()],
+            windowRows: [['currentname' => 'Metros', 'five_season_wins' => 3, 'five_season_losses' => 2]],
+            playoffRows: [['team_name' => 'Metros', 'total_wins' => 12, 'total_losses' => 8]],
+            heatRows: [['currentname' => 'Metros', 'total_wins' => 6, 'total_losses' => 4]],
+        );
+
+        $result = $this->service->getAllFranchiseHistory(2024);
+
+        self::assertCount(1, $result);
+        $row = $result[0];
+
+        // Summary fields passed through verbatim
+        self::assertSame(1, $row['teamid']);
+        self::assertSame('Metros', $row['team_name']);
+        self::assertSame('.667', $row['winpct']);
+        self::assertSame(5, $row['playoffs']);
+
+        // Five-season window merged + winpct derived: 3 of 5 = 0.600
+        self::assertSame(3, $row['five_season_wins']);
+        self::assertSame(2, $row['five_season_losses']);
+        self::assertSame(5, $row['totalgames']);
+        self::assertSame('0.600', $row['five_season_winpct']);
+
+        // Playoff totals + derived winpct: 12 of 20 = 0.600
+        self::assertSame(12, $row['playoff_total_wins']);
+        self::assertSame(8, $row['playoff_total_losses']);
+        self::assertSame('0.600', $row['playoff_winpct']);
+
+        // HEAT totals + derived winpct: 6 of 10 = 0.600
+        self::assertSame(6, $row['heat_total_wins']);
+        self::assertSame(4, $row['heat_total_losses']);
+        self::assertSame('0.600', $row['heat_winpct']);
+    }
+
+    public function testTitlesAreSurfacedInAssembledRow(): void
+    {
+        $this->stubRepo(
+            summaryRows: [$this->summaryRow([
+                'heat_titles' => 4,
+                'div_titles' => 7,
+                'conf_titles' => 3,
+                'ibl_titles' => 2,
+            ])],
+        );
+
+        $row = $this->service->getAllFranchiseHistory(2024)[0];
+
+        self::assertSame(4, $row['heat_titles']);
+        self::assertSame(7, $row['div_titles']);
+        self::assertSame(3, $row['conf_titles']);
+        self::assertSame(2, $row['ibl_titles']);
+    }
+
+    public function testTeamAbsentFromPlayoffAndHeatTotalsDefaultsToZero(): void
+    {
+        // Summary present, but no playoff/heat rows for this team
+        $this->stubRepo(
+            summaryRows: [$this->summaryRow(['team_name' => 'Sharks'])],
+            windowRows: [['currentname' => 'Sharks', 'five_season_wins' => 4, 'five_season_losses' => 1]],
+            playoffRows: [],
+            heatRows: [],
+        );
+
+        $row = $this->service->getAllFranchiseHistory(2024)[0];
+
+        self::assertSame(0, $row['playoff_total_wins']);
+        self::assertSame(0, $row['playoff_total_losses']);
+        self::assertSame('.000', $row['playoff_winpct']);
+        self::assertSame(0, $row['heat_total_wins']);
+        self::assertSame(0, $row['heat_total_losses']);
+        self::assertSame('.000', $row['heat_winpct']);
+    }
+
+    public function testZeroGamesInWindowYieldsNullFiveSeasonWinpct(): void
+    {
+        // Team present in window map but with zero games → null (distinct from '.000')
+        $this->stubRepo(
+            summaryRows: [$this->summaryRow()],
+            windowRows: [['currentname' => 'Metros', 'five_season_wins' => 0, 'five_season_losses' => 0]],
+        );
+
+        $row = $this->service->getAllFranchiseHistory(2024)[0];
+
+        self::assertSame(0, $row['totalgames']);
+        self::assertNull($row['five_season_winpct']);
+    }
+
+    public function testTeamAbsentFromWindowMapHasZeroFiveSeasonRecord(): void
+    {
+        // No window row for this team at all
+        $this->stubRepo(
+            summaryRows: [$this->summaryRow()],
+            windowRows: [['currentname' => 'OtherTeam', 'five_season_wins' => 9, 'five_season_losses' => 1]],
+        );
+
+        $row = $this->service->getAllFranchiseHistory(2024)[0];
+
+        self::assertSame(0, $row['five_season_wins']);
+        self::assertSame(0, $row['five_season_losses']);
+        self::assertNull($row['five_season_winpct']);
+    }
+
+    public function testEmptyRepositoryReturnsEmptyArray(): void
+    {
+        $this->stubRepo();
+
+        self::assertSame([], $this->service->getAllFranchiseHistory(2024));
+    }
+
+    public function testPreservesSummaryRowOrder(): void
+    {
+        $this->stubRepo(
+            summaryRows: [
+                $this->summaryRow(['teamid' => 1, 'team_name' => 'Metros']),
+                $this->summaryRow(['teamid' => 2, 'team_name' => 'Sharks']),
+                $this->summaryRow(['teamid' => 3, 'team_name' => 'Bears']),
+            ],
+        );
+
+        $result = $this->service->getAllFranchiseHistory(2024);
+
+        self::assertSame([1, 2, 3], array_column($result, 'teamid'));
+    }
+
+    public function testPlayoffTotalsWithZeroGamesYieldZeroWinpct(): void
+    {
+        // Team present in raw playoff totals but with zero games → '.000' via the
+        // buildPlayoffTotals ternary (distinct from the absent-team '??' default).
+        $this->stubRepo(
+            summaryRows: [$this->summaryRow()],
+            playoffRows: [['team_name' => 'Metros', 'total_wins' => 0, 'total_losses' => 0]],
+        );
+
+        $row = $this->service->getAllFranchiseHistory(2024)[0];
+
+        self::assertSame(0, $row['playoff_total_wins']);
+        self::assertSame(0, $row['playoff_total_losses']);
+        self::assertSame('.000', $row['playoff_winpct']);
+    }
+
+    public function testHeatTotalsWithNullSumsTreatedAsZero(): void
+    {
+        // SUM() over no matching rows can surface NULL; Service coalesces to 0
+        $this->stubRepo(
+            summaryRows: [$this->summaryRow()],
+            heatRows: [['currentname' => 'Metros', 'total_wins' => null, 'total_losses' => null]],
+        );
+
+        $row = $this->service->getAllFranchiseHistory(2024)[0];
+
+        self::assertSame(0, $row['heat_total_wins']);
+        self::assertSame(0, $row['heat_total_losses']);
+        self::assertSame('.000', $row['heat_winpct']);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the assembly logic from `FranchiseHistoryRepository` into a new `FranchiseHistoryService`, implementing backlog finding 2.3 (FranchiseHistory / PlayerMovement — No Service Layer) for the FranchiseHistory half.

**Why this is a genuine Service (not ceremony):** `FranchiseHistoryRepository::getAllFranchiseHistory()` performed substantial in-PHP assembly after four DB fetches: building a `$windowByTeam` lookup map, merging three independent sources (5-season window, playoff totals, HEAT totals), computing derived win-pct via `StatsFormatter`, and assembling 21-field `FranchiseRow`s. These assembly branches were testable only through a live database. This PR extracts that logic into a Service, enabling DB-free unit tests of the winpct/default/merge branches — the seam the backlog finding predicted.

**PlayerMovement half — DECLINED:** `PlayerMovementRepository::getPlayerMovements()` is a single JOIN with zero PHP assembly; a Service would be pass-through ceremony (cf. 2.9/2.11).

## Changes

- **NEW** `FranchiseHistoryService` — owns all assembly (windowByTeam map, winpct derivation via StatsFormatter, absent-team defaults, FranchiseRow build)
- **NEW** `FranchiseHistoryServiceInterface` — `getAllFranchiseHistory()` + relocated `@phpstan-type FranchiseRow`
- **REDUCED** `FranchiseHistoryRepository` — four raw-fetch methods only; no derivation
- **UPDATED** `FranchiseHistoryRepositoryInterface` — raw-row method signatures; loses `FranchiseRow` + `getAllFranchiseHistory()`
- **REWIRED** `modules/FranchiseHistory/index.php` — Repository → Service → View
- **RE-POINTED** View + ViewInterface `@phpstan-import-type` to ServiceInterface
- **NEW** `FranchiseHistoryServiceTest` — DB-free assembly + boundary tests (positive, absent-team defaults, null winpct, empty repo)
- **UPDATED** `FranchiseHistoryRepositoryTest` — drops reflection/source-grep probes of assembly; retains raw-query assertions
- **UPDATED** backlog 2.3 split-status in `docs/maintenance-backlog.md`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

Generated with [Claude Code](https://claude.ai/code)