### PR TITLE
refactor: extract PythagoreanCalculator from StandingsRepository (finding 7.14)

### DIFF
--- a/ibl5/classes/Standings/PythagoreanCalculator.php
+++ b/ibl5/classes/Standings/PythagoreanCalculator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Standings;
+
+/**
+ * PythagoreanCalculator - Derives a team's total points scored and points allowed
+ * from raw season shooting totals.
+ *
+ * Stateless: holds no DB connection and no state. Used by StandingsRepository to
+ * turn raw offense/defense shooting rows into the {pointsScored, pointsAllowed}
+ * shape consumed by standings views. This computes the point totals only -- the
+ * Pythagorean win-percentage formula itself lives in
+ * \BasketballStats\StatsFormatter::calculatePythagoreanWinPercentage().
+ */
+class PythagoreanCalculator
+{
+    /**
+     * Derive points scored and points allowed from raw shooting totals.
+     *
+     * @param array{off_fgm: int, off_ftm: int, off_tgm: int, def_fgm: int, def_ftm: int, def_tgm: int, ...<string, mixed>} $stats
+     * @return array{pointsScored: int, pointsAllowed: int}
+     */
+    public function calculate(array $stats): array
+    {
+        $pointsScored = \BasketballStats\StatsFormatter::calculatePoints(
+            $stats['off_fgm'],
+            $stats['off_ftm'],
+            $stats['off_tgm']
+        );
+
+        $pointsAllowed = \BasketballStats\StatsFormatter::calculatePoints(
+            $stats['def_fgm'],
+            $stats['def_ftm'],
+            $stats['def_tgm']
+        );
+
+        return [
+            'pointsScored' => $pointsScored,
+            'pointsAllowed' => $pointsAllowed,
+        ];
+    }
+}

--- a/ibl5/classes/Standings/StandingsRepository.php
+++ b/ibl5/classes/Standings/StandingsRepository.php
@@ -30,10 +30,13 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
 {
     private string $teamAwardsTable;
 
+    private readonly PythagoreanCalculator $pythagoreanCalculator;
+
     public function __construct(\mysqli $db, ?LeagueContext $leagueContext = null)
     {
         parent::__construct($db, $leagueContext);
         $this->teamAwardsTable = 'ibl_team_awards';
+        $this->pythagoreanCalculator = new PythagoreanCalculator();
     }
 
     /**
@@ -175,7 +178,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
             return null;
         }
 
-        return $this->calculatePythagoreanStats($stats);
+        return $this->pythagoreanCalculator->calculate($stats);
     }
 
     /**
@@ -234,7 +237,7 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
         /** @var array<int, PythagoreanStats> $result */
         $result = [];
         foreach ($rows as $row) {
-            $result[$row['teamid']] = $this->calculatePythagoreanStats($row);
+            $result[$row['teamid']] = $this->pythagoreanCalculator->calculate($row);
         }
 
         return $result;
@@ -613,32 +616,6 @@ class StandingsRepository extends \BaseMysqliRepository implements StandingsRepo
             $result[$row['teamid']] = $row['game_count'];
         }
         return $result;
-    }
-
-    /**
-     * Calculate Pythagorean stats from raw shooting data
-     *
-     * @param array{off_fgm: int, off_ftm: int, off_tgm: int, def_fgm: int, def_ftm: int, def_tgm: int, ...<string, mixed>} $stats
-     * @return PythagoreanStats
-     */
-    private function calculatePythagoreanStats(array $stats): array
-    {
-        $pointsScored = \BasketballStats\StatsFormatter::calculatePoints(
-            $stats['off_fgm'],
-            $stats['off_ftm'],
-            $stats['off_tgm']
-        );
-
-        $pointsAllowed = \BasketballStats\StatsFormatter::calculatePoints(
-            $stats['def_fgm'],
-            $stats['def_ftm'],
-            $stats['def_tgm']
-        );
-
-        return [
-            'pointsScored' => $pointsScored,
-            'pointsAllowed' => $pointsAllowed,
-        ];
     }
 
     /**

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1334,7 +1334,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 | 7.11 | ⬜ Open | 🟨 | Inconsistent caching decorators. Upfront decision: add `Cached*Repository` for SeasonHighs/FranchiseRecordBook/etc. vs document why page-cache suffices. |
 | 7.12 | ✅ Implemented | — | TeamOrderBy enum (#1032). |
 | 7.13 | ✅ Implemented | — | DraftRepository injects TeamIdentityRepositoryInterface. |
-| 7.14 | ⬜ Open | 🟩 | `calculatePythagoreanStats` present (verified); StandingsRepository 681 LOC. Move calc to Service; green-green. |
+| 7.14 | ✅ Implemented | 🟩 | Extracted `Standings\PythagoreanCalculator` (pure `calculate()`); StandingsRepository delegates both call sites; green-green. |
 | 7.15 | ⬜ Open | 🟩 | 8 map*/FIELD_MAP members (verified); PlayerRepository 622 LOC. Extract PlayerDataMapper/Hydrator; green-green. |
 | 7.16 | ✅ Implemented | — | Hidden caches dropped (#1040). |
 | 7.17 | ⬜ Open | 🟩 | `getPlayerNews`→nuke_stories cross-query. Annotate `@see` (trivial) or extract LegacyNewsRepository; green-green. |
@@ -1444,6 +1444,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Status:** Completed (verified 2026-05-29 audit) — `DraftRepository` constructor now injects `TeamIdentityRepositoryInterface`; no inline `new CommonMysqliRepository`.
 
 ### 7.14 `StandingsRepository` Contains Business Logic
+**Status:** ✅ Implemented -- extracted the points-scored/allowed math into stateless `Standings\PythagoreanCalculator::calculate()`; SQL subquery builders left private in the repository.
 **Location:** `ibl5/classes/Standings/StandingsRepository.php` lines 602-663
 **Problem:** `calculatePythagoreanStats` returns a derived shape; subquery builders carry basketball semantics.
 **Suggested direction:** Move calc to `StandingsService` or `StatsFormatter`; keep SQL builders private.

--- a/ibl5/tests/Standings/PythagoreanCalculatorTest.php
+++ b/ibl5/tests/Standings/PythagoreanCalculatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Standings;
+
+use PHPUnit\Framework\TestCase;
+use Standings\PythagoreanCalculator;
+
+/**
+ * @covers \Standings\PythagoreanCalculator
+ */
+class PythagoreanCalculatorTest extends TestCase
+{
+    public function testCalculateReturnsPointsScoredAndAllowed(): void
+    {
+        // Same inputs the existing StandingsRepository characterization pins:
+        // pointsScored = 2*1000 + 500 + 300 = 2800
+        // pointsAllowed = 2*900 + 450 + 250 = 2500
+        $stats = [
+            'off_fgm' => 1000, 'off_ftm' => 500, 'off_tgm' => 300,
+            'def_fgm' => 900, 'def_ftm' => 450, 'def_tgm' => 250,
+        ];
+
+        $result = (new PythagoreanCalculator())->calculate($stats);
+
+        $this->assertSame(['pointsScored' => 2800, 'pointsAllowed' => 2500], $result);
+    }
+
+    public function testCalculateWithAllZeroInputsReturnsZeroPoints(): void
+    {
+        // Boundary: all-zero shooting yields 0/0. No division occurs -- calculatePoints
+        // is 2*fgm + ftm + tgm, so zero inputs return zero, not a guarded value.
+        $stats = [
+            'off_fgm' => 0, 'off_ftm' => 0, 'off_tgm' => 0,
+            'def_fgm' => 0, 'def_ftm' => 0, 'def_tgm' => 0,
+        ];
+
+        $result = (new PythagoreanCalculator())->calculate($stats);
+
+        $this->assertSame(['pointsScored' => 0, 'pointsAllowed' => 0], $result);
+    }
+
+    public function testCalculateIgnoresExtraKeysOnTolerantShape(): void
+    {
+        // Call site #2 (getAllPythagoreanStats, L237) passes $row, which also carries
+        // `teamid` (and other) keys. The `...<string, mixed>` @param tail must accept
+        // them and the calc must ignore them — pins that the extra-key call site is safe.
+        $stats = [
+            'off_fgm' => 1000, 'off_ftm' => 500, 'off_tgm' => 300,
+            'def_fgm' => 900, 'def_ftm' => 450, 'def_tgm' => 250,
+            'teamid' => 7,
+        ];
+
+        $result = (new PythagoreanCalculator())->calculate($stats);
+
+        $this->assertSame(['pointsScored' => 2800, 'pointsAllowed' => 2500], $result);
+    }
+}


### PR DESCRIPTION
## Summary

Behavior-preserving refactor: extracts the private `calculatePythagoreanStats()` method from `StandingsRepository` into a new stateless `Standings\PythagoreanCalculator` class with a pure `calculate(array $stats): array` method. Both internal call sites in the repository delegate to an owned instance.

No GM-facing capability changes. SQL subquery builders remain private and byte-identical in the repository.

## Changes

- **New:** `ibl5/classes/Standings/PythagoreanCalculator.php` — extracted pure calculator
- **Modified:** `ibl5/classes/Standings/StandingsRepository.php` — owned field + constructor init + two delegating call sites; private method removed
- **New:** `ibl5/tests/Standings/PythagoreanCalculatorTest.php` — 3 unit tests pinning the extracted class against existing characterization numbers
- **Modified:** `ibl5/docs/maintenance-backlog.md` — status flip + detail note + frontmatter bump

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.