### PR TITLE
chore: automouse self-heal — auto-requeue staleness-FP skips

### DIFF
--- a/.claude/rules/automouse-workflow.md
+++ b/.claude/rules/automouse-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: Automouse autonomous workflow (formerly "nightly") — launchd fires claude -p on a recurring schedule, running two context-isolated agents per plan (implementation + post-plan) with time guards and incremental checkpoints.
-last_verified: 2026-06-20
+last_verified: 2026-06-28
 paths: "bin/automouse-*"
 ---
 
@@ -24,6 +24,8 @@ A headless `claude -p` process runs on a recurring schedule via macOS `launchd`.
 | Re-enable the automouse job | `launchctl load ~/Library/LaunchAgents/com.ibl5.automouse.plist` |
 | Force-trigger now | `launchctl start com.ibl5.automouse` |
 | Requeue skipped plans | `bin/automouse-queue requeue` |
+| Self-heal staleness-FP skips | `bin/automouse-self-heal` |
+| Preview self-heal (no changes) | `bin/automouse-self-heal --dry-run` |
 | Check logs | `cat ~/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse/logs/$(date +%Y-%m-%d).log` |
 
 ## Directory Layout
@@ -32,7 +34,8 @@ A headless `claude -p` process runs on a recurring schedule via macOS `launchd`.
 ~/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse/
   queue/    symlinks to ~/.claude/plans/*.md (oldest runs first)
   done/     symlinks moved here after successful execution
-  skipped/  symlinks moved here when skipped (ambiguity/errors/poison-pill)
+  skipped/  symlinks moved here when skipped (ambiguity/errors/poison-pill);
+            a sibling <plan>.md.staleness marker tags a *staleness* skip (read by bin/automouse-self-heal)
   handoff/  JSON files bridging state from implementation to post-plan agent
   reports/  per-run markdown reports (YYYY-MM-DD-{done|skipped|env-stop|no-queue|error}-<slug>.md);
             plus YYYY-MM-DD-costs.md — per-phase token cost roll-up written by automouse-run
@@ -49,6 +52,19 @@ entry untouched for more than `NIGHTLY_ARCHIVE_AGE_DAYS` (default **7**) into a 
 (`done/`, `skipped/`) are judged on their *own* mtime — the disposition date — and their
 absolute targets keep resolving after the move. `queue/` (pending work) and `handoff/`
 (transient) are never touched. The step is non-fatal: an archival error never aborts the run.
+
+### Self-heal
+
+Before the startup archival block, `automouse-run` freshens the local master checkout (a
+`git fetch` + `merge --ff-only`), then runs `bin/automouse-self-heal`. The self-heal script
+scans `skipped/` for plans carrying a `<plan>.md.staleness` sidecar marker — the signal that
+a plan was skipped specifically by the staleness gate, not for ambiguity / already-merged /
+poison-pill. For each such plan, it re-runs `bin/check-plan-staleness` against the
+freshly-pulled master; if the guard now passes, `bin/automouse-queue` is invoked to requeue
+the plan (which also evicts the `.staleness` and `.attempts` sidecars). Use
+`bin/automouse-self-heal --dry-run` to preview what would be healed without acting. The step
+is non-fatal and forward-only: only staleness skips made after this PR carry the marker;
+plans already in `skipped/` before this PR landed need a one-time manual `bin/automouse-queue`.
 
 ## How It Works
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -584,6 +584,8 @@ jobs:
         run: bin/test-refactor-flag
       - name: bin/test-automouse-queue
         run: bin/test-automouse-queue
+      - name: bin/test-automouse-self-heal
+        run: bin/test-automouse-self-heal
       - name: bin/test-automouse-concurrency
         run: bin/test-automouse-concurrency
       - name: bin/test-wt-status

--- a/bin/automouse-prompt-impl
+++ b/bin/automouse-prompt-impl
@@ -61,8 +61,9 @@ If `bin/check-plan-staleness` exits non-zero, the plan is STALE. Take the skip-w
 
 1. Capture the unresolved paths the helper printed (its `STALE: <token>` lines).
 2. `mv "$NIGHTLY_DIR/queue/$PLAN_FILE" "$NIGHTLY_DIR/skipped/"`
-3. Write a STALENESS-specific report to `$NIGHTLY_DIR/reports/$(date +%Y-%m-%d)-skipped-<slug>.md` (derive `<slug>` from the plan title). The title and body must make it visibly a **staleness skip** — clearly distinct wording from the ambiguity skip — and must list the specific unresolved repo paths the helper emitted.
-4. STOP.
+3. `touch "$NIGHTLY_DIR/skipped/$PLAN_FILE.staleness"` — drop a sidecar marker that records this skip as a **staleness** skip (not ambiguity / already-merged / poison-pill). At the next run's top, `bin/automouse-self-heal` reads this marker and auto-requeues the plan **iff** `bin/check-plan-staleness` now passes against the freshly-pulled master; a skip without the marker is never auto-recovered.
+4. Write a STALENESS-specific report to `$NIGHTLY_DIR/reports/$(date +%Y-%m-%d)-skipped-<slug>.md` (derive `<slug>` from the plan title). The title and body must make it visibly a **staleness skip** — clearly distinct wording from the ambiguity skip — and must list the specific unresolved repo paths the helper emitted.
+5. STOP.
 
 If `bin/check-plan-staleness` exits 0, the plan is fresh — continue to Step 2.6.
 

--- a/bin/automouse-queue
+++ b/bin/automouse-queue
@@ -34,8 +34,8 @@ mkdir -p "$QUEUE_DIR"
 # entry. rm -f is a no-op when nothing is there.
 evict_dispositions() {
     local name=$1
-    rm -f "$SKIPPED_DIR/$name" "$SKIPPED_DIR/${name}.attempts" \
-          "$DONE_DIR/$name" "$DONE_DIR/${name}.attempts"
+    rm -f "$SKIPPED_DIR/$name" "$SKIPPED_DIR/${name}.attempts" "$SKIPPED_DIR/${name}.staleness" \
+          "$DONE_DIR/$name" "$DONE_DIR/${name}.attempts" "$DONE_DIR/${name}.staleness"
 }
 
 show_queue() {

--- a/bin/automouse-run
+++ b/bin/automouse-run
@@ -445,6 +445,23 @@ PLANS_RUN=0
 
 echo "=== Automouse session starting at $(date) ===" >> "$LOG"
 
+# Freshen the reference checkout's master so the self-heal staleness guard below
+# sees origin's latest — a re-created file or a widened guard only exists locally
+# once pulled. automouse-run has no other top-of-run pull (the per-plan pull in
+# automouse-prompt-impl runs AFTER this and never when the queue holds only
+# skipped plans), so without this the empty-queue recovery case never advances
+# master and the FP is never seen. ff-only never diverges the read-only main
+# checkout (ADR-0062); both lines are non-fatal so a fetch hiccup can't abort the
+# night.
+git -C "$REPO" fetch origin master >> "$LOG" 2>&1 || true
+git -C "$REPO" merge --ff-only origin/master >> "$LOG" 2>&1 || true
+
+# Self-heal: requeue staleness-skipped plans whose guard now passes. Runs BEFORE
+# archival so a marked plan isn't swept into skipped.archive/ first. Non-fatal
+# (|| true): a self-heal hiccup must never abort the night (mirrors the || true
+# on the archive_stale block).
+"$REPO/bin/automouse-self-heal" >> "$LOG" 2>&1 || true
+
 # Startup archival: shrink the accumulating output dirs by moving entries idle
 # for $ARCHIVE_AGE_DAYS into sibling `.archive/` folders. queue/ (pending work,
 # iterated below) and handoff/ (transient, cleaned at loop end) are excluded by

--- a/bin/automouse-self-heal
+++ b/bin/automouse-self-heal
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Requeue plans that were skipped by the staleness gate and now pass it.
+#
+# Usage:
+#   bin/automouse-self-heal           # requeue eligible plans
+#   bin/automouse-self-heal --dry-run # preview without acting
+#
+# Only plans carrying a <plan>.md.staleness sidecar marker are eligible —
+# ambiguity / already-merged / poison-pill skips are never recovered.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+: "${NIGHTLY_DIR:=$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse}"
+: "${PLANS_DIR:=$HOME/.claude/plans}"
+: "${STALENESS_GUARD:=$SCRIPT_DIR/check-plan-staleness}"
+
+SKIPPED_DIR="$NIGHTLY_DIR/skipped"
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+healed=0
+still_stale=0
+healed_names_file="$(mktemp)"
+trap 'rm -f "$healed_names_file"' EXIT
+
+if ! ls "$SKIPPED_DIR"/*.md >/dev/null 2>&1; then
+    echo "self-heal: skipped/ is empty — nothing to recover."
+    exit 0
+fi
+
+for f in "$SKIPPED_DIR"/*.md; do
+    [ -e "$f" ] || continue
+
+    name="$(basename "$f")"
+    marker="$SKIPPED_DIR/${name}.staleness"
+
+    # Core safety gate: only staleness-marked skips are eligible.
+    [ -f "$marker" ] || continue
+
+    # Run the staleness guard quietly against the skipped/ symlink.
+    if "$STALENESS_GUARD" "$f" >/dev/null 2>&1; then
+        # Guard passes — this plan is eligible for recovery.
+        if [ "$DRY_RUN" -eq 1 ]; then
+            echo "would heal: $name (staleness guard now passes)"
+            healed=$((healed + 1))
+            continue
+        fi
+
+        # Real mode: requeue via automouse-queue (owns mv + sidecar eviction).
+        if NIGHTLY_DIR="$NIGHTLY_DIR" PLANS_DIR="$PLANS_DIR" \
+           "$SCRIPT_DIR/automouse-queue" "$name" >/dev/null 2>&1; then
+            echo "healed: $name (staleness guard now passes — requeued)"
+            printf '%s\n' "$name" >> "$healed_names_file"
+            healed=$((healed + 1))
+        else
+            echo "self-heal: requeue failed for $name (left in skipped/)"
+        fi
+    else
+        # Guard still fails — leave the plan in skipped/.
+        if [ "$DRY_RUN" -eq 1 ]; then
+            echo "still stale: $name (staleness guard still flags it)"
+        fi
+        still_stale=$((still_stale + 1))
+    fi
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "self-heal (dry-run): $healed would heal, $still_stale still stale. No changes made."
+    exit 0
+fi
+
+if [ "$healed" -gt 0 ]; then
+    mkdir -p "$NIGHTLY_DIR/reports"
+    report="$NIGHTLY_DIR/reports/$(date +%Y-%m-%d)-self-heal.md"
+    {
+        echo "# Automouse Self-Heal Report — $(date +%Y-%m-%d)"
+        echo ""
+        echo "Plans recovered from staleness skip and requeued:"
+        echo ""
+        while IFS= read -r n; do
+            echo "- $n"
+        done < "$healed_names_file"
+    } > "$report"
+fi
+
+echo "self-heal: $healed plan(s) recovered, $still_stale still stale."
+exit 0

--- a/bin/test-automouse-queue
+++ b/bin/test-automouse-queue
@@ -169,6 +169,19 @@ assert_present "row8 queued untouched"  "$NDIR/queue/plan-h.md"
 echo "ok: row8 — already-queued errors, no partial eviction"
 
 # ---------------------------------------------------------------------------
+# Row 9 — .staleness sidecar evicted alongside symlink on (re)queue
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-i.md"
+ln -s "$PDIR/plan-i.md" "$NDIR/skipped/plan-i.md"
+touch "$NDIR/skipped/plan-i.md.staleness"
+run_queue plan-i >/dev/null 2>&1
+assert_absent  "row9 skipped symlink gone"   "$NDIR/skipped/plan-i.md"
+assert_absent  "row9 staleness marker gone"  "$NDIR/skipped/plan-i.md.staleness"
+assert_present "row9 queued"                  "$NDIR/queue/plan-i.md"
+echo "ok: row9 — .staleness eviction"
+
+# ---------------------------------------------------------------------------
 if [ "$FAILED" -ne 0 ]; then
     echo "RESULT: FAILED"
     exit 1

--- a/bin/test-automouse-self-heal
+++ b/bin/test-automouse-self-heal
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Regression harness for bin/automouse-self-heal.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/automouse-self-heal"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+NDIR="$TMP/automouse"
+PDIR="$TMP/plans"
+
+FAILED=0
+
+setup() {
+    rm -rf "$NDIR"
+    mkdir -p "$NDIR/queue" "$NDIR/skipped" "$NDIR/done" "$NDIR/reports"
+    rm -rf "$PDIR"
+    mkdir -p "$PDIR"
+}
+
+assert_present() {
+    local label=$1 path=$2
+    if [ ! -e "$path" ]; then
+        echo "FAIL: $label — expected present: $path"
+        FAILED=1
+    fi
+}
+
+assert_absent() {
+    local label=$1 path=$2
+    if [ -e "$path" ]; then
+        echo "FAIL: $label — expected absent: $path"
+        FAILED=1
+    fi
+}
+
+# Stub guard: exit 0 when basename contains "fresh", else exit 1.
+cat > "$TMP/stub-guard" <<'GUARD_EOF'
+#!/usr/bin/env bash
+case "$(basename "${1:-}")" in
+  *fresh*) exit 0 ;;
+  *)       exit 1 ;;
+esac
+GUARD_EOF
+chmod +x "$TMP/stub-guard"
+
+run_heal() {
+    NIGHTLY_DIR="$NDIR" PLANS_DIR="$PDIR" STALENESS_GUARD="$TMP/stub-guard" "$SCRIPT" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Row 1 — POSITIVE (healable): staleness-marked plan passes guard → requeued
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-fresh.md"
+ln -s "$PDIR/plan-fresh.md" "$NDIR/skipped/plan-fresh.md"
+touch "$NDIR/skipped/plan-fresh.md.staleness"
+run_heal >/dev/null 2>&1
+assert_absent  "row1 skipped symlink gone"  "$NDIR/skipped/plan-fresh.md"
+assert_present "row1 queued"                "$NDIR/queue/plan-fresh.md"
+assert_absent  "row1 staleness marker gone" "$NDIR/skipped/plan-fresh.md.staleness"
+echo "ok: row1 — POSITIVE healable"
+
+# ---------------------------------------------------------------------------
+# Row 2 — NEGATIVE (still-stale): marked plan fails guard → stays in skipped/
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-stale.md"
+ln -s "$PDIR/plan-stale.md" "$NDIR/skipped/plan-stale.md"
+touch "$NDIR/skipped/plan-stale.md.staleness"
+run_heal >/dev/null 2>&1
+assert_present "row2 skipped stays"         "$NDIR/skipped/plan-stale.md"
+assert_absent  "row2 not queued"            "$NDIR/queue/plan-stale.md"
+assert_present "row2 marker retained"       "$NDIR/skipped/plan-stale.md.staleness"
+echo "ok: row2 — NEGATIVE still-stale"
+
+# ---------------------------------------------------------------------------
+# Row 3 — NEGATIVE (core safety, no marker): guard would pass but NO marker → not requeued
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-fresh-nomarker.md"
+ln -s "$PDIR/plan-fresh-nomarker.md" "$NDIR/skipped/plan-fresh-nomarker.md"
+# deliberately NO .staleness marker
+run_heal >/dev/null 2>&1
+assert_present "row3 skipped stays"   "$NDIR/skipped/plan-fresh-nomarker.md"
+assert_absent  "row3 not queued"      "$NDIR/queue/plan-fresh-nomarker.md"
+echo "ok: row3 — NEGATIVE core safety (no marker, not recovered)"
+
+# ---------------------------------------------------------------------------
+# Row 4 — DRY-RUN: healable plan listed but not moved, no report written
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-fresh-dry.md"
+ln -s "$PDIR/plan-fresh-dry.md" "$NDIR/skipped/plan-fresh-dry.md"
+touch "$NDIR/skipped/plan-fresh-dry.md.staleness"
+out=$(run_heal --dry-run 2>&1)
+assert_present "row4 skipped still present" "$NDIR/skipped/plan-fresh-dry.md"
+assert_absent  "row4 not queued"            "$NDIR/queue/plan-fresh-dry.md"
+assert_present "row4 marker still present"  "$NDIR/skipped/plan-fresh-dry.md.staleness"
+if ! echo "$out" | grep -q "would heal"; then
+    echo "FAIL: row4 — expected 'would heal' in dry-run output, got: $out"
+    FAILED=1
+fi
+if ls "$NDIR/reports/"*-self-heal.md >/dev/null 2>&1; then
+    echo "FAIL: row4 — report must not be written in dry-run mode"
+    FAILED=1
+fi
+echo "ok: row4 — DRY-RUN"
+
+# ---------------------------------------------------------------------------
+# Row 5 — EDGE (empty skipped/): no-op, exit 0
+# ---------------------------------------------------------------------------
+setup
+rc=0
+run_heal >/dev/null 2>&1 || rc=$?
+if [ "$rc" -ne 0 ]; then
+    echo "FAIL: row5 — expected exit 0 on empty skipped/, got $rc"
+    FAILED=1
+fi
+echo "ok: row5 — EDGE empty skipped/"
+
+# ---------------------------------------------------------------------------
+# Row 6 — CLEANUP: .attempts + .staleness sidecars gone after requeue
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-fresh-clean.md"
+ln -s "$PDIR/plan-fresh-clean.md" "$NDIR/skipped/plan-fresh-clean.md"
+touch "$NDIR/skipped/plan-fresh-clean.md.attempts"
+touch "$NDIR/skipped/plan-fresh-clean.md.staleness"
+run_heal >/dev/null 2>&1
+assert_absent  "row6 skipped symlink gone"  "$NDIR/skipped/plan-fresh-clean.md"
+assert_absent  "row6 attempts gone"         "$NDIR/skipped/plan-fresh-clean.md.attempts"
+assert_absent  "row6 staleness gone"        "$NDIR/skipped/plan-fresh-clean.md.staleness"
+assert_present "row6 queued"                "$NDIR/queue/plan-fresh-clean.md"
+echo "ok: row6 — CLEANUP sidecars evicted"
+
+# ---------------------------------------------------------------------------
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
Adds `bin/automouse-self-heal`, a script that runs at the top of every automouse session and automatically re-queues plans that were skipped specifically by the staleness gate and that now pass the current staleness guard. This recovers staleness false-positives after their cause is fixed (e.g. `bin/check-plan-staleness` is widened, or a referenced file is re-created on master) instead of letting the plan sit dead in `skipped/` forever.

**Changes:**
- `bin/automouse-self-heal` — NEW script: scans `skipped/` for plans carrying a `.staleness` sidecar marker, re-queues those whose guard now passes via `bin/automouse-queue`
- `bin/test-automouse-self-heal` — NEW regression harness covering all branches (positive, negative still-stale, negative no-marker safety gate, dry-run, empty dir, sidecar cleanup)
- `bin/automouse-queue` — `evict_dispositions()` now also removes the `.staleness` sidecar (so manual requeue and self-heal both clean the marker)
- `bin/test-automouse-queue` — new Row 9 asserting `.staleness` eviction
- `bin/automouse-run` — freshens local master + invokes self-heal once per run, before the startup archival block
- `bin/automouse-prompt-impl` — Step 2.5 staleness-skip recipe: `touch` the `.staleness` marker after the `mv`
- `.github/workflows/tests.yml` — adds `bin/test-automouse-self-heal` step in `harness-tests` job
- `.claude/rules/automouse-workflow.md` — documents self-heal; bumps `last_verified`

**The load-bearing safety gate:** self-heal requeues **only** plans carrying a `<plan>.md.staleness` sidecar marker — plans skipped for any other reason (ambiguity, already-merged, poison-pill attempt-threshold) have no marker and are never recovered, preventing infinite nightly churn.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: automouse self-heal + its regression test automate the existing manual automouse-queue requeue flow within the established automouse subsystem; no new architectural constraint or decision surface introduced -->