### PR TITLE
chore: add inter-PR collision detector advisory guard

### DIFF
--- a/.github/workflows/pr-collisions-cron.yml
+++ b/.github/workflows/pr-collisions-cron.yml
@@ -1,0 +1,30 @@
+name: PR Collision Sweep (cron)
+
+on:
+  schedule:
+    - cron: '17 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-collisions-cron
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Sweep open PRs for collisions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run bin/check-pr-collisions --sweep
+        run: bin/check-pr-collisions --sweep
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-collisions.yml
+++ b/.github/workflows/pr-collisions.yml
@@ -1,0 +1,48 @@
+name: PR Collision Check
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'ibl5/tests/e2e/smoke/accessibility.spec.ts'
+      - 'ibl5/phpstan-baseline.neon'
+      - 'ibl5/phpstan-tests-baseline.neon'
+      - 'ibl5/phpstan-baseline-counts.json'
+      - 'ibl5/coverage-baseline.json'
+      - 'ibl5/tests/e2e/fixtures/ci-seed.sql'
+      - 'ibl5/tests/e2e/smoke/visual-regression.spec.ts-snapshots/**'
+      - 'ibl5/tests/e2e/vr-manifest.ts'
+      - 'bin/check-pr-collisions'
+      - '.github/workflows/pr-collisions.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-collisions-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-collisions:
+    name: Check inter-PR collisions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run bin/check-pr-collisions
+        run: bin/check-pr-collisions --pr "${{ github.event.pull_request.number }}" | tee pr-collisions.txt
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post collision comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: pr-collisions
+          path: pr-collisions.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -576,6 +576,8 @@ jobs:
         uses: actions/checkout@v7
       - name: bin/test-cleanup-safety
         run: bin/test-cleanup-safety
+      - name: bin/test-check-pr-collisions
+        run: bin/test-check-pr-collisions
       - name: bin/test-check-phpunit-hygiene
         run: bin/test-check-phpunit-hygiene
       - name: bin/test-refactor-flag

--- a/bin/check-pr-collisions
+++ b/bin/check-pr-collisions
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/check-pr-collisions — Advisory inter-PR collision detector.
+#
+# Groups open PRs that touch the same collision-prone file and emits
+# a markdown collision report / recommended merge order.
+#
+# Modes:
+#   --pr <n>    Emit this PR's collision body to stdout (no posting)
+#   --sweep     Iterate every open PR and post/refresh its sticky comment (default)
+#
+# Exit codes: 0 = ran (report/sweep generated); 2 = usage error.
+# The guard is advisory — never exits 1 to fail CI.
+
+set -euo pipefail
+
+GH_CMD="${GH_CMD:-gh}"
+STICKY_HEADER="pr-collisions"
+STICKY_MARKER="<!-- Sticky Pull Request Comment${STICKY_HEADER} -->"
+
+COLLISION_PATHS=(
+    "ibl5/tests/e2e/smoke/accessibility.spec.ts"
+    "ibl5/phpstan-baseline.neon"
+    "ibl5/phpstan-tests-baseline.neon"
+    "ibl5/phpstan-baseline-counts.json"
+    "ibl5/coverage-baseline.json"
+    "ibl5/tests/e2e/fixtures/ci-seed.sql"
+    "ibl5/tests/e2e/smoke/visual-regression.spec.ts-snapshots/"
+    "ibl5/tests/e2e/vr-manifest.ts"
+)
+
+usage() {
+    cat <<'EOF'
+Usage: bin/check-pr-collisions [--pr <n>] [--sweep] [--help|-h]
+
+Groups open PRs that edit the same collision-prone file and emits a collision
+report / recommended merge order.
+
+Options:
+  --pr <n>     Emit collision body for PR <n> to stdout (no posting).
+  --sweep      Iterate every open PR and post/refresh sticky comments (default).
+  --help, -h   Show this message.
+
+Environment (test seams):
+  GH_CMD       Override the gh command (default: "gh").
+EOF
+}
+
+MODE="sweep"
+PR_NUM=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pr requires a PR number" >&2
+                usage >&2
+                exit 2
+            fi
+            MODE="pr"
+            PR_NUM="$2"
+            shift 2
+            ;;
+        --sweep)
+            MODE="sweep"
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+# One call for all modes — both per-PR and sweep need all PRs' files to detect siblings.
+PRS_JSON="$("$GH_CMD" pr list --base master --state open --limit 200 \
+    --json number,headRefName,title,isDraft,files 2>/dev/null || echo '[]')"
+
+# pr_touches <n> <path> — exits 0 if PR <n> touches <path> (exact or dir-prefix)
+pr_touches() {
+    local n="$1" p="$2"
+    if [[ "$p" == */ ]]; then
+        jq -e --argjson n "$n" --arg p "$p" \
+            'any(.[] | select(.number==$n) | .files[]; .path | startswith($p))' \
+            <<<"$PRS_JSON" >/dev/null 2>&1
+    else
+        jq -e --argjson n "$n" --arg p "$p" \
+            'any(.[] | select(.number==$n) | .files[]; .path == $p)' \
+            <<<"$PRS_JSON" >/dev/null 2>&1
+    fi
+}
+
+# prs_touching <path> — print ascending-sorted non-draft PR numbers touching <path>
+prs_touching() {
+    local p="$1"
+    if [[ "$p" == */ ]]; then
+        jq -r --arg p "$p" \
+            '.[] | select((.isDraft | not) and (any(.files[]; .path | startswith($p)))) | .number' \
+            <<<"$PRS_JSON" | sort -nu
+    else
+        jq -r --arg p "$p" \
+            '.[] | select((.isDraft | not) and (any(.files[]; .path == $p))) | .number' \
+            <<<"$PRS_JSON" | sort -nu
+    fi
+}
+
+benign_body() {
+    cat <<'EOF'
+## Inter-PR Collision Check
+
+No inter-PR collisions detected for this PR.
+
+> **Advisory only — does not block merge.**
+EOF
+}
+
+warn_body() {
+    local n="$1"
+    printf '## Inter-PR Collision Check\n\n'
+    printf '**Warning:** This PR edits files also edited by other open PRs.\n'
+    printf 'Merging in parallel may cause ratchet drift or rebase conflicts.\n\n'
+
+    for path in "${COLLISION_PATHS[@]}"; do
+        if ! pr_touches "$n" "$path"; then
+            continue
+        fi
+
+        local all_prs=()
+        while IFS= read -r p; do
+            [[ -n "$p" ]] && all_prs+=("$p")
+        done < <(prs_touching "$path")
+
+        local siblings=()
+        for p in "${all_prs[@]}"; do
+            [[ "$p" != "$n" ]] && siblings+=("$p")
+        done
+
+        if [[ ${#siblings[@]} -eq 0 ]]; then
+            continue
+        fi
+
+        # shellcheck disable=SC2016
+        printf '**Collision on `%s`:**\n' "$path"
+        local sib_refs=""
+        for s in "${siblings[@]}"; do
+            sib_refs+="#${s}, "
+        done
+        printf 'Siblings: %s\n\n' "${sib_refs%, }"
+
+        local order_refs=""
+        for p in "${all_prs[@]}"; do
+            order_refs+="#${p}, "
+        done
+        printf '**Recommended merge order:** %s\n' "${order_refs%, }"
+        printf '(Rebase remaining PRs after each merge.)\n\n'
+    done
+
+    printf '> **Advisory only — does not block merge.**\n'
+}
+
+pr_body() {
+    local n="$1"
+
+    local is_draft
+    is_draft="$(jq -r --argjson n "$n" '.[] | select(.number==$n) | .isDraft' <<<"$PRS_JSON")"
+
+    if [[ -z "$is_draft" || "$is_draft" == "true" ]]; then
+        benign_body
+        return
+    fi
+
+    local has_collision=0
+    for path in "${COLLISION_PATHS[@]}"; do
+        if pr_touches "$n" "$path"; then
+            local total
+            total="$(prs_touching "$path" | wc -l | tr -d ' ')"
+            if [[ "$total" -gt 1 ]]; then
+                has_collision=1
+                break
+            fi
+        fi
+    done
+
+    if [[ "$has_collision" -eq 1 ]]; then
+        warn_body "$n"
+    else
+        benign_body
+    fi
+}
+
+post_sticky() {
+    local n="$1"
+    local body="$2"
+    local tmpfile
+    tmpfile="$(mktemp)"
+
+    printf '%s\n%s\n' "$body" "$STICKY_MARKER" > "$tmpfile"
+
+    local existing_id
+    existing_id="$("$GH_CMD" api "repos/{owner}/{repo}/issues/$n/comments" --paginate \
+        --jq ".[] | select(.body | contains(\"$STICKY_MARKER\")) | .id" | head -1 || true)"
+
+    if [[ -n "$existing_id" ]]; then
+        "$GH_CMD" api --method PATCH "repos/{owner}/{repo}/issues/comments/$existing_id" \
+            -F body=@"$tmpfile" >/dev/null || true
+    else
+        "$GH_CMD" pr comment "$n" --body-file "$tmpfile" >/dev/null || true
+    fi
+
+    rm -f "$tmpfile"
+}
+
+if [[ "$MODE" == "pr" ]]; then
+    pr_body "$PR_NUM"
+    exit 0
+fi
+
+# Sweep mode
+pr_count="$(jq 'length' <<<"$PRS_JSON")"
+if [[ "$pr_count" -eq 0 ]]; then
+    echo "No open PRs."
+    exit 0
+fi
+
+while IFS= read -r n; do
+    body="$(pr_body "$n")"
+    post_sticky "$n" "$body" || printf 'Warning: failed to post for PR %s\n' "$n" >&2
+done < <(jq -r '.[].number' <<<"$PRS_JSON")

--- a/bin/test-check-pr-collisions
+++ b/bin/test-check-pr-collisions
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-check-pr-collisions — regression harness for bin/check-pr-collisions.
+#
+# All GitHub calls are intercepted by a stub gh (via GH_CMD). No network required.
+# Pins: grouping, ascending merge order, draft exclusion, dir-prefix matching,
+# benign self-clear path, empty-set sweep, and sticky-marker convergence.
+#
+# Run: bin/test-check-pr-collisions  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GUARD="$SCRIPT_DIR/check-pr-collisions"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" 2>/dev/null' EXIT
+
+FAILED=0
+
+pass()     { echo "ok: $1"; }
+failcase() { echo "FAIL: $1"; FAILED=1; }
+
+assert_match() {
+    if printf '%s' "$3" | grep -qE "$2"; then
+        pass "$1"
+    else
+        failcase "$1 — expected to match: $2"
+        printf '%s\n' "$3" | sed 's/^/    /'
+    fi
+}
+
+assert_absent() {
+    if printf '%s' "$3" | grep -qE "$2"; then
+        failcase "$1 — expected NOT to match: $2"
+        printf '%s\n' "$3" | sed 's/^/    /'
+    else
+        pass "$1"
+    fi
+}
+
+# --- Stub gh setup ---
+
+STUBBIN="$TMP/stubbin"
+GH_PRS_FIXTURE="$TMP/prs.json"
+GH_COMMENT_LOG="$TMP/comment.log"
+export GH_PRS_FIXTURE GH_COMMENT_LOG
+
+mkdir -p "$STUBBIN"
+
+cat > "$STUBBIN/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+cmd="$1 ${2:-}"
+shift 2 2>/dev/null || shift 1 2>/dev/null || true
+
+case "$cmd" in
+    "pr list")
+        cat "${GH_PRS_FIXTURE}"
+        ;;
+    "api --method")
+        # PATCH — succeed silently
+        exit 0
+        ;;
+    "api repos"*)
+        # GET issue comments — return nothing (no existing sticky comment)
+        printf ''
+        ;;
+    "pr comment")
+        # Args after "pr comment": <n> [--body-file <file>] [--body <text>]
+        body_file=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --body-file) body_file="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        if [[ -n "$body_file" && -f "$body_file" ]]; then
+            cat "$body_file" >> "${GH_COMMENT_LOG:-/dev/null}"
+            printf '\n---END---\n' >> "${GH_COMMENT_LOG:-/dev/null}"
+        fi
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+
+chmod +x "$STUBBIN/gh"
+
+# --- Core fixture (8 PRs) ---
+
+cat > "$GH_PRS_FIXTURE" <<'FIXTURE'
+[
+  {"number": 10, "headRefName": "pr-10", "title": "PR 10", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/accessibility.spec.ts"}]},
+  {"number": 11, "headRefName": "pr-11", "title": "PR 11", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/accessibility.spec.ts"}]},
+  {"number": 12, "headRefName": "pr-12", "title": "PR 12", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/accessibility.spec.ts"}]},
+  {"number": 13, "headRefName": "pr-13", "title": "PR 13 (draft)", "isDraft": true,
+   "files": [{"path": "ibl5/tests/e2e/smoke/accessibility.spec.ts"}]},
+  {"number": 14, "headRefName": "pr-14", "title": "PR 14", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/visual-regression.spec.ts-snapshots/a-chromium.png"}]},
+  {"number": 15, "headRefName": "pr-15", "title": "PR 15", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/visual-regression.spec.ts-snapshots/b-chromium.png"}]},
+  {"number": 20, "headRefName": "pr-20", "title": "PR 20", "isDraft": false,
+   "files": [{"path": "ibl5/phpstan-baseline.neon"}]},
+  {"number": 21, "headRefName": "pr-21", "title": "PR 21", "isDraft": false,
+   "files": [{"path": "ibl5/some/unrelated/file.php"}]}
+]
+FIXTURE
+
+# Shorthand: run --pr mode and capture output
+pr_body() {
+    GH_CMD="$STUBBIN/gh" "$GUARD" --pr "$1" 2>/dev/null
+}
+
+# --- Test cases ---
+
+# (a) Grouping: --pr 11 body names siblings #10 and #12
+body11="$(pr_body 11)"
+assert_match "grouping-names-#10"  '#10' "$body11"
+assert_match "grouping-names-#12"  '#12' "$body11"
+
+# (b) Order: recommended merge order is ascending #10, #11, #12
+assert_match "order-ascending" '#10.*#11.*#12' "$body11"
+
+# (c) Benign — collision-prone file but no sibling: #20 touches phpstan-baseline alone
+body20="$(pr_body 20)"
+assert_match  "benign-no-sibling"        'No inter-PR collisions detected' "$body20"
+assert_absent "benign-no-sibling-no-ref" '#[0-9]' "$body20"
+
+# (d) Benign — no collision-prone file: #21 touches only an unrelated file
+body21="$(pr_body 21)"
+assert_match "benign-no-collision-file" 'No inter-PR collisions detected' "$body21"
+
+# (e) Draft excluded from siblings: #10's body must NOT list draft #13
+body10="$(pr_body 10)"
+assert_absent "draft-excluded-from-siblings" '#13' "$body10"
+
+# (e cont) Draft's own body is benign
+body13="$(pr_body 13)"
+assert_match "draft-own-body-benign" 'No inter-PR collisions detected' "$body13"
+
+# (f) Empty set: --sweep over [] exits 0 and prints "No open PRs."
+printf '[]' > "$GH_PRS_FIXTURE"
+sweep_out="$(GH_CMD="$STUBBIN/gh" "$GUARD" --sweep 2>/dev/null)"
+assert_match "empty-sweep-message" 'No open PRs\.' "$sweep_out"
+
+# Restore populated fixture for remaining tests
+cat > "$GH_PRS_FIXTURE" <<'FIXTURE'
+[
+  {"number": 10, "headRefName": "pr-10", "title": "PR 10", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/accessibility.spec.ts"}]},
+  {"number": 11, "headRefName": "pr-11", "title": "PR 11", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/accessibility.spec.ts"}]},
+  {"number": 12, "headRefName": "pr-12", "title": "PR 12", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/accessibility.spec.ts"}]},
+  {"number": 13, "headRefName": "pr-13", "title": "PR 13 (draft)", "isDraft": true,
+   "files": [{"path": "ibl5/tests/e2e/smoke/accessibility.spec.ts"}]},
+  {"number": 14, "headRefName": "pr-14", "title": "PR 14", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/visual-regression.spec.ts-snapshots/a-chromium.png"}]},
+  {"number": 15, "headRefName": "pr-15", "title": "PR 15", "isDraft": false,
+   "files": [{"path": "ibl5/tests/e2e/smoke/visual-regression.spec.ts-snapshots/b-chromium.png"}]},
+  {"number": 20, "headRefName": "pr-20", "title": "PR 20", "isDraft": false,
+   "files": [{"path": "ibl5/phpstan-baseline.neon"}]},
+  {"number": 21, "headRefName": "pr-21", "title": "PR 21", "isDraft": false,
+   "files": [{"path": "ibl5/some/unrelated/file.php"}]}
+]
+FIXTURE
+
+# (g) Directory-prefix match: #14 body names #15 (both under snapshots/ prefix)
+body14="$(pr_body 14)"
+assert_match "dir-prefix-match-#15" '#15' "$body14"
+
+# (h) Sweep posts sticky marker: run --sweep and check comment log
+rm -f "$GH_COMMENT_LOG"
+GH_CMD="$STUBBIN/gh" "$GUARD" --sweep >/dev/null 2>&1
+log_content="$(cat "$GH_COMMENT_LOG" 2>/dev/null || true)"
+
+# Colliding PR numbers appear in the log (as sibling refs in each other's bodies)
+assert_match "sweep-log-has-#10" '#10' "$log_content"
+assert_match "sweep-log-has-#11" '#11' "$log_content"
+assert_match "sweep-log-has-#12" '#12' "$log_content"
+
+# The exact sticky marker is present in at least one posted body
+assert_match "sweep-posts-sticky-marker" \
+    '<!-- Sticky Pull Request Commentpr-collisions -->' "$log_content"
+
+# --- Results ---
+
+if [[ "$FAILED" -ne 0 ]]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
Adds `bin/check-pr-collisions`, a GH_CMD-stubbed regression harness, and two workflows (per-PR sticky comment + daily sweep) to detect when multiple open PRs edit the same collision-prone file (axe ratchet allowlists, PHPStan/coverage baselines, VR snapshots, E2E seed). Non-blocking — advisory comment only, never a required check.

Confirmed live collision: PRs #1163, #1188, #1189 all edit the `page-has-heading-one` allowlist in `ibl5/tests/e2e/smoke/accessibility.spec.ts:62`; #1203 edits the PHPStan baseline.

## Changes
- `bin/check-pr-collisions` — guard script with `--pr <n>` and `--sweep` modes
- `bin/test-check-pr-collisions` — GH_CMD-stubbed harness (8 behavioral assertions)
- `.github/workflows/pr-collisions.yml` — Workflow A: per-PR path-filtered sticky comment
- `.github/workflows/pr-collisions-cron.yml` — Workflow B: daily sweep refresh
- `.github/workflows/tests.yml` — registers harness in `harness-tests` job

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: extends the existing advisory-guard pattern (hot-files, orphan-css); no new architectural constraint, non-blocking comment-only guard -->