### PR TITLE
fix(deps): clear high-severity npm audit advisories (tmp, ws)

### DIFF
--- a/ibl5/package-lock.json
+++ b/ibl5/package-lock.json
@@ -3369,56 +3369,12 @@
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/enhanced-resolve": {
@@ -5859,28 +5815,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/qs": {
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -6399,28 +6333,6 @@
         "ws": "~8.20.1"
       }
     },
-    "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
       "dev": true,
@@ -6714,9 +6626,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7294,15 +7206,17 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/ibl5/package.json
+++ b/ibl5/package.json
@@ -29,15 +29,13 @@
   "overrides": {
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "tmp": "0.2.6",
+    "tmp": "0.2.7",
     "chrome-launcher": "1.2.1",
     "engine.io": "6.6.8",
     "engine.io-client": "6.6.5",
     "socket.io-adapter": "2.5.7",
     "uuid": "14.0.0",
-    "puppeteer-core": {
-      "ws": "8.21.0"
-    },
+    "ws": "8.21.0",
     "eslint": {
       "brace-expansion": "5.0.6"
     }


### PR DESCRIPTION
## Why

The **JS Dependency Audit** gate (`npm audit --audit-level=high`, `tests.yml:203`) started failing on **every open PR** (#1088, #1108, #1109, #1110, #1112, …) after new advisories were published. `npm audit` reads the live advisory DB, so newly-published advisories break all branches at once regardless of code — this is not any individual PR's fault. The affected packages are dev-only tooling (Lighthouse CI / socket.io); no shipped code is impacted.

## Fix (override edits only)

| Pkg | Advisory | Sev | Before | After |
|-----|----------|-----|--------|-------|
| `tmp` | GHSA-7c78-jf6q-g5cm | high | override pinned `0.2.6` — *exactly* the vuln range `>=0.2.6 <0.2.7` | `0.2.7` |
| `ws` | GHSA-96hv-2xvq-fx4p | high | puppeteer-scoped override missed socket.io/engine.io ws copies | top-level `ws: 8.21.0` (covers whole tree; replaces the redundant scoped one) |

## Intentionally left

`js-yaml` (GHSA-h67p-54hq-rp68) is **moderate**, so it does not trip the high gate. Its only patch is `4.2.0`, a **major** bump that breaks `@lhci/utils` (requires js-yaml `^3.13.1`). Forcing it would risk Lighthouse CI for a dev-only moderate DoS — not worth it.

## Verification

```
npm audit --audit-level=high  → exit 0   (was exit 1, 5 high)
```
All `ws` copies resolve to 8.21.0, all `tmp` to 0.2.7. 3 moderate (js-yaml chain) remain, below the gate.

Once merged, the blocked PRs clear the audit on rebase — they need no changes of their own.