### PR TITLE
refactor: convert Auth\DevAutoLogin static→instance with injectable 'auth' logger

### DIFF
--- a/ibl5/classes/Auth/DevAutoLogin.php
+++ b/ibl5/classes/Auth/DevAutoLogin.php
@@ -26,7 +26,14 @@ final class DevAutoLogin
 {
     private const ENV_VAR_NAME = 'DEV_AUTO_LOGIN';
 
-    public static function tryAutoLogin(\mysqli $db): void
+    private \Psr\Log\LoggerInterface $logger;
+
+    public function __construct(?\Psr\Log\LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?? LoggerFactory::getChannel('auth');
+    }
+
+    public function tryAutoLogin(\mysqli $db): void
     {
         // Guard 1: already authenticated — nothing to do
         if (isset($_SESSION['auth_user_id']) && is_int($_SESSION['auth_user_id']) && $_SESSION['auth_user_id'] > 0) {
@@ -35,12 +42,12 @@ final class DevAutoLogin
 
         // Guard 2: only on localhost (exact match or *.localhost subdomains for worktrees)
         $serverName = $_SERVER['SERVER_NAME'] ?? null;
-        if (!is_string($serverName) || !self::isLocalhost($serverName)) {
+        if (!is_string($serverName) || !$this->isLocalhost($serverName)) {
             return;
         }
 
         // Guard 3: DEV_AUTO_LOGIN must be set to a non-empty username
-        $username = self::getAutoLoginUsername();
+        $username = $this->getAutoLoginUsername();
         if ($username === null) {
             return;
         }
@@ -62,7 +69,7 @@ final class DevAutoLogin
         $stmt->close();
 
         if (!is_array($row) || !isset($row['user_id'])) {
-            LoggerFactory::getChannel('auth')->debug('Dev auto-login: user not found', ['username' => $username]);
+            $this->logger->debug('Dev auto-login: user not found', ['username' => $username]);
             return;
         }
 
@@ -74,10 +81,10 @@ final class DevAutoLogin
         $_SESSION['auth_user_id'] = (int) $row['user_id'];
         $_SESSION['auth_username'] = $username;
 
-        LoggerFactory::getChannel('auth')->debug('Dev auto-login activated', ['username' => $username]);
+        $this->logger->debug('Dev auto-login activated', ['username' => $username]);
     }
 
-    private static function getAutoLoginUsername(): ?string
+    private function getAutoLoginUsername(): ?string
     {
         // Check environment variable first (e.g., set in Docker Compose)
         $envValue = getenv(self::ENV_VAR_NAME);
@@ -111,7 +118,7 @@ final class DevAutoLogin
         return null;
     }
 
-    private static function isLocalhost(string $serverName): bool
+    private function isLocalhost(string $serverName): bool
     {
         if ($serverName === 'localhost' || $serverName === '127.0.0.1') {
             return true;

--- a/ibl5/classes/Bootstrap/AuthBootstrap.php
+++ b/ibl5/classes/Bootstrap/AuthBootstrap.php
@@ -40,7 +40,7 @@ class AuthBootstrap implements BootstrapStepInterface
         // E2E tests set _no_auto_login cookie to opt out.
         $noAutoLogin = isset($_COOKIE['_no_auto_login']) && $_COOKIE['_no_auto_login'] === '1';
         if (!$authService->isAuthenticated() && !$noAutoLogin) {
-            \Auth\DevAutoLogin::tryAutoLogin($mysqliDb);
+            (new \Auth\DevAutoLogin())->tryAutoLogin($mysqliDb);
         }
 
         // Populate legacy $user global for backward compat

--- a/ibl5/tests/Auth/DevAutoLoginTest.php
+++ b/ibl5/tests/Auth/DevAutoLoginTest.php
@@ -60,7 +60,7 @@ class DevAutoLoginTest extends TestCase
         putenv('DEV_AUTO_LOGIN=SomeOtherUser');
 
         $db = static::createStub(\mysqli::class);
-        DevAutoLogin::tryAutoLogin($db);
+        (new DevAutoLogin())->tryAutoLogin($db);
 
         // Session should remain unchanged — not overwritten with the env var user.
         // Both halves of the contract are asserted: tryAutoLogin() must leave the
@@ -79,7 +79,7 @@ class DevAutoLoginTest extends TestCase
         putenv('DEV_AUTO_LOGIN=A-Jay');
 
         $db = static::createStub(\mysqli::class);
-        DevAutoLogin::tryAutoLogin($db);
+        (new DevAutoLogin())->tryAutoLogin($db);
 
         self::assertArrayNotHasKey('auth_user_id', $_SESSION);
     }
@@ -102,7 +102,7 @@ class DevAutoLoginTest extends TestCase
         putenv('DEV_AUTO_LOGIN');
 
         $db = static::createStub(\mysqli::class);
-        DevAutoLogin::tryAutoLogin($db);
+        (new DevAutoLogin())->tryAutoLogin($db);
 
         self::assertArrayNotHasKey('auth_user_id', $_SESSION);
     }
@@ -113,7 +113,7 @@ class DevAutoLoginTest extends TestCase
         putenv('DEV_AUTO_LOGIN=');
 
         $db = static::createStub(\mysqli::class);
-        DevAutoLogin::tryAutoLogin($db);
+        (new DevAutoLogin())->tryAutoLogin($db);
 
         self::assertArrayNotHasKey('auth_user_id', $_SESSION);
     }
@@ -133,7 +133,7 @@ class DevAutoLoginTest extends TestCase
         $db = static::createStub(\mysqli::class);
         $db->method('prepare')->willReturn($stmt);
 
-        DevAutoLogin::tryAutoLogin($db);
+        (new DevAutoLogin())->tryAutoLogin($db);
 
         self::assertSame(99, $_SESSION['auth_user_id']);
         self::assertSame('TestUser', $_SESSION['auth_username']);
@@ -166,7 +166,7 @@ class DevAutoLoginTest extends TestCase
         $db = static::createStub(\mysqli::class);
         $db->method('prepare')->willReturn($stmt);
 
-        DevAutoLogin::tryAutoLogin($db);
+        (new DevAutoLogin())->tryAutoLogin($db);
 
         self::assertArrayNotHasKey('auth_user_id', $_SESSION);
     }
@@ -179,8 +179,57 @@ class DevAutoLoginTest extends TestCase
         $db = static::createStub(\mysqli::class);
         $db->method('prepare')->willReturn(false);
 
-        DevAutoLogin::tryAutoLogin($db);
+        (new DevAutoLogin())->tryAutoLogin($db);
 
         self::assertArrayNotHasKey('auth_user_id', $_SESSION);
+    }
+
+    public function testInjectedLoggerReceivesActivationLog(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        putenv('DEV_AUTO_LOGIN=TestUser');
+
+        $result = static::createStub(\mysqli_result::class);
+        $result->method('fetch_assoc')->willReturn(['user_id' => 99]);
+
+        $stmt = static::createStub(\mysqli_stmt::class);
+        $stmt->method('get_result')->willReturn($result);
+
+        $db = static::createStub(\mysqli::class);
+        $db->method('prepare')->willReturn($stmt);
+
+        $spy = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $spy->expects(self::once())
+            ->method('debug')
+            ->with('Dev auto-login activated', ['username' => 'TestUser']);
+
+        (new DevAutoLogin($spy))->tryAutoLogin($db);
+
+        // Seam proof: the injected logger received the activation log in place of
+        // the static getChannel('auth') factory (and the session was still set).
+        self::assertSame(99, $_SESSION['auth_user_id']);
+        self::assertSame('TestUser', $_SESSION['auth_username']);
+    }
+
+    public function testNoArgConstructorFallsBackToAuthChannelAndStillActivates(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        putenv('DEV_AUTO_LOGIN=TestUser');
+
+        $result = static::createStub(\mysqli_result::class);
+        $result->method('fetch_assoc')->willReturn(['user_id' => 99]);
+
+        $stmt = static::createStub(\mysqli_stmt::class);
+        $stmt->method('get_result')->willReturn($result);
+
+        $db = static::createStub(\mysqli::class);
+        $db->method('prepare')->willReturn($stmt);
+
+        // No logger arg — the ?? getChannel('auth') fallback must fire (the production
+        // AuthBootstrap form) without a TypeError, and the session writes are unchanged.
+        (new DevAutoLogin())->tryAutoLogin($db);
+
+        self::assertSame(99, $_SESSION['auth_user_id']);
+        self::assertSame('TestUser', $_SESSION['auth_username']);
     }
 }


### PR DESCRIPTION
## Summary

Converts `Auth\DevAutoLogin` from an all-static class to an instance class with an injectable `?\Psr\Log\LoggerInterface` constructor parameter. This is the deferred remainder of maintenance-48's logger DI sweep — DevAutoLogin was excluded because it had no DI seam (no constructor). The conversion:

- Adds `__construct(?\Psr\Log\LoggerInterface $logger = null)` with `?? LoggerFactory::getChannel('auth')` fallback (m48 pattern)
- De-statics `tryAutoLogin()` and its private helpers (`getAutoLoginUsername()`, `isLocalhost()`)
- Rewrites the two internal `LoggerFactory::getChannel('auth')->debug(...)` calls to `$this->logger->debug(...)`
- Rewrites the single production call site in `AuthBootstrap` from `::tryAutoLogin` → `(new DevAutoLogin())->tryAutoLogin`
- Rewrites 8 existing test static calls to instance calls (guards/behavior unchanged), adds 2 new tests (logger-seam + no-arg-fallback boundary)

**Behavior is byte-identical:** all three auth guards, session mutation, `session_regenerate_id(true)`, and the `'auth'` logger channel are unchanged.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

## Verification

All 10 `DevAutoLoginTest` cases green, PHPStan clean, zero residual static `::tryAutoLogin` calls in production, E2E row #14 (dev auto-login still works end-to-end on localhost) covered by Phase 5.

Generated with [Claude Code](https://claude.ai/code)
<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>