### PR TITLE
docs: document ApiHandler vs Api/Controller and Trading/Trade conventions (4.1, 4.9)

### DIFF
--- a/ibl5/docs/ARCHITECTURE_PATTERNS.md
+++ b/ibl5/docs/ARCHITECTURE_PATTERNS.md
@@ -1,6 +1,6 @@
 ---
 description: Canonical interface-driven Repository/Service/View patterns for new modules.
-last_verified: 2026-05-19
+last_verified: 2026-06-22
 ---
 
 # IBL5 Architecture Patterns
@@ -311,3 +311,45 @@ As the codebase migrates toward Laravel/modern PHP, all database interactions sh
 | Processor | Complex operations | `ProcessorInterface` |
 | View | HTML rendering | `ViewInterface` |
 | Facade | Simplified API | `Interface` |
+
+---
+
+## Naming Conventions
+
+Two cross-module naming distinctions that recur in `ibl5/classes/`. Both are
+conventions to follow, not bugs to fix.
+
+### `*ApiHandler` (module-local HTMX) vs `Api\Controller\*Controller` (REST)
+
+The codebase has two parallel HTTP-endpoint styles. They are distinct on purpose:
+
+| Style | Lives under | Dispatched by | Returns | Use for |
+|-------|-------------|---------------|---------|---------|
+| `*ApiHandler` | a **feature module** namespace (e.g. `DepthChartEntry\DepthChartEntryApiHandler`) | instantiated **directly** in the owning `ibl5/modules/<Module>/index.php` | an **HTML partial** for an HTMX swap into an already-rendered page | in-page interactivity within one module's UI (HTMX `hx-get`/`hx-post` fragment endpoints) |
+| `Api\Controller\*Controller` | `ibl5/classes/Api/Controller/` | the central `ibl5/classes/Api/Router.php` route table | a **JSON** REST response | the versioned external REST API (API-key auth, rate limiting, ETag caching — see API_GUIDE.md) |
+
+**Rule of thumb:** if a new endpoint feeds an HTMX fragment swap inside one
+module's page, it is a `*ApiHandler` in that module. If it is a routed,
+JSON, externally consumed REST endpoint, it is an `Api\Controller\*Controller`
+registered in `Api/Router.php`. A `*ApiHandler` is **not** part of the REST API
+and is never registered in `Api/Router.php`.
+
+Current `*ApiHandler` inventory (module-local HTMX):
+`DepthChartEntry\DepthChartEntryApiHandler`,
+`DraftHistory\DraftHistoryApiHandler`,
+`FranchiseRecordBook\FranchiseRecordBookApiHandler`,
+`LeagueStarters\LeagueStartersApiHandler`,
+`NextSim\NextSimTabApiHandler`,
+`SavedDepthChart\SavedDepthChartApiHandler`,
+`Team\TeamApiHandler`,
+`Trading\TradeRosterPreviewApiHandler`.
+
+### `Trading*` vs `Trade*` prefix within `Trading/`
+
+This convention is documented at its source, next to the code it governs:
+**`ibl5/classes/Trading/README.md`**. In brief: `Trading*` is reserved for
+module-level entry points (Service, View, Controller); `Trade*` is for
+single-trade-scoped domain objects (repositories, validator, processor, offer).
+It is advisory-enforced by the `TradingPrefixConventionRule` PHPStan rule
+(`ibl5/phpstan-rules/TradingPrefixConventionRule.php`). See that README for the
+full inventory and rationale.

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -743,7 +743,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
-| 4.1 | ⬜ Open | 🟩 | Trading/Trade prefix convention undocumented. Document the rule (+ optional rename sweep). Green-green. |
+| 4.1 | ✅ Implemented | — | Convention already documented at `ibl5/classes/Trading/README.md` (canonical home); cross-linked from `ibl5/docs/ARCHITECTURE_PATTERNS.md` (2026-06-22). Rename sweep explicitly out of scope. |
 | 4.2 | ✅ Implemented | — | CashConsideration→`BuyoutLedgerRepository` (2026-05-20). |
 | 4.3 | ✅ Implemented | — | `Services/` deleted. |
 | 4.4 | ✅ Implemented | — | `Shared/SharedRepository` deleted. |
@@ -751,7 +751,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 | 4.6 | ⬜ Open | 🟨 | PlayerMovement/TransactionHistory rename; same URL-break decision as 4.5. |
 | 4.7 | ✅ Implemented | — | →FreeAgencyOfferView (2026-05-17). |
 | 4.8 | ⬜ Open | 🟩 | Both `*DemandCalculator` present (verified). Internal class rename; green-green. |
-| 4.9 | ⬜ Open | 🟩 | `*ApiHandler` vs `Api/Controller` — document the convention (cheap path); green-green. |
+| 4.9 | ✅ Implemented | — | `*ApiHandler` (module-local HTMX) vs `Api\Controller\*Controller` (REST) documented in `ibl5/docs/ARCHITECTURE_PATTERNS.md` (2026-06-22). |
 | 4.10 | ⬜ Open | 🟨 | DepthChartEntry/SavedDepthChart still old-named (verified). Module rename = URL break → decision. |
 | 4.11 | ⬜ Open | 🟩 | `TradeQueueProcessor` present (verified). Internal rename → `NightlyTradeBatchRunner`; green-green. |
 | 4.12 | ✅ Implemented | — | car_to→car_tvr (migration 128). |
@@ -777,6 +777,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Reserve `Trading*` for module-level entry points (Service, View); `Trade*` for domain objects; document.
 **Est. effort:** S
 **Risk if untouched:** Wrong prefix on new classes; grep returns partial results.
+**Status:** Documented (2026-06-22) — the `Trading*`/`Trade*` rule has a canonical home at `ibl5/classes/Trading/README.md` (inventory + rationale), advisory-enforced by `TradingPrefixConventionRule` (`ibl5/phpstan-rules/TradingPrefixConventionRule.php`), and is cross-linked from `ibl5/docs/ARCHITECTURE_PATTERNS.md`. Optional rename sweep explicitly out of scope.
 
 ### 4.2 `CashConsiderationRepository` vs `TradeCashRepository`
 **Location:** `ibl5/classes/Trading/BuyoutLedgerRepository.php`, `TradeCashRepository.php`
@@ -833,6 +834,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Document or rename `*ApiHandler` → `*HtmxHandler`/`*PartialHandler`.
 **Est. effort:** S (doc) / M (rename)
 **Risk if untouched:** New HTMX endpoints land in `Api/Controller/`; new REST endpoints land as module-local handlers.
+**Status:** Documented (2026-06-22) — distinction now in `ibl5/docs/ARCHITECTURE_PATTERNS.md` § Naming Conventions (`*ApiHandler` = module-local HTMX partial handler instantiated in `ibl5/modules/*/index.php`; `Api\Controller\*Controller` = routed REST endpoint in `ibl5/classes/Api/Router.php`). Cheap doc path taken; rename out of scope.
 
 ### 4.10 `DepthChartEntry/` vs `SavedDepthChart/`
 **Location:** Two modules for one feature (live editing vs snapshot management)


### PR DESCRIPTION
Documents two code-organization naming conventions from the maintenance backlog:

- **4.9** — adds a "Naming Conventions" section to `ibl5/docs/ARCHITECTURE_PATTERNS.md` distinguishing `*ApiHandler` (module-local HTMX partial handlers, instantiated in `ibl5/modules/*/index.php`) from `Api\Controller\*Controller` (REST endpoints dispatched by `ibl5/classes/Api/Router.php`).
- **4.1** — convention already documented at `ibl5/classes/Trading/README.md` (canonical home, advisory-enforced by `TradingPrefixConventionRule`); this PR cross-links it from ARCHITECTURE_PATTERNS.md and flips the backlog row to ✅ Implemented.

Both rows 4.1 and 4.9 in `ibl5/docs/maintenance-backlog.md` are updated to `✅ Implemented` with Status notes.

<!-- no-adr: references existing TradingPrefixConventionRule.php and edits existing docs; no new phpstan rule or tool script introduced -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.