### PR TITLE
fix(a11y): add per-position aria-label to league-starters shared renderers and next-sim table

### DIFF
--- a/ibl5/classes/BasketballStats/Tables/Per36Minutes.php
+++ b/ibl5/classes/BasketballStats/Tables/Per36Minutes.php
@@ -27,9 +27,10 @@ class Per36Minutes
      * @param string $yr Year filter (empty for current season)
      * @param list<int> $starterPids Starter player IDs
      * @param string $moduleName Module name
+     * @param string $ariaLabel Optional aria-label for the table scroll region (empty = no attribute)
      * @return string HTML table
      */
-    public static function render(\mysqli $db, $result, Team $team, string $yr, array $starterPids = [], string $moduleName = ""): string
+    public static function render(\mysqli $db, $result, Team $team, string $yr, array $starterPids = [], string $moduleName = "", string $ariaLabel = ''): string
     {
         $resolvedRows = PlayerRowTransformer::resolveWithStats($db, $result, $yr);
 
@@ -63,7 +64,7 @@ class Per36Minutes
 
         ob_start();
         ?>
-<table class="ibl-data-table team-table responsive-table sortable" style="<?= \UI\TableStyles::inlineTeamVars($team->color1, $team->color2) ?>">
+<table class="ibl-data-table team-table responsive-table sortable"<?= $ariaLabel !== '' ? ' aria-label="' . \Security\HtmlSanitizer::e($ariaLabel) . '"' : '' ?> style="<?= \UI\TableStyles::inlineTeamVars($team->color1, $team->color2) ?>">
     <thead>
         <tr>
 <?php if ($moduleName === "LeagueStarters"): ?>

--- a/ibl5/classes/BasketballStats/Tables/SeasonAverages.php
+++ b/ibl5/classes/BasketballStats/Tables/SeasonAverages.php
@@ -32,9 +32,10 @@ class SeasonAverages
      * @param string $yr Year filter (empty for current season)
      * @param list<int> $starterPids Starter player IDs
      * @param string $moduleName Module name
+     * @param string $ariaLabel Optional aria-label for the table scroll region (empty = no attribute)
      * @return string HTML table
      */
-    public static function render(\mysqli $db, $result, Team $team, string $yr, array $starterPids = [], string $moduleName = ""): string
+    public static function render(\mysqli $db, $result, Team $team, string $yr, array $starterPids = [], string $moduleName = "", string $ariaLabel = ''): string
     {
         $playerRows = PlayerRowTransformer::resolveWithStats($db, $result, $yr);
 
@@ -46,7 +47,7 @@ class SeasonAverages
 
         ob_start();
         ?>
-<table class="ibl-data-table team-table responsive-table sortable" style="<?= \UI\TableStyles::inlineTeamVars($team->color1, $team->color2) ?>">
+<table class="ibl-data-table team-table responsive-table sortable"<?= $ariaLabel !== '' ? ' aria-label="' . \Security\HtmlSanitizer::e($ariaLabel) . '"' : '' ?> style="<?= \UI\TableStyles::inlineTeamVars($team->color1, $team->color2) ?>">
     <thead>
         <tr>
 <?php if ($moduleName === "LeagueStarters"): ?>

--- a/ibl5/classes/BasketballStats/Tables/SeasonTotals.php
+++ b/ibl5/classes/BasketballStats/Tables/SeasonTotals.php
@@ -32,9 +32,10 @@ class SeasonTotals
      * @param string $yr Year filter (empty for current season)
      * @param list<int> $starterPids Starter player IDs
      * @param string $moduleName Module name
+     * @param string $ariaLabel Optional aria-label for the table scroll region (empty = no attribute)
      * @return string HTML table
      */
-    public static function render(\mysqli $db, $result, Team $team, string $yr, array $starterPids = [], string $moduleName = ""): string
+    public static function render(\mysqli $db, $result, Team $team, string $yr, array $starterPids = [], string $moduleName = "", string $ariaLabel = ''): string
     {
         $playerRows = PlayerRowTransformer::resolveWithStats($db, $result, $yr);
 
@@ -46,7 +47,7 @@ class SeasonTotals
 
         ob_start();
         ?>
-<table class="ibl-data-table team-table responsive-table sortable" style="<?= \UI\TableStyles::inlineTeamVars($team->color1, $team->color2) ?>">
+<table class="ibl-data-table team-table responsive-table sortable"<?= $ariaLabel !== '' ? ' aria-label="' . \Security\HtmlSanitizer::e($ariaLabel) . '"' : '' ?> style="<?= \UI\TableStyles::inlineTeamVars($team->color1, $team->color2) ?>">
     <thead>
         <tr>
 <?php if ($moduleName === "LeagueStarters"): ?>

--- a/ibl5/classes/LeagueStarters/LeagueStartersView.php
+++ b/ibl5/classes/LeagueStarters/LeagueStartersView.php
@@ -86,7 +86,7 @@ class LeagueStartersView implements LeagueStartersViewInterface
             $labelSafe = HtmlSanitizer::safeHtmlOutput($label);
             $html .= '<div>';
             $html .= '<h2 class="ibl-table-title">' . $labelSafe . '</h2>';
-            $html .= $this->renderTableForDisplay($db, $season, $display, $startersByPosition[$position], $userTeam);
+            $html .= $this->renderTableForDisplay($db, $season, $display, $startersByPosition[$position], $userTeam, $label);
             $html .= '</div>';
         }
 
@@ -100,17 +100,17 @@ class LeagueStartersView implements LeagueStartersViewInterface
      *
      * @param array<int, Player> $result
      */
-    private function renderTableForDisplay(\mysqli $db, Season $season, string $display, array $result, Team $team): string
+    private function renderTableForDisplay(\mysqli $db, Season $season, string $display, array $result, Team $team, string $ariaLabel = ''): string
     {
         switch ($display) {
             case 'total_s':
-                return \BasketballStats\Tables\SeasonTotals::render($db, $result, $team, '', [], $this->moduleName);
+                return \BasketballStats\Tables\SeasonTotals::render($db, $result, $team, '', [], $this->moduleName, $ariaLabel);
             case 'avg_s':
-                return \BasketballStats\Tables\SeasonAverages::render($db, $result, $team, '', [], $this->moduleName);
+                return \BasketballStats\Tables\SeasonAverages::render($db, $result, $team, '', [], $this->moduleName, $ariaLabel);
             case 'per36mins':
-                return \BasketballStats\Tables\Per36Minutes::render($db, $result, $team, '', [], $this->moduleName);
+                return \BasketballStats\Tables\Per36Minutes::render($db, $result, $team, '', [], $this->moduleName, $ariaLabel);
             default:
-                return \UI\Tables\Ratings::render($db, $result, $team, '', $season, $this->moduleName);
+                return \UI\Tables\Ratings::render($db, $result, $team, '', $season, $this->moduleName, [], $ariaLabel);
         }
     }
 }

--- a/ibl5/classes/NextSim/NextSimView.php
+++ b/ibl5/classes/NextSim/NextSimView.php
@@ -238,7 +238,7 @@ window.IBL_initNextSimHighlight();
 
         ob_start();
         ?>
-<table class="ibl-data-table team-table responsive-table" style="<?= TableStyles::inlineTeamVars($userTeam->color1, $userTeam->color2) ?>">
+<table class="ibl-data-table team-table responsive-table" aria-label="<?= HtmlSanitizer::e(self::POSITION_LABELS[$position] ?? $position) ?>" style="<?= TableStyles::inlineTeamVars($userTeam->color1, $userTeam->color2) ?>">
 <colgroup span="2"></colgroup><colgroup span="2"></colgroup><colgroup span="6"></colgroup><colgroup span="6"></colgroup><colgroup span="4"></colgroup><colgroup span="4"></colgroup><colgroup span="1"></colgroup>
     <thead>
         <tr>

--- a/ibl5/classes/UI/Contracts/RatingsInterface.php
+++ b/ibl5/classes/UI/Contracts/RatingsInterface.php
@@ -19,7 +19,8 @@ interface RatingsInterface
      * @param \Season\Season $season Season object
      * @param string $moduleName Module name for styling variations
      * @param list<int> $starterPids Starter player IDs
+     * @param string $ariaLabel Optional aria-label for the table scroll region (empty = no attribute)
      * @return string HTML table
      */
-    public static function render($db, $data, $team, string $yr, $season, string $moduleName = "", array $starterPids = []): string;
+    public static function render($db, $data, $team, string $yr, $season, string $moduleName = "", array $starterPids = [], string $ariaLabel = ''): string;
 }

--- a/ibl5/classes/UI/Tables/Ratings.php
+++ b/ibl5/classes/UI/Tables/Ratings.php
@@ -28,15 +28,16 @@ class Ratings implements RatingsInterface
      * @param Season $season Season object
      * @param string $moduleName Module name for styling variations
      * @param list<int> $starterPids Starter player IDs
+     * @param string $ariaLabel Optional aria-label for the table scroll region (empty = no attribute)
      * @return string HTML table
      */
-    public static function render($db, $data, $team, string $yr, $season, string $moduleName = "", array $starterPids = []): string
+    public static function render($db, $data, $team, string $yr, $season, string $moduleName = "", array $starterPids = [], string $ariaLabel = ''): string
     {
         $players = PlayerRowTransformer::resolvePlayers($db, $data, $yr);
 
         ob_start();
         ?>
-<table class="ibl-data-table team-table responsive-table sortable" style="<?= \UI\TableStyles::inlineTeamVars($team->color1, $team->color2) ?>">
+<table class="ibl-data-table team-table responsive-table sortable"<?= $ariaLabel !== '' ? ' aria-label="' . \Security\HtmlSanitizer::e($ariaLabel) . '"' : '' ?> style="<?= \UI\TableStyles::inlineTeamVars($team->color1, $team->color2) ?>">
     <thead>
         <tr>
 <?php if ($moduleName === "LeagueStarters"): ?>

--- a/ibl5/docs/a11y-backlog.md
+++ b/ibl5/docs/a11y-backlog.md
@@ -49,7 +49,7 @@ This audit (2026-06-20, verified against the live `accessibility.spec.ts` `KNOWN
 | **target-size** (topics ×100, homepage, news article) | ⬜ unplanned | 🟦 not auto-mergeable | Fix is **CSS** `min-height`/`min-width`/padding → changes rendered pixels → VR baseline regen + human review. Automouse can implement; merge is held. Small-count hits also seed-dependent. |
 | **landmark-unique** — standings | ✅ implemented | — | #1164 merged; `StandingsView::renderHeader()` derives per-region `aria-label`; removed from `KNOWN_FAILING`. |
 | **landmark-unique** — schedule + team schedule | ✅ implemented | — | **Re-checked:** the duplicate is each schedule View's **own** `<nav class="ibl-jump-menu">` (`LeagueScheduleView.php:84`, `TeamScheduleView.php:144`) colliding with the site nav — NOT a shared-nav change. One invisible `aria-label` per View (e.g. "Jump to month") → like standings. **DONE:** each schedule View's jump-menu nav now carries `aria-label="Jump to month"`; removed from `KNOWN_FAILING['landmark-unique']`. |
-| **landmark-unique** — league starters + next sim | ⬜ unplanned | 🟠 scope | The scroll-region label is auto-derived by `responsive-tables.js:163` from each `<table>`'s `aria-label`, **but** those tables are built by **shared** renderers (`UI\Tables\Ratings`, `BasketballStats\Tables\*`) with no aria-label param. Route an optional per-table label through them (the position/section title already exists) → invisible → 🟢. |
+| **landmark-unique** — league starters + next sim | ✅ implemented | — | **DONE:** league-starters threads per-position `aria-label` through the shared renderers (optional param, char-pinned); next-sim sets an inline per-position `aria-label`; both removed from `KNOWN_FAILING['landmark-unique']`. |
 | **label** (leagueControlPanel `.ibl-input`) | 📋 planned | 🟢 auto-mergeable | Plan `leaguecontrolpanel-aria-label-a11y` **queued** (automouse); aria-label-only (invisible), admin-gate/CSRF/handler untouched, auto-merge eligible. |
 | **select-name** (leagueControlPanel `<select>` ×6) | 📋 planned | 🟢 auto-mergeable | Same plan, bundled. |
 | **landmark-one-main** (leagueControlPanel) | ⬜ unplanned | 🔴 not safe | Needs a `<main>` landmark, which means routing the legacy root page through `PageLayout` — the maintenance-2.27 module conversion. Refactor-scale. (The page IS now ratchet-tracked — allowlisted — via the `label`/`select-name` plan.) |
@@ -59,7 +59,7 @@ This audit (2026-06-20, verified against the live `accessibility.spec.ts` `KNOWN
 
 **One-line takeaways for picking work:**
 - **Ready to plan as auto-mergeable now:** `page-has-heading-one` next sim (single-title promote) **and** schedule/team-schedule (stale allowlist removal — no code change). `label`/`select-name` already planned + queued.
-- **Auto-mergeable after a small scope/decision:** `landmark-unique` league-starters/next-sim (renderer param); `link-name` News subset (seed-verify); `page-has-heading-one` multi-title (which-`h2` decision).
+- **Auto-mergeable after a small scope/decision:** `link-name` News subset (seed-verify); `page-has-heading-one` multi-title (which-`h2` decision).
 - **Automouse-safe but a human must merge:** `target-size` (VR), `page-has-heading-one` title-less + a11y-5 Team page (VR).
 - **Not automouse-safe:** `landmark-one-main` + `region` on leagueControlPanel (2.27 refactor); everything on `faprep.php` (delete).
 
@@ -105,7 +105,7 @@ Was a single `<h4>`-after-`<h2>` skip on `record holders`; fixed in `a11y-2-head
 
 **schedule + team schedule — ✅ implemented.** Each schedule View now emits `<nav class="ibl-jump-menu schedule-months" aria-label="Jump to month">` (`LeagueScheduleView.php:84`, `TeamScheduleView.php:144`), disambiguating it from the shared site `<nav class="nav-grain">` (`NavigationView.php:53`). Removed from `KNOWN_FAILING['landmark-unique']`.
 
-**league starters + next sim — ⬜ unplanned, 🟠 scope.** `responsive-tables.js:163` sets each scroll-region's `aria-label` from `table.getAttribute("aria-label") || "Scrollable data table"` — so multiple tables get the same generic name. The distinguishing labels already exist (position/section titles), but the `<table>` markup is produced by **shared** renderers (`UI\Tables\Ratings::render`, `BasketballStats\Tables\*::render`) that take no aria-label argument. Add an optional per-table `aria-label` param (or wrap) so the View can pass the section name; the JS then propagates it. Invisible → 🟢 once that small cross-cutting scope is added.
+**league starters + next sim — ✅ implemented.** `LeagueStartersView` now threads a per-position `aria-label` (e.g. "Point Guards") through `renderTableForDisplay()` into the four shared renderers (`UI\Tables\Ratings`, `BasketballStats\Tables\SeasonTotals/SeasonAverages/Per36Minutes`), each with a new optional `$ariaLabel` param (char-pinned; default = no attribute, byte-identical). `NextSimView::renderPositionTable()` emits an inline `aria-label` from `POSITION_LABELS[$position]` directly on the `<table>` tag. Both removed from `KNOWN_FAILING['landmark-unique']`.
 
 ### landmark-one-main — best-practice, moderate — ⬜ unplanned, 🔴 not safe
 **leagueControlPanel:** no `<main>` because the root page bypasses `PageLayout`. Fixing means routing it through `PageLayout` — the maintenance-2.27 module conversion (refactor-scale). The page is now ratchet-tracked (allowlisted for this rule) via the `label`/`select-name` plan, so regressions are caught; the fix itself waits on 2.27. **faprep:** → delete (maintenance 3.9).
@@ -144,6 +144,7 @@ Tracked separately in [`a11y-contrast-backlog.md`](a11y-contrast-backlog.md). Th
 | `a11y-5-heading-one-burndown` | 📋 PR open (#1163), `auto_merge: false` — 4 promotes + Team-page `<h1>` add (VR review). |
 | `standings-landmark-unique-aria-label` | ✅ superseded — the standings fix already merged independently as **#1164**; the plan file is redundant (not queued). |
 | `a11y-landmark-unique-schedule` | ✅ implemented — schedule + team-schedule jump-menu `aria-label`; auto-merge eligible. |
+| `a11y-landmark-unique-starters-sim` | ✅ implemented — per-table `aria-label` via shared-renderer optional param + next-sim inline; both pages removed from `KNOWN_FAILING['landmark-unique']`; auto-merge eligible. |
 | `leaguecontrolpanel-aria-label-a11y` | 📋 queued for automouse — `label` + `select-name` via aria-label; auto-merge eligible. |
 | `a11y-heading-one-multi-title` | ✅ implemented — 6 multi-title pages promoted; standings + voting results deferred (page-level `<h1>` decision). |
 

--- a/ibl5/infection.json5
+++ b/ibl5/infection.json5
@@ -15,7 +15,6 @@
             // Group-B Views: no output-assertion test yet — honest per-file deferral
             // reasons below; gate 2 in check-infection-excludes fires if a test later
             // appears for one of these and it is not re-included. See ADR 0065.
-            "LeagueStarters/LeagueStartersView.php", // no output-assertion test yet — deferred Pass 2
             "Negotiation/NegotiationDemandsBreakdownView.php", // no output-assertion test yet — deferred Pass 2
             "Player/Views/PlayerAwardsView.php", // no output-assertion test yet — deferred Pass 2
             "Player/Views/PlayerButtonsView.php", // no output-assertion test yet — deferred Pass 2

--- a/ibl5/tests/BasketballStats/Tables/Per36MinutesTest.php
+++ b/ibl5/tests/BasketballStats/Tables/Per36MinutesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\BasketballStats\Tables;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use BasketballStats\Tables\Per36Minutes;
+
+/**
+ * @covers \BasketballStats\Tables\Per36Minutes
+ */
+#[AllowMockObjectsWithoutExpectations]
+class Per36MinutesTest extends TestCase
+{
+    private function createMockTeam(): \Team\Team
+    {
+        $team = $this->createMock(\Team\Team::class);
+        $team->color1 = 'FF0000';
+        $team->color2 = '0000FF';
+        $team->teamid = 1;
+        $team->name = 'Test Team';
+        return $team;
+    }
+
+    /**
+     * Characterization pin: render() with no $ariaLabel arg emits table open tag with NO aria-label
+     */
+    public function testTableOpenTagHasNoAriaLabel(): void
+    {
+        $mockDb = $this->createMock(\mysqli::class);
+        $html = Per36Minutes::render($mockDb, [], $this->createMockTeam(), '', [], '');
+
+        $this->assertStringContainsString('<table class="ibl-data-table team-table responsive-table sortable"', $html);
+        $this->assertStringNotContainsString('aria-label', $html);
+    }
+}

--- a/ibl5/tests/BasketballStats/Tables/SeasonAveragesTest.php
+++ b/ibl5/tests/BasketballStats/Tables/SeasonAveragesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\BasketballStats\Tables;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use BasketballStats\Tables\SeasonAverages;
+
+/**
+ * @covers \BasketballStats\Tables\SeasonAverages
+ */
+#[AllowMockObjectsWithoutExpectations]
+class SeasonAveragesTest extends TestCase
+{
+    private function createMockTeam(): \Team\Team
+    {
+        $team = $this->createMock(\Team\Team::class);
+        $team->color1 = 'FF0000';
+        $team->color2 = '0000FF';
+        $team->teamid = 1;
+        $team->name = 'Test Team';
+        return $team;
+    }
+
+    private function createMockDb(): \mysqli
+    {
+        $mockResult = self::createStub(\mysqli_result::class);
+        $mockResult->method('fetch_assoc')->willReturn(null);
+
+        $mockStmt = self::createStub(\mysqli_stmt::class);
+        $mockStmt->method('execute')->willReturn(true);
+        $mockStmt->method('bind_param')->willReturn(true);
+        $mockStmt->method('get_result')->willReturn($mockResult);
+
+        $mockDb = self::createStub(\mysqli::class);
+        $mockDb->method('prepare')->willReturn($mockStmt);
+
+        return $mockDb;
+    }
+
+    /**
+     * Characterization pin: render() with no $ariaLabel arg emits table open tag with NO aria-label
+     */
+    public function testTableOpenTagHasNoAriaLabel(): void
+    {
+        $html = SeasonAverages::render($this->createMockDb(), [], $this->createMockTeam(), '', [], '');
+
+        $this->assertStringContainsString('<table class="ibl-data-table team-table responsive-table sortable"', $html);
+        $this->assertStringNotContainsString('aria-label', $html);
+    }
+}

--- a/ibl5/tests/BasketballStats/Tables/SeasonTotalsTest.php
+++ b/ibl5/tests/BasketballStats/Tables/SeasonTotalsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\BasketballStats\Tables;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use BasketballStats\Tables\SeasonTotals;
+
+/**
+ * @covers \BasketballStats\Tables\SeasonTotals
+ */
+#[AllowMockObjectsWithoutExpectations]
+class SeasonTotalsTest extends TestCase
+{
+    private function createMockTeam(): \Team\Team
+    {
+        $team = $this->createMock(\Team\Team::class);
+        $team->color1 = 'FF0000';
+        $team->color2 = '0000FF';
+        $team->teamid = 1;
+        $team->name = 'Test Team';
+        return $team;
+    }
+
+    private function createMockDb(): \mysqli
+    {
+        $mockResult = self::createStub(\mysqli_result::class);
+        $mockResult->method('fetch_assoc')->willReturn(null);
+
+        $mockStmt = self::createStub(\mysqli_stmt::class);
+        $mockStmt->method('execute')->willReturn(true);
+        $mockStmt->method('bind_param')->willReturn(true);
+        $mockStmt->method('get_result')->willReturn($mockResult);
+
+        $mockDb = self::createStub(\mysqli::class);
+        $mockDb->method('prepare')->willReturn($mockStmt);
+
+        return $mockDb;
+    }
+
+    /**
+     * Characterization pin: render() with no $ariaLabel arg emits table open tag with NO aria-label
+     */
+    public function testTableOpenTagHasNoAriaLabel(): void
+    {
+        $html = SeasonTotals::render($this->createMockDb(), [], $this->createMockTeam(), '', [], '');
+
+        $this->assertStringContainsString('<table class="ibl-data-table team-table responsive-table sortable"', $html);
+        $this->assertStringNotContainsString('aria-label', $html);
+    }
+}

--- a/ibl5/tests/LeagueStarters/LeagueStartersViewTest.php
+++ b/ibl5/tests/LeagueStarters/LeagueStartersViewTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\LeagueStarters;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use LeagueStarters\LeagueStartersView;
+
+/**
+ * @covers \LeagueStarters\LeagueStartersView
+ */
+#[AllowMockObjectsWithoutExpectations]
+class LeagueStartersViewTest extends TestCase
+{
+    private function createMockTeam(): \Team\Team
+    {
+        $team = $this->createMock(\Team\Team::class);
+        $team->color1 = 'FF0000';
+        $team->color2 = '0000FF';
+        $team->teamid = 1;
+        $team->name = 'Test Team';
+        return $team;
+    }
+
+    /**
+     * Per-position aria-label is threaded into the table via renderTableContent()
+     */
+    public function testRenderTableContentEmitsPerPositionAriaLabel(): void
+    {
+        $mockDb = $this->createMock(\mysqli::class);
+        $mockSeason = $this->createMock(\Season\Season::class);
+        $mockSeason->lastSimEndDate = '2025-01-01';
+
+        $view = new LeagueStartersView('LeagueStarters');
+        $html = $view->renderTableContent($mockDb, $mockSeason, [
+            'PG' => [],
+            'SG' => [],
+            'SF' => [],
+            'PF' => [],
+            'C' => [],
+        ], $this->createMockTeam(), 'ratings');
+
+        $this->assertStringContainsString('aria-label="Point Guards"', $html);
+        $this->assertStringContainsString('aria-label="Centers"', $html);
+    }
+
+    /**
+     * The emitted aria-label value is HTML-escaped (passes through HtmlSanitizer::e())
+     */
+    public function testAriaLabelIsHtmlEscaped(): void
+    {
+        $mockDb = $this->createMock(\mysqli::class);
+        $mockSeason = $this->createMock(\Season\Season::class);
+        $mockSeason->lastSimEndDate = '2025-01-01';
+
+        $view = new LeagueStartersView('LeagueStarters');
+        $html = $view->renderTableContent($mockDb, $mockSeason, [
+            'PG' => [],
+            'SG' => [],
+            'SF' => [],
+            'PF' => [],
+            'C' => [],
+        ], $this->createMockTeam(), 'ratings');
+
+        // Position labels are static literals — "Point Guards" escapes to itself
+        $this->assertStringContainsString('aria-label="Point Guards"', $html);
+        // Not unescaped (label is static, so no entities expected, but attribute must be quoted)
+        $this->assertStringNotContainsString("aria-label='Point Guards'", $html);
+    }
+}

--- a/ibl5/tests/NextSim/NextSimViewTest.php
+++ b/ibl5/tests/NextSim/NextSimViewTest.php
@@ -201,6 +201,26 @@ class NextSimViewTest extends TestCase
         $this->assertStringContainsString('IBL_initNextSimHighlight', $result);
     }
 
+    public function testRenderPositionTableEmitsPerPositionAriaLabel(): void
+    {
+        $games = $this->createGameData();
+        $pgHtml = $this->view->renderPositionTable($games, 'PG', $this->userTeam, $this->userStarters);
+        $cHtml = $this->view->renderPositionTable($games, 'C', $this->userTeam, $this->userStarters);
+
+        $this->assertStringContainsString('aria-label="Point Guards"', $pgHtml);
+        $this->assertStringContainsString('aria-label="Centers"', $cHtml);
+    }
+
+    public function testRenderAriaLabelIsHtmlEscaped(): void
+    {
+        $games = $this->createGameData();
+        $html = $this->view->render($games, $this->userTeam, $this->userStarters);
+
+        // Position labels are static literals — they escape to themselves
+        $this->assertStringContainsString('aria-label="Point Guards"', $html);
+        $this->assertStringContainsString('aria-label="Centers"', $html);
+    }
+
     /**
      * @return array<int, array{game: Game, date: \DateTime, dayNumber: int, opposingTeam: Team, locationPrefix: string, opposingStarters: array<string, Player>, opponentTier: string, opponentPowerRanking: float}>
      */

--- a/ibl5/tests/UI/Tables/RatingsTest.php
+++ b/ibl5/tests/UI/Tables/RatingsTest.php
@@ -100,6 +100,23 @@ class RatingsTest extends TestCase
     }
 
     /**
+     * Characterization pin: render() with no $ariaLabel arg emits table open tag with NO aria-label
+     */
+    public function testTableOpenTagHasNoAriaLabel(): void
+    {
+        $mockDb = $this->createMock(\mysqli::class);
+        $mockSeason = $this->createMock(Season::class);
+        $mockSeason->lastSimEndDate = '2025-01-01';
+
+        $team = $this->createMockTeam();
+
+        $html = Ratings::render($mockDb, [], $team, '', $mockSeason, 'NextSim');
+
+        $this->assertStringContainsString('<table class="ibl-data-table team-table responsive-table sortable"', $html);
+        $this->assertStringNotContainsString('aria-label', $html);
+    }
+
+    /**
      * Test that first player is rendered with correct data (not blank/zero)
      */
     public function testFirstPlayerHasData(): void

--- a/ibl5/tests/e2e/smoke/accessibility.spec.ts
+++ b/ibl5/tests/e2e/smoke/accessibility.spec.ts
@@ -104,8 +104,6 @@ const KNOWN_FAILING: Record<string, Set<string>> = {
 
   // Multiple landmarks share role+name. See ibl5/docs/a11y-backlog.md §landmark-unique.
   'landmark-unique': new Set([
-    'league starters',
-    'next sim',
   ]),
 
   // No <main> landmark — legacy root page bypasses PageLayout. See ibl5/docs/a11y-backlog.md §landmark-one-main.


### PR DESCRIPTION
## Summary

Fixes axe `landmark-unique` violations on the League Starters and Next Sim pages.

`responsive-tables.js` derives each scroll-region's `aria-label` from the `<table>`'s `aria-label` attribute. These pages rendered multiple same-named `"Scrollable data table"` regions because no `aria-label` was set on the tables.

**Changes:**
- Add optional `string $ariaLabel = ''` param to four shared renderers (`UI\Tables\Ratings`, `BasketballStats\Tables\SeasonTotals`, `SeasonAverages`, `Per36Minutes`); keep `RatingsInterface` in sync. Default behavior is byte-identical (no attribute emitted).
- Thread the position label (e.g. `"Point Guards"`) from `LeagueStartersView::renderTableContent()` into each renderer via `renderTableForDisplay()`.
- Add inline per-position `aria-label` to `NextSimView::renderPositionTable()`'s `<table>` tag (does not use shared renderers).
- Remove `'league starters'` and `'next sim'` from `KNOWN_FAILING['landmark-unique']` in the accessibility E2E spec.
- Flip both pages to ✅ implemented in `ibl5/docs/a11y-backlog.md`.

All `aria-label` values pass through `HtmlSanitizer::e()` (static constants, but escaped per `RequireEscapedOutputRule`).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.