### PR TITLE
a11y: burn down empty-table-header (cap space, player page, free agency, depth chart, next sim)

### DIFF
--- a/ibl5/classes/CapSpace/CapSpaceView.php
+++ b/ibl5/classes/CapSpace/CapSpaceView.php
@@ -59,7 +59,7 @@ class CapSpaceView implements CapSpaceViewInterface
             $html .= $yearEnd . '<br>Total</th>';
         }
 
-        $html .= '<th class="divider" aria-label="Separator"></th>';
+        $html .= '<th class="divider"><span class="sr-only">Separator</span></th>';
 
         // Position columns (current year only)
         foreach (\JSB::PLAYER_POSITIONS as $position) {
@@ -71,7 +71,7 @@ class CapSpaceView implements CapSpaceViewInterface
             $html .= $safePosition . '</th>';
         }
 
-        $html .= '<th class="divider" aria-label="Separator"></th>';
+        $html .= '<th class="divider"><span class="sr-only">Separator</span></th>';
         $html .= '<th>FA Slots</th>';
         $html .= '<th>Has MLE</th>';
         $html .= '<th>Has LLE</th>';

--- a/ibl5/classes/CapSpace/CapSpaceView.php
+++ b/ibl5/classes/CapSpace/CapSpaceView.php
@@ -59,7 +59,7 @@ class CapSpaceView implements CapSpaceViewInterface
             $html .= $yearEnd . '<br>Total</th>';
         }
 
-        $html .= '<th class="divider"></th>';
+        $html .= '<th class="divider" aria-label="Separator"></th>';
 
         // Position columns (current year only)
         foreach (\JSB::PLAYER_POSITIONS as $position) {
@@ -71,7 +71,7 @@ class CapSpaceView implements CapSpaceViewInterface
             $html .= $safePosition . '</th>';
         }
 
-        $html .= '<th class="divider"></th>';
+        $html .= '<th class="divider" aria-label="Separator"></th>';
         $html .= '<th>FA Slots</th>';
         $html .= '<th>Has MLE</th>';
         $html .= '<th>Has LLE</th>';

--- a/ibl5/classes/FreeAgency/FreeAgencyView.php
+++ b/ibl5/classes/FreeAgency/FreeAgencyView.php
@@ -385,7 +385,7 @@ class FreeAgencyView
         </tr>
         <tr>
             <?php if ($showOptionsColumn): ?>
-            <th aria-label="Actions"></th>
+            <th><span class="sr-only">Actions</span></th>
             <?php endif; ?>
             <th>Pos</th>
             <th>Player</th>

--- a/ibl5/classes/FreeAgency/FreeAgencyView.php
+++ b/ibl5/classes/FreeAgency/FreeAgencyView.php
@@ -385,7 +385,7 @@ class FreeAgencyView
         </tr>
         <tr>
             <?php if ($showOptionsColumn): ?>
-            <th></th>
+            <th aria-label="Actions"></th>
             <?php endif; ?>
             <th>Pos</th>
             <th>Player</th>

--- a/ibl5/classes/NextSim/NextSimView.php
+++ b/ibl5/classes/NextSim/NextSimView.php
@@ -246,16 +246,16 @@ window.IBL_initNextSimHighlight();
             <th class="sticky-col">Player</th>
             <th>Pos</th>
             <th>Age</th>
-            <th class="sep-team"></th>
+            <th class="sep-team" aria-label="Separator"></th>
             <th>2ga</th>
             <th>2g%</th>
-            <th class="sep-team"></th>
+            <th class="sep-team" aria-label="Separator"></th>
             <th>fta</th>
             <th>ft%</th>
-            <th class="sep-team"></th>
+            <th class="sep-team" aria-label="Separator"></th>
             <th>3ga</th>
             <th>3g%</th>
-            <th class="sep-team"></th>
+            <th class="sep-team" aria-label="Separator"></th>
             <th>orb</th>
             <th>drb</th>
             <th>ast</th>
@@ -263,20 +263,20 @@ window.IBL_initNextSimHighlight();
             <th>tvr</th>
             <th>blk</th>
             <th>foul</th>
-            <th class="sep-team"></th>
+            <th class="sep-team" aria-label="Separator"></th>
             <th>oo</th>
             <th>do</th>
             <th>po</th>
             <th>to</th>
-            <th class="sep-team"></th>
+            <th class="sep-team" aria-label="Separator"></th>
             <th>od</th>
             <th>dd</th>
             <th>pd</th>
             <th>td</th>
-            <th class="sep-team"></th>
+            <th class="sep-team" aria-label="Separator"></th>
             <th>Clu</th>
             <th>Con</th>
-            <th class="sep-team"></th>
+            <th class="sep-team" aria-label="Separator"></th>
             <th>Days Injured</th>
         </tr>
     </thead>

--- a/ibl5/classes/NextSim/NextSimView.php
+++ b/ibl5/classes/NextSim/NextSimView.php
@@ -246,16 +246,16 @@ window.IBL_initNextSimHighlight();
             <th class="sticky-col">Player</th>
             <th>Pos</th>
             <th>Age</th>
-            <th class="sep-team" aria-label="Separator"></th>
+            <th class="sep-team"><span class="sr-only">Separator</span></th>
             <th>2ga</th>
             <th>2g%</th>
-            <th class="sep-team" aria-label="Separator"></th>
+            <th class="sep-team"><span class="sr-only">Separator</span></th>
             <th>fta</th>
             <th>ft%</th>
-            <th class="sep-team" aria-label="Separator"></th>
+            <th class="sep-team"><span class="sr-only">Separator</span></th>
             <th>3ga</th>
             <th>3g%</th>
-            <th class="sep-team" aria-label="Separator"></th>
+            <th class="sep-team"><span class="sr-only">Separator</span></th>
             <th>orb</th>
             <th>drb</th>
             <th>ast</th>
@@ -263,20 +263,20 @@ window.IBL_initNextSimHighlight();
             <th>tvr</th>
             <th>blk</th>
             <th>foul</th>
-            <th class="sep-team" aria-label="Separator"></th>
+            <th class="sep-team"><span class="sr-only">Separator</span></th>
             <th>oo</th>
             <th>do</th>
             <th>po</th>
             <th>to</th>
-            <th class="sep-team" aria-label="Separator"></th>
+            <th class="sep-team"><span class="sr-only">Separator</span></th>
             <th>od</th>
             <th>dd</th>
             <th>pd</th>
             <th>td</th>
-            <th class="sep-team" aria-label="Separator"></th>
+            <th class="sep-team"><span class="sr-only">Separator</span></th>
             <th>Clu</th>
             <th>Con</th>
-            <th class="sep-team" aria-label="Separator"></th>
+            <th class="sep-team"><span class="sr-only">Separator</span></th>
             <th>Days Injured</th>
         </tr>
     </thead>

--- a/ibl5/classes/Player/Views/PlayerTradingCardBackView.php
+++ b/ibl5/classes/Player/Views/PlayerTradingCardBackView.php
@@ -113,7 +113,7 @@ class PlayerTradingCardBackView
             . '<h3 class="section-title">Player Highs</h3>'
             . '<table class="highs-table">'
             . '<tr>'
-            . '<th class="highs-header"></th>'
+            . '<th class="highs-header" aria-label="Category"></th>'
             . '<th class="highs-header" colspan="2">Regular Season</th>'
             . '<th class="highs-header" colspan="2">Playoffs</th>'
             . '</tr>'

--- a/ibl5/classes/Player/Views/PlayerTradingCardBackView.php
+++ b/ibl5/classes/Player/Views/PlayerTradingCardBackView.php
@@ -113,7 +113,7 @@ class PlayerTradingCardBackView
             . '<h3 class="section-title">Player Highs</h3>'
             . '<table class="highs-table">'
             . '<tr>'
-            . '<th class="highs-header" aria-label="Category"></th>'
+            . '<th class="highs-header"><span class="sr-only">Category</span></th>'
             . '<th class="highs-header" colspan="2">Regular Season</th>'
             . '<th class="highs-header" colspan="2">Playoffs</th>'
             . '</tr>'

--- a/ibl5/design/base.css
+++ b/ibl5/design/base.css
@@ -204,3 +204,26 @@ img {
 }
 
 } /* end @layer components (mobile overrides) */
+
+/* ==========================================================================
+   Accessibility utilities — @layer utilities
+   ========================================================================== */
+
+@layer utilities {
+
+/* Visually-hidden: hides text from sighted users while keeping it readable by
+   screen readers. Used for empty <th> accessible names (empty-table-header). */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border-width: 0;
+}
+
+} /* end @layer utilities */

--- a/ibl5/docs/a11y-backlog.md
+++ b/ibl5/docs/a11y-backlog.md
@@ -46,11 +46,11 @@ last_verified: 2026-06-14
 **Direction:** Fix the level jump. Bundle into `a11y-2-heading-one-single-title` (same view, same render).
 **Disposition:** ✅ enforced — `a11y-2-heading-one-single-title` (merged).
 
-### empty-table-header — best-practice, minor — 🟢
+### empty-table-header — best-practice, minor — ✅ fixed
 **Location:** cap space (`CapSpaceView` th[data-sort-col=7,13]), player page (`.highs-header`), free agency (`FreeAgencyView` sticky-col `th[data-sort-col=0]`), depth chart entry (`.dc-lineup-preview-table` first th + `.sep-team` separators, 9 nodes), next sim (`.next-sim-position-section` tables, 40 nodes).
 **Problem:** `<th>` cells with no text (icon-only sort columns / sticky row-label column / separator + position-section headers). Template-driven, seed-independent.
-**Direction:** Add a visually-hidden label or `aria-label`/`scope` to each empty header. No visual change.
-**Disposition:** 🟢 — `a11y-3-empty-table-header`.
+**Fix:** Added `aria-label` to each empty header. No visual change.
+**Disposition:** ✅ — fixed in `a11y-3-empty-table-header`; removed from `KNOWN_FAILING` in `accessibility.spec.ts`.
 
 ### link-name — wcag2a (level A), serious — 🔵
 **Location:** news index/categories/article (12 nodes each — consistent → template icon-link in `modules/News`); homepage + debug menu (12 nodes — the `last-sim-recap` panel team links, **data-dependent**).

--- a/ibl5/jslib/depth-chart-lineup-preview.js
+++ b/ibl5/jslib/depth-chart-lineup-preview.js
@@ -757,7 +757,7 @@
      */
     function renderPreviewDesktopTable(lineup, slotMinutes) {
         var html = '<table class="ibl-data-table dc-lineup-preview-table dc-lineup-preview-table--desktop"><thead><tr>';
-        html += '<th></th>';
+        html += '<th aria-label="Depth tier"></th>';
         for (var h = 0; h < SLOTS.length; h++) {
             html += '<th>' + SLOTS[h].label + '</th>';
         }
@@ -811,7 +811,7 @@
      */
     function renderPreviewMobileTable(lineup, slotMinutes, lastNameFreq) {
         var html = '<table class="ibl-data-table dc-lineup-preview-table dc-lineup-preview-table--mobile"><thead><tr>';
-        html += '<th></th>';
+        html += '<th aria-label="Position"></th>';
         for (var d = 0; d <= BACKUP_ROWS; d++) {
             html += '<th>' + (DEPTH_LABELS[d] || ((d + 1) + 'th')) + '</th>';
         }

--- a/ibl5/jslib/depth-chart-lineup-preview.js
+++ b/ibl5/jslib/depth-chart-lineup-preview.js
@@ -757,7 +757,7 @@
      */
     function renderPreviewDesktopTable(lineup, slotMinutes) {
         var html = '<table class="ibl-data-table dc-lineup-preview-table dc-lineup-preview-table--desktop"><thead><tr>';
-        html += '<th aria-label="Depth tier"></th>';
+        html += '<th><span class="sr-only">Depth tier</span></th>';
         for (var h = 0; h < SLOTS.length; h++) {
             html += '<th>' + SLOTS[h].label + '</th>';
         }
@@ -811,7 +811,7 @@
      */
     function renderPreviewMobileTable(lineup, slotMinutes, lastNameFreq) {
         var html = '<table class="ibl-data-table dc-lineup-preview-table dc-lineup-preview-table--mobile"><thead><tr>';
-        html += '<th aria-label="Position"></th>';
+        html += '<th><span class="sr-only">Position</span></th>';
         for (var d = 0; d <= BACKUP_ROWS; d++) {
             html += '<th>' + (DEPTH_LABELS[d] || ((d + 1) + 'th')) + '</th>';
         }

--- a/ibl5/tests/FreeAgency/fixtures/fa-under-contract.golden.html
+++ b/ibl5/tests/FreeAgency/fixtures/fa-under-contract.golden.html
@@ -158,7 +158,7 @@
                 Contract Offers                            </th>
         </tr>
         <tr>
-                        <th></th>
+                        <th><span class="sr-only">Actions</span></th>
                         <th>Pos</th>
             <th>Player</th>
                         <th>Age</th>
@@ -268,7 +268,7 @@
                             </th>
         </tr>
         <tr>
-                        <th></th>
+                        <th><span class="sr-only">Actions</span></th>
                         <th>Pos</th>
             <th>Player</th>
                         <th>Age</th>
@@ -324,7 +324,7 @@
                 All Other Free Agents                            </th>
         </tr>
         <tr>
-                        <th></th>
+                        <th><span class="sr-only">Actions</span></th>
                         <th>Pos</th>
             <th>Player</th>
                         <th class="sep-r-team">Team</th>

--- a/ibl5/tests/e2e/smoke/accessibility.spec.ts
+++ b/ibl5/tests/e2e/smoke/accessibility.spec.ts
@@ -91,16 +91,6 @@ const KNOWN_FAILING: Record<string, Set<string>> = {
   'heading-order': new Set([
   ]),
 
-  // Empty <th> cells (icon-only sort headers, separator headers). See ibl5/docs/a11y-backlog.md.
-  // Burn-down: a11y-3-empty-table-header.
-  'empty-table-header': new Set([
-    'cap space',
-    'player page',
-    'free agency',
-    'depth chart entry',
-    'next sim',
-  ]),
-
   // Links with no discernible text. Seed-dependent (data-driven sim-recap + News template).
   // See ibl5/docs/a11y-backlog.md §link-name.
   'link-name': new Set([


### PR DESCRIPTION
## Summary

Fixes all `empty-table-header` axe violations flagged by the 2026-06-13 accessibility audit. Adds visually-hidden accessible names to empty `<th>` cells across five pages without changing any visible layout. Removes the affected pages from the `KNOWN_FAILING` allowlist in the E2E accessibility ratchet.

**Pages fixed:**
- Cap space — sort icon columns (`data-sort-col="7"` and `data-sort-col="13"`)
- Player page — season-highs `.highs-header` empty header
- Free agency — sticky row-label column header across 3 tables
- Depth chart entry — `.dc-lineup-preview-table--desktop` separator headers
- Next sim — per-position section empty header cells

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.