### PR TITLE
chore(vr): classify diff cells as NEW vs CHANGED, render NEW section in PR comment

### DIFF
--- a/.claude/rules/visual-review-prs.md
+++ b/.claude/rules/visual-review-prs.md
@@ -7,12 +7,12 @@ paths:
   - "ibl5/tests/e2e/vr-review-comment.ts"
   - "bin/vr-changed-coverage"
   - "bin/vr-review-comment"
-last_verified: 2026-06-22
+last_verified: 2026-06-24
 ---
 
 # Visual-review PRs
 
-See ADR-0068 for the decision and rationale.
+See ADR-0068 and ADR-0069 for the decisions and rationale.
 
 ## What runs
 
@@ -38,6 +38,12 @@ per-SHA report dirs whose newest commit is older than 14 days.
 - Diffing views are grouped per module in `<details>` blocks; each link deep-links into the
   per-SHA Playwright HTML report (filtered by test title) where the before/after/diff slider
   shows desktop + mobile.
+- A **"🆕 New views (no prior baseline — review the render)"** section lists failing cells
+  whose baseline was never committed (a brand-new VR row). These have no before/after — the
+  link shows the first render; sanity-check it, then `update-baselines` commits it as the
+  baseline. NEW cells are excluded from the "changed view(s)" count so a first-render never
+  reads as a regression. Classification uses `git ls-files` on the tracked index (not disk),
+  per ADR-0069.
 - The per-SHA Pages URL shape is `https://a-jay85.github.io/IBL5/<sha>/visual-review/`.
 - A **"⚠️ Changed but NOT covered by the VR manifest"** section lists changed website paths
   that match no manifest row — review those by hand or add a `vr-manifest.ts` row. A

--- a/bin/vr-review-comment
+++ b/bin/vr-review-comment
@@ -12,12 +12,13 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
 
 const __dir = dirname(fileURLToPath(import.meta.url));
 const ibl5Dir = resolve(__dir, '..', 'ibl5');
 
 const { VR_MANIFEST } = await import(resolve(ibl5Dir, 'tests/e2e/vr-manifest.ts'));
-const { buildComment, extractDiffCells } = await import(
+const { buildComment, extractDiffCells, classifyCells } = await import(
   resolve(ibl5Dir, 'tests/e2e/vr-review-comment.ts')
 );
 
@@ -71,8 +72,44 @@ if (resultsPath !== null && existsSync(resultsPath)) {
 
 const diffCells = extractDiffCells(report, VR_MANIFEST);
 
+// Classify NEW (no committed baseline) vs CHANGED (committed baseline = real
+// diff). Signal: `git ls-files <snapshot path>` reads the TRACKED INDEX, not the
+// working tree — so a brand-new row (whose .png Playwright `missing` mode just
+// wrote UNTRACKED into the working dir) returns NO output line, while a committed
+// baseline prints its path. existsSync is WRONG here: missing-mode writes the
+// untracked baseline during the run. Discriminator is the printed line, NOT the
+// exit code (both tracked and untracked paths exit 0).
+const repoRoot = resolve(__dir, '..'); // bin/ is at repo root; .. == repo root
+const SNAPSHOT_DIR = 'ibl5/tests/e2e/smoke/visual-regression.spec.ts-snapshots';
+const snapshotPath = (title: string): string => `${SNAPSHOT_DIR}/${title}.png`;
+
+let trackedTitles = new Set<string>();
+if (diffCells.length > 0) {
+  // Guard: never call `git ls-files` with no pathspec — it lists the whole tree.
+  const paths = diffCells.map((c) => snapshotPath(c.title));
+  let tracked: string[] = [];
+  try {
+    const out = execFileSync('git', ['ls-files', '-z', '--', ...paths], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+    });
+    tracked = out.split('\0').filter((p) => p.length > 0);
+  } catch {
+    // git unavailable / not a repo ⇒ fail safe to "all CHANGED" (no NEW section),
+    // which is the existing behavior — never crash the comment build.
+    tracked = paths;
+  }
+  const trackedSet = new Set(tracked);
+  // Map tracked PATHS back to TITLES for the title-keyed classifier.
+  trackedTitles = new Set(
+    diffCells.map((c) => c.title).filter((t) => trackedSet.has(snapshotPath(t))),
+  );
+}
+
+const classifiedCells = classifyCells(diffCells, trackedTitles);
+
 const markdown = buildComment({
-  diffCells,
+  diffCells: classifiedCells,
   uncoveredChangedPaths: coverage.uncoveredChangedPaths ?? [],
   globalChange: coverage.globalChange ?? false,
   pagesUrl,

--- a/ibl5/docs/decisions/0069-vr-comment-new-vs-changed.md
+++ b/ibl5/docs/decisions/0069-vr-comment-new-vs-changed.md
@@ -1,0 +1,133 @@
+---
+description: Classify each failing visual-review cell as NEW (no committed baseline) vs CHANGED (a real pixel regression) using git ls-files on the tracked index, and render NEW views in a distinct section of the sticky PR comment.
+last_verified: 2026-06-24
+---
+
+# ADR-0069: NEW vs CHANGED classification in the visual-review PR comment
+
+**Status:** Accepted
+**Date:** 2026-06-24
+
+## Lineage
+
+Extends **ADR-0068** (`ibl5/docs/decisions/0068-visual-review-pr-publishing.md`) — does NOT supersede it. ADR-0068 established the sticky PR comment and its module-grouped diff-cell format; this ADR adds a classification layer on top of that format.
+
+## Context
+
+The sticky `visual-review` PR comment (ADR-0068) frames every failing VR cell identically
+as a "changed view" — implying a pixel regression that must be scrutinized against a
+committed before/after. But a row whose baseline was **never committed** is not a
+regression: Playwright's default `missing` mode writes the new render as a baseline AND
+fails the test. This means `extractDiffCells` includes both genuine regressions and
+first-renders in the same list, framed the same way.
+
+Reviewers cannot tell "this is the first render of a brand-new view — sanity-check it"
+from "this is a real diff against a committed before/after." The result is either
+over-scrutiny of first-renders (treating them as regressions) or under-scrutiny (mentally
+dismissing all red cells as "probably new baselines").
+
+This touches the `buildComment` markup — a mechanical-enforcement surface per
+`.claude/rules/visual-review-prs.md` § "Modifying the selection logic" — so an ADR is
+required.
+
+## Decision
+
+Classify each failing cell as **NEW** (its baseline snapshot is NOT committed to the git
+index) or **CHANGED** (a committed baseline exists → a real pixel regression). NEW cells
+render in a distinct, clearly-labeled **"🆕 New views (no prior baseline — review the
+render)"** section; CHANGED cells render in the existing "changed view(s)" section.
+
+The **"changed view(s)" count excludes NEW cells** so a first-render never reads as a
+regression count. An all-NEW PR omits the changed-views header entirely and does not
+print "No visual diffs detected" — the NEW section IS the signal.
+
+The classification is **presentation-only, not an approval fork**: applying
+`update-baselines` commits the new baseline for NEW rows and updates it for CHANGED rows
+identically. No new sign-off mechanism is introduced.
+
+### The classification signal: `git ls-files` on the tracked index
+
+The signal is `git ls-files <snapshot path>` read against the **tracked index**, not the
+working tree. A brand-new row's snapshot path returns **empty stdout** — Playwright's
+`missing` mode writes the `.png` UNTRACKED into the working directory, so it is not in
+the index. A CHANGED row's committed baseline prints its path.
+
+`existsSync` / disk-existence is **invalid** here: `missing` mode writes the untracked
+baseline into the working dir during the run, making the file present on disk for both
+NEW and CHANGED rows.
+
+The discriminator is the **printed path line, NOT the exit code**: both a tracked and an
+untracked path exit 0 from `git ls-files`. A naive `if git ls-files …; then` would mark
+everything CHANGED. The correct check is whether the path appears as a non-empty stdout
+line.
+
+A single batched `git ls-files -z -- <paths>` call is used over all failing cells'
+snapshot paths (never over the whole manifest — that could hit ARG_MAX and is wasteful).
+The `-z` NUL-delimiter output is unambiguous about empty results and robust against
+hypothetical path oddities.
+
+### Architecture: pure builder, I/O in the wrapper
+
+The builder `ibl5/tests/e2e/vr-review-comment.ts` remains **pure — no I/O**. The new
+`classifyCells(cells, trackedTitles: Set<string>)` function is keyed on title and
+receives the tracked/untracked result as **data** from the wrapper. The `git ls-files`
+call lives entirely in `bin/vr-review-comment`.
+
+This preserves the builder's existing "No I/O" contract and keeps the classifier
+independently unit-testable from a plain Set with zero git/fs dependency.
+
+### Fail-safe on git error
+
+If `git ls-files` throws (git unavailable, not a git repo), the wrapper falls back to
+treating all cells as CHANGED — the pre-existing behavior — and never crashes the comment
+build. The NEW label is lost in that failure mode; the comment is otherwise identical to
+today's output.
+
+## Alternatives Considered
+
+- **Secondary signal: `-diff.png` attachment presence/absence** — At the attachment
+  level, `missing` mode emits `{expected, actual, NO -diff.png}` while a real regression
+  emits `{expected, actual, -diff.png}`. The discriminator is presence/absence of the
+  `-diff.png` attachment. Rejected: the primary git signal is simpler, requires no
+  attachment-set parsing the builder does not do today, and is sufficient for this repo's
+  workflow. Primary-git-only is chosen.
+
+- **Pure title-keyed `classifyCells` that itself calls git** — would push I/O into the
+  pure builder layer, violating its "No I/O" contract. Rejected in favor of the
+  wrapper-computes-Set / builder-receives-data seam described above.
+
+- **`existsSync` on the working-tree snapshot path** — Invalid because `missing` mode
+  writes the untracked baseline into the working dir during the run. Disk presence cannot
+  distinguish NEW from CHANGED in that environment.
+
+## Consequences
+
+- **Positive:** Reviewers no longer over-scrutinize first-renders as regressions. The
+  labeled NEW section says "review the render," not "investigate a diff," giving the
+  correct mental model.
+- **Positive:** The "changed view(s)" count is accurate — it excludes first-renders,
+  which are not regressions.
+- **Positive:** The builder remains pure and the new `classifyCells` is independently
+  unit-testable.
+- **Negative:** Classification is git-index-coupled — a `git ls-files` failure fails safe
+  to "all CHANGED" (pre-existing behavior), losing only the NEW label, never crashing the
+  comment build.
+- **Negative:** The signal depends on `standings.png` (and other committed baselines)
+  remaining in the tracked index. If a baseline is deleted from the index without a
+  replacement, the cell would be misclassified as NEW rather than CHANGED. This is an
+  edge case unlikely in normal workflow.
+
+## References
+
+- `bin/vr-review-comment` — CLI wrapper; contains the `git ls-files` call and Set
+  construction.
+- `ibl5/tests/e2e/vr-review-comment.ts` — pure builder; `classifyCells`, `buildComment`,
+  `DiffCell.isNew`.
+- `ibl5/tests/ts-unit/vr-review-comment.test.ts` — unit tests for the classifier and
+  `buildComment` NEW/CHANGED rendering.
+- `.claude/rules/visual-review-prs.md` — operator-facing rule; "Reading the comment"
+  section documents the NEW section.
+- `ibl5/playwright.visual.config.ts` — snapshot path template
+  (`snapshotPathTemplate: '{testDir}/{testFileDir}/{testFileName}-snapshots/{arg}{ext}'`).
+- `ibl5/docs/decisions/0068-visual-review-pr-publishing.md` — the publishing pipeline
+  this classification layer extends.

--- a/ibl5/tests/e2e/vr-review-comment.ts
+++ b/ibl5/tests/e2e/vr-review-comment.ts
@@ -14,6 +14,13 @@ export type DiffCell = {
   viewport: Viewport;
   /** The Playwright test title (snapshot filename without .png), e.g. `standings-mobile`. */
   title: string;
+  /**
+   * True when this cell's baseline snapshot is NOT committed to the git index
+   * (a brand-new view rendered in Playwright `missing` mode — no prior baseline
+   * to diff against). Set by classifyCells from the wrapper's git ls-files
+   * result; absent/false ⇒ a real pixel regression against a committed baseline.
+   */
+  isNew?: boolean;
 };
 
 // ── Playwright JSON report (only the fields we read) ─────────────────────────
@@ -64,6 +71,16 @@ export function extractDiffCells(report: PwReport, manifest: VrRow[]): DiffCell[
   return cells;
 }
 
+/**
+ * Classify each diff cell NEW vs CHANGED by whether its baseline snapshot is in
+ * the git tracked index. `trackedTitles` is the set of titles whose snapshot
+ * .png IS committed (the wrapper computes this via `git ls-files`, keeping this
+ * function pure). NEW ⇔ the title is NOT tracked.
+ */
+export function classifyCells(cells: DiffCell[], trackedTitles: Set<string>): DiffCell[] {
+  return cells.map((cell) => ({ ...cell, isNew: !trackedTitles.has(cell.title) }));
+}
+
 export type BuildCommentInput = {
   diffCells: DiffCell[];
   uncoveredChangedPaths: string[];
@@ -106,29 +123,56 @@ export function buildComment(input: BuildCommentInput): string {
     lines.push('');
   }
 
-  if (diffCells.length > 0) {
+  const changedCells = diffCells.filter((c) => !c.isNew);
+  const newCells = diffCells.filter((c) => c.isNew);
+
+  // Render one "grouped by module" block under a section heading.
+  const renderModuleSection = (heading: string, cells: DiffCell[]): void => {
     const byModule = new Map<string, DiffCell[]>();
-    for (const cell of diffCells) {
+    for (const cell of cells) {
       const arr = byModule.get(cell.module) ?? [];
       arr.push(cell);
       byModule.set(cell.module, arr);
     }
-
-    lines.push(`### ${diffCells.length} changed view(s) across ${byModule.size} module(s)`);
+    lines.push(`### ${heading.replace('{n}', String(cells.length)).replace('{m}', String(byModule.size))}`);
     lines.push('');
     for (const module of [...byModule.keys()].sort()) {
-      const cells = byModule.get(module)!;
-      lines.push(`<details><summary><strong>${module}</strong> — ${cells.length} view(s)</summary>`);
+      const group = byModule.get(module)!;
+      lines.push(`<details><summary><strong>${module}</strong> — ${group.length} view(s)</summary>`);
       lines.push('');
-      for (const cell of cells.sort((a, b) => a.title.localeCompare(b.title))) {
+      for (const cell of group.sort((a, b) => a.title.localeCompare(b.title))) {
         lines.push(`- [${cell.title} — ${cell.viewport}](${reportLink(pagesUrl, cell.title)})`);
       }
       lines.push('');
       lines.push('</details>');
       lines.push('');
     }
-  } else if (!globalChange && uncoveredChangedPaths.length === 0) {
-    // Boundary: nothing diffed and nothing uncovered — safe no-diff body.
+  };
+
+  if (changedCells.length > 0) {
+    renderModuleSection('{n} changed view(s) across {m} module(s)', changedCells);
+  }
+
+  if (newCells.length > 0) {
+    lines.push('### 🆕 New views (no prior baseline — review the render)');
+    lines.push('');
+    lines.push(
+      'These views have **no committed baseline** — Playwright wrote the first ' +
+        'render and the run failed by design. There is no "before"; the link shows ' +
+        'the new render. Confirm it looks right, then apply `update-baselines` to ' +
+        'commit these as the baselines.',
+    );
+    lines.push('');
+    renderModuleSection('{n} new view(s) across {m} module(s)', newCells);
+  }
+
+  if (
+    changedCells.length === 0 &&
+    newCells.length === 0 &&
+    !globalChange &&
+    uncoveredChangedPaths.length === 0
+  ) {
+    // Boundary: nothing diffed, nothing new, nothing uncovered — safe no-diff body.
     lines.push('_No visual diffs detected and no changed page falls outside VR coverage._');
     lines.push('');
   }

--- a/ibl5/tests/ts-unit/vr-review-comment.test.ts
+++ b/ibl5/tests/ts-unit/vr-review-comment.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { resolve } from 'path';
 import type { VrRow } from '../e2e/vr-manifest';
 import {
   buildComment,
+  classifyCells,
   extractDiffCells,
   titleToModule,
   type DiffCell,
@@ -94,5 +99,157 @@ describe('extractDiffCells / titleToModule', () => {
     expect(cells).toHaveLength(2);
     expect(cells).toContainEqual({ module: 'standings', viewport: 'mobile', title: 'standings-mobile' });
     expect(cells).toContainEqual({ module: 'player-movement', viewport: 'desktop', title: 'player-movement-empty' });
+  });
+});
+
+describe('classifyCells', () => {
+  it('3A: sets isNew=false for tracked title and isNew=true for untracked', () => {
+    const cells: DiffCell[] = [
+      { module: 'standings', viewport: 'desktop', title: 'standings' },
+      { module: 'standings', viewport: 'desktop', title: 'brand-new' },
+    ];
+    const result = classifyCells(cells, new Set(['standings']));
+    expect(result.find((c) => c.title === 'standings')!.isNew).toBe(false);
+    expect(result.find((c) => c.title === 'brand-new')!.isNew).toBe(true);
+  });
+
+  it('3A boundary: all-tracked ⇒ every isNew=false', () => {
+    const cells: DiffCell[] = [
+      { module: 'standings', viewport: 'desktop', title: 'standings' },
+      { module: 'standings', viewport: 'mobile', title: 'standings-mobile' },
+    ];
+    const result = classifyCells(cells, new Set(['standings', 'standings-mobile']));
+    expect(result.every((c) => c.isNew === false)).toBe(true);
+  });
+
+  it('3A boundary: empty Set ⇒ every isNew=true', () => {
+    const cells: DiffCell[] = [
+      { module: 'standings', viewport: 'desktop', title: 'standings' },
+    ];
+    const result = classifyCells(cells, new Set());
+    expect(result.every((c) => c.isNew === true)).toBe(true);
+  });
+
+  it('3A purity: input cells are not mutated', () => {
+    const cells: DiffCell[] = [
+      { module: 'standings', viewport: 'desktop', title: 'standings' },
+    ];
+    classifyCells(cells, new Set());
+    expect(cells[0].isNew).toBeUndefined();
+  });
+
+  it('3G: classifyCells on empty array returns []', () => {
+    expect(classifyCells([], new Set(['standings']))).toEqual([]);
+  });
+});
+
+describe('buildComment — NEW vs CHANGED', () => {
+  it('3B: mixed input renders NEW in 🆕 section and CHANGED in changed section', () => {
+    const diffCells: DiffCell[] = [
+      { module: 'standings', viewport: 'desktop', title: 'standings', isNew: false },
+      { module: 'player-movement', viewport: 'desktop', title: 'player-movement', isNew: true },
+    ];
+    const md = buildComment({ diffCells, uncoveredChangedPaths: [], globalChange: false, pagesUrl: PAGES_URL });
+
+    expect(md).toContain('🆕 New views');
+    expect(md).toContain('changed view(s)');
+    expect(md).toContain('no committed baseline');
+    // standings is CHANGED, not NEW
+    const newSectionStart = md.indexOf('🆕 New views');
+    const changedSectionStart = md.indexOf('changed view(s)');
+    expect(changedSectionStart).toBeLessThan(newSectionStart);
+    // player-movement link appears after the NEW heading
+    const playerMovementIdx = md.indexOf('player-movement');
+    expect(playerMovementIdx).toBeGreaterThan(newSectionStart);
+    // standings link appears before NEW heading (in CHANGED section)
+    const standingsIdx = md.indexOf('[standings');
+    expect(standingsIdx).toBeGreaterThan(-1);
+    expect(standingsIdx).toBeLessThan(newSectionStart);
+  });
+
+  it('3C: half-finish guard — changed header reads 1 changed view(s) with 2 NEW cells present', () => {
+    const diffCells: DiffCell[] = [
+      { module: 'standings', viewport: 'desktop', title: 'standings', isNew: false },
+      { module: 'player-movement', viewport: 'desktop', title: 'player-movement', isNew: true },
+      { module: 'player-movement', viewport: 'mobile', title: 'player-movement-mobile', isNew: true },
+    ];
+    const md = buildComment({ diffCells, uncoveredChangedPaths: [], globalChange: false, pagesUrl: PAGES_URL });
+
+    expect(md).toContain('1 changed view(s)');
+    expect(md).toContain('2 new view(s)');
+    expect(md).not.toContain('3 changed view(s)');
+  });
+
+  it('3D: all-NEW — emits 🆕 New views, no changed view(s) header, no No visual diffs detected', () => {
+    const diffCells: DiffCell[] = [
+      { module: 'standings', viewport: 'desktop', title: 'standings', isNew: true },
+    ];
+    const md = buildComment({ diffCells, uncoveredChangedPaths: [], globalChange: false, pagesUrl: PAGES_URL });
+
+    expect(md).toContain('🆕 New views');
+    expect(md).not.toContain('changed view(s)');
+    expect(md).not.toContain('No visual diffs detected');
+  });
+
+  it('3E: all-CHANGED — emits changed view(s), no 🆕 New views (regression guard)', () => {
+    const diffCells: DiffCell[] = [
+      { module: 'standings', viewport: 'desktop', title: 'standings', isNew: false },
+    ];
+    const md = buildComment({ diffCells, uncoveredChangedPaths: [], globalChange: false, pagesUrl: PAGES_URL });
+
+    expect(md).toContain('changed view(s)');
+    expect(md).not.toContain('🆕 New views');
+  });
+
+  it('3F: boundary none — No visual diffs detected body still renders, no 🆕, no #?q=', () => {
+    const md = buildComment({ diffCells: [], uncoveredChangedPaths: [], globalChange: false, pagesUrl: PAGES_URL });
+
+    expect(md).toContain('No visual diffs detected');
+    expect(md).not.toContain('🆕');
+    expect(md).not.toContain('#?q=');
+  });
+});
+
+describe('CLI end-to-end (bin/vr-review-comment against real git index)', () => {
+  it('3 (CLI row): classifies committed-baseline title as CHANGED and uncommitted title as NEW', () => {
+    // standings.png is a committed baseline; standings-nobaselinexyz.png is not.
+    const repoRoot = resolve(__dirname, '../../..');
+    const tmpResults = `${tmpdir()}/vr-review-comment-test-${Date.now()}.json`;
+    const fakeReport = {
+      suites: [
+        {
+          specs: [],
+          suites: [
+            {
+              specs: [
+                { title: 'standings', ok: false },
+                { title: 'standings-nobaselinexyz', ok: false },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    writeFileSync(tmpResults, JSON.stringify(fakeReport));
+
+    const stdout = execFileSync(
+      'bun',
+      [
+        'bin/vr-review-comment',
+        `--results=${tmpResults}`,
+        '--coverage=/nonexistent',
+        '--pages-url=https://example/IBL5/deadbeef/visual-review/',
+      ],
+      { cwd: repoRoot, encoding: 'utf-8' },
+    );
+
+    expect(stdout).toContain('🆕 New views');
+    expect(stdout).toContain('standings-nobaselinexyz');
+    expect(stdout).toContain('1 changed view(s)');
+    // The NEW title must NOT appear in the CHANGED section
+    const changedSectionEnd = stdout.indexOf('🆕 New views');
+    expect(changedSectionEnd).toBeGreaterThan(-1);
+    const standsNoBaselineInChanged = stdout.substring(0, changedSectionEnd).indexOf('standings-nobaselinexyz');
+    expect(standsNoBaselineInChanged).toBe(-1);
   });
 });


### PR DESCRIPTION
## Summary

Classifies each failing visual-review cell as **NEW** (no committed baseline) vs **CHANGED** (real pixel regression against a committed baseline) and renders NEW cells in a distinct labeled section of the sticky PR comment.

**Problem:** The merged VR sticky comment (ADR-0068) frames every failing cell identically. But a brand-new view whose baseline was never committed is not a regression — Playwright's `missing` mode writes the render as the baseline AND fails the test. Reviewers couldn't tell "first render, just sanity-check" from "real diff against a committed baseline."

**Signal:** `git ls-files <snapshot path>` reads the **tracked index**, not the working tree. An untracked (NEW) path returns empty stdout; a committed (CHANGED) path prints its path. Discriminator is the printed line, NOT the exit code (both exit 0).

**Architecture preserved:** the builder (`ibl5/tests/e2e/vr-review-comment.ts`) stays pure — no I/O. The `git ls-files` call lives in the wrapper (`bin/vr-review-comment`); the pure layer receives the tracked/untracked result as a `Set<string>` of tracked titles.

**Changes:**
- `ibl5/tests/e2e/vr-review-comment.ts` — adds `classifyCells(cells, trackedTitles)` and partitions `buildComment` into CHANGED/NEW sections; the "changed view(s)" count excludes NEW
- `bin/vr-review-comment` — batches `git ls-files -z` over failing cell snapshot paths, builds the tracked-title Set, classifies, passes into `buildComment`
- `ibl5/tests/ts-unit/vr-review-comment.test.ts` — adds classifier unit tests (boundaries: mixed/all-NEW/all-CHANGED/none) and a CLI end-to-end row against the real git index
- `ibl5/docs/decisions/0069-vr-comment-new-vs-changed.md` — new ADR documenting the classification decision and git-ls-files-over-disk-existence rationale
- `.claude/rules/visual-review-prs.md` — documents the NEW section, bumps `last_verified`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.