### PR TITLE
ci: single-source Playwright image tag from package.json (ADR-0070)

### DIFF
--- a/.github/actions/setup-docker-e2e/action.yml
+++ b/.github/actions/setup-docker-e2e/action.yml
@@ -68,10 +68,17 @@ runs:
       shell: bash
       run: docker compose -f docker-compose.ci.yml up -d mariadb --wait
 
+    - name: Derive Playwright image tag
+      if: inputs.with-playwright == 'true'
+      shell: bash
+      run: |
+        tag="$(bin/playwright-image-tag ibl5/package.json)"
+        echo "PW_IMAGE=$tag" >> "$GITHUB_ENV"
+
     - name: Pull Playwright image (background)
       if: inputs.with-playwright == 'true'
       shell: bash
-      run: nohup docker pull mcr.microsoft.com/playwright:v1.60.0-jammy > /tmp/playwright-pull.log 2>&1 &
+      run: nohup docker pull "$PW_IMAGE" > /tmp/playwright-pull.log 2>&1 &
 
     - name: Create database and apply migrations
       shell: bash
@@ -173,11 +180,11 @@ runs:
       shell: bash
       run: |
         deadline=$((SECONDS + 300))
-        while ! docker image inspect mcr.microsoft.com/playwright:v1.60.0-jammy >/dev/null 2>&1; do
+        while ! docker image inspect "$PW_IMAGE" >/dev/null 2>&1; do
           if [ $SECONDS -ge $deadline ]; then
             echo "::warning::Background pull timed out after 5 min — retrying foreground"
             pkill -f "docker pull mcr.microsoft.com/playwright" || true
-            docker pull mcr.microsoft.com/playwright:v1.60.0-jammy
+            docker pull "$PW_IMAGE"
             break
           fi
           sleep 2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -69,24 +69,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Verify all surfaces pin v1.60.0-jammy
-        run: |
-          EXPECTED="v1.60.0-jammy"
-          EXPECTED_NPM="1.60.0"
-          fail=0
-          grep -q "playwright:${EXPECTED}" ibl5/bin/visual-regression.sh \
-            || { echo "drift: ibl5/bin/visual-regression.sh"; fail=1; }
-          grep -q "playwright:${EXPECTED}" .github/actions/setup-docker-e2e/action.yml \
-            || { echo "drift: .github/actions/setup-docker-e2e/action.yml"; fail=1; }
-          grep -q "playwright:${EXPECTED}" .github/workflows/e2e-tests.yml \
-            || { echo "drift: .github/workflows/e2e-tests.yml"; fail=1; }
-          grep -q "\"@playwright/test\": \"${EXPECTED_NPM}\"" ibl5/package.json \
-            || { echo "drift: ibl5/package.json"; fail=1; }
-          grep -q "\"@playwright/test@${EXPECTED_NPM}\"" ibl5/bun.lock \
-            || { echo "drift: ibl5/bun.lock"; fail=1; }
-          grep -q "\"@playwright/test\": \"${EXPECTED_NPM}\"" IBL6/package.json \
-            || { echo "drift: IBL6/package.json"; fail=1; }
-          exit $fail
+      - name: Verify Playwright image tag is derived, never hardcoded
+        run: bin/check-playwright-pinning
 
   e2e:
     name: Visual Regression
@@ -174,7 +158,7 @@ jobs:
             -e "IBL_TEST_USER_REGULAR=$IBL_TEST_USER_REGULAR" \
             -e "IBL_TEST_PASS_REGULAR=$IBL_TEST_PASS_REGULAR" \
             -e "HOME=/tmp" \
-            mcr.microsoft.com/playwright:v1.60.0-jammy \
+            "$PW_IMAGE" \
             npx playwright test --config=playwright.visual.config.ts
 
       # --- Visual-review publishing (review run only) ---
@@ -240,7 +224,7 @@ jobs:
             -e "IBL_TEST_USER_REGULAR=$IBL_TEST_USER_REGULAR" \
             -e "IBL_TEST_PASS_REGULAR=$IBL_TEST_PASS_REGULAR" \
             -e "HOME=/tmp" \
-            mcr.microsoft.com/playwright:v1.60.0-jammy \
+            "$PW_IMAGE" \
             npx playwright test --config=playwright.visual.config.ts --update-snapshots
 
       - name: Commit and push updated baselines
@@ -407,7 +391,7 @@ jobs:
             -e "IBL_TEST_USER_REGULAR=$IBL_TEST_USER_REGULAR" \
             -e "IBL_TEST_PASS_REGULAR=$IBL_TEST_PASS_REGULAR" \
             -e "HOME=/tmp" \
-            mcr.microsoft.com/playwright:v1.60.0-jammy \
+            "$PW_IMAGE" \
             npx playwright test \
               --project=chromium \
               --shard=${{ matrix.shard-index }}/${{ matrix.total-shards }} \
@@ -509,7 +493,7 @@ jobs:
             -e "IBL_TEST_USER_REGULAR=$IBL_TEST_USER_REGULAR" \
             -e "IBL_TEST_PASS_REGULAR=$IBL_TEST_PASS_REGULAR" \
             -e "HOME=/tmp" \
-            mcr.microsoft.com/playwright:v1.60.0-jammy \
+            "$PW_IMAGE" \
             npx playwright test \
               --project=mutators \
               --workers=1 \
@@ -579,8 +563,13 @@ jobs:
           done
           echo "ibl6 is healthy"
 
+      - name: Derive Playwright image tag
+        run: |
+          tag="$(bin/playwright-image-tag IBL6/package.json)"
+          echo "PW_IMAGE=$tag" >> "$GITHUB_ENV"
+
       - name: Pull Playwright image
-        run: docker pull mcr.microsoft.com/playwright:v1.60.0-jammy
+        run: docker pull "$PW_IMAGE"
 
       - name: Install IBL6 dependencies
         working-directory: IBL6
@@ -597,7 +586,7 @@ jobs:
             -w /IBL6 \
             -e "BASE_URL=http://ibl6:3001" \
             -e "HOME=/tmp" \
-            mcr.microsoft.com/playwright:v1.60.0-jammy \
+            "$PW_IMAGE" \
             npx playwright test --config=playwright.visual.config.ts
 
       - name: Regenerate IBL6 visual regression baselines
@@ -611,7 +600,7 @@ jobs:
             -w /IBL6 \
             -e "BASE_URL=http://ibl6:3001" \
             -e "HOME=/tmp" \
-            mcr.microsoft.com/playwright:v1.60.0-jammy \
+            "$PW_IMAGE" \
             npx playwright test --config=playwright.visual.config.ts --update-snapshots
 
       - name: Commit and push updated IBL6 baselines
@@ -677,8 +666,13 @@ jobs:
           done
           echo "ibl6 is healthy"
 
+      - name: Derive Playwright image tag
+        run: |
+          tag="$(bin/playwright-image-tag IBL6/package.json)"
+          echo "PW_IMAGE=$tag" >> "$GITHUB_ENV"
+
       - name: Pull Playwright image
-        run: docker pull mcr.microsoft.com/playwright:v1.60.0-jammy
+        run: docker pull "$PW_IMAGE"
 
       - name: Install IBL6 dependencies
         working-directory: IBL6
@@ -693,7 +687,7 @@ jobs:
             -w /IBL6 \
             -e "BASE_URL=http://ibl6:3001" \
             -e "HOME=/tmp" \
-            mcr.microsoft.com/playwright:v1.60.0-jammy \
+            "$PW_IMAGE" \
             npx playwright test
 
       - name: Upload IBL6 E2E report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -590,6 +590,8 @@ jobs:
         run: bin/test-adr-check
       - name: bin/test-postplan-arm-conditions
         run: bin/test-postplan-arm-conditions
+      - name: bin/test-playwright-version
+        run: bin/test-playwright-version
 
   gate:
     name: Tests and Analysis

--- a/IBL6/package.json
+++ b/IBL6/package.json
@@ -50,6 +50,7 @@
 	"overrides": {
 		"effect": "^3.20.0"
 	},
+	"//pin": "@playwright/test is exact-pinned (no caret) so bin/playwright-image-tag derives IBL6's Playwright Docker image tag from THIS version at runtime (ADR-0070). IBL6 is manually version-managed and intentionally NOT in .github/dependabot.yml — bump this by hand; an ibl5 Dependabot bump cannot break IBL6.",
 	"dependencies": {
 		"@sveltejs/adapter-node": "^5.5.3",
 		"daisyui": "^5.0.54",

--- a/bin/check-playwright-pinning
+++ b/bin/check-playwright-pinning
@@ -1,0 +1,34 @@
+#!/bin/bash
+# bin/check-playwright-pinning — regression guard (ADR-0070): the Playwright
+# Docker image tag must be DERIVED from package.json at runtime, never hardcoded.
+# Fails if a hardcoded image literal reappears in any derivation surface. Replaces
+# the old "all surfaces pin v1.60.0" lockstep guard, which structurally cannot drift
+# now that the tag is single-sourced. This file is NOT in the default surface list,
+# and its own pattern below has a "[" (not a digit) after ":v", so it never self-matches.
+#
+# Usage: bin/check-playwright-pinning [file ...]   (default: the 3 derivation surfaces)
+set -eu
+
+pat='mcr\.microsoft\.com/playwright:v[0-9]'
+
+if [ "$#" -gt 0 ]; then
+  set -- "$@"
+else
+  set -- ibl5/bin/visual-regression.sh \
+         .github/actions/setup-docker-e2e/action.yml \
+         .github/workflows/e2e-tests.yml
+fi
+
+fail=0
+for f in "$@"; do
+  if [ ! -f "$f" ]; then
+    echo "check-playwright-pinning: missing surface: $f" >&2
+    fail=1
+    continue
+  fi
+  if grep -nE "$pat" "$f"; then
+    echo "check-playwright-pinning: hardcoded Playwright image literal in $f — derive it from package.json via bin/playwright-image-tag (ADR-0070)" >&2
+    fail=1
+  fi
+done
+exit "$fail"

--- a/bin/playwright-image-tag
+++ b/bin/playwright-image-tag
@@ -1,0 +1,28 @@
+#!/bin/bash
+# bin/playwright-image-tag — derive the pinned Playwright Docker image ref from
+# a package.json's exact-pinned @playwright/test version. Single source of truth
+# for the version-to-image-tag mapping (see ADR-0070). Used by visual-regression.sh,
+# the setup-docker-e2e composite action, and the IBL6 E2E jobs so the installed
+# @playwright/test client and the Docker image tag can never drift.
+#
+# Usage: bin/playwright-image-tag <path-to-package.json>
+# Echoes e.g. the Microsoft Playwright image ref tagged with the pinned version.
+set -eu
+
+pkg="${1:?usage: playwright-image-tag <path-to-package.json>}"
+if [ ! -f "$pkg" ]; then
+  echo "playwright-image-tag: no such file: $pkg" >&2
+  exit 1
+fi
+
+# Exact-pin only (value starts with a digit, no caret) — doubles as a pin-convention
+# guard. Anchored on "@playwright/test" so @axe-core/playwright, eslint-plugin-playwright
+# and the bare "playwright" dep are never matched.
+ver="$(grep -oE '"@playwright/test": *"[0-9]+\.[0-9]+\.[0-9]+"' "$pkg" \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+if [ -z "$ver" ]; then
+  echo "playwright-image-tag: no exact @playwright/test version in $pkg" >&2
+  exit 1
+fi
+
+printf 'mcr.microsoft.com/playwright:v%s-jammy\n' "$ver"

--- a/bin/test-playwright-version
+++ b/bin/test-playwright-version
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-playwright-version — regression test for the single-sourced Playwright
+# image-tag derivation (ADR-0070). Covers:
+#   1. bin/playwright-image-tag maps a package.json @playwright/test version to the
+#      Docker image ref, including a BUMPED version (the self-heal proof — no real bump).
+#   2. bin/playwright-image-tag fails on a package.json with no exact pin.
+#   3. bin/check-playwright-pinning REJECTS a hardcoded literal and PASSES on the
+#      derived ($PW_IMAGE) form.
+#
+# Run: bin/test-playwright-version  (exit 0 = all pass, 1 = a case failed)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TAG="$SCRIPT_DIR/playwright-image-tag"
+GUARD="$SCRIPT_DIR/check-playwright-pinning"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILED=0
+
+expect_eq() { # name want got
+    if [ "$3" = "$2" ]; then echo "ok: $1"
+    else echo "FAIL: $1 — expected [$2], got [$3]"; FAILED=1; fi
+}
+expect_exit() { # name want-code got-code
+    if [ "$3" -eq "$2" ]; then echo "ok: $1 (exit $3)"
+    else echo "FAIL: $1 — expected exit $2, got $3"; FAILED=1; fi
+}
+
+# 1. bumped version derives bumped tag (self-heal proof)
+printf '{\n  "devDependencies": {\n    "@playwright/test": "9.9.9"\n  }\n}\n' > "$TMP/bumped.json"
+got="$("$TAG" "$TMP/bumped.json")"
+expect_eq "bumped version derives bumped tag" \
+    "mcr.microsoft.com/playwright:v9.9.9-jammy" "$got"
+
+# 2. real ibl5/package.json derives a well-formed tag (version-agnostic so it
+#    survives future Dependabot bumps)
+REAL="$(cd "$SCRIPT_DIR/.." && pwd)/ibl5/package.json"
+got="$("$TAG" "$REAL")"
+case "$got" in
+    mcr.microsoft.com/playwright:v[0-9]*.[0-9]*.[0-9]*-jammy)
+        echo "ok: real package.json derives well-formed tag ($got)" ;;
+    *)  echo "FAIL: real package.json derived malformed tag: [$got]"; FAILED=1 ;;
+esac
+
+# 3. missing @playwright/test → non-zero exit
+printf '{\n  "devDependencies": {}\n}\n' > "$TMP/empty.json"
+"$TAG" "$TMP/empty.json" >/dev/null 2>&1
+expect_exit "missing @playwright/test fails" 1 "$?"
+
+# 4. guard REJECTS a hardcoded literal
+printf 'docker pull %s\n' "mcr.microsoft.com/playwright:v1.2.3-jammy" > "$TMP/bad.yml"
+"$GUARD" "$TMP/bad.yml" >/dev/null 2>&1
+expect_exit "guard rejects hardcoded literal" 1 "$?"
+
+# 5. guard PASSES on the derived form
+printf 'docker pull "$PW_IMAGE"\n' > "$TMP/good.yml"
+"$GUARD" "$TMP/good.yml" >/dev/null 2>&1
+expect_exit "guard passes derived form" 0 "$?"
+
+if [ "$FAILED" -eq 0 ]; then echo "ALL PASS"; exit 0; fi
+echo "SOME FAILED"; exit 1

--- a/ibl5/bin/visual-regression.sh
+++ b/ibl5/bin/visual-regression.sh
@@ -9,11 +9,14 @@
 
 set -euo pipefail
 
-PLAYWRIGHT_IMAGE="${PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v1.60.0-jammy}"
-
 # Resolve ibl5/ directory (script lives in ibl5/bin/)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 IBL5_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Single-source the Playwright image tag from ibl5/package.json so the Docker
+# image and the installed @playwright/test client can never drift (ADR-0070).
+# bin/playwright-image-tag lives at the repo root (ibl5/../bin).
+PLAYWRIGHT_IMAGE="${PLAYWRIGHT_IMAGE:-$("$IBL5_DIR/../bin/playwright-image-tag" "$IBL5_DIR/package.json")}"
 
 # ---------- Pre-flight checks ----------
 

--- a/ibl5/docs/decisions/0070-single-source-playwright-version.md
+++ b/ibl5/docs/decisions/0070-single-source-playwright-version.md
@@ -1,0 +1,48 @@
+---
+description: Derive the Playwright Docker image tag from each package's package.json at runtime so the image and the installed client cannot drift; the drift guard becomes a no-hardcoded-literal regression guard.
+last_verified: 2026-06-27
+---
+
+# ADR-0070: Single-source the Playwright version from each package.json
+
+**Status:** Accepted
+**Date:** 2026-06-27
+
+## Context
+
+The Playwright version was hand-mirrored across ~13 literal `mcr.microsoft.com/playwright:v<ver>-jammy` occurrences in three CI surfaces (`ibl5/bin/visual-regression.sh`, `.github/actions/setup-docker-e2e/action.yml`, `.github/workflows/e2e-tests.yml`) plus version strings in `ibl5/package.json`, `ibl5/bun.lock`, and `IBL6/package.json`. Dependabot bumps only `ibl5/package.json` and its lockfiles, so a `@playwright/test` bump (PR #1210, 1.60.0→1.61.1) left every other surface stale, producing two failures: the "Playwright version drift guard" job failed against its hardcoded `EXPECTED`, and every E2E/VR job failed because tests installed client 1.61.1 but ran inside the stale `v1.60.0-jammy` image (browser-binary mismatch). The lockstep was real but enforced by hand-mirroring, which Dependabot cannot maintain.
+
+The precise root cause: the test *client* already tracked `package.json` (bun/npm install resolved the bump); only the Docker *image tag* stayed a frozen literal.
+
+## Decision
+
+Derive the Docker image tag from each package's own `package.json` at runtime, so the image tag follows the same source the client already follows.
+
+- A single helper `bin/playwright-image-tag <package.json>` echoes the full image ref, reused by `ibl5/bin/visual-regression.sh`, the `setup-docker-e2e` composite action, the IBL6 E2E jobs, and the regression test — one copy of the version-to-tag logic.
+- ibl5 jobs derive from `ibl5/package.json`: the `setup-docker-e2e` action derives once and exports `PW_IMAGE` via `$GITHUB_ENV`, which propagates to the rest of each calling job.
+- IBL6 jobs derive from `IBL6/package.json` via a per-job step (they call the action without `with-playwright`).
+- The "Playwright version drift guard" job is repurposed into a regression guard (`bin/check-playwright-pinning`) that fails only if a hardcoded image literal is re-introduced into a derivation surface. Its job id and name are unchanged.
+- `ibl5/bun.lock` is dropped from guarding: CI runs `bun install` non-frozen, so the lockfile is a cache key, not a correctness gate; a stale entry is a harmless cache miss.
+- IBL6 stays manually version-managed and is intentionally NOT added to `.github/dependabot.yml`; only its derivation is fixed so an ibl5 bump cannot break it.
+
+## Alternatives Considered
+
+- **Add IBL6 to Dependabot too.** Rejected (owner decision): IBL6 is a separate app on a deliberate manual cadence; coupling it to Dependabot was not wanted. Fixing only the derivation removes the breakage risk without forcing version coupling.
+- **Inline the derive `grep` in each surface.** Rejected: duplicates the regex across five places that drift. A single helper is the true single source and is directly unit-tested.
+- **Per-job derive step for ibl5 jobs instead of the composite export.** Rejected: the action is the single derivation point those jobs already share; `$GITHUB_ENV` propagation is documented and a propagation failure is fail-safe (empty image → red E2E, blocks merge).
+- **Delete the drift guard.** Rejected: re-hardcoding a literal would silently re-introduce the failure class. The repurposed guard preserves that protection.
+
+## Consequences
+
+- Positive: a Dependabot `@playwright/test` bump in `/ibl5` self-heals across every CI surface; E2E/VR go green and auto-merge can proceed.
+- Positive: ibl5 and IBL6 Playwright versions may now legitimately differ; the old guard's cross-package version-equality requirement is gone.
+- Positive: the regression guard plus `bin/test-playwright-version` (a bumped temp `package.json` mapping to a bumped tag) prove self-heal mechanically, without a real bump.
+- Negative/risk: ibl5-job derivation depends on composite-action `$GITHUB_ENV` propagation. Mitigated: it is documented behavior and fail-safe (a failure yields a red E2E that this very PR would surface, since master 1.60.0 makes the derived tag byte-identical to the prior literal).
+
+## References
+
+- `bin/playwright-image-tag` — the derive helper.
+- `bin/check-playwright-pinning` — the repurposed regression guard.
+- `bin/test-playwright-version` — the self-heal + guard-reject regression test.
+- `.github/workflows/e2e-tests.yml`, `.github/actions/setup-docker-e2e/action.yml`, `ibl5/bin/visual-regression.sh` — the three derivation surfaces.
+- `.github/dependabot.yml` — unchanged; IBL6 deliberately excluded.

--- a/ibl5/package.json
+++ b/ibl5/package.json
@@ -41,7 +41,7 @@
       "brace-expansion": "5.0.6"
     }
   },
-  "//pin": "@playwright/test is exact-pinned (no caret) to keep all 5 surfaces in lock-step with the v1.60.0-jammy Docker image; CI job 'playwright-version-drift' enforces this. The transitive playwright-core@1.58.2 carried via @axe-core/playwright is left untouched — overriding it risks an incompatible axe-core/playwright-core pair, and it is separate from the runtime Playwright that executes tests.",
+  "//pin": "@playwright/test is exact-pinned (no caret) so bin/playwright-image-tag derives the Playwright Docker image tag from THIS version at runtime — the image and the installed client cannot drift (ADR-0070). Dependabot bumps this; every CI surface follows automatically. The transitive playwright-core carried via @axe-core/playwright is left untouched — overriding it risks an incompatible axe-core/playwright-core pair, and it is separate from the runtime Playwright that executes tests.",
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@lhci/cli": "^0.15.1",


### PR DESCRIPTION
## Summary

Derives the Playwright Docker image tag at runtime from each package's own `package.json` so the image tag and the installed `@playwright/test` client can never drift — the lockstep becomes structural (ADR-0070).

**Root cause closed:** Dependabot bumps `ibl5/package.json`; the installed client follows immediately. Only the Docker image *tag* stayed a frozen literal, causing browser-binary mismatches (PR #1210: 1.60.0→1.61.1 → every E2E/VR job red).

**Changes:**
- `bin/playwright-image-tag` (new) — single source of the version→tag mapping; used by all derivation surfaces.
- `bin/check-playwright-pinning` (new) — repurposed drift guard: fails if anyone re-introduces a hardcoded `mcr.microsoft.com/playwright:v<digit>...` literal.
- `bin/test-playwright-version` (new) — self-heal proof (bumped temp package.json → bumped tag) + guard reject-path test.
- `.github/actions/setup-docker-e2e/action.yml` — derive step + 3 literal swaps; exports `$PW_IMAGE` via `$GITHUB_ENV`.
- `.github/workflows/e2e-tests.yml` — 9 ibl5 literal swaps, 2 IBL6 derive steps, guard step rewrite.
- `ibl5/bin/visual-regression.sh` — derive line (moves after `IBL5_DIR` resolution).
- `ibl5/docs/decisions/0070-single-source-playwright-version.md` — ADR.

**IBL6:** derives from `IBL6/package.json`; stays manually version-managed (not added to Dependabot — owner decision).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.