### PR TITLE
feat: Cap "What-If" Calculator (Sandbox)

### DIFF
--- a/ibl5/classes/CapWhatIf/CapWhatIfService.php
+++ b/ibl5/classes/CapWhatIf/CapWhatIfService.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CapWhatIf;
+
+use CapWhatIf\Contracts\CapWhatIfServiceInterface;
+use League\League;
+use Season\Season;
+use Team\Contracts\TeamCapCalculatorInterface;
+use Team\Contracts\TeamQueryRepositoryInterface;
+
+/**
+ * CapWhatIfService - hypothetical cap-scenario computation (sandbox, no persistence).
+ *
+ * Starts from a GM's real contract rows and applies two optional deltas — waive
+ * one rostered player and/or add one flat-salary signing of N years at $X — then
+ * costs both the baseline and the resulting scenario through the league's
+ * authoritative cap walk ({@see TeamCapCalculatorInterface::getSalaryCapArrayFromContractRows()}).
+ * No SQL is added: baseline rows come from the existing roster query and cash
+ * considerations stay pinned to the real team ledger.
+ *
+ * @phpstan-import-type ScenarioResult from CapWhatIfServiceInterface
+ * @phpstan-import-type CapYearMap from CapWhatIfServiceInterface
+ * @phpstan-import-type CapContractRow from TeamCapCalculatorInterface
+ *
+ * @see CapWhatIfServiceInterface
+ */
+class CapWhatIfService implements CapWhatIfServiceInterface
+{
+    /** Number of contract years the salary model supports (salary_yr1..salary_yr6). */
+    private const MAX_YEARS = 6;
+
+    /** Sentinel pid for the hypothetical signing — never collides with a real roster pid. */
+    private const SYNTHETIC_PID = -1;
+
+    private TeamQueryRepositoryInterface $teamQueryRepo;
+    private TeamCapCalculatorInterface $teamCapCalculator;
+
+    /**
+     * @param \mysqli $db Database connection (used to construct default collaborators)
+     * @param TeamQueryRepositoryInterface|null $teamQueryRepo Roster source (created internally if not provided)
+     * @param TeamCapCalculatorInterface|null $teamCapCalculator Cap walk (created internally if not provided)
+     */
+    public function __construct(
+        \mysqli $db,
+        ?TeamQueryRepositoryInterface $teamQueryRepo = null,
+        ?TeamCapCalculatorInterface $teamCapCalculator = null
+    ) {
+        $this->teamQueryRepo = $teamQueryRepo ?? new \Team\TeamQueryRepository($db);
+        $this->teamCapCalculator = $teamCapCalculator ?? new \Team\TeamCapCalculator($db, $this->teamQueryRepo);
+    }
+
+    /**
+     * @see CapWhatIfServiceInterface::computeScenario()
+     *
+     * @return ScenarioResult
+     */
+    public function computeScenario(
+        string $teamName,
+        int $teamId,
+        Season $season,
+        ?int $waivePid,
+        int $years,
+        int $salary
+    ): array {
+        $years = $this->clamp($years, 0, self::MAX_YEARS);
+        $salary = $this->clamp($salary, 0, League::HARD_CAP_MAX);
+
+        $rows = $this->teamQueryRepo->getRosterUnderContractOrderedByName($teamId);
+
+        $baselineSpent = $this->normalizeYears(
+            $this->teamCapCalculator->getSalaryCapArrayFromContractRows($rows, $teamId, $season)
+        );
+
+        // Apply the waive delta (no-op if the pid is not on the roster).
+        $waivedName = null;
+        $modifiedRows = [];
+        foreach ($rows as $row) {
+            if ($waivePid !== null && ($row['pid'] ?? null) === $waivePid && $waivedName === null) {
+                $name = $row['name'] ?? null;
+                $waivedName = is_string($name) ? $name : '';
+                continue;
+            }
+            $modifiedRows[] = $row;
+        }
+
+        // Apply the add-signing delta (flat $X for N years), phase-aware so the
+        // first paid year always lands in year1.
+        if ($years >= 1 && $salary >= 1) {
+            $modifiedRows[] = $this->buildSyntheticRow($season, $years, $salary);
+        }
+
+        $scenarioSpent = $this->normalizeYears(
+            $this->teamCapCalculator->getSalaryCapArrayFromContractRows($modifiedRows, $teamId, $season)
+        );
+
+        $overCap = [];
+        foreach ($scenarioSpent as $key => $spent) {
+            $overCap[$key] = $spent > League::HARD_CAP_MAX;
+        }
+
+        return [
+            'baseline' => [
+                'spent' => $baselineSpent,
+                'space' => $this->toSpace($baselineSpent),
+            ],
+            'scenario' => [
+                'spent' => $scenarioSpent,
+                'space' => $this->toSpace($scenarioSpent),
+            ],
+            'overCap' => $overCap,
+            'waivedName' => $waivedName,
+            'years' => $years,
+            'salary' => $salary,
+        ];
+    }
+
+    /**
+     * Build the hypothetical signing row so its first paid year lands in year1
+     * under both season phases. The cap walk starts at `cy` (regular) or `cy+1`
+     * (offseason); seeding `cy = 1` (regular) / `cy = 0` (offseason) makes the
+     * first walked year `salary_yr1` either way, and `cyt = years` walks exactly
+     * `years` slots — never indexing past `salary_yr6`.
+     *
+     * @return CapContractRow
+     */
+    private function buildSyntheticRow(Season $season, int $years, int $salary): array
+    {
+        // Static keys keep the shape concrete (no dynamic-key @var cast). `cyt`
+        // gates how many years the cap walk sums, so years beyond `$years` are
+        // funded 0 and never read.
+        return [
+            'pid' => self::SYNTHETIC_PID,
+            'cy' => $season->isOffseasonPhase() ? 0 : 1,
+            'cyt' => $years,
+            'salary_yr1' => $years >= 1 ? $salary : 0,
+            'salary_yr2' => $years >= 2 ? $salary : 0,
+            'salary_yr3' => $years >= 3 ? $salary : 0,
+            'salary_yr4' => $years >= 4 ? $salary : 0,
+            'salary_yr5' => $years >= 5 ? $salary : 0,
+            'salary_yr6' => $years >= 6 ? $salary : 0,
+        ];
+    }
+
+    /**
+     * Materialize all six year keys (year1..year6), defaulting missing years to 0.
+     * The cap walk emits a sparse array (only years with commitments), so callers
+     * computing cap space must not index missing keys directly.
+     *
+     * @param array<string, int> $spent
+     * @return CapYearMap
+     */
+    private function normalizeYears(array $spent): array
+    {
+        $normalized = [];
+        for ($i = 1; $i <= self::MAX_YEARS; $i++) {
+            $key = 'year' . $i;
+            $normalized[$key] = $spent[$key] ?? 0;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Convert a per-year spent map into a per-year cap-space map.
+     *
+     * @param CapYearMap $spent
+     * @return CapYearMap
+     */
+    private function toSpace(array $spent): array
+    {
+        $space = [];
+        foreach ($spent as $key => $value) {
+            $space[$key] = League::HARD_CAP_MAX - $value;
+        }
+
+        return $space;
+    }
+
+    private function clamp(int $value, int $min, int $max): int
+    {
+        return max($min, min($max, $value));
+    }
+}

--- a/ibl5/classes/CapWhatIf/CapWhatIfView.php
+++ b/ibl5/classes/CapWhatIf/CapWhatIfView.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CapWhatIf;
+
+use CapWhatIf\Contracts\CapWhatIfViewInterface;
+use Security\HtmlSanitizer;
+
+/**
+ * CapWhatIfView - HTML rendering for the cap "what-if" sandbox.
+ *
+ * Emits a GET form (waive select + signing inputs, no CSRF token) and a
+ * baseline-vs-scenario result table reusing the shared table classes. Every
+ * dynamic value is escaped via {@see HtmlSanitizer::e()}; over-cap scenario
+ * years carry the shared {@see self::OVER_CAP_FLAG_CLASS} highlight class.
+ *
+ * @phpstan-import-type ScenarioResult from \CapWhatIf\Contracts\CapWhatIfServiceInterface
+ *
+ * @see CapWhatIfViewInterface
+ */
+class CapWhatIfView implements CapWhatIfViewInterface
+{
+    /** Shared cell-highlight class flagging a scenario year that exceeds the hard cap. */
+    private const OVER_CAP_FLAG_CLASS = 'ibl-stat-highlight';
+
+    /**
+     * @see CapWhatIfViewInterface::render()
+     *
+     * @param ScenarioResult $scenarioData
+     * @param list<array<string, mixed>> $rosterPlayers
+     */
+    public function render(array $scenarioData, array $rosterPlayers, int $beginningYear, int $endingYear): string
+    {
+        $html = '';
+        $html .= '<h2 class="ibl-title">Cap Calculator</h2>';
+        $html .= $this->renderForm($scenarioData, $rosterPlayers);
+
+        if ($scenarioData['waivedName'] !== null && $scenarioData['waivedName'] !== '') {
+            $html .= '<p>Waiving: ' . HtmlSanitizer::e($scenarioData['waivedName']) . '</p>';
+        }
+
+        $html .= $this->renderResultTable($scenarioData, $beginningYear, $endingYear);
+
+        return $html;
+    }
+
+    /**
+     * Render the GET form: waive select + signing inputs. No CSRF token (GET,
+     * mutates no server state).
+     *
+     * @param ScenarioResult $scenarioData
+     * @param list<array<string, mixed>> $rosterPlayers
+     */
+    private function renderForm(array $scenarioData, array $rosterPlayers): string
+    {
+        $html = '<form method="get">';
+        $html .= '<input type="hidden" name="name" value="CapWhatIf">';
+
+        $html .= '<label>Waive: <select name="waive">';
+        $html .= '<option value="">&mdash; none &mdash;</option>';
+        foreach ($rosterPlayers as $player) {
+            $pid = $player['pid'] ?? '';
+            $name = $player['name'] ?? '';
+            $html .= '<option value="' . HtmlSanitizer::e($pid) . '">'
+                . HtmlSanitizer::e($name) . '</option>';
+        }
+        $html .= '</select></label>';
+
+        $html .= '<label>Years: <input type="number" name="years" min="1" max="6" value="'
+            . HtmlSanitizer::e($scenarioData['years']) . '"></label>';
+        $html .= '<label>Salary: <input type="number" name="salary" min="0" max="'
+            . HtmlSanitizer::e(\League\League::HARD_CAP_MAX) . '" value="'
+            . HtmlSanitizer::e($scenarioData['salary']) . '"></label>';
+
+        $html .= '<button type="submit">Calculate</button>';
+        $html .= '</form>';
+
+        return $html;
+    }
+
+    /**
+     * Render the per-year baseline-vs-scenario table.
+     *
+     * @param ScenarioResult $scenarioData
+     */
+    private function renderResultTable(array $scenarioData, int $beginningYear, int $endingYear): string
+    {
+        $html = '<div class="sticky-scroll-wrapper"><div class="sticky-scroll-container">';
+        $html .= '<table class="sortable ibl-data-table sticky-table">';
+        $html .= '<thead><tr>';
+        $html .= '<th class="sticky-col sticky-corner">Year</th>';
+        $html .= '<th>Baseline Spent</th><th>Baseline Space</th>';
+        $html .= '<th>Scenario Spent</th><th>Scenario Space</th>';
+        $html .= '</tr></thead><tbody>';
+
+        for ($i = 1; $i <= 6; $i++) {
+            $key = 'year' . $i;
+            $yearLabel = ($beginningYear + $i - 1) . '-' . ($endingYear + $i - 1);
+            $isOverCap = $scenarioData['overCap'][$key] ?? false;
+            $scenarioCellClass = $isOverCap ? ' class="' . self::OVER_CAP_FLAG_CLASS . '"' : '';
+
+            $html .= '<tr>';
+            $html .= '<td class="sticky-col">' . HtmlSanitizer::e($yearLabel) . '</td>';
+            $html .= '<td>' . HtmlSanitizer::e($scenarioData['baseline']['spent'][$key] ?? 0) . '</td>';
+            $html .= '<td>' . HtmlSanitizer::e($scenarioData['baseline']['space'][$key] ?? 0) . '</td>';
+            $html .= '<td' . $scenarioCellClass . '>' . HtmlSanitizer::e($scenarioData['scenario']['spent'][$key] ?? 0) . '</td>';
+            $html .= '<td>' . HtmlSanitizer::e($scenarioData['scenario']['space'][$key] ?? 0) . '</td>';
+            $html .= '</tr>';
+        }
+
+        $html .= '</tbody></table></div></div>';
+
+        return $html;
+    }
+}

--- a/ibl5/classes/CapWhatIf/Contracts/CapWhatIfServiceInterface.php
+++ b/ibl5/classes/CapWhatIf/Contracts/CapWhatIfServiceInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CapWhatIf\Contracts;
+
+use Season\Season;
+
+/**
+ * CapWhatIfServiceInterface - hypothetical cap-scenario computation.
+ *
+ * Computes a sandbox scenario from a GM's real current contracts plus two
+ * optional hypothetical deltas (waive one rostered player, add one signing of
+ * N years at $X). Nothing is persisted; the result is derived entirely from the
+ * passed inputs via the league's authoritative cap walk.
+ *
+ * @phpstan-type CapYearMap array<string, int>
+ * @phpstan-type CapSide array{spent: CapYearMap, space: CapYearMap}
+ * @phpstan-type ScenarioResult array{baseline: CapSide, scenario: CapSide, overCap: array<string, bool>, waivedName: ?string, years: int, salary: int}
+ */
+interface CapWhatIfServiceInterface
+{
+    /**
+     * Compute the baseline-vs-scenario cap totals for a team.
+     *
+     * @param string $teamName Owner's team name (resolved server-side)
+     * @param int $teamId Owner's team id (resolved server-side, never from request)
+     * @param Season $season Current season (drives offseason contract-year rollover)
+     * @param int|null $waivePid Hypothetically waived player id, or null for no waive
+     * @param int $years Hypothetical signing length in years (clamped 0–6)
+     * @param int $salary Hypothetical flat per-year salary (clamped 0–HARD_CAP_MAX)
+     * @return ScenarioResult
+     */
+    public function computeScenario(
+        string $teamName,
+        int $teamId,
+        Season $season,
+        ?int $waivePid,
+        int $years,
+        int $salary
+    ): array;
+}

--- a/ibl5/classes/CapWhatIf/Contracts/CapWhatIfViewInterface.php
+++ b/ibl5/classes/CapWhatIf/Contracts/CapWhatIfViewInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CapWhatIf\Contracts;
+
+/**
+ * CapWhatIfViewInterface - Contract for the cap "what-if" sandbox view.
+ *
+ * Renders the GET form (waive select + signing inputs) and the baseline-vs-
+ * scenario result table. All dynamic output is HTML-escaped by the concrete
+ * implementation; the form carries no CSRF token because the endpoint is an
+ * idempotent GET that mutates no server state.
+ *
+ * @phpstan-import-type ScenarioResult from CapWhatIfServiceInterface
+ *
+ * @see \CapWhatIf\CapWhatIfView For the concrete implementation
+ */
+interface CapWhatIfViewInterface
+{
+    /**
+     * Render the cap calculator page body.
+     *
+     * @param ScenarioResult $scenarioData Computed baseline/scenario cap totals
+     * @param list<array<string, mixed>> $rosterPlayers Owner's rostered players (for the waive select)
+     * @param int $beginningYear Starting year for column labels
+     * @param int $endingYear Ending year for column labels
+     * @return string HTML output
+     */
+    public function render(array $scenarioData, array $rosterPlayers, int $beginningYear, int $endingYear): string;
+}

--- a/ibl5/classes/Module/ModuleRegistry.php
+++ b/ibl5/classes/Module/ModuleRegistry.php
@@ -13,6 +13,7 @@ final class ModuleRegistry
         'ApiKeys',
         'AwardHistory',
         'CapSpace',
+        'CapWhatIf',
         'CareerLeaderboards',
         'ComparePlayers',
         'ContractList',

--- a/ibl5/classes/Navigation/NavigationMenuBuilder.php
+++ b/ibl5/classes/Navigation/NavigationMenuBuilder.php
@@ -207,6 +207,7 @@ class NavigationMenuBuilder implements NavigationMenuBuilderInterface
             ['label' => 'Next Sim', 'url' => 'modules.php?name=NextSim'],
             ['label' => 'Depth Chart Entry', 'url' => 'modules.php?name=DepthChartEntry'],
             ['label' => 'Trading', 'url' => 'modules.php?name=Trading&op=reviewtrade'],
+            ['label' => 'Cap Calculator', 'url' => 'modules.php?name=CapWhatIf'],
             ['label' => 'Voting', 'url' => 'modules.php?name=Voting'],
         ];
 

--- a/ibl5/classes/Team/Contracts/TeamCapCalculatorInterface.php
+++ b/ibl5/classes/Team/Contracts/TeamCapCalculatorInterface.php
@@ -17,6 +17,8 @@ use Season\Season;
  * calculator, not a generic Service/Shared bucket).
  *
  * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
+ *
+ * @phpstan-type CapContractRow array{cy?: int|null, cyt?: int|null, salary_yr1?: int|null, salary_yr2?: int|null, salary_yr3?: int|null, salary_yr4?: int|null, salary_yr5?: int|null, salary_yr6?: int|null, ...}
  */
 interface TeamCapCalculatorInterface
 {
@@ -26,6 +28,20 @@ interface TeamCapCalculatorInterface
      * @return array<string, int> Array of salary cap spent by year
      */
     public function getSalaryCapArray(string $teamName, int $teamId, Season $season): array;
+
+    /**
+     * Get salary cap array for all contract years from passed-in contract rows.
+     *
+     * Runs the same per-season cap walk as {@see self::getSalaryCapArray()} but over
+     * caller-supplied contract rows, so hypothetical scenarios (waived / added
+     * contracts) can be costed with the league's authoritative cap math. Cash
+     * considerations are still pulled by {@see $teamId} (the what-if mutates only
+     * contracts, never cash).
+     *
+     * @param list<CapContractRow> $contractRows Contract rows to walk (real or hypothetical)
+     * @return array<string, int> Array of salary cap spent by year
+     */
+    public function getSalaryCapArrayFromContractRows(array $contractRows, int $teamId, Season $season): array;
 
     /**
      * Get total current season salaries from player result array

--- a/ibl5/classes/Team/TeamCapCalculator.php
+++ b/ibl5/classes/Team/TeamCapCalculator.php
@@ -23,6 +23,7 @@ use Trading\Contracts\BuyoutLedgerRepositoryInterface;
  * (ADR-0028: a domain calculator, not a generic Service/Shared bucket).
  *
  * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
+ * @phpstan-import-type CapContractRow from TeamCapCalculatorInterface
  *
  * @see TeamCapCalculatorInterface
  */
@@ -54,11 +55,23 @@ class TeamCapCalculator implements TeamCapCalculatorInterface
      */
     public function getSalaryCapArray(string $teamName, int $teamId, Season $season): array
     {
-        /** @var array<string, int> $salaryCapSpent */
-        $salaryCapSpent = [];
         $resultContracts = $this->teamQueryRepo->getRosterUnderContractOrderedByName($teamId);
 
-        foreach ($resultContracts as $contract) {
+        return $this->getSalaryCapArrayFromContractRows($resultContracts, $teamId, $season);
+    }
+
+    /**
+     * @see TeamCapCalculatorInterface::getSalaryCapArrayFromContractRows()
+     *
+     * @param list<CapContractRow> $contractRows
+     * @return array<string, int>
+     */
+    public function getSalaryCapArrayFromContractRows(array $contractRows, int $teamId, Season $season): array
+    {
+        /** @var array<string, int> $salaryCapSpent */
+        $salaryCapSpent = [];
+
+        foreach ($contractRows as $contract) {
             $yearUnderContract = $contract['cy'] ?? 0;
             if ($season->isOffseasonPhase()) {
                 $yearUnderContract++;

--- a/ibl5/modules/CapWhatIf/index.php
+++ b/ibl5/modules/CapWhatIf/index.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CapWhatIf Module - owner-only salary-cap "what-if" sandbox.
+ *
+ * Starts from the authenticated GM's real contracts and models two hypothetical
+ * deltas (waive one player, add one signing) via {@see CapWhatIf\CapWhatIfService}.
+ * The endpoint is an idempotent GET — it mutates no server state and carries no
+ * CSRF token. The team is resolved server-side from the session identity; a
+ * request-supplied `teamid` is never read.
+ *
+ * @see CapWhatIf\CapWhatIfService For scenario computation
+ * @see CapWhatIf\CapWhatIfView For HTML rendering
+ */
+
+if (!defined('MODULE_FILE')) {
+    die("You can't access this file directly...");
+}
+
+use CapWhatIf\CapWhatIfService;
+use CapWhatIf\CapWhatIfView;
+use League\League;
+use Repositories\TeamIdentityRepository;
+
+global $mysqli_db, $authService;
+
+$module_name = basename(dirname(__FILE__));
+get_lang($module_name);
+
+PageLayout\PageLayout::header();
+
+// Resolve the OWNER's team from session identity — never from the request.
+$cookieArray = $authService->getCookieArray();
+$username = is_array($cookieArray) && isset($cookieArray[1]) && is_string($cookieArray[1])
+    ? $cookieArray[1]
+    : '';
+
+$commonRepo = new TeamIdentityRepository($mysqli_db);
+$teamName = $commonRepo->getTeamnameFromUsername($username);
+
+if ($teamName === null || $teamName === '' || $teamName === League::FREE_AGENTS_TEAM_NAME) {
+    echo '<p class="ibl-centerbox">You must be a team GM to use the Cap Calculator.</p>';
+    PageLayout\PageLayout::footer();
+    return;
+}
+
+$teamid = $commonRepo->getTidFromTeamname($teamName) ?? 0;
+if ($teamid === 0) {
+    echo '<p class="ibl-centerbox">Team not found.</p>';
+    PageLayout\PageLayout::footer();
+    return;
+}
+
+// Scenario inputs come only from $_GET, each narrowed ($_GET values are mixed).
+// teamid is NEVER read from the request.
+$waivePid = isset($_GET['waive']) && is_numeric($_GET['waive']) ? (int) $_GET['waive'] : null;
+$years = isset($_GET['years']) && is_numeric($_GET['years']) ? (int) $_GET['years'] : 0;
+$salary = isset($_GET['salary']) && is_numeric($_GET['salary']) ? (int) $_GET['salary'] : 0;
+
+$season = new \Season\Season($mysqli_db);
+$teamQueryRepo = new \Team\TeamQueryRepository($mysqli_db);
+$rosterPlayers = $teamQueryRepo->getRosterUnderContractOrderedByName($teamid);
+
+$service = new CapWhatIfService($mysqli_db, $teamQueryRepo);
+$view = new CapWhatIfView();
+
+$scenarioData = $service->computeScenario($teamName, $teamid, $season, $waivePid, $years, $salary);
+
+$beginningYear = $season->isOffseasonPhase() ? $season->beginningYear + 1 : $season->beginningYear;
+$endingYear = $season->isOffseasonPhase() ? $season->endingYear + 1 : $season->endingYear;
+
+echo $view->render($scenarioData, $rosterPlayers, $beginningYear, $endingYear);
+
+PageLayout\PageLayout::footer();

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -133,6 +133,9 @@
         <testsuite name="CapSpace Module Tests">
             <directory>tests/CapSpace</directory>
         </testsuite>
+        <testsuite name="CapWhatIf Module Tests">
+            <directory>tests/CapWhatIf</directory>
+        </testsuite>
         <testsuite name="AwardHistory Module Tests">
             <directory>tests/AwardHistory</directory>
         </testsuite>

--- a/ibl5/tests/CapWhatIf/CapWhatIfServiceTest.php
+++ b/ibl5/tests/CapWhatIf/CapWhatIfServiceTest.php
@@ -178,6 +178,16 @@ class CapWhatIfServiceTest extends TestCase
         self::assertSame($result['baseline']['spent'], $result['scenario']['spent']);
     }
 
+    public function testSalaryClampedToHardCapMax(): void
+    {
+        // Empty roster isolates the signing; salary above the cap clamps down.
+        $result = $this->buildService([])
+            ->computeScenario('Metros', 1, $this->season(false), null, 1, League::HARD_CAP_MAX + 1000);
+
+        self::assertSame(League::HARD_CAP_MAX, $result['salary']);
+        self::assertSame(League::HARD_CAP_MAX, $result['scenario']['spent']['year1']);
+    }
+
     public function testOverCapFlaggedWhenYearExceedsHardCap(): void
     {
         $overCapRoster = [

--- a/ibl5/tests/CapWhatIf/CapWhatIfServiceTest.php
+++ b/ibl5/tests/CapWhatIf/CapWhatIfServiceTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CapWhatIf;
+
+use CapWhatIf\CapWhatIfService;
+use League\League;
+use PHPUnit\Framework\TestCase;
+use Season\Season;
+use Team\Contracts\TeamQueryRepositoryInterface;
+use Team\TeamCapCalculator;
+use Tests\WideUnit\Mocks\MockDatabase;
+use Trading\Contracts\BuyoutLedgerRepositoryInterface;
+
+/**
+ * Unit tests for {@see CapWhatIfService}.
+ *
+ * The service is wired with the REAL {@see TeamCapCalculator} over a stubbed
+ * roster repository (and empty cash), so the baseline/scenario numbers exercise
+ * the league's authoritative cap walk rather than a re-stubbed echo. Controlled
+ * rows mirror the seeded Metros actives (`ci-seed.sql:205-224`) but are exact
+ * and immune to seed size.
+ *
+ * @covers \CapWhatIf\CapWhatIfService
+ */
+class CapWhatIfServiceTest extends TestCase
+{
+    private MockDatabase $mockDb;
+
+    protected function setUp(): void
+    {
+        $this->mockDb = new MockDatabase();
+    }
+
+    /**
+     * Build a service whose roster query returns the given rows, costed by the
+     * real cap calculator with empty cash considerations.
+     *
+     * @param list<array<string, mixed>> $rows
+     */
+    private function buildService(array $rows): CapWhatIfService
+    {
+        /** @var TeamQueryRepositoryInterface&\PHPUnit\Framework\MockObject\Stub $stubRepo */
+        $stubRepo = self::createStub(TeamQueryRepositoryInterface::class);
+        $stubRepo->method('getRosterUnderContractOrderedByName')->willReturn($rows);
+
+        /** @var BuyoutLedgerRepositoryInterface&\PHPUnit\Framework\MockObject\Stub $stubCash */
+        $stubCash = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $stubCash->method('getTeamCashForSalary')->willReturn([]);
+
+        $calculator = new TeamCapCalculator($this->mockDb, $stubRepo, $stubCash);
+
+        return new CapWhatIfService($this->mockDb, $stubRepo, $calculator);
+    }
+
+    private function season(bool $offseason): Season
+    {
+        $season = self::createStub(Season::class);
+        $season->method('isOffseasonPhase')->willReturn($offseason);
+        return $season;
+    }
+
+    /**
+     * Seeded-Metros-mirroring active roster: pid 1 (yr1=800, yr2=880),
+     * pid 2 (yr1=600, yr2=660). year1 total 1400, year2 total 1540.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function metrosRoster(): array
+    {
+        return [
+            ['pid' => 1, 'name' => 'Player One', 'cy' => 1, 'cyt' => 3, 'salary_yr1' => 800, 'salary_yr2' => 880],
+            ['pid' => 2, 'name' => 'Player Two', 'cy' => 1, 'cyt' => 2, 'salary_yr1' => 600, 'salary_yr2' => 660],
+        ];
+    }
+
+    public function testBaselineReproducesRealCap(): void
+    {
+        $result = $this->buildService($this->metrosRoster())
+            ->computeScenario('Metros', 1, $this->season(false), null, 0, 0);
+
+        self::assertSame(1400, $result['baseline']['spent']['year1']);
+        self::assertSame(1540, $result['baseline']['spent']['year2']);
+        self::assertSame(League::HARD_CAP_MAX - 1400, $result['baseline']['space']['year1']);
+        self::assertSame(5600, $result['baseline']['space']['year1']);
+    }
+
+    public function testWaiveReducesYearTotalsByThatPlayersSalary(): void
+    {
+        $service = $this->buildService($this->metrosRoster());
+
+        $waiveOne = $service->computeScenario('Metros', 1, $this->season(false), 1, 0, 0);
+        self::assertSame(1400 - 800, $waiveOne['scenario']['spent']['year1']);
+        self::assertSame(6400, $waiveOne['scenario']['space']['year1']);
+        self::assertSame('Player One', $waiveOne['waivedName']);
+
+        $waiveTwo = $service->computeScenario('Metros', 1, $this->season(false), 2, 0, 0);
+        self::assertSame(1400 - 600, $waiveTwo['scenario']['spent']['year1']);
+        self::assertSame('Player Two', $waiveTwo['waivedName']);
+    }
+
+    public function testAddSigningRaisesEachYearByFlatSalary(): void
+    {
+        $result = $this->buildService($this->metrosRoster())
+            ->computeScenario('Metros', 1, $this->season(false), null, 3, 1000);
+
+        self::assertSame(1400 + 1000, $result['scenario']['spent']['year1']);
+        self::assertSame(1540 + 1000, $result['scenario']['spent']['year2']);
+        self::assertSame(0 + 1000, $result['scenario']['spent']['year3']);
+        self::assertSame(0, $result['scenario']['spent']['year4']);
+    }
+
+    public function testCombinedWaiveAndAddComputesNetPerYear(): void
+    {
+        $result = $this->buildService($this->metrosRoster())
+            ->computeScenario('Metros', 1, $this->season(false), 1, 2, 500);
+
+        self::assertSame(1400 - 800 + 500, $result['scenario']['spent']['year1']);
+        self::assertSame('Player One', $result['waivedName']);
+    }
+
+    public function testSyntheticSigningLandsFirstYearInYear1RegularPhase(): void
+    {
+        $result = $this->buildService($this->metrosRoster())
+            ->computeScenario('Metros', 1, $this->season(false), null, 2, 500);
+
+        $delta = $result['scenario']['spent']['year1'] - $result['baseline']['spent']['year1'];
+        self::assertSame(500, $delta);
+    }
+
+    public function testSyntheticSigningLandsFirstYearInYear1OffseasonPhase(): void
+    {
+        $result = $this->buildService($this->metrosRoster())
+            ->computeScenario('Metros', 1, $this->season(true), null, 2, 500);
+
+        $delta = $result['scenario']['spent']['year1'] - $result['baseline']['spent']['year1'];
+        self::assertSame(500, $delta);
+    }
+
+    public function testWaivePidNotOnRosterIsNoOp(): void
+    {
+        $result = $this->buildService($this->metrosRoster())
+            ->computeScenario('Metros', 1, $this->season(false), 999999, 0, 0);
+
+        self::assertSame($result['baseline']['spent'], $result['scenario']['spent']);
+        self::assertNull($result['waivedName']);
+    }
+
+    public function testZeroYearsOrZeroSalaryAddsNoSigning(): void
+    {
+        $service = $this->buildService($this->metrosRoster());
+
+        $zeroYears = $service->computeScenario('Metros', 1, $this->season(false), null, 0, 1000);
+        self::assertSame($zeroYears['baseline']['spent'], $zeroYears['scenario']['spent']);
+
+        $zeroSalary = $service->computeScenario('Metros', 1, $this->season(false), null, 3, 0);
+        self::assertSame($zeroSalary['baseline']['spent'], $zeroSalary['scenario']['spent']);
+    }
+
+    public function testYearsClampedToSixNoUndefinedSeventhYear(): void
+    {
+        // Empty roster isolates the synthetic signing: 6 flat years, no salary_yr7.
+        $result = $this->buildService([])
+            ->computeScenario('Metros', 1, $this->season(false), null, 99, 500);
+
+        self::assertSame(6, $result['years']);
+        self::assertSame(500, $result['scenario']['spent']['year6']);
+        self::assertArrayNotHasKey('year7', $result['scenario']['spent']);
+    }
+
+    public function testNegativeSalaryClampedToZeroAddsNoSigning(): void
+    {
+        $result = $this->buildService($this->metrosRoster())
+            ->computeScenario('Metros', 1, $this->season(false), null, 3, -5);
+
+        self::assertSame(0, $result['salary']);
+        self::assertSame($result['baseline']['spent'], $result['scenario']['spent']);
+    }
+
+    public function testOverCapFlaggedWhenYearExceedsHardCap(): void
+    {
+        $overCapRoster = [
+            ['pid' => 1, 'name' => 'Whale', 'cy' => 1, 'cyt' => 1, 'salary_yr1' => League::HARD_CAP_MAX + 1000],
+        ];
+
+        $result = $this->buildService($overCapRoster)
+            ->computeScenario('Metros', 1, $this->season(false), null, 0, 0);
+
+        self::assertTrue($result['overCap']['year1']);
+        self::assertFalse($result['overCap']['year2']);
+    }
+}

--- a/ibl5/tests/CapWhatIf/CapWhatIfViewTest.php
+++ b/ibl5/tests/CapWhatIf/CapWhatIfViewTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CapWhatIf;
+
+use CapWhatIf\CapWhatIfView;
+use CapWhatIf\Contracts\CapWhatIfViewInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for {@see CapWhatIfView} HTML rendering — title/form/select structure,
+ * output escaping, the GET (no-CSRF) decision, and the over-cap flag class.
+ *
+ * @covers \CapWhatIf\CapWhatIfView
+ */
+class CapWhatIfViewTest extends TestCase
+{
+    private CapWhatIfViewInterface $view;
+
+    protected function setUp(): void
+    {
+        $this->view = new CapWhatIfView();
+    }
+
+    /**
+     * @param array<string, bool> $overCap
+     * @return array{baseline: array{spent: array<string,int>, space: array<string,int>}, scenario: array{spent: array<string,int>, space: array<string,int>}, overCap: array<string, bool>, waivedName: ?string, years: int, salary: int}
+     */
+    private function scenarioData(array $overCap = [], ?string $waivedName = null): array
+    {
+        $zeros = ['year1' => 0, 'year2' => 0, 'year3' => 0, 'year4' => 0, 'year5' => 0, 'year6' => 0];
+
+        return [
+            'baseline' => ['spent' => $zeros, 'space' => $zeros],
+            'scenario' => ['spent' => $zeros, 'space' => $zeros],
+            'overCap' => $overCap,
+            'waivedName' => $waivedName,
+            'years' => 1,
+            'salary' => 0,
+        ];
+    }
+
+    public function testRendersTitleFormAndOptionPerRosterPlayer(): void
+    {
+        $roster = [
+            ['pid' => 10, 'name' => 'Alpha Guard'],
+            ['pid' => 20, 'name' => 'Beta Forward'],
+        ];
+
+        $output = $this->view->render($this->scenarioData(), $roster, 2025, 2026);
+
+        $this->assertStringContainsString('<h2 class="ibl-title">Cap Calculator</h2>', $output);
+        $this->assertStringContainsString('<form method="get">', $output);
+        $this->assertStringContainsString('value="10"', $output);
+        $this->assertStringContainsString('Alpha Guard', $output);
+        $this->assertStringContainsString('value="20"', $output);
+        $this->assertStringContainsString('Beta Forward', $output);
+        // One <option> per roster player, plus the leading "none" option.
+        $this->assertSame(3, substr_count($output, '<option'));
+    }
+
+    public function testEscapesPlayerName(): void
+    {
+        $roster = [['pid' => 1, 'name' => '<script>x</script>']];
+
+        $output = $this->view->render($this->scenarioData(), $roster, 2025, 2026);
+
+        $this->assertStringNotContainsString('<script>x</script>', $output);
+        $this->assertStringContainsString('&lt;script&gt;', $output);
+    }
+
+    public function testEmitsNoCsrfTokenField(): void
+    {
+        $output = $this->view->render($this->scenarioData(), [], 2025, 2026);
+
+        $this->assertStringNotContainsString('_csrf_token', $output);
+        $this->assertStringNotContainsString('csrf_token', $output);
+    }
+
+    public function testOverCapYearCarriesFlagClass(): void
+    {
+        $flagged = $this->view->render($this->scenarioData(['year1' => true]), [], 2025, 2026);
+        $this->assertStringContainsString('class="ibl-stat-highlight"', $flagged);
+
+        $clean = $this->view->render($this->scenarioData(['year1' => false]), [], 2025, 2026);
+        $this->assertStringNotContainsString('class="ibl-stat-highlight"', $clean);
+    }
+
+    public function testRendersWaivedNameNoticeWhenPresent(): void
+    {
+        $output = $this->view->render($this->scenarioData([], 'Waived Player'), [], 2025, 2026);
+        $this->assertStringContainsString('Waiving: Waived Player', $output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/CapWhatIfEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/CapWhatIfEntryPointTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+/**
+ * Entry-point tests for modules/CapWhatIf/index.php.
+ *
+ * The team is resolved server-side from the authenticated identity; these cover
+ * the valid render, the owner-scoping guarantee (a request-supplied teamid is
+ * never read), the no-team notice, and garbage-input resilience.
+ */
+class CapWhatIfEntryPointTest extends ModuleEntryPointTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb->onQuery('ibl_settings', [
+            ['setting_key' => 'Current Season Phase', 'value' => 'Regular Season'],
+            ['setting_key' => 'Current Season Ending Year', 'value' => '2026'],
+        ]);
+        $this->mockDb->onQuery('ibl_sim_dates', []);
+    }
+
+    /**
+     * Resolve the authenticated GM to the Metros (teamid 1) with a two-player
+     * roster.
+     */
+    private function seedMetrosOwner(): void
+    {
+        // getTeamnameFromUsername (gm_username lookup) → Metros.
+        $this->mockDb->onQuery('gm_username', [['team_name' => 'Metros']]);
+        // getTidFromTeamname (teamid lookup) → 1.
+        $this->mockDb->onQuery('teamid FROM ibl_team_info', [['teamid' => 1]]);
+        // getRosterUnderContractOrderedByName → two active contracts.
+        $this->mockDb->onQuery('FROM ibl_plr p', [
+            ['pid' => 1, 'name' => 'Player One', 'cy' => 1, 'cyt' => 3, 'salary_yr1' => 800, 'salary_yr2' => 880],
+            ['pid' => 2, 'name' => 'Player Two', 'cy' => 1, 'cyt' => 2, 'salary_yr1' => 600, 'salary_yr2' => 660],
+        ]);
+    }
+
+    public function testValidScenarioRendersResultTableForOwner(): void
+    {
+        $this->authenticateAs('metrosgm');
+        $this->seedMetrosOwner();
+
+        $output = $this->runModule('CapWhatIf', ['waive' => '1', 'years' => '3', 'salary' => '1000']);
+
+        $this->assertStringContainsString('Cap Calculator', $output);
+        $this->assertStringContainsString('<table', $output);
+        $this->assertStringContainsString('Player One', $output);
+    }
+
+    public function testInjectedTeamidDoesNotChangeResolvedTeam(): void
+    {
+        $this->authenticateAs('metrosgm');
+        $this->seedMetrosOwner();
+
+        $this->runModule('CapWhatIf', ['teamid' => '2', 'years' => '1', 'salary' => '500']);
+
+        // The roster query must bind the OWNER's teamid (1), never the injected 2.
+        $rosterQueries = array_filter(
+            $this->mockDb->getExecutedQueries(),
+            static fn (string $q): bool => stripos($q, 'FROM ibl_plr p') !== false
+        );
+        $this->assertNotEmpty($rosterQueries);
+        foreach ($rosterQueries as $q) {
+            $this->assertStringContainsString('p.teamid = 1', $q);
+            $this->assertStringNotContainsString('p.teamid = 2', $q);
+        }
+    }
+
+    public function testNoTeamUserSeesNoticeNotCapTable(): void
+    {
+        $this->authenticateAs('freeagent');
+        $this->mockDb->onQuery('gm_username', [['team_name' => 'Free Agents']]);
+
+        $output = $this->runModule('CapWhatIf', []);
+
+        $this->assertStringContainsString('must be a team GM', $output);
+        $this->assertStringNotContainsString('<table', $output);
+    }
+
+    public function testGarbageInputDoesNotCrash(): void
+    {
+        $this->authenticateAs('metrosgm');
+        $this->seedMetrosOwner();
+
+        $output = $this->runModule('CapWhatIf', ['years' => '99', 'salary' => '-5', 'waive' => 'abc']);
+
+        $this->assertStringContainsString('Cap Calculator', $output);
+        $this->assertStringNotContainsString('Fatal error', $output);
+        $this->assertStringNotContainsString('Warning', $output);
+    }
+}

--- a/ibl5/tests/Team/TeamCapCalculatorTest.php
+++ b/ibl5/tests/Team/TeamCapCalculatorTest.php
@@ -216,6 +216,46 @@ class TeamCapCalculatorTest extends TestCase
         self::assertSame([], $this->buildCalculator()->getSalaryCapArray('Test', 1, $this->season(false)));
     }
 
+    // ── getSalaryCapArrayFromContractRows (extracted; delegation equivalence) ─
+
+    public function testGetSalaryCapArrayFromContractRowsMatchesPublicWalk(): void
+    {
+        // Same stub rows as testGetSalaryCapArrayAccumulatesContractSalariesByYear,
+        // proving the extracted method reproduces the public wrapper's year-array.
+        $rows = [
+            ['cy' => 1, 'cyt' => 3, 'salary_yr1' => 1000, 'salary_yr2' => 1100, 'salary_yr3' => 1200],
+        ];
+        $this->stubCash->method('getTeamCashForSalary')->willReturn([]);
+
+        $result = $this->buildCalculator()
+            ->getSalaryCapArrayFromContractRows($rows, 1, $this->season(false));
+
+        self::assertSame(['year1' => 1000, 'year2' => 1100, 'year3' => 1200], $result);
+    }
+
+    public function testGetSalaryCapArrayFromContractRowsAdvancesYearInOffseason(): void
+    {
+        $rows = [
+            ['cy' => 1, 'cyt' => 3, 'salary_yr1' => 1000, 'salary_yr2' => 1100, 'salary_yr3' => 1200],
+        ];
+        $this->stubCash->method('getTeamCashForSalary')->willReturn([]);
+
+        $result = $this->buildCalculator()
+            ->getSalaryCapArrayFromContractRows($rows, 1, $this->season(true));
+
+        self::assertSame(['year1' => 1100, 'year2' => 1200], $result);
+    }
+
+    public function testGetSalaryCapArrayFromContractRowsReturnsEmptyForNoCommitments(): void
+    {
+        $this->stubCash->method('getTeamCashForSalary')->willReturn([]);
+
+        self::assertSame(
+            [],
+            $this->buildCalculator()->getSalaryCapArrayFromContractRows([], 1, $this->season(false))
+        );
+    }
+
     // ── getTotalCurrentSeasonSalaries / getTotalNextSeasonSalaries ─
 
     public function testGetTotalCurrentSeasonSalariesSumsCurrentYearAcrossPlayers(): void

--- a/ibl5/tests/e2e/flows/cap-whatif.spec.ts
+++ b/ibl5/tests/e2e/flows/cap-whatif.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '../fixtures/auth';
+import type { Page } from '@playwright/test';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+
+// Cap "What-If" Calculator — owner-only sandbox (GET, no persistence).
+// The auth fixture owns Metros (teamid 1); the page renders BOTH the baseline
+// and the scenario in a single request, so all delta assertions read from one
+// page render and are immune to parallel roster mutation and seed size.
+//
+// Seed grounding (ci-seed.sql:373): pid 200000031 "Waive Target" is a Metros
+// (tid=1) active player with salary_yr1 = 1.
+const WAIVE_TARGET_PID = '200000031';
+const WAIVE_TARGET_SALARY_YR1 = 1;
+
+interface Year1Cells {
+  baselineSpent: number;
+  baselineSpace: number;
+  scenarioSpent: number;
+  scenarioSpace: number;
+}
+
+// Columns: [0] Year, [1] Baseline Spent, [2] Baseline Space,
+//          [3] Scenario Spent, [4] Scenario Space. First tbody row = year1.
+async function readYear1(page: Page): Promise<Year1Cells> {
+  const cells = page.locator('table.ibl-data-table tbody tr').first().locator('td');
+  const toNum = async (i: number): Promise<number> =>
+    parseInt(((await cells.nth(i).textContent()) ?? '').trim(), 10);
+  return {
+    baselineSpent: await toNum(1),
+    baselineSpace: await toNum(2),
+    scenarioSpent: await toNum(3),
+    scenarioSpace: await toNum(4),
+  };
+}
+
+test.describe('Cap What-If Calculator flow', () => {
+  test.beforeEach(async ({ appState }) => {
+    await appState({ 'Current Season Ending Year': '2026', 'Trivia Mode': 'Off' });
+  });
+
+  test('baseline view renders with a numeric cap table', async ({ page }) => {
+    await page.goto('modules.php?name=CapWhatIf');
+    await assertNoPhpErrors(page, 'on Cap Calculator baseline');
+
+    await expect(page.locator('.ibl-title')).toContainText(/Cap Calculator/i);
+    await expect(page.locator('table.ibl-data-table').first()).toBeVisible();
+    await expect(page.locator('form[method="get"]')).toBeVisible();
+
+    // With no scenario params, baseline and scenario columns are identical.
+    const y1 = await readYear1(page);
+    expect(Number.isNaN(y1.baselineSpace)).toBe(false);
+    expect(y1.scenarioSpent).toBe(y1.baselineSpent);
+    expect(y1.scenarioSpace).toBe(y1.baselineSpace);
+  });
+
+  test('adding a signing raises year1 scenario spent by the flat salary', async ({ page }) => {
+    await page.goto('modules.php?name=CapWhatIf&years=2&salary=1000');
+    await assertNoPhpErrors(page, 'on Cap Calculator signing scenario');
+
+    const y1 = await readYear1(page);
+    expect(y1.scenarioSpent - y1.baselineSpent).toBe(1000);
+  });
+
+  test('waiving + adding computes the net year1 delta', async ({ page }) => {
+    // Waive the seeded Waive Target (salary_yr1 = 1) and add 3yr @ $1000.
+    // Net year1 spent delta = -1 + 1000 = 999; space moves the opposite way.
+    await page.goto(
+      `modules.php?name=CapWhatIf&waive=${WAIVE_TARGET_PID}&years=3&salary=1000`,
+    );
+    await assertNoPhpErrors(page, 'on Cap Calculator combined scenario');
+
+    await expect(page.getByText(/Waiving:\s*Waive Target/)).toBeVisible();
+
+    const y1 = await readYear1(page);
+    const expectedDelta = 1000 - WAIVE_TARGET_SALARY_YR1;
+    expect(y1.scenarioSpent - y1.baselineSpent).toBe(expectedDelta);
+    expect(y1.baselineSpace - y1.scenarioSpace).toBe(expectedDelta);
+  });
+
+  test('request-supplied teamid does not change the resolved owner team', async ({ page }) => {
+    // teamid=2 is ignored — the page must still render the OWNER's (Metros)
+    // roster, proven by the Metros-only Waive Target appearing in the waive
+    // select. Team 2's roster would not contain it.
+    await page.goto('modules.php?name=CapWhatIf&teamid=2');
+    await assertNoPhpErrors(page, 'on Cap Calculator with teamid injection');
+
+    const waiveSelect = page.locator('select[name="waive"]');
+    await expect(waiveSelect.locator('option', { hasText: 'Waive Target' })).toHaveCount(1);
+  });
+});

--- a/ibl5/tests/e2e/flows/navigation.spec.ts
+++ b/ibl5/tests/e2e/flows/navigation.spec.ts
@@ -32,6 +32,32 @@ test.describe('Navigation bar (authenticated, desktop)', () => {
     await expect(teamPageLink).toBeVisible();
   });
 
+  test('my team dropdown shows owner Cap Calculator link', async ({ page }) => {
+    // Cap Calculator lives in getIblTeamMenu(), so it is owner-gated (teamId !== null)
+    // and IBL-only. The auth fixture owns Metros (teamid 1).
+    await page.goto('index.php');
+    const nav = desktopNav(page);
+    await nav.getByRole('button', { name: 'My Team' }).click();
+
+    const capCalcLink = nav.locator('.nav-dropdown-item', {
+      hasText: 'Cap Calculator',
+    }).first();
+    await expect(capCalcLink).toBeVisible();
+    await expect(capCalcLink).toHaveAttribute(
+      'href',
+      /modules\.php\?name=CapWhatIf/,
+    );
+  });
+
+  test('Cap Calculator link is absent in Olympics context', async ({ page }) => {
+    // getIblTeamMenu() only returns for currentLeague === 'ibl', so the link
+    // never appears under Olympics — no OLYMPICS_HIDDEN_NAV_MODULES edit needed.
+    await page.goto('index.php?league=olympics');
+    await expect(
+      desktopNav(page).locator('.nav-dropdown-item', { hasText: 'Cap Calculator' }),
+    ).not.toBeAttached();
+  });
+
   test('my team dropdown shows admin-only Voting Results link', async ({ page }) => {
     // The default auth fixture is the CI main user: roles_mask=1 (ADMIN,
     // setup-docker-e2e action.yml ~L128) and gm_username on team Metros

--- a/ibl5/tests/e2e/vr-manifest.ts
+++ b/ibl5/tests/e2e/vr-manifest.ts
@@ -147,6 +147,8 @@ export const VR_MANIFEST: VrRow[] = [
     anchor: 'form[action*="ApiKeys"]', viewports: ['desktop', 'mobile'], skipContentCheck: true },
   { name: 'cap-space', auth: 'auth', url: 'modules.php?name=CapSpace&teamid=1',
     anchor: '.ibl-data-table', viewports: ['desktop', 'mobile'] },
+  { name: 'cap-whatif', auth: 'auth', url: 'modules.php?name=CapWhatIf',
+    anchor: 'form[method="get"]', viewports: ['desktop', 'mobile'] },
   { name: 'depth-chart-entry', auth: 'auth', url: 'modules.php?name=DepthChartEntry',
     anchor: 'form[name="DepthChartEntry"]', viewports: ['desktop', 'mobile'] },
   { name: 'draft', auth: 'auth', url: 'modules.php?name=Draft',


### PR DESCRIPTION
## Summary

Add an owner-only interactive sandbox (`modules.php?name=CapWhatIf`) that lets GMs model hypothetical cap scenarios — waive one rostered player and/or add one hypothetical signing — then renders per-season cap totals and cap space. **Nothing is persisted.** Computation delegates to the existing `TeamCapCalculator` cap walk via a newly extracted `getSalaryCapArrayFromContractRows()` method.

## Key Design Decisions

- **GET, not POST** — request mutates zero server state; no CSRF surface; form is idempotent and bookmarkable.
- **Extraction, not duplication** — Phase 1 extracts `getSalaryCapArrayFromContractRows()` from the existing `TeamCapCalculator` so the sandbox reuses the league's real cap math.
- **Owner-scoped** — `teamid` resolved server-side from session identity; never read from request.
- **Nav placement** — My Team sidebar (IBL only); no `OLYMPICS_HIDDEN_NAV_MODULES` change needed.

## refactor-flag note

Phase 1 moves the `getSalaryCapArray` body into the new extracted method. `bin/refactor-flag` is resolved by the same PR modifying `tests/Team/TeamCapCalculatorTest.php`.

## Manual Testing

| # | Step |
|---|------|
| 32 | Does the new Cap "What-If" Calculator page look right, and does the what-if flow — waive a player / add a contract and read the updated cap table — feel clear and smooth? |