### PR TITLE
fix(a11y): derive unique aria-label per standings region landmark

### DIFF
--- a/ibl5/classes/Standings/StandingsView.php
+++ b/ibl5/classes/Standings/StandingsView.php
@@ -266,7 +266,7 @@ class StandingsView implements StandingsViewInterface
         ?>
         <h2 class="ibl-title"><?= \Security\HtmlSanitizer::e($region) . ' ' . \Security\HtmlSanitizer::e($groupingType); ?></h2>
         <div class="table-scroll-wrapper">
-        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="<?= \Security\HtmlSanitizer::e($region) . ' ' . \Security\HtmlSanitizer::e($groupingType) . ' Standings'; ?>">
         <table class="sortable ibl-data-table">
             <thead>
                 <tr>

--- a/ibl5/docs/a11y-backlog.md
+++ b/ibl5/docs/a11y-backlog.md
@@ -64,11 +64,13 @@ last_verified: 2026-06-20
 **Direction:** CSS `min-height`/`min-width`/padding on the affected components.
 **Disposition:** 🟡 (CSS sizing changes risk **visual-regression baseline** breakage → needs VR review, `auto_merge: false`) **+ 🔵** (the small-count hits are sim-recap data-dependent; verify topics(100) on CI seed). Plan after a VR-aware human pass.
 
-### landmark-unique — best-practice, moderate — 🟡
-**Location:** standings (per-region scroll regions all `aria-label="Standings"`), league starters (`aria-label="Scrollable data table"` generic, ×2), next sim (`.next-sim-position-section` scroll regions share a label), schedule + team schedule (`.nav-grain` duplicate landmark).
-**Problem:** Multiple landmarks share the same role+name. Mixed root causes: (a) Standings — label *is* mechanically derivable from the existing `$region`/`$groupingType` vars; (b) league starters — generic default label needs a chosen per-table name; (c) `.nav-grain` — a nav-component element resolving to a duplicate landmark (needs investigation, likely affects the shared nav).
-**Direction:** Unique `aria-label` per region. Standings subset could be mechanical; the rest need judgment + the `.nav-grain` nav-component fix needs care (shared across all pages).
-**Disposition:** 🟡 — supervised (mixed label judgment + shared-nav blast radius; best-practice/moderate, not WCAG-AA).
+### landmark-unique — best-practice, moderate — 🟡 (standings subset ✅ enforced)
+**Location (remaining):** league starters (`aria-label="Scrollable data table"` generic, ×2), next sim (`.next-sim-position-section` scroll regions share a label), schedule + team schedule (`.nav-grain` duplicate landmark).
+**Problem:** Multiple landmarks share the same role+name. Remaining mixed root causes: (a) league starters — generic default label needs a chosen per-table name; (b) `.nav-grain` — a nav-component element resolving to a duplicate landmark (needs investigation, likely affects the shared nav across all pages).
+**Direction:** Unique `aria-label` per landmark. The remaining subsets need judgment (league-starters per-table name) + care (the `.nav-grain` nav-component fix is shared across all pages).
+**Disposition:** 🟡 — supervised for the remaining league-starters + `.nav-grain` subsets (mixed label judgment + shared-nav blast radius; best-practice/moderate, not WCAG-AA).
+
+**Standings subset — ✅ enforced.** Standings rendered one scroll-region landmark per region all labelled `aria-label="Standings"`; `StandingsView::renderHeader()` now derives a unique name from the in-scope `$region`/`$groupingType` vars (e.g. "Eastern Conference Standings", "Atlantic Division Standings"). Removed `'standings'` from `KNOWN_FAILING['landmark-unique']` in `accessibility.spec.ts` — the ratchet now enforces `landmark-unique` on the standings page.
 
 ### landmark-one-main — best-practice, moderate — 🟡
 **Location:** league control panel (`leagueControlPanel.php`), faprep (`faprep.php`).

--- a/ibl5/docs/a11y-backlog.md
+++ b/ibl5/docs/a11y-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: WCAG 2.x full-rule (non-contrast) accessibility failure inventory and burn-down backlog per axe rule. Companion to a11y-contrast-backlog.md.
-last_verified: 2026-06-20
+last_verified: 2026-06-21
 ---
 
 # A11y Full-Rule Backlog (non-contrast)

--- a/ibl5/tests/Standings/__snapshots__/render-full.html
+++ b/ibl5/tests/Standings/__snapshots__/render-full.html
@@ -1,6 +1,6 @@
         <h2 class="ibl-title">Eastern Conference</h2>
         <div class="table-scroll-wrapper">
-        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Eastern Conference Standings">
         <table class="sortable ibl-data-table">
             <thead>
                 <tr>
@@ -65,7 +65,7 @@
         </tr>
         </tbody></table></div></div>        <h2 class="ibl-title">Western Conference</h2>
         <div class="table-scroll-wrapper">
-        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Western Conference Standings">
         <table class="sortable ibl-data-table">
             <thead>
                 <tr>
@@ -92,7 +92,7 @@
             <tbody>
         </tbody></table></div></div>        <h2 class="ibl-title">Atlantic Division</h2>
         <div class="table-scroll-wrapper">
-        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Atlantic Division Standings">
         <table class="sortable ibl-data-table">
             <thead>
                 <tr>
@@ -157,7 +157,7 @@
         </tr>
         </tbody></table></div></div>        <h2 class="ibl-title">Central Division</h2>
         <div class="table-scroll-wrapper">
-        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Central Division Standings">
         <table class="sortable ibl-data-table">
             <thead>
                 <tr>
@@ -184,7 +184,7 @@
             <tbody>
         </tbody></table></div></div>        <h2 class="ibl-title">Midwest Division</h2>
         <div class="table-scroll-wrapper">
-        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Midwest Division Standings">
         <table class="sortable ibl-data-table">
             <thead>
                 <tr>
@@ -211,7 +211,7 @@
             <tbody>
         </tbody></table></div></div>        <h2 class="ibl-title">Pacific Division</h2>
         <div class="table-scroll-wrapper">
-        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Pacific Division Standings">
         <table class="sortable ibl-data-table">
             <thead>
                 <tr>

--- a/ibl5/tests/Standings/__snapshots__/renderRegion-eastern.html
+++ b/ibl5/tests/Standings/__snapshots__/renderRegion-eastern.html
@@ -1,6 +1,6 @@
         <h2 class="ibl-title">Eastern Conference</h2>
         <div class="table-scroll-wrapper">
-        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Standings">
+        <div class="table-scroll-container" tabindex="0" role="region" aria-label="Eastern Conference Standings">
         <table class="sortable ibl-data-table">
             <thead>
                 <tr>

--- a/ibl5/tests/e2e/smoke/accessibility.spec.ts
+++ b/ibl5/tests/e2e/smoke/accessibility.spec.ts
@@ -109,7 +109,6 @@ const KNOWN_FAILING: Record<string, Set<string>> = {
 
   // Multiple landmarks share role+name. See ibl5/docs/a11y-backlog.md §landmark-unique.
   'landmark-unique': new Set([
-    'standings',
     'league starters',
     'next sim',
     'schedule',


### PR DESCRIPTION
## Summary

Fixes axe `landmark-unique` for the standings page subset.

`StandingsView::renderHeader()` emits one `<div role="region">` landmark per standings region (per-conference / per-division loop). All of them shared the same hardcoded `aria-label="Standings"`, which axe `landmark-unique` flags as duplicate landmarks.

**Fix:** derive the accessible name from the `$region` and `$groupingType` variables already in scope, producing per-region names like "Eastern Conference Standings" / "Atlantic Division Standings" — unique per landmark. Uses the existing `\Security\HtmlSanitizer::e()` wrap (already on the `<h2>` one line above) to satisfy `RequireEscapedOutputRule`.

Removes `'standings'` from `KNOWN_FAILING['landmark-unique']` in `accessibility.spec.ts` — the ratchet now enforces `landmark-unique` on the standings page.

Updates `a11y-backlog.md` to mark the standings subset enforced; the remaining league-starters and `.nav-grain` subsets stay supervised backlog (explicitly out of scope).

## Changes

- `ibl5/classes/Standings/StandingsView.php` — `renderHeader()` line 269: replace hardcoded `aria-label="Standings"` with derived per-region value
- `ibl5/tests/e2e/smoke/accessibility.spec.ts` — remove `'standings'` from `KNOWN_FAILING['landmark-unique']`
- `ibl5/docs/a11y-backlog.md` — mark standings subset enforced; bump `last_verified`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---
Generated with [Claude Code](https://claude.ai/code)