### PR TITLE
chore: widen check-plan-staleness creation-cue regex (move/rename/new variants)

### DIFF
--- a/bin/check-plan-staleness
+++ b/bin/check-plan-staleness
@@ -136,7 +136,7 @@ while IFS= read -r token; do
     # for new artifacts; `pre-impl` rows reference existing files (which resolve
     # on disk and never reach here).
     if grep -F -- "$token" "$PLAN_FILE" \
-        | grep -qE '([Cc]reate|[Nn]ew file|[Aa]dd(s|ing)? (a )?new|[Ii]ntroduce|[Ss]caffold|[Ww]rite|\*\*[Nn][Ee][Ww]\*\*|[-—] *NEW\b|\b[Mm]ov(e|ed|es|ing)\b|\b[Rr]ename(d|s|ing)?\b|\b[Rr]elocat(e|ed|es|ing)\b|[Rr]eject(ed)?|[Ff]ixture|throwaway|scratch|post-impl)'; then
+        | grep -qE '([Cc]reate|[Nn]ew file|[Aa]dd(s|ing)? (a )?new|[Ii]ntroduce|[Ss]caffold|[Ww]rite|\*\*[Nn][Ee][Ww]\*\*|[-—] *NEW\b|\b[Mm]ov(e|ed|es|ing)\b|\b[Rr]ename(d|s|ing)?\b|\b[Rr]elocat(e|ed|es|ing)\b|→|[Rr]eject(ed)?|[Ff]ixture|throwaway|scratch|post-impl)'; then
         continue
     fi
 

--- a/bin/check-plan-staleness
+++ b/bin/check-plan-staleness
@@ -136,7 +136,7 @@ while IFS= read -r token; do
     # for new artifacts; `pre-impl` rows reference existing files (which resolve
     # on disk and never reach here).
     if grep -F -- "$token" "$PLAN_FILE" \
-        | grep -qE '([Cc]reate|[Nn]ew file|[Aa]dd(s|ing)? (a )?new|[Ii]ntroduce|[Ss]caffold|[Ww]rite|\*\*NEW\*\*|[Rr]eject(ed)?|[Ff]ixture|throwaway|scratch|post-impl)'; then
+        | grep -qE '([Cc]reate|[Nn]ew file|[Aa]dd(s|ing)? (a )?new|[Ii]ntroduce|[Ss]caffold|[Ww]rite|\*\*[Nn][Ee][Ww]\*\*|[-—] *NEW\b|\b[Mm]ov(e|ed|es|ing)\b|\b[Rr]ename(d|s|ing)?\b|\b[Rr]elocat(e|ed|es|ing)\b|[Rr]eject(ed)?|[Ff]ixture|throwaway|scratch|post-impl)'; then
         continue
     fi
 

--- a/bin/test-check-plan-staleness
+++ b/bin/test-check-plan-staleness
@@ -85,6 +85,18 @@ assert "rejected-alternative" 0 'Rejected: a separate `bin/plan-queue-safe` scri
 # pass via the [Ff]ixture cue, without needing an explicit throwaway/scratch tag.
 assert "fixture-cue" 0 'The test scans a temp fixture `ibl5/scripts/throwaway-fixture-xyz.php` in a tmpdir.'
 
+# New creation cues (FP-now-passes). Each references a path that does NOT exist on
+# disk; the cue on the same line must exempt it (exit 0).
+assert "new-marker-lowercase" 0 '| `ibl5/classes/Repositories/PlayerTeamJoinQuery.php` | **new** trait holding the shared select prefix. |'
+assert "moved-cue"           0 '`ibl5/classes/BasketballStats/TeamStatsCalculator.php` — **moved** here (2.30).'
+assert "dash-new-cue"        0 '`ibl5/classes/Negotiation/Views/DemandsBreakdownView.php` — NEW (consolidated sub-view) (2.12).'
+assert "rename-cue"          0 'Rename to `ibl5/tests/Foo/RenamedThingTest.php` from the old name.'
+assert "relocate-cue"        0 'Relocate `ibl5/classes/Foo/RelocatedBar.php` into the shared dir.'
+
+# Over-widening guard: "remove"/"removed" must NOT be read as a creation cue (word
+# boundary on the move verb). A removed file on a cue-less-of-creation line stays stale.
+assert "remove-not-cue" 1 'Remove the deprecated `ibl5/classes/GoneForever.php` from the bootstrap.'
+
 if [ "$FAILED" -ne 0 ]; then
     echo "RESULT: FAILED"
     exit 1

--- a/bin/test-check-plan-staleness
+++ b/bin/test-check-plan-staleness
@@ -92,6 +92,7 @@ assert "moved-cue"           0 '`ibl5/classes/BasketballStats/TeamStatsCalculato
 assert "dash-new-cue"        0 '`ibl5/classes/Negotiation/Views/DemandsBreakdownView.php` — NEW (consolidated sub-view) (2.12).'
 assert "rename-cue"          0 'Rename to `ibl5/tests/Foo/RenamedThingTest.php` from the old name.'
 assert "relocate-cue"        0 'Relocate `ibl5/classes/Foo/RelocatedBar.php` into the shared dir.'
+assert "arrow-rename-cue"    0 '`ibl5/classes/FreeAgency/FreeAgencyDemandCalculator.php` → `…/FreeAgencyMarketDemandCalculator.php` (4.8).'
 
 # Over-widening guard: "remove"/"removed" must NOT be read as a creation cue (word
 # boundary on the move verb). A removed file on a cue-less-of-creation line stays stale.


### PR DESCRIPTION
## Summary

- Extends `bin/check-plan-staleness` line 139's creation-cue alternation to recognise `**new**` (case-insensitive bold), `— NEW` (plain dash prefix), and `move`/`rename`/`relocate` verbs — fixing false-positive STALE skips that poison-pilled four valid plans in automouse (2026-06-27/28 run).
- Pins a word-boundary on the move verb so `remove`/`removed` (deletions) do **not** trigger the exemption — the poison-pill detection for genuinely missing files is preserved.
- Adds 6 paired regression rows to `bin/test-check-plan-staleness`: 5 FP-now-passes (new cues exit 0) + 1 over-widening guard (`remove` still exits 1).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.