### PR TITLE
ci: ratchet coverage gate from 70% to 80%

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
 
     - name: Check coverage threshold
       working-directory: ibl5
-      run: php bin/check-coverage coverage/clover.xml 70
+      run: php bin/check-coverage coverage/clover.xml 80
 
     - name: Check coverage regression
       working-directory: ibl5
@@ -130,7 +130,7 @@ jobs:
     - name: Check if threshold needs ratcheting
       working-directory: ibl5
       run: |
-        THRESHOLD=70
+        THRESHOLD=80
         BUFFER=5
         COVERAGE=$(php -r '
           $xml = simplexml_load_file("coverage/clover.xml");


### PR DESCRIPTION
## Summary

- Raises the CI coverage threshold check from 70% to 80%
- Updates both the `check-coverage` call and the ratchet-threshold variable in `tests.yml`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.ai/code)