### PR TITLE
chore: add post-review-findings helper + wire pr-review/security-audit to inline threads

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,10 +1,10 @@
 ---
 allowed-tools: Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr comment:*),
   Bash(gh issue view:*), Bash(gh search:*), Bash(gh pr list:*), Bash(gh api:*),
-  Bash(git log:*), Bash(git rev-parse:*), Bash(git show:*)
+  Bash(git log:*), Bash(git rev-parse:*), Bash(git show:*), Bash(source:*)
 description: Token-efficient code review for pull requests
 model: sonnet
-last_verified: 2026-05-21
+last_verified: 2026-06-28
 ---
 
 Provide a code review for the given pull request. This command optimizes token usage by fetching the diff once and distributing only what each agent needs.
@@ -12,7 +12,7 @@ Provide a code review for the given pull request. This command optimizes token u
 ## Step 1: Eligibility check
 
 Use a **Haiku** agent to check if the pull request:
-(a) is closed, (b) is a draft, (c) does not need a code review (e.g. automated PR, or very simple and obviously ok), or (d) already has a code review from you earlier.
+(a) is closed, (b) is a draft, (c) does not need a code review (e.g. automated PR, or very simple and obviously ok), or (d) already has a code review from you earlier (check both PR issue comments and PR **reviews** — `gh pr view --json comments,reviews` — for a prior `### Code review` heading from you, since findings are now posted as a review body with inline threads, not only as issue comments).
 
 If any of these are true, do not proceed. Tell the user why.
 
@@ -90,9 +90,38 @@ gh pr view --json state --jq '.state'
 
 If the result is not `"OPEN"`, do not post a comment. Tell the user the PR is no longer open.
 
-## Step 7: Post comment
+## Step 7: Post findings
 
-Use `gh pr comment` to post the review. Use the PR number and head SHA from Step 2a for links.
+Source the shared posting helper (same idiom as `bin/lib/pr-armable.sh`):
+
+```bash
+source "$(git rev-parse --show-toplevel)/bin/lib/post-review-findings.sh"
+```
+
+**If issues survived Step 5,** build a findings JSON array (write to a temp file — not a shell arg — to avoid quoting limits). Each element:
+```json
+{ "path": "repo/relative/path.php",
+  "line": 17,
+  "body": "<description> (CLAUDE.md says \"<rule>\")\n\n<full-SHA range link>",
+  "score": 85 }
+```
+- `path` is the repo-relative file path (matching `+++ b/<path>` in the diff).
+- `line` is a single anchor line on the new-file (right) side.
+- `body` is the description in the format below, followed by the full-SHA link. Do NOT add the footer — the helper adds it.
+- `score` is the Haiku score from Step 4.
+
+Then call:
+```bash
+post_review_findings "$PR_NUMBER" "$HEAD_SHA" "Code review" "$findings_file"
+```
+
+The helper routes on-diff findings to a batch resolvable review POST (inline threads) and out-of-diff findings to a fallback `gh pr comment`. Nothing is dropped.
+
+**If no issues survived Step 5,** call:
+```bash
+post_review_summary "$PR_NUMBER" "Code review" \
+    "No issues found. <1-2 sentence evidence summary>"
+```
 
 ### Notes:
 - Do not check build signal or attempt to build or typecheck the app. These will run separately.
@@ -100,42 +129,18 @@ Use `gh pr comment` to post the review. Use the PR number and head SHA from Step
 - Make a todo list first.
 - You must cite and link each bug (e.g. if referring to a CLAUDE.md, you must link it).
 
-### Comment format (if issues found):
+### Per-finding body format:
 
----
+```
+<brief description of bug> (CLAUDE.md says "<...>")
 
-### Code review
+https://github.com/a-jay85/IBL5/blob/FULL_SHA/path/to/file.php#L13-L17
+```
 
-Found N issues:
-
-1. \<brief description of bug\> (CLAUDE.md says "\<...\>")
-
-\<link to file and line with full sha1 + line range for context, e.g. https://github.com/a-jay85/IBL5/blob/FULL_SHA/path/to/file.php#L13-L17\>
-
-2. \<brief description of bug\> (bug due to \<file and code snippet\>)
-
-\<link to file and line with full sha1 + line range for context\>
-
-Generated with [Claude Code](https://claude.ai/code)
-
-\<sub\>If this code review was useful, please react with thumbs-up. Otherwise, react with thumbs-down.\</sub\>
-
----
-
-### Comment format (if no issues):
-
----
-
-### Code review
-
-No issues found. \<1-2 sentence evidence summary assembled from agent responses, e.g. "Architecture follows Repository/Service/View split. Native-type comparisons consistent with schema. No bind\_param mismatches in modified files."\>
-
-Generated with [Claude Code](https://claude.ai/code)
-
----
+(The heading `### Code review`, the found-N summary line, and the footer are emitted by the helper — do NOT include them in individual finding bodies.)
 
 ### Link format rules:
 - Must use the full git SHA (from Step 2a's `headRefOid`)
 - Format: `https://github.com/a-jay85/IBL5/blob/{FULL_SHA}/path/to/file#L{start}-L{end}`
 - Provide at least 1 line of context before and after the line you are commenting about
-- Do NOT use `$(git rev-parse HEAD)` or any bash interpolation in the comment — expand the SHA beforehand
+- Do NOT use `$(git rev-parse HEAD)` or any bash interpolation in the body string — expand the SHA beforehand

--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -1,9 +1,9 @@
 ---
 allowed-tools: Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr comment:*),
-  Bash(gh api:*), Bash(git rev-parse:*)
+  Bash(gh api:*), Bash(git rev-parse:*), Bash(source:*)
 description: Token-efficient security audit for pull requests
 model: sonnet
-last_verified: 2026-04-29
+last_verified: 2026-06-28
 ---
 
 Perform a security audit on the given pull request. This command optimizes token usage by fetching the diff once and passing it to a single merged security agent.
@@ -11,7 +11,7 @@ Perform a security audit on the given pull request. This command optimizes token
 ## Step 1: Eligibility check
 
 Use a **Haiku** agent to check if the pull request:
-(a) is closed, (b) is a draft, (c) has zero PHP files changed, or (d) already has a `### Security audit` comment from you.
+(a) is closed, (b) is a draft, (c) has zero PHP files changed, or (d) already has a `### Security audit` from you in a PR issue comment OR a PR **review** body — `gh pr view --json comments,reviews` — since findings now post as a review with inline threads, not only as issue comments.
 
 If any of these are true, do not proceed. Tell the user why.
 
@@ -77,31 +77,48 @@ gh pr view --json state --jq '.state'
 
 If the result is not `"OPEN"`, do not post a comment. Tell the user the PR is no longer open.
 
-## Step 7: Post comment
+## Step 7: Post findings
 
-Use `gh pr comment` to post the audit results. Use the PR number and head SHA from Step 2a for links.
+Source the shared posting helper (same idiom as `bin/lib/pr-armable.sh`):
 
-### Comment format (if issues found):
+```bash
+source "$(git rev-parse --show-toplevel)/bin/lib/post-review-findings.sh"
+```
 
----
+**If findings survived Step 5,** build a findings JSON array (write to a temp file — not a shell arg). Each element:
+```json
+{ "path": "repo/relative/path.php",
+  "line": 17,
+  "body": "**[SEVERITY]** Vulnerability type in `Class::method()` — description\n\n<full-SHA range link>",
+  "score": 88 }
+```
+- `path` is the repo-relative file path.
+- `line` is a single anchor line on the new-file (right) side.
+- `body` is the finding description in the format below, followed by the full-SHA link. Do NOT add the footer — the helper adds it.
+- `score` is the Haiku score from Step 4.
 
-### Security audit
+Then call:
+```bash
+post_review_findings "$PR_NUMBER" "$HEAD_SHA" "Security audit" "$findings_file"
+```
 
-Found N issue(s):
+The helper routes on-diff findings to a batch resolvable review POST (inline threads) and out-of-diff findings to a fallback `gh pr comment`. Nothing is dropped.
 
+**If no findings survived Step 5,** call:
+```bash
+post_review_summary "$PR_NUMBER" "Security audit" \
+    "No security issues found. <brief evidence per category> (XSS and input validation are enforced by PHPStan custom rules.)"
+```
+
+### Per-finding body format:
+
+```
 **[SEVERITY]** Vulnerability type in `Class::method()` — description
 
-<link to file and line with full SHA + line range>
+https://github.com/a-jay85/IBL5/blob/FULL_SHA/path/to/file.php#L13-L17
+```
 
-**[SEVERITY]** Vulnerability type in `Class::method()` — description
-
-<link to file and line with full SHA + line range>
-
-Generated with [Claude Code](https://claude.ai/code)
-
-<sub>If this security audit was useful, please react with thumbs-up. Otherwise, react with thumbs-down.</sub>
-
----
+(The heading `### Security audit`, the found-N summary line, and the footer are emitted by the helper — do NOT include them in individual finding bodies.)
 
 ### Severity mapping:
 - **CRITICAL** — SQL injection, command injection
@@ -111,23 +128,11 @@ Generated with [Claude Code](https://claude.ai/code)
 
 (XSS and input validation are not in this list because `RequireEscapedOutputRule` and `BanRawSuperglobalsRule` catch them in CI before this audit runs.)
 
-### Comment format (if no issues):
-
----
-
-### Security audit
-
-No security issues found. \<brief evidence per category that launched, e.g. "SQL: all queries use prepared statements via fetchOne()/fetchAll(). CSRF: token validated via CsrfGuard::validateSubmittedToken() on line N. Auth: is\_user() guard on state-changing endpoints."\> (XSS and input validation are enforced by PHPStan custom rules.)
-
-Generated with [Claude Code](https://claude.ai/code)
-
----
-
 ### Link format rules:
 - Must use the full git SHA (from Step 2a's `headRefOid`)
 - Format: `https://github.com/a-jay85/IBL5/blob/{FULL_SHA}/path/to/file#L{start}-L{end}`
 - Provide at least 1 line of context before and after the line you are commenting about
-- Do NOT use `$(git rev-parse HEAD)` or any bash interpolation in the comment — expand the SHA beforehand
+- Do NOT use `$(git rev-parse HEAD)` or any bash interpolation in the body string — expand the SHA beforehand
 
 ### Notes:
 - Do not check build signal or attempt to build or typecheck the app. These will run separately.

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -5,7 +5,7 @@ disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
   - Skill
-last_verified: 2026-06-24
+last_verified: 2026-06-28
 ---
 
 # Post-Plan Orchestrator
@@ -302,7 +302,7 @@ Run the pattern-detection block from that file to get SQL and Forms category cou
 
 Combine ALL issues from 4B and 4C into one numbered list.
 
-**Skip the scoring agent if the combined list is empty** — jump straight to posting "No issues found." comments in the two `gh pr comment` steps below.
+**Skip the scoring agent if the combined list is empty** — jump straight to the `post_review_summary` no-issues path below.
 
 Otherwise launch a **single Haiku agent**, pass it the issues list plus the **Scoring scale and Thresholds sections** from `_review-rubric.md` (not the full Automatic Zero or false-positive lists — review agents have already filtered those). Instruct it to return JSON scores per that rubric. Parse the response and assign scores back to each issue.
 
@@ -310,19 +310,26 @@ Otherwise launch a **single Haiku agent**, pass it the issues list plus the **Sc
 
 **Re-check PR state:** `gh pr view --json state --jq '.state'` — skip posting if not `OPEN`.
 
-**Post two `gh pr comment` entries** (code review + security audit) using full SHA from 4A.
+**Post results for code review and security audit** using the shared posting helper. Source it mirroring the pr-armable.sh idiom used by the Phase 6.5 condition blocks:
 
-Code review format (issues found): `### Code review\n\nFound N issues:\n\n1. <description> (CLAUDE.md says "<rule>")\n\n<link>`
+```bash
+source "$(git rev-parse --show-toplevel)/bin/lib/post-review-findings.sh"
+```
 
-Code review format (no issues): `### Code review\n\nNo issues found.` followed by a 1-2 sentence evidence summary assembled from agent responses (e.g., "Architecture follows Repository/Service/View split. Native-type comparisons consistent with schema. No bind_param mismatches in modified files.").
+The helper provides two public functions:
 
-Security audit format (issues found): `### Security audit\n\nFound N issue(s):\n\n**[SEVERITY]** Type in \`Class::method()\` — description\n\n<link>` Severity: CRITICAL (SQLi/CMDi), HIGH (missing auth/open redirect), MEDIUM (CSRF/missing auth on non-critical endpoints), LOW (best practice).
+- `post_review_findings PR_NUMBER HEAD_SHA REVIEW_TITLE FINDINGS_FILE` — splits findings into on-diff (→ batch resolvable inline review threads) and out-of-diff (→ single fallback `gh pr comment`). Nothing is dropped. The `<!-- score: N -->` marker is appended automatically; the heading envelope and footer are emitted by the helper — do NOT re-add them.
+- `post_review_summary PR_NUMBER REVIEW_TITLE BODY` — for the no-issues path; posts a single `gh pr comment` with the heading, evidence body, and footer.
 
-Security audit format (no issues): `### Security audit\n\nNo security issues found.` followed by brief evidence per category that launched (e.g., "SQL: all queries use prepared statements. CSRF: token validated on line N. Auth: guard present on state-changing endpoints.") and `(XSS and input validation are enforced by PHPStan custom rules.)`
+**For code review:**
+- Issues survived filter → build a JSON findings array (one object per issue: `path` = repo-relative file, `line` = single anchor line on new-file side, `body` = `<description> (CLAUDE.md says "<rule>")` + full-SHA range link, `score` = Haiku score) to a temp file; call `post_review_findings "$PR" "$FULL_SHA" "Code review" <file>`.
+- No issues → call `post_review_summary "$PR" "Code review" "No issues found. <1-2 sentence evidence summary>"`.
 
-**Link format:** `https://github.com/a-jay85/IBL5/blob/{FULL_SHA}/path/to/file#L{start}-L{end}` — expand SHA beforehand, never use bash interpolation in the comment. Include 1 line of context before/after.
+**For security audit:**
+- Issues survived filter → build findings JSON (`body` = `**[SEVERITY]** Type in \`Class::method()\` — description` + full-SHA range link, `score`); call `post_review_findings "$PR" "$FULL_SHA" "Security audit" <file>`. Severity: CRITICAL (SQLi/CMDi), HIGH (missing auth/open redirect), MEDIUM (CSRF/missing auth on non-critical endpoints), LOW (best practice).
+- No issues → call `post_review_summary "$PR" "Security audit" "No security issues found. <brief evidence per category> (XSS and input validation are enforced by PHPStan custom rules.)"`.
 
-Both comments end with: `Generated with [Claude Code](https://claude.ai/code)` and `<sub>If this was useful, react with thumbs-up. Otherwise, thumbs-down.</sub>`
+**Link format (in `body` field):** `https://github.com/a-jay85/IBL5/blob/{FULL_SHA}/path/to/file#L{start}-L{end}` — expand SHA from 4A beforehand, never use bash interpolation in the body string. Include 1 line of context before/after the anchor line.
 
 ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,10 @@ jobs:
               # bin/test-postplan-arm-conditions reads the Phase 6.5 condition
               # blocks here, so a SKILL.md-only edit must run the harness job.
               - '.claude/skills/post-plan/SKILL.md'
+              # bin/test-post-review-findings reads the Step 7 / Step 1 blocks here,
+              # so a command-only edit must run the harness job too.
+              - '.claude/commands/pr-review.md'
+              - '.claude/commands/security-audit.md'
             ibl6:
               - 'IBL6/**'
               - '.github/workflows/tests.yml'
@@ -598,6 +602,8 @@ jobs:
         run: bin/test-adr-check
       - name: bin/test-postplan-arm-conditions
         run: bin/test-postplan-arm-conditions
+      - name: bin/test-post-review-findings
+        run: bin/test-post-review-findings
       - name: bin/test-playwright-version
         run: bin/test-playwright-version
 

--- a/bin/lib/post-review-findings.sh
+++ b/bin/lib/post-review-findings.sh
@@ -1,0 +1,139 @@
+# Shared posting helper for code-review & security-audit findings — converts a
+# JSON findings array into either resolvable inline GitHub review threads (on-diff
+# lines) or a single fallback issue comment (out-of-diff lines).  Sourced by
+# /post-plan Phase 4D, /pr-review Step 7, and /security-audit Step 7.
+#
+# Usage: source "$(git rev-parse --show-toplevel)/bin/lib/post-review-findings.sh"
+#
+# Public API:
+#   post_review_findings PR_NUMBER HEAD_SHA REVIEW_TITLE FINDINGS_FILE
+#   post_review_summary  PR_NUMBER REVIEW_TITLE BODY
+#
+# Test seam: GH_CMD (default `gh`) and REPO_SLUG (default `a-jay85/IBL5`) are
+# overridable env-vars so the shim test can drive both without network calls.
+#
+# This file is SOURCED, not executed: no `set -euo pipefail` at file scope.
+
+GH_CMD="${GH_CMD:-gh}"
+REPO_SLUG="${REPO_SLUG:-a-jay85/IBL5}"
+
+# Two-line footer appended by the helper envelope (callers must NOT add it).
+PRF_FOOTER='Generated with [Claude Code](https://claude.ai/code)
+
+<sub>If this was useful, react with thumbs-up. Otherwise, react with thumbs-down.</sub>'
+
+# prf_diff_right_lines PR_NUMBER
+#   Emits "path<TAB>line" for every right-side (context or added) line in the
+#   PR diff.  Deleted lines (-) are skipped and do not advance the counter.
+#   Handles both "@@ -a,b +c,d @@" and "@@ -a +c @@" (single-line) hunk forms.
+prf_diff_right_lines() {
+    local pr="$1"
+    "$GH_CMD" pr diff "$pr" | awk '
+        /^diff --git / { cur_file = "" }
+        /^\+\+\+ b\// {
+            sub(/^\+\+\+ b\//, "")
+            cur_file = $0
+        }
+        /^@@ / {
+            # Extract the +start from "+start" or "+start,count"
+            match($0, /\+[0-9]+/)
+            rline = substr($0, RSTART+1, RLENGTH-1) + 0
+            next
+        }
+        cur_file != "" && /^\+/ && !/^\+\+\+/ {
+            print cur_file "\t" rline
+            rline++
+            next
+        }
+        cur_file != "" && /^ / {
+            print cur_file "\t" rline
+            rline++
+            next
+        }
+        cur_file != "" && /^-/ && !/^---/ {
+            next
+        }
+    '
+}
+
+# post_review_findings PR_NUMBER HEAD_SHA REVIEW_TITLE FINDINGS_FILE
+#   Partitions findings by whether their path:line is present in the PR diff.
+#   On-diff  → one atomic batch review POST (resolvable inline threads).
+#   Out-of-diff → one fallback gh pr comment (nothing is dropped).
+#   Empty findings array → no-op.
+post_review_findings() {
+    local pr="$1" head_sha="$2" title="$3" findings_file="$4"
+    local tmp; tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp'" RETURN
+
+    local count
+    count=$(jq 'length' "$findings_file")
+    [ "$count" -eq 0 ] && return 0
+
+    # Build path:line set from the diff
+    local lines_file="$tmp/lines.json"
+    prf_diff_right_lines "$pr" \
+        | jq -R 'split("\t") | .[0]+":"+.[1]' \
+        | jq -s '.' > "$lines_file"
+
+    # Partition: on-diff vs out-of-diff
+    local on_file="$tmp/on.json" off_file="$tmp/off.json"
+    jq --slurpfile lineset "$lines_file" \
+        '[.[] | select( (.path+":"+(.line|tostring)) as $k | $lineset[0] | index($k) != null )]' \
+        "$findings_file" > "$on_file"
+    jq --slurpfile lineset "$lines_file" \
+        '[.[] | select( (.path+":"+(.line|tostring)) as $k | $lineset[0] | index($k) == null )]' \
+        "$findings_file" > "$off_file"
+
+    local on_count off_count
+    on_count=$(jq 'length' "$on_file")
+    off_count=$(jq 'length' "$off_file")
+
+    # On-diff: batch review POST
+    if [ "$on_count" -gt 0 ]; then
+        local envelope="### ${title}
+
+Found ${on_count} issue(s). See inline threads below.
+
+${PRF_FOOTER}"
+        local payload_file="$tmp/payload.json"
+        jq -n \
+            --arg sha "$head_sha" \
+            --arg ev "COMMENT" \
+            --arg body "$envelope" \
+            --argjson comments "$(jq '[.[] | {path, line, side:"RIGHT", body: (.body + "\n\n<!-- score: " + (.score|tostring) + " -->")}]' "$on_file")" \
+            '{commit_id: $sha, event: $ev, body: $body, comments: $comments}' \
+            > "$payload_file"
+        "$GH_CMD" api --method POST \
+            "repos/${REPO_SLUG}/pulls/${pr}/reviews" \
+            --input "$payload_file"
+    fi
+
+    # Out-of-diff: fallback comment
+    if [ "$off_count" -gt 0 ]; then
+        local fallback_file="$tmp/fallback.txt"
+        {
+            printf '### %s\n\n' "$title"
+            printf 'Found %d issue(s) on lines not present in the diff:\n\n' "$off_count"
+            jq -r 'to_entries[] | "\(.key + 1). \(.value.body)\n\n<!-- score: \(.value.score) -->"' "$off_file"
+            printf '\n%s\n' "$PRF_FOOTER"
+        } > "$fallback_file"
+        "$GH_CMD" pr comment "$pr" --body-file "$fallback_file"
+    fi
+}
+
+# post_review_summary PR_NUMBER REVIEW_TITLE BODY
+#   Posts a single issue comment for the no-issues path (no findings survived the
+#   filter).  The heading and footer are emitted by this function; callers pass
+#   only the evidence body (e.g. "No issues found. Architecture clean.").
+post_review_summary() {
+    local pr="$1" title="$2" body="$3"
+    local tmp; tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp'" RETURN
+
+    local out="$tmp/summary.txt"
+    printf '### %s\n\n%s\n\n%s\n' "$title" "$body" "$PRF_FOOTER" > "$out"
+    "$GH_CMD" pr comment "$pr" --body-file "$out"
+}

--- a/bin/test-post-review-findings
+++ b/bin/test-post-review-findings
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-post-review-findings — regression guard for bin/lib/post-review-findings.sh
+#
+# Verifies that:
+#   • on-diff findings → batch resolvable review POST (not a plain comment)
+#   • out-of-diff findings → fallback gh pr comment (nothing dropped)
+#   • mixed partition → each finding lands in the right channel
+#   • no-issues path → evidence comment with footer, no review POST
+#   • score marker <!-- score: N --> encoded in every finding body
+#   • empty findings array → complete no-op
+#   • all 3 callers reference post-review-findings.sh (structural)
+#   • /pr-review & /security-audit Step 1 guards check PR reviews (structural)
+#
+# Run: bin/test-post-review-findings  (exit 0 = all pass, 1 = some failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$REPO_ROOT/bin/lib/post-review-findings.sh"
+
+BASE_TMP="$(mktemp -d)"
+trap 'rm -rf "$BASE_TMP"' EXIT
+FAILED=0
+
+# ── gh shim ───────────────────────────────────────────────────────────────────
+SHIMD="$BASE_TMP/shim"
+mkdir -p "$SHIMD"
+cat > "$SHIMD/gh" <<'SHIM'
+#!/usr/bin/env bash
+# shim for: gh pr diff N  |  gh api --method POST .../reviews --input F
+#           gh pr comment N --body-file F
+if [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
+    cat "$GH_DIFF_FIXTURE"
+    exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "--method" ] && [ "$3" = "POST" ]; then
+    input_file=""
+    for ((i=1; i<=$#; i++)); do
+        if [ "${!i}" = "--input" ]; then j=$((i+1)); input_file="${!j}"; fi
+    done
+    cp "$input_file" "$REVIEW_OUT"
+    echo '{"id":1}'
+    exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "comment" ]; then
+    body_file=""
+    for ((i=1; i<=$#; i++)); do
+        if [ "${!i}" = "--body-file" ]; then j=$((i+1)); body_file="${!j}"; fi
+    done
+    cp "$body_file" "$COMMENT_OUT"
+    exit 0
+fi
+exit 1
+SHIM
+chmod +x "$SHIMD/gh"
+
+# ── diff fixture ──────────────────────────────────────────────────────────────
+# Single file classes/Foo.php, hunk @@ -10,3 +10,4 @@
+# Right-side lines in diff: 10 (ctx), 11 (ctx), 12 (added), 13 (ctx)
+# → line 12 is on-diff; line 999 is out-of-diff.
+GH_DIFF_FIXTURE="$BASE_TMP/diff.txt"
+cat > "$GH_DIFF_FIXTURE" <<'DIFF'
+diff --git a/classes/Foo.php b/classes/Foo.php
+--- a/classes/Foo.php
++++ b/classes/Foo.php
+@@ -10,3 +10,4 @@
+ context line 10
+ context line 11
++added line 12
+ context line 13
+DIFF
+
+# ── output capture files ──────────────────────────────────────────────────────
+REVIEW_OUT="$BASE_TMP/review.json"
+COMMENT_OUT="$BASE_TMP/comment.txt"
+
+# Export all vars the shim and lib need to see from child processes
+export GH_CMD="$SHIMD/gh"
+export REPO_SLUG="a-jay85/IBL5"
+export GH_DIFF_FIXTURE
+export REVIEW_OUT
+export COMMENT_OUT
+
+# Source the lib once (GH_CMD and REPO_SLUG already exported above; lib's
+# `:-` defaults are no-ops because the vars are already set)
+# shellcheck disable=SC1090
+source "$LIB"
+
+reset_outputs() { rm -f "$REVIEW_OUT" "$COMMENT_OUT"; }
+
+# ── assertion helpers ─────────────────────────────────────────────────────────
+ok()   { printf 'ok: %s\n' "$*"; }
+fail() { printf 'FAIL: %s\n' "$*"; FAILED=1; }
+
+assert_jq() { # label jq-expr file
+    local label="$1" expr="$2" file="$3"
+    if jq -e "$expr" "$file" >/dev/null 2>&1; then
+        ok "$label"
+    else
+        fail "$label — jq '$expr' failed on: $(head -5 "$file" 2>/dev/null)"
+    fi
+}
+
+assert_contains() { # label file text
+    if grep -qF "$3" "$2" 2>/dev/null; then
+        ok "$1 contains expected text"
+    else
+        fail "$1 missing '$3'"
+    fi
+}
+
+assert_absent() { # label file
+    if [ ! -f "$2" ]; then
+        ok "$1 absent (correct)"
+    else
+        fail "$1 should NOT exist but does"
+    fi
+}
+
+# ── case 1: on-diff ───────────────────────────────────────────────────────────
+# Finding anchored on a line that IS in the diff (line 12).
+# Expect: $REVIEW_OUT posted as batch review; $COMMENT_OUT absent.
+reset_outputs
+f1="$BASE_TMP/f1.json"
+printf '[{"path":"classes/Foo.php","line":12,"body":"Bug X — link","score":85}]' > "$f1"
+post_review_findings 42 deadbeefcafe "Code review" "$f1"
+
+assert_jq       "case1: commit_id"       '.commit_id == "deadbeefcafe"'                        "$REVIEW_OUT"
+assert_jq       "case1: event COMMENT"   '.event == "COMMENT"'                                 "$REVIEW_OUT"
+assert_jq       "case1: comments count"  '.comments | length == 1'                             "$REVIEW_OUT"
+assert_jq       "case1: path"            '.comments[0].path == "classes/Foo.php"'              "$REVIEW_OUT"
+assert_jq       "case1: line"            '.comments[0].line == 12'                             "$REVIEW_OUT"
+assert_jq       "case1: side RIGHT"      '.comments[0].side == "RIGHT"'                        "$REVIEW_OUT"
+assert_jq       "case1: body has Bug X"  '.comments[0].body | contains("Bug X")'              "$REVIEW_OUT"
+assert_jq       "case1: score marker"    '.comments[0].body | contains("<!-- score: 85 -->")' "$REVIEW_OUT"
+assert_absent   "case1: no fallback"     "$COMMENT_OUT"
+
+# ── case 2: out-of-diff (NEGATIVE) ───────────────────────────────────────────
+# Finding on line NOT in the diff (line 999).
+# Expect: $COMMENT_OUT posted as fallback; $REVIEW_OUT absent.
+reset_outputs
+f2="$BASE_TMP/f2.json"
+printf '[{"path":"classes/Foo.php","line":999,"body":"Bug Y — link","score":90}]' > "$f2"
+post_review_findings 42 deadbeefcafe "Code review" "$f2"
+
+assert_contains "case2: heading"         "$COMMENT_OUT" "### Code review"
+assert_contains "case2: Bug Y present"   "$COMMENT_OUT" "Bug Y"
+assert_contains "case2: score marker 90" "$COMMENT_OUT" "<!-- score: 90 -->"
+assert_absent   "case2: no review POST"  "$REVIEW_OUT"
+
+# ── case 3: mixed ─────────────────────────────────────────────────────────────
+# Two findings: line 12 on-diff, line 999 out-of-diff.
+# Expect: review has 1 comment (line 12); fallback has Bug Off.
+reset_outputs
+f3="$BASE_TMP/f3.json"
+printf '[{"path":"classes/Foo.php","line":12,"body":"Bug On","score":80},{"path":"classes/Foo.php","line":999,"body":"Bug Off","score":82}]' > "$f3"
+post_review_findings 42 deadbeefcafe "Code review" "$f3"
+
+assert_jq       "case3: review count 1"  '.comments | length == 1'   "$REVIEW_OUT"
+assert_jq       "case3: inline line 12"  '.comments[0].line == 12'   "$REVIEW_OUT"
+assert_contains "case3: fallback Bug Off" "$COMMENT_OUT" "Bug Off"
+
+# ── case 4: no-issues path ───────────────────────────────────────────────────
+# Expect: $COMMENT_OUT with heading + body + footer; $REVIEW_OUT absent.
+reset_outputs
+post_review_summary 42 "Code review" "No issues found. Architecture clean."
+
+assert_contains "case4: heading"   "$COMMENT_OUT" "### Code review"
+assert_contains "case4: body"      "$COMMENT_OUT" "No issues found."
+assert_contains "case4: footer"    "$COMMENT_OUT" "Generated with [Claude Code]"
+assert_absent   "case4: no review" "$REVIEW_OUT"
+
+# ── case 6: BOUNDARY — empty findings ────────────────────────────────────────
+reset_outputs
+f6="$BASE_TMP/f6.json"
+printf '[]' > "$f6"
+post_review_findings 42 deadbeefcafe "Code review" "$f6"
+
+assert_absent "case6: no review on empty"   "$REVIEW_OUT"
+assert_absent "case6: no comment on empty"  "$COMMENT_OUT"
+
+# ── structural case 7: all 3 callers reference the helper ────────────────────
+for f in \
+    "$REPO_ROOT/.claude/skills/post-plan/SKILL.md" \
+    "$REPO_ROOT/.claude/commands/pr-review.md" \
+    "$REPO_ROOT/.claude/commands/security-audit.md"
+do
+    name="$(basename "$f")"
+    if grep -q 'post-review-findings.sh' "$f" 2>/dev/null; then
+        ok "case7: $name references post-review-findings.sh"
+    else
+        fail "case7: $name does NOT reference post-review-findings.sh"
+    fi
+done
+
+# ── structural case 8: Step 1 re-run guards check PR reviews ─────────────────
+# The fix adds `gh pr view --json comments,reviews` (or equivalent) so that a
+# prior posting as a review body (not just an issue comment) is detected.
+# Assert "reviews" (plural) appears in the Step 1 → Step 2 region of each file.
+for f in \
+    "$REPO_ROOT/.claude/commands/pr-review.md" \
+    "$REPO_ROOT/.claude/commands/security-audit.md"
+do
+    name="$(basename "$f")"
+    step1=$(awk '/^## Step 1/,/^## Step 2/' "$f" 2>/dev/null)
+    if printf '%s' "$step1" | grep -qi 'reviews'; then
+        ok "case8: $name Step 1 checks PR reviews for prior findings"
+    else
+        fail "case8: $name Step 1 does NOT check PR reviews — re-run guard broken after findings move off issue comments"
+    fi
+done
+
+# ── summary ───────────────────────────────────────────────────────────────────
+if [ "$FAILED" -eq 0 ]; then
+    echo "All post-review-findings checks passed."
+else
+    echo "Some post-review-findings checks FAILED."
+fi
+exit "$FAILED"


### PR DESCRIPTION
## Summary

PR1 of 3: switch code-review and security-audit findings from issue comments to resolvable inline review threads.

- Adds `bin/lib/post-review-findings.sh` — sourced posting helper that batch-posts on-diff findings as resolvable review threads (GitHub API `POST /pulls/{N}/reviews`) and routes out-of-diff findings to a fallback summary comment. Appends `<!-- score: N -->` to every finding body for PR2.
- Adds `bin/test-post-review-findings` — shim-test covering 8 behavioral + structural cases, wired into CI.
- Updates `.claude/skills/post-plan/SKILL.md`, `.claude/commands/pr-review.md`, `.claude/commands/security-audit.md` to call the helper.

No-issues path and out-of-diff findings continue to post as `gh pr comment` (unchanged channel); only on-diff issues move to resolvable threads.

<!-- no-adr: review-pipeline tooling mirroring the established pr-armable.sh + test-postplan-arm-conditions pattern; presentation-only (issue comment -> resolvable review thread), introduces no new architectural constraint -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.