### PR TITLE
ci: stop update-baselines label from triggering a full CI suite

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,13 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      src: ${{ github.event_name == 'push' || github.event.action == 'labeled' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
+      # NOTE: a `labeled` event intentionally does NOT set src=true. Adding any
+      # label used to force the full E2E suite (api-e2e/shards/mutators) to rerun.
+      # Only the Visual Regression job should respond to a label — see `baseline` below.
+      src: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
+      # True only for the `update-baselines` label. Gates the Visual Regression job
+      # alone so applying that label reruns baseline regen without a CI storm.
+      baseline: ${{ github.event.action == 'labeled' && github.event.label.name == 'update-baselines' }}
     steps:
       - uses: dorny/paths-filter@v4
         id: filter
@@ -87,7 +93,7 @@ jobs:
   e2e:
     name: Visual Regression
     needs: [changes]
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.baseline == 'true'
     runs-on: ubuntu-latest
     # 30 min (was 20) — full-page matrix over 49 modules is ~4-6x the
     # wall-clock of the prior 13 element crops.
@@ -493,7 +499,7 @@ jobs:
   ibl6-visual:
     name: IBL6 Visual Regression
     needs: [changes]
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.baseline == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -129,7 +129,9 @@ jobs:
   mutation-pr:
     name: Infection PHP (per-PR diff)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Skip on `labeled` events (e.g. update-baselines/human-approved bookkeeping
+    # labels) — those carry no code change for this diff job to analyse.
+    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     timeout-minutes: 15
 
     services:


### PR DESCRIPTION
## Problem

Applying any PR label fires GitHub's `labeled` event. The `changes` job in `e2e-tests.yml` set `src=true` for **any** labeled action, so adding `update-baselines` (or `human-approved`, etc.) re-ran the **entire** E2E suite — `api-e2e`, the `e2e-shards` matrix, `e2e-mutators`, `ibl6-e2e` — plus `mutation.yml`'s `mutation-pr` job. Only the visual-regression jobs actually consume the `update-baselines` label, so the rest was a wasted CI storm.

## Fix

- **`e2e-tests.yml`**: drop `github.event.action == 'labeled'` from the `src` output so a label no longer truthifies it; add a new `baseline` output (`true` only when the label is `update-baselines`). Gate the two baseline-regen jobs — `Visual Regression` and `IBL6 Visual Regression` — on `src || baseline`. The heavy jobs stay on `src` only.
- **`mutation.yml`**: skip `mutation-pr` on `labeled` events (no code change to analyse).

## Result

| Action | Heavy jobs that run |
|---|---|
| `update-baselines` label | Visual Regression + IBL6 Visual Regression only |
| Any other label (e.g. `human-approved`) | none |
| push / synchronize | unchanged (full suite) |

## Safety

The required **E2E Tests** status check is the `gate` job (`if: always()`, `exit 1` only on `contains(needs.*.result, 'failure'|'cancelled')`). Skipped children are neither failure nor cancelled, so the gate passes — auto-merge on `human-approved` is unaffected. `merge-reports` stays `src`-gated (no shard blobs exist on a label event). The post-regen `synchronize` event still runs the full verification.