### PR TITLE
chore: docs-only light ship path that arms auto-merge directly, skipping post-plan

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,15 +1,15 @@
 ---
-description: "Commit, push, and open a PR; optionally arm gated auto-merge by delegating to /post-plan (never arms directly)."
-last_verified: 2026-06-20
+description: "Commit, push, and open a PR; arm gated auto-merge by delegating to /post-plan, except a mechanically-gated docs-only light path that arms directly."
+last_verified: 2026-06-22
 ---
 
 # /ship — Commit, push, PR, optionally arm gated auto-merge
 
-`/ship` is an **interactive-only** wrapper around `/commit-commands:commit-push-pr`. It routes commit/push/PR work down one of two paths: a plain **no-merge** path that opens a PR and leaves it open, or a gated **auto-merge** path that fires `bin/post-plan-now` and lets `/post-plan` Phase 6.5 decide whether auto-merge actually arms. The user's invocation text is available as `$ARGUMENTS`.
+`/ship` is an **interactive-only** wrapper around `/commit-commands:commit-push-pr`. It routes commit/push/PR work down one of three paths: a plain **no-merge** path that opens a PR and leaves it open; a gated **auto-merge** path that fires `bin/post-plan-now` and lets `/post-plan` Phase 6.5 decide whether auto-merge actually arms; or — only when the change is mechanically proven **docs-only** — a **light path** that opens the PR and arms `gh pr merge --auto` directly, skipping `/post-plan` (ADR-0067). The user's invocation text is available as `$ARGUMENTS`.
 
-> ## Core invariant — `/ship` ONLY routes; it NEVER arms auto-merge itself.
+> ## Core invariant — `/ship` arms directly ONLY on the mechanically-gated docs-only light path; otherwise it ONLY routes.
 >
-> Arming is owned exclusively by `/post-plan` Phase 6.5. That phase runs the teeth this wrapper structurally cannot supply from conversation context:
+> For any change that contains code, SQL, auth, output, config, templates, tests, or merge-gate machinery, arming is owned exclusively by `/post-plan` Phase 6.5. That phase runs the teeth this wrapper structurally cannot supply from conversation context:
 > - code review (any finding scored **≥ 80 blocks** — condition **(2)**),
 > - Phase-5 local verification status (condition **(4)**),
 > - planned-test / planned-file completeness (condition **(3)**),
@@ -17,6 +17,8 @@ last_verified: 2026-06-20
 > - the independent `human-signoff` required GitHub check.
 >
 > The merge path therefore **delegates rather than reimplements**: conditions (2)/(3)/(4) plus CI-green and the `human-signoff` check are produced by post-plan phases (review scoring, Phase-5 verification, CI watch) that a chat-context wrapper cannot reproduce. A routing bug **fails safe** — the worst case is the wrong path is taken, never an unreviewed merge.
+>
+> **The single carve-out (ADR-0067):** when `bin/ship-light-eligible` exits 0, the diff is Markdown-only and touches no merge-gate machinery, so post-plan's teeth have *nothing to bite on* — there is no code to review, no security surface to audit, no app behavior to E2E. There `/ship` may arm `gh pr merge --auto` directly. This is safe because eligibility is a **mechanical** predicate (never a "feels small" judgment), the merge-gate machinery excludes *itself* — both the arming machinery and the gate-authoring/review/security docs (`plan.md`, `_plan-verification.md`, `pr-review.md`, `security-audit.md`, the shared `.claude/commands/_*.md`), so a gate edit can neither self-arm nor weaken the gates unreviewed — and **skipping post-plan is not skipping CI** — the branch-protection required contexts (`Tests and Analysis`, `E2E Tests`, `human-signoff`) all run on a docs-only PR and gate the `--auto` merge. `check-docs` is **not** a required context, so the light path runs it locally before arming (Step 3b-light).
 
 ## Step 1 — Precondition gate (refuse on ANY; before touching anything)
 
@@ -38,7 +40,28 @@ Evaluate all three before doing any work. On any hit, refuse with the one-line r
 
 Run `/commit-commands:commit-push-pr`: commit, push, open the PR, and **leave it OPEN**. Report the PR URL. Do **not** fire `bin/post-plan-now`.
 
-## Step 3b — Merge-wanted path (delegate the gated arming, NEVER arm directly)
+## Step 3b — Merge-wanted path: route light vs delegated
+
+Before doing anything else on the merge path, run the eligibility predicate:
+
+```bash
+bin/ship-light-eligible
+```
+
+- **Exit 0 (docs-only)** → take the **light path** (Step 3b-light below).
+- **Exit 1 (anything else)** → take the **delegated path** (Step 3b-heavy below). This is the default; on any doubt or a non-zero/error exit, delegate.
+
+### Step 3b-light — Docs-only light path (arm directly, per ADR-0067)
+
+Only reachable when `bin/ship-light-eligible` exited 0. The diff is Markdown-only and touches no merge-gate machinery, so `/post-plan` adds nothing.
+
+- **Doc-validity gate (required before arming).** Run `bin/check-docs --since=origin/master`. `check-docs` (dead references, `last_verified` freshness, ADR transitions) is **not** a branch-protection required context, so it would not block `--auto` on its own — enforce it here. If it fails, **do not arm**: fix the docs and re-run, or fall back to Step 3b-heavy. Only proceed when it passes.
+- Run `/commit-commands:commit-push-pr`: commit, push, open the PR.
+- Arm GitHub-native auto-merge: `gh pr merge --auto --squash <pr>` (the PR merges itself once the required contexts — `Tests and Analysis`, `E2E Tests`, `human-signoff` — pass; CI still gates it).
+- Do **not** fire `bin/post-plan-now`.
+- Report: PR URL, that the light path was taken (docs-only, post-plan skipped), and that CI required checks still gate the merge.
+
+### Step 3b-heavy — Delegated path (delegate the gated arming, NEVER arm directly)
 
 First, a cheap **advisory prediction** — clearly label it *"advisory only; `/post-plan` Phase 6.5 makes the real call"*. Emit a warning for each that matches:
 
@@ -60,7 +83,8 @@ Then the actions:
 | `$CLAUDE_HEADLESS=1` | **Refuse** (Step 1.2 — interactive-only) |
 | Clean tree AND 0 commits ahead of `origin/master` | **Refuse** (Step 1.3 — nothing to ship) |
 | Intent resolves `--no-merge` | **No-merge path** (Step 3a — open PR, leave OPEN) |
-| Intent resolves `--merge` | **Merge path** (Step 3b — dirty tree, fire `bin/post-plan-now`) |
+| Intent resolves `--merge`, `bin/ship-light-eligible` exits 0 | **Light path** (Step 3b-light — commit-push-pr, arm `gh pr merge --auto` directly) |
+| Intent resolves `--merge`, `bin/ship-light-eligible` exits non-0 | **Delegated path** (Step 3b-heavy — dirty tree, fire `bin/post-plan-now`) |
 | Intent ambiguous | **`AskUserQuestion`** (Step 2.3 — never assume merge) |
 
-Arming is always delegated to `bin/post-plan-now` → `/post-plan` Phase 6.5. `/ship` never runs `gh pr merge --auto` or `--enable-auto-merge` itself.
+Arming is delegated to `bin/post-plan-now` → `/post-plan` Phase 6.5 for every change **except** the mechanically-gated docs-only light path (ADR-0067), where `/ship` arms `gh pr merge --auto` directly. `/ship` never arms directly on any diff that `bin/ship-light-eligible` does not clear.

--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -1,6 +1,6 @@
 ---
-description: All work happens in a worktree (never the main checkout); worktree setup and the implementation→/post-plan handoff (auto-fired in a detached fresh session) for multi-step work.
-last_verified: 2026-06-20
+description: All work happens in a worktree (never the main checkout); worktree setup and the implementation handoff — routed by bin/ship-light-eligible to a docs-only light path or the full /post-plan auto-fire.
+last_verified: 2026-06-22
 ---
 
 # Workflow Continuity Rule
@@ -31,11 +31,18 @@ Never run `/post-plan` **inline** in this session — it re-reads the full imple
 
 ### Interactive sessions — auto-fire the handoff
 
-When implementation is **verified complete**, your **final action** is:
+When implementation is **verified complete**, route the handoff by *what the change touches* — assess first with the mechanical predicate (ADR-0067), never a "this feels small" judgment:
 
 ```bash
-bin/post-plan-now --auto
+bin/ship-light-eligible
 ```
+
+- **Exit 0 — docs-only:** the diff is Markdown-only and touches no merge-gate machinery, so `/post-plan`'s code review, security audit, and E2E would have nothing to check. Take the **light path**: invoke `/ship --merge`, which gates on `bin/check-docs --since=origin/master`, then opens the PR and arms `gh pr merge --auto` directly (see `.claude/commands/ship.md` § Step 3b-light). Skipping post-plan is **not** skipping CI — the required contexts (`Tests and Analysis`, `E2E Tests`, `human-signoff`) still gate the merge.
+- **Exit 1 / non-zero — anything else** (any non-Markdown file, or an edit to the merge-gate machinery itself): your **final action** is the full handoff:
+
+  ```bash
+  bin/post-plan-now --auto
+  ```
 
 This spawns a detached, fresh **Sonnet 4.6** `/post-plan` on this branch (supervised by launchd, so it survives you closing Claude Code). It removes the manual "open a new session and hand off" step. Notes:
 

--- a/bin/ship-light-eligible
+++ b/bin/ship-light-eligible
@@ -1,0 +1,129 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * bin/ship-light-eligible — mechanical predicate for the docs-only light ship path.
+ *
+ * Single source of truth shared by `.claude/commands/ship.md` (the /ship light
+ * path) and `.claude/rules/workflow-continuity.md` (the interactive auto-fire
+ * routing). Decides whether the current branch's changes are safe to open as a
+ * PR and arm `gh pr merge --auto` directly, SKIPPING /post-plan's code review,
+ * security audit, and E2E — because the diff touches nothing those teeth check.
+ *
+ * Eligible IFF ALL hold (see ADR-0067):
+ *   - there is at least one change vs the merge-base with origin/master;
+ *   - EVERY changed path is a Markdown file (`*.md`, case-insensitive) — no code,
+ *     SQL, config, templates, or tests, i.e. no surface post-plan reviews;
+ *   - NONE of the changed paths is a merge-gate / arming-machinery file (the
+ *     EXCLUDE set below) — those must never self-arm via the path they define.
+ *
+ * Exit 0  eligible (prints "eligible: ...").
+ * Exit 1  ineligible (prints "ineligible: <reason>" naming the disqualifier).
+ * Exit 2  error (not a git repo, origin/master unknown, usage).
+ *
+ * Note: skipping post-plan is NOT skipping CI — the branch-protection required
+ * contexts (Tests and Analysis, E2E Tests, human-signoff) still gate the merge.
+ * (check-docs is not a required context; the light path runs it locally first.)
+ */
+
+// Files that DEFINE the merge-gate machinery — what arms a merge AND what decides
+// which future changes need human review. A change to any of them must not ride the
+// light path: an unreviewed edit could arm itself or weaken the very criteria/teeth
+// that gate everything else. Never light-path eligible even though Markdown. See ADR-0067.
+//
+// Two prefixes below cover the rest: `.claude/skills/post-plan/` (the post-plan
+// orchestrator) and `.claude/commands/_` (the shared gate/review/security/test-spec
+// components: _plan-verification, _review-agents, _review-rubric, _security-agents,
+// _test-spec-agent, _test-spec-corpus).
+const EXCLUDE = [
+    // Arming machinery.
+    '.claude/commands/ship.md',
+    '.claude/rules/workflow-continuity.md',
+    '.claude/rules/auto-commit.md',
+    '.claude/rules/commit-conventions.md',
+    // Gate-authoring / review / security machinery (decides what needs review).
+    '.claude/commands/plan.md',
+    '.claude/commands/pr-review.md',
+    '.claude/commands/security-audit.md',
+];
+
+/** Path prefixes whose every Markdown file is merge-gate machinery. */
+const EXCLUDE_PREFIXES = [
+    '.claude/skills/post-plan/',
+    '.claude/commands/_',
+];
+
+/** Run a git command, returning trimmed stdout; null on non-zero exit. */
+function git(string $args): ?string
+{
+    $out = [];
+    $code = 0;
+    exec('git ' . $args . ' 2>/dev/null', $out, $code);
+    return $code === 0 ? implode("\n", $out) : null;
+}
+
+function fail(string $reason): never
+{
+    fwrite(STDOUT, "ineligible: {$reason}\n");
+    exit(1);
+}
+
+function error(string $msg): never
+{
+    fwrite(STDERR, "error: {$msg}\n");
+    exit(2);
+}
+
+if (git('rev-parse --is-inside-work-tree') === null) {
+    error('not inside a git work tree');
+}
+
+$base = git('merge-base origin/master HEAD') ?? git('rev-parse origin/master');
+if ($base === null || $base === '') {
+    error('cannot resolve origin/master (fetch first?)');
+}
+
+// Full change set = committed-ahead ∪ uncommitted (staged/unstaged/untracked).
+$files = [];
+foreach (explode("\n", (string) git('diff --name-only ' . escapeshellarg($base) . ' HEAD')) as $f) {
+    if ($f !== '') {
+        $files[$f] = true;
+    }
+}
+foreach (explode("\n", (string) git('status --porcelain -uall')) as $line) {
+    if ($line === '') {
+        continue;
+    }
+    // Porcelain v1: "XY <path>" or "XY <old> -> <new>" for renames.
+    $path = substr($line, 3);
+    if (str_contains($path, ' -> ')) {
+        $path = substr($path, (int) strpos($path, ' -> ') + 4);
+    }
+    $files[trim($path, '"')] = true;
+}
+
+$paths = array_keys($files);
+if ($paths === []) {
+    fail('no changes vs origin/master');
+}
+
+foreach ($paths as $p) {
+    if (strtolower(pathinfo($p, PATHINFO_EXTENSION)) !== 'md') {
+        fail("non-Markdown file changed: {$p}");
+    }
+    $excludedPrefix = false;
+    foreach (EXCLUDE_PREFIXES as $prefix) {
+        if (str_starts_with($p, $prefix)) {
+            $excludedPrefix = true;
+            break;
+        }
+    }
+    if (in_array($p, EXCLUDE, true) || $excludedPrefix) {
+        fail("merge-gate machinery changed (self-gating): {$p}");
+    }
+}
+
+fwrite(STDOUT, 'eligible: docs-only (' . count($paths) . " markdown file(s))\n");
+exit(0);

--- a/ibl5/docs/decisions/0067-docs-only-light-ship-path.md
+++ b/ibl5/docs/decisions/0067-docs-only-light-ship-path.md
@@ -1,0 +1,36 @@
+---
+description: Docs-only changes may open a PR and arm auto-merge directly, skipping /post-plan's review/security/E2E teeth, gated by a mechanical predicate.
+last_verified: 2026-06-22
+---
+
+# ADR-0067: Docs-only light ship path
+
+**Status:** Accepted
+**Date:** 2026-06-22
+
+## Context
+
+Every verified-complete interactive change fires `bin/post-plan-now --auto` → full `/post-plan` (code review, security audit, E2E, CI watch) before auto-merge arms. `ship.md`'s Core invariant deliberately routes *all* arming through `/post-plan` Phase 6.5 because those agentic teeth cannot run from chat context. But for a pure documentation change — Markdown only — none of those teeth apply: there is no code to review, no SQL/auth/output surface to audit, no app behavior to E2E. Running the heavy pipeline (including a Docker-rebuilt E2E stack) to land a prose edit is pure overhead, and it was the only path to auto-merge.
+
+## Decision
+
+Add a **docs-only light ship path**: when a branch's full change set (committed-ahead ∪ uncommitted) is exclusively Markdown and touches none of the merge-gate/arming machinery, `/ship` and the interactive auto-fire may open the PR and arm `gh pr merge --auto` **directly**, skipping `/post-plan`. Eligibility is decided by a single mechanical predicate, `bin/ship-light-eligible` (exit 0 eligible / 1 ineligible / 2 error) — never a subjective "feels small" judgment — and is consumed by both `.claude/commands/ship.md` and `.claude/rules/workflow-continuity.md`. Skipping `/post-plan` does **not** skip CI: the branch-protection required contexts (`Tests and Analysis`, `E2E Tests`, `human-signoff`) all run on a docs-only PR and gate the `--auto` merge (their `pull_request` triggers carry no `paths` filter, and each has an `if: always()` gate job that reports the required context even when its work skips). Because `check-docs` (dead-reference / `last_verified` validation) is **not** itself a required context, the light path runs `bin/check-docs --since=origin/master` locally and refuses to arm if it fails — so doc validity is enforced before merge, not left to a non-blocking CI status. The merge-gate machinery is excluded from eligibility so a gate edit can never ride the path it defines: both the *arming* machinery (`ship.md`, `workflow-continuity.md`, `auto-commit.md`, `commit-conventions.md`, the `post-plan` skill) and the *gate-authoring / review / security* machinery (`plan.md` and `_plan-verification.md`, which author the hold criteria deciding what future changes need review; `pr-review.md` / `security-audit.md` and the shared `.claude/commands/_*.md` components, which define the review and audit teeth). An unreviewed edit to any of these could otherwise arm itself or silently weaken the gates protecting everything else.
+
+## Alternatives Considered
+
+- **Status quo (all via `/post-plan`)** — every change runs the full pipeline. Rejected because: post-plan's review/security/E2E add zero signal for a prose-only diff, so the cost is unjustified.
+- **Route low-risk → `/ship --no-merge`** — open the PR, human merges. Rejected because: it does not auto-merge, so it still relies on the user's attention to land trivial docs.
+- **Subjective size/complexity classifier** — Claude judges "is this small/low-risk". Rejected because: a misclassification auto-merges unreviewed code; the safe predicate is mechanical (does the diff touch any surface post-plan checks?), and prose size is irrelevant to safety.
+
+## Consequences
+
+- Positive: documentation lands fast without the heavy pipeline, while CI required checks still gate the merge.
+- Positive: the file-path predicate is mechanical and testable (`bin/ship-light-eligible` + its Cli test), not a judgment call that can drift.
+- Negative: it narrows `ship.md`'s "never arm directly" Core invariant to a carved-out, machine-checked exception — one more code path to keep correct, justified by the self-gating exclusion and the still-required CI checks.
+
+## References
+
+- `bin/ship-light-eligible` — the eligibility predicate (single source of truth).
+- `ibl5/tests/Cli/ShipLightEligibleCliTest.php` — its tests.
+- `.claude/commands/ship.md` — the `/ship` light path.
+- `.claude/rules/workflow-continuity.md` — the interactive auto-fire routing.

--- a/ibl5/tests/Cli/ShipLightEligibleCliTest.php
+++ b/ibl5/tests/Cli/ShipLightEligibleCliTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('cli')]
+final class ShipLightEligibleCliTest extends TestCase
+{
+    private string $repo;
+    private string $script;
+
+    protected function setUp(): void
+    {
+        $this->script = (string) realpath(__DIR__ . '/../../../bin/ship-light-eligible');
+        $this->repo = sys_get_temp_dir() . '/ship-light-' . uniqid();
+        mkdir($this->repo, 0755, true);
+
+        // A throwaway repo with an origin/master ref the helper diffs against.
+        $this->git('init -q');
+        $this->git('config user.email t@example.com');
+        $this->git('config user.name Test');
+        $this->git('config commit.gpgsign false');
+        file_put_contents($this->repo . '/baseline.md', "# baseline\n");
+        $this->git('add -A');
+        $this->git('commit -qm baseline');
+        $this->git('update-ref refs/remotes/origin/master HEAD');
+    }
+
+    protected function tearDown(): void
+    {
+        exec('rm -rf ' . escapeshellarg($this->repo));
+    }
+
+    public function testEligibleForDocsOnlyChange(): void
+    {
+        file_put_contents($this->repo . '/guide.md', "new doc\n");
+
+        [$exit, $out] = $this->runScript();
+
+        self::assertSame(0, $exit, "docs-only change must be eligible; got: {$out}");
+        self::assertStringContainsString('eligible: docs-only', $out);
+    }
+
+    public function testIneligibleForNonMarkdownChange(): void
+    {
+        file_put_contents($this->repo . '/script.php', "<?php\n");
+
+        [$exit, $out] = $this->runScript();
+
+        self::assertSame(1, $exit, 'a non-Markdown change must be ineligible');
+        self::assertStringContainsString('non-Markdown', $out);
+    }
+
+    public function testIneligibleWhenGateMachineryChanged(): void
+    {
+        // A Markdown file, but one that DEFINES the arming machinery → self-gating.
+        mkdir($this->repo . '/.claude/rules', 0755, true);
+        file_put_contents($this->repo . '/.claude/rules/workflow-continuity.md', "edit\n");
+
+        [$exit, $out] = $this->runScript();
+
+        self::assertSame(1, $exit, 'editing arming machinery must be ineligible');
+        self::assertStringContainsString('self-gating', $out);
+    }
+
+    public function testIneligibleWhenGateAuthoringDocChanged(): void
+    {
+        // plan.md authors the hold criteria that decide what future changes need review.
+        mkdir($this->repo . '/.claude/commands', 0755, true);
+        file_put_contents($this->repo . '/.claude/commands/plan.md', "edit\n");
+
+        [$exit, $out] = $this->runScript();
+
+        self::assertSame(1, $exit, 'editing plan-gate authoring docs must be ineligible');
+        self::assertStringContainsString('self-gating', $out);
+    }
+
+    public function testIneligibleWhenSharedGateComponentChanged(): void
+    {
+        // Any .claude/commands/_*.md is a shared review/security/test-spec component.
+        mkdir($this->repo . '/.claude/commands', 0755, true);
+        file_put_contents($this->repo . '/.claude/commands/_review-rubric.md', "edit\n");
+
+        [$exit, $out] = $this->runScript();
+
+        self::assertSame(1, $exit, 'editing a shared gate component must be ineligible');
+        self::assertStringContainsString('self-gating', $out);
+    }
+
+    public function testIneligibleWhenNoChanges(): void
+    {
+        [$exit, $out] = $this->runScript();
+
+        self::assertSame(1, $exit, 'a clean tree must be ineligible');
+        self::assertStringContainsString('no changes', $out);
+    }
+
+    /** @return array{0:int,1:string} */
+    private function runScript(): array
+    {
+        $output = [];
+        $exit = 0;
+        exec(
+            'cd ' . escapeshellarg($this->repo) . ' && '
+                . escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($this->script) . ' 2>&1',
+            $output,
+            $exit
+        );
+        return [$exit, implode("\n", $output)];
+    }
+
+    private function git(string $args): void
+    {
+        exec('cd ' . escapeshellarg($this->repo) . ' && git ' . $args . ' 2>&1');
+    }
+}


### PR DESCRIPTION
## Summary

Adds a mechanically-gated **docs-only light ship path**: a Markdown-only change opens a PR and arms `gh pr merge --auto` directly, **skipping `/post-plan`** — its code review, security audit, and E2E have nothing to check on a prose diff. For anything else, the existing delegated path (fire `bin/post-plan-now` → `/post-plan` Phase 6.5) is unchanged.

Motivated by the realization that an `.md`-only PR doesn't need the heavy pipeline. The routing decision is **mechanical, not a "feels small" judgment**.

## What's here

- **`bin/ship-light-eligible`** — single-source predicate (exit 0 docs-only / 1 ineligible / 2 error). Eligible iff every changed file is `*.md` **and** none is merge-gate machinery.
- **`ship.md`** — Step 3b routes light vs delegated; Core invariant carves out the one exception; the light path runs `bin/check-docs` locally before arming.
- **`workflow-continuity.md`** — the interactive auto-fire assesses the predicate first.
- **`ADR-0067`** — records the carve-out to the "never arm directly" invariant.
- **`ShipLightEligibleCliTest`** — 6 cases.

## Safety

- **Exclusion set**: the predicate refuses both the *arming* machinery (`ship.md`, `workflow-continuity.md`, `auto-commit.md`, `commit-conventions.md`, post-plan) **and** the *gate-authoring/review/security* docs (`plan.md`, `_plan-verification.md`, `pr-review.md`, `security-audit.md`, shared `.claude/commands/_*.md`) — a gate edit can neither self-arm nor weaken the gates unreviewed.
- **CI still gates**: required contexts `Tests and Analysis`, `E2E Tests`, `human-signoff` all run on docs-only PRs (PR triggers have no `paths` filter; each has an `if: always()` gate job that reports). `check-docs` is *not* a required context, so the light path enforces it locally before arming.
- This PR is **ineligible for its own light path** (touches code + gate machinery) — correctly routed to human review.

## Verification

- `ShipLightEligibleCliTest` — 6/6 green
- PHPStan `analyse` + `analyse:tests` — clean
- Full PHPUnit suite — 6104 pass
- `check-docs` + `adr-check` — pass

## Why opened for human merge (not auto-merged)

It introduces a code-review *bypass*; a subtle hole in the predicate means future code could merge with zero agentic review. That warrants a human (you) on the diff before it goes live. Optionally run `/security-audit` on the predicate.

<!-- no-adr: ADR-0067 added in this PR documents the invariant carve-out -->