### PR TITLE
refactor: SeasonArchiveService — local player-name collector (backlog 1.13)

### DIFF
--- a/ibl5/classes/SeasonArchive/SeasonArchiveService.php
+++ b/ibl5/classes/SeasonArchive/SeasonArchiveService.php
@@ -31,9 +31,6 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
 
     private SeasonArchiveRepositoryInterface $repository;
 
-    /** @var array<string, true> Player names accumulated during getSeasonDetail() assembly */
-    private array $collectedPlayerNames = [];
-
     public function __construct(SeasonArchiveRepositoryInterface $repository)
     {
         $this->repository = $repository;
@@ -132,8 +129,9 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
             $teamIds[$teamName] = $colorData['teamid'];
         }
 
-        // Reset accumulator — extractAward/extractAwardList populate it during assembly
-        $this->collectedPlayerNames = [];
+        // Player names collected during assembly, consumed below for player-ID lookup
+        /** @var array<string, true> $collectedPlayerNames */
+        $collectedPlayerNames = [];
 
         $seasonData = [
             'year' => $year,
@@ -141,8 +139,8 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
             'tournaments' => [
                 'heatChampion' => $this->getHeatChampionFromTeamAwards($teamAwards),
                 'heatUrl' => $this->getChallongeUrl('heat', $year),
-                'oneOnOneChampion' => $this->extractAward($awards, 'One-on-One Tournament Champion'),
-                'rookieOneOnOneChampion' => $this->extractAward($awards, 'Rookie One-on-One Tournament Champion'),
+                'oneOnOneChampion' => $this->extractAward($awards, 'One-on-One Tournament Champion', $collectedPlayerNames),
+                'rookieOneOnOneChampion' => $this->extractAward($awards, 'Rookie One-on-One Tournament Champion', $collectedPlayerNames),
                 'oneOnOneUrl' => 'https://challonge.com/users/coldbeatle89/tournaments',
                 'iblFinalsWinner' => $iblFinals['winner'],
                 'iblFinalsLoser' => $iblFinals['loser'],
@@ -151,56 +149,56 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
             ],
             'allStarWeekend' => [
                 'gameMvps' => array_merge(
-                    $this->extractAwardList($awards, 'All-Star Game MVP'),
-                    $this->extractAwardList($awards, 'All-Star Game Co-MVP'),
+                    $this->extractAwardList($awards, 'All-Star Game MVP', $collectedPlayerNames),
+                    $this->extractAwardList($awards, 'All-Star Game Co-MVP', $collectedPlayerNames),
                 ),
-                'slamDunkWinner' => $this->extractAward($awards, 'Slam Dunk Competition - Winner'),
-                'threePointWinner' => $this->extractAward($awards, 'Three-Point Contest - Winner'),
-                'rookieSophomoreMvp' => $this->extractAward($awards, 'Rookie-Sophomore Challenge - MVP'),
-                'slamDunkParticipants' => $this->extractAwardList($awards, 'Slam Dunk Competition'),
-                'threePointParticipants' => $this->extractAwardList($awards, 'Three-Point Contest'),
-                'rookieSophomoreParticipants' => $this->extractAwardList($awards, 'Rookie-Sophomore Challenge'),
+                'slamDunkWinner' => $this->extractAward($awards, 'Slam Dunk Competition - Winner', $collectedPlayerNames),
+                'threePointWinner' => $this->extractAward($awards, 'Three-Point Contest - Winner', $collectedPlayerNames),
+                'rookieSophomoreMvp' => $this->extractAward($awards, 'Rookie-Sophomore Challenge - MVP', $collectedPlayerNames),
+                'slamDunkParticipants' => $this->extractAwardList($awards, 'Slam Dunk Competition', $collectedPlayerNames),
+                'threePointParticipants' => $this->extractAwardList($awards, 'Three-Point Contest', $collectedPlayerNames),
+                'rookieSophomoreParticipants' => $this->extractAwardList($awards, 'Rookie-Sophomore Challenge', $collectedPlayerNames),
             ],
             'majorAwards' => [
-                'mvp' => $this->extractAward($awards, 'Most Valuable Player (1st)'),
-                'dpoy' => $this->extractAward($awards, 'Defensive Player of the Year (1st)'),
-                'roy' => $this->extractAward($awards, 'Rookie of the Year (1st)'),
-                'sixthMan' => $this->extractAward($awards, '6th Man Award (1st)'),
+                'mvp' => $this->extractAward($awards, 'Most Valuable Player (1st)', $collectedPlayerNames),
+                'dpoy' => $this->extractAward($awards, 'Defensive Player of the Year (1st)', $collectedPlayerNames),
+                'roy' => $this->extractAward($awards, 'Rookie of the Year (1st)', $collectedPlayerNames),
+                'sixthMan' => $this->extractAward($awards, '6th Man Award (1st)', $collectedPlayerNames),
                 'gmOfYear' => $this->getGmOfTheYear($gmAwards, $year),
-                'finalsMvp' => $this->extractAward($awards, 'IBL Finals MVP'),
+                'finalsMvp' => $this->extractAward($awards, 'IBL Finals MVP', $collectedPlayerNames),
             ],
             'allLeagueTeams' => [
-                'first' => $this->extractAwardList($awards, 'All-League First Team'),
-                'second' => $this->extractAwardList($awards, 'All-League Second Team'),
-                'third' => $this->extractAwardList($awards, 'All-League Third Team'),
+                'first' => $this->extractAwardList($awards, 'All-League First Team', $collectedPlayerNames),
+                'second' => $this->extractAwardList($awards, 'All-League Second Team', $collectedPlayerNames),
+                'third' => $this->extractAwardList($awards, 'All-League Third Team', $collectedPlayerNames),
             ],
             'allDefensiveTeams' => [
-                'first' => $this->extractAwardList($awards, 'All-Defensive Team (1st)'),
-                'second' => $this->extractAwardList($awards, 'All-Defensive Team (2nd)'),
-                'third' => $this->extractAwardList($awards, 'All-Defensive Team (3rd)'),
+                'first' => $this->extractAwardList($awards, 'All-Defensive Team (1st)', $collectedPlayerNames),
+                'second' => $this->extractAwardList($awards, 'All-Defensive Team (2nd)', $collectedPlayerNames),
+                'third' => $this->extractAwardList($awards, 'All-Defensive Team (3rd)', $collectedPlayerNames),
             ],
             'allRookieTeams' => [
-                'first' => $this->extractAwardList($awards, 'All-Rookie Team (1st)'),
-                'second' => $this->extractAwardList($awards, 'All-Rookie Team (2nd)'),
-                'third' => $this->extractAwardList($awards, 'All-Rookie Team (3rd)'),
+                'first' => $this->extractAwardList($awards, 'All-Rookie Team (1st)', $collectedPlayerNames),
+                'second' => $this->extractAwardList($awards, 'All-Rookie Team (2nd)', $collectedPlayerNames),
+                'third' => $this->extractAwardList($awards, 'All-Rookie Team (3rd)', $collectedPlayerNames),
             ],
             'statisticalLeaders' => [
-                'scoring' => $this->extractAward($awards, 'Scoring Leader (1st)'),
-                'rebounds' => $this->extractAward($awards, 'Rebounding Leader (1st)'),
-                'assists' => $this->extractAward($awards, 'Assists Leader (1st)'),
-                'steals' => $this->extractAward($awards, 'Steals Leader (1st)'),
-                'blocks' => $this->extractAward($awards, 'Blocks Leader (1st)'),
+                'scoring' => $this->extractAward($awards, 'Scoring Leader (1st)', $collectedPlayerNames),
+                'rebounds' => $this->extractAward($awards, 'Rebounding Leader (1st)', $collectedPlayerNames),
+                'assists' => $this->extractAward($awards, 'Assists Leader (1st)', $collectedPlayerNames),
+                'steals' => $this->extractAward($awards, 'Steals Leader (1st)', $collectedPlayerNames),
+                'blocks' => $this->extractAward($awards, 'Blocks Leader (1st)', $collectedPlayerNames),
             ],
             'playoffBracket' => $playoffBracket,
             'heatStandings' => $heatStandings,
             'teamAwards' => $parsedTeamAwards,
             'championRosters' => [
-                'ibl' => $this->extractAwardList($awards, 'IBL Champion'),
-                'heat' => $this->extractAwardList($awards, 'IBL HEAT Championship'),
+                'ibl' => $this->extractAwardList($awards, 'IBL Champion', $collectedPlayerNames),
+                'heat' => $this->extractAwardList($awards, 'IBL HEAT Championship', $collectedPlayerNames),
             ],
             'allStarRosters' => [
-                'east' => $this->extractAwardList($awards, 'Eastern Conference All-Star'),
-                'west' => $this->extractAwardList($awards, 'Western Conference All-Star'),
+                'east' => $this->extractAwardList($awards, 'Eastern Conference All-Star', $collectedPlayerNames),
+                'west' => $this->extractAwardList($awards, 'Western Conference All-Star', $collectedPlayerNames),
             ],
             'allStarCoaches' => $this->getAllStarCoaches($gmAwards, $year, $teamConferences),
             'iblChampionCoach' => $this->getIblChampionCoach($gmTenures, $iblFinals['winner'], $year),
@@ -209,7 +207,7 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
             'teamIds' => $teamIds,
         ];
 
-        $seasonData['playerIds'] = $this->repository->getPlayerIdsByNames(array_keys($this->collectedPlayerNames));
+        $seasonData['playerIds'] = $this->repository->getPlayerIdsByNames(array_keys($collectedPlayerNames));
 
         return $seasonData;
     }
@@ -252,15 +250,16 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
      *
      * @param list<AwardRow> $awards All awards for a year
      * @param string $awardName Exact award name to match
+     * @param array<string, true> $collected Player-name accumulator (by reference)
      * @return string Winner name, or empty string if not found
      */
-    private function extractAward(array $awards, string $awardName): string
+    private function extractAward(array $awards, string $awardName, array &$collected = []): string
     {
         foreach ($awards as $award) {
             if (trim($award['award']) === $awardName) {
                 $name = trim($award['name']);
                 if ($name !== '') {
-                    $this->collectedPlayerNames[$name] = true;
+                    $collected[$name] = true;
                 }
 
                 return $name;
@@ -277,9 +276,10 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
      *
      * @param list<AwardRow> $awards All awards for a year
      * @param string $awardName Award name to match (exact match after trim)
+     * @param array<string, true> $collected Player-name accumulator (by reference)
      * @return list<string> List of player names
      */
-    private function extractAwardList(array $awards, string $awardName): array
+    private function extractAwardList(array $awards, string $awardName, array &$collected = []): array
     {
         $names = [];
         foreach ($awards as $award) {
@@ -287,7 +287,7 @@ class SeasonArchiveService implements SeasonArchiveServiceInterface
                 $name = trim($award['name']);
                 $names[] = $name;
                 if ($name !== '') {
-                    $this->collectedPlayerNames[$name] = true;
+                    $collected[$name] = true;
                 }
             }
         }

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -91,7 +91,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 1.10 | ✅ Implemented | — | Verified: `syncPropertiesFromPlayerData` gone, zero public nullable props. `Player.php` 671 LOC = typed-getter bulk (residual). |
 | 1.11 | ⬜ Open | 🟩 | `insertTeamBoxscore()` 30-arg signature now lives in `BoxscoreRepository:252`; 557 LOC. Array-param + injectable ProgressReporter; pin with a DB-integration test. |
 | 1.12 | ✅ Implemented | — | #1145 — split into Index/Detail views, byte-identical golden-master. |
-| 1.13 | ⬜ Open | 🟩 | Mutable `$collectedPlayerNames` accumulator; 530 LOC. Local var / collector VO; green-green. |
+| 1.13 | ✅ Implemented | — | Mutable `$collectedPlayerNames` accumulator → local var passed by-ref; green-green; getAllSeasons() untouched. |
 | 1.14 | ✅ Implemented | — | `TradeCapCalculator` extracted (#1143). |
 | 1.15 | ⬜ Open | 🟩 | YourAccountView 536 LOC, 6 SVG + 6 page variants. Green-green with VR pin; auth *display* only (no auth-logic change → no security surface). |
 | 1.16 | ✅ Implemented | — | `computeJsbProduction()` moved to service (verified). |
@@ -191,6 +191,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/classes/SeasonArchive/SeasonArchiveIndexView.php`, `ibl5/classes/SeasonArchive/SeasonDetailView.php`, and shared `ibl5/classes/SeasonArchive/SeasonArchiveRenderHelpers.php` trait. Output byte-identical (verified by golden-master snapshots).
 
 ### 1.13 SeasonArchiveService — Mutable Instance State Accumulator
+**Status:** ✅ Implemented — `$collectedPlayerNames` instance property replaced by a local variable in `getSeasonDetail()` passed by reference into `extractAward()`/`extractAwardList()` (optional `&$collected = []` param). Cross-call contamination structurally impossible; `getAllSeasons()` unchanged. Green-green (existing `testAccumulatorResetsBetweenCalls` + new `testReusedInstanceCollectsSameNamesAsFreshInstance`).
 **Location:** `ibl5/classes/SeasonArchive/SeasonArchiveService.php` line 35 (530 LOC)
 **Problem:** `private array $collectedPlayerNames = []` is a side-effect accumulator populated during `extractAward()`/`extractAwardList()` inside `getSeasonDetail()`. Reset only at start of `getSeasonDetail()` — not on construction — creating cross-contamination risk if reused.
 **Suggested direction:** Replace with a local variable passed into extract helpers; or use a `PlayerNameCollector` value object.

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Long-running backlog of maintenance-cost reduction opportunities, organized by axis. Each item is a candidate for a future plan.
-last_verified: 2026-06-25
+last_verified: 2026-06-26
 ---
 
 # Maintenance-Cost Reduction Backlog

--- a/ibl5/tests/SeasonArchive/SeasonArchiveServiceTest.php
+++ b/ibl5/tests/SeasonArchive/SeasonArchiveServiceTest.php
@@ -499,6 +499,80 @@ class SeasonArchiveServiceTest extends TestCase
         $this->assertNotContains('Season1 MVP', $capturedNames[1]);
     }
 
+    public function testReusedInstanceCollectsSameNamesAsFreshInstance(): void
+    {
+        $awards1989 = [
+            ['year' => 1989, 'award' => 'Most Valuable Player (1st)', 'name' => 'Season1 MVP', 'table_id' => 1],
+        ];
+        $awards1990 = [
+            ['year' => 1990, 'award' => 'Most Valuable Player (1st)', 'name' => 'Season2 MVP', 'table_id' => 2],
+        ];
+
+        $buildRepo = static function (array $awards) {
+            $repo = self::createStub(SeasonArchiveRepositoryInterface::class);
+            $repo->method('getTeamConferences')->willReturn([]);
+            $repo->method('getAwardsByYear')->willReturn($awards);
+            $repo->method('getPlayoffResultsByYear')->willReturn([]);
+            $repo->method('getTeamAwardsByYear')->willReturn([]);
+            $repo->method('getAllGmAwardsWithTeams')->willReturn([]);
+            $repo->method('getAllGmTenuresWithTeams')->willReturn([]);
+            $repo->method('getHeatWinLossByYear')->willReturn([]);
+            $repo->method('getTeamColors')->willReturn([]);
+
+            return $repo;
+        };
+
+        // Fresh single-call instance for 1990 — the reference set of collected names.
+        $freshNames = [];
+        $freshRepo = $buildRepo($awards1990);
+        $freshRepo->method('getPlayerIdsByNames')->willReturnCallback(
+            static function (array $names) use (&$freshNames): array {
+                $freshNames = $names;
+
+                return [];
+            },
+        );
+        (new SeasonArchiveService($freshRepo))->getSeasonDetail(1990);
+
+        // Reused instance: 1989 first (potential contaminant), then 1990 on the SAME instance.
+        $reusedNames = [];
+        $callCount = 0;
+        $reusedRepo = self::createStub(SeasonArchiveRepositoryInterface::class);
+        $reusedRepo->method('getTeamConferences')->willReturn([]);
+        $reusedRepo->method('getPlayoffResultsByYear')->willReturn([]);
+        $reusedRepo->method('getTeamAwardsByYear')->willReturn([]);
+        $reusedRepo->method('getAllGmAwardsWithTeams')->willReturn([]);
+        $reusedRepo->method('getAllGmTenuresWithTeams')->willReturn([]);
+        $reusedRepo->method('getHeatWinLossByYear')->willReturn([]);
+        $reusedRepo->method('getTeamColors')->willReturn([]);
+        $reusedRepo->method('getAwardsByYear')->willReturnCallback(
+            static function (int $year) use ($awards1989, $awards1990, &$callCount): array {
+                $callCount++;
+
+                return $callCount === 1 ? $awards1989 : $awards1990;
+            },
+        );
+        $reusedRepo->method('getPlayerIdsByNames')->willReturnCallback(
+            static function (array $names) use (&$reusedNames): array {
+                $reusedNames = $names;   // overwritten each call; ends on the 1990 call
+
+                return [];
+            },
+        );
+
+        $service = new SeasonArchiveService($reusedRepo);
+        $service->getSeasonDetail(1989);
+        $service->getSeasonDetail(1990);
+
+        // The reused instance's second (1990) collected-name set must EQUAL the fresh
+        // single-call set — no stale 'Season1 MVP' carryover changes the collected names.
+        sort($freshNames);
+        sort($reusedNames);
+        $this->assertSame($freshNames, $reusedNames);
+        $this->assertContains('Season2 MVP', $reusedNames);
+        $this->assertNotContains('Season1 MVP', $reusedNames);
+    }
+
     public function testAllStarCoachesIncludedInSeasonDetail(): void
     {
         $mockRepo = $this->createMock(SeasonArchiveRepositoryInterface::class);


### PR DESCRIPTION
## Summary

`SeasonArchiveService` accumulated player names into a mutable instance property `$collectedPlayerNames`. This PR converts that accumulator to a **local variable** in `getSeasonDetail()`, passed **by reference** into the two extract helpers via an optional `array &$collected = []` parameter. The accumulator can no longer outlive a single `getSeasonDetail()` call, structurally eliminating cross-call contamination risk.

**Behavior-preserving refactor.** `getAllSeasons()` is untouched (line 65 retains two-arg form via optional default). Existing `testAccumulatorResetsBetweenCalls` + new `testReusedInstanceCollectsSameNamesAsFreshInstance` provide the green-green proof.

Backlog finding 1.13 — maintenance-backlog.md updated to ✅ Implemented.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.