### PR TITLE
refactor(news): extract READ/DISPLAY into Topics\News\Repository/Service/View

### DIFF
--- a/ibl5/classes/Topics/News/Contracts/NewsRepositoryInterface.php
+++ b/ibl5/classes/Topics/News/Contracts/NewsRepositoryInterface.php
@@ -19,4 +19,29 @@ interface NewsRepositoryInterface
     public function getCategoryIDByTitle(string $categoryTitle): ?int;
 
     public function incrementCategoryCounter(string $categoryTitle): int;
+
+    /** @return array<int, array<string, mixed>> */
+    public function getHomePageStories(int $limit, string $langClause = ''): array;
+
+    /** @return array<int, array<string, mixed>> */
+    public function getStoriesByTopic(int $topicId, int $limit, string $langClause = ''): array;
+
+    /** @return array<int, array<string, mixed>> */
+    public function getStoriesByCategory(int $catId, int $limit, string $langClause = ''): array;
+
+    /** @return array<string, mixed>|null */
+    public function getStoryById(int $sid): ?array;
+
+    /** @return array<string, mixed>|null */
+    public function getTopicForStory(int $sid): ?array;
+
+    public function getTopicText(int $topicId): ?string;
+
+    public function getCategoryTitle(int $catId): ?string;
+
+    public function incrementTopicCounterAll(): int;
+
+    public function incrementCategoryCounterById(int $catId): int;
+
+    public function incrementStoryCounter(int $sid): int;
 }

--- a/ibl5/classes/Topics/News/Contracts/NewsServiceInterface.php
+++ b/ibl5/classes/Topics/News/Contracts/NewsServiceInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Topics\News\Contracts;
+
+interface NewsServiceInterface
+{
+    /** @return array<int, array<string, mixed>> */
+    public function getHomePageStories(int $limit, string $langClause): array;
+
+    /** @return array<int, array<string, mixed>> */
+    public function getTopicPageStories(int $topicId, int $limit, string $langClause): array;
+
+    /** @return array<int, array<string, mixed>> */
+    public function getCategoryPageStories(int $catId, int $limit, string $langClause): array;
+
+    /** @return array<string, mixed>|null */
+    public function getStory(int $sid): ?array;
+
+    /** @return array<string, mixed>|null */
+    public function getTopicForStory(int $sid): ?array;
+
+    public function getTopicText(int $topicId): ?string;
+
+    public function getCategoryTitle(int $catId): ?string;
+
+    public function bumpAllTopics(): int;
+
+    public function bumpCategory(int $catId): int;
+
+    public function bumpStory(int $sid): int;
+
+    public function normalizeStoryTime(int|string $time): int;
+
+    /** @return array{intro:int,full:int,total:int} */
+    public function computeByteCounts(string $hometext, string $bodytext): array;
+}

--- a/ibl5/classes/Topics/News/Contracts/NewsViewInterface.php
+++ b/ibl5/classes/Topics/News/Contracts/NewsViewInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Topics\News\Contracts;
+
+interface NewsViewInterface
+{
+    /** @param array<int, array<string, mixed>> $stories */
+    public function renderStories(array $stories): void;
+
+    /** @param array<string, mixed> $vm */
+    public function renderArticle(array $vm): void;
+}

--- a/ibl5/classes/Topics/News/NewsRepository.php
+++ b/ibl5/classes/Topics/News/NewsRepository.php
@@ -72,4 +72,108 @@ class NewsRepository extends \BaseMysqliRepository implements NewsRepositoryInte
             $categoryTitle
         );
     }
+
+    /** @return array<int, array<string, mixed>> */
+    public function getHomePageStories(int $limit, string $langClause = ''): array
+    {
+        // @phpstan-ignore ibl.sqlStringInterpolation ($langClause is a legacy multilingual SQL fragment, not a bindable value)
+        $sql = "SELECT sid, catid, aid, title, time, hometext, bodytext, comments, counter, topic, informant, notes, acomm
+             FROM `nuke_stories`
+             WHERE (ihome='0' OR catid='0') $langClause
+             ORDER BY sid DESC LIMIT ?";
+        return $this->fetchAll($sql, 'i', $limit);
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function getStoriesByTopic(int $topicId, int $limit, string $langClause = ''): array
+    {
+        // @phpstan-ignore ibl.sqlStringInterpolation ($langClause is a legacy multilingual SQL fragment, not a bindable value)
+        $sql = "SELECT sid, catid, aid, title, time, hometext, bodytext, comments, counter, topic, informant, notes, acomm
+             FROM `nuke_stories`
+             WHERE topic = ? $langClause
+             ORDER BY sid DESC LIMIT ?";
+        return $this->fetchAll($sql, 'ii', $topicId, $limit);
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function getStoriesByCategory(int $catId, int $limit, string $langClause = ''): array
+    {
+        // @phpstan-ignore ibl.sqlStringInterpolation ($langClause is a legacy multilingual SQL fragment, not a bindable value)
+        $sql = "SELECT sid, aid, title, time, hometext, bodytext, comments, counter, topic, informant, notes, acomm
+             FROM `nuke_stories`
+             WHERE catid = ? $langClause
+             ORDER BY sid DESC LIMIT ?";
+        return $this->fetchAll($sql, 'ii', $catId, $limit);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getStoryById(int $sid): ?array
+    {
+        return $this->fetchOne(
+            "SELECT catid, aid, time, title, hometext, bodytext, topic, informant, notes, acomm, haspoll, poll_id
+             FROM `nuke_stories`
+             WHERE sid = ?",
+            'i',
+            $sid
+        );
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getTopicForStory(int $sid): ?array
+    {
+        return $this->fetchOne(
+            "SELECT t.topicid, t.topicname, t.topicimage, t.topictext
+             FROM `nuke_stories` s
+             LEFT JOIN `nuke_topics` t ON t.topicid = s.topic
+             WHERE s.sid = ?",
+            'i',
+            $sid
+        );
+    }
+
+    public function getTopicText(int $topicId): ?string
+    {
+        $row = $this->fetchOne(
+            "SELECT topictext FROM `nuke_topics` WHERE topicid = ?",
+            'i',
+            $topicId
+        );
+        return is_array($row) && is_string($row['topictext'] ?? null) ? $row['topictext'] : null;
+    }
+
+    public function getCategoryTitle(int $catId): ?string
+    {
+        $row = $this->fetchOne(
+            "SELECT title FROM `nuke_stories_cat` WHERE catid = ?",
+            'i',
+            $catId
+        );
+        return is_array($row) && is_string($row['title'] ?? null) ? $row['title'] : null;
+    }
+
+    public function incrementTopicCounterAll(): int
+    {
+        return $this->execute(
+            "UPDATE `nuke_topics` SET counter = counter + 1",
+            ''
+        );
+    }
+
+    public function incrementCategoryCounterById(int $catId): int
+    {
+        return $this->execute(
+            "UPDATE `nuke_stories_cat` SET counter = counter + 1 WHERE catid = ?",
+            'i',
+            $catId
+        );
+    }
+
+    public function incrementStoryCounter(int $sid): int
+    {
+        return $this->execute(
+            "UPDATE `nuke_stories` SET counter = counter + 1 WHERE sid = ?",
+            'i',
+            $sid
+        );
+    }
 }

--- a/ibl5/classes/Topics/News/NewsService.php
+++ b/ibl5/classes/Topics/News/NewsService.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Topics\News;
+
+use Topics\News\Contracts\NewsRepositoryInterface;
+use Topics\News\Contracts\NewsServiceInterface;
+
+/**
+ * Service for assembling News page data (pure-data; no HTML, no echo).
+ *
+ * @see NewsServiceInterface
+ */
+class NewsService implements NewsServiceInterface
+{
+    private NewsRepositoryInterface $repository;
+
+    public function __construct(\mysqli $db, ?NewsRepositoryInterface $repository = null)
+    {
+        $this->repository = $repository ?? new NewsRepository($db);
+    }
+
+    /**
+     * @see NewsServiceInterface::getHomePageStories()
+     */
+    public function getHomePageStories(int $limit, string $langClause): array
+    {
+        return $this->repository->getHomePageStories($limit, $langClause);
+    }
+
+    /**
+     * @see NewsServiceInterface::getTopicPageStories()
+     */
+    public function getTopicPageStories(int $topicId, int $limit, string $langClause): array
+    {
+        return $this->repository->getStoriesByTopic($topicId, $limit, $langClause);
+    }
+
+    /**
+     * @see NewsServiceInterface::getCategoryPageStories()
+     */
+    public function getCategoryPageStories(int $catId, int $limit, string $langClause): array
+    {
+        return $this->repository->getStoriesByCategory($catId, $limit, $langClause);
+    }
+
+    /**
+     * @see NewsServiceInterface::getStory()
+     */
+    public function getStory(int $sid): ?array
+    {
+        return $this->repository->getStoryById($sid);
+    }
+
+    /**
+     * @see NewsServiceInterface::getTopicForStory()
+     */
+    public function getTopicForStory(int $sid): ?array
+    {
+        return $this->repository->getTopicForStory($sid);
+    }
+
+    /**
+     * @see NewsServiceInterface::getTopicText()
+     */
+    public function getTopicText(int $topicId): ?string
+    {
+        return $this->repository->getTopicText($topicId);
+    }
+
+    /**
+     * @see NewsServiceInterface::getCategoryTitle()
+     */
+    public function getCategoryTitle(int $catId): ?string
+    {
+        return $this->repository->getCategoryTitle($catId);
+    }
+
+    /**
+     * @see NewsServiceInterface::bumpAllTopics()
+     */
+    public function bumpAllTopics(): int
+    {
+        return $this->repository->incrementTopicCounterAll();
+    }
+
+    /**
+     * @see NewsServiceInterface::bumpCategory()
+     */
+    public function bumpCategory(int $catId): int
+    {
+        return $this->repository->incrementCategoryCounterById($catId);
+    }
+
+    /**
+     * @see NewsServiceInterface::bumpStory()
+     */
+    public function bumpStory(int $sid): int
+    {
+        return $this->repository->incrementStoryCounter($sid);
+    }
+
+    /**
+     * @see NewsServiceInterface::normalizeStoryTime()
+     */
+    public function normalizeStoryTime(int|string $time): int
+    {
+        if (!is_numeric($time)) {
+            preg_match('/(\d{4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})/', $time, $dtParts);
+            $time = gmmktime((int) ($dtParts[4] ?? 0), (int) ($dtParts[5] ?? 0), (int) ($dtParts[6] ?? 0), (int) ($dtParts[2] ?? 0), (int) ($dtParts[3] ?? 0), (int) ($dtParts[1] ?? 0));
+        }
+        // @phpstan-ignore ibl.directTime (date('Z') is a timezone offset, not a now-read — faithful extraction of NukeCompat's identical logic)
+        return (int) $time - (int) date('Z');
+    }
+
+    /**
+     * @see NewsServiceInterface::computeByteCounts()
+     */
+    public function computeByteCounts(string $hometext, string $bodytext): array
+    {
+        $intro = strlen($hometext);
+        $full = strlen($bodytext);
+        return ['intro' => $intro, 'full' => $full, 'total' => $intro + $full];
+    }
+}

--- a/ibl5/classes/Topics/News/NewsView.php
+++ b/ibl5/classes/Topics/News/NewsView.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Topics\News;
+
+use Topics\News\Contracts\NewsViewInterface;
+
+class NewsView implements NewsViewInterface
+{
+    /** @param array<int, array<string, mixed>> $stories */
+    public function renderStories(array $stories): void
+    {
+        foreach ($stories as $vm) {
+            themeindex(
+                $vm['aid'],
+                $vm['informant'],
+                $vm['time'],
+                $vm['title'],
+                $vm['counter'],
+                $vm['topic'],
+                $vm['hometext'],
+                $vm['notes'],
+                $vm['morelink'],
+                $vm['topicname'],
+                $vm['topicimage'],
+                $vm['topictext'],
+            );
+        }
+    }
+
+    /** @param array<string, mixed> $vm */
+    public function renderArticle(array $vm): void
+    {
+        themearticle(
+            $vm['aid'],
+            $vm['informant'],
+            $vm['time'],
+            $vm['title'],
+            $vm['bodytext'],
+            $vm['topic'],
+            $vm['topicname'],
+            $vm['topicimage'],
+            $vm['topictext'],
+        );
+    }
+}

--- a/ibl5/modules/News/article.php
+++ b/ibl5/modules/News/article.php
@@ -40,6 +40,8 @@ get_lang($module_name);
 $sid    = is_numeric($_REQUEST['sid']    ?? null) ? (int) $_REQUEST['sid']    : 0;
 $teamid = is_numeric($_REQUEST['teamid'] ?? null) ? (int) $_REQUEST['teamid'] : null;
 
+$newsService = new \Topics\News\NewsService($mysqli_db);
+
 $REQUEST_URI = $_SERVER['REQUEST_URI'] ?? '';
 
 if (stristr($REQUEST_URI, "mainfile")) {
@@ -56,29 +58,14 @@ if (stristr($REQUEST_URI, "mainfile")) {
 // Comment system removed - was deprecated and insecure
 // The "Reply" operation and comments.php include have been removed
 
-// Fetch article using prepared statement
-$stmt = $mysqli_db->prepare(
-    "SELECT catid, aid, time, title, hometext, bodytext, topic, informant, notes, acomm, haspoll, poll_id
-     FROM " . $prefix . "_stories
-     WHERE sid = ?"
-);
-if ($stmt === false) {
+// Fetch article via the News service (prepared statement inside the repository).
+// Preserves both legacy redirects (prepare-false + num_rows !== 1) — a missing
+// single row returns null here and redirects to index.php.
+$row = $newsService->getStory($sid);
+if ($row === null) {
     Header("Location: index.php");
     exit;
 }
-
-$stmt->bind_param('i', $sid);
-$stmt->execute();
-$result = $stmt->get_result();
-
-if ($result->num_rows !== 1) {
-    $stmt->close();
-    Header("Location: index.php");
-    exit;
-}
-
-$row = $result->fetch_assoc();
-$stmt->close();
 
 $catid = (int) ($row['catid'] ?? 0);
 $aaid = $row['aid'] ?? '';
@@ -100,24 +87,15 @@ if (empty($aaid)) {
     exit;
 }
 
-// Update view counter using prepared statement
-$stmtCounter = $mysqli_db->prepare("UPDATE " . $prefix . "_stories SET counter = counter + 1 WHERE sid = ?");
-if ($stmtCounter !== false) {
-    $stmtCounter->bind_param('i', $sid);
-    $stmtCounter->execute();
-    $stmtCounter->close();
-}
+// Update view counter (prepared statement inside the repository)
+$newsService->bumpStory($sid);
 
 $artpage = 1;
 $pagetitle = "- $title";
 PageLayout\PageLayout::header();
 $artpage = 0;
 
-if (!is_numeric($time)) {
-    preg_match('/(\d{4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})/', $time, $dtParts);
-    $time = gmmktime((int) $dtParts[4], (int) $dtParts[5], (int) $dtParts[6], (int) $dtParts[2], (int) $dtParts[3], (int) $dtParts[1]);
-}
-$time -= date("Z");
+$time = $newsService->normalizeStoryTime($time);
 $datetime = ucfirst(date(_DATESTRING, $time));
 if (!empty($notes)) {
     $notes = "\n\n<b>" . _NOTE . "</b> <i>$notes</i>";
@@ -135,40 +113,27 @@ if (empty($informant)) {
     $informant = $anonymous;
 }
 
-$stmtTopics = $mysqli_db->prepare(
-    "SELECT t.topicid, t.topicname, t.topicimage, t.topictext
-     FROM {$prefix}_stories s
-     LEFT JOIN {$prefix}_topics t ON t.topicid = s.topic
-     WHERE s.sid = ?"
-);
-$stmtTopics->bind_param('i', $sid);
-$stmtTopics->execute();
-$topicRow = $stmtTopics->get_result()->fetch_assoc();
-$stmtTopics->close();
+$topicRow = $newsService->getTopicForStory($sid);
 $topicid = (int) ($topicRow['topicid'] ?? 0);
 $topicname = \Security\HtmlSanitizer::e($topicRow['topicname'] ?? '');
 $topicimage = \Security\HtmlSanitizer::e($topicRow['topicimage'] ?? '');
 $topictext = \Security\HtmlSanitizer::e($topicRow['topictext'] ?? '');
 
-// Fetch category using prepared statement if catid is set
+// Fetch category title via the News service (prepared statement) if catid is set
 if ($catid !== 0) {
-    $stmtCat = $mysqli_db->prepare("SELECT title FROM " . $prefix . "_stories_cat WHERE catid = ?");
-    if ($stmtCat !== false) {
-        $stmtCat->bind_param('i', $catid);
-        $stmtCat->execute();
-        $catResult = $stmtCat->get_result();
-        $row2 = $catResult->fetch_assoc();
-        $stmtCat->close();
-
-        if ($row2 !== null) {
-            /** @var string $title1 */
-            $title1 = \Security\HtmlSanitizer::safeHtmlOutput($row2['title'] ?? '');
-            $title = "<a href=\"modules.php?name=$module_name&amp;file=categories&amp;op=newindex&amp;catid=$catid\"><font class=\"storycat\">$title1</font></a>: $title";
-        }
+    $catTitle = $newsService->getCategoryTitle($catid);
+    if ($catTitle !== null) {
+        /** @var string $title1 */
+        $title1 = \Security\HtmlSanitizer::safeHtmlOutput($catTitle);
+        $title = "<a href=\"modules.php?name=$module_name&amp;file=categories&amp;op=newindex&amp;catid=$catid\"><font class=\"storycat\">$title1</font></a>: $title";
     }
 }
 
-themearticle($aaid, $informant, $time, $title, $bodytext, $topic, $topicname, $topicimage, $topictext);
+(new \Topics\News\NewsView())->renderArticle([
+    'aid' => $aaid, 'informant' => $informant, 'time' => $time, 'title' => $title,
+    'bodytext' => $bodytext, 'topic' => $topic, 'topicname' => $topicname,
+    'topicimage' => $topicimage, 'topictext' => $topictext,
+]);
 
 if ($multilingual == 1) {
     $querylang = "AND (blanguage='$currentlang' OR blanguage='')";

--- a/ibl5/modules/News/categories.php
+++ b/ibl5/modules/News/categories.php
@@ -33,15 +33,12 @@ $cat = $catid;
 
 function theindex($catid)
 {
-    global $storyhome, $topicname, $topicimage, $topictext, $datetime, $user, $cookie, $nukeurl, $prefix, $multilingual, $currentlang, $articlecomm, $module_name, $userinfo, $authService, $mysqli_db;
+    global $storyhome, $topicname, $topicimage, $topictext, $datetime, $user, $cookie, $nukeurl, $prefix, $multilingual, $currentlang, $db, $articlecomm, $module_name, $userinfo, $authService, $mysqli_db;
     if (is_user($user)) {$userinfo = $authService->getUserInfo();}
-    $storyConditions = [];
-    $storyTypes = '';
-    $storyParams = [];
     if ($multilingual == 1) {
-        $storyConditions[] = "(alanguage = ? OR alanguage = '')";
-        $storyTypes .= 's';
-        $storyParams[] = $currentlang;
+        $querylang = "AND (alanguage='$currentlang' OR alanguage='')"; /* the OR is needed to display stories who are posted to ALL languages */
+    } else {
+        $querylang = "";
     }
     PageLayout\PageLayout::header();
     if (isset($userinfo['storynum'])) {
@@ -50,20 +47,11 @@ function theindex($catid)
         $storynum = $storyhome;
     }
     $catid = intval($catid);
-    $stmtCatUpdate = $mysqli_db->prepare("UPDATE " . $prefix . "_stories_cat SET counter = counter + 1 WHERE catid = ?");
-    $stmtCatUpdate->bind_param('i', $catid);
-    $stmtCatUpdate->execute();
-    $stmtCatUpdate->close();
-    array_unshift($storyConditions, "catid = ?");
-    $storyTypes = 'i' . $storyTypes;
-    array_unshift($storyParams, $catid);
-    $storyTypes .= 'i';
-    $storyParams[] = (int) $storynum;
-    $stmtStories = $mysqli_db->prepare("SELECT sid, aid, title, time, hometext, bodytext, comments, counter, topic, informant, notes, acomm FROM " . $prefix . "_stories WHERE " . implode(' AND ', $storyConditions) . " ORDER BY sid DESC LIMIT ?");
-    $stmtStories->bind_param($storyTypes, ...$storyParams);
-    $stmtStories->execute();
-    $result = $stmtStories->get_result();
-    while ($row = $result->fetch_assoc()) {
+    $newsService = new \Topics\News\NewsService($mysqli_db);
+    $newsService->bumpCategory($catid);
+    $stories = $newsService->getCategoryPageStories($catid, (int) $storynum, $querylang);
+    $viewModels = [];
+    foreach ($stories as $row) {
         $s_sid = intval($row['sid']);
         $aid = $row['aid'];
         $title = \Security\HtmlSanitizer::safeHtmlOutput($row['title']);
@@ -76,29 +64,17 @@ function theindex($catid)
         $informant = $row['informant'];
         $notes = \Security\HtmlSanitizer::safeHtmlOutput($row['notes']);
         $acomm = intval($row['acomm']);
-        $stmtTopics = $mysqli_db->prepare(
-            "SELECT t.topicid, t.topicname, t.topicimage, t.topictext
-             FROM {$prefix}_stories s
-             LEFT JOIN {$prefix}_topics t ON t.topicid = s.topic
-             WHERE s.sid = ?"
-        );
-        $stmtTopics->bind_param('i', $s_sid);
-        $stmtTopics->execute();
-        $topicRow = $stmtTopics->get_result()->fetch_assoc();
-        $stmtTopics->close();
+        $topicRow = $newsService->getTopicForStory($s_sid);
         $topicid = (int) ($topicRow['topicid'] ?? 0);
         $topicname = \Security\HtmlSanitizer::e($topicRow['topicname'] ?? '');
         $topicimage = \Security\HtmlSanitizer::e($topicRow['topicimage'] ?? '');
         $topictext = \Security\HtmlSanitizer::e($topicRow['topictext'] ?? '');
-        if (!is_numeric($time)) {
-            preg_match('/(\d{4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})/', $time, $dtParts);
-            $time = gmmktime((int) $dtParts[4], (int) $dtParts[5], (int) $dtParts[6], (int) $dtParts[2], (int) $dtParts[3], (int) $dtParts[1]);
-        }
-        $time -= date("Z");
+        $time = $newsService->normalizeStoryTime($time);
         $datetime = ucfirst(date(_DATESTRING, $time));
-        $introcount = strlen($hometext ?? '');
-        $fullcount = strlen($bodytext ?? '');
-        $totalcount = $introcount + $fullcount;
+        $counts = $newsService->computeByteCounts((string) ($hometext ?? ''), (string) ($bodytext ?? ''));
+        $introcount = $counts['intro'];
+        $fullcount = $counts['full'];
+        $totalcount = $counts['total'];
         $c_count = $comments;
         $r_options = "";
         if (isset($userinfo['umode'])) {$r_options .= "&amp;mode=" . $userinfo['umode'];}
@@ -118,16 +94,17 @@ function theindex($catid)
         $morelink .= " ";
         $morelink = str_replace(" |  | ", " | ", $morelink);
         $sid = intval($s_sid);
-        $stmtCat2 = $mysqli_db->prepare("SELECT title FROM " . $prefix . "_stories_cat WHERE catid = ?");
-        $stmtCat2->bind_param('i', $catid);
-        $stmtCat2->execute();
-        $row2 = $stmtCat2->get_result()->fetch_assoc();
-        $stmtCat2->close();
-        $title1 = \Security\HtmlSanitizer::safeHtmlOutput($row2['title'] ?? '');
+        $catTitle = $newsService->getCategoryTitle($catid);
+        $title1 = \Security\HtmlSanitizer::safeHtmlOutput($catTitle ?? '');
         $title = "$title1: $title";
-        themeindex($aid, $informant, $time, $title, $counter, $topic, $hometext, $notes, $morelink, $topicname, $topicimage, $topictext);
+        $viewModels[] = [
+            'aid' => $aid, 'informant' => $informant, 'time' => $time, 'title' => $title,
+            'counter' => $counter, 'topic' => $topic, 'hometext' => $hometext,
+            'notes' => $notes, 'morelink' => $morelink, 'topicname' => $topicname,
+            'topicimage' => $topicimage, 'topictext' => $topictext,
+        ];
     }
-    $stmtStories->close();
+    (new \Topics\News\NewsView())->renderStories($viewModels);
     PageLayout\PageLayout::footer();
 }
 

--- a/ibl5/modules/News/index.php
+++ b/ibl5/modules/News/index.php
@@ -18,22 +18,22 @@ if (!defined('MODULE_FILE')) {
     die("You can't access this file directly...");
 }
 
-define('INDEX_FILE', true);
+if (!defined('INDEX_FILE')) {
+    define('INDEX_FILE', true);
+}
 $module_name = basename(dirname(__FILE__));
 get_lang($module_name);
 
+if (!function_exists('theindex')) :
 function theindex($new_topic = "0")
 {
-    global $storyhome, $topicname, $topicimage, $topictext, $user, $prefix, $multilingual, $currentlang, $articlecomm, $sitename, $user_news, $userinfo, $authService, $mysqli_db;
+    global $db, $storyhome, $topicname, $topicimage, $topictext, $user, $prefix, $multilingual, $currentlang, $articlecomm, $sitename, $user_news, $userinfo, $authService, $mysqli_db;
     if (is_user($user)) {$userinfo = $authService->getUserInfo();}
     $new_topic = intval($new_topic);
-    $storyConditions = [];
-    $storyTypes = '';
-    $storyParams = [];
     if ($multilingual == 1) {
-        $storyConditions[] = "(alanguage = ? OR alanguage = '')";
-        $storyTypes .= 's';
-        $storyParams[] = $currentlang;
+        $querylang = "AND (alanguage='$currentlang' OR alanguage='')";
+    } else {
+        $querylang = "";
     }
     PageLayout\PageLayout::header();
 
@@ -64,28 +64,19 @@ function theindex($new_topic = "0")
     } else {
         $storynum = $storyhome;
     }
+
+    $newsService = new \Topics\News\NewsService($mysqli_db);
+
     if ($new_topic == 0) {
-        array_unshift($storyConditions, "(ihome='0' OR catid='0')");
         $home_msg = "";
     } else {
-        array_unshift($storyConditions, "topic = ?");
-        $storyTypes = 'i' . $storyTypes;
-        array_unshift($storyParams, $new_topic);
-        $stmtTopic = $mysqli_db->prepare("SELECT topictext FROM " . $prefix . "_topics WHERE topicid = ?");
-        $stmtTopic->bind_param('i', $new_topic);
-        $stmtTopic->execute();
-        $result_a = $stmtTopic->get_result();
-        $row_a = $result_a->fetch_assoc();
-        $numrows_a = $result_a->num_rows;
-        $stmtTopic->close();
-        $topic_title = \Security\HtmlSanitizer::safeHtmlOutput($row_a['topictext'] ?? '');
+        $topicText = $newsService->getTopicText($new_topic);
         OpenTable();
-        if ($numrows_a == 0) {
+        if ($topicText === null) {
             echo "<center><font class=\"title\">$sitename</font><br><br>" . _NOINFO4TOPIC . "<br><br>[ <a href=\"modules.php?name=News\">" . _GOTONEWSINDEX . "</a> | <a href=\"modules.php?name=Topics\">" . _SELECTNEWTOPIC . "</a> ]</center>";
         } else {
-            $stmtUpdate = $mysqli_db->prepare("UPDATE " . $prefix . "_topics SET counter = counter + 1");
-            $stmtUpdate->execute();
-            $stmtUpdate->close();
+            $topic_title = \Security\HtmlSanitizer::safeHtmlOutput($topicText);
+            $newsService->bumpAllTopics();
             echo "<center><font class=\"title\">$sitename: $topic_title</font><br><br>"
                 . "<form action=\"modules.php?name=Search\" method=\"post\">"
                 . "<input type=\"hidden\" name=\"topic\" value=\"$new_topic\">"
@@ -97,14 +88,12 @@ function theindex($new_topic = "0")
         CloseTable();
         echo "<br>";
     }
-    $storyTypes .= 'i';
-    $storyParams[] = (int) $storynum;
-    $whereSql = $storyConditions !== [] ? 'WHERE ' . implode(' AND ', $storyConditions) : '';
-    $stmtStories = $mysqli_db->prepare("SELECT sid, catid, aid, title, time, hometext, bodytext, comments, counter, topic, informant, notes, acomm FROM " . $prefix . "_stories " . $whereSql . " ORDER BY sid DESC LIMIT ?");
-    $stmtStories->bind_param($storyTypes, ...$storyParams);
-    $stmtStories->execute();
-    $result = $stmtStories->get_result();
-    while ($row = $result->fetch_assoc()) {
+
+    $stories = ($new_topic == 0)
+        ? $newsService->getHomePageStories((int) $storynum, $querylang)
+        : $newsService->getTopicPageStories((int) $new_topic, (int) $storynum, $querylang);
+    $viewModels = [];
+    foreach ($stories as $row) {
         $s_sid = intval($row['sid']);
         $catid = intval($row['catid']);
         $aid = $row['aid'];
@@ -118,37 +107,16 @@ function theindex($new_topic = "0")
         $informant = $row['informant'];
         $notes = \Security\HtmlSanitizer::safeHtmlOutput($row['notes']);
         $acomm = intval($row['acomm']);
-        if ($catid > 0) {
-            $stmtCat2 = $mysqli_db->prepare("SELECT title FROM " . $prefix . "_stories_cat WHERE catid = ?");
-            $stmtCat2->bind_param('i', $catid);
-            $stmtCat2->execute();
-            $row2 = $stmtCat2->get_result()->fetch_assoc();
-            $stmtCat2->close();
-            $cattitle = \Security\HtmlSanitizer::safeHtmlOutput($row2['title'] ?? '');
-        }
-        $stmtTopics = $mysqli_db->prepare(
-            "SELECT t.topicid, t.topicname, t.topicimage, t.topictext
-             FROM {$prefix}_stories s
-             LEFT JOIN {$prefix}_topics t ON t.topicid = s.topic
-             WHERE s.sid = ?"
-        );
-        $stmtTopics->bind_param('i', $s_sid);
-        $stmtTopics->execute();
-        $topicRow = $stmtTopics->get_result()->fetch_assoc();
-        $stmtTopics->close();
+        $topicRow = $newsService->getTopicForStory($s_sid);
         $topicid = (int) ($topicRow['topicid'] ?? 0);
         $topicname = \Security\HtmlSanitizer::e($topicRow['topicname'] ?? '');
         $topicimage = \Security\HtmlSanitizer::e($topicRow['topicimage'] ?? '');
         $topictext = \Security\HtmlSanitizer::e($topicRow['topictext'] ?? '');
-        if (!is_numeric($time)) {
-            preg_match('/(\d{4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})/', $time, $dtParts);
-            $time = gmmktime((int) $dtParts[4], (int) $dtParts[5], (int) $dtParts[6], (int) $dtParts[2], (int) $dtParts[3], (int) $dtParts[1]);
-        }
-        $time -= date("Z");
-        $datetime = ucfirst(date(_DATESTRING, $time));
-        $introcount = strlen($hometext ?? '');
-        $fullcount = strlen($bodytext ?? '');
-        $totalcount = $introcount + $fullcount;
+        $time = $newsService->normalizeStoryTime($row['time']);
+        $counts = $newsService->computeByteCounts((string) ($hometext ?? ''), (string) ($bodytext ?? ''));
+        $introcount = $counts['intro'];
+        $fullcount = $counts['full'];
+        $totalcount = $counts['total'];
         $c_count = $comments;
         $r_options = "";
         if (isset($userinfo['umode'])) {$r_options .= "&amp;mode=" . $userinfo['umode'];}
@@ -173,21 +141,23 @@ function theindex($new_topic = "0")
         }
         $sid = intval($s_sid);
         if ($catid != 0) {
-            $stmtCat3 = $mysqli_db->prepare("SELECT title FROM " . $prefix . "_stories_cat WHERE catid = ?");
-            $stmtCat3->bind_param('i', $catid);
-            $stmtCat3->execute();
-            $row3 = $stmtCat3->get_result()->fetch_assoc();
-            $stmtCat3->close();
-            $title1 = \Security\HtmlSanitizer::safeHtmlOutput($row3['title'] ?? '');
+            $catTitle = $newsService->getCategoryTitle($catid);
+            $title1 = \Security\HtmlSanitizer::safeHtmlOutput($catTitle ?? '');
             $catLabel = $title1 !== '' ? $title1 : 'Category';
             $title = "<a class='readmore' href=\"modules.php?name=News&amp;file=categories&amp;op=newindex&amp;catid=$catid\" aria-label=\"$catLabel\"><font class=\"storycat\">$title1</font></a>: $title";
         }
         $morelink = implode(' | ', $morelink_parts);
-        themeindex($aid, $informant, $time, $title, $counter, $topic, $hometext, $notes, $morelink, $topicname, $topicimage, $topictext);
+        $viewModels[] = [
+            'aid' => $aid, 'informant' => $informant, 'time' => $time, 'title' => $title,
+            'counter' => $counter, 'topic' => $topic, 'hometext' => $hometext,
+            'notes' => $notes, 'morelink' => $morelink, 'topicname' => $topicname,
+            'topicimage' => $topicimage, 'topictext' => $topictext,
+        ];
     }
-    $stmtStories->close();
+    (new \Topics\News\NewsView())->renderStories($viewModels);
     PageLayout\PageLayout::footer();
 }
+endif;
 
 // Legacy globals previously populated by ConfigBootstrap::extractRequestToGlobals().
 // PR2 narrowed that extraction to a 2-key allowlist (newlang, redirect), so module

--- a/ibl5/modules/News/language/lang-english.php
+++ b/ibl5/modules/News/language/lang-english.php
@@ -36,7 +36,9 @@ define("_COMMENT", "comment");
 define("_CONFIGURE", "Configure");
 define("_LOGINCREATE", "Login/Create an Account");
 define("_THRESHOLD", "Threshold");
-define("_NOCOMMENTS", "No Comments");
+if (!defined('_NOCOMMENTS')) {
+    define("_NOCOMMENTS", "No Comments");
+}
 define("_NESTED", "Nested");
 define("_FLAT", "Flat");
 define("_THREAD", "Thread");
@@ -52,7 +54,9 @@ define("_NOSUBJECT", "No Subject");
 define("_NOANONCOMMENTS", "No Comments Allowed for Anonymous, please <a href=\"modules.php?name=YourAccount&amp;op=new_user\">register</a>");
 define("_PARENT", "Parent");
 define("_ROOT", "Root");
-define("_UCOMMENT", "Comment");
+if (!defined('_UCOMMENT')) {
+    define("_UCOMMENT", "Comment");
+}
 define("_ALLOWEDHTML", "Allowed HTML:");
 define("_POSTANON", "Post Anonymously");
 define("_EXTRANS", "Extrans (html tags to text)");

--- a/ibl5/phpstan-stubs/nuke-globals.stub.php
+++ b/ibl5/phpstan-stubs/nuke-globals.stub.php
@@ -84,6 +84,12 @@ function themeheader(): void {}
 /** @return void */
 function themefooter(): void {}
 
+/** @return void */
+function themeindex(mixed $aid, mixed $informant, mixed $time, mixed $title, mixed $counter, mixed $topic, mixed $thetext, mixed $notes, mixed $morelink, mixed $topicname, mixed $topicimage, mixed $topictext): void {}
+
+/** @return void */
+function themearticle(mixed $aid, mixed $informant, mixed $datetime, mixed $title, mixed $thetext, mixed $topic, mixed $topicname, mixed $topicimage, mixed $topictext): void {}
+
 /** @return int 1 if admin, 0 otherwise */
 function is_admin(mixed $admin = null): int { return 0; }
 

--- a/ibl5/tests/Module/EntryPoints/NewsEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/NewsEntryPointTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Module\EntryPoints;
+
+class NewsEntryPointTest extends ModuleEntryPointTestCase
+{
+    public function testRendersHomePageStories(): void
+    {
+        // Topic JOIN query (contains LEFT JOIN)
+        $this->mockDb->onQuery('LEFT JOIN', [
+            ['topicid' => 1, 'topicname' => 'IBL', 'topicimage' => 'i.png', 'topictext' => 't'],
+        ]);
+        // Category title query (contains nuke_stories_cat)
+        $this->mockDb->onQuery('nuke_stories_cat', [
+            ['title' => 'Trades'],
+        ]);
+        // Main story list (fallback pool — unrouted SELECT)
+        $this->mockDb->setMockData([
+            [
+                'sid' => 1, 'catid' => 0, 'aid' => 'AP', 'title' => 'Story One',
+                'time' => '2026-05-13 12:00:00', 'hometext' => 'home', 'bodytext' => 'body',
+                'comments' => 0, 'counter' => 0, 'topic' => 1, 'informant' => 'AP',
+                'notes' => '', 'acomm' => 0,
+            ],
+        ]);
+
+        $output = $this->runModule(
+            'News',
+            extraGlobals: ['storyhome' => 10, 'multilingual' => 0, 'user_news' => 0, 'articlecomm' => 0],
+        );
+
+        $this->assertNotEmpty($output);
+        // bodytext='body' → fullcount > 0 → Read More link is built
+        $this->assertStringContainsString('news-article__link', $output);
+    }
+
+    public function testTopicPathRendersWithoutError(): void
+    {
+        // Topic text query (contains topictext)
+        $this->mockDb->onQuery('topictext', [
+            ['topictext' => 'Some Topic'],
+        ]);
+        // Topic JOIN query (contains LEFT JOIN)
+        $this->mockDb->onQuery('LEFT JOIN', [
+            ['topicid' => 1, 'topicname' => 'IBL', 'topicimage' => 'i.png', 'topictext' => 't'],
+        ]);
+        // Category title query (contains nuke_stories_cat)
+        $this->mockDb->onQuery('nuke_stories_cat', [
+            ['title' => 'Trades'],
+        ]);
+        // Main story list (fallback pool)
+        $this->mockDb->setMockData([
+            [
+                'sid' => 2, 'catid' => 0, 'aid' => 'AP', 'title' => 'Topic Story',
+                'time' => '2026-05-13 12:00:00', 'hometext' => 'home', 'bodytext' => 'body',
+                'comments' => 0, 'counter' => 0, 'topic' => 1, 'informant' => 'AP',
+                'notes' => '', 'acomm' => 0,
+            ],
+        ]);
+
+        $output = $this->runModule(
+            'News',
+            get: ['new_topic' => '1'],
+            extraGlobals: ['storyhome' => 10, 'multilingual' => 0, 'user_news' => 0, 'articlecomm' => 0],
+        );
+
+        $this->assertNotEmpty($output);
+    }
+}

--- a/ibl5/tests/Module/EntryPoints/theme-stubs.php
+++ b/ibl5/tests/Module/EntryPoints/theme-stubs.php
@@ -50,3 +50,17 @@ if (!function_exists('CloseTable')) {
         echo '</div>';
     }
 }
+
+if (!function_exists('themeindex')) {
+    function themeindex(mixed $aid, mixed $informant, mixed $time, mixed $title, mixed $counter, mixed $topic, mixed $thetext, mixed $notes, mixed $morelink, mixed $topicname, mixed $topicimage, mixed $topictext): void
+    {
+        echo (string) $title . ' ' . (string) $morelink;
+    }
+}
+
+if (!function_exists('themearticle')) {
+    function themearticle(mixed $aid, mixed $informant, mixed $datetime, mixed $title, mixed $thetext, mixed $topic, mixed $topicname, mixed $topicimage, mixed $topictext): void
+    {
+        echo (string) $title . ' ' . (string) $thetext;
+    }
+}

--- a/ibl5/tests/Topics/News/NewsRepositoryTest.php
+++ b/ibl5/tests/Topics/News/NewsRepositoryTest.php
@@ -99,4 +99,97 @@ class NewsRepositoryTest extends TestCase
         $this->assertStringContainsString('nuke_stories_cat', $queries[0]);
         $this->assertStringContainsString('counter', $queries[0]);
     }
+
+    public function testGetStoryByIdReturnsRow(): void
+    {
+        $this->mockDb->setMockData([
+            [
+                'catid' => 2,
+                'aid' => 'AP',
+                'time' => '2026-05-13 12:00:00',
+                'title' => 'T',
+                'hometext' => 'h',
+                'bodytext' => 'b',
+                'topic' => 1,
+                'informant' => 'i',
+                'notes' => 'n',
+                'acomm' => 0,
+                'haspoll' => 0,
+                'poll_id' => 0,
+            ],
+        ]);
+
+        $result = $this->newsService->getStoryById(5);
+
+        $this->assertIsArray($result);
+        $this->assertSame('T', $result['title']);
+    }
+
+    public function testGetStoryByIdReturnsNullWhenAbsent(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->newsService->getStoryById(99999);
+
+        $this->assertNull($result);
+    }
+
+    public function testGetTopicTextReturnsNullWhenAbsent(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->newsService->getTopicText(1);
+
+        $this->assertNull($result);
+    }
+
+    public function testGetHomePageStoriesQueriesStoriesTable(): void
+    {
+        $this->mockDb->setMockData([['sid' => 1, 'title' => 'X']]);
+
+        $result = $this->newsService->getHomePageStories(10);
+
+        $this->assertNotEmpty($result);
+        $queries = $this->mockDb->getExecutedQueries();
+        $this->assertStringContainsString('nuke_stories', $queries[0]);
+        $this->assertStringContainsString('LIMIT', $queries[0]);
+    }
+
+    public function testGetStoriesByCategoryOmitsCatidColumn(): void
+    {
+        $this->mockDb->setMockData([['sid' => 1]]);
+
+        $this->newsService->getStoriesByCategory(2, 10);
+
+        $queries = $this->mockDb->getExecutedQueries();
+        $this->assertStringNotContainsString('SELECT sid, catid', $queries[0]);
+        $this->assertStringContainsString('SELECT sid, aid', $queries[0]);
+    }
+
+    public function testIncrementTopicCounterAllHasNoWhere(): void
+    {
+        $this->newsService->incrementTopicCounterAll();
+
+        $queries = $this->mockDb->getExecutedQueries();
+        $this->assertStringContainsString('UPDATE', $queries[0]);
+        $this->assertStringContainsString('nuke_topics', $queries[0]);
+        $this->assertStringContainsString('counter', $queries[0]);
+        $this->assertStringNotContainsString('WHERE', $queries[0]);
+    }
+
+    public function testIncrementStoryCounterParameterized(): void
+    {
+        $this->newsService->incrementStoryCounter(5);
+
+        $queries = $this->mockDb->getExecutedQueries();
+        $this->assertStringContainsString('WHERE sid =', $queries[0]);
+    }
+
+    public function testIncrementCategoryCounterByIdParameterized(): void
+    {
+        $this->newsService->incrementCategoryCounterById(2);
+
+        $queries = $this->mockDb->getExecutedQueries();
+        $this->assertStringContainsString('WHERE catid =', $queries[0]);
+    }
 }

--- a/ibl5/tests/Topics/News/NewsServiceTest.php
+++ b/ibl5/tests/Topics/News/NewsServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Topics\News;
+
+use PHPUnit\Framework\TestCase;
+use Topics\News\Contracts\NewsRepositoryInterface;
+use Topics\News\NewsService;
+
+class NewsServiceTest extends TestCase
+{
+    // ============================================
+    // DELEGATION / PASSTHROUGH
+    // ============================================
+
+    public function testGetStoryReturnsNullForMissingSid(): void
+    {
+        $repo = self::createStub(NewsRepositoryInterface::class);
+        $repo->method('getStoryById')->willReturn(null);
+
+        $service = new NewsService(self::createStub(\mysqli::class), $repo);
+
+        $this->assertNull($service->getStory(99999));
+    }
+
+    public function testGetHomePageStoriesDelegatesToRepository(): void
+    {
+        $rows = [['sid' => 1], ['sid' => 2]];
+
+        $repo = self::createStub(NewsRepositoryInterface::class);
+        $repo->method('getHomePageStories')->willReturn($rows);
+
+        $service = new NewsService(self::createStub(\mysqli::class), $repo);
+
+        $result = $service->getHomePageStories(10, '');
+        $this->assertCount(2, $result);
+        $this->assertSame($rows, $result);
+    }
+
+    public function testBumpStoryDelegates(): void
+    {
+        $repo = $this->createMock(NewsRepositoryInterface::class);
+        $repo->expects($this->once())
+            ->method('incrementStoryCounter')
+            ->with(5)
+            ->willReturn(1);
+
+        $service = new NewsService(self::createStub(\mysqli::class), $repo);
+
+        $service->bumpStory(5);
+    }
+
+    // ============================================
+    // normalizeStoryTime
+    // ============================================
+
+    public function testNormalizeStoryTimeParsesDatetimeString(): void
+    {
+        $service = new NewsService(self::createStub(\mysqli::class), self::createStub(NewsRepositoryInterface::class));
+
+        $input = '2026-05-13 12:00:00';
+        $expected = (int) gmmktime(12, 0, 0, 5, 13, 2026) - (int) date('Z');
+
+        $this->assertSame($expected, $service->normalizeStoryTime($input));
+    }
+
+    public function testNormalizeStoryTimePassesThroughNumericTimestamp(): void
+    {
+        $service = new NewsService(self::createStub(\mysqli::class), self::createStub(NewsRepositoryInterface::class));
+
+        $input = 1700000000;
+        $expected = 1700000000 - (int) date('Z');
+
+        $this->assertSame($expected, $service->normalizeStoryTime($input));
+    }
+
+    // ============================================
+    // computeByteCounts
+    // ============================================
+
+    public function testComputeByteCounts(): void
+    {
+        $service = new NewsService(self::createStub(\mysqli::class), self::createStub(NewsRepositoryInterface::class));
+
+        $result = $service->computeByteCounts('abc', 'de');
+
+        $this->assertSame(3, $result['intro']);
+        $this->assertSame(2, $result['full']);
+        $this->assertSame(5, $result['total']);
+        $this->assertSame($result['intro'] + $result['full'], $result['total']);
+    }
+}


### PR DESCRIPTION
## Summary

Behavior-preserving extraction of the News module's three legacy read/display entrypoints into a `Topics\News\` Repository/Service/View triad:

- **`NewsRepository`** — 10 new prepared-statement read/counter methods (`getHomePageStories`, `getStoriesByTopic`, `getStoriesByCategory`, `getStoryById`, `getTopicForStory`, `getTopicText`, `getCategoryTitle`, counter bumps). All legacy `$db->sql_query(...)` string-interpolated reads move to `BaseMysqliRepository::fetchOne/fetchAll/execute` with typed `bind_param` parameters, including bound `LIMIT ?` replacing string-interpolated `limit $storynum`.
- **`NewsService`** — pure data assembly: passthrough delegates + `normalizeStoryTime()` (extracts the verbatim `preg_match`/`gmmktime` block present in all 3 entrypoints) + `computeByteCounts()`.
- **`NewsView`** — theme-call dispatch seam: calls `themeindex()`/`themearticle()` with the **same arguments in the same order** as today. No HTML literals; no raw `echo`; output via theme functions only.
- **Controllers** (`modules/News/index.php`, `article.php`, `categories.php`) — thin: instantiate service/view, keep per-path glue strings byte-identical (incl. `<font class="storycat">`, `<b>` morelink in categories, the recap card and `blocks("Center")` stays inline in index).

Refactor is green-green; the unchanged `news.png`/`news-mobile.png` VR snapshots and the unmodified `news.spec.ts` are the pre-impl oracle. No snapshot regeneration.

## Security

Legacy SQL reads on a public module move to prepared statements; the parameterization is verbatim-behavior-preserving. `$langClause` is a pre-built server-config fragment (no user input). Output escaping stays in controllers and theme layer; `NewsView` calls already-escaping theme functions only (`RequireEscapedOutputRule` passes).

## Depends-on

None.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
