### PR TITLE
refactor: remove confirmed-dead CSS rules from ibl5/design/ (~70 lines)

### DIFF
--- a/ibl5/design/base.css
+++ b/ibl5/design/base.css
@@ -133,15 +133,6 @@ A:hover {
     text-decoration: none;
 }
 
-.tiny {
-    background: none;
-    color: #000000;
-    font-size: 1rem;
-    font-weight: normal;
-    font-family: var(--font-sans);
-    text-decoration: none;
-}
-
 /* --- Layout Constraints ---
    Prevent legacy table-based layouts from causing horizontal overflow.
    Scoped to non-.ibl-data-table elements so modern tables don't inherit

--- a/ibl5/design/components/forms.css
+++ b/ibl5/design/components/forms.css
@@ -6,8 +6,7 @@
    ========================================================================== */
 
 .ibl-input,
-.ibl-select,
-.ibl-textarea {
+.ibl-select {
     font-family: var(--font-sans);
     font-size: var(--text-lg);
     color: var(--navy-800);
@@ -20,8 +19,7 @@
 }
 
 .ibl-input:focus,
-.ibl-select:focus,
-.ibl-textarea:focus {
+.ibl-select:focus {
     outline: none;
     border-color: var(--accent-500);
     box-shadow: var(--ring-accent);
@@ -32,8 +30,7 @@
 }
 
 .ibl-input:disabled,
-.ibl-select:disabled,
-.ibl-textarea:disabled {
+.ibl-select:disabled {
     background-color: var(--gray-100);
     color: var(--gray-500);
     cursor: not-allowed;

--- a/ibl5/design/components/leaders.css
+++ b/ibl5/design/components/leaders.css
@@ -124,10 +124,6 @@
     overflow: hidden;
 }
 
-.leaders-tabbed__leader-rank {
-    display: none;
-}
-
 .leaders-tabbed__leader-name {
     font-weight: 600;
     font-size: var(--text-lg);

--- a/ibl5/design/components/navigation.css
+++ b/ibl5/design/components/navigation.css
@@ -196,26 +196,6 @@
     border-radius: 0;
 }
 
-/* Accent variant tabs */
-.ibl-tabs--accent {
-    background: var(--gradient-accent);
-}
-
-.ibl-tabs--accent .ibl-tab {
-    color: rgba(255, 255, 255, 0.7);
-}
-
-.ibl-tabs--accent .ibl-tab:hover {
-    color: white;
-    background: rgba(0, 0, 0, 0.1);
-}
-
-.ibl-tabs--accent .ibl-tab--active {
-    color: white;
-    background: rgba(0, 0, 0, 0.15);
-    border-bottom-color: white;
-}
-
 /* ==========================================================================
    Jump Menu (Month/Season Selector)
    ========================================================================== */

--- a/ibl5/design/components/next-sim.css
+++ b/ibl5/design/components/next-sim.css
@@ -94,12 +94,6 @@
     background: var(--team-row-hover-bg);
 }
 
-/* User label with orange accent */
-.next-sim-user-label {
-    color: var(--accent-500);
-    font-weight: 700;
-}
-
 /* Player + Game cells: team-colored background + text (matches ibl-team-cell--colored) */
 .next-sim-row--user .ibl-player-cell,
 .next-sim-row--opponent .ibl-player-cell,

--- a/ibl5/design/components/player-cards.css
+++ b/ibl5/design/components/player-cards.css
@@ -563,18 +563,6 @@
     background: linear-gradient(90deg, color-mix(in srgb, var(--card-border) 20%, transparent) 0%, color-mix(in srgb, var(--card-border) 10%, transparent) 100%);
 }
 
-/* Footer Row (e.g., Total Salary) */
-.player-stats-card .footer-row td,
-.player-stats-card .stats-table .footer-row td {
-    background: rgba(0, 0, 0, 0.3);
-    color: var(--card-accent);
-    font-weight: 600;
-    font-style: italic;
-    padding: var(--pc-pad-lg);
-    text-align: center;
-    border-top: 2px solid color-mix(in srgb, var(--card-border) 30%, transparent);
-}
-
 /* Team Links */
 .player-stats-card table a,
 .player-stats-card .stats-table a {

--- a/ibl5/design/components/search.css
+++ b/ibl5/design/components/search.css
@@ -218,28 +218,6 @@
     content: none;
 }
 
-/* Admin links */
-.search-result__admin {
-    display: inline-flex;
-    gap: var(--space-2);
-    margin-left: auto;
-}
-
-.search-result__admin a {
-    font-family: var(--font-display);
-    font-size: var(--text-xs);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: var(--tracking-display);
-    color: var(--gray-400);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-}
-
-.search-result__admin a:hover {
-    color: var(--accent-500);
-}
-
 /* Pagination */
 .search-pagination {
     display: flex;

--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -470,7 +470,7 @@ tr:has(.contract-hint-cell):focus-within .contract-hint-cell {
    Mobile Sticky Column Support
 
    Use .responsive-table class on tables with sticky columns.
-   Add .sticky-col, .sticky-col-1, .sticky-col-2, .sticky-col-3 to columns that should stick.
+   Add .sticky-col, .sticky-col-1, .sticky-col-2 to columns that should stick.
    ========================================================================== */
 
 @media (max-width: 768px) {
@@ -528,18 +528,8 @@ tr:has(.contract-hint-cell):focus-within .contract-hint-cell {
         min-width: 36px;
     }
 
-    /* Three sticky columns (rd + pick + player pattern) */
-    .ibl-data-table.responsive-table th.sticky-col-3,
-    .ibl-data-table.responsive-table td.sticky-col-3 {
-        position: sticky;
-        left: 72px;
-        z-index: 1;
-        min-width: 100px;
-    }
-
     .ibl-data-table.responsive-table thead th.sticky-col-1,
-    .ibl-data-table.responsive-table thead th.sticky-col-2,
-    .ibl-data-table.responsive-table thead th.sticky-col-3 {
+    .ibl-data-table.responsive-table thead th.sticky-col-2 {
         background: var(--team-header-bg, var(--gradient-navy-header));
         z-index: 3;
     }
@@ -552,13 +542,8 @@ tr:has(.contract-hint-cell):focus-within .contract-hint-cell {
         box-shadow: none;
     }
 
-    /* Col-2 gets shadow only for 2-column sticky layouts */
-    .ibl-data-table.responsive-table:not(:has(.sticky-col-3)) td.sticky-col-2 {
-        box-shadow: var(--shadow-sticky-col);
-    }
-
-    /* Col-3 gets shadow for 3-column sticky layouts */
-    .ibl-data-table.responsive-table td.sticky-col-3 {
+    /* Col-2 (rightmost sticky column) gets shadow */
+    .ibl-data-table.responsive-table td.sticky-col-2 {
         box-shadow: var(--shadow-sticky-col);
     }
 

--- a/ibl5/design/components/tables/contact-list.css
+++ b/ibl5/design/components/tables/contact-list.css
@@ -11,15 +11,6 @@
     max-width: 800px;
 }
 
-.contact-table .team-cell {
-    border-radius: var(--radius-sm);
-    padding: 0.5rem 0.75rem;
-}
-
-.contact-table .team-cell a {
-    font-weight: 600;
-}
-
 .contact-table .gm-cell a {
     color: var(--gray-700);
 }


### PR DESCRIPTION
## Summary

Delete CSS rules whose classes are emitted by zero rendered markup — confirmed by an orphan-CSS audit. Nine source files under `ibl5/design/` are edited; ~70 lines removed.

No PHP/JS/Twig/markup is touched. No behavioral change and no visual change: every removed rule matches zero rendered elements, so all Visual-Regression baselines stay byte-identical.

**Removed:**
- `forms.css` — drop `.ibl-textarea` from 3 grouped rules
- `search.css` — delete `.search-result__admin` block
- `player-cards.css` — delete `.player-stats-card .footer-row td` rule
- `tables/contact-list.css` — delete `.contact-table .team-cell` rules
- `next-sim.css` — delete `.next-sim-user-label` rule
- `leaders.css` — delete `.leaders-tabbed__leader-rank` rule
- `base.css` — delete legacy `.tiny` utility
- `navigation.css` — delete `.ibl-tabs--accent*` rules
- `tables.css` — sticky-col-3 coupled trim (4 sub-edits, including simplifying the vacuous `:not(:has(.sticky-col-3))` guard)

## Verification

The repo's Visual Regression CI job is a blocking PR gate on `ibl5/design/**` changes. Because every removed rule matches zero rendered elements, all screenshots stay byte-identical → VR green. If any rule were secretly live, its page would diff → VR red → merge blocked.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

Generated with [Claude Code](https://claude.ai/code)