### PR TITLE
harden: deterministically prevent the two PR #1105 E2E failure causes

### DIFF
--- a/ibl5/config/discord.config.example.php
+++ b/ibl5/config/discord.config.example.php
@@ -7,6 +7,17 @@
  *
  * IMPORTANT: Never commit discord.config.php to version control!
  * It is excluded via .gitignore to protect your webhook URLs.
+ *
+ * DELIBERATELY no 'testing' key here. In non-production environments
+ * (CI E2E, a fresh dev checkout running on THIS example because no real
+ * discord.config.php exists) Discord::postToChannel() resolves the webhook
+ * via `$webhooks['testing'] ?? null` and only POSTs when it is non-null. The
+ * placeholder URLs below are real discord.com URLs that return HTTP 400, which
+ * sendCurlPOST() throws on — so the first code path that COMPLETES a
+ * Discord-posting action (a played 1v1 game, a finalized trade, etc.) would
+ * fail there. Omitting 'testing' makes non-prod posting a deterministic no-op
+ * instead. To get non-prod posts, add your own 'testing' webhook in
+ * discord.config.php (the gitignored real config).
  */
 
 return [
@@ -19,7 +30,6 @@ return [
         'rookie-options' => 'https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN',
         'trades' => 'https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN',
         'waiver-wire' => 'https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN',
-        'testing' => 'https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN',
     ],
     'iblbot_url' => 'http://localhost:50000',
 ];

--- a/ibl5/tests/e2e/flows/csrf-rejection.spec.ts
+++ b/ibl5/tests/e2e/flows/csrf-rejection.spec.ts
@@ -31,9 +31,11 @@ function forgedToken(): string {
  * A page can render several CSRF tokens (each gate has its own per-action
  * token — e.g. the admin DebugMenu toggle in the page chrome). Pass `formName`
  * to scope extraction to a specific `<form name="...">`; the token for that
- * form is the first `_csrf_token` after the form's opening tag. Without it the
- * first token on the page is returned, which on a module page is the chrome's
- * token, not the module form's.
+ * form is the first `_csrf_token` after the form's opening tag.
+ *
+ * Without `formName`, the page must contain exactly one token — if it has
+ * more, extraction is ambiguous (the first match may be the chrome's token,
+ * not the form under test) and this throws rather than silently picking one.
  */
 async function fetchToken(
   request: APIRequestContext,
@@ -45,7 +47,17 @@ async function fetchToken(
     throw new Error(`token fetch GET ${path} failed: ${resp.status()}`);
   }
   let body = await resp.text();
-  if (formName !== undefined) {
+  if (formName === undefined) {
+    const tokenCount = (
+      body.match(/name="_csrf_token" value="[0-9a-f]+"/g) ?? []
+    ).length;
+    if (tokenCount > 1) {
+      throw new Error(
+        `ambiguous _csrf_token on ${path}: ${tokenCount} tokens found — ` +
+          `pass a formName to scope extraction to the form under test`,
+      );
+    }
+  } else {
     const formIdx = body.indexOf(`name="${formName}"`);
     if (formIdx === -1) {
       throw new Error(`form name="${formName}" not found on ${path}`);


### PR DESCRIPTION
Follow-up to #1105. Two small, deterministic guards so neither root cause behind the shard-1 E2E failure can silently recur. **Stacked on #1105** (`security-csrf-token-additions`) because the `fetchToken` guard builds on the `formName` param added there; retarget to `master` once #1105 merges.

## Root causes (from #1105)
The new "OneOnOneGame play with valid token" E2E exposed two latent issues, neither in the CSRF gate:
1. **Wrong CSRF token fetched.** The test helper returned the *first* `_csrf_token` on the page — for an admin user that's the DebugMenu chrome form's token, not the form under test. The gate correctly rejected it.
2. **Discord 400 aborted a completed mutation.** `playGame()` posts to Discord; CI runs on the example config whose webhooks are placeholder URLs that return HTTP 400, and `sendCurlPOST` throws. First E2E to *complete* a Discord-posting action.

## Deterministic guards
- **`config/discord.config.example.php`** — drop the `testing` webhook. `postToChannel` resolves the non-prod webhook via `$webhooks['testing'] ?? null` and only POSTs when non-null, so non-prod posting becomes a guaranteed no-op for **all 7 callers** (4 of which don't wrap the post in try/catch). Config-only → no mutation-coverage impact on Discord's unit-untestable HTTP boundary.
- **`fetchToken` (csrf-rejection.spec.ts)** — without a `formName`, the page must contain exactly one token; **>1 now throws** with a "pass a formName" message instead of silently picking the first. Both existing callers stay green (LCP renders one token; OneOnOne is form-scoped).

The per-caller `try/catch` swallow added to `playGame` in #1105 stays as defense-in-depth.

## Verification
- `vendor/bin/phpunit tests/Discord/` — 27 pass; nothing references the `testing` key.
- `composer run analyse` — clean.
- ESLint (e2e spec) + `bin/check-e2e-hygiene` — clean.