### PR TITLE
refactor: extract NonHeadToHeadTiebreaker, DraftOrderTiebreakerResolver, PlayoffSeedingCalculator from ProjectedDraftOrderService

### DIFF
--- a/ibl5/classes/ProjectedDraftOrder/DraftOrderTiebreakerResolver.php
+++ b/ibl5/classes/ProjectedDraftOrder/DraftOrderTiebreakerResolver.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProjectedDraftOrder;
+
+use ProjectedDraftOrder\Contracts\ProjectedDraftOrderRepositoryInterface;
+
+/**
+ * Sorts teams by record for draft order (worst first), resolving ties via
+ * aggregate head-to-head and non-H2H tiebreakers.
+ *
+ * @phpstan-import-type StandingsRow from ProjectedDraftOrderRepositoryInterface
+ */
+class DraftOrderTiebreakerResolver
+{
+    private NonHeadToHeadTiebreaker $nonH2hTiebreaker;
+
+    public function __construct(NonHeadToHeadTiebreaker $nonH2hTiebreaker)
+    {
+        $this->nonH2hTiebreaker = $nonH2hTiebreaker;
+    }
+
+    /**
+     * Sort teams by record for draft order (worst first).
+     *
+     * Tiebreaker loser gets the earlier (better) pick in both lottery and playoff contexts.
+     * Uses multi-way aggregate H2H for groups of 3+ teams with the same pct.
+     *
+     * @param list<StandingsRow> $teams
+     * @param array<int, array<int, int>> $h2h
+     * @param array<int, float> $pointDiffs
+     * @return list<StandingsRow>
+     */
+    public function sortTeamsByRecord(array $teams, array $h2h, array $pointDiffs): array
+    {
+        // Step 1: Sort by pct ascending (worst first)
+        usort($teams, static fn (array $a, array $b): int => $a['pct'] <=> $b['pct']);
+
+        // Step 2: Resolve tied groups using multi-way aggregate H2H
+        return $this->resolveTiedGroups($teams, $h2h, $pointDiffs);
+    }
+
+    /**
+     * Walk the pct-sorted list, identify consecutive same-pct groups, and sort each.
+     *
+     * @param list<StandingsRow> $teams
+     * @param array<int, array<int, int>> $h2h
+     * @param array<int, float> $pointDiffs
+     * @return list<StandingsRow>
+     */
+    private function resolveTiedGroups(array $teams, array $h2h, array $pointDiffs): array
+    {
+        $result = [];
+        $i = 0;
+        $count = count($teams);
+
+        while ($i < $count) {
+            $groupStart = $i;
+            $currentPct = $teams[$i]['pct'];
+
+            // Find end of consecutive same-pct group
+            while ($i < $count && $teams[$i]['pct'] === $currentPct) {
+                $i++;
+            }
+
+            $group = array_slice($teams, $groupStart, $i - $groupStart);
+
+            if (count($group) > 1) {
+                $group = $this->sortTiedGroup($group, $h2h, $pointDiffs);
+            }
+
+            array_push($result, ...$group);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sort a group of teams with the same pct using aggregate H2H then fallback tiebreakers.
+     *
+     * For draft order: worse aggregate H2H → earlier (better) pick.
+     *
+     * @param list<StandingsRow> $group
+     * @param array<int, array<int, int>> $h2h
+     * @param array<int, float> $pointDiffs
+     * @return list<StandingsRow>
+     */
+    private function sortTiedGroup(array $group, array $h2h, array $pointDiffs): array
+    {
+        $tids = array_map(static fn (array $t): int => $t['teamid'], $group);
+
+        $aggregateH2HPct = \Standings\AggregateTiebreaker::computeAggregateH2HPcts(
+            $tids,
+            /** @return array{wins: int, losses: int} */
+            static fn (int $tid, int $oppTid): array => [
+                'wins' => $h2h[$tid][$oppTid] ?? 0,
+                'losses' => $h2h[$oppTid][$tid] ?? 0,
+            ],
+        );
+
+        usort($group, function (array $a, array $b) use ($aggregateH2HPct, $pointDiffs): int {
+            $h2hDiff = $aggregateH2HPct[$a['teamid']] <=> $aggregateH2HPct[$b['teamid']];
+            if ($h2hDiff !== 0) {
+                return $h2hDiff;
+            }
+
+            return -$this->nonH2hTiebreaker->applyNonH2HTiebreakers($a, $b, $pointDiffs);
+        });
+
+        return $group;
+    }
+}

--- a/ibl5/classes/ProjectedDraftOrder/NonHeadToHeadTiebreaker.php
+++ b/ibl5/classes/ProjectedDraftOrder/NonHeadToHeadTiebreaker.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProjectedDraftOrder;
+
+use ProjectedDraftOrder\Contracts\ProjectedDraftOrderRepositoryInterface;
+
+/**
+ * Non-head-to-head tiebreaker logic shared by draft order and playoff seeding.
+ *
+ * @phpstan-import-type StandingsRow from ProjectedDraftOrderRepositoryInterface
+ */
+class NonHeadToHeadTiebreaker
+{
+    /**
+     * Apply non-H2H tiebreakers: division winner, division record, conference record,
+     * point differential, alphabetical.
+     *
+     * Returns negative if A is the better team, positive if B is better.
+     *
+     * @param StandingsRow $a
+     * @param StandingsRow $b
+     * @param array<int, float> $pointDiffs
+     */
+    public function applyNonH2HTiebreakers(array $a, array $b, array $pointDiffs): int
+    {
+        // 2. Division winner status
+        $aDivWinner = ($a['clinched_division'] ?? 0) === 1;
+        $bDivWinner = ($b['clinched_division'] ?? 0) === 1;
+        if ($aDivWinner !== $bDivWinner) {
+            return $aDivWinner ? -1 : 1;
+        }
+
+        // 3. Division record (same-division teams only)
+        if ($a['division'] === $b['division']) {
+            $aDivPct = $this->safeWinPct($a['div_wins'], $a['div_losses']);
+            $bDivPct = $this->safeWinPct($b['div_wins'], $b['div_losses']);
+            $divDiff = $bDivPct <=> $aDivPct;
+            if ($divDiff !== 0) {
+                return $divDiff;
+            }
+        }
+
+        // 4. Conference record
+        $aConfPct = $this->safeWinPct($a['conf_wins'], $a['conf_losses']);
+        $bConfPct = $this->safeWinPct($b['conf_wins'], $b['conf_losses']);
+        $confDiff = $bConfPct <=> $aConfPct;
+        if ($confDiff !== 0) {
+            return $confDiff;
+        }
+
+        // 5. Point differential
+        $aNetPts = $pointDiffs[$a['teamid']] ?? 0.0;
+        $bNetPts = $pointDiffs[$b['teamid']] ?? 0.0;
+        $ptsDiff = $bNetPts <=> $aNetPts;
+        if ($ptsDiff !== 0) {
+            return $ptsDiff;
+        }
+
+        // Fallback: alphabetical by team name (for deterministic ordering)
+        return $a['team_name'] <=> $b['team_name'];
+    }
+
+    private function safeWinPct(?int $wins, ?int $losses): float
+    {
+        $w = $wins ?? 0;
+        $l = $losses ?? 0;
+        $total = $w + $l;
+        if ($total === 0) {
+            return 0.0;
+        }
+        return $w / $total;
+    }
+}

--- a/ibl5/classes/ProjectedDraftOrder/PlayoffSeedingCalculator.php
+++ b/ibl5/classes/ProjectedDraftOrder/PlayoffSeedingCalculator.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProjectedDraftOrder;
+
+use ProjectedDraftOrder\Contracts\ProjectedDraftOrderRepositoryInterface;
+
+/**
+ * Determines playoff teams and compares teams for playoff seeding (best team first).
+ *
+ * @phpstan-import-type StandingsRow from ProjectedDraftOrderRepositoryInterface
+ */
+class PlayoffSeedingCalculator
+{
+    private NonHeadToHeadTiebreaker $nonH2hTiebreaker;
+
+    public function __construct(NonHeadToHeadTiebreaker $nonH2hTiebreaker)
+    {
+        $this->nonH2hTiebreaker = $nonH2hTiebreaker;
+    }
+
+    /**
+     * Determine playoff teams, division winners, conference winner, and non-playoff teams.
+     *
+     * @param list<StandingsRow> $conferenceTeams
+     * @param array<int, array<int, int>> $h2h
+     * @param array<int, float> $pointDiffs
+     * @return array{wildCards: list<StandingsRow>, divisionWinners: list<StandingsRow>, conferenceWinner: StandingsRow|null, nonPlayoff: list<StandingsRow>}
+     */
+    public function determinePlayoffTeams(array $conferenceTeams, array $h2h, array $pointDiffs): array
+    {
+        if ($conferenceTeams === []) {
+            return ['wildCards' => [], 'divisionWinners' => [], 'conferenceWinner' => null, 'nonPlayoff' => []];
+        }
+
+        $byDivision = [];
+        foreach ($conferenceTeams as $team) {
+            $byDivision[$team['division']][] = $team;
+        }
+
+        $divisionWinners = [];
+        $nonWinners = [];
+
+        foreach ($byDivision as $divisionTeams) {
+            usort($divisionTeams, fn (array $a, array $b): int => $this->compareTeamsForPlayoffSeeding($a, $b, $h2h, $pointDiffs));
+            $divisionWinners[] = $divisionTeams[0];
+            for ($i = 1; $i < count($divisionTeams); $i++) {
+                $nonWinners[] = $divisionTeams[$i];
+            }
+        }
+
+        // Sort non-winners by record (best first) to pick top 6
+        usort($nonWinners, fn (array $a, array $b): int => $this->compareTeamsForPlayoffSeeding($a, $b, $h2h, $pointDiffs));
+
+        $wildCards = array_slice($nonWinners, 0, 6);
+        $nonPlayoff = array_slice($nonWinners, 6);
+
+        // Conference winner is the best division winner
+        usort($divisionWinners, fn (array $a, array $b): int => $this->compareTeamsForPlayoffSeeding($a, $b, $h2h, $pointDiffs));
+        $conferenceWinner = $divisionWinners[0];
+        $divisionOnlyWinners = array_slice($divisionWinners, 1);
+
+        return [
+            'wildCards' => array_values($wildCards),
+            'divisionWinners' => array_values($divisionOnlyWinners),
+            'conferenceWinner' => $conferenceWinner,
+            'nonPlayoff' => array_values($nonPlayoff),
+        ];
+    }
+
+    /**
+     * Compare two teams for playoff seeding (best team first).
+     *
+     * @param StandingsRow $a
+     * @param StandingsRow $b
+     * @param array<int, array<int, int>> $h2h
+     * @param array<int, float> $pointDiffs
+     */
+    private function compareTeamsForPlayoffSeeding(array $a, array $b, array $h2h, array $pointDiffs): int
+    {
+        // Higher pct is better (sort descending)
+        $pctDiff = $b['pct'] <=> $a['pct'];
+        if ($pctDiff !== 0) {
+            return $pctDiff;
+        }
+
+        return $this->applyTiebreakers($a, $b, $h2h, $pointDiffs);
+    }
+
+    /**
+     * Apply NBA tiebreakers between two teams (pairwise H2H + remaining tiebreakers).
+     *
+     * Used by playoff seeding. Draft order uses multi-way aggregate H2H instead.
+     *
+     * Returns negative if A wins the tiebreaker, positive if B wins.
+     *
+     * @param StandingsRow $a
+     * @param StandingsRow $b
+     * @param array<int, array<int, int>> $h2h
+     * @param array<int, float> $pointDiffs
+     */
+    private function applyTiebreakers(array $a, array $b, array $h2h, array $pointDiffs): int
+    {
+        // 1. Head-to-head record (pairwise)
+        $aWinsVsB = $h2h[$a['teamid']][$b['teamid']] ?? 0;
+        $bWinsVsA = $h2h[$b['teamid']][$a['teamid']] ?? 0;
+        if ($aWinsVsB !== $bWinsVsA) {
+            return $bWinsVsA <=> $aWinsVsB;
+        }
+
+        // 2-6. Non-H2H tiebreakers
+        return $this->nonH2hTiebreaker->applyNonH2HTiebreakers($a, $b, $pointDiffs);
+    }
+}

--- a/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderService.php
+++ b/ibl5/classes/ProjectedDraftOrder/ProjectedDraftOrderService.php
@@ -30,10 +30,19 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
      */
     private \Psr\Log\LoggerInterface $logger;
 
+    private NonHeadToHeadTiebreaker $nonH2hTiebreaker;
+
+    private DraftOrderTiebreakerResolver $draftOrderResolver;
+
+    private PlayoffSeedingCalculator $playoffSeeding;
+
     public function __construct(ProjectedDraftOrderRepositoryInterface $repository, ?\Psr\Log\LoggerInterface $logger = null)
     {
         $this->repository = $repository;
         $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
+        $this->nonH2hTiebreaker = new NonHeadToHeadTiebreaker();
+        $this->draftOrderResolver = new DraftOrderTiebreakerResolver($this->nonH2hTiebreaker);
+        $this->playoffSeeding = new PlayoffSeedingCalculator($this->nonH2hTiebreaker);
     }
 
     /** @return ProjectedDraftOrderResult */
@@ -60,7 +69,7 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
 
         foreach (League::CONFERENCE_NAMES as $conference) {
             $conferenceTeams = $teamsByConference[$conference] ?? [];
-            $result = $this->determinePlayoffTeams($conferenceTeams, $h2h, $pointDiffs);
+            $result = $this->playoffSeeding->determinePlayoffTeams($conferenceTeams, $h2h, $pointDiffs);
             array_push($nonPlayoffTeams, ...$result['nonPlayoff']);
             array_push($wildCardTeams, ...$result['wildCards']);
             array_push($divisionWinnerTeams, ...$result['divisionWinners']);
@@ -71,14 +80,14 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
 
         $teamMap = $this->buildTeamMap($standings);
 
-        $nonPlayoffSorted = $this->sortTeamsByRecord($nonPlayoffTeams, $h2h, $pointDiffs);
-        $wildCardsSorted = $this->sortTeamsByRecord($wildCardTeams, $h2h, $pointDiffs);
-        $divisionWinnersSorted = $this->sortTeamsByRecord($divisionWinnerTeams, $h2h, $pointDiffs);
-        $conferenceWinnersSorted = $this->sortTeamsByRecord($conferenceWinnerTeams, $h2h, $pointDiffs);
+        $nonPlayoffSorted = $this->draftOrderResolver->sortTeamsByRecord($nonPlayoffTeams, $h2h, $pointDiffs);
+        $wildCardsSorted = $this->draftOrderResolver->sortTeamsByRecord($wildCardTeams, $h2h, $pointDiffs);
+        $divisionWinnersSorted = $this->draftOrderResolver->sortTeamsByRecord($divisionWinnerTeams, $h2h, $pointDiffs);
+        $conferenceWinnersSorted = $this->draftOrderResolver->sortTeamsByRecord($conferenceWinnerTeams, $h2h, $pointDiffs);
 
         $round1Order = array_merge($nonPlayoffSorted, $wildCardsSorted, $divisionWinnersSorted, $conferenceWinnersSorted);
 
-        $allTeamsSorted = $this->sortTeamsByRecord(array_values($teamMap), $h2h, $pointDiffs);
+        $allTeamsSorted = $this->draftOrderResolver->sortTeamsByRecord(array_values($teamMap), $h2h, $pointDiffs);
 
         $pickOwnership = $this->buildPickOwnershipMap($pickOwnershipRows);
 
@@ -304,249 +313,6 @@ class ProjectedDraftOrderService implements ProjectedDraftOrderServiceInterface
             $map[$team['teamid']] = $team;
         }
         return $map;
-    }
-
-    /**
-     * Determine playoff teams, division winners, conference winner, and non-playoff teams.
-     *
-     * @param list<StandingsRow> $conferenceTeams
-     * @param array<int, array<int, int>> $h2h
-     * @param array<int, float> $pointDiffs
-     * @return array{wildCards: list<StandingsRow>, divisionWinners: list<StandingsRow>, conferenceWinner: StandingsRow|null, nonPlayoff: list<StandingsRow>}
-     */
-    private function determinePlayoffTeams(array $conferenceTeams, array $h2h, array $pointDiffs): array
-    {
-        if ($conferenceTeams === []) {
-            return ['wildCards' => [], 'divisionWinners' => [], 'conferenceWinner' => null, 'nonPlayoff' => []];
-        }
-
-        $byDivision = [];
-        foreach ($conferenceTeams as $team) {
-            $byDivision[$team['division']][] = $team;
-        }
-
-        $divisionWinners = [];
-        $nonWinners = [];
-
-        foreach ($byDivision as $divisionTeams) {
-            usort($divisionTeams, fn (array $a, array $b): int => $this->compareTeamsForPlayoffSeeding($a, $b, $h2h, $pointDiffs));
-            $divisionWinners[] = $divisionTeams[0];
-            for ($i = 1; $i < count($divisionTeams); $i++) {
-                $nonWinners[] = $divisionTeams[$i];
-            }
-        }
-
-        // Sort non-winners by record (best first) to pick top 6
-        usort($nonWinners, fn (array $a, array $b): int => $this->compareTeamsForPlayoffSeeding($a, $b, $h2h, $pointDiffs));
-
-        $wildCards = array_slice($nonWinners, 0, 6);
-        $nonPlayoff = array_slice($nonWinners, 6);
-
-        // Conference winner is the best division winner
-        usort($divisionWinners, fn (array $a, array $b): int => $this->compareTeamsForPlayoffSeeding($a, $b, $h2h, $pointDiffs));
-        $conferenceWinner = $divisionWinners[0];
-        $divisionOnlyWinners = array_slice($divisionWinners, 1);
-
-        return [
-            'wildCards' => array_values($wildCards),
-            'divisionWinners' => array_values($divisionOnlyWinners),
-            'conferenceWinner' => $conferenceWinner,
-            'nonPlayoff' => array_values($nonPlayoff),
-        ];
-    }
-
-    /**
-     * Compare two teams for playoff seeding (best team first).
-     *
-     * @param StandingsRow $a
-     * @param StandingsRow $b
-     * @param array<int, array<int, int>> $h2h
-     * @param array<int, float> $pointDiffs
-     */
-    private function compareTeamsForPlayoffSeeding(array $a, array $b, array $h2h, array $pointDiffs): int
-    {
-        // Higher pct is better (sort descending)
-        $pctDiff = $b['pct'] <=> $a['pct'];
-        if ($pctDiff !== 0) {
-            return $pctDiff;
-        }
-
-        return $this->applyTiebreakers($a, $b, $h2h, $pointDiffs);
-    }
-
-    /**
-     * Sort teams by record for draft order (worst first).
-     *
-     * Tiebreaker loser gets the earlier (better) pick in both lottery and playoff contexts.
-     * Uses multi-way aggregate H2H for groups of 3+ teams with the same pct.
-     *
-     * @param list<StandingsRow> $teams
-     * @param array<int, array<int, int>> $h2h
-     * @param array<int, float> $pointDiffs
-     * @return list<StandingsRow>
-     */
-    private function sortTeamsByRecord(array $teams, array $h2h, array $pointDiffs): array
-    {
-        // Step 1: Sort by pct ascending (worst first)
-        usort($teams, static fn (array $a, array $b): int => $a['pct'] <=> $b['pct']);
-
-        // Step 2: Resolve tied groups using multi-way aggregate H2H
-        return $this->resolveTiedGroups($teams, $h2h, $pointDiffs);
-    }
-
-    /**
-     * Walk the pct-sorted list, identify consecutive same-pct groups, and sort each.
-     *
-     * @param list<StandingsRow> $teams
-     * @param array<int, array<int, int>> $h2h
-     * @param array<int, float> $pointDiffs
-     * @return list<StandingsRow>
-     */
-    private function resolveTiedGroups(array $teams, array $h2h, array $pointDiffs): array
-    {
-        $result = [];
-        $i = 0;
-        $count = count($teams);
-
-        while ($i < $count) {
-            $groupStart = $i;
-            $currentPct = $teams[$i]['pct'];
-
-            // Find end of consecutive same-pct group
-            while ($i < $count && $teams[$i]['pct'] === $currentPct) {
-                $i++;
-            }
-
-            $group = array_slice($teams, $groupStart, $i - $groupStart);
-
-            if (count($group) > 1) {
-                $group = $this->sortTiedGroup($group, $h2h, $pointDiffs);
-            }
-
-            array_push($result, ...$group);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Sort a group of teams with the same pct using aggregate H2H then fallback tiebreakers.
-     *
-     * For draft order: worse aggregate H2H → earlier (better) pick.
-     *
-     * @param list<StandingsRow> $group
-     * @param array<int, array<int, int>> $h2h
-     * @param array<int, float> $pointDiffs
-     * @return list<StandingsRow>
-     */
-    private function sortTiedGroup(array $group, array $h2h, array $pointDiffs): array
-    {
-        $tids = array_map(static fn (array $t): int => $t['teamid'], $group);
-
-        $aggregateH2HPct = \Standings\AggregateTiebreaker::computeAggregateH2HPcts(
-            $tids,
-            /** @return array{wins: int, losses: int} */
-            static fn (int $tid, int $oppTid): array => [
-                'wins' => $h2h[$tid][$oppTid] ?? 0,
-                'losses' => $h2h[$oppTid][$tid] ?? 0,
-            ],
-        );
-
-        usort($group, function (array $a, array $b) use ($aggregateH2HPct, $pointDiffs): int {
-            $h2hDiff = $aggregateH2HPct[$a['teamid']] <=> $aggregateH2HPct[$b['teamid']];
-            if ($h2hDiff !== 0) {
-                return $h2hDiff;
-            }
-
-            return -$this->applyNonH2HTiebreakers($a, $b, $pointDiffs);
-        });
-
-        return $group;
-    }
-
-    /**
-     * Apply NBA tiebreakers between two teams (pairwise H2H + remaining tiebreakers).
-     *
-     * Used by playoff seeding. Draft order uses multi-way aggregate H2H instead.
-     *
-     * Returns negative if A wins the tiebreaker, positive if B wins.
-     *
-     * @param StandingsRow $a
-     * @param StandingsRow $b
-     * @param array<int, array<int, int>> $h2h
-     * @param array<int, float> $pointDiffs
-     */
-    private function applyTiebreakers(array $a, array $b, array $h2h, array $pointDiffs): int
-    {
-        // 1. Head-to-head record (pairwise)
-        $aWinsVsB = $h2h[$a['teamid']][$b['teamid']] ?? 0;
-        $bWinsVsA = $h2h[$b['teamid']][$a['teamid']] ?? 0;
-        if ($aWinsVsB !== $bWinsVsA) {
-            return $bWinsVsA <=> $aWinsVsB;
-        }
-
-        // 2-6. Non-H2H tiebreakers
-        return $this->applyNonH2HTiebreakers($a, $b, $pointDiffs);
-    }
-
-    /**
-     * Apply non-H2H tiebreakers: division winner, division record, conference record,
-     * point differential, alphabetical.
-     *
-     * Returns negative if A is the better team, positive if B is better.
-     *
-     * @param StandingsRow $a
-     * @param StandingsRow $b
-     * @param array<int, float> $pointDiffs
-     */
-    private function applyNonH2HTiebreakers(array $a, array $b, array $pointDiffs): int
-    {
-        // 2. Division winner status
-        $aDivWinner = ($a['clinched_division'] ?? 0) === 1;
-        $bDivWinner = ($b['clinched_division'] ?? 0) === 1;
-        if ($aDivWinner !== $bDivWinner) {
-            return $aDivWinner ? -1 : 1;
-        }
-
-        // 3. Division record (same-division teams only)
-        if ($a['division'] === $b['division']) {
-            $aDivPct = $this->safeWinPct($a['div_wins'], $a['div_losses']);
-            $bDivPct = $this->safeWinPct($b['div_wins'], $b['div_losses']);
-            $divDiff = $bDivPct <=> $aDivPct;
-            if ($divDiff !== 0) {
-                return $divDiff;
-            }
-        }
-
-        // 4. Conference record
-        $aConfPct = $this->safeWinPct($a['conf_wins'], $a['conf_losses']);
-        $bConfPct = $this->safeWinPct($b['conf_wins'], $b['conf_losses']);
-        $confDiff = $bConfPct <=> $aConfPct;
-        if ($confDiff !== 0) {
-            return $confDiff;
-        }
-
-        // 5. Point differential
-        $aNetPts = $pointDiffs[$a['teamid']] ?? 0.0;
-        $bNetPts = $pointDiffs[$b['teamid']] ?? 0.0;
-        $ptsDiff = $bNetPts <=> $aNetPts;
-        if ($ptsDiff !== 0) {
-            return $ptsDiff;
-        }
-
-        // Fallback: alphabetical by team name (for deterministic ordering)
-        return $a['team_name'] <=> $b['team_name'];
-    }
-
-    private function safeWinPct(?int $wins, ?int $losses): float
-    {
-        $w = $wins ?? 0;
-        $l = $losses ?? 0;
-        $total = $w + $l;
-        if ($total === 0) {
-            return 0.0;
-        }
-        return $w / $total;
     }
 
     /**

--- a/ibl5/tests/ProjectedDraftOrder/DraftOrderTiebreakerResolverTest.php
+++ b/ibl5/tests/ProjectedDraftOrder/DraftOrderTiebreakerResolverTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ProjectedDraftOrder;
+
+use PHPUnit\Framework\TestCase;
+use ProjectedDraftOrder\Contracts\ProjectedDraftOrderRepositoryInterface;
+use ProjectedDraftOrder\DraftOrderTiebreakerResolver;
+use ProjectedDraftOrder\NonHeadToHeadTiebreaker;
+
+/**
+ * @covers \ProjectedDraftOrder\DraftOrderTiebreakerResolver
+ * @phpstan-import-type StandingsRow from ProjectedDraftOrderRepositoryInterface
+ */
+class DraftOrderTiebreakerResolverTest extends TestCase
+{
+    private DraftOrderTiebreakerResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new DraftOrderTiebreakerResolver(new NonHeadToHeadTiebreaker());
+    }
+
+    /**
+     * Build a minimal StandingsRow for sorting tests.
+     * @return StandingsRow
+     */
+    private function row(int $teamid, string $name, int $wins, int $losses): array
+    {
+        $total = $wins + $losses;
+        return [
+            'teamid' => $teamid,
+            'team_name' => $name,
+            'wins' => $wins,
+            'losses' => $losses,
+            'pct' => $total > 0 ? $wins / $total : 0.0,
+            'conference' => 'Eastern',
+            'division' => 'Atlantic',
+            'conf_wins' => null,
+            'conf_losses' => null,
+            'div_wins' => null,
+            'div_losses' => null,
+            'clinched_division' => null,
+            'color1' => 'AA0001',
+            'color2' => 'BB0001',
+        ];
+    }
+
+    /**
+     * @param list<StandingsRow> $teams
+     * @return list<int>
+     */
+    private function ids(array $teams): array
+    {
+        return array_column($teams, 'teamid');
+    }
+
+    // ── Boundary cases ────────────────────────────────────────────────────
+
+    public function testEmptyListReturnsEmpty(): void
+    {
+        $this->assertSame([], $this->resolver->sortTeamsByRecord([], [], []));
+    }
+
+    public function testSingleTeamReturnedUnchanged(): void
+    {
+        $team = $this->row(1, 'Solo', 40, 42);
+
+        $result = $this->resolver->sortTeamsByRecord([$team], [], []);
+
+        $this->assertSame([1], $this->ids($result));
+    }
+
+    // ── pct ordering ──────────────────────────────────────────────────────
+
+    public function testDistinctPctsWorstFirst(): void
+    {
+        $teams = [
+            $this->row(1, 'Best', 60, 22),
+            $this->row(2, 'Mid', 41, 41),
+            $this->row(3, 'Worst', 20, 62),
+        ];
+
+        $result = $this->resolver->sortTeamsByRecord($teams, [], []);
+
+        $this->assertSame([3, 2, 1], $this->ids($result));
+    }
+
+    // ── Tied group: H2H decides ───────────────────────────────────────────
+
+    public function testSamePctH2HWorseAggregateSortedFirst(): void
+    {
+        // Team 1 beat Team 2: aggregate H2H pct — team1=1.0, team2=0.0.
+        // Draft order: worse H2H aggregate (lower pct) gets earlier pick.
+        $teams = [
+            $this->row(1, 'Team1', 41, 41),
+            $this->row(2, 'Team2', 41, 41),
+        ];
+        $h2h = [1 => [2 => 1], 2 => [1 => 0]];
+
+        $result = $this->resolver->sortTeamsByRecord($teams, $h2h, []);
+
+        $this->assertSame([2, 1], $this->ids($result));
+    }
+
+    // ── 3-way tied group with cyclic H2H ──────────────────────────────────
+
+    public function testThreeWaySamePctCyclicH2HAlphabeticalSignInverted(): void
+    {
+        // Cyclic H2H: A→B, B→C, C→A. All aggregate pcts = 0.5.
+        // Falls through to sign-inverted alphabetical: 'TeamC' first, 'TeamA' last.
+        $teams = [
+            $this->row(1, 'TeamA', 41, 41),
+            $this->row(2, 'TeamB', 41, 41),
+            $this->row(3, 'TeamC', 41, 41),
+        ];
+        $h2h = [
+            1 => [2 => 1, 3 => 0],
+            2 => [1 => 0, 3 => 1],
+            3 => [1 => 1, 2 => 0],
+        ];
+
+        $result = $this->resolver->sortTeamsByRecord($teams, $h2h, []);
+
+        $this->assertSame([3, 2, 1], $this->ids($result));
+    }
+
+    // ── Tied group: empty H2H, sign-inverted alphabetical fallback ─────────
+
+    public function testSamePctNoH2HSignInvertedAlphabetical(): void
+    {
+        // No games played — aggregate H2H pcts both 0.0, ties → non-H2H tail.
+        // Sign-inverted alphabetical: alphabetically later team sorts first.
+        $teams = [
+            $this->row(1, 'TeamA', 41, 41),
+            $this->row(2, 'TeamB', 41, 41),
+        ];
+
+        $result = $this->resolver->sortTeamsByRecord($teams, [], []);
+
+        $this->assertSame([2, 1], $this->ids($result));
+    }
+}

--- a/ibl5/tests/ProjectedDraftOrder/NonHeadToHeadTiebreakerTest.php
+++ b/ibl5/tests/ProjectedDraftOrder/NonHeadToHeadTiebreakerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ProjectedDraftOrder;
+
+use PHPUnit\Framework\TestCase;
+use ProjectedDraftOrder\Contracts\ProjectedDraftOrderRepositoryInterface;
+use ProjectedDraftOrder\NonHeadToHeadTiebreaker;
+
+/**
+ * @covers \ProjectedDraftOrder\NonHeadToHeadTiebreaker
+ * @phpstan-import-type StandingsRow from ProjectedDraftOrderRepositoryInterface
+ */
+class NonHeadToHeadTiebreakerTest extends TestCase
+{
+    private NonHeadToHeadTiebreaker $tiebreaker;
+
+    protected function setUp(): void
+    {
+        $this->tiebreaker = new NonHeadToHeadTiebreaker();
+    }
+
+    /**
+     * Build a minimal StandingsRow for tiebreaker tests.
+     * @return StandingsRow
+     */
+    private function row(
+        int $teamid,
+        string $name,
+        string $division = 'Atlantic',
+        string $conference = 'Eastern',
+        ?int $clinchedDiv = null,
+        ?int $divWins = null,
+        ?int $divLosses = null,
+        ?int $confWins = null,
+        ?int $confLosses = null,
+    ): array {
+        return [
+            'teamid' => $teamid,
+            'team_name' => $name,
+            'wins' => 41,
+            'losses' => 41,
+            'pct' => 0.5,
+            'conference' => $conference,
+            'division' => $division,
+            'conf_wins' => $confWins,
+            'conf_losses' => $confLosses,
+            'div_wins' => $divWins,
+            'div_losses' => $divLosses,
+            'clinched_division' => $clinchedDiv,
+            'color1' => 'AA0001',
+            'color2' => 'BB0001',
+        ];
+    }
+
+    // ── Arm 2: Division winner status ─────────────────────────────────────
+
+    public function testDivisionWinnerStatusAWinsReturnsNegative(): void
+    {
+        $a = $this->row(1, 'Team A', clinchedDiv: 1);
+        $b = $this->row(2, 'Team B', clinchedDiv: null);
+
+        $result = $this->tiebreaker->applyNonH2HTiebreakers($a, $b, []);
+
+        $this->assertLessThan(0, $result);
+    }
+
+    public function testDivisionWinnerStatusBWinsReturnsPositive(): void
+    {
+        $a = $this->row(1, 'Team A', clinchedDiv: null);
+        $b = $this->row(2, 'Team B', clinchedDiv: 1);
+
+        $result = $this->tiebreaker->applyNonH2HTiebreakers($a, $b, []);
+
+        $this->assertGreaterThan(0, $result);
+    }
+
+    // ── Arm 3: Division record (same division only) ────────────────────────
+
+    public function testDivisionRecordABetterReturnsNegative(): void
+    {
+        $a = $this->row(1, 'Team A', divWins: 10, divLosses: 2);
+        $b = $this->row(2, 'Team B', divWins: 2, divLosses: 10);
+
+        $result = $this->tiebreaker->applyNonH2HTiebreakers($a, $b, []);
+
+        $this->assertLessThan(0, $result);
+    }
+
+    public function testDivisionRecordSkippedForDifferentDivisions(): void
+    {
+        // Different divisions — div record arm must NOT fire even if div records differ.
+        // Falls through to conf record (both null → 0.0 tie) → alphabetical.
+        $a = $this->row(1, 'Team A', division: 'Atlantic', divWins: 10, divLosses: 0);
+        $b = $this->row(2, 'Team B', division: 'Central', divWins: 0, divLosses: 10);
+
+        $result = $this->tiebreaker->applyNonH2HTiebreakers($a, $b, []);
+
+        // Alphabetical: 'Team A' < 'Team B' → returns negative
+        $this->assertLessThan(0, $result);
+    }
+
+    // ── Arm 4: Conference record ──────────────────────────────────────────
+
+    public function testConferenceRecordABetterReturnsNegative(): void
+    {
+        $a = $this->row(1, 'Team A', division: 'Atlantic', confWins: 30, confLosses: 10);
+        $b = $this->row(2, 'Team B', division: 'Atlantic', confWins: 10, confLosses: 30);
+
+        $result = $this->tiebreaker->applyNonH2HTiebreakers($a, $b, []);
+
+        $this->assertLessThan(0, $result);
+    }
+
+    // ── safeWinPct zero-total boundary (via conf record arm) ──────────────
+
+    public function testSafeWinPctZeroTotalFallsThroughToAlphabetical(): void
+    {
+        // Both conf_wins=null, conf_losses=null → safeWinPct returns 0.0 for both.
+        // Conf record arm does not decide → falls to alphabetical.
+        $a = $this->row(1, 'Team A', division: 'Atlantic');
+        $b = $this->row(2, 'Team B', division: 'Atlantic');
+
+        $result = $this->tiebreaker->applyNonH2HTiebreakers($a, $b, []);
+
+        $this->assertLessThan(0, $result);
+    }
+
+    // ── Arm 5: Point differential ─────────────────────────────────────────
+
+    public function testPointDiffABetterReturnsNegative(): void
+    {
+        $a = $this->row(1, 'Team A');
+        $b = $this->row(2, 'Team B');
+
+        $pointDiffs = [1 => 50.0, 2 => -50.0];
+        $result = $this->tiebreaker->applyNonH2HTiebreakers($a, $b, $pointDiffs);
+
+        $this->assertLessThan(0, $result);
+    }
+
+    // ── Fallback: alphabetical ────────────────────────────────────────────
+
+    public function testAlphabeticalFallbackAFirstReturnsNegative(): void
+    {
+        $a = $this->row(1, 'Alpha');
+        $b = $this->row(2, 'Zeta');
+
+        $result = $this->tiebreaker->applyNonH2HTiebreakers($a, $b, []);
+
+        $this->assertLessThan(0, $result);
+    }
+
+    public function testAlphabeticalFallbackBFirstReturnsPositive(): void
+    {
+        $a = $this->row(1, 'Zeta');
+        $b = $this->row(2, 'Alpha');
+
+        $result = $this->tiebreaker->applyNonH2HTiebreakers($a, $b, []);
+
+        $this->assertGreaterThan(0, $result);
+    }
+}

--- a/ibl5/tests/ProjectedDraftOrder/PlayoffSeedingCalculatorTest.php
+++ b/ibl5/tests/ProjectedDraftOrder/PlayoffSeedingCalculatorTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ProjectedDraftOrder;
+
+use PHPUnit\Framework\TestCase;
+use ProjectedDraftOrder\Contracts\ProjectedDraftOrderRepositoryInterface;
+use ProjectedDraftOrder\NonHeadToHeadTiebreaker;
+use ProjectedDraftOrder\PlayoffSeedingCalculator;
+
+/**
+ * @covers \ProjectedDraftOrder\PlayoffSeedingCalculator
+ * @phpstan-import-type StandingsRow from ProjectedDraftOrderRepositoryInterface
+ */
+class PlayoffSeedingCalculatorTest extends TestCase
+{
+    private PlayoffSeedingCalculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new PlayoffSeedingCalculator(new NonHeadToHeadTiebreaker());
+    }
+
+    /**
+     * Build a minimal StandingsRow for seeding tests.
+     * @return StandingsRow
+     */
+    private function row(int $teamid, string $name, int $wins, int $losses, string $division = 'Atlantic'): array
+    {
+        $total = $wins + $losses;
+        return [
+            'teamid' => $teamid,
+            'team_name' => $name,
+            'wins' => $wins,
+            'losses' => $losses,
+            'pct' => $total > 0 ? $wins / $total : 0.0,
+            'conference' => 'Eastern',
+            'division' => $division,
+            'conf_wins' => null,
+            'conf_losses' => null,
+            'div_wins' => null,
+            'div_losses' => null,
+            'clinched_division' => null,
+            'color1' => 'AA0001',
+            'color2' => 'BB0001',
+        ];
+    }
+
+    /**
+     * @param list<StandingsRow> $teams
+     * @return list<int>
+     */
+    private function ids(array $teams): array
+    {
+        return array_column($teams, 'teamid');
+    }
+
+    // ── Empty conference ──────────────────────────────────────────────────
+
+    public function testEmptyConferenceReturnsEmptyBuckets(): void
+    {
+        $result = $this->calculator->determinePlayoffTeams([], [], []);
+
+        $this->assertSame(
+            ['wildCards' => [], 'divisionWinners' => [], 'conferenceWinner' => null, 'nonPlayoff' => []],
+            $result
+        );
+    }
+
+    // ── Full conference: 6 wild cards + division winners + non-playoff ────
+
+    public function testFullConferenceSplit(): void
+    {
+        // Atlantic: teamids 1-7, wins descending (70,60,50,40,30,20,10)
+        // Central:  teamids 8-14, wins descending (65,55,45,35,25,15,5)
+        $atlantic = [
+            $this->row(1, 'A1', 70, 12),
+            $this->row(2, 'A2', 60, 22),
+            $this->row(3, 'A3', 50, 32),
+            $this->row(4, 'A4', 40, 42),
+            $this->row(5, 'A5', 30, 52),
+            $this->row(6, 'A6', 20, 62),
+            $this->row(7, 'A7', 10, 72),
+        ];
+        $central = [
+            $this->row(8, 'C1', 65, 17, 'Central'),
+            $this->row(9, 'C2', 55, 27, 'Central'),
+            $this->row(10, 'C3', 45, 37, 'Central'),
+            $this->row(11, 'C4', 35, 47, 'Central'),
+            $this->row(12, 'C5', 25, 57, 'Central'),
+            $this->row(13, 'C6', 15, 67, 'Central'),
+            $this->row(14, 'C7', 5, 77, 'Central'),
+        ];
+        $conference = array_merge($atlantic, $central);
+
+        $result = $this->calculator->determinePlayoffTeams($conference, [], []);
+
+        // Conference winner: team1 (70W best overall)
+        $this->assertSame(1, $result['conferenceWinner']['teamid']);
+
+        // Non-conf division winner: Central winner team8
+        $this->assertSame([8], $this->ids($result['divisionWinners']));
+
+        // Wild cards: top-6 non-division-winners sorted best first
+        $this->assertSame([2, 9, 3, 10, 4, 11], $this->ids($result['wildCards']));
+
+        // Non-playoff: remaining 6 non-winners, worst-first in the sorted list
+        $this->assertSame([5, 12, 6, 13, 7, 14], $this->ids($result['nonPlayoff']));
+    }
+
+    // ── Pairwise H2H decides tied division winner (applyTiebreakers path) ─
+
+    public function testH2HTiebreakerDecidesDivisionWinner(): void
+    {
+        // Two teams in same division with equal pct, team1 beat team2 once.
+        // applyTiebreakers: aWinsVsB=1 > bWinsVsA=0 → return bWinsVsA <=> aWinsVsB = -1 → team1 wins.
+        $team1 = $this->row(1, 'Team1', 41, 41);
+        $team2 = $this->row(2, 'Team2', 41, 41);
+        $h2h = [1 => [2 => 1], 2 => [1 => 0]];
+
+        $result = $this->calculator->determinePlayoffTeams([$team1, $team2], $h2h, []);
+
+        $this->assertSame(1, $result['conferenceWinner']['teamid']);
+        $this->assertSame([2], $this->ids($result['wildCards']));
+    }
+
+    // ── pct-based seeding (compareTeamsForPlayoffSeeding pct branch) ──────
+
+    public function testHigherPctTeamBecomesConferenceWinner(): void
+    {
+        // Two divisions. Best overall record wins the conference.
+        $atlantic = [
+            $this->row(1, 'A1', 70, 12),
+            $this->row(2, 'A2', 30, 52),
+        ];
+        $central = [
+            $this->row(3, 'C1', 65, 17, 'Central'),
+            $this->row(4, 'C2', 25, 57, 'Central'),
+        ];
+
+        $result = $this->calculator->determinePlayoffTeams(array_merge($atlantic, $central), [], []);
+
+        $this->assertSame(1, $result['conferenceWinner']['teamid']);
+        $this->assertSame([3], $this->ids($result['divisionWinners']));
+    }
+}

--- a/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderServiceCharacterizationTest.php
+++ b/ibl5/tests/ProjectedDraftOrder/ProjectedDraftOrderServiceCharacterizationTest.php
@@ -1,0 +1,479 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ProjectedDraftOrder;
+
+use PHPUnit\Framework\TestCase;
+use ProjectedDraftOrder\Contracts\ProjectedDraftOrderRepositoryInterface;
+use ProjectedDraftOrder\Contracts\ProjectedDraftOrderServiceInterface;
+use ProjectedDraftOrder\ProjectedDraftOrderService;
+use Tests\ProjectedDraftOrder\Support\StandingsFixtures;
+
+/**
+ * Golden-master characterization pin for calculateDraftOrder().
+ *
+ * CAPTURE PROCEDURE: each assertion uses a frozen expected literal captured by
+ * running this test once against the unmodified service and copying the actual
+ * ordering from the failure diff. Do not hand-update these — regenerate via the
+ * same capture procedure if behavior is intentionally changed.
+ *
+ * @covers \ProjectedDraftOrder\ProjectedDraftOrderService
+ * @phpstan-import-type DraftSlot from ProjectedDraftOrderServiceInterface
+ */
+class ProjectedDraftOrderServiceCharacterizationTest extends TestCase
+{
+    use StandingsFixtures;
+
+    private object $stubRepository;
+    private ProjectedDraftOrderService $service;
+
+    protected function setUp(): void
+    {
+        $this->stubRepository = self::createStub(ProjectedDraftOrderRepositoryInterface::class);
+        $this->stubRepository->method('getPickOwnership')->willReturn([]);
+        $this->stubRepository->method('getPointDifferentials')->willReturn([]);
+        $this->service = new ProjectedDraftOrderService($this->stubRepository);
+    }
+
+    /**
+     * @param list<DraftSlot> $slots
+     * @return list<array{pick: int, teamId: int}>
+     */
+    private function pickSequence(array $slots): array
+    {
+        return array_map(static fn (array $s): array => ['pick' => $s['pick'], 'teamId' => $s['teamId']], $slots);
+    }
+
+    // ── Row 5: empty standings early-return ───────────────────────────────
+    public function testEmptyStandingsReturnsEmptyRounds(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn([]);
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        $this->assertSame(['round1' => [], 'round2' => []], $result);
+    }
+
+    // ── Row 7: one full DraftSlot snapshot locks slot shape ───────────────
+    public function testFullLeagueRound1SlotShape(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildFullLeagueStandings());
+
+        $result = $this->service->calculateDraftOrder(2026);
+        $firstSlot = $result['round1'][0];
+
+        $this->assertArrayHasKey('pick', $firstSlot);
+        $this->assertArrayHasKey('teamId', $firstSlot);
+        $this->assertArrayHasKey('teamName', $firstSlot);
+        $this->assertArrayHasKey('wins', $firstSlot);
+        $this->assertArrayHasKey('losses', $firstSlot);
+        $this->assertArrayHasKey('color1', $firstSlot);
+        $this->assertArrayHasKey('color2', $firstSlot);
+        $this->assertArrayHasKey('ownerId', $firstSlot);
+        $this->assertArrayHasKey('ownerName', $firstSlot);
+        $this->assertArrayHasKey('ownerColor1', $firstSlot);
+        $this->assertArrayHasKey('ownerColor2', $firstSlot);
+        $this->assertArrayHasKey('isTraded', $firstSlot);
+        $this->assertArrayHasKey('notes', $firstSlot);
+        $this->assertArrayHasKey('movement', $firstSlot);
+        $this->assertArrayHasKey('player', $firstSlot);
+        $this->assertCount(28, $result['round1']);
+    }
+
+    // ── Row 1: full-league pick sequence (round1 + round2) ───────────────
+    public function testFullLeaguePickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildFullLeagueStandings());
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 28], ['pick' => 2, 'teamId' => 27], ['pick' => 3, 'teamId' => 26],
+            ['pick' => 4, 'teamId' => 25], ['pick' => 5, 'teamId' => 24], ['pick' => 6, 'teamId' => 23],
+            ['pick' => 7, 'teamId' => 14], ['pick' => 8, 'teamId' => 13], ['pick' => 9, 'teamId' => 12],
+            ['pick' => 10, 'teamId' => 11], ['pick' => 11, 'teamId' => 10], ['pick' => 12, 'teamId' => 9],
+            ['pick' => 13, 'teamId' => 21], ['pick' => 14, 'teamId' => 20], ['pick' => 15, 'teamId' => 19],
+            ['pick' => 16, 'teamId' => 18], ['pick' => 17, 'teamId' => 17], ['pick' => 18, 'teamId' => 16],
+            ['pick' => 19, 'teamId' => 7], ['pick' => 20, 'teamId' => 6], ['pick' => 21, 'teamId' => 5],
+            ['pick' => 22, 'teamId' => 4], ['pick' => 23, 'teamId' => 3], ['pick' => 24, 'teamId' => 2],
+            ['pick' => 25, 'teamId' => 22], ['pick' => 26, 'teamId' => 8], ['pick' => 27, 'teamId' => 15],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 28], ['pick' => 2, 'teamId' => 27], ['pick' => 3, 'teamId' => 26],
+            ['pick' => 4, 'teamId' => 25], ['pick' => 5, 'teamId' => 24], ['pick' => 6, 'teamId' => 23],
+            ['pick' => 7, 'teamId' => 22], ['pick' => 8, 'teamId' => 21], ['pick' => 9, 'teamId' => 20],
+            ['pick' => 10, 'teamId' => 19], ['pick' => 11, 'teamId' => 18], ['pick' => 12, 'teamId' => 17],
+            ['pick' => 13, 'teamId' => 16], ['pick' => 14, 'teamId' => 15], ['pick' => 15, 'teamId' => 14],
+            ['pick' => 16, 'teamId' => 13], ['pick' => 17, 'teamId' => 12], ['pick' => 18, 'teamId' => 11],
+            ['pick' => 19, 'teamId' => 10], ['pick' => 20, 'teamId' => 9], ['pick' => 21, 'teamId' => 8],
+            ['pick' => 22, 'teamId' => 7], ['pick' => 23, 'teamId' => 6], ['pick' => 24, 'teamId' => 5],
+            ['pick' => 25, 'teamId' => 4], ['pick' => 26, 'teamId' => 3], ['pick' => 27, 'teamId' => 2],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+
+    // ── Row 1 (continued): weak-div-winner sequence ───────────────────────
+    public function testWeakDivisionWinnerPickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildStandingsWithWeakDivisionWinner());
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 7], ['pick' => 2, 'teamId' => 6], ['pick' => 3, 'teamId' => 28],
+            ['pick' => 4, 'teamId' => 21], ['pick' => 5, 'teamId' => 5], ['pick' => 6, 'teamId' => 4],
+            ['pick' => 7, 'teamId' => 27], ['pick' => 8, 'teamId' => 20], ['pick' => 9, 'teamId' => 3],
+            ['pick' => 10, 'teamId' => 2], ['pick' => 11, 'teamId' => 26], ['pick' => 12, 'teamId' => 19],
+            ['pick' => 13, 'teamId' => 25], ['pick' => 14, 'teamId' => 18], ['pick' => 15, 'teamId' => 14],
+            ['pick' => 16, 'teamId' => 24], ['pick' => 17, 'teamId' => 17], ['pick' => 18, 'teamId' => 13],
+            ['pick' => 19, 'teamId' => 23], ['pick' => 20, 'teamId' => 16], ['pick' => 21, 'teamId' => 12],
+            ['pick' => 22, 'teamId' => 11], ['pick' => 23, 'teamId' => 10], ['pick' => 24, 'teamId' => 9],
+            ['pick' => 25, 'teamId' => 1], ['pick' => 26, 'teamId' => 22], ['pick' => 27, 'teamId' => 15],
+            ['pick' => 28, 'teamId' => 8],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 7], ['pick' => 2, 'teamId' => 6], ['pick' => 3, 'teamId' => 28],
+            ['pick' => 4, 'teamId' => 21], ['pick' => 5, 'teamId' => 5], ['pick' => 6, 'teamId' => 4],
+            ['pick' => 7, 'teamId' => 27], ['pick' => 8, 'teamId' => 20], ['pick' => 9, 'teamId' => 3],
+            ['pick' => 10, 'teamId' => 2], ['pick' => 11, 'teamId' => 26], ['pick' => 12, 'teamId' => 19],
+            ['pick' => 13, 'teamId' => 1], ['pick' => 14, 'teamId' => 25], ['pick' => 15, 'teamId' => 18],
+            ['pick' => 16, 'teamId' => 14], ['pick' => 17, 'teamId' => 24], ['pick' => 18, 'teamId' => 17],
+            ['pick' => 19, 'teamId' => 13], ['pick' => 20, 'teamId' => 23], ['pick' => 21, 'teamId' => 16],
+            ['pick' => 22, 'teamId' => 12], ['pick' => 23, 'teamId' => 22], ['pick' => 24, 'teamId' => 15],
+            ['pick' => 25, 'teamId' => 11], ['pick' => 26, 'teamId' => 10], ['pick' => 27, 'teamId' => 9],
+            ['pick' => 28, 'teamId' => 8],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+
+    // ── Row 1 (continued): tied H2H sequence ─────────────────────────────
+    public function testTiedStandingsPickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildTiedStandings());
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 102],
+            ['pick' => 4, 'teamId' => 101], ['pick' => 5, 'teamId' => 25], ['pick' => 6, 'teamId' => 18],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 12],
+            ['pick' => 10, 'teamId' => 11], ['pick' => 11, 'teamId' => 10], ['pick' => 12, 'teamId' => 9],
+            ['pick' => 13, 'teamId' => 23], ['pick' => 14, 'teamId' => 16], ['pick' => 15, 'teamId' => 22],
+            ['pick' => 16, 'teamId' => 15], ['pick' => 17, 'teamId' => 21], ['pick' => 18, 'teamId' => 14],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 4],
+            ['pick' => 22, 'teamId' => 7], ['pick' => 23, 'teamId' => 3], ['pick' => 24, 'teamId' => 2],
+            ['pick' => 25, 'teamId' => 20], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 13],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 102],
+            ['pick' => 4, 'teamId' => 101], ['pick' => 5, 'teamId' => 25], ['pick' => 6, 'teamId' => 18],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 23],
+            ['pick' => 10, 'teamId' => 16], ['pick' => 11, 'teamId' => 12], ['pick' => 12, 'teamId' => 22],
+            ['pick' => 13, 'teamId' => 15], ['pick' => 14, 'teamId' => 11], ['pick' => 15, 'teamId' => 10],
+            ['pick' => 16, 'teamId' => 21], ['pick' => 17, 'teamId' => 14], ['pick' => 18, 'teamId' => 9],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 20],
+            ['pick' => 22, 'teamId' => 13], ['pick' => 23, 'teamId' => 4], ['pick' => 24, 'teamId' => 7],
+            ['pick' => 25, 'teamId' => 3], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 2],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+
+    // ── Row 1 (continued): conference-record sequence ─────────────────────
+    public function testConfRecordPickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildTiedStandingsWithConfRecords());
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        // TeamA (101) has worse conf record (10-30 = 0.25) → better draft pick (earlier)
+        // TeamB (102) has better conf record (20-20 = 0.5) → worse draft pick (later)
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 25],
+            ['pick' => 4, 'teamId' => 18], ['pick' => 5, 'teamId' => 101], ['pick' => 6, 'teamId' => 102],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 12],
+            ['pick' => 10, 'teamId' => 11], ['pick' => 11, 'teamId' => 10], ['pick' => 12, 'teamId' => 9],
+            ['pick' => 13, 'teamId' => 23], ['pick' => 14, 'teamId' => 16], ['pick' => 15, 'teamId' => 22],
+            ['pick' => 16, 'teamId' => 15], ['pick' => 17, 'teamId' => 21], ['pick' => 18, 'teamId' => 14],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 4],
+            ['pick' => 22, 'teamId' => 7], ['pick' => 23, 'teamId' => 3], ['pick' => 24, 'teamId' => 2],
+            ['pick' => 25, 'teamId' => 20], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 13],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 25],
+            ['pick' => 4, 'teamId' => 18], ['pick' => 5, 'teamId' => 101], ['pick' => 6, 'teamId' => 102],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 23],
+            ['pick' => 10, 'teamId' => 16], ['pick' => 11, 'teamId' => 12], ['pick' => 12, 'teamId' => 22],
+            ['pick' => 13, 'teamId' => 15], ['pick' => 14, 'teamId' => 11], ['pick' => 15, 'teamId' => 10],
+            ['pick' => 16, 'teamId' => 21], ['pick' => 17, 'teamId' => 14], ['pick' => 18, 'teamId' => 9],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 20],
+            ['pick' => 22, 'teamId' => 13], ['pick' => 23, 'teamId' => 4], ['pick' => 24, 'teamId' => 7],
+            ['pick' => 25, 'teamId' => 3], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 2],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+
+    // ── Row 1 (continued): point-differential sequence ───────────────────
+    public function testPointDiffPickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildTiedStandingsWithSameConfRecords());
+        $this->stubRepository->method('getPointDifferentials')->willReturn([
+            ['teamid' => 101, 'pointsFor' => 100.0, 'pointsAgainst' => 90.0],
+            ['teamid' => 102, 'pointsFor' => 90.0, 'pointsAgainst' => 100.0],
+        ]);
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        // TeamA (101) has +10 net pts → better team → later draft pick
+        // TeamB (102) has -10 net pts → worse team → earlier draft pick
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 25],
+            ['pick' => 4, 'teamId' => 18], ['pick' => 5, 'teamId' => 102], ['pick' => 6, 'teamId' => 101],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 12],
+            ['pick' => 10, 'teamId' => 11], ['pick' => 11, 'teamId' => 10], ['pick' => 12, 'teamId' => 9],
+            ['pick' => 13, 'teamId' => 23], ['pick' => 14, 'teamId' => 16], ['pick' => 15, 'teamId' => 22],
+            ['pick' => 16, 'teamId' => 15], ['pick' => 17, 'teamId' => 21], ['pick' => 18, 'teamId' => 14],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 4],
+            ['pick' => 22, 'teamId' => 7], ['pick' => 23, 'teamId' => 3], ['pick' => 24, 'teamId' => 2],
+            ['pick' => 25, 'teamId' => 20], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 13],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 25],
+            ['pick' => 4, 'teamId' => 18], ['pick' => 5, 'teamId' => 102], ['pick' => 6, 'teamId' => 101],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 23],
+            ['pick' => 10, 'teamId' => 16], ['pick' => 11, 'teamId' => 12], ['pick' => 12, 'teamId' => 22],
+            ['pick' => 13, 'teamId' => 15], ['pick' => 14, 'teamId' => 11], ['pick' => 15, 'teamId' => 10],
+            ['pick' => 16, 'teamId' => 21], ['pick' => 17, 'teamId' => 14], ['pick' => 18, 'teamId' => 9],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 20],
+            ['pick' => 22, 'teamId' => 13], ['pick' => 23, 'teamId' => 4], ['pick' => 24, 'teamId' => 7],
+            ['pick' => 25, 'teamId' => 3], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 2],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+
+    // ── Row 1 (continued): 3-way aggregate H2H sequence ──────────────────
+    public function testThreeWayTiedPickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildThreeWayTiedStandings());
+        // 301 beat 302 once; 302 beat 303 once; 303 beat 301 once (cyclic)
+        $this->stubRepository->method('getPlayedGames')->willReturn([
+            ['visitor_teamid' => 301, 'visitor_score' => 110, 'home_teamid' => 302, 'home_score' => 100],
+            ['visitor_teamid' => 302, 'visitor_score' => 110, 'home_teamid' => 303, 'home_score' => 100],
+            ['visitor_teamid' => 303, 'visitor_score' => 110, 'home_teamid' => 301, 'home_score' => 100],
+        ]);
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 25], ['pick' => 2, 'teamId' => 18], ['pick' => 3, 'teamId' => 24],
+            ['pick' => 4, 'teamId' => 17], ['pick' => 5, 'teamId' => 303], ['pick' => 6, 'teamId' => 302],
+            ['pick' => 7, 'teamId' => 301], ['pick' => 8, 'teamId' => 23], ['pick' => 9, 'teamId' => 16],
+            ['pick' => 10, 'teamId' => 11], ['pick' => 11, 'teamId' => 10], ['pick' => 12, 'teamId' => 9],
+            ['pick' => 13, 'teamId' => 22], ['pick' => 14, 'teamId' => 15], ['pick' => 15, 'teamId' => 21],
+            ['pick' => 16, 'teamId' => 14], ['pick' => 17, 'teamId' => 20], ['pick' => 18, 'teamId' => 13],
+            ['pick' => 19, 'teamId' => 8], ['pick' => 20, 'teamId' => 7], ['pick' => 21, 'teamId' => 4],
+            ['pick' => 22, 'teamId' => 6], ['pick' => 23, 'teamId' => 3], ['pick' => 24, 'teamId' => 2],
+            ['pick' => 25, 'teamId' => 19], ['pick' => 26, 'teamId' => 5], ['pick' => 27, 'teamId' => 12],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 25], ['pick' => 2, 'teamId' => 18], ['pick' => 3, 'teamId' => 24],
+            ['pick' => 4, 'teamId' => 17], ['pick' => 5, 'teamId' => 303], ['pick' => 6, 'teamId' => 302],
+            ['pick' => 7, 'teamId' => 301], ['pick' => 8, 'teamId' => 23], ['pick' => 9, 'teamId' => 16],
+            ['pick' => 10, 'teamId' => 22], ['pick' => 11, 'teamId' => 15], ['pick' => 12, 'teamId' => 11],
+            ['pick' => 13, 'teamId' => 21], ['pick' => 14, 'teamId' => 14], ['pick' => 15, 'teamId' => 10],
+            ['pick' => 16, 'teamId' => 9], ['pick' => 17, 'teamId' => 20], ['pick' => 18, 'teamId' => 13],
+            ['pick' => 19, 'teamId' => 8], ['pick' => 20, 'teamId' => 7], ['pick' => 21, 'teamId' => 19],
+            ['pick' => 22, 'teamId' => 12], ['pick' => 23, 'teamId' => 4], ['pick' => 24, 'teamId' => 6],
+            ['pick' => 25, 'teamId' => 3], ['pick' => 26, 'teamId' => 5], ['pick' => 27, 'teamId' => 2],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+
+    // ── Row 1 (continued): tied playoff teams sequence ────────────────────
+    public function testTiedPlayoffTeamsPickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildTiedPlayoffTeams());
+        // PlayoffA (201) beat PlayoffB (202) — pairwise H2H in playoff seeding
+        $this->stubRepository->method('getPlayedGames')->willReturn([
+            ['visitor_teamid' => 201, 'visitor_score' => 110, 'home_teamid' => 202, 'home_score' => 100],
+        ]);
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 25],
+            ['pick' => 4, 'teamId' => 18], ['pick' => 5, 'teamId' => 5], ['pick' => 6, 'teamId' => 24],
+            ['pick' => 7, 'teamId' => 17], ['pick' => 8, 'teamId' => 4], ['pick' => 9, 'teamId' => 12],
+            ['pick' => 10, 'teamId' => 11], ['pick' => 11, 'teamId' => 3], ['pick' => 12, 'teamId' => 10],
+            ['pick' => 13, 'teamId' => 23], ['pick' => 14, 'teamId' => 16], ['pick' => 15, 'teamId' => 22],
+            ['pick' => 16, 'teamId' => 15], ['pick' => 17, 'teamId' => 2], ['pick' => 18, 'teamId' => 9],
+            ['pick' => 19, 'teamId' => 21], ['pick' => 20, 'teamId' => 14], ['pick' => 21, 'teamId' => 1],
+            ['pick' => 22, 'teamId' => 8], ['pick' => 23, 'teamId' => 202], ['pick' => 24, 'teamId' => 7],
+            ['pick' => 25, 'teamId' => 201], ['pick' => 26, 'teamId' => 20], ['pick' => 27, 'teamId' => 13],
+            ['pick' => 28, 'teamId' => 6],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 25],
+            ['pick' => 4, 'teamId' => 18], ['pick' => 5, 'teamId' => 5], ['pick' => 6, 'teamId' => 24],
+            ['pick' => 7, 'teamId' => 17], ['pick' => 8, 'teamId' => 4], ['pick' => 9, 'teamId' => 12],
+            ['pick' => 10, 'teamId' => 23], ['pick' => 11, 'teamId' => 16], ['pick' => 12, 'teamId' => 11],
+            ['pick' => 13, 'teamId' => 3], ['pick' => 14, 'teamId' => 10], ['pick' => 15, 'teamId' => 22],
+            ['pick' => 16, 'teamId' => 15], ['pick' => 17, 'teamId' => 2], ['pick' => 18, 'teamId' => 9],
+            ['pick' => 19, 'teamId' => 21], ['pick' => 20, 'teamId' => 14], ['pick' => 21, 'teamId' => 1],
+            ['pick' => 22, 'teamId' => 8], ['pick' => 23, 'teamId' => 202], ['pick' => 24, 'teamId' => 20],
+            ['pick' => 25, 'teamId' => 13], ['pick' => 26, 'teamId' => 201], ['pick' => 27, 'teamId' => 7],
+            ['pick' => 28, 'teamId' => 6],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+
+    // ── Row 6: zero-games yields 28+28 picks numbered 1-28 ───────────────
+    public function testZeroGameStandings28Picks(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildZeroGameStandings());
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        $this->assertCount(28, $result['round1']);
+        $this->assertCount(28, $result['round2']);
+        $this->assertSame(range(1, 28), array_column($result['round1'], 'pick'));
+        $this->assertSame(range(1, 28), array_column($result['round2'], 'pick'));
+    }
+
+    // ── Row 2: div-winner-status branch decides via round-2 sequence ──────
+    public function testDivisionWinnerStatusPickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildTiedWithDivisionWinnerStatus());
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        // Round-2 picks 13-14: TeamB (202, non-div-winner) picks before TeamA (201, div-winner)
+        // because div-winner-status means "better" team → later draft pick
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 6], ['pick' => 2, 'teamId' => 5], ['pick' => 3, 'teamId' => 26],
+            ['pick' => 4, 'teamId' => 4], ['pick' => 5, 'teamId' => 25], ['pick' => 6, 'teamId' => 3],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 2], ['pick' => 9, 'teamId' => 1],
+            ['pick' => 10, 'teamId' => 23], ['pick' => 11, 'teamId' => 22], ['pick' => 12, 'teamId' => 21],
+            ['pick' => 13, 'teamId' => 202], ['pick' => 14, 'teamId' => 13], ['pick' => 15, 'teamId' => 19],
+            ['pick' => 16, 'teamId' => 12], ['pick' => 17, 'teamId' => 18], ['pick' => 18, 'teamId' => 11],
+            ['pick' => 19, 'teamId' => 17], ['pick' => 20, 'teamId' => 10], ['pick' => 21, 'teamId' => 16],
+            ['pick' => 22, 'teamId' => 9], ['pick' => 23, 'teamId' => 15], ['pick' => 24, 'teamId' => 8],
+            ['pick' => 25, 'teamId' => 201], ['pick' => 26, 'teamId' => 20], ['pick' => 27, 'teamId' => 14],
+            ['pick' => 28, 'teamId' => 7],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 6], ['pick' => 2, 'teamId' => 5], ['pick' => 3, 'teamId' => 26],
+            ['pick' => 4, 'teamId' => 4], ['pick' => 5, 'teamId' => 25], ['pick' => 6, 'teamId' => 3],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 2], ['pick' => 9, 'teamId' => 1],
+            ['pick' => 10, 'teamId' => 23], ['pick' => 11, 'teamId' => 22], ['pick' => 12, 'teamId' => 21],
+            ['pick' => 13, 'teamId' => 202], ['pick' => 14, 'teamId' => 201], ['pick' => 15, 'teamId' => 13],
+            ['pick' => 16, 'teamId' => 19], ['pick' => 17, 'teamId' => 12], ['pick' => 18, 'teamId' => 18],
+            ['pick' => 19, 'teamId' => 11], ['pick' => 20, 'teamId' => 17], ['pick' => 21, 'teamId' => 10],
+            ['pick' => 22, 'teamId' => 16], ['pick' => 23, 'teamId' => 9], ['pick' => 24, 'teamId' => 15],
+            ['pick' => 25, 'teamId' => 20], ['pick' => 26, 'teamId' => 8], ['pick' => 27, 'teamId' => 14],
+            ['pick' => 28, 'teamId' => 7],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+
+    // ── Row 3: division-record branch decides ordering ────────────────────
+    public function testDivisionRecordPickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildTiedWithDivisionRecords());
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        // TeamB (402, div 2-8 = worse div record) picks before TeamA (401, div 8-2 = better)
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 402],
+            ['pick' => 4, 'teamId' => 401], ['pick' => 5, 'teamId' => 25], ['pick' => 6, 'teamId' => 18],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 12],
+            ['pick' => 10, 'teamId' => 11], ['pick' => 11, 'teamId' => 10], ['pick' => 12, 'teamId' => 9],
+            ['pick' => 13, 'teamId' => 23], ['pick' => 14, 'teamId' => 16], ['pick' => 15, 'teamId' => 22],
+            ['pick' => 16, 'teamId' => 15], ['pick' => 17, 'teamId' => 21], ['pick' => 18, 'teamId' => 14],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 4],
+            ['pick' => 22, 'teamId' => 7], ['pick' => 23, 'teamId' => 3], ['pick' => 24, 'teamId' => 2],
+            ['pick' => 25, 'teamId' => 20], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 13],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 402],
+            ['pick' => 4, 'teamId' => 401], ['pick' => 5, 'teamId' => 25], ['pick' => 6, 'teamId' => 18],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 23],
+            ['pick' => 10, 'teamId' => 16], ['pick' => 11, 'teamId' => 12], ['pick' => 12, 'teamId' => 22],
+            ['pick' => 13, 'teamId' => 15], ['pick' => 14, 'teamId' => 11], ['pick' => 15, 'teamId' => 10],
+            ['pick' => 16, 'teamId' => 21], ['pick' => 17, 'teamId' => 14], ['pick' => 18, 'teamId' => 9],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 20],
+            ['pick' => 22, 'teamId' => 13], ['pick' => 23, 'teamId' => 4], ['pick' => 24, 'teamId' => 7],
+            ['pick' => 25, 'teamId' => 3], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 2],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+
+    // ── Row 4: alphabetical terminal fallback ─────────────────────────────
+    public function testAlphabeticalFallbackPickSequence(): void
+    {
+        $this->stubRepository->method('getAllTeamsWithStandings')->willReturn($this->buildFullyTiedPair());
+
+        $result = $this->service->calculateDraftOrder(2026);
+
+        // ZoneTeam (502) picks before ArcticTeam (501): 'Z' > 'A' alphabetically means
+        // ZoneTeam is "worse" in the tiebreaker → earlier draft pick (sign-inverted in sortTiedGroup)
+        $expectedRound1 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 502],
+            ['pick' => 4, 'teamId' => 25], ['pick' => 5, 'teamId' => 18], ['pick' => 6, 'teamId' => 501],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 12],
+            ['pick' => 10, 'teamId' => 11], ['pick' => 11, 'teamId' => 10], ['pick' => 12, 'teamId' => 9],
+            ['pick' => 13, 'teamId' => 23], ['pick' => 14, 'teamId' => 16], ['pick' => 15, 'teamId' => 22],
+            ['pick' => 16, 'teamId' => 15], ['pick' => 17, 'teamId' => 21], ['pick' => 18, 'teamId' => 14],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 4],
+            ['pick' => 22, 'teamId' => 7], ['pick' => 23, 'teamId' => 3], ['pick' => 24, 'teamId' => 2],
+            ['pick' => 25, 'teamId' => 20], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 13],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+        $expectedRound2 = [
+            ['pick' => 1, 'teamId' => 26], ['pick' => 2, 'teamId' => 19], ['pick' => 3, 'teamId' => 502],
+            ['pick' => 4, 'teamId' => 25], ['pick' => 5, 'teamId' => 18], ['pick' => 6, 'teamId' => 501],
+            ['pick' => 7, 'teamId' => 24], ['pick' => 8, 'teamId' => 17], ['pick' => 9, 'teamId' => 23],
+            ['pick' => 10, 'teamId' => 16], ['pick' => 11, 'teamId' => 12], ['pick' => 12, 'teamId' => 22],
+            ['pick' => 13, 'teamId' => 15], ['pick' => 14, 'teamId' => 11], ['pick' => 15, 'teamId' => 10],
+            ['pick' => 16, 'teamId' => 21], ['pick' => 17, 'teamId' => 14], ['pick' => 18, 'teamId' => 9],
+            ['pick' => 19, 'teamId' => 5], ['pick' => 20, 'teamId' => 8], ['pick' => 21, 'teamId' => 20],
+            ['pick' => 22, 'teamId' => 13], ['pick' => 23, 'teamId' => 4], ['pick' => 24, 'teamId' => 7],
+            ['pick' => 25, 'teamId' => 3], ['pick' => 26, 'teamId' => 6], ['pick' => 27, 'teamId' => 2],
+            ['pick' => 28, 'teamId' => 1],
+        ];
+
+        $this->assertSame($expectedRound1, $this->pickSequence($result['round1']));
+        $this->assertSame($expectedRound2, $this->pickSequence($result['round2']));
+    }
+}

--- a/ibl5/tests/ProjectedDraftOrder/Support/StandingsFixtures.php
+++ b/ibl5/tests/ProjectedDraftOrder/Support/StandingsFixtures.php
@@ -1,0 +1,471 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ProjectedDraftOrder\Support;
+
+trait StandingsFixtures
+{
+    /**
+     * @return array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}
+     */
+    private function makeStandingsRow(
+        int $teamid,
+        string $name,
+        int $wins,
+        int $losses,
+        string $conference,
+        string $division,
+        ?int $clinched_division = null,
+    ): array {
+        $total = $wins + $losses;
+        $pct = $total > 0 ? round($wins / $total, 3) : 0.0;
+
+        return [
+            'teamid' => $teamid,
+            'team_name' => $name,
+            'wins' => $wins,
+            'losses' => $losses,
+            'pct' => $pct,
+            'conference' => $conference,
+            'division' => $division,
+            'conf_wins' => null,
+            'conf_losses' => null,
+            'div_wins' => null,
+            'div_losses' => null,
+            'clinched_division' => $clinched_division,
+            'color1' => 'AA' . str_pad((string) $teamid, 4, '0', STR_PAD_LEFT),
+            'color2' => 'BB' . str_pad((string) $teamid, 4, '0', STR_PAD_LEFT),
+        ];
+    }
+
+    /**
+     * Build 28 teams across 2 conferences / 4 divisions with distinct records.
+     *
+     * Eastern: Atlantic (teams 1-7), Central (teams 8-14)
+     * Western: Midwest (teams 15-21), Pacific (teams 22-28)
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildFullLeagueStandings(): array
+    {
+        $teams = [];
+        $conferences = [
+            'Eastern' => ['Atlantic', 'Central'],
+            'Western' => ['Midwest', 'Pacific'],
+        ];
+
+        $teamid = 1;
+        foreach ($conferences as $conf => $divisions) {
+            foreach ($divisions as $div) {
+                for ($i = 0; $i < 7; $i++) {
+                    $wins = 82 - (($teamid - 1) * 3);
+                    if ($wins < 0) {
+                        $wins = 0;
+                    }
+                    $losses = 82 - $wins;
+                    $pct = $wins > 0 ? round($wins / 82.0, 3) : 0.0;
+                    $teams[] = [
+                        'teamid' => $teamid,
+                        'team_name' => 'Team' . $teamid,
+                        'wins' => $wins,
+                        'losses' => $losses,
+                        'pct' => $pct,
+                        'conference' => $conf,
+                        'division' => $div,
+                        'conf_wins' => null,
+                        'conf_losses' => null,
+                        'div_wins' => null,
+                        'div_losses' => null,
+                        'clinched_division' => null,
+                        'color1' => 'AA' . str_pad((string) $teamid, 4, '0', STR_PAD_LEFT),
+                        'color2' => 'BB' . str_pad((string) $teamid, 4, '0', STR_PAD_LEFT),
+                    ];
+                    $teamid++;
+                }
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build standings where a division winner has a worse record than some wild card teams.
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildStandingsWithWeakDivisionWinner(): array
+    {
+        $teams = [];
+        $teamid = 1;
+
+        // Eastern Atlantic: WeakDivWinner at 30-52 but best in division
+        $atlanticRecords = [
+            ['name' => 'WeakDivWinner', 'wins' => 30, 'losses' => 52, 'clinched_division' => 1],
+            ['name' => 'AtlTeam2', 'wins' => 28, 'losses' => 54, 'clinched_division' => null],
+            ['name' => 'AtlTeam3', 'wins' => 25, 'losses' => 57, 'clinched_division' => null],
+            ['name' => 'AtlTeam4', 'wins' => 22, 'losses' => 60, 'clinched_division' => null],
+            ['name' => 'AtlTeam5', 'wins' => 20, 'losses' => 62, 'clinched_division' => null],
+            ['name' => 'AtlTeam6', 'wins' => 18, 'losses' => 64, 'clinched_division' => null],
+            ['name' => 'AtlTeam7', 'wins' => 15, 'losses' => 67, 'clinched_division' => null],
+        ];
+
+        foreach ($atlanticRecords as $rec) {
+            $teams[] = $this->makeStandingsRow($teamid++, $rec['name'], $rec['wins'], $rec['losses'], 'Eastern', 'Atlantic', $rec['clinched_division']);
+        }
+
+        // Eastern Central: Strong division
+        $centralRecords = [
+            ['name' => 'CenTeam1', 'wins' => 65, 'losses' => 17],
+            ['name' => 'CenTeam2', 'wins' => 60, 'losses' => 22],
+            ['name' => 'CenTeam3', 'wins' => 55, 'losses' => 27],
+            ['name' => 'CenTeam4', 'wins' => 50, 'losses' => 32],
+            ['name' => 'CenTeam5', 'wins' => 45, 'losses' => 37],
+            ['name' => 'CenTeam6', 'wins' => 40, 'losses' => 42],
+            ['name' => 'CenTeam7', 'wins' => 35, 'losses' => 47],
+        ];
+
+        foreach ($centralRecords as $rec) {
+            $teams[] = $this->makeStandingsRow($teamid++, $rec['name'], $rec['wins'], $rec['losses'], 'Eastern', 'Central');
+        }
+
+        // Western: 14 teams with middling records
+        foreach (['Midwest', 'Pacific'] as $div) {
+            for ($i = 0; $i < 7; $i++) {
+                $wins = 50 - ($i * 5);
+                $teams[] = $this->makeStandingsRow($teamid++, $div . 'T' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build two tied non-playoff teams for head-to-head tiebreaker testing.
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildTiedStandings(): array
+    {
+        $teams = [];
+        $teamid = 1;
+
+        // Eastern Atlantic: first 5 are strong playoff teams
+        for ($i = 0; $i < 5; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'EATop' . ($i + 1), 60 - ($i * 3), 22 + ($i * 3), 'Eastern', 'Atlantic');
+        }
+        // Two tied weak teams (will be non-playoff)
+        $teams[] = $this->makeStandingsRow(101, 'TeamA', 25, 57, 'Eastern', 'Atlantic');
+        $teams[] = $this->makeStandingsRow(102, 'TeamB', 25, 57, 'Eastern', 'Atlantic');
+
+        // Eastern Central: 7 strong teams
+        for ($i = 0; $i < 7; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'ECTop' . ($i + 1), 55 - ($i * 3), 27 + ($i * 3), 'Eastern', 'Central');
+        }
+
+        // Western: 14 teams
+        foreach (['Midwest', 'Pacific'] as $div) {
+            for ($i = 0; $i < 7; $i++) {
+                $wins = 50 - ($i * 5);
+                $teams[] = $this->makeStandingsRow($teamid++, $div . 'T' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build two tied non-playoff teams with different conference records.
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildTiedStandingsWithConfRecords(): array
+    {
+        $teams = [];
+        $teamid = 1;
+
+        for ($i = 0; $i < 5; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'EATop' . ($i + 1), 60 - ($i * 3), 22 + ($i * 3), 'Eastern', 'Atlantic');
+        }
+        $teamA = $this->makeStandingsRow(101, 'TeamA', 25, 57, 'Eastern', 'Atlantic');
+        $teamA['conf_wins'] = 10;
+        $teamA['conf_losses'] = 30;
+        $teams[] = $teamA;
+        $teamB = $this->makeStandingsRow(102, 'TeamB', 25, 57, 'Eastern', 'Atlantic');
+        $teamB['conf_wins'] = 20;
+        $teamB['conf_losses'] = 20;
+        $teams[] = $teamB;
+
+        for ($i = 0; $i < 7; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'ECTop' . ($i + 1), 55 - ($i * 3), 27 + ($i * 3), 'Eastern', 'Central');
+        }
+
+        foreach (['Midwest', 'Pacific'] as $div) {
+            for ($i = 0; $i < 7; $i++) {
+                $wins = 50 - ($i * 5);
+                $teams[] = $this->makeStandingsRow($teamid++, $div . 'T' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Like buildTiedStandingsWithConfRecords but both teams have identical conf records.
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildTiedStandingsWithSameConfRecords(): array
+    {
+        $teams = [];
+        $teamid = 1;
+
+        for ($i = 0; $i < 5; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'EATop' . ($i + 1), 60 - ($i * 3), 22 + ($i * 3), 'Eastern', 'Atlantic');
+        }
+        $teamA = $this->makeStandingsRow(101, 'TeamA', 25, 57, 'Eastern', 'Atlantic');
+        $teamA['conf_wins'] = 15;
+        $teamA['conf_losses'] = 25;
+        $teams[] = $teamA;
+        $teamB = $this->makeStandingsRow(102, 'TeamB', 25, 57, 'Eastern', 'Atlantic');
+        $teamB['conf_wins'] = 15;
+        $teamB['conf_losses'] = 25;
+        $teams[] = $teamB;
+
+        for ($i = 0; $i < 7; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'ECTop' . ($i + 1), 55 - ($i * 3), 27 + ($i * 3), 'Eastern', 'Central');
+        }
+
+        foreach (['Midwest', 'Pacific'] as $div) {
+            for ($i = 0; $i < 7; $i++) {
+                $wins = 50 - ($i * 5);
+                $teams[] = $this->makeStandingsRow($teamid++, $div . 'T' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build 28 teams all with 0-0 record.
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildZeroGameStandings(): array
+    {
+        $teams = [];
+        $teamid = 1;
+        $conferences = [
+            'Eastern' => ['Atlantic', 'Central'],
+            'Western' => ['Midwest', 'Pacific'],
+        ];
+
+        foreach ($conferences as $conf => $divisions) {
+            foreach ($divisions as $div) {
+                for ($i = 0; $i < 7; $i++) {
+                    $teams[] = $this->makeStandingsRow($teamid, 'T' . str_pad((string) $teamid, 2, '0', STR_PAD_LEFT), 0, 0, $conf, $div);
+                    $teamid++;
+                }
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build standings with two tied playoff teams for testing playoff tiebreaker direction.
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildTiedPlayoffTeams(): array
+    {
+        $teams = [];
+        $teamid = 1;
+
+        // Eastern Atlantic: Two tied playoff-quality teams
+        $teams[] = $this->makeStandingsRow(201, 'PlayoffA', 50, 32, 'Eastern', 'Atlantic');
+        $teams[] = $this->makeStandingsRow(202, 'PlayoffB', 50, 32, 'Eastern', 'Atlantic');
+        for ($i = 0; $i < 5; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'EAFill' . ($i + 1), 45 - ($i * 5), 37 + ($i * 5), 'Eastern', 'Atlantic');
+        }
+
+        // Eastern Central: 7 teams
+        for ($i = 0; $i < 7; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'ECFill' . ($i + 1), 55 - ($i * 4), 27 + ($i * 4), 'Eastern', 'Central');
+        }
+
+        // Western: 14 teams
+        foreach (['Midwest', 'Pacific'] as $div) {
+            for ($i = 0; $i < 7; $i++) {
+                $wins = 50 - ($i * 5);
+                $teams[] = $this->makeStandingsRow($teamid++, $div . 'Fill' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build 28-team standings with three tied non-playoff teams (25-57) in Eastern Atlantic.
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildThreeWayTiedStandings(): array
+    {
+        $teams = [];
+        $teamid = 1;
+
+        // Eastern Atlantic: 4 strong playoff teams + 3 tied weak teams
+        for ($i = 0; $i < 4; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'EATop' . ($i + 1), 60 - ($i * 3), 22 + ($i * 3), 'Eastern', 'Atlantic');
+        }
+        $teams[] = $this->makeStandingsRow(301, 'TiedTeamA', 25, 57, 'Eastern', 'Atlantic');
+        $teams[] = $this->makeStandingsRow(302, 'TiedTeamB', 25, 57, 'Eastern', 'Atlantic');
+        $teams[] = $this->makeStandingsRow(303, 'TiedTeamC', 25, 57, 'Eastern', 'Atlantic');
+
+        // Eastern Central: 7 strong teams
+        for ($i = 0; $i < 7; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'ECTop' . ($i + 1), 55 - ($i * 3), 27 + ($i * 3), 'Eastern', 'Central');
+        }
+
+        // Western: 14 teams
+        foreach (['Midwest', 'Pacific'] as $div) {
+            for ($i = 0; $i < 7; $i++) {
+                $wins = 50 - ($i * 5);
+                $teams[] = $this->makeStandingsRow($teamid++, $div . 'T' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build a 28-team league where two same-pct teams meet in round-2's all-teams sort,
+     * with div-winner status as the sole discriminator.
+     *
+     * TeamA (id=201, clinched_division=1, pct=0.5) is Eastern Atlantic division winner.
+     * TeamB (id=202, clinched_division=null, pct=0.5) is Western Midwest non-playoff.
+     * No H2H games, no point-diffs → div-winner status decides in applyNonH2HTiebreakers.
+     * They're in different round-1 buckets (divisionWinners vs nonPlayoff) and meet in
+     * the round-2 allTeamsSorted call only.
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildTiedWithDivisionWinnerStatus(): array
+    {
+        $teams = [];
+        $teamid = 1;
+
+        // Eastern Atlantic: TeamA is the sole division winner (clinched_division=1, 41-41)
+        // Remaining 6 Atlantic teams are clearly below 0.5 pct
+        $teams[] = $this->makeStandingsRow(201, 'TeamA', 41, 41, 'Eastern', 'Atlantic', 1);
+        $atlanticWins = [28, 24, 20, 16, 12, 8];
+        foreach ($atlanticWins as $w) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'AtlTeam' . $teamid, $w, 82 - $w, 'Eastern', 'Atlantic');
+        }
+
+        // Eastern Central: strong teams, all distinct pcts above 0.5
+        $centralWins = [75, 70, 65, 60, 55, 50, 45];
+        foreach ($centralWins as $w) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'CenTeam' . $teamid, $w, 82 - $w, 'Eastern', 'Central');
+        }
+
+        // Western Midwest: 6 strong teams (will be wild cards) + TeamB (non-playoff, 41-41)
+        $midwestWins = [72, 67, 62, 57, 52, 47];
+        foreach ($midwestWins as $w) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'MidTeam' . $teamid, $w, 82 - $w, 'Western', 'Midwest');
+        }
+        $teams[] = $this->makeStandingsRow(202, 'TeamB', 41, 41, 'Western', 'Midwest', null);
+
+        // Western Pacific: 7 teams — one div winner + 6 non-winners all below TeamB's pct
+        $pacificWins = [69, 39, 34, 29, 24, 19, 14];
+        foreach ($pacificWins as $w) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'PacTeam' . $teamid, $w, 82 - $w, 'Western', 'Pacific');
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build a 28-team league where two same-pct same-division teams differ only in
+     * division record — the div-record branch in applyNonH2HTiebreakers decides.
+     *
+     * TeamA (id=401, pct=0.5, div_wins=8, div_losses=2) and
+     * TeamB (id=402, pct=0.5, div_wins=2, div_losses=8) are in Eastern Atlantic.
+     * No H2H games, equal conf records (null), equal point-diffs.
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildTiedWithDivisionRecords(): array
+    {
+        $teams = [];
+        $teamid = 1;
+
+        // Eastern Atlantic: 5 strong playoff teams + TeamA + TeamB (both non-playoff, 25-57)
+        for ($i = 0; $i < 5; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'EATop' . ($i + 1), 60 - ($i * 3), 22 + ($i * 3), 'Eastern', 'Atlantic');
+        }
+        $teamA = $this->makeStandingsRow(401, 'TeamA', 25, 57, 'Eastern', 'Atlantic');
+        $teamA['div_wins'] = 8;
+        $teamA['div_losses'] = 2;
+        $teams[] = $teamA;
+        $teamB = $this->makeStandingsRow(402, 'TeamB', 25, 57, 'Eastern', 'Atlantic');
+        $teamB['div_wins'] = 2;
+        $teamB['div_losses'] = 8;
+        $teams[] = $teamB;
+
+        // Eastern Central: 7 strong teams
+        for ($i = 0; $i < 7; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'ECTop' . ($i + 1), 55 - ($i * 3), 27 + ($i * 3), 'Eastern', 'Central');
+        }
+
+        // Western: 14 teams
+        foreach (['Midwest', 'Pacific'] as $div) {
+            for ($i = 0; $i < 7; $i++) {
+                $wins = 50 - ($i * 5);
+                $teams[] = $this->makeStandingsRow($teamid++, $div . 'T' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
+            }
+        }
+
+        return $teams;
+    }
+
+    /**
+     * Build a 28-team league where two teams are identical in every tiebreaker field;
+     * alphabetical team_name is the sole discriminator.
+     *
+     * TeamA="ArcticTeam" (id=501) and TeamB="ZoneTeam" (id=502) share pct=0.5,
+     * same division, null conf/div records, and zero point-diffs. No H2H games.
+     * "ArcticTeam" < "ZoneTeam" alphabetically, so ArcticTeam wins the tiebreaker
+     * (returns negative in applyNonH2HTiebreakers → comes later in draft order = worse pick).
+     *
+     * @return list<array{teamid: int, team_name: string, wins: int, losses: int, pct: float, conference: string, division: string, conf_wins: int|null, conf_losses: int|null, div_wins: int|null, div_losses: int|null, clinched_division: int|null, color1: string, color2: string}>
+     */
+    private function buildFullyTiedPair(): array
+    {
+        $teams = [];
+        $teamid = 1;
+
+        // Eastern Atlantic: 5 strong playoff teams + fully-tied pair (non-playoff)
+        for ($i = 0; $i < 5; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'EATop' . ($i + 1), 60 - ($i * 3), 22 + ($i * 3), 'Eastern', 'Atlantic');
+        }
+        $teams[] = $this->makeStandingsRow(501, 'ArcticTeam', 25, 57, 'Eastern', 'Atlantic');
+        $teams[] = $this->makeStandingsRow(502, 'ZoneTeam', 25, 57, 'Eastern', 'Atlantic');
+
+        // Eastern Central: 7 strong teams
+        for ($i = 0; $i < 7; $i++) {
+            $teams[] = $this->makeStandingsRow($teamid++, 'ECTop' . ($i + 1), 55 - ($i * 3), 27 + ($i * 3), 'Eastern', 'Central');
+        }
+
+        // Western: 14 teams
+        foreach (['Midwest', 'Pacific'] as $div) {
+            for ($i = 0; $i < 7; $i++) {
+                $wins = 50 - ($i * 5);
+                $teams[] = $this->makeStandingsRow($teamid++, $div . 'T' . ($i + 1), $wins, 82 - $wins, 'Western', $div);
+            }
+        }
+
+        return $teams;
+    }
+}


### PR DESCRIPTION
Behavior-preserving refactor of the sorting/tiebreaker logic in `ProjectedDraftOrderService` (620 LOC → thin orchestrator). Pins current `calculateDraftOrder()` output with a golden-master characterization test, then extracts:

- `NonHeadToHeadTiebreaker` — shared helper (`applyNonH2HTiebreakers` + `safeWinPct`), moved verbatim
- `DraftOrderTiebreakerResolver` — holds `sortTeamsByRecord` / `resolveTiedGroups` / `sortTiedGroup`
- `PlayoffSeedingCalculator` — holds `determinePlayoffTeams` / `compareTeamsForPlayoffSeeding` / `applyTiebreakers`

No schema, no migration, no security surface, no UI change. Constructor signature of `ProjectedDraftOrderService` unchanged (collaborators instantiated internally). Existing 30 service tests stay green and untouched.

Fixes backlog item 1.5: independently testable domain units with direct PHPUnit coverage of every tiebreaker arm.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.