### PR TITLE
test: Axis-6 coverage breadth — small/moderate-gap modules (6.1/6.18/6.19)

### DIFF
--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1155,7 +1155,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
-| 6.1 | ⬜ Open | 🟩 | BulkImport 0 tests; additive unit tests. |
+| 6.1 | ✅ Implemented | — | All 7 concrete BulkImport classes already have substantive tests under tests/Unit/BulkImport/ (verified). |
 | 6.2 | ⬜ Open | 🟩 | PdoConnection tests 🟩; `MySQL` is the deprecated class slated for removal (5.18) — don't invest there. |
 | 6.3 | ✅ Implemented | — | ModuleAccessControlTest + ModuleRegistryTest exist. |
 | 6.4 | ◑ Partial | 🟩 | Header side-effect test exists; broader structure/CSS coverage still thin → additive. |
@@ -1172,8 +1172,8 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 | 6.15 | ✅ Implemented | — | VotingRepositoryTest + SubmissionResultTest added (aggregation, column allowlist). |
 | 6.16 | ◑ Partial | 🟩 | ApiKeyRepositoryTest + RateLimitRepositoryTest added; data repos + JsonResponder/SystemClock still untested. |
 | 6.17 | ◑ Partial | 🟩 | TradeAssetRepositoryTest + TradeOfferRepositoryTest added (draft-pick mapping, offer lifecycle); TradeExecutionRepository untested + TradeFormRepository partial. |
-| 6.18 | ⬜ Open | 🟩 | Moderate-gap modules; per-module targeted tests, additive. |
-| 6.19 | ⬜ Open | 🟩 | Additive. **`Shared (3/1)` sub-item stale** — `Shared/` deleted (2.23). |
+| 6.18 | ◑ Partial | 🟩 | Unit tests added: DraftPickLocator repo, LeagueSchedule Game, TransactionHistory repo, CapSpace repo. NextSim/SavedDepthChart/DepthChartEntry verified covered. Residual: SQL aggregation/ordering + SDC write-path are DB-integration-only. |
+| 6.19 | ◑ Partial | 🟩 | AllStarAppearances + GMContactList repo unit tests added. Season entity predicates blocked by `Season\Season`→mock alias (QueryRepo plumbing covered). `Shared` N/A (deleted 2.23). |
 
 ### 6.1 BulkImport — Zero Tests, 9 Files
 **Location:** `ibl5/classes/BulkImport`
@@ -1181,6 +1181,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** PHPUnit for `BulkImportSummary` aggregation, `ArchiveExtractor` file handling, `ImportEntry` state transitions.
 **Est. effort:** M
 **Risk if untouched:** Bulk imports fail silently; error aggregation untested.
+**Status:** ✅ Already covered (verified 2026-06-26) — all 7 concrete classes have substantive unit tests under tests/Unit/BulkImport/ (ArchiveExtractorTest 27, BulkImportSummaryTest 9, ImportEntryTest 3, plus BulkImportRunner/BackupArchiveLocator/FileTypeHandler/JsbFileType). The finding's "zero tests" premise is stale; no new tests added.
 
 ### 6.2 Database — Zero Tests, 2 Files
 **Location:** `ibl5/classes/Database`
@@ -1313,6 +1314,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Per-module targeted PHPUnit — see test-coverage audit detail.
 **Est. effort:** S each (M for CapSpace, NextSim, DepthChartEntry)
 **Risk if untouched:** Per-module: stashed picks mislocated; schedule phase boundaries wrong; cap floor misreported; saved DC corrupted; transaction log misordered; cap exploitation; invalid DC entries saved.
+**Status:** ◑ Partial (2026-06-26) — added unit coverage: DraftPickLocatorRepositoryTest (pick grouping), LeagueScheduleGameTest (Game value object), TransactionHistoryRepositoryTest (year int-cast + filter branches), CapSpaceRepositoryTest (post-season contract rows). Verified already covered: NextSim (all classes tested; Service is a thin delegator), SavedDepthChart (22-test WideUnit service suite exercises repo read paths), DepthChartEntry (11-test Validator covers "invalid DC entries"). CapSpace cap-math is already covered by CapSpaceServiceTest. Residual (DatabaseIntegration-only): transaction ORDER BY correctness, SavedDepthChart write-path (insert_id), aggregation correctness.
 
 ### 6.19 Small Modules With Single-Test Coverage
 **Location:** `AllStarAppearances` (4/1), `GMContactList` (4/1), `Season` (3/1), `Shared` (3/1)
@@ -1320,6 +1322,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Targeted single-class tests.
 **Est. effort:** S each
 **Risk if untouched:** AS appearances double-counted; duplicate GMs; season state inconsistencies; shared data leaks.
+**Status:** ◑ Partial (2026-06-26) — added AllStarAppearancesRepositoryTest and GMContactListRepositoryTest (return-shape + empty negative). Season: phase plumbing covered by SeasonQueryRepositoryTest (getSeasonPhase, calculatePhaseSimNumber); the Season-entity phase predicates (isFreeAgencyPhase, areTradesAllowed, areWaiversAllowed, advancesContractYears) are structurally untestable because classes/Bootstrap/TestAliasesBootstrap.php:22 aliases Season\Season → the mock — left as-is (removing the alias is a cross-suite infra change, out of scope). Shared: N/A (deleted, backlog 2.23). Residual (DatabaseIntegration-only): AS-appearance aggregation / GM dedup correctness.
 
 ---
 

--- a/ibl5/tests/AllStarAppearances/AllStarAppearancesRepositoryTest.php
+++ b/ibl5/tests/AllStarAppearances/AllStarAppearancesRepositoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AllStarAppearances;
+
+use AllStarAppearances\AllStarAppearancesRepository;
+use PHPUnit\Framework\TestCase;
+use Tests\WideUnit\Mocks\MockDatabase;
+
+class AllStarAppearancesRepositoryTest extends TestCase
+{
+    private MockDatabase $mockDb;
+
+    protected function setUp(): void
+    {
+        $this->mockDb = new MockDatabase();
+    }
+
+    public function testGetAllStarAppearancesReturnsMappedRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['name' => 'Star Player', 'pid' => 10, 'appearances' => 5],
+            ['name' => 'Sub Player', 'pid' => 11, 'appearances' => 1],
+        ]);
+        $repo = new AllStarAppearancesRepository($this->mockDb);
+
+        $result = $repo->getAllStarAppearances();
+
+        $this->assertSame([
+            ['name' => 'Star Player', 'pid' => 10, 'appearances' => 5],
+            ['name' => 'Sub Player', 'pid' => 11, 'appearances' => 1],
+        ], $result);
+        $this->assertQueryExecuted('ibl_awards');
+    }
+
+    public function testGetAllStarAppearancesReturnsEmptyArrayWhenNoAwards(): void
+    {
+        $this->mockDb->setMockData([]);
+        $repo = new AllStarAppearancesRepository($this->mockDb);
+
+        $this->assertSame([], $repo->getAllStarAppearances());
+    }
+
+    private function assertQueryExecuted(string $substring): void
+    {
+        $queries = $this->mockDb->getExecutedQueries();
+        $found = false;
+        foreach ($queries as $query) {
+            if (str_contains($query, $substring)) {
+                $found = true;
+                break;
+            }
+        }
+        self::assertTrue(
+            $found,
+            "Expected a query containing '{$substring}' but none was found. Queries: " . implode("\n", $queries)
+        );
+    }
+}

--- a/ibl5/tests/AllStarAppearances/AllStarAppearancesRepositoryTest.php
+++ b/ibl5/tests/AllStarAppearances/AllStarAppearancesRepositoryTest.php
@@ -5,16 +5,15 @@ declare(strict_types=1);
 namespace Tests\AllStarAppearances;
 
 use AllStarAppearances\AllStarAppearancesRepository;
-use PHPUnit\Framework\TestCase;
-use Tests\WideUnit\Mocks\MockDatabase;
+use Tests\WideUnit\WideUnitTestCase;
 
-class AllStarAppearancesRepositoryTest extends TestCase
+class AllStarAppearancesRepositoryTest extends WideUnitTestCase
 {
-    private MockDatabase $mockDb;
-
-    protected function setUp(): void
+    private function repo(): AllStarAppearancesRepository
     {
-        $this->mockDb = new MockDatabase();
+        $db = $this->mockDb;
+        self::assertNotNull($db);
+        return new AllStarAppearancesRepository($db);
     }
 
     public function testGetAllStarAppearancesReturnsMappedRows(): void
@@ -23,9 +22,8 @@ class AllStarAppearancesRepositoryTest extends TestCase
             ['name' => 'Star Player', 'pid' => 10, 'appearances' => 5],
             ['name' => 'Sub Player', 'pid' => 11, 'appearances' => 1],
         ]);
-        $repo = new AllStarAppearancesRepository($this->mockDb);
 
-        $result = $repo->getAllStarAppearances();
+        $result = $this->repo()->getAllStarAppearances();
 
         $this->assertSame([
             ['name' => 'Star Player', 'pid' => 10, 'appearances' => 5],
@@ -37,24 +35,7 @@ class AllStarAppearancesRepositoryTest extends TestCase
     public function testGetAllStarAppearancesReturnsEmptyArrayWhenNoAwards(): void
     {
         $this->mockDb->setMockData([]);
-        $repo = new AllStarAppearancesRepository($this->mockDb);
 
-        $this->assertSame([], $repo->getAllStarAppearances());
-    }
-
-    private function assertQueryExecuted(string $substring): void
-    {
-        $queries = $this->mockDb->getExecutedQueries();
-        $found = false;
-        foreach ($queries as $query) {
-            if (str_contains($query, $substring)) {
-                $found = true;
-                break;
-            }
-        }
-        self::assertTrue(
-            $found,
-            "Expected a query containing '{$substring}' but none was found. Queries: " . implode("\n", $queries)
-        );
+        $this->assertSame([], $this->repo()->getAllStarAppearances());
     }
 }

--- a/ibl5/tests/CapSpace/CapSpaceRepositoryTest.php
+++ b/ibl5/tests/CapSpace/CapSpaceRepositoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CapSpace;
+
+use CapSpace\CapSpaceRepository;
+use PHPUnit\Framework\TestCase;
+use Tests\WideUnit\Mocks\MockDatabase;
+
+class CapSpaceRepositoryTest extends TestCase
+{
+    private MockDatabase $mockDb;
+
+    protected function setUp(): void
+    {
+        $this->mockDb = new MockDatabase();
+    }
+
+    public function testGetPlayersUnderContractAfterSeasonReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['cy' => 1, 'cyt' => 3],
+            ['cy' => 2, 'cyt' => 4],
+        ]);
+        $repo = new CapSpaceRepository($this->mockDb);
+
+        $result = $repo->getPlayersUnderContractAfterSeason(5);
+
+        $this->assertSame([
+            ['cy' => 1, 'cyt' => 3],
+            ['cy' => 2, 'cyt' => 4],
+        ], $result);
+    }
+
+    public function testGetPlayersUnderContractAfterSeasonReturnsEmptyWhenNoFutureContracts(): void
+    {
+        $this->mockDb->setMockData([]);
+        $repo = new CapSpaceRepository($this->mockDb);
+
+        $this->assertSame([], $repo->getPlayersUnderContractAfterSeason(5));
+    }
+}

--- a/ibl5/tests/DraftPickLocator/DraftPickLocatorRepositoryTest.php
+++ b/ibl5/tests/DraftPickLocator/DraftPickLocatorRepositoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DraftPickLocator;
+
+use DraftPickLocator\DraftPickLocatorRepository;
+use PHPUnit\Framework\TestCase;
+use Tests\WideUnit\Mocks\MockDatabase;
+
+class DraftPickLocatorRepositoryTest extends TestCase
+{
+    private MockDatabase $mockDb;
+
+    protected function setUp(): void
+    {
+        $this->mockDb = new MockDatabase();
+    }
+
+    public function testGetAllDraftPicksGroupedByTeamGroupsRowsByTeamId(): void
+    {
+        $this->mockDb->setMockData([
+            ['teampick_teamid' => 1, 'ownerofpick' => 'Team A', 'year' => 2026, 'round' => 1],
+            ['teampick_teamid' => 1, 'ownerofpick' => 'Team A', 'year' => 2027, 'round' => 2],
+            ['teampick_teamid' => 2, 'ownerofpick' => 'Team B', 'year' => 2026, 'round' => 1],
+        ]);
+        $repo = new DraftPickLocatorRepository($this->mockDb);
+
+        $result = $repo->getAllDraftPicksGroupedByTeam();
+
+        $this->assertSame([
+            1 => [
+                ['ownerofpick' => 'Team A', 'year' => 2026, 'round' => 1],
+                ['ownerofpick' => 'Team A', 'year' => 2027, 'round' => 2],
+            ],
+            2 => [
+                ['ownerofpick' => 'Team B', 'year' => 2026, 'round' => 1],
+            ],
+        ], $result);
+    }
+
+    public function testGetAllDraftPicksGroupedByTeamReturnsEmptyArrayWhenNoPicks(): void
+    {
+        $this->mockDb->setMockData([]);
+        $repo = new DraftPickLocatorRepository($this->mockDb);
+
+        $this->assertSame([], $repo->getAllDraftPicksGroupedByTeam());
+    }
+
+    public function testGetDraftPicksForTeamReturnsPicks(): void
+    {
+        $this->mockDb->setMockData([
+            ['ownerofpick' => 'Team A', 'year' => 2026, 'round' => 1],
+            ['ownerofpick' => 'Team A', 'year' => 2027, 'round' => 2],
+        ]);
+        $repo = new DraftPickLocatorRepository($this->mockDb);
+
+        $result = $repo->getDraftPicksForTeam(1);
+
+        $this->assertSame([
+            ['ownerofpick' => 'Team A', 'year' => 2026, 'round' => 1],
+            ['ownerofpick' => 'Team A', 'year' => 2027, 'round' => 2],
+        ], $result);
+    }
+
+    public function testGetDraftPicksForTeamReturnsEmptyArrayForTeamWithNoPicks(): void
+    {
+        $this->mockDb->setMockData([]);
+        $repo = new DraftPickLocatorRepository($this->mockDb);
+
+        $this->assertSame([], $repo->getDraftPicksForTeam(99));
+    }
+}

--- a/ibl5/tests/GMContactList/GMContactListRepositoryTest.php
+++ b/ibl5/tests/GMContactList/GMContactListRepositoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GMContactList;
+
+use GMContactList\GMContactListRepository;
+use PHPUnit\Framework\TestCase;
+use Tests\WideUnit\Mocks\MockDatabase;
+
+class GMContactListRepositoryTest extends TestCase
+{
+    private MockDatabase $mockDb;
+
+    protected function setUp(): void
+    {
+        $this->mockDb = new MockDatabase();
+    }
+
+    public function testGetAllTeamContactsReturnsMappedContacts(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1, 'team_city' => 'Springfield', 'team_name' => 'Bears', 'color1' => '#111', 'color2' => '#222', 'owner_name' => 'Alice', 'discord_id' => 123456],
+            ['teamid' => 2, 'team_city' => 'Shelbyville', 'team_name' => 'Eagles', 'color1' => '#333', 'color2' => '#444', 'owner_name' => 'Bob', 'discord_id' => null],
+        ]);
+        $repo = new GMContactListRepository($this->mockDb);
+
+        $result = $repo->getAllTeamContacts();
+
+        $this->assertSame([
+            ['teamid' => 1, 'team_city' => 'Springfield', 'team_name' => 'Bears', 'color1' => '#111', 'color2' => '#222', 'owner_name' => 'Alice', 'discord_id' => 123456],
+            ['teamid' => 2, 'team_city' => 'Shelbyville', 'team_name' => 'Eagles', 'color1' => '#333', 'color2' => '#444', 'owner_name' => 'Bob', 'discord_id' => null],
+        ], $result);
+        $this->assertQueryExecuted('ibl_team_info');
+    }
+
+    public function testGetAllTeamContactsReturnsEmptyArrayWhenNoTeams(): void
+    {
+        $this->mockDb->setMockData([]);
+        $repo = new GMContactListRepository($this->mockDb);
+
+        $this->assertSame([], $repo->getAllTeamContacts());
+    }
+
+    private function assertQueryExecuted(string $substring): void
+    {
+        $queries = $this->mockDb->getExecutedQueries();
+        $found = false;
+        foreach ($queries as $query) {
+            if (str_contains($query, $substring)) {
+                $found = true;
+                break;
+            }
+        }
+        self::assertTrue(
+            $found,
+            "Expected a query containing '{$substring}' but none was found. Queries: " . implode("\n", $queries)
+        );
+    }
+}

--- a/ibl5/tests/GMContactList/GMContactListRepositoryTest.php
+++ b/ibl5/tests/GMContactList/GMContactListRepositoryTest.php
@@ -5,16 +5,15 @@ declare(strict_types=1);
 namespace Tests\GMContactList;
 
 use GMContactList\GMContactListRepository;
-use PHPUnit\Framework\TestCase;
-use Tests\WideUnit\Mocks\MockDatabase;
+use Tests\WideUnit\WideUnitTestCase;
 
-class GMContactListRepositoryTest extends TestCase
+class GMContactListRepositoryTest extends WideUnitTestCase
 {
-    private MockDatabase $mockDb;
-
-    protected function setUp(): void
+    private function repo(): GMContactListRepository
     {
-        $this->mockDb = new MockDatabase();
+        $db = $this->mockDb;
+        self::assertNotNull($db);
+        return new GMContactListRepository($db);
     }
 
     public function testGetAllTeamContactsReturnsMappedContacts(): void
@@ -23,9 +22,8 @@ class GMContactListRepositoryTest extends TestCase
             ['teamid' => 1, 'team_city' => 'Springfield', 'team_name' => 'Bears', 'color1' => '#111', 'color2' => '#222', 'owner_name' => 'Alice', 'discord_id' => 123456],
             ['teamid' => 2, 'team_city' => 'Shelbyville', 'team_name' => 'Eagles', 'color1' => '#333', 'color2' => '#444', 'owner_name' => 'Bob', 'discord_id' => null],
         ]);
-        $repo = new GMContactListRepository($this->mockDb);
 
-        $result = $repo->getAllTeamContacts();
+        $result = $this->repo()->getAllTeamContacts();
 
         $this->assertSame([
             ['teamid' => 1, 'team_city' => 'Springfield', 'team_name' => 'Bears', 'color1' => '#111', 'color2' => '#222', 'owner_name' => 'Alice', 'discord_id' => 123456],
@@ -37,24 +35,7 @@ class GMContactListRepositoryTest extends TestCase
     public function testGetAllTeamContactsReturnsEmptyArrayWhenNoTeams(): void
     {
         $this->mockDb->setMockData([]);
-        $repo = new GMContactListRepository($this->mockDb);
 
-        $this->assertSame([], $repo->getAllTeamContacts());
-    }
-
-    private function assertQueryExecuted(string $substring): void
-    {
-        $queries = $this->mockDb->getExecutedQueries();
-        $found = false;
-        foreach ($queries as $query) {
-            if (str_contains($query, $substring)) {
-                $found = true;
-                break;
-            }
-        }
-        self::assertTrue(
-            $found,
-            "Expected a query containing '{$substring}' but none was found. Queries: " . implode("\n", $queries)
-        );
+        $this->assertSame([], $this->repo()->getAllTeamContacts());
     }
 }

--- a/ibl5/tests/LeagueSchedule/LeagueScheduleGameTest.php
+++ b/ibl5/tests/LeagueSchedule/LeagueScheduleGameTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\LeagueSchedule;
+
+use LeagueSchedule\Game;
+use PHPUnit\Framework\TestCase;
+
+class LeagueScheduleGameTest extends TestCase
+{
+    /** @return array{game_date: string, box_id: int, visitor_teamid: int, home_teamid: int, visitor_score: int, home_score: int} */
+    private function makeRow(int $visitorScore, int $homeScore, int $visitorTeamId = 1, int $homeTeamId = 2): array
+    {
+        return [
+            'game_date' => '2026-01-15',
+            'box_id' => 101,
+            'visitor_teamid' => $visitorTeamId,
+            'home_teamid' => $homeTeamId,
+            'visitor_score' => $visitorScore,
+            'home_score' => $homeScore,
+        ];
+    }
+
+    public function testConstructorMarksUnplayedWhenScoresEqual(): void
+    {
+        $game = new Game($this->makeRow(0, 0));
+
+        $this->assertTrue($game->isUnplayed);
+        $this->assertSame(2, $game->winningTeamID); // equal → home wins ternary
+    }
+
+    public function testConstructorSetsWinningTeamWhenVisitorWins(): void
+    {
+        $game = new Game($this->makeRow(110, 100));
+
+        $this->assertFalse($game->isUnplayed);
+        $this->assertSame(1, $game->winningTeamID);
+    }
+
+    public function testConstructorSetsWinningTeamWhenHomeWins(): void
+    {
+        $game = new Game($this->makeRow(95, 108));
+
+        $this->assertFalse($game->isUnplayed);
+        $this->assertSame(2, $game->winningTeamID);
+    }
+
+    public function testGetOpposingTeamIDWhenUserIsVisitor(): void
+    {
+        $game = new Game($this->makeRow(100, 95));
+
+        $this->assertSame(2, $game->getOpposingTeamID(1));
+    }
+
+    public function testGetOpposingTeamIDWhenUserIsHome(): void
+    {
+        $game = new Game($this->makeRow(100, 95));
+
+        $this->assertSame(1, $game->getOpposingTeamID(2));
+    }
+
+    public function testGetOpposingTeamIDWhenUserIsNeitherReturnsVisitor(): void
+    {
+        $game = new Game($this->makeRow(100, 95));
+
+        $this->assertSame(1, $game->getOpposingTeamID(9999));
+    }
+
+    public function testGetUserTeamLocationPrefixIsAtSignWhenVisitor(): void
+    {
+        $game = new Game($this->makeRow(100, 95));
+
+        $this->assertSame('@', $game->getUserTeamLocationPrefix(1));
+    }
+
+    public function testGetUserTeamLocationPrefixIsVsWhenHome(): void
+    {
+        $game = new Game($this->makeRow(100, 95));
+
+        $this->assertSame('vs', $game->getUserTeamLocationPrefix(2));
+    }
+
+    public function testGetUserTeamLocationPrefixIsVsWhenNeither(): void
+    {
+        $game = new Game($this->makeRow(100, 95));
+
+        $this->assertSame('vs', $game->getUserTeamLocationPrefix(9999));
+    }
+}

--- a/ibl5/tests/TransactionHistory/TransactionHistoryRepositoryTest.php
+++ b/ibl5/tests/TransactionHistory/TransactionHistoryRepositoryTest.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace Tests\TransactionHistory;
 
-use PHPUnit\Framework\TestCase;
 use TransactionHistory\TransactionHistoryRepository;
-use Tests\WideUnit\Mocks\MockDatabase;
+use Tests\WideUnit\WideUnitTestCase;
 
-class TransactionHistoryRepositoryTest extends TestCase
+class TransactionHistoryRepositoryTest extends WideUnitTestCase
 {
-    private MockDatabase $mockDb;
-
-    protected function setUp(): void
+    private function repo(): TransactionHistoryRepository
     {
-        $this->mockDb = new MockDatabase();
+        $db = $this->mockDb;
+        self::assertNotNull($db);
+        return new TransactionHistoryRepository($db);
     }
 
     // ORDER BY correctness (time DESC) is DB-integration-only; MockDatabase returns data in feed order.
@@ -25,9 +24,8 @@ class TransactionHistoryRepositoryTest extends TestCase
             ['year' => '2025'],
             ['year' => '2024'],
         ]);
-        $repo = new TransactionHistoryRepository($this->mockDb);
 
-        $result = $repo->getAvailableYears();
+        $result = $this->repo()->getAvailableYears();
 
         $this->assertSame([2025, 2024], $result);
     }
@@ -35,18 +33,16 @@ class TransactionHistoryRepositoryTest extends TestCase
     public function testGetAvailableYearsReturnsEmptyArrayWhenNoRows(): void
     {
         $this->mockDb->setMockData([]);
-        $repo = new TransactionHistoryRepository($this->mockDb);
 
-        $this->assertSame([], $repo->getAvailableYears());
+        $this->assertSame([], $this->repo()->getAvailableYears());
     }
 
     public function testGetTransactionsWithNoFiltersReturnsRows(): void
     {
         $row = ['sid' => '1', 'catid' => '1', 'title' => 'Trade', 'time' => '2025-03-01 12:00:00'];
         $this->mockDb->setMockData([$row]);
-        $repo = new TransactionHistoryRepository($this->mockDb);
 
-        $result = $repo->getTransactions(null, null, null);
+        $result = $this->repo()->getTransactions(null, null, null);
 
         $this->assertSame([$row], $result);
         $this->assertQueryExecuted('nuke_stories');
@@ -56,9 +52,8 @@ class TransactionHistoryRepositoryTest extends TestCase
     {
         $row = ['sid' => '2', 'catid' => '2', 'title' => 'Waiver', 'time' => '2025-04-01 10:00:00'];
         $this->mockDb->setMockData([$row]);
-        $repo = new TransactionHistoryRepository($this->mockDb);
 
-        $result = $repo->getTransactions(2, null, null);
+        $result = $this->repo()->getTransactions(2, null, null);
 
         $this->assertSame([$row], $result);
     }
@@ -67,9 +62,8 @@ class TransactionHistoryRepositoryTest extends TestCase
     {
         $row = ['sid' => '3', 'catid' => '1', 'title' => 'FA Sign', 'time' => '2025-12-15 09:00:00'];
         $this->mockDb->setMockData([$row]);
-        $repo = new TransactionHistoryRepository($this->mockDb);
 
-        $result = $repo->getTransactions(null, 2025, 12);
+        $result = $this->repo()->getTransactions(null, 2025, 12);
 
         $this->assertSame([$row], $result);
     }
@@ -78,9 +72,8 @@ class TransactionHistoryRepositoryTest extends TestCase
     {
         $row = ['sid' => '4', 'catid' => '1', 'title' => 'Cut', 'time' => '2025-03-10 08:00:00'];
         $this->mockDb->setMockData([$row]);
-        $repo = new TransactionHistoryRepository($this->mockDb);
 
-        $result = $repo->getTransactions(null, null, 3);
+        $result = $this->repo()->getTransactions(null, null, 3);
 
         $this->assertSame([$row], $result);
     }
@@ -88,24 +81,7 @@ class TransactionHistoryRepositoryTest extends TestCase
     public function testGetTransactionsReturnsEmptyArrayWhenNoRows(): void
     {
         $this->mockDb->setMockData([]);
-        $repo = new TransactionHistoryRepository($this->mockDb);
 
-        $this->assertSame([], $repo->getTransactions(null, null, null));
-    }
-
-    private function assertQueryExecuted(string $substring): void
-    {
-        $queries = $this->mockDb->getExecutedQueries();
-        $found = false;
-        foreach ($queries as $query) {
-            if (str_contains($query, $substring)) {
-                $found = true;
-                break;
-            }
-        }
-        self::assertTrue(
-            $found,
-            "Expected a query containing '{$substring}' but none was found. Queries: " . implode("\n", $queries)
-        );
+        $this->assertSame([], $this->repo()->getTransactions(null, null, null));
     }
 }

--- a/ibl5/tests/TransactionHistory/TransactionHistoryRepositoryTest.php
+++ b/ibl5/tests/TransactionHistory/TransactionHistoryRepositoryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\TransactionHistory;
+
+use PHPUnit\Framework\TestCase;
+use TransactionHistory\TransactionHistoryRepository;
+use Tests\WideUnit\Mocks\MockDatabase;
+
+class TransactionHistoryRepositoryTest extends TestCase
+{
+    private MockDatabase $mockDb;
+
+    protected function setUp(): void
+    {
+        $this->mockDb = new MockDatabase();
+    }
+
+    // ORDER BY correctness (time DESC) is DB-integration-only; MockDatabase returns data in feed order.
+
+    public function testGetAvailableYearsCastsToIntDescending(): void
+    {
+        $this->mockDb->setMockData([
+            ['year' => '2025'],
+            ['year' => '2024'],
+        ]);
+        $repo = new TransactionHistoryRepository($this->mockDb);
+
+        $result = $repo->getAvailableYears();
+
+        $this->assertSame([2025, 2024], $result);
+    }
+
+    public function testGetAvailableYearsReturnsEmptyArrayWhenNoRows(): void
+    {
+        $this->mockDb->setMockData([]);
+        $repo = new TransactionHistoryRepository($this->mockDb);
+
+        $this->assertSame([], $repo->getAvailableYears());
+    }
+
+    public function testGetTransactionsWithNoFiltersReturnsRows(): void
+    {
+        $row = ['sid' => '1', 'catid' => '1', 'title' => 'Trade', 'time' => '2025-03-01 12:00:00'];
+        $this->mockDb->setMockData([$row]);
+        $repo = new TransactionHistoryRepository($this->mockDb);
+
+        $result = $repo->getTransactions(null, null, null);
+
+        $this->assertSame([$row], $result);
+        $this->assertQueryExecuted('nuke_stories');
+    }
+
+    public function testGetTransactionsWithCategoryFilter(): void
+    {
+        $row = ['sid' => '2', 'catid' => '2', 'title' => 'Waiver', 'time' => '2025-04-01 10:00:00'];
+        $this->mockDb->setMockData([$row]);
+        $repo = new TransactionHistoryRepository($this->mockDb);
+
+        $result = $repo->getTransactions(2, null, null);
+
+        $this->assertSame([$row], $result);
+    }
+
+    public function testGetTransactionsWithYearAndDecemberMonthBuildsRange(): void
+    {
+        $row = ['sid' => '3', 'catid' => '1', 'title' => 'FA Sign', 'time' => '2025-12-15 09:00:00'];
+        $this->mockDb->setMockData([$row]);
+        $repo = new TransactionHistoryRepository($this->mockDb);
+
+        $result = $repo->getTransactions(null, 2025, 12);
+
+        $this->assertSame([$row], $result);
+    }
+
+    public function testGetTransactionsWithMonthOnlyFilter(): void
+    {
+        $row = ['sid' => '4', 'catid' => '1', 'title' => 'Cut', 'time' => '2025-03-10 08:00:00'];
+        $this->mockDb->setMockData([$row]);
+        $repo = new TransactionHistoryRepository($this->mockDb);
+
+        $result = $repo->getTransactions(null, null, 3);
+
+        $this->assertSame([$row], $result);
+    }
+
+    public function testGetTransactionsReturnsEmptyArrayWhenNoRows(): void
+    {
+        $this->mockDb->setMockData([]);
+        $repo = new TransactionHistoryRepository($this->mockDb);
+
+        $this->assertSame([], $repo->getTransactions(null, null, null));
+    }
+
+    private function assertQueryExecuted(string $substring): void
+    {
+        $queries = $this->mockDb->getExecutedQueries();
+        $found = false;
+        foreach ($queries as $query) {
+            if (str_contains($query, $substring)) {
+                $found = true;
+                break;
+            }
+        }
+        self::assertTrue(
+            $found,
+            "Expected a query containing '{$substring}' but none was found. Queries: " . implode("\n", $queries)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds PHPUnit unit tests for six modules with small/moderate coverage gaps identified in the Axis-6 coverage audit (findings 6.1, 6.18, 6.19):

- **DraftPickLocator** (6.18) — `getAllDraftPicksGroupedByTeam` grouping logic + empty boundary
- **LeagueSchedule/Game** (6.1) — `getOpposingTeamID`, `getUserTeamLocationPrefix`, `isUnplayed`, `winningTeamID` + neither-slot boundary
- **TransactionHistory** (6.1) — `getAvailableYears` cast + all four `getTransactions` filter branches + empty boundary
- **CapSpace** (6.1) — `getPlayersUnderContractAfterSeason` + empty boundary
- **AllStarAppearances** (6.19) — `getAllStarAppearances` mapping + `ibl_awards` table-hit + empty boundary
- **GMContactList** (6.19) — `getAllTeamContacts` mapping + `discord_id=null` row + empty boundary

Also flips 6.1/6.18/6.19 status in `docs/maintenance-backlog.md`.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.