### PR TITLE
chore(tooling): shared pr-armable predicate + pr-triage cross-PR classifier

### DIFF
--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -5,7 +5,7 @@ disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
   - Skill
-last_verified: 2026-06-21
+last_verified: 2026-06-24
 ---
 
 # Post-Plan Orchestrator
@@ -501,6 +501,19 @@ Enable auto-merge **before** watching CI. This is the earliest point all gating 
 
 **These conditions only ever HOLD, never RELEASE.** They are an AND-of-not-blocked set: every condition can *add* a block; none can clear another's. Conditions (7)–(9) are **additive brakes on top of** the deterministic floors (1)–(6) and the independent `human-signoff` required GitHub check — they exist to catch what those miss, never to override them. post-plan **always runs and opens the PR**; these conditions decide only whether auto-merge *arms*. A held PR stays open for a human to merge.
 
+**Conditions (1)/(5)/(6)/(8) come from the shared predicate `bin/lib/pr-armable.sh`** — the single source of truth also used by `bin/pr-triage`, so the live-readable arming judgment has **one executable home** and cannot drift between consumers (hand-re-derived divergence is exactly what mis-armed #1163/#1188). The run-only conditions (2)/(3)/(4)/(7)/(9) stay inline below — they read post-plan-run-local state (`/tmp`, the local plan file, the realized diff) that no cross-PR consumer can see, so they cannot move into the shared predicate.
+
+**Each condition block is SELF-CONTAINED** — it `source`s the predicate and fetches its own inputs in-block, exactly as condition (7) re-derives `$PLAN_FILE` and the original (6)/(8) ran their own `gh pr view`. **Do not** hoist the `source` or a shared `PR_JSON` into a preamble block: a sourced function or a shell variable does not survive into a separately-executed block (only exported env vars like `$CLAUDE_HEADLESS` do), and a missing `source` would make `pr_feat_hold` a no-op — **failing OPEN, auto-arming a `feat:` PR**. Each block re-`source`ing the lib is idempotent and cheap. Every block extracts gh output with `gh ... --jq` (gh does the decode — no `echo`/`printf` round-trip needed); when a block must round-trip a multi-field `PR_JSON` it uses `printf '%s'` (never `echo`, whose zsh `\n` expansion corrupts jq's parse).
+
+**Condition (1) — Manual-Testing clearance (mechanized via the shared predicate).** Previously a prose gate ("PR says No manual testing needed") the orchestrator eyeballed — itself a judgment-error surface. Now deterministic: `pr_manual_testing_clearance` returns `CLEARED` (the `No manual testing needed` sentinel is present — the positive signal Phase 6 writes after resolving every manual-testing item), `HELD` (real manual rows remain), or `UNKNOWN` (no `## Manual Testing` section at all). **Fail-closed: arm only on `CLEARED`.** Phase 6 always writes the section, so a post-plan PR is `CLEARED` or `HELD`, never `UNKNOWN` on this path — the armed set is unchanged; the stricter `UNKNOWN→block` only matters to `bin/pr-triage`'s cross-PR sweep of hand-made PRs:
+
+```bash
+# condition (1): block unless the Manual-Testing section is the positive sentinel.
+source "$(git rev-parse --show-toplevel)/bin/lib/pr-armable.sh"
+CLEAR=$(pr_manual_testing_clearance "$(gh pr view --json body --jq '.body')")
+[ "$CLEAR" != "CLEARED" ] && echo "BLOCKED: Manual-Testing not cleared (state=$CLEAR) — held for human review"
+```
+
 **Condition (4) blocks on the VALUE, not file presence** — the status file is non-empty for `pass` and `skipped` too (it always contains `PHASE5_VERIFY_STATUS=...`), so the `[ -s ... ]` idiom condition (3) uses would wrongly block every `pass`/`skipped`. Block only on the literal `fail` value; **absent file OR `pass` OR `skipped` = PASS (non-blocking)** — a `skipped` status (docs-only / PHP-less PR with no mapped E2E) must NOT block, or every such PR would stop arming, a regression worse than #887:
 
 ```bash
@@ -511,27 +524,31 @@ grep -q 'PHASE5_VERIFY_STATUS=fail' /tmp/post-plan-phase5-status-$PPID 2>/dev/nu
 **Condition (5) — golden-snapshot safety (headless only).** If `$GOLDEN_CHANGED` is `true` AND `$CLAUDE_HEADLESS` is set, **block** auto-merge: a change to `engine/internal/sim/testdata/golden.json` means the engine's simulation output changed, and a snapshot change with no human present is exactly when not to auto-ship (an agent can turn a red `TestGolden` green by regenerating the snapshot, silently masking a regression). In **interactive** mode (`$CLAUDE_HEADLESS` unset), do **not** block — emit a prominent warning with the same text so the human confirms intent before merging. This condition is independent of `HAS_GO` (a golden-only diff is `HAS_GO=false` but must still trigger it):
 
 ```bash
-# condition (5): blocks ONLY when golden changed AND running headless (automouse autonomous)
-[ "$GOLDEN_CHANGED" = true ] && [ -n "$CLAUDE_HEADLESS" ] \
+# condition (5): blocks ONLY when golden changed AND running headless (automouse autonomous).
+# Self-contained: source the predicate and fetch the live file list here. Detection
+# is the Phase-3 diff flag $GOLDEN_CHANGED (a shell var — may be empty in a fresh
+# block) OR the shared predicate's live file-list check (pr_golden_hold, the same
+# one bin/pr-triage uses — reliable regardless of block isolation). Mode policy
+# (headless-only block) stays in the caller; $CLAUDE_HEADLESS is an env var so it
+# survives. Interactive (unset) still warns rather than blocks.
+source "$(git rev-parse --show-toplevel)/bin/lib/pr-armable.sh"
+{ [ "${GOLDEN_CHANGED:-}" = true ] || [ -n "$(pr_golden_hold "$(gh pr view --json files --jq '.files')")" ]; } \
+  && [ -n "${CLAUDE_HEADLESS:-}" ] \
   && echo "BLOCKED: golden.json (simulation behavior) changed in headless mode — confirm this was an intentional 'make -C engine golden-update', not a masked regression"
 ```
 
 **Condition (6) — merge-order dependency (both modes).** When a PR must not merge ahead of another (a refactor that ships first, a migration-number sequence, shared files that re-conflict on merge), its body declares the predecessors with a `Depends-on:` line, e.g. `Depends-on: #1066, #1071`. Arming auto-merge here would let GitHub queue the merge the instant checks pass — out of order — so block until every named PR is `MERGED`. Reads the **live** PR body via `gh` (independent of which branch's skill is running), so a stale local checkout can't bypass it. No `Depends-on:` line ⇒ no dependency ⇒ never blocks. This gate prevents *premature arming only*; it does not rebase — after a predecessor merges, the successor still needs its own `git merge master` + re-green before its checks pass and a later post-plan run can arm:
 
 ```bash
-# condition (6): block if any Depends-on: PR is not yet MERGED.
-# Bare `gh pr view` (no arg) resolves the current branch's PR, matching Phase 3's idiom.
-# Anchor the marker to start-of-line (`^[[:space:]]*depends-on:`) so only a real marker
-# line matches — an INLINE prose mention (e.g. "...the `Depends-on:` gate (#1077)...")
-# must NOT be parsed as a dependency, or every PR documenting the mechanism self-blocks.
-# `while read` (not `for d in $DEPS`) so it splits per-line in bash AND zsh — zsh does
-# not word-split unquoted expansions, so a `for` loop would see all numbers as one word.
-gh pr view --json body --jq '.body' \
-  | grep -iE '^[[:space:]]*depends-on:' | grep -oE '[0-9]+' \
-  | while read -r d; do
-      st=$(gh pr view "$d" --json state --jq '.state' 2>/dev/null)
-      [ "$st" != "MERGED" ] && echo "BLOCKED: depends on #$d (state=${st:-unknown}, not yet MERGED)"
-    done
+# condition (6): block if any Depends-on: predecessor is not yet MERGED — shared
+# predicate (also used by bin/pr-triage). Self-contained: source + fetch the body
+# here. pr_dep_holds anchors the marker to start-of-line (an inline prose mention
+# is ignored) and splits per-line (bash+zsh safe), echoing `depends-on:#N` for
+# each unmerged predecessor.
+source "$(git rev-parse --show-toplevel)/bin/lib/pr-armable.sh"
+pr_dep_holds "$(gh pr view --json body --jq '.body')" | while read -r dep; do
+  echo "BLOCKED: depends on ${dep#depends-on:} — not yet MERGED"
+done
 ```
 
 **Condition (7) — plan-time hold (`auto_merge: false`).** The plan author predicts at plan-time (via `/plan` Step 4 gate 14) whether the change wants a human at merge, and records it as a line-1 frontmatter field. If the located plan file declares `auto_merge: false`, **block** — the PR opens and gets reviewed, but auto-merge does not arm. Parse the line-1 YAML frontmatter only (a body documenting the syntax can't self-select). **Derive `$PLAN_FILE` inside this block** — bash variables do not survive across phases/shells (see Phase 3's note), so a bare `$PLAN_FILE` assigned in Phase 1 would be empty here and the check would silently no-op. The snippet re-derives the path from the branch slug (the same derivation `bin/post-plan-now` and Phase 1's interactive fallback use; in automouse the authoritative path the postplan prompt supplies is identical, since the queue symlinks plans by branch slug). Absent file or absent field ⇒ no hold:
@@ -552,10 +569,15 @@ AUTO_MERGE=$(awk '
 **Condition (8) — commit-type floor (never arm `feat:`).** A literal PR-title grep, deterministic. Mirrors the required `human-signoff` check (`.github/workflows/human-signoff.yml`) as defense-in-depth, so post-plan **never arms a `feat:` PR in the first place** (no arm-then-strip). This is a floor, not a soft signal — commit-type weighs into condition (9) only to *add* holds on maintenance PRs; it can never *release* a `feat:`:
 
 ```bash
-# condition (8): block if the PR title is a conventional-commit feature (feat:/feat(scope):/feat!:)
-gh pr view --json title --jq '.title' \
-  | grep -qiE '^feat(\([^)]*\))?!?:' \
-  && echo "BLOCKED: feat: PR — auto-merge held for the human-signoff floor (post-plan never arms feat:)"
+# condition (8): block a conventional-commit feature title — shared predicate
+# (also used by bin/pr-triage). REFINEMENT: pr_feat_hold is label-aware — a feat:
+# carrying the `human-approved` label does NOT block (the maintainer has signed
+# off, matching the human-signoff check). At post-plan's normal call time (PR
+# just created) no label is present, so this blocks every feat: exactly as before;
+# the label-aware path only releases on a later re-run after a human labeled it.
+source "$(git rev-parse --show-toplevel)/bin/lib/pr-armable.sh"
+FEAT_HOLD=$(pr_feat_hold "$(gh pr view --json title --jq '.title')" "$(gh pr view --json labels --jq '.labels')")
+[ -n "$FEAT_HOLD" ] && echo "BLOCKED: feat: PR — auto-merge held for the human-signoff floor (post-plan never arms an unlabeled feat:)"
 ```
 
 **Condition (9) — PR-time safety verdict (both modes).** Read the realized diff (`/tmp/post-plan-diff-$PPID`) plus the Phase-3 flags (`HAS_MIGRATION`, `GOLDEN_CHANGED`, `COUNT_*`) and the PR title, and **enumerate every concrete reason this PR should wait for a human**. If the list is non-empty, **block**. This catches *drift* — a plan that looked auto-merge-safe at plan-time but whose realized implementation grew past it. Frame it as enumerating holds, **never** as certifying safe: certifying safe is proving a negative, which is unreliable, and the only dangerous failure is *under*-holding (a false ARM); a false HOLD merely costs a human merge. **Bias hard to HOLD on any doubt.** Hold-triggers to look for in the realized diff:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,9 @@ jobs:
               - 'bin/**'
               - 'ibl5/bin/**'
               - '.github/workflows/tests.yml'
+              # bin/test-postplan-arm-conditions reads the Phase 6.5 condition
+              # blocks here, so a SKILL.md-only edit must run the harness job.
+              - '.claude/skills/post-plan/SKILL.md'
             ibl6:
               - 'IBL6/**'
               - '.github/workflows/tests.yml'
@@ -585,6 +588,8 @@ jobs:
         run: bin/test-check-plan
       - name: bin/test-adr-check
         run: bin/test-adr-check
+      - name: bin/test-postplan-arm-conditions
+        run: bin/test-postplan-arm-conditions
 
   gate:
     name: Tests and Analysis

--- a/bin/lib/pr-armable.sh
+++ b/bin/lib/pr-armable.sh
@@ -1,0 +1,106 @@
+# Shared auto-merge "live hold" predicate — the single source of truth for the
+# `/post-plan` Phase 6.5 arming conditions that are derivable from a LIVE PR with
+# no post-plan-run-local state. Sourced by both `bin/pr-triage` (cross-PR) and
+# `/post-plan` Phase 6.5 (current branch) so the shared logic can never drift.
+#
+# Usage: source "$(dirname "$0")/lib/pr-armable.sh"
+#
+# Covers the four live-derivable conditions:
+#   (1) Manual-Testing clearance   -> pr_manual_testing_clearance <body>
+#   (5) golden-snapshot touch      -> pr_golden_hold <files_json>
+#   (6) Depends-on merge-order     -> pr_dep_holds <body>
+#   (8) feat: floor                -> pr_feat_hold <title> <labels_json>
+#
+# Conditions (2) review>=80, (3) MISSING-tests, (4) Phase-5 local verify, (7)
+# non-UI auto_merge:false, (9) realized-diff verdict are deliberately NOT here:
+# they are knowable only from a post-plan run's local state (/tmp, the local plan
+# file, the realized diff) and cannot be evaluated for an arbitrary PR. Callers
+# fail CLOSED on them — a PR is only ARMABLE with a POSITIVE clearance signal
+# (pr_manual_testing_clearance == CLEARED), never the mere absence of holds.
+#
+# This file is SOURCED, not executed: no `set -euo pipefail` at file scope.
+#
+# Test seam: GH_CMD (default `gh`) is a single-token command (a path to a shim in
+# tests) invoked as `"$GH_CMD" pr view ...`. Only pr_dep_holds touches it.
+
+GH_CMD="${GH_CMD:-gh}"
+
+# pr_manual_testing_clearance <body>
+#   The fail-closed positive-clearance axis (Phase 6.5 condition (1), mechanized).
+#   Echoes exactly one of:
+#     CLEARED  — a `## Manual Testing` section exists AND its body matches
+#                `No manual testing needed` (case-insensitive). This is the
+#                positive "post-plan evaluated and cleared this" signal.
+#     HELD     — a `## Manual Testing` section exists but is NOT the sentinel
+#                (it carries real manual rows) -> a human must review.
+#     UNKNOWN  — there is NO `## Manual Testing` section at all (a hand-made PR,
+#                or one post-plan never processed) -> NOT auto-armable.
+#   The sentinel has two suffixes in the source ("...unit and E2E tests" and
+#   "...automated tests"), so this PREFIX-matches `No manual testing needed`.
+pr_manual_testing_clearance() {
+    local body="$1"
+    local section content
+    section=$(printf '%s\n' "$body" | sed -n '/## Manual Testing/,/^## /p')
+    if [ -z "$section" ]; then
+        echo "UNKNOWN"
+        return
+    fi
+    # Drop the heading line; inspect the remaining content for the sentinel.
+    content=$(printf '%s\n' "$section" | sed '1d')
+    if printf '%s\n' "$content" | grep -qiE '^[[:space:]]*No manual testing needed'; then
+        echo "CLEARED"
+    else
+        echo "HELD"
+    fi
+}
+
+# pr_golden_hold <files_json>
+#   Phase 6.5 condition (5), detection only. Reports the raw FACT that the PR's
+#   `--json files` array touches the engine golden snapshot; the CALLER applies
+#   the mode policy (Phase 6.5: hold only when headless; pr-triage --arm: always
+#   hold). Echoes `golden-changed` when present, nothing otherwise.
+#   Pass the `.files` array, e.g. `gh pr view N --json files --jq '.files'`.
+pr_golden_hold() {
+    local files_json="$1"
+    if printf '%s' "$files_json" \
+        | jq -e 'any(.[]?; .path == "engine/internal/sim/testdata/golden.json")' \
+            >/dev/null 2>&1; then
+        echo "golden-changed"
+    fi
+}
+
+# pr_feat_hold <title> <labels_json>
+#   Phase 6.5 condition (8), the `feat:` floor. A conventional-commit feature
+#   title holds for human sign-off UNLESS the `human-approved` label is already
+#   applied (the label, set by a maintainer, flips it). Echoes
+#   `feat-awaiting-signoff` when held, nothing otherwise.
+#   Pass the `.labels` array, e.g. `gh pr view N --json labels --jq '.labels'`.
+pr_feat_hold() {
+    local title="$1" labels_json="$2"
+    if printf '%s' "$title" | grep -qiE '^feat(\([^)]*\))?!?:'; then
+        if printf '%s' "$labels_json" \
+            | jq -e 'any(.[]?; .name == "human-approved")' >/dev/null 2>&1; then
+            return  # label flips it — not held
+        fi
+        echo "feat-awaiting-signoff"
+    fi
+}
+
+# pr_dep_holds <body>
+#   Phase 6.5 condition (6), merge-order. For each anchored `Depends-on: #N` line
+#   (start-of-line only, so an inline prose mention of the marker is ignored),
+#   query the predecessor's state and echo `depends-on:#N` for any that is not
+#   yet MERGED. `while read` (not a `for` loop) splits per-line in bash AND zsh.
+pr_dep_holds() {
+    local body="$1" nums d st
+    # `|| true`: grep exits 1 on no-match, which would abort a `set -o pipefail`
+    # caller (this file is sourced into one) when the result is captured.
+    nums=$(printf '%s\n' "$body" \
+        | grep -iE '^[[:space:]]*depends-on:' \
+        | grep -oE '[0-9]+' || true)
+    [ -z "$nums" ] && return 0
+    printf '%s\n' "$nums" | while read -r d; do
+        st=$("$GH_CMD" pr view "$d" --json state 2>/dev/null | jq -r '.state // empty')
+        [ "$st" != "MERGED" ] && echo "depends-on:#$d"
+    done
+}

--- a/bin/lib/pr-armable.sh
+++ b/bin/lib/pr-armable.sh
@@ -40,7 +40,7 @@ GH_CMD="${GH_CMD:-gh}"
 pr_manual_testing_clearance() {
     local body="$1"
     local section content
-    section=$(printf '%s\n' "$body" | sed -n '/## Manual Testing/,/^## /p')
+    section=$(printf '%s\n' "$body" | sed -n '/^## Manual Testing/,/^## /p')
     if [ -z "$section" ]; then
         echo "UNKNOWN"
         return

--- a/bin/pr-triage
+++ b/bin/pr-triage
@@ -1,0 +1,253 @@
+#!/bin/bash
+
+# Cross-PR auto-merge triage. Classifies every OPEN PR into exactly one bucket
+# (first-match-wins) and prints a report. With --arm it arms
+# `gh pr merge --squash --auto --delete-branch` on ONLY the ARMABLE bucket.
+#
+# ARMABLE is FAIL-CLOSED: it requires a POSITIVE clearance signal (the
+# `No manual testing needed` Manual-Testing sentinel that /post-plan writes after
+# resolving every manual-testing item), never the mere absence of holds. A PR
+# with no `## Manual Testing` section is UNCLEARED -> routed to a human, never
+# auto-armed. This is why pr-triage never auto-arms a hand-made visual-change PR.
+#
+# The four live holds (Manual-Testing / golden / Depends-on / feat:) are shared
+# verbatim with /post-plan Phase 6.5 via bin/lib/pr-armable.sh, so the arming
+# judgment has one executable home and cannot drift. The live CI-check reading
+# (DIRTY / BLOCKED-CHECK) is pr-triage's own — Phase 6.5 delegates it to `--auto`.
+#
+# Bucket precedence (first match wins):
+#   1. DIRTY                  merge conflict (mergeStateStatus == DIRTY)
+#   2. BLOCKED-CHECK          a required Tests/E2E check is failing/pending/
+#                             cancelled/absent, or body declares an expected-red
+#   3. HELD                   Manual-Testing real rows, golden touched, or a
+#                             belt-and-suspenders body hold marker
+#   4. BLOCKED-DEP            an unmerged Depends-on: predecessor
+#   5. FEAT-AWAITING-SIGNOFF  feat: title without the human-approved label
+#   6. UNCLEARED              no Manual-Testing section (fail-closed; never armed)
+#   7. ARMABLE                CLEARED + not dirty + all required checks green
+#
+# Exit codes: 0 = report generated; 1 = an attempted --arm merge failed;
+#             2 = usage error or gh not authenticated.
+
+set -euo pipefail
+
+GH_CMD="${GH_CMD:-gh}"
+GH_API_CMD="${GH_API_CMD:-gh api}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/pr-armable.sh
+source "$SCRIPT_DIR/lib/pr-armable.sh"
+
+usage() {
+    cat <<'EOF'
+Usage: bin/pr-triage [--arm] [--help|-h]
+
+Classifies every OPEN PR into one bucket (first-match-wins) and prints a report.
+
+Options:
+  --arm        Arm `gh pr merge --squash --auto --delete-branch` on ONLY the
+               ARMABLE bucket. Without it, the tool is read-only (report only).
+  --help, -h   Show this message.
+
+Environment (test seams):
+  GH_CMD        Override the gh command (default: "gh").
+  GH_API_CMD    Override the gh api command (default: "gh api").
+
+ARMABLE is fail-closed: a PR is armed only with a positive Manual-Testing
+clearance ("No manual testing needed"), all required checks green-and-current,
+and no DIRTY/HELD/dep/feat hold. A PR with no `## Manual Testing` section is
+UNCLEARED and routed to a human. Reads one page (200 PRs / 100 check-runs).
+
+Exit codes: 0 = report generated; 1 = an attempted --arm merge failed;
+            2 = usage error / gh not authenticated.
+EOF
+}
+
+ARM=0
+for arg in "$@"; do
+    case "$arg" in
+        --arm)
+            ARM=1
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --*)
+            echo "unknown flag: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            echo "unexpected argument: $arg" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "ERROR: GitHub CLI is not authenticated." >&2
+    echo "Run 'gh auth login' to authenticate, then retry." >&2
+    exit 2
+fi
+
+REMOTE_URL="$(git remote get-url origin 2>/dev/null)" || {
+    echo "ERROR: cannot read origin remote URL" >&2
+    exit 2
+}
+SLUG="$(echo "$REMOTE_URL" | sed -E 's#^(https://github\.com/|ssh://git@github\.com/|git@github\.com:)##; s#\.git$##')"
+if [ -z "$SLUG" ]; then
+    echo "ERROR: cannot parse repo slug from origin URL: $REMOTE_URL" >&2
+    exit 2
+fi
+
+# --- required contexts (decision 5): protection API, else hardcoded fallback ---
+PROT="$($GH_API_CMD "repos/$SLUG/branches/master/protection" 2>/dev/null || echo '{}')"
+REQUIRED=()
+while IFS= read -r ctx; do
+    [ -n "$ctx" ] && REQUIRED+=("$ctx")
+done < <(echo "$PROT" | jq -r '.required_status_checks.contexts[]?' 2>/dev/null)
+if [ "${#REQUIRED[@]}" -eq 0 ]; then
+    # Fallback: token lacks admin/repo scope for the protection API.
+    REQUIRED=("Tests and Analysis" "E2E Tests" "human-signoff")
+fi
+
+# BLOCKED-CHECK evaluates only the non-signoff contexts (decision 1):
+# human-signoff is the feat: floor's lever, handled by bucket FEAT, not here.
+is_blocked_check_ctx() {
+    case "$1" in
+        "human-signoff") return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# state_of <latest_json> <ctx> -> green|failing|pending|cancelled|absent
+state_of() {
+    echo "$1" | jq -r --arg n "$2" '
+        map(select(.name == $n)) as $m
+        | if ($m | length) == 0 then "absent"
+          elif ($m[0].status != "completed") then "pending"
+          elif ($m[0].conclusion == "cancelled") then "cancelled"
+          elif ($m[0].conclusion | IN("success","skipped","neutral")) then "green"
+          else "failing" end'
+}
+
+# rerun_id <latest_json> <ctx> -> the workflow-run id from .details_url, or empty
+# `|| true`: grep exits 1 when details_url lacks a runs/<id> segment; without it
+# the captured substitution would abort under `set -o pipefail`.
+rerun_id() {
+    echo "$1" | jq -r --arg n "$2" 'map(select(.name == $n)) | .[0].details_url // ""' \
+        | grep -oE 'runs/[0-9]+' | grep -oE '[0-9]+' | head -1 || true
+}
+
+EXPECTED_RED_RE='expected[ -]?red|will be RED|Expected CI check.*RED'
+HELD_BODY_RE='auto_merge:[[:space:]]*false|auto_postplan:[[:space:]]*false|human reviewer|human authz|requires human review|do NOT auto-merge|DNM'
+
+PRS_JSON="$("$GH_CMD" pr list --state open --limit 200 \
+    --json number,title,body,labels,mergeStateStatus,headRefOid,files 2>/dev/null || echo '[]')"
+
+PR_COUNT="$(echo "$PRS_JSON" | jq 'length')"
+
+printf '%-7s  %-22s  %-26s  %s\n' "PR#" "BUCKET" "NEXT-ACTION" "SIGNALS"
+printf '%-7s  %-22s  %-26s  %s\n' "-------" "----------------------" "--------------------------" "-------"
+
+EXIT=0
+RERUN_HINTS=""
+
+i=0
+while [ "$i" -lt "$PR_COUNT" ]; do
+    PR="$(echo "$PRS_JSON" | jq ".[$i]")"
+    i=$((i + 1))
+
+    num="$(echo "$PR" | jq -r '.number')"
+    title="$(echo "$PR" | jq -r '.title')"
+    body="$(echo "$PR" | jq -r '.body // ""')"
+    mss="$(echo "$PR" | jq -r '.mergeStateStatus // ""')"
+    sha="$(echo "$PR" | jq -r '.headRefOid')"
+    labels="$(echo "$PR" | jq -c '.labels // []')"
+    files="$(echo "$PR" | jq -c '.files // []')"
+
+    # --- live check-runs for this PR's head SHA (dedupe: latest run per name) ---
+    CR_JSON="$($GH_API_CMD "repos/$SLUG/commits/$sha/check-runs?per_page=100" 2>/dev/null \
+        || echo '{"check_runs":[]}')"
+    LATEST="$(echo "$CR_JSON" | jq '[.check_runs | group_by(.name) | .[]
+        | sort_by(.completed_at // .started_at) | last]')"
+
+    # --- compute signals ---
+    clearance="$(pr_manual_testing_clearance "$body")"
+    golden="$(pr_golden_hold "$files")"
+    feat="$(pr_feat_hold "$title" "$labels")"
+    deps="$(pr_dep_holds "$body" | tr '\n' ' ')"
+
+    check_signals=""
+    blocked_check=0
+    cancelled_ctx=""
+    armable_checks_green=1
+    for ctx in "${REQUIRED[@]}"; do
+        st="$(state_of "$LATEST" "$ctx")"
+        check_signals="${check_signals}${ctx}=${st}; "
+        [ "$st" != "green" ] && armable_checks_green=0
+        if is_blocked_check_ctx "$ctx" && [ "$st" != "green" ]; then
+            blocked_check=1
+            [ "$st" = "cancelled" ] && cancelled_ctx="$ctx"
+        fi
+    done
+    expected_red=0
+    if echo "$body" | grep -qiE "$EXPECTED_RED_RE"; then
+        expected_red=1
+        blocked_check=1
+    fi
+
+    held_body=0
+    if echo "$body" | grep -qiE "$HELD_BODY_RE"; then
+        held_body=1
+    fi
+
+    # --- bucket (first match wins) ---
+    bucket=""
+    action=""
+    if [ "$mss" = "DIRTY" ]; then
+        bucket="DIRTY"; action="rebase onto master"
+    elif [ "$blocked_check" = "1" ]; then
+        bucket="BLOCKED-CHECK"; action="fix / re-run CI"
+        if [ -n "$cancelled_ctx" ]; then
+            rid="$(rerun_id "$LATEST" "$cancelled_ctx")"
+            [ -n "$rid" ] && RERUN_HINTS="${RERUN_HINTS}hint: gh run rerun ${rid}  # ${cancelled_ctx} was CANCELLED on PR #${num}"$'\n'
+        fi
+    elif [ "$clearance" = "HELD" ] || [ -n "$golden" ] || [ "$held_body" = "1" ]; then
+        bucket="HELD"; action="human review"
+    elif [ -n "$deps" ]; then
+        bucket="BLOCKED-DEP"; action="wait for predecessor"
+    elif [ -n "$feat" ]; then
+        bucket="FEAT-AWAITING-SIGNOFF"; action="human sign-off + label"
+    elif [ "$clearance" = "UNKNOWN" ]; then
+        bucket="UNCLEARED"; action="human review (no clearance)"
+    elif [ "$clearance" = "CLEARED" ] && [ "$mss" != "DIRTY" ] && [ "$armable_checks_green" = "1" ]; then
+        bucket="ARMABLE"; action="arm auto-merge"
+    else
+        # Defensive: cleared but a check is not green yet (race) -> not armable.
+        bucket="UNCLEARED"; action="human review (checks not green)"
+    fi
+
+    signals="clearance=${clearance}; ${check_signals}held_body=$([ "$held_body" = 1 ] && echo yes || echo no); golden=$([ -n "$golden" ] && echo yes || echo no); deps=$([ -n "$deps" ] && echo "${deps% }" || echo none); feat=$([ -n "$feat" ] && echo yes || echo no); expected_red=$([ "$expected_red" = 1 ] && echo yes || echo no)"
+
+    printf '%-7s  %-22s  %-26s  %s\n' "#$num" "$bucket" "$action" "$signals"
+
+    # --- --arm side-effect: ONLY the ARMABLE bucket ---
+    if [ "$ARM" = "1" ] && [ "$bucket" = "ARMABLE" ]; then
+        if "$GH_CMD" pr merge "$num" --squash --auto --delete-branch >/dev/null 2>&1; then
+            echo "  armed auto-merge on #$num"
+        else
+            echo "  ARM FAILED on #$num (gh pr merge exited non-zero)" >&2
+            EXIT=1
+        fi
+    fi
+done
+
+if [ -n "$RERUN_HINTS" ]; then
+    echo
+    printf '%s' "$RERUN_HINTS"
+fi
+
+exit "$EXIT"

--- a/bin/test-postplan-arm-conditions
+++ b/bin/test-postplan-arm-conditions
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-postplan-arm-conditions — regression guard for the /post-plan Phase 6.5
+# auto-merge conditions that call the shared predicate bin/lib/pr-armable.sh
+# (conditions (1) Manual-Testing, (5) golden, (6) Depends-on, (8) feat:).
+#
+# Why this exists: those conditions live as separate ```bash blocks inside
+# SKILL.md, and the orchestrator may run each block in its OWN shell. A block
+# that relied on a hoisted `source` or a shared `PR_JSON` from a preamble would
+# then have an UNDEFINED predicate function — and for condition (8) that fails
+# OPEN (no BLOCKED line emitted → a feat: PR auto-arms). This test runs each
+# block in an isolated `bash -c` against a gh shim and asserts the holds, plus a
+# structural check that every predicate-using block re-`source`s the lib itself.
+#
+# Run: bin/test-postplan-arm-conditions  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$REPO_ROOT/.claude/skills/post-plan/SKILL.md"
+
+BASE_TMP="$(mktemp -d)"
+trap 'rm -rf "$BASE_TMP"' EXIT
+FAILED=0
+
+# A gh shim emulating the only calls the condition blocks make:
+#   gh pr view <n> --json state          -> predecessor state (#1100 OPEN else MERGED)
+#   gh pr view --json <fields> --jq F    -> jq -r F applied to $GH_PR_FIXTURE
+SHIMD="$BASE_TMP/shim"
+mkdir -p "$SHIMD"
+cat > "$SHIMD/gh" <<'SHIM'
+#!/usr/bin/env bash
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  if [[ "$3" =~ ^[0-9]+$ ]]; then
+    case "$3" in 1100) echo '{"state":"OPEN"}' ;; *) echo '{"state":"MERGED"}' ;; esac
+    exit 0
+  fi
+  filter='.'
+  for ((i=1; i<=$#; i++)); do
+    if [ "${!i}" = "--jq" ]; then j=$((i+1)); filter="${!j}"; fi
+  done
+  jq -r "$filter" "$GH_PR_FIXTURE"
+  exit 0
+fi
+exit 1
+SHIM
+chmod +x "$SHIMD/gh"
+
+# extract_block <literal-marker> — print the first ```bash fenced block whose
+# body contains the literal marker substring (e.g. "# condition (8)"). Uses
+# index() (literal), not regex, so the parens in the marker are matched verbatim.
+extract_block() {
+    awk -v want="$1" '
+        /^```bash$/ { inb=1; buf=""; next }
+        /^```$/     { if (inb && index(buf, want) > 0) { printf "%s", buf } ; inb=0; next }
+        inb         { buf = buf $0 "\n" }
+    ' "$SKILL"
+}
+
+# run_isolated <block> <fixture-json> <golden_changed> <headless> — run the block
+# in its OWN fresh shell (the failure model) and echo its stdout.
+run_isolated() {
+    printf '%s' "$2" > "$BASE_TMP/fixture.json"
+    PATH="$SHIMD:$PATH" GH_PR_FIXTURE="$BASE_TMP/fixture.json" \
+        GOLDEN_CHANGED="$3" CLAUDE_HEADLESS="$4" \
+        bash -c "$1" 2>&1
+}
+
+expect_block() { # name  BLOCK|NONE  output
+    local got_block=0
+    [[ "$3" == *BLOCKED* ]] && got_block=1
+    if { [ "$2" = "BLOCK" ] && [ "$got_block" -eq 1 ]; } \
+        || { [ "$2" = "NONE" ] && [ "$got_block" -eq 0 ]; }; then
+        echo "ok: $1"
+    else
+        echo "FAIL: $1 — expected $2, got: '$3'"
+        FAILED=1
+    fi
+}
+
+assert_self_contained() { # marker name
+    local block; block="$(extract_block "$1")"
+    if [ -z "$block" ]; then
+        echo "FAIL: $2 — no block matching '$1' found in SKILL.md"
+        FAILED=1
+        return
+    fi
+    if printf '%s' "$block" | grep -q 'source' && printf '%s' "$block" | grep -q 'pr-armable.sh'; then
+        echo "ok: $2 self-sources the predicate"
+    else
+        echo "FAIL: $2 — block uses the predicate but does NOT source pr-armable.sh in-block (hoisted source = fail-open risk)"
+        FAILED=1
+    fi
+}
+
+B1="$(extract_block '# condition (1)')"
+B5="$(extract_block '# condition (5)')"
+B6="$(extract_block '# condition (6)')"
+B8="$(extract_block '# condition (8)')"
+
+# --- structural: every predicate-using block must source the lib itself ---
+assert_self_contained '# condition (1)' "condition (1)"
+assert_self_contained '# condition (5)' "condition (5)"
+assert_self_contained '# condition (6)' "condition (6)"
+assert_self_contained '# condition (8)' "condition (8)"
+
+# --- behavioral: each block, run in isolation, holds correctly ---
+expect_block "(1) HELD manual rows -> BLOCK" BLOCK \
+    "$(run_isolated "$B1" '{"body":"## Manual Testing\n\n- review the new <h1>"}' '' '')"
+expect_block "(1) cleared sentinel -> NONE" NONE \
+    "$(run_isolated "$B1" '{"body":"## Manual Testing\nNo manual testing needed — automated."}' '' '')"
+expect_block "(1) no section (UNKNOWN) -> BLOCK (fail-closed)" BLOCK \
+    "$(run_isolated "$B1" '{"body":"hand-made PR, no manual testing heading"}' '' '')"
+
+expect_block "(5) golden + headless -> BLOCK" BLOCK \
+    "$(run_isolated "$B5" '{"files":[{"path":"engine/internal/sim/testdata/golden.json"}]}' '' '1')"
+expect_block "(5) golden + interactive -> NONE (warn-only)" NONE \
+    "$(run_isolated "$B5" '{"files":[{"path":"engine/internal/sim/testdata/golden.json"}]}' '' '')"
+
+expect_block "(6) unmerged Depends-on -> BLOCK" BLOCK \
+    "$(run_isolated "$B6" '{"body":"x\nDepends-on: #1100"}' '' '')"
+expect_block "(6) merged Depends-on -> NONE" NONE \
+    "$(run_isolated "$B6" '{"body":"x\nDepends-on: #1071"}' '' '')"
+
+# The fail-open this whole test exists to catch:
+expect_block "(8) feat: no label -> BLOCK (fail-open guard)" BLOCK \
+    "$(run_isolated "$B8" '{"title":"feat: shiny","labels":[]}' '' '')"
+expect_block "(8) feat: + human-approved -> NONE" NONE \
+    "$(run_isolated "$B8" '{"title":"feat: shiny","labels":[{"name":"human-approved"}]}' '' '')"
+expect_block "(8) fix: title -> NONE" NONE \
+    "$(run_isolated "$B8" '{"title":"fix: bug","labels":[]}' '' '')"
+
+if [ "$FAILED" -eq 0 ]; then
+    echo "All post-plan arm-condition checks passed."
+else
+    echo "Some post-plan arm-condition checks FAILED."
+fi
+exit "$FAILED"

--- a/ibl5/docs/decisions/0069-pr-triage-auto-arm.md
+++ b/ibl5/docs/decisions/0069-pr-triage-auto-arm.md
@@ -1,0 +1,37 @@
+---
+description: Cross-PR auto-merge triage via a shared, fail-closed armability predicate sourced by both /post-plan Phase 6.5 and bin/pr-triage.
+last_verified: 2026-06-24
+---
+
+# ADR-0069: Shared fail-closed armability predicate + cross-PR auto-arm
+
+**Status:** Accepted
+**Date:** 2026-06-24
+
+## Context
+
+`/post-plan` Phase 6.5 decided whether to arm `gh pr merge --auto`, but its arming judgment lived only inside that per-branch run, expressed as a mix of inline bash and one prose gate (condition (1), "PR says No manual testing needed", which a human/agent eyeballed). There was no cross-PR view of which open PRs were safe to auto-merge and which were deliberately held, so closing the backlog meant re-deriving "is this armable?" by hand — and that hand re-derivation mis-classified two visual-change PRs (#1163, #1188) as armable when their `## Manual Testing` rows should have held them for a human.
+
+## Decision
+
+Extract the live-readable arming holds into one shared predicate, `bin/lib/pr-armable.sh` — Manual-Testing clearance (1), golden-snapshot touch (5), Depends-on merge-order (6), and the `feat:` floor (8) — sourced by **both** `/post-plan` Phase 6.5 and a new cross-PR `bin/pr-triage --arm`, so the shared judgment has one executable home and cannot drift. Arming is **fail-closed / positive-clearance**: a PR is ARMABLE only when it carries the positive `No manual testing needed` sentinel that `/post-plan` writes after resolving every manual-testing item **and** all required checks are green-and-current — never the mere absence of holds. A PR with no `## Manual Testing` section is UNCLEARED and routed to a human, never auto-armed. The run-only Phase 6.5 conditions (2 review≥80, 3 missing-tests, 4 Phase-5 verify, 7 non-UI `auto_merge: false`, 9 realized-diff verdict) read post-plan-run-local state and stay inline; `bin/pr-triage` cannot positively clear them, so it fails closed. Covered by `ibl5/tests/Cli/PrArmableLibCliTest.php` and `ibl5/tests/Cli/PrTriageCliTest.php`.
+
+## Alternatives Considered
+
+- **Copy the Phase 6.5 idioms into `bin/pr-triage`** — a second implementation of the same buckets. Rejected: a divergent copy is the exact drift surface that mis-armed #1163/#1188.
+- **Persist post-plan's full nine-condition verdict onto the PR** (label/body) so all conditions become cross-PR-readable. Rejected for now: a stale persisted "armable" fails OPEN — a PR that grows a SQL/UI surface after post-plan ran still carries the green marker. Deferred as a SHA-stamped follow-up (ignored when marker SHA ≠ head).
+- **Absence-based ARMABLE** (arm when no hold matched). Rejected: fails open on a hand-made PR with green checks and no Manual-Testing section — #1188's twin.
+
+## Consequences
+
+- Positive: the live armability judgment has one executable home (`bin/lib/pr-armable.sh`); condition (1) is mechanized rather than eyeballed.
+- Positive: `bin/pr-triage` replaces manual PR-closing toil with a fail-closed cross-PR sweep that arms only the deliberate-hold complement.
+- Negative: a new autonomous-merge surface that must stay in lockstep with Phase 6.5 — the four shared conditions are the contract, and a Phase 6.5 change that diverges from the predicate breaks the Cli characterization.
+
+## References
+
+- `bin/lib/pr-armable.sh` — the shared live-hold predicate.
+- `bin/pr-triage` — the cross-PR classifier + `--arm` gate.
+- `.claude/skills/post-plan/SKILL.md` — Phase 6.5 sources the predicate for conditions (1)/(5)/(6)/(8).
+- `bin/check-master-ci-green` — the check-runs dedupe idiom `bin/pr-triage` reuses.
+- `ibl5/tests/Cli/PrArmableLibCliTest.php`, `ibl5/tests/Cli/PrTriageCliTest.php` — the safety proof.

--- a/ibl5/tests/Cli/PrArmableLibCliTest.php
+++ b/ibl5/tests/Cli/PrArmableLibCliTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Characterization of the shared live-hold predicate bin/lib/pr-armable.sh.
+ *
+ * These rows pin the EXACT decision each function makes — the same logic that
+ * /post-plan Phase 6.5 conditions (1)/(5)/(6)/(8) now call, so a refactor of
+ * either consumer that diverges from these decisions fails here.
+ */
+#[Group('cli')]
+final class PrArmableLibCliTest extends TestCase
+{
+    private string $libPath;
+    private string $tmpDir;
+    private string $shimDir;
+    private string $harness;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/lib/pr-armable.sh');
+        self::assertNotFalse($resolved, 'bin/lib/pr-armable.sh must exist');
+        $this->libPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/pr-armable-test-' . bin2hex(random_bytes(8));
+        $this->shimDir = $this->tmpDir . '/shims';
+        mkdir($this->shimDir, 0755, true);
+
+        // Dispatcher harness: source the lib, then invoke the named function.
+        // Shell functions are callable via "$@" exactly like an executable.
+        $this->harness = $this->tmpDir . '/harness.sh';
+        file_put_contents(
+            $this->harness,
+            "#!/bin/bash\nset -uo pipefail\nsource " . escapeshellarg($this->libPath) . "\n\"\$@\"\n"
+        );
+        chmod($this->harness, 0755);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    // --- (1) Manual-Testing clearance: the fail-closed positive-clearance axis ---
+
+    public function testClearanceSentinelUnitE2eSuffixIsCleared(): void
+    {
+        $body = "# PR\n\n## Manual Testing\n\nNo manual testing needed — all changes are covered by unit and E2E tests.\n";
+        self::assertSame('CLEARED', $this->runFn('pr_manual_testing_clearance', [$body])['output']);
+    }
+
+    public function testClearanceSentinelAutomatedSuffixIsCleared(): void
+    {
+        // The OTHER sentinel suffix the source writes (Phase 6 vs Phase 1).
+        $body = "## Manual Testing\nNo manual testing needed — all changes are covered by automated tests.";
+        self::assertSame('CLEARED', $this->runFn('pr_manual_testing_clearance', [$body])['output']);
+    }
+
+    public function testClearanceRealRowsIsHeld(): void
+    {
+        $body = "## Manual Testing\n\n- Review that the new <h1> renders correctly\n\n## Notes\nx";
+        self::assertSame('HELD', $this->runFn('pr_manual_testing_clearance', [$body])['output']);
+    }
+
+    public function testClearanceNoSectionIsUnknownFailClosed(): void
+    {
+        // No `## Manual Testing` section at all -> UNKNOWN -> never auto-armable.
+        $body = "# Some hand-made PR\n\nJust a description, no manual testing heading.";
+        self::assertSame('UNKNOWN', $this->runFn('pr_manual_testing_clearance', [$body])['output']);
+    }
+
+    // --- (5) golden-snapshot touch ---
+
+    public function testGoldenHoldFiresWhenGoldenTouched(): void
+    {
+        $files = '[{"path":"ibl5/x.php"},{"path":"engine/internal/sim/testdata/golden.json"}]';
+        self::assertSame('golden-changed', $this->runFn('pr_golden_hold', [$files])['output']);
+    }
+
+    public function testGoldenHoldEmptyWhenGoldenUntouched(): void
+    {
+        $files = '[{"path":"ibl5/x.php"}]';
+        self::assertSame('', $this->runFn('pr_golden_hold', [$files])['output']);
+    }
+
+    // --- (8) feat: floor — label-aware ---
+
+    public function testFeatHoldFiresOnFeatTitleWithoutLabel(): void
+    {
+        self::assertSame(
+            'feat-awaiting-signoff',
+            $this->runFn('pr_feat_hold', ['feat: shiny new page', '[]'])['output']
+        );
+    }
+
+    public function testFeatHoldClearedByHumanApprovedLabel(): void
+    {
+        self::assertSame(
+            '',
+            $this->runFn('pr_feat_hold', ['feat(x): y', '[{"name":"human-approved"}]'])['output']
+        );
+    }
+
+    public function testFeatHoldEmptyForNonFeatTitle(): void
+    {
+        self::assertSame('', $this->runFn('pr_feat_hold', ['fix(a11y): z', '[]'])['output']);
+    }
+
+    public function testFeatHoldFiresOnBangVariant(): void
+    {
+        self::assertSame(
+            'feat-awaiting-signoff',
+            $this->runFn('pr_feat_hold', ['feat!: breaking', '[]'])['output']
+        );
+    }
+
+    // --- (6) Depends-on merge-order (needs a gh shim for predecessor state) ---
+
+    public function testDepHoldsFiresOnUnmergedPredecessor(): void
+    {
+        $this->writeGhShim(['1100' => 'OPEN']);
+        $body = "body line\nDepends-on: #1100\nmore";
+        $result = $this->runFn('pr_dep_holds', [$body], ['GH_CMD' => $this->shimDir . '/gh']);
+        self::assertSame('depends-on:#1100', $result['output']);
+    }
+
+    public function testDepHoldsEmptyWhenPredecessorMerged(): void
+    {
+        $this->writeGhShim(['1071' => 'MERGED']);
+        $result = $this->runFn('pr_dep_holds', ["Depends-on: #1071"], ['GH_CMD' => $this->shimDir . '/gh']);
+        self::assertSame('', $result['output']);
+    }
+
+    public function testDepHoldsIgnoresInlineProseMention(): void
+    {
+        // An inline (not start-of-line) mention of the marker must NOT be parsed.
+        $this->writeGhShim(['1100' => 'OPEN']);
+        $body = "see the `Depends-on: #1100` gate documented inline";
+        $result = $this->runFn('pr_dep_holds', [$body], ['GH_CMD' => $this->shimDir . '/gh']);
+        self::assertSame('', $result['output']);
+    }
+
+    /**
+     * @param list<string> $args
+     * @param array<string,string> $env
+     * @return array{output: string, exit: int}
+     */
+    private function runFn(string $fn, array $args, array $env = []): array
+    {
+        $envPrefix = '';
+        foreach ($env as $k => $v) {
+            $envPrefix .= $k . '=' . escapeshellarg($v) . ' ';
+        }
+        $cmd = $envPrefix . 'bash ' . escapeshellarg($this->harness) . ' ' . escapeshellarg($fn);
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+        $cmd .= ' 2>&1';
+
+        $output = [];
+        $exit = 0;
+        exec($cmd, $output, $exit);
+        return ['output' => trim(implode("\n", $output)), 'exit' => $exit];
+    }
+
+    /**
+     * @param array<int,string> $states  map of PR number => state
+     *        (PHP coerces the numeric-string keys to int)
+     */
+    private function writeGhShim(array $states): void
+    {
+        $cases = '';
+        foreach ($states as $n => $state) {
+            $cases .= "    $n) echo '{\"state\":\"$state\"}' ;;\n";
+        }
+        $script = "#!/bin/bash\n"
+            . "# Shim: `gh pr view <n> --json state` -> {\"state\":...}\n"
+            . "if [ \"\$1\" = \"pr\" ] && [ \"\$2\" = \"view\" ]; then\n"
+            . "  case \"\$3\" in\n"
+            . $cases
+            . "    *) echo '{\"state\":\"OPEN\"}' ;;\n"
+            . "  esac\n"
+            . "  exit 0\n"
+            . "fi\n"
+            . "exit 1\n";
+        file_put_contents($this->shimDir . '/gh', $script);
+        chmod($this->shimDir . '/gh', 0755);
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/ibl5/tests/Cli/PrTriageCliTest.php
+++ b/ibl5/tests/Cli/PrTriageCliTest.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * End-to-end behavior of bin/pr-triage: one assertion per bucket, plus the
+ * fail-closed negative-path rows that are the whole safety story (an --arm run
+ * must arm ONLY the ARMABLE bucket, never a HELD / BLOCKED / FEAT / UNCLEARED PR).
+ *
+ * A single `gh` shim on PATH dispatches every call pr-triage makes (auth / pr
+ * list / api protection / api check-runs / pr view state / pr merge) from
+ * fixtures whose paths are passed via env. `pr merge` appends the PR# to a
+ * merge-attempts log — the sentinel proving exactly which PRs were armed.
+ */
+#[Group('cli')]
+final class PrTriageCliTest extends TestCase
+{
+    private string $scriptPath;
+    private string $tmpDir;
+    private string $shimDir;
+    private string $repoDir;
+    private string $crDir;
+    private string $mergeLog;
+    private string $contextsFixture;
+
+    protected function setUp(): void
+    {
+        $resolved = realpath(__DIR__ . '/../../../bin/pr-triage');
+        self::assertNotFalse($resolved, 'bin/pr-triage must exist');
+        $this->scriptPath = $resolved;
+
+        $this->tmpDir = sys_get_temp_dir() . '/pr-triage-test-' . bin2hex(random_bytes(8));
+        $this->shimDir = $this->tmpDir . '/shims';
+        $this->repoDir = $this->tmpDir . '/repo';
+        $this->crDir = $this->tmpDir . '/checkruns';
+        $this->mergeLog = $this->tmpDir . '/merge-attempts.log';
+        mkdir($this->shimDir, 0755, true);
+        mkdir($this->repoDir, 0755, true);
+        mkdir($this->crDir, 0755, true);
+
+        exec('git init -b master ' . escapeshellarg($this->repoDir) . ' 2>&1');
+        exec('git -C ' . escapeshellarg($this->repoDir) . ' remote add origin https://github.com/test/repo.git 2>&1');
+
+        // Required-contexts fixture (the protection API response).
+        $this->contextsFixture = $this->tmpDir . '/contexts.json';
+        file_put_contents(
+            $this->contextsFixture,
+            json_encode(['required_status_checks' => ['contexts' => ['Tests and Analysis', 'E2E Tests', 'human-signoff']]])
+        );
+
+        $this->writeGhShim(0);
+
+        // Standard check-run fixtures shared across tests.
+        $this->writeCheckRuns('shaGREEN', [
+            $this->checkRun('Tests and Analysis', 'completed', 'success'),
+            $this->checkRun('E2E Tests', 'completed', 'success'),
+            $this->checkRun('human-signoff', 'completed', 'success'),
+        ]);
+        $this->writeCheckRuns('shaFAIL', [
+            $this->checkRun('Tests and Analysis', 'completed', 'success'),
+            $this->checkRun('E2E Tests', 'completed', 'failure'),
+            $this->checkRun('human-signoff', 'completed', 'success'),
+        ]);
+        $this->writeCheckRuns('shaCANCEL', [
+            $this->checkRun('Tests and Analysis', 'completed', 'cancelled', 'https://github.com/test/repo/actions/runs/55555/job/9'),
+            $this->checkRun('E2E Tests', 'completed', 'success'),
+            $this->checkRun('human-signoff', 'completed', 'success'),
+        ]);
+        // shaABSENT: E2E Tests check-run is missing entirely (missing != green).
+        $this->writeCheckRuns('shaABSENT', [
+            $this->checkRun('Tests and Analysis', 'completed', 'success'),
+            $this->checkRun('human-signoff', 'completed', 'success'),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRm($this->tmpDir);
+    }
+
+    private const CLEARED = "## Manual Testing\nNo manual testing needed — all changes are covered by automated tests.";
+
+    /**
+     * The comprehensive fixture exercising every bucket exactly once, at the
+     * head of each test that needs the full matrix.
+     *
+     * @return list<array<string,mixed>>
+     */
+    private function allBucketsFixture(): array
+    {
+        return [
+            $this->pr(1,    'fix: dirty',          self::CLEARED,                              'DIRTY', 'shaGREEN'),
+            $this->pr(2,    'fix: failing check',  self::CLEARED,                              'CLEAN', 'shaFAIL'),
+            $this->pr(1163, 'fix(a11y): cancel',   self::CLEARED,                              'CLEAN', 'shaCANCEL'),
+            $this->pr(4,    'fix: absent check',   self::CLEARED,                              'CLEAN', 'shaABSENT'),
+            $this->pr(1188, 'fix(a11y): new h1',   "## Manual Testing\n\n- Review the new <h1> renders", 'CLEAN', 'shaGREEN'),
+            $this->pr(5,    'fix: golden',         self::CLEARED,                              'CLEAN', 'shaGREEN', [['path' => 'engine/internal/sim/testdata/golden.json']]),
+            $this->pr(6,    'fix: dnm frontmatter', self::CLEARED . "\n\nauto_merge: false",    'CLEAN', 'shaGREEN'),
+            $this->pr(7,    'fix: prose hold',     self::CLEARED . "\n\nNeeds a human reviewer first.", 'CLEAN', 'shaGREEN'),
+            $this->pr(8,    'fix: has dep',        self::CLEARED . "\n\nDepends-on: #1100",     'CLEAN', 'shaGREEN'),
+            $this->pr(9,    'feat: shiny',         self::CLEARED,                              'CLEAN', 'shaGREEN'),
+            $this->pr(10,   'fix: handmade',       "Just a body, no manual testing heading.",  'CLEAN', 'shaGREEN'),
+            $this->pr(11,   'fix: clean armable',  self::CLEARED,                              'CLEAN', 'shaGREEN'),
+            $this->pr(12,   'feat: approved',      self::CLEARED,                              'CLEAN', 'shaGREEN', [], [['name' => 'human-approved']]),
+        ];
+    }
+
+    public function testEachBucketClassifiedCorrectly(): void
+    {
+        $this->writePrs($this->allBucketsFixture());
+        $r = $this->runScript([]);
+        self::assertSame(0, $r['exit'], $r['output']);
+
+        $this->assertBucket($r['output'], 1, 'DIRTY');
+        $this->assertBucket($r['output'], 2, 'BLOCKED-CHECK');
+        $this->assertBucket($r['output'], 1163, 'BLOCKED-CHECK');   // stale-CANCELLED
+        $this->assertBucket($r['output'], 4, 'BLOCKED-CHECK');      // absent required check
+        $this->assertBucket($r['output'], 1188, 'HELD');           // real Manual-Testing row
+        $this->assertBucket($r['output'], 5, 'HELD');              // golden touched
+        $this->assertBucket($r['output'], 6, 'HELD');              // auto_merge: false
+        $this->assertBucket($r['output'], 7, 'HELD');              // prose human reviewer
+        $this->assertBucket($r['output'], 8, 'BLOCKED-DEP');
+        $this->assertBucket($r['output'], 9, 'FEAT-AWAITING-SIGNOFF');
+        $this->assertBucket($r['output'], 10, 'UNCLEARED');        // fail-closed: no section
+        $this->assertBucket($r['output'], 11, 'ARMABLE');
+        $this->assertBucket($r['output'], 12, 'ARMABLE');          // feat + human-approved label
+    }
+
+    public function testArmArmsOnlyArmableBucket(): void
+    {
+        $this->writePrs($this->allBucketsFixture());
+        $r = $this->runScript(['--arm']);
+        self::assertSame(0, $r['exit'], $r['output']);
+
+        $armed = $this->mergedPrs();
+        // ONLY the two ARMABLE PRs are armed.
+        self::assertEqualsCanonicalizing([11, 12], $armed, 'merge log: ' . implode(',', $armed));
+
+        // The fail-closed guarantee: none of the deliberate-hold buckets armed.
+        foreach ([1, 2, 1163, 4, 1188, 5, 6, 7, 8, 9, 10] as $heldPr) {
+            self::assertNotContains($heldPr, $armed, "PR #$heldPr must NOT be armed");
+        }
+    }
+
+    public function testUnclearedHandMadePrIsNeverArmed(): void
+    {
+        // The advisor's core correction: a green, non-feat, no-hold PR with NO
+        // Manual-Testing section must NOT auto-arm (it is UNCLEARED, not ARMABLE).
+        $this->writePrs([
+            $this->pr(10, 'fix: handmade green', 'A body with no manual testing heading at all.', 'CLEAN', 'shaGREEN'),
+        ]);
+        $r = $this->runScript(['--arm']);
+        self::assertSame(0, $r['exit'], $r['output']);
+        $this->assertBucket($r['output'], 10, 'UNCLEARED');
+        self::assertSame([], $this->mergedPrs(), 'an UNCLEARED PR must never be armed');
+    }
+
+    public function testArmStaleCancelledEmitsRerunHintAndDoesNotArm(): void
+    {
+        $this->writePrs([
+            $this->pr(1163, 'fix(a11y): cancel', self::CLEARED, 'CLEAN', 'shaCANCEL'),
+        ]);
+        $r = $this->runScript(['--arm']);
+        self::assertSame(0, $r['exit'], $r['output']);
+        self::assertSame([], $this->mergedPrs(), 'a CANCELLED-check PR must not arm');
+        self::assertStringContainsString('gh run rerun 55555', $r['output'], 'rerun id parsed from details_url');
+    }
+
+    public function testArmDoesArmArmablePr(): void
+    {
+        $this->writePrs([
+            $this->pr(11, 'fix: clean armable', self::CLEARED, 'CLEAN', 'shaGREEN'),
+        ]);
+        $r = $this->runScript(['--arm']);
+        self::assertSame(0, $r['exit'], $r['output']);
+        self::assertSame([11], $this->mergedPrs());
+    }
+
+    public function testFeatWithHumanApprovedLabelIsArmable(): void
+    {
+        $this->writePrs([
+            $this->pr(12, 'feat: approved', self::CLEARED, 'CLEAN', 'shaGREEN', [], [['name' => 'human-approved']]),
+        ]);
+        $r = $this->runScript(['--arm']);
+        $this->assertBucket($r['output'], 12, 'ARMABLE');
+        self::assertSame([12], $this->mergedPrs());
+    }
+
+    public function testPrecedenceDirtyBeatsFeat(): void
+    {
+        // A PR that is both DIRTY and feat: -> DIRTY wins (first match).
+        $this->writePrs([
+            $this->pr(20, 'feat: conflicted', self::CLEARED, 'DIRTY', 'shaGREEN'),
+        ]);
+        $r = $this->runScript([]);
+        $this->assertBucket($r['output'], 20, 'DIRTY');
+    }
+
+    public function testNoFlagRunIsReadOnly(): void
+    {
+        $this->writePrs([
+            $this->pr(11, 'fix: clean armable', self::CLEARED, 'CLEAN', 'shaGREEN'),
+        ]);
+        $r = $this->runScript([]);
+        $this->assertBucket($r['output'], 11, 'ARMABLE');
+        self::assertSame([], $this->mergedPrs(), 'a no-flag report must never arm');
+    }
+
+    public function testArmFailureExitsOne(): void
+    {
+        // gh pr merge shim that fails -> exit 1 + a failure line.
+        $this->writeGhShim(0, /* mergeFails */ true);
+        $this->writePrs([
+            $this->pr(11, 'fix: clean armable', self::CLEARED, 'CLEAN', 'shaGREEN'),
+        ]);
+        $r = $this->runScript(['--arm']);
+        self::assertSame(1, $r['exit'], $r['output']);
+        self::assertStringContainsString('ARM FAILED', $r['output']);
+    }
+
+    public function testBogusFlagExitsTwo(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --bogus 2>&1', $output, $exit);
+        self::assertSame(2, $exit);
+        self::assertStringContainsString('unknown flag', implode("\n", $output));
+    }
+
+    public function testHelpExitsZero(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec(escapeshellcmd($this->scriptPath) . ' --help 2>&1', $output, $exit);
+        self::assertSame(0, $exit);
+        self::assertStringContainsString('Usage:', implode("\n", $output));
+    }
+
+    public function testUnauthenticatedExitsTwo(): void
+    {
+        $this->writeGhShim(1);
+        $this->writePrs([]);
+        $r = $this->runScript([]);
+        self::assertSame(2, $r['exit']);
+        self::assertStringContainsString('gh auth login', $r['output']);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private function assertBucket(string $output, int $pr, string $bucket): void
+    {
+        $found = false;
+        foreach (explode("\n", $output) as $line) {
+            if (preg_match('/^#' . $pr . '\s/', $line) === 1) {
+                self::assertStringContainsString($bucket, $line, "PR #$pr expected bucket $bucket; got: $line");
+                $found = true;
+                break;
+            }
+        }
+        self::assertTrue($found, "no report row for PR #$pr in:\n$output");
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function mergedPrs(): array
+    {
+        if (!is_file($this->mergeLog)) {
+            return [];
+        }
+        $raw = trim((string) file_get_contents($this->mergeLog));
+        if ($raw === '') {
+            return [];
+        }
+        return array_map('intval', explode("\n", $raw));
+    }
+
+    /**
+     * @param list<array<string,mixed>> $files
+     * @param list<array<string,string>> $labels
+     * @return array<string,mixed>
+     */
+    private function pr(int $number, string $title, string $body, string $mss, string $sha, array $files = [], array $labels = []): array
+    {
+        return [
+            'number' => $number,
+            'title' => $title,
+            'body' => $body,
+            'labels' => $labels,
+            'mergeStateStatus' => $mss,
+            'headRefOid' => $sha,
+            'files' => $files,
+        ];
+    }
+
+    /**
+     * @param list<array<string,mixed>> $prs
+     */
+    private function writePrs(array $prs): void
+    {
+        file_put_contents($this->tmpDir . '/prs.json', (string) json_encode($prs));
+    }
+
+    /**
+     * @param list<array<string,mixed>> $runs
+     */
+    private function writeCheckRuns(string $sha, array $runs): void
+    {
+        file_put_contents($this->crDir . '/' . $sha . '.json', (string) json_encode(['check_runs' => $runs]));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function checkRun(string $name, string $status, ?string $conclusion, ?string $detailsUrl = null): array
+    {
+        $run = ['name' => $name, 'status' => $status, 'completed_at' => '2026-06-24T00:00:00Z'];
+        if ($conclusion !== null) {
+            $run['conclusion'] = $conclusion;
+        }
+        if ($detailsUrl !== null) {
+            $run['details_url'] = $detailsUrl;
+        }
+        return $run;
+    }
+
+    /**
+     * @param list<string> $args
+     * @return array{output: string, exit: int}
+     */
+    private function runScript(array $args): array
+    {
+        $env = 'PATH=' . escapeshellarg($this->shimDir . ':' . getenv('PATH'))
+            . ' PRS=' . escapeshellarg($this->tmpDir . '/prs.json')
+            . ' CRDIR=' . escapeshellarg($this->crDir)
+            . ' CONTEXTS=' . escapeshellarg($this->contextsFixture)
+            . ' MERGELOG=' . escapeshellarg($this->mergeLog);
+
+        $argStr = '';
+        foreach ($args as $arg) {
+            $argStr .= ' ' . escapeshellarg($arg);
+        }
+        $cmd = 'cd ' . escapeshellarg($this->repoDir)
+            . ' && ' . $env
+            . ' bash ' . escapeshellarg($this->scriptPath) . $argStr . ' 2>&1';
+
+        $output = [];
+        $exit = 0;
+        exec($cmd, $output, $exit);
+        return ['output' => implode("\n", $output), 'exit' => $exit];
+    }
+
+    private function writeGhShim(int $authExit, bool $mergeFails = false): void
+    {
+        $mergeExit = $mergeFails ? 1 : 0;
+        $script = <<<SHIM
+#!/bin/bash
+# Multi-call gh shim for pr-triage. Fixtures via env: PRS, CRDIR, CONTEXTS, MERGELOG.
+if [ "\$1" = "auth" ] && [ "\$2" = "status" ]; then exit $authExit; fi
+if [ "\$1" = "api" ]; then
+  url="\$2"
+  case "\$url" in
+    *"/branches/master/protection") cat "\$CONTEXTS"; exit 0 ;;
+    *"/commits/"*"/check-runs"*)
+      sha=\$(echo "\$url" | sed -E 's#.*/commits/([^/]+)/check-runs.*#\\1#')
+      cat "\$CRDIR/\$sha.json" 2>/dev/null || echo '{"check_runs":[]}'
+      exit 0 ;;
+  esac
+  echo '{}'; exit 0
+fi
+if [ "\$1" = "pr" ] && [ "\$2" = "list" ]; then cat "\$PRS"; exit 0; fi
+if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
+  case "\$3" in
+    1100) echo '{"state":"OPEN"}' ;;
+    1071) echo '{"state":"MERGED"}' ;;
+    *) echo '{"state":"OPEN"}' ;;
+  esac
+  exit 0
+fi
+if [ "\$1" = "pr" ] && [ "\$2" = "merge" ]; then echo "\$3" >> "\$MERGELOG"; exit $mergeExit; fi
+exit 1
+SHIM;
+        file_put_contents($this->shimDir . '/gh', $script);
+        chmod($this->shimDir . '/gh', 0755);
+    }
+
+    private function recursiveRm(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRm($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `bin/lib/pr-armable.sh` as the **single source of truth** for the four live-derivable Phase 6.5 auto-merge holds (conditions 1/5/6/8: Manual-Testing clearance, golden-snapshot touch, Depends-on merge-order, and `feat:` floor) — closes the drift surface where the armability judgment was re-derived by hand and mis-classified #1163/#1188
- Adds `bin/pr-triage` cross-PR classifier (`--arm` flag gates `gh pr merge --squash --auto`) with a **fail-closed positive-clearance** rule: ARMABLE requires the `No manual testing needed` sentinel, never mere absence of holds; hand-made PRs with no `## Manual Testing` section route to a new **UNCLEARED** bucket, never auto-armed
- Refactors `/post-plan` Phase 6.5 conditions (1)/(5)/(6)/(8) to source the shared library (each block self-contained — a hoisted preamble would make (8) fail open on `feat:` PRs)
- Adds `bin/test-postplan-arm-conditions` harness regression guard wired into `harness-tests` CI job
- Adds `PrArmableLibCliTest` (26 characterization rows reproducing pre-refactor Phase 6.5 decisions) and `PrTriageCliTest` (all 7 bucket assertions + full negative-path coverage)
- ADR 0069 documenting the shared-predicate + fail-closed autonomous-merge design

This PR's own merge is held by `auto_merge: false` frontmatter — a self-gating bootstrap hazard: the just-built arming logic must not gate its own merge.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.