### PR TITLE
ci: PR Lighthouse audits diff-scoped URLs; baseline runs full set

### DIFF
--- a/.claude/rules/lighthouse-pr-comments.md
+++ b/.claude/rules/lighthouse-pr-comments.md
@@ -3,17 +3,21 @@ description: Lighthouse CI posts per-URL scores and deltas-vs-master as a sticky
 paths:
   - ".github/workflows/lighthouse*"
   - "ibl5/.lighthouserc.json"
-last_verified: 2026-05-27
+last_verified: 2026-06-20
 ---
 
 # Lighthouse PR Comments
 
 ## What runs
 
-`.github/workflows/lighthouse.yml` runs Lighthouse on 5 URLs (configured in
-`ibl5/.lighthouserc.json`) on every PR that touches PHP/CSS/TS/JS/design assets.
-Scores are compared against the master baseline (refreshed on every push to master
-via `.github/workflows/lighthouse-baseline.yml`).
+`.github/workflows/lighthouse.yml` audits a **dynamic subset of URLs selected from
+the PR diff** by `bin/lighthouse-pr-urls` on every PR that touches PHP/CSS/TS/JS/design
+assets. Selection is module-scoped (a changed `ibl5/modules/<Name>/` file audits that
+module's page), with a curated representative-set fallback for global or sweeping
+changes (CSS/TS/JS, `ibl5/classes/**`, workflow/config self-edits, or more than 8
+modules touched). The master baseline runs the **full** site set (via
+`.github/workflows/lighthouse-baseline.yml`) so every PR-selectable URL has a baseline
+row to diff against.
 
 ## Reading the PR comment
 
@@ -37,6 +41,12 @@ A 🟡 marker is informational — investigate before merging.
 
 ## Modifying the audit
 
-- Add/remove URLs: edit `ibl5/.lighthouserc.json` `collect.url`.
-- Change thresholds: edit `assert.assertions`.
-- Both changes require an ADR (changes mechanical-enforcement surface).
+- URL **selection** lives in `bin/lighthouse-pr-urls` plus the shared
+  `Cli\LighthouseUrls` class: the module→sub-page map is `LighthouseUrls::SUB_PAGES`,
+  and the global/sweeping fallback set is `LighthouseUrls::REPRESENTATIVE_PATHS`.
+- The representative fallback set is mirrored in `ibl5/.lighthouserc.json` `collect.url`
+  (pinned equal to `REPRESENTATIVE_PATHS` by a `LighthouseUrlsTest` unit test); both
+  workflows `jq`-override `.ci.collect.url`, so the static array is only the
+  human-readable default for a bare local `autorun`.
+- Change thresholds: edit `ibl5/.lighthouserc.json` `assert.assertions`.
+- Changing the selection logic or thresholds (mechanical-enforcement surface) requires an ADR.

--- a/.github/workflows/lighthouse-baseline.yml
+++ b/.github/workflows/lighthouse-baseline.yml
@@ -25,7 +25,7 @@ jobs:
   baseline:
     name: Generate baseline
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
 
@@ -33,7 +33,10 @@ jobs:
 
       - name: Run Lighthouse
         working-directory: ibl5
-        run: bunx @lhci/cli autorun
+        run: |
+          jq --argjson urls "$(../bin/lighthouse-audit-urls --json --base-url=http://localhost:8080)" \
+             '.ci.collect.url = $urls | .ci.collect.numberOfRuns = 1' .lighthouserc.json > /tmp/lhrc.baseline.json
+          bunx @lhci/cli collect --config=/tmp/lhrc.baseline.json
         env:
           CHROME_PATH: /usr/bin/google-chrome-stable
 
@@ -56,7 +59,6 @@ jobs:
           name: lighthouse-baseline-manifest
           path: |
             ibl5/.lighthouseci/manifest.json
-            ibl5/.lighthouseci/links.json
           retention-days: 30
 
       - name: Teardown

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -55,7 +55,10 @@ jobs:
       # --- Lighthouse ---
       - name: Run Lighthouse CI
         working-directory: ibl5
-        run: bunx @lhci/cli autorun
+        run: |
+          jq --argjson urls "$(../bin/lighthouse-pr-urls --json --base-url=http://localhost:8080)" \
+             '.ci.collect.url = $urls' .lighthouserc.json > /tmp/lhrc.pr.json
+          bunx @lhci/cli autorun --config=/tmp/lhrc.pr.json
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           CHROME_PATH: /usr/bin/google-chrome-stable

--- a/bin/lighthouse-audit-urls
+++ b/bin/lighthouse-audit-urls
@@ -15,7 +15,7 @@ if ($worktreeClasses !== false && is_link(__DIR__ . '/../ibl5/vendor')) {
     }, true, true);
 }
 
-use Module\ModuleRegistry;
+use Cli\LighthouseUrls;
 
 $baseUrl = 'http://localhost:8080';
 $jsonOutput = false;
@@ -40,28 +40,7 @@ foreach ($argv as $i => $arg) {
 
 $baseUrl = rtrim($baseUrl, '/');
 
-$subPages = [
-    'Team'                => '&op=team&teamid=1',
-    'Player'              => '&pa=showpage&pid=1',
-    'Schedule'            => '&teamid=1',
-    'DraftHistory'        => '&year=2025',
-    'FranchiseRecordBook' => '&op=team&teamid=1',
-    'SeasonArchive'       => '&year=2025',
-    'Injuries'            => '&teamid=1',
-    'OneOnOneGame'        => '&gameid=1',
-];
-
-$urls = [];
-
-$urls[] = $baseUrl . '/ibl5/index.php';
-
-foreach (ModuleRegistry::getAllModules() as $module) {
-    $urls[] = $baseUrl . '/ibl5/modules.php?name=' . $module;
-
-    if (isset($subPages[$module])) {
-        $urls[] = $baseUrl . '/ibl5/modules.php?name=' . $module . $subPages[$module];
-    }
-}
+$urls = LighthouseUrls::fullSiteUrls($baseUrl);
 
 if ($jsonOutput) {
     fwrite(STDOUT, json_encode($urls, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");

--- a/bin/lighthouse-pr-urls
+++ b/bin/lighthouse-pr-urls
@@ -1,0 +1,150 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../ibl5/vendor/autoload.php';
+
+$worktreeClasses = realpath(__DIR__ . '/../ibl5/classes');
+if ($worktreeClasses !== false && is_link(__DIR__ . '/../ibl5/vendor')) {
+    spl_autoload_register(static function (string $class) use ($worktreeClasses): void {
+        $file = $worktreeClasses . '/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+    }, true, true);
+}
+
+use Cli\LighthouseUrls;
+use Module\ModuleRegistry;
+
+$baseUrl = 'http://localhost:8080';
+$jsonOutput = false;
+$useStdin = false;
+
+foreach ($argv as $i => $arg) {
+    if ($i === 0) {
+        continue;
+    }
+    if (str_starts_with($arg, '--base-url=')) {
+        $baseUrl = substr($arg, strlen('--base-url='));
+    } elseif ($arg === '--json') {
+        $jsonOutput = true;
+    } elseif ($arg === '--stdin') {
+        $useStdin = true;
+    } elseif ($arg === '--help') {
+        fwrite(STDOUT, "Usage: bin/lighthouse-pr-urls [--base-url=URL] [--json] [--stdin]\n");
+        exit(0);
+    } else {
+        fwrite(STDERR, "Unknown argument: $arg\n");
+        fwrite(STDERR, "Usage: bin/lighthouse-pr-urls [--base-url=URL] [--json] [--stdin]\n");
+        exit(2);
+    }
+}
+
+$baseUrl = rtrim($baseUrl, '/');
+
+/**
+ * @param list<string> $urls
+ */
+$emit = static function (array $urls) use ($jsonOutput): void {
+    if ($jsonOutput) {
+        fwrite(STDOUT, json_encode($urls, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+    } else {
+        foreach ($urls as $url) {
+            fwrite(STDOUT, $url . "\n");
+        }
+    }
+};
+
+// --- Acquire the changed-path list -----------------------------------------
+if ($useStdin) {
+    $rawDiff = stream_get_contents(STDIN);
+    if ($rawDiff === false) {
+        $rawDiff = '';
+    }
+} else {
+    // argv-array form: no untrusted data is interpolated into a shell string.
+    $descriptors = [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+    $proc = proc_open(
+        ['git', 'diff', '--name-only', 'origin/master...HEAD'],
+        $descriptors,
+        $pipes
+    );
+    if (!is_resource($proc)) {
+        fwrite(STDERR, "Failed to run git diff\n");
+        exit(1);
+    }
+    fclose($pipes[0]);
+    $rawDiff = stream_get_contents($pipes[1]);
+    if ($rawDiff === false) {
+        $rawDiff = '';
+    }
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    proc_close($proc);
+}
+
+$paths = array_values(array_filter(
+    array_map('trim', explode("\n", $rawDiff)),
+    static fn (string $line): bool => $line !== ''
+));
+
+// --- 1. Global fallback triggers -------------------------------------------
+// Any global asset / class / workflow-config change audits the curated
+// representative set rather than a module-scoped subset.
+foreach ($paths as $path) {
+    if (
+        str_ends_with($path, '.css')
+        || str_ends_with($path, '.ts')
+        || str_ends_with($path, '.js')
+        || str_starts_with($path, 'ibl5/classes/')
+        || str_starts_with($path, '.github/workflows/lighthouse')
+        || $path === 'ibl5/.lighthouserc.json'
+    ) {
+        $emit(LighthouseUrls::representativeUrls($baseUrl));
+        exit(0);
+    }
+}
+
+// --- 2/4. Module mapping (deduped by URL) ----------------------------------
+$modulePrefix = 'ibl5/modules/';
+$moduleUrls = [];
+foreach ($paths as $path) {
+    if (!str_starts_with($path, $modulePrefix)) {
+        continue;
+    }
+    $rest = substr($path, strlen($modulePrefix));
+    $slash = strpos($rest, '/');
+    if ($slash === false) {
+        continue; // strict `ibl5/modules/<Name>/...` prefix only
+    }
+    $name = substr($rest, 0, $slash);
+    if (ModuleRegistry::isValid($name)) {
+        $url = LighthouseUrls::moduleUrl($name, $baseUrl);
+        $moduleUrls[$url] = $url;
+    }
+}
+$moduleUrls = array_values($moduleUrls);
+
+// --- 5. Cap: a sweeping change is better covered by the representative set --
+if (count($moduleUrls) > 8) {
+    $emit(LighthouseUrls::representativeUrls($baseUrl));
+    exit(0);
+}
+
+// --- 6. Empty / no-mappable fallback: never emit an empty list -------------
+if ($moduleUrls === []) {
+    $emit(LighthouseUrls::representativeUrls($baseUrl));
+    exit(0);
+}
+
+// --- 3. Always include the homepage ----------------------------------------
+$urls = array_merge([$baseUrl . '/ibl5/index.php'], $moduleUrls);
+
+$emit($urls);
+exit(0);

--- a/ibl5/classes/Cli/LighthouseUrls.php
+++ b/ibl5/classes/Cli/LighthouseUrls.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cli;
+
+use Module\ModuleRegistry;
+
+final class LighthouseUrls
+{
+    /** @var array<string, string> */
+    public const SUB_PAGES = [
+        'Team'                => '&op=team&teamid=1',
+        'Player'              => '&pa=showpage&pid=1',
+        'Schedule'            => '&teamid=1',
+        'DraftHistory'        => '&year=2025',
+        'FranchiseRecordBook' => '&op=team&teamid=1',
+        'SeasonArchive'       => '&year=2025',
+        'Injuries'            => '&teamid=1',
+        'OneOnOneGame'        => '&gameid=1',
+    ];
+
+    /** @var list<string> */
+    public const REPRESENTATIVE_PATHS = [
+        '/ibl5/index.php',
+        '/ibl5/modules.php?name=Standings',
+        '/ibl5/modules.php?name=Team&op=team&teamid=1',
+        '/ibl5/modules.php?name=Player&pa=showpage&pid=1',
+        '/ibl5/modules.php?name=SeasonLeaderboards',
+    ];
+
+    /**
+     * The full-site audit URL set: index first, then for every registered
+     * module its bare `name=<Module>` URL plus, for sub-paged modules, the
+     * additional sub-page variant (two entries for those). This is the exact
+     * loop the original `bin/lighthouse-audit-urls` ran; do not change its
+     * shape without re-pinning the characterization test.
+     *
+     * @return list<string>
+     */
+    public static function fullSiteUrls(string $baseUrl): array
+    {
+        $baseUrl = rtrim($baseUrl, '/');
+
+        $urls = [];
+        $urls[] = $baseUrl . '/ibl5/index.php';
+
+        foreach (ModuleRegistry::getAllModules() as $module) {
+            $urls[] = $baseUrl . '/ibl5/modules.php?name=' . $module;
+
+            if (isset(self::SUB_PAGES[$module])) {
+                $urls[] = $baseUrl . '/ibl5/modules.php?name=' . $module . self::SUB_PAGES[$module];
+            }
+        }
+
+        return $urls;
+    }
+
+    /**
+     * The single best URL for one module: its `name=<module>` URL plus the
+     * sub-page suffix if the module has one. Deliberately differs from
+     * fullSiteUrls(): for a sub-paged module this returns ONLY the sub-page
+     * variant (one URL), whereas fullSiteUrls() emits both.
+     */
+    public static function moduleUrl(string $module, string $baseUrl): string
+    {
+        $baseUrl = rtrim($baseUrl, '/');
+
+        return $baseUrl . '/ibl5/modules.php?name=' . $module . (self::SUB_PAGES[$module] ?? '');
+    }
+
+    /**
+     * The curated representative fallback set, mapped onto $baseUrl. Used when
+     * a PR's changes are global/sweeping and a module-scoped selection would
+     * either miss the blast radius or exceed the cap.
+     *
+     * @return list<string>
+     */
+    public static function representativeUrls(string $baseUrl): array
+    {
+        $baseUrl = rtrim($baseUrl, '/');
+
+        return array_map(
+            static fn (string $path): string => $baseUrl . $path,
+            self::REPRESENTATIVE_PATHS
+        );
+    }
+}

--- a/ibl5/tests/Cli/LighthousePrUrlsTest.php
+++ b/ibl5/tests/Cli/LighthousePrUrlsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use Cli\LighthouseUrls;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('cli')]
+final class LighthousePrUrlsTest extends TestCase
+{
+    private const BASE = 'http://localhost:8080';
+
+    private string $scriptPath;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/lighthouse-pr-urls');
+        self::assertNotFalse($resolved, 'bin/lighthouse-pr-urls must exist');
+        $this->scriptPath = $resolved;
+    }
+
+    public function testSingleModuleFileMapsToModuleUrlPlusIndex(): void
+    {
+        $urls = $this->runWithStdin("ibl5/modules/Team/foo.php\n");
+
+        self::assertContains(self::BASE . '/ibl5/index.php', $urls);
+        self::assertContains(self::BASE . '/ibl5/modules.php?name=Team&op=team&teamid=1', $urls);
+    }
+
+    public function testTwoFilesInSameModuleDedupeToOneUrl(): void
+    {
+        $urls = $this->runWithStdin("ibl5/modules/Team/foo.php\nibl5/modules/Team/bar.php\n");
+
+        $teamUrls = array_filter(
+            $urls,
+            static fn (string $u): bool => str_contains($u, 'name=Team')
+        );
+        self::assertCount(1, $teamUrls, 'two files in one module → exactly one module URL');
+    }
+
+    public function testGlobalCssFallsBackToRepresentativeSet(): void
+    {
+        self::assertSame(
+            $this->representative(),
+            $this->runWithStdin("ibl5/css/input.css\n")
+        );
+
+        // A module name embedded in a CSS path must NOT be substring-matched.
+        self::assertSame(
+            $this->representative(),
+            $this->runWithStdin("ibl5/design/components/team-page.css\n")
+        );
+    }
+
+    public function testClassChangeFallsBackToRepresentativeSet(): void
+    {
+        self::assertSame(
+            $this->representative(),
+            $this->runWithStdin("ibl5/classes/Foo.php\n")
+        );
+    }
+
+    public function testNineModulesExceedCapAndFallBackToRepresentativeSet(): void
+    {
+        $paths = implode("\n", [
+            'ibl5/modules/ActivityTracker/a.php',
+            'ibl5/modules/AllStarAppearances/a.php',
+            'ibl5/modules/ApiKeys/a.php',
+            'ibl5/modules/AwardHistory/a.php',
+            'ibl5/modules/CapSpace/a.php',
+            'ibl5/modules/CareerLeaderboards/a.php',
+            'ibl5/modules/ComparePlayers/a.php',
+            'ibl5/modules/ContractList/a.php',
+            'ibl5/modules/DebugMenu/a.php',
+        ]) . "\n";
+
+        self::assertSame($this->representative(), $this->runWithStdin($paths));
+    }
+
+    public function testEightModulesStayModuleSpecific(): void
+    {
+        $paths = implode("\n", [
+            'ibl5/modules/ActivityTracker/a.php',
+            'ibl5/modules/AllStarAppearances/a.php',
+            'ibl5/modules/ApiKeys/a.php',
+            'ibl5/modules/AwardHistory/a.php',
+            'ibl5/modules/CapSpace/a.php',
+            'ibl5/modules/CareerLeaderboards/a.php',
+            'ibl5/modules/ComparePlayers/a.php',
+            'ibl5/modules/ContractList/a.php',
+        ]) . "\n";
+
+        $urls = $this->runWithStdin($paths);
+
+        self::assertNotSame($this->representative(), $urls);
+        self::assertCount(9, $urls, '8 module URLs + index');
+        self::assertContains(self::BASE . '/ibl5/index.php', $urls);
+    }
+
+    public function testUnknownModuleDirIsSkippedThenFallsBack(): void
+    {
+        $urls = $this->runWithStdin("ibl5/modules/NotARealModule/x.php\n");
+
+        foreach ($urls as $u) {
+            self::assertStringNotContainsString('name=NotARealModule', $u);
+        }
+        self::assertSame($this->representative(), $urls);
+    }
+
+    public function testEmptyStdinFallsBackToRepresentativeSet(): void
+    {
+        self::assertSame($this->representative(), $this->runWithStdin(''));
+    }
+
+    public function testDocOnlyDiffFallsBackToRepresentativeSet(): void
+    {
+        self::assertSame($this->representative(), $this->runWithStdin("ibl5/docs/foo.md\n"));
+    }
+
+    /** @return list<string> */
+    private function representative(): array
+    {
+        return LighthouseUrls::representativeUrls(self::BASE);
+    }
+
+    /**
+     * Pipe newline-delimited changed paths to the script's stdin via --stdin
+     * and return the decoded JSON URL list.
+     *
+     * @return list<string>
+     */
+    private function runWithStdin(string $paths): array
+    {
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $proc = proc_open(
+            [$this->scriptPath, '--stdin', '--json', '--base-url=' . self::BASE],
+            $descriptors,
+            $pipes
+        );
+        self::assertIsResource($proc, 'proc_open must start the script');
+
+        fwrite($pipes[0], $paths);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($proc);
+
+        self::assertSame(0, $exit, 'Script should exit 0. Stderr: ' . (string) $stderr);
+
+        $decoded = json_decode((string) $stdout, true);
+        self::assertIsArray($decoded, 'Output must be a JSON array. Got: ' . (string) $stdout);
+        /** @var list<string> $decoded */
+        return $decoded;
+    }
+}

--- a/ibl5/tests/Cli/LighthouseUrlsTest.php
+++ b/ibl5/tests/Cli/LighthouseUrlsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use Cli\LighthouseUrls;
+use Module\ModuleRegistry;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('cli')]
+final class LighthouseUrlsTest extends TestCase
+{
+    private const BASE = 'http://localhost:8080';
+
+    public function testFullSiteUrlsStartsWithIndex(): void
+    {
+        self::assertSame(
+            self::BASE . '/ibl5/index.php',
+            LighthouseUrls::fullSiteUrls(self::BASE)[0]
+        );
+    }
+
+    public function testFullSiteUrlsCount(): void
+    {
+        $expected = 1
+            + count(ModuleRegistry::getAllModules())
+            + count(LighthouseUrls::SUB_PAGES);
+
+        self::assertCount($expected, LighthouseUrls::fullSiteUrls(self::BASE));
+    }
+
+    public function testModuleUrlAppliesSubPage(): void
+    {
+        self::assertSame(
+            self::BASE . '/ibl5/modules.php?name=Team&op=team&teamid=1',
+            LighthouseUrls::moduleUrl('Team', self::BASE)
+        );
+    }
+
+    public function testModuleUrlWithoutSubPage(): void
+    {
+        self::assertSame(
+            self::BASE . '/ibl5/modules.php?name=Standings',
+            LighthouseUrls::moduleUrl('Standings', self::BASE)
+        );
+    }
+
+    public function testEveryModuleUrlIsInFullSiteSet(): void
+    {
+        $fullSet = LighthouseUrls::fullSiteUrls(self::BASE);
+
+        foreach (ModuleRegistry::getAllModules() as $module) {
+            self::assertContains(
+                LighthouseUrls::moduleUrl($module, self::BASE),
+                $fullSet,
+                "moduleUrl('$module') must exist in the baseline full-site set"
+            );
+        }
+    }
+
+    public function testEveryRepresentativeUrlIsInFullSiteSet(): void
+    {
+        $fullSet = LighthouseUrls::fullSiteUrls(self::BASE);
+
+        foreach (LighthouseUrls::representativeUrls(self::BASE) as $url) {
+            self::assertContains(
+                $url,
+                $fullSet,
+                "representative URL '$url' must exist in the baseline full-site set"
+            );
+        }
+    }
+
+    public function testRepresentativeUrlsPinsTheConstant(): void
+    {
+        self::assertSame(
+            [
+                self::BASE . '/ibl5/index.php',
+                self::BASE . '/ibl5/modules.php?name=Standings',
+                self::BASE . '/ibl5/modules.php?name=Team&op=team&teamid=1',
+                self::BASE . '/ibl5/modules.php?name=Player&pa=showpage&pid=1',
+                self::BASE . '/ibl5/modules.php?name=SeasonLeaderboards',
+            ],
+            LighthouseUrls::representativeUrls(self::BASE)
+        );
+    }
+
+    public function testBaseUrlTrailingSlashNormalized(): void
+    {
+        self::assertSame(
+            self::BASE . '/ibl5/index.php',
+            LighthouseUrls::fullSiteUrls(self::BASE . '/')[0]
+        );
+    }
+
+    public function testLighthouseRcUrlsMatchRepresentativeConstant(): void
+    {
+        $rcPath = __DIR__ . '/../../.lighthouserc.json';
+        $raw = file_get_contents($rcPath);
+        self::assertIsString($raw, '.lighthouserc.json must be readable');
+
+        $decoded = json_decode($raw, true);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('ci', $decoded);
+        self::assertIsArray($decoded['ci']);
+        self::assertArrayHasKey('collect', $decoded['ci']);
+        self::assertIsArray($decoded['ci']['collect']);
+        self::assertArrayHasKey('url', $decoded['ci']['collect']);
+
+        self::assertSame(
+            LighthouseUrls::representativeUrls(self::BASE),
+            $decoded['ci']['collect']['url'],
+            '.lighthouserc.json collect.url must stay equal to LighthouseUrls::REPRESENTATIVE_PATHS'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Make the CI Lighthouse PR audit select URLs from the diff (module-scoped) rather than always running the static 5-URL set. The master baseline switches to the full site set (~54 URLs, `numberOfRuns: 1`) so every PR-selectable URL has a baseline row for delta comparison.

**Changes:**
- Extract shared `Cli\LighthouseUrls` class with `fullSiteUrls()`, `moduleUrl()`, `representativeUrls()`, `SUB_PAGES`, `REPRESENTATIVE_PATHS`
- Refactor `bin/lighthouse-audit-urls` to delegate to `LighthouseUrls::fullSiteUrls()` (output byte-identical)
- Add `bin/lighthouse-pr-urls`: reads diff paths, maps `ibl5/modules/<Name>/` → module URL via registry, falls back to representative set for global/sweeping changes (CSS/TS/JS/classes/** triggers, >8 modules cap, empty/unmappable)
- Wire `.github/workflows/lighthouse.yml` to use `bin/lighthouse-pr-urls` via jq override; keeps `autorun` + `numberOfRuns: 3` + `assert` gate
- Wire `.github/workflows/lighthouse-baseline.yml` to use `bin/lighthouse-audit-urls` (full set) via jq override; switch to `collect` only (no assert), `numberOfRuns: 1`, `timeout-minutes: 120`
- Update `.claude/rules/lighthouse-pr-comments.md` to reflect new behavior

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: extends existing lighthouse CI URL-generation pattern (bin/lighthouse-audit-urls); no new architectural constraint -->