### PR TITLE
ci: mechanize column-rename sweep + drive critical-columns from schema-assertions

### DIFF
--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -191,6 +191,12 @@ jobs:
     name: Schema Completeness
     runs-on: ubuntu-latest
 
+    env:
+      DB_HOST: 127.0.0.1
+      DB_USER: root
+      DB_PASS: root
+      DB_NAME: ibl5_completeness
+
     services:
       mariadb:
         image: mariadb:10.11
@@ -209,10 +215,50 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
 
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.5'
+        extensions: mbstring, intl, mysqli
+        coverage: none
+
+    - name: Cache vendor directory
+      uses: actions/cache@v5
+      with:
+        path: ibl5/vendor
+        key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-vendor-
+
+    - name: Install dependencies
+      working-directory: ibl5
+      run: composer install --no-progress --no-interaction
+
+    # config.php.example reads DB creds from getenv(); the job-level DB_* env
+    # vars point it at the CI MariaDB service (ibl5_completeness).
+    - name: Create config.php for CI
+      working-directory: ibl5
+      run: cp config.php.example config.php
+
     - name: Apply all migrations
       run: |
         chmod +x ibl5/bin/run-migrations-ci.sh
         ibl5/bin/run-migrations-ci.sh -h 127.0.0.1 -u root -proot ibl5_completeness
+
+    - name: Check for stale renamed-column references
+      env:
+        PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        chmod +x bin/check-column-rename-sweep
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          printf '%s' "$PR_BODY" | bin/check-column-rename-sweep \
+            --db-host=127.0.0.1 --db-user=root --db-pass=root \
+            --db-name=ibl5_completeness --bypass-from-stdin
+        else
+          bin/check-column-rename-sweep \
+            --db-host=127.0.0.1 --db-user=root --db-pass=root \
+            --db-name=ibl5_completeness
+        fi
 
     - name: Check FK integrity
       run: |
@@ -265,40 +311,12 @@ jobs:
         echo "PASS: All ${#REQUIRED_TABLES[@]} required tables exist."
 
     - name: Check critical columns
-      run: |
-        # Verify key columns that the application depends on
-        CHECKS=(
-          "ibl_plr:pid,name,teamid,pos,uuid"
-          "ibl_team_info:teamid,team_city,team_name,uuid"
-          "ibl_schedule:game_date,season_year,visitor_teamid,home_teamid,uuid"
-          "ibl_settings:setting_key,value"
-          "ibl_draft_picks:pickid,ownerofpick,owner_teamid,year,round"
-          "ibl_trade_info:id,tradeofferid,itemid,trade_from,trade_to"
-          "ibl_standings:teamid,team_name,wins,losses,pct"
-        )
-
-        FAIL=0
-        for check in "${CHECKS[@]}"; do
-          table="${check%%:*}"
-          columns="${check##*:}"
-          IFS=',' read -ra cols <<< "$columns"
-          for col in "${cols[@]}"; do
-            count=$(mysql -h 127.0.0.1 -u root -proot ibl5_completeness -N -e "
-              SELECT COUNT(*) FROM information_schema.COLUMNS
-              WHERE TABLE_SCHEMA = 'ibl5_completeness'
-                AND TABLE_NAME = '$table' AND COLUMN_NAME = '$col';
-            ")
-            if [ "$count" = "0" ]; then
-              echo "FAIL: $table.$col missing"
-              FAIL=1
-            fi
-          done
-        done
-
-        if [ "$FAIL" = "1" ]; then
-          exit 1
-        fi
-        echo "PASS: All critical columns present."
+      working-directory: ibl5
+      # Critical-columns coverage is driven from config/schema-assertions.php
+      # (single source of truth, enforced by MigrationFileIntegrityTest). A rename
+      # that updates the assertion automatically updates this check — no hardcoded
+      # column list to keep in sync.
+      run: php bin/validate-schema
 
   destructive-migration-scan:
     name: Destructive Migration Scan

--- a/bin/check-column-rename-sweep
+++ b/bin/check-column-rename-sweep
@@ -1,0 +1,225 @@
+#!/bin/bash
+
+# Scans ibl5/scripts/, ibl5/bin/, and ibl5/api.php for bare SQL column
+# references that were renamed by a migration but are absent from the live
+# schema — the exact blind spot that caused PR #637 (a scripts/ file that was
+# never modified by the rename PR but still used the old column name).
+#
+# Unlike bin/check-destructive-migrations, this scan is WHOLE-TREE, never
+# diff-scoped: the offending file in PR #637 was untouched by the rename PR,
+# so any diff-scoping silently neuters the gate.
+#
+# False-positive design (D2): a renamed old-name is only flagged when it is
+# ABSENT from the live post-migration schema. If 'name' is renamed in
+# ibl_settings → setting_key but 'name' still exists in ibl_plr, the gate
+# correctly passes — the word still resolves to a live column. Accepted
+# residual: a bare 'name' intended for ibl_settings will resolve to ibl_plr's
+# 'name' rather than throwing; that is a semantic bug, not a missing-column
+# crash, and is out of scope for this gate.
+#
+# Exit codes: 0 = pass, 1 = stale references found, 2 = usage error.
+
+set -euo pipefail
+
+BYPASS_MIN_LENGTH=20
+MIGRATIONS_DIR="ibl5/migrations"
+SCAN_PATHS="ibl5/scripts/ ibl5/bin/ ibl5/api.php"
+
+usage() {
+    cat <<'EOF'
+Usage: bin/check-column-rename-sweep [--columns-file=<path>|--db-host=<h> --db-user=<u> --db-pass=<p> --db-name=<n>] [--bypass-from-stdin] [--help|-h]
+
+Scans ibl5/scripts/, ibl5/bin/, and ibl5/api.php for references to column
+names that were renamed in a migration but are no longer present in the live
+schema (the PR #637 blind-spot paths PHPStan never checks).
+
+Column-set source (mutually exclusive; one required):
+  --columns-file=<path>       One column name per line. Used by tests (no DB).
+  --db-host=<h>               }
+  --db-user=<u>               } Together, query information_schema.COLUMNS
+  --db-pass=<p>               } via the mysql CLI.
+  --db-name=<n>               }
+
+Options:
+  --bypass-from-stdin   Read PR body from stdin for the global bypass marker:
+                          <!-- check-column-rename: <reason >= 20 chars> -->
+  --help, -h            Show this message.
+
+Scan paths (whole-tree, not diff-scoped):
+  ibl5/scripts/, ibl5/bin/, ibl5/api.php
+
+Exit codes: 0 = pass, 1 = stale references found, 2 = usage error.
+EOF
+}
+
+COLUMNS_FILE=""
+DB_HOST=""
+DB_USER=""
+DB_PASS=""
+DB_NAME=""
+BYPASS_STDIN=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --columns-file=*)
+            COLUMNS_FILE="${arg#--columns-file=}"
+            ;;
+        --db-host=*)
+            DB_HOST="${arg#--db-host=}"
+            ;;
+        --db-user=*)
+            DB_USER="${arg#--db-user=}"
+            ;;
+        --db-pass=*)
+            DB_PASS="${arg#--db-pass=}"
+            ;;
+        --db-name=*)
+            DB_NAME="${arg#--db-name=}"
+            ;;
+        --bypass-from-stdin)
+            BYPASS_STDIN=1
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --*)
+            echo "unknown flag: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            echo "unknown argument: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Validate: columns-file and db-* are mutually exclusive
+DB_FLAGS_SET=0
+if [ -n "$DB_HOST" ] || [ -n "$DB_USER" ] || [ -n "$DB_PASS" ] || [ -n "$DB_NAME" ]; then
+    DB_FLAGS_SET=1
+fi
+
+if [ -n "$COLUMNS_FILE" ] && [ "$DB_FLAGS_SET" = "1" ]; then
+    echo "error: --columns-file and --db-* flags are mutually exclusive" >&2
+    usage >&2
+    exit 2
+fi
+
+if [ -z "$COLUMNS_FILE" ] && [ "$DB_FLAGS_SET" = "0" ]; then
+    echo "error: either --columns-file or all four --db-* flags are required" >&2
+    usage >&2
+    exit 2
+fi
+
+# Handle PR-body bypass
+PR_BODY_BYPASS=""
+if [ "$BYPASS_STDIN" = "1" ]; then
+    PR_BODY="$(cat)"
+    REASON="$(printf '%s' "$PR_BODY" | sed -n 's/.*<!--[[:space:]]*check-column-rename:[[:space:]]*\(.\{1,\}\)[[:space:]]*-->.*/\1/p' | head -1)"
+    REASON="$(printf '%s' "$REASON" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    if [ -n "$REASON" ] && [ "${#REASON}" -ge "$BYPASS_MIN_LENGTH" ]; then
+        PR_BODY_BYPASS="$REASON"
+    fi
+fi
+
+# Temp files (bash 3.2 compatible — no associative arrays)
+TMP_DIR="$(mktemp -d)"
+RENAME_MAP_FILE="$TMP_DIR/rename_map.txt"  # format: old_name<TAB>mig_basename
+TMP_COLUMNS_FILE="$TMP_DIR/columns.txt"
+touch "$RENAME_MAP_FILE"
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+# Build rename map from all migrations except 000_baseline_schema.sql
+# Format: old_name<TAB>migration_basename (one pair per line, deduped to first occurrence)
+while IFS= read -r migfile; do
+    migbase="$(basename "$migfile")"
+    while IFS= read -r line; do
+        old_name=""
+        new_name=""
+
+        # CHANGE COLUMN [IF EXISTS] `old` `new` (backtick-quoted)
+        if printf '%s' "$line" | grep -qiE 'CHANGE[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+`[^`]+`[[:space:]]+`[^`]+`'; then
+            old_name="$(printf '%s' "$line" | sed -E 's/.*CHANGE[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+`([^`]+)`[[:space:]]+`([^`]+)`.*/\2/I')"
+            new_name="$(printf '%s' "$line" | sed -E 's/.*CHANGE[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+`([^`]+)`[[:space:]]+`([^`]+)`.*/\3/I')"
+        # RENAME COLUMN [IF EXISTS] `old` TO `new` (backtick-quoted)
+        elif printf '%s' "$line" | grep -qiE 'RENAME[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+`[^`]+`[[:space:]]+TO[[:space:]]+`[^`]+`'; then
+            old_name="$(printf '%s' "$line" | sed -E 's/.*RENAME[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+`([^`]+)`[[:space:]]+TO[[:space:]]+`([^`]+)`.*/\2/I')"
+            new_name="$(printf '%s' "$line" | sed -E 's/.*RENAME[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+`([^`]+)`[[:space:]]+TO[[:space:]]+`([^`]+)`.*/\3/I')"
+        # CHANGE COLUMN [IF EXISTS] old new (un-backticked — for test fixtures)
+        elif printf '%s' "$line" | grep -qiE 'CHANGE[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*'; then
+            old_name="$(printf '%s' "$line" | sed -E 's/.*CHANGE[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*).*/\2/I')"
+            new_name="$(printf '%s' "$line" | sed -E 's/.*CHANGE[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*).*/\3/I')"
+        # RENAME COLUMN [IF EXISTS] old TO new (un-backticked — for test fixtures)
+        elif printf '%s' "$line" | grep -qiE 'RENAME[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+TO[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*'; then
+            old_name="$(printf '%s' "$line" | sed -E 's/.*RENAME[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]+TO[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*).*/\2/I')"
+            new_name="$(printf '%s' "$line" | sed -E 's/.*RENAME[[:space:]]+COLUMN([[:space:]]+IF[[:space:]]+EXISTS)?[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]+TO[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*).*/\3/I')"
+        fi
+
+        # Add to map if names differ and not already mapped (first migration wins)
+        if [ -n "$old_name" ] && [ -n "$new_name" ] && [ "$old_name" != "$new_name" ]; then
+            if ! grep -qxF "${old_name}"$'\t'"${migbase}" "$RENAME_MAP_FILE" 2>/dev/null; then
+                if ! awk -F'\t' -v k="$old_name" '$1 == k {found=1} END {exit !found}' \
+                     "$RENAME_MAP_FILE" 2>/dev/null; then
+                    printf '%s\t%s\n' "$old_name" "$migbase" >> "$RENAME_MAP_FILE"
+                fi
+            fi
+        fi
+    done < "$migfile"
+done < <(find "$MIGRATIONS_DIR" -name '*.sql' -not -name '000_baseline_schema.sql' 2>/dev/null | sort)
+
+# Obtain the existing-column set
+if [ -n "$COLUMNS_FILE" ]; then
+    cp "$COLUMNS_FILE" "$TMP_COLUMNS_FILE"
+else
+    mysql -h "$DB_HOST" -u "$DB_USER" "-p${DB_PASS}" -N -e \
+        "SELECT DISTINCT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='${DB_NAME}';" \
+        > "$TMP_COLUMNS_FILE" 2>/dev/null || {
+        echo "error: could not query information_schema.COLUMNS — check DB flags" >&2
+        exit 2
+    }
+fi
+
+# Find candidates: old names NOT in the live schema
+# Grep the blind-spot paths for each candidate (word-boundary match)
+HITS=""
+while IFS='	' read -r old_name mig_basename; do
+    [ -n "$old_name" ] || continue
+    # Skip if old_name is still in the live schema (FP-filter, D2)
+    if grep -qxF "$old_name" "$TMP_COLUMNS_FILE" 2>/dev/null; then
+        continue
+    fi
+    # Grep the blind-spot paths
+    for scan_path in $SCAN_PATHS; do
+        [ -e "$scan_path" ] || continue
+        while IFS= read -r hit; do
+            [ -n "$hit" ] && HITS="${HITS}${hit}  (renamed in ${mig_basename})"$'\n'
+        done < <(grep -rwnE "\b${old_name}\b" "$scan_path" 2>/dev/null || true)
+    done
+done < "$RENAME_MAP_FILE"
+
+if [ -z "$HITS" ]; then
+    echo "No stale renamed-column references detected."
+    exit 0
+fi
+
+if [ -n "$PR_BODY_BYPASS" ]; then
+    echo "PASS (bypass): $PR_BODY_BYPASS"
+    exit 0
+fi
+
+echo "Stale renamed-column references detected:"
+echo ""
+printf '%s' "$HITS"
+echo ""
+echo "To bypass (for a legitimate reason), add an HTML comment to the PR body:"
+echo "  <!-- check-column-rename: <reason at least 20 chars> -->"
+echo ""
+echo "Or fix the reference to use the post-rename column name."
+exit 1

--- a/ibl5/config/schema-assertions.php
+++ b/ibl5/config/schema-assertions.php
@@ -39,6 +39,26 @@ return [
     new SchemaAssertion('ibl_settings', 'setting_key'),
     new SchemaAssertion('ibl_settings', 'value'),
 
+    // Ported from .github/workflows/migration-safety.yml "Check critical columns"
+    // CHECKS array when that step was replaced by bin/validate-schema. These are
+    // application-critical columns that were not yet covered by an assertion.
+    new SchemaAssertion('ibl_plr', 'pos'),
+    new SchemaAssertion('ibl_plr', 'uuid'),
+    new SchemaAssertion('ibl_team_info', 'team_city'),
+    new SchemaAssertion('ibl_team_info', 'uuid'),
+    new SchemaAssertion('ibl_schedule', 'uuid'),
+    new SchemaAssertion('ibl_draft_picks', 'pickid'),
+    new SchemaAssertion('ibl_draft_picks', 'ownerofpick'),
+    new SchemaAssertion('ibl_draft_picks', 'year'),
+    new SchemaAssertion('ibl_draft_picks', 'round'),
+    new SchemaAssertion('ibl_trade_info', 'id'),
+    new SchemaAssertion('ibl_trade_info', 'tradeofferid'),
+    new SchemaAssertion('ibl_trade_info', 'itemid'),
+    new SchemaAssertion('ibl_standings', 'team_name'),
+    new SchemaAssertion('ibl_standings', 'wins'),
+    new SchemaAssertion('ibl_standings', 'losses'),
+    new SchemaAssertion('ibl_standings', 'pct'),
+
     // Migration 099: gm_username → gm_display_name (column stores display names, not usernames)
     new SchemaAssertion('ibl_gm_tenures', 'gm_display_name'),
 

--- a/ibl5/tests/Cli/CheckColumnRenameSweepCliTest.php
+++ b/ibl5/tests/Cli/CheckColumnRenameSweepCliTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class CheckColumnRenameSweepCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/check-column-rename-sweep');
+        self::assertNotFalse($resolved, 'bin/check-column-rename-sweep must exist');
+        $this->scriptPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/col-rename-sweep-test-' . bin2hex(random_bytes(8));
+        mkdir($this->tmpDir, 0755, true);
+
+        mkdir($this->tmpDir . '/ibl5/migrations', 0755, true);
+        mkdir($this->tmpDir . '/ibl5/scripts', 0755, true);
+        mkdir($this->tmpDir . '/ibl5/bin', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    public function testStaleRefFires(): void
+    {
+        $this->writeMigration(
+            '100_rename_legacyZorp.sql',
+            "ALTER TABLE foo CHANGE COLUMN `legacyZorp` `new_zorp` INT;\n"
+        );
+        file_put_contents($this->tmpDir . '/ibl5/scripts/foo.php', "SELECT legacyZorp FROM foo;\n");
+        $colFile = $this->writeColumnsFile(['new_zorp', 'other_col']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('legacyZorp', $result['output']);
+        self::assertStringContainsString('100_rename_legacyZorp.sql', $result['output']);
+    }
+
+    public function testFalsePositiveFilterSkips(): void
+    {
+        // Same rename, but old name is still present in the live schema (the
+        // name→setting_key shape: 'name' still exists in ibl_plr etc).
+        $this->writeMigration(
+            '100_rename_legacyZorp.sql',
+            "ALTER TABLE foo CHANGE COLUMN `legacyZorp` `new_zorp` INT;\n"
+        );
+        file_put_contents($this->tmpDir . '/ibl5/scripts/foo.php', "SELECT legacyZorp FROM foo;\n");
+        // legacyZorp is still present elsewhere in the schema → FP-filter passes
+        $colFile = $this->writeColumnsFile(['legacyZorp', 'new_zorp', 'other_col']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No stale renamed-column references detected', $result['output']);
+    }
+
+    public function testNoStaleRefExitsZero(): void
+    {
+        $this->writeMigration(
+            '100_rename_legacyZorp.sql',
+            "ALTER TABLE foo CHANGE COLUMN `legacyZorp` `new_zorp` INT;\n"
+        );
+        // scripts/ references the NEW name, not the old one
+        file_put_contents($this->tmpDir . '/ibl5/scripts/foo.php', "SELECT new_zorp FROM foo;\n");
+        $colFile = $this->writeColumnsFile(['new_zorp']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No stale renamed-column references detected', $result['output']);
+    }
+
+    public function testWordBoundaryNoSubstringMatch(): void
+    {
+        $this->writeMigration(
+            '100_rename_legacyZorp.sql',
+            "ALTER TABLE foo CHANGE COLUMN `legacyZorp` `new_zorp` INT;\n"
+        );
+        // Only the superstring appears — word boundary must prevent a match
+        file_put_contents(
+            $this->tmpDir . '/ibl5/scripts/foo.php',
+            "SELECT legacyZorpExtra FROM foo;\n"
+        );
+        $colFile = $this->writeColumnsFile(['new_zorp']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+    }
+
+    public function testPrBodyBypassExitsZero(): void
+    {
+        $this->writeMigration(
+            '100_rename_legacyZorp.sql',
+            "ALTER TABLE foo CHANGE COLUMN `legacyZorp` `new_zorp` INT;\n"
+        );
+        file_put_contents($this->tmpDir . '/ibl5/scripts/foo.php', "SELECT legacyZorp FROM foo;\n");
+        $colFile = $this->writeColumnsFile(['new_zorp']);
+
+        $prBody = '<!-- check-column-rename: intentional backward-compat alias still in use -->';
+        $result = $this->runScript(['--columns-file=' . $colFile, '--bypass-from-stdin'], $prBody);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('PASS (bypass)', $result['output']);
+    }
+
+    public function testBothColumnSourcesExitsTwo(): void
+    {
+        $colFile = $this->writeColumnsFile(['new_zorp']);
+
+        $result = $this->runScript([
+            '--columns-file=' . $colFile,
+            '--db-name=somedb',
+        ]);
+
+        self::assertSame(2, $result['exit'], "Output: {$result['output']}");
+    }
+
+    public function testHelpFlagExitsZero(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --help 2>&1', $output, $exit);
+
+        self::assertSame(0, $exit);
+        $text = implode("\n", $output);
+        self::assertStringContainsString('Usage:', $text);
+        self::assertStringContainsString('ibl5/scripts/', $text);
+    }
+
+    public function testBogusArgExitsTwo(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --bogus 2>&1', $output, $exit);
+
+        self::assertSame(2, $exit);
+        self::assertStringContainsString('unknown flag', implode("\n", $output));
+    }
+
+    public function testRenameColumnSyntaxDetected(): void
+    {
+        // RENAME COLUMN syntax (as used in migration 113+)
+        $this->writeMigration(
+            '113_rename_rating.sql',
+            "ALTER TABLE ibl_plr RENAME COLUMN `r_to` TO `r_tvr`;\n"
+        );
+        file_put_contents($this->tmpDir . '/ibl5/scripts/ratings.php', "SELECT r_to FROM ibl_plr;\n");
+        $colFile = $this->writeColumnsFile(['r_tvr']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('r_to', $result['output']);
+    }
+
+    /**
+     * @param list<string> $args
+     * @return array{output: string, exit: int}
+     */
+    private function runScript(array $args = [], ?string $stdin = null): array
+    {
+        $output = [];
+        $exit = 0;
+
+        $argStr = '';
+        foreach ($args as $arg) {
+            $argStr .= ' ' . escapeshellarg($arg);
+        }
+
+        $cmd = 'cd ' . escapeshellarg($this->tmpDir) . ' && ';
+
+        if ($stdin !== null) {
+            $cmd .= 'printf \'%s\' ' . escapeshellarg($stdin) . ' | ';
+        }
+
+        $cmd .= 'bash ' . escapeshellarg($this->scriptPath) . $argStr . ' 2>&1';
+
+        exec($cmd, $output, $exit);
+
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function writeMigration(string $filename, string $content): void
+    {
+        file_put_contents($this->tmpDir . '/ibl5/migrations/' . $filename, $content);
+    }
+
+    /** @param list<string> $columns */
+    private function writeColumnsFile(array $columns): string
+    {
+        $path = $this->tmpDir . '/columns.txt';
+        file_put_contents($path, implode("\n", $columns) . "\n");
+        return $path;
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/ibl5/tests/Cli/CheckColumnRenameSweepCliTest.php
+++ b/ibl5/tests/Cli/CheckColumnRenameSweepCliTest.php
@@ -116,6 +116,23 @@ final class CheckColumnRenameSweepCliTest extends TestCase
         self::assertStringContainsString('PASS (bypass)', $result['output']);
     }
 
+    public function testShortPrBodyBypassExitsOne(): void
+    {
+        $this->writeMigration(
+            '100_rename_legacyZorp.sql',
+            "ALTER TABLE foo CHANGE COLUMN `legacyZorp` `new_zorp` INT;\n"
+        );
+        file_put_contents($this->tmpDir . '/ibl5/scripts/foo.php', "SELECT legacyZorp FROM foo;\n");
+        $colFile = $this->writeColumnsFile(['new_zorp']);
+
+        // Reason shorter than BYPASS_MIN_LENGTH=20 must NOT bypass
+        $prBody = '<!-- check-column-rename: too short -->';
+        $result = $this->runScript(['--columns-file=' . $colFile, '--bypass-from-stdin'], $prBody);
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('legacyZorp', $result['output']);
+    }
+
     public function testBothColumnSourcesExitsTwo(): void
     {
         $colFile = $this->writeColumnsFile(['new_zorp']);


### PR DESCRIPTION
Closes #0

Adds two CI gates to the `schema-completeness` job in `migration-safety.yml`:

1. **Gate 1 — `bin/check-column-rename-sweep`:** builds a rename map from all migration history (CHANGE COLUMN / RENAME COLUMN statements) and greps `ibl5/scripts/`, `ibl5/bin/`, and `ibl5/api.php` for stale old-column names that are no longer present in the live schema. Whole-tree scan (not diff-scoped) because the PR #637 failure mode is a file the rename PR never touched. False-positive filter: only fires when the old name is absent from the completeness schema — so `name → setting_key` doesn't fire because `name` still exists in `ibl_plr`.

2. **Gate 2 — drop the hardcoded `CHECKS=()` array:** 16 missing columns are ported into `ibl5/config/schema-assertions.php`, then the step is replaced by `php bin/validate-schema` — the same canonical validator that `MigrationFileIntegrityTest::testChangeColumnRenamesHaveSchemaAssertions` already enforces. Renames that update their assertion automatically update this check.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: mechanically enforces existing SQL column-naming ADRs across PHPStan-blind paths; no new architectural constraint -->