### PR TITLE
test: ratchet target-size enforcement on topics, homepage, news article

### DIFF
--- a/ibl5/tests/e2e/smoke/accessibility.spec.ts
+++ b/ibl5/tests/e2e/smoke/accessibility.spec.ts
@@ -92,10 +92,8 @@ const KNOWN_FAILING: Record<string, Set<string>> = {
   ]),
 
   // Touch targets < 24×24px. Seed-dependent for small-count hits. See ibl5/docs/a11y-backlog.md.
+  // Empirically clean on the CI seed (axe target-size: 0 violations on topics/homepage/news article) — ratchet tightened.
   'target-size': new Set([
-    'topics',
-    'homepage',
-    'news article',
   ]),
 
   // Multiple landmarks share role+name. See ibl5/docs/a11y-backlog.md §landmark-unique.


### PR DESCRIPTION
## Summary

Phase 1 (CI-seed reproduce gate) empirically found **zero** axe `target-size` violations on the CI seed for all three audited pages:

- Topics: 33 passing nodes / 0 violations
- Homepage: 24 passing nodes / 0 violations
- News article: 8 passing nodes / 0 violations

This is the plan's explicit conditional branch. The dev-DB hits (likely at mobile-width or with a larger dataset) do not reproduce at the desktop Chromium viewport that CI enforces.

**Consequence:** Phases 3 (CSS), 5 (VR row), and 6 (VR regen) were all skipped — nothing to resize. Only Phase 4 ratchet applied: emptied the `target-size` Set in `accessibility.spec.ts` (key + comment retained). The full a11y spec is green for all three pages with `target-size` now enforced (verified with `--no-deps` public run against the seeded stack).

## Changes

- `ibl5/tests/e2e/smoke/accessibility.spec.ts` — emptied the `'target-size'` Set (was `['topics', 'homepage', 'news article']`, now `[]`); all three pages now enforce the rule

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

(The plan's truly-manual row #11 was for VR human review of restyled UI. No CSS changed, no rendered pixels changed, no VR review needed.)

---

Note: `auto_merge: false` is set in plan frontmatter. The hold justification (VR human review) is moot for this test-only ratchet, but the PR stays held for human merge as a harmless conservative choice.
