### PR TITLE
refactor: inject ?LoggerInterface into 20 single-channel classes (backlog 14.14 / C16c)

### DIFF
--- a/ibl5/classes/Api/Controller/TradeDeclineController.php
+++ b/ibl5/classes/Api/Controller/TradeDeclineController.php
@@ -16,11 +16,17 @@ class TradeDeclineController implements ControllerInterface
     private TeamIdentityRepositoryInterface $commonRepository;
     private string $serverName;
 
-    public function __construct(\mysqli $db, TeamIdentityRepositoryInterface $commonRepository, string $serverName = '')
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('discord').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
+    public function __construct(\mysqli $db, TeamIdentityRepositoryInterface $commonRepository, string $serverName = '', ?\Psr\Log\LoggerInterface $logger = null)
     {
         $this->db = $db;
         $this->commonRepository = $commonRepository;
         $this->serverName = $serverName;
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('discord');
     }
 
     /**
@@ -85,7 +91,7 @@ class TradeDeclineController implements ControllerInterface
                     Discord::sendDM($offeringGmDiscordId, $declineMessage);
                 } catch (\Exception $e) {
                     // Log but don't fail the decline
-                    \Logging\LoggerFactory::getChannel('discord')->error('Discord decline notification failed', ['error' => $e->getMessage()]);
+                    $this->logger->error('Discord decline notification failed', ['error' => $e->getMessage()]);
                 }
             }
         }

--- a/ibl5/classes/ApiKeys/ApiKeysService.php
+++ b/ibl5/classes/ApiKeys/ApiKeysService.php
@@ -19,9 +19,15 @@ class ApiKeysService implements ApiKeysServiceInterface
 {
     private ApiKeysRepositoryInterface $repository;
 
-    public function __construct(ApiKeysRepositoryInterface $repository)
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
+    public function __construct(ApiKeysRepositoryInterface $repository, ?\Psr\Log\LoggerInterface $logger = null)
     {
         $this->repository = $repository;
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /**
@@ -40,7 +46,7 @@ class ApiKeysService implements ApiKeysServiceInterface
 
         $this->repository->createKey($userId, $keyHash, $keyPrefix, $username);
 
-        \Logging\LoggerFactory::getChannel('audit')->info('api_key_generated', [
+        $this->logger->info('api_key_generated', [
             'action' => 'api_key_generated',
             'user_id' => $userId,
             'username' => $username,
@@ -60,7 +66,7 @@ class ApiKeysService implements ApiKeysServiceInterface
     {
         $this->repository->revokeByUserId($userId);
 
-        \Logging\LoggerFactory::getChannel('audit')->info('api_key_revoked', [
+        $this->logger->info('api_key_revoked', [
             'action' => 'api_key_revoked',
             'user_id' => $userId,
         ]);

--- a/ibl5/classes/DepthChartEntry/DepthChartEntryRepository.php
+++ b/ibl5/classes/DepthChartEntry/DepthChartEntryRepository.php
@@ -14,9 +14,15 @@ use DepthChartEntry\Contracts\DepthChartEntryRepositoryInterface;
  */
 class DepthChartEntryRepository extends \BaseMysqliRepository implements DepthChartEntryRepositoryInterface
 {
-    public function __construct(\mysqli $db)
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('db').
+     */
+    private \Psr\Log\LoggerInterface $channelLogger;
+
+    public function __construct(\mysqli $db, ?\Psr\Log\LoggerInterface $logger = null)
     {
         parent::__construct($db);
+        $this->channelLogger = $logger ?? \Logging\LoggerFactory::getChannel('db');
     }
 
     /**
@@ -77,7 +83,7 @@ class DepthChartEntryRepository extends \BaseMysqliRepository implements DepthCh
 
             return true;
         } catch (\RuntimeException $e) {
-            \Logging\LoggerFactory::getChannel('db')->error('updatePlayerDepthChart failed', [
+            $this->channelLogger->error('updatePlayerDepthChart failed', [
                 'exception' => $e,
                 'context' => ['playerName' => $playerName],
             ]);
@@ -99,7 +105,7 @@ class DepthChartEntryRepository extends \BaseMysqliRepository implements DepthCh
 
             return true;
         } catch (\RuntimeException $e) {
-            \Logging\LoggerFactory::getChannel('db')->error('updateTeamHistory failed', [
+            $this->channelLogger->error('updateTeamHistory failed', [
                 'exception' => $e,
                 'context' => ['teamName' => $teamName],
             ]);

--- a/ibl5/classes/Discord/Discord.php
+++ b/ibl5/classes/Discord/Discord.php
@@ -197,14 +197,14 @@ class Discord
 
         // Skip if recipient has no Discord ID
         if ($recipientDiscordId === '') {
-            self::$logger?->warning('sendDM skipped: recipient has no Discord ID');
+            (self::$logger ?? \Logging\LoggerFactory::getChannel('discord'))->warning('sendDM skipped: recipient has no Discord ID');
             return null;
         }
 
         self::loadConfig();
 
         if (self::$iblbotUrl === '') {
-            self::$logger?->warning('sendDM skipped: iblbot_url is empty in config');
+            (self::$logger ?? \Logging\LoggerFactory::getChannel('discord'))->warning('sendDM skipped: iblbot_url is empty in config');
             return null;
         }
 
@@ -269,14 +269,14 @@ class Discord
 
         // Skip if recipient has no Discord ID
         if ($recipientDiscordId === '') {
-            self::$logger?->warning('sendTradeDM skipped: recipient has no Discord ID', ['trade_id' => $tradeOfferId, 'team' => $offeringTeamName]);
+            (self::$logger ?? \Logging\LoggerFactory::getChannel('discord'))->warning('sendTradeDM skipped: recipient has no Discord ID', ['trade_id' => $tradeOfferId, 'team' => $offeringTeamName]);
             return null;
         }
 
         self::loadConfig();
 
         if (self::$iblbotUrl === '') {
-            self::$logger?->warning('sendTradeDM skipped: iblbot_url is empty in config', ['trade_id' => $tradeOfferId]);
+            (self::$logger ?? \Logging\LoggerFactory::getChannel('discord'))->warning('sendTradeDM skipped: iblbot_url is empty in config', ['trade_id' => $tradeOfferId]);
             return null;
         }
 

--- a/ibl5/classes/Discord/Discord.php
+++ b/ibl5/classes/Discord/Discord.php
@@ -16,6 +16,11 @@ class Discord
 
     private TeamIdentityRepositoryInterface $commonRepo;
 
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('discord').
+     */
+    private static ?\Psr\Log\LoggerInterface $logger = null;
+
     /** @var array<string, string> Discord webhook URLs loaded from config */
     private static array $webhooks = [];
 
@@ -71,9 +76,10 @@ class Discord
         return self::isProduction() ? self::IBL_GUILD_ID : self::IBL_GUILD_ID_TESTING;
     }
 
-    public function __construct(TeamIdentityRepositoryInterface $commonRepo)
+    public function __construct(TeamIdentityRepositoryInterface $commonRepo, ?\Psr\Log\LoggerInterface $logger = null)
     {
         $this->commonRepo = $commonRepo;
+        self::$logger = $logger ?? \Logging\LoggerFactory::getChannel('discord');
         self::loadConfig();
     }
 
@@ -191,14 +197,14 @@ class Discord
 
         // Skip if recipient has no Discord ID
         if ($recipientDiscordId === '') {
-            \Logging\LoggerFactory::getChannel('discord')->warning('sendDM skipped: recipient has no Discord ID');
+            self::$logger?->warning('sendDM skipped: recipient has no Discord ID');
             return null;
         }
 
         self::loadConfig();
 
         if (self::$iblbotUrl === '') {
-            \Logging\LoggerFactory::getChannel('discord')->warning('sendDM skipped: iblbot_url is empty in config');
+            self::$logger?->warning('sendDM skipped: iblbot_url is empty in config');
             return null;
         }
 
@@ -263,14 +269,14 @@ class Discord
 
         // Skip if recipient has no Discord ID
         if ($recipientDiscordId === '') {
-            \Logging\LoggerFactory::getChannel('discord')->warning('sendTradeDM skipped: recipient has no Discord ID', ['trade_id' => $tradeOfferId, 'team' => $offeringTeamName]);
+            self::$logger?->warning('sendTradeDM skipped: recipient has no Discord ID', ['trade_id' => $tradeOfferId, 'team' => $offeringTeamName]);
             return null;
         }
 
         self::loadConfig();
 
         if (self::$iblbotUrl === '') {
-            \Logging\LoggerFactory::getChannel('discord')->warning('sendTradeDM skipped: iblbot_url is empty in config', ['trade_id' => $tradeOfferId]);
+            self::$logger?->warning('sendTradeDM skipped: iblbot_url is empty in config', ['trade_id' => $tradeOfferId]);
             return null;
         }
 

--- a/ibl5/classes/FreeAgency/FreeAgencyAdminProcessor.php
+++ b/ibl5/classes/FreeAgency/FreeAgencyAdminProcessor.php
@@ -24,10 +24,16 @@ class FreeAgencyAdminProcessor implements FreeAgencyAdminProcessorInterface
     private FreeAgencyAdminRepositoryInterface $repository;
     private \mysqli $db;
 
-    public function __construct(FreeAgencyAdminRepositoryInterface $repository, \mysqli $db)
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
+    public function __construct(FreeAgencyAdminRepositoryInterface $repository, \mysqli $db, ?\Psr\Log\LoggerInterface $logger = null)
     {
         $this->repository = $repository;
         $this->db = $db;
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /**
@@ -238,7 +244,7 @@ class FreeAgencyAdminProcessor implements FreeAgencyAdminProcessorInterface
         $successCount = $counts['successCount'];
         $errorCount = $counts['errorCount'];
 
-        \Logging\LoggerFactory::getChannel('audit')->info('fa_signings_executed', [
+        $this->logger->info('fa_signings_executed', [
             'action' => 'fa_signings_executed',
             'day' => $day,
             'success_count' => $successCount,
@@ -269,7 +275,7 @@ class FreeAgencyAdminProcessor implements FreeAgencyAdminProcessorInterface
     {
         $this->repository->clearAllOffers();
 
-        \Logging\LoggerFactory::getChannel('audit')->info('fa_offers_cleared', [
+        $this->logger->info('fa_offers_cleared', [
             'action' => 'fa_offers_cleared',
         ]);
 

--- a/ibl5/classes/FreeAgency/FreeAgencyController.php
+++ b/ibl5/classes/FreeAgency/FreeAgencyController.php
@@ -21,11 +21,17 @@ class FreeAgencyController
     private \Utilities\NukeCompat $nukeCompat;
     private AuthServiceInterface $authService;
 
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     public function __construct(
         \mysqli $db,
         TeamIdentityRepositoryInterface $commonRepository,
         AuthServiceInterface $authService,
-        ?\Utilities\NukeCompat $nukeCompat = null
+        ?\Utilities\NukeCompat $nukeCompat = null,
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->db = $db;
         $this->commonRepository = $commonRepository;
@@ -36,6 +42,7 @@ class FreeAgencyController
         $this->view = new FreeAgencyView($commonRepository);
         $this->processor = new FreeAgencyProcessor($db, $commonRepository);
         $this->nukeCompat = $nukeCompat ?? new \Utilities\NukeCompat();
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /**
@@ -115,7 +122,7 @@ class FreeAgencyController
             $postData = $_POST;
             $result = $this->processor->processOfferSubmission($postData);
         } catch (\Throwable $e) {
-            \Logging\LoggerFactory::getChannel('audit')->error('fa_offer_error', [
+            $this->logger->error('fa_offer_error', [
                 'error' => $e->getMessage(),
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),
@@ -171,7 +178,7 @@ class FreeAgencyController
             $teamName = isset($_POST['teamname']) && is_string($_POST['teamname']) ? $_POST['teamname'] : '';
             $this->processor->deleteOffers($teamName, $playerID);
         } catch (\Throwable $e) {
-            \Logging\LoggerFactory::getChannel('audit')->error('fa_delete_error', [
+            $this->logger->error('fa_delete_error', [
                 'error' => $e->getMessage(),
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),

--- a/ibl5/classes/FreeAgency/FreeAgencyProcessor.php
+++ b/ibl5/classes/FreeAgency/FreeAgencyProcessor.php
@@ -23,11 +23,17 @@ class FreeAgencyProcessor implements FreeAgencyProcessorInterface
     private Season $season;
     private TeamIdentityRepositoryInterface $commonRepo;
 
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     public function __construct(
         \mysqli $mysqli_db,
         TeamIdentityRepositoryInterface $commonRepo,
         ?FreeAgencyDemandCalculatorInterface $calculator = null,
-        ?FreeAgencyRepositoryInterface $repository = null
+        ?FreeAgencyRepositoryInterface $repository = null,
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->mysqli_db = $mysqli_db;
         $this->season = new Season($mysqli_db);
@@ -37,6 +43,7 @@ class FreeAgencyProcessor implements FreeAgencyProcessorInterface
             new FreeAgencyDemandRepository($this->mysqli_db)
         );
         $this->repository = $repository ?? new FreeAgencyRepository($this->mysqli_db);
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /**
@@ -252,7 +259,7 @@ class FreeAgencyProcessor implements FreeAgencyProcessorInterface
         }
 
         if ($saved) {
-            \Logging\LoggerFactory::getChannel('audit')->info('fa_offer_submitted', [
+            $this->logger->info('fa_offer_submitted', [
                 'action' => 'fa_offer_submitted',
                 'player_id' => $player->getPlayerID() ?? 0,
                 'player_name' => $playerName,
@@ -323,7 +330,7 @@ _**{$playerTeam}** GM <@!$playerTeamDiscordID> could not be reached for comment.
 
         $this->repository->deleteOffer($teamid, $playerID);
 
-        \Logging\LoggerFactory::getChannel('audit')->info('fa_offer_deleted', [
+        $this->logger->info('fa_offer_deleted', [
             'action' => 'fa_offer_deleted',
             'team_name' => $teamName,
             'player_id' => $playerID,

--- a/ibl5/classes/LeagueControlPanel/LeagueControlPanelProcessor.php
+++ b/ibl5/classes/LeagueControlPanel/LeagueControlPanelProcessor.php
@@ -38,16 +38,23 @@ class LeagueControlPanelProcessor implements LeagueControlPanelProcessorInterfac
     private string $league;
     private ?MaintenanceRepositoryInterface $maintenanceRepository;
 
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('admin').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     public function __construct(
         LeagueControlPanelRepositoryInterface $repository,
         AwardGenerationServiceInterface $awardGenerationService,
         string $league = LeagueContext::LEAGUE_IBL,
         ?MaintenanceRepositoryInterface $maintenanceRepository = null,
+        ?\Psr\Log\LoggerInterface $logger = null,
     ) {
         $this->repository = $repository;
         $this->awardGenerationService = $awardGenerationService;
         $this->league = $league;
         $this->maintenanceRepository = $maintenanceRepository;
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('admin');
     }
 
     /**
@@ -83,7 +90,7 @@ class LeagueControlPanelProcessor implements LeagueControlPanelProcessorInterfac
         };
 
         if ($result['success']) {
-            \Logging\LoggerFactory::getChannel('admin')->info('admin_action', [
+            $this->logger->info('admin_action', [
                 'action' => $action,
                 'message' => $result['message'],
             ]);

--- a/ibl5/classes/Mail/MailService.php
+++ b/ibl5/classes/Mail/MailService.php
@@ -26,6 +26,11 @@ class MailService implements MailServiceInterface
     private array $smtpConfig;
     private string $defaultFromName;
 
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('mail').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     private const VALID_TRANSPORTS = ['smtp', 'mail', 'log'];
 
     private const DEFAULT_CONFIG = [
@@ -44,7 +49,7 @@ class MailService implements MailServiceInterface
     /**
      * @param MailConfig $config
      */
-    public function __construct(array $config)
+    public function __construct(array $config, ?\Psr\Log\LoggerInterface $logger = null)
     {
         $transport = $config['transport'] ?? 'log';
         if (!in_array($transport, self::VALID_TRANSPORTS, true)) {
@@ -65,6 +70,8 @@ class MailService implements MailServiceInterface
         $this->defaultFromName = is_string($config['default_from_name'] ?? null)
             ? $config['default_from_name']
             : self::DEFAULT_CONFIG['default_from_name'];
+
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('mail');
     }
 
     /**
@@ -184,7 +191,7 @@ class MailService implements MailServiceInterface
 
             return $mail->send();
         } catch (PHPMailerException $e) {
-            \Logging\LoggerFactory::getChannel('mail')->error('SMTP send failed', ['error' => $e->getMessage()]);
+            $this->logger->error('SMTP send failed', ['error' => $e->getMessage()]);
             return false;
         }
     }
@@ -200,7 +207,7 @@ class MailService implements MailServiceInterface
 
     private function sendViaLog(string $to, string $subject, string $body, string $fromEmail): bool
     {
-        \Logging\LoggerFactory::getChannel('mail')->info('LOG transport — mail sent', [
+        $this->logger->info('LOG transport — mail sent', [
             'to' => $to,
             'from' => $fromEmail,
             'subject' => $subject,

--- a/ibl5/classes/OneOnOneGame/OneOnOneGameService.php
+++ b/ibl5/classes/OneOnOneGame/OneOnOneGameService.php
@@ -23,12 +23,19 @@ class OneOnOneGameService implements OneOnOneGameServiceInterface
     private OneOnOneGameRepositoryInterface $repository;
     private OneOnOneGameEngineInterface $gameEngine;
 
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     public function __construct(
         OneOnOneGameRepositoryInterface $repository,
-        ?OneOnOneGameEngineInterface $gameEngine = null
+        ?OneOnOneGameEngineInterface $gameEngine = null,
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->repository = $repository;
         $this->gameEngine = $gameEngine ?? new OneOnOneGameEngine();
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /**
@@ -63,7 +70,7 @@ class OneOnOneGameService implements OneOnOneGameServiceInterface
         // Post to Discord
         $this->postToDiscord($result, $gameId);
 
-        \Logging\LoggerFactory::getChannel('audit')->info('one_on_one_game_played', [
+        $this->logger->info('one_on_one_game_played', [
             'action' => 'one_on_one_game_played',
             'game_id' => $gameId,
             'player1_id' => $player1Id,

--- a/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderService.php
+++ b/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderService.php
@@ -25,9 +25,15 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
 
     private ProjectedDraftOrderRepositoryInterface $repository;
 
-    public function __construct(ProjectedDraftOrderRepositoryInterface $repository)
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
+    public function __construct(ProjectedDraftOrderRepositoryInterface $repository, ?\Psr\Log\LoggerInterface $logger = null)
     {
         $this->repository = $repository;
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /** @return ProjectedDraftOrderResult */
@@ -181,7 +187,7 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
         $ownerName = $ownership !== null ? $ownership['ownerName'] : $firstTeamName;
         $this->repository->upsertLotteryWinnerAward($seasonYear, $ownerName);
 
-        \Logging\LoggerFactory::getChannel('audit')->info('lottery_order_saved', [
+        $this->logger->info('lottery_order_saved', [
             'action' => 'lottery_order_saved',
             'season_year' => $seasonYear,
             'first_pick_team' => $firstTeamName,

--- a/ibl5/classes/SavedDepthChart/SavedDepthChartService.php
+++ b/ibl5/classes/SavedDepthChart/SavedDepthChartService.php
@@ -20,10 +20,16 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
     private SavedDepthChartRepository $repository;
     private \mysqli $db;
 
-    public function __construct(\mysqli $db)
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
+    public function __construct(\mysqli $db, ?\Psr\Log\LoggerInterface $logger = null)
     {
         $this->db = $db;
         $this->repository = new SavedDepthChartRepository($db);
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /**
@@ -56,7 +62,7 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
 
                     $this->db->commit();
 
-                    \Logging\LoggerFactory::getChannel('audit')->info('depth_chart_saved', [
+                    $this->logger->info('depth_chart_saved', [
                         'action' => 'depth_chart_saved',
                         'dc_id' => $loadedDcId,
                         'team_id' => $teamid,
@@ -82,7 +88,7 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
 
                 $this->db->commit();
 
-                \Logging\LoggerFactory::getChannel('audit')->info('depth_chart_saved', [
+                $this->logger->info('depth_chart_saved', [
                     'action' => 'depth_chart_saved',
                     'dc_id' => $mostRecent['id'],
                     'team_id' => $teamid,
@@ -113,7 +119,7 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
 
             $this->db->commit();
 
-            \Logging\LoggerFactory::getChannel('audit')->info('depth_chart_saved', [
+            $this->logger->info('depth_chart_saved', [
                 'action' => 'depth_chart_saved',
                 'dc_id' => $dcId,
                 'team_id' => $teamid,

--- a/ibl5/classes/Trading/TradeOffer.php
+++ b/ibl5/classes/Trading/TradeOffer.php
@@ -28,6 +28,11 @@ use Discord\Discord;
  */
 class TradeOffer implements TradeOfferInterface
 {
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('trade').
+     */
+    protected \Psr\Log\LoggerInterface $logger;
+
     protected \mysqli $db;
     protected TradeOfferRepositoryInterface $offerRepository;
     protected TradeAssetRepositoryInterface $assetRepository;
@@ -48,7 +53,8 @@ class TradeOffer implements TradeOfferInterface
         ?TradeCashRepositoryInterface $cashRepository = null,
         ?BuyoutLedgerRepositoryInterface $cashConsiderationRepository = null,
         ?Season $season = null,
-        ?TradeValidator $validator = null
+        ?TradeValidator $validator = null,
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->db = $db;
         $this->commonRepository = $commonRepository;
@@ -59,13 +65,14 @@ class TradeOffer implements TradeOfferInterface
         $this->season = $season ?? new Season($db);
         $this->cashHandler = new CashTransactionHandler($db, $this->commonRepository, $this->cashConsiderationRepository, $this->cashRepository);
         $this->validator = $validator ?? new TradeValidator($db);
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('trade');
 
         // Initialize Discord with error handling (may fail if column doesn't exist)
         try {
             $this->discord = new Discord($this->commonRepository);
         } catch (\Exception $e) {
             // Discord unavailable - will skip notifications
-            \Logging\LoggerFactory::getChannel('trade')->warning('Discord initialization failed in TradeOffer', ['error' => $e->getMessage()]);
+            $this->logger->warning('Discord initialization failed in TradeOffer', ['error' => $e->getMessage()]);
             $this->discord = null;
         }
     }
@@ -488,7 +495,7 @@ class TradeOffer implements TradeOfferInterface
     {
         // Skip notification if Discord is not available
         if ($this->discord === null) {
-            \Logging\LoggerFactory::getChannel('trade')->warning('Discord notification skipped: Discord class not initialized', ['trade_id' => $tradeOfferId]);
+            $this->logger->warning('Discord notification skipped: Discord class not initialized', ['trade_id' => $tradeOfferId]);
             return;
         }
 
@@ -499,7 +506,7 @@ class TradeOffer implements TradeOfferInterface
             $receivingUserDiscordID = $this->discord->getDiscordIDFromTeamname($listeningTeamName);
 
             if ($receivingUserDiscordID === '' || $receivingUserDiscordID === '0') {
-                \Logging\LoggerFactory::getChannel('trade')->warning('Discord notification skipped: no Discord ID for team', ['trade_id' => $tradeOfferId, 'team' => $listeningTeamName]);
+                $this->logger->warning('Discord notification skipped: no Discord ID for team', ['trade_id' => $tradeOfferId, 'team' => $listeningTeamName]);
                 return;
             }
 
@@ -507,7 +514,7 @@ class TradeOffer implements TradeOfferInterface
 
             Discord::sendTradeDM($receivingUserDiscordID, $tradeOfferId, $offeringTeamName, $cleanTradeText);
         } catch (\Exception $e) {
-            \Logging\LoggerFactory::getChannel('trade')->error('Discord notification failed', ['trade_id' => $tradeOfferId, 'error' => $e->getMessage()]);
+            $this->logger->error('Discord notification failed', ['trade_id' => $tradeOfferId, 'error' => $e->getMessage()]);
         }
     }
 }

--- a/ibl5/classes/Updater/ScheduleUpdater.php
+++ b/ibl5/classes/Updater/ScheduleUpdater.php
@@ -46,11 +46,17 @@ class ScheduleUpdater extends \BaseMysqliRepository {
 
     private string $basePath;
 
-    public function __construct(\mysqli $db, Season $season, ?LeagueContext $leagueContext = null, ?JsbSourceResolverInterface $sourceResolver = null, ?string $basePath = null) {
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('db').
+     */
+    private \Psr\Log\LoggerInterface $channelLogger;
+
+    public function __construct(\mysqli $db, Season $season, ?LeagueContext $leagueContext = null, ?JsbSourceResolverInterface $sourceResolver = null, ?string $basePath = null, ?\Psr\Log\LoggerInterface $logger = null) {
         parent::__construct($db, $leagueContext);
         $this->season = $season;
         $this->sourceResolver = $sourceResolver;
         $this->basePath = $basePath ?? \Bootstrap\AppPaths::root();
+        $this->channelLogger = $logger ?? \Logging\LoggerFactory::getChannel('db');
     }
 
     /**
@@ -325,7 +331,7 @@ class ScheduleUpdater extends \BaseMysqliRepository {
                     $log .= "Inserted game: {$visitorName} @ {$homeName} on {$date}<br>";
                 } catch (\Exception $e) {
                     $errorMessage = "Failed to insert schedule data for game between {$visitorName} and {$homeName}: " . $e->getMessage();
-                    \Logging\LoggerFactory::getChannel('db')->error('ScheduleUpdater database insert error', ['error' => $errorMessage]);
+                    $this->channelLogger->error('ScheduleUpdater database insert error', ['error' => $errorMessage]);
                     echo '<strong class="ibl-form-error">Script Error: Failed to insert schedule data for game between ' . HtmlSanitizer::e($visitorName) . ' and ' . HtmlSanitizer::e($homeName) . '.</strong>';
                     throw new \RuntimeException($errorMessage, 1002);
                 }

--- a/ibl5/classes/Updater/Steps/ResetExtensionAttemptsStep.php
+++ b/ibl5/classes/Updater/Steps/ResetExtensionAttemptsStep.php
@@ -14,9 +14,16 @@ use Updater\StepResult;
  */
 class ResetExtensionAttemptsStep implements PipelineStepInterface
 {
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('db').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     public function __construct(
         private readonly \mysqli $db,
+        ?\Psr\Log\LoggerInterface $logger = null,
     ) {
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('db');
     }
 
     public function getLabel(): string
@@ -37,7 +44,7 @@ class ResetExtensionAttemptsStep implements PipelineStepInterface
             $stmt->close();
         } catch (\Exception $e) {
             $errorMessage = 'Failed to reset sim contract extension attempts: ' . $e->getMessage();
-            \Logging\LoggerFactory::getChannel('db')->error('ResetExtensionAttemptsStep database error', ['error' => $errorMessage]);
+            $this->logger->error('ResetExtensionAttemptsStep database error', ['error' => $errorMessage]);
             throw new \RuntimeException($errorMessage, 1002);
         }
 

--- a/ibl5/classes/Voting/VotingSubmissionService.php
+++ b/ibl5/classes/Voting/VotingSubmissionService.php
@@ -22,6 +22,11 @@ use Voting\Contracts\VotingSubmissionServiceInterface;
  */
 class VotingSubmissionService implements VotingSubmissionServiceInterface
 {
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     /** @var array<string, string> EOY category code => display label (with article) */
     private const EOY_CATEGORIES = [
         'MVP' => 'an MVP',
@@ -48,7 +53,9 @@ class VotingSubmissionService implements VotingSubmissionServiceInterface
 
     public function __construct(
         private readonly VotingRepositoryInterface $repository,
+        ?\Psr\Log\LoggerInterface $logger = null,
     ) {
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /**
@@ -71,7 +78,7 @@ class VotingSubmissionService implements VotingSubmissionServiceInterface
         $this->repository->saveEoyVote($teamName, $ballot);
         $this->repository->markEoyVoteCast($teamName);
 
-        \Logging\LoggerFactory::getChannel('audit')->info('eoy_vote_submitted', [
+        $this->logger->info('eoy_vote_submitted', [
             'action' => 'eoy_vote_submitted',
             'team_name' => $teamName,
         ]);
@@ -100,7 +107,7 @@ class VotingSubmissionService implements VotingSubmissionServiceInterface
         $this->repository->saveAsgVote($teamName, $ballot);
         $this->repository->markAsgVoteCast($teamName);
 
-        \Logging\LoggerFactory::getChannel('audit')->info('asg_vote_submitted', [
+        $this->logger->info('asg_vote_submitted', [
             'action' => 'asg_vote_submitted',
             'team_name' => $teamName,
         ]);

--- a/ibl5/classes/Waivers/WaiversController.php
+++ b/ibl5/classes/Waivers/WaiversController.php
@@ -31,6 +31,11 @@ class WaiversController implements WaiversControllerInterface
     private \Utilities\NukeCompat $nukeCompat;
     private \mysqli $db;
 
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     public function __construct(
         WaiversServiceInterface $service,
         WaiversProcessorInterface $processor,
@@ -38,7 +43,8 @@ class WaiversController implements WaiversControllerInterface
         \Repositories\Contracts\TeamIdentityRepositoryInterface $teamIdentityRepo,
         \Repositories\Contracts\SalaryCapRepositoryInterface $salaryCapRepo,
         \Utilities\NukeCompat $nukeCompat,
-        \mysqli $db
+        \mysqli $db,
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->service = $service;
         $this->processor = $processor;
@@ -47,6 +53,7 @@ class WaiversController implements WaiversControllerInterface
         $this->salaryCapRepo = $salaryCapRepo;
         $this->nukeCompat = $nukeCompat;
         $this->db = $db;
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /**
@@ -99,7 +106,7 @@ class WaiversController implements WaiversControllerInterface
                 $postData = $_POST;
                 $result = $this->processWaiverSubmission($postData);
             } catch (\Throwable $e) {
-                \Logging\LoggerFactory::getChannel('audit')->error('waiver_submission_error', [
+                $this->logger->error('waiver_submission_error', [
                     'error' => $e->getMessage(),
                     'file' => $e->getFile(),
                     'line' => $e->getLine(),

--- a/ibl5/classes/Waivers/WaiversProcessor.php
+++ b/ibl5/classes/Waivers/WaiversProcessor.php
@@ -32,13 +32,19 @@ class WaiversProcessor implements WaiversProcessorInterface
     private \Topics\News\NewsRepository $newsService;
     private \mysqli $db;
 
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     public function __construct(
         WaiversRepositoryInterface $repository,
         \Repositories\Contracts\TeamIdentityRepositoryInterface $teamIdentityRepo,
         \Repositories\Contracts\PlayerLookupRepositoryInterface $playerLookupRepo,
         WaiversValidatorInterface $validator,
         \Topics\News\NewsRepository $newsService,
-        \mysqli $db
+        \mysqli $db,
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->repository = $repository;
         $this->teamIdentityRepo = $teamIdentityRepo;
@@ -47,6 +53,7 @@ class WaiversProcessor implements WaiversProcessorInterface
         $this->newsService = $newsService;
         $this->db = $db;
         $this->contractCalculator = new PlayerContractCalculator();
+        $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
     /**
@@ -180,10 +187,10 @@ class WaiversProcessor implements WaiversProcessorInterface
         try {
             Discord::postToChannel('#waiver-wire', $hometext);
         } catch (\Throwable $discordErr) {
-            \Logging\LoggerFactory::getChannel('audit')->warning('waiver_discord_notification_failed', ['error' => $discordErr->getMessage()]);
+            $this->logger->warning('waiver_discord_notification_failed', ['error' => $discordErr->getMessage()]);
         }
 
-        \Logging\LoggerFactory::getChannel('audit')->info('player_waived', [
+        $this->logger->info('player_waived', [
             'action' => 'player_waived',
             'player_id' => $playerID,
             'player_name' => $playerName,
@@ -239,10 +246,10 @@ class WaiversProcessor implements WaiversProcessorInterface
         try {
             Discord::postToChannel('#waiver-wire', $hometext);
         } catch (\Throwable $discordErr) {
-            \Logging\LoggerFactory::getChannel('audit')->warning('waiver_discord_notification_failed', ['error' => $discordErr->getMessage()]);
+            $this->logger->warning('waiver_discord_notification_failed', ['error' => $discordErr->getMessage()]);
         }
 
-        \Logging\LoggerFactory::getChannel('audit')->info('player_signed_from_waivers', [
+        $this->logger->info('player_signed_from_waivers', [
             'action' => 'player_signed_from_waivers',
             'player_id' => $playerID,
             'player_name' => $playerName,

--- a/ibl5/classes/Waivers/WaiversRepository.php
+++ b/ibl5/classes/Waivers/WaiversRepository.php
@@ -16,13 +16,19 @@ use Waivers\Contracts\WaiversRepositoryInterface;
 class WaiversRepository extends BaseMysqliRepository implements WaiversRepositoryInterface
 {
     /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('db').
+     */
+    private \Psr\Log\LoggerInterface $channelLogger;
+
+    /**
      * Constructor
      *
      * @param \mysqli $db Active mysqli connection
      */
-    public function __construct(\mysqli $db)
+    public function __construct(\mysqli $db, ?\Psr\Log\LoggerInterface $logger = null)
     {
         parent::__construct($db);
+        $this->channelLogger = $logger ?? \Logging\LoggerFactory::getChannel('db');
     }
     
     /**
@@ -75,7 +81,7 @@ class WaiversRepository extends BaseMysqliRepository implements WaiversRepositor
 
             return $affectedRows > 0;
         } catch (\RuntimeException $e) {
-            \Logging\LoggerFactory::getChannel('db')->error('Failed to sign player from waivers', ['error' => $e->getMessage()]);
+            $this->channelLogger->error('Failed to sign player from waivers', ['error' => $e->getMessage()]);
             return false;
         }
     }

--- a/ibl5/classes/YourAccount/YourAccountService.php
+++ b/ibl5/classes/YourAccount/YourAccountService.php
@@ -27,6 +27,11 @@ class YourAccountService implements YourAccountServiceInterface
     private string $adminEmail;
     private int $minPasswordLength;
 
+    /**
+     * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('auth').
+     */
+    private \Psr\Log\LoggerInterface $logger;
+
     public function __construct(
         AuthServiceInterface $authService,
         TeamIdentityRepositoryInterface $commonRepository,
@@ -35,6 +40,7 @@ class YourAccountService implements YourAccountServiceInterface
         string $siteName,
         string $adminEmail,
         int $minPasswordLength = 5,
+        ?\Psr\Log\LoggerInterface $logger = null,
     ) {
         $this->authService = $authService;
         $this->commonRepository = $commonRepository;
@@ -43,6 +49,7 @@ class YourAccountService implements YourAccountServiceInterface
         $this->siteName = $siteName;
         $this->adminEmail = $adminEmail;
         $this->minPasswordLength = $minPasswordLength;
+        $this->logger = $logger ?? LoggerFactory::getChannel('auth');
     }
 
     /**
@@ -51,7 +58,7 @@ class YourAccountService implements YourAccountServiceInterface
     public function attemptLogin(string $username, string $password, bool $rememberMe, string $clientIp): array
     {
         if ($this->authService->attempt($username, $password, $rememberMe)) {
-            LoggerFactory::getChannel('auth')->info('login_success', [
+            $this->logger->info('login_success', [
                 'username' => $username,
                 'client_ip' => $clientIp,
             ]);
@@ -59,7 +66,7 @@ class YourAccountService implements YourAccountServiceInterface
         }
 
         $error = $this->authService->getLastError();
-        LoggerFactory::getChannel('auth')->warning('login_failed', [
+        $this->logger->warning('login_failed', [
             'username' => $username,
             'client_ip' => $clientIp,
             'error' => $error,
@@ -93,7 +100,7 @@ class YourAccountService implements YourAccountServiceInterface
                 },
             );
 
-            LoggerFactory::getChannel('auth')->info('user_registered', [
+            $this->logger->info('user_registered', [
                 'username' => $username,
             ]);
             return ['success' => true, 'error' => null];
@@ -145,7 +152,7 @@ class YourAccountService implements YourAccountServiceInterface
             return ['success' => false, 'error' => $error];
         }
 
-        LoggerFactory::getChannel('auth')->info('password_reset_requested');
+        $this->logger->info('password_reset_requested');
         return ['success' => true, 'error' => null];
     }
 
@@ -160,7 +167,7 @@ class YourAccountService implements YourAccountServiceInterface
 
         try {
             $this->authService->resetPassword($selector, $token, $newPassword);
-            LoggerFactory::getChannel('auth')->info('password_reset_completed');
+            $this->logger->info('password_reset_completed');
             return ['success' => true, 'error' => null];
         } catch (\RuntimeException) {
             $error = $this->authService->getLastError() ?? 'An error occurred while resetting your password.';
@@ -173,7 +180,7 @@ class YourAccountService implements YourAccountServiceInterface
      */
     public function logout(): void
     {
-        LoggerFactory::getChannel('auth')->info('logout');
+        $this->logger->info('logout');
         $this->authService->logout();
     }
 

--- a/ibl5/tests/Trading/TradeOfferTest.php
+++ b/ibl5/tests/Trading/TradeOfferTest.php
@@ -62,6 +62,7 @@ class TradeOfferTest extends TestCase
                 $this->cashHandler = $cashHandler;
                 $this->validator = $validator;
                 $this->discord = $discord;
+                $this->logger = \Logging\LoggerFactory::getChannel('trade');
             }
         };
     }

--- a/ibl5/tests/UpdateAllTheThings/ScheduleUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/ScheduleUpdaterTest.php
@@ -340,4 +340,25 @@ class ScheduleUpdaterTest extends TestCase
         $this->assertNotEmpty($queries);
         $this->assertSame('DELETE FROM ibl_olympics_schedule', $queries[0]);
     }
+
+    // ==================== DI Seam ====================
+
+    public function testInjectedLoggerIsStoredAsChannelLogger(): void
+    {
+        // Stub (no expectations) is sufficient — we just verify the identity, not call tracking
+        $logger = self::createStub(\Psr\Log\LoggerInterface::class);
+        // Logger is the 6th (last) param — verify it lands in $channelLogger, not shadowing parent $logger
+        $updater = new ScheduleUpdater($this->mockDb, $this->mockSeason, null, null, null, $logger);
+
+        $ref = new \ReflectionProperty(ScheduleUpdater::class, 'channelLogger');
+        $this->assertSame($logger, $ref->getValue($updater));
+    }
+
+    public function testConstructsWithoutLoggerArgAndFallbackFires(): void
+    {
+        // no logger arg → trailing-optional defaults to null, fallback fires, no TypeError
+        $updater = new ScheduleUpdater($this->mockDb, $this->mockSeason);
+        $reflection = new \ReflectionClass($updater);
+        $this->assertTrue($reflection->hasMethod('update'));
+    }
 }

--- a/ibl5/tests/Voting/VotingSubmissionServiceTest.php
+++ b/ibl5/tests/Voting/VotingSubmissionServiceTest.php
@@ -418,6 +418,29 @@ final class VotingSubmissionServiceTest extends TestCase
         $this->assertAuditLogNotEmitted('asg_vote_submitted');
     }
 
+    // ==================== DI Seam ====================
+
+    public function testInjectedLoggerReceivesCallOnEoySuccess(): void
+    {
+        $ballot = self::validEoyBallot();
+        $repo = self::createStub(VotingRepositoryInterface::class);
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('info')
+            ->with('eoy_vote_submitted', self::arrayHasKey('team_name'));
+
+        $service = new VotingSubmissionService($repo, $logger);
+        $service->submitEoyVote('Test Team', $ballot);
+    }
+
+    public function testConstructsWithoutLoggerArgAndFallbackFires(): void
+    {
+        // no logger arg → fallback fires; prove the service is usable (no TypeError)
+        $repo = self::createStub(VotingRepositoryInterface::class);
+        $service = new VotingSubmissionService($repo);
+        $result = $service->submitEoyVote('Other Team', self::validEoyBallot());
+        $this->assertFalse($result->hasErrors());
+    }
+
     // ==================== Fixtures ====================
 
     /**

--- a/ibl5/tests/Waivers/WaiversRepositoryTest.php
+++ b/ibl5/tests/Waivers/WaiversRepositoryTest.php
@@ -109,25 +109,25 @@ class WaiversRepositoryTest extends TestCase
     public function testSignPlayerFromWaiversWithNewContractDuringFreeAgency(): void
     {
         $this->mockDb->setReturnTrue(true);
-        
+
         $team = [
             'team_name' => 'Los Angeles Lakers',
             'teamid' => 14
         ];
-        
+
         $contractData = [
             'hasExistingContract' => false,
             'salary' => 76
         ];
-        
+
         $result = $this->repository->signPlayerFromWaivers(
             456,
             $team,
             $contractData
         );
-        
+
         $this->assertTrue($result);
-        
+
         $queries = $this->mockDb->getExecutedQueries();
         $this->assertCount(1, $queries);
         $this->assertStringContainsString('UPDATE ibl_plr', $queries[0]);
@@ -139,5 +139,36 @@ class WaiversRepositoryTest extends TestCase
         $this->assertStringContainsString('droptime', $queries[0]);
         $this->assertStringContainsString('= 0', $queries[0]);
     }
-    
+
+    // ==================== DI Seam ====================
+
+    public function testInjectedChannelLoggerReceivesCallOnDbError(): void
+    {
+        $mockDb = new MockDatabase();
+        $mockDb->setReturnTrue(false); // make the UPDATE fail → RuntimeException → logger path
+
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')
+            ->with('Failed to sign player from waivers', self::arrayHasKey('error'));
+
+        $repo = new WaiversRepository($mockDb, $logger);
+        $result = $repo->signPlayerFromWaivers(
+            123,
+            ['teamid' => 1, 'team_name' => 'Test'],
+            ['hasExistingContract' => false, 'salary' => 100]
+        );
+
+        $this->assertFalse($result);
+    }
+
+    public function testConstructsWithoutLoggerArgAndFallbackFires(): void
+    {
+        // no logger arg → fallback fires; prove the repo is usable (no TypeError)
+        $mockDb = new MockDatabase();
+        $repo = new WaiversRepository($mockDb);
+        $mockDb->setReturnTrue(true);
+        $result = $repo->dropPlayerToWaivers(1, time());
+        $this->assertTrue($result);
+    }
+
 }


### PR DESCRIPTION
## Summary

Injects `?\Psr\Log\LoggerInterface` into 20 single-channel classes under `ibl5/classes/`, retiring the inline `\Logging\LoggerFactory::getChannel('<chan>')` locator calls. Replicates the established pattern from `BaseMysqliRepository`: optional trailing constructor param + per-class channel fallback + inline-call rewrites.

This is a green-green, no-behavior-change refactor (backlog 14.14 / chunk C16c). All existing `new X(...)` call sites are unchanged (trailing-optional param). No migrations, no security surface, no container registration changes.

**In-scope:** 20 single-channel classes with a constructor seam.
**Out of scope / deferred:** 7 multi-channel classes, `DevAutoLogin` (all-static), and the hard-cutover (removing the fallback entirely).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.