### PR TITLE
refactor: StandingsView dual-path green-green refactor (finding 1.6)

### DIFF
--- a/ibl5/classes/Standings/StandingsView.php
+++ b/ibl5/classes/Standings/StandingsView.php
@@ -62,11 +62,7 @@ class StandingsView implements StandingsViewInterface
     public function render(): string
     {
         // Pre-load all streak, Pythagorean, and H2H data in bulk queries
-        $this->allStreakData = $this->repository->getAllStreakData();
-        $this->allPythagoreanStats = $this->repository->getAllPythagoreanStats($this->seasonYear);
-        $this->seriesMatrix = $this->seriesRecordsService->buildSeriesMatrix(
-            $this->repository->getSeriesRecords()
-        );
+        $this->ensureBulkDataLoaded();
 
         // Bulk-fetch all standings in 1 query instead of 6
         $allStandings = $this->repository->getAllStandings();
@@ -98,11 +94,12 @@ class StandingsView implements StandingsViewInterface
     }
 
     /**
-     * @see StandingsViewInterface::renderRegion()
+     * Lazily load streak, Pythagorean, and H2H series-matrix data into the
+     * shared cache properties if not already populated. Idempotent: a second
+     * call is a no-op because each property is non-null after the first.
      */
-    public function renderRegion(string $region): string
+    private function ensureBulkDataLoaded(): void
     {
-        // If called standalone (not via render()), load data on demand
         if ($this->allStreakData === null) {
             $this->allStreakData = $this->repository->getAllStreakData();
         }
@@ -114,6 +111,15 @@ class StandingsView implements StandingsViewInterface
                 $this->repository->getSeriesRecords()
             );
         }
+    }
+
+    /**
+     * @see StandingsViewInterface::renderRegion()
+     */
+    public function renderRegion(string $region): string
+    {
+        // If called standalone (not via render()), load data on demand
+        $this->ensureBulkDataLoaded();
 
         $groupingType = $this->getGroupingType($region);
         $standings = $this->repository->getStandingsByRegion($region);

--- a/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
+++ b/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Standings;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use SeriesRecords\SeriesRecordsService;
+use Standings\StandingsView;
+use Standings\Contracts\StandingsRepositoryInterface;
+
+/**
+ * Golden-master pin + divergence-guard for StandingsView.
+ *
+ * Captures EXACT current output of both render paths — inconsistency and all —
+ * before the ensureBulkDataLoaded() refactor, then verifies byte-identity after.
+ *
+ * The deliberate sort inconsistency between render() (multi-key PHP sort) and
+ * renderRegion() (SQL-order trust) is PRESERVED. Fixing it is DEFERRED to a
+ * separate future plan.
+ *
+ * @covers \Standings\StandingsView
+ */
+#[AllowMockObjectsWithoutExpectations]
+class StandingsViewGoldenMasterTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Divergence fixture helpers
+    // -------------------------------------------------------------------------
+
+    /** @return array<string, mixed> BulkStandingsRow for Team A (teamid=1, clinched_division=1, clinch tier=2) */
+    private function bulkTeamA(): array
+    {
+        return [
+            'teamid' => 1,
+            'team_name' => 'Team Alpha',
+            'league_record' => '50-32',
+            'pct' => '0.610',
+            'conf_gb' => '0.0',
+            'div_gb' => '0.0',
+            'conf_magic_number' => 0,
+            'div_magic_number' => 0,
+            'games_unplayed' => 0,
+            'conf_record' => '30-16',
+            'div_record' => '10-4',
+            'home_record' => '28-14',
+            'away_record' => '22-18',
+            'homeGames' => 42,
+            'awayGames' => 40,
+            'clinched_conference' => 0,
+            'clinched_division' => 1,
+            'clinched_playoffs' => 0,
+            'clinched_league' => 0,
+            'wins' => 50,
+            'conference' => 'Eastern',
+            'division' => 'Atlantic',
+            'color1' => '000080',
+            'color2' => 'FFFFFF',
+        ];
+    }
+
+    /** @return array<string, mixed> BulkStandingsRow for Team B (teamid=2, clinched_playoffs=1, clinch tier=1) */
+    private function bulkTeamB(): array
+    {
+        return [
+            'teamid' => 2,
+            'team_name' => 'Team Beta',
+            'league_record' => '50-32',
+            'pct' => '0.610',
+            'conf_gb' => '0.0',
+            'div_gb' => '0.0',
+            'conf_magic_number' => 0,
+            'div_magic_number' => 0,
+            'games_unplayed' => 0,
+            'conf_record' => '30-16',
+            'div_record' => '10-4',
+            'home_record' => '28-14',
+            'away_record' => '22-18',
+            'homeGames' => 42,
+            'awayGames' => 40,
+            'clinched_conference' => 0,
+            'clinched_division' => 0,
+            'clinched_playoffs' => 1,
+            'clinched_league' => 0,
+            'wins' => 50,
+            'conference' => 'Eastern',
+            'division' => 'Atlantic',
+            'color1' => '800000',
+            'color2' => 'FFFFFF',
+        ];
+    }
+
+    /** @return array<string, mixed> StandingsRow for Team A (teamid=1, clinched_division=1) */
+    private function regionTeamA(): array
+    {
+        return [
+            'teamid' => 1,
+            'team_name' => 'Team Alpha',
+            'league_record' => '50-32',
+            'pct' => '0.610',
+            'gamesBack' => '0.0',
+            'magicNumber' => 0,
+            'games_unplayed' => 0,
+            'conf_record' => '30-16',
+            'div_record' => '10-4',
+            'home_record' => '28-14',
+            'away_record' => '22-18',
+            'homeGames' => 42,
+            'awayGames' => 40,
+            'clinched_conference' => 0,
+            'clinched_division' => 1,
+            'clinched_playoffs' => 0,
+            'clinched_league' => 0,
+            'wins' => 50,
+            'color1' => '000080',
+            'color2' => 'FFFFFF',
+        ];
+    }
+
+    /** @return array<string, mixed> StandingsRow for Team B (teamid=2, clinched_playoffs=1) */
+    private function regionTeamB(): array
+    {
+        return [
+            'teamid' => 2,
+            'team_name' => 'Team Beta',
+            'league_record' => '50-32',
+            'pct' => '0.610',
+            'gamesBack' => '0.0',
+            'magicNumber' => 0,
+            'games_unplayed' => 0,
+            'conf_record' => '30-16',
+            'div_record' => '10-4',
+            'home_record' => '28-14',
+            'away_record' => '22-18',
+            'homeGames' => 42,
+            'awayGames' => 40,
+            'clinched_conference' => 0,
+            'clinched_division' => 0,
+            'clinched_playoffs' => 1,
+            'clinched_league' => 0,
+            'wins' => 50,
+            'color1' => '800000',
+            'color2' => 'FFFFFF',
+        ];
+    }
+
+    /**
+     * Build a fresh StandingsView with the divergence fixture wired in.
+     *
+     * @param list<array<string, mixed>> $regionEasternRows Rows getStandingsByRegion('Eastern') returns
+     */
+    private function buildView(array $regionEasternRows = []): StandingsView
+    {
+        $repo = $this->createMock(StandingsRepositoryInterface::class);
+        $repo->method('getAllStandings')->willReturn([$this->bulkTeamA(), $this->bulkTeamB()]);
+        $repo->method('getAllStreakData')->willReturn([]);
+        $repo->method('getAllPythagoreanStats')->willReturn([]);
+        $repo->method('getSeriesRecords')->willReturn([]);
+        $repo->method('getStandingsByRegion')->willReturnCallback(
+            static fn (string $region): array => $region === 'Eastern' ? $regionEasternRows : []
+        );
+
+        return new StandingsView($repo, 2025, new SeriesRecordsService());
+    }
+
+    /**
+     * Snapshot helper — writes on first run; compares on subsequent runs.
+     *
+     * On the first run (no snapshot file yet) the snapshot is auto-created from
+     * $actual and the test passes. Commit the generated files before editing
+     * StandingsView.php so that later runs catch any divergence.
+     */
+    private function assertSnapshotMatches(string $actual, string $snapshotFilename): void
+    {
+        $snapshotDir = __DIR__ . '/__snapshots__';
+        $path = $snapshotDir . '/' . $snapshotFilename;
+
+        if (!file_exists($path)) {
+            if (!is_dir($snapshotDir)) {
+                mkdir($snapshotDir, 0755, true);
+            }
+            file_put_contents($path, $actual);
+            $this->addToAssertionCount(1);
+            return;
+        }
+
+        $expected = file_get_contents($path);
+        $this->assertSame($expected, $actual, "Golden master mismatch for $snapshotFilename");
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    public function testRenderFullOutputMatchesGoldenMaster(): void
+    {
+        $view = $this->buildView();
+        $this->assertSnapshotMatches($view->render(), 'render-full.html');
+    }
+
+    public function testRenderRegionEasternMatchesGoldenMaster(): void
+    {
+        // SQL-trust order: [team2, team1] — lower clinch tier first (mirrors raw ORDER BY conf_gb ASC)
+        $view = $this->buildView([$this->regionTeamB(), $this->regionTeamA()]);
+        $this->assertSnapshotMatches($view->renderRegion('Eastern'), 'renderRegion-eastern.html');
+    }
+
+    /**
+     * Divergence / collapse-guard.
+     *
+     * render() applies multi-key PHP sortStandings() — clinch-DESC is key #2,
+     * so team1 (clinched_division=1, score=2) precedes team2 (clinched_playoffs=1, score=1).
+     *
+     * renderRegion() trusts the SQL-supplied order [team2, team1] unchanged
+     * (only H2H tie-breaking via resolveH2HTiedGroups, which is a no-op here
+     * because seriesMatrix is empty).
+     *
+     * This test goes RED if anyone routes renderRegion() through sortStandings()
+     * or adaptBulkRows() — the forbidden path convergence.
+     */
+    public function testRenderAndRenderRegionDivergeInRowOrder(): void
+    {
+        // Fresh view for render()
+        $renderView = $this->buildView();
+        $renderHtml = $renderView->render();
+
+        // Fresh view for renderRegion() — SQL order is [team2, team1]
+        $regionView = $this->buildView([$this->regionTeamB(), $this->regionTeamA()]);
+        $regionHtml = $regionView->renderRegion('Eastern');
+
+        // Slice the Eastern Conference block from the full render() output.
+        // Atlantic Division ALSO contains these two teams, so we must not scan the full HTML.
+        $easternStart = strpos($renderHtml, 'Eastern Conference');
+        $this->assertNotFalse($easternStart, 'Eastern Conference heading not found in render() output');
+
+        $nextH2Pos = strpos($renderHtml, '<h2', $easternStart + 1);
+        $easternBlock = $nextH2Pos !== false
+            ? substr($renderHtml, $easternStart, $nextH2Pos - $easternStart)
+            : substr($renderHtml, $easternStart);
+
+        preg_match_all('/data-team-id="(\d+)"/', $easternBlock, $renderMatches);
+        $renderOrder = array_map('intval', $renderMatches[1]);
+
+        preg_match_all('/data-team-id="(\d+)"/', $regionHtml, $regionMatches);
+        $regionOrder = array_map('intval', $regionMatches[1]);
+
+        // render() — clinch-DESC: team1 (clinched_division, tier=2) before team2 (clinched_playoffs, tier=1)
+        $this->assertSame([1, 2], $renderOrder, 'render() Eastern must emit clinch-DESC order [1, 2]');
+        // renderRegion() — trusts SQL order supplied by mock: [team2, team1]
+        $this->assertSame([2, 1], $regionOrder, 'renderRegion() Eastern must emit SQL-trust order [2, 1]');
+        // Collapse guard — paths still diverge after the refactor
+        $this->assertNotSame($renderOrder, $regionOrder, 'Divergence guard: render() and renderRegion() must produce different Eastern row orders');
+    }
+}

--- a/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
+++ b/ibl5/tests/Standings/StandingsViewGoldenMasterTest.php
@@ -181,7 +181,7 @@ class StandingsViewGoldenMasterTest extends TestCase
                 mkdir($snapshotDir, 0755, true);
             }
             file_put_contents($path, $actual);
-            $this->addToAssertionCount(1);
+            $this->assertFileExists($path, "Snapshot $snapshotFilename was not created");
             return;
         }
 
@@ -250,6 +250,7 @@ class StandingsViewGoldenMasterTest extends TestCase
         // renderRegion() — trusts SQL order supplied by mock: [team2, team1]
         $this->assertSame([2, 1], $regionOrder, 'renderRegion() Eastern must emit SQL-trust order [2, 1]');
         // Collapse guard — paths still diverge after the refactor
+        // @phpstan-ignore method.alreadyNarrowedType (PHPStan narrows these to literal arrays after assertSame; the runtime divergence is what matters here)
         $this->assertNotSame($renderOrder, $regionOrder, 'Divergence guard: render() and renderRegion() must produce different Eastern row orders');
     }
 }

--- a/ibl5/tests/Standings/__snapshots__/render-full.html
+++ b/ibl5/tests/Standings/__snapshots__/render-full.html
@@ -1,0 +1,239 @@
+        <h2 class="ibl-title">Eastern Conference</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr data-team-id="1" class="clinch-division">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #000080; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=1" class="ibl-team-cell__name" aria-label="Team Alpha"><img src="images/logo/new1.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">Y</span>-Team Alpha</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+                <tr data-team-id="2" class="clinch-playoffs">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #800000; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=2" class="ibl-team-cell__name" aria-label="Team Beta"><img src="images/logo/new2.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">X</span>-Team Beta</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+        </tbody></table></div></div>        <h2 class="ibl-title">Western Conference</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+        </tbody></table></div></div>        <h2 class="ibl-title">Atlantic Division</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr data-team-id="1" class="clinch-division">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #000080; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=1" class="ibl-team-cell__name" aria-label="Team Alpha"><img src="images/logo/new1.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">Y</span>-Team Alpha</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+                <tr data-team-id="2" class="clinch-playoffs">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #800000; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=2" class="ibl-team-cell__name" aria-label="Team Beta"><img src="images/logo/new2.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">X</span>-Team Beta</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+        </tbody></table></div></div>        <h2 class="ibl-title">Central Division</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+        </tbody></table></div></div>        <h2 class="ibl-title">Midwest Division</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+        </tbody></table></div></div>        <h2 class="ibl-title">Pacific Division</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+        </tbody></table></div></div>

--- a/ibl5/tests/Standings/__snapshots__/renderRegion-eastern.html
+++ b/ibl5/tests/Standings/__snapshots__/renderRegion-eastern.html
@@ -1,0 +1,66 @@
+        <h2 class="ibl-title">Eastern Conference</h2>
+        <div class="table-scroll-wrapper">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <table class="sortable ibl-data-table">
+            <thead>
+                <tr>
+                    <th class="sticky-col">Team</th>
+                    <th>W-L</th>
+                    <th>Win%</th>
+                    <th>Pyth<br>W-L%</th>
+                    <th>GB</th>
+                    <th>Magic<br>#</th>
+                    <th>Games<br>Left</th>
+                    <th>Conf.</th>
+                    <th>Div.</th>
+                    <th>Home</th>
+                    <th>Away</th>
+                    <th>Home<br>Played</th>
+                    <th>Away<br>Played</th>
+                    <th>Last 10<br>W-L</th>
+                    <th>Streak</th>
+                    <th>Power<br>Rank</th>
+                    <th>SOS</th>
+                    <th>Rem.<br>SOS</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr data-team-id="2" class="clinch-playoffs">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #800000; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=2" class="ibl-team-cell__name" aria-label="Team Beta"><img src="images/logo/new2.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">X</span>-Team Beta</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+                <tr data-team-id="1" class="clinch-division">
+            <td class="ibl-team-cell--colored sticky-col" style="--team-cell-bg: #000080; --team-cell-color: #FFFFFF;"><a href="modules.php?name=Team&amp;op=team&amp;teamid=1" class="ibl-team-cell__name" aria-label="Team Alpha"><img src="images/logo/new1.png" alt="" class="ibl-team-cell__logo" width="24" height="24" loading="lazy"><span class="ibl-team-cell__text"><span class="ibl-clinched-indicator">Y</span>-Team Alpha</span></a></td>            <td>50-32</td>
+            <td>0.610</td>
+            <td>0.000</td>
+            <td>0.0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>30-16</td>
+            <td>10-4</td>
+            <td>28-14</td>
+            <td>22-18</td>
+            <td>42</td>
+            <td>40</td>
+            <td>0-0</td>
+            <td sorttable_customkey="0"> 0</td>
+            <td><span class="ibl-stat-highlight">0</span></td>
+            <td>0.000</td>
+            <td>0.000</td>
+        </tr>
+        </tbody></table></div></div>


### PR DESCRIPTION
## Summary

Pure green-green refactor of `StandingsView`. Extracts the three lazy-load blocks (`getAllStreakData`, `getAllPythagoreanStats`, `getSeriesRecords`) that existed separately in `render()` (eager, unconditional) and `renderRegion()` (null-guarded lazy) into a single private helper `ensureBulkDataLoaded()`. Both call sites repoint to the new helper. Output is byte-identical to pre-refactor — confirmed by committed golden-master snapshots.

## What changes

- **`ibl5/classes/Standings/StandingsView.php`**: adds `private ensureBulkDataLoaded(): void` helper; `render()` and `renderRegion()` repoint to it. All rendering logic, sort paths, and null-clears are byte-for-byte unchanged.
- **`ibl5/tests/Standings/StandingsViewGoldenMasterTest.php`** (new): golden-master pin for `render()` full output and `renderRegion('Eastern')` output + divergence-assertion collapse-guard.
- **`ibl5/tests/Standings/__snapshots__/render-full.html`** and **`renderRegion-eastern.html`** (new): committed before any edit; byte-identity verified post-refactor.

## Deferred-Bug Note (PRESERVED, NOT fixed)

The two render paths sort the same teams differently and this PR **preserves** that:
- **`render()`** groups bulk rows, then applies multi-key PHP `sortStandings()` — `conf_gb`/`div_gb` ASC → clinch-tier DESC → wins DESC → teamid ASC — then H2H tie-breaking via `resolveH2HTiedGroups()`.
- **`renderRegion()`** trusts `getStandingsByRegion()`'s SQL `ORDER BY conf_gb/div_gb ASC` only (no clinch-tier, wins, or teamid keys in PHP) and applies only H2H tie-breaking on top.

For teams tied on GB but differing on clinch tier / wins / teamid, the two paths emit different row order. The fix (picking one canonical ordering for both paths) is **deliberately deferred** to a separate future plan — it is a behavior change, out of scope here.

## Behavior-identity argument

A grep of the suite confirms no test method calls both `render()` and `renderRegion()` on a single instance, and no consecutive-different-return stub exists on `getAllStreakData`/`getAllPythagoreanStats`/`getSeriesRecords`. Therefore eager-overwrite (`render()` original block) vs. lazy-reuse (`ensureBulkDataLoaded()`'s `=== null` guards) cannot diverge for any existing test or the single-call production path.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: green-green refactor adds only a test file plus a private-helper extraction; no new bin script, rule, workflow, migration, or dependency is introduced -->