### PR TITLE
fix(trading): bind trade submit to session team (IDOR D-03)

### DIFF
--- a/ibl5/classes/Trading/Contracts/TradingControllerInterface.php
+++ b/ibl5/classes/Trading/Contracts/TradingControllerInterface.php
@@ -13,9 +13,13 @@ interface TradingControllerInterface
     public function handleRosterPreviewApi(mixed $user): void;
 
     /**
+     * Submit a new trade offer. Takes the authenticated $user (not a form field)
+     * because the offering team must be bound to the session identity — the posted
+     * offeringTeam is audit-logged but never trusted (IDOR D-03).
+     *
      * @param array<string, mixed> $post
      */
-    public function submitTradeOffer(array $post): void;
+    public function submitTradeOffer(mixed $user, array $post): void;
 
     /**
      * @param array<string, mixed> $post

--- a/ibl5/classes/Trading/TradingController.php
+++ b/ibl5/classes/Trading/TradingController.php
@@ -126,15 +126,39 @@ class TradingController implements TradingControllerInterface
      *
      * @param array<string, mixed> $post
      */
-    public function submitTradeOffer(array $post): void
+    public function submitTradeOffer(mixed $user, array $post): void
     {
         if (!\Security\CsrfGuard::validateSubmittedToken('trade_offer')) {
             \Utilities\HtmxHelper::redirect('/ibl5/modules.php?name=Trading&error=' . rawurlencode('Invalid or expired form submission. Please try again.'));
         }
 
+        // Identity is derived from the authenticated session, never from form input —
+        // the IDOR check below must trust who the user actually is, not who they claim.
+        if (!$this->nukeCompat->isUser($user)) {
+            $this->nukeCompat->loginBox();
+            return;
+        }
+
+        $decoded = $this->nukeCompat->cookieDecode($user);
+        $username = is_string($decoded[1] ?? null) ? $decoded[1] : '';
+        $sessionTeam = $this->teamIdentityRepo->getTeamnameFromUsername($username);
+
+        if ($sessionTeam === null || $sessionTeam === '' || $sessionTeam === \League\League::FREE_AGENTS_TEAM_NAME) {
+            \Utilities\HtmxHelper::redirect('/ibl5/modules.php?name=Trading&op=reviewtrade&error=' . rawurlencode('Could not resolve your team.'));
+        }
+
         $rawFieldsCounter = $post['fieldsCounter'] ?? 0;
         $fieldsCounter = (is_numeric($rawFieldsCounter) ? (int) $rawFieldsCounter : 0) + 1;
-        $offeringTeam = is_string($post['offeringTeam'] ?? null) ? $post['offeringTeam'] : '';
+        // IDOR (D-03): the offering team is bound to the session, never the POST body.
+        // We read the posted value only to audit-log a tamper attempt, then discard it.
+        $postOfferingTeam = is_string($post['offeringTeam'] ?? null) ? $post['offeringTeam'] : '';
+        if ($postOfferingTeam !== '' && $postOfferingTeam !== $sessionTeam) {
+            $this->auditLogger->warning('trade_offer_team_mismatch', [
+                'post' => $postOfferingTeam,
+                'session' => $sessionTeam,
+            ]);
+        }
+        $offeringTeam = $sessionTeam;
         $listeningTeam = is_string($post['listeningTeam'] ?? null) ? $post['listeningTeam'] : '';
         $rawSwitch = $post['switchCounter'] ?? 0;
         $switchCounter = is_numeric($rawSwitch) ? (int) $rawSwitch : 0;

--- a/ibl5/modules/Trading/maketradeoffer.php
+++ b/ibl5/modules/Trading/maketradeoffer.php
@@ -9,7 +9,7 @@ try {
     die("Error loading system files. Please contact the administrator.");
 }
 
-global $mysqli_db;
+global $mysqli_db, $user;
 
 if (!isset($mysqli_db) || !($mysqli_db instanceof mysqli)) {
     \Logging\LoggerFactory::getChannel('trade')->critical('Database connection not available');
@@ -31,4 +31,4 @@ $controller = new \Trading\TradingController(
     $teamIdentityRepo, $nukeCompat, $mysqli_db
 );
 
-$controller->submitTradeOffer($_POST);
+$controller->submitTradeOffer($user, $_POST);

--- a/ibl5/tests/Trading/TradingControllerSubmitOfferTest.php
+++ b/ibl5/tests/Trading/TradingControllerSubmitOfferTest.php
@@ -7,6 +7,7 @@ namespace Tests\Trading;
 use PHPUnit\Framework\TestCase;
 use Tests\WideUnit\Mocks\MockDatabase;
 use Repositories\Contracts\TeamIdentityRepositoryInterface;
+use Security\CsrfGuard;
 use Trading\Contracts\TradingServiceInterface;
 use Trading\Contracts\TradeProcessorInterface;
 use Trading\Contracts\TradeOfferRepositoryInterface;
@@ -17,9 +18,10 @@ use Trading\TradingController;
 /**
  * Tests for TradingController::submitTradeOffer()
  *
- * All code paths in submitTradeOffer() reach HtmxHelper::redirect() which calls
- * exit — full invocation tests require E2E coverage. These tests verify
- * instantiation and interface compliance only.
+ * Post-auth paths in submitTradeOffer() reach HtmxHelper::redirect() which calls
+ * exit — full invocation (happy path + IDOR override) requires E2E coverage. These
+ * tests verify interface compliance and the pre-redirect unauthenticated bail
+ * (which returns rather than exiting), proving the auth gate guards the endpoint.
  */
 class TradingControllerSubmitOfferTest extends TestCase
 {
@@ -28,18 +30,28 @@ class TradingControllerSubmitOfferTest extends TestCase
     protected function setUp(): void
     {
         $this->mockDb = new MockDatabase();
+        $_SESSION = [];
+        $_POST = [];
     }
 
-    private function buildController(): TradingController
+    protected function tearDown(): void
     {
+        $_SESSION = [];
+        $_POST = [];
+    }
+
+    private function buildController(
+        ?\Utilities\NukeCompat $nukeCompat = null,
+        ?TradeOfferInterface $tradeOffer = null,
+    ): TradingController {
         return new TradingController(
             self::createStub(TradingServiceInterface::class),
             self::createStub(TradeProcessorInterface::class),
             self::createStub(TradeOfferRepositoryInterface::class),
-            self::createStub(TradeOfferInterface::class),
+            $tradeOffer ?? self::createStub(TradeOfferInterface::class),
             self::createStub(TradingViewInterface::class),
             self::createStub(TeamIdentityRepositoryInterface::class),
-            self::createStub(\Utilities\NukeCompat::class),
+            $nukeCompat ?? self::createStub(\Utilities\NukeCompat::class),
             $this->mockDb,
         );
     }
@@ -51,5 +63,27 @@ class TradingControllerSubmitOfferTest extends TestCase
             \Trading\Contracts\TradingControllerInterface::class,
             (array) class_implements($controller)
         );
+    }
+
+    public function testUnauthenticatedCallShowsLoginAndDoesNotCreateOffer(): void
+    {
+        // Pass CSRF so execution reaches the auth gate (CSRF failure would exit first).
+        $token = CsrfGuard::generateRawToken('trade_offer');
+        $_POST['_csrf_token'] = $token;
+
+        $loginBoxCalled = false;
+        $nukeCompat = self::createStub(\Utilities\NukeCompat::class);
+        $nukeCompat->method('isUser')->willReturn(false);
+        $nukeCompat->method('loginBox')->willReturnCallback(function () use (&$loginBoxCalled): void {
+            $loginBoxCalled = true;
+        });
+
+        $tradeOffer = self::createMock(TradeOfferInterface::class);
+        $tradeOffer->expects(self::never())->method('createTradeOffer');
+
+        $controller = $this->buildController(nukeCompat: $nukeCompat, tradeOffer: $tradeOffer);
+        $controller->submitTradeOffer(null, ['offeringTeam' => 'Stars', '_csrf_token' => $token]);
+
+        $this->assertTrue($loginBoxCalled);
     }
 }

--- a/ibl5/tests/e2e/security/trade-idor.spec.ts
+++ b/ibl5/tests/e2e/security/trade-idor.spec.ts
@@ -15,7 +15,8 @@ import { collectNewOfferIds } from '../helpers/trading';
  * those endpoints to the session; its coverage lives with that change.)
  *
  * Two distinct fixtures:
- *   - authTest (Metros, teamid=1): D-03 submit-override IDOR.
+ *   - authTest (Metros, teamid=1): D-03 submit-override IDOR + the unresolvable-team
+ *     guard (session team forced to Free Agents via the `_test_team` override).
  *   - publicTest (unauthenticated): refusal of the submit endpoint.
  */
 
@@ -83,6 +84,63 @@ authTest.describe('Trade submit IDOR: offeringTeam bound to session (D-03)', () 
         newIds.length,
         'created offer must be visible on the Metros review page — proving it was bound to Metros, not Stars',
       ).toBeGreaterThan(0);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// D-03 guard: a session whose team resolves to Free Agents / is unresolvable is
+// refused BEFORE any offer is created (submitTradeOffer's resolve-team bail)
+// ---------------------------------------------------------------------------
+
+authTest.describe('Trade submit refuses an unresolvable session team (D-03 guard)', () => {
+  authTest.afterAll(async ({ request }) => {
+    // Defensive: the bail should create nothing, but reset in case a regression
+    // run did write an offer before failing.
+    await resetTradeOffers(request);
+  });
+
+  authTest(
+    'session team = Free Agents is refused at the resolve-team guard — no offer created',
+    async ({ appState, page, context }) => {
+      await appState({ 'Allow Trades': 'Yes', 'Current Season Ending Year': '2026' });
+
+      // Land on a real trade form AS the normal session team (Metros) so we hold a
+      // server-issued CSRF token + a live submit button — an otherwise-valid request.
+      const onForm = await findTradeFormWithBothRosters(page);
+      expect(onForm, 'CI seed must provide a partner with checkable players on both sides').toBe(true);
+
+      // Check one player on each roster — a complete, otherwise-valid offer. (The
+      // submit button is client-side disabled until both sides have a selection;
+      // the server-side guard runs ahead of offer construction regardless.)
+      await page.locator('.trading-roster.team-table').first().locator('input[type="checkbox"]').first().check();
+      await page.locator('.trading-roster.team-table').nth(1).locator('input[type="checkbox"]').first().check();
+
+      // Flip ONLY the resolved team to Free Agents via the `_test_team` override
+      // (TestCookieOverrides::getTeamOverride). The CSRF token is session-bound, not
+      // team-bound, so it stays valid — the request reaches submitTradeOffer's
+      // resolve-team check, where sessionTeam === FREE_AGENTS_TEAM_NAME forces the
+      // bail before any DB write.
+      await context.addCookies([
+        { name: '_test_team', value: 'Free Agents', domain: new URL(page.url()).hostname, path: '/' },
+      ]);
+
+      const submitBtn = page.locator('form[name="Trade_Offer"] button[type="submit"]');
+      await Promise.all([page.waitForURL(/op=reviewtrade/), submitBtn.click()]);
+
+      // The bail redirects to reviewtrade with this exact message (rawurlencode of
+      // 'Could not resolve your team.'). The string is unique to the resolve-team
+      // branch — a CSRF failure redirects with 'Invalid...' and no op=reviewtrade,
+      // and a successful submit carries result=offer_sent. Asserting the message
+      // (not merely the absence of offer_sent) means deleting the guard fails this.
+      const errorParam = new URL(page.url()).searchParams.get('error') ?? '';
+      expect(
+        errorParam,
+        'Free-Agents/unresolvable session team must be refused at the resolve-team guard',
+      ).toContain('Could not resolve your team');
+      for (const marker of SUCCESS_MARKERS) {
+        expect(page.url(), `unresolvable-team submit must not yield ${marker}`).not.toContain(marker);
+      }
     },
   );
 });

--- a/ibl5/tests/e2e/security/trade-idor.spec.ts
+++ b/ibl5/tests/e2e/security/trade-idor.spec.ts
@@ -1,0 +1,168 @@
+import { test as authTest, expect } from '../fixtures/auth';
+import { test as publicTest } from '../fixtures/public';
+import type { Page } from '@playwright/test';
+import { gotoWithRetry } from '../helpers/navigation';
+import { resetTradeOffers } from '../helpers/cleanup';
+import { collectNewOfferIds } from '../helpers/trading';
+
+/**
+ * IDOR / missing-auth coverage for the trade submit endpoint (security finding
+ * D-03). These rows cannot live in the PHPUnit suite: the controller is
+ * static-walled — every post-auth path ends in HtmxHelper::redirect() (which
+ * exit()s) — so the happy path and the IDOR-different-team path are E2E-only.
+ *
+ * (Accept/reject IDOR — D-04/D-05 — is owned by the trade-refactor PR that binds
+ * those endpoints to the session; its coverage lives with that change.)
+ *
+ * Two distinct fixtures:
+ *   - authTest (Metros, teamid=1): D-03 submit-override IDOR.
+ *   - publicTest (unauthenticated): refusal of the submit endpoint.
+ */
+
+const MAKE_ENDPOINT = '/ibl5/modules/Trading/maketradeoffer.php';
+
+// Success-result marker — its ABSENCE proves the action did not complete.
+const SUCCESS_MARKERS = ['result=offer_sent'];
+
+// ---------------------------------------------------------------------------
+// D-03: submit IDOR — offeringTeam is bound to the session, never the POST body
+// ---------------------------------------------------------------------------
+
+authTest.describe('Trade submit IDOR: offeringTeam bound to session (D-03)', () => {
+  authTest.afterAll(async ({ request }) => {
+    await resetTradeOffers(request);
+  });
+
+  authTest(
+    'tampered offeringTeam=Stars is ignored — created offer is bound to Metros',
+    async ({ appState, page }) => {
+      await appState({ 'Allow Trades': 'Yes', 'Current Season Ending Year': '2026' });
+
+      // Baseline the existing offers before creating one (this navigates to the
+      // review page).
+      const existingIds = await collectAllOfferIds(page);
+
+      // Find a partner whose form offers a checkable player on BOTH rosters so
+      // the submitted offer is non-empty; the page is left on that form.
+      const onForm = await findTradeFormWithBothRosters(page);
+      expect(onForm, 'CI seed must provide a partner with checkable players on both sides').toBe(true);
+
+      // Tamper the hidden offeringTeam field to spoof another team. The session
+      // override must win: the created offer's user-side trade_from stays Metros.
+      await page
+        .locator('form[name="Trade_Offer"] input[name="offeringTeam"]')
+        .evaluate((el) => {
+          (el as HTMLInputElement).value = 'Stars';
+        });
+
+      // Check one player on each roster.
+      await page
+        .locator('.trading-roster.team-table')
+        .first()
+        .locator('input[type="checkbox"]')
+        .first()
+        .check();
+      await page
+        .locator('.trading-roster.team-table')
+        .nth(1)
+        .locator('input[type="checkbox"]')
+        .first()
+        .check();
+
+      const submitBtn = page.locator('form[name="Trade_Offer"] button[type="submit"]');
+      await Promise.all([page.waitForURL(/result=offer_sent/), submitBtn.click()]);
+
+      // The created offer appears on the MetROS review page only if at least one
+      // row has trade_from=Metros or trade_to=Metros (TradingService groupTradeOffers
+      // filter). createTradeOffer writes the offering-team items with
+      // trade_from = offeringTeam. Had the spoofed 'Stars' been trusted, every row
+      // would be Stars/partner and the offer would be invisible to Metros. Its
+      // presence here proves the session override (offeringTeam=Metros) won.
+      const newIds = await collectNewOfferIds(page, existingIds);
+      expect(
+        newIds.length,
+        'created offer must be visible on the Metros review page — proving it was bound to Metros, not Stars',
+      ).toBeGreaterThan(0);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Unauthenticated refusal of the submit endpoint (D-03)
+// ---------------------------------------------------------------------------
+
+publicTest.describe('Trade submit endpoint refuses unauthenticated requests', () => {
+  // NOTE on what is proven: CSRF validation is the FIRST check in each controller
+  // method and exit()s on failure, so an unauthenticated request (which holds no
+  // valid token) is refused at the CSRF gate, BEFORE the isUser() auth gate is
+  // reached. Either way the action does not complete — we assert the absence of a
+  // success result, which both gates guarantee. The auth gate itself is covered
+  // directly by the PHPUnit characterization tests (unauthenticated, CSRF primed).
+  for (const [name, endpoint, form] of [
+    ['maketradeoffer.php (submit)', MAKE_ENDPOINT, { offeringTeam: 'Stars', listeningTeam: 'Metros' }],
+  ] as const) {
+    publicTest(`${name} does not complete for an unauthenticated user`, async ({ request }) => {
+      const response = await request.post(endpoint, { form, maxRedirects: 0 });
+      const location = response.headers()['location'] ?? '';
+      for (const marker of SUCCESS_MARKERS) {
+        expect(location, `unauthenticated ${name} must not yield ${marker}`).not.toContain(marker);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Collect all offer IDs currently on the Metros review page. */
+async function collectAllOfferIds(page: Page): Promise<Set<number>> {
+  await gotoWithRetry(page, 'modules.php?name=Trading&op=reviewtrade');
+  const buttons = page.locator('[data-preview-offer]');
+  const count = await buttons.count();
+  const ids = new Set<number>();
+  for (let i = 0; i < count; i++) {
+    const idStr = await buttons.nth(i).getAttribute('data-preview-offer');
+    ids.add(parseInt(idStr ?? '0', 10));
+  }
+  return ids;
+}
+
+/**
+ * Walk the available trade partners and land on the first form whose two
+ * rosters each expose a checkable item. Returns true if such a form was found
+ * (page is left on it), false otherwise.
+ */
+async function findTradeFormWithBothRosters(page: Page, maxTries = 12): Promise<boolean> {
+  await gotoWithRetry(page, 'modules.php?name=Trading');
+  const teamLinks = page.locator('.trading-team-select a');
+  const linkCount = await teamLinks.count();
+
+  for (let i = 0; i < Math.min(linkCount, maxTries); i++) {
+    const href = await teamLinks.nth(i).getAttribute('href');
+    if (!href) continue;
+    await page.goto(href);
+
+    const form = page.locator('form[name="Trade_Offer"]');
+    if ((await form.count()) === 0) {
+      await gotoWithRetry(page, 'modules.php?name=Trading');
+      continue;
+    }
+
+    const userBoxes = page
+      .locator('.trading-roster.team-table')
+      .first()
+      .locator('input[type="checkbox"]');
+    const partnerBoxes = page
+      .locator('.trading-roster.team-table')
+      .nth(1)
+      .locator('input[type="checkbox"]');
+
+    const [userCount, partnerCount] = await Promise.all([userBoxes.count(), partnerBoxes.count()]);
+    if (userCount > 0 && partnerCount > 0) {
+      return true;
+    }
+    await gotoWithRetry(page, 'modules.php?name=Trading');
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Fix the High-severity IDOR hole in the trade **submit** endpoint (D-03). Any
logged-in user could submit a trade offer **as an arbitrary team**, because the
offering team was read from `$_POST` and `maketradeoffer.php` lacked an auth gate.

**Changes:**
- `TradingControllerInterface.php` / `TradingController.php`: extend
  `submitTradeOffer` with `mixed $user`; gate `isUser()`, derive the offering team
  from the session cookie via `TeamIdentityRepository::getTeamnameFromUsername()`,
  reject null / empty / Free-Agents, and audit-log a `trade_offer_team_mismatch`
  when the posted `offeringTeam` differs from the session team (the posted value is
  logged, never trusted).
- `maketradeoffer.php`: pass `$GLOBALS['user'] ?? null` to the controller
  (mirrors `countertradeoffer.php`).
- PHPUnit: unauthenticated-bail characterization test for `submitTradeOffer`.
- E2E `tests/e2e/security/trade-idor.spec.ts`: D-03 submit-override IDOR (a real
  offer is submitted — `result=offer_sent` — while the tampered `offeringTeam` is
  ignored and the created offer stays bound to the session team) + unauthenticated
  refusal of the submit endpoint.

Reference pattern: `counterTradeOffer()` (already hardened, TradingController.php
lines 308–368).

### Out of scope — follow-up (D-04 / D-05)

This PR is **submit-only**. `acceptTradeOffer` and `rejectTradeOffer` still take
only `$post` and remain ungated — **accept / reject IDOR (D-04 / D-05) is NOT fixed
here.** Those are bound to the session by the N-party trade refactor **#1066**
(PR-A, Phase 4: `TradeExecutionService::assertActingTeamIsParty` + `isUser()` guard
on both standalone entry files). **Until #1066 lands, accept / reject remain
exploitable** — any logged-in user can accept/reject any offer by ID.

## Manual Testing

None required — the submit path is fully covered by E2E
(`tests/e2e/security/trade-idor.spec.ts`):

- **Legit happy path:** a GM submits a real trade offer; the test waits for
  `result=offer_sent` (fails if the submit did not complete) and asserts the offer
  appears on the GM's review page — proving no legitimate submit is locked out.
- **IDOR negative:** the hidden `offeringTeam` is tampered to another team; the
  created offer is still bound to the session team (visible on the session team's
  review page), proving the spoof is ignored.
- **Unresolvable-team guard:** the session team is forced to Free Agents (via the
  `_test_team` override); an otherwise-valid submit bails with the unique "Could
  not resolve your team" message and creates no offer.

No commissioner/admin force-submit path exists today (plan investigation finding
#1), so none can be silently broken.

Generated with [Claude Code](https://claude.ai/code)
<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>
