### PR TITLE
test: Axis-6 coverage for LeagueStarters/FreeAgencyPreview/SeasonHighs/TeamSchedule

### DIFF
--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1161,12 +1161,12 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 | 6.4 | ◑ Partial | 🟩 | Header side-effect test exists; broader structure/CSS coverage still thin → additive. |
 | 6.5 | ✅ Implemented | — | TeamStatsCalculatorTest exists. |
 | 6.6 | ✅ Implemented | — | StrengthOfScheduleCalculatorTest exists. |
-| 6.7 | ⬜ Open | 🟩 | LeagueStarters thin; additive. |
+| 6.7 | ✅ Implemented | 🟩 | LeagueStarters thin; additive. |
 | 6.8 | ⬜ Open | 🟩 | ApiKeys thin; additive (security tests catch, don't introduce surface). |
 | 6.9 | ✅ Implemented | — | ContractListServiceTest extended (#1161, 2026-06-20). |
-| 6.10 | ⬜ Open | 🟩 | FreeAgencyPreview thin; additive — coordinate with PR #1162 (future-year restore). |
-| 6.11 | ⬜ Open | 🟩 | SeasonHighs thin; additive. |
-| 6.12 | ⬜ Open | 🟩 | TeamSchedule thin; additive. |
+| 6.10 | ✅ Implemented | 🟩 | FreeAgencyPreview thin; additive — coordinate with PR #1162 (future-year restore). |
+| 6.11 | ✅ Implemented | 🟩 | SeasonHighs thin; additive. |
+| 6.12 | ✅ Implemented | 🟩 | TeamSchedule thin; additive. |
 | 6.13 | ⬜ Open | 🟩 | Player 0.24 ratio; additive (L — chunk it). |
 | 6.14 | ⬜ Open | 🟩 | Updater steps; additive. |
 | 6.15 | ⬜ Open | 🟩 | Voting; additive. |
@@ -1227,6 +1227,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Service all-star selection, Repository correctness, API response format.
 **Est. effort:** M
 **Risk if untouched:** All-Star eligibility/voting aggregation untested.
+**Status:** Implemented (2026-06-27) — added LeagueStartersApiHandler handle() response-format + invalid-display-fallback tests and Service boundary tests (non-int teamid skip, per-team/position dedupe) in tests/LeagueStarters/. Repository SQL correctness remains owned by the gated tests/DatabaseIntegration/LeagueStartersRepositoryTest.php.
 
 ### 6.8 ApiKeys — Thin (6 files, 2 tests, 0.33 ratio)
 **Location:** `ibl5/classes/ApiKeys`
@@ -1249,6 +1250,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Eligibility filtering, contract-expiration, projection accuracy.
 **Est. effort:** M
 **Risk if untouched:** Preview misses eligible players or includes ineligible.
+**Status:** Implemented (2026-06-27) — added FreeAgencyPreviewService contract-end boundary tests (cy=6 final-year eligible, cy=5 with year-6 salary excluded) in tests/FreeAgencyPreview/. Held to the current getUpcomingFreeAgents() API to avoid colliding with PR #1162. Repository correctness owned by gated tests/DatabaseIntegration/FreeAgencyPreviewRepositoryTest.php.
 
 ### 6.11 SeasonHighs — Thin (6 files, 2 tests)
 **Location:** `ibl5/classes/SeasonHighs`
@@ -1256,6 +1258,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** High-water filtering, repository correctness, stat-type formatting.
 **Est. effort:** M
 **Risk if untouched:** Wrong records on player profile pages.
+**Status:** Implemented (2026-06-27) — added host-runnable SeasonHighsRepository transformation tests (normalizeRow int-casts/color defaults/optional keys, getSeasonHighsBatch bucketing/sort/tiebreak/empty-stats short-circuit) in tests/SeasonHighs/SeasonHighsRepositoryTest.php. Gated tests/DatabaseIntegration/SeasonHighsRepositoryTest.php still covers the SQL.
 
 ### 6.12 TeamSchedule — Thin (6 files, 2 tests)
 **Location:** `ibl5/classes/TeamSchedule`
@@ -1263,6 +1266,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Playoff bracket construction, game-order, opponent lookup.
 **Est. effort:** M
 **Risk if untouched:** Seeding incorrect; game sequence out of order.
+**Status:** Implemented (2026-06-27) — added TeamScheduleService opponent-lookup/opponent-text, SOS-tier (populated vs empty rankings), and next-sim-highlight tests in tests/TeamSchedule/. Repository correctness owned by gated tests/DatabaseIntegration/TeamScheduleRepositoryTest.php; no playoff-bracket unit exists on master (View-only month relabel).
 
 ### 6.13 Player Module — Large + Subthreshold (71 files, 17 tests, 0.24 ratio)
 **Location:** `ibl5/classes/Player`

--- a/ibl5/tests/FreeAgencyPreview/FreeAgencyPreviewServiceTest.php
+++ b/ibl5/tests/FreeAgencyPreview/FreeAgencyPreviewServiceTest.php
@@ -125,6 +125,29 @@ class FreeAgencyPreviewServiceTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    public function testPlayerInFinalContractYearIsEligible(): void
+    {
+        $this->mockRepository->method('getActivePlayers')->willReturn([
+            self::createActivePlayer(['cy' => 6, 'name' => 'Final Year']),
+        ]);
+
+        $result = $this->service->getUpcomingFreeAgents(2025);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Final Year', $result[0]['name']);
+    }
+
+    public function testPlayerWithYearSixSalaryIsExcluded(): void
+    {
+        $this->mockRepository->method('getActivePlayers')->willReturn([
+            self::createActivePlayer(['cy' => 5, 'salary_yr6' => 500, 'name' => 'Still Under']),
+        ]);
+
+        $result = $this->service->getUpcomingFreeAgents(2025);
+
+        $this->assertSame([], $result);
+    }
+
     /**
      * @param array<string, mixed> $overrides
      * @return array{pid: int, teamid: int, name: string, teamname: string, pos: string, age: int, draftyear: int, exp: int, cy: int, cyt: int, salary_yr1: int, salary_yr2: int, salary_yr3: int, salary_yr4: int, salary_yr5: int, salary_yr6: int, r_fga: int, r_fgp: int, r_fta: int, r_ftp: int, r_3ga: int, r_3gp: int, r_orb: int, r_drb: int, r_ast: int, r_stl: int, r_blk: int, r_tvr: int, r_foul: int, oo: int, r_drive_off: int, po: int, r_trans_off: int, od: int, dd: int, pd: int, td: int, loyalty: int, winner: int, playing_time: int, security: int, tradition: int, team_city: string|null, color1: string|null, color2: string|null}

--- a/ibl5/tests/LeagueStarters/LeagueStartersApiHandlerTest.php
+++ b/ibl5/tests/LeagueStarters/LeagueStartersApiHandlerTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\LeagueStarters;
 
+use Auth\Contracts\AuthServiceInterface;
 use LeagueStarters\LeagueStartersApiHandler;
 use Repositories\Contracts\TeamIdentityRepositoryInterface;
+use Tests\WideUnit\Mocks\TestDataFactory;
 use Tests\WideUnit\WideUnitTestCase;
 
 /**
@@ -13,6 +15,12 @@ use Tests\WideUnit\WideUnitTestCase;
  */
 class LeagueStartersApiHandlerTest extends WideUnitTestCase
 {
+
+    protected function tearDown(): void
+    {
+        unset($_GET['display']);
+        parent::tearDown();
+    }
 
     public function testValidDisplayModesContainsAllExpectedModes(): void
     {
@@ -28,5 +36,51 @@ class LeagueStartersApiHandlerTest extends WideUnitTestCase
         sort($modes);
 
         $this->assertSame($expected, $modes);
+    }
+
+    public function testHandleRendersAllPositionTables(): void
+    {
+        $_GET['display'] = 'ratings';
+        $handler = $this->buildHandler();
+
+        $output = $this->captureOutput(fn () => $handler->handle());
+
+        $this->assertStringContainsString('Point Guards', $output);
+        $this->assertStringContainsString('Centers', $output);
+    }
+
+    public function testHandleFallsBackToRatingsForInvalidDisplay(): void
+    {
+        $_GET['display'] = 'not-a-mode';
+        $handler = $this->buildHandler();
+
+        $output = $this->captureOutput(fn () => $handler->handle());
+
+        $this->assertStringContainsString('Point Guards', $output);
+        $this->assertNotEmpty($output);
+    }
+
+    private function buildHandler(): LeagueStartersApiHandler
+    {
+        $db = $this->mockDb;
+        self::assertNotNull($db);
+
+        $auth = self::createStub(AuthServiceInterface::class);
+        $auth->method('getUsername')->willReturn('testuser');
+
+        $commonRepo = self::createStub(TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTeamnameFromUsername')->willReturn('Test Team');
+
+        $season = self::createStub(\Season\Season::class);
+        $season->lastSimEndDate = '2025-01-01';
+
+        $db->setMockTeamData([TestDataFactory::createTeam([
+            'teamid' => 1,
+            'team_name' => 'Test Team',
+            'league_record' => '0-0',
+        ])]);
+        $db->onQuery('teamid BETWEEN', []);
+
+        return new LeagueStartersApiHandler($db, $commonRepo, $auth, $season);
     }
 }

--- a/ibl5/tests/LeagueStarters/LeagueStartersServiceTest.php
+++ b/ibl5/tests/LeagueStarters/LeagueStartersServiceTest.php
@@ -165,6 +165,48 @@ class LeagueStartersServiceTest extends TestCase
         $this->assertNotSame($result['PG'][0], $result['PG'][1]);
     }
 
+    public function testNonIntTeamIdRowIsSkipped(): void
+    {
+        $mockRepo = self::createStub(LeagueStartersRepositoryInterface::class);
+
+        $row = $this->makeStarterRow(101, 1, 'PG', 'Test Team');
+        $row['teamid'] = '1';
+        $mockRepo->method('getAllStartersWithTeamData')->willReturn([$row]);
+        $mockRepo->method('getPlaceholderRow')->willReturn(
+            TestDataFactory::createPlayer(['pid' => 4040404, 'teamid' => 0, 'name' => 'Placeholder', 'loyalty' => 0, 'playing_time' => 0, 'winner' => 0, 'tradition' => 0, 'security' => 0])
+        );
+
+        $this->mockDb->onQuery('SELECT[\s\S]*ibl_team_info[\s\S]*teamid BETWEEN', [
+            $this->makeTeamRow(1, 'Test Team', 'Test City'),
+        ]);
+
+        $service = new LeagueStartersService($this->mockDb, $this->mockLeague, $mockRepo);
+        $result = $service->getAllStartersByPosition();
+
+        $this->assertSame(4040404, $result['PG'][0]->getPlayerID());
+    }
+
+    public function testFirstStarterWinsPerTeamPosition(): void
+    {
+        $mockRepo = self::createStub(LeagueStartersRepositoryInterface::class);
+        $mockRepo->method('getAllStartersWithTeamData')->willReturn([
+            $this->makeStarterRow(101, 1, 'PG', 'Test Team'),
+            $this->makeStarterRow(102, 1, 'PG', 'Test Team'),
+        ]);
+        $mockRepo->method('getPlaceholderRow')->willReturn(
+            TestDataFactory::createPlayer(['pid' => 4040404, 'teamid' => 0, 'name' => 'Placeholder', 'loyalty' => 0, 'playing_time' => 0, 'winner' => 0, 'tradition' => 0, 'security' => 0])
+        );
+
+        $this->mockDb->onQuery('SELECT[\s\S]*ibl_team_info[\s\S]*teamid BETWEEN', [
+            $this->makeTeamRow(1, 'Test Team', 'Test City'),
+        ]);
+
+        $service = new LeagueStartersService($this->mockDb, $this->mockLeague, $mockRepo);
+        $result = $service->getAllStartersByPosition();
+
+        $this->assertSame(101, $result['PG'][0]->getPlayerID());
+    }
+
     // ============================================
     // MULTIPLE INSTANCES TEST
     // ============================================

--- a/ibl5/tests/SeasonHighs/SeasonHighsRepositoryTest.php
+++ b/ibl5/tests/SeasonHighs/SeasonHighsRepositoryTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SeasonHighs;
+
+use Tests\WideUnit\WideUnitTestCase;
+
+/**
+ * @covers \SeasonHighs\SeasonHighsRepository
+ */
+class SeasonHighsRepositoryTest extends WideUnitTestCase
+{
+    private function repo(): \SeasonHighs\SeasonHighsRepository
+    {
+        $db = $this->mockDb;
+        self::assertNotNull($db);
+        return new \SeasonHighs\SeasonHighsRepository($db);
+    }
+
+    public function testGetSeasonHighsNormalizesPlayerRow(): void
+    {
+        $this->mockDb->onQuery('ibl_box_scores', [[
+            'name'            => 'High Scorer',
+            'date'            => '2025-01-15',
+            'POINTS'          => '38',
+            'pid'             => '7',
+            'teamid'          => '3',
+            'team_city'       => 'City',
+            'color1'          => '00FF00',
+            'color2'          => '0000FF',
+            'box_id'          => '99',
+            'game_of_that_day' => '1',
+        ]]);
+
+        $result = $this->repo()->getSeasonHighs('(`game_2gm`*2)', 'POINTS', '', '2025-01-01', '2025-01-31');
+
+        $this->assertCount(1, $result);
+        $entry = $result[0];
+
+        $this->assertSame(38, $entry['value']);
+        $this->assertSame(7, $entry['pid']);
+        $this->assertSame(3, $entry['teamid']);
+        $this->assertSame(99, $entry['boxId']);
+        $this->assertSame(1, $entry['gameOfThatDay']);
+        $this->assertSame('00FF00', $entry['color1']);
+    }
+
+    public function testGetSeasonHighsAppliesColorAndKeyDefaults(): void
+    {
+        $this->mockDb->onQuery('ibl_box_scores', [[
+            'name'      => 'No Colors',
+            'date'      => '2025-01-10',
+            'POINTS'    => '12',
+            'teamid'    => '5',
+            'team_city' => 'Somewhere',
+        ]]);
+
+        $result = $this->repo()->getSeasonHighs('(`game_2gm`*2)', 'POINTS', '', '2025-01-01', '2025-01-31');
+
+        $this->assertCount(1, $result);
+        $entry = $result[0];
+
+        $this->assertSame('FFFFFF', $entry['color1']);
+        $this->assertSame('000000', $entry['color2']);
+        $this->assertArrayNotHasKey('pid', $entry);
+        $this->assertArrayNotHasKey('boxId', $entry);
+    }
+
+    public function testGetSeasonHighsTeamSuffixShapeOmitsPid(): void
+    {
+        $this->mockDb->onQuery('ibl_box_scores', [[
+            'name'      => 'Hawks',
+            'date'      => '2025-01-20',
+            'POINTS'    => '120',
+            'teamid'    => '2',
+            'team_city' => 'Atlanta',
+            'color1'    => 'FF0000',
+            'color2'    => '000000',
+        ]]);
+
+        $result = $this->repo()->getSeasonHighs('(`game_2gm`*2)', 'POINTS', '_teams', '2025-01-01', '2025-01-31');
+
+        $this->assertCount(1, $result);
+        $entry = $result[0];
+
+        $this->assertSame(2, $entry['teamid']);
+        $this->assertArrayNotHasKey('pid', $entry);
+    }
+
+    public function testGetSeasonHighsBatchBucketsSortsAndSkipsUnknown(): void
+    {
+        $this->mockDb->onQuery('ibl_box_scores', [
+            ['stat_category' => 'POINTS',  'stat_value' => '40', 'date' => '2025-01-15', 'name' => 'P1'],
+            ['stat_category' => 'POINTS',  'stat_value' => '50', 'date' => '2025-01-16', 'name' => 'P2'],
+            ['stat_category' => 'ASSISTS', 'stat_value' => '10', 'date' => '2025-01-10', 'name' => 'P3'],
+            ['stat_category' => 'UNKNOWN', 'stat_value' => '99', 'date' => '2025-01-01', 'name' => 'P4'],
+        ]);
+
+        $result = $this->repo()->getSeasonHighsBatch(
+            ['POINTS' => 'gamePTS', 'ASSISTS' => 'gameAST'],
+            '',
+            '2025-01-01',
+            '2025-01-31'
+        );
+
+        $this->assertSame(50, $result['POINTS'][0]['value']);
+        $this->assertSame(40, $result['POINTS'][1]['value']);
+        $this->assertSame(10, $result['ASSISTS'][0]['value']);
+        $this->assertArrayNotHasKey('UNKNOWN', $result);
+    }
+
+    public function testGetSeasonHighsBatchTieBreaksByDateAscending(): void
+    {
+        $this->mockDb->onQuery('ibl_box_scores', [
+            ['stat_category' => 'POINTS', 'stat_value' => '30', 'date' => '2025-02-02', 'name' => 'Later'],
+            ['stat_category' => 'POINTS', 'stat_value' => '30', 'date' => '2025-01-01', 'name' => 'Earlier'],
+        ]);
+
+        $result = $this->repo()->getSeasonHighsBatch(
+            ['POINTS' => 'gamePTS'],
+            '',
+            '2025-01-01',
+            '2025-02-28'
+        );
+
+        $this->assertSame('Earlier', $result['POINTS'][0]['name']);
+        $this->assertSame('Later', $result['POINTS'][1]['name']);
+    }
+
+    public function testGetSeasonHighsBatchEmptyStatsShortCircuits(): void
+    {
+        $result = $this->repo()->getSeasonHighsBatch([], '', '2025-01-01', '2025-01-31');
+
+        $this->assertSame([], $result);
+        $this->assertQueryNotExecuted('ibl_box_scores');
+    }
+
+    public function testGetSeasonHighsBatchInitializesEmptyEntryPerStat(): void
+    {
+        $this->mockDb->onQuery('ibl_box_scores', []);
+
+        $result = $this->repo()->getSeasonHighsBatch(
+            ['POINTS' => 'gamePTS', 'ASSISTS' => 'gameAST'],
+            '',
+            '2025-01-01',
+            '2025-01-31'
+        );
+
+        $this->assertArrayHasKey('POINTS', $result);
+        $this->assertArrayHasKey('ASSISTS', $result);
+        $this->assertSame([], $result['POINTS']);
+        $this->assertSame([], $result['ASSISTS']);
+    }
+}

--- a/ibl5/tests/TeamSchedule/TeamScheduleServiceTest.php
+++ b/ibl5/tests/TeamSchedule/TeamScheduleServiceTest.php
@@ -184,6 +184,99 @@ class TeamScheduleServiceTest extends TestCase
     }
 
     // ============================================
+    // OPPONENT LOOKUP TESTS
+    // ============================================
+
+    public function testOpponentLookupPopulatesOpponentTextWithRecord(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2024-01-10', visitor: 2, home: 1, vScore: 90, hScore: 100),
+            $this->makeGameRow('2024-01-12', visitor: 1, home: 2, vScore: 105, hScore: 95),
+        ]);
+
+        $service = new TeamScheduleService($this->mockDb, $this->stubRepository);
+        $season = new Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('Opponents', $result[0]['opposingTeam']->name);
+        $this->assertSame('Opponents', $result[1]['opposingTeam']->name);
+        $this->assertStringContainsString('Opponents', $result[0]['opponentText']);
+        $this->assertStringContainsString('(30-10)', $result[0]['opponentText']);
+        $this->assertStringContainsString('Opponents', $result[1]['opponentText']);
+    }
+
+    public function testOpponentTierAssignedWhenPowerRankingsProvided(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2024-01-10', visitor: 2, home: 1, vScore: 90, hScore: 100),
+        ]);
+
+        $service = new TeamScheduleService(
+            $this->mockDb,
+            $this->stubRepository,
+            [1 => 50.0, 2 => 90.0]
+        );
+        $season = new Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertNotSame('', $result[0]['opponentTier']);
+    }
+
+    public function testOpponentTierEmptyWhenNoPowerRankings(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2024-01-10', visitor: 2, home: 1, vScore: 90, hScore: 100),
+        ]);
+
+        $service = new TeamScheduleService($this->mockDb, $this->stubRepository);
+        $season = new Season($this->mockDb);
+
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertSame('', $result[0]['opponentTier']);
+    }
+
+    public function testUnplayedGameWithinNextSimWindowIsHighlighted(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2025-01-15', visitor: 2, home: 1, vScore: 0, hScore: 0),
+        ]);
+
+        $season = self::createStub(Season::class);
+        $season->endingYear = 2025;
+        $season->projectedNextSimEndDate = new \DateTime('2025-01-20');
+
+        $service = new TeamScheduleService($this->mockDb, $this->stubRepository);
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertSame('next-sim', $result[0]['highlight']);
+    }
+
+    public function testUnplayedGameBeyondNextSimWindowIsNotHighlighted(): void
+    {
+        $this->setupTeamMockData();
+        $this->stubRepository->method('getSchedule')->willReturn([
+            $this->makeGameRow('2025-02-10', visitor: 2, home: 1, vScore: 0, hScore: 0),
+        ]);
+
+        $season = self::createStub(Season::class);
+        $season->endingYear = 2025;
+        $season->projectedNextSimEndDate = new \DateTime('2025-01-20');
+
+        $service = new TeamScheduleService($this->mockDb, $this->stubRepository);
+        $result = $service->getProcessedSchedule(1, $season);
+
+        $this->assertSame('', $result[0]['highlight']);
+    }
+
+    // ============================================
     // HELPERS
     // ============================================
 


### PR DESCRIPTION
## Summary

Adds PHPUnit unit tests for four read-path modules that were missing Axis-6 coverage (rows 6.7, 6.10, 6.11, 6.12 in the maintenance backlog):

- **LeagueStartersApiHandler** — `handle()` return shape + invalid-display fallback
- **LeagueStartersService** — non-int teamid skip + first-starter-per-position dedupe
- **FreeAgencyPreviewService** — `cy=6` eligibility boundary + `salary_yr6` exclusion
- **SeasonHighsRepository** — `normalizeRow` int-cast/defaults/\_teams shape; `getSeasonHighsBatch` bucketing/sort/tie-break/empty-stats
- **TeamScheduleService** — opponent lookup, SOS tier assignment, next-sim highlight window

Also flips rows 6.7/6.10/6.11/6.12 in `ibl5/docs/maintenance-backlog.md` to ✅ Implemented.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.