### PR TITLE
fix: widen staleness guard FP exemptions, CI-wire its test, add pre-queue check

### DIFF
--- a/.claude/commands/queue.md
+++ b/.claude/commands/queue.md
@@ -1,6 +1,6 @@
 ---
 description: "Queue one or more completed /plan files for automouse autonomous execution."
-last_verified: 2026-06-20
+last_verified: 2026-06-27
 ---
 
 # /queue — Queue Plans for Automouse Run
@@ -26,13 +26,29 @@ Acceptable input forms per plan:
 
 If the user says "queue the plan" without naming it, look for the plan file written in this conversation (the most recent `/plan` output).
 
-## Step 2: Queue each plan
+## Step 2: Pre-queue staleness check
+
+Before queuing, run the automouse staleness guard on each plan so a stale or false-positive path reference surfaces **now** (a human is present to judge it) instead of silently burning an overnight automouse slot as a poison pill — the guard otherwise runs only inside the automouse impl prompt at 2am.
+
+Resolve each plan's file the same way `bin/automouse-queue` does: from the input form, strip a leading `~/.claude/plans/` and/or a trailing `.md` to get `<slug>`, then check `~/.claude/plans/<slug>.md`:
+
+```bash
+bin/check-plan-staleness ~/.claude/plans/<slug>.md
+```
+
+- **Exit 0** — no unresolved repo-path tokens; proceed to Step 3.
+- **Exit 1** — the guard prints one `STALE: <token>` per path the plan references that does not exist in the checkout. These are often **false positives** (a to-be-created ADR placeholder, a rejected-alternative path, an untagged test fixture). Show the user the `STALE:` lines and ask whether to **queue anyway** (the token is a non-dependency the plan creates/rejects/uses only as a temp fixture) or **fix the plan first** (a genuinely renamed/deleted dependency would poison-pill the run). Do **not** hard-block — a present human can correctly judge a false positive and queue anyway; that is exactly today's morning-recovery flow, moved earlier.
+- **Exit 2** — usage error or the plan file is missing; fix the path before queuing.
+
+Then proceed to Step 3.
+
+## Step 3: Queue each plan
 
 Run `bin/automouse-queue <slug-or-filename>` for each plan. The script resolves slugs to `~/.claude/plans/<slug>.md` automatically.
 
 If queuing multiple plans, run each command sequentially — the script shows the updated queue after each add.
 
-## Step 3: Confirm
+## Step 4: Confirm
 
 Show the user the final queue state (already printed by the last `bin/automouse-queue` invocation). State how many plans were queued.
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -586,6 +586,8 @@ jobs:
         run: bin/test-wt-status
       - name: bin/test-check-plan
         run: bin/test-check-plan
+      - name: bin/test-check-plan-staleness
+        run: bin/test-check-plan-staleness
       - name: bin/test-adr-check
         run: bin/test-adr-check
       - name: bin/test-postplan-arm-conditions

--- a/bin/check-plan-staleness
+++ b/bin/check-plan-staleness
@@ -90,6 +90,17 @@ while IFS= read -r token; do
         *...*) continue ;;
     esac
 
+    # Skip new-ADR numeric placeholders. A plan that will create an ADR cites it
+    # at a placeholder path like `ibl5/docs/decisions/00NN-slug.md` — the number
+    # is assigned at impl time by bin/next-adr. Real ADR files use digits only in
+    # the number slot and lowercase-kebab slugs, so an uppercase "NN" in a
+    # docs/decisions path is always a placeholder, never a dependency the plan
+    # reads. (Recurring FP class A — e.g. plan pr-triage-gated-auto-arm.) The
+    # case is case-sensitive, so a real ADR like 0069-foo.md never matches.
+    case "$token" in
+        *docs/decisions/*NN*) continue ;;
+    esac
+
     # Validate charset; this also drops `$VAR/...` shell-variable tokens.
     if ! printf '%s' "$token" | grep -qE '^[A-Za-z0-9._/-]+$'; then
         continue
@@ -125,7 +136,7 @@ while IFS= read -r token; do
     # for new artifacts; `pre-impl` rows reference existing files (which resolve
     # on disk and never reach here).
     if grep -F -- "$token" "$PLAN_FILE" \
-        | grep -qE '([Cc]reate|[Nn]ew file|[Aa]dd(s|ing)? (a )?new|[Ii]ntroduce|[Ss]caffold|throwaway|scratch|post-impl)'; then
+        | grep -qE '([Cc]reate|[Nn]ew file|[Aa]dd(s|ing)? (a )?new|[Ii]ntroduce|[Ss]caffold|[Ww]rite|\*\*NEW\*\*|[Rr]eject(ed)?|[Ff]ixture|throwaway|scratch|post-impl)'; then
         continue
     fi
 

--- a/bin/test-check-plan-staleness
+++ b/bin/test-check-plan-staleness
@@ -3,11 +3,14 @@
 #
 # bin/test-check-plan-staleness — regression test for bin/check-plan-staleness.
 #
-# The guard relaxes two false-positive classes (bare bin/ tokens that live at
-# ibl5/bin/, and to-be-created files referenced in a creation context). This
-# test pins both the relaxations AND the negative case: a missing path that is
-# NOT in a creation context must still be flagged stale. Without the negative
-# case, a relaxed guard could silently stop catching real poison-pill plans.
+# The guard skips several documented non-dependency path classes: bare bin/
+# tokens that live at ibl5/bin/, ellipsis (`ibl5/...`) meta-notation, ADR numeric
+# placeholders (`docs/decisions/00NN-…`), and to-be-created/non-dependency paths
+# carried by a same-line cue (create / new file / Write / **NEW** / Reject(ed) /
+# fixture / scaffold / throwaway / scratch / post-impl). This test pins each
+# relaxation AND the load-bearing negative: a missing path on a cue-LESS line
+# must still flag stale. Without the negatives, a relaxed guard could silently
+# stop catching real poison-pill plans.
 #
 # Run: bin/test-check-plan-staleness  (exit 0 = all pass, 1 = a case failed)
 
@@ -59,6 +62,28 @@ assert "existing-path" 0 'See `bin/check-plan-staleness` for the guard itself.'
 # path dependency and must pass (exit 0), even though "ibl5/..." does not exist on
 # disk. Regression for the automouse false-positive that skipped maintenance-30.
 assert "ellipsis-placeholder" 0 'Every backtick `ibl5/...` token in the body resolves to a real file.'
+
+# Class A: a new-ADR numeric placeholder (`00NN`, assigned later by bin/next-adr)
+# on a line with NO creation cue — must pass via the placeholder skip-case, not a
+# cue. Isolates the skip-case (red against the pre-patch guard).
+assert "adr-placeholder" 0 '### Phase 5 — ADR `ibl5/docs/decisions/00NN-some-future-adr.md` (Tier: self).'
+
+# Class B: a path the plan will Write (verb "Write") must pass via the [Ww]rite
+# cue. Digit-only ADR number so the placeholder skip-case does NOT apply — this
+# exercises the cue, not the skip.
+assert "write-cue-adr" 0 'Phase 4 — Write `ibl5/docs/decisions/0099-fictional-adr.md` documenting the change.'
+
+# Class B: a Critical-Files table row marking a path **NEW** must pass via the
+# **NEW** bold-marker cue (the row has no "create"/"file" word).
+assert "new-marker-critical-file" 0 '| `ibl5/classes/BrandNewService.php` | **NEW** — a service handler. |'
+
+# Class B: a rejected-alternative path in an ## Approach section must pass via the
+# [Rr]eject(ed)? cue (the path is explicitly NOT built).
+assert "rejected-alternative" 0 'Rejected: a separate `bin/plan-queue-safe` script (redundant with check-plan).'
+
+# Class C: a throwaway test-fixture path described with the word "fixture" must
+# pass via the [Ff]ixture cue, without needing an explicit throwaway/scratch tag.
+assert "fixture-cue" 0 'The test scans a temp fixture `ibl5/scripts/throwaway-fixture-xyz.php` in a tmpdir.'
 
 if [ "$FAILED" -ne 0 ]; then
     echo "RESULT: FAILED"


### PR DESCRIPTION
## Summary

- Fixes three false-positive classes in `bin/check-plan-staleness`: new-ADR `00NN` placeholder paths, rejected-alternative paths (`[Rr]eject(ed)?`), `**NEW**`-marked Critical-Files entries, `Write`-cued paths, and `fixture`-cued temp paths
- Adds 5 new regression cases to `bin/test-check-plan-staleness` + refreshes its header comment; load-bearing negatives (`stale-modify`, `stale-bin-token`) are preserved
- CI-wires `bin/test-check-plan-staleness` as a required step in the `test` job (`.github/workflows/tests.yml`)
- Integrates the guard into `/queue` as a new Step 2 so a human can judge any remaining `STALE:` flags before an overnight automouse slot burns as a poison pill

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)