### PR TITLE
docs: sweep auto_postplan→auto_merge key and update ADR-0062 for #1137

### DIFF
--- a/ibl5/docs/a11y-backlog.md
+++ b/ibl5/docs/a11y-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: WCAG 2.x full-rule (non-contrast) accessibility failure inventory and burn-down backlog per axe rule. Companion to a11y-contrast-backlog.md.
-last_verified: 2026-06-14
+last_verified: 2026-06-20
 ---
 
 # A11y Full-Rule Backlog (non-contrast)
@@ -15,7 +15,7 @@ last_verified: 2026-06-14
 
 **Disposition legend:**
 - 🟢 **nightly-safe** — fix is mechanical + verifiable by extending the spec ratchet (green-green); planned + queued.
-- 🟡 **supervised** — needs human judgment (label wording, "which heading is THE title", architectural refactor) or carries VR-regression risk → `auto_postplan: false`.
+- 🟡 **supervised** — needs human judgment (label wording, "which heading is THE title", architectural refactor) or carries VR-regression risk → `auto_merge: false`.
 - 🔵 **seed-verify** — re-run axe on the CI-seed stack to confirm reproducibility before planning.
 - ⚪ **out of scope** — covered elsewhere (contrast backlog) or the page is slated for deletion.
 
@@ -62,7 +62,7 @@ last_verified: 2026-06-14
 **Location:** topics (100 nodes!), homepage + news article + debug menu (2 nodes — sim-recap `leaders-tabbed` team links).
 **Problem:** Touch targets < 24×24px without sufficient spacing. WCAG 2.2 — a brand-new rule family for this codebase. The topics(100) hit is a dense small-link list.
 **Direction:** CSS `min-height`/`min-width`/padding on the affected components.
-**Disposition:** 🟡 (CSS sizing changes risk **visual-regression baseline** breakage → needs VR review, `auto_postplan: false`) **+ 🔵** (the small-count hits are sim-recap data-dependent; verify topics(100) on CI seed). Plan after a VR-aware human pass.
+**Disposition:** 🟡 (CSS sizing changes risk **visual-regression baseline** breakage → needs VR review, `auto_merge: false`) **+ 🔵** (the small-count hits are sim-recap data-dependent; verify topics(100) on CI seed). Plan after a VR-aware human pass.
 
 ### landmark-unique — best-practice, moderate — 🟡
 **Location:** standings (per-region scroll regions all `aria-label="Standings"`), league starters (`aria-label="Scrollable data table"` generic, ×2), next sim (`.next-sim-position-section` scroll regions share a label), schedule + team schedule (`.nav-grain` duplicate landmark).

--- a/ibl5/docs/decisions/0062-human-signoff-gate-for-feature-prs.md
+++ b/ibl5/docs/decisions/0062-human-signoff-gate-for-feature-prs.md
@@ -1,6 +1,6 @@
 ---
 description: Feature PRs (conventional-commit `feat:`) cannot merge until a human applies the `human-approved` label — a required CI check, not a convention, blocks auto-merge.
-last_verified: 2026-06-14
+last_verified: 2026-06-20
 ---
 
 # ADR-0062: Human sign-off gate for feature PRs
@@ -17,7 +17,7 @@ The nightly autonomous pipeline (`bin/nightly-run` → `/post-plan` Phase 6.5) a
 
 Feature PRs require explicit human sign-off, enforced mechanically by a **required status check**, not by convention. The workflow `.github/workflows/human-signoff.yml` classifies a PR as a feature by its conventional-commit title (`^feat(scope)?!?:`) and fails (red) until a human applies the `human-approved` label in the GitHub UI; non-feature work (`fix`/`refactor`/`chore`/`ci`/`docs`/`revert`) passes automatically so the nightly pipeline can still auto-merge maintenance. The check is added to master's required contexts, so a queued `--auto` merge never completes while it is red. **This required check is the deterministic block** — it holds regardless of what the autonomous flow does, because the merge is gated by GitHub, not by anyone's discipline.
 
-The nightly bot runs as the repo owner with the owner's `gh` credentials, so GitHub cannot tell a bot merge from a human one; the only bot/human discriminator lives in the headless execution path. `bin/nightly-run` (`neutralize_feat_signoff`) uses it as **best-effort defense-in-depth**, not a second deterministic layer: after each post-plan run it strips `--auto` arming and any `human-approved` label from `feat:` PRs the bot authored. Note the timing — post-plan arms `--auto` then watches CI to completion (Phase 7) *before* returning to `nightly-run`, so this cleanup runs too late to beat a label that was applied during the watch. The actual safeguard against the bot self-applying the label is that the post-plan flow does not apply it (verified by inspection); `neutralize_feat_signoff` is a tidy-up and a tripwire, and Layer A blocks the merge either way.
+The nightly bot runs as the repo owner with the owner's `gh` credentials, so GitHub cannot tell a bot merge from a human one. **Defense-in-depth lives in the post-plan layer and is deterministic:** `/post-plan` Phase 6.5 condition (8) is a literal PR-title grep (`^feat(scope)?!?:`) that refuses to *arm* `gh pr merge --auto` on a feature PR in the first place — so the bot never queues a `feat:` merge, and there is no arm-then-strip race to lose. The remaining safeguard against the bot self-applying the `human-approved` label is that the post-plan flow does not apply it (verified by inspection). Layer A (the required check) blocks the merge regardless. (This replaced an earlier runtime-strip mechanism — see **Update** below.)
 
 ## Alternatives Considered
 
@@ -33,6 +33,10 @@ The nightly bot runs as the repo owner with the owner's `gh` credentials, so Git
 - Negative: the nightly pipeline can no longer ship *any* new feature without a human applying the label the next morning — a deliberate throughput cost for UX-bearing changes.
 - Negative / residual: `gh pr merge --admin` would bypass the required check (admin override, since `enforce_admins: false` is kept for the direct-push paths). It is closed only by the fact the nightly flow does not use `--admin`, not by GitHub — a known, documented gap, not a guarantee. Likewise the title classifier can be dodged by editing a `feat:` PR's title; titles are the team contract (post-plan enforces conventional commits), so this is accepted, not defended.
 
+## Update (2026-06-20, PR #1137)
+
+The originally-shipped **Layer B** was a runtime strip: `bin/nightly-run`'s `neutralize_feat_signoff()` stripped `--auto` arming and any `human-approved` label from bot-authored `feat:` PRs *after* each post-plan run. Because post-plan arms `--auto` then watches CI to completion before returning to `nightly-run`, that cleanup ran too late to beat a label applied mid-watch — best-effort, not deterministic. PR #1137 **removed `neutralize_feat_signoff()`** and replaced the arm-then-strip pattern with the upstream deterministic refusal now described in the Decision (Phase 6.5 condition (8)): post-plan never arms a `feat:` PR, so nothing needs stripping. Layer A — this ADR's core decision, the required `human-signoff` check — is unchanged. The same refactor moved the general merge-hold lever from the inert `auto_postplan: false` plan-frontmatter key to `auto_merge: false`, read deterministically at Phase 6.5 condition (7).
+
 ## Lineage
 
 Relates to (does not supersede) ADR-0017 (`0017-dependabot-full-ci-and-auto-merge.md`), which established auto-merge for dependabot PRs — that path is gated separately on `dependabot[bot]` authorship and is unaffected. This ADR corrects the gap left by #1072, which is retained only as the de-facto first attempt.
@@ -40,6 +44,6 @@ Relates to (does not supersede) ADR-0017 (`0017-dependabot-full-ci-and-auto-merg
 ## References
 
 - `.github/workflows/human-signoff.yml` — Layer A, the required status check.
-- `bin/nightly-run` — Layer B, `neutralize_feat_signoff` strips auto-merge/label from `feat:` PRs.
+- `bin/nightly-run` — formerly held Layer B (`neutralize_feat_signoff`), removed by PR #1137; the `feat:` block now lives upstream in post-plan Phase 6.5 condition (8) (see Update).
 - `.claude/skills/post-plan/SKILL.md` — Phase 6.5 arms `gh pr merge --auto` (the behaviour this gate constrains).
 - `.claude/rules/nightly-workflow.md` — nightly pipeline overview.


### PR DESCRIPTION
## Summary

- Rename `auto_postplan: false` → `auto_merge: false` in `a11y-backlog.md` disposition legend and the target-size entry (two occurrences)
- Update ADR-0062 (`0062-human-signoff-gate-for-feature-prs.md`) to document the removal of Layer B (`neutralize_feat_signoff`) and its replacement by the deterministic Phase 6.5 condition (8) upstream refusal; rename the key reference; add an Update section
- Bump `last_verified` to 2026-06-20 in both files

These are follow-up documentation corrections after PR #1137 refactored the merge-hold lever from the inert `auto_postplan` key to `auto_merge`.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.ai/code)