### PR TITLE
ci: fail loud on Discord alert delivery in smoke-prod + main notify jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,6 +294,8 @@ jobs:
           PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
             '{content: {receivingUserDiscordID: $id, message: $msg}}')
 
+          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
+          # delivery failure turns this notify job RED — surfaced via GitHub's native
+          # workflow-failure email. A silently-dropped alert is worse than none.
           echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
-            || echo "IBLbot notification failed (bot may be down)"
+            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'

--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -267,9 +267,11 @@ jobs:
           PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
             '{content: {receivingUserDiscordID: $id, message: $msg}}')
 
+          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
+          # delivery failure turns this notify job RED — surfaced via GitHub's native
+          # workflow-failure email. A silently-dropped alert is worse than none.
           echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
-            || echo "IBLbot notification failed (bot may be down)"
+            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
 
   notify-scheduled-failure:
     name: Notify Scheduled Failure
@@ -302,9 +304,11 @@ jobs:
           PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
             '{content: {receivingUserDiscordID: $id, message: $msg}}')
 
+          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
+          # delivery failure turns this notify job RED — surfaced via GitHub's native
+          # workflow-failure email. A silently-dropped alert is worse than none.
           echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
-            || echo "IBLbot notification failed (bot may be down)"
+            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
 
   notify-ibl6-degradation:
     name: Notify IBL6 Degradation
@@ -337,9 +341,11 @@ jobs:
           PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
             '{content: {receivingUserDiscordID: $id, message: $msg}}')
 
+          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
+          # delivery failure turns this notify job RED — surfaced via GitHub's native
+          # workflow-failure email. A silently-dropped alert is worse than none.
           echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
-            || echo "IBLbot notification failed (bot may be down)"
+            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
 
   notify-inconclusive:
     name: Notify Smoke Inconclusive
@@ -380,6 +386,8 @@ jobs:
           PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
             '{content: {receivingUserDiscordID: $id, message: $msg}}')
 
+          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
+          # delivery failure turns this notify job RED — surfaced via GitHub's native
+          # workflow-failure email. A silently-dropped alert is worse than none.
           echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
-            || echo "IBLbot notification failed (bot may be down)"
+            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'


### PR DESCRIPTION
## Summary

Follow-up sweep to #1120 (ADR-0065 *Fail-loud delivery*). Extends the same fail-loud treatment to the remaining **hard failure-alert** notify jobs that still swallowed delivery errors.

Each ended its Discord DM step with `... || echo "IBLbot notification failed"`, so an SSH/curl failure left the notify job **GREEN** even when the alert never reached Discord — a silently dropped failure alert with no alert-on-the-alert.

**Change (5 sites, byte-identical):** drop the `|| echo` swallow and add `-f` to curl (`-sf`, so a non-2xx IBLbot response also fails, not just a transport error). A delivery failure now turns the notify job **RED**, surfaced via GitHub's native workflow-failure email.

| File | Notify jobs hardened |
|------|----------------------|
| `smoke-prod.yml` | `rollback-and-notify`, `notify-scheduled-failure`, `notify-ibl6-degradation`, `notify-inconclusive` (4) |
| `main.yml` | CI-failure notify (1) |

All five are **dedicated failure/degradation/inconclusive** notify jobs — none send a success/recovery DM, so reddening the job on a missed alert is correct. `rollback-and-notify` performs the revert *before* the DM (last step), so a red job after a successful revert correctly reads as "reverted, but alert delivery failed."

### Intentionally left soft
The two **advisory** `::warning::` sites (`log-review.yml`, `doc-freshness-audit.yml`) keep their swallow — they are non-critical and should not redden a run on a missed DM.

## Security surface

None. CI workflow YAML only — no app code, no runtime path, no DB, no auth. Reuses the existing, already-vetted `secrets.PRIVATE_KEY` / `secrets.HOST` / `secrets.OWNER_DISCORD_ID` SSH+Discord pattern; no new secret, no new endpoint.

## Residual gap (not closed here)

Same as ADR-0065: IBLbot returning HTTP 200 with an error body would still pass. Closing it needs a body-level health assertion or a dead-man's-switch heartbeat — tracked separately.

## Manual Testing

No manual testing needed — delivery path verified end-to-end in #1120 (throwaway `workflow_dispatch` → IBLbot HTTP 200 → DM landed). This PR changes only the error-handling of the identical step.

---
Generated with [Claude Code](https://claude.ai/code)

