### PR TITLE
chore: gate Docker preview/E2E/Lighthouse builds on website-affecting changes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,6 +35,7 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       # NOTE: a `labeled` event intentionally does NOT set src=true. Adding any
@@ -45,26 +46,23 @@ jobs:
       # alone so applying that label reruns baseline regen without a CI storm.
       baseline: ${{ github.event.action == 'labeled' && github.event.label.name == 'update-baselines' }}
     steps:
-      - uses: dorny/paths-filter@v4
-        id: filter
+      - uses: actions/checkout@v7
         if: github.event_name == 'pull_request' && github.event.action != 'labeled'
         with:
-          filters: |
-            src:
-              - '**.php'
-              - '**.ts'
-              - '**.js'
-              - '**.css'
-              - 'ibl5/design/**'
-              - 'ibl5/migrations/**.sql'
-              - 'Dockerfile'
-              - 'docker-compose*.yml'
-              - 'docker/**'
-              - 'ibl5/tests/e2e/**'
-              - 'IBL6/**'
-              - 'docker/Dockerfile.ibl6'
-              - '.github/workflows/e2e-tests.yml'
-              - '.github/scripts/**'
+          fetch-depth: 0
+      - name: Compute website-affecting
+        id: filter
+        if: github.event_name == 'pull_request' && github.event.action != 'labeled'
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD)
+          if [ -z "$CHANGED" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$CHANGED" | bin/website-affecting; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
 
   playwright-version-drift:
     name: Playwright version drift guard

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,24 +19,26 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       src: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
     steps:
-      - uses: dorny/paths-filter@v4
-        id: filter
+      - uses: actions/checkout@v7
         with:
-          filters: |
-            src:
-              - '**.php'
-              - '**.css'
-              - '**.ts'
-              - '**.js'
-              - 'ibl5/design/**'
-              - 'ibl5/migrations/**.sql'
-              - 'Dockerfile'
-              - 'docker-compose*.yml'
-              - '.github/workflows/lighthouse.yml'
+          fetch-depth: 0
+      - name: Compute website-affecting
+        id: filter
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD)
+          if [ -z "$CHANGED" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$CHANGED" | bin/website-affecting; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
 
   lighthouse:
     name: Performance Audit

--- a/bin/website-affecting
+++ b/bin/website-affecting
@@ -1,0 +1,110 @@
+#!/bin/bash
+# bin/website-affecting — classify a list of changed files as website-affecting or not.
+#
+# Reads a newline-separated list of repo-relative changed file paths from stdin
+# (as emitted by `git diff --name-only`). Exits 0 = "affects website (RUN/BUILD)",
+# exits 1 = "does NOT affect website (SKIP)".
+#
+# Fail-safe: empty stdin, unexpected input, or any internal error → exit 0 (BUILD).
+# Caller is responsible for computing the file list; this script only classifies it.
+#
+# Usage:
+#   git diff --name-only master...HEAD | bin/website-affecting
+#   printf 'README.md\ndocs/foo.md\n' | bin/website-affecting
+#   bin/website-affecting --help
+#
+# Exit codes:
+#   0  Affects website — callers should run/build.
+#   1  Does NOT affect website — callers may skip.
+#
+# Deny-set (a file is non-website if it matches ALL of the following):
+#   - matches the deny regex: (\.md$|^docs/|^ibl5/docs/|^\.claude/|^bin/)
+#   - is NOT in the carve-out set (paths that must always trigger, even though
+#     they match the deny regex):
+#       bin/website-affecting  (the predicate itself — changing the gate must trigger it)
+#
+# Workflow files (.github/workflows/e2e-tests.yml, .github/workflows/lighthouse.yml)
+# are naturally website-side (none of their paths match the deny regex) — no
+# explicit carve-out needed.
+#
+# Anchoring is load-bearing:
+#   ^bin/      so ibl5/bin/* (app bin, website-side) is NOT denied
+#   ^docs/     top-level docs dir
+#   ^ibl5/docs/  in-repo ibl5 docs
+#   ^\.claude/ local claude rules/commands
+#   \.md$      any markdown (docs) anywhere
+#
+# shellcheck shell=bash
+
+set -u
+
+DENY_REGEX='(\.md$|^docs/|^ibl5/docs/|^\.claude/|^bin/)'
+
+# Carve-out: paths that match the deny regex but must still trigger (exact match).
+is_carveout() {
+    case "$1" in
+        bin/website-affecting) return 0 ;;
+    esac
+    return 1
+}
+
+if [ "${1:-}" = "--help" ]; then
+    cat <<'HELP'
+bin/website-affecting — classify changed files as website-affecting or not.
+
+Reads newline-separated repo-relative paths from stdin (git diff --name-only).
+Exit 0 = affects website (RUN/BUILD). Exit 1 = does not affect website (SKIP).
+Fail-safe: empty or unexpected input → exit 0 (BUILD).
+
+Deny-set (non-website if matched and not in carve-out):
+  \.md$          any markdown file
+  ^docs/         top-level docs/
+  ^ibl5/docs/    ibl5 internal docs
+  ^\.claude/     local .claude rules/commands
+  ^bin/          host repo bin/ scripts
+
+Carve-out (always website-side despite matching deny regex):
+  bin/website-affecting  (the predicate itself)
+
+Naturally website-side (not denied, no carve-out needed):
+  ibl5/**  .github/**  docker/**  Dockerfile  docker-compose*.yml  *.php *.ts *.js *.css
+HELP
+    exit 0
+fi
+
+TOTAL=0
+WEBSITE_COUNT=0
+
+while IFS= read -r line; do
+    # Skip blank lines
+    [ -z "$line" ] && continue
+    TOTAL=$((TOTAL + 1))
+
+    # A file is non-website iff: matches deny regex AND NOT in carve-out.
+    if printf '%s' "$line" | grep -qE "$DENY_REGEX"; then
+        if is_carveout "$line"; then
+            # Carve-out: treat as website-affecting
+            WEBSITE_COUNT=$((WEBSITE_COUNT + 1))
+        fi
+        # else: denied and not in carve-out — non-website, don't increment WEBSITE_COUNT
+    else
+        # Does not match deny regex → website-affecting
+        WEBSITE_COUNT=$((WEBSITE_COUNT + 1))
+    fi
+done
+
+# Fail-safe: empty input → exit 0 (build)
+if [ "$TOTAL" -eq 0 ]; then
+    printf 'website-affecting: yes (empty diff — fail-safe build)\n' >&2
+    exit 0
+fi
+
+if [ "$WEBSITE_COUNT" -gt 0 ]; then
+    printf 'website-affecting: yes (%d changed file(s), %d website-side)\n' \
+        "$TOTAL" "$WEBSITE_COUNT" >&2
+    exit 0
+else
+    printf 'website-affecting: no (all %d changed file(s) are non-website)\n' \
+        "$TOTAL" >&2
+    exit 1
+fi

--- a/bin/wt-up
+++ b/bin/wt-up
@@ -14,6 +14,7 @@ USE_PR=false
 SEED_DB=false
 PROD_DB=false
 NO_DATA=false
+FORCE=false
 
 # Parse arguments
 for arg in "$@"; do
@@ -22,19 +23,21 @@ for arg in "$@"; do
         --seed) SEED_DB=true ;;
         --prod) PROD_DB=true ;;
         --no-data) NO_DATA=true ;;
+        --force) FORCE=true ;;
         -*) echo "Unknown option: $arg" >&2; exit 1 ;;
         *) WORKTREE_NAME="$arg" ;;
     esac
 done
 
 if [ -z "$WORKTREE_NAME" ]; then
-    echo "Usage: bin/wt-up <worktree-name> [--pr] [--seed] [--prod] [--no-data]" >&2
+    echo "Usage: bin/wt-up <worktree-name> [--pr] [--seed] [--prod] [--no-data] [--force]" >&2
     echo "" >&2
     echo "Options:" >&2
     echo "  --pr            Use PR number as URL slug (e.g., pr-42.localhost)" >&2
     echo "  --seed          Import ci-seed.sql for test data (schema + CI seed)" >&2
     echo "  --prod          Sync live production DB via bin/db-sync-prod (default; requires .env REMOTE_* creds)" >&2
     echo "  --no-data       Schema only, no seed data" >&2
+    echo "  --force         Build the stack even if no website-affecting changes vs master" >&2
     echo "" >&2
     echo "Without prod creds, use --seed or --no-data." >&2
     echo "The DB volume is always purged to ensure a clean database." >&2
@@ -50,6 +53,21 @@ WORKTREE_PATH="$WT_PARENT/$WORKTREE_NAME"
 if [ ! -d "$WORKTREE_PATH" ]; then
     echo "Error: Worktree not found at $WORKTREE_PATH" >&2
     exit 1
+fi
+
+# Skip the whole stack bring-up if no changed file (vs the master merge-base)
+# affects the actual website. Fails toward building: an unknown path, an empty
+# diff, or any predicate error -> build. Override with --force.
+if [ "$FORCE" = false ]; then
+    CHANGED=$(git -C "$WORKTREE_PATH" diff --name-only master...HEAD 2>/dev/null || true)
+    if [ -n "$CHANGED" ]; then
+        if ! printf '%s\n' "$CHANGED" | "$REPO_ROOT/bin/website-affecting" >/dev/null 2>&1; then
+            echo "No website-affecting changes vs master — skipping preview." >&2
+            echo "  (docs / .claude / host bin / utility-only diff)" >&2
+            echo "  Pass --force to build anyway." >&2
+            exit 0
+        fi
+    fi
 fi
 
 # Determine URL slug

--- a/ibl5/tests/Cli/WebsiteAffectingCliTest.php
+++ b/ibl5/tests/Cli/WebsiteAffectingCliTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[Group('cli')]
+final class WebsiteAffectingCliTest extends TestCase
+{
+    private string $scriptPath;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/website-affecting');
+        self::assertNotFalse($resolved, 'bin/website-affecting must exist');
+        $this->scriptPath = $resolved;
+    }
+
+    // =========================================================================
+    // SKIP cases (exit 1 — non-website)
+    // =========================================================================
+
+    public function testDocsOnlyDiffExitsOne(): void
+    {
+        // Row 1: docs-only diff → SKIP
+        $result = $this->runPredicate("README.md\ndocs/x.md\nibl5/docs/y.md\n");
+        self::assertSame(1, $result['exit'], $result['stderr']);
+    }
+
+    public function testClaudeOnlyDiffExitsOne(): void
+    {
+        // Row 2: .claude/ only → SKIP
+        $result = $this->runPredicate(".claude/rules/foo.md\n.claude/commands/bar.md\n");
+        self::assertSame(1, $result['exit'], $result['stderr']);
+    }
+
+    public function testHostBinOnlyDiffExitsOne(): void
+    {
+        // Row 3: host bin/ only → SKIP
+        $result = $this->runPredicate("bin/wt-new\nbin/lib/db-helpers.sh\n");
+        self::assertSame(1, $result['exit'], $result['stderr']);
+    }
+
+    public function testHostBinWithWebishExtensionExitsOne(): void
+    {
+        // Row 4: host bin/ with website-ish extension — the bug being fixed → SKIP
+        $result = $this->runPredicate("bin/foo.js\nbin/tool.ts\n");
+        self::assertSame(1, $result['exit'], $result['stderr']);
+    }
+
+    // =========================================================================
+    // RUN cases (exit 0 — website-affecting)
+    // =========================================================================
+
+    public function testSinglePhpChangeExitsZero(): void
+    {
+        // Row 5: single PHP change → RUN
+        $result = $this->runPredicate("ibl5/modules/Schedule/index.php\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testTsJsCssUnderWebsiteTreeExitsZero(): void
+    {
+        // Row 6: .ts/.js/.css under website tree → RUN
+        $result = $this->runPredicate("ibl5/jslib/foo.ts\nibl5/themes/IBL/style/x.css\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testIbl5BinChangeExitsZero(): void
+    {
+        // Row 7: ibl5/bin/ app-bin (^bin/ must not match ibl5/bin/) → RUN
+        $result = $this->runPredicate("ibl5/bin/validate-schema\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testE2eTestDirChangeExitsZero(): void
+    {
+        // Row 8: ibl5/tests/e2e/ → RUN (E2E test dir stays website-side)
+        $result = $this->runPredicate("ibl5/tests/e2e/foo.spec.ts\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testMixedDiffExitsZero(): void
+    {
+        // Row 9: mixed (docs + one PHP file) → RUN (any website file forces build)
+        $result = $this->runPredicate("docs/foo.md\nibl5/modules/Schedule/index.php\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testEmptyStdinExitsZero(): void
+    {
+        // Row 10: empty stdin → RUN (fail-safe default)
+        $result = $this->runPredicate('');
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testGarbageInputExitsZero(): void
+    {
+        // Row 11: garbage / unexpected input → RUN (fail-safe on unexpected input)
+        $result = $this->runPredicate("   leading whitespace\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testPredicateSelfChangeExitsZero(): void
+    {
+        // Row 12: bin/website-affecting itself → RUN (carve-out from ^bin/)
+        $result = $this->runPredicate("bin/website-affecting\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testWorkflowSelfChangeExitsZero(): void
+    {
+        // Row 13: workflow files → RUN (naturally website-side, not denied)
+        $result = $this->runPredicate(
+            ".github/workflows/e2e-tests.yml\n.github/workflows/lighthouse.yml\n"
+        );
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testCiAdjacentPathsExitZero(): void
+    {
+        // Row 14: CI-adjacent paths → RUN (preserve existing e2e triggers)
+        $result = $this->runPredicate(
+            ".github/scripts/foo\n.github/actions/setup-docker-e2e/action.yml\n"
+        );
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    // =========================================================================
+    // --help
+    // =========================================================================
+
+    public function testHelpExitsZeroAndPrintsDenySet(): void
+    {
+        // Row 15: --help prints deny-set/contract and exits 0
+        $result = $this->runRaw('--help');
+        self::assertSame(0, $result['exit'], $result['output']);
+        self::assertStringContainsString('\.md$', $result['output']);
+        self::assertStringContainsString('^bin/', $result['output']);
+        self::assertStringContainsString('^docs/', $result['output']);
+        self::assertStringContainsString('^\.claude/', $result['output']);
+        self::assertStringContainsString('bin/website-affecting', $result['output']);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /**
+     * Pipe $stdin to the predicate script and return exit code + stderr verdict.
+     * @return array{exit: int, stderr: string}
+     */
+    private function runPredicate(string $stdin): array
+    {
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $proc = proc_open(escapeshellcmd($this->scriptPath), $descriptors, $pipes);
+        self::assertIsResource($proc, 'Failed to start website-affecting');
+
+        fwrite($pipes[0], $stdin);
+        fclose($pipes[0]);
+        fclose($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $exit = proc_close($proc);
+
+        return ['exit' => $exit, 'stderr' => (string) $stderr];
+    }
+
+    /**
+     * Run the predicate with raw arguments (for --help).
+     * @return array{exit: int, output: string}
+     */
+    private function runRaw(string $args): array
+    {
+        $cmd = escapeshellcmd($this->scriptPath) . ' ' . $args . ' 2>&1';
+        $output = [];
+        $exit = 0;
+        exec($cmd, $output, $exit);
+
+        return ['exit' => $exit, 'output' => implode("\n", $output)];
+    }
+}


### PR DESCRIPTION
## Summary

Adds `bin/website-affecting`, a standalone bash predicate that classifies a changed-file list (via stdin) as website-affecting or not. Both `bin/wt-up` and CI (`e2e-tests.yml`, `lighthouse.yml`) replace their inline allowlists with a call to this single-source predicate.

**Deny-set (all anchored):** `\.md$`, `^docs/`, `^ibl5/docs/`, `^\.claude/`, `^bin/` — with a mandatory carve-out for `bin/website-affecting` itself so a change to the gate triggers the gate.

**Fail-safe design:** Unknown/empty/error → exit 0 (RUN). The worst mechanical failure is a wasted Docker build, never a silent skip of a real website PR.

**Lever-3 mechanization:** `WebsiteAffectingCliTest.php` covers all 15 classification cases including negative paths — runs in `tests.yml` (gated by `**.php`) independently of the two workflows this PR re-gates.

<!-- no-adr: shared denylist predicate consolidates two existing CI path-filter allowlists; introduces no new architectural constraint -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.