### PR TITLE
feat: invert dev auto-login from opt-out to opt-in (_auto_login cookie)

### DIFF
--- a/.claude/commands/_plan-verification.md
+++ b/.claude/commands/_plan-verification.md
@@ -1,6 +1,6 @@
 ---
 description: Requires plans to classify every verification step into the test-type taxonomy at plan-write time, preventing manual-testing items from deferring to post-plan cleanup, and grounds seed/DOM-dependent E2E assertions in real fixtures.
-last_verified: 2026-06-13
+last_verified: 2026-06-19
 ---
 
 # Plan Verification Matrix
@@ -75,7 +75,7 @@ Any E2E verification-matrix row that asserts a **seed-** or **DOM-dependent** va
 The source must be one of:
 
 - A specific row or count from `ibl5/tests/e2e/fixtures/ci-seed.sql` (cite the table and the rows that produce the expected value), or
-- The rendered form DOM, fetched live from the worktree stack: `curl http://<slug>.localhost/ibl5/modules.php?name=X` (cite the element the assertion targets).
+- The rendered form DOM, fetched live from the worktree stack: `curl --cookie "_auto_login=1" http://<slug>.localhost/ibl5/modules.php?name=X` (cite the element the assertion targets). The `_auto_login=1` cookie opts into dev auto-login — localhost is logged-out by default, so an auth-gated form returns the login page without it (see `.claude/rules/browser-login.md`).
 
 Two gotchas this rule exists to catch (cross-referenced from memory):
 

--- a/.claude/rules/browser-login.md
+++ b/.claude/rules/browser-login.md
@@ -1,21 +1,25 @@
 ---
-description: Dev auto-login setup: localhost sessions are pre-authenticated via DEV_AUTO_LOGIN; do not navigate to login forms. Identity matrix for all test layers.
-last_verified: 2026-05-04
+description: Localhost browsing is logged-out by default; set an `_auto_login=1` cookie to auto-authenticate via DEV_AUTO_LOGIN. Identity matrix for all test layers.
+last_verified: 2026-06-19
 ---
 
 # Browser Auto-Login
 
-On localhost (`main.localhost`, `localhost`, `127.0.0.1`), dev auto-login is active.
-You are automatically authenticated as the user in `ibl5/.env.test` (`DEV_AUTO_LOGIN`).
+On localhost (`main.localhost`, `localhost`, `127.0.0.1`, `<slug>.localhost`), manual browsing is **logged-out by default**. Dev auto-login is opt-in: it only fires when an `_auto_login=1` cookie is present AND `DEV_AUTO_LOGIN` is set in `ibl5/.env.test`.
 
-- Do NOT navigate to login forms or enter credentials — the session is pre-authenticated on first page load.
-- If you see a login page, `.env.test` may be misconfigured or Docker needs restarting.
+To auto-authenticate as the `.env.test` `DEV_AUTO_LOGIN` user:
+- **curl:** `curl --cookie "_auto_login=1" http://<slug>.localhost/ibl5/...`
+- **Playwright:** `page.context().addCookies([{ name: '_auto_login', value: '1', domain, path: '/' }])`
+
+Without the cookie you will see the login form — that is expected, not a misconfiguration.
+
+A separate `_e2e=1` cookie gates PageCache-skip for unauthenticated E2E browser contexts (no auth effect).
 
 ## Identity Matrix
 
 | Layer | User | Source | Used by |
 |-------|------|--------|---------|
-| Local browser dev | A-Jay (or per-developer) | `.env.test` `DEV_AUTO_LOGIN` | Localhost browsing on real dev DB |
+| Local browser dev | A-Jay (or per-developer) | `.env.test` `DEV_AUTO_LOGIN` + `_auto_login=1` cookie | Localhost browsing on real dev DB |
 | CI E2E browser | Configured at runtime | `secrets.IBL_TEST_USER` / `IBL_TEST_PASS` | Playwright in CI |
 | DatabaseIntegration tests | testadmin / testgm | `tests/DatabaseIntegration/Fixtures/db-seed.sql` | PHPUnit `#[Group('database')]` tests |
 

--- a/bin/check-orphan-css
+++ b/bin/check-orphan-css
@@ -241,9 +241,12 @@ if [ "$DO_CRAWL" = "1" ]; then
     for route in "${ROUTES[@]}"; do
         url="${BASE_URL}${route}"
         echo "  Crawling: $url"
+        # Opt into dev auto-login (.claude/rules/browser-login.md): on localhost
+        # auto-login is opt-in via the _auto_login cookie, so without it the crawl
+        # would hit logged-out pages and miss CSS used only on auth-gated views.
         # Extract whole space-delimited class tokens; use awk+tr (not sed)
         # for BSD compatibility (BSD sed 's/[\t]//g' strips literal t)
-        curl -s --max-time 10 "$url" 2>/dev/null \
+        curl -s --max-time 10 --cookie "_auto_login=1" "$url" 2>/dev/null \
             | grep -oE 'class="[^"]*"' \
             | awk -F'"' '{print $2}' \
             | tr ' ' '\n' \

--- a/ibl5/classes/Auth/DevAutoLogin.php
+++ b/ibl5/classes/Auth/DevAutoLogin.php
@@ -9,18 +9,20 @@ use Logging\LoggerFactory;
 /**
  * Transparent dev-only auto-login for local development.
  *
- * When DEV_AUTO_LOGIN=<username> is set in .env.test and the request
- * originates from localhost, automatically authenticates as that user
- * without requiring login form interaction. This is especially useful
- * for browser-based verification via Chrome DevTools MCP.
+ * When DEV_AUTO_LOGIN=<username> is set in .env.test, the request originates
+ * from localhost, AND the request carries an _auto_login=1 opt-in cookie,
+ * automatically authenticates as that user without requiring login form
+ * interaction. This is especially useful for browser-based verification via
+ * Chrome DevTools MCP and Playwright.
  *
- * Safety: three independent guards must ALL pass:
+ * Manual browsing is logged-out by default: absent the _auto_login cookie no
+ * auto-login occurs, so a developer can stay signed out on localhost.
+ *
+ * Safety: four independent guards must ALL pass:
  * 1. Session is not already authenticated
- * 2. SERVER_NAME is localhost/127.0.0.1/main.localhost
- * 3. DEV_AUTO_LOGIN env var or .env.test entry is set to a non-empty username
- *
- * The caller (mainfile.php) also checks for the _no_auto_login cookie
- * which E2E tests set to opt out of auto-authentication.
+ * 2. The _auto_login=1 opt-in cookie is present
+ * 3. SERVER_NAME is localhost/127.0.0.1/*.localhost
+ * 4. DEV_AUTO_LOGIN env var or .env.test entry is set to a non-empty username
  */
 final class DevAutoLogin
 {
@@ -40,13 +42,19 @@ final class DevAutoLogin
             return;
         }
 
-        // Guard 2: only on localhost (exact match or *.localhost subdomains for worktrees)
+        // Guard 2: opt-in required — only auto-login when the _auto_login=1 cookie is present.
+        // Manual/MCP/curl browsing is logged-out by default; automation opts in explicitly.
+        if (($_COOKIE['_auto_login'] ?? null) !== '1') {
+            return;
+        }
+
+        // Guard 3: only on localhost (exact match or *.localhost subdomains for worktrees)
         $serverName = $_SERVER['SERVER_NAME'] ?? null;
         if (!is_string($serverName) || !$this->isLocalhost($serverName)) {
             return;
         }
 
-        // Guard 3: DEV_AUTO_LOGIN must be set to a non-empty username
+        // Guard 4: DEV_AUTO_LOGIN must be set to a non-empty username
         $username = $this->getAutoLoginUsername();
         if ($username === null) {
             return;

--- a/ibl5/classes/Bootstrap/AuthBootstrap.php
+++ b/ibl5/classes/Bootstrap/AuthBootstrap.php
@@ -36,10 +36,10 @@ class AuthBootstrap implements BootstrapStepInterface
         );
         $authService->tryRememberMe();
 
-        // Dev-only auto-login: bypasses login forms on localhost when DEV_AUTO_LOGIN is set.
-        // E2E tests set _no_auto_login cookie to opt out.
-        $noAutoLogin = isset($_COOKIE['_no_auto_login']) && $_COOKIE['_no_auto_login'] === '1';
-        if (!$authService->isAuthenticated() && !$noAutoLogin) {
+        // Dev-only auto-login: bypasses login forms on localhost when DEV_AUTO_LOGIN is set
+        // AND the request carries an _auto_login=1 opt-in cookie. Policy lives in DevAutoLogin's
+        // guards (opt-in, localhost, env); call unconditionally and let them decide.
+        if (!$authService->isAuthenticated()) {
             (new \Auth\DevAutoLogin())->tryAutoLogin($mysqliDb);
         }
 

--- a/ibl5/modules.php
+++ b/ibl5/modules.php
@@ -49,10 +49,11 @@ if (is_string($requestName) && $requestName !== '') {
 
     // E2E tests use per-request cookie overrides (_test_overrides) that
     // change page content. Cached responses ignore these overrides.
-    // Also skip cache entirely during E2E runs (_no_auto_login signals
-    // a Playwright test context) to avoid cross-worker cache pollution.
+    // Public E2E browser contexts also set _e2e=1 to skip PageCache for
+    // unauthenticated GETs, avoiding cross-worker cache pollution. (Decoupled
+    // from the _auto_login auth opt-in.)
     $isE2eTesting = (isset($_COOKIE['_test_overrides']) && $_COOKIE['_test_overrides'] !== '')
-        || (isset($_COOKIE['_no_auto_login']) && $_COOKIE['_no_auto_login'] === '1');
+        || (isset($_COOKIE['_e2e']) && $_COOKIE['_e2e'] === '1');
 
     if (
         $_SERVER['REQUEST_METHOD'] === 'GET'

--- a/ibl5/phpstan-rules/BanRawSuperglobalsRule.php
+++ b/ibl5/phpstan-rules/BanRawSuperglobalsRule.php
@@ -42,7 +42,7 @@ final class BanRawSuperglobalsRule implements Rule
         ],
         '_COOKIE' => [
             'suffixes' => ['Controller.php', 'ApiHandler.php', 'Bootstrap.php', 'Authenticator.php'],
-            'files' => ['CsrfGuard.php', 'LeagueContext.php', 'TestCookieOverrides.php'],
+            'files' => ['CsrfGuard.php', 'LeagueContext.php', 'TestCookieOverrides.php', 'DevAutoLogin.php'],
         ],
         '_SESSION' => [
             'suffixes' => ['Bootstrap.php'],

--- a/ibl5/tests/Auth/DevAutoLoginTest.php
+++ b/ibl5/tests/Auth/DevAutoLoginTest.php
@@ -31,7 +31,7 @@ class DevAutoLoginTest extends TestCase
         $this->originalCookies = $_COOKIE;
 
         unset($_SESSION['auth_user_id'], $_SESSION['auth_username']);
-        unset($_COOKIE['_no_auto_login']);
+        unset($_COOKIE['_auto_login']);
         putenv('DEV_AUTO_LOGIN');
     }
 
@@ -118,10 +118,46 @@ class DevAutoLoginTest extends TestCase
         self::assertArrayNotHasKey('auth_user_id', $_SESSION);
     }
 
+    public function testDoesNothingWhenOptInCookieAbsentOnLocalhost(): void
+    {
+        // All other guards satisfied (localhost host, env user set, user would resolve),
+        // but the _auto_login opt-in cookie is absent — the default manual-browsing state.
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        putenv('DEV_AUTO_LOGIN=TestUser');
+        // setUp() already unset $_COOKIE['_auto_login'].
+
+        $db = static::createStub(\mysqli::class);
+        (new DevAutoLogin())->tryAutoLogin($db);
+
+        self::assertArrayNotHasKey('auth_user_id', $_SESSION);
+    }
+
+    public function testSetsSessionWhenOptInCookiePresentOnLocalhost(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        $_COOKIE['_auto_login'] = '1';
+        putenv('DEV_AUTO_LOGIN=TestUser');
+
+        $result = static::createStub(\mysqli_result::class);
+        $result->method('fetch_assoc')->willReturn(['user_id' => 7]);
+
+        $stmt = static::createStub(\mysqli_stmt::class);
+        $stmt->method('get_result')->willReturn($result);
+
+        $db = static::createStub(\mysqli::class);
+        $db->method('prepare')->willReturn($stmt);
+
+        (new DevAutoLogin())->tryAutoLogin($db);
+
+        self::assertSame(7, $_SESSION['auth_user_id']);
+        self::assertSame('TestUser', $_SESSION['auth_username']);
+    }
+
     #[DataProvider('allowedHostProvider')]
     public function testSetsSessionWhenAllConditionsMet(string $host): void
     {
         $_SERVER['SERVER_NAME'] = $host;
+        $_COOKIE['_auto_login'] = '1';
         putenv('DEV_AUTO_LOGIN=TestUser');
 
         $result = static::createStub(\mysqli_result::class);
@@ -155,6 +191,7 @@ class DevAutoLoginTest extends TestCase
     public function testDoesNothingWhenUserNotFoundInDatabase(): void
     {
         $_SERVER['SERVER_NAME'] = 'localhost';
+        $_COOKIE['_auto_login'] = '1';
         putenv('DEV_AUTO_LOGIN=NonExistentUser');
 
         $result = static::createStub(\mysqli_result::class);
@@ -174,6 +211,7 @@ class DevAutoLoginTest extends TestCase
     public function testDoesNothingWhenPrepareFailsReturningFalse(): void
     {
         $_SERVER['SERVER_NAME'] = 'localhost';
+        $_COOKIE['_auto_login'] = '1';
         putenv('DEV_AUTO_LOGIN=TestUser');
 
         $db = static::createStub(\mysqli::class);
@@ -187,6 +225,7 @@ class DevAutoLoginTest extends TestCase
     public function testInjectedLoggerReceivesActivationLog(): void
     {
         $_SERVER['SERVER_NAME'] = 'localhost';
+        $_COOKIE['_auto_login'] = '1';
         putenv('DEV_AUTO_LOGIN=TestUser');
 
         $result = static::createStub(\mysqli_result::class);
@@ -214,6 +253,7 @@ class DevAutoLoginTest extends TestCase
     public function testNoArgConstructorFallsBackToAuthChannelAndStillActivates(): void
     {
         $_SERVER['SERVER_NAME'] = 'localhost';
+        $_COOKIE['_auto_login'] = '1';
         putenv('DEV_AUTO_LOGIN=TestUser');
 
         $result = static::createStub(\mysqli_result::class);

--- a/ibl5/tests/e2e/auth-regular.setup.ts
+++ b/ibl5/tests/e2e/auth-regular.setup.ts
@@ -21,17 +21,8 @@ setup('authenticate regular (non-admin) user', async ({ page, request }) => {
     console.warn(`Failed to clear auth throttle (HTTP ${throttleResp.status()}) — login may fail if throttled`);
   }
 
-  // DEV_AUTO_LOGIN (PHP) auto-authenticates whichever user the developer's
-  // .env.test names — usually an admin. Set `_no_auto_login` BEFORE the
-  // first navigation so the login form actually renders for our non-admin
-  // credentials. Without this, a dev with DEV_AUTO_LOGIN=A-Jay would write
-  // the admin's session into regular.json. Same cookie pattern as
-  // tests/e2e/helpers/public-storage-state.ts.
-  const baseUrl = process.env.BASE_URL ?? 'http://main.localhost/ibl5/';
-  await page.context().addCookies([
-    { name: '_no_auto_login', value: '1', domain: new URL(baseUrl).hostname, path: '/' },
-  ]);
-
+  // Auto-login is now opt-in (_auto_login=1 cookie) — the login form renders by
+  // default on localhost without any opt-out cookie. Navigate directly.
   await page.goto('modules.php?name=YourAccount');
 
   const loginForm = page.locator('form', { has: page.locator('#login-username') });

--- a/ibl5/tests/e2e/auth.setup.ts
+++ b/ibl5/tests/e2e/auth.setup.ts
@@ -20,6 +20,11 @@ setup('authenticate', async ({ page, request }) => {
     console.warn(`Failed to clear auth throttle (HTTP ${throttleResp.status()}) — login may fail if throttled`);
   }
 
+  const baseUrl = process.env.BASE_URL ?? 'http://main.localhost/ibl5/';
+  await page.context().addCookies([
+    { name: '_auto_login', value: '1', domain: new URL(baseUrl).hostname, path: '/' },
+  ]);
+
   await page.goto('modules.php?name=YourAccount');
 
   // Check if already authenticated (e.g., DEV_AUTO_LOGIN redirected away from YourAccount)

--- a/ibl5/tests/e2e/fixtures/public.ts
+++ b/ibl5/tests/e2e/fixtures/public.ts
@@ -5,7 +5,7 @@ import { publicStorageState } from '../helpers/public-storage-state';
 /**
  * Public (unauthenticated) test fixture with appState control.
  *
- * - Sets _no_auto_login cookie so DevAutoLogin doesn't fire.
+ * - Sets _e2e cookie so PageCache is skipped; stays logged out (no auth opt-in).
  * - Uses cookie-based state overrides — no DB races in parallel tests.
  */
 export const test = base.extend<{ appState: SetStateFn }>({

--- a/ibl5/tests/e2e/flows/ajax-api-endpoints.spec.ts
+++ b/ibl5/tests/e2e/flows/ajax-api-endpoints.spec.ts
@@ -195,11 +195,11 @@ test.describe('Saved Depth Chart API', () => {
   });
 
   test('unauthenticated request returns 401', async ({ request }) => {
-    // Use a fresh request context: strip auth cookies, set _no_auto_login
-    // to prevent DevAutoLogin from auto-authenticating the request
+    // Use a fresh request context: strip auth cookies, set _e2e to skip
+    // PageCache; auto-login does not fire (opt-in is absent by default)
     const response = await request.get(
       'modules.php?name=DepthChartEntry&op=api&action=list',
-      { headers: { Cookie: '_no_auto_login=1' } },
+      { headers: { Cookie: '_e2e=1' } },
     );
 
     const contentType = response.headers()['content-type'] ?? '';
@@ -450,7 +450,7 @@ test.describe('Saved Depth Chart API: load and rename', () => {
   test('unauthenticated load returns 401 JSON', async ({ request }) => {
     const response = await request.get(
       'modules.php?name=DepthChartEntry&op=api&action=load&id=1',
-      { headers: { Cookie: '_no_auto_login=1' } },
+      { headers: { Cookie: '_e2e=1' } },
     );
     expect(response.status()).toBe(401);
     const contentType = response.headers()['content-type'] ?? '';

--- a/ibl5/tests/e2e/helpers/public-storage-state.ts
+++ b/ibl5/tests/e2e/helpers/public-storage-state.ts
@@ -1,9 +1,10 @@
 /**
  * Shared storageState for unauthenticated (public) E2E tests.
  *
- * Sets the `_no_auto_login` cookie so DevAutoLogin (PHP) doesn't
- * auto-authenticate the request. Without this cookie, all "public"
- * tests on *.localhost get silently promoted to an admin session.
+ * Sets the `_e2e=1` cookie so PageCache is skipped for unauthenticated GETs,
+ * avoiding cross-worker cache pollution. Does NOT set `_auto_login`, so these
+ * contexts stay logged out (auto-login is opt-in; absent the cookie DevAutoLogin
+ * does not fire).
  *
  * Usage (bare @playwright/test files):
  *   import { publicStorageState } from '../helpers/public-storage-state';
@@ -34,7 +35,7 @@ export function publicStorageState(): StorageState {
   return {
     cookies: [
       {
-        name: '_no_auto_login',
+        name: '_e2e',
         value: '1',
         domain,
         path: '/',

--- a/ibl5/tests/e2e/smoke/auth-regular-user-provisioned.spec.ts
+++ b/ibl5/tests/e2e/smoke/auth-regular-user-provisioned.spec.ts
@@ -7,8 +7,9 @@ import { test, expect } from '../fixtures/base';
  * setup-file regression doesn't mask a provisioning regression.
  *
  * Test classification: API-test (Tier 2 plan, verification row 3).
- * Uses the base fixture (no storageState) and manually sets `_no_auto_login`
- * to opt out of DevAutoLogin so the login form renders.
+ * Uses the base fixture (no storageState). The login form renders by default
+ * because auto-login is now opt-in (_auto_login=1 cookie required); no
+ * opt-out cookie is needed.
  */
 
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -25,11 +26,7 @@ async function loginViaForm(page: Page, username: string, password: string): Pro
 }
 
 test.describe('Regular (non-admin) test user provisioning', () => {
-  test.beforeEach(async ({ page, request }) => {
-    const baseUrl = process.env.BASE_URL ?? 'http://main.localhost/ibl5/';
-    await page.context().addCookies([
-      { name: '_no_auto_login', value: '1', domain: new URL(baseUrl).hostname, path: '/' },
-    ]);
+  test.beforeEach(async ({ request }) => {
     await request.delete('test-state.php?action=clear-throttle');
   });
 


### PR DESCRIPTION
## Summary

Inverts the localhost dev auto-login model from opt-out to opt-in:
- **Before:** every localhost request auto-logs in unless  cookie is set
- **After:** localhost requests are logged-out by default;  cookie opts in

### Changes
- **** — new Guard 2 (opt-in cookie check) inserted after the already-authenticated guard; class docstring rewritten to opt-in model
- **** — inline `_no_auto_login` cookie read removed; delegates entirely to `DevAutoLogin`'s guards
- **** — page-cache-skip signal decoupled: `_no_auto_login` replaced by dedicated `_e2e=1` cookie
- **`DevAutoLoginTest.php`** — negative-path test (no cookie → no session) + positive-path test (cookie → session) added; existing positive tests given opt-in cookie; `setUp()` cookie key updated
- **E2E harness** — `auth.setup.ts` opts in with `_auto_login=1`; `auth-regular.setup.ts` opt-out block removed; `public-storage-state.ts` / `public.ts` / `ajax-api-endpoints.spec.ts` migrated to `_e2e=1`; `auth-regular-user-provisioned.spec.ts` opt-out block removed
- **`browser-login.md`** — rewritten to the opt-in model + `last_verified` bumped

### Why
Manual/MCP/curl browsing on localhost should default to logged-out, so developers can stay unauthenticated. Only automated tooling (Playwright, curl with explicit cookie) opts in.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

Generated with [Claude Code](https://claude.ai/code)