### PR TITLE
docs: document scripts/archive + symlink strategy (findings 8.7 & 8.8)

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -28,3 +28,22 @@ container.
 
 `bin/db-query` is a symlink to `ibl5/bin/db-query` so the DB CLI is reachable
 from both paths. See **`ibl5/bin/README.md`** for the app-scoped folder.
+
+## Symlink strategy
+
+The repo keeps its symlink surface deliberately tiny. **There is exactly one
+tracked symlink:** `bin/db-query → ../ibl5/bin/db-query`.
+
+**Why the real file lives in `ibl5/bin/`, not here:** `docker-compose.yml`
+bind-mounts only `./ibl5` into the container, so any script that must run
+**inside Docker** (or needs the PHP app's autoload / `config.php`) is physically
+pinned to `ibl5/bin/` — a symlink in this folder cannot relocate the real file
+out of the mount. `db-query` is such a script, so its source of truth is
+`ibl5/bin/db-query`, and `bin/db-query` is a thin convenience symlink so the DB
+CLI is reachable from the repo-root `bin/` path too.
+
+**Convention for new symlinks:** prefer **not** to add them. If a tool needs to
+be reachable from two paths, add a short wrapper that `exec`s the canonical
+script, or relocate the script to its correct home (`bin/` vs `ibl5/bin/` vs
+`ibl5/scripts/`). A `.symlinks` manifest is intentionally **not** maintained —
+one tracked symlink does not warrant one.

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1483,8 +1483,8 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 | 8.4 | ✅ Implemented | — | `shellScripts/` absent from tree + index (verified); follows 8.1. |
 | 8.5 | ◑ Partial | 🟩 | `tradition.php` deleted; `scripts/plrScratchpad.php` still present (verified) → archive it. |
 | 8.6 | ⬜ Open | 🟩 | `classes/Scripts/` present (verified); rename→`Maintenance`, namespace sweep, green-green. |
-| 8.7 | ⬜ Open | 🟩 | Document symlink strategy (docs). |
-| 8.8 | ⬜ Open | 🟩 | `scripts/archive/README.md` (docs). |
+| 8.7 | ✅ Implemented | — | Document symlink strategy (docs). **Status:** Added `## Symlink strategy` to `bin/README.md` stating the convention (single tracked symlink `bin/db-query` → `ibl5/bin/db-query`; real files pinned to `ibl5/bin/` by the `./ibl5` Docker bind-mount; new symlinks discouraged) (this PR). |
+| 8.8 | ✅ Implemented | — | `scripts/archive/README.md` (docs). **Status:** Added `ibl5/scripts/archive/README.md` documenting the two retained-but-not-run 2007 box-score import scripts + the archive policy (this PR). |
 | 8.9 | ⬜ Open | 🟩 | bin/lib manifest + helper rename. |
 | 8.10 | ⬜ Open | 🟨 | Interactive-vs-CI convention — upfront decision (`check-*`/`test-*` prefix vs a dedicated `ci/` subdir). |
 | 8.11 | ⬜ Open | 🟩 | Move `automouse-*` to bin/automouse/ + README; caller sweep (launchd plist refs). |
@@ -1542,14 +1542,14 @@ one-time backfill (its tables now live in the baseline schema + migrations).
 **Est. effort:** M
 **Risk if untouched:** New scripts placed in wrong folder.
 
-### 8.7 Symlink Strategy Undocumented
+### 8.7 Symlink Strategy Undocumented — RESOLVED
 **Location:** `/bin/db-query` → `../ibl5/bin/db-query`
 **Problem:** One-off symlink; no manifest or convention.
 **Suggested direction:** bin/README.md documenting the pattern; optional `.symlinks` manifest.
 **Est. effort:** S
 **Risk if untouched:** Symlinks rot when scripts move.
 
-### 8.8 Archive Directory Disorganized
+### 8.8 Archive Directory Disorganized — RESOLVED
 **Location:** `ibl5/scripts/archive/`
 **Problem:** 2 legacy scripts; no README documenting why archived.
 **Suggested direction:** Add `scripts/archive/README.md` with filename + deprecation date + reason + safe-to-delete flag.

--- a/ibl5/scripts/archive/README.md
+++ b/ibl5/scripts/archive/README.md
@@ -1,0 +1,39 @@
+---
+description: Why ibl5/scripts/archive/ exists and the policy for what lands here — retained-but-not-run one-time scripts kept for reference.
+last_verified: 2026-06-21
+---
+
+# `scripts/archive/` — retained-but-not-run scripts
+
+This directory holds **one-time / legacy scripts kept for reference only**. They
+are **not** part of any routine workflow and are **not** wired into CI, cron, or
+the app. They remain in the repository as a record of how a specific historical
+data operation was performed, in case a similar fix-up is ever needed again.
+
+> **Do not run these against a live database without first re-reading the script
+> and confirming the target data and date ranges still apply.** They were written
+> for a specific point-in-time backfill and hard-code dates, team-id maps, and
+> file-format offsets.
+
+## Contents
+
+| Script | Archived | Purpose |
+|--------|----------|---------|
+| `importBoxscoresFromHtml.php` | 2026-02-12 | One-time import of Dec 11-13 2007 box scores from HTML pages on iblhoops.net, plus backfill of Dec 7-10 quarter scores / attendance / capacity / W-L. Writes via `Boxscore\BoxscoreRepository`. |
+| `importBxsMissing.php` | 2026-02-12 | One-time extraction of Dec 7-10 2007 box scores from the legacy `IBL5.bxs` binary (3000-byte records, 94-byte player entries — differs from the `.sco` 2000/53 format). Writes via `Boxscore\BoxscoreRepository`. |
+
+## Policy — what lands here
+
+A script belongs in `scripts/archive/` when **all** of these hold:
+
+- It was a **one-time** or **point-in-time** operation (a backfill, a migration
+  fix-up, a historical import) that has already been run and is **not** expected
+  to run again on a schedule.
+- It is worth **keeping for reference** — it documents a non-obvious data shape,
+  format, or recovery procedure — rather than deleting outright.
+- It is **not** referenced by CI, cron, the app, or any other tooling.
+
+When archiving a script, move it here and add a row above with its **archived
+date** (the date it was moved/added) and a one-line **purpose**. If a script is
+genuinely dead and not worth keeping for reference, **delete** it instead of
+archiving — this directory is for scripts with documentary value, not a graveyard.


### PR DESCRIPTION
Resolves two open maintenance-backlog findings from the `scripts/` area:

**8.8** — Add `ibl5/scripts/archive/README.md` documenting the two retained-but-not-run one-time 2007 box-score import scripts (`importBoxscoresFromHtml.php`, `importBxsMissing.php`), why they are kept for reference, and the policy for what lands in `scripts/archive/`.

**8.7** — Add a `## Symlink strategy` section to `bin/README.md` stating the convention: exactly one tracked symlink (`bin/db-query → ../ibl5/bin/db-query`), why the real file is pinned to `ibl5/bin/` (Docker bind-mount scope), and that new symlinks are discouraged.

Both backlog rows flipped to ✅ Implemented in `ibl5/docs/maintenance-backlog.md` (standing rule: status flip ships with the work, no separate follow-up).

## Changes

- `ibl5/scripts/archive/README.md` — new file (finding 8.8)
- `bin/README.md` — append `## Symlink strategy` section (finding 8.7)
- `ibl5/docs/maintenance-backlog.md` — flip rows 8.7 + 8.8 to ✅, append to body headings `— RESOLVED`, bump `last_verified`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: edits existing bin/README.md doc and references existing bin/check-docs gate; no new tool script or architectural decision introduced -->