### PR TITLE
refactor: inject repository interface and memoize active-DC fetch in SavedDepthChartService

### DIFF
--- a/ibl5/classes/SavedDepthChart/SavedDepthChartService.php
+++ b/ibl5/classes/SavedDepthChart/SavedDepthChartService.php
@@ -17,7 +17,7 @@ use Season\Season;
  */
 class SavedDepthChartService implements SavedDepthChartServiceInterface
 {
-    private SavedDepthChartRepository $repository;
+    private SavedDepthChartRepositoryInterface $repository;
     private \mysqli $db;
 
     /**
@@ -25,10 +25,22 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
      */
     private \Psr\Log\LoggerInterface $logger;
 
-    public function __construct(\mysqli $db, ?\Psr\Log\LoggerInterface $logger = null)
-    {
+    /**
+     * Per-teamid memo of getActiveDepthChartForTeam() within one request.
+     * Stores null too — array_key_exists() distinguishes "not fetched"
+     * from "fetched, no active DC".
+     *
+     * @var array<int, SavedDepthChartRow|null>
+     */
+    private array $activeDcCache = [];
+
+    public function __construct(
+        \mysqli $db,
+        ?SavedDepthChartRepositoryInterface $repo = null,
+        ?\Psr\Log\LoggerInterface $logger = null
+    ) {
         $this->db = $db;
-        $this->repository = new SavedDepthChartRepository($db);
+        $this->repository = $repo ?? new SavedDepthChartRepository($db);
         $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
     }
 
@@ -184,7 +196,7 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
         $parts = [];
 
         // Find active DC (most recently updated) for sim range, date range, and win-loss record
-        $activeDc = $this->repository->getActiveDepthChartForTeam($teamid);
+        $activeDc = $this->getActiveDc($teamid);
 
         // Use the active DC's name if it has one, otherwise default label
         if ($activeDc !== null && $activeDc['name'] !== null && $activeDc['name'] !== '') {
@@ -237,7 +249,7 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
         $savedDcs = $this->repository->getSavedDepthChartsForTeam($teamid);
 
         // Find active DC (most recently updated if multiple)
-        $activeDc = $this->repository->getActiveDepthChartForTeam($teamid);
+        $activeDc = $this->getActiveDc($teamid);
 
         // Hide active DC if it matches live ibl_plr settings exactly
         $hideActiveDc = false;
@@ -425,6 +437,20 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
     }
 
     /**
+     * Memoized active-DC fetch, keyed by teamid.
+     *
+     * @return SavedDepthChartRow|null
+     */
+    private function getActiveDc(int $teamid): ?array
+    {
+        if (!array_key_exists($teamid, $this->activeDcCache)) {
+            $this->activeDcCache[$teamid] = $this->repository->getActiveDepthChartForTeam($teamid);
+        }
+
+        return $this->activeDcCache[$teamid];
+    }
+
+    /**
      * Build a human-readable dropdown label for a saved depth chart
      *
      * @param SavedDepthChartRow $dc
@@ -490,11 +516,12 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
      */
     public function nameOrCreateActive(int $teamid, string $username, string $name, Season $season): array
     {
-        $activeDc = $this->repository->getActiveDepthChartForTeam($teamid);
+        $activeDc = $this->getActiveDc($teamid);
 
         if ($activeDc !== null) {
             $this->repository->updateName($activeDc['id'], $teamid, $name);
             $this->repository->deactivateOthersForTeam($teamid, $activeDc['id'], $season->lastSimEndDate, $season->lastSimNumber);
+            unset($this->activeDcCache[$teamid]);
             return ['success' => true, 'id' => $activeDc['id'], 'name' => $name];
         }
 

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -87,7 +87,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 1.6 | ✅ Implemented | — | Dual-path unified, byte-identical (#1146). View still 610 LOC = residual size, not this concern. |
 | 1.7 | ✅ Implemented | — | `TeamPageDataPreparer`+`TeamCardRenderer` (#1144); `TeamService` ~115 LOC (absent from >500 list). |
 | 1.8 | ✅ Implemented | — | Verified: no inline `new TeamQueryRepository`/`BuyoutLedgerRepository` in the view. Still 590 LOC = residual. |
-| 1.9 | ⬜ Open | 🟩 | Verified `new SavedDepthChartRepository($db)` at L31; 599 LOC. Memoize active-DC + inject interface; green-green. |
+| 1.9 | ✅ Implemented | — | Memoized active-DC fetch (`getActiveDc()`) + injected `SavedDepthChartRepositoryInterface`; green-green. |
 | 1.10 | ✅ Implemented | — | Verified: `syncPropertiesFromPlayerData` gone, zero public nullable props. `Player.php` 671 LOC = typed-getter bulk (residual). |
 | 1.11 | ⬜ Open | 🟩 | `insertTeamBoxscore()` 30-arg signature now lives in `BoxscoreRepository:252`; 557 LOC. Array-param + injectable ProgressReporter; pin with a DB-integration test. |
 | 1.12 | ✅ Implemented | — | #1145 — split into Index/Detail views, byte-identical golden-master. |
@@ -170,6 +170,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** Memoize active DC per call chain; accept `SavedDepthChartRepositoryInterface`.
 **Est. effort:** S
 **Risk if untouched:** Every DC dropdown render triggers 3+ redundant queries; pattern proliferates.
+**Status:** Completed (PR for finding 1.9) — `SavedDepthChartService` constructor now accepts an optional `SavedDepthChartRepositoryInterface` (defaults to `new SavedDepthChartRepository($db)`); the active-DC fetch is memoized per teamid via private `getActiveDc()`, reused by `buildCurrentLiveLabel()`, `getDropdownOptions()`, and `nameOrCreateActive()` — collapsing the two redundant reads in `SavedDepthChartApiHandler::handleList()` into one. Cache invalidated after `nameOrCreateActive()` writes. Green-green.
 
 ### 1.10 Player (facade) — 50+ Public Properties Duplicating PlayerData
 **Location:** `ibl5/classes/Player/Player.php` (558 lines)

--- a/ibl5/tests/SavedDepthChart/SavedDepthChartServiceTest.php
+++ b/ibl5/tests/SavedDepthChart/SavedDepthChartServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\SavedDepthChart;
 
 use SavedDepthChart\SavedDepthChartService;
+use SavedDepthChart\Contracts\SavedDepthChartRepositoryInterface;
 use Tests\WideUnit\WideUnitTestCase;
 use Season\Season;
 
@@ -307,6 +308,181 @@ class SavedDepthChartServiceTest extends WideUnitTestCase
 
         $this->assertFalse($result['success']);
         $this->assertSame('No players found on roster', $result['error']);
+    }
+
+    // ── characterization (Phase 1b) ──────────────────────────────────────────
+
+    /** @return array{id:int,teamid:int,username:string,name:string|null,phase:string,season_year:int,sim_start_date:string,sim_end_date:string|null,sim_number_start:int,sim_number_end:int|null,is_active:int,created_at:string,updated_at:string} */
+    private function makeActiveDcRow(int $id = 42, string $name = 'Championship DC'): array
+    {
+        return [
+            'id' => $id, 'teamid' => 1, 'username' => 'testuser',
+            'name' => $name, 'phase' => 'Regular Season', 'season_year' => 2024,
+            'sim_start_date' => '2024-01-01', 'sim_end_date' => null,
+            'sim_number_start' => 1, 'sim_number_end' => null, 'is_active' => 1,
+            'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00',
+        ];
+    }
+
+    public function testGetDropdownOptionsOutputUnchangedWithSingleActiveDc(): void
+    {
+        $activeDcRow = $this->makeActiveDcRow(42);
+        $dcPlayerRow = [
+            'id' => 1, 'depth_chart_id' => 42, 'pid' => 100, 'player_name' => 'Player One',
+            'ordinal' => 1, 'dc_pg_depth' => 1, 'dc_sg_depth' => 0, 'dc_sf_depth' => 0,
+            'dc_pf_depth' => 0, 'dc_c_depth' => 0, 'dc_can_play_in_game' => 1,
+            'dc_minutes' => 30, 'dc_of' => 1, 'dc_df' => 1, 'dc_oi' => 1, 'dc_di' => 1, 'dc_bh' => 1,
+        ];
+        $liveRosterRow = [
+            'pid' => 200, 'name' => 'Other Player', 'ordinal' => 1,
+            'dc_pg_depth' => 0, 'dc_sg_depth' => 0, 'dc_sf_depth' => 0,
+            'dc_pf_depth' => 0, 'dc_c_depth' => 0, 'dc_can_play_in_game' => 1,
+            'dc_minutes' => 30, 'dc_of' => 1, 'dc_df' => 1, 'dc_oi' => 1, 'dc_di' => 1, 'dc_bh' => 1,
+        ];
+
+        $repo = $this->createStub(SavedDepthChartRepositoryInterface::class);
+        $repo->method('getActiveDepthChartForTeam')->willReturn($activeDcRow);
+        $repo->method('getSavedDepthChartsForTeam')->willReturn([$activeDcRow]);
+        $repo->method('getPlayersForDepthChart')->willReturn([$dcPlayerRow]);
+        $repo->method('getLiveRosterSettings')->willReturn([$liveRosterRow]);
+        $repo->method('getWinLossRecord')->willReturn(['wins' => 3, 'losses' => 1]);
+
+        $service = new SavedDepthChartService($this->mockDb, $repo);
+        $result = $service->getDropdownOptions(1, new Season($this->mockDb));
+
+        $this->assertCount(1, $result);
+        $this->assertSame(42, $result[0]['id']);
+        $this->assertTrue($result[0]['isActive']);
+        $this->assertNotEmpty($result[0]['label']);
+    }
+
+    public function testBuildCurrentLiveLabelContainsRecordWithActiveDc(): void
+    {
+        $activeDcRow = $this->makeActiveDcRow(42, 'Championship DC');
+
+        $repo = $this->createStub(SavedDepthChartRepositoryInterface::class);
+        $repo->method('getActiveDepthChartForTeam')->willReturn($activeDcRow);
+        $repo->method('getWinLossRecord')->willReturn(['wins' => 3, 'losses' => 1]);
+
+        $service = new SavedDepthChartService($this->mockDb, $repo);
+        $label = $service->buildCurrentLiveLabel(1, new Season($this->mockDb));
+
+        $this->assertStringContainsString('(3-1)', $label);
+        $this->assertStringContainsString('Championship DC', $label);
+    }
+
+    public function testBuildCurrentLiveLabelFallsBackWhenNoActiveDc(): void
+    {
+        $repo = $this->createStub(SavedDepthChartRepositoryInterface::class);
+        $repo->method('getActiveDepthChartForTeam')->willReturn(null);
+
+        $service = new SavedDepthChartService($this->mockDb, $repo);
+        $label = $service->buildCurrentLiveLabel(1, new Season($this->mockDb));
+
+        $this->assertStringContainsString('Current (Live)', $label);
+        $this->assertStringContainsString('Sim ', $label);
+    }
+
+    // ── memoization + injected-interface seam (Phase 3) ─────────────────────
+
+    public function testActiveDcFetchedOnceForBothDropdownReads(): void
+    {
+        $activeDcRow = $this->makeActiveDcRow(42);
+        $dcPlayerRow = [
+            'id' => 1, 'depth_chart_id' => 42, 'pid' => 100, 'player_name' => 'Player One',
+            'ordinal' => 1, 'dc_pg_depth' => 1, 'dc_sg_depth' => 0, 'dc_sf_depth' => 0,
+            'dc_pf_depth' => 0, 'dc_c_depth' => 0, 'dc_can_play_in_game' => 1,
+            'dc_minutes' => 30, 'dc_of' => 1, 'dc_df' => 1, 'dc_oi' => 1, 'dc_di' => 1, 'dc_bh' => 1,
+        ];
+        $liveRosterRow = [
+            'pid' => 200, 'name' => 'Other Player', 'ordinal' => 1,
+            'dc_pg_depth' => 0, 'dc_sg_depth' => 0, 'dc_sf_depth' => 0,
+            'dc_pf_depth' => 0, 'dc_c_depth' => 0, 'dc_can_play_in_game' => 1,
+            'dc_minutes' => 30, 'dc_of' => 1, 'dc_df' => 1, 'dc_oi' => 1, 'dc_di' => 1, 'dc_bh' => 1,
+        ];
+
+        $mock = $this->createMock(SavedDepthChartRepositoryInterface::class);
+        $mock->expects($this->once())
+            ->method('getActiveDepthChartForTeam')
+            ->with(1)
+            ->willReturn($activeDcRow);
+        $mock->method('getSavedDepthChartsForTeam')->willReturn([$activeDcRow]);
+        $mock->method('getPlayersForDepthChart')->willReturn([$dcPlayerRow]);
+        $mock->method('getLiveRosterSettings')->willReturn([$liveRosterRow]);
+        $mock->method('getWinLossRecord')->willReturn(['wins' => 3, 'losses' => 1]);
+
+        $service = new SavedDepthChartService($this->mockDb, $mock);
+        $season = new Season($this->mockDb);
+        $service->getDropdownOptions(1, $season);
+        $service->buildCurrentLiveLabel(1, $season);
+    }
+
+    public function testMemoizationIsolatesDistinctTeams(): void
+    {
+        $dcTeam1 = $this->makeActiveDcRow(101, 'Team 1 DC');
+        $dcTeam1['teamid'] = 1;
+        $dcTeam2 = $this->makeActiveDcRow(202, 'Team 2 DC');
+        $dcTeam2['teamid'] = 2;
+        // Different pids in DC vs live → isDepthChartMatchingLive returns false → hideActiveDc = false
+        $dcPlayerRow = [
+            'id' => 1, 'depth_chart_id' => 0, 'pid' => 100, 'player_name' => 'P1',
+            'ordinal' => 1, 'dc_pg_depth' => 1, 'dc_sg_depth' => 0, 'dc_sf_depth' => 0,
+            'dc_pf_depth' => 0, 'dc_c_depth' => 0, 'dc_can_play_in_game' => 1,
+            'dc_minutes' => 30, 'dc_of' => 1, 'dc_df' => 1, 'dc_oi' => 1, 'dc_di' => 1, 'dc_bh' => 1,
+        ];
+        $liveRosterRow = [
+            'pid' => 200, 'name' => 'P2', 'ordinal' => 1,
+            'dc_pg_depth' => 0, 'dc_sg_depth' => 0, 'dc_sf_depth' => 0,
+            'dc_pf_depth' => 0, 'dc_c_depth' => 0, 'dc_can_play_in_game' => 1,
+            'dc_minutes' => 30, 'dc_of' => 1, 'dc_df' => 1, 'dc_oi' => 1, 'dc_di' => 1, 'dc_bh' => 1,
+        ];
+
+        $mock = $this->createStub(SavedDepthChartRepositoryInterface::class);
+        $mock->method('getActiveDepthChartForTeam')->willReturnMap([
+            [1, $dcTeam1],
+            [2, $dcTeam2],
+        ]);
+        $mock->method('getSavedDepthChartsForTeam')->willReturnMap([
+            [1, [$dcTeam1]],
+            [2, [$dcTeam2]],
+        ]);
+        $mock->method('getPlayersForDepthChart')->willReturn([$dcPlayerRow]);
+        $mock->method('getLiveRosterSettings')->willReturn([$liveRosterRow]);
+        $mock->method('getWinLossRecord')->willReturn(['wins' => 0, 'losses' => 0]);
+
+        $service = new SavedDepthChartService($this->mockDb, $mock);
+        $season = new Season($this->mockDb);
+
+        $resultTeam1 = $service->getDropdownOptions(1, $season);
+        $resultTeam2 = $service->getDropdownOptions(2, $season);
+
+        $ids1 = array_column($resultTeam1, 'id');
+        $ids2 = array_column($resultTeam2, 'id');
+
+        $this->assertContains(101, $ids1);
+        $this->assertNotContains(202, $ids1);
+        $this->assertContains(202, $ids2);
+        $this->assertNotContains(101, $ids2);
+    }
+
+    public function testActiveDcCacheInvalidatedAfterRename(): void
+    {
+        $activeDcRow = $this->makeActiveDcRow(42);
+
+        $mock = $this->createMock(SavedDepthChartRepositoryInterface::class);
+        $mock->expects($this->exactly(2))
+            ->method('getActiveDepthChartForTeam')
+            ->with(1)
+            ->willReturn($activeDcRow);
+        $mock->method('updateName')->willReturn(true);
+        $mock->method('deactivateOthersForTeam');
+        $mock->method('getWinLossRecord')->willReturn(['wins' => 2, 'losses' => 0]);
+
+        $service = new SavedDepthChartService($this->mockDb, $mock);
+        $season = new Season($this->mockDb);
+
+        $service->nameOrCreateActive(1, 'gm', 'New Name', $season);
+        $service->buildCurrentLiveLabel(1, $season);
     }
 
 }

--- a/ibl5/tests/SavedDepthChart/SavedDepthChartServiceTest.php
+++ b/ibl5/tests/SavedDepthChart/SavedDepthChartServiceTest.php
@@ -340,7 +340,7 @@ class SavedDepthChartServiceTest extends WideUnitTestCase
             'dc_minutes' => 30, 'dc_of' => 1, 'dc_df' => 1, 'dc_oi' => 1, 'dc_di' => 1, 'dc_bh' => 1,
         ];
 
-        $repo = $this->createStub(SavedDepthChartRepositoryInterface::class);
+        $repo = self::createStub(SavedDepthChartRepositoryInterface::class);
         $repo->method('getActiveDepthChartForTeam')->willReturn($activeDcRow);
         $repo->method('getSavedDepthChartsForTeam')->willReturn([$activeDcRow]);
         $repo->method('getPlayersForDepthChart')->willReturn([$dcPlayerRow]);
@@ -360,7 +360,7 @@ class SavedDepthChartServiceTest extends WideUnitTestCase
     {
         $activeDcRow = $this->makeActiveDcRow(42, 'Championship DC');
 
-        $repo = $this->createStub(SavedDepthChartRepositoryInterface::class);
+        $repo = self::createStub(SavedDepthChartRepositoryInterface::class);
         $repo->method('getActiveDepthChartForTeam')->willReturn($activeDcRow);
         $repo->method('getWinLossRecord')->willReturn(['wins' => 3, 'losses' => 1]);
 
@@ -373,7 +373,7 @@ class SavedDepthChartServiceTest extends WideUnitTestCase
 
     public function testBuildCurrentLiveLabelFallsBackWhenNoActiveDc(): void
     {
-        $repo = $this->createStub(SavedDepthChartRepositoryInterface::class);
+        $repo = self::createStub(SavedDepthChartRepositoryInterface::class);
         $repo->method('getActiveDepthChartForTeam')->willReturn(null);
 
         $service = new SavedDepthChartService($this->mockDb, $repo);
@@ -437,7 +437,7 @@ class SavedDepthChartServiceTest extends WideUnitTestCase
             'dc_minutes' => 30, 'dc_of' => 1, 'dc_df' => 1, 'dc_oi' => 1, 'dc_di' => 1, 'dc_bh' => 1,
         ];
 
-        $mock = $this->createStub(SavedDepthChartRepositoryInterface::class);
+        $mock = self::createStub(SavedDepthChartRepositoryInterface::class);
         $mock->method('getActiveDepthChartForTeam')->willReturnMap([
             [1, $dcTeam1],
             [2, $dcTeam2],

--- a/ibl5/tests/WideUnit/Mocks/Season.php
+++ b/ibl5/tests/WideUnit/Mocks/Season.php
@@ -222,4 +222,9 @@ class Season
     {
         return $this->lastSimNumber;
     }
+
+    public function calculatePhaseSimNumber(int $overallSimNumber, string $phase, int $seasonYear): int
+    {
+        return $overallSimNumber;
+    }
 }


### PR DESCRIPTION
## Summary

Backlog 1.9 — two coupled behavior-preserving changes to `SavedDepthChartService`:

1. **Inject `SavedDepthChartRepositoryInterface`** via optional constructor param (3rd param, before the existing optional logger), defaulting to `new SavedDepthChartRepository($db)`. Zero churn at all three production call sites.
2. **Memoize `getActiveDepthChartForTeam()` per teamid** via private `getActiveDc()` accessor. Collapses the two redundant fetches in `SavedDepthChartApiHandler::handleList()` into one. Cache invalidated after the mutations in `nameOrCreateActive()`.

Also extends `tests/WideUnit/Mocks/Season.php` with the missing `calculatePhaseSimNumber()` stub so populated-label tests can render without fataling on the aliased mock.

Green-green: no behavior change, all public outputs byte-identical before and after.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.