### PR TITLE
docs(plan): forbid delegating /plan to general-purpose agents

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -65,6 +65,8 @@ The Plan agent auto-loads CLAUDE.md, all always-loaded rules (agent-tiering, cor
 
 Launch a **single Plan agent** (`subagent_type: "plan-architect"` — its definition carries `model: opus` and `effort: xhigh`; do NOT pass an inline `model` override) with a prompt containing ALL of these:
 
+**Run this step inline — never delegate `/plan` itself.** The orchestrating session owns Steps 1–5 directly and spawns exactly **one** `plan-architect` per PR-sized unit. Do NOT hand the whole `/plan` invocation to a `general-purpose`/`claude` sub-agent (or fan it out across several), and do NOT have any such agent fire `/plan` on your behalf. Those agent types carry `Tools: *` — they *can* spawn further agents, so delegating `/plan` to them produces a `general-purpose → plan-architect` nest, exactly the multi-level `plan-architect` tree the flat-fan-out rule forbids (`agent-tiering.md` § Nested Sub-Agents). `plan-architect`/`Plan`/`Explore` cannot cause this themselves — they lack the `Agent` tool — so the only way the nest appears is an orchestrator delegating `/plan` outward. Keep planning one level deep: this session → one `plan-architect`.
+
 1. **Task description** from `$ARGUMENTS` — when the work was split in Step 2.5, scope this to the single PR being planned and state which PR it is and what it depends on
 2. **Exploration results** from Step 2 — file paths, code traces, existing patterns, test coverage findings
 3. **The full `$VERIFICATION_RULE`** from Step 1, prefixed with: `MANDATORY — you must follow this rule exactly:`


### PR DESCRIPTION
## Summary
- Adds an explicit guard to `.claude/commands/plan.md` Step 3: run `/plan` inline, never delegate the whole invocation to a `general-purpose`/`claude` sub-agent.
- Those agent types carry `Tools: *` and can spawn further agents, so delegating `/plan` to them produces a `general-purpose → plan-architect` nest — exactly the multi-level tree the flat-fan-out rule forbids (`agent-tiering.md` § Nested Sub-Agents).
- `plan-architect`/`Plan`/`Explore` lack the `Agent` tool and cannot cause the nest themselves; the only way it appears is an orchestrator delegating `/plan` outward.

## Why
Keeps planning one level deep: orchestrating session → exactly one `plan-architect` per PR-sized unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)