### PR TITLE
refactor: SearchView ob_start migration + result-list dedup (backlog 1.20)

### DIFF
--- a/ibl5/classes/Search/SearchView.php
+++ b/ibl5/classes/Search/SearchView.php
@@ -37,21 +37,16 @@ class SearchView implements SearchViewInterface
      */
     public function render(array $data): string
     {
-        $output = '<div class="search-page">';
-        $output .= $this->renderPageHeader($data['topicText'], $data['type']);
-        $output .= $this->renderSearchForm($data);
-
+        ob_start();
+        ?><div class="search-page"><?= HtmlSanitizer::trusted($this->renderPageHeader($data['topicText'], $data['type'])) ?><?= HtmlSanitizer::trusted($this->renderSearchForm($data)) ?><?php
         if ($data['error'] !== '') {
-            $output .= $this->renderError($data['error']);
+            ?><?= HtmlSanitizer::trusted($this->renderError($data['error'])) ?><?php
         }
-
         if ($data['results'] !== null) {
-            $output .= $this->renderResults($data);
+            ?><?= HtmlSanitizer::trusted($this->renderResults($data)) ?><?php
         }
-
-        $output .= '</div>';
-
-        return $output;
+        ?></div><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -69,7 +64,9 @@ class SearchView implements SearchViewInterface
         }
 
         $safeTitle = HtmlSanitizer::safeHtmlOutput($title);
-        return '<h1 class="ibl-title">' . $safeTitle . '</h1>';
+        ob_start();
+        ?><h1 class="ibl-title"><?= HtmlSanitizer::trusted($safeTitle) ?></h1><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -81,48 +78,22 @@ class SearchView implements SearchViewInterface
     {
         $query = HtmlSanitizer::safeHtmlOutput($data['query']);
         $type = $data['type'];
-
-        $output = '<form action="modules.php?name=Search" method="post" class="search-form">';
-
-        // Search input row
-        $output .= '<div class="search-form__input-row">';
-        $output .= '<div class="ibl-search search-form__search-bar">';
-        $output .= '<svg class="ibl-search__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>';
-        $output .= '<input type="text" name="query" class="ibl-search__input" value="' . $query . '" placeholder="Search...">';
         $safeSearch = HtmlSanitizer::safeHtmlOutput(_SEARCH);
-        $output .= '<button type="submit" class="ibl-search__btn">' . $safeSearch . '</button>';
-        $output .= '</div></div>';
-
-        // Filter row
-        $output .= '<div class="search-form__filters">';
-        $output .= $this->renderTopicSelect($data['topics'], $data['topic']);
-        $output .= $this->renderCategorySelect($data['categories'], $data['category']);
-        $output .= $this->renderAuthorSelect($data['authors'], $data['author']);
-        $output .= $this->renderDaysSelect($data['days']);
-        $output .= '</div>';
-
-        // Search type radio buttons
-        $output .= '<div class="search-form__types">';
         $safeSearchOn = HtmlSanitizer::safeHtmlOutput(_SEARCHON);
-        $output .= '<span class="search-form__types-label">' . $safeSearchOn . '</span>';
         /** @var string $storiesLabel */
         $storiesLabel = _SSTORIES;
-        $output .= $this->renderTypeRadio('stories', $storiesLabel, $type);
+        /** @var string $usersLabel */
+        $usersLabel = _SUSERS;
 
+        ob_start();
+        ?><form action="modules.php?name=Search" method="post" class="search-form"><div class="search-form__input-row"><div class="ibl-search search-form__search-bar"><svg class="ibl-search__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg><input type="text" name="query" class="ibl-search__input" value="<?= HtmlSanitizer::trusted($query) ?>" placeholder="Search..."><button type="submit" class="ibl-search__btn"><?= HtmlSanitizer::trusted($safeSearch) ?></button></div></div><div class="search-form__filters"><?= HtmlSanitizer::trusted($this->renderTopicSelect($data['topics'], $data['topic'])) ?><?= HtmlSanitizer::trusted($this->renderCategorySelect($data['categories'], $data['category'])) ?><?= HtmlSanitizer::trusted($this->renderAuthorSelect($data['authors'], $data['author'])) ?><?= HtmlSanitizer::trusted($this->renderDaysSelect($data['days'])) ?></div><div class="search-form__types"><span class="search-form__types-label"><?= HtmlSanitizer::trusted($safeSearchOn) ?></span><?= HtmlSanitizer::trusted($this->renderTypeRadio('stories', $storiesLabel, $type)) ?><?php
         if ($data['articleComm']) {
             /** @var string $commentsLabel */
             $commentsLabel = _SCOMMENTS;
-            $output .= $this->renderTypeRadio('comments', $commentsLabel, $type);
+            ?><?= HtmlSanitizer::trusted($this->renderTypeRadio('comments', $commentsLabel, $type)) ?><?php
         }
-
-        /** @var string $usersLabel */
-        $usersLabel = _SUSERS;
-        $output .= $this->renderTypeRadio('users', $usersLabel, $type);
-        $output .= '</div>';
-
-        $output .= '</form>';
-
-        return $output;
+        ?><?= HtmlSanitizer::trusted($this->renderTypeRadio('users', $usersLabel, $type)) ?></div></form><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -132,19 +103,17 @@ class SearchView implements SearchViewInterface
      */
     private function renderTopicSelect(array $topics, int $selectedTopic): string
     {
-        $output = '<select name="topic" aria-label="Topic" class="search-form__select">';
         $safeAllTopics = HtmlSanitizer::safeHtmlOutput(_ALLTOPICS);
-        $output .= '<option value="">' . $safeAllTopics . '</option>';
-
+        ob_start();
+        ?><select name="topic" aria-label="Topic" class="search-form__select"><option value=""><?= HtmlSanitizer::trusted($safeAllTopics) ?></option><?php
         foreach ($topics as $topic) {
             $topicId = $topic['topicId'];
             $topicText = HtmlSanitizer::safeHtmlOutput($topic['topicText']);
             $selected = ($topicId === $selectedTopic) ? ' selected' : '';
-            $output .= '<option value="' . $topicId . '"' . $selected . '>' . $topicText . '</option>';
+            ?><option value="<?= HtmlSanitizer::trusted((string) $topicId) ?>"<?= HtmlSanitizer::trusted($selected) ?>><?= HtmlSanitizer::trusted($topicText) ?></option><?php
         }
-
-        $output .= '</select>';
-        return $output;
+        ?></select><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -154,19 +123,17 @@ class SearchView implements SearchViewInterface
      */
     private function renderCategorySelect(array $categories, int $selectedCategory): string
     {
-        $output = '<select name="category" aria-label="Category" class="search-form__select">';
         $safeArticles = HtmlSanitizer::safeHtmlOutput(_ARTICLES);
-        $output .= '<option value="0">' . $safeArticles . '</option>';
-
+        ob_start();
+        ?><select name="category" aria-label="Category" class="search-form__select"><option value="0"><?= HtmlSanitizer::trusted($safeArticles) ?></option><?php
         foreach ($categories as $cat) {
             $catId = $cat['catId'];
             $title = HtmlSanitizer::safeHtmlOutput($cat['title']);
             $selected = ($catId === $selectedCategory) ? ' selected' : '';
-            $output .= '<option value="' . $catId . '"' . $selected . '>' . $title . '</option>';
+            ?><option value="<?= HtmlSanitizer::trusted((string) $catId) ?>"<?= HtmlSanitizer::trusted($selected) ?>><?= HtmlSanitizer::trusted($title) ?></option><?php
         }
-
-        $output .= '</select>';
-        return $output;
+        ?></select><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -176,18 +143,16 @@ class SearchView implements SearchViewInterface
      */
     private function renderAuthorSelect(array $authors, string $selectedAuthor): string
     {
-        $output = '<select name="author" aria-label="Author" class="search-form__select">';
         $safeAllAuthors = HtmlSanitizer::safeHtmlOutput(_ALLAUTHORS);
-        $output .= '<option value="">' . $safeAllAuthors . '</option>';
-
+        ob_start();
+        ?><select name="author" aria-label="Author" class="search-form__select"><option value=""><?= HtmlSanitizer::trusted($safeAllAuthors) ?></option><?php
         foreach ($authors as $authorName) {
             $safe = HtmlSanitizer::safeHtmlOutput($authorName);
             $selected = ($authorName === $selectedAuthor) ? ' selected' : '';
-            $output .= '<option value="' . $safe . '"' . $selected . '>' . $safe . '</option>';
+            ?><option value="<?= HtmlSanitizer::trusted($safe) ?>"<?= HtmlSanitizer::trusted($selected) ?>><?= HtmlSanitizer::trusted($safe) ?></option><?php
         }
-
-        $output .= '</select>';
-        return $output;
+        ?></select><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -216,16 +181,15 @@ class SearchView implements SearchViewInterface
             90 => '3 ' . $monthsLabel,
         ];
 
-        $output = '<select name="days" aria-label="Date range" class="search-form__select">';
-
+        ob_start();
+        ?><select name="days" aria-label="Date range" class="search-form__select"><?php
         foreach ($options as $value => $label) {
             $selected = ($value === $selectedDays) ? ' selected' : '';
             $safeLabel = HtmlSanitizer::safeHtmlOutput($label);
-            $output .= '<option value="' . $value . '"' . $selected . '>' . $safeLabel . '</option>';
+            ?><option value="<?= HtmlSanitizer::trusted((string) $value) ?>"<?= HtmlSanitizer::trusted($selected) ?>><?= HtmlSanitizer::trusted($safeLabel) ?></option><?php
         }
-
-        $output .= '</select>';
-        return $output;
+        ?></select><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -237,10 +201,12 @@ class SearchView implements SearchViewInterface
         $id = 'search-type-' . $value;
 
         $safeLabel = HtmlSanitizer::safeHtmlOutput($label);
-        return '<label class="search-form__type" for="' . $id . '">
-            <input type="radio" name="type" value="' . $value . '" id="' . $id . '"' . $checked . '>
-            <span class="search-form__type-label">' . $safeLabel . '</span>
-        </label>';
+        ob_start();
+        ?><label class="search-form__type" for="<?= HtmlSanitizer::trusted($id) ?>">
+            <input type="radio" name="type" value="<?= HtmlSanitizer::trusted($value) ?>" id="<?= HtmlSanitizer::trusted($id) ?>"<?= HtmlSanitizer::trusted($checked) ?>>
+            <span class="search-form__type-label"><?= HtmlSanitizer::trusted($safeLabel) ?></span>
+        </label><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -249,7 +215,9 @@ class SearchView implements SearchViewInterface
     private function renderError(string $error): string
     {
         $safeError = HtmlSanitizer::safeHtmlOutput($error);
-        return '<div class="ibl-alert ibl-alert--error search-error">' . $safeError . '</div>';
+        ob_start();
+        ?><div class="ibl-alert ibl-alert--error search-error"><?= HtmlSanitizer::trusted($safeError) ?></div><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -266,35 +234,45 @@ class SearchView implements SearchViewInterface
             return '';
         }
 
-        $output = '<div class="search-results">';
         $safeSearchResults = HtmlSanitizer::safeHtmlOutput(_SEARCHRESULTS);
-        $output .= '<h3 class="search-results__heading">' . $safeSearchResults . '</h3>';
-
+        ob_start();
+        ?><div class="search-results"><h3 class="search-results__heading"><?= HtmlSanitizer::trusted($safeSearchResults) ?></h3><?php
         if (count($results) === 0) {
             $safeNoMatches = HtmlSanitizer::safeHtmlOutput(_NOMATCHES);
-            $output .= '<div class="ibl-empty-state"><p class="ibl-empty-state__text">' . $safeNoMatches . '</p></div>';
-            $output .= '</div>';
-            return $output;
+            ?><div class="ibl-empty-state"><p class="ibl-empty-state__text"><?= HtmlSanitizer::trusted($safeNoMatches) ?></p></div></div><?php
+            return (string) ob_get_clean();
         }
-
         if ($type === 'comments') {
             /** @var list<CommentResult> $commentResults */
             $commentResults = $results;
-            $output .= $this->renderCommentResults($commentResults);
+            ?><?= HtmlSanitizer::trusted($this->renderCommentResults($commentResults)) ?><?php
         } elseif ($type === 'users') {
             /** @var list<UserResult> $userResults */
             $userResults = $results;
-            $output .= $this->renderUserResults($userResults);
+            ?><?= HtmlSanitizer::trusted($this->renderUserResults($userResults)) ?><?php
         } else {
             /** @var list<StoryResult> $storyResults */
             $storyResults = $results;
-            $output .= $this->renderStoryResults($storyResults);
+            ?><?= HtmlSanitizer::trusted($this->renderStoryResults($storyResults)) ?><?php
         }
+        ?><?= HtmlSanitizer::trusted($this->renderPagination($data)) ?></div><?php
+        return (string) ob_get_clean();
+    }
 
-        $output .= $this->renderPagination($data);
-        $output .= '</div>';
-
-        return $output;
+    /**
+     * Wrap pre-built per-item card bodies in the shared results-list scaffold.
+     *
+     * @param list<string> $itemBodies Already-escaped inner HTML for each card body
+     * @param string       $itemModifier Extra class appended to "search-result"
+     *                                    ('' for stories/comments, ' search-result--compact' for users)
+     */
+    private function renderResultList(array $itemBodies, string $itemModifier = ''): string
+    {
+        ob_start();
+        ?><div class="search-results__list"><?php foreach ($itemBodies as $index => $itemBody) {
+            $delay = min($index * 40, 400);
+        ?><div class="search-result<?= HtmlSanitizer::trusted($itemModifier) ?>" style="--anim-delay: <?= (int) $delay ?>ms"><?= HtmlSanitizer::trusted($itemBody) ?></div><?php } ?></div><?php
+        return (string) ob_get_clean();
     }
 
     /**
@@ -304,9 +282,8 @@ class SearchView implements SearchViewInterface
      */
     private function renderStoryResults(array $results): string
     {
-        $output = '<div class="search-results__list">';
-
-        foreach ($results as $index => $result) {
+        $itemBodies = [];
+        foreach ($results as $result) {
             $sid = $result['sid'];
             $title = HtmlSanitizer::safeHtmlOutput($result['title']);
             $aid = HtmlSanitizer::safeHtmlOutput($result['aid']);
@@ -315,47 +292,35 @@ class SearchView implements SearchViewInterface
             $comments = $result['comments'];
             $topicId = $result['topicId'];
             $topicText = HtmlSanitizer::safeHtmlOutput($result['topicText']);
-            $delay = min($index * 40, 400);
 
-            $output .= '<div class="search-result" style="--anim-delay: ' . $delay . 'ms">';
-            $output .= '<div class="search-result__header">';
-            $output .= '<a href="modules.php?name=News&amp;file=article&amp;sid=' . $sid . '" class="search-result__title">' . $title . '</a>';
-            $output .= '</div>';
-
-            $output .= '<div class="search-result__meta">';
-
+            ob_start();
+            ?><div class="search-result__header"><a href="modules.php?name=News&amp;file=article&amp;sid=<?= (int) $sid ?>" class="search-result__title"><?= HtmlSanitizer::trusted($title) ?></a></div><div class="search-result__meta"><?php
             if ($informant !== '') {
                 $safeContributedBy = HtmlSanitizer::safeHtmlOutput(_CONTRIBUTEDBY);
-                $output .= '<span class="search-result__meta-item">' . $safeContributedBy . ' ' . $informant . '</span>';
+                ?><span class="search-result__meta-item"><?= HtmlSanitizer::trusted($safeContributedBy) ?> <?= HtmlSanitizer::trusted($informant) ?></span><?php
             }
-
             $safePostedBy = HtmlSanitizer::safeHtmlOutput(_POSTEDBY);
             $safeOn = HtmlSanitizer::safeHtmlOutput(_ON);
-            $output .= '<span class="search-result__meta-item">' . $safePostedBy . ' ' . $aid . ' ' . $safeOn . ' ' . $time . '</span>';
-
+            ?><span class="search-result__meta-item"><?= HtmlSanitizer::trusted($safePostedBy) ?> <?= HtmlSanitizer::trusted($aid) ?> <?= HtmlSanitizer::trusted($safeOn) ?> <?= HtmlSanitizer::trusted($time) ?></span><?php
             if ($topicText !== '') {
                 $safeTopic = HtmlSanitizer::safeHtmlOutput(_TOPIC);
-                $output .= '<span class="search-result__meta-item">' . $safeTopic . ': <a href="modules.php?name=Search&amp;query=&amp;topic=' . $topicId . '">' . $topicText . '</a></span>';
+                ?><span class="search-result__meta-item"><?= HtmlSanitizer::trusted($safeTopic) ?>: <a href="modules.php?name=Search&amp;query=&amp;topic=<?= (int) $topicId ?>"><?= HtmlSanitizer::trusted($topicText) ?></a></span><?php
             }
-
-            $output .= '<span class="search-result__meta-item">';
+            ?><span class="search-result__meta-item"><?php
             if ($comments === 0) {
                 $safeNoComments = HtmlSanitizer::safeHtmlOutput(_NOCOMMENTS);
-                $output .= $safeNoComments;
+                ?><?= HtmlSanitizer::trusted($safeNoComments) ?><?php
             } elseif ($comments === 1) {
                 $safeUComment = HtmlSanitizer::safeHtmlOutput(_UCOMMENT);
-                $output .= $comments . ' ' . $safeUComment;
+                ?><?= HtmlSanitizer::trusted((string) $comments) ?> <?= HtmlSanitizer::trusted($safeUComment) ?><?php
             } else {
                 $safeUComments = HtmlSanitizer::safeHtmlOutput(_UCOMMENTS);
-                $output .= $comments . ' ' . $safeUComments;
+                ?><?= HtmlSanitizer::trusted((string) $comments) ?> <?= HtmlSanitizer::trusted($safeUComments) ?><?php
             }
-            $output .= '</span>';
-
-            $output .= '</div></div>';
+            ?></span></div><?php
+            $itemBodies[] = (string) ob_get_clean();
         }
-
-        $output .= '</div>';
-        return $output;
+        return $this->renderResultList($itemBodies);
     }
 
     /**
@@ -365,9 +330,8 @@ class SearchView implements SearchViewInterface
      */
     private function renderCommentResults(array $results): string
     {
-        $output = '<div class="search-results__list">';
-
-        foreach ($results as $index => $result) {
+        $itemBodies = [];
+        foreach ($results as $result) {
             $teamid = $result['teamid'];
             $sid = $result['sid'];
             $subject = HtmlSanitizer::safeHtmlOutput($result['subject']);
@@ -375,36 +339,25 @@ class SearchView implements SearchViewInterface
             $name = HtmlSanitizer::safeHtmlOutput($result['name']);
             $articleTitle = HtmlSanitizer::safeHtmlOutput($result['articleTitle']);
             $replyCount = $result['replyCount'];
-            $delay = min($index * 40, 400);
 
-            $output .= '<div class="search-result" style="--anim-delay: ' . $delay . 'ms">';
-            $output .= '<div class="search-result__header">';
-            $output .= '<a href="modules.php?name=News&amp;file=article&amp;thold=-1&amp;mode=flat&amp;order=1&amp;sid=' . $sid . '#' . $teamid . '" class="search-result__title">' . $subject . '</a>';
-            $output .= '</div>';
-
-            $output .= '<div class="search-result__meta">';
-
+            ob_start();
+            ?><div class="search-result__header"><a href="modules.php?name=News&amp;file=article&amp;thold=-1&amp;mode=flat&amp;order=1&amp;sid=<?= (int) $sid ?>#<?= (int) $teamid ?>" class="search-result__title"><?= HtmlSanitizer::trusted($subject) ?></a></div><div class="search-result__meta"><?php
             if ($name !== '') {
                 $safePostedBy = HtmlSanitizer::safeHtmlOutput(_POSTEDBY);
                 $safeOn = HtmlSanitizer::safeHtmlOutput(_ON);
-                $output .= '<span class="search-result__meta-item">' . $safePostedBy . ' ' . $name . ' ' . $safeOn . ' ' . $date . '</span>';
+                ?><span class="search-result__meta-item"><?= HtmlSanitizer::trusted($safePostedBy) ?> <?= HtmlSanitizer::trusted($name) ?> <?= HtmlSanitizer::trusted($safeOn) ?> <?= HtmlSanitizer::trusted($date) ?></span><?php
             }
-
             if ($articleTitle !== '') {
                 $safeAttachArt = HtmlSanitizer::safeHtmlOutput(_ATTACHART);
-                $output .= '<span class="search-result__meta-item">' . $safeAttachArt . ': ' . $articleTitle . '</span>';
+                ?><span class="search-result__meta-item"><?= HtmlSanitizer::trusted($safeAttachArt) ?>: <?= HtmlSanitizer::trusted($articleTitle) ?></span><?php
             }
-
             /** @var string $replyLabel */
             $replyLabel = ($replyCount === 1) ? _SREPLY : _SREPLIES;
             $safeReplyLabel = HtmlSanitizer::safeHtmlOutput($replyLabel);
-            $output .= '<span class="search-result__meta-item">' . $replyCount . ' ' . $safeReplyLabel . '</span>';
-
-            $output .= '</div></div>';
+            ?><span class="search-result__meta-item"><?= (int) $replyCount ?> <?= HtmlSanitizer::trusted($safeReplyLabel) ?></span></div><?php
+            $itemBodies[] = (string) ob_get_clean();
         }
-
-        $output .= '</div>';
-        return $output;
+        return $this->renderResultList($itemBodies);
     }
 
     /**
@@ -414,28 +367,19 @@ class SearchView implements SearchViewInterface
      */
     private function renderUserResults(array $results): string
     {
-        $output = '<div class="search-results__list">';
-
-        foreach ($results as $index => $result) {
-            $userId = $result['userId'];
+        $itemBodies = [];
+        foreach ($results as $result) {
             $username = HtmlSanitizer::safeHtmlOutput($result['username']);
             $name = HtmlSanitizer::safeHtmlOutput($result['name']);
-            $delay = min($index * 40, 400);
 
             $safeNoName = HtmlSanitizer::safeHtmlOutput(_NONAME);
             $displayName = ($name !== '') ? $name : $safeNoName;
 
-            $output .= '<div class="search-result search-result--compact" style="--anim-delay: ' . $delay . 'ms">';
-            $output .= '<div class="search-result__header">';
-            $output .= '<span class="search-result__title">' . $username . '</span>';
-            $output .= '<span class="search-result__subtitle">' . $displayName . '</span>';
-            $output .= '</div>';
-
-            $output .= '</div>';
+            ob_start();
+            ?><div class="search-result__header"><span class="search-result__title"><?= HtmlSanitizer::trusted($username) ?></span><span class="search-result__subtitle"><?= HtmlSanitizer::trusted($displayName) ?></span></div><?php
+            $itemBodies[] = (string) ob_get_clean();
         }
-
-        $output .= '</div>';
-        return $output;
+        return $this->renderResultList($itemBodies, ' search-result--compact');
     }
 
     /**
@@ -460,26 +404,20 @@ class SearchView implements SearchViewInterface
             return '';
         }
 
-        $output = '<div class="search-pagination">';
-
+        ob_start();
+        ?><div class="search-pagination"><?php
         if ($hasPrev) {
             $prev = $min - $offset;
-            $output .= '<a href="modules.php?name=Search&amp;author=' . $author . '&amp;topic=' . $topic . '&amp;min=' . $prev . '&amp;query=' . $query . '&amp;type=' . $type . '&amp;category=' . $category . '" class="search-pagination__link search-pagination__link--prev">';
             $safePrevMatches = HtmlSanitizer::safeHtmlOutput(_PREVMATCHES);
-            $output .= '&larr; ' . $safePrevMatches;
-            $output .= '</a>';
+            ?><a href="modules.php?name=Search&amp;author=<?= HtmlSanitizer::trusted($author) ?>&amp;topic=<?= HtmlSanitizer::trusted((string) $topic) ?>&amp;min=<?= HtmlSanitizer::trusted((string) $prev) ?>&amp;query=<?= HtmlSanitizer::trusted($query) ?>&amp;type=<?= HtmlSanitizer::trusted($type) ?>&amp;category=<?= HtmlSanitizer::trusted((string) $category) ?>" class="search-pagination__link search-pagination__link--prev">&larr; <?= HtmlSanitizer::trusted($safePrevMatches) ?></a><?php
         }
-
         if ($hasMore) {
             $next = $min + $offset;
-            $output .= '<a href="modules.php?name=Search&amp;author=' . $author . '&amp;topic=' . $topic . '&amp;min=' . $next . '&amp;query=' . $query . '&amp;type=' . $type . '&amp;category=' . $category . '" class="search-pagination__link search-pagination__link--next">';
             $safeNextMatches = HtmlSanitizer::safeHtmlOutput(_NEXTMATCHES);
-            $output .= $safeNextMatches . ' &rarr;';
-            $output .= '</a>';
+            ?><a href="modules.php?name=Search&amp;author=<?= HtmlSanitizer::trusted($author) ?>&amp;topic=<?= HtmlSanitizer::trusted((string) $topic) ?>&amp;min=<?= HtmlSanitizer::trusted((string) $next) ?>&amp;query=<?= HtmlSanitizer::trusted($query) ?>&amp;type=<?= HtmlSanitizer::trusted($type) ?>&amp;category=<?= HtmlSanitizer::trusted((string) $category) ?>" class="search-pagination__link search-pagination__link--next"><?= HtmlSanitizer::trusted($safeNextMatches) ?> &rarr;</a><?php
         }
-
-        $output .= '</div>';
-        return $output;
+        ?></div><?php
+        return (string) ob_get_clean();
     }
 
 }

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -98,7 +98,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 1.17 | ◑ Partial | 🟩 | Constructor logger injected w/ `db` fallback (#1089, L585), but the `perf` channel is still static `LoggerFactory::getChannel('perf')` at L281. Inject perf logger; green-green. |
 | 1.18 | ⬜ Open | 🟩 | 11 `echo` in StandingsUpdater (verified). echo→LoggerInterface; remove dead `$log`; `82`→`League` const. CLI. |
 | 1.19 | ⬜ Open | 🟨 | `processPlrData`+`processPlrDataForYear` 80% duplicated; 510 LOC. `.plr` parse is engine-fidelity-critical → add characterization pins (mechanical scope) before merging the two paths, then 🟩. |
-| 1.20 | ⬜ Open | 🟩 | SearchView 485 LOC string-concat. Extract `renderResultTable()` + ob_start migration; VR pin. |
+| 1.20 | ✅ Implemented | 🟩 | SearchView 485 LOC string-concat. Extracted `renderResultList()` + ob_start migration; VR pin. |
 
 ### 1.1 RecordHoldersService — Hardcoded Team Registry + Multi-Concern Formatter
 **Location:** `ibl5/classes/RecordHolders/RecordHoldersService.php`
@@ -248,6 +248,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Extract `renderResultTable(string $title, array $headers, array $rows): string`; migrate to `ob_start()`.
 **Est. effort:** S
 **Risk if untouched:** New result types require copy-paste; `NukeCompat` dep invisible in type signature.
+**Status:** Implemented (2026-06-26) — migrated all renderers to `ob_start()` and extracted shared `renderResultList()` scaffold; byte-identical output (golden-master test + VR pin); escaping preserved (`RequireEscapedOutputRule` green).
 
 ---
 

--- a/ibl5/phpstan-tests-baseline.neon
+++ b/ibl5/phpstan-tests-baseline.neon
@@ -253,12 +253,6 @@ parameters:
 			path: tests/Player/PlayerImageHelperTest.php
 
 		-
-			rawMessage: 'Parameter #1 $data of method Search\SearchView::render() expects array{query: string, type: string, topic: int, category: int, author: string, days: int, min: int, offset: int, ...}, array{query: string, type: string, topic: int, category: int, author: string, days: int, min: int, offset: int, ...} given.'
-			identifier: argument.type
-			count: 6
-			path: tests/Search/SearchViewTest.php
-
-		-
 			rawMessage: 'Parameter #1 $games of method Statistics\TeamStatsCalculator::calculate() expects list<array{visitor_teamid: int, visitor_score: int, home_teamid: int, home_score: int}>, array{array{visitor_score: 100, home_score: 95}} given.'
 			identifier: argument.type
 			count: 1

--- a/ibl5/tests/Search/SearchViewTest.php
+++ b/ibl5/tests/Search/SearchViewTest.php
@@ -238,9 +238,129 @@ class SearchViewTest extends TestCase
         $this->assertStringContainsString('Basketball', $html);
     }
 
+    // --- Golden-master characterization tests (Phase 0) ---
+
+    public function testGoldenMasterStories(): void
+    {
+        $data = self::createPageData([
+            'query' => 'basketball',
+            'topicText' => 'All Topics',
+            'offset' => 10,
+            'results' => [
+                ['sid' => 1, 'aid' => 'admin', 'informant' => 'reporter', 'title' => 'Story One', 'time' => 1700000000, 'comments' => 0, 'topicId' => 1, 'topicText' => 'News'],
+                ['sid' => 2, 'aid' => 'editor', 'informant' => '', 'title' => 'Story Two', 'time' => 1700000000, 'comments' => 1, 'topicId' => 0, 'topicText' => ''],
+                ['sid' => 3, 'aid' => 'writer', 'informant' => 'contrib', 'title' => 'Story Three', 'time' => 1700000000, 'comments' => 5, 'topicId' => 2, 'topicText' => 'Sports'],
+            ],
+            'hasMore' => true,
+        ]);
+
+        $expected = <<<'STORIES_GOLDEN'
+<div class="search-page"><h1 class="ibl-title">Search in All Topics</h1><form action="modules.php?name=Search" method="post" class="search-form"><div class="search-form__input-row"><div class="ibl-search search-form__search-bar"><svg class="ibl-search__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg><input type="text" name="query" class="ibl-search__input" value="basketball" placeholder="Search..."><button type="submit" class="ibl-search__btn">Search</button></div></div><div class="search-form__filters"><select name="topic" aria-label="Topic" class="search-form__select"><option value="">All Topics</option></select><select name="category" aria-label="Category" class="search-form__select"><option value="0">All Categories</option></select><select name="author" aria-label="Author" class="search-form__select"><option value="">All Authors</option></select><select name="days" aria-label="Date range" class="search-form__select"><option value="0" selected>All</option><option value="7">1 Week</option><option value="14">2 Weeks</option><option value="30">1 Month</option><option value="60">2 Months</option><option value="90">3 Months</option></select></div><div class="search-form__types"><span class="search-form__types-label">Search on</span><label class="search-form__type" for="search-type-stories">
+            <input type="radio" name="type" value="stories" id="search-type-stories" checked>
+            <span class="search-form__type-label">Stories</span>
+        </label><label class="search-form__type" for="search-type-users">
+            <input type="radio" name="type" value="users" id="search-type-users">
+            <span class="search-form__type-label">Users</span>
+        </label></div></form><div class="search-results"><h3 class="search-results__heading">Search Results</h3><div class="search-results__list"><div class="search-result" style="--anim-delay: 0ms"><div class="search-result__header"><a href="modules.php?name=News&amp;file=article&amp;sid=1" class="search-result__title">Story One</a></div><div class="search-result__meta"><span class="search-result__meta-item">Contributed by reporter</span><span class="search-result__meta-item">Posted by admin on <time datetime="2023-11-14T22:13:20+00:00" class="local-time">Tuesday, November 14 @ 22:13 GMT</time></span><span class="search-result__meta-item">Topic: <a href="modules.php?name=Search&amp;query=&amp;topic=1">News</a></span><span class="search-result__meta-item">No comments</span></div></div><div class="search-result" style="--anim-delay: 40ms"><div class="search-result__header"><a href="modules.php?name=News&amp;file=article&amp;sid=2" class="search-result__title">Story Two</a></div><div class="search-result__meta"><span class="search-result__meta-item">Posted by editor on <time datetime="2023-11-14T22:13:20+00:00" class="local-time">Tuesday, November 14 @ 22:13 GMT</time></span><span class="search-result__meta-item">1 comment</span></div></div><div class="search-result" style="--anim-delay: 80ms"><div class="search-result__header"><a href="modules.php?name=News&amp;file=article&amp;sid=3" class="search-result__title">Story Three</a></div><div class="search-result__meta"><span class="search-result__meta-item">Contributed by contrib</span><span class="search-result__meta-item">Posted by writer on <time datetime="2023-11-14T22:13:20+00:00" class="local-time">Tuesday, November 14 @ 22:13 GMT</time></span><span class="search-result__meta-item">Topic: <a href="modules.php?name=Search&amp;query=&amp;topic=2">Sports</a></span><span class="search-result__meta-item">5 comments</span></div></div></div><div class="search-pagination"><a href="modules.php?name=Search&amp;author=&amp;topic=0&amp;min=10&amp;query=basketball&amp;type=stories&amp;category=0" class="search-pagination__link search-pagination__link--next">Next Matches &rarr;</a></div></div></div>
+STORIES_GOLDEN;
+
+        $this->assertSame($expected, $this->view->render($data));
+    }
+
+    public function testGoldenMasterComments(): void
+    {
+        $data = self::createPageData([
+            'query' => 'basketball',
+            'type' => 'comments',
+            'topicText' => 'All Topics',
+            'articleComm' => true,
+            'results' => [
+                ['teamid' => 11, 'sid' => 10, 'subject' => 'Comment One', 'date' => 1700000000, 'name' => 'Alice', 'articleTitle' => 'Article A', 'replyCount' => 1],
+                ['teamid' => 22, 'sid' => 20, 'subject' => 'Comment Two', 'date' => 1700000000, 'name' => '', 'articleTitle' => 'Article B', 'replyCount' => 3],
+            ],
+        ]);
+
+        $expected = <<<'COMMENTS_GOLDEN'
+<div class="search-page"><h1 class="ibl-title">Search in All Topics</h1><form action="modules.php?name=Search" method="post" class="search-form"><div class="search-form__input-row"><div class="ibl-search search-form__search-bar"><svg class="ibl-search__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg><input type="text" name="query" class="ibl-search__input" value="basketball" placeholder="Search..."><button type="submit" class="ibl-search__btn">Search</button></div></div><div class="search-form__filters"><select name="topic" aria-label="Topic" class="search-form__select"><option value="">All Topics</option></select><select name="category" aria-label="Category" class="search-form__select"><option value="0">All Categories</option></select><select name="author" aria-label="Author" class="search-form__select"><option value="">All Authors</option></select><select name="days" aria-label="Date range" class="search-form__select"><option value="0" selected>All</option><option value="7">1 Week</option><option value="14">2 Weeks</option><option value="30">1 Month</option><option value="60">2 Months</option><option value="90">3 Months</option></select></div><div class="search-form__types"><span class="search-form__types-label">Search on</span><label class="search-form__type" for="search-type-stories">
+            <input type="radio" name="type" value="stories" id="search-type-stories">
+            <span class="search-form__type-label">Stories</span>
+        </label><label class="search-form__type" for="search-type-comments">
+            <input type="radio" name="type" value="comments" id="search-type-comments" checked>
+            <span class="search-form__type-label">Comments</span>
+        </label><label class="search-form__type" for="search-type-users">
+            <input type="radio" name="type" value="users" id="search-type-users">
+            <span class="search-form__type-label">Users</span>
+        </label></div></form><div class="search-results"><h3 class="search-results__heading">Search Results</h3><div class="search-results__list"><div class="search-result" style="--anim-delay: 0ms"><div class="search-result__header"><a href="modules.php?name=News&amp;file=article&amp;thold=-1&amp;mode=flat&amp;order=1&amp;sid=10#11" class="search-result__title">Comment One</a></div><div class="search-result__meta"><span class="search-result__meta-item">Posted by Alice on <time datetime="2023-11-14T22:13:20+00:00" class="local-time">Tuesday, November 14 @ 22:13 GMT</time></span><span class="search-result__meta-item">Attached Article: Article A</span><span class="search-result__meta-item">1 reply</span></div></div><div class="search-result" style="--anim-delay: 40ms"><div class="search-result__header"><a href="modules.php?name=News&amp;file=article&amp;thold=-1&amp;mode=flat&amp;order=1&amp;sid=20#22" class="search-result__title">Comment Two</a></div><div class="search-result__meta"><span class="search-result__meta-item">Attached Article: Article B</span><span class="search-result__meta-item">3 replies</span></div></div></div></div></div>
+COMMENTS_GOLDEN;
+
+        $this->assertSame($expected, $this->view->render($data));
+    }
+
+    public function testGoldenMasterUsers(): void
+    {
+        $data = self::createPageData([
+            'query' => 'basketball',
+            'type' => 'users',
+            'topicText' => 'All Topics',
+            'results' => [
+                ['userId' => 1, 'username' => 'alice', 'name' => 'Alice Smith'],
+                ['userId' => 2, 'username' => 'bob', 'name' => ''],
+            ],
+        ]);
+
+        $expected = <<<'USERS_GOLDEN'
+<div class="search-page"><h1 class="ibl-title">Search Users</h1><form action="modules.php?name=Search" method="post" class="search-form"><div class="search-form__input-row"><div class="ibl-search search-form__search-bar"><svg class="ibl-search__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg><input type="text" name="query" class="ibl-search__input" value="basketball" placeholder="Search..."><button type="submit" class="ibl-search__btn">Search</button></div></div><div class="search-form__filters"><select name="topic" aria-label="Topic" class="search-form__select"><option value="">All Topics</option></select><select name="category" aria-label="Category" class="search-form__select"><option value="0">All Categories</option></select><select name="author" aria-label="Author" class="search-form__select"><option value="">All Authors</option></select><select name="days" aria-label="Date range" class="search-form__select"><option value="0" selected>All</option><option value="7">1 Week</option><option value="14">2 Weeks</option><option value="30">1 Month</option><option value="60">2 Months</option><option value="90">3 Months</option></select></div><div class="search-form__types"><span class="search-form__types-label">Search on</span><label class="search-form__type" for="search-type-stories">
+            <input type="radio" name="type" value="stories" id="search-type-stories">
+            <span class="search-form__type-label">Stories</span>
+        </label><label class="search-form__type" for="search-type-users">
+            <input type="radio" name="type" value="users" id="search-type-users" checked>
+            <span class="search-form__type-label">Users</span>
+        </label></div></form><div class="search-results"><h3 class="search-results__heading">Search Results</h3><div class="search-results__list"><div class="search-result search-result--compact" style="--anim-delay: 0ms"><div class="search-result__header"><span class="search-result__title">alice</span><span class="search-result__subtitle">Alice Smith</span></div></div><div class="search-result search-result--compact" style="--anim-delay: 40ms"><div class="search-result__header"><span class="search-result__title">bob</span><span class="search-result__subtitle">Anonymous</span></div></div></div></div></div>
+USERS_GOLDEN;
+
+        $this->assertSame($expected, $this->view->render($data));
+    }
+
+    public function testGoldenMasterEmptyResults(): void
+    {
+        $data = self::createPageData([
+            'query' => 'test',
+            'topicText' => 'All Topics',
+            'results' => [],
+        ]);
+
+        $expected = <<<'EMPTY_GOLDEN'
+<div class="search-page"><h1 class="ibl-title">Search in All Topics</h1><form action="modules.php?name=Search" method="post" class="search-form"><div class="search-form__input-row"><div class="ibl-search search-form__search-bar"><svg class="ibl-search__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg><input type="text" name="query" class="ibl-search__input" value="test" placeholder="Search..."><button type="submit" class="ibl-search__btn">Search</button></div></div><div class="search-form__filters"><select name="topic" aria-label="Topic" class="search-form__select"><option value="">All Topics</option></select><select name="category" aria-label="Category" class="search-form__select"><option value="0">All Categories</option></select><select name="author" aria-label="Author" class="search-form__select"><option value="">All Authors</option></select><select name="days" aria-label="Date range" class="search-form__select"><option value="0" selected>All</option><option value="7">1 Week</option><option value="14">2 Weeks</option><option value="30">1 Month</option><option value="60">2 Months</option><option value="90">3 Months</option></select></div><div class="search-form__types"><span class="search-form__types-label">Search on</span><label class="search-form__type" for="search-type-stories">
+            <input type="radio" name="type" value="stories" id="search-type-stories" checked>
+            <span class="search-form__type-label">Stories</span>
+        </label><label class="search-form__type" for="search-type-users">
+            <input type="radio" name="type" value="users" id="search-type-users">
+            <span class="search-form__type-label">Users</span>
+        </label></div></form><div class="search-results"><h3 class="search-results__heading">Search Results</h3><div class="ibl-empty-state"><p class="ibl-empty-state__text">No matches found</p></div></div></div>
+EMPTY_GOLDEN;
+
+        $this->assertSame($expected, $this->view->render($data));
+    }
+
+    public function testEscapesHtmlSpecialCharsInStoryTitle(): void
+    {
+        $data = self::createPageData([
+            'query' => 'test',
+            'topicText' => 'All Topics',
+            'results' => [
+                ['sid' => 99, 'aid' => 'admin', 'informant' => '', 'title' => '<script>"&\'', 'time' => 1700000000, 'comments' => 0, 'topicId' => 0, 'topicText' => ''],
+            ],
+        ]);
+
+        $html = $this->view->render($data);
+
+        $this->assertStringContainsString('&lt;script&gt;&quot;&amp;&apos;', $html);
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
     /**
      * @param array<string, mixed> $overrides
-     * @return array{query: string, type: string, topic: int, category: int, author: string, days: int, min: int, offset: int, topicText: string, topics: list<array{topicId: int, topicText: string}>, categories: list<array{catId: int, title: string}>, authors: list<string>, results: list<mixed>|null, hasMore: bool, isAdmin: bool, adminFile: string, articleComm: bool, error: string}
+     * @return array{query: string, type: string, topic: int, category: int, author: string, days: int, min: int, offset: int, topicText: string, topics: list<array{topicId: int, topicText: string}>, categories: list<array{catId: int, title: string}>, authors: list<string>, results: list<mixed>|null, hasMore: bool, articleComm: bool, error: string}
      */
     private static function createPageData(array $overrides = []): array
     {
@@ -259,13 +379,11 @@ class SearchViewTest extends TestCase
             'authors' => [],
             'results' => null,
             'hasMore' => false,
-            'isAdmin' => false,
-            'adminFile' => '',
             'articleComm' => false,
             'error' => '',
         ];
 
-        /** @var array{query: string, type: string, topic: int, category: int, author: string, days: int, min: int, offset: int, topicText: string, topics: list<array{topicId: int, topicText: string}>, categories: list<array{catId: int, title: string}>, authors: list<string>, results: list<mixed>|null, hasMore: bool, isAdmin: bool, adminFile: string, articleComm: bool, error: string} */
+        /** @var array{query: string, type: string, topic: int, category: int, author: string, days: int, min: int, offset: int, topicText: string, topics: list<array{topicId: int, topicText: string}>, categories: list<array{catId: int, title: string}>, authors: list<string>, results: list<mixed>|null, hasMore: bool, articleComm: bool, error: string} */
         return array_merge($defaults, $overrides);
     }
 }


### PR DESCRIPTION
## Summary

Backlog finding 1.20: migrates `SearchView` (485 LOC) from string concatenation to `ob_start()` output buffering, extracts shared `renderResultList()` scaffold to dedup the three result-type renderers, and produces **byte-identical** rendered HTML.

This is a behavior-preserving refactor — no rendered strings change, no new UI/UX. The byte-identical guarantee is mechanized by:
1. PHPUnit golden-master `assertSame` on literal `render()` output (all three result types + empty boundary + XSS special-char case)
2. Existing visual-regression pin (`search` VrRow with committed `search.png`/`search-mobile.png` baselines)
3. `RequireEscapedOutputRule` PHPStan enforcement (`composer run analyse` green proves no unescaped sink)

## Changes
- `ibl5/classes/Search/SearchView.php`: extracted `renderResultList()`, migrated all renderers to `ob_start()`
- `ibl5/tests/Search/SearchViewTest.php`: added golden-master byte-identity characterization tests + XSS escaping assertion
- `ibl5/docs/maintenance-backlog.md`: flip 1.20 to ✅ Implemented, add Status line, bump last_verified
- `ibl5/phpstan-tests-baseline.neon`: removed now-resolved baseline entries

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

---

Generated with [Claude Code](https://claude.ai/code)