### PR TITLE
feat: add Automouse Hold Challenge to /plan — re-scrutinize auto_merge:false verdicts

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -95,6 +95,8 @@ Conditionally — include a section **only when it applies**; never emit an empt
   - Output rendering → escaped output (enforced by `RequireEscapedOutputRule`); note it so the impl agent doesn't fight the PHPStan rule.
   XSS and input validation are deterministically enforced by PHPStan custom rules — note which apply, do not write redundant manual checks.
 
+**Self-apply the Automouse Hold Challenge.** Before you classify any design decision `irreducible`, recommend a hold, or let a verification gap / reversible schema tightening default to a supervised verdict, ask yourself the question that breaks false holds in practice: *"What would I add to this plan to make it safe for automouse to merge unattended?"* If the honest answer is a buildable mechanical check — a lever-3 self-check (Verification-gap mechanization above) or the Step 3 § Schema-safety guard — **add that phase and its matrix rows** instead of leaning toward a hold. Carry a hold forward **only** when it is *intrinsic* (subjective UI/UX taste, a touched security surface, an irreversibly-destructive / design-data-blocked change, or a self-gating change to the merge-gate machinery itself) or you can state concretely *why no mechanical check is buildable*. Do **not** pressure an intrinsic hold into arming — that is a safety regression; just name its category. The orchestrator re-runs this challenge in Step 4.5, so do not leave it a reducible hold you could have dissolved.
+
 #### Agent-tiering guidance to inject (item 4 above)
 
 This guidance was relocated from `agent-tiering.md` (it is plan-authoring-only). Inject it verbatim into the Plan-agent prompt:
@@ -159,6 +161,29 @@ After receiving the Plan agent's output, check these gates yourself — do NOT d
 
 If validation fails on any gate, fix the matrix yourself rather than re-running the Plan agent.
 
+## Step 4.5: Challenge the auto-merge hold
+
+If you did **not** set `auto_merge: false` (Step 4 gate 14), skip this step — there is nothing to challenge.
+
+When you *are* about to hold the merge, run an adversarial second pass on that verdict yourself (Opus — irreducibility is Opus-tier judgment, never delegated). The forcing question, lifted from the manual re-prompt that breaks false holds in practice, is: **"What would I add to this plan to make it safe for automouse to merge unattended?"** Apply it according to the hold's *type* — the standard differs, and conflating them regresses safety in one direction or autonomy in the other.
+
+**Reducible holds — dissolve or prove infeasible.** The hold is *reducible* when its only basis is one of:
+- a **verification gap** (gate 15) — correctness is silent, integration-only, observable-only-in-prod, or "I can't tell mechanically whether it works";
+- a **reversible schema tightening** (gate 14c-reducible) — a `varchar` narrowing, or a length / `NOT NULL` add;
+- a **CI/config/tooling** change you "can't verify."
+
+You may **not** keep the hold on that basis alone. Resolve it one of two ways — **both are passing outcomes**, this is not a one-way push to arm:
+- (a) **Dissolve it.** Add the mechanization phase — a lever-3 self-check (Step 3 § Verification-gap mechanization) or the Step 3 § Schema-safety guard — and its matrix rows, then **remove `auto_merge: false`**. The check now does the watching; the hold is gone.
+- (b) **Confirm it, with cause.** Keep the hold only if you can state concretely *why no mechanical check can be built* for this specific gap. "It would be effort" is not a reason; "the only signal is subjective human perception of X" or "the asserting artifact does not exist until prod" is.
+
+**Intrinsic holds — name the category and stand.** Do **not** apply pressure to these; an intrinsic hold *should* wait for a human, and challenging it into arming is the safety regression this step exists to prevent. A hold stands as-is when it rests on:
+- **subjective UI/UX taste** (gate 14a/d) — a genuine look-and-feel / flow judgment;
+- a **touched security surface** (gate 14b);
+- an **irreversibly-destructive or design-data-blocked** change (gate 14c) — DROP / lossy backfill / in-place data mutation, a column-rename sweep, an FK-ordering migration, or a migration whose *target shape* depends on prod data unreadable from CI;
+- a **self-gating / bootstrap hazard** — a change to the auto-merge, merge-gate, or `/post-plan` machinery **itself**, where arming would let the half-built or just-rewritten mechanism gate its *own* change. No self-run check can be trusted here, because the thing under change *is* the verifier; a human must merge it under the old, known-good floor. (This is why it is not a mere verification gap — lever 3 can't mechanize a check whose own validity the PR is rewriting.)
+
+**Record the outcome.** Every plan that *keeps* `auto_merge: false` must carry an `## Automouse Hold Justification` section (its presence is enforced by `bin/check-plan`; validity is your judgment). State in it: the hold **category** (reducible-confirmed or intrinsic) and which gate-14/15 trigger it rests on, plus one line — for a reducible-confirmed hold, *why no mechanical check is buildable*; for an intrinsic hold, *why the judgment is irreducible*. A reducible hold you **dissolved** carries no section, because the plan no longer holds.
+
 ## Step 5: Write the plan file
 
 Derive a kebab-case slug from the task description (max 50 chars, lowercase, alphanumeric and hyphens only).
@@ -177,7 +202,7 @@ Then run the mechanical linter on each plan file you wrote and fix anything it r
 bin/check-plan "$PLAN_PATH"
 ```
 
-It enforces the deterministic gates from Step 4 (matrix present, no false manuals, no `DECIDE`/`TBD`/`subject to …` tokens, no unresolved decision-trigger surface, reuse targets resolve). A non-zero exit prints each violation prefixed by its gate (`[1]`/`[3]`/`[7]`/`[8]`/`[R]`); resolve each and re-run. Do not leave a plan written until `bin/check-plan` passes.
+It enforces the deterministic gates from Step 4 (matrix present, no false manuals, no `DECIDE`/`TBD`/`subject to …` tokens, no unresolved decision-trigger surface, reuse targets resolve). A non-zero exit prints each violation prefixed by its gate (`[1]`/`[3]`/`[7]`/`[8]`/`[H]`/`[R]`); resolve each and re-run. Do not leave a plan written until `bin/check-plan` passes.
 
 ### Declaring the implementation model (optional)
 
@@ -202,7 +227,7 @@ auto_merge: false
 ---
 ```
 
-Either field may appear alone; the block above shows both (a mechanical column-rename sweep, e.g., can be Sonnet-eligible **and** want a human at merge). Absence of `auto_merge` leaves the PR eligible to auto-merge (still subject to every other Phase-6.5 condition). Only the line-1 block is parsed (Phase 6.5), so a body that documents the syntax can't opt a plan out. Failure modes are bounded: absent/garbled → eligible to arm (post-plan's own gates — code review, security audit, CI-green-required, the `feat:` floor, the PR-time safety verdict, and the headless golden-snapshot block — still apply); a wrongly-applied `false` → the PR just waits for a manual merge.
+Either field may appear alone; the block above shows both (a mechanical column-rename sweep, e.g., can be Sonnet-eligible **and** want a human at merge). A plan that keeps `auto_merge: false` must also carry the `## Automouse Hold Justification` section from Step 4.5 — `bin/check-plan` gate `[H]` fails the plan if it is missing. Absence of `auto_merge` leaves the PR eligible to auto-merge (still subject to every other Phase-6.5 condition). Only the line-1 block is parsed (Phase 6.5), so a body that documents the syntax can't opt a plan out. Failure modes are bounded: absent/garbled → eligible to arm (post-plan's own gates — code review, security audit, CI-green-required, the `feat:` floor, the PR-time safety verdict, and the headless golden-snapshot block — still apply); a wrongly-applied `false` → the PR just waits for a manual merge.
 
 ## Step 6: Report
 

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -42,6 +42,12 @@
 # Whole-word DECIDE/TBD and the "subject to …" phrases ARE FP-free, so they stay.
 #
 # Plus a NEW conservative check the gates describe but never enforced:
+#   H  Hold justification    — a plan whose line-1 frontmatter declares
+#                              `auto_merge: false` must carry an
+#                              `## Automouse Hold Justification` section (the
+#                              Step-4.5 artifact). PRESENCE only — validity of the
+#                              rationale stays Opus judgment; this just catches a
+#                              hold declared with the challenge skipped entirely.
 #   R  Reuse-target exists   — a `Class::method` token named in a **Reuse** note
 #                              must resolve: if the class exists in ibl5/ but the
 #                              method name appears nowhere as a `function`, it is a
@@ -268,6 +274,38 @@ done < <(
 if grep -iE 'composer\.json' "$PLAN_FILE" | grep -qiE 'require(-dev)?'; then
     if [ "$GATE8_RESOLVED" -eq 0 ]; then
         viol "[8] decision-trigger surface ibl5/composer.json (new-dependency) added without an ADR step or no-adr: marker"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Gate H: Auto-merge hold justification present.
+# ---------------------------------------------------------------------------
+# A plan that holds the merge (`auto_merge: false` in its line-1 frontmatter)
+# must carry an `## Automouse Hold Justification` section — the artifact /plan
+# Step 4.5 produces when it confirms a hold rather than dissolving it. This is a
+# PRESENCE backstop only: the script cannot judge whether the justification is
+# valid (reducible-confirmed vs intrinsic, infeasibility reasoning) — that stays
+# Opus judgment in Step 4.5. It only catches the case where a hold was declared
+# but the challenge was skipped entirely, leaving no recorded rationale.
+#
+# Parse ONLY the first frontmatter block (the `---`…`---` fence that, by the
+# Step-5 convention, opens the file). This keeps the check false-positive-free
+# against a plan BODY that merely documents the `auto_merge: false` syntax inside
+# a fenced code example.
+FM_HOLD=0
+while IFS= read -r fm_line; do
+    case "$fm_line" in
+        auto_merge:*false*) FM_HOLD=1; break ;;
+    esac
+done < <(awk '
+    NR==1 && /^---[[:space:]]*$/ { inf=1; next }
+    inf && /^---[[:space:]]*$/   { exit }
+    inf                          { print }
+' "$PLAN_FILE")
+
+if [ "$FM_HOLD" -eq 1 ]; then
+    if ! grep -qiE '^##[[:space:]]+Automouse Hold Justification[[:space:]]*$' "$PLAN_FILE"; then
+        viol "[H] plan declares auto_merge: false but has no '## Automouse Hold Justification' section (Step 4.5 — record why the hold is reducible-confirmed or intrinsic)"
     fi
 fi
 

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -221,6 +221,33 @@ Phase 1 — Create `bin/foo` for the new tool.
 Phase 2 — Create ibl5/docs/decisions/0099-x.md documenting the decision.
 '
 
+# Gate H: a plan whose line-1 frontmatter declares `auto_merge: false` but has NO
+# `## Automouse Hold Justification` section must flag (exit 1).
+assert "gateH-hold-no-justification" 1 '---
+auto_merge: false
+---'"$M"
+
+# Gate H: the same hold WITH the justification section passes (exit 0).
+assert "gateH-hold-with-justification" 0 '---
+auto_merge: false
+---'"$M"'
+## Automouse Hold Justification
+
+Intrinsic (gate 14b): touched security surface — per-site authz verdicts are distributed across the diff.
+'
+
+# Gate H: no hold (frontmatter without `auto_merge: false`) — section absent is
+# fine, must NOT flag (exit 0).
+assert "gateH-no-hold-armed" 0 '---
+impl_model: sonnet
+---'"$M"
+
+# Gate H FP-guard: a plan that merely DOCUMENTS the `auto_merge: false` syntax in
+# its body (not in line-1 frontmatter) must NOT flag (exit 0).
+assert "gateH-body-mentions-syntax-only" 0 "$M"'
+Note: setting `auto_merge: false` in the line-1 frontmatter holds the merge.
+'
+
 if [ "$FAILED" -ne 0 ]; then
     echo "RESULT: FAILED"
     exit 1


### PR DESCRIPTION
## Why

Over recent sessions, false `auto_merge: false` verdicts from `/plan` have been getting dissolved by hand — re-prompting "what would you add to make this safe for automouse?" repeatedly turned an "unsafe" plan into an auto-mergeable one. The machinery to avoid those holds already exists in `/plan` (the 3 autonomy levers + Step 4 gates 14/15); the gap was **enforcement** — nothing forced the re-scrutiny on the first pass. This institutionalizes that manual second pass.

## What

- **Step 3 injection** — the plan-architect self-applies the challenge on its first draft (the verbatim forcing question), so the wrong "irreducible" anchor never forms.
- **Step 4.5 (new)** — orchestrator adversarial verify (Opus). Type-aware so it doesn't regress safety in either direction:
  - **Reducible** holds (verification gap, reversible schema tightening, CI/config "can't verify") → must be **dissolved** via mechanization *or* have infeasibility stated concretely. Both are passing outcomes — symmetric, not a one-way push to arm.
  - **Intrinsic** holds (subjective UI/UX, touched security surface, irreversibly-destructive / data-blocked, **self-gating change to the merge-gate machinery itself**) → name the category and stand. Deliberately **not** pressured.
- **`bin/check-plan` gate `[H]`** — presence backstop: any `auto_merge: false` plan must carry an `## Automouse Hold Justification` section. Frontmatter-scoped so a body that merely documents the syntax doesn't false-positive. Presence only — validity stays Opus judgment.
- **`bin/test-check-plan`** — 4 gate-H cases (fires / passes-with-section / armed-no-section / FP-guard).

## Validation

- `bin/test-check-plan` — all 24 cases pass (incl. 4 new).
- `shellcheck bin/check-plan` clean; `bin/check-docs --since=master` clean.
- No retroactive breakage: automouse execution uses `check-plan-staleness`, **not** `check-plan`, so the 18 existing held plans on disk are not re-linted.
- **Taxonomy validated against the real corpus** — hand-classified the held plans; 3 classify cleanly as intrinsic, 2 (`god-class-net-teamservice`, `gate-rebase-skip-storm`) are reducible false-holds the mechanism now catches, and `decouple-postplan-from-automerge` fit **no** bucket → surfaced the **self-gating / bootstrap-hazard** intrinsic category, added here.

## Notes

- Not arming auto-merge — workflow-rule change worth a human eyeball. (Also no plan file backs this branch; it wasn't a `/plan` run.)