### PR TITLE
chore: ban re-declaring WideUnitTestCase query-assertion helpers (PHPStan rule)

### DIFF
--- a/ibl5/docs/DEVELOPMENT_GUIDE.md
+++ b/ibl5/docs/DEVELOPMENT_GUIDE.md
@@ -1,6 +1,6 @@
 ---
 description: Development standards, priorities, and workflow for IBL5.
-last_verified: 2026-05-19
+last_verified: 2026-06-28
 ---
 
 # Development Guide
@@ -363,6 +363,7 @@ last_verified: 2026-05-19
 **Test Infrastructure Improvements:**
 - Created standalone TestDataFactory class in Tests\WideUnit\Mocks\ namespace for centralized fixture creation
 - WideUnitTestCase base class provides mock database and helper assertions
+- **Enforced:** `BanRedeclaredMockDbQueryHelperRule` (PHPStan, `analyse:tests`) fails CI if a test re-declares `assertQueryExecuted()` / `assertQueryNotExecuted()` — extend `Tests\WideUnit\WideUnitTestCase` instead of re-implementing its query-assertion helpers
 - All wide-unit tests use TestDataFactory::createPlayer/createTeam/createSeason static methods
 - Refactored mock classes from inline definitions to proper namespaced classes in tests/WideUnit/Mocks/
 - Enhanced autoloader.php to support Tests\ namespace

--- a/ibl5/phpstan-rules/BanRedeclaredMockDbQueryHelperRule.php
+++ b/ibl5/phpstan-rules/BanRedeclaredMockDbQueryHelperRule.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Bans re-declaring the query-assertion helpers that
+ * `Tests\WideUnit\WideUnitTestCase` already provides.
+ *
+ * Tests copy-paste a private `assertQueryExecuted()` / `assertQueryNotExecuted()`
+ * instead of extending `WideUnitTestCase`, which supplies them (plus `setUp`,
+ * global `$mysqli_db` injection, and the query-tracking helpers). The canonical
+ * pattern is documented in `docs/DEVELOPMENT_GUIDE.md`; this rule enforces it.
+ *
+ * The sole legitimate definer — `WideUnitTestCase.php` itself — is exempt by
+ * basename, mirroring `BanGlobalKeywordRule`'s `ALLOWED_FILES` idiom.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final class BanRedeclaredMockDbQueryHelperRule implements Rule
+{
+    /** @var list<string> */
+    private const BANNED_METHODS = [
+        'assertQueryExecuted',
+        'assertQueryNotExecuted',
+    ];
+
+    /** @var list<string> */
+    private const ALLOWED_FILES = [
+        'WideUnitTestCase.php',
+    ];
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $name = $node->name->toString();
+
+        if (!in_array($name, self::BANNED_METHODS, true)) {
+            return [];
+        }
+
+        $file = $scope->getFile();
+        foreach (self::ALLOWED_FILES as $allowedFile) {
+            if (str_ends_with($file, DIRECTORY_SEPARATOR . $allowedFile)) {
+                return [];
+            }
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'Test re-declares `' . $name . '()`, which Tests\WideUnit\WideUnitTestCase already provides. '
+                . 'Extend Tests\WideUnit\WideUnitTestCase instead of re-implementing its query-assertion helper.'
+            )
+                ->identifier('ibl.redeclaredMockDbQueryHelper')
+                ->build(),
+        ];
+    }
+}

--- a/ibl5/phpstan-tests.neon
+++ b/ibl5/phpstan-tests.neon
@@ -36,3 +36,7 @@ services:
         class: PHPStanRules\RequireMeaningfulAssertionsRule
         tags:
             - phpstan.rules.rule
+    -
+        class: PHPStanRules\BanRedeclaredMockDbQueryHelperRule
+        tags:
+            - phpstan.rules.rule

--- a/ibl5/tests/Extension/ExtensionRepositoryTest.php
+++ b/ibl5/tests/Extension/ExtensionRepositoryTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Extension;
 
-use PHPUnit\Framework\TestCase;
 use Extension\ExtensionRepository;
 use Logging\LoggerFactory;
 use Monolog\Handler\TestHandler;
 use Tests\WideUnit\Mocks\MockDatabase;
+use Tests\WideUnit\WideUnitTestCase;
 
 /**
  * Tests for ExtensionRepository
@@ -21,20 +21,19 @@ use Tests\WideUnit\Mocks\MockDatabase;
  *
  * @covers \Extension\ExtensionRepository
  */
-class ExtensionRepositoryTest extends TestCase
+class ExtensionRepositoryTest extends WideUnitTestCase
 {
-    private MockDatabase $mockDb;
-    private ExtensionRepository $repository;
-
-    protected function setUp(): void
-    {
-        $this->mockDb = new MockDatabase();
-        $this->repository = new ExtensionRepository($this->mockDb);
-    }
-
     protected function tearDown(): void
     {
         LoggerFactory::reset();
+        parent::tearDown();
+    }
+
+    private function repo(): ExtensionRepository
+    {
+        $db = $this->mockDb;
+        self::assertNotNull($db);
+        return new ExtensionRepository($db);
     }
 
     // ============================================
@@ -48,7 +47,7 @@ class ExtensionRepositoryTest extends TestCase
             'year4' => 1300, 'year5' => 1400,
         ];
 
-        $result = $this->repository->updatePlayerContract('Test Player', $offer, 800);
+        $result = $this->repo()->updatePlayerContract('Test Player', $offer, 800);
 
         $this->assertTrue($result);
         $this->assertQueryExecuted('UPDATE ibl_plr');
@@ -61,14 +60,14 @@ class ExtensionRepositoryTest extends TestCase
             'year4' => 0, 'year5' => 0,
         ];
 
-        $result = $this->repository->updatePlayerContract('Test Player', $offer, 800);
+        $result = $this->repo()->updatePlayerContract('Test Player', $offer, 800);
 
         $this->assertTrue($result);
     }
 
     public function testMarksExtensionUsedThisSim(): void
     {
-        $result = $this->repository->markExtensionUsedThisSim('Test Team');
+        $result = $this->repo()->markExtensionUsedThisSim('Test Team');
 
         $this->assertTrue($result);
         $this->assertQueryExecuted('used_extension_this_chunk');
@@ -76,7 +75,7 @@ class ExtensionRepositoryTest extends TestCase
 
     public function testMarksExtensionUsedThisSeason(): void
     {
-        $result = $this->repository->markExtensionUsedThisSeason('Test Team');
+        $result = $this->repo()->markExtensionUsedThisSeason('Test Team');
 
         $this->assertTrue($result);
         $this->assertQueryExecuted('used_extension_this_season');
@@ -95,7 +94,7 @@ class ExtensionRepositoryTest extends TestCase
         $this->mockDb->setNumRows(1);
         $this->mockDb->setReturnTrue(true);
 
-        $result = $this->repository->createAcceptedExtensionStory(
+        $result = $this->repo()->createAcceptedExtensionStory(
             'Test Player',
             'Test Team',
             120.0,
@@ -116,7 +115,7 @@ class ExtensionRepositoryTest extends TestCase
         $this->mockDb->setNumRows(1);
         $this->mockDb->setReturnTrue(true);
 
-        $result = $this->repository->createRejectedExtensionStory(
+        $result = $this->repo()->createRejectedExtensionStory(
             'Test Player',
             'Test Team',
             100.0,
@@ -137,7 +136,7 @@ class ExtensionRepositoryTest extends TestCase
             ['contract_wins' => 50, 'contract_losses' => 32, 'contract_avg_w' => 2500, 'contract_avg_l' => 2000],
         ]);
 
-        $result = $this->repository->getTeamTraditionData('Test Team');
+        $result = $this->repo()->getTeamTraditionData('Test Team');
 
         $this->assertSame(50, $result['currentSeasonWins']);
         $this->assertSame(32, $result['currentSeasonLosses']);
@@ -150,7 +149,7 @@ class ExtensionRepositoryTest extends TestCase
         // Empty mock data — no rows returned
         $this->mockDb->setMockData([]);
 
-        $result = $this->repository->getTeamTraditionData('Nonexistent Team');
+        $result = $this->repo()->getTeamTraditionData('Nonexistent Team');
 
         $this->assertSame(41, $result['currentSeasonWins']);
         $this->assertSame(41, $result['currentSeasonLosses']);
@@ -171,7 +170,7 @@ class ExtensionRepositoryTest extends TestCase
             'year4' => 0, 'year5' => 0,
         ];
 
-        $this->repository->saveAcceptedExtension(
+        $this->repo()->saveAcceptedExtension(
             'Test Player',
             'Test Team',
             $offer,
@@ -335,24 +334,5 @@ class ExtensionRepositoryTest extends TestCase
     {
         $repo = new ExtensionRepository(new MockDatabase());
         $this->assertIsObject($repo);
-    }
-
-    /**
-     * Assert that at least one executed query contains the given substring.
-     */
-    private function assertQueryExecuted(string $substring): void
-    {
-        $queries = $this->mockDb->getExecutedQueries();
-        $found = false;
-        foreach ($queries as $query) {
-            if (str_contains($query, $substring)) {
-                $found = true;
-                break;
-            }
-        }
-        self::assertTrue(
-            $found,
-            "Expected a query containing '{$substring}' but none was found. Queries: " . implode("\n", $queries)
-        );
     }
 }

--- a/ibl5/tests/PHPStanRules/BanRedeclaredMockDbQueryHelperRuleTest.php
+++ b/ibl5/tests/PHPStanRules/BanRedeclaredMockDbQueryHelperRuleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanRules\BanRedeclaredMockDbQueryHelperRule;
+
+/**
+ * @extends RuleTestCase<BanRedeclaredMockDbQueryHelperRule>
+ */
+final class BanRedeclaredMockDbQueryHelperRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new BanRedeclaredMockDbQueryHelperRule();
+    }
+
+    public function testFlagsRedeclaredAssertQueryExecuted(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/RedeclaresAssertQueryExecuted.php'],
+            [
+                [
+                    'Test re-declares `assertQueryExecuted()`, which Tests\WideUnit\WideUnitTestCase already provides. '
+                    . 'Extend Tests\WideUnit\WideUnitTestCase instead of re-implementing its query-assertion helper.',
+                    9,
+                ],
+            ],
+        );
+    }
+
+    public function testFlagsRedeclaredAssertQueryNotExecuted(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/RedeclaresAssertQueryNotExecuted.php'],
+            [
+                [
+                    'Test re-declares `assertQueryNotExecuted()`, which Tests\WideUnit\WideUnitTestCase already provides. '
+                    . 'Extend Tests\WideUnit\WideUnitTestCase instead of re-implementing its query-assertion helper.',
+                    9,
+                ],
+            ],
+        );
+    }
+
+    public function testDoesNotFlagWideUnitTestCaseDefiner(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/WideUnitTestCase.php'],
+            [],
+        );
+    }
+
+    public function testDoesNotFlagCleanTestClass(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/CleanRepositoryTest.php'],
+            [],
+        );
+    }
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/CleanRepositoryTest.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/CleanRepositoryTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules\Fixtures;
+
+final class CleanRepositoryTest
+{
+    public function testSomethingHappens(): void
+    {
+    }
+
+    private function buildSubject(): void
+    {
+    }
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/RedeclaresAssertQueryExecuted.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/RedeclaresAssertQueryExecuted.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules\Fixtures;
+
+final class RedeclaresAssertQueryExecuted
+{
+    private function assertQueryExecuted(string $substring): void
+    {
+    }
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/RedeclaresAssertQueryNotExecuted.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/RedeclaresAssertQueryNotExecuted.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules\Fixtures;
+
+final class RedeclaresAssertQueryNotExecuted
+{
+    private function assertQueryNotExecuted(string $substring): void
+    {
+    }
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/WideUnitTestCase.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/WideUnitTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules\Fixtures;
+
+/**
+ * Basename-match exemption fixture: a class declaring the query-assertion helper
+ * in a file named WideUnitTestCase.php is the sole legitimate definer and must
+ * NOT be flagged.
+ */
+abstract class WideUnitTestCase
+{
+    protected function assertQueryExecuted(string $substring): void
+    {
+    }
+}


### PR DESCRIPTION
Adds a custom PHPStan rule (`BanRedeclaredMockDbQueryHelperRule`) that fails CI when a test re-declares `assertQueryExecuted` or `assertQueryNotExecuted` — helpers already provided by `Tests\WideUnit\WideUnitTestCase`. Fixes the one pre-existing violation in `ExtensionRepositoryTest`, registers the rule in `phpstan-tests.neon`, and documents the now-enforced convention.

## Why

PR #1222 copy-pasted the `assertQueryExecuted` helper into three new repository tests instead of extending `WideUnitTestCase`. The canonical pattern was documented but not enforced; this rule makes it a CI gate.

## What changed

- `phpstan-rules/BanRedeclaredMockDbQueryHelperRule.php` — new rule (ClassMethod node)
- `tests/PHPStanRules/BanRedeclaredMockDbQueryHelperRuleTest.php` — rule unit tests (4 cases)
- `tests/PHPStanRules/Fixtures/` — positive/negative fixtures for the rule
- `phpstan-tests.neon` — rule registered in `services:`
- `tests/Extension/ExtensionRepositoryTest.php` — refactored to extend `WideUnitTestCase` (deletes copy-pasted helper)
- `docs/DEVELOPMENT_GUIDE.md` — convention note + `last_verified` bump

<!-- no-adr: enforces existing WideUnitTestCase test convention; no new architecture -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.