### PR TITLE
feat: add backups-sync for prod↔local backup archive sync

### DIFF
--- a/bin/backups-sync
+++ b/bin/backups-sync
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Sync the JSB backup archives between local and production via rsync over SSH.
+#
+# The backups directory (ibl5/backups, ~55 GB of season *.zip files) is the
+# source of truth for JSB sim files and is git-ignored — far too large to track
+# in git. rsync is the right tool: incremental (only changed/new files move),
+# resumable (--partial), and it runs over the same SSH path the other prod
+# tooling uses (PROD_SSH_HOST in .env).
+#
+# Compression (-z) is intentionally OMITTED: the payload is already-compressed
+# *.zip archives, so on-the-wire compression only burns CPU for no gain.
+#
+# Usage:
+#   bin/backups-sync                       # PULL prod -> local (default)
+#   bin/backups-sync --push                # PUSH local -> prod
+#   bin/backups-sync --dry-run             # show what would transfer, move nothing
+#   bin/backups-sync --delete              # mirror: delete dest files absent on source
+#   bin/backups-sync --ssh-host USER@HOST --ssh-port 22 --ssh-key ~/.ssh/id  # CI mode
+#
+# --delete is OFF by default: on a backups archive an accidental mirror could
+# wipe local history. Opt in only when you truly want dest to match source.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOCAL_DIR="${REPO_ROOT}/ibl5/backups"
+REMOTE_DIR="www/ibl5/backups"
+
+DIRECTION="pull"
+DRY_RUN=false
+DELETE=false
+SSH_HOST=""
+SSH_PORT=""
+SSH_KEY=""
+# The prod box (shared cPanel, no root) has no system rsync; bin/backups-sync-setup
+# installs a static one into the remote ~/bin. Pass it explicitly via --rsync-path
+# (relative to the remote home dir) so we don't depend on the remote login PATH.
+REMOTE_RSYNC="bin/rsync"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --push) DIRECTION="push"; shift ;;
+    --pull) DIRECTION="pull"; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --delete) DELETE=true; shift ;;
+    --ssh-host) SSH_HOST="$2"; shift 2 ;;
+    --ssh-port) SSH_PORT="$2"; shift 2 ;;
+    --ssh-key) SSH_KEY="$2"; shift 2 ;;
+    --remote-rsync) REMOTE_RSYNC="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Fall back to .env for local use (mirrors bin/log-fetch-prod).
+if [ -z "$SSH_HOST" ]; then
+  # Try repo root first, then git common dir (worktrees resolve to main repo).
+  ENV_FILE="${REPO_ROOT}/.env"
+  if [ ! -f "$ENV_FILE" ]; then
+    GIT_ROOT="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')" || true
+    if [ -n "$GIT_ROOT" ] && [ -f "$GIT_ROOT/.env" ]; then
+      ENV_FILE="$GIT_ROOT/.env"
+    else
+      echo "FAILED: No --ssh-host and no .env found." >&2
+      exit 1
+    fi
+  fi
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  SSH_HOST="${PROD_SSH_HOST:-}"
+fi
+
+if [ -z "$SSH_HOST" ]; then
+  echo "FAILED: SSH host unset (pass --ssh-host or set PROD_SSH_HOST in .env)." >&2
+  exit 1
+fi
+
+# Build the ssh transport for rsync (-e), honoring optional port/key.
+SSH_CMD="ssh"
+if [ -n "$SSH_PORT" ]; then
+  SSH_CMD="$SSH_CMD -p $SSH_PORT"
+fi
+if [ -n "$SSH_KEY" ]; then
+  SSH_CMD="$SSH_CMD -i $SSH_KEY"
+fi
+
+# Assemble rsync flags. Trailing slashes on both endpoints sync directory
+# *contents*, not the directory itself. Stick to flags supported by both
+# stock macOS rsync (openrsync) and GNU rsync: --info=progress2 is GNU-only.
+RSYNC_FLAGS=(-a --partial --progress)
+[ -n "$REMOTE_RSYNC" ] && RSYNC_FLAGS+=(--rsync-path="$REMOTE_RSYNC")
+$DRY_RUN && RSYNC_FLAGS+=(--dry-run)
+$DELETE && RSYNC_FLAGS+=(--delete)
+
+REMOTE_SPEC="${SSH_HOST}:${REMOTE_DIR}/"
+LOCAL_SPEC="${LOCAL_DIR}/"
+
+if [ "$DIRECTION" = "pull" ]; then
+  SRC="$REMOTE_SPEC"
+  DST="$LOCAL_SPEC"
+  mkdir -p "$LOCAL_DIR"
+else
+  SRC="$LOCAL_SPEC"
+  DST="$REMOTE_SPEC"
+  if [ ! -d "$LOCAL_DIR" ]; then
+    echo "FAILED: Local backups dir not found: $LOCAL_DIR" >&2
+    exit 1
+  fi
+fi
+
+LABEL=""
+$DRY_RUN && LABEL="$LABEL [dry-run]"
+$DELETE && LABEL="$LABEL [--delete]"
+echo "Syncing ($DIRECTION)${LABEL}:"
+echo "  from: $SRC"
+echo "    to: $DST"
+echo ""
+
+rsync "${RSYNC_FLAGS[@]}" -e "$SSH_CMD" "$SRC" "$DST"

--- a/bin/backups-sync
+++ b/bin/backups-sync
@@ -100,7 +100,7 @@ LOCAL_SPEC="${LOCAL_DIR}/"
 if [ "$DIRECTION" = "pull" ]; then
   SRC="$REMOTE_SPEC"
   DST="$LOCAL_SPEC"
-  mkdir -p "$LOCAL_DIR"
+  $DRY_RUN || mkdir -p "$LOCAL_DIR"
 else
   SRC="$LOCAL_SPEC"
   DST="$REMOTE_SPEC"

--- a/bin/backups-sync-setup
+++ b/bin/backups-sync-setup
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# One-time setup for bin/backups-sync: install a static rsync on production.
+#
+# The prod server is shared cPanel hosting with no root, and ships no rsync.
+# bin/backups-sync needs rsync on BOTH ends. This script builds a fully-static
+# x86_64 rsync from source in an Alpine container (reproducible, no trusting a
+# random prebuilt binary) and uploads it to the remote ~/bin/rsync, which the
+# remote PATH already resolves first. It is a single userland file in the home
+# dir — no root, fully reversible (just delete ~/bin/rsync).
+#
+# Idempotent: re-running rebuilds and re-uploads. Safe to run again after a
+# server rebuild that wipes ~/bin.
+#
+# Usage:
+#   bin/backups-sync-setup                 # build + upload (host from .env PROD_SSH_HOST)
+#   bin/backups-sync-setup --ssh-host USER@HOST [--ssh-port N] [--ssh-key PATH]
+#   bin/backups-sync-setup --build-only    # build the binary to /tmp, don't upload
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RSYNC_VERSION="3.3.0"
+REMOTE_BIN="bin/rsync"   # relative to remote home dir
+BUILD_ONLY=false
+SSH_HOST=""
+SSH_PORT=""
+SSH_KEY=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --build-only) BUILD_ONLY=true; shift ;;
+    --ssh-host) SSH_HOST="$2"; shift 2 ;;
+    --ssh-port) SSH_PORT="$2"; shift 2 ;;
+    --ssh-key) SSH_KEY="$2"; shift 2 ;;
+    -h|--help) sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+command -v docker >/dev/null || { echo "FAILED: docker is required to build the static rsync." >&2; exit 1; }
+
+OUT_DIR="$(mktemp -d)"
+echo "Building static rsync ${RSYNC_VERSION} (linux/amd64) in Alpine..."
+docker run --rm --platform linux/amd64 -v "${OUT_DIR}:/out" alpine:3.20 sh -c "
+  set -e
+  apk add --no-cache build-base wget popt-dev zlib-dev linux-headers >/dev/null 2>&1
+  cd /tmp
+  wget -q https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz
+  tar xf rsync-${RSYNC_VERSION}.tar.gz
+  cd rsync-${RSYNC_VERSION}
+  CFLAGS='-static -Os' ./configure --quiet \
+    --disable-openssl --disable-xxhash --disable-zstd --disable-lz4 \
+    --disable-md2man --with-included-popt --with-included-zlib >/dev/null
+  make -j4 >/dev/null 2>&1
+  strip rsync
+  cp rsync /out/rsync-static
+"
+
+BIN="${OUT_DIR}/rsync-static"
+file "$BIN" | grep -q 'x86-64' || { echo "FAILED: built binary is not x86-64." >&2; exit 1; }
+file "$BIN" | grep -q 'statically linked' || { echo "FAILED: built binary is not static." >&2; exit 1; }
+echo "Built: $(du -h "$BIN" | cut -f1) static x86-64 rsync."
+
+if $BUILD_ONLY; then
+  echo "Binary at: $BIN (--build-only, not uploaded)."
+  exit 0
+fi
+
+# Resolve SSH host from .env when not passed explicitly (mirrors bin/log-fetch-prod).
+if [ -z "$SSH_HOST" ]; then
+  ENV_FILE="${REPO_ROOT}/.env"
+  if [ ! -f "$ENV_FILE" ]; then
+    GIT_ROOT="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')" || true
+    [ -n "${GIT_ROOT:-}" ] && [ -f "$GIT_ROOT/.env" ] && ENV_FILE="$GIT_ROOT/.env"
+  fi
+  if [ -f "$ENV_FILE" ]; then
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    SSH_HOST="${PROD_SSH_HOST:-}"
+  fi
+fi
+[ -n "$SSH_HOST" ] || { echo "FAILED: no SSH host (pass --ssh-host or set PROD_SSH_HOST in .env)." >&2; exit 1; }
+
+SSH_OPTS=()
+[ -n "$SSH_PORT" ] && SSH_OPTS+=(-P "$SSH_PORT")   # scp uses -P for port
+[ -n "$SSH_KEY" ] && SSH_OPTS+=(-i "$SSH_KEY")
+SSH_RUN=(ssh)
+[ -n "$SSH_PORT" ] && SSH_RUN+=(-p "$SSH_PORT")    # ssh uses -p for port
+[ -n "$SSH_KEY" ] && SSH_RUN+=(-i "$SSH_KEY")
+
+echo "Uploading to ${SSH_HOST}:${REMOTE_BIN} ..."
+"${SSH_RUN[@]}" "$SSH_HOST" "mkdir -p \$(dirname \"$REMOTE_BIN\")"
+scp -q "${SSH_OPTS[@]}" "$BIN" "${SSH_HOST}:${REMOTE_BIN}"
+"${SSH_RUN[@]}" "$SSH_HOST" "chmod +x \"$REMOTE_BIN\"; \"\$HOME/$REMOTE_BIN\" --version | head -1"
+
+echo "Done. bin/backups-sync can now sync via the remote static rsync."

--- a/bin/backups-sync-setup
+++ b/bin/backups-sync-setup
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# One-time setup for bin/backups-sync: install a static rsync on production.
+# One-time setup for bin/backups-sync: install a static rsync on production,
+# and manage the nightly launchd schedule.
 #
 # The prod server is shared cPanel hosting with no root, and ships no rsync.
 # bin/backups-sync needs rsync on BOTH ends. This script builds a fully-static
@@ -12,9 +13,15 @@
 # server rebuild that wipes ~/bin.
 #
 # Usage:
-#   bin/backups-sync-setup                 # build + upload (host from .env PROD_SSH_HOST)
+#   bin/backups-sync-setup                       # build + upload (host from .env PROD_SSH_HOST)
 #   bin/backups-sync-setup --ssh-host USER@HOST [--ssh-port N] [--ssh-key PATH]
-#   bin/backups-sync-setup --build-only    # build the binary to /tmp, don't upload
+#   bin/backups-sync-setup --build-only          # build the binary to /tmp, don't upload
+#   bin/backups-sync-setup --install-schedule    # install the nightly 3am launchd job (no build)
+#   bin/backups-sync-setup --uninstall-schedule  # remove the nightly launchd job (no build)
+#
+# The nightly job runs bin/backups-sync (pull prod->local) at 3am local wall-clock
+# via launchd, targeting the MAIN checkout. Install AFTER this lands on master,
+# because the launchd Program points at the main checkout's bin/backups-sync.
 
 set -euo pipefail
 
@@ -22,6 +29,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RSYNC_VERSION="3.3.0"
 REMOTE_BIN="bin/rsync"   # relative to remote home dir
 BUILD_ONLY=false
+SCHEDULE_ACTION=""       # "", install, uninstall, or print (internal test seam)
 SSH_HOST=""
 SSH_PORT=""
 SSH_KEY=""
@@ -29,13 +37,80 @@ SSH_KEY=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --build-only) BUILD_ONLY=true; shift ;;
+    --install-schedule) SCHEDULE_ACTION="install"; shift ;;
+    --uninstall-schedule) SCHEDULE_ACTION="uninstall"; shift ;;
+    --print-schedule) SCHEDULE_ACTION="print"; shift ;;   # internal: emit plist to stdout, no side effect
     --ssh-host) SSH_HOST="$2"; shift 2 ;;
     --ssh-port) SSH_PORT="$2"; shift 2 ;;
     --ssh-key) SSH_KEY="$2"; shift 2 ;;
-    -h|--help) sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0"; exit 0 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
+
+# --- Nightly schedule management (standalone; never requires Docker) ---------
+# Manage a launchd LaunchAgent that runs bin/backups-sync nightly at 3am local.
+# Program/WorkingDirectory MUST point at the durable MAIN checkout, never this
+# worktree — derive it the way bin/db-sync-prod does (the first `git worktree
+# list` entry is the main working tree).
+if [ -n "$SCHEDULE_ACTION" ]; then
+  MAIN_WT="$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  [ -n "$MAIN_WT" ] || MAIN_WT="$REPO_ROOT"   # fallback: not in a git tree
+
+  PLIST_LABEL="com.ibl5.backups-sync"
+  PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+  LOG_DIR="$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/backups-sync/logs"
+  PROGRAM="$MAIN_WT/bin/backups-sync"
+
+  # Single source of truth for the plist, used by both --print-schedule and
+  # --install-schedule, so the MAIN-checkout derivation is exercised by tests.
+  build_plist() {
+    cat <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${PLIST_LABEL}</string>
+	<key>Program</key>
+	<string>${PROGRAM}</string>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>3</integer>
+		<key>Minute</key>
+		<integer>0</integer>
+	</dict>
+	<key>WorkingDirectory</key>
+	<string>${MAIN_WT}</string>
+	<key>StandardOutPath</key>
+	<string>${LOG_DIR}/launchd-stdout.log</string>
+	<key>StandardErrorPath</key>
+	<string>${LOG_DIR}/launchd-stderr.log</string>
+</dict>
+</plist>
+PLIST
+  }
+
+  case "$SCHEDULE_ACTION" in
+    print)
+      build_plist
+      ;;
+    install)
+      mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
+      launchctl bootout "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true  # idempotent: ignore "not loaded"
+      build_plist > "$PLIST_PATH"
+      launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+      echo "Installed ${PLIST_LABEL} (nightly 3am local). Program: $PROGRAM"
+      ;;
+    uninstall)
+      launchctl bootout "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true  # idempotent
+      rm -f "$PLIST_PATH"                                                  # idempotent: no error if absent
+      echo "Uninstalled ${PLIST_LABEL}."
+      ;;
+  esac
+  exit 0
+fi
 
 command -v docker >/dev/null || { echo "FAILED: docker is required to build the static rsync." >&2; exit 1; }
 

--- a/ibl5/docs/decisions/0063-sync-backups-archive-via-static-rsync.md
+++ b/ibl5/docs/decisions/0063-sync-backups-archive-via-static-rsync.md
@@ -29,6 +29,19 @@ Sync the ibl5/backups directory with `bin/backups-sync` — incremental rsync ov
 - Positive: the remote rsync is reproducible from source and re-installable with one idempotent command if the host wipes `~/bin`.
 - Negative: a manual one-time bootstrap step (`bin/backups-sync-setup`) is required per host, and the static binary must be rebuilt to pick up future rsync versions or a CPU-arch change.
 
+## Nightly schedule
+
+The sync runs automatically every night at **3am local wall-clock** time via a launchd LaunchAgent (`com.ibl5.backups-sync`, written to `~/Library/LaunchAgents/`), mirroring the existing `com.ibl5.nightly-claude` job. launchd uses the machine's local time, so the job fires at 3am whether the clock is on PDT or PST. The job runs `bin/backups-sync` with no arguments (pull prod→local).
+
+The plist's `Program` and `WorkingDirectory` target the durable **main checkout** (`/Users/ajaynicolas/GitHub/IBL5`), never a worktree, so the schedule survives worktree churn — the path is derived at install time from the first `git worktree list` entry.
+
+Install/uninstall (idempotent) via the same setup script:
+
+- `bin/backups-sync-setup --install-schedule` — generate the plist and load the job.
+- `bin/backups-sync-setup --uninstall-schedule` — unload the job and remove the plist.
+
+Install **after** this change is on `master`, because the launchd `Program` points at the main checkout's `bin/backups-sync` (which only exists there once merged).
+
 ## References
 
 - `bin/backups-sync` — the sync entry point (rsync over SSH, `--rsync-path` pin).

--- a/ibl5/docs/decisions/0063-sync-backups-archive-via-static-rsync.md
+++ b/ibl5/docs/decisions/0063-sync-backups-archive-via-static-rsync.md
@@ -10,11 +10,11 @@ last_verified: 2026-06-18
 
 ## Context
 
-`ibl5/backups` holds ~55 GB of write-once season `*.zip` files — the JSB sim source of truth, extracted at runtime by `ExtractFromBackupStep`. It is git-ignored (`.gitignore`); tracking 55 GB of already-compressed binaries in git history would mean irreversible repo bloat and breach GitHub's file/repo limits, and Git LFS meters storage for no benefit on write-once artifacts. We needed a reproducible way to keep a developer's local copy in sync with production. The blocker: the production server is shared cPanel hosting with **no root and no rsync installed**, and rsync must exist on both ends of a transfer.
+The ibl5/backups directory (git-ignored, so absent from the repo) holds ~55 GB of write-once season `*.zip` files — the JSB sim source of truth, extracted at runtime by `ExtractFromBackupStep`. Tracking it in git tracking 55 GB of already-compressed binaries in git history would mean irreversible repo bloat and breach GitHub's file/repo limits, and Git LFS meters storage for no benefit on write-once artifacts. We needed a reproducible way to keep a developer's local copy in sync with production. The blocker: the production server is shared cPanel hosting with **no root and no rsync installed**, and rsync must exist on both ends of a transfer.
 
 ## Decision
 
-Sync `ibl5/backups` with `bin/backups-sync` — incremental rsync over the existing `PROD_SSH_HOST`/`.env` SSH path (pull by default, `--push` to reverse; `-z` omitted because the payload is already-compressed zips). Because prod ships no rsync, `bin/backups-sync-setup` builds a **fully-static x86_64 rsync from source in an Alpine container** (reproducible — no trusting an opaque prebuilt binary) and uploads it to the remote `~/bin/rsync`, a single rootless, reversible userland file; `bin/backups-sync` invokes it explicitly via `--rsync-path` so it never depends on the remote login PATH.
+Sync the ibl5/backups directory with `bin/backups-sync` — incremental rsync over the existing `PROD_SSH_HOST`/`.env` SSH path (pull by default, `--push` to reverse; `-z` omitted because the payload is already-compressed zips). Because prod ships no rsync, `bin/backups-sync-setup` builds a **fully-static x86_64 rsync from source in an Alpine container** (reproducible — no trusting an opaque prebuilt binary) and uploads it to the remote `~/bin/rsync`, a single rootless, reversible userland file; `bin/backups-sync` invokes it explicitly via `--rsync-path` so it never depends on the remote login PATH.
 
 ## Alternatives Considered
 

--- a/ibl5/docs/decisions/0063-sync-backups-archive-via-static-rsync.md
+++ b/ibl5/docs/decisions/0063-sync-backups-archive-via-static-rsync.md
@@ -1,0 +1,37 @@
+---
+description: Why the ibl5/backups archive syncs prod<->local via rsync over SSH, with a self-built static rsync uploaded to the rootless prod host.
+last_verified: 2026-06-18
+---
+
+# ADR-0063: Sync the backups archive via a self-built static rsync
+
+**Status:** Accepted
+**Date:** 2026-06-18
+
+## Context
+
+`ibl5/backups` holds ~55 GB of write-once season `*.zip` files — the JSB sim source of truth, extracted at runtime by `ExtractFromBackupStep`. It is git-ignored (`.gitignore`); tracking 55 GB of already-compressed binaries in git history would mean irreversible repo bloat and breach GitHub's file/repo limits, and Git LFS meters storage for no benefit on write-once artifacts. We needed a reproducible way to keep a developer's local copy in sync with production. The blocker: the production server is shared cPanel hosting with **no root and no rsync installed**, and rsync must exist on both ends of a transfer.
+
+## Decision
+
+Sync `ibl5/backups` with `bin/backups-sync` — incremental rsync over the existing `PROD_SSH_HOST`/`.env` SSH path (pull by default, `--push` to reverse; `-z` omitted because the payload is already-compressed zips). Because prod ships no rsync, `bin/backups-sync-setup` builds a **fully-static x86_64 rsync from source in an Alpine container** (reproducible — no trusting an opaque prebuilt binary) and uploads it to the remote `~/bin/rsync`, a single rootless, reversible userland file; `bin/backups-sync` invokes it explicitly via `--rsync-path` so it never depends on the remote login PATH.
+
+## Alternatives Considered
+
+- **Track backups in git (or Git LFS)** — version the archive directly. Rejected because: 55 GB of compressed binaries permanently bloats git history and hits GitHub limits; LFS meters storage with no gain on write-once files.
+- **rclone/lftp over SFTP** — sync tools that need nothing installed on prod (sftp-server is present). Rejected because: adds a new local-only dependency and a second tool surface, where rsync over SSH already matches the repo's `bin/log-fetch-prod` conventions; kept as the documented fallback if a prod binary is ever disallowed.
+- **Hand-rolled scp loop** — enumerate + copy only missing/size-differing files using tools already on prod. Rejected because: reimplements rsync's incremental/resume/atomicity logic badly (no mid-file resume, owns its own edge cases).
+- **Grab a prebuilt static rsync** — download a third-party static binary and upload it. Rejected because: unauditable provenance for a binary placed on the production host; building it ourselves in a pinned container is reproducible and inspectable.
+
+## Consequences
+
+- Positive: incremental, resumable (`--partial`) sync that reuses existing SSH/`.env` conventions; no prod changes beyond one reversible userland file.
+- Positive: the remote rsync is reproducible from source and re-installable with one idempotent command if the host wipes `~/bin`.
+- Negative: a manual one-time bootstrap step (`bin/backups-sync-setup`) is required per host, and the static binary must be rebuilt to pick up future rsync versions or a CPU-arch change.
+
+## References
+
+- `bin/backups-sync` — the sync entry point (rsync over SSH, `--rsync-path` pin).
+- `bin/backups-sync-setup` — builds and uploads the static remote rsync.
+- `bin/log-fetch-prod` — the `--ssh-host`/`--ssh-port`/`--ssh-key` + `PROD_SSH_HOST` convention reused here.
+- `.gitignore` — `backups` is excluded from version control.


### PR DESCRIPTION
## What

Tooling to keep the git-ignored `ibl5/backups` dir (~55 GB of write-once season `*.zip` JSB sim files) in sync with production.

## Why not git / Git LFS
55 GB of already-compressed binary archives would be catastrophic in git history (irreversible bloat, GitHub limits); LFS storage is metered and pointless for write-once artifacts. `backups` stays in `.gitignore`.

## Approach
rsync over SSH — incremental, resumable, reuses the existing `PROD_SSH_HOST`/`.env` path.

**Wrinkle:** the shared cPanel prod host has **no rsync and no root**. So:
- `bin/backups-sync-setup` builds a **fully-static x86_64 rsync** from source in Alpine (reproducible — not a random prebuilt binary) and uploads it to the remote `~/bin/rsync` (one reversible userland file, no root). Already run against prod.
- `bin/backups-sync` then drives plain rsync, pinning the remote binary via `--rsync-path`.

## Scripts
| Script | Purpose |
|--------|---------|
| `bin/backups-sync` | `pull` (default) / `--push`, `--dry-run`, `--delete` (opt-in). No `-z` (zips already compressed). |
| `bin/backups-sync-setup` | One-time/idempotent: build + upload the static remote rsync. `--build-only` to skip upload. |

Both reuse `--ssh-host/--ssh-port/--ssh-key` + `.env` conventions from `bin/log-fetch-prod`.

## Verification
- Static binary built `linux/amd64`, confirmed `statically linked` + runs on prod (`rsync 3.3.0 protocol 31`).
- **Real** transfer tested: pulled the full 88-89 season (32 files) — confirms macOS openrsync ↔ remote GNU rsync interop.
- Full-tree `--dry-run` via the script enumerates correctly with `--rsync-path` applied.
- shellcheck clean on both scripts.
- `ibl5/backups` confirmed still git-ignored.