### PR TITLE
fix(check-plan): add word boundaries to gate-8 composer require regex

### DIFF
--- a/bin/check-plan
+++ b/bin/check-plan
@@ -271,7 +271,7 @@ done < <(
 # Composer dependency add — a MODIFY, not a new-file path, so handle it separately
 # from the path-token loop: flag when a line names ibl5/composer.json alongside a
 # require / require-dev dependency add.
-if grep -iE 'composer\.json' "$PLAN_FILE" | grep -qiE 'require(-dev)?'; then
+if grep -iE 'composer\.json' "$PLAN_FILE" | grep -qiE '\brequire(-dev)?\b'; then
     if [ "$GATE8_RESOLVED" -eq 0 ]; then
         viol "[8] decision-trigger surface ibl5/composer.json (new-dependency) added without an ADR step or no-adr: marker"
     fi


### PR DESCRIPTION
## Summary

- Gate 8 in `bin/check-plan` used `require(-dev)?` to detect composer dependency additions, which matched the word "required" in plan prose (e.g. "required by ADR-0042"), triggering false-positive violations
- Tightened to `\brequire(-dev)?\b` so only the bare keywords `require` / `require-dev` (not substrings of other words) fire the gate

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.ai/code)