### PR TITLE
refactor: extract regular-season-games constant in StandingsUpdater

### DIFF
--- a/ibl5/classes/League/League.php
+++ b/ibl5/classes/League/League.php
@@ -31,6 +31,9 @@ class League extends BaseMysqliRepository
     const SOFT_CAP_MAX = 5000;
     const HARD_CAP_MAX = 7000;
 
+    /** Games in a full IBL regular season (per team). */
+    const REGULAR_SEASON_GAMES = 82;
+
     const FREE_AGENTS_TEAMID = 0;
     const FREE_AGENTS_TEAM_NAME = 'Free Agents';
     const MAX_REAL_TEAMID = 28;

--- a/ibl5/classes/Updater/StandingsUpdater.php
+++ b/ibl5/classes/Updater/StandingsUpdater.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Updater;
 
+use League\League;
 use Season\Season;
 use Standings\Contracts\StandingsRepositoryInterface;
 
@@ -282,7 +283,7 @@ class StandingsUpdater {
         foreach ($standings as $team) {
             $totalGames = $team['wins'] + $team['losses'];
             $pct = $totalGames > 0 ? round($team['wins'] / $totalGames, 3) : 0.000;
-            $gamesUnplayed = 82 - $team['home_wins'] - $team['home_losses'] - $team['away_wins'] - $team['away_losses'];
+            $gamesUnplayed = League::REGULAR_SEASON_GAMES - $team['home_wins'] - $team['home_losses'] - $team['away_wins'] - $team['away_losses'];
 
             $leagueRecord = $team['wins'] . '-' . $team['losses'];
             $confRecord = $team['conf_wins'] . '-' . $team['conf_losses'];
@@ -350,7 +351,7 @@ class StandingsUpdater {
                 $belowTeamTotalLosses = 0;
             }
 
-            $magicNumber = 82 + 1 - $teamTotalWins - $belowTeamTotalLosses;
+            $magicNumber = League::REGULAR_SEASON_GAMES + 1 - $teamTotalWins - $belowTeamTotalLosses;
 
             $this->repository->updateMagicNumber($teamid, $magicNumber, $groupingMagicNumber);
             $log .= "Updated {$groupingMagicNumber} for {$teamName} to {$magicNumber}<br>";
@@ -409,7 +410,7 @@ class StandingsUpdater {
         /** @var int $leastLosingestTeamLosses */
         $leastLosingestTeamLosses = $leastLosingestTeam['losses'];
 
-        $magicNumber = 82 + 1 - $winningestTeamWins - $leastLosingestTeamLosses;
+        $magicNumber = League::REGULAR_SEASON_GAMES + 1 - $winningestTeamWins - $leastLosingestTeamLosses;
 
         if ($magicNumber > 0 && $first['wins'] === $second['wins']) {
             if ($this->repository->isRegionSeasonOver($grouping, $region)) {
@@ -460,7 +461,7 @@ class StandingsUpdater {
 
                 /** @var int $bottomTeamLosses */
                 $bottomTeamLosses = $sixLosingestTeams[$j]['losses'];
-                $magicNumber = 82 + 1 - $contendingTeamWins - $bottomTeamLosses;
+                $magicNumber = League::REGULAR_SEASON_GAMES + 1 - $contendingTeamWins - $bottomTeamLosses;
 
                 if ($magicNumber <= 0) {
                     $teamsEliminated++;

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -96,7 +96,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 1.15 | ⬜ Open | 🟩 | YourAccountView 536 LOC, 6 SVG + 6 page variants. Green-green with VR pin; auth *display* only (no auth-logic change → no security surface). |
 | 1.16 | ✅ Implemented | — | `computeJsbProduction()` moved to service (verified). |
 | 1.17 | ◑ Partial | 🟩 | Constructor logger injected w/ `db` fallback (#1089, L585), but the `perf` channel is still static `LoggerFactory::getChannel('perf')` at L281. Inject perf logger; green-green. |
-| 1.18 | ⬜ Open | 🟩 | 11 `echo` in StandingsUpdater (verified). echo→LoggerInterface; remove dead `$log`; `82`→`League` const. CLI. |
+| 1.18 | ◑ Partial | 🟩 | StandingsUpdater. `82`→`League::REGULAR_SEASON_GAMES` DONE (refactor PR). echo→logger + `$log` removal DEFERRED: behavior-changing — echoes feed the rendered pipeline `capturedLog` (UpdateStandingsStep→UpdaterController); `$log` feeds admin-rendered `DebugOutput::display`. Needs a non-`refactor:` PR. |
 | 1.19 | ⬜ Open | 🟨 | `processPlrData`+`processPlrDataForYear` 80% duplicated; 510 LOC. `.plr` parse is engine-fidelity-critical → add characterization pins (mechanical scope) before merging the two paths, then 🟩. |
 | 1.20 | ✅ Implemented | 🟩 | SearchView 485 LOC string-concat. Extracted `renderResultList()` + ob_start migration; VR pin. |
 
@@ -229,11 +229,12 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Risk if untouched:** Repository unit tests require full logging subsystem; slow-query behavior can't be disabled for tests.
 
 ### 1.18 StandingsUpdater — `echo` Mixed with Data Computation
-**Location:** `ibl5/classes/Updater/StandingsUpdater.php` lines 70, 91, 280
-**Problem:** `update()`, `computeAndInsertStandings()`, `computeAndInsertAll()` use `echo` for progress. `$log` variable built but never used. Magic constant `82` (games/season) inline.
-**Suggested direction:** Replace `echo` with `LoggerInterface`; remove dead `$log`; extract `82` to `League::REGULAR_SEASON_GAMES`.
+**Location:** `ibl5/classes/Updater/StandingsUpdater.php` (echoes at update()/computeAndInsertStandings()/computeAndInsertAll(); magic `82` at the gamesUnplayed and magic-number sites).
+**Status:** PARTIAL — magic `82` extracted to `League::REGULAR_SEASON_GAMES` (refactor PR, this batch). The echo cleanup is DEFERRED.
+**Problem:** `update()`, `computeAndInsertStandings()`, `computeAndInsertAll()` use `echo` for progress. The echoed output is NOT discardable: `UpdateStandingsStep::execute()` captures it (`ob_start`/`ob_get_clean`) into `StepResult::capturedLog` and `UpdaterController` renders it to the user as a collapsible log; the two `$log` accumulators are rendered to admins via `\UI\DebugOutput::display()`. So echo→logger and `$log` removal are behavior-changing, not a pure refactor.
+**Suggested direction:** Separate non-`refactor:` PR that migrates the echoes to a logger while preserving (or deliberately changing) the rendered pipeline/admin output; `auto_merge: false`.
 **Est. effort:** S
-**Risk if untouched:** Updater can't run from test/queue; abandoned logging intent.
+**Risk if untouched:** Progress output mixed with computation in the updater; logging intent unrealized.
 
 ### 1.19 PlrParserService — Duplicate Pass-1 Logic
 **Location:** `ibl5/classes/PlrParser/PlrParserService.php`

--- a/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
@@ -611,11 +611,6 @@ class StandingsUpdaterTest extends TestCase
         }
     }
 
-    public function testRegularSeasonGamesConstantEquals82(): void
-    {
-        $this->assertSame(82, \League\League::REGULAR_SEASON_GAMES);
-    }
-
     public function testConstructorAcceptsOptionalIsOlympicsFlag(): void
     {
         $updater = new \Updater\StandingsUpdater($this->repository, $this->mockSeason, true);

--- a/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
+++ b/ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php
@@ -611,6 +611,11 @@ class StandingsUpdaterTest extends TestCase
         }
     }
 
+    public function testRegularSeasonGamesConstantEquals82(): void
+    {
+        $this->assertSame(82, \League\League::REGULAR_SEASON_GAMES);
+    }
+
     public function testConstructorAcceptsOptionalIsOlympicsFlag(): void
     {
         $updater = new \Updater\StandingsUpdater($this->repository, $this->mockSeason, true);


### PR DESCRIPTION
## Summary

Extracts the magic constant `82` (games per IBL regular season) from `StandingsUpdater` to `League::REGULAR_SEASON_GAMES`. This is a **behavior-preserving substitution** — four literal `82`s become references to the new constant. No signatures, no logic, no rendering is changed.

## ⚠️ Backlog 1.18 Partial Close — READ BEFORE MERGING

The original backlog item 1.18 pre-resolved **three** sub-changes: (1) replace 11 `echo` with an injected `LoggerInterface`, (2) remove the "dead" `$log` variable, (3) extract magic `82` to a `League` constant.

**This PR ships only (3).** Changes (1) and (2) are NOT behavior-preserving and cannot ship under a `refactor:` / GREEN-GREEN bar:

- The 11 `echo` statements are user-rendered HTML: `UpdateStandingsStep::execute()` captures them via `ob_start()`/`ob_get_clean()` into `StepResult::capturedLog`, and `UpdaterController` renders that to the user as a collapsible pipeline log. Moving them to a file/DB logger would empty the rendered log — a user-visible regression.
- `$log` is NOT dead: both accumulators are passed to `\UI\DebugOutput::display($log, ...)`, which echoes to admins (HTML-escaped). Removing `$log` changes admin-visible output.

**Backlog 1.18 remains Open (partial)** — the echo→logger + `$log` cleanup needs a separate, explicitly non-`refactor:` PR with `auto_merge: false`.

## Changes

- `ibl5/classes/League/League.php` — added `const REGULAR_SEASON_GAMES = 82`
- `ibl5/classes/Updater/StandingsUpdater.php` — added `use League\League`; replaced 4× `82` literals
- `ibl5/tests/UpdateAllTheThings/StandingsUpdaterTest.php` — added `testRegularSeasonGamesConstantEquals82`
- `ibl5/docs/maintenance-backlog.md` — updated row 1.18 to Partial, corrected false claims, bumped `last_verified`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.