### PR TITLE
ci: PR fast-canary — cheap early conflict/semantic-breakage signal

### DIFF
--- a/.github/workflows/pr-canary.yml
+++ b/.github/workflows/pr-canary.yml
@@ -1,0 +1,88 @@
+name: PR Fast-Canary
+
+# Advisory early-signal: on each master push, trial-merge latest master into every
+# open PR head and run ONLY the cheap checks (PHPStan + default-group PHPUnit), skipping
+# the heavy E2E suite. Reports per-PR via a sticky comment. NOT a required check — the
+# merge queue owns the authoritative full-suite gate.
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '.claude/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/CODEOWNERS'
+      - 'LICENSE'
+      - '**/LICENSE'
+      - '.gitignore'
+      - '**/.gitignore'
+      - '.gitattributes'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-canary
+  cancel-in-progress: true
+
+jobs:
+  enumerate:
+    name: Enumerate open PRs
+    runs-on: ubuntu-latest
+    outputs:
+      prs: ${{ steps.list.outputs.prs }}
+      count: ${{ steps.list.outputs.count }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: List open PRs as a JSON array
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prs=$(gh pr list --base master --state open --json number --jq '[.[].number]')
+          echo "prs=$prs" >> "$GITHUB_OUTPUT"
+          echo "count=$(printf '%s' "$prs" | jq 'length')" >> "$GITHUB_OUTPUT"
+
+  canary:
+    name: Canary PR #${{ matrix.pr }}
+    needs: enumerate
+    if: needs.enumerate.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJSON(needs.enumerate.outputs.prs) }}
+    steps:
+      - name: Checkout master (full history)
+        uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: mbstring, intl, mysqli
+          coverage: none
+      - name: Cache vendor directory
+        uses: actions/cache@v6
+        with:
+          path: ibl5/vendor
+          key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-vendor-
+      - name: Create config.php
+        working-directory: ibl5
+        run: cp config.php.example config.php
+      - name: Install dependencies
+        working-directory: ibl5
+        run: composer install --no-progress --no-interaction
+      - name: Run fast-canary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bin/pr-canary-check --pr "${{ matrix.pr }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -606,6 +606,8 @@ jobs:
         run: bin/test-post-review-findings
       - name: bin/test-playwright-version
         run: bin/test-playwright-version
+      - name: bin/test-pr-canary-check
+        run: bin/test-pr-canary-check
 
   gate:
     name: Tests and Analysis

--- a/bin/pr-canary-check
+++ b/bin/pr-canary-check
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/pr-canary-check — Advisory per-PR fast-canary helper.
+#
+# For one PR number: trial-merges latest master into the PR head, runs
+# composer run analyse (PHPStan) + composer run test (default-group PHPUnit),
+# renders a pass/fail report body, and posts it as a create-or-update sticky
+# comment on the PR.
+#
+# Exit codes: 0 = ran (findings are advisory — never exits 1 on a finding);
+#             2 = usage error.
+# NOT a required check — advisory only, never blocks merge.
+
+set -euo pipefail
+
+GH_CMD="${GH_CMD:-gh}"
+STICKY_MARKER="<!-- pr-fast-canary -->"
+
+# Test seams — override in tests to inject stub commands without real git/composer.
+do_trial_merge() { ${CANARY_MERGE_CMD:-git merge --no-commit --no-ff FETCH_HEAD}; }
+do_analyse()     { ( cd "$REPO_ROOT/ibl5" && ${CANARY_ANALYSE_CMD:-composer run analyse}; ); }
+do_test()        { ( cd "$REPO_ROOT/ibl5" && ${CANARY_TEST_CMD:-composer run test}; ); }
+
+usage() {
+    cat <<'EOF'
+Usage: bin/pr-canary-check --pr <n> [--help|-h]
+
+Advisory per-PR fast-canary: trial-merge latest master into the PR head,
+run PHPStan + default-group PHPUnit, post a sticky comment on the PR.
+
+Options:
+  --pr <n>     PR number to canary-check (required).
+  --help, -h   Show this message.
+
+Environment (test seams):
+  GH_CMD              Override the gh command (default: "gh").
+  CANARY_MERGE_CMD    Override the trial-merge command.
+  CANARY_ANALYSE_CMD  Override the composer run analyse command.
+  CANARY_TEST_CMD     Override the composer run test command.
+EOF
+}
+
+PR_NUM=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pr requires a PR number" >&2
+                usage >&2
+                exit 2
+            fi
+            PR_NUM="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$PR_NUM" ]]; then
+    echo "Error: --pr <n> is required" >&2
+    usage >&2
+    exit 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Trial-merge: only fetch for real when the merge cmd is not injected
+merge=clean
+[ -z "${CANARY_MERGE_CMD:-}" ] && git fetch --no-tags origin "refs/pull/${PR_NUM}/head"
+if ! do_trial_merge >/tmp/canary-merge.log 2>&1; then
+    merge=conflict
+    git merge --abort || true
+fi
+
+# set -e-safe capture: run checks only when the merge was clean
+analyse=skipped
+test=skipped
+if [ "$merge" = clean ]; then
+    analyse=pass; if ! do_analyse >/tmp/canary-analyse.log 2>&1; then analyse=fail; fi
+    test=pass;    if ! do_test    >/tmp/canary-test.log    2>&1; then test=fail;    fi
+fi
+
+render_body() {
+    local merge_status analyse_status test_status overall
+
+    case "$merge" in
+        clean)    merge_status="clean" ;;
+        conflict) merge_status="CONFLICT" ;;
+        *)        merge_status="$merge" ;;
+    esac
+
+    case "$analyse" in
+        pass)    analyse_status="PASS" ;;
+        fail)    analyse_status="FAIL" ;;
+        skipped) analyse_status="skipped" ;;
+        *)       analyse_status="$analyse" ;;
+    esac
+
+    case "$test" in
+        pass)    test_status="PASS" ;;
+        fail)    test_status="FAIL" ;;
+        skipped) test_status="skipped" ;;
+        *)       test_status="$test" ;;
+    esac
+
+    if [ "$merge" = conflict ] || [ "$analyse" = fail ] || [ "$test" = fail ]; then
+        overall="FAIL"
+    else
+        overall="PASS"
+    fi
+
+    local run_link=""
+    if [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
+        run_link="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+    fi
+
+    printf '## PR Fast-Canary\n\n'
+    printf '**Merge:** %s\n\n' "$merge_status"
+    printf '**PHPStan (`composer run analyse`):** %s\n\n' "$analyse_status"
+    printf '**PHPUnit (`composer run test`):** %s\n\n' "$test_status"
+    printf '**Overall:** %s\n\n' "$overall"
+    if [[ -n "$run_link" ]]; then
+        printf '[Run log](%s)\n\n' "$run_link"
+    fi
+    printf '> **Advisory only — does not block merge.** The merge queue runs the authoritative full suite.\n\n'
+    printf '%s\n' "$STICKY_MARKER"
+}
+
+post_sticky() {
+    local n="$1"
+    local body="$2"
+    local tmpfile
+    tmpfile="$(mktemp)"
+
+    printf '%s\n' "$body" > "$tmpfile"
+
+    local existing_id
+    existing_id="$("$GH_CMD" api "repos/{owner}/{repo}/issues/$n/comments" --paginate \
+        --jq ".[] | select(.body | contains(\"$STICKY_MARKER\")) | .id" | head -1 || true)"
+
+    if [[ -n "$existing_id" ]]; then
+        "$GH_CMD" api --method PATCH "repos/{owner}/{repo}/issues/comments/$existing_id" \
+            -F body=@"$tmpfile" >/dev/null || true
+    else
+        "$GH_CMD" pr comment "$n" --body-file "$tmpfile" >/dev/null || true
+    fi
+
+    rm -f "$tmpfile"
+}
+
+body="$(render_body)"
+printf '%s\n' "$body"
+post_sticky "$PR_NUM" "$body"
+exit 0

--- a/bin/test-pr-canary-check
+++ b/bin/test-pr-canary-check
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-pr-canary-check — regression harness for bin/pr-canary-check.
+#
+# All GitHub calls are intercepted by a stub gh (via GH_CMD). No network,
+# no real git merge, no real PHP required. Proves every decision path of
+# the helper including all failure paths, set-e-safe capture, and sticky
+# comment create-vs-update routing.
+#
+# Run: bin/test-pr-canary-check  (exit 0 = all pass, exit 1 = a case failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GUARD="$SCRIPT_DIR/pr-canary-check"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" 2>/dev/null' EXIT
+
+FAILED=0
+
+pass()     { echo "ok: $1"; }
+failcase() { echo "FAIL: $1"; FAILED=1; }
+
+assert_match() {
+    if printf '%s' "$3" | grep -qE "$2"; then
+        pass "$1"
+    else
+        failcase "$1 — expected to match: $2"
+        printf '%s\n' "$3" | sed 's/^/    /'
+    fi
+}
+
+assert_absent() {
+    if printf '%s' "$3" | grep -qE "$2"; then
+        failcase "$1 — expected NOT to match: $2"
+        printf '%s\n' "$3" | sed 's/^/    /'
+    else
+        pass "$1"
+    fi
+}
+
+# --- Stub gh setup ---
+
+STUBBIN="$TMP/stubbin"
+GH_COMMENT_LOG="$TMP/comment.log"
+GH_PATCH_LOG="$TMP/patch.log"
+GH_API_LOG="$TMP/api.log"
+export GH_COMMENT_LOG GH_PATCH_LOG GH_API_LOG
+
+mkdir -p "$STUBBIN"
+
+cat > "$STUBBIN/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+cmd="$1 ${2:-}"
+shift 2 2>/dev/null || shift 1 2>/dev/null || true
+
+case "$cmd" in
+    "api --method")
+        # PATCH — log the full invocation for assertion, succeed silently
+        printf 'PATCH %s\n' "$@" >> "${GH_PATCH_LOG:-/dev/null}"
+        printf 'PATCH %s\n' "$@" >> "${GH_API_LOG:-/dev/null}"
+        exit 0
+        ;;
+    "api "*)
+        # GET comments — log the call, return existing id or nothing
+        printf 'GET %s\n' "$cmd" >> "${GH_API_LOG:-/dev/null}"
+        if [[ -n "${GH_RETURN_EXISTING_ID:-}" ]]; then
+            printf '%s\n' "$GH_RETURN_EXISTING_ID"
+        fi
+        ;;
+    "pr comment")
+        # Log body file content to GH_COMMENT_LOG
+        body_file=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --body-file) body_file="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        if [[ -n "$body_file" && -f "$body_file" ]]; then
+            cat "$body_file" >> "${GH_COMMENT_LOG:-/dev/null}"
+            printf '\n---END---\n' >> "${GH_COMMENT_LOG:-/dev/null}"
+        fi
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+
+chmod +x "$STUBBIN/gh"
+
+# Shorthand: run canary with stub gh and injected seams, capture stdout + exit code
+run_canary() {
+    # Usage: run_canary [extra env vars...] -- [args to pass to pr-canary-check]
+    local extra_env=()
+    while [[ "${1:-}" != "--" && $# -gt 0 ]]; do
+        extra_env+=("$1")
+        shift
+    done
+    [[ "${1:-}" == "--" ]] && shift
+    env GH_CMD="$STUBBIN/gh" "${extra_env[@]+"${extra_env[@]}"}" "$GUARD" "$@" 2>/dev/null
+}
+
+run_canary_rc() {
+    # Like run_canary but returns the exit code, discards output
+    local extra_env=()
+    while [[ "${1:-}" != "--" && $# -gt 0 ]]; do
+        extra_env+=("$1")
+        shift
+    done
+    [[ "${1:-}" == "--" ]] && shift
+    env GH_CMD="$STUBBIN/gh" "${extra_env[@]+"${extra_env[@]}"}" "$GUARD" "$@" >/dev/null 2>&1
+    return $?
+}
+
+# --- Row 1: Usage errors ---
+
+run_canary_rc -- --pr && failcase "row1-pr-missing-value-exits2" || {
+    rc=$?; [ "$rc" -eq 2 ] && pass "row1-pr-missing-value-exits2" || failcase "row1-pr-missing-value-exits2 (got exit $rc)"
+}
+
+run_canary_rc -- --unknown-flag && failcase "row1-unknown-flag-exits2" || {
+    rc=$?; [ "$rc" -eq 2 ] && pass "row1-unknown-flag-exits2" || failcase "row1-unknown-flag-exits2 (got exit $rc)"
+}
+
+run_canary_rc -- --help && pass "row1-help-exits0" || failcase "row1-help-exits0 (got exit $?)"
+
+# --- Row 2: Merge conflict ---
+
+body_conflict="$(run_canary "CANARY_MERGE_CMD=false" "CANARY_ANALYSE_CMD=false" "CANARY_TEST_CMD=false" -- --pr 42)"
+rc_conflict=0
+run_canary_rc "CANARY_MERGE_CMD=false" "CANARY_ANALYSE_CMD=false" "CANARY_TEST_CMD=false" -- --pr 42 || rc_conflict=$?
+
+assert_match "row2-conflict-body-says-CONFLICT" 'CONFLICT' "$body_conflict"
+assert_match "row2-conflict-phpstan-skipped"    'PHPStan.*skipped' "$body_conflict"
+assert_match "row2-conflict-phpunit-skipped"    'PHPUnit.*skipped' "$body_conflict"
+assert_match "row2-conflict-overall-FAIL"       'Overall.*FAIL' "$body_conflict"
+[ "$rc_conflict" -eq 0 ] && pass "row2-conflict-exits0" || failcase "row2-conflict-exits0 (got $rc_conflict)"
+
+# --- Row 3: PHPStan FAIL (set-e-safe capture) ---
+
+body_analyse_fail="$(run_canary "CANARY_MERGE_CMD=true" "CANARY_ANALYSE_CMD=false" "CANARY_TEST_CMD=true" -- --pr 42)"
+rc_analyse_fail=0
+run_canary_rc "CANARY_MERGE_CMD=true" "CANARY_ANALYSE_CMD=false" "CANARY_TEST_CMD=true" -- --pr 42 || rc_analyse_fail=$?
+
+assert_match "row3-phpstan-fail-body"   'PHPStan.*FAIL'  "$body_analyse_fail"
+assert_match "row3-phpstan-overall-fail" 'Overall.*FAIL' "$body_analyse_fail"
+[ "$rc_analyse_fail" -eq 0 ] && pass "row3-phpstan-fail-exits0" || failcase "row3-phpstan-fail-exits0 (got $rc_analyse_fail)"
+
+# --- Row 4: PHPUnit FAIL ---
+
+body_test_fail="$(run_canary "CANARY_MERGE_CMD=true" "CANARY_ANALYSE_CMD=true" "CANARY_TEST_CMD=false" -- --pr 42)"
+rc_test_fail=0
+run_canary_rc "CANARY_MERGE_CMD=true" "CANARY_ANALYSE_CMD=true" "CANARY_TEST_CMD=false" -- --pr 42 || rc_test_fail=$?
+
+assert_match "row4-phpunit-fail-body"    'PHPUnit.*FAIL'  "$body_test_fail"
+assert_match "row4-phpunit-overall-fail" 'Overall.*FAIL'  "$body_test_fail"
+[ "$rc_test_fail" -eq 0 ] && pass "row4-phpunit-fail-exits0" || failcase "row4-phpunit-fail-exits0 (got $rc_test_fail)"
+
+# --- Row 5: All pass ---
+
+body_pass="$(run_canary "CANARY_MERGE_CMD=true" "CANARY_ANALYSE_CMD=true" "CANARY_TEST_CMD=true" -- --pr 42)"
+
+assert_match "row5-all-pass-overall" 'Overall.*PASS' "$body_pass"
+assert_match "row5-merge-clean"      'Merge.*clean'  "$body_pass"
+assert_match "row5-phpstan-pass"     'PHPStan.*PASS' "$body_pass"
+assert_match "row5-phpunit-pass"     'PHPUnit.*PASS' "$body_pass"
+
+# --- Row 6: Disclaimer + marker in every rendered body ---
+
+assert_match "row6-disclaimer-conflict"      'Advisory only'           "$body_conflict"
+assert_match "row6-marker-conflict"          '<!-- pr-fast-canary -->' "$body_conflict"
+assert_match "row6-disclaimer-analyse-fail"  'Advisory only'           "$body_analyse_fail"
+assert_match "row6-marker-analyse-fail"      '<!-- pr-fast-canary -->' "$body_analyse_fail"
+assert_match "row6-disclaimer-test-fail"     'Advisory only'           "$body_test_fail"
+assert_match "row6-marker-test-fail"         '<!-- pr-fast-canary -->' "$body_test_fail"
+assert_match "row6-disclaimer-pass"          'Advisory only'           "$body_pass"
+assert_match "row6-marker-pass"              '<!-- pr-fast-canary -->' "$body_pass"
+
+# --- Row 7: Sticky create (no existing comment) ---
+
+rm -f "$GH_COMMENT_LOG" "$GH_PATCH_LOG"
+GH_RETURN_EXISTING_ID="" \
+    run_canary "CANARY_MERGE_CMD=true" "CANARY_ANALYSE_CMD=true" "CANARY_TEST_CMD=true" -- --pr 99 >/dev/null 2>&1 || true
+log_create="$(cat "$GH_COMMENT_LOG" 2>/dev/null || true)"
+assert_match "row7-create-has-marker"   '<!-- pr-fast-canary -->' "$log_create"
+patch_log_create="$(cat "$GH_PATCH_LOG" 2>/dev/null || true)"
+assert_absent "row7-create-no-patch"    'PATCH' "$patch_log_create"
+
+# --- Row 8: Sticky update (existing comment id) ---
+
+rm -f "$GH_COMMENT_LOG" "$GH_PATCH_LOG"
+GH_RETURN_EXISTING_ID="999" \
+    run_canary "CANARY_MERGE_CMD=true" "CANARY_ANALYSE_CMD=true" "CANARY_TEST_CMD=true" -- --pr 99 >/dev/null 2>&1 || true
+patch_log_update="$(cat "$GH_PATCH_LOG" 2>/dev/null || true)"
+comment_log_update="$(cat "$GH_COMMENT_LOG" 2>/dev/null || true)"
+assert_match "row8-update-issues-patch" 'PATCH.*issues/comments/999' "$patch_log_update"
+[ -z "$comment_log_update" ] && pass "row8-update-no-create" \
+    || failcase "row8-update-no-create (gh pr comment was called when PATCH path should have run)"
+
+# --- Row 9: No statuses or check-runs ever called ---
+
+rm -f "$GH_API_LOG"
+for seam_combo in \
+    "CANARY_MERGE_CMD=false" \
+    "CANARY_MERGE_CMD=true CANARY_ANALYSE_CMD=false CANARY_TEST_CMD=true" \
+    "CANARY_MERGE_CMD=true CANARY_ANALYSE_CMD=true CANARY_TEST_CMD=false" \
+    "CANARY_MERGE_CMD=true CANARY_ANALYSE_CMD=true CANARY_TEST_CMD=true"
+do
+    eval "env GH_CMD=\"$STUBBIN/gh\" $seam_combo \"$GUARD\" --pr 42 >/dev/null 2>&1" || true
+done
+api_log="$(cat "$GH_API_LOG" 2>/dev/null || true)"
+assert_absent "row9-api-no-statuses"   'statuses'   "$api_log"
+assert_absent "row9-api-no-check-runs" 'check-runs' "$api_log"
+grep_result="$(grep -cE 'statuses|check-runs' "$GUARD" 2>/dev/null || true)"
+[ "${grep_result:-0}" -eq 0 ] && pass "row9-grep-source-no-statuses-check-runs" \
+    || failcase "row9-grep-source-no-statuses-check-runs (found $grep_result matches)"
+
+# --- Results ---
+
+if [[ "$FAILED" -ne 0 ]]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
## Summary

Adds a cheap early-warning canary that trial-merges every open PR onto the latest master after each master push, runs only PHPStan + default-group PHPUnit (no E2E, no DB service), and posts a sticky per-PR comment with a pass/fail verdict.

**This is PR 1 of 3** in the merge-queue migration. PR2 adds the GitHub merge queue; PR3 retires `rebase-prs.yml`. This PR ships the advisory signal; it introduces no required check and cannot block any merge.

### Files changed
- `bin/pr-canary-check` — the testable per-PR helper (trial-merge + guarded analyse/test + sticky post)
- `bin/test-pr-canary-check` — stub-gh regression harness proving all 9 decision paths
- `.github/workflows/pr-canary.yml` — enumerate + matrix-canary workflow
- `.github/workflows/tests.yml` — wires `bin/test-pr-canary-check` into the `harness-tests` CI job

<!-- no-adr: advisory early-signal CI tooling; introduces no architectural constraint — the merge-queue architecture decision is recorded in the ADR shipped by the queue-plumbing PR (PR2) -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.