### PR TITLE
test: close Axis 6 coverage gap for ContractListService (backlog 6.9)

### DIFF
--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1003,6 +1003,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Service CY salary mapping (cy1 vs cy2), cap aggregation, sort stability.
 **Est. effort:** M
 **Risk if untouched:** Wrong contract years displayed; cap off by year.
+**Status:** Completed (verified 2026-06-20) — `tests/ContractList/ContractListServiceTest.php` extended with cap2-6/acap2-6 math, cy=6 boundary, cy=4 full-vector, cy=0 years 4-6, and mixed-cy accumulation coverage.
 
 ### 6.10 FreeAgencyPreview — Thin (6 files, 2 tests)
 **Location:** `ibl5/classes/FreeAgencyPreview`

--- a/ibl5/tests/ContractList/ContractListServiceTest.php
+++ b/ibl5/tests/ContractList/ContractListServiceTest.php
@@ -134,6 +134,97 @@ class ContractListServiceTest extends TestCase
         $this->assertSame('Yes', $result['contracts'][0]['bird']);
     }
 
+    public function testCapTotalsAndAvgCapsAccumulateForAllSixYears(): void
+    {
+        $this->mockRepository->method('getActivePlayerContracts')->willReturn([
+            self::createPlayerContract([
+                'cy' => 0,
+                'salary_yr1' => 2800,
+                'salary_yr2' => 5600,
+                'salary_yr3' => 8400,
+                'salary_yr4' => 11200,
+                'salary_yr5' => 14000,
+                'salary_yr6' => 16800,
+            ]),
+        ]);
+
+        $result = $this->service->getContractsWithCalculations();
+
+        $this->assertEquals(28, $result['capTotals']['cap1']);
+        $this->assertEquals(56, $result['capTotals']['cap2']);
+        $this->assertEquals(84, $result['capTotals']['cap3']);
+        $this->assertEquals(112, $result['capTotals']['cap4']);
+        $this->assertEquals(140, $result['capTotals']['cap5']);
+        $this->assertEquals(168, $result['capTotals']['cap6']);
+        $this->assertEquals(1, $result['avgCaps']['acap1']);
+        $this->assertEquals(2, $result['avgCaps']['acap2']);
+        $this->assertEquals(3, $result['avgCaps']['acap3']);
+        $this->assertEquals(4, $result['avgCaps']['acap4']);
+        $this->assertEquals(5, $result['avgCaps']['acap5']);
+        $this->assertEquals(6, $result['avgCaps']['acap6']);
+    }
+
+    public function testDynamicMappingZeroesYearsBeyondSixAtCyBoundary(): void
+    {
+        $this->mockRepository->method('getActivePlayerContracts')->willReturn([
+            self::createPlayerContract(['cy' => 6, 'salary_yr1' => 111, 'salary_yr6' => 900]),
+        ]);
+
+        $result = $this->service->getContractsWithCalculations();
+
+        $this->assertSame(900, $result['contracts'][0]['con1']);
+        $this->assertSame(0, $result['contracts'][0]['con2']);
+        $this->assertSame(0, $result['contracts'][0]['con3']);
+        $this->assertSame(0, $result['contracts'][0]['con4']);
+        $this->assertSame(0, $result['contracts'][0]['con5']);
+        $this->assertSame(0, $result['contracts'][0]['con6']);
+    }
+
+    public function testDynamicMappingFullVectorForMidRangeCy(): void
+    {
+        $this->mockRepository->method('getActivePlayerContracts')->willReturn([
+            self::createPlayerContract(['cy' => 4, 'salary_yr4' => 400, 'salary_yr5' => 500, 'salary_yr6' => 600]),
+        ]);
+
+        $result = $this->service->getContractsWithCalculations();
+
+        $this->assertSame(400, $result['contracts'][0]['con1']);
+        $this->assertSame(500, $result['contracts'][0]['con2']);
+        $this->assertSame(600, $result['contracts'][0]['con3']);
+        $this->assertSame(0, $result['contracts'][0]['con4']);
+        $this->assertSame(0, $result['contracts'][0]['con5']);
+        $this->assertSame(0, $result['contracts'][0]['con6']);
+    }
+
+    public function testDirectMappingForCyZeroCoversYearsFourToSix(): void
+    {
+        $this->mockRepository->method('getActivePlayerContracts')->willReturn([
+            self::createPlayerContract(['cy' => 0, 'salary_yr4' => 400, 'salary_yr5' => 500, 'salary_yr6' => 600]),
+        ]);
+
+        $result = $this->service->getContractsWithCalculations();
+
+        $this->assertSame(400, $result['contracts'][0]['con4']);
+        $this->assertSame(500, $result['contracts'][0]['con5']);
+        $this->assertSame(600, $result['contracts'][0]['con6']);
+    }
+
+    public function testCapTotalsAccumulateAcrossMixedCyPlayers(): void
+    {
+        $this->mockRepository->method('getActivePlayerContracts')->willReturn([
+            self::createPlayerContract(['cy' => 0, 'salary_yr1' => 500, 'salary_yr2' => 700]),
+            self::createPlayerContract(['cy' => 3, 'salary_yr3' => 300, 'salary_yr4' => 400]),
+        ]);
+
+        $result = $this->service->getContractsWithCalculations();
+
+        // Player A: cy=0 → con1=500, con2=700
+        // Player B: cy=3 → year1=3→salary_yr3=300, year2=4→salary_yr4=400
+        // cap1 = (500+300)/100 = 8, cap2 = (700+400)/100 = 11
+        $this->assertEquals(8, $result['capTotals']['cap1']);
+        $this->assertEquals(11, $result['capTotals']['cap2']);
+    }
+
     /**
      * @param array<string, mixed> $overrides
      * @return array{pid: int, name: string, pos: string, teamname: string, teamid: int, cy: int, cyt: int, salary_yr1: int, salary_yr2: int, salary_yr3: int, salary_yr4: int, salary_yr5: int, salary_yr6: int, bird: string, team_city: string|null, color1: string|null, color2: string|null}


### PR DESCRIPTION
## Summary

Purely-additive, test-only PR. Extends `ibl5/tests/ContractList/ContractListServiceTest.php` with five new one-behavior-per-test methods that lock in current `ContractListService::getContractsWithCalculations()` behavior across four previously uncovered branches:

1. **cap2..cap6 / acap2..acap6 math** — single cy=0 player verifies all six cap totals (salary/100) and avg caps (salary/28/100)
2. **cy=6 dynamic-mapping boundary** — year1=salary_yr6, year2..year6=0 (years >= 7 zero out)
3. **cy=4 mid-range full con-vector crossover** — con1=400, con2=500, con3=600, con4..con6=0
4. **cy=0 direct mapping years 4-6** — con4=400, con5=500, con6=600 (existing tests only covered years 1-3)
5. **Mixed-cy multi-player accumulation** — cy=0 + cy=3 player cap totals sum correctly

Also marks backlog finding 6.9 as completed in `ibl5/docs/maintenance-backlog.md`.

**ZERO production code edited.** The service logic is already correct; these are characterization tests pinning current behavior.

**Security surface: none touched.** Test-only change — no SQL, no endpoint, no output rendering, no auth, no input handling.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.