### PR TITLE
feat: TEMP gate red-path verification — will be closed

### DIFF
--- a/.claude/rules/nightly-workflow.md
+++ b/.claude/rules/nightly-workflow.md
@@ -62,3 +62,7 @@ absolute targets keep resolving after the move. `queue/` (pending work) and `han
 ## Headless Mode
 
 `bin/nightly-run` sets `CLAUDE_HEADLESS=1`. This environment variable gates `/post-plan` Phase 10 (Preview Environment), which is skipped since no human is present to verify visually. All other phases run normally.
+
+## Feature PRs cannot auto-merge
+
+Conventional-commit **`feat:`** PRs are gated by the required `human-signoff` check and will **not** auto-merge overnight — they wait for a human to apply the `human-approved` label after inspection (ADR-0062). Post-plan still arms `--auto`, but `bin/nightly-run` strips it from `feat:` PRs (`neutralize_feat_signoff`), and the required check blocks the merge regardless. Maintenance PRs (`fix`/`refactor`/`chore`/`ci`/`docs`/`revert`) auto-merge as before. Check the morning `gh pr list` for `feat:` PRs awaiting your label.

--- a/.github/workflows/human-signoff.yml
+++ b/.github/workflows/human-signoff.yml
@@ -1,0 +1,62 @@
+name: Human Sign-off
+
+# Deterministic human-sign-off gate for feature PRs.
+#
+# Why this exists: the nightly autonomous pipeline (bin/nightly-run → /post-plan
+# Phase 6.5) arms `gh pr merge --squash --auto`, and master's branch protection
+# requires no reviews — so feature PRs merged unattended overnight (see the
+# revert of #1073–#1076). A docs/frontmatter convention (#1072) could not stop
+# this: the nightly path never reads it and GitHub has nothing to block on.
+#
+# This job IS that block. Once added to master's required status checks, a
+# `feat:` PR stays un-mergeable (red required check) until a human inspects it
+# and applies the `human-approved` label. `--auto` queues but GitHub never
+# completes the merge while a required check is red. Non-feature work
+# (fix/refactor/chore/docs/ci/revert/…) passes automatically, so the nightly
+# pipeline can still auto-merge maintenance.
+
+on:
+  pull_request:
+    branches: [ master ]
+    # labeled/unlabeled re-run the gate so applying the label flips red→green;
+    # edited re-runs when the title (the classifier input) changes.
+    types: [opened, reopened, synchronize, edited, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: human-signoff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  human-signoff:
+    name: human-signoff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require human sign-off for feature PRs
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          # Classifier: conventional-commit feature PRs require sign-off. Matches
+          # feat:, feat(scope):, and the breaking-change feat!: / feat(scope)!:.
+          if ! printf '%s' "$TITLE" | grep -qiE '^feat(\([^)]*\))?!?:'; then
+            echo "Title is not a feat: PR — human sign-off not required."
+            echo "  title: $TITLE"
+            exit 0
+          fi
+
+          # A human grants sign-off by applying the 'human-approved' label in the
+          # GitHub UI after manual inspection. (Comma-wrap both sides so the grep
+          # matches whole label names, never a substring.)
+          if printf '%s' ",$LABELS," | grep -q ',human-approved,'; then
+            echo "'human-approved' label present — human sign-off granted."
+            exit 0
+          fi
+
+          echo "::error title=Human sign-off required::This feature PR must be manually inspected by a maintainer, who then applies the 'human-approved' label. Auto-merge cannot satisfy this gate."
+          exit 1

--- a/bin/nightly-run
+++ b/bin/nightly-run
@@ -275,6 +275,32 @@ append_cost_row() {
     printf '| %s | %s | %s |\n' "$plan" "$phase" "$cost" >> "$report"
 }
 
+# Human-sign-off guard (Layer B of the deterministic gate; see
+# .github/workflows/human-signoff.yml for Layer A). The nightly bot runs as the
+# repo owner with the owner's `gh` creds, so GitHub cannot distinguish a bot
+# merge from a human one — the only bot/human discriminator lives here, in the
+# headless execution path. /post-plan Phase 6.5 arms `gh pr merge --auto` for
+# every PR including feature PRs; this strips that arming, and any
+# `human-approved` label, from any `feat:` PR the bot authored, so the gate
+# stays satisfiable only by a human applying the label in the UI. Layer A
+# already blocks the *merge* (required red check); this closes the residual
+# where the autonomous flow could arm auto or self-apply the label. Best-effort:
+# never aborts the run (`|| true` throughout; guarded by `set -e`-safe `if`).
+neutralize_feat_signoff() {
+    command -v gh >/dev/null 2>&1 || return 0
+    local n
+    gh pr list --author "@me" --state open --json number,title \
+        --jq '.[] | select(.title|test("(?i)^feat(\\([^)]*\\))?!?:")) | .number' \
+        2>/dev/null \
+    | while read -r n; do
+        [ -n "$n" ] || continue
+        gh pr merge "$n" --disable-auto 2>/dev/null || true
+        gh pr edit "$n" --remove-label "human-approved" 2>/dev/null || true
+        printf '[%s] human-signoff guard: stripped auto-merge/label from feat PR #%s\n' \
+            "$(date +%H:%M:%S)" "$n" >> "$LOG"
+    done || true
+}
+
 # Decrement the current plan's attempt counter by one ("refund"). Used when a
 # phase is cut short by an environmental failure (usage/rate limit, auth error,
 # transient) rather than a genuine plan failure — the plan should retry cleanly
@@ -604,6 +630,11 @@ PLAN_FILE=$PLAN_NAME" \
             write_env_stop_report "$PLAN_NAME" postplan "$REASON" "$PP_LOG_BEFORE"
             break
         fi
+
+        # Layer B: post-plan may have armed `gh pr merge --auto` on a feature PR.
+        # Strip that (and any human-approved label) so feature PRs can only merge
+        # after a human applies the label. Runs after every completed post-plan.
+        neutralize_feat_signoff
     fi
 
     # If the plan moved out of queue/ (to done/ or skipped/), clean up its attempt file

--- a/ibl5/docs/decisions/0062-human-signoff-gate-for-feature-prs.md
+++ b/ibl5/docs/decisions/0062-human-signoff-gate-for-feature-prs.md
@@ -1,0 +1,42 @@
+---
+description: Feature PRs (conventional-commit `feat:`) cannot merge until a human applies the `human-approved` label — a required CI check, not a convention, blocks auto-merge.
+last_verified: 2026-06-14
+---
+
+# ADR-0062: Human sign-off gate for feature PRs
+
+**Status:** Accepted
+**Date:** 2026-06-14
+**Deciders:** a-jay85
+
+## Context
+
+The nightly autonomous pipeline (`bin/nightly-run` → `/post-plan` Phase 6.5) arms `gh pr merge --squash --auto`, and master's branch protection requires only two status checks and **zero reviews** (no `CODEOWNERS`). So whole user-facing features merged unattended overnight (#1073 Trade Block, #1074 Watchlist, #1075 Big Board, #1076 counter-offer; #1067 was rolled back separately by #1070), with no chance for a human to inspect UX before it shipped. The prior attempt, #1072, added `auto_postplan: false` and a manual-UI verification step to the `/plan` docs — but that was inert: the nightly path never reads plan frontmatter, and GitHub had no required check to block on, so `--auto` completed regardless. A convention an LLM is asked to honour is not a gate.
+
+## Decision
+
+Feature PRs require explicit human sign-off, enforced mechanically by a **required status check**, not by convention. The workflow `.github/workflows/human-signoff.yml` classifies a PR as a feature by its conventional-commit title (`^feat(scope)?!?:`) and fails (red) until a human applies the `human-approved` label in the GitHub UI; non-feature work (`fix`/`refactor`/`chore`/`ci`/`docs`/`revert`) passes automatically so the nightly pipeline can still auto-merge maintenance. The check is added to master's required contexts, so a queued `--auto` merge never completes while it is red. Because the nightly bot runs as the repo owner with the owner's `gh` credentials — GitHub cannot tell a bot merge from a human one — a second deterministic layer lives in `bin/nightly-run` (`neutralize_feat_signoff`): after every post-plan run it strips any `--auto` arming and any `human-approved` label from `feat:` PRs the bot authored, so the gate is satisfiable only by a human.
+
+## Alternatives Considered
+
+- **`CODEOWNERS` + required reviews** — require a human approving review. Rejected because: single-maintainer repo; the bot authors PRs as the owner and GitHub forbids self-approval, so it would permanently block *all* automerge (including maintenance), not just features.
+- **Keep the `/plan` doc convention (#1072), maybe extend it** — frontmatter `auto_postplan: false` + manual-UI prose. Rejected because: proven inert — the nightly path never reads it and no required check enforces it; it is the exact failure this ADR corrects.
+- **Path-based classifier (gate only UI-touching PRs)** — fire on `*.tpl`/`design/`/`*.css`/View paths. Rejected because: path globs are more fragile than titles and need maintenance as the tree moves; "all features need sign-off" is the fail-closed default the owner chose.
+- **`enforce_admins: true` to close the `--admin` bypass** — make even admins satisfy required checks. Rejected because: `bin/merge-master-to-prod` and CI baseline auto-commits push directly to master and would break; the residual `gh pr merge --admin` path is not used by the nightly flow and is documented instead.
+
+## Consequences
+
+- Positive: deterministic, GitHub-enforced block — a feature PR cannot merge unattended; the six PRs that motivated this (#1067/#1069/#1073/#1074/#1075/#1076 are all `feat:`-titled) would all have been held.
+- Positive: maintenance work (`fix`/`refactor`/`chore`/`ci`/`docs`/`revert`) still auto-merges, so the nightly pipeline keeps its throughput on low-risk changes.
+- Negative: the nightly pipeline can no longer ship *any* new feature without a human applying the label the next morning — a deliberate throughput cost for UX-bearing changes. The residual `--admin` bypass remains open at the GitHub layer (mitigated only by Layer B + the fact the nightly flow never uses it), the price of keeping `enforce_admins: false` for the direct-push paths.
+
+## Lineage
+
+Relates to (does not supersede) ADR-0017 (`0017-dependabot-full-ci-and-auto-merge.md`), which established auto-merge for dependabot PRs — that path is gated separately on `dependabot[bot]` authorship and is unaffected. This ADR corrects the gap left by #1072, which is retained only as the de-facto first attempt.
+
+## References
+
+- `.github/workflows/human-signoff.yml` — Layer A, the required status check.
+- `bin/nightly-run` — Layer B, `neutralize_feat_signoff` strips auto-merge/label from `feat:` PRs.
+- `.claude/skills/post-plan/SKILL.md` — Phase 6.5 arms `gh pr merge --auto` (the behaviour this gate constrains).
+- `.claude/rules/nightly-workflow.md` — nightly pipeline overview.


### PR DESCRIPTION
Throwaway PR to confirm the human-signoff required check goes RED on a `feat:` title and GREEN once `human-approved` is applied. Will be closed; do not merge.