### PR TITLE
feat: harden mutation testing config integrity (PR 3 of 4)

### DIFF
--- a/ibl5/bin/check-infection-excludes
+++ b/ibl5/bin/check-infection-excludes
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Validates infection.json5's mutate-scope excludes. Three gates, all run from
+# the ibl5/ directory (cwd-relative classes/ and tests/), invoked with no args by
+# both mutation.yml jobs ("mutation" and "mutation-pr") which rely only on the
+# exit code (0 = pass, 1 = fail).
+#
+#   Path gate  — every file-level "...php" exclude must resolve to classes/<path>.
+#   Gate 1     — every file-level "...php" exclude must carry a trailing
+#                "// <reason>" of >= 12 non-whitespace chars on the SAME line.
+#                (The reason is read from the substring AFTER the path's closing
+#                quote, so a stray quoted token cannot be mistaken for the path.)
+#   Gate 2     — a file-level "...php" exclude whose reason does NOT contain the
+#                literal token "infra-exclude" must NOT have a test referencing its
+#                basename in tests/ (a referencing test = stale deferral → re-include).
+#
+# Exemptions (no special-casing needed for the first; documented for reviewers):
+#   - Dir/glob excludes ("Bootstrap", "Database", "OneOnOneGame", "*/Contracts/*")
+#     are auto-exempt from ALL gates: the extractor grep -oE '"[^"]+\.php"' only
+#     matches entries ending in .php, so non-.php entries never reach any gate.
+#   - "infra-exclude"-marked files (permanent low-level infra such as JSB.php) are
+#     exempt from Gate 2 ONLY; they still satisfy Gate 1 (must carry a reason).
+
 CONFIG="infection.json5"
 
 if [ ! -f "$CONFIG" ]; then
@@ -8,7 +29,10 @@ if [ ! -f "$CONFIG" ]; then
     exit 1
 fi
 
-excludes=$(grep -v '^\s*//' "$CONFIG" | grep -oE '"[^"]+\.php"' | tr -d '"')
+# --- Path-resolution gate (existing behaviour, unchanged) -------------------
+# || true: a config with no file-level .php excludes (only dir/glob entries) yields
+# no grep matches; under `set -o pipefail` that would abort. An empty set is valid.
+excludes=$(grep -v '^\s*//' "$CONFIG" | grep -oE '"[^"]+\.php"' | tr -d '"') || true
 
 broken=()
 for path in $excludes; do
@@ -17,15 +41,83 @@ for path in $excludes; do
     fi
 done
 
-if [ ${#broken[@]} -eq 0 ]; then
-    echo "OK: all file excludes in $CONFIG resolve."
-    exit 0
-else
+# --- Gate 1 (reason required) + Gate 2 (stale-deferral detector) ------------
+missing_reason=()
+stale_deferral=()
+
+while IFS= read -r line; do
+    # Only file-level .php excludes carry reasons; skip everything else.
+    case "$line" in
+        *.php*) ;;
+        *) continue ;;
+    esac
+
+    # Extract the quoted path token (first "...php" on the line); strip quotes.
+    path=$(printf '%s\n' "$line" | grep -oE '"[^"]+\.php"' | head -1 | tr -d '"') || true
+    [ -z "$path" ] && continue
+
+    # Reason = text after the path's closing quote, then after the "//".
+    after="${line#*\""$path"\"}"
+    if [[ "$after" == *"//"* ]]; then
+        reason="${after#*//}"
+    else
+        reason=""
+    fi
+
+    # Gate 1: reason must have >= 12 non-whitespace chars.
+    nws="$(printf '%s' "$reason" | tr -d '[:space:]')"
+    if [ "${#nws}" -lt 12 ]; then
+        missing_reason+=("$path")
+        continue
+    fi
+
+    # Gate 2: infra-exclude marker is exempt; otherwise a referencing test fails.
+    if [[ "$reason" != *"infra-exclude"* ]]; then
+        classname="${path##*/}"
+        classname="${classname%.php}"
+        if grep -rql "$classname" tests/ --include='*.php' 2>/dev/null; then
+            stale_deferral+=("$path")
+        fi
+    fi
+done < <(grep -v '^[[:space:]]*//' "$CONFIG")
+
+# --- Report -----------------------------------------------------------------
+fail=0
+
+if [ ${#broken[@]} -ne 0 ]; then
+    fail=1
     echo "ERROR: ${#broken[@]} stale exclude(s) in $CONFIG:" >&2
     for p in "${broken[@]}"; do
         echo "  - $p  (classes/$p not found)" >&2
     done
     echo "" >&2
     echo "Fix: update or remove these entries in $CONFIG." >&2
-    exit 1
 fi
+
+if [ ${#missing_reason[@]} -ne 0 ]; then
+    fail=1
+    echo "ERROR: ${#missing_reason[@]} exclude(s) with reason-missing in $CONFIG:" >&2
+    for p in "${missing_reason[@]}"; do
+        echo "  - $p  (needs a trailing \"// <reason>\" of >= 12 non-whitespace chars)" >&2
+    done
+    echo "" >&2
+    echo "Fix: append a same-line // reason explaining why the file is excluded." >&2
+fi
+
+if [ ${#stale_deferral[@]} -ne 0 ]; then
+    fail=1
+    echo "ERROR: ${#stale_deferral[@]} stale exclude(s) in $CONFIG now has a test:" >&2
+    for p in "${stale_deferral[@]}"; do
+        echo "  - $p  (a test references this class — now has a test, consider re-including it)" >&2
+    done
+    echo "" >&2
+    echo "Fix: remove the exclude (re-include the file into mutate-scope), or mark it" >&2
+    echo "     infra-exclude in its reason if it is permanent low-level infra." >&2
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "OK: all file excludes in $CONFIG resolve, are documented, and are not stale."
+    exit 0
+fi
+
+exit 1

--- a/ibl5/docs/decisions/0065-mutation-scope-classes-only.md
+++ b/ibl5/docs/decisions/0065-mutation-scope-classes-only.md
@@ -1,0 +1,34 @@
+---
+description: Why mutation testing (Infection) is scoped to classes/ only — scripts/, modules/, and root .php are intentionally out of scope.
+last_verified: 2026-06-18
+---
+
+# ADR-0065: Mutation testing scoped to classes/ only
+
+**Status:** Accepted
+**Date:** 2026-06-18
+
+## Context
+
+Infection's `infection.json5` sets `source.directories: ["classes"]`. Everything outside `classes/` — `scripts/`, `modules/`, and root-level `.php` entry points — is therefore never mutated. This was never written down, so a reader auditing mutation scope cannot tell whether the omission is deliberate or an oversight. A fourth PR in the mutation-hardening effort was originally scoped to extend mutation into `scripts/`; investigation showed that work is not worthwhile, and the effort dropped it. This ADR records *why* the boundary sits at `classes/` so the decision is discoverable next to its lineage (ADR-0019, ADR-0020), rather than buried in a JSON5 comment.
+
+## Decision
+
+Keep Infection's mutate-scope at `source.directories: ["classes"]`. Do not extend it to `scripts/`, `modules/`, or root `.php`. The rationale, from the dropped-PR-4 investigation:
+
+- `scripts/updateAllTheThings.php` — its logic was already extracted into the tested `classes/Updater/` namespace (UpdaterService + the per-step classes, covered by `tests/UpdateAllTheThings`). The script is a thin driver around already-mutated code.
+- `scripts/reconstructPlr.php` — delegates to the tested `classes/PlrParser/`. Mutating the script would re-test parsing logic that already lives under `classes/`.
+- The remaining scripts (e.g. `scripts/patch_2007_asg_sco.php` and the archival/import one-offs) are single-use patch and migration tools with no ongoing behavior worth a mutation budget.
+- `modules/` and root `.php` are thin entry/glue layers that delegate into `classes/`; their logic is exercised through the `classes/` code Infection already mutates and through E2E.
+
+Therefore `classes/` is the correct, intentional mutate-scope. Within `classes/`, a small set of paths is further excluded (see `infection.json5` and `phpunit-mutation.xml`): low-level infra (`classes/Database`, `classes/JSB.php`), interface-only `Contracts`, the `OneOnOneGame` engine, and the Group-B View files that lack output-assertion tests. Those per-file exclusions are documented inline and enforced by `ibl5/bin/check-infection-excludes`.
+
+## Consequences
+
+- Positive: the `classes/`-only boundary is documented where future mutation-scope audits look (`ibl5/docs/decisions/`), not in a config comment.
+- Positive: no mutation budget is spent on thin script/glue layers whose real logic already lives under `classes/` and is mutated there.
+- Negative: genuinely script-only logic (if any is ever added directly to `scripts/` rather than extracted into `classes/`) would escape mutation testing. Mitigated by the existing convention of extracting logic into `classes/` (the `updateAllTheThings`/`reconstructPlr` precedent).
+
+## Lineage
+
+- ADR-0019 (mutation-unlock-repositories) and ADR-0020 (mutation-unlock-controllers-handlers) progressively widened the mutate-scope *within* `classes/`. This ADR records the outer boundary of that effort: `classes/` is where mutation stops. It does not supersede either; it complements them by documenting why the scope is not widened beyond `classes/`.

--- a/ibl5/infection.json5
+++ b/ibl5/infection.json5
@@ -6,16 +6,23 @@
             "*/Contracts/*",
             "Bootstrap", "Database",
             "OneOnOneGame",
-            // Views lacking output-assertion tests — honest per-file
-            // exclusion reasons land in PR mutation-config-hygiene.
-            "LeagueStarters/LeagueStartersView.php",
-            "Negotiation/NegotiationDemandsBreakdownView.php",
-            "Player/Views/PlayerAwardsView.php",
-            "Player/Views/PlayerButtonsView.php",
-            "Player/Views/PlayerMenuView.php",
-            "Player/Views/PlayerTradingCardBackView.php",
-            "Player/Views/PlayerTradingCardFlipView.php",
-            "Player/Views/PlayerTradingCardFrontView.php"
+            // JSB engine glue is coverage-excluded (see phpunit-mutation.xml);
+            // exclude it here too so nothing Infection mutates lacks coverage. The
+            // infra-exclude marker makes it gate-2-exempt in check-infection-excludes.
+            // (MySQL.php lives at classes/Database/MySQL.php, already covered by the
+            //  "Database" dir exclude above — no separate entry needed.)
+            "JSB.php", // infra-exclude: low-level JSB engine glue, coverage-excluded — never mutated
+            // Group-B Views: no output-assertion test yet — honest per-file deferral
+            // reasons below; gate 2 in check-infection-excludes fires if a test later
+            // appears for one of these and it is not re-included. See ADR 0065.
+            "LeagueStarters/LeagueStartersView.php", // no output-assertion test yet — deferred Pass 2
+            "Negotiation/NegotiationDemandsBreakdownView.php", // no output-assertion test yet — deferred Pass 2
+            "Player/Views/PlayerAwardsView.php", // no output-assertion test yet — deferred Pass 2
+            "Player/Views/PlayerButtonsView.php", // no output-assertion test yet — deferred Pass 2
+            "Player/Views/PlayerMenuView.php", // no output-assertion test yet — deferred Pass 2
+            "Player/Views/PlayerTradingCardBackView.php", // no output-assertion test yet — deferred Pass 2
+            "Player/Views/PlayerTradingCardFlipView.php", // no output-assertion test yet — deferred Pass 2
+            "Player/Views/PlayerTradingCardFrontView.php" // no output-assertion test yet — deferred Pass 2
         ]
     },
     "phpUnit": {

--- a/ibl5/phpunit-mutation.xml
+++ b/ibl5/phpunit-mutation.xml
@@ -3,8 +3,16 @@
   PHPUnit configuration for mutation testing (Infection).
   Differs from phpunit.xml:
     1. Includes the 'database' group (DB integration tests provide repo coverage)
-    2. Broader <source> — includes Repositories, Views, Controllers, Handlers
-       so coverage-xml reports cover everything infection.json5 considers in-scope.
+    2. Broader <source> than infection.json5's mutate-scope, BY DESIGN:
+       - This file's coverage-excludes {classes/*/Contracts, classes/OneOnOneGame,
+         classes/Database (which contains MySQL.php), classes/JSB.php} are a SUBSET
+         of infection.json5's mutate-excludes, so nothing Infection mutates lacks
+         coverage (no spurious "Not Covered" mutants against minMsi=100).
+       - This <source> is a deliberate SUPERSET: Bootstrap and the Group-B View
+         files get coverage generated here but are NOT mutated (excluded in
+         infection.json5). Do NOT add them to the <exclude> below to "balance" it.
+       infection.json5's excludes are the authoritative mutate-scope; this file
+       only controls which classes get coverage-xml generated.
   Used only by the CI mutation workflow's coverage-generation step.
 -->
 <phpunit bootstrap="tests/bootstrap.php"

--- a/ibl5/tests/Cli/CheckInfectionExcludesCliTest.php
+++ b/ibl5/tests/Cli/CheckInfectionExcludesCliTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Drives bin/check-infection-excludes against fixture infection.json5 files in a
+ * temp dir. The script reads infection.json5 from cwd and greps cwd-relative
+ * classes/ and tests/, so each fixture provides all three; the script is run via
+ * `cd <tmpDir> && bash <scriptPath>` (host realpath to repo-root bin/).
+ */
+#[Group('cli')]
+final class CheckInfectionExcludesCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        // check-infection-excludes lives at ibl5/bin/ (app-pinned, run from the ibl5/
+        // working dir in CI) — two levels up from tests/Cli/, NOT repo-root bin/.
+        $resolved = realpath(__DIR__ . '/../../bin/check-infection-excludes');
+        self::assertNotFalse($resolved, 'bin/check-infection-excludes must exist');
+        $this->scriptPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/infection-excludes-test-' . bin2hex(random_bytes(8));
+        mkdir($this->tmpDir, 0755, true);
+        mkdir($this->tmpDir . '/classes', 0755, true);
+        mkdir($this->tmpDir . '/tests', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    public function testReconciledConfigExitsZero(): void
+    {
+        $this->writeClass('Foo.php');
+        $this->writeConfig(['"Foo.php" // low-level glue, never mutated here']);
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('OK', $result['output']);
+    }
+
+    public function testMissingReasonExitsNonZero(): void
+    {
+        $this->writeClass('Foo.php');
+        $this->writeConfig(['"Foo.php"']);
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('reason-missing', $result['output']);
+        self::assertStringContainsString('Foo.php', $result['output']);
+    }
+
+    public function testShortReasonExitsNonZero(): void
+    {
+        $this->writeClass('Foo.php');
+        // 7 non-whitespace chars (< 12) — too short.
+        $this->writeConfig(['"Foo.php" // tooshrt']);
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('reason-missing', $result['output']);
+    }
+
+    public function testExcludedFileWithReferencingTestExitsNonZero(): void
+    {
+        $this->writeClass('Foo.php');
+        $this->writeTest('FooTest.php', "<?php\n// exercises Foo\n");
+        // Reason is honest deferral (no infra-exclude marker) → gate 2 applies.
+        $this->writeConfig(['"Foo.php" // no output-assertion test yet — deferred']);
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('stale exclude', $result['output']);
+    }
+
+    public function testInfraExcludeMarkerSkipsStaleGate(): void
+    {
+        $this->writeClass('Foo.php');
+        $this->writeTest('FooTest.php', "<?php\n// exercises Foo\n");
+        // infra-exclude marker → gate 2 skipped even though a test references Foo.
+        $this->writeConfig(['"Foo.php" // infra-exclude: low-level glue never mutated']);
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('OK', $result['output']);
+    }
+
+    public function testStalePathStillFires(): void
+    {
+        // Note: Foo.php intentionally NOT created under classes/.
+        $this->writeConfig(['"Foo.php" // infra-exclude: low-level glue never mutated']);
+
+        $result = $this->runScript();
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('not found', $result['output']);
+        self::assertStringContainsString('Foo.php', $result['output']);
+    }
+
+    public function testDirLevelExcludeNeedsNoReason(): void
+    {
+        // Dir-level entry has no .php token → parser-invisible, needs no reason.
+        $this->writeConfig(['"OneOnOneGame"']);
+
+        $result = $this->runScript();
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('OK', $result['output']);
+    }
+
+    /**
+     * @param list<string> $excludeLines raw lines for the excludes array
+     */
+    private function writeConfig(array $excludeLines): void
+    {
+        $body = implode(",\n            ", $excludeLines);
+        $json5 = "{\n"
+            . "    \"source\": {\n"
+            . "        \"directories\": [\"classes\"],\n"
+            . "        \"excludes\": [\n"
+            . "            {$body}\n"
+            . "        ]\n"
+            . "    }\n"
+            . "}\n";
+        file_put_contents($this->tmpDir . '/infection.json5', $json5);
+    }
+
+    private function writeClass(string $relPath): void
+    {
+        $full = $this->tmpDir . '/classes/' . $relPath;
+        $dir = dirname($full);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents($full, "<?php\nclass Stub {}\n");
+    }
+
+    private function writeTest(string $filename, string $content): void
+    {
+        file_put_contents($this->tmpDir . '/tests/' . $filename, $content);
+    }
+
+    /**
+     * @return array{output: string, exit: int}
+     */
+    private function runScript(): array
+    {
+        $output = [];
+        $exit = 0;
+        $cmd = 'cd ' . escapeshellarg($this->tmpDir) . ' && '
+            . 'bash ' . escapeshellarg($this->scriptPath) . ' 2>&1';
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

Hardens `bin/check-infection-excludes` with two new gates, reconciles `infection.json5` / `phpunit-mutation.xml`, and adds ADR-0065 documenting the `source.directories: ["classes"]` scope decision.

**Changes:**
1. **Config reconcile** (`infection.json5`): adds `JSB.php` as an `infra-exclude` (gate-2-exempt, gate-1 satisfied); adds honest deferral reasons to the 8 Group-B View excludes remaining after PR 2. (`MySQL.php` is already covered by the existing `Database` dir-level exclude — no bare file entry needed.)
2. **Script hardening** (`bin/check-infection-excludes`): gate 1 — every file-level `.php` exclude must carry a trailing `// reason` ≥12 non-whitespace chars; gate 2 — a deferred exclude that now has a referencing test fires a stale-deferral failure (skipped for `infra-exclude`-marked files). Exit contract (0/pass, 1/fail) preserved for both CI call sites.
3. **PHPUnit Cli test** (`tests/Cli/CheckInfectionExcludesCliTest.php`): 7 tests covering both gates, both exemptions, and the dir-level auto-exempt path.
4. **ADR-0065** (`docs/decisions/0065-mutation-scope-classes-only.md`): documents why `source.directories: ["classes"]` is intentional, with lineage to ADR-0019/0020.

**Plan deviations:**
- ADR number: plan said 0064 (fallback 0063); both were taken on the PR-2 base → used 0065.
- `MySQL.php`: plan said add as bare file-level exclude; already covered by `Database` dir exclude → only `JSB.php` added; header comment documents the MySQL.php-via-Database-dir relationship.
- Test realpath: plan said `../../../bin/`; `check-infection-excludes` lives at `ibl5/bin/` → uses `../../bin/`.
- Fixed a latent pre-existing bug: extraction line aborted under `set -o pipefail` on a config with no `.php` excludes (now `|| true`).

Depends-on: #1121

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)