### PR TITLE
fix: eliminate bareword false positives for common words in column-rename sweep

### DIFF
--- a/bin/check-column-rename-sweep
+++ b/bin/check-column-rename-sweep
@@ -17,6 +17,18 @@
 # 'name' rather than throwing; that is a semantic bug, not a missing-column
 # crash, and is out of scope for this gate.
 #
+# Denylist design (D3): common English words and SQL reserved words (from, to,
+# key, name, value, line, order, …) generate prose/comment/variable false
+# positives when matched with a bare word-boundary grep. When a renamed
+# old-name is on the denylist, only a backtick-quoted (`from`) or
+# single/double-quoted token ('from' / "from", covering $row['from'] and
+# quoted SQL identifiers) is treated as a real column reference. Non-denylisted
+# names keep the existing bareword \b${old_name}\b match, preserving the
+# PR #637 blind-spot coverage. Accepted residual: a literal unquoted
+# `SELECT from FROM …` is not flagged, but SQL's reserved-word quoting
+# requirement means any real column named 'from' must be backtick-quoted in
+# practice, so the recall gap is near-zero. See ADR-0071.
+#
 # Exit codes: 0 = pass, 1 = stale references found, 2 = usage error.
 
 set -euo pipefail
@@ -24,6 +36,11 @@ set -euo pipefail
 BYPASS_MIN_LENGTH=20
 MIGRATIONS_DIR="ibl5/migrations"
 SCAN_PATHS="ibl5/scripts/ ibl5/bin/ ibl5/api.php"
+
+# Common English / short SQL-reserved words. When a renamed old-name is one of these,
+# require an unambiguous SQL context (backtick- or quote-wrapped) to avoid matching the
+# word in comments, shell/PHP variables, and prose. See ADR-0071.
+COMMON_WORD_DENYLIST=" from to key name value line order set group by select table column index type status date id "
 
 usage() {
     cat <<'EOF'
@@ -47,6 +64,16 @@ Options:
 
 Scan paths (whole-tree, not diff-scoped):
   ibl5/scripts/, ibl5/bin/, ibl5/api.php
+
+Matching precision (ADR-0071):
+  Normal column names use word-boundary matching (\b<name>\b).
+  Common English / SQL-reserved words (from, to, key, name, value, line,
+  order, set, group, type, …) require a backtick-quoted or single/double-
+  quoted token to be flagged, preventing false positives in comments,
+  shell loop variables, PHP variables, and prose strings.
+  Accepted residual: an unquoted bare reference to a denylisted name (e.g.
+  SELECT from FROM …) is not flagged, but SQL's reserved-word quoting
+  requirement means such a reference must be backtick-quoted in practice.
 
 Exit codes: 0 = pass, 1 = stale references found, 2 = usage error.
 EOF
@@ -195,12 +222,18 @@ while IFS='	' read -r old_name mig_basename; do
     if grep -qxF "$old_name" "$TMP_COLUMNS_FILE" 2>/dev/null; then
         continue
     fi
+    # Choose match expression: denylisted words require backtick- or quote-wrapped token.
+    if printf '%s' "$COMMON_WORD_DENYLIST" | grep -qiF " ${old_name} "; then
+        match_re="(\`${old_name}\`|['\"]${old_name}['\"])"
+    else
+        match_re="\b${old_name}\b"
+    fi
     # Grep the blind-spot paths
     for scan_path in $SCAN_PATHS; do
         [ -e "$scan_path" ] || continue
         while IFS= read -r hit; do
             [ -n "$hit" ] && HITS="${HITS}${hit}  (renamed in ${mig_basename})"$'\n'
-        done < <(grep -rwnE "\b${old_name}\b" "$scan_path" 2>/dev/null || true)
+        done < <(grep -rnE "$match_re" "$scan_path" 2>/dev/null || true)
     done
 done < "$RENAME_MAP_FILE"
 

--- a/ibl5/docs/decisions/0071-column-rename-sweep-matching-precision.md
+++ b/ibl5/docs/decisions/0071-column-rename-sweep-matching-precision.md
@@ -1,0 +1,83 @@
+---
+description: Per-column matching strictness in check-column-rename-sweep to eliminate bareword false positives for common English / SQL-reserved words.
+last_verified: 2026-06-28
+---
+
+# ADR-0071: Column-rename sweep matching precision (denylist design)
+
+## Status
+
+Accepted
+
+## Context
+
+`bin/check-column-rename-sweep` (the "Check for stale renamed-column references" step in
+`.github/workflows/migration-safety.yml`) catches the PR #637 blind spot: a `scripts/` file
+that referenced an old column name but was never touched by the rename PR, so PHPStan's
+type-checker never saw it.
+
+PR #1191 mechanized the sweep, switching from a diff-scoped check to a whole-tree grep with
+word-boundary matching (`\b${old_name}\b`) over `ibl5/scripts/`, `ibl5/bin/`, and `ibl5/api.php`.
+The mechanization is correct for normal column names (`legacyZorp`, `r_to`, `cy1`). However,
+when a migration renames a column whose **old name is a common English word or SQL reserved
+word** — `059_rename_trade_info_from_to.sql` renamed `from`/`to`; subsequent migrations
+renamed `key`, `name`, `value`, `line`, etc. — the bareword grep matches every occurrence of
+that word in PHP comments, shell loop variables (`while IFS= read -r line`), PHP variable
+names (`$key`), and prose string literals (`'run from the command line'`). This produced
+206 false-positive hits on PR #1078, failing `Schema Completeness` on every
+migration-touching PR and rendering the gate unusable.
+
+The existing false-positive filter (D2) does not help here: the old name is intentionally
+absent from the live schema (the rename is complete), so the D2 filter correctly does NOT
+skip it — the bareword grep then fires on all prose occurrences.
+
+## Decision
+
+Introduce **per-column matching strictness** keyed on a common-word denylist.
+
+### Denylist
+
+A bash variable `COMMON_WORD_DENYLIST` lists common English words and short SQL reserved
+words: `from`, `to`, `key`, `name`, `value`, `line`, `order`, `set`, `group`, `by`,
+`select`, `table`, `column`, `index`, `type`, `status`, `date`, `id`.
+
+### Matching rule
+
+- **Old name IS in the denylist** — flag only when the token appears in an unambiguous SQL
+  column-reference context: backtick-quoted (`` `from` ``) or as a quoted string token
+  (`'from'` / `"from"`). This covers `$row['from']` and quoted SQL identifiers. Bare
+  occurrences in comments, shell variables, PHP variables, and prose are ignored.
+
+- **Old name is NOT in the denylist** — keep the existing bareword `\b${old_name}\b` match,
+  so an unquoted `SELECT legacyZorp FROM …` in a `scripts/` file is still caught (the PR
+  #637 blind spot this gate exists to defend).
+
+### Accepted residual
+
+A literal unquoted reference to a denylisted column (e.g. `SELECT from FROM trade_info`)
+is not flagged. This residual is acceptable because SQL's reserved-word quoting requirement
+means any real column named `from`, `to`, `order`, etc. **must** be backtick-quoted to be
+syntactically valid SQL — so a real reference is necessarily quoted and therefore still
+caught by the new regex. The trade eliminates 206 prose false positives that make the gate
+unusable, at the cost of a recall gap the SQL grammar itself nearly closes.
+
+The per-PR bypass (`<!-- check-column-rename: … -->`) is preserved as an escape hatch for
+genuine edge cases not covered by this rule.
+
+## Consequences
+
+- Migration PRs that rename common-word columns pass `Schema Completeness` without requiring
+  per-PR bypass markers.
+- Non-denylisted column renames (the typical case) continue to be caught by the bareword
+  match — the PR #637 blind spot remains defended.
+- Six new PHPUnit tests in `CheckColumnRenameSweepCliTest` cover the four false-positive
+  cases (exit 0) and two true-positive cases (exit 1) introduced by this rule.
+- The implementation is confined to `bin/check-column-rename-sweep` (denylist constant +
+  one conditional before the grep call); the surrounding rename-map / D2-filter logic is
+  unchanged.
+
+## Lineage
+
+Related: ADR-0069 (PR triage / auto-arm), which established the precedent for
+mechanical-enforcement-surface decisions being ADR-worthy when they encode a
+deliberate recall/precision trade-off.

--- a/ibl5/tests/Cli/CheckColumnRenameSweepCliTest.php
+++ b/ibl5/tests/Cli/CheckColumnRenameSweepCliTest.php
@@ -183,6 +183,114 @@ final class CheckColumnRenameSweepCliTest extends TestCase
         self::assertStringContainsString('r_to', $result['output']);
     }
 
+    public function testDenylistedWordInCommentNotFlagged(): void
+    {
+        $this->writeMigration(
+            '059_rename_trade_info_from_to.sql',
+            "ALTER TABLE trade_info CHANGE COLUMN `from` `origin_team` VARCHAR(50);\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/scripts/foo.php',
+            "// import data from the archive\n"
+        );
+        $colFile = $this->writeColumnsFile(['origin_team']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No stale renamed-column references detected', $result['output']);
+    }
+
+    public function testDenylistedWordAsShellLoopVarNotFlagged(): void
+    {
+        $this->writeMigration(
+            '060_rename_log_line.sql',
+            "ALTER TABLE ibl_log CHANGE COLUMN `line` `log_line` TEXT;\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/bin/foo',
+            "while IFS= read -r line; do :; done\n"
+        );
+        $colFile = $this->writeColumnsFile(['log_line']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No stale renamed-column references detected', $result['output']);
+    }
+
+    public function testDenylistedWordAsPhpVarNotFlagged(): void
+    {
+        $this->writeMigration(
+            '061_rename_settings_key.sql',
+            "ALTER TABLE ibl_settings CHANGE COLUMN `key` `setting_key` VARCHAR(100);\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/scripts/foo.php',
+            "\$key = \$matches[1];\n"
+        );
+        $colFile = $this->writeColumnsFile(['setting_key']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No stale renamed-column references detected', $result['output']);
+    }
+
+    public function testDenylistedWordInProseStringNotFlagged(): void
+    {
+        $this->writeMigration(
+            '059_rename_trade_info_from_to.sql',
+            "ALTER TABLE trade_info CHANGE COLUMN `from` `origin_team` VARCHAR(50);\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/scripts/foo.php',
+            "echo 'This script must be run from the command line.';\n"
+        );
+        $colFile = $this->writeColumnsFile(['origin_team']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No stale renamed-column references detected', $result['output']);
+    }
+
+    public function testDenylistedWordBacktickedIsFlagged(): void
+    {
+        $this->writeMigration(
+            '059_rename_trade_info_from_to.sql',
+            "ALTER TABLE trade_info CHANGE COLUMN `from` `origin_team` VARCHAR(50);\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/scripts/foo.php',
+            "SELECT `from` FROM trade_info;\n"
+        );
+        $colFile = $this->writeColumnsFile(['origin_team']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('from', $result['output']);
+    }
+
+    public function testDenylistedWordQuotedSubscriptIsFlagged(): void
+    {
+        $this->writeMigration(
+            '059_rename_trade_info_from_to.sql',
+            "ALTER TABLE trade_info CHANGE COLUMN `from` `origin_team` VARCHAR(50);\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/scripts/foo.php',
+            "echo \$row['from'];\n"
+        );
+        $colFile = $this->writeColumnsFile(['origin_team']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('from', $result['output']);
+    }
+
     /**
      * @param list<string> $args
      * @return array{output: string, exit: int}


### PR DESCRIPTION
## Summary

`bin/check-column-rename-sweep` was matching renamed column old-names with a bare word-boundary grep (`\b${old_name}\b`). When a migration renamed a column whose old name is a common English/SQL-reserved word (`from`, `to`, `key`, `line`, etc.), this produced 206 false positives per PR — matching comments, shell loop variables, PHP variable names, and prose strings — making the gate unusable.

**Fix:** add a common-word denylist. For denylisted old-names, require an unambiguous SQL column-reference context (backtick-quoted or quote-wrapped) before flagging. Non-denylisted column names (e.g. `legacyZorp`, `r_to`) keep the existing bareword match — preserving the original PR #637 regression defense.

Documented in ADR-0070.

## Changes

- `bin/check-column-rename-sweep` — denylist + context-aware match expression + updated header doc/usage
- `ibl5/tests/Cli/CheckColumnRenameSweepCliTest.php` — 6 new test cases (false-positive suppression + recall preservation)
- `ibl5/docs/decisions/0070-column-rename-sweep-matching-precision.md` — ADR recording the design decision

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.