### PR TITLE
docs: add work-triage rule and ADR-0067 unified deployment funnel

### DIFF
--- a/.claude/rules/work-triage.md
+++ b/.claude/rules/work-triage.md
@@ -1,0 +1,42 @@
+---
+description: Triage every non-trivial unit of work as ad-hoc vs /plan before starting, with an ad-hoc safety mirror; the gateway that feeds the deployment funnel (ADR-0067).
+last_verified: 2026-06-22
+---
+
+# Work Triage Rule
+
+## Triage before non-trivial work
+
+Before starting **any non-trivial unit of work** — whether you proposed it or the user assigned it — decide: implement **ad-hoc** (just do it, then `/ship`) or route through **`/plan`**. State the call and one line of why, then proceed. The user should never have to ask "is this big enough for a `/plan`?" — that judgment is yours to volunteer.
+
+This is the **gateway** of the deployment funnel (ADR-0067): triage decides plan-vs-ad-hoc; everything downstream (`/post-plan`, auto-queue, auto-merge arming) flows from there.
+
+## The ad-hoc bar
+
+Work is ad-hoc-safe only when **all** hold:
+- **Known blast radius** — you can name every file/behavior it touches.
+- **An existing pattern to copy** — not novel infrastructure.
+- **No multi-phase reasoning** — a single coherent change, not a sequence with intermediate decisions.
+- **No unresolved design fork** — nothing where the codebase can't reveal the right choice.
+
+If any are open, it wants a `/plan`.
+
+**Resolve empirical unknowns first.** Run the cheap scan (existing occurrences, false-positive risk, how the thing is emitted) *before* declaring the verdict — the scan often collapses an apparent design fork into an ad-hoc change.
+
+## Ad-hoc safety mirror
+
+Even when the bar above says ad-hoc, run a quick safety check — the same surfaces `/plan` Step 4 gate 14 holds for. If the change touches any of:
+- a **security surface** (SQL, POST/form endpoint, auth/authz-gated route, user-facing output rendering),
+- a **destructive or schema-tightening migration**,
+- **new or redesigned user-visible UI/UX**, or
+- a property needing **subjective human judgment** to confirm,
+
+then prefer `/plan`, so the defense and its verification are designed up front. Whatever still ships ad-hoc is caught at PR time by `/post-plan` Phase 6.5 condition (9) — but designing it in the plan beats relying on the backstop.
+
+## Calibration
+
+Surface the verdict only when scope is **non-trivial or borderline**. Skip the ritual for obviously trivial edits (typo, one-line fix) — just do them; don't add ceremony.
+
+## Headless
+
+In a headless/automouse run there is no user to recommend `/plan` to, and automouse only executes pre-vetted plans. This rule is a no-op there — it governs interactive work-start only.

--- a/ibl5/docs/decisions/0067-unified-deployment-funnel.md
+++ b/ibl5/docs/decisions/0067-unified-deployment-funnel.md
@@ -1,0 +1,42 @@
+---
+description: Unifies the deployment funnel so every PR-opening path flows through /post-plan; triage is a loaded rule, /plan auto-queues, /ship drops merge-intent tokens.
+last_verified: 2026-06-22
+---
+
+# ADR-0067: Unified deployment funnel — one pipeline through /post-plan
+
+**Status:** Accepted
+**Date:** 2026-06-22
+
+## Context
+
+The in-Claude deployment funnel (`/plan`, `/post-plan`, `/ship`, `/queue`, `commit-commands`) grew piecemeal. Its decision points were scattered across three mechanisms with inconsistent handoffs: the plan-vs-ad-hoc triage lived only in a per-project memory note (no enforcement surface); `/ship --no-merge` opened a raw PR via `commit-push-pr` with zero code review / security audit / verification, coupling safety to *merge intent* instead of to the work; and `/plan` emitted no queue-safety verdict and never auto-queued, leaving the `/plan → /queue` handoff fully manual. The intent is that Claude auto-routes each unit of work to the right funnel exit (auto-merge / queue / post-plan / plan / ship) without the user hand-picking the branch.
+
+## Decision
+
+Collapse the funnel to a single pipeline with one variable:
+
+- **Triage is a loaded rule.** `.claude/rules/work-triage.md` decides plan-vs-ad-hoc before any non-trivial work, with an ad-hoc safety mirror (the gate-14 surfaces). It is the single gateway.
+- **Every PR-opening path flows through `/post-plan`.** `/post-plan` always opens the PR and runs review + audit + verification; **auto-merge arming is the only variable**, decided by Phase 6.5's conditions.
+- **`/plan` auto-queues queue-safe plans.** When `bin/check-plan` passes (which already enforces no-unresolved-decisions), `/plan` auto-invokes `bin/automouse-queue` unless the session opts to implement now. Queue-safety is independent of `auto_merge`.
+- **`/ship` collapses to a thin `/post-plan` wrapper.** The `--no-merge` / `--merge` tokens and the merge-intent resolution are removed; `/ship` fires bare `bin/post-plan-now` after its precondition gate. A reviewed-but-held PR still happens automatically whenever Phase 6.5 holds the work — no token to remember.
+
+## Alternatives Considered
+
+- **Docs-only direct-arm bypass (PR #1193).** A light path that armed `gh pr merge --auto` directly, skipping `/post-plan`, for Markdown-only diffs. Rejected and closed: a second arming path violates the single-pipeline model, and `/post-plan` already self-scales to near-nothing on a prose diff (Phase 3 `DOCS_ONLY`, Phase 4/5 agent + suite skips).
+- **Route `/ship --no-merge` through post-plan-with-hold.** Keep the token but make it open a reviewed-but-held PR. Rejected in favor of removing the token entirely: the held-PR outcome already emerges automatically when work is not arming-safe, and the user never reaches for the flag (see the zero-token-default preference).
+
+## Consequences
+
+- Positive: one front door for work; consistent review/audit/verification on every PR; one arming authority (Phase 6.5); less for the user to remember.
+- Positive: triage is enforced in-repo (a rule), not recalled from memory.
+- Negative: the deliberate hold of an *arming-eligible* PR purely to eyeball it is gone — accepted, because that outcome contradicts "safe → ship automatically," and `auto_merge: false` still covers planned work that genuinely wants a human at merge.
+
+## References
+
+- `.claude/rules/work-triage.md` — the triage gateway rule (added in this PR).
+- `.claude/rules/workflow-continuity.md` — the implementation → `/post-plan` auto-fire handoff.
+- `.claude/commands/plan.md` — `/plan` (auto-queue added in PR B).
+- `.claude/commands/ship.md` — `/ship` (simplified in PR C).
+- `.claude/skills/post-plan/SKILL.md` — Phase 6.5, the single arming authority.
+- `bin/automouse-queue` — the queue command `/plan` invokes.


### PR DESCRIPTION
## Summary

Adds two new docs:
- `.claude/rules/work-triage.md` — promotes the plan-vs-ad-hoc triage judgment from a per-project memory note into a loaded, in-repo rule, with an ad-hoc safety mirror (gate-14 surfaces).
- `ibl5/docs/decisions/0067-unified-deployment-funnel.md` — records the unified deployment funnel redesign as ADR-0067, resolving the new rule's `adr-check` trigger in-PR.

Part 1 of 3 in the deployment-funnel redesign. PR B (/plan auto-queue) and PR C (/ship simplification) cite this ADR in prose; they should merge after this.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.