### PR TITLE
fix(check-pr-collisions): drop prescriptive "Recommended merge order" wording

### DIFF
--- a/bin/check-pr-collisions
+++ b/bin/check-pr-collisions
@@ -124,7 +124,9 @@ warn_body() {
     local n="$1"
     printf '## Inter-PR Collision Check\n\n'
     printf '**Warning:** This PR edits files also edited by other open PRs.\n'
-    printf 'Merging in parallel may cause ratchet drift or rebase conflicts.\n\n'
+    printf 'Merging in parallel may cause ratchet drift or rebase conflicts.\n'
+    printf 'Coordinate before merging — pick the sequence by each PR'\''s readiness\n'
+    printf '(CI green, mergeable, not held), then rebase the rest after each merge.\n\n'
 
     for path in "${COLLISION_PATHS[@]}"; do
         if ! pr_touches "$n" "$path"; then
@@ -157,8 +159,8 @@ warn_body() {
         for p in "${all_prs[@]}"; do
             order_refs+="#${p}, "
         done
-        printf '**Recommended merge order:** %s\n' "${order_refs%, }"
-        printf '(Rebase remaining PRs after each merge.)\n\n'
+        printf '**All open PRs touching this file:** %s\n' "${order_refs%, }"
+        printf '_(Listed lowest-number-first — this is **not** a recommended merge order.)_\n\n'
     done
 
     printf '> **Advisory only — does not block merge.**\n'

--- a/bin/check-pr-collisions
+++ b/bin/check-pr-collisions
@@ -4,7 +4,7 @@
 # bin/check-pr-collisions — Advisory inter-PR collision detector.
 #
 # Groups open PRs that touch the same collision-prone file and emits
-# a markdown collision report / recommended merge order.
+# a markdown collision report / sibling PR listing.
 #
 # Modes:
 #   --pr <n>    Emit this PR's collision body to stdout (no posting)
@@ -35,7 +35,7 @@ usage() {
 Usage: bin/check-pr-collisions [--pr <n>] [--sweep] [--help|-h]
 
 Groups open PRs that edit the same collision-prone file and emits a collision
-report / recommended merge order.
+report / sibling PR listing.
 
 Options:
   --pr <n>     Emit collision body for PR <n> to stdout (no posting).

--- a/bin/test-check-pr-collisions
+++ b/bin/test-check-pr-collisions
@@ -4,7 +4,7 @@
 # bin/test-check-pr-collisions — regression harness for bin/check-pr-collisions.
 #
 # All GitHub calls are intercepted by a stub gh (via GH_CMD). No network required.
-# Pins: grouping, ascending merge order, draft exclusion, dir-prefix matching,
+# Pins: grouping, ascending PR-number listing, draft exclusion, dir-prefix matching,
 # benign self-clear path, empty-set sweep, and sticky-marker convergence.
 #
 # Run: bin/test-check-pr-collisions  (exit 0 = all pass, 1 = a case failed)
@@ -123,8 +123,10 @@ body11="$(pr_body 11)"
 assert_match "grouping-names-#10"  '#10' "$body11"
 assert_match "grouping-names-#12"  '#12' "$body11"
 
-# (b) Order: recommended merge order is ascending #10, #11, #12
-assert_match "order-ascending" '#10.*#11.*#12' "$body11"
+# (b) Listing: PRs are listed ascending #10, #11, #12 (lowest-first, not a merge order)
+assert_match "listing-ascending" '#10.*#11.*#12' "$body11"
+# (b cont) The list is explicitly NOT framed as a recommended merge order
+assert_absent "no-prescriptive-order" 'Recommended merge order' "$body11"
 
 # (c) Benign — collision-prone file but no sibling: #20 touches phpstan-baseline alone
 body20="$(pr_body 20)"


### PR DESCRIPTION
## Summary

- `bin/check-pr-collisions` labelled sibling PRs as "**Recommended merge order**" but was just listing them in ascending numeric order — implying a calculated sequencing that didn't exist
- Renamed to "**All open PRs touching this file:**" with an explicit `_(Listed lowest-number-first — this is **not** a recommended merge order.)_` disclaimer
- Added two lines of coordination guidance above the per-file blocks (pick sequence by readiness, then rebase)
- Updated test harness: renamed `order-ascending` case to `listing-ascending`, added `no-prescriptive-order` assertion that `"Recommended merge order"` is absent

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)