### PR TITLE
test(a11y): remove stale schedule/team-schedule from page-has-heading-one allowlist

### DIFF
--- a/ibl5/tests/e2e/smoke/accessibility.spec.ts
+++ b/ibl5/tests/e2e/smoke/accessibility.spec.ts
@@ -68,11 +68,9 @@ const KNOWN_FAILING: Record<string, Set<string>> = {
     'player page',
     'award history',
     'player database',
-    'schedule',
     'news index',
     'news categories',
     'news article',
-    'team schedule',
     'team page',
     'voting results',
     // Auth pages


### PR DESCRIPTION
## Summary

Removes two stale entries from `KNOWN_FAILING['page-has-heading-one']` in the accessibility E2E spec:
- `'schedule'` (was exempted, now enforced — `LeagueScheduleView::renderHeader()` emits `<h1 class="ibl-title">Schedule</h1>` unconditionally)
- `'team schedule'` (was exempted, now enforced — `TeamScheduleView::renderHeader()` emits the same unconditional h1)

Both pages already satisfy `page-has-heading-one`. Removing the allowlist entries ratchets the test so regressions cannot be silently re-introduced.

No production code change. The `color-contrast` and `landmark-unique` Sets are untouched.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.