### PR TITLE
ci: deterministic human-signoff gate for feature PRs (ADR-0062)

### DIFF
--- a/.claude/rules/nightly-workflow.md
+++ b/.claude/rules/nightly-workflow.md
@@ -62,3 +62,7 @@ absolute targets keep resolving after the move. `queue/` (pending work) and `han
 ## Headless Mode
 
 `bin/nightly-run` sets `CLAUDE_HEADLESS=1`. This environment variable gates `/post-plan` Phase 10 (Preview Environment), which is skipped since no human is present to verify visually. All other phases run normally.
+
+## Feature PRs cannot auto-merge
+
+Conventional-commit **`feat:`** PRs are gated by the required `human-signoff` check and will **not** auto-merge overnight — they wait for a human to apply the `human-approved` label after inspection (ADR-0062). Post-plan still arms `--auto`, but `bin/nightly-run` strips it from `feat:` PRs (`neutralize_feat_signoff`), and the required check blocks the merge regardless. Maintenance PRs (`fix`/`refactor`/`chore`/`ci`/`docs`/`revert`) auto-merge as before. Check the morning `gh pr list` for `feat:` PRs awaiting your label.

--- a/.claude/rules/nightly-workflow.md
+++ b/.claude/rules/nightly-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: Nightly autonomous workflow — launchd fires claude -p at 00:03 and 05:03 daily, running two context-isolated agents per plan (implementation + post-plan) with time guards and incremental checkpoints.
-last_verified: 2026-06-11
+last_verified: 2026-06-18
 paths: "bin/nightly-*"
 ---
 

--- a/.github/workflows/human-signoff.yml
+++ b/.github/workflows/human-signoff.yml
@@ -1,0 +1,62 @@
+name: Human Sign-off
+
+# Deterministic human-sign-off gate for feature PRs.
+#
+# Why this exists: the nightly autonomous pipeline (bin/nightly-run → /post-plan
+# Phase 6.5) arms `gh pr merge --squash --auto`, and master's branch protection
+# requires no reviews — so feature PRs merged unattended overnight (see the
+# revert of #1073–#1076). A docs/frontmatter convention (#1072) could not stop
+# this: the nightly path never reads it and GitHub has nothing to block on.
+#
+# This job IS that block. Once added to master's required status checks, a
+# `feat:` PR stays un-mergeable (red required check) until a human inspects it
+# and applies the `human-approved` label. `--auto` queues but GitHub never
+# completes the merge while a required check is red. Non-feature work
+# (fix/refactor/chore/docs/ci/revert/…) passes automatically, so the nightly
+# pipeline can still auto-merge maintenance.
+
+on:
+  pull_request:
+    branches: [ master ]
+    # labeled/unlabeled re-run the gate so applying the label flips red→green;
+    # edited re-runs when the title (the classifier input) changes.
+    types: [opened, reopened, synchronize, edited, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: human-signoff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  human-signoff:
+    name: human-signoff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require human sign-off for feature PRs
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          # Classifier: conventional-commit feature PRs require sign-off. Matches
+          # feat:, feat(scope):, and the breaking-change feat!: / feat(scope)!:.
+          if ! printf '%s' "$TITLE" | grep -qiE '^feat(\([^)]*\))?!?:'; then
+            echo "Title is not a feat: PR — human sign-off not required."
+            echo "  title: $TITLE"
+            exit 0
+          fi
+
+          # A human grants sign-off by applying the 'human-approved' label in the
+          # GitHub UI after manual inspection. (Comma-wrap both sides so the grep
+          # matches whole label names, never a substring.)
+          if printf '%s' ",$LABELS," | grep -q ',human-approved,'; then
+            echo "'human-approved' label present — human sign-off granted."
+            exit 0
+          fi
+
+          echo "::error title=Human sign-off required::This feature PR must be manually inspected by a maintainer, who then applies the 'human-approved' label. Auto-merge cannot satisfy this gate."
+          exit 1

--- a/bin/nightly-run
+++ b/bin/nightly-run
@@ -284,6 +284,33 @@ append_cost_row() {
     printf '| %s | %s | %s |\n' "$plan" "$phase" "$cost" >> "$report"
 }
 
+# Human-sign-off guard — best-effort defense-in-depth, NOT the deterministic
+# block. The required `human-signoff` check (.github/workflows/human-signoff.yml)
+# is what actually blocks the merge; it holds no matter what this does. The
+# nightly bot runs as the repo owner with the owner's `gh` creds, so GitHub
+# can't distinguish bot from human — the only discriminator lives here, in the
+# headless path. /post-plan Phase 6.5 arms `gh pr merge --auto` for every PR;
+# this strips that arming, and any `human-approved` label, from `feat:` PRs the
+# bot authored. Caveat: post-plan watches CI to completion before returning
+# here, so this runs too late to beat a label applied mid-watch — it's tidy-up
+# and a tripwire, not a race-free guarantee. The real safeguard against
+# self-labeling is that post-plan never applies the label. Never aborts the run
+# (`|| true` throughout; guarded by a `set -e`-safe `if`).
+neutralize_feat_signoff() {
+    command -v gh >/dev/null 2>&1 || return 0
+    local n
+    gh pr list --author "@me" --state open --json number,title \
+        --jq '.[] | select(.title|test("(?i)^feat(\\([^)]*\\))?!?:")) | .number' \
+        2>/dev/null \
+    | while read -r n; do
+        [ -n "$n" ] || continue
+        gh pr merge "$n" --disable-auto 2>/dev/null || true
+        gh pr edit "$n" --remove-label "human-approved" 2>/dev/null || true
+        printf '[%s] human-signoff guard: stripped auto-merge/label from feat PR #%s\n' \
+            "$(date +%H:%M:%S)" "$n" >> "$LOG"
+    done || true
+}
+
 # Decrement the current plan's attempt counter by one ("refund"). Used when a
 # phase is cut short by an environmental failure (usage/rate limit, auth error,
 # transient) rather than a genuine plan failure — the plan should retry cleanly
@@ -665,6 +692,11 @@ PLAN_FILE=$PLAN_NAME" \
             write_env_stop_report "$PLAN_NAME" postplan "$REASON" "$PP_LOG_BEFORE"
             break
         fi
+
+        # Layer B: post-plan may have armed `gh pr merge --auto` on a feature PR.
+        # Strip that (and any human-approved label) so feature PRs can only merge
+        # after a human applies the label. Runs after every completed post-plan.
+        neutralize_feat_signoff
     fi
 
     # If the plan moved out of queue/ (to done/ or skipped/), clean up its attempt file

--- a/ibl5/docs/decisions/0062-human-signoff-gate-for-feature-prs.md
+++ b/ibl5/docs/decisions/0062-human-signoff-gate-for-feature-prs.md
@@ -1,0 +1,45 @@
+---
+description: Feature PRs (conventional-commit `feat:`) cannot merge until a human applies the `human-approved` label — a required CI check, not a convention, blocks auto-merge.
+last_verified: 2026-06-14
+---
+
+# ADR-0062: Human sign-off gate for feature PRs
+
+**Status:** Accepted
+**Date:** 2026-06-14
+**Deciders:** a-jay85
+
+## Context
+
+The nightly autonomous pipeline (`bin/nightly-run` → `/post-plan` Phase 6.5) arms `gh pr merge --squash --auto`, and master's branch protection requires only two status checks and **zero reviews** (no `CODEOWNERS`). So whole user-facing features merged unattended overnight (#1073 Trade Block, #1074 Watchlist, #1075 Big Board, #1076 counter-offer; #1067 was rolled back separately by #1070), with no chance for a human to inspect UX before it shipped. The prior attempt, #1072, added `auto_postplan: false` and a manual-UI verification step to the `/plan` docs — but that was inert: the nightly path never reads plan frontmatter, and GitHub had no required check to block on, so `--auto` completed regardless. A convention an LLM is asked to honour is not a gate.
+
+## Decision
+
+Feature PRs require explicit human sign-off, enforced mechanically by a **required status check**, not by convention. The workflow `.github/workflows/human-signoff.yml` classifies a PR as a feature by its conventional-commit title (`^feat(scope)?!?:`) and fails (red) until a human applies the `human-approved` label in the GitHub UI; non-feature work (`fix`/`refactor`/`chore`/`ci`/`docs`/`revert`) passes automatically so the nightly pipeline can still auto-merge maintenance. The check is added to master's required contexts, so a queued `--auto` merge never completes while it is red. **This required check is the deterministic block** — it holds regardless of what the autonomous flow does, because the merge is gated by GitHub, not by anyone's discipline.
+
+The nightly bot runs as the repo owner with the owner's `gh` credentials, so GitHub cannot tell a bot merge from a human one; the only bot/human discriminator lives in the headless execution path. `bin/nightly-run` (`neutralize_feat_signoff`) uses it as **best-effort defense-in-depth**, not a second deterministic layer: after each post-plan run it strips `--auto` arming and any `human-approved` label from `feat:` PRs the bot authored. Note the timing — post-plan arms `--auto` then watches CI to completion (Phase 7) *before* returning to `nightly-run`, so this cleanup runs too late to beat a label that was applied during the watch. The actual safeguard against the bot self-applying the label is that the post-plan flow does not apply it (verified by inspection); `neutralize_feat_signoff` is a tidy-up and a tripwire, and Layer A blocks the merge either way.
+
+## Alternatives Considered
+
+- **`CODEOWNERS` + required reviews** — require a human approving review. Rejected because: single-maintainer repo; the bot authors PRs as the owner and GitHub forbids self-approval, so it would permanently block *all* automerge (including maintenance), not just features.
+- **Keep the `/plan` doc convention (#1072), maybe extend it** — frontmatter `auto_postplan: false` + manual-UI prose. Rejected because: proven inert — the nightly path never reads it and no required check enforces it; it is the exact failure this ADR corrects.
+- **Path-based classifier (gate only UI-touching PRs)** — fire on `*.tpl`/`design/`/`*.css`/View paths. Rejected because: path globs are more fragile than titles and need maintenance as the tree moves; "all features need sign-off" is the fail-closed default the owner chose.
+- **`enforce_admins: true` to close the `--admin` bypass** — make even admins satisfy required checks. Rejected because: `bin/merge-master-to-prod` and CI baseline auto-commits push directly to master and would break; the residual `gh pr merge --admin` path is not used by the nightly flow and is documented instead.
+
+## Consequences
+
+- Positive: deterministic, GitHub-enforced block — a feature PR cannot merge unattended; the six PRs that motivated this (#1067/#1069/#1073/#1074/#1075/#1076 are all `feat:`-titled) would all have been held.
+- Positive: maintenance work (`fix`/`refactor`/`chore`/`ci`/`docs`/`revert`) still auto-merges, so the nightly pipeline keeps its throughput on low-risk changes.
+- Negative: the nightly pipeline can no longer ship *any* new feature without a human applying the label the next morning — a deliberate throughput cost for UX-bearing changes.
+- Negative / residual: `gh pr merge --admin` would bypass the required check (admin override, since `enforce_admins: false` is kept for the direct-push paths). It is closed only by the fact the nightly flow does not use `--admin`, not by GitHub — a known, documented gap, not a guarantee. Likewise the title classifier can be dodged by editing a `feat:` PR's title; titles are the team contract (post-plan enforces conventional commits), so this is accepted, not defended.
+
+## Lineage
+
+Relates to (does not supersede) ADR-0017 (`0017-dependabot-full-ci-and-auto-merge.md`), which established auto-merge for dependabot PRs — that path is gated separately on `dependabot[bot]` authorship and is unaffected. This ADR corrects the gap left by #1072, which is retained only as the de-facto first attempt.
+
+## References
+
+- `.github/workflows/human-signoff.yml` — Layer A, the required status check.
+- `bin/nightly-run` — Layer B, `neutralize_feat_signoff` strips auto-merge/label from `feat:` PRs.
+- `.claude/skills/post-plan/SKILL.md` — Phase 6.5 arms `gh pr merge --auto` (the behaviour this gate constrains).
+- `.claude/rules/nightly-workflow.md` — nightly pipeline overview.


### PR DESCRIPTION
## Deterministic human-sign-off gate for feature PRs

Fixes the gap that let #1073–#1076 auto-merge overnight with no human review. #1072 (doc/frontmatter) was **inert** — the nightly path never reads it and GitHub had no required check to block on.

### Layer A — the deterministic block (`.github/workflows/human-signoff.yml`)
A **required status check**: red for any `feat:` PR without the `human-approved` label, green once a human applies it. `--auto` queues but GitHub never completes the merge while it is red. `fix`/`refactor`/`chore`/`ci`/`docs`/`revert` pass automatically, so maintenance still auto-merges. This is the guarantee — GitHub enforces it, no discipline required.

### Layer B — best-effort defense-in-depth (`bin/nightly-run` `neutralize_feat_signoff`)
The bot runs as the repo owner with the owner's `gh` creds, so GitHub cannot distinguish bot from human — the only discriminator lives in the headless path. After each post-plan run it strips `--auto` arming and any `human-approved` label from `feat:` PRs the bot authored. **Not race-free:** post-plan watches CI to completion before returning, so this runs too late to beat a label applied mid-watch. The real safeguard against self-labeling is that post-plan never applies the label; this is tidy-up + a tripwire. Layer A blocks the merge either way.

### Verified live (on PR #1098, since closed)
- `feat:` + no label → **human-signoff FAIL** (red). ✓
- `feat:` + `human-approved` → **human-signoff PASS** (green). ✓
- This PR (`ci:` title) → exempt, **PASS**. ✓
- Classifier gates all six motivating PRs (#1067/#1069/#1073/#1074/#1075/#1076 are all `feat:`).
- `actionlint`, `bin/adr-check` (ADR-0062), `bin/check-docs`, `bash -n` all pass.

### ⚠️ Activation (one-time, AFTER this merges to master)
The check only *enforces* once it is a required context. Additive POST (does not disturb `strict` or the existing two checks):
```bash
gh api -X POST repos/a-jay85/IBL5/branches/master/protection/required_status_checks/contexts \
  --input - <<< '["human-signoff"]'
# verify:
gh api repos/a-jay85/IBL5/branches/master/protection/required_status_checks --jq .contexts
```
The `human-approved` label is already created. Doing this *before* merge would strand every PR on a never-running expected check.