### PR TITLE
test: Axis-6 coverage — StandingsUpdater, PowerRankingsUpdater, RecordParser, PlayerContractValidator, PlayerImageHelper, PlayerStats; backlog 6.13/6.14 → Partial

### DIFF
--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Long-running backlog of maintenance-cost reduction opportunities, organized by axis. Each item is a candidate for a future plan.
-last_verified: 2026-06-27
+last_verified: 2026-06-28
 ---
 
 # Maintenance-Cost Reduction Backlog

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1167,8 +1167,8 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 | 6.10 | ✅ Implemented | 🟩 | FreeAgencyPreview thin; additive — coordinate with PR #1162 (future-year restore). |
 | 6.11 | ✅ Implemented | 🟩 | SeasonHighs thin; additive. |
 | 6.12 | ✅ Implemented | 🟩 | TeamSchedule thin; additive. |
-| 6.13 | ⬜ Open | 🟩 | Player 0.24 ratio; additive (L — chunk it). |
-| 6.14 | ⬜ Open | 🟩 | Updater steps; additive. |
+| 6.13 | ◑ Partial | 🟩 | Player 0.24 ratio; additive (L — chunk it). |
+| 6.14 | ◑ Partial | 🟩 | Updater steps; additive. |
 | 6.15 | ✅ Implemented | — | VotingRepositoryTest + SubmissionResultTest added (aggregation, column allowlist). |
 | 6.16 | ◑ Partial | 🟩 | ApiKeyRepositoryTest + RateLimitRepositoryTest added; data repos + JsonResponder/SystemClock still untested. |
 | 6.17 | ◑ Partial | 🟩 | TradeAssetRepositoryTest + TradeOfferRepositoryTest added (draft-pick mapping, offer lifecycle); TradeExecutionRepository untested + TradeFormRepository partial. |
@@ -1275,6 +1275,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Page-type routing, contract rules, stats aggregation, image-helper edge cases.
 **Est. effort:** L
 **Risk if untouched:** Profile regressions cascade; contract validation bypass.
+**Status:** ◑ Partial (this PR, 2026-06-27). Added negative-path/boundary coverage on the named critical classes — `PlayerContractValidator` (offseason renegotiation advance; non-draft-pick and already-set option-year rejections), `PlayerImageHelper` (`renderPhoto`/`renderLargePlayerCell` escaping; `renderThumbnail` invalid-id placeholder), `PlayerStats` (empty boxscore line; missing historical columns) — in `ibl5/tests/Player/PlayerContractValidatorTest.php`, `ibl5/tests/Player/PlayerImageHelperTest.php`, `ibl5/tests/Player/PlayerStatsTest.php`. `PlayerPageService`/`PlayerPageType` page-type routing already covered (`ibl5/tests/Player/PlayerPageServiceTest.php`, `ibl5/tests/Player/PlayerPageTypeTest.php`). **Residual:** `Player/Views/`, `Player/Stats/Views/`, `PlayerRepository`, and `PlayerPageController` full routing remain untested; the 71-file module is still well below a 0.5 ratio.
 
 ### 6.14 Updater Module — Large + Subthreshold (37 files, 9 tests)
 **Location:** `ibl5/classes/Updater`
@@ -1282,6 +1283,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Per-step W-L aggregation, date ordering, format parsing.
 **Est. effort:** L
 **Risk if untouched:** Nightly automation corrupts standings/schedules/stats silently.
+**Status:** ◑ Partial (this PR, 2026-06-27). Added `ibl5/tests/Updater/StandingsUpdaterTest.php` (league/home/away/conference/division W-L aggregation, plus unknown-team-skip, empty-config, and zero-games boundaries) and `ibl5/tests/Updater/PowerRankingsUpdaterTest.php` (ranking formula + div-by-zero guard); extended `ibl5/tests/Updater/RecordParserTest.php` with empty/non-numeric/leading-dash boundaries. `ScheduleUpdater` already covered (`ibl5/tests/Updater/ScheduleUpdaterTest.php`). **Residual:** `Updater/Steps/` (22 step classes), `OlympicsFlatStandingsUpdater`, `UpdaterView`, and `JsbSourceResolver` remain untested; the 37-file module is still well below a 0.5 ratio.
 
 ### 6.15 Voting Module — Subthreshold (17 files, 4 tests)
 **Location:** `ibl5/classes/Voting`

--- a/ibl5/tests/Player/PlayerContractValidatorTest.php
+++ b/ibl5/tests/Player/PlayerContractValidatorTest.php
@@ -346,6 +346,56 @@ class PlayerContractValidatorTest extends TestCase
         );
     }
 
+    public function testCanRenegotiateAdvancesContractYearDuringOffseason(): void
+    {
+        $playerData = new PlayerData();
+        $playerData->contractCurrentYear = 5;
+        $playerData->contractYear6Salary = 600;
+
+        $season = self::createStub(Season::class);
+        $season->method('isOffseasonPhase')->willReturn(true);
+
+        $this->assertTrue($this->validator->canRenegotiateContract($playerData, $season));
+    }
+
+    public function testCannotRenegotiateSameDataWithoutOffseasonBump(): void
+    {
+        $playerData = new PlayerData();
+        $playerData->contractCurrentYear = 5;
+        $playerData->contractYear6Salary = 600;
+
+        $this->assertFalse($this->validator->canRenegotiateContract($playerData));
+    }
+
+    public function testCannotRookieOptionWhenNotDraftPick(): void
+    {
+        $playerData = new PlayerData();
+        $playerData->draftRound = 0;
+        $playerData->yearsOfExperience = 2;
+
+        $this->assertFalse($this->validator->canRookieOption($playerData, 'Free Agency'));
+    }
+
+    public function testCannotRookieOptionFirstRoundWhenYear4SalaryAlreadySet(): void
+    {
+        $playerData = new PlayerData();
+        $playerData->draftRound = 1;
+        $playerData->yearsOfExperience = 2;
+        $playerData->contractYear4Salary = 500;
+
+        $this->assertFalse($this->validator->canRookieOption($playerData, 'Free Agency'));
+    }
+
+    public function testCannotRookieOptionSecondRoundWhenYear3SalaryAlreadySet(): void
+    {
+        $playerData = new PlayerData();
+        $playerData->draftRound = 2;
+        $playerData->yearsOfExperience = 1;
+        $playerData->contractYear3Salary = 300;
+
+        $this->assertFalse($this->validator->canRookieOption($playerData, 'Free Agency'));
+    }
+
     private function createMockSeason(int $endingYear): Season&\PHPUnit\Framework\MockObject\Stub
     {
         $season = self::createStub(Season::class);

--- a/ibl5/tests/Player/PlayerImageHelperTest.php
+++ b/ibl5/tests/Player/PlayerImageHelperTest.php
@@ -379,4 +379,56 @@ class PlayerImageHelperTest extends TestCase
         $this->assertStringNotContainsString('<script>', $result);
         $this->assertStringContainsString('&lt;script&gt;', $result);
     }
+
+    public function testRenderThumbnailReturnsPlaceholderForInvalidId(): void
+    {
+        $result = PlayerImageHelper::renderThumbnail(0);
+
+        $this->assertStringContainsString('data:image/png;base64', $result);
+        $this->assertStringContainsString('ibl-player-photo', $result);
+    }
+
+    public function testRenderThumbnailUsesPlayerUrlForValidId(): void
+    {
+        $result = PlayerImageHelper::renderThumbnail(123);
+
+        $this->assertStringContainsString('./images/player/123.jpg', $result);
+        $this->assertStringContainsString('ibl-player-photo', $result);
+    }
+
+    public function testRenderPhotoEscapesAltText(): void
+    {
+        $result = PlayerImageHelper::renderPhoto(123, '<script>alert(1)</script>');
+
+        $this->assertStringNotContainsString('<script>', $result);
+        $this->assertStringContainsString('&lt;script&gt;', $result);
+        $this->assertStringContainsString('width="65"', $result);
+        $this->assertStringContainsString('height="90"', $result);
+    }
+
+    public function testRenderPhotoUsesProvidedDimensions(): void
+    {
+        $result = PlayerImageHelper::renderPhoto(123, 'x', 40, 50);
+
+        $this->assertStringContainsString('width="40"', $result);
+        $this->assertStringContainsString('height="50"', $result);
+    }
+
+    public function testRenderLargePlayerCellLinksPhotoAndName(): void
+    {
+        $result = PlayerImageHelper::renderLargePlayerCell(123, 'John Smith');
+
+        $this->assertStringContainsString('class="player-cell"', $result);
+        $this->assertStringContainsString('pid=123', $result);
+        $this->assertStringContainsString('<img', $result);
+        $this->assertStringContainsString('John Smith', $result);
+    }
+
+    public function testRenderLargePlayerCellEscapesName(): void
+    {
+        $result = PlayerImageHelper::renderLargePlayerCell(123, '<script>alert(1)</script>');
+
+        $this->assertStringNotContainsString('<script>', $result);
+        $this->assertStringContainsString('&lt;script&gt;', $result);
+    }
 }

--- a/ibl5/tests/Player/PlayerStatsTest.php
+++ b/ibl5/tests/Player/PlayerStatsTest.php
@@ -241,6 +241,16 @@ class PlayerStatsTest extends TestCase
         $this->assertSame('0.0', $this->stats->seasonAssistsPerGame);
     }
 
+    public function testFillHistoricalMissingColumnsDefaultToZero(): void
+    {
+        $this->stats->exposedFillHistorical([]);
+
+        $this->assertSame(0, $this->stats->seasonGamesPlayed);
+        $this->assertSame(0, $this->stats->seasonMinutes);
+        $this->assertSame(0, $this->stats->seasonPoints);
+        $this->assertSame(0, $this->stats->seasonTotalRebounds);
+    }
+
     // --- fillBoxscoreStats() tests ---
 
     public function testFillBoxscoreStatsExtractsNameFromFixedOffset(): void
@@ -287,6 +297,14 @@ class PlayerStatsTest extends TestCase
 
         $this->assertSame('Short Name', $this->stats->name);
         $this->assertSame('PG', $this->stats->position);
+    }
+
+    public function testFillBoxscoreStatsHandlesEmptyLineWithoutError(): void
+    {
+        $this->stats->exposedFillBoxscoreStats('');
+
+        $this->assertSame('', $this->stats->name);
+        $this->assertSame('', $this->stats->position);
     }
 
     // --- Helper methods ---

--- a/ibl5/tests/Updater/PowerRankingsUpdaterTest.php
+++ b/ibl5/tests/Updater/PowerRankingsUpdaterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Updater;
+
+use PHPUnit\Framework\TestCase;
+use Season\Season;
+use Statistics\TeamStatsCalculator;
+use Tests\WideUnit\Mocks\MockDatabase;
+use Updater\PowerRankingsUpdater;
+
+class PowerRankingsUpdaterTest extends TestCase
+{
+    private MockDatabase $db;
+
+    /**
+     * @param array{wins:int,losses:int,homeWins:int,homeLosses:int,awayWins:int,awayLosses:int,winPoints:int,lossPoints:int,winsInLast10Games:int,lossesInLast10Games:int,streak:int,streakType:string} $teamStats
+     */
+    private function buildUpdater(array $teamStats): PowerRankingsUpdater
+    {
+        $this->db = new MockDatabase();
+        $this->db->onQuery('streak_type, streak', [
+            ['teamid' => 5, 'streak_type' => $teamStats['streakType'], 'streak' => $teamStats['streak']],
+        ]);
+        $this->db->onQuery('team_name FROM ibl_team_info', [
+            ['teamid' => 5, 'team_name' => 'Alpha'],
+        ]);
+
+        $season = self::createStub(Season::class);
+        $season->phase = 'Regular Season';
+        $season->beginningYear = 2024;
+        $season->endingYear = 2025;
+
+        $calc = self::createStub(TeamStatsCalculator::class);
+        $calc->method('calculate')->willReturn($teamStats);
+
+        return new PowerRankingsUpdater($this->db, $season, $calc, null);
+    }
+
+    private function runUpdate(PowerRankingsUpdater $u): void
+    {
+        ob_start();
+        $u->update();
+        ob_end_clean();
+    }
+
+    private function assertExecutedQueryContains(string $needle): void
+    {
+        $hit = array_filter(
+            $this->db->getExecutedQueries(),
+            static fn (string $q): bool => str_contains($q, $needle),
+        );
+        $this->assertNotEmpty($hit, "No executed query contained: {$needle}");
+    }
+
+    public function testUpdateWritesComputedRankingToPowerTable(): void
+    {
+        $stats = [
+            'wins' => 10, 'losses' => 5,
+            'homeWins' => 5, 'homeLosses' => 2,
+            'awayWins' => 5, 'awayLosses' => 3,
+            'winPoints' => 70, 'lossPoints' => 15,
+            'winsInLast10Games' => 7, 'lossesInLast10Games' => 3,
+            'streak' => 4, 'streakType' => 'W',
+        ];
+
+        $u = $this->buildUpdater($stats);
+        $this->runUpdate($u);
+
+        $this->assertExecutedQueryContains('UPDATE ibl_power');
+        $this->assertExecutedQueryContains('ranking = 80');
+    }
+
+    public function testRankingIsZeroWhenNoPointsAccumulated(): void
+    {
+        $stats = [
+            'wins' => 0, 'losses' => 0,
+            'homeWins' => 0, 'homeLosses' => 0,
+            'awayWins' => 0, 'awayLosses' => 0,
+            'winPoints' => 0, 'lossPoints' => 0,
+            'winsInLast10Games' => 0, 'lossesInLast10Games' => 0,
+            'streak' => 0, 'streakType' => '-',
+        ];
+
+        $u = $this->buildUpdater($stats);
+        $this->runUpdate($u);
+
+        $this->assertExecutedQueryContains('ranking = 0');
+    }
+}

--- a/ibl5/tests/Updater/RecordParserTest.php
+++ b/ibl5/tests/Updater/RecordParserTest.php
@@ -89,4 +89,31 @@ class RecordParserTest extends TestCase
         $this->assertSame(0, $result['wins']);
         $this->assertSame(0, $result['losses']);
     }
+
+    public function testExtractWinsFromEmptyStringReturnsZero(): void
+    {
+        $this->assertSame(0, RecordParser::extractWins(''));
+    }
+
+    public function testExtractLossesFromEmptyStringReturnsZero(): void
+    {
+        $this->assertSame(0, RecordParser::extractLosses(''));
+    }
+
+    public function testExtractWinsFromNonNumericReturnsZero(): void
+    {
+        $this->assertSame(0, RecordParser::extractWins('abc-def'));
+    }
+
+    public function testExtractWinsFromLeadingDashReturnsZero(): void
+    {
+        $this->assertSame(0, RecordParser::extractWins('-5'));
+    }
+
+    public function testParseRecordIgnoresExtraSeparators(): void
+    {
+        $result = RecordParser::parseRecord('45-37-12');
+        $this->assertSame(45, $result['wins']);
+        $this->assertSame(37, $result['losses']);
+    }
 }

--- a/ibl5/tests/Updater/StandingsUpdaterTest.php
+++ b/ibl5/tests/Updater/StandingsUpdaterTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Updater;
+
+use PHPUnit\Framework\TestCase;
+use Season\Season;
+use Standings\Contracts\StandingsRepositoryInterface;
+use Updater\StandingsUpdater;
+
+class StandingsUpdaterTest extends TestCase
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $captured = [];
+
+    /**
+     * @param array<int, array{conference:string,division:string,teamName:string}> $teamMap
+     * @param list<array{visitor_teamid:int,visitor_score:int,home_teamid:int,home_score:int}> $games
+     */
+    private function buildUpdater(array $teamMap, array $games): TestableStandingsUpdater
+    {
+        $repo = self::createStub(StandingsRepositoryInterface::class);
+        $repo->method('fetchTeamMapForSeason')->willReturn($teamMap);
+        $repo->method('fetchPlayedGamesForSeason')->willReturn($games);
+        $repo->method('upsertStandings')->willReturnCallback(
+            function (array $p): void { $this->captured[(int) $p['teamid']] = $p; }
+        );
+
+        $season = self::createStub(Season::class);
+        $season->phase = 'Regular Season';
+        $season->beginningYear = 2024;
+        $season->endingYear = 2025;
+
+        return new TestableStandingsUpdater($repo, $season);
+    }
+
+    private function runCompute(TestableStandingsUpdater $u): string
+    {
+        ob_start();
+        $u->exposedComputeAndInsertStandings();
+        return (string) ob_get_clean();
+    }
+
+    /** @return array{visitor_teamid:int,visitor_score:int,home_teamid:int,home_score:int} */
+    private function game(int $visitor, int $vScore, int $home, int $hScore): array
+    {
+        return ['visitor_teamid' => $visitor, 'visitor_score' => $vScore, 'home_teamid' => $home, 'home_score' => $hScore];
+    }
+
+    /** @return array{conference:string,division:string,teamName:string} */
+    private function team(string $conf, string $div, string $name = 'Team'): array
+    {
+        return ['conference' => $conf, 'division' => $div, 'teamName' => $name];
+    }
+
+    public function testTalliesLeagueWinsAndLossesPerTeam(): void
+    {
+        $u = $this->buildUpdater(
+            [1 => $this->team('Eastern', 'Atlantic', 'Alpha'), 2 => $this->team('Eastern', 'Atlantic', 'Beta')],
+            [$this->game(2, 90, 1, 100), $this->game(1, 110, 2, 95)]
+        );
+        $this->runCompute($u);
+
+        $this->assertSame(2, $this->captured[1]['wins']);
+        $this->assertSame(0, $this->captured[1]['losses']);
+        $this->assertSame('2-0', $this->captured[1]['leagueRecord']);
+        $this->assertSame(0, $this->captured[2]['wins']);
+        $this->assertSame(2, $this->captured[2]['losses']);
+    }
+
+    public function testTracksHomeAndAwaySplitsSeparately(): void
+    {
+        $u = $this->buildUpdater(
+            [1 => $this->team('Eastern', 'Atlantic', 'Alpha'), 2 => $this->team('Eastern', 'Atlantic', 'Beta')],
+            [$this->game(2, 90, 1, 100), $this->game(1, 110, 2, 95)]
+        );
+        $this->runCompute($u);
+
+        $this->assertSame(1, $this->captured[1]['homeWins']);
+        $this->assertSame(1, $this->captured[1]['awayWins']);
+        $this->assertSame('1-0', $this->captured[1]['homeRecord']);
+        $this->assertSame('1-0', $this->captured[1]['awayRecord']);
+    }
+
+    public function testCountsConferenceAndDivisionGamesWhenSameRegion(): void
+    {
+        $u = $this->buildUpdater(
+            [1 => $this->team('Eastern', 'Atlantic', 'Alpha'), 2 => $this->team('Eastern', 'Atlantic', 'Beta')],
+            [$this->game(2, 90, 1, 100), $this->game(1, 110, 2, 95)]
+        );
+        $this->runCompute($u);
+
+        $this->assertSame(2, $this->captured[1]['confWins']);
+        $this->assertSame(2, $this->captured[1]['divWins']);
+    }
+
+    public function testConferenceGameInDifferentDivisionDoesNotCountAsDivision(): void
+    {
+        $u = $this->buildUpdater(
+            [1 => $this->team('Eastern', 'Atlantic', 'Alpha'), 2 => $this->team('Eastern', 'Central', 'Beta')],
+            [$this->game(1, 110, 2, 95)]
+        );
+        $this->runCompute($u);
+
+        $this->assertSame(1, $this->captured[1]['confWins']);
+        $this->assertSame(0, $this->captured[1]['divWins']);
+    }
+
+    public function testCrossConferenceGameCountsNeitherConferenceNorDivision(): void
+    {
+        $u = $this->buildUpdater(
+            [1 => $this->team('Eastern', 'Atlantic', 'Alpha'), 3 => $this->team('Western', 'Pacific', 'Gamma')],
+            [$this->game(1, 110, 3, 95)]
+        );
+        $this->runCompute($u);
+
+        $this->assertSame(1, $this->captured[1]['wins']);
+        $this->assertSame(0, $this->captured[1]['confWins']);
+        $this->assertSame(0, $this->captured[1]['divWins']);
+    }
+
+    public function testGameReferencingUnknownTeamIsSkipped(): void
+    {
+        $u = $this->buildUpdater(
+            [1 => $this->team('Eastern', 'Atlantic', 'Alpha'), 2 => $this->team('Eastern', 'Atlantic', 'Beta')],
+            [$this->game(2, 90, 1, 100), $this->game(99, 85, 1, 95)]
+        );
+        $this->runCompute($u);
+
+        $this->assertSame(1, $this->captured[1]['wins']);
+        $this->assertArrayNotHasKey(99, $this->captured);
+    }
+
+    public function testEmptyTeamMapProducesNoUpsertsAndLogsError(): void
+    {
+        $u = $this->buildUpdater([], []);
+        $output = $this->runCompute($u);
+
+        $this->assertSame([], $this->captured);
+        $this->assertStringContainsString('No league config', $output);
+    }
+
+    public function testTeamWithNoGamesGetsZeroPctAndZeroRecord(): void
+    {
+        $u = $this->buildUpdater(
+            [1 => $this->team('Eastern', 'Atlantic', 'Alpha'), 2 => $this->team('Eastern', 'Atlantic', 'Beta')],
+            []
+        );
+        $this->runCompute($u);
+
+        $this->assertSame(0.0, $this->captured[1]['pct']);
+        $this->assertSame(0, $this->captured[1]['wins']);
+        $this->assertSame('0-0', $this->captured[1]['leagueRecord']);
+    }
+}
+
+class TestableStandingsUpdater extends StandingsUpdater
+{
+    public function exposedComputeAndInsertStandings(): void
+    {
+        $this->computeAndInsertStandings();
+    }
+}


### PR DESCRIPTION
## Summary

Additive, **test-only** PHPUnit coverage for maintenance-backlog **Axis-6 findings 6.13 (Player) and 6.14 (Updater)** — the two largest sub-threshold modules. PR 4 of a 4-plan chunking.

New test files:
- `ibl5/tests/Updater/StandingsUpdaterTest.php` — league/home/away/conference/division W-L aggregation, plus unknown-team-skip, empty-config, zero-games boundaries
- `ibl5/tests/Updater/PowerRankingsUpdaterTest.php` — ranking formula + div-by-zero guard

Extended test files:
- `ibl5/tests/Updater/RecordParserTest.php` — empty/non-numeric/leading-dash boundaries
- `ibl5/tests/Player/PlayerContractValidatorTest.php` — offseason renegotiation advance; non-draft-pick and already-set option-year rejections
- `ibl5/tests/Player/PlayerImageHelperTest.php` — renderPhoto/renderLargePlayerCell escaping; renderThumbnail invalid-id placeholder
- `ibl5/tests/Player/PlayerStatsTest.php` — empty boxscore line; missing historical columns

Documentation:
- `ibl5/docs/maintenance-backlog.md` — findings 6.13 and 6.14 flipped from ⬜ Open → ◑ Partial

No production code changes.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.