### PR TITLE
feat: add main-checkout guard to bin/next-adr and bin/next-migration

### DIFF
--- a/bin/lib/git-helpers.sh
+++ b/bin/lib/git-helpers.sh
@@ -20,6 +20,18 @@ resolve_canonical_root() {
     echo "$repo_root"
 }
 
+# Return 0 if <repo_root> IS the main checkout (its canonical root resolves to
+# itself), 1 if it is a linked worktree. Pure path logic — no `git`, no exit —
+# so callers compose it in an `if` and own their own refusal message. Mirrors the
+# discriminator in resolve_canonical_root: main checkout's .git is a directory,
+# so canonical == passed-in root; a worktree's .git is a file resolving elsewhere.
+is_main_checkout() {
+    local repo_root="$1"
+    local canonical
+    canonical=$(resolve_canonical_root "$repo_root")
+    [ "$repo_root" = "$canonical" ]
+}
+
 # Print <path> with each component's true on-disk case.
 # macOS APFS is case-insensitive: launching from ~/github vs ~/GitHub yields the
 # same files but different path strings, which splits worktree registration and

--- a/bin/next-adr
+++ b/bin/next-adr
@@ -31,6 +31,14 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CANONICAL_ROOT=$(resolve_canonical_root "$REPO_ROOT")
 CANONICAL_DIR="$CANONICAL_ROOT/ibl5/docs/decisions"
 
+if is_main_checkout "$REPO_ROOT"; then
+    echo "Error: refusing to run from the main checkout — bin/next-adr cp's the" >&2
+    echo "       template into THIS repo root before any content is written, which" >&2
+    echo "       strands an empty ADR on master. Create a worktree first:" >&2
+    echo "         bin/wt-new <slug>" >&2
+    exit 1
+fi
+
 get_max() {
     local dir="$1"
     if [ ! -d "$dir" ]; then

--- a/bin/next-migration
+++ b/bin/next-migration
@@ -11,6 +11,13 @@ MAIN_DIR="$REPO_ROOT/ibl5/migrations"
 CANONICAL_ROOT=$(resolve_canonical_root "$REPO_ROOT")
 CANONICAL_DIR="$CANONICAL_ROOT/ibl5/migrations"
 
+if is_main_checkout "$REPO_ROOT"; then
+    echo "Error: refusing to hand out a migration number from the main checkout." >&2
+    echo "       Create a worktree first:" >&2
+    echo "         bin/wt-new <slug>" >&2
+    exit 1
+fi
+
 get_max() {
     local dir="$1"
     if [ -d "$dir" ]; then

--- a/ibl5/docs/decisions/README.md
+++ b/ibl5/docs/decisions/README.md
@@ -1,6 +1,6 @@
 ---
 description: Index of IBL5 Architecture Decision Records (ADRs). Source of truth for every load-bearing decision and its rationale.
-last_verified: 2026-05-13
+last_verified: 2026-06-18
 ---
 
 # IBL5 Architecture Decision Records
@@ -11,7 +11,7 @@ Every load-bearing decision in IBL5 is captured here as a numbered ADR so that f
 
 - **Reading:** start with the ADR most relevant to the surface you're touching. Each rule file and each PHPStan custom rule links back to the ADR that justifies it.
 - **Writing:** when you make a new significant decision, create an ADR first — the CI gate (`bin/adr-check`, workflow `adr-required.yml`) blocks PRs that add mechanical-enforcement surfaces without an accompanying ADR. See the "When an ADR is required" section below.
-- **Creating one:** run `bin/next-adr "kebab-title"` from the repo root. It copies `0000-template.md` into the next numbered slot and prints the path. The template is Michael Nygard format, adapted for IBL5's frontmatter schema.
+- **Creating one:** run `bin/next-adr "kebab-title"` from a worktree (`bin/wt-new <slug>`); it refuses to run from the main checkout to avoid stranding an empty template on `master`. It copies `0000-template.md` into the next numbered slot and prints the path. The template is Michael Nygard format, adapted for IBL5's frontmatter schema.
 
 ## Index
 

--- a/ibl5/tests/Cli/GitHelpersGuardTest.php
+++ b/ibl5/tests/Cli/GitHelpersGuardTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class GitHelpersGuardTest extends TestCase
+{
+    private string $libPath;
+
+    protected function setUp(): void
+    {
+        $this->libPath = (string) realpath(__DIR__ . '/../../../bin/lib/git-helpers.sh');
+    }
+
+    public function testIsMainCheckoutTrueWhenGitIsDirectory(): void
+    {
+        $t = sys_get_temp_dir() . '/ghgt-main-' . uniqid();
+        mkdir($t . '/.git', 0755, true);
+
+        $output = [];
+        $exit = 0;
+        $lib = escapeshellarg($this->libPath);
+        $dir = escapeshellarg($t);
+        exec("bash -c 'source $lib; if is_main_checkout $dir; then echo MAIN; else echo WT; fi' 2>&1", $output, $exit);
+
+        exec('rm -rf ' . escapeshellarg($t));
+        self::assertSame(0, $exit);
+        self::assertSame('MAIN', implode("\n", $output));
+    }
+
+    public function testIsMainCheckoutFalseForWorktreeLayout(): void
+    {
+        $t = sys_get_temp_dir() . '/ghgt-wt-' . uniqid();
+        $m = sys_get_temp_dir() . '/ghgt-main-' . uniqid();
+        mkdir($m . '/.git/worktrees/wt', 0755, true);
+        mkdir($t, 0755, true);
+        file_put_contents($t . '/.git', 'gitdir: ' . $m . '/.git/worktrees/wt');
+
+        $lib = escapeshellarg($this->libPath);
+        $dir = escapeshellarg($t);
+        $output = [];
+        $exit = 0;
+        exec("bash -c 'source $lib; if is_main_checkout $dir; then echo MAIN; else echo WT; fi' 2>&1", $output, $exit);
+        self::assertSame(0, $exit);
+        self::assertSame('WT', implode("\n", $output), 'is_main_checkout should return 1 for worktree layout');
+
+        // Guard against false-pass: canonical must differ from $t
+        $canonical = [];
+        exec("bash -c 'source $lib; resolve_canonical_root $dir' 2>&1", $canonical);
+        $canonicalPath = implode("\n", $canonical);
+        self::assertNotEmpty($canonicalPath, 'resolve_canonical_root must return a non-empty path');
+        self::assertNotSame($t, $canonicalPath, 'resolve_canonical_root must differ from the worktree root');
+
+        exec('rm -rf ' . escapeshellarg($t) . ' ' . escapeshellarg($m));
+    }
+}

--- a/ibl5/tests/Cli/NextAdrGuardCliTest.php
+++ b/ibl5/tests/Cli/NextAdrGuardCliTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class NextAdrGuardCliTest extends TestCase
+{
+    public function testRefusesFromMainCheckoutAndStrandsNoFile(): void
+    {
+        $t = sys_get_temp_dir() . '/nadr-guard-' . uniqid();
+        mkdir($t . '/bin/lib', 0755, true);
+        mkdir($t . '/ibl5/docs/decisions', 0755, true);
+
+        $scriptSrc = (string) realpath(__DIR__ . '/../../../bin/next-adr');
+        $libSrc    = (string) realpath(__DIR__ . '/../../../bin/lib/git-helpers.sh');
+        $tplSrc    = (string) realpath(__DIR__ . '/../../../ibl5/docs/decisions/0000-template.md');
+
+        copy($scriptSrc, $t . '/bin/next-adr');
+        chmod($t . '/bin/next-adr', 0755);
+        copy($libSrc, $t . '/bin/lib/git-helpers.sh');
+        copy($tplSrc, $t . '/ibl5/docs/decisions/0000-template.md');
+
+        // .git as a DIRECTORY → main checkout layout
+        mkdir($t . '/.git', 0755, true);
+
+        $output = [];
+        $exit = 0;
+        exec(escapeshellarg($t . '/bin/next-adr') . ' guard-test 2>&1', $output, $exit);
+
+        $outputStr = implode("\n", $output);
+
+        exec('rm -rf ' . escapeshellarg($t));
+
+        self::assertNotSame(0, $exit, 'guard must exit non-zero from main checkout');
+        self::assertStringContainsString('bin/wt-new', $outputStr, 'error message must mention bin/wt-new');
+        self::assertEmpty(
+            glob($t . '/ibl5/docs/decisions/[0-9][0-9][0-9][0-9]-guard-test.md'),
+            'guard must not strand an ADR template file on the main checkout',
+        );
+    }
+}

--- a/ibl5/tests/Cli/NextAdrGuardCliTest.php
+++ b/ibl5/tests/Cli/NextAdrGuardCliTest.php
@@ -34,13 +34,13 @@ final class NextAdrGuardCliTest extends TestCase
 
         $outputStr = implode("\n", $output);
 
-        exec('rm -rf ' . escapeshellarg($t));
-
         self::assertNotSame(0, $exit, 'guard must exit non-zero from main checkout');
         self::assertStringContainsString('bin/wt-new', $outputStr, 'error message must mention bin/wt-new');
         self::assertEmpty(
             glob($t . '/ibl5/docs/decisions/[0-9][0-9][0-9][0-9]-guard-test.md'),
             'guard must not strand an ADR template file on the main checkout',
         );
+
+        exec('rm -rf ' . escapeshellarg($t));
     }
 }

--- a/ibl5/tests/Cli/NextMigrationGuardCliTest.php
+++ b/ibl5/tests/Cli/NextMigrationGuardCliTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class NextMigrationGuardCliTest extends TestCase
+{
+    public function testRefusesFromMainCheckout(): void
+    {
+        $t = sys_get_temp_dir() . '/nmig-guard-' . uniqid();
+        mkdir($t . '/bin/lib', 0755, true);
+        mkdir($t . '/ibl5/migrations', 0755, true);
+
+        $scriptSrc = (string) realpath(__DIR__ . '/../../../bin/next-migration');
+        $libSrc    = (string) realpath(__DIR__ . '/../../../bin/lib/git-helpers.sh');
+
+        copy($scriptSrc, $t . '/bin/next-migration');
+        chmod($t . '/bin/next-migration', 0755);
+        copy($libSrc, $t . '/bin/lib/git-helpers.sh');
+
+        // Seed one migration so get_max would otherwise succeed
+        file_put_contents($t . '/ibl5/migrations/001-initial.sql', '-- placeholder');
+
+        // .git as a DIRECTORY → main checkout layout
+        mkdir($t . '/.git', 0755, true);
+
+        $output = [];
+        $exit = 0;
+        exec(escapeshellarg($t . '/bin/next-migration') . ' 2>&1', $output, $exit);
+
+        exec('rm -rf ' . escapeshellarg($t));
+
+        self::assertNotSame(0, $exit, 'guard must exit non-zero from main checkout');
+        self::assertStringContainsString('bin/wt-new', implode("\n", $output), 'error message must mention bin/wt-new');
+    }
+}


### PR DESCRIPTION
Adds a `is_main_checkout` predicate to `bin/lib/git-helpers.sh` and guards both `bin/next-adr` and `bin/next-migration` against running from the main checkout. `bin/next-adr` was silently copying the template into the main checkout before any content was written, stranding an empty ADR on `master`. The guard fires before the `cp` call, so no file is created.

## Changes

- **`bin/lib/git-helpers.sh`** — adds `is_main_checkout(repo_root)`: pure path predicate (no `git`, no exit), reuses `resolve_canonical_root`. Returns 0 if main checkout, 1 if linked worktree.
- **`bin/next-adr`** — inserts guard after canonical resolution, before `get_max()`; exits 1 with message including `bin/wt-new <slug>`.
- **`bin/next-migration`** — same guard pattern (consistency; this script only prints a number, no file leak, but enforces the invariant).
- **`ibl5/tests/Cli/GitHelpersGuardTest.php`** — unit-tests both predicate branches against temp `.git` fixtures.
- **`ibl5/tests/Cli/NextAdrGuardCliTest.php`** — regression: fake main checkout → guard fires + no `NNNN-guard-test.md` stranded.
- **`ibl5/tests/Cli/NextMigrationGuardCliTest.php`** — guard fires from fake main checkout.
- **`ibl5/docs/decisions/README.md`** — wording: "from a worktree" + `last_verified` bump.

<!-- no-adr: bin/next-adr, bin/next-migration, bin/wt-new, bin/check-docs are all pre-existing scripts (the gate's new-tool-script heuristic mis-flags the mentions); this PR edits two existing scripts and references the others, adding no new bin/* file -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.