### PR TITLE
docs: auto-commit rule reflects worktree commit nudge

### DIFF
--- a/.claude/rules/auto-commit.md
+++ b/.claude/rules/auto-commit.md
@@ -1,13 +1,18 @@
 ---
-description: Commit/PR work from the worktree; the Stop hook warns if the main checkout is dirty (work landed in the wrong place); amend when fixing unpushed work
-last_verified: 2026-06-13
+description: Commit/PR work from the worktree; the Stop hook nudges to commit in a worktree and warns if the main checkout is dirty (work landed in the wrong place); amend when fixing unpushed work
+last_verified: 2026-06-19
 ---
 
 # Auto-Commit
 
 All work happens in a worktree, never the main checkout (ADR-0062, `workflow-continuity.md`). Worktree work is committed by `/post-plan` (auto-fired) or `/commit-commands:commit-push-pr` — not by this hook.
 
-The `$HOME/.claude/hooks/auto-commit-reminder.sh` Stop hook is now a **misplaced-work warning**, not a commit reminder: it fires at turn-end when the **main checkout** has uncommitted changes (and no plan workflow is active), telling you the work landed in the wrong place and to move it into a worktree (`bin/wt-new`). It stays silent in worktrees and during `/post-plan`. It is a warning, not a hard block — heed it unless you have a deliberate reason to be touching the main checkout.
+The `$HOME/.claude/hooks/auto-commit-reminder.sh` Stop hook fires at turn-end when there are uncommitted changes, and nudges the right action depending on **where** the work is:
+
+- **Main checkout** (master) dirty → **misplaced-work warning**: the work landed in the wrong place; move it into a worktree (`bin/wt-new`) — the main checkout is reference/read-only.
+- **Worktree** dirty → **commit nudge**: this is the correct place to work; if you finished a unit of work, commit it via `/commit-commands:commit` (or `commit-push-pr`).
+
+It stays silent when the tree is clean, on loop re-fire, and while a plan workflow is active (which covers `/post-plan` auto-fire committing in a worktree). It nudges on **uncommitted** changes only — push is owned by `commit-push-pr`/`/post-plan`. It is a nudge, not a hard block — ignore it if you are mid-task, just exploring, or have a deliberate reason to be touching the main checkout.
 
 When you finish a unit of work in a worktree (impl, fix, refactor, config, docs) and are not using the `/post-plan` auto-fire handoff, invoke `/commit-commands:commit` (or `commit-push-pr`). Skip it when mid-task or when the user is only exploring.
 


### PR DESCRIPTION
## What

Updates `.claude/rules/auto-commit.md` to match the new behavior of the `auto-commit-reminder.sh` Stop hook.

## Why

The hook previously stayed **silent in worktrees** — we'd lost the commit reminder when correctly working in a worktree. The hook now nudges in both places:

- **Main checkout dirty** → misplaced-work warning (unchanged)
- **Worktree dirty** → commit nudge (`/commit-commands:commit` / `commit-push-pr`) — restored

The rule doc still claimed "stays silent in worktrees," so this brings it back in sync.

## Notes

- Doc-only change (`.claude/rules/`); the hook itself lives outside the repo (`~/.claude/hooks/`) and was already updated.
- Nudges on **uncommitted** changes only; push stays owned by `commit-push-pr`/`/post-plan`. Silent on clean tree, loop re-fire, and active plan workflow (covers `/post-plan` auto-fire).