### PR TITLE
chore: add Step 5.5 auto-queue to /plan command; bump stale ADR freshness

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -245,10 +245,25 @@ auto_merge: false
 
 Either field may appear alone; the block above shows both (a mechanical column-rename sweep, e.g., can be Sonnet-eligible **and** want a human at merge). A plan that keeps `auto_merge: false` must also carry the `## Automouse Hold Justification` section from Step 4.5 — `bin/check-plan` gate `[H]` fails the plan if it is missing. Absence of `auto_merge` leaves the PR eligible to auto-merge (still subject to every other Phase-6.5 condition). Only the line-1 block is parsed (Phase 6.5), so a body that documents the syntax can't opt a plan out. Failure modes are bounded: absent/garbled → eligible to arm (post-plan's own gates — code review, security audit, CI-green-required, the `feat:` floor, the PR-time safety verdict, and the headless golden-snapshot block — still apply); a wrongly-applied `false` → the PR just waits for a manual merge.
 
+## Step 5.5: Auto-queue queue-safe plans
+
+A plan is **queue-safe** the moment `bin/check-plan` (Step 5) exits 0 — that gate already enforces no unresolved decisions, no `DECIDE`/`TBD`/`subject to…` tokens, resolved decision-triggers, and resolved reuse targets, so a passing plan is fully specified for unattended automouse execution. Queue-safety is **independent of `auto_merge`**: a plan held for human merge (`auto_merge: false`) is still safe to *implement* autonomously — only its merge waits (Phase 6.5 condition (7)).
+
+For every plan that passed `bin/check-plan` in Step 5, decide its disposition by this precedence (the default is **queue**):
+
+1. **Explicit token in `$ARGUMENTS`** wins outright: `--implement` (or "implement now") → do NOT queue; leave the plan on disk and report it ready to implement. `--queue` → queue.
+2. **Else, clear session intent to implement now** (the user said they will implement it in this session, or implementation is already underway) → do NOT queue.
+3. **Else, default: auto-queue.** Run `bin/automouse-queue <slug>` for the plan.
+
+When the work was split into multiple PRs (Step 2.5), queue **every** queue-safe unit, running `bin/automouse-queue <slug>` once per plan in dependency order (the order they must merge). A plan that did not pass `bin/check-plan` is never queued — fix it first.
+
+Report which plans were queued (and which were left for in-session implementation) in Step 6.
+
 ## Step 6: Report
 
 Tell the user:
 - The plan file path — **all of them** when the work was split into multiple PRs
+- The **disposition** of each plan: auto-queued for automouse (default), or left for in-session implementation (`--implement` / clear implement-now intent) — and the resulting `bin/automouse-queue` state
 - A one-line matrix summary per plan (e.g., "12 items: 7 PHPUnit, 3 E2E, 2 CLI-executable, 0 truly-manual")
 - Whether any security surface was flagged and how each is defended (or "no security surface touched")
 - Whether the PR is eligible to auto-merge on green CI (default) or is held for a human merge (`auto_merge: false`, per Step 4 gate 14) — and why, if held

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -3,7 +3,7 @@ description: "Plan an implementation task: enforces a verification matrix, direc
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
-last_verified: 2026-06-27
+last_verified: 2026-06-28
 
 ---
 

--- a/ibl5/docs/decisions/0015-materialize-playoff-and-season-aggregates.md
+++ b/ibl5/docs/decisions/0015-materialize-playoff-and-season-aggregates.md
@@ -1,6 +1,6 @@
 ---
 description: Materialize vw_playoff_series_results and team season win/loss records into refresh-on-pipeline tables for indexed lookups
-last_verified: 2026-04-28
+last_verified: 2026-06-27
 ---
 
 # ADR-0015: Materialize Playoff Series and Team Season Aggregate Tables

--- a/ibl5/docs/decisions/0016-remove-duckdb-analytics.md
+++ b/ibl5/docs/decisions/0016-remove-duckdb-analytics.md
@@ -1,6 +1,6 @@
 ---
 description: Rationale for removing the DuckDB OLAP analytics layer, write-back tables, and associated tooling.
-last_verified: 2026-04-28
+last_verified: 2026-06-27
 ---
 
 # ADR-0016: Remove DuckDB Analytics Layer


### PR DESCRIPTION
## Summary

Part 2 of 3 in the deployment-funnel redesign (ADR-0067). Adds a Step 5.5 to the `/plan` command skill that auto-queues every queue-safe plan for automouse, making `/plan → automouse` automatic. The `--implement` flag (or clear in-session implement-now intent) opts out of queuing.

Queue-safety is defined as `bin/check-plan` exits 0 — the same gate that enforces no unresolved decisions, DECIDE/TBD tokens, or broken reuse targets before a plan is written. No new predicate needed.

**Changes:**
- `.claude/commands/plan.md`: Insert Step 5.5 (auto-queue logic), add disposition bullet to Step 6 report, bump `last_verified`
- Two ADR docs: bump stale `last_verified` values that `bin/check-docs` flags

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.