### PR TITLE
refactor: extract PlayerDataMapper from PlayerRepository (backlog 7.15)

### DIFF
--- a/ibl5/classes/Player/PlayerDataMapper.php
+++ b/ibl5/classes/Player/PlayerDataMapper.php
@@ -1,0 +1,374 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Player;
+
+/**
+ * PlayerDataMapper - Maps raw database rows to PlayerData DTOs.
+ *
+ * Owns the declarative FIELD_MAP and the row→PlayerData transformation logic
+ * extracted from PlayerRepository (backlog 7.15). Dependency-free: makes no
+ * database calls, so it does not extend BaseMysqliRepository.
+ *
+ * @phpstan-import-type PlayerRow from \Repositories\Contracts\PlayerLookupRepositoryInterface
+ * @phpstan-import-type HistoricalPlayerRow from \Player\Contracts\PlayerRepositoryInterface
+ */
+class PlayerDataMapper
+{
+    /**
+     * Declarative field map: PlayerData property → DB column for each mapping category.
+     * Used by tests to verify every PlayerData property is accounted for.
+     *
+     * @var array<string, list<array{target: string, source: string}>>
+     */
+    public const FIELD_MAP = [
+        'basic' => [
+            ['target' => 'playerID', 'source' => 'pid'],
+            ['target' => 'ordinal', 'source' => 'ordinal'],
+            ['target' => 'name', 'source' => 'name'],
+            ['target' => 'nickname', 'source' => 'nickname'],
+            ['target' => 'age', 'source' => 'age'],
+            ['target' => 'teamid', 'source' => 'teamid'],
+            ['target' => 'teamName', 'source' => 'teamname'],
+            ['target' => 'teamColor1', 'source' => 'color1'],
+            ['target' => 'teamColor2', 'source' => 'color2'],
+            ['target' => 'position', 'source' => 'pos'],
+        ],
+        'ratings_current' => [
+            ['target' => 'ratingFieldGoalAttempts', 'source' => 'r_fga'],
+            ['target' => 'ratingFieldGoalPercentage', 'source' => 'r_fgp'],
+            ['target' => 'ratingFreeThrowAttempts', 'source' => 'r_fta'],
+            ['target' => 'ratingFreeThrowPercentage', 'source' => 'r_ftp'],
+            ['target' => 'ratingThreePointAttempts', 'source' => 'r_3ga'],
+            ['target' => 'ratingThreePointPercentage', 'source' => 'r_3gp'],
+            ['target' => 'ratingOffensiveRebounds', 'source' => 'r_orb'],
+            ['target' => 'ratingDefensiveRebounds', 'source' => 'r_drb'],
+            ['target' => 'ratingAssists', 'source' => 'r_ast'],
+            ['target' => 'ratingSteals', 'source' => 'r_stl'],
+            ['target' => 'ratingTurnovers', 'source' => 'r_tvr'],
+            ['target' => 'ratingBlocks', 'source' => 'r_blk'],
+            ['target' => 'ratingFouls', 'source' => 'r_foul'],
+            ['target' => 'ratingOutsideOffense', 'source' => 'oo'],
+            ['target' => 'ratingOutsideDefense', 'source' => 'od'],
+            ['target' => 'ratingDriveOffense', 'source' => 'r_drive_off'],
+            ['target' => 'ratingDriveDefense', 'source' => 'dd'],
+            ['target' => 'ratingPostOffense', 'source' => 'po'],
+            ['target' => 'ratingPostDefense', 'source' => 'pd'],
+            ['target' => 'ratingTransitionOffense', 'source' => 'r_trans_off'],
+            ['target' => 'ratingTransitionDefense', 'source' => 'td'],
+            ['target' => 'ratingClutch', 'source' => 'clutch'],
+            ['target' => 'ratingConsistency', 'source' => 'consistency'],
+            ['target' => 'ratingTalent', 'source' => 'talent'],
+            ['target' => 'ratingSkill', 'source' => 'skill'],
+            ['target' => 'ratingIntangibles', 'source' => 'intangibles'],
+        ],
+        'ratings_historical' => [
+            ['target' => 'ratingFieldGoalAttempts', 'source' => 'r_2ga'],
+            ['target' => 'ratingFieldGoalPercentage', 'source' => 'r_2gp'],
+            ['target' => 'ratingFreeThrowAttempts', 'source' => 'r_fta'],
+            ['target' => 'ratingFreeThrowPercentage', 'source' => 'r_ftp'],
+            ['target' => 'ratingThreePointAttempts', 'source' => 'r_3ga'],
+            ['target' => 'ratingThreePointPercentage', 'source' => 'r_3gp'],
+            ['target' => 'ratingOffensiveRebounds', 'source' => 'r_orb'],
+            ['target' => 'ratingDefensiveRebounds', 'source' => 'r_drb'],
+            ['target' => 'ratingAssists', 'source' => 'r_ast'],
+            ['target' => 'ratingSteals', 'source' => 'r_stl'],
+            ['target' => 'ratingBlocks', 'source' => 'r_blk'],
+            ['target' => 'ratingTurnovers', 'source' => 'r_tvr'],
+            ['target' => 'ratingOutsideOffense', 'source' => 'r_oo'],
+            ['target' => 'ratingOutsideDefense', 'source' => 'r_od'],
+            ['target' => 'ratingDriveOffense', 'source' => 'r_drive_off'],
+            ['target' => 'ratingDriveDefense', 'source' => 'r_dd'],
+            ['target' => 'ratingPostOffense', 'source' => 'r_po'],
+            ['target' => 'ratingPostDefense', 'source' => 'r_pd'],
+            ['target' => 'ratingTransitionOffense', 'source' => 'r_trans_off'],
+            ['target' => 'ratingTransitionDefense', 'source' => 'r_td'],
+        ],
+        'free_agency' => [
+            ['target' => 'freeAgencyLoyalty', 'source' => 'loyalty'],
+            ['target' => 'freeAgencyPlayingTime', 'source' => 'playing_time'],
+            ['target' => 'freeAgencyPlayForWinner', 'source' => 'winner'],
+            ['target' => 'freeAgencyTradition', 'source' => 'tradition'],
+            ['target' => 'freeAgencySecurity', 'source' => 'security'],
+        ],
+        'contract' => [
+            ['target' => 'yearsOfExperience', 'source' => 'exp'],
+            ['target' => 'birdYears', 'source' => 'bird'],
+            ['target' => 'contractCurrentYear', 'source' => 'cy'],
+            ['target' => 'contractTotalYears', 'source' => 'cyt'],
+            ['target' => 'contractYear1Salary', 'source' => 'salary_yr1'],
+            ['target' => 'contractYear2Salary', 'source' => 'salary_yr2'],
+            ['target' => 'contractYear3Salary', 'source' => 'salary_yr3'],
+            ['target' => 'contractYear4Salary', 'source' => 'salary_yr4'],
+            ['target' => 'contractYear5Salary', 'source' => 'salary_yr5'],
+            ['target' => 'contractYear6Salary', 'source' => 'salary_yr6'],
+        ],
+        'draft' => [
+            ['target' => 'draftYear', 'source' => 'draftyear'],
+            ['target' => 'draftRound', 'source' => 'draftround'],
+            ['target' => 'draftPickNumber', 'source' => 'draftpickno'],
+            ['target' => 'draftTeamOriginalName', 'source' => 'draftedby'],
+            ['target' => 'draftTeamCurrentName', 'source' => 'draftedbycurrentname'],
+            ['target' => 'collegeName', 'source' => 'college'],
+        ],
+        'physical' => [
+            ['target' => 'heightFeet', 'source' => 'htft'],
+            ['target' => 'heightInches', 'source' => 'htin'],
+            ['target' => 'weightPounds', 'source' => 'wt'],
+        ],
+        'status' => [
+            ['target' => 'daysRemainingForInjury', 'source' => 'injured'],
+            ['target' => 'isRetired', 'source' => 'retired'],
+            ['target' => 'timeDroppedOnWaivers', 'source' => 'droptime'],
+        ],
+    ];
+
+    /** @var list<string> Properties set by non-repository logic or only in specific code paths */
+    public const EXCLUDED_FROM_FIELD_MAP = [
+        'plr',
+        'historicalYear',
+        'currentSeasonSalary',
+        'salaryJSB',
+        'decoratedName',
+        'nameStatusClass',
+    ];
+
+    /**
+     * Fill a PlayerData object from a current player row
+     *
+     * @param PlayerRow $plrRow Database row from `ibl_plr`
+     */
+    public function fillFromCurrentRow(array $plrRow): PlayerData
+    {
+        $playerData = new PlayerData();
+
+        // Basic player information
+        $this->mapBasicFields($playerData, $plrRow);
+
+        // Ratings - use helper to map array of field pairs
+        $this->mapRatingsFromCurrentRow($playerData, $plrRow);
+
+        // Free agency preferences
+        $this->mapFreeAgencyFields($playerData, $plrRow);
+
+        // Contract information
+        $this->mapContractFields($playerData, $plrRow);
+
+        // Draft information
+        $this->mapDraftFields($playerData, $plrRow);
+
+        // Physical attributes
+        $this->mapPhysicalFields($playerData, $plrRow);
+
+        // Status fields
+        $this->mapStatusFields($playerData, $plrRow);
+
+        return $playerData;
+    }
+
+    /**
+     * Fill a PlayerData object from a historical player row
+     *
+     * @param HistoricalPlayerRow $plrRow
+     */
+    public function fillFromHistoricalRow(array $plrRow): PlayerData
+    {
+        $playerData = new PlayerData();
+
+        // Basic historical player information
+        $playerData->playerID = $plrRow['pid'] ?? null;
+        $playerData->historicalYear = $plrRow['year'] ?? null;
+        $name = $plrRow['name'] ?? null;
+        $playerData->name = $name !== null ? stripslashes($name) : null;
+        $team = $plrRow['team'] ?? null;
+        $playerData->teamName = $team !== null ? stripslashes($team) : null;
+        $playerData->teamid = $plrRow['teamid'] ?? null;
+
+        // Ratings from historical row (note different column names)
+        $this->mapRatingsFromHistoricalRow($playerData, $plrRow);
+
+        // Salary
+        $playerData->salaryJSB = $plrRow['salary'] ?? null;
+
+        // Initialize contract fields for historical data (values are snapshots, not current)
+        $playerData->contractCurrentYear = 0;
+        $playerData->contractTotalYears = 0;
+        $playerData->contractYear1Salary = 0;
+        $playerData->contractYear2Salary = 0;
+        $playerData->contractYear3Salary = 0;
+        $playerData->contractYear4Salary = 0;
+        $playerData->contractYear5Salary = 0;
+        $playerData->contractYear6Salary = 0;
+
+        return $playerData;
+    }
+
+    /**
+     * Map basic player fields
+     *
+     * @param PlayerRow $plrRow Database row from `ibl_plr`
+     */
+    private function mapBasicFields(PlayerData $playerData, array $plrRow): void
+    {
+        $playerData->playerID = $plrRow['pid'];
+        $playerData->ordinal = $plrRow['ordinal'];
+        $playerData->name = stripslashes($plrRow['name']);
+        $playerData->nickname = $this->getOptionalStrippedValue($plrRow, 'nickname');
+        $playerData->age = $plrRow['age'];
+        $playerData->teamid = $plrRow['teamid'];
+        $playerData->teamName = isset($plrRow['teamname']) ? stripslashes($plrRow['teamname']) : null;
+        /** @var string|null $color1 */
+        $color1 = $plrRow['color1'] ?? null;
+        $playerData->teamColor1 = $color1;
+        /** @var string|null $color2 */
+        $color2 = $plrRow['color2'] ?? null;
+        $playerData->teamColor2 = $color2;
+        $playerData->position = $plrRow['pos'] ?? '';
+    }
+
+    /**
+     * @param PlayerRow $plrRow Database row from `ibl_plr`
+     */
+    private function mapRatingsFromCurrentRow(PlayerData $playerData, array $plrRow): void
+    {
+        $playerData->ratingFieldGoalAttempts = $plrRow['r_fga'];
+        $playerData->ratingFieldGoalPercentage = $plrRow['r_fgp'];
+        $playerData->ratingFreeThrowAttempts = $plrRow['r_fta'];
+        $playerData->ratingFreeThrowPercentage = $plrRow['r_ftp'];
+        $playerData->ratingThreePointAttempts = $plrRow['r_3ga'];
+        $playerData->ratingThreePointPercentage = $plrRow['r_3gp'];
+        $playerData->ratingOffensiveRebounds = $plrRow['r_orb'];
+        $playerData->ratingDefensiveRebounds = $plrRow['r_drb'];
+        $playerData->ratingAssists = $plrRow['r_ast'];
+        $playerData->ratingSteals = $plrRow['r_stl'];
+        $playerData->ratingTurnovers = $plrRow['r_tvr'];
+        $playerData->ratingBlocks = $plrRow['r_blk'];
+        $playerData->ratingFouls = $plrRow['r_foul'];
+        $playerData->ratingOutsideOffense = $plrRow['oo'];
+        $playerData->ratingOutsideDefense = $plrRow['od'];
+        $playerData->ratingDriveOffense = $plrRow['r_drive_off'];
+        $playerData->ratingDriveDefense = $plrRow['dd'];
+        $playerData->ratingPostOffense = $plrRow['po'];
+        $playerData->ratingPostDefense = $plrRow['pd'];
+        $playerData->ratingTransitionOffense = $plrRow['r_trans_off'];
+        $playerData->ratingTransitionDefense = $plrRow['td'];
+        $playerData->ratingClutch = $plrRow['clutch'];
+        $playerData->ratingConsistency = $plrRow['consistency'];
+        $playerData->ratingTalent = $plrRow['talent'];
+        $playerData->ratingSkill = $plrRow['skill'];
+        $playerData->ratingIntangibles = $plrRow['intangibles'];
+    }
+
+    /**
+     * @param PlayerRow $plrRow Database row from `ibl_plr`
+     */
+    private function mapFreeAgencyFields(PlayerData $playerData, array $plrRow): void
+    {
+        $playerData->freeAgencyLoyalty = $plrRow['loyalty'];
+        $playerData->freeAgencyPlayingTime = $plrRow['playing_time'];
+        $playerData->freeAgencyPlayForWinner = $plrRow['winner'];
+        $playerData->freeAgencyTradition = $plrRow['tradition'];
+        $playerData->freeAgencySecurity = $plrRow['security'];
+    }
+
+    /**
+     * @param PlayerRow $plrRow Database row from `ibl_plr`
+     */
+    private function mapContractFields(PlayerData $playerData, array $plrRow): void
+    {
+        $playerData->yearsOfExperience = $plrRow['exp'];
+        $playerData->birdYears = $plrRow['bird'];
+        $playerData->contractCurrentYear = $plrRow['cy'];
+        $playerData->contractTotalYears = $plrRow['cyt'];
+        $playerData->contractYear1Salary = $plrRow['salary_yr1'];
+        $playerData->contractYear2Salary = $plrRow['salary_yr2'];
+        $playerData->contractYear3Salary = $plrRow['salary_yr3'];
+        $playerData->contractYear4Salary = $plrRow['salary_yr4'];
+        $playerData->contractYear5Salary = $plrRow['salary_yr5'];
+        $playerData->contractYear6Salary = $plrRow['salary_yr6'];
+    }
+
+    /**
+     * Map draft fields
+     *
+     * @param PlayerRow $plrRow Database row from `ibl_plr`
+     */
+    private function mapDraftFields(PlayerData $playerData, array $plrRow): void
+    {
+        $playerData->draftYear = $plrRow['draftyear'];
+        $playerData->draftRound = $plrRow['draftround'];
+        $playerData->draftPickNumber = $plrRow['draftpickno'];
+        $playerData->draftTeamOriginalName = $this->getOptionalStrippedValue($plrRow, 'draftedby');
+        $playerData->draftTeamCurrentName = $this->getOptionalStrippedValue($plrRow, 'draftedbycurrentname');
+        $playerData->collegeName = $this->getOptionalStrippedValue($plrRow, 'college');
+    }
+
+    /**
+     * Map physical attribute fields
+     *
+     * @param PlayerRow $plrRow Database row from `ibl_plr`
+     */
+    private function mapPhysicalFields(PlayerData $playerData, array $plrRow): void
+    {
+        $htft = $plrRow['htft'] ?? null;
+        $playerData->heightFeet = $htft !== null ? (int) $htft : null;
+        $htin = $plrRow['htin'] ?? null;
+        $playerData->heightInches = $htin !== null ? (int) $htin : null;
+        $wt = $plrRow['wt'] ?? null;
+        $playerData->weightPounds = $wt !== null ? (int) $wt : null;
+    }
+
+    /**
+     * Map status fields
+     *
+     * @param PlayerRow $plrRow Database row from `ibl_plr`
+     */
+    private function mapStatusFields(PlayerData $playerData, array $plrRow): void
+    {
+        $playerData->daysRemainingForInjury = $plrRow['injured'];
+        $playerData->isRetired = $plrRow['retired'] ?? null;
+        $playerData->timeDroppedOnWaivers = $plrRow['droptime'];
+    }
+
+    /**
+     * Helper method to get optional string value with stripslashes, or null if not set/empty
+     *
+     * @param array<string, mixed> $row
+     */
+    private function getOptionalStrippedValue(array $row, string $key): ?string
+    {
+        $value = $row[$key] ?? null;
+        if (!is_string($value) || $value === '') {
+            return null;
+        }
+        return stripslashes($value);
+    }
+
+    /**
+     * @param HistoricalPlayerRow $plrRow
+     */
+    private function mapRatingsFromHistoricalRow(PlayerData $playerData, array $plrRow): void
+    {
+        $playerData->ratingFieldGoalAttempts = $plrRow['r_2ga'] ?? null;
+        $playerData->ratingFieldGoalPercentage = $plrRow['r_2gp'] ?? null;
+        $playerData->ratingFreeThrowAttempts = $plrRow['r_fta'] ?? null;
+        $playerData->ratingFreeThrowPercentage = $plrRow['r_ftp'] ?? null;
+        $playerData->ratingThreePointAttempts = $plrRow['r_3ga'] ?? null;
+        $playerData->ratingThreePointPercentage = $plrRow['r_3gp'] ?? null;
+        $playerData->ratingOffensiveRebounds = $plrRow['r_orb'] ?? null;
+        $playerData->ratingDefensiveRebounds = $plrRow['r_drb'] ?? null;
+        $playerData->ratingAssists = $plrRow['r_ast'] ?? null;
+        $playerData->ratingSteals = $plrRow['r_stl'] ?? null;
+        $playerData->ratingBlocks = $plrRow['r_blk'] ?? null;
+        $playerData->ratingTurnovers = $plrRow['r_tvr'] ?? null;
+        $playerData->ratingOutsideOffense = $plrRow['r_oo'] ?? null;
+        $playerData->ratingOutsideDefense = $plrRow['r_od'] ?? null;
+        $playerData->ratingDriveOffense = $plrRow['r_drive_off'] ?? null;
+        $playerData->ratingDriveDefense = $plrRow['r_dd'] ?? null;
+        $playerData->ratingPostOffense = $plrRow['r_po'] ?? null;
+        $playerData->ratingPostDefense = $plrRow['r_pd'] ?? null;
+        $playerData->ratingTransitionOffense = $plrRow['r_trans_off'] ?? null;
+        $playerData->ratingTransitionDefense = $plrRow['r_td'] ?? null;
+    }
+}

--- a/ibl5/classes/Player/PlayerRepository.php
+++ b/ibl5/classes/Player/PlayerRepository.php
@@ -24,123 +24,7 @@ use Player\Contracts\PlayerRepositoryInterface;
  */
 class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryInterface
 {
-    /**
-     * Declarative field map: PlayerData property → DB column for each mapping category.
-     * Used by tests to verify every PlayerData property is accounted for.
-     *
-     * @var array<string, list<array{target: string, source: string}>>
-     */
-    public const FIELD_MAP = [
-        'basic' => [
-            ['target' => 'playerID', 'source' => 'pid'],
-            ['target' => 'ordinal', 'source' => 'ordinal'],
-            ['target' => 'name', 'source' => 'name'],
-            ['target' => 'nickname', 'source' => 'nickname'],
-            ['target' => 'age', 'source' => 'age'],
-            ['target' => 'teamid', 'source' => 'teamid'],
-            ['target' => 'teamName', 'source' => 'teamname'],
-            ['target' => 'teamColor1', 'source' => 'color1'],
-            ['target' => 'teamColor2', 'source' => 'color2'],
-            ['target' => 'position', 'source' => 'pos'],
-        ],
-        'ratings_current' => [
-            ['target' => 'ratingFieldGoalAttempts', 'source' => 'r_fga'],
-            ['target' => 'ratingFieldGoalPercentage', 'source' => 'r_fgp'],
-            ['target' => 'ratingFreeThrowAttempts', 'source' => 'r_fta'],
-            ['target' => 'ratingFreeThrowPercentage', 'source' => 'r_ftp'],
-            ['target' => 'ratingThreePointAttempts', 'source' => 'r_3ga'],
-            ['target' => 'ratingThreePointPercentage', 'source' => 'r_3gp'],
-            ['target' => 'ratingOffensiveRebounds', 'source' => 'r_orb'],
-            ['target' => 'ratingDefensiveRebounds', 'source' => 'r_drb'],
-            ['target' => 'ratingAssists', 'source' => 'r_ast'],
-            ['target' => 'ratingSteals', 'source' => 'r_stl'],
-            ['target' => 'ratingTurnovers', 'source' => 'r_tvr'],
-            ['target' => 'ratingBlocks', 'source' => 'r_blk'],
-            ['target' => 'ratingFouls', 'source' => 'r_foul'],
-            ['target' => 'ratingOutsideOffense', 'source' => 'oo'],
-            ['target' => 'ratingOutsideDefense', 'source' => 'od'],
-            ['target' => 'ratingDriveOffense', 'source' => 'r_drive_off'],
-            ['target' => 'ratingDriveDefense', 'source' => 'dd'],
-            ['target' => 'ratingPostOffense', 'source' => 'po'],
-            ['target' => 'ratingPostDefense', 'source' => 'pd'],
-            ['target' => 'ratingTransitionOffense', 'source' => 'r_trans_off'],
-            ['target' => 'ratingTransitionDefense', 'source' => 'td'],
-            ['target' => 'ratingClutch', 'source' => 'clutch'],
-            ['target' => 'ratingConsistency', 'source' => 'consistency'],
-            ['target' => 'ratingTalent', 'source' => 'talent'],
-            ['target' => 'ratingSkill', 'source' => 'skill'],
-            ['target' => 'ratingIntangibles', 'source' => 'intangibles'],
-        ],
-        'ratings_historical' => [
-            ['target' => 'ratingFieldGoalAttempts', 'source' => 'r_2ga'],
-            ['target' => 'ratingFieldGoalPercentage', 'source' => 'r_2gp'],
-            ['target' => 'ratingFreeThrowAttempts', 'source' => 'r_fta'],
-            ['target' => 'ratingFreeThrowPercentage', 'source' => 'r_ftp'],
-            ['target' => 'ratingThreePointAttempts', 'source' => 'r_3ga'],
-            ['target' => 'ratingThreePointPercentage', 'source' => 'r_3gp'],
-            ['target' => 'ratingOffensiveRebounds', 'source' => 'r_orb'],
-            ['target' => 'ratingDefensiveRebounds', 'source' => 'r_drb'],
-            ['target' => 'ratingAssists', 'source' => 'r_ast'],
-            ['target' => 'ratingSteals', 'source' => 'r_stl'],
-            ['target' => 'ratingBlocks', 'source' => 'r_blk'],
-            ['target' => 'ratingTurnovers', 'source' => 'r_tvr'],
-            ['target' => 'ratingOutsideOffense', 'source' => 'r_oo'],
-            ['target' => 'ratingOutsideDefense', 'source' => 'r_od'],
-            ['target' => 'ratingDriveOffense', 'source' => 'r_drive_off'],
-            ['target' => 'ratingDriveDefense', 'source' => 'r_dd'],
-            ['target' => 'ratingPostOffense', 'source' => 'r_po'],
-            ['target' => 'ratingPostDefense', 'source' => 'r_pd'],
-            ['target' => 'ratingTransitionOffense', 'source' => 'r_trans_off'],
-            ['target' => 'ratingTransitionDefense', 'source' => 'r_td'],
-        ],
-        'free_agency' => [
-            ['target' => 'freeAgencyLoyalty', 'source' => 'loyalty'],
-            ['target' => 'freeAgencyPlayingTime', 'source' => 'playing_time'],
-            ['target' => 'freeAgencyPlayForWinner', 'source' => 'winner'],
-            ['target' => 'freeAgencyTradition', 'source' => 'tradition'],
-            ['target' => 'freeAgencySecurity', 'source' => 'security'],
-        ],
-        'contract' => [
-            ['target' => 'yearsOfExperience', 'source' => 'exp'],
-            ['target' => 'birdYears', 'source' => 'bird'],
-            ['target' => 'contractCurrentYear', 'source' => 'cy'],
-            ['target' => 'contractTotalYears', 'source' => 'cyt'],
-            ['target' => 'contractYear1Salary', 'source' => 'salary_yr1'],
-            ['target' => 'contractYear2Salary', 'source' => 'salary_yr2'],
-            ['target' => 'contractYear3Salary', 'source' => 'salary_yr3'],
-            ['target' => 'contractYear4Salary', 'source' => 'salary_yr4'],
-            ['target' => 'contractYear5Salary', 'source' => 'salary_yr5'],
-            ['target' => 'contractYear6Salary', 'source' => 'salary_yr6'],
-        ],
-        'draft' => [
-            ['target' => 'draftYear', 'source' => 'draftyear'],
-            ['target' => 'draftRound', 'source' => 'draftround'],
-            ['target' => 'draftPickNumber', 'source' => 'draftpickno'],
-            ['target' => 'draftTeamOriginalName', 'source' => 'draftedby'],
-            ['target' => 'draftTeamCurrentName', 'source' => 'draftedbycurrentname'],
-            ['target' => 'collegeName', 'source' => 'college'],
-        ],
-        'physical' => [
-            ['target' => 'heightFeet', 'source' => 'htft'],
-            ['target' => 'heightInches', 'source' => 'htin'],
-            ['target' => 'weightPounds', 'source' => 'wt'],
-        ],
-        'status' => [
-            ['target' => 'daysRemainingForInjury', 'source' => 'injured'],
-            ['target' => 'isRetired', 'source' => 'retired'],
-            ['target' => 'timeDroppedOnWaivers', 'source' => 'droptime'],
-        ],
-    ];
-
-    /** @var list<string> Properties set by non-repository logic or only in specific code paths */
-    public const EXCLUDED_FROM_FIELD_MAP = [
-        'plr',
-        'historicalYear',
-        'currentSeasonSalary',
-        'salaryJSB',
-        'decoratedName',
-        'nameStatusClass',
-    ];
+    private PlayerDataMapper $mapper;
 
     /** @var array{allStar: int, threePoint: int, dunkContest: int, rookieSoph: int}|null */
     private ?array $cachedAllStarWeekendCounts = null;
@@ -155,6 +39,7 @@ class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryI
     public function __construct(\mysqli $db)
     {
         parent::__construct($db);
+        $this->mapper = new PlayerDataMapper();
     }
 
     /**
@@ -184,239 +69,25 @@ class PlayerRepository extends BaseMysqliRepository implements PlayerRepositoryI
     /**
      * Fill a PlayerData object from a current player row
      *
+     * @see PlayerDataMapper::fillFromCurrentRow()
+     *
      * @param PlayerRow $plrRow Database row from `ibl_plr`
      */
     public function fillFromCurrentRow(array $plrRow): PlayerData
     {
-        $playerData = new PlayerData();
-
-        // Basic player information
-        $this->mapBasicFields($playerData, $plrRow);
-        
-        // Ratings - use helper to map array of field pairs
-        $this->mapRatingsFromCurrentRow($playerData, $plrRow);
-        
-        // Free agency preferences
-        $this->mapFreeAgencyFields($playerData, $plrRow);
-        
-        // Contract information
-        $this->mapContractFields($playerData, $plrRow);
-        
-        // Draft information
-        $this->mapDraftFields($playerData, $plrRow);
-        
-        // Physical attributes
-        $this->mapPhysicalFields($playerData, $plrRow);
-        
-        // Status fields
-        $this->mapStatusFields($playerData, $plrRow);
-
-        return $playerData;
-    }
-
-    /**
-     * Map basic player fields
-     *
-     * @param PlayerRow $plrRow Database row from `ibl_plr`
-     */
-    private function mapBasicFields(PlayerData $playerData, array $plrRow): void
-    {
-        $playerData->playerID = $plrRow['pid'];
-        $playerData->ordinal = $plrRow['ordinal'];
-        $playerData->name = stripslashes($plrRow['name']);
-        $playerData->nickname = $this->getOptionalStrippedValue($plrRow, 'nickname');
-        $playerData->age = $plrRow['age'];
-        $playerData->teamid = $plrRow['teamid'];
-        $playerData->teamName = isset($plrRow['teamname']) ? stripslashes($plrRow['teamname']) : null;
-        /** @var string|null $color1 */
-        $color1 = $plrRow['color1'] ?? null;
-        $playerData->teamColor1 = $color1;
-        /** @var string|null $color2 */
-        $color2 = $plrRow['color2'] ?? null;
-        $playerData->teamColor2 = $color2;
-        $playerData->position = $plrRow['pos'] ?? '';
-    }
-
-    /**
-     * @param PlayerRow $plrRow Database row from `ibl_plr`
-     */
-    private function mapRatingsFromCurrentRow(PlayerData $playerData, array $plrRow): void
-    {
-        $playerData->ratingFieldGoalAttempts = $plrRow['r_fga'];
-        $playerData->ratingFieldGoalPercentage = $plrRow['r_fgp'];
-        $playerData->ratingFreeThrowAttempts = $plrRow['r_fta'];
-        $playerData->ratingFreeThrowPercentage = $plrRow['r_ftp'];
-        $playerData->ratingThreePointAttempts = $plrRow['r_3ga'];
-        $playerData->ratingThreePointPercentage = $plrRow['r_3gp'];
-        $playerData->ratingOffensiveRebounds = $plrRow['r_orb'];
-        $playerData->ratingDefensiveRebounds = $plrRow['r_drb'];
-        $playerData->ratingAssists = $plrRow['r_ast'];
-        $playerData->ratingSteals = $plrRow['r_stl'];
-        $playerData->ratingTurnovers = $plrRow['r_tvr'];
-        $playerData->ratingBlocks = $plrRow['r_blk'];
-        $playerData->ratingFouls = $plrRow['r_foul'];
-        $playerData->ratingOutsideOffense = $plrRow['oo'];
-        $playerData->ratingOutsideDefense = $plrRow['od'];
-        $playerData->ratingDriveOffense = $plrRow['r_drive_off'];
-        $playerData->ratingDriveDefense = $plrRow['dd'];
-        $playerData->ratingPostOffense = $plrRow['po'];
-        $playerData->ratingPostDefense = $plrRow['pd'];
-        $playerData->ratingTransitionOffense = $plrRow['r_trans_off'];
-        $playerData->ratingTransitionDefense = $plrRow['td'];
-        $playerData->ratingClutch = $plrRow['clutch'];
-        $playerData->ratingConsistency = $plrRow['consistency'];
-        $playerData->ratingTalent = $plrRow['talent'];
-        $playerData->ratingSkill = $plrRow['skill'];
-        $playerData->ratingIntangibles = $plrRow['intangibles'];
-    }
-
-    /**
-     * @param PlayerRow $plrRow Database row from `ibl_plr`
-     */
-    private function mapFreeAgencyFields(PlayerData $playerData, array $plrRow): void
-    {
-        $playerData->freeAgencyLoyalty = $plrRow['loyalty'];
-        $playerData->freeAgencyPlayingTime = $plrRow['playing_time'];
-        $playerData->freeAgencyPlayForWinner = $plrRow['winner'];
-        $playerData->freeAgencyTradition = $plrRow['tradition'];
-        $playerData->freeAgencySecurity = $plrRow['security'];
-    }
-
-    /**
-     * @param PlayerRow $plrRow Database row from `ibl_plr`
-     */
-    private function mapContractFields(PlayerData $playerData, array $plrRow): void
-    {
-        $playerData->yearsOfExperience = $plrRow['exp'];
-        $playerData->birdYears = $plrRow['bird'];
-        $playerData->contractCurrentYear = $plrRow['cy'];
-        $playerData->contractTotalYears = $plrRow['cyt'];
-        $playerData->contractYear1Salary = $plrRow['salary_yr1'];
-        $playerData->contractYear2Salary = $plrRow['salary_yr2'];
-        $playerData->contractYear3Salary = $plrRow['salary_yr3'];
-        $playerData->contractYear4Salary = $plrRow['salary_yr4'];
-        $playerData->contractYear5Salary = $plrRow['salary_yr5'];
-        $playerData->contractYear6Salary = $plrRow['salary_yr6'];
-    }
-
-    /**
-     * Map draft fields
-     *
-     * @param PlayerRow $plrRow Database row from `ibl_plr`
-     */
-    private function mapDraftFields(PlayerData $playerData, array $plrRow): void
-    {
-        $playerData->draftYear = $plrRow['draftyear'];
-        $playerData->draftRound = $plrRow['draftround'];
-        $playerData->draftPickNumber = $plrRow['draftpickno'];
-        $playerData->draftTeamOriginalName = $this->getOptionalStrippedValue($plrRow, 'draftedby');
-        $playerData->draftTeamCurrentName = $this->getOptionalStrippedValue($plrRow, 'draftedbycurrentname');
-        $playerData->collegeName = $this->getOptionalStrippedValue($plrRow, 'college');
-    }
-
-    /**
-     * Map physical attribute fields
-     *
-     * @param PlayerRow $plrRow Database row from `ibl_plr`
-     */
-    private function mapPhysicalFields(PlayerData $playerData, array $plrRow): void
-    {
-        $htft = $plrRow['htft'] ?? null;
-        $playerData->heightFeet = $htft !== null ? (int) $htft : null;
-        $htin = $plrRow['htin'] ?? null;
-        $playerData->heightInches = $htin !== null ? (int) $htin : null;
-        $wt = $plrRow['wt'] ?? null;
-        $playerData->weightPounds = $wt !== null ? (int) $wt : null;
-    }
-
-    /**
-     * Map status fields
-     *
-     * @param PlayerRow $plrRow Database row from `ibl_plr`
-     */
-    private function mapStatusFields(PlayerData $playerData, array $plrRow): void
-    {
-        $playerData->daysRemainingForInjury = $plrRow['injured'];
-        $playerData->isRetired = $plrRow['retired'] ?? null;
-        $playerData->timeDroppedOnWaivers = $plrRow['droptime'];
-    }
-
-    /**
-     * Helper method to get optional string value with stripslashes, or null if not set/empty
-     *
-     * @param array<string, mixed> $row
-     */
-    private function getOptionalStrippedValue(array $row, string $key): ?string
-    {
-        $value = $row[$key] ?? null;
-        if (!is_string($value) || $value === '') {
-            return null;
-        }
-        return stripslashes($value);
+        return $this->mapper->fillFromCurrentRow($plrRow);
     }
 
     /**
      * Fill a PlayerData object from a historical player row
      *
+     * @see PlayerDataMapper::fillFromHistoricalRow()
+     *
      * @param HistoricalPlayerRow $plrRow
      */
     public function fillFromHistoricalRow(array $plrRow): PlayerData
     {
-        $playerData = new PlayerData();
-
-        // Basic historical player information
-        $playerData->playerID = $plrRow['pid'] ?? null;
-        $playerData->historicalYear = $plrRow['year'] ?? null;
-        $name = $plrRow['name'] ?? null;
-        $playerData->name = $name !== null ? stripslashes($name) : null;
-        $team = $plrRow['team'] ?? null;
-        $playerData->teamName = $team !== null ? stripslashes($team) : null;
-        $playerData->teamid = $plrRow['teamid'] ?? null;
-
-        // Ratings from historical row (note different column names)
-        $this->mapRatingsFromHistoricalRow($playerData, $plrRow);
-
-        // Salary
-        $playerData->salaryJSB = $plrRow['salary'] ?? null;
-
-        // Initialize contract fields for historical data (values are snapshots, not current)
-        $playerData->contractCurrentYear = 0;
-        $playerData->contractTotalYears = 0;
-        $playerData->contractYear1Salary = 0;
-        $playerData->contractYear2Salary = 0;
-        $playerData->contractYear3Salary = 0;
-        $playerData->contractYear4Salary = 0;
-        $playerData->contractYear5Salary = 0;
-        $playerData->contractYear6Salary = 0;
-
-        return $playerData;
-    }
-
-    /**
-     * @param HistoricalPlayerRow $plrRow
-     */
-    private function mapRatingsFromHistoricalRow(PlayerData $playerData, array $plrRow): void
-    {
-        $playerData->ratingFieldGoalAttempts = $plrRow['r_2ga'] ?? null;
-        $playerData->ratingFieldGoalPercentage = $plrRow['r_2gp'] ?? null;
-        $playerData->ratingFreeThrowAttempts = $plrRow['r_fta'] ?? null;
-        $playerData->ratingFreeThrowPercentage = $plrRow['r_ftp'] ?? null;
-        $playerData->ratingThreePointAttempts = $plrRow['r_3ga'] ?? null;
-        $playerData->ratingThreePointPercentage = $plrRow['r_3gp'] ?? null;
-        $playerData->ratingOffensiveRebounds = $plrRow['r_orb'] ?? null;
-        $playerData->ratingDefensiveRebounds = $plrRow['r_drb'] ?? null;
-        $playerData->ratingAssists = $plrRow['r_ast'] ?? null;
-        $playerData->ratingSteals = $plrRow['r_stl'] ?? null;
-        $playerData->ratingBlocks = $plrRow['r_blk'] ?? null;
-        $playerData->ratingTurnovers = $plrRow['r_tvr'] ?? null;
-        $playerData->ratingOutsideOffense = $plrRow['r_oo'] ?? null;
-        $playerData->ratingOutsideDefense = $plrRow['r_od'] ?? null;
-        $playerData->ratingDriveOffense = $plrRow['r_drive_off'] ?? null;
-        $playerData->ratingDriveDefense = $plrRow['r_dd'] ?? null;
-        $playerData->ratingPostOffense = $plrRow['r_po'] ?? null;
-        $playerData->ratingPostDefense = $plrRow['r_pd'] ?? null;
-        $playerData->ratingTransitionOffense = $plrRow['r_trans_off'] ?? null;
-        $playerData->ratingTransitionDefense = $plrRow['r_td'] ?? null;
+        return $this->mapper->fillFromHistoricalRow($plrRow);
     }
 
     /**

--- a/ibl5/classes/Player/README.md
+++ b/ibl5/classes/Player/README.md
@@ -58,17 +58,33 @@ A simple data container that holds player information without any business logic
 Handles all database operations for player data following the Repository pattern. This class:
 - Encapsulates data loading logic
 - Provides methods to load players from different sources
-- Translates database rows into PlayerData objects
+- Delegates row→DTO mapping to `PlayerDataMapper`
 - Isolates the rest of the code from database schema changes
-- Uses focused helper methods to organize field mapping
 
 **Key Methods**:
 - `loadByID(int $playerID): PlayerData` - Load a player by ID
-- `fillFromCurrentRow(array $plrRow): PlayerData` - Create PlayerData from current season row
-- `fillFromHistoricalRow(array $plrRow): PlayerData` - Create PlayerData from historical row
+- `fillFromCurrentRow(array $plrRow): PlayerData` - Delegates to `PlayerDataMapper::fillFromCurrentRow()`
+- `fillFromHistoricalRow(array $plrRow): PlayerData` - Delegates to `PlayerDataMapper::fillFromHistoricalRow()`
 - `getFreeAgencyDemands(string $playerName)` - Query free agency demands
 
-**Private Helper Methods** (for better organization):
+**Location**: `/ibl5/classes/Player/PlayerRepository.php`
+
+---
+
+### PlayerDataMapper
+**Responsibility**: Row→DTO Mapping
+
+A dependency-free class that owns the declarative field map and all row→PlayerData transformation logic (extracted from `PlayerRepository`, backlog 7.15). Makes no database calls.
+
+**Constants**:
+- `FIELD_MAP` - Declarative property→column mapping for all PlayerData fields
+- `EXCLUDED_FROM_FIELD_MAP` - Properties set outside the field map
+
+**Public Methods**:
+- `fillFromCurrentRow(array $plrRow): PlayerData` - Map a current-season `ibl_plr` row to PlayerData
+- `fillFromHistoricalRow(array $plrRow): PlayerData` - Map a historical row to PlayerData
+
+**Private Helper Methods**:
 - `mapBasicFields()` - Map player identity and team information
 - `mapRatingsFromCurrentRow()` / `mapRatingsFromHistoricalRow()` - Map rating fields
 - `mapFreeAgencyFields()` - Map free agency preferences
@@ -78,7 +94,7 @@ Handles all database operations for player data following the Repository pattern
 - `mapStatusFields()` - Map status flags
 - `getOptionalStrippedValue()` - Helper for nullable string fields
 
-**Location**: `/ibl5/classes/Player/PlayerRepository.php`
+**Location**: `/ibl5/classes/Player/PlayerDataMapper.php`
 
 ---
 

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1335,7 +1335,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 | 7.12 | ✅ Implemented | — | TeamOrderBy enum (#1032). |
 | 7.13 | ✅ Implemented | — | DraftRepository injects TeamIdentityRepositoryInterface. |
 | 7.14 | ✅ Implemented | 🟩 | Extracted `Standings\PythagoreanCalculator` (pure `calculate()`); StandingsRepository delegates both call sites; green-green. |
-| 7.15 | ⬜ Open | 🟩 | 8 map*/FIELD_MAP members (verified); PlayerRepository 622 LOC. Extract PlayerDataMapper/Hydrator; green-green. |
+| 7.15 | ✅ Implemented | 🟩 | 8 map*/FIELD_MAP members (verified); PlayerRepository 622 LOC. Extract PlayerDataMapper/Hydrator; green-green. |
 | 7.16 | ✅ Implemented | — | Hidden caches dropped (#1040). |
 | 7.17 | ⬜ Open | 🟩 | `getPlayerNews`→nuke_stories cross-query. Annotate `@see` (trivial) or extract LegacyNewsRepository; green-green. |
 | 7.18 | ⬜ Open | 🟩 | Duplicate player-lookup JOINs (PlayerRepository vs CommonMysqli). Delegate one; green-green with characterization pin (column drift noted). |
@@ -1457,6 +1457,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Extract `PlayerDataMapper` / `PlayerHydrator`.
 **Est. effort:** M
 **Risk if untouched:** Two responsibilities change together; both harder to test.
+**Status:** Implemented — extracted `ibl5/classes/Player/PlayerDataMapper.php` (constants + 8 map* methods); `PlayerRepository` delegates. Green-green refactor.
 
 ### 7.16 `RecordHoldersRepository` Has Hidden In-Memory Caches
 **Location:** `ibl5/classes/RecordHolders/RecordHoldersRepository.php` lines 45-49

--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -6,6 +6,6 @@
         "ibl.sqlStringInterpolation": 31
     },
     "phpstan-tests-baseline.neon": {
-        "argument.type": 72
+        "argument.type": 73
     }
 }

--- a/ibl5/phpstan-tests-baseline.neon
+++ b/ibl5/phpstan-tests-baseline.neon
@@ -247,6 +247,12 @@ parameters:
 			path: tests/Negotiation/NegotiationDemandCalculatorTest.php
 
 		-
+			rawMessage: 'Parameter #1 $plrRow of method Player\PlayerDataMapper::fillFromCurrentRow() expects array{pid: int, name: string, nickname: string|null, age: int|null, teamid: int, teamname: string|null, pos: string, stamina: int|null, ..., ...<string, mixed>}, non-empty-array<string, mixed> given.'
+			identifier: argument.type
+			count: 1
+			path: tests/Player/PlayerDataMapperFieldMapTest.php
+
+		-
 			rawMessage: 'Parameter #1 $playerID of static method Player\PlayerImageHelper::getImageUrl() expects int|string|null, float given.'
 			identifier: argument.type
 			count: 1

--- a/ibl5/tests/Player/PlayerDataMapperFieldMapTest.php
+++ b/ibl5/tests/Player/PlayerDataMapperFieldMapTest.php
@@ -6,22 +6,21 @@ namespace Tests\Player;
 
 use PHPUnit\Framework\TestCase;
 use Player\PlayerData;
-use Player\PlayerRepository;
+use Player\PlayerDataMapper;
 
-class PlayerRepositoryFieldMapTest extends TestCase
+class PlayerDataMapperFieldMapTest extends TestCase
 {
-    private PlayerRepository $repository;
+    private PlayerDataMapper $mapper;
 
     protected function setUp(): void
     {
-        $db = self::createStub(\mysqli::class);
-        $this->repository = new PlayerRepository($db);
+        $this->mapper = new PlayerDataMapper();
     }
 
     public function testFillFromCurrentRowMapsAllExpectedFields(): void
     {
         $row = $this->buildFullCurrentRow();
-        $player = $this->repository->fillFromCurrentRow($row);
+        $player = $this->mapper->fillFromCurrentRow($row);
 
         self::assertSame(100, $player->playerID);
         self::assertSame(5, $player->ordinal);
@@ -103,7 +102,7 @@ class PlayerRepositoryFieldMapTest extends TestCase
     public function testFillFromHistoricalRowMapsAllExpectedFields(): void
     {
         $row = $this->buildFullHistoricalRow();
-        $player = $this->repository->fillFromHistoricalRow($row);
+        $player = $this->mapper->fillFromHistoricalRow($row);
 
         self::assertSame(200, $player->playerID);
         self::assertSame(2015, $player->historicalYear);
@@ -162,7 +161,7 @@ class PlayerRepositoryFieldMapTest extends TestCase
         $row['wt'] = null;
         $row['retired'] = null;
 
-        $player = $this->repository->fillFromCurrentRow($row);
+        $player = $this->mapper->fillFromCurrentRow($row);
 
         self::assertNull($player->nickname);
         self::assertNull($player->teamName);
@@ -177,12 +176,38 @@ class PlayerRepositoryFieldMapTest extends TestCase
         self::assertNull($player->isRetired);
     }
 
+    public function testFillFromCurrentRowMapsEmptyStringOptionalFieldsToNull(): void
+    {
+        $row = $this->buildFullCurrentRow();
+        $row['nickname'] = '';
+        $row['draftedby'] = '';
+        $row['draftedbycurrentname'] = '';
+        $row['college'] = '';
+
+        $player = $this->mapper->fillFromCurrentRow($row);
+
+        self::assertNull($player->nickname);
+        self::assertNull($player->draftTeamOriginalName);
+        self::assertNull($player->draftTeamCurrentName);
+        self::assertNull($player->collegeName);
+    }
+
+    public function testFillFromCurrentRowMapsNonStringOptionalFieldToNull(): void
+    {
+        $row = $this->buildFullCurrentRow();
+        $row['draftedby'] = 12345; // non-string → getOptionalStrippedValue returns null
+
+        $player = $this->mapper->fillFromCurrentRow($row);
+
+        self::assertNull($player->draftTeamOriginalName);
+    }
+
     public function testFillFromCurrentRowStripsSlashesFromName(): void
     {
         $row = $this->buildFullCurrentRow();
         $row['name'] = "O\\'Brien";
 
-        $player = $this->repository->fillFromCurrentRow($row);
+        $player = $this->mapper->fillFromCurrentRow($row);
         self::assertSame("O'Brien", $player->name);
     }
 
@@ -195,14 +220,14 @@ class PlayerRepositoryFieldMapTest extends TestCase
         );
 
         $mappedTargets = [];
-        foreach (PlayerRepository::FIELD_MAP as $entries) {
+        foreach (PlayerDataMapper::FIELD_MAP as $entries) {
             foreach ($entries as $entry) {
                 $mappedTargets[] = $entry['target'];
             }
         }
         $mappedTargets = array_unique($mappedTargets);
 
-        $accountedFor = array_merge($mappedTargets, PlayerRepository::EXCLUDED_FROM_FIELD_MAP);
+        $accountedFor = array_merge($mappedTargets, PlayerDataMapper::EXCLUDED_FROM_FIELD_MAP);
 
         $unmapped = array_diff($allProperties, $accountedFor);
 
@@ -221,7 +246,7 @@ class PlayerRepositoryFieldMapTest extends TestCase
             $reflection->getProperties()
         );
 
-        foreach (PlayerRepository::FIELD_MAP as $category => $entries) {
+        foreach (PlayerDataMapper::FIELD_MAP as $category => $entries) {
             foreach ($entries as $entry) {
                 self::assertContains(
                     $entry['target'],
@@ -240,7 +265,7 @@ class PlayerRepositoryFieldMapTest extends TestCase
             $reflection->getProperties()
         );
 
-        foreach (PlayerRepository::EXCLUDED_FROM_FIELD_MAP as $prop) {
+        foreach (PlayerDataMapper::EXCLUDED_FROM_FIELD_MAP as $prop) {
             self::assertContains(
                 $prop,
                 $validProperties,

--- a/ibl5/tests/WideUnit/Mocks/TestDataFactory.php
+++ b/ibl5/tests/WideUnit/Mocks/TestDataFactory.php
@@ -89,7 +89,7 @@ class TestDataFactory
             'stamina' => 50,
             'used_extension_this_season' => 0,
             'used_extension_this_chunk' => 0,
-            // Free-agency rating fields (read by PlayerRepository::mapFreeAgencyFields)
+            // Free-agency rating fields (read by PlayerDataMapper::mapFreeAgencyFields)
             'loyalty' => 50,
             'playing_time' => 50,
             'winner' => 50,


### PR DESCRIPTION
## Summary

Extracts row→DTO mapping out of `PlayerRepository` into a new, dependency-free `Player\PlayerDataMapper` class (backlog finding 7.15).

**`PlayerRepository`** (622 LOC, a hot file) mixed two responsibilities: data access (SQL queries) and row→PlayerData mapping (the `FIELD_MAP` / `EXCLUDED_FROM_FIELD_MAP` constants plus 8 private `map*` methods and the `getOptionalStrippedValue` helper).

**This PR:**
- Creates `ibl5/classes/Player/PlayerDataMapper.php` — owns the moved constants and mapping logic; makes no DB calls
- `PlayerRepository` instantiates the mapper internally and delegates `fillFromCurrentRow` / `fillFromHistoricalRow` as one-line wrappers
- Renames `PlayerRepositoryFieldMapTest.php` → `PlayerDataMapperFieldMapTest.php` and retargets it to construct `PlayerDataMapper` directly
- Removes ~200 LOC from `PlayerRepository` (strictly improves the 500 LOC hot-file threshold)

**Behavior-preserving refactor. Bar is GREEN-GREEN.** Public behavior of `PlayerRepository` is identical before and after.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.