### PR TITLE
refactor: extract AnnouncementDispatcherInterface from RecordBreakingDetector (backlog 1.3)

### DIFF
--- a/ibl5/classes/RecordHolders/Contracts/AnnouncementDispatcherInterface.php
+++ b/ibl5/classes/RecordHolders/Contracts/AnnouncementDispatcherInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RecordHolders\Contracts;
+
+/**
+ * Contract for dispatching record-breaking announcement messages.
+ *
+ * Implementations decide where messages go (Discord, nowhere for dry-run, a
+ * test spy, etc.). Called once per message; the caller catches any throwable so
+ * one failed dispatch does not abort the remaining announcements.
+ *
+ * @see RecordBreakingDetectorInterface
+ */
+interface AnnouncementDispatcherInterface
+{
+    /**
+     * Dispatch a single record announcement to its destination(s).
+     *
+     * Called once per announcement message. Implementations decide where the
+     * message goes (Discord channels, nowhere for dry-run, a test spy, etc.).
+     * The caller catches any throwable so one failed dispatch does not abort the
+     * remaining announcements.
+     *
+     * @param string $message The formatted announcement message
+     */
+    public function dispatch(string $message): void;
+}

--- a/ibl5/classes/RecordHolders/DiscordAnnouncementDispatcher.php
+++ b/ibl5/classes/RecordHolders/DiscordAnnouncementDispatcher.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RecordHolders;
+
+use Discord\Discord;
+use RecordHolders\Contracts\AnnouncementDispatcherInterface;
+
+/**
+ * Posts record announcements to the configured Discord channels.
+ *
+ * This is the production default injected into RecordBreakingDetector when no
+ * dispatcher is provided. It wraps the static Discord::postToChannel() call
+ * that previously lived in the detector's private sendDiscordNotification().
+ */
+final class DiscordAnnouncementDispatcher implements AnnouncementDispatcherInterface
+{
+    public function dispatch(string $message): void
+    {
+        Discord::postToChannel('#trades', $message);
+        Discord::postToChannel('#general-chat', $message);
+    }
+}

--- a/ibl5/classes/RecordHolders/NullAnnouncementDispatcher.php
+++ b/ibl5/classes/RecordHolders/NullAnnouncementDispatcher.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RecordHolders;
+
+use RecordHolders\Contracts\AnnouncementDispatcherInterface;
+
+/**
+ * No-op dispatcher for dry-run scenarios and test isolation.
+ *
+ * Detection still runs and detectAndAnnounce() still returns its full
+ * announcement list; nothing is dispatched to any external channel.
+ */
+final class NullAnnouncementDispatcher implements AnnouncementDispatcherInterface
+{
+    public function dispatch(string $message): void
+    {
+        // Intentional no-op: dry-run / test null-object — nothing is sent.
+    }
+}

--- a/ibl5/classes/RecordHolders/RecordBreakingDetector.php
+++ b/ibl5/classes/RecordHolders/RecordBreakingDetector.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace RecordHolders;
 
+use RecordHolders\Contracts\AnnouncementDispatcherInterface;
 use RecordHolders\Contracts\RecordBreakingDetectorInterface;
 use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
 use Utilities\BoxScoreUrlBuilder;
-use Discord\Discord;
 
 /**
  * RecordBreakingDetector - Detects and announces broken/tied all-time IBL records.
@@ -22,6 +22,8 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
 {
     private RecordHoldersRepositoryInterface $repository;
 
+    private AnnouncementDispatcherInterface $dispatcher;
+
     private const SITE_BASE_URL = 'https://iblhoops.net';
 
     /**
@@ -33,9 +35,12 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
         'heat' => 'HEAT',
     ];
 
-    public function __construct(RecordHoldersRepositoryInterface $repository)
-    {
+    public function __construct(
+        RecordHoldersRepositoryInterface $repository,
+        ?AnnouncementDispatcherInterface $dispatcher = null
+    ) {
         $this->repository = $repository;
+        $this->dispatcher = $dispatcher ?? new DiscordAnnouncementDispatcher();
     }
 
     /**
@@ -117,9 +122,15 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
         $qdAnnouncements = $this->detectNewQuadrupleDoubles($allTargetDates);
         array_push($announcements, ...$qdAnnouncements);
 
-        // Send all Discord notifications
+        // Dispatch each announcement independently — one failed dispatch must
+        // not abort the remaining announcements (finding 1.3 resilience fix).
         foreach ($announcements as $message) {
-            $this->sendDiscordNotification($message);
+            try {
+                $this->dispatcher->dispatch($message);
+            } catch (\Throwable) {
+                // Swallow deliberately: a dispatch failure (e.g. Discord outage)
+                // must not stop later announcements from being dispatched.
+            }
         }
 
         return $announcements;
@@ -411,15 +422,6 @@ class RecordBreakingDetector implements RecordBreakingDetectorInterface
         return "**NEW QUADRUPLE DOUBLE!**\n"
             . $playerLink . ' (' . $teamName . ') recorded a quadruple double (' . $linkedStats
             . ') in a ' . $gameTypeLabel . ' game!';
-    }
-
-    /**
-     * Send a Discord notification about a record.
-     */
-    private function sendDiscordNotification(string $message): void
-    {
-        Discord::postToChannel('#trades', $message);
-        Discord::postToChannel('#general-chat', $message);
     }
 
     /**

--- a/ibl5/docs/decisions/0013-weekly-log-review-workflow.md
+++ b/ibl5/docs/decisions/0013-weekly-log-review-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: ADR for weekly production log review via GitHub Action and Discord DM notification.
-last_verified: 2026-04-26
+last_verified: 2026-06-25
 ---
 
 # ADR-0013: Weekly Log Review Workflow

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -81,7 +81,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 |---|--------|-----------|-----------------|
 | 1.1 | ◑ Partial | 🟩 | Narrow fix done (stubs/cache, −39 LOC); the formatter god-class split is **PR #1167** open (queued `extract-recordformatter`, armed green-green). Service still 687 LOC. |
 | 1.2 | ✅ Implemented | — | `StreakCalculator` exists (#1040); HEAT CTE → `vw_heat_champions` (migration 149, #1090). Repo still 823 LOC = separate cohesive batch-query concern, not this finding. |
-| 1.3 | ⬜ Open | 🟩 | Verified `detectAndAnnounce()` + private `sendDiscordNotification()` still coupled. Inject dispatcher interface; green-green, no security/UI/schema. |
+| 1.3 | ✅ Implemented | 🟩 | `AnnouncementDispatcherInterface` injected (defaulted to `DiscordAnnouncementDispatcher`); dispatch loop now isolates per-message failures; `NullAnnouncementDispatcher` for dry-run/tests. Green-green + 1 tested resilience delta. |
 | 1.4 | ✅ Implemented | — | `JsbImportService` now 177-LOC facade + 10 `Importers/` (#801). |
 | 1.5 | ✅ Implemented | — | #1148 — 3 collaborators extracted; service ~386 LOC. |
 | 1.6 | ✅ Implemented | — | Dual-path unified, byte-identical (#1146). View still 610 LOC = residual size, not this concern. |
@@ -122,6 +122,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** Return announcement list from `detectAndAnnounce()`; or inject `AnnouncementDispatcher` interface with a null impl for tests.
 **Est. effort:** S
 **Risk if untouched:** Discord outage silently aborts announcements mid-way; dry-run impossible without modifying class.
+**Status:** Implemented (2026-06-25) — injected `AnnouncementDispatcherInterface` (defaulted to `DiscordAnnouncementDispatcher`); `detectAndAnnounce()` dispatches per-message with `try/catch` isolation so a Discord outage no longer aborts the loop; `NullAnnouncementDispatcher` enables dry-run/testable detection. Private `sendDiscordNotification()` removed.
 
 ### 1.4 JsbImportService — One Class Handling 10 File Formats
 **Location:** `ibl5/classes/JsbParser/JsbImportService.php` (853 lines)

--- a/ibl5/tests/RecordHolders/RecordBreakingDetectorTest.php
+++ b/ibl5/tests/RecordHolders/RecordBreakingDetectorTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Tests\RecordHolders;
 
 use PHPUnit\Framework\TestCase;
+use RecordHolders\NullAnnouncementDispatcher;
 use RecordHolders\RecordBreakingDetector;
+use RecordHolders\Contracts\AnnouncementDispatcherInterface;
 use RecordHolders\Contracts\RecordHoldersRepositoryInterface;
 
 final class RecordBreakingDetectorTest extends TestCase
@@ -416,6 +418,145 @@ final class RecordBreakingDetectorTest extends TestCase
 
         $this->assertCount(1, $teamConfigs);
         $this->assertSame($expectedConfig, $teamConfigs[0]);
+    }
+
+    // --- Pre-impl contract pin (characterization) ---
+
+    /**
+     * Pins the exact announcement-list contract detectAndAnnounce() returns for a
+     * broken player record — count, header, player name, value, previous holder.
+     * Runs green on master before any production edit; the refactor must keep it green.
+     */
+    public function testDetectAndAnnounceReturnsExactAnnouncementContract(): void
+    {
+        $newRecord = $this->makePlayerRecord(['name' => 'New Star', 'date' => '2007-01-15', 'value' => 85]);
+        $previousRecord = $this->makePlayerRecord(['name' => 'Bob Pettit', 'date' => '1996-01-16', 'value' => 80]);
+
+        // Populate only 'points' so exactly one announcement is produced.
+        $batchResult = $this->buildPlayerBatchResult([]);
+        $batchResult['points'] = [$newRecord, $previousRecord];
+
+        $this->mockRepository->method('getTopPlayerSingleGameBatch')->willReturn($batchResult);
+        $this->mockRepository->method('getTopTeamSingleGameBatch')->willReturn($this->buildTeamBatchResult([]));
+        $this->mockRepository->method('getQuadrupleDoubles')->willReturn([]);
+
+        $result = $this->detector->detectAndAnnounce(['2007-01-15']);
+
+        $expectedMessage = "**NEW IBL RECORD!**\n"
+            . '[New Star](https://iblhoops.net/modules.php?name=Player&pa=showpage&pid=100) (Heat) '
+            . 'just recorded **85 points** in a regular season game, '
+            . "breaking Bob Pettit's all-time record of 80 points!";
+
+        $this->assertCount(1, $result);
+        $this->assertSame($expectedMessage, $result[0]);
+    }
+
+    // --- Post-impl dispatch integration tests ---
+
+    /**
+     * Matrix row 2: each returned announcement is dispatched exactly once, in order.
+     */
+    public function testDispatchesEachAnnouncementExactlyOnce(): void
+    {
+        $newRecord = $this->makePlayerRecord(['name' => 'New Star', 'date' => '2007-01-15', 'value' => 85]);
+        $previousRecord = $this->makePlayerRecord(['name' => 'Bob Pettit', 'date' => '1996-01-16', 'value' => 80]);
+
+        $batchResult = $this->buildPlayerBatchResult([]);
+        $batchResult['points'] = [$newRecord, $previousRecord];
+
+        $this->mockRepository->method('getTopPlayerSingleGameBatch')->willReturn($batchResult);
+        $this->mockRepository->method('getTopTeamSingleGameBatch')->willReturn($this->buildTeamBatchResult([]));
+        $this->mockRepository->method('getQuadrupleDoubles')->willReturn([]);
+
+        $spy = new class implements AnnouncementDispatcherInterface {
+            /** @var list<string> */
+            public array $captured = [];
+
+            public function dispatch(string $message): void
+            {
+                $this->captured[] = $message;
+            }
+        };
+
+        $detector = new RecordBreakingDetector($this->mockRepository, $spy);
+        $result = $detector->detectAndAnnounce(['2007-01-15']);
+
+        $this->assertNotEmpty($result);
+        $this->assertSame($result, $spy->captured, 'Each announcement must be dispatched exactly once, in order');
+    }
+
+    /**
+     * Matrix row 3: NullDispatcher dispatches nothing, yet detectAndAnnounce()
+     * still returns the full announcement list — detection is unaffected by no-op dispatch.
+     */
+    public function testNullDispatcherDispatchesNothingButDetectionStillReturnsFullResult(): void
+    {
+        $newRecord = $this->makePlayerRecord(['name' => 'New Star', 'date' => '2007-01-15', 'value' => 85]);
+        $previousRecord = $this->makePlayerRecord(['name' => 'Bob Pettit', 'date' => '1996-01-16', 'value' => 80]);
+
+        $batchResult = $this->buildPlayerBatchResult([]);
+        $batchResult['points'] = [$newRecord, $previousRecord];
+
+        $this->mockRepository->method('getTopPlayerSingleGameBatch')->willReturn($batchResult);
+        $this->mockRepository->method('getTopTeamSingleGameBatch')->willReturn($this->buildTeamBatchResult([]));
+        $this->mockRepository->method('getQuadrupleDoubles')->willReturn([]);
+
+        $detector = new RecordBreakingDetector($this->mockRepository, new NullAnnouncementDispatcher());
+        $result = $detector->detectAndAnnounce(['2007-01-15']);
+
+        $expectedMessage = "**NEW IBL RECORD!**\n"
+            . '[New Star](https://iblhoops.net/modules.php?name=Player&pa=showpage&pid=100) (Heat) '
+            . 'just recorded **85 points** in a regular season game, '
+            . "breaking Bob Pettit's all-time record of 80 points!";
+
+        $this->assertCount(1, $result, 'Detection must still return full results with NullDispatcher');
+        $this->assertSame($expectedMessage, $result[0]);
+    }
+
+    /**
+     * Matrix row 4: a dispatcher that throws on the first announcement does NOT abort
+     * the rest — later announcements are still dispatched and no exception propagates.
+     */
+    public function testFailingDispatchDoesNotAbortRemainingAnnouncements(): void
+    {
+        // Two separate announcements: a broken player record and a broken team record.
+        $playerRecord = $this->makePlayerRecord(['name' => 'New Star', 'date' => '2007-01-15', 'value' => 85]);
+        $prevPlayerRecord = $this->makePlayerRecord(['name' => 'Bob Pettit', 'date' => '1996-01-16', 'value' => 80]);
+        $teamRecord = $this->makeTeamRecord(['team_name' => 'Heat', 'date' => '2007-01-15', 'value' => 150]);
+        $prevTeamRecord = $this->makeTeamRecord(['team_name' => 'Bulls', 'date' => '2000-03-10', 'value' => 145]);
+
+        $playerBatch = $this->buildPlayerBatchResult([]);
+        $playerBatch['points'] = [$playerRecord, $prevPlayerRecord];
+
+        $teamBatch = $this->buildTeamBatchResult([]);
+        $teamBatch['team_points'] = [$teamRecord, $prevTeamRecord];
+
+        $this->mockRepository->method('getTopPlayerSingleGameBatch')->willReturn($playerBatch);
+        $this->mockRepository->method('getTopTeamSingleGameBatch')->willReturn($teamBatch);
+        $this->mockRepository->method('getQuadrupleDoubles')->willReturn([]);
+
+        // Throws on first dispatch, records every subsequent message.
+        $throwingDispatcher = new class implements AnnouncementDispatcherInterface {
+            /** @var list<string> */
+            public array $capturedAfterFirst = [];
+            private bool $isFirst = true;
+
+            public function dispatch(string $message): void
+            {
+                if ($this->isFirst) {
+                    $this->isFirst = false;
+                    throw new \RuntimeException('Simulated dispatch failure on first message');
+                }
+                $this->capturedAfterFirst[] = $message;
+            }
+        };
+
+        $detector = new RecordBreakingDetector($this->mockRepository, $throwingDispatcher);
+        $result = $detector->detectAndAnnounce(['2007-01-15']);
+
+        $this->assertCount(2, $result, 'detectAndAnnounce must return all announcements regardless of dispatch failures');
+        $this->assertCount(1, $throwingDispatcher->capturedAfterFirst, 'Announcements after a failed dispatch must still be dispatched');
+        $this->assertSame($result[1], $throwingDispatcher->capturedAfterFirst[0], 'Second announcement must be dispatched after the first one failed');
     }
 
     // --- Helper methods ---


### PR DESCRIPTION
## Summary

Backlog finding **1.3**: `RecordBreakingDetector::detectAndAnnounce()` mixes record-change detection with Discord dispatch via a private `sendDiscordNotification()` that calls the static `Discord::postToChannel()`. This makes detection untestable as a dispatch flow, makes dry-run impossible, and — the real risk — a single failing dispatch aborts the rest of the announcement loop mid-way.

This PR injects an `AnnouncementDispatcherInterface` (per-message `dispatch(string): void`) into the constructor as a **defaulted** parameter, defaulting to a Discord-backed impl that wraps the current `sendDiscordNotification()` logic. The dispatch loop in `detectAndAnnounce()` calls `$this->dispatcher->dispatch($message)` per announcement, wrapped in a `try/catch` so one failing dispatch no longer aborts the remaining announcements. A `NullAnnouncementDispatcher` gives tests (and dry-run callers) a no-op impl.

**This is a pure refactor** — no GM-visible capability change. The public contract `detectAndAnnounce(array $gameDates): list<string>` is identical. Discord dispatch is unchanged in production. The one intentional behavior delta (per-message failure isolation) is an internal robustness improvement covered by tests.

## Changes

- **NEW** `ibl5/classes/RecordHolders/Contracts/AnnouncementDispatcherInterface.php` — `dispatch(string): void` contract
- **NEW** `ibl5/classes/RecordHolders/DiscordAnnouncementDispatcher.php` — default impl wrapping `Discord::postToChannel()`
- **NEW** `ibl5/classes/RecordHolders/NullAnnouncementDispatcher.php` — no-op impl for dry-run/tests
- **CHANGE** `ibl5/classes/RecordHolders/RecordBreakingDetector.php` — inject dispatcher (defaulted), dispatch loop with `try/catch`, delete private `sendDiscordNotification()`
- **CHANGE** `ibl5/tests/RecordHolders/RecordBreakingDetectorTest.php` — +1 pre-impl characterization pin, +3 post-impl dispatch tests
- **CHANGE** `ibl5/docs/maintenance-backlog.md` — flip 1.3 status to Implemented

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.