### PR TITLE
refactor: continue tables.css component split + alias exact-match hex to design tokens (backlog 11.3, 11.14)

### DIFF
--- a/ibl5/design/components/debug.css
+++ b/ibl5/design/components/debug.css
@@ -149,12 +149,12 @@
 }
 
 .debug-toggle-on {
-    background: #22c55e;
-    box-shadow: 0 0 4px #22c55e;
+    background: var(--success-500);
+    box-shadow: 0 0 4px var(--success-500);
 }
 
 .debug-toggle-off {
-    background: #ef4444;
+    background: var(--error-500);
 }
 
 } /* end @layer components */

--- a/ibl5/design/components/tables.css
+++ b/ibl5/design/components/tables.css
@@ -376,78 +376,6 @@
     padding: 0;
 }
 
-/* Salary year columns — right-aligned (shared between Contracts and Free Agency) */
-.team-table th.col-salary,
-.team-table td.col-salary {
-    text-align: right;
-}
-
-/* Contract hint cells — show salary zeros with dotted underline; reveal action link on hover/tap.
-   The link lives in the first hint cell and spans all 5 via width: 500% + overflow: visible. */
-.contract-hint-cell {
-    position: relative;
-    overflow: visible;
-    cursor: pointer;
-    text-decoration: underline;
-    text-decoration-style: dotted;
-    text-decoration-color: var(--gray-400);
-    text-underline-offset: 2px;
-    -webkit-tap-highlight-color: transparent;
-}
-
-.ibl-data-table .contract-hint-link,
-.ibl-data-table .contract-hint-link:visited {
-    display: none;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 0;
-    background-color: inherit;
-    color: var(--accent-700);
-    text-decoration-line: none;
-    font-weight: 600;
-    white-space: nowrap;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    /* width set by contract-hint.js */
-}
-
-/* Underline only the clickable (anchor) variant; the non-clickable <span>
-   variant (used when viewing another GM's roster or during Draft/Free Agency)
-   displays the label without underline to signal it's not actionable. */
-.ibl-data-table a.contract-hint-link,
-.ibl-data-table a.contract-hint-link:visited {
-    text-decoration-line: underline;
-}
-
-/* Desktop: reveal link and hide zeros on hover */
-@media (hover: hover) {
-    tr:has(.contract-hint-cell):hover .contract-hint-link {
-        display: flex;
-    }
-    tr:has(.contract-hint-cell):hover .contract-hint-cell:has(.contract-hint-link) {
-        z-index: 1;
-    }
-    tr:has(.contract-hint-cell):hover .contract-hint-cell {
-        color: transparent;
-        text-decoration: none;
-    }
-}
-
-/* Mobile: reveal link and hide zeros on focus/tap */
-tr:has(.contract-hint-cell):focus-within .contract-hint-link {
-    display: flex;
-}
-tr:has(.contract-hint-cell):focus-within .contract-hint-cell:has(.contract-hint-link) {
-    z-index: 1;
-}
-tr:has(.contract-hint-cell):focus-within .contract-hint-cell {
-    color: transparent;
-    text-decoration: none;
-}
-
 /* Team-colored tfoot */
 .team-table tfoot tr {
     background-color: var(--team-row-highlight-bg);
@@ -1204,19 +1132,6 @@ td.ibl-team-cell--colored {
         min-width: 36px;
     }
 
-    /* Trading team select — show team name (override global hide) but hide city */
-    .trading-team-select .ibl-team-cell__text {
-        display: inline;
-    }
-
-    .trading-team-select .ibl-team-cell__city {
-        display: none;
-    }
-
-    /* Re-sort by team name on mobile (desktop sorts by city) */
-    .trading-team-select td {
-        order: var(--mobile-order, 0);
-    }
 }
 
 /* ==========================================================================
@@ -1376,25 +1291,6 @@ td.ibl-team-cell--colored {
     outline: none;
     background-color: var(--accent-100);
     border-radius: var(--radius-sm);
-}
-
-/* ==========================================================================
-   Sorted Column Highlight (Season & Career Leaderboards)
-
-   Highlights the column corresponding to the active sort dimension.
-   Applied via .sorted-col class on <th> and <td> elements.
-   ========================================================================== */
-
-.ibl-data-table th.sorted-col {
-    background: var(--navy-600);
-}
-
-.ibl-data-table td.sorted-col {
-    background-color: var(--accent-100);
-}
-
-.ibl-data-table tbody tr:hover td.sorted-col {
-    background-color: var(--accent-200);
 }
 
 } /* end @layer components */

--- a/ibl5/design/components/tables/free-agency.css
+++ b/ibl5/design/components/tables/free-agency.css
@@ -141,4 +141,76 @@ table.sortable thead th {
     font-weight: bold;
 }
 
+/* Salary year columns — right-aligned (shared between Contracts and Free Agency) */
+.team-table th.col-salary,
+.team-table td.col-salary {
+    text-align: right;
+}
+
+/* Contract hint cells — show salary zeros with dotted underline; reveal action link on hover/tap.
+   The link lives in the first hint cell and spans all 5 via width: 500% + overflow: visible. */
+.contract-hint-cell {
+    position: relative;
+    overflow: visible;
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-decoration-color: var(--gray-400);
+    text-underline-offset: 2px;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.ibl-data-table .contract-hint-link,
+.ibl-data-table .contract-hint-link:visited {
+    display: none;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 0;
+    background-color: inherit;
+    color: var(--accent-700);
+    text-decoration-line: none;
+    font-weight: 600;
+    white-space: nowrap;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    /* width set by contract-hint.js */
+}
+
+/* Underline only the clickable (anchor) variant; the non-clickable <span>
+   variant (used when viewing another GM's roster or during Draft/Free Agency)
+   displays the label without underline to signal it's not actionable. */
+.ibl-data-table a.contract-hint-link,
+.ibl-data-table a.contract-hint-link:visited {
+    text-decoration-line: underline;
+}
+
+/* Desktop: reveal link and hide zeros on hover */
+@media (hover: hover) {
+    tr:has(.contract-hint-cell):hover .contract-hint-link {
+        display: flex;
+    }
+    tr:has(.contract-hint-cell):hover .contract-hint-cell:has(.contract-hint-link) {
+        z-index: 1;
+    }
+    tr:has(.contract-hint-cell):hover .contract-hint-cell {
+        color: transparent;
+        text-decoration: none;
+    }
+}
+
+/* Mobile: reveal link and hide zeros on focus/tap */
+tr:has(.contract-hint-cell):focus-within .contract-hint-link {
+    display: flex;
+}
+tr:has(.contract-hint-cell):focus-within .contract-hint-cell:has(.contract-hint-link) {
+    z-index: 1;
+}
+tr:has(.contract-hint-cell):focus-within .contract-hint-cell {
+    color: transparent;
+    text-decoration: none;
+}
+
 } /* end @layer components */

--- a/ibl5/design/components/tables/leaderboards.css
+++ b/ibl5/design/components/tables/leaderboards.css
@@ -1,0 +1,22 @@
+@layer components {
+
+/* ==========================================================================
+   Sorted Column Highlight (Season & Career Leaderboards)
+
+   Highlights the column corresponding to the active sort dimension.
+   Applied via .sorted-col class on <th> and <td> elements.
+   ========================================================================== */
+
+.ibl-data-table th.sorted-col {
+    background: var(--navy-600);
+}
+
+.ibl-data-table td.sorted-col {
+    background-color: var(--accent-100);
+}
+
+.ibl-data-table tbody tr:hover td.sorted-col {
+    background-color: var(--accent-200);
+}
+
+} /* end @layer components */

--- a/ibl5/design/components/tables/trading.css
+++ b/ibl5/design/components/tables/trading.css
@@ -372,6 +372,20 @@
     .trading-cash-exchange input[type="number"] {
         width: 100px;
     }
+
+    /* Show team name in team-cell (override global hide) but hide city */
+    .trading-team-select .ibl-team-cell__text {
+        display: inline;
+    }
+
+    .trading-team-select .ibl-team-cell__city {
+        display: none;
+    }
+
+    /* Re-sort by team name on mobile (desktop sorts by city) */
+    .trading-team-select td {
+        order: var(--mobile-order, 0);
+    }
 }
 
 } /* end @layer components */

--- a/ibl5/design/input.css
+++ b/ibl5/design/input.css
@@ -145,6 +145,7 @@
 @import './components/tables/player-movement.css';
 @import './components/tables/franchise-record-book.css';
 @import './components/tables/free-agency.css';
+@import './components/tables/leaderboards.css';
 @import './components/cards.css';
 @import './components/forms.css';
 @import './components/navigation.css';


### PR DESCRIPTION
## Summary

Two pure-CSS, pixel-identical refactors:

- **11.3** — continues the component split of `design/components/tables.css` (~1,400 LOC) by moving remaining component-specific table blocks into `tables/<component>.css` files, matching the 14 existing paired files. Shared core stays in `tables.css`.
- **11.14** — replaces hardcoded hex color literals in `design/` component CSS with existing design-token `var(--…)` aliases, only where the token's declared value exactly matches the hex. Pixel-identical by construction.

PR title is `refactor:` per the plan. No user-visible changes.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.