### PR TITLE
refactor: extract RecordFormatter collaborator from RecordHoldersService

### DIFF
--- a/ibl5/classes/RecordHolders/Contracts/RecordFormatterInterface.php
+++ b/ibl5/classes/RecordHolders/Contracts/RecordFormatterInterface.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RecordHolders\Contracts;
+
+/**
+ * Formatter interface for Record Holders module.
+ *
+ * Transforms already-fetched DB rows into view-ready display structures.
+ * Repository-free: all team-lookup is a const registry, all helpers static.
+ *
+ * @phpstan-import-type FormattedPlayerRecord from RecordHoldersServiceInterface
+ * @phpstan-import-type FormattedSeasonRecord from RecordHoldersServiceInterface
+ * @phpstan-import-type FormattedTeamGameRecord from RecordHoldersServiceInterface
+ * @phpstan-import-type FormattedTeamSeasonRecord from RecordHoldersServiceInterface
+ * @phpstan-import-type FormattedFranchiseRecord from RecordHoldersServiceInterface
+ */
+interface RecordFormatterInterface
+{
+    /**
+     * Format player single-game records from DB rows.
+     *
+     * @param list<array{pid: int, name: string, teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, value: int}> $dbRecords
+     * @param string $gameType
+     * @return list<FormattedPlayerRecord>
+     */
+    public function formatPlayerRecords(array $dbRecords, string $gameType): array;
+
+    /**
+     * Format quadruple double records.
+     *
+     * @param list<array{pid: int, name: string, teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, points: int, rebounds: int, assists: int, steals: int, blocks: int}> $dbRecords
+     * @return list<FormattedPlayerRecord>
+     */
+    public function formatQuadrupleDoubles(array $dbRecords): array;
+
+    /**
+     * Format the all-star appearances record.
+     *
+     * @param list<array{name: string, pid: int|null, appearances: int}> $dbRecords
+     * @return array{name: string, pid: int|null, teams: string, teamTids: string, amount: int, years: string}
+     */
+    public function formatAllStarRecord(array $dbRecords): array;
+
+    /**
+     * Format player full-season records from DB rows.
+     *
+     * @param list<array{pid: int, name: string, teamid: int, team: string, year: int, value: float|int}> $dbRecords
+     * @return list<FormattedSeasonRecord>
+     */
+    public function formatPlayerSeasonRecords(array $dbRecords): array;
+
+    /**
+     * Format team single-game records from DB rows.
+     *
+     * @param list<array{teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, value: int}> $dbRecords
+     * @return list<FormattedTeamGameRecord>
+     */
+    public function formatTeamGameRecords(array $dbRecords): array;
+
+    /**
+     * Format margin of victory records.
+     *
+     * @param list<array{winner_tid: int, winner_name: string, loser_tid: int, loser_name: string, date: string, box_id: int, game_of_that_day: int, margin: int}> $dbRecords
+     * @return list<FormattedTeamGameRecord>
+     */
+    public function formatMarginRecords(array $dbRecords): array;
+
+    /**
+     * Format season win/loss records.
+     *
+     * @param list<array{team_name: string, year: int, wins: int, losses: int}> $dbRecords
+     * @return list<FormattedTeamSeasonRecord>
+     */
+    public function formatSeasonWinLossRecords(array $dbRecords): array;
+
+    /**
+     * Format season start records.
+     *
+     * @param list<array{team_name: string, year: int, wins: int, losses: int}> $dbRecords
+     * @param string $type 'best' or 'worst'
+     * @return list<FormattedTeamSeasonRecord>
+     */
+    public function formatSeasonStartRecords(array $dbRecords, string $type): array;
+
+    /**
+     * Format streak records.
+     *
+     * @param list<array{team_name: string, streak: int, start_date: string, end_date: string, start_year: int, end_year: int}> $dbRecords
+     * @return list<FormattedTeamSeasonRecord>
+     */
+    public function formatStreakRecords(array $dbRecords): array;
+
+    /**
+     * Format franchise records (titles, appearances).
+     *
+     * @param list<array{team_name: string, count: int, years: string}> $dbRecords
+     * @return list<FormattedFranchiseRecord>
+     */
+    public function formatFranchiseRecords(array $dbRecords): array;
+
+    /**
+     * Detect ties in formatted records (multiple entries sharing the same top value).
+     *
+     * Only keeps entries that match the top (first) value.
+     *
+     * @param list<array<string, mixed>> $records Each record must have an 'amount' key
+     * @return list<array<string, mixed>>
+     */
+    public function detectTies(array $records): array;
+
+    /**
+     * Add " [tie]" suffix to category name if there are multiple records.
+     *
+     * @param list<array<string, mixed>> $records
+     */
+    public function addTieLabel(string $category, array $records): string;
+}

--- a/ibl5/classes/RecordHolders/RecordFormatter.php
+++ b/ibl5/classes/RecordHolders/RecordFormatter.php
@@ -1,0 +1,441 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RecordHolders;
+
+use RecordHolders\Contracts\RecordFormatterInterface;
+
+/**
+ * RecordFormatter - Pure display-formatting for Record Holders.
+ *
+ * Transforms already-fetched DB rows into view-ready arrays/strings.
+ * Repository-free: team-lookup is a const registry; all helpers are static.
+ *
+ * @phpstan-import-type FormattedPlayerRecord from \RecordHolders\Contracts\RecordHoldersServiceInterface
+ * @phpstan-import-type FormattedSeasonRecord from \RecordHolders\Contracts\RecordHoldersServiceInterface
+ * @phpstan-import-type FormattedTeamGameRecord from \RecordHolders\Contracts\RecordHoldersServiceInterface
+ * @phpstan-import-type FormattedTeamSeasonRecord from \RecordHolders\Contracts\RecordHoldersServiceInterface
+ * @phpstan-import-type FormattedFranchiseRecord from \RecordHolders\Contracts\RecordHoldersServiceInterface
+ *
+ * @see RecordFormatterInterface
+ */
+class RecordFormatter implements RecordFormatterInterface
+{
+    /**
+     * Single source of truth for team ID → abbreviation + name.
+     *
+     * Abbreviations correspond to image files in images/topics/{abbr}.png.
+     * Derive all team lookups from this registry so a rebrand is a one-line edit.
+     *
+     * @var array<int, array{abbr: string, name: string}>
+     */
+    private const TEAM_REGISTRY = [
+        1  => ['abbr' => 'bos', 'name' => 'Celtics'],
+        2  => ['abbr' => 'mia', 'name' => 'Heat'],
+        3  => ['abbr' => 'nyk', 'name' => 'Knicks'],
+        4  => ['abbr' => 'bkn', 'name' => 'Nets'],
+        5  => ['abbr' => 'orl', 'name' => 'Magic'],
+        6  => ['abbr' => 'mil', 'name' => 'Bucks'],
+        7  => ['abbr' => 'chi', 'name' => 'Bulls'],
+        8  => ['abbr' => 'nor', 'name' => 'Pelicans'],
+        9  => ['abbr' => 'atl', 'name' => 'Hawks'],
+        10 => ['abbr' => 'cha', 'name' => 'Sting'],
+        11 => ['abbr' => 'ind', 'name' => 'Pacers'],
+        12 => ['abbr' => 'tor', 'name' => 'Raptors'],
+        13 => ['abbr' => 'uta', 'name' => 'Jazz'],
+        14 => ['abbr' => 'min', 'name' => 'Timberwolves'],
+        15 => ['abbr' => 'den', 'name' => 'Nuggets'],
+        16 => ['abbr' => 'lva', 'name' => 'Aces'],
+        17 => ['abbr' => 'hou', 'name' => 'Rockets'],
+        18 => ['abbr' => 'por', 'name' => 'Trailblazers'],
+        19 => ['abbr' => 'lac', 'name' => 'Clippers'],
+        20 => ['abbr' => 'van', 'name' => 'Grizzlies'],
+        21 => ['abbr' => 'lal', 'name' => 'Lakers'],
+        22 => ['abbr' => 'braves', 'name' => 'Braves'],
+        23 => ['abbr' => 'phx', 'name' => 'Suns'],
+        24 => ['abbr' => 'gsw', 'name' => 'Warriors'],
+        25 => ['abbr' => 'det', 'name' => 'Pistons'],
+        26 => ['abbr' => 'sac', 'name' => 'Kings'],
+        27 => ['abbr' => 'was', 'name' => 'Bullets'],
+        28 => ['abbr' => 'dal', 'name' => 'Mavericks'],
+    ];
+
+    /**
+     * @see RecordFormatterInterface::formatPlayerRecords()
+     *
+     * @param list<array{pid: int, name: string, teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, value: int}> $dbRecords
+     * @return list<FormattedPlayerRecord>
+     */
+    public function formatPlayerRecords(array $dbRecords, string $gameType): array
+    {
+        /** @var list<FormattedPlayerRecord> $formatted */
+        $formatted = [];
+        foreach ($dbRecords as $record) {
+            $teamAbbr = self::teamAbbreviation($record['teamid']);
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
+            $formatted[] = [
+                'pid' => $record['pid'],
+                'name' => $record['name'],
+                'teamAbbr' => $teamAbbr,
+                'teamTid' => $record['teamid'],
+                'teamYr' => (string) $seasonYear,
+                'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
+                'dateDisplay' => $this->formatDateDisplay($record['date'], $gameType),
+                'oppAbbr' => self::teamAbbreviation($record['oppTid']),
+                'oppTid' => $record['oppTid'],
+                'oppYr' => (string) $seasonYear,
+                'amount' => (string) $record['value'],
+            ];
+        }
+        return $formatted;
+    }
+
+    /**
+     * @see RecordFormatterInterface::formatQuadrupleDoubles()
+     *
+     * @param list<array{pid: int, name: string, teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, points: int, rebounds: int, assists: int, steals: int, blocks: int}> $dbRecords
+     * @return list<FormattedPlayerRecord>
+     */
+    public function formatQuadrupleDoubles(array $dbRecords): array
+    {
+        /** @var list<FormattedPlayerRecord> $formatted */
+        $formatted = [];
+
+        foreach ($dbRecords as $record) {
+            $gameType = IblSeasonDateHelper::getGameTypeFromDate($record['date']);
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
+            $teamAbbr = self::teamAbbreviation($record['teamid']);
+
+            // Build multi-line amount string
+            $amount = $record['points'] . "pts\n"
+                . $record['rebounds'] . "rbs\n"
+                . $record['assists'] . "ast\n"
+                . $record['steals'] . "stl";
+            if ($record['blocks'] >= 10) {
+                $amount .= "\n" . $record['blocks'] . 'blk';
+            }
+
+            $formatted[] = [
+                'pid' => $record['pid'],
+                'name' => $record['name'],
+                'teamAbbr' => $teamAbbr,
+                'teamTid' => $record['teamid'],
+                'teamYr' => (string) $seasonYear,
+                'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
+                'dateDisplay' => $this->formatDateDisplay($record['date'], $gameType),
+                'oppAbbr' => self::teamAbbreviation($record['oppTid']),
+                'oppTid' => $record['oppTid'],
+                'oppYr' => (string) $seasonYear,
+                'amount' => $amount,
+            ];
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * @see RecordFormatterInterface::formatAllStarRecord()
+     *
+     * @param list<array{name: string, pid: int|null, appearances: int}> $dbRecords
+     * @return array{name: string, pid: int|null, teams: string, teamTids: string, amount: int, years: string}
+     */
+    public function formatAllStarRecord(array $dbRecords): array
+    {
+        if ($dbRecords === []) {
+            return ['name' => '', 'pid' => null, 'teams' => '', 'teamTids' => '', 'amount' => 0, 'years' => ''];
+        }
+
+        $topRecord = $dbRecords[0];
+
+        return [
+            'name' => $topRecord['name'],
+            'pid' => $topRecord['pid'],
+            'teams' => '',
+            'teamTids' => '',
+            'amount' => $topRecord['appearances'],
+            'years' => '',
+        ];
+    }
+
+    /**
+     * @see RecordFormatterInterface::formatPlayerSeasonRecords()
+     *
+     * @param list<array{pid: int, name: string, teamid: int, team: string, year: int, value: float|int}> $dbRecords
+     * @return list<FormattedSeasonRecord>
+     */
+    public function formatPlayerSeasonRecords(array $dbRecords): array
+    {
+        /** @var list<FormattedSeasonRecord> $formatted */
+        $formatted = [];
+        foreach ($dbRecords as $record) {
+            $formatted[] = [
+                'pid' => $record['pid'],
+                'name' => $record['name'],
+                'teamAbbr' => self::teamAbbreviation($record['teamid']),
+                'teamTid' => $record['teamid'],
+                'teamYr' => (string) $record['year'],
+                'season' => $this->formatSeasonYearRange($record['year']),
+                'amount' => \BasketballStats\StatsFormatter::formatWithDecimals((float) $record['value'], 1),
+            ];
+        }
+        return $formatted;
+    }
+
+    /**
+     * @see RecordFormatterInterface::formatTeamGameRecords()
+     *
+     * @param list<array{teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, value: int}> $dbRecords
+     * @return list<FormattedTeamGameRecord>
+     */
+    public function formatTeamGameRecords(array $dbRecords): array
+    {
+        /** @var list<FormattedTeamGameRecord> $formatted */
+        $formatted = [];
+        foreach ($dbRecords as $record) {
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
+            $formatted[] = [
+                'teamAbbr' => self::teamAbbreviation($record['teamid']),
+                'teamTid' => $record['teamid'],
+                'teamYr' => (string) $seasonYear,
+                'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
+                'dateDisplay' => $this->formatDateDisplay($record['date'], 'regularSeason'),
+                'oppAbbr' => self::teamAbbreviation($record['oppTid']),
+                'oppTid' => $record['oppTid'],
+                'oppYr' => (string) $seasonYear,
+                'amount' => (string) $record['value'],
+            ];
+        }
+        return $formatted;
+    }
+
+    /**
+     * @see RecordFormatterInterface::formatMarginRecords()
+     *
+     * @param list<array{winner_tid: int, winner_name: string, loser_tid: int, loser_name: string, date: string, box_id: int, game_of_that_day: int, margin: int}> $dbRecords
+     * @return list<FormattedTeamGameRecord>
+     */
+    public function formatMarginRecords(array $dbRecords): array
+    {
+        /** @var list<FormattedTeamGameRecord> $formatted */
+        $formatted = [];
+        foreach ($dbRecords as $record) {
+            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
+            $formatted[] = [
+                'teamAbbr' => self::teamAbbreviation($record['winner_tid']),
+                'teamTid' => $record['winner_tid'],
+                'teamYr' => (string) $seasonYear,
+                'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
+                'dateDisplay' => $this->formatDateDisplay($record['date'], 'regularSeason'),
+                'oppAbbr' => self::teamAbbreviation($record['loser_tid']),
+                'oppTid' => $record['loser_tid'],
+                'oppYr' => (string) $seasonYear,
+                'amount' => (string) $record['margin'],
+            ];
+        }
+        return $formatted;
+    }
+
+    /**
+     * @see RecordFormatterInterface::formatSeasonWinLossRecords()
+     *
+     * @param list<array{team_name: string, year: int, wins: int, losses: int}> $dbRecords
+     * @return list<FormattedTeamSeasonRecord>
+     */
+    public function formatSeasonWinLossRecords(array $dbRecords): array
+    {
+        /** @var list<FormattedTeamSeasonRecord> $formatted */
+        $formatted = [];
+        foreach ($dbRecords as $record) {
+            $endingYear = $record['year'];
+            $formatted[] = [
+                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
+                'teamTid' => self::teamIdByName($record['team_name']),
+                'teamYr' => (string) $endingYear,
+                'season' => $this->formatSeasonYearRange($endingYear),
+                'amount' => $record['wins'] . '-' . $record['losses'],
+            ];
+        }
+        /** @var list<FormattedTeamSeasonRecord> $withTies */
+        $withTies = $this->detectTies($formatted);
+        return $withTies;
+    }
+
+    /**
+     * @see RecordFormatterInterface::formatSeasonStartRecords()
+     *
+     * @param list<array{team_name: string, year: int, wins: int, losses: int}> $dbRecords
+     * @param string $type 'best' or 'worst'
+     * @return list<FormattedTeamSeasonRecord>
+     */
+    public function formatSeasonStartRecords(array $dbRecords, string $type): array
+    {
+        /** @var list<FormattedTeamSeasonRecord> $formatted */
+        $formatted = [];
+        foreach ($dbRecords as $record) {
+            $formatted[] = [
+                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
+                'teamTid' => self::teamIdByName($record['team_name']),
+                'teamYr' => (string) $record['year'],
+                'season' => $this->formatSeasonYearRange($record['year']),
+                'amount' => $record['wins'] . '-' . $record['losses'],
+            ];
+        }
+        /** @var list<FormattedTeamSeasonRecord> $withTies */
+        $withTies = $this->detectTies($formatted);
+        return $withTies;
+    }
+
+    /**
+     * @see RecordFormatterInterface::formatStreakRecords()
+     *
+     * @param list<array{team_name: string, streak: int, start_date: string, end_date: string, start_year: int, end_year: int}> $dbRecords
+     * @return list<FormattedTeamSeasonRecord>
+     */
+    public function formatStreakRecords(array $dbRecords): array
+    {
+        /** @var list<FormattedTeamSeasonRecord> $formatted */
+        $formatted = [];
+        foreach ($dbRecords as $record) {
+            $season = $this->formatSeasonYearRange($record['start_year']);
+            if ($record['start_year'] !== $record['end_year']) {
+                $season .= ', ' . $this->formatSeasonYearRange($record['end_year']);
+            }
+            $formatted[] = [
+                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
+                'teamTid' => self::teamIdByName($record['team_name']),
+                'teamYr' => (string) $record['start_year'],
+                'season' => $season,
+                'amount' => (string) $record['streak'],
+            ];
+        }
+        /** @var list<FormattedTeamSeasonRecord> $withTies */
+        $withTies = $this->detectTies($formatted);
+        return $withTies;
+    }
+
+    /**
+     * @see RecordFormatterInterface::formatFranchiseRecords()
+     *
+     * @param list<array{team_name: string, count: int, years: string}> $dbRecords
+     * @return list<FormattedFranchiseRecord>
+     */
+    public function formatFranchiseRecords(array $dbRecords): array
+    {
+        /** @var list<FormattedFranchiseRecord> $formatted */
+        $formatted = [];
+        foreach ($dbRecords as $record) {
+            $formatted[] = [
+                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
+                'teamTid' => self::teamIdByName($record['team_name']),
+                'amount' => (string) $record['count'],
+                'years' => strip_tags($record['years']),
+            ];
+        }
+        return $formatted;
+    }
+
+    /**
+     * @see RecordFormatterInterface::detectTies()
+     *
+     * @param list<array<string, mixed>> $records Each record must have an 'amount' key
+     * @return list<array<string, mixed>>
+     */
+    public function detectTies(array $records): array
+    {
+        if (count($records) <= 1) {
+            return $records;
+        }
+
+        $topAmount = $records[0]['amount'];
+        $tied = [];
+        foreach ($records as $record) {
+            if ($record['amount'] === $topAmount) {
+                $tied[] = $record;
+            }
+        }
+        return $tied;
+    }
+
+    /**
+     * @see RecordFormatterInterface::addTieLabel()
+     *
+     * @param list<array<string, mixed>> $records
+     */
+    public function addTieLabel(string $category, array $records): string
+    {
+        if (count($records) > 1) {
+            return $category . ' [tie]';
+        }
+        return $category;
+    }
+
+    private static function teamAbbreviation(int $teamId): string
+    {
+        return self::TEAM_REGISTRY[$teamId]['abbr'] ?? '';
+    }
+
+    private static function teamIdByName(string $teamName): int
+    {
+        /** @var array<string, int>|null $byName */
+        static $byName = null;
+        if ($byName === null) {
+            $byName = [];
+            foreach (self::TEAM_REGISTRY as $id => $info) {
+                $byName[$info['name']] = $id;
+            }
+        }
+        return $byName[$teamName] ?? 0;
+    }
+
+    private static function teamAbbreviationByName(string $teamName): string
+    {
+        return self::teamAbbreviation(self::teamIdByName($teamName));
+    }
+
+    /**
+     * Format a date for display based on game type.
+     *
+     * Regular season / Playoffs: "January 16, 1996"
+     * HEAT: "HEAT\nOctober 16, 1995" (newline-separated for two-line display)
+     */
+    private function formatDateDisplay(string $date, string $gameType): string
+    {
+        if ($date === '' || $date === '0000-00-00') {
+            return '';
+        }
+
+        $timestamp = strtotime($date);
+        if ($timestamp === false) {
+            return $date;
+        }
+
+        if ($gameType === 'heat') {
+            return "HEAT\n" . date('F j, Y', $timestamp);
+        }
+
+        return date('F j, Y', $timestamp);
+    }
+
+    /**
+     * Build a box score URL using the IBL6 SvelteKit URL pattern.
+     *
+     * Returns empty string if gameOfThatDay is not available (historical records).
+     */
+    private function buildBoxScoreUrl(string $date, int $gameOfThatDay, int $boxId = 0): string
+    {
+        return \Utilities\BoxScoreUrlBuilder::buildUrl($date, $gameOfThatDay, $boxId);
+    }
+
+    /**
+     * Format a season ending year into "YYYY-YY" range format.
+     *
+     * Example: 1996 → "1995-96"
+     */
+    private function formatSeasonYearRange(int $endingYear): string
+    {
+        $beginYear = $endingYear - 1;
+        $endYearShort = substr((string) $endingYear, 2);
+        return $beginYear . '-' . $endYearShort;
+    }
+}

--- a/ibl5/classes/RecordHolders/RecordHoldersService.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersService.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace RecordHolders;
 
+use RecordHolders\Contracts\RecordFormatterInterface;
 use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
 use RecordHolders\Contracts\RecordHoldersServiceInterface;
 
 /**
  * RecordHoldersService - Business logic for all-time IBL record holders.
  *
- * Orchestrates repository calls, formats data for view rendering,
- * handles tie detection and date formatting.
+ * Thin orchestrator: fetches data from the repository and delegates all
+ * formatting to RecordFormatter (injected as RecordFormatterInterface).
  *
  * @phpstan-import-type AllRecordsData from RecordHoldersServiceInterface
  * @phpstan-import-type FormattedPlayerRecord from RecordHoldersServiceInterface
@@ -25,45 +26,7 @@ use RecordHolders\Contracts\RecordHoldersServiceInterface;
 class RecordHoldersService implements RecordHoldersServiceInterface
 {
     private RecordHoldersRepositoryInterface $repository;
-
-    /**
-     * Single source of truth for team ID → abbreviation + name.
-     *
-     * Abbreviations correspond to image files in images/topics/{abbr}.png.
-     * Derive all team lookups from this registry so a rebrand is a one-line edit.
-     *
-     * @var array<int, array{abbr: string, name: string}>
-     */
-    private const TEAM_REGISTRY = [
-        1  => ['abbr' => 'bos', 'name' => 'Celtics'],
-        2  => ['abbr' => 'mia', 'name' => 'Heat'],
-        3  => ['abbr' => 'nyk', 'name' => 'Knicks'],
-        4  => ['abbr' => 'bkn', 'name' => 'Nets'],
-        5  => ['abbr' => 'orl', 'name' => 'Magic'],
-        6  => ['abbr' => 'mil', 'name' => 'Bucks'],
-        7  => ['abbr' => 'chi', 'name' => 'Bulls'],
-        8  => ['abbr' => 'nor', 'name' => 'Pelicans'],
-        9  => ['abbr' => 'atl', 'name' => 'Hawks'],
-        10 => ['abbr' => 'cha', 'name' => 'Sting'],
-        11 => ['abbr' => 'ind', 'name' => 'Pacers'],
-        12 => ['abbr' => 'tor', 'name' => 'Raptors'],
-        13 => ['abbr' => 'uta', 'name' => 'Jazz'],
-        14 => ['abbr' => 'min', 'name' => 'Timberwolves'],
-        15 => ['abbr' => 'den', 'name' => 'Nuggets'],
-        16 => ['abbr' => 'lva', 'name' => 'Aces'],
-        17 => ['abbr' => 'hou', 'name' => 'Rockets'],
-        18 => ['abbr' => 'por', 'name' => 'Trailblazers'],
-        19 => ['abbr' => 'lac', 'name' => 'Clippers'],
-        20 => ['abbr' => 'van', 'name' => 'Grizzlies'],
-        21 => ['abbr' => 'lal', 'name' => 'Lakers'],
-        22 => ['abbr' => 'braves', 'name' => 'Braves'],
-        23 => ['abbr' => 'phx', 'name' => 'Suns'],
-        24 => ['abbr' => 'gsw', 'name' => 'Warriors'],
-        25 => ['abbr' => 'det', 'name' => 'Pistons'],
-        26 => ['abbr' => 'sac', 'name' => 'Kings'],
-        27 => ['abbr' => 'was', 'name' => 'Bullets'],
-        28 => ['abbr' => 'dal', 'name' => 'Mavericks'],
-    ];
+    private RecordFormatterInterface $formatter;
 
     /**
      * Full-season stat columns in ibl_hist and the games column to divide by.
@@ -78,9 +41,12 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         'Highest Blocks Average in a Regular Season' => ['statColumn' => 'blk', 'gamesColumn' => 'games'],
     ];
 
-    public function __construct(RecordHoldersRepositoryInterface $repository)
-    {
+    public function __construct(
+        RecordHoldersRepositoryInterface $repository,
+        ?RecordFormatterInterface $formatter = null,
+    ) {
         $this->repository = $repository;
+        $this->formatter = $formatter ?? new RecordFormatter();
     }
 
     /**
@@ -96,8 +62,8 @@ class RecordHoldersService implements RecordHoldersServiceInterface
                 'playoffs' => $this->getPlayerSingleGameRecords('playoffs'),
                 'heat' => $this->getPlayerSingleGameRecords('heat'),
             ],
-            'quadrupleDoubles' => $this->formatQuadrupleDoubles(),
-            'allStarRecord' => $this->formatAllStarRecord(),
+            'quadrupleDoubles' => $this->formatter->formatQuadrupleDoubles($this->repository->getQuadrupleDoubles()),
+            'allStarRecord' => $this->formatter->formatAllStarRecord($this->repository->getMostAllStarAppearances()),
             'playerFullSeason' => $this->getPlayerFullSeasonRecords(),
             'teamGameRecords' => $this->getTeamGameRecords(),
             'teamSeasonRecords' => $this->getTeamSeasonRecords(),
@@ -119,113 +85,14 @@ class RecordHoldersService implements RecordHoldersServiceInterface
 
         $records = [];
         foreach ($batchResults as $category => $dbRecords) {
-            $formatted = $this->formatPlayerRecords($dbRecords, $gameType);
+            $formatted = $this->formatter->formatPlayerRecords($dbRecords, $gameType);
             /** @var list<FormattedPlayerRecord> $withTies */
-            $withTies = $this->detectTies($formatted);
-            $categoryLabel = $this->addTieLabel($category, $withTies);
+            $withTies = $this->formatter->detectTies($formatted);
+            $categoryLabel = $this->formatter->addTieLabel($category, $withTies);
             $records[$categoryLabel] = $withTies;
         }
 
         return $records;
-    }
-
-    /**
-     * Format player single-game records from DB rows.
-     *
-     * @param list<array{pid: int, name: string, teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, value: int}> $dbRecords
-     * @param string $gameType
-     * @return list<FormattedPlayerRecord>
-     */
-    private function formatPlayerRecords(array $dbRecords, string $gameType): array
-    {
-        /** @var list<FormattedPlayerRecord> $formatted */
-        $formatted = [];
-        foreach ($dbRecords as $record) {
-            $teamAbbr = self::teamAbbreviation($record['teamid']);
-            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
-            $formatted[] = [
-                'pid' => $record['pid'],
-                'name' => $record['name'],
-                'teamAbbr' => $teamAbbr,
-                'teamTid' => $record['teamid'],
-                'teamYr' => (string) $seasonYear,
-                'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
-                'dateDisplay' => $this->formatDateDisplay($record['date'], $gameType),
-                'oppAbbr' => self::teamAbbreviation($record['oppTid']),
-                'oppTid' => $record['oppTid'],
-                'oppYr' => (string) $seasonYear,
-                'amount' => (string) $record['value'],
-            ];
-        }
-        return $formatted;
-    }
-
-    /**
-     * Format quadruple double records.
-     *
-     * @return list<FormattedPlayerRecord>
-     */
-    private function formatQuadrupleDoubles(): array
-    {
-        $dbRecords = $this->repository->getQuadrupleDoubles();
-        /** @var list<FormattedPlayerRecord> $formatted */
-        $formatted = [];
-
-        foreach ($dbRecords as $record) {
-            $gameType = IblSeasonDateHelper::getGameTypeFromDate($record['date']);
-            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
-            $teamAbbr = self::teamAbbreviation($record['teamid']);
-
-            // Build multi-line amount string
-            $amount = $record['points'] . "pts\n"
-                . $record['rebounds'] . "rbs\n"
-                . $record['assists'] . "ast\n"
-                . $record['steals'] . "stl";
-            if ($record['blocks'] >= 10) {
-                $amount .= "\n" . $record['blocks'] . 'blk';
-            }
-
-            $formatted[] = [
-                'pid' => $record['pid'],
-                'name' => $record['name'],
-                'teamAbbr' => $teamAbbr,
-                'teamTid' => $record['teamid'],
-                'teamYr' => (string) $seasonYear,
-                'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
-                'dateDisplay' => $this->formatDateDisplay($record['date'], $gameType),
-                'oppAbbr' => self::teamAbbreviation($record['oppTid']),
-                'oppTid' => $record['oppTid'],
-                'oppYr' => (string) $seasonYear,
-                'amount' => $amount,
-            ];
-        }
-
-        return $formatted;
-    }
-
-    /**
-     * Format the all-star appearances record.
-     *
-     * @return array{name: string, pid: int|null, teams: string, teamTids: string, amount: int, years: string}
-     */
-    private function formatAllStarRecord(): array
-    {
-        $dbRecords = $this->repository->getMostAllStarAppearances();
-
-        if ($dbRecords === []) {
-            return ['name' => '', 'pid' => null, 'teams' => '', 'teamTids' => '', 'amount' => 0, 'years' => ''];
-        }
-
-        $topRecord = $dbRecords[0];
-
-        return [
-            'name' => $topRecord['name'],
-            'pid' => $topRecord['pid'],
-            'teams' => '',
-            'teamTids' => '',
-            'amount' => $topRecord['appearances'],
-            'years' => '',
-        ];
     }
 
     /**
@@ -239,23 +106,11 @@ class RecordHoldersService implements RecordHoldersServiceInterface
 
         $records = [];
         foreach ($batchResults as $category => $dbRecords) {
-            /** @var list<FormattedSeasonRecord> $formatted */
-            $formatted = [];
-            foreach ($dbRecords as $record) {
-                $formatted[] = [
-                    'pid' => $record['pid'],
-                    'name' => $record['name'],
-                    'teamAbbr' => self::teamAbbreviation($record['teamid']),
-                    'teamTid' => $record['teamid'],
-                    'teamYr' => (string) $record['year'],
-                    'season' => $this->formatSeasonYearRange($record['year']),
-                    'amount' => \BasketballStats\StatsFormatter::formatWithDecimals((float) $record['value'], 1),
-                ];
-            }
+            $formatted = $this->formatter->formatPlayerSeasonRecords($dbRecords);
 
             /** @var list<FormattedSeasonRecord> $withTies */
-            $withTies = $this->detectTies($formatted);
-            $categoryLabel = $this->addTieLabel($category, $withTies);
+            $withTies = $this->formatter->detectTies($formatted);
+            $categoryLabel = $this->formatter->addTieLabel($category, $withTies);
             $records[$categoryLabel] = $withTies;
         }
 
@@ -286,90 +141,36 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         $batchResults = $this->repository->getTopTeamSingleGameBatch($batchConfig, $dateFilter);
 
         foreach ($batchResults as $category => $dbRecords) {
-            $formatted = $this->formatTeamGameRecords($dbRecords);
+            $formatted = $this->formatter->formatTeamGameRecords($dbRecords);
             /** @var list<FormattedTeamGameRecord> $withTies */
-            $withTies = $this->detectTies($formatted);
-            $categoryLabel = $this->addTieLabel($category, $withTies);
+            $withTies = $this->formatter->detectTies($formatted);
+            $categoryLabel = $this->formatter->addTieLabel($category, $withTies);
             $records[$categoryLabel] = $withTies;
         }
 
         // Half scores (these use a different query structure, keep as individual calls)
-        $mostHalf = $this->formatTeamGameRecords($this->repository->getTopTeamHalfScore('first', 'DESC'));
+        $mostHalf = $this->formatter->formatTeamGameRecords($this->repository->getTopTeamHalfScore('first', 'DESC'));
         /** @var list<FormattedTeamGameRecord> $mostHalfTies */
-        $mostHalfTies = $this->detectTies($mostHalf);
-        $records[$this->addTieLabel('Most Points in a Single Half', $mostHalfTies)] = $mostHalfTies;
+        $mostHalfTies = $this->formatter->detectTies($mostHalf);
+        $records[$this->formatter->addTieLabel('Most Points in a Single Half', $mostHalfTies)] = $mostHalfTies;
 
-        $fewestHalf = $this->formatTeamGameRecords($this->repository->getTopTeamHalfScore('second', 'ASC'));
+        $fewestHalf = $this->formatter->formatTeamGameRecords($this->repository->getTopTeamHalfScore('second', 'ASC'));
         /** @var list<FormattedTeamGameRecord> $fewestHalfTies */
-        $fewestHalfTies = $this->detectTies($fewestHalf);
-        $records[$this->addTieLabel('Fewest Points in a Single Half', $fewestHalfTies)] = $fewestHalfTies;
+        $fewestHalfTies = $this->formatter->detectTies($fewestHalf);
+        $records[$this->formatter->addTieLabel('Fewest Points in a Single Half', $fewestHalfTies)] = $fewestHalfTies;
 
         // Margin of victory (overall and playoffs)
-        $marginOverall = $this->formatMarginRecords($this->repository->getLargestMarginOfVictory('1=1'));
+        $marginOverall = $this->formatter->formatMarginRecords($this->repository->getLargestMarginOfVictory('1=1'));
         /** @var list<FormattedTeamGameRecord> $marginOverallTies */
-        $marginOverallTies = $this->detectTies($marginOverall);
-        $records[$this->addTieLabel('Largest Margin of Victory [overall]', $marginOverallTies)] = $marginOverallTies;
+        $marginOverallTies = $this->formatter->detectTies($marginOverall);
+        $records[$this->formatter->addTieLabel('Largest Margin of Victory [overall]', $marginOverallTies)] = $marginOverallTies;
 
-        $marginPlayoffs = $this->formatMarginRecords($this->repository->getLargestMarginOfVictory('bs.game_type = 2'));
+        $marginPlayoffs = $this->formatter->formatMarginRecords($this->repository->getLargestMarginOfVictory('bs.game_type = 2'));
         /** @var list<FormattedTeamGameRecord> $marginPlayoffTies */
-        $marginPlayoffTies = $this->detectTies($marginPlayoffs);
-        $records[$this->addTieLabel('Largest Margin of Victory [playoffs]', $marginPlayoffTies)] = $marginPlayoffTies;
+        $marginPlayoffTies = $this->formatter->detectTies($marginPlayoffs);
+        $records[$this->formatter->addTieLabel('Largest Margin of Victory [playoffs]', $marginPlayoffTies)] = $marginPlayoffTies;
 
         return $records;
-    }
-
-    /**
-     * Format team single-game records from DB rows.
-     *
-     * @param list<array{teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, value: int}> $dbRecords
-     * @return list<FormattedTeamGameRecord>
-     */
-    private function formatTeamGameRecords(array $dbRecords): array
-    {
-        /** @var list<FormattedTeamGameRecord> $formatted */
-        $formatted = [];
-        foreach ($dbRecords as $record) {
-            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
-            $formatted[] = [
-                'teamAbbr' => self::teamAbbreviation($record['teamid']),
-                'teamTid' => $record['teamid'],
-                'teamYr' => (string) $seasonYear,
-                'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
-                'dateDisplay' => $this->formatDateDisplay($record['date'], 'regularSeason'),
-                'oppAbbr' => self::teamAbbreviation($record['oppTid']),
-                'oppTid' => $record['oppTid'],
-                'oppYr' => (string) $seasonYear,
-                'amount' => (string) $record['value'],
-            ];
-        }
-        return $formatted;
-    }
-
-    /**
-     * Format margin of victory records.
-     *
-     * @param list<array{winner_tid: int, winner_name: string, loser_tid: int, loser_name: string, date: string, box_id: int, game_of_that_day: int, margin: int}> $dbRecords
-     * @return list<FormattedTeamGameRecord>
-     */
-    private function formatMarginRecords(array $dbRecords): array
-    {
-        /** @var list<FormattedTeamGameRecord> $formatted */
-        $formatted = [];
-        foreach ($dbRecords as $record) {
-            $seasonYear = IblSeasonDateHelper::dateToSeasonEndingYear($record['date']);
-            $formatted[] = [
-                'teamAbbr' => self::teamAbbreviation($record['winner_tid']),
-                'teamTid' => $record['winner_tid'],
-                'teamYr' => (string) $seasonYear,
-                'boxScoreUrl' => $this->buildBoxScoreUrl($record['date'], $record['game_of_that_day'], $record['box_id']),
-                'dateDisplay' => $this->formatDateDisplay($record['date'], 'regularSeason'),
-                'oppAbbr' => self::teamAbbreviation($record['loser_tid']),
-                'oppTid' => $record['loser_tid'],
-                'oppYr' => (string) $seasonYear,
-                'amount' => (string) $record['margin'],
-            ];
-        }
-        return $formatted;
     }
 
     /**
@@ -383,104 +184,26 @@ class RecordHoldersService implements RecordHoldersServiceInterface
 
         // Best/worst season record
         $best = $this->repository->getBestWorstSeasonRecord('DESC');
-        $records['Best Season Record'] = $this->formatSeasonWinLossRecords($best);
+        $records['Best Season Record'] = $this->formatter->formatSeasonWinLossRecords($best);
 
         $worst = $this->repository->getBestWorstSeasonRecord('ASC');
-        $records['Worst Season Record'] = $this->formatSeasonWinLossRecords($worst);
+        $records['Worst Season Record'] = $this->formatter->formatSeasonWinLossRecords($worst);
 
         // Best/worst season start
         $bestStart = $this->repository->getBestWorstSeasonStart('best');
-        $records['Best Season Record, Start'] = $this->formatSeasonStartRecords($bestStart, 'best');
+        $records['Best Season Record, Start'] = $this->formatter->formatSeasonStartRecords($bestStart, 'best');
 
         $worstStart = $this->repository->getBestWorstSeasonStart('worst');
-        $records['Worst Season Record, Start'] = $this->formatSeasonStartRecords($worstStart, 'worst');
+        $records['Worst Season Record, Start'] = $this->formatter->formatSeasonStartRecords($worstStart, 'worst');
 
         // Longest winning/losing streaks
         $winStreak = $this->repository->getLongestStreak('winning');
-        $records['Longest Winning Streak'] = $this->formatStreakRecords($winStreak);
+        $records['Longest Winning Streak'] = $this->formatter->formatStreakRecords($winStreak);
 
         $loseStreak = $this->repository->getLongestStreak('losing');
-        $records['Longest Losing Streak'] = $this->formatStreakRecords($loseStreak);
+        $records['Longest Losing Streak'] = $this->formatter->formatStreakRecords($loseStreak);
 
         return $records;
-    }
-
-    /**
-     * Format season win/loss records.
-     *
-     * @param list<array{team_name: string, year: int, wins: int, losses: int}> $dbRecords
-     * @return list<FormattedTeamSeasonRecord>
-     */
-    private function formatSeasonWinLossRecords(array $dbRecords): array
-    {
-        /** @var list<FormattedTeamSeasonRecord> $formatted */
-        $formatted = [];
-        foreach ($dbRecords as $record) {
-            $endingYear = $record['year'];
-            $formatted[] = [
-                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
-                'teamTid' => self::teamIdByName($record['team_name']),
-                'teamYr' => (string) $endingYear,
-                'season' => $this->formatSeasonYearRange($endingYear),
-                'amount' => $record['wins'] . '-' . $record['losses'],
-            ];
-        }
-        /** @var list<FormattedTeamSeasonRecord> $withTies */
-        $withTies = $this->detectTies($formatted);
-        return $withTies;
-    }
-
-    /**
-     * Format season start records.
-     *
-     * @param list<array{team_name: string, year: int, wins: int, losses: int}> $dbRecords
-     * @param string $type 'best' or 'worst'
-     * @return list<FormattedTeamSeasonRecord>
-     */
-    private function formatSeasonStartRecords(array $dbRecords, string $type): array
-    {
-        /** @var list<FormattedTeamSeasonRecord> $formatted */
-        $formatted = [];
-        foreach ($dbRecords as $record) {
-            $formatted[] = [
-                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
-                'teamTid' => self::teamIdByName($record['team_name']),
-                'teamYr' => (string) $record['year'],
-                'season' => $this->formatSeasonYearRange($record['year']),
-                'amount' => $record['wins'] . '-' . $record['losses'],
-            ];
-        }
-        /** @var list<FormattedTeamSeasonRecord> $withTies */
-        $withTies = $this->detectTies($formatted);
-        return $withTies;
-    }
-
-    /**
-     * Format streak records.
-     *
-     * @param list<array{team_name: string, streak: int, start_date: string, end_date: string, start_year: int, end_year: int}> $dbRecords
-     * @return list<FormattedTeamSeasonRecord>
-     */
-    private function formatStreakRecords(array $dbRecords): array
-    {
-        /** @var list<FormattedTeamSeasonRecord> $formatted */
-        $formatted = [];
-        foreach ($dbRecords as $record) {
-            $season = $this->formatSeasonYearRange($record['start_year']);
-            if ($record['start_year'] !== $record['end_year']) {
-                $season .= ', ' . $this->formatSeasonYearRange($record['end_year']);
-            }
-            $formatted[] = [
-                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
-                'teamTid' => self::teamIdByName($record['team_name']),
-                'teamYr' => (string) $record['start_year'],
-                'season' => $season,
-                'amount' => (string) $record['streak'],
-            ];
-        }
-        /** @var list<FormattedTeamSeasonRecord> $withTies */
-        $withTies = $this->detectTies($formatted);
-        return $withTies;
     }
 
     /**
@@ -494,74 +217,30 @@ class RecordHoldersService implements RecordHoldersServiceInterface
 
         // Most playoff appearances
         $playoffs = $this->repository->getMostPlayoffAppearances();
-        $records['Most Playoff Appearances'] = $this->formatFranchiseRecords($playoffs);
+        $records['Most Playoff Appearances'] = $this->formatter->formatFranchiseRecords($playoffs);
 
         // Most division championships
         $divisions = $this->repository->getMostTitlesByType('Division');
-        $records['Most Division Championships'] = $this->formatFranchiseRecords($divisions);
+        $records['Most Division Championships'] = $this->formatter->formatFranchiseRecords($divisions);
 
         // Most IBL Finals appearances (Conference Championship winners)
         $finals = $this->repository->getMostTitlesByType('Conference');
-        $records['Most IBL Finals Appearances'] = $this->formatFranchiseRecords($finals);
+        $records['Most IBL Finals Appearances'] = $this->formatter->formatFranchiseRecords($finals);
 
         // Most IBL Championships
         $championships = $this->repository->getMostTitlesByType('IBL Champions');
-        $records['Most IBL Championships'] = $this->formatFranchiseRecords($championships);
+        $records['Most IBL Championships'] = $this->formatter->formatFranchiseRecords($championships);
 
         // Add tie labels
         /** @var array<string, list<FormattedFranchiseRecord>> $labeled */
         $labeled = [];
         foreach ($records as $category => $data) {
             /** @var list<FormattedFranchiseRecord> $withTies */
-            $withTies = $this->detectTies($data);
-            $labeled[$this->addTieLabel($category, $withTies)] = $withTies;
+            $withTies = $this->formatter->detectTies($data);
+            $labeled[$this->formatter->addTieLabel($category, $withTies)] = $withTies;
         }
 
         return $labeled;
-    }
-
-    /**
-     * Format franchise records (titles, appearances).
-     *
-     * @param list<array{team_name: string, count: int, years: string}> $dbRecords
-     * @return list<FormattedFranchiseRecord>
-     */
-    private function formatFranchiseRecords(array $dbRecords): array
-    {
-        /** @var list<FormattedFranchiseRecord> $formatted */
-        $formatted = [];
-        foreach ($dbRecords as $record) {
-            $formatted[] = [
-                'teamAbbr' => self::teamAbbreviationByName($record['team_name']),
-                'teamTid' => self::teamIdByName($record['team_name']),
-                'amount' => (string) $record['count'],
-                'years' => strip_tags($record['years']),
-            ];
-        }
-        return $formatted;
-    }
-
-    private static function teamAbbreviation(int $teamId): string
-    {
-        return self::TEAM_REGISTRY[$teamId]['abbr'] ?? '';
-    }
-
-    private static function teamIdByName(string $teamName): int
-    {
-        /** @var array<string, int>|null $byName */
-        static $byName = null;
-        if ($byName === null) {
-            $byName = [];
-            foreach (self::TEAM_REGISTRY as $id => $info) {
-                $byName[$info['name']] = $id;
-            }
-        }
-        return $byName[$teamName] ?? 0;
-    }
-
-    private static function teamAbbreviationByName(string $teamName): string
-    {
-        return self::teamAbbreviation(self::teamIdByName($teamName));
     }
 
     /**
@@ -599,89 +278,4 @@ class RecordHoldersService implements RecordHoldersServiceInterface
         }
         return $map;
     }
-
-    /**
-     * Detect ties in formatted records (multiple entries sharing the same top value).
-     *
-     * Only keeps entries that match the top (first) value.
-     * Returns the same array shape as the input, with only top-value entries.
-     *
-     * @param list<array<string, mixed>> $records Each record must have an 'amount' key
-     * @return list<array<string, mixed>>
-     */
-    private function detectTies(array $records): array
-    {
-        if (count($records) <= 1) {
-            return $records;
-        }
-
-        $topAmount = $records[0]['amount'];
-        $tied = [];
-        foreach ($records as $record) {
-            if ($record['amount'] === $topAmount) {
-                $tied[] = $record;
-            }
-        }
-        return $tied;
-    }
-
-    /**
-     * Add " [tie]" suffix to category name if there are multiple records.
-     *
-     * @param list<array<string, mixed>> $records
-     */
-    private function addTieLabel(string $category, array $records): string
-    {
-        if (count($records) > 1) {
-            return $category . ' [tie]';
-        }
-        return $category;
-    }
-
-    /**
-     * Format a date for display based on game type.
-     *
-     * Regular season / Playoffs: "January 16, 1996"
-     * HEAT: "HEAT\nOctober 16, 1995" (newline-separated for two-line display)
-     */
-    private function formatDateDisplay(string $date, string $gameType): string
-    {
-        if ($date === '' || $date === '0000-00-00') {
-            return '';
-        }
-
-        $timestamp = strtotime($date);
-        if ($timestamp === false) {
-            return $date;
-        }
-
-        if ($gameType === 'heat') {
-            return "HEAT\n" . date('F j, Y', $timestamp);
-        }
-
-        return date('F j, Y', $timestamp);
-    }
-
-    /**
-     * Build a box score URL using the IBL6 SvelteKit URL pattern.
-     *
-     * Returns empty string if gameOfThatDay is not available (historical records).
-     */
-    private function buildBoxScoreUrl(string $date, int $gameOfThatDay, int $boxId = 0): string
-    {
-        return \Utilities\BoxScoreUrlBuilder::buildUrl($date, $gameOfThatDay, $boxId);
-    }
-
-    /**
-     * Format a season ending year into "YYYY-YY" range format.
-     *
-     * Example: 1996 → "1995-96"
-     */
-    private function formatSeasonYearRange(int $endingYear): string
-    {
-        $beginYear = $endingYear - 1;
-        $endYearShort = substr((string) $endingYear, 2);
-        return $beginYear . '-' . $endYearShort;
-    }
-
 }

--- a/ibl5/tests/RecordHolders/RecordFormatterTest.php
+++ b/ibl5/tests/RecordHolders/RecordFormatterTest.php
@@ -1,0 +1,406 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\RecordHolders;
+
+use PHPUnit\Framework\TestCase;
+use RecordHolders\RecordFormatter;
+
+final class RecordFormatterTest extends TestCase
+{
+    private RecordFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new RecordFormatter();
+    }
+
+    // -------------------------------------------------------------------------
+    // formatPlayerRecords
+    // -------------------------------------------------------------------------
+
+    public function testFormatPlayerRecordsMapsFields(): void
+    {
+        $row = $this->makePlayerRow(teamid: 1, oppTid: 2, value: 42);
+        $result = $this->formatter->formatPlayerRecords([$row], 'regularSeason');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('bos', $result[0]['teamAbbr']);
+        $this->assertSame('mia', $result[0]['oppAbbr']);
+        $this->assertSame('42', $result[0]['amount']);
+        $this->assertSame('1996', $result[0]['teamYr']);
+    }
+
+    public function testFormatPlayerRecordsEmptyInput(): void
+    {
+        $this->assertSame([], $this->formatter->formatPlayerRecords([], 'regularSeason'));
+    }
+
+    public function testFormatPlayerRecordsUnknownTeamIdReturnsEmptyAbbr(): void
+    {
+        $row = $this->makePlayerRow(teamid: 999, oppTid: 998);
+        $result = $this->formatter->formatPlayerRecords([$row], 'regularSeason');
+
+        $this->assertSame('', $result[0]['teamAbbr']);
+        $this->assertSame('', $result[0]['oppAbbr']);
+    }
+
+    // -------------------------------------------------------------------------
+    // formatQuadrupleDoubles
+    // -------------------------------------------------------------------------
+
+    public function testFormatQuadrupleDoublesBuildsMultiLineAmount(): void
+    {
+        $row = $this->makeQDRow(points: 30, rebounds: 12, assists: 10, steals: 10, blocks: 10);
+        $result = $this->formatter->formatQuadrupleDoubles([$row]);
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString("30pts", $result[0]['amount']);
+        $this->assertStringContainsString("12rbs", $result[0]['amount']);
+        $this->assertStringContainsString("10ast", $result[0]['amount']);
+        $this->assertStringContainsString("10stl", $result[0]['amount']);
+        $this->assertStringContainsString("10blk", $result[0]['amount']);
+    }
+
+    public function testFormatQuadrupleDoublesOmitsBlkLineWhenBlocksUnderTen(): void
+    {
+        $row = $this->makeQDRow(blocks: 9);
+        $result = $this->formatter->formatQuadrupleDoubles([$row]);
+
+        $this->assertStringNotContainsString("blk", $result[0]['amount']);
+    }
+
+    // -------------------------------------------------------------------------
+    // formatAllStarRecord
+    // -------------------------------------------------------------------------
+
+    public function testFormatAllStarRecordReturnsTopRecord(): void
+    {
+        $records = [['name' => 'LeBron James', 'pid' => 42, 'appearances' => 15]];
+        $result = $this->formatter->formatAllStarRecord($records);
+
+        $this->assertSame('LeBron James', $result['name']);
+        $this->assertSame(42, $result['pid']);
+        $this->assertSame(15, $result['amount']);
+    }
+
+    public function testFormatAllStarRecordEmptyInputReturnsEmptyShape(): void
+    {
+        $result = $this->formatter->formatAllStarRecord([]);
+
+        $this->assertSame('', $result['name']);
+        $this->assertNull($result['pid']);
+        $this->assertSame(0, $result['amount']);
+        $this->assertSame('', $result['years']);
+    }
+
+    // -------------------------------------------------------------------------
+    // formatPlayerSeasonRecords
+    // -------------------------------------------------------------------------
+
+    public function testFormatPlayerSeasonRecordsBuildsSeasonString(): void
+    {
+        $row = ['pid' => 1, 'name' => 'Player', 'teamid' => 1, 'team' => 'Celtics', 'year' => 1994, 'value' => 25.6];
+        $result = $this->formatter->formatPlayerSeasonRecords([$row]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('1993-94', $result[0]['season']);
+        $this->assertSame('bos', $result[0]['teamAbbr']);
+    }
+
+    public function testFormatPlayerSeasonRecordsFormatsAmountOneDecimal(): void
+    {
+        $row = ['pid' => 1, 'name' => 'Player', 'teamid' => 1, 'team' => 'Celtics', 'year' => 1994, 'value' => 25.0];
+        $result = $this->formatter->formatPlayerSeasonRecords([$row]);
+
+        $this->assertSame('25.0', $result[0]['amount']);
+    }
+
+    public function testFormatPlayerSeasonRecordsEmptyInput(): void
+    {
+        $this->assertSame([], $this->formatter->formatPlayerSeasonRecords([]));
+    }
+
+    // -------------------------------------------------------------------------
+    // formatTeamGameRecords
+    // -------------------------------------------------------------------------
+
+    public function testFormatTeamGameRecordsMapsFields(): void
+    {
+        $row = $this->makeTeamGameRow(teamid: 1, oppTid: 2, value: 150);
+        $result = $this->formatter->formatTeamGameRecords([$row]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('bos', $result[0]['teamAbbr']);
+        $this->assertSame('mia', $result[0]['oppAbbr']);
+        $this->assertSame('150', $result[0]['amount']);
+    }
+
+    public function testFormatTeamGameRecordsEmptyInput(): void
+    {
+        $this->assertSame([], $this->formatter->formatTeamGameRecords([]));
+    }
+
+    // -------------------------------------------------------------------------
+    // formatMarginRecords
+    // -------------------------------------------------------------------------
+
+    public function testFormatMarginRecordsMapsWinnerAndLoser(): void
+    {
+        $row = [
+            'winner_tid' => 1, 'winner_name' => 'Celtics',
+            'loser_tid' => 2, 'loser_name' => 'Heat',
+            'date' => '1996-01-16', 'box_id' => 0, 'game_of_that_day' => 1, 'margin' => 35,
+        ];
+        $result = $this->formatter->formatMarginRecords([$row]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('bos', $result[0]['teamAbbr']);
+        $this->assertSame('mia', $result[0]['oppAbbr']);
+        $this->assertSame('35', $result[0]['amount']);
+    }
+
+    public function testFormatMarginRecordsEmptyInput(): void
+    {
+        $this->assertSame([], $this->formatter->formatMarginRecords([]));
+    }
+
+    // -------------------------------------------------------------------------
+    // formatSeasonWinLossRecords
+    // -------------------------------------------------------------------------
+
+    public function testFormatSeasonWinLossRecordsBuildsAmount(): void
+    {
+        $row = ['team_name' => 'Celtics', 'year' => 1996, 'wins' => 55, 'losses' => 27];
+        $result = $this->formatter->formatSeasonWinLossRecords([$row]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('55-27', $result[0]['amount']);
+        $this->assertSame('bos', $result[0]['teamAbbr']);
+        $this->assertSame('1995-96', $result[0]['season']);
+    }
+
+    public function testFormatSeasonWinLossRecordsTrimsToTopTied(): void
+    {
+        $rows = [
+            ['team_name' => 'Celtics', 'year' => 1996, 'wins' => 55, 'losses' => 27],
+            ['team_name' => 'Heat', 'year' => 1997, 'wins' => 55, 'losses' => 27],
+            ['team_name' => 'Knicks', 'year' => 1995, 'wins' => 50, 'losses' => 32],
+        ];
+        $result = $this->formatter->formatSeasonWinLossRecords($rows);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('bos', $result[0]['teamAbbr']);
+        $this->assertSame('mia', $result[1]['teamAbbr']);
+    }
+
+    // -------------------------------------------------------------------------
+    // formatSeasonStartRecords
+    // -------------------------------------------------------------------------
+
+    public function testFormatSeasonStartRecordsBuildsAmount(): void
+    {
+        $row = ['team_name' => 'Heat', 'year' => 1997, 'wins' => 10, 'losses' => 0];
+        $result = $this->formatter->formatSeasonStartRecords([$row], 'best');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('10-0', $result[0]['amount']);
+        $this->assertSame('mia', $result[0]['teamAbbr']);
+    }
+
+    public function testFormatSeasonStartRecordsSingleRowNoTieTrimming(): void
+    {
+        $row = ['team_name' => 'Celtics', 'year' => 1996, 'wins' => 8, 'losses' => 2];
+        $result = $this->formatter->formatSeasonStartRecords([$row], 'best');
+
+        $this->assertCount(1, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // formatStreakRecords
+    // -------------------------------------------------------------------------
+
+    public function testFormatStreakRecordsSingleSeasonStreak(): void
+    {
+        $row = [
+            'team_name' => 'Bulls', 'streak' => 15,
+            'start_date' => '1995-01-01', 'end_date' => '1995-02-10',
+            'start_year' => 1995, 'end_year' => 1995,
+        ];
+        $result = $this->formatter->formatStreakRecords([$row]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('chi', $result[0]['teamAbbr']);
+        $this->assertSame('15', $result[0]['amount']);
+        $this->assertSame('1994-95', $result[0]['season']);
+    }
+
+    public function testFormatStreakRecordsCrossYearSeasonJoin(): void
+    {
+        $row = [
+            'team_name' => 'Bulls', 'streak' => 20,
+            'start_date' => '1995-12-01', 'end_date' => '1996-01-20',
+            'start_year' => 1995, 'end_year' => 1996,
+        ];
+        $result = $this->formatter->formatStreakRecords([$row]);
+
+        $this->assertSame('1994-95, 1995-96', $result[0]['season']);
+    }
+
+    // -------------------------------------------------------------------------
+    // formatFranchiseRecords
+    // -------------------------------------------------------------------------
+
+    public function testFormatFranchiseRecordsMapsFields(): void
+    {
+        $row = ['team_name' => 'Celtics', 'count' => 8, 'years' => '1990, 1992, 1994'];
+        $result = $this->formatter->formatFranchiseRecords([$row]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('bos', $result[0]['teamAbbr']);
+        $this->assertSame('8', $result[0]['amount']);
+        $this->assertSame('1990, 1992, 1994', $result[0]['years']);
+    }
+
+    public function testFormatFranchiseRecordsStripsTagsFromYears(): void
+    {
+        $row = ['team_name' => 'Celtics', 'count' => 3, 'years' => '<b>1990</b>, <i>1992</i>'];
+        $result = $this->formatter->formatFranchiseRecords([$row]);
+
+        $this->assertSame('1990, 1992', $result[0]['years']);
+    }
+
+    // -------------------------------------------------------------------------
+    // detectTies
+    // -------------------------------------------------------------------------
+
+    public function testDetectTiesKeepsAllMatchingTopAmount(): void
+    {
+        $records = [
+            ['amount' => '30', 'name' => 'A'],
+            ['amount' => '30', 'name' => 'B'],
+            ['amount' => '28', 'name' => 'C'],
+        ];
+        $result = $this->formatter->detectTies($records);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('A', $result[0]['name']);
+        $this->assertSame('B', $result[1]['name']);
+    }
+
+    public function testDetectTiesSingleRecordReturnedUnchanged(): void
+    {
+        $records = [['amount' => '30', 'name' => 'A']];
+        $result = $this->formatter->detectTies($records);
+
+        $this->assertSame($records, $result);
+    }
+
+    public function testDetectTiesEmptyInputReturnedUnchanged(): void
+    {
+        $this->assertSame([], $this->formatter->detectTies([]));
+    }
+
+    public function testDetectTiesNoTieReturnsOnlyFirst(): void
+    {
+        $records = [
+            ['amount' => '30', 'name' => 'A'],
+            ['amount' => '28', 'name' => 'B'],
+        ];
+        $result = $this->formatter->detectTies($records);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('A', $result[0]['name']);
+    }
+
+    // -------------------------------------------------------------------------
+    // addTieLabel
+    // -------------------------------------------------------------------------
+
+    public function testAddTieLabelAppendsSuffixForMultipleRecords(): void
+    {
+        $records = [['amount' => '30'], ['amount' => '30']];
+        $result = $this->formatter->addTieLabel('Most Points', $records);
+
+        $this->assertSame('Most Points [tie]', $result);
+    }
+
+    public function testAddTieLabelNoSuffixForSingleRecord(): void
+    {
+        $records = [['amount' => '30']];
+        $result = $this->formatter->addTieLabel('Most Points', $records);
+
+        $this->assertSame('Most Points', $result);
+    }
+
+    public function testAddTieLabelNoSuffixForEmptyRecords(): void
+    {
+        $result = $this->formatter->addTieLabel('Most Points', []);
+
+        $this->assertSame('Most Points', $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array{pid: int, name: string, teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, value: int}
+     */
+    private function makePlayerRow(int $teamid = 1, int $oppTid = 2, int $value = 30): array
+    {
+        return [
+            'pid' => 1,
+            'name' => 'Test Player',
+            'teamid' => $teamid,
+            'team_name' => 'Celtics',
+            'date' => '1996-01-16',
+            'box_id' => 0,
+            'game_of_that_day' => 1,
+            'oppTid' => $oppTid,
+            'opp_team_name' => 'Heat',
+            'value' => $value,
+        ];
+    }
+
+    /**
+     * @return array{pid: int, name: string, teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, points: int, rebounds: int, assists: int, steals: int, blocks: int}
+     */
+    private function makeQDRow(int $points = 20, int $rebounds = 12, int $assists = 11, int $steals = 10, int $blocks = 5): array
+    {
+        return [
+            'pid' => 1,
+            'name' => 'Test Player',
+            'teamid' => 1,
+            'team_name' => 'Celtics',
+            'date' => '1996-01-16',
+            'box_id' => 0,
+            'game_of_that_day' => 1,
+            'oppTid' => 2,
+            'opp_team_name' => 'Heat',
+            'points' => $points,
+            'rebounds' => $rebounds,
+            'assists' => $assists,
+            'steals' => $steals,
+            'blocks' => $blocks,
+        ];
+    }
+
+    /**
+     * @return array{teamid: int, team_name: string, date: string, box_id: int, game_of_that_day: int, oppTid: int, opp_team_name: string, value: int}
+     */
+    private function makeTeamGameRow(int $teamid = 1, int $oppTid = 2, int $value = 130): array
+    {
+        return [
+            'teamid' => $teamid,
+            'team_name' => 'Celtics',
+            'date' => '1996-01-16',
+            'box_id' => 0,
+            'game_of_that_day' => 1,
+            'oppTid' => $oppTid,
+            'opp_team_name' => 'Heat',
+            'value' => $value,
+        ];
+    }
+}

--- a/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
+++ b/ibl5/tests/RecordHolders/RecordHoldersServiceTest.php
@@ -6,6 +6,7 @@ namespace Tests\RecordHolders;
 
 use League\League;
 use PHPUnit\Framework\TestCase;
+use RecordHolders\RecordFormatter;
 use RecordHolders\RecordHoldersService;
 use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
 
@@ -544,7 +545,7 @@ final class RecordHoldersServiceTest extends TestCase
 
     public function testTeamRegistryContainsExactlyMaxRealTeamidEntries(): void
     {
-        $reflection = new \ReflectionClass(RecordHoldersService::class);
+        $reflection = new \ReflectionClass(RecordFormatter::class);
         $registry = $reflection->getConstant('TEAM_REGISTRY');
         $this->assertIsArray($registry);
         $this->assertCount(League::MAX_REAL_TEAMID, $registry);
@@ -552,7 +553,7 @@ final class RecordHoldersServiceTest extends TestCase
 
     public function testTeamRegistryEachEntryHasAbbrAndName(): void
     {
-        $reflection = new \ReflectionClass(RecordHoldersService::class);
+        $reflection = new \ReflectionClass(RecordFormatter::class);
         /** @var array<int, array{abbr: string, name: string}> $registry */
         $registry = $reflection->getConstant('TEAM_REGISTRY');
         $this->assertIsArray($registry);


### PR DESCRIPTION
## Summary

Extracts the entire formatting cluster from `RecordHoldersService` (687 LOC god-class) into a new `RecordFormatter` collaborator, shrinking the Service to a thin orchestrator. Behavior-preserving (green-green): `RecordHoldersServiceTest` passes with zero assertion edits.

**What changed:**
- **New** `RecordFormatterInterface` — public formatter surface (`Contracts/RecordFormatterInterface.php`)
- **New** `RecordFormatter` — extracted formatting collaborator with zero constructor dependencies (`new RecordFormatter()`)
- **Thinned** `RecordHoldersService` — constructor gains optional `?RecordFormatterInterface $formatter = null` (DI-with-default pattern mirroring `TopicsService`); all `format*`/`detectTies`/`addTieLabel` calls delegate to `$this->formatter`
- **New** `RecordFormatterTest` — isolation tests for each public formatter method; tests all 12 methods with happy-path + negative/boundary cases (no repository mock needed)
- **Refactor win:** formatter methods are now unit-testable in isolation with `new RecordFormatter()`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.