### PR TITLE
chore(deps): bump undici to 6.27.0 to address CVE-2026-12151

### DIFF
--- a/ibl5/IBLbot/package-lock.json
+++ b/ibl5/IBLbot/package-lock.json
@@ -2782,9 +2782,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/ibl5/IBLbot/package.json
+++ b/ibl5/IBLbot/package.json
@@ -21,7 +21,7 @@
     "express": "^4.22.2"
   },
   "overrides": {
-    "undici": "6.24.1"
+    "undici": "6.27.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",


### PR DESCRIPTION
## Summary

- Bumps `undici` from 6.24.1 → 6.27.0 in `ibl5/IBLbot/` to address CVE-2026-12151
- Applied via the `overrides` field in `package.json` (IBLbot has a transitive dep on undici)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.ai/code)