### PR TITLE
refactor: extract TradeOffer cap math into TradeCapCalculator (Backlog 1.14)

### DIFF
--- a/ibl5/classes/Trading/Contracts/TradeCapCalculatorInterface.php
+++ b/ibl5/classes/Trading/Contracts/TradeCapCalculatorInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trading\Contracts;
+
+/**
+ * TradeCapCalculatorInterface - Salary-cap math for a pending trade offer
+ *
+ * Owns the cap arithmetic extracted from {@see \Trading\TradeOffer}: it computes
+ * each team's current-season cap total and the amounts each side sends/receives,
+ * following the same calculator-collaborator shape as
+ * {@see \Team\Contracts\TeamCapCalculatorInterface} and
+ * {@see \FreeAgency\FreeAgencyCapCalculator} (ADR-0028).
+ *
+ * @phpstan-type TradeFormData array{offeringTeam: string, listeningTeam: string, switchCounter: int, fieldsCounter: int, check: array<int, string|null>, index: array<int, string>, type: array<int, string>, contract: array<int, string>, userSendsCash: array<int, int>, partnerSendsCash: array<int, int>}
+ */
+interface TradeCapCalculatorInterface
+{
+    /**
+     * Calculate salary cap data for both teams in a trade offer.
+     *
+     * Returns each team's current-season cap total (contracts + cash records +
+     * new cash considerations) and the amounts being sent between teams.
+     * For self-trades (offeringTeam === listeningTeam), sent amounts are zeroed.
+     *
+     * @param TradeFormData $tradeData
+     * @return array{userCurrentSeasonCapTotal: int, partnerCurrentSeasonCapTotal: int, userCapSentToPartner: int, partnerCapSentToUser: int}
+     */
+    public function calculateSalaryCapData(array $tradeData): array;
+}

--- a/ibl5/classes/Trading/TradeCapCalculator.php
+++ b/ibl5/classes/Trading/TradeCapCalculator.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trading;
+
+use Repositories\Contracts\TeamIdentityRepositoryInterface;
+use Trading\Contracts\BuyoutLedgerRepositoryInterface;
+use Trading\Contracts\TradeCapCalculatorInterface;
+use Season\Season;
+
+/**
+ * TradeCapCalculator - Salary-cap arithmetic for trade offers
+ *
+ * Holds the cap math extracted from {@see TradeOffer::calculateSalaryCapData()}
+ * and {@see TradeOffer::sumCashRecordSalaries()}, following the established
+ * calculator-collaborator pattern of {@see \Team\TeamCapCalculator} and
+ * {@see \FreeAgency\FreeAgencyCapCalculator} (ADR-0028).
+ *
+ * @phpstan-import-type TradeFormData from TradeCapCalculatorInterface
+ *
+ * @see TradeCapCalculatorInterface
+ */
+class TradeCapCalculator implements TradeCapCalculatorInterface
+{
+    private TeamIdentityRepositoryInterface $commonRepository;
+    private BuyoutLedgerRepositoryInterface $cashConsiderationRepository;
+    private Season $season;
+    private TradeValidator $validator;
+
+    /**
+     * @param TeamIdentityRepositoryInterface $commonRepository Team identity repository (required)
+     * @param BuyoutLedgerRepositoryInterface|null $cashConsiderationRepository Cash consideration repository (created from $db if not provided)
+     * @param Season|null $season Season entity (created from $db if not provided)
+     * @param TradeValidator|null $validator Trade validator (created from $db if not provided)
+     * @param \mysqli|null $db Database connection — only needed when any of the above is null
+     */
+    public function __construct(
+        TeamIdentityRepositoryInterface $commonRepository,
+        ?BuyoutLedgerRepositoryInterface $cashConsiderationRepository = null,
+        ?Season $season = null,
+        ?TradeValidator $validator = null,
+        ?\mysqli $db = null
+    ) {
+        $this->commonRepository = $commonRepository;
+        // TradeOffer always injects all four collaborators; $db is only needed for standalone fallback-construct.
+        $this->cashConsiderationRepository = $cashConsiderationRepository
+            ?? ($db !== null ? new BuyoutLedgerRepository($db) : throw new \LogicException('$db required when $cashConsiderationRepository is not provided'));
+        $this->season = $season
+            ?? ($db !== null ? new Season($db) : throw new \LogicException('$db required when $season is not provided'));
+        $this->validator = $validator
+            ?? ($db !== null ? new TradeValidator($db) : throw new \LogicException('$db required when $validator is not provided'));
+    }
+
+    /**
+     * @see TradeCapCalculatorInterface::calculateSalaryCapData()
+     *
+     * @param TradeFormData $tradeData
+     * @return array{userCurrentSeasonCapTotal: int, partnerCurrentSeasonCapTotal: int, userCapSentToPartner: int, partnerCapSentToUser: int}
+     */
+    public function calculateSalaryCapData(array $tradeData): array
+    {
+        $userCurrentSeasonCapTotal = 0;
+        $partnerCurrentSeasonCapTotal = 0;
+        $userCapSentToPartner = 0;
+        $partnerCapSentToUser = 0;
+
+        // Calculate user team salary data from form
+        $switchCounter = $tradeData['switchCounter'];
+        for ($j = 0; $j < $switchCounter; $j++) {
+            $isChecked = $tradeData['check'][$j] ?? null;
+            $salaryAmount = (int) ($tradeData['contract'][$j] ?? '0');
+            $userCurrentSeasonCapTotal += $salaryAmount;
+
+            if ($isChecked === "on") {
+                $userCapSentToPartner += $salaryAmount;
+            }
+        }
+
+        // Calculate partner team salary data from form
+        $fieldsCounter = $tradeData['fieldsCounter'];
+        for ($j = $switchCounter; $j < $fieldsCounter; $j++) {
+            $isChecked = $tradeData['check'][$j] ?? null;
+            $salaryAmount = (int) ($tradeData['contract'][$j] ?? '0');
+            $partnerCurrentSeasonCapTotal += $salaryAmount;
+
+            if ($isChecked === "on") {
+                $partnerCapSentToUser += $salaryAmount;
+            }
+        }
+
+        // Include existing cash transaction records (e.g. "Cash from Heat")
+        // which are stored as player records with names starting with '|'
+        // but excluded from the form's hidden contract fields
+        $userTeamId = $this->commonRepository->getTidFromTeamname($tradeData['offeringTeam']) ?? 0;
+        $partnerTeamId = $this->commonRepository->getTidFromTeamname($tradeData['listeningTeam']) ?? 0;
+
+        $userCurrentSeasonCapTotal += $this->sumCashRecordSalaries($userTeamId);
+        $partnerCurrentSeasonCapTotal += $this->sumCashRecordSalaries($partnerTeamId);
+
+        // Add new cash considerations from this trade offer
+        $cashConsiderations = $this->validator->getCurrentSeasonCashConsiderations(
+            $tradeData['userSendsCash'],
+            $tradeData['partnerSendsCash']
+        );
+
+        $userCurrentSeasonCapTotal += $cashConsiderations['cashSentToThem'];
+        $userCurrentSeasonCapTotal -= $cashConsiderations['cashSentToMe'];
+        $partnerCurrentSeasonCapTotal += $cashConsiderations['cashSentToMe'];
+        $partnerCurrentSeasonCapTotal -= $cashConsiderations['cashSentToThem'];
+
+        // Self-trade: both sides are the same team, so no players actually move.
+        // Zero out sent/received to avoid double-counting.
+        if ($tradeData['offeringTeam'] === $tradeData['listeningTeam']) {
+            $userCapSentToPartner = 0;
+            $partnerCapSentToUser = 0;
+        }
+
+        return [
+            'userCurrentSeasonCapTotal' => $userCurrentSeasonCapTotal,
+            'partnerCurrentSeasonCapTotal' => $partnerCurrentSeasonCapTotal,
+            'userCapSentToPartner' => $userCapSentToPartner,
+            'partnerCapSentToUser' => $partnerCapSentToUser
+        ];
+    }
+
+    /**
+     * Sum current-season salary from cash consideration records for a team.
+     *
+     * Cash entries (trades, buyouts) are excluded from form hidden fields
+     * but still affect the team's salary cap. This computes their current-year
+     * impact using the same contract-year logic as the form.
+     *
+     * Playoffs counts as offseason for trade cap math (contract years have
+     * effectively rolled over), unlike the FA cap calculation.
+     *
+     * @param int $teamId Team ID
+     * @return int Sum of cash record salaries for the current season (may be negative)
+     */
+    private function sumCashRecordSalaries(int $teamId): int
+    {
+        $cashRecords = $this->cashConsiderationRepository->getTeamCashForSalary($teamId);
+
+        $isOffseason = $this->season->advancesContractYears();
+
+        return BuyoutLedgerRepository::sumCurrentSeasonSalaryFromRows($cashRecords, $isOffseason);
+    }
+}

--- a/ibl5/classes/Trading/TradeOffer.php
+++ b/ibl5/classes/Trading/TradeOffer.php
@@ -9,6 +9,7 @@ use Trading\Contracts\TradeOfferRepositoryInterface;
 use Trading\Contracts\TradeAssetRepositoryInterface;
 use Trading\Contracts\TradeCashRepositoryInterface;
 use Trading\Contracts\BuyoutLedgerRepositoryInterface;
+use Trading\Contracts\TradeCapCalculatorInterface;
 use Repositories\Contracts\TeamIdentityRepositoryInterface;
 use Season\Season;
 use Discord\Discord;
@@ -42,6 +43,7 @@ class TradeOffer implements TradeOfferInterface
     protected Season $season;
     protected CashTransactionHandler $cashHandler;
     protected TradeValidator $validator;
+    protected ?TradeCapCalculatorInterface $tradeCapCalculator = null;
     protected ?Discord $discord;
 
     public function __construct(
@@ -54,7 +56,8 @@ class TradeOffer implements TradeOfferInterface
         ?BuyoutLedgerRepositoryInterface $cashConsiderationRepository = null,
         ?Season $season = null,
         ?TradeValidator $validator = null,
-        ?\Psr\Log\LoggerInterface $logger = null
+        ?\Psr\Log\LoggerInterface $logger = null,
+        ?TradeCapCalculatorInterface $tradeCapCalculator = null
     ) {
         $this->db = $db;
         $this->commonRepository = $commonRepository;
@@ -66,6 +69,12 @@ class TradeOffer implements TradeOfferInterface
         $this->cashHandler = new CashTransactionHandler($db, $this->commonRepository, $this->cashConsiderationRepository, $this->cashRepository);
         $this->validator = $validator ?? new TradeValidator($db);
         $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('trade');
+        $this->tradeCapCalculator = $tradeCapCalculator ?? new TradeCapCalculator(
+            $this->commonRepository,
+            $this->cashConsiderationRepository,
+            $this->season,
+            $this->validator
+        );
 
         // Initialize Discord with error handling (may fail if column doesn't exist)
         try {
@@ -182,89 +191,14 @@ class TradeOffer implements TradeOfferInterface
      */
     protected function calculateSalaryCapData(array $tradeData): array
     {
-        $userCurrentSeasonCapTotal = 0;
-        $partnerCurrentSeasonCapTotal = 0;
-        $userCapSentToPartner = 0;
-        $partnerCapSentToUser = 0;
-
-        // Calculate user team salary data from form
-        $switchCounter = $tradeData['switchCounter'];
-        for ($j = 0; $j < $switchCounter; $j++) {
-            $isChecked = $tradeData['check'][$j] ?? null;
-            $salaryAmount = (int) ($tradeData['contract'][$j] ?? '0');
-            $userCurrentSeasonCapTotal += $salaryAmount;
-
-            if ($isChecked === "on") {
-                $userCapSentToPartner += $salaryAmount;
-            }
-        }
-
-        // Calculate partner team salary data from form
-        $fieldsCounter = $tradeData['fieldsCounter'];
-        for ($j = $switchCounter; $j < $fieldsCounter; $j++) {
-            $isChecked = $tradeData['check'][$j] ?? null;
-            $salaryAmount = (int) ($tradeData['contract'][$j] ?? '0');
-            $partnerCurrentSeasonCapTotal += $salaryAmount;
-
-            if ($isChecked === "on") {
-                $partnerCapSentToUser += $salaryAmount;
-            }
-        }
-
-        // Include existing cash transaction records (e.g. "Cash from Heat")
-        // which are stored as player records with names starting with '|'
-        // but excluded from the form's hidden contract fields
-        $userTeamId = $this->commonRepository->getTidFromTeamname($tradeData['offeringTeam']) ?? 0;
-        $partnerTeamId = $this->commonRepository->getTidFromTeamname($tradeData['listeningTeam']) ?? 0;
-
-        $userCurrentSeasonCapTotal += $this->sumCashRecordSalaries($userTeamId);
-        $partnerCurrentSeasonCapTotal += $this->sumCashRecordSalaries($partnerTeamId);
-
-        // Add new cash considerations from this trade offer
-        $cashConsiderations = $this->validator->getCurrentSeasonCashConsiderations(
-            $tradeData['userSendsCash'],
-            $tradeData['partnerSendsCash']
-        );
-
-        $userCurrentSeasonCapTotal += $cashConsiderations['cashSentToThem'];
-        $userCurrentSeasonCapTotal -= $cashConsiderations['cashSentToMe'];
-        $partnerCurrentSeasonCapTotal += $cashConsiderations['cashSentToMe'];
-        $partnerCurrentSeasonCapTotal -= $cashConsiderations['cashSentToThem'];
-
-        // Self-trade: both sides are the same team, so no players actually move.
-        // Zero out sent/received to avoid double-counting.
-        if ($tradeData['offeringTeam'] === $tradeData['listeningTeam']) {
-            $userCapSentToPartner = 0;
-            $partnerCapSentToUser = 0;
-        }
-
-        return [
-            'userCurrentSeasonCapTotal' => $userCurrentSeasonCapTotal,
-            'partnerCurrentSeasonCapTotal' => $partnerCurrentSeasonCapTotal,
-            'userCapSentToPartner' => $userCapSentToPartner,
-            'partnerCapSentToUser' => $partnerCapSentToUser
-        ];
-    }
-
-    /**
-     * Sum current-season salary from cash consideration records for a team
-     *
-     * Cash entries (trades, buyouts) are excluded from form hidden fields
-     * but still affect the team's salary cap. This computes their current-year
-     * impact using the same contract-year logic as the form.
-     *
-     * @param int $teamId Team ID
-     * @return int Sum of cash record salaries for the current season (may be negative)
-     */
-    private function sumCashRecordSalaries(int $teamId): int
-    {
-        $cashRecords = $this->cashConsiderationRepository->getTeamCashForSalary($teamId);
-
-        // Playoffs counts as offseason for trade cap math (contract years have
-        // effectively rolled over), unlike the FA cap calculation.
-        $isOffseason = $this->season->advancesContractYears();
-
-        return BuyoutLedgerRepository::sumCurrentSeasonSalaryFromRows($cashRecords, $isOffseason);
+        // Fallback-safe: constructor-skipping test doubles never set $tradeCapCalculator,
+        // so we guard with isset-safe ?? rather than accessing the typed property directly.
+        return ($this->tradeCapCalculator ?? new TradeCapCalculator(
+            $this->commonRepository,
+            $this->cashConsiderationRepository,
+            $this->season,
+            $this->validator
+        ))->calculateSalaryCapData($tradeData);
     }
 
     /**

--- a/ibl5/tests/Trading/TradeCapCalculatorTest.php
+++ b/ibl5/tests/Trading/TradeCapCalculatorTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Trading;
+
+use PHPUnit\Framework\TestCase;
+use Trading\Contracts\BuyoutLedgerRepositoryInterface;
+use Trading\TradeCapCalculator;
+use Trading\TradeValidator;
+use Season\Season;
+
+/**
+ * @covers \Trading\TradeCapCalculator
+ */
+class TradeCapCalculatorTest extends TestCase
+{
+    /**
+     * @return array{offeringTeam: string, listeningTeam: string, switchCounter: int, fieldsCounter: int, check: array<int, string|null>, index: array<int, string>, type: array<int, string>, contract: array<int, string>, userSendsCash: array<int, int>, partnerSendsCash: array<int, int>}
+     */
+    private function makeTradeData(int $switchCounter = 0, int $fieldsCounter = 0): array
+    {
+        return [
+            'offeringTeam' => 'Lakers',
+            'listeningTeam' => 'Celtics',
+            'switchCounter' => $switchCounter,
+            'fieldsCounter' => $fieldsCounter,
+            'check' => [],
+            'index' => [],
+            'type' => [],
+            'contract' => [],
+            'userSendsCash' => [1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0, 6 => 0],
+            'partnerSendsCash' => [1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0, 6 => 0],
+        ];
+    }
+
+    /**
+     * @return array{cy: int, salary_yr1: int, salary_yr2: int, salary_yr3: int, salary_yr4: int, salary_yr5: int, salary_yr6: int}
+     */
+    private function makeDiscriminatorRow(): array
+    {
+        // yr1=100, yr2=500: yr1 ≠ yr2 proves cy-offset changes the sum
+        return ['cy' => 1, 'salary_yr1' => 100, 'salary_yr2' => 500, 'salary_yr3' => 0, 'salary_yr4' => 0, 'salary_yr5' => 0, 'salary_yr6' => 0];
+    }
+
+    /** V6: advances=true → cy 1→2 → yr2=500 per team */
+    public function testCalculateSalaryCapDataAdvancesTrue(): void
+    {
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTidFromTeamname')->willReturn(1);
+        $cashConsiderationRepo = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashConsiderationRepo->method('getTeamCashForSalary')->willReturn([$this->makeDiscriminatorRow()]);
+        $season = self::createStub(Season::class);
+        $season->method('advancesContractYears')->willReturn(true);
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        $calculator = new TradeCapCalculator($commonRepo, $cashConsiderationRepo, $season, $validator);
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 500, 'partnerCurrentSeasonCapTotal' => 500, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $calculator->calculateSalaryCapData($this->makeTradeData())
+        );
+    }
+
+    /** V7: advances=false → cy stays 1 → yr1=100 per team */
+    public function testCalculateSalaryCapDataAdvancesFalse(): void
+    {
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTidFromTeamname')->willReturn(1);
+        $cashConsiderationRepo = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashConsiderationRepo->method('getTeamCashForSalary')->willReturn([$this->makeDiscriminatorRow()]);
+        $season = self::createStub(Season::class);
+        $season->method('advancesContractYears')->willReturn(false);
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        $calculator = new TradeCapCalculator($commonRepo, $cashConsiderationRepo, $season, $validator);
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 100, 'partnerCurrentSeasonCapTotal' => 100, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $calculator->calculateSalaryCapData($this->makeTradeData())
+        );
+    }
+
+    /** V8: self-trade (offeringTeam === listeningTeam) zeroes sent keys despite checked contracts */
+    public function testCalculateSalaryCapDataSelfTradeZeroesCapSentKeys(): void
+    {
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTidFromTeamname')->willReturn(1);
+        $cashConsiderationRepo = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashConsiderationRepo->method('getTeamCashForSalary')->willReturn([]);
+        $season = self::createStub(Season::class);
+        $season->method('advancesContractYears')->willReturn(false);
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        $calculator = new TradeCapCalculator($commonRepo, $cashConsiderationRepo, $season, $validator);
+        $tradeData = $this->makeTradeData(1, 2);
+        $tradeData['offeringTeam'] = 'Lakers';
+        $tradeData['listeningTeam'] = 'Lakers';
+        $tradeData['check'] = [0 => 'on', 1 => 'on'];
+        $tradeData['type'] = [0 => '1', 1 => '1'];
+        $tradeData['contract'] = [0 => '500', 1 => '600'];
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 500, 'partnerCurrentSeasonCapTotal' => 600, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $calculator->calculateSalaryCapData($tradeData)
+        );
+    }
+
+    /** V9: cash record CY-offset row summed into cap total alongside contracts */
+    public function testCalculateSalaryCapDataCashRecordCyOffsetIncludedInTotal(): void
+    {
+        // advances=true → cy 1→2 → yr2=500 per team; contracts 300 (user), 400 (partner)
+        // user total = 300+500=800, partner total = 400+500=900, sent = 300, received = 400
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTidFromTeamname')->willReturn(1);
+        $cashConsiderationRepo = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashConsiderationRepo->method('getTeamCashForSalary')->willReturn([$this->makeDiscriminatorRow()]);
+        $season = self::createStub(Season::class);
+        $season->method('advancesContractYears')->willReturn(true);
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        $calculator = new TradeCapCalculator($commonRepo, $cashConsiderationRepo, $season, $validator);
+        $tradeData = $this->makeTradeData(1, 2);
+        $tradeData['check'] = [0 => 'on', 1 => 'on'];
+        $tradeData['type'] = [0 => '1', 1 => '1'];
+        $tradeData['contract'] = [0 => '300', 1 => '400'];
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 800, 'partnerCurrentSeasonCapTotal' => 900, 'userCapSentToPartner' => 300, 'partnerCapSentToUser' => 400],
+            $calculator->calculateSalaryCapData($tradeData)
+        );
+    }
+}

--- a/ibl5/tests/Trading/TradeOfferTest.php
+++ b/ibl5/tests/Trading/TradeOfferTest.php
@@ -513,4 +513,156 @@ class TradeOfferTest extends TestCase
 
         $this->assertTrue($result['success']);
     }
+
+    // ── Characterization pin — PRE-IMPL — do not edit ────────────
+
+    /**
+     * Exposes the protected calculateSalaryCapData() for the characterization pin.
+     * The test double sets only the four props that method reads; it never sets
+     * tradeCapCalculator (added later) — the Phase-4 delegator must tolerate this.
+     */
+    private function makeCapPinSubject(
+        \Repositories\Contracts\TeamIdentityRepositoryInterface $commonRepo,
+        BuyoutLedgerRepositoryInterface $cashConsiderationRepo,
+        Season $season,
+        TradeValidator $validator
+    ): TradeOfferCapPinDouble {
+        return new TradeOfferCapPinDouble($commonRepo, $cashConsiderationRepo, $season, $validator);
+    }
+
+    /**
+     * @return array{cy: int, salary_yr1: int, salary_yr2: int, salary_yr3: int, salary_yr4: int, salary_yr5: int, salary_yr6: int}
+     */
+    private function makeDiscriminatorRow(): array
+    {
+        // yr1=100, yr2=500: yr1 ≠ yr2 proves cy-offset changes the sum
+        return ['cy' => 1, 'salary_yr1' => 100, 'salary_yr2' => 500, 'salary_yr3' => 0, 'salary_yr4' => 0, 'salary_yr5' => 0, 'salary_yr6' => 0];
+    }
+
+    /** V1: advances=true → cy 1→2 → yr2=500 per team */
+    public function testCapPinCalculateSalaryCapDataAdvancesTrue(): void
+    {
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTidFromTeamname')->willReturn(1);
+        $cashConsiderationRepo = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashConsiderationRepo->method('getTeamCashForSalary')->willReturn([$this->makeDiscriminatorRow()]);
+        $season = self::createStub(Season::class);
+        $season->method('advancesContractYears')->willReturn(true);
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        $subject = $this->makeCapPinSubject($commonRepo, $cashConsiderationRepo, $season, $validator);
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 500, 'partnerCurrentSeasonCapTotal' => 500, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $subject->exposeCalculateSalaryCapData($this->makeTradeData())
+        );
+    }
+
+    /** V2: advances=false → cy stays 1 → yr1=100 per team */
+    public function testCapPinCalculateSalaryCapDataAdvancesFalse(): void
+    {
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTidFromTeamname')->willReturn(1);
+        $cashConsiderationRepo = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashConsiderationRepo->method('getTeamCashForSalary')->willReturn([$this->makeDiscriminatorRow()]);
+        $season = self::createStub(Season::class);
+        $season->method('advancesContractYears')->willReturn(false);
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        $subject = $this->makeCapPinSubject($commonRepo, $cashConsiderationRepo, $season, $validator);
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 100, 'partnerCurrentSeasonCapTotal' => 100, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $subject->exposeCalculateSalaryCapData($this->makeTradeData())
+        );
+    }
+
+    /** V3: self-trade (offeringTeam === listeningTeam) zeroes sent keys despite checked contracts */
+    public function testCapPinSelfTradeZeroesCapSentKeys(): void
+    {
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTidFromTeamname')->willReturn(1);
+        $cashConsiderationRepo = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashConsiderationRepo->method('getTeamCashForSalary')->willReturn([]);
+        $season = self::createStub(Season::class);
+        $season->method('advancesContractYears')->willReturn(false);
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        $subject = $this->makeCapPinSubject($commonRepo, $cashConsiderationRepo, $season, $validator);
+        $tradeData = $this->makeTradeData(1, 2);
+        $tradeData['offeringTeam'] = 'Lakers';
+        $tradeData['listeningTeam'] = 'Lakers';
+        $tradeData['check'] = [0 => 'on', 1 => 'on'];
+        $tradeData['type'] = [0 => '1', 1 => '1'];
+        $tradeData['contract'] = [0 => '500', 1 => '600'];
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 500, 'partnerCurrentSeasonCapTotal' => 600, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $subject->exposeCalculateSalaryCapData($tradeData)
+        );
+    }
+
+    /** V4: cash record CY-offset row summed into cap total alongside contracts */
+    public function testCapPinCashRecordCyOffsetIncludedInTotal(): void
+    {
+        // advances=true → cy 1→2 → yr2=500 per team; contracts 300 (user), 400 (partner)
+        // user total = 300+500=800, partner total = 400+500=900, sent = 300, received = 400
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTidFromTeamname')->willReturn(1);
+        $cashConsiderationRepo = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashConsiderationRepo->method('getTeamCashForSalary')->willReturn([$this->makeDiscriminatorRow()]);
+        $season = self::createStub(Season::class);
+        $season->method('advancesContractYears')->willReturn(true);
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        $subject = $this->makeCapPinSubject($commonRepo, $cashConsiderationRepo, $season, $validator);
+        $tradeData = $this->makeTradeData(1, 2);
+        $tradeData['check'] = [0 => 'on', 1 => 'on'];
+        $tradeData['type'] = [0 => '1', 1 => '1'];
+        $tradeData['contract'] = [0 => '300', 1 => '400'];
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 800, 'partnerCurrentSeasonCapTotal' => 900, 'userCapSentToPartner' => 300, 'partnerCapSentToUser' => 400],
+            $subject->exposeCalculateSalaryCapData($tradeData)
+        );
+    }
+}
+
+/**
+ * Test double for the characterization pin: exposes the protected
+ * calculateSalaryCapData() without going through the real constructor.
+ * Sets only the four props that method reads; never sets tradeCapCalculator
+ * (added in Phase 4) — the fallback delegator must tolerate this.
+ *
+ * @phpstan-import-type TradeFormData from \Trading\TradeOffer
+ */
+class TradeOfferCapPinDouble extends TradeOffer
+{
+    // @phpstan-ignore constructor.missingParentCall (test double: skip real ctor, inject the four cap collaborators directly)
+    public function __construct(
+        \Repositories\Contracts\TeamIdentityRepositoryInterface $commonRepo,
+        \Trading\Contracts\BuyoutLedgerRepositoryInterface $cashConsiderationRepo,
+        Season $season,
+        TradeValidator $validator
+    ) {
+        $this->db = new MockDatabase();
+        $this->commonRepository = $commonRepo;
+        $this->cashConsiderationRepository = $cashConsiderationRepo;
+        $this->season = $season;
+        $this->validator = $validator;
+        $this->logger = \Logging\LoggerFactory::getChannel('trade');
+    }
+
+    /**
+     * @phpstan-param TradeFormData $tradeData
+     * @return array{userCurrentSeasonCapTotal: int, partnerCurrentSeasonCapTotal: int, userCapSentToPartner: int, partnerCapSentToUser: int}
+     */
+    public function exposeCalculateSalaryCapData(array $tradeData): array
+    {
+        return $this->calculateSalaryCapData($tradeData);
+    }
 }


### PR DESCRIPTION
## Summary

Extracts salary-cap math from `Trading\TradeOffer` into a dedicated `Trading\TradeCapCalculator` collaborator (with `TradeCapCalculatorInterface`), following the established `Team\TeamCapCalculator` + `Team\Contracts\TeamCapCalculatorInterface` precedent.

**Approach:** The extraction is behavior-preserving. `TradeOffer::calculateSalaryCapData()` becomes a thin delegator (with isset-safe `??` fallback for constructor-skipping test doubles). The characterization pin and all existing tests pass identically before and after — the literal green-green proof.

**Files changed:**
- `classes/Trading/TradeCapCalculator.php` (new) — extracted cap arithmetic
- `classes/Trading/Contracts/TradeCapCalculatorInterface.php` (new) — calculator contract
- `classes/Trading/TradeOffer.php` — inject calculator, convert to thin delegator, delete `sumCashRecordSalaries()`
- `tests/Trading/TradeCapCalculatorTest.php` (new) — direct unit tests for calculator
- `tests/Trading/TradeOfferTest.php` — additive characterization pin (Phase 1)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)