### PR TITLE
ci: block CSRF form fields missing the leading-underscore (_csrf_token)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -548,6 +548,19 @@ jobs:
         working-directory: ibl5
         run: bin/check-infection-excludes
 
+  csrf-field-name:
+    name: CSRF field-name guard
+    runs-on: ubuntu-latest
+    # Runs unconditionally: a wrong CSRF field name (name="csrf_token" without the
+    # leading underscore) silently rejects every form submission and is invisible to
+    # PHPStan/tests. The check is a few seconds of grep with no dependencies.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Check CSRF form field names
+        working-directory: ibl5
+        run: bin/check-csrf-field-name
+
   harness-tests:
     name: Shell harness regression tests
     needs: [changes]
@@ -576,7 +589,7 @@ jobs:
   gate:
     name: Tests and Analysis
     if: always()
-    needs: [changes, test, audit-php, audit-js, ibl6-checks, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, infection-excludes, harness-tests]
+    needs: [changes, test, audit-php, audit-js, ibl6-checks, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, infection-excludes, csrf-field-name, harness-tests]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1

--- a/ibl5/bin/check-csrf-field-name
+++ b/ibl5/bin/check-csrf-field-name
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bans the CSRF hidden-field name written WITHOUT its leading underscore.
+#
+# CsrfGuard validates the token from $_POST['_csrf_token']. A form field emitted
+# as name="csrf_token" (no underscore) is therefore silently rejected — every
+# submission fails CSRF with no visible error. This is invisible to PHPStan/tests
+# and shipped once already (PR #1074), so a content grep is the right gate: it
+# covers PHP string literals, heredocs, inline-HTML templates, and .js/.html
+# uniformly, where an AST rule would miss the inline-HTML form markup.
+#
+# The pattern anchors to the `name="`/`name='` prefix so the WRONG form ("c…)
+# matches while the CORRECT name="_csrf_token" ("_…) does not.
+
+# grep -E pattern: name="csrf_token" or name='csrf_token'
+PATTERN='name=["'\'']csrf_token["'\'']'
+
+# Scan app source for markup that can carry a form field. --include keeps the scan
+# to source file types (so this extensionless script never self-matches its own
+# PATTERN); --exclude-dir drops vendored/build/fixture trees.
+matches=$(grep -rnE "$PATTERN" . \
+  --include='*.php' \
+  --include='*.phtml' \
+  --include='*.html' \
+  --include='*.tpl' \
+  --include='*.js' \
+  --exclude-dir=vendor \
+  --exclude-dir=node_modules \
+  --exclude-dir=.git \
+  --exclude-dir=cache \
+  --exclude-dir=Fixtures \
+  2>/dev/null || true)
+
+if [ -n "$matches" ]; then
+  echo "ERROR: CSRF form field(s) use the wrong name (missing leading underscore):" >&2
+  echo "$matches" >&2
+  echo "" >&2
+  echo 'Fix: use name="_csrf_token" (leading underscore). The bare "csrf_token" is' >&2
+  echo "     silently rejected by CsrfGuard — every form submission fails CSRF with" >&2
+  echo "     no error. Prefer CsrfGuard's field helper over hand-rolled markup." >&2
+  exit 1
+fi
+
+echo 'OK: no bare csrf_token form fields found (all use name="_csrf_token").'
+exit 0


### PR DESCRIPTION
## What

Adds a blocking CI gate that fails when a form emits the CSRF hidden field as `name="csrf_token"` (without the leading underscore).

- `ibl5/bin/check-csrf-field-name` — greps source for `name=["']csrf_token["']`, anchored to the `name=` prefix so the **wrong** form matches but the correct `name="_csrf_token"` does not.
- New `csrf-field-name` job in `.github/workflows/tests.yml`, wired into `gate.needs` → **merge-blocking**. Failure message states the fix.

## Why

`CsrfGuard` validates the token from `$_POST['_csrf_token']`. A field emitted as the bare `name="csrf_token"` is **silently rejected** — every submission fails CSRF with no visible error. This shipped once already (PR #1074) and is invisible to PHPStan and the test suite.

## Why grep, not a PHPStan rule

CSRF fields are emitted as **inline HTML** in mixed PHP/HTML templates (e.g. `classes/Trading/TradingView.php`), which a PHPStan `String_` AST rule cannot see — exactly where hand-rolled form markup (and a likely typo) lives. A content grep covers string literals, heredocs, inline HTML, and `.js`/`.html` uniformly.

## Verification

- GREEN on the clean tree (only existing bare match is `$_SESSION['csrf_tokens']`, plural, not a `name=` attr).
- RED on a planted inline-HTML violation (`name="csrf_token"`).
- Correct `name="_csrf_token"` not false-flagged.
- `shellcheck --severity=warning` clean.

## Follow-up

On merge, the `feedback_csrf_raw_token_field_name` memory line becomes bucket-A (redundant with a merge-blocking gate whose message states the fix) and can be retired from the always-loaded index.