### PR TITLE
fix: add aria-label to all select/input controls on League Control Panel

### DIFF
--- a/ibl5/classes/LeagueControlPanel/LeagueControlPanelView.php
+++ b/ibl5/classes/LeagueControlPanel/LeagueControlPanelView.php
@@ -79,7 +79,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
     <label>Current League:</label>
     <span class="league-badge <?= HtmlSanitizer::e($badgeClass) ?>"><?= HtmlSanitizer::e(strtoupper($leagueConfig['short_name'])) ?></span>
     <label>Switch to:</label>
-    <select onchange="window.location.href=this.value" class="ibl-select ibl-select--auto">
+    <select onchange="window.location.href=this.value" aria-label="Switch league" class="ibl-select ibl-select--auto">
         <option value="leagueControlPanel.php?league=ibl"<?= $currentLeague === 'ibl' ? ' selected' : '' ?>>IBL</option>
         <option value="leagueControlPanel.php?league=olympics"<?= $currentLeague === 'olympics' ? ' selected' : '' ?>>Olympics</option>
     </select>
@@ -121,7 +121,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
 <section class="updater-section">
     <div class="updater-section__label">Season Phase</div>
     <div class="lcp-control-row">
-        <select name="SeasonPhase" class="ibl-select ibl-select--auto">
+        <select name="SeasonPhase" aria-label="Current season phase" class="ibl-select ibl-select--auto">
         <?php foreach ($phases as $phase): ?>
             <option value="<?= HtmlSanitizer::e($phase) ?>"<?= $panelData['phase'] === $phase ? ' selected' : '' ?>><?= HtmlSanitizer::e($phase) ?></option>
         <?php endforeach; ?>
@@ -172,7 +172,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
     <?= HtmlSanitizer::trusted($this->renderUpdateAllButton()) ?>
     <div class="lcp-note">Upload sim backup to <strong>backups/</strong> before running</div>
     <div class="lcp-control-row">
-        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
+        <input type="number" name="SimLengthInDays" aria-label="Sim length in days" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
         <button type="submit" name="action" value="set_sim_length" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Set Sim Length in Days</button>
     </div>
     <div class="lcp-note">You must click the button — pressing Enter will not work</div>
@@ -208,7 +208,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
     <?= HtmlSanitizer::trusted($this->renderUpdateAllButton()) ?>
     <div class="lcp-note">Upload sim backup to <strong>backups/</strong> before running</div>
     <div class="lcp-control-row">
-        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
+        <input type="number" name="SimLengthInDays" aria-label="Sim length in days" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
         <button type="submit" name="action" value="set_sim_length" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Set Sim Length in Days</button>
     </div>
     <div class="lcp-note">You must click the button — pressing Enter will not work</div>
@@ -229,7 +229,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
     <?= HtmlSanitizer::trusted($this->renderUpdateAllButton()) ?>
     <div class="lcp-note">Upload sim backup to <strong>backups/</strong> before running</div>
     <div class="lcp-control-row">
-        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
+        <input type="number" name="SimLengthInDays" aria-label="Sim length in days" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
         <button type="submit" name="action" value="set_sim_length" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Set Sim Length in Days</button>
     </div>
     <div class="lcp-note">You must click the button — pressing Enter will not work</div>
@@ -260,7 +260,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
     <?= HtmlSanitizer::trusted($this->renderUpdateAllButton()) ?>
     <div class="lcp-note">Upload sim backup to <strong>backups/</strong> before running</div>
     <div class="lcp-control-row">
-        <input type="number" name="SimLengthInDays" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
+        <input type="number" name="SimLengthInDays" aria-label="Sim length in days" min="1" max="180" size="3" value="<?= HtmlSanitizer::e((string) $panelData['simLengthInDays']) ?>" onkeydown="if(event.key==='Enter')event.preventDefault()" class="ibl-input ibl-input--sm w-20">
         <button type="submit" name="action" value="set_sim_length" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Set Sim Length in Days</button>
     </div>
     <div class="lcp-note">You must click the button — pressing Enter will not work</div>
@@ -351,7 +351,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
         ob_start();
         ?>
 <div class="lcp-control-row">
-    <select name="Waivers" class="ibl-select ibl-select--auto">
+    <select name="Waivers" aria-label="Allow waiver moves" class="ibl-select ibl-select--auto">
         <option value="Yes"<?= $panelData['allowWaivers'] === 'Yes' ? ' selected' : '' ?>>Yes</option>
         <option value="No"<?= $panelData['allowWaivers'] === 'No' ? ' selected' : '' ?>>No</option>
     </select>
@@ -369,7 +369,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
         ob_start();
         ?>
 <div class="lcp-control-row">
-    <select name="Trades" class="ibl-select ibl-select--auto">
+    <select name="Trades" aria-label="Allow trades" class="ibl-select ibl-select--auto">
         <option value="Yes"<?= $panelData['allowTrades'] === 'Yes' ? ' selected' : '' ?>>Yes</option>
         <option value="No"<?= $panelData['allowTrades'] === 'No' ? ' selected' : '' ?>>No</option>
     </select>
@@ -387,7 +387,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
         ob_start();
         ?>
 <div class="lcp-control-row">
-    <select name="ShowDraftLink" class="ibl-select ibl-select--auto">
+    <select name="ShowDraftLink" aria-label="Show draft link" class="ibl-select ibl-select--auto">
         <option value="On"<?= $panelData['showDraftLink'] === 'On' ? ' selected' : '' ?>>On</option>
         <option value="Off"<?= $panelData['showDraftLink'] === 'Off' ? ' selected' : '' ?>>Off</option>
     </select>
@@ -405,7 +405,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
         ob_start();
         ?>
 <div class="lcp-control-row">
-    <select name="FANotifs" class="ibl-select ibl-select--auto">
+    <select name="FANotifs" aria-label="Free agency notifications" class="ibl-select ibl-select--auto">
         <option value="On"<?= $panelData['freeAgencyNotifications'] === 'On' ? ' selected' : '' ?>>On</option>
         <option value="Off"<?= $panelData['freeAgencyNotifications'] === 'Off' ? ' selected' : '' ?>>Off</option>
     </select>
@@ -429,7 +429,7 @@ class LeagueControlPanelView implements LeagueControlPanelViewInterface
 <div class="lcp-note">Requires Leaders.htm and completed EOY voting</div>
 <?php if (!$panelData['hasFinalsMvp']): ?>
 <div class="lcp-control-row">
-    <input type="text" name="finals_mvp_name" placeholder="Finals MVP name" class="ibl-input ibl-input--sm" maxlength="32">
+    <input type="text" name="finals_mvp_name" aria-label="Finals MVP name" placeholder="Finals MVP name" class="ibl-input ibl-input--sm" maxlength="32">
     <button type="submit" name="action" value="set_finals_mvp" class="ibl-btn ibl-btn--secondary ibl-btn--sm">Set Finals MVP</button>
 </div>
 <?php endif; ?>

--- a/ibl5/tests/e2e/smoke/accessibility.spec.ts
+++ b/ibl5/tests/e2e/smoke/accessibility.spec.ts
@@ -53,6 +53,8 @@ const KNOWN_FAILING: Record<string, Set<string>> = {
     'gm contact list',
     'draft',
     'next sim',
+    // Legacy admin page — PHP-Nuke palette debt. See ibl5/docs/a11y-backlog.md.
+    'league control panel',
   ]),
 
   // No <h1> on page — most module pages use <h2 class="ibl-title">. See ibl5/docs/a11y-backlog.md.
@@ -113,6 +115,16 @@ const KNOWN_FAILING: Record<string, Set<string>> = {
     'next sim',
     'schedule',
     'team schedule',
+  ]),
+
+  // No <main> landmark — legacy root page bypasses PageLayout. See ibl5/docs/a11y-backlog.md §landmark-one-main.
+  'landmark-one-main': new Set([
+    'league control panel',
+  ]),
+
+  // Content outside landmark regions — same root-page bypass. See ibl5/docs/a11y-backlog.md §region.
+  'region': new Set([
+    'league control panel',
   ]),
 };
 
@@ -211,6 +223,11 @@ const authPages: Array<{
     state: { 'Current Season Phase': 'Free Agency', 'EOY Voting': 'Yes' },
   },
   { name: 'training camp ratings diff', url: 'modules.php?name=TrainingCampRatingsDiff' },
+  {
+    name: 'league control panel',
+    url: 'leagueControlPanel.php',
+    state: { 'Current Season Phase': 'Regular Season', 'Current Season Ending Year': '2026' },
+  },
 ];
 
 authTest.describe('Authenticated page accessibility', () => {


### PR DESCRIPTION
## Summary

Fixes the two WCAG-2.0 level-A critical axe failures on the admin League Control Panel page:
- `select-name`: `<select>` elements with no accessible name
- `label`: form `<input>` with no programmatic label

Adds static `aria-label` attributes to all 6 `<select>` controls and all 5 `<input>` occurrences in `LeagueControlPanelView.php`. No visible UI change — `aria-label` is invisible to sighted users. Also adds the page to the E2E accessibility ratchet (`accessibility.spec.ts`) so both rules are enforced going forward, with all other currently-failing rules empirically allowlisted.

## Changes

- `ibl5/classes/LeagueControlPanel/LeagueControlPanelView.php`: Added `aria-label` attributes to all `<select>` and `.ibl-input` controls
- `ibl5/tests/e2e/smoke/accessibility.spec.ts`: Added `league control panel` page to ratchet, pinned to Regular Season phase, allowlisted non-target rules

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.