### PR TITLE
ci: plumb GitHub merge queue (workflow triggers + human-signoff merge_group verdict) + enablement runbook + ADR

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,7 @@
 name: E2E Tests
 
 on:
+  merge_group:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
@@ -41,7 +42,7 @@ jobs:
       # NOTE: a `labeled` event intentionally does NOT set src=true. Adding any
       # label used to force the full E2E suite (api-e2e/shards/mutators) to rerun.
       # Only the Visual Regression job should respond to a label — see `baseline` below.
-      src: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
+      src: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
       # True only for the `update-baselines` label. Gates the Visual Regression job
       # alone so applying that label reruns baseline regen without a CI storm.
       baseline: ${{ github.event.action == 'labeled' && github.event.label.name == 'update-baselines' }}

--- a/.github/workflows/human-signoff.yml
+++ b/.github/workflows/human-signoff.yml
@@ -21,13 +21,16 @@ on:
     # labeled/unlabeled re-run the gate so applying the label flips red→green;
     # edited re-runs when the title (the classifier input) changes.
     types: [opened, reopened, synchronize, edited, ready_for_review, labeled, unlabeled]
+  # On a merge_group, github.event.pull_request is null; the run step resolves
+  # every batched PR from the commit range instead (ADR-0072 / D2).
+  merge_group:
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: human-signoff-${{ github.event.pull_request.number }}
+  group: human-signoff-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -35,28 +38,29 @@ jobs:
     name: human-signoff
     runs-on: ubuntu-latest
     steps:
+      # Checkout is required so the run step can source the shared classifier lib.
+      # fetch-depth: 0 lets the merge_group branch run `git log base..head`.
+      - name: Checkout (for the shared classifier lib)
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Require human sign-off for feature PRs
         env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
           TITLE: ${{ github.event.pull_request.title }}
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
+          # shellcheck source=bin/lib/human-signoff-classifier.sh
+          source bin/lib/human-signoff-classifier.sh
 
-          # Classifier: conventional-commit feature PRs require sign-off. Matches
-          # feat:, feat(scope):, and the breaking-change feat!: / feat(scope)!:.
-          if ! printf '%s' "$TITLE" | grep -qiE '^feat(\([^)]*\))?!?:'; then
-            echo "Title is not a feat: PR — human sign-off not required."
-            echo "  title: $TITLE"
-            exit 0
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            # Defense-in-depth: every batched PR re-checked (ADR-0072 / D3).
+            hs_eval_merge_group "$MG_BASE_SHA" "$MG_HEAD_SHA"
+          else
+            # Entry gate (unchanged behaviour) — blocks a feat: PR from the queue.
+            hs_eval_pull_request "$TITLE" "$LABELS"
           fi
-
-          # A human grants sign-off by applying the 'human-approved' label in the
-          # GitHub UI after manual inspection. (Comma-wrap both sides so the grep
-          # matches whole label names, never a substring.)
-          if printf '%s' ",$LABELS," | grep -q ',human-approved,'; then
-            echo "'human-approved' label present — human sign-off granted."
-            exit 0
-          fi
-
-          echo "::error title=Human sign-off required::This feature PR must be manually inspected by a maintainer, who then applies the 'human-approved' label. Auto-merge cannot satisfy this gate."
-          exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches: [ master, develop ]
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
 
 permissions:
   contents: read
@@ -26,9 +27,9 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      src: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
-      shell: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.shell == 'true' }}
-      ibl6: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.ibl6 == 'true' }}
+      src: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
+      shell: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.shell == 'true' }}
+      ibl6: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.ibl6 == 'true' }}
     steps:
       - uses: dorny/paths-filter@v4
         id: filter
@@ -58,6 +59,9 @@ jobs:
               # so a command-only edit must run the harness job too.
               - '.claude/commands/pr-review.md'
               - '.claude/commands/security-audit.md'
+              # bin/test-human-signoff-classifier guards the classifier lib that
+              # human-signoff.yml sources, so a workflow-only edit must run it too.
+              - '.github/workflows/human-signoff.yml'
             ibl6:
               - 'IBL6/**'
               - '.github/workflows/tests.yml'
@@ -541,6 +545,8 @@ jobs:
         run: bin/test-postplan-arm-conditions
       - name: bin/test-post-review-findings
         run: bin/test-post-review-findings
+      - name: bin/test-human-signoff-classifier
+        run: bin/test-human-signoff-classifier
       - name: bin/test-playwright-version
         run: bin/test-playwright-version
       - name: bin/test-pr-canary-check

--- a/bin/lib/human-signoff-classifier.sh
+++ b/bin/lib/human-signoff-classifier.sh
@@ -1,0 +1,96 @@
+# shellcheck shell=bash
+#
+# bin/lib/human-signoff-classifier.sh — single source of truth for the
+# .github/workflows/human-signoff.yml feature-PR sign-off classifier (ADR-0062),
+# sourced by BOTH the workflow (pull_request + merge_group branches) and the
+# regression harness bin/test-human-signoff-classifier so the logic cannot drift.
+#
+# Usage: source "$(dirname "$0")/lib/human-signoff-classifier.sh"
+# This file is SOURCED, not executed: no `set -euo pipefail` at file scope.
+# It IS, however, sourced INTO a `set -euo pipefail` workflow step, so every
+# function must be strict-mode safe (see hs_pr_numbers_in_range / ADR-0072 D3).
+#
+# Test seam: GH_CMD (default `gh`) and GIT_CMD (default `git`) are single-token
+# commands; the harness points GH_CMD at a shim and runs GIT_CMD in a throwaway
+# repo (by cd-ing into it, so the default `git` operates there).
+
+GH_CMD="${GH_CMD:-gh}"
+GIT_CMD="${GIT_CMD:-git}"
+
+# hs_is_feat_title <title> — 0 if the title is a conventional-commit feature
+# (feat:, feat(scope):, feat!:, feat(scope)!:), 1 otherwise. Mirrors the grep in
+# /post-plan Phase 6.5 condition (8) and pr-armable.sh pr_feat_hold.
+hs_is_feat_title() {
+    printf '%s' "$1" | grep -qiE '^feat(\([^)]*\))?!?:'
+}
+
+# hs_pr_cleared <title> <labels_csv> — 0 if the PR may merge (non-feat, OR feat
+# with the human-approved label), 1 if it is a feat: PR still awaiting sign-off.
+# Comma-wrap both sides so the label match is whole-name, never a substring.
+hs_pr_cleared() {
+    local title="$1" labels="$2"
+    if ! hs_is_feat_title "$title"; then
+        return 0
+    fi
+    if printf '%s' ",$labels," | grep -q ',human-approved,'; then
+        return 0
+    fi
+    return 1
+}
+
+# hs_pr_numbers_in_range <base_sha> <head_sha> — echo, one per line (sorted,
+# deduped), the PR numbers parsed from the squash/merge commit subjects GitHub
+# writes on the merge-group temp branch (each carries a trailing "(#N)").
+#
+# Strict-mode safe (ADR-0072 D3): `git log` is captured SEPARATELY with `|| return
+# 1` so a real failure (bad SHA) surfaces fail-closed; the PARSE-ONLY pipeline is
+# `|| true`-terminated so a no-match is empty-output-and-success, NOT a `set -e`
+# abort. Do NOT collapse these into one piped assignment — that re-introduces the
+# fail-closed brick-the-queue bug.
+hs_pr_numbers_in_range() {
+    local subjects
+    subjects="$("$GIT_CMD" log --format='%s' "${1}..${2}")" || return 1
+    printf '%s\n' "$subjects" \
+        | grep -oE '\(#[0-9]+\)' \
+        | grep -oE '[0-9]+' \
+        | sort -un \
+        || true
+}
+
+# hs_eval_pull_request <title> <labels_csv> — the ENTRY gate (behaviour
+# unchanged from the original inline classifier). 0 = cleared, 1 = needs sign-off.
+hs_eval_pull_request() {
+    if hs_pr_cleared "$1" "$2"; then
+        echo "Entry gate: PR cleared (title: $1)"
+        return 0
+    fi
+    echo "::error title=Human sign-off required::This feature PR must be manually inspected by a maintainer, who then applies the 'human-approved' label. Auto-merge cannot satisfy this gate."
+    return 1
+}
+
+# hs_eval_merge_group <base_sha> <head_sha> — defense-in-depth re-check on the
+# merge group. Every batched PR is classified; any feat: PR without the
+# human-approved label fails the whole group (the merge stalls). Entry already
+# enforced this per-PR, so an EMPTY enumeration is a vacuous PASS (warn, do not
+# brick the queue) — ADR-0072 D3.
+hs_eval_merge_group() {
+    local prs n title labels fail=0 count=0
+    prs="$(hs_pr_numbers_in_range "$1" "$2")"
+    if [ -z "$prs" ]; then
+        echo "::warning::merge_group: no PR numbers parsed from ${1}..${2}; entry gate already enforced sign-off — passing (defense-in-depth no-op)."
+        return 0
+    fi
+    for n in $prs; do
+        count=$((count + 1))
+        title="$("$GH_CMD" pr view "$n" --json title --jq .title)"
+        labels="$("$GH_CMD" pr view "$n" --json labels --jq '[.labels[].name] | join(",")')"
+        if hs_pr_cleared "$title" "$labels"; then
+            echo "merge_group: PR #$n cleared (title: $title)"
+        else
+            echo "::error title=Human sign-off required::merge_group PR #$n is a feat: PR without the 'human-approved' label (title: $title)."
+            fail=1
+        fi
+    done
+    echo "merge_group: evaluated $count PR(s)."
+    return $fail
+}

--- a/bin/test-human-signoff-classifier
+++ b/bin/test-human-signoff-classifier
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-human-signoff-classifier — regression guard for
+# bin/lib/human-signoff-classifier.sh, which BOTH .github/workflows/human-signoff.yml
+# and this test source. Every classifier/resolver case runs in an ISOLATED
+# `bash -c` under the SAME `set -euo pipefail` the workflow run step uses, so the
+# test exercises production shell semantics (mirrors bin/test-postplan-arm-conditions'
+# isolated-block fidelity). The merge_group path uses a gh shim + a throwaway git
+# repo whose commit subjects carry "(#N)".
+#
+# Run: bin/test-human-signoff-classifier  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$REPO_ROOT/bin/lib/human-signoff-classifier.sh"
+
+FAILED=0
+LAST_OUT=""
+expect() { # name expected_rc actual_rc
+    if [ "$2" -eq "$3" ]; then
+        echo "ok: $1"
+    else
+        echo "FAIL: $1 — expected rc=$2 got rc=$3; output: $LAST_OUT"
+        FAILED=1
+    fi
+}
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+SHIMD="$TMP/shim"; mkdir -p "$SHIMD"
+cat > "$SHIMD/gh" <<'SHIM'
+#!/usr/bin/env bash
+# Emulates: gh pr view <n> --json title --jq .title  /  --json labels --jq '...'
+n="$3"; field=""
+for ((i=1; i<=$#; i++)); do
+    if [ "${!i}" = "--json" ]; then j=$((i+1)); field="${!j}"; fi
+done
+case "$n:$field" in
+    101:title)  echo "feat: unsigned feature" ;;
+    101:labels) echo "" ;;
+    102:title)  echo "feat: signed feature" ;;
+    102:labels) echo "human-approved" ;;
+    103:title)  echo "fix: maintenance" ;;
+    103:labels) echo "" ;;
+esac
+SHIM
+chmod +x "$SHIMD/gh"
+
+# run_pr <title> <labels> — eval the entry gate under production strict mode.
+# Args are passed positionally into bash -c (no interpolation into the script
+# body) so titles cannot inject shell.
+run_pr() {
+    LAST_OUT=$(bash -c "set -euo pipefail; source '$LIB'; hs_eval_pull_request \"\$1\" \"\$2\"" _ "$1" "$2" 2>&1)
+    return $?
+}
+
+# run_mg <repo> <base> <head> — eval the merge_group resolver under production
+# strict mode, with cwd=repo (GIT_CMD default `git`) and GH_CMD=the shim.
+run_mg() {
+    LAST_OUT=$(cd "$1" && GH_CMD="$SHIMD/gh" \
+        bash -c "set -euo pipefail; source '$LIB'; hs_eval_merge_group \"\$1\" \"\$2\"" _ "$2" "$3" 2>&1)
+    return $?
+}
+
+build_repo() { # subjects...  -> sets REPO BASE HEAD
+    REPO="$TMP/repo.$RANDOM.$RANDOM"; mkdir -p "$REPO"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@t
+    git -C "$REPO" config user.name t
+    git -C "$REPO" commit -q --allow-empty -m base
+    BASE=$(git -C "$REPO" rev-parse HEAD)
+    for s in "$@"; do git -C "$REPO" commit -q --allow-empty -m "$s"; done
+    HEAD=$(git -C "$REPO" rev-parse HEAD)
+}
+
+# ---- pull_request entry gate ----
+run_pr "feat: shiny new page" "";               expect "feat: no label -> FAIL" 1 "$?"
+run_pr "feat: shiny new page" "human-approved";  expect "feat: + human-approved -> PASS" 0 "$?"
+run_pr "feat(ui): scoped" "";                    expect "feat(scope): no label -> FAIL" 1 "$?"
+run_pr "feat!: breaking" "";                     expect "feat!: no label -> FAIL" 1 "$?"
+run_pr "fix: a bug" "";                          expect "fix: -> PASS" 0 "$?"
+run_pr "ci: plumb merge queue" "";               expect "ci: -> PASS" 0 "$?"
+run_pr "feat: x" "not-human-approved-yet";       expect "feat: + lookalike label -> FAIL" 1 "$?"
+
+# ---- merge_group resolver (production strict mode) ----
+build_repo "feat: signed feature (#102)" "fix: maintenance (#103)" "feat: unsigned feature (#101)"
+run_mg "$REPO" "$BASE" "$HEAD"; expect "merge_group multi-PR with one unlabeled feat: -> FAIL" 1 "$?"
+
+build_repo "feat: signed feature (#102)" "fix: maintenance (#103)"
+run_mg "$REPO" "$BASE" "$HEAD"; expect "merge_group all-clear group -> PASS" 0 "$?"
+
+build_repo "feat: unsigned feature (#101)"
+run_mg "$REPO" "$BASE" "$HEAD"; expect "merge_group single unlabeled feat: -> FAIL" 1 "$?"
+
+# D3 DISCRIMINATOR: empty enumeration MUST be a vacuous PASS under strict mode,
+# NOT a stall. Fails if hs_pr_numbers_in_range lets grep-no-match/pipefail bubble
+# up under `set -euo pipefail`.
+build_repo "raw commit with no PR number"
+run_mg "$REPO" "$BASE" "$HEAD"; expect "merge_group no parsable PRs -> PASS (D3 vacuous no-op)" 0 "$?"
+
+# parser unit check (also under strict mode)
+build_repo "feat: a (#102)" "fix: b (#103)" "chore: c (#103)"
+nums=$(cd "$REPO" && bash -c "set -euo pipefail; source '$LIB'; hs_pr_numbers_in_range \"\$1\" \"\$2\"" _ "$BASE" "$HEAD" | tr '\n' ',')
+if [ "$nums" = "102,103," ]; then echo "ok: hs_pr_numbers_in_range dedupes+sorts"; else echo "FAIL: parser got '$nums'"; FAILED=1; fi
+
+if [ "$FAILED" -eq 0 ]; then
+    echo "All human-signoff classifier checks passed."
+else
+    echo "Some human-signoff classifier checks FAILED."
+fi
+exit "$FAILED"

--- a/ibl5/docs/decisions/0072-adopt-github-merge-queue.md
+++ b/ibl5/docs/decisions/0072-adopt-github-merge-queue.md
@@ -1,0 +1,45 @@
+---
+description: Adopt GitHub native merge queue on master; required checks gate PR entry and the merge group; human-signoff preserved at entry and re-checked on merge_group; eager rebase retired in a follow-up.
+last_verified: 2026-06-28
+---
+
+# ADR-0072: Adopt GitHub native merge queue
+
+**Status:** Accepted
+**Date:** 2026-06-28
+**Deciders:** a-jay85
+
+## Context
+
+`.github/workflows/rebase-prs.yml` eagerly rebases every open PR on each `master` push, causing CI storms and serialized human re-merges whenever several PRs are in flight. GitHub's native merge queue instead does just-in-time rebase and re-runs the required checks **at merge time** on a temporary branch (base + PRs ahead + this PR), batching merges and validating the exact tree that will land. The PR-1 fast-canary already supplies cheap early conflict/semantic-breakage signal, so the queue's heavier merge-time validation is not the only feedback a contributor sees.
+
+## Decision
+
+Adopt the merge queue on `master`. The three required contexts (`Tests and Analysis`, `E2E Tests`, `human-signoff`) gate **both** PR entry **and** the `merge_group`; each required workflow triggers on `pull_request` **and** `merge_group` (non-required workflows are excluded to avoid needless merge-group runs). The heavy suites **run fully** on `merge_group` — skip-as-pass is rejected because GitHub's handling of a skipped required check on the merge group is undocumented/inconsistent. `human-signoff` is preserved **at entry** (a red PR cannot be added to the queue) and **re-checked** on `merge_group` per-PR via `bin/lib/human-signoff-classifier.sh` (sourced by the workflow, regression-guarded by `bin/test-human-signoff-classifier`), so the ADR-0062 backstop stays intact with zero security regression. Enablement is a settings change performed via `ibl5/docs/runbooks/merge-queue-enablement.md` **after** this PR merges (the workflow edits are inert while the queue is off). `.github/workflows/rebase-prs.yml` is retired in a follow-up PR once the queue is proven live.
+
+## Alternatives Considered
+
+- **Keep eager rebase-all (`rebase-prs.yml`)** — rebase every open PR on each master push. Rejected because: CI waste + serialized human re-merges, the exact pain this ADR removes.
+- **Skip-as-pass on `merge_group`** — let required checks report skipped/neutral on the merge group. Rejected because: GitHub's skipped-required-check handling on the merge group is undocumented/inconsistent, so the suites must run fully.
+- **Enable the queue and retire `rebase-prs.yml` in one PR** — Rejected because: rollback needs `rebase-prs.yml` as the fallback until the queue is proven, so it is retired only after live confirmation (D5).
+- **`head_ref` / commit-SHA enumeration for the merge_group verdict** — Rejected because: `head_ref` names only the last batched PR and the queue rebases PR commits to new SHAs, so both miss PRs; the verdict instead parses `(#N)` from the merge-group commit subjects (D2).
+- **Fail-closed on an empty merge_group enumeration** — Rejected because: a wrong `(#N)` format assumption would stall every merge; entry remains the authoritative gate, so an empty parse is a vacuous pass (D3), with the runbook turning the assumption into a checked one.
+
+## Consequences
+
+- Positive: no eager-rebase CI storms; just-in-time rebase only at merge time; batched merges.
+- Positive: the human-signoff floor is preserved at entry and re-checked on the merge group — zero security regression versus the current required-check floor.
+- Negative: added merge-time validation latency, and a flaky required check can stall the queue (mitigated by the PR-1 canary for early signal and the rollback runbook).
+- Negative: the empty-enumeration vacuous-pass (D3) trades a narrow mid-queue label-removal window for not bricking the queue — `ibl5/docs/runbooks/merge-queue-enablement.md` Step 3 converts the `(#N)` assumption into a checked one.
+- Negative: the queue/required-check settings live outside the repo (drift risk); the runbook is the source of truth for that configuration.
+
+## References
+
+- `.github/workflows/human-signoff.yml` — entry + merge_group sign-off gate, sources the classifier lib.
+- `bin/lib/human-signoff-classifier.sh` — shared sourced classifier + merge-group PR resolver.
+- `bin/test-human-signoff-classifier` — regression harness exercising both resolution paths under production `set -euo pipefail`.
+- `.github/workflows/tests.yml` — `merge_group` trigger + dorny outputs forced true + the new harness step.
+- `.github/workflows/e2e-tests.yml` — `merge_group` trigger + `src` forced true.
+- `ibl5/docs/runbooks/merge-queue-enablement.md` — operator enable/verify/rollback sequence.
+- `.github/workflows/rebase-prs.yml` — eager-rebase fallback, retired in the follow-up PR after live queue confirmation.
+- Relates to (does not supersede) `ibl5/docs/decisions/0062-human-signoff-gate-for-feature-prs.md` and `ibl5/docs/decisions/0067-unified-deployment-funnel.md`.

--- a/ibl5/docs/decisions/README.md
+++ b/ibl5/docs/decisions/README.md
@@ -1,6 +1,6 @@
 ---
 description: Index of IBL5 Architecture Decision Records (ADRs). Source of truth for every load-bearing decision and its rationale.
-last_verified: 2026-06-18
+last_verified: 2026-06-28
 ---
 
 # IBL5 Architecture Decision Records
@@ -26,6 +26,7 @@ Every load-bearing decision in IBL5 is captured here as a numbered ADR so that f
 | [0016](0016-remove-duckdb-analytics.md) | Remove DuckDB analytics layer | Accepted | JSB source decompiled; DuckDB OLAP layer and write-back tables removed. |
 | [0017](0017-dependabot-full-ci-and-auto-merge.md) | Dependabot full CI and auto-merge | Accepted | Force all CI checks on Dependabot PRs; auto-squash-merge on pass. |
 | [0023](0023-deploy-rehearsal-pre-flight-gate.md) | Deploy rehearsal pre-flight gate | Accepted | Reusable workflow dry-runs `composer --no-dev` + migrate + validate-schema against disposable MariaDB before prod deploy. |
+| [0072](0072-adopt-github-merge-queue.md) | Adopt GitHub native merge queue | Accepted | Merge queue on `master`; required checks gate PR entry + the merge group; human-signoff preserved at entry and re-checked on `merge_group`; eager rebase retired in a follow-up. |
 
 ## When an ADR is Required
 

--- a/ibl5/docs/runbooks/merge-queue-enablement.md
+++ b/ibl5/docs/runbooks/merge-queue-enablement.md
@@ -1,0 +1,134 @@
+---
+description: Operator runbook to enable, verify, and roll back the GitHub native merge queue on master (ADR-0072) — run after the plumbing PR merges, before the rebase-prs.yml retirement PR.
+last_verified: 2026-06-28
+---
+
+# Merge-queue enablement runbook
+
+Turns the GitHub native merge queue **on** for `master` (ADR-0072). The workflow
+plumbing already merged (the three required workflows trigger on `merge_group`);
+enabling the queue itself is a repo-settings change, performed here.
+
+## When to run
+
+- **After** the plumbing PR (this PR, "PR 2 of 3") merges to `master`.
+- **Before** PR 3 (which retires `.github/workflows/rebase-prs.yml`).
+- Requires repo-admin on `a-jay85/IBL5`. Confirm `gh auth status` shows admin scope.
+
+## Why ordering matters (ADR-0072 D5)
+
+The workflow edits are **inert while the queue is off** (`merge_group` triggers
+never fire), so the plumbing PR merged harmlessly under the existing known-good
+required-check floor. Turning the queue ON is the settings change below.
+`.github/workflows/rebase-prs.yml` still exists as the rollback fallback until
+PR 3 merges — **do not merge PR 3 until the queue is proven** (Step 3). A clean
+rollback at this stage = delete the ruleset, and eager rebase is still present.
+
+## Step 1 — turn off `strict` ("require branches up to date"), superseded by the queue (D6)
+
+The queue does just-in-time rebase, so the per-PR `strict` toggle is redundant.
+Record the current state, then PATCH `strict:false`:
+
+```bash
+REPO=a-jay85/IBL5
+gh api repos/$REPO/branches/master/protection/required_status_checks --jq '{strict, checks}'   # record current
+gh api --method PATCH repos/$REPO/branches/master/protection/required_status_checks --input - <<'JSON'
+{ "strict": false }
+JSON
+```
+
+## Step 2 — enable the merge queue via a ruleset
+
+The `merge_queue` rule is only available through rulesets, not classic branch
+protection. The three required contexts (`Tests and Analysis`, `E2E Tests`,
+`human-signoff`) already live in classic branch protection and the queue gates
+the merge group on the branch's required checks, so they are **not** duplicated
+here:
+
+```bash
+REPO=a-jay85/IBL5
+gh api --method POST repos/$REPO/rulesets --input - <<'JSON'
+{
+  "name": "master merge queue",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/heads/master"], "exclude": [] } },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "SQUASH",
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 5,
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 5,
+        "min_entries_to_merge_wait_minutes": 5,
+        "check_response_timeout_minutes": 60
+      }
+    }
+  ]
+}
+JSON
+```
+
+Confirm the ruleset is active:
+
+```bash
+gh api repos/$REPO/rulesets --jq '.[] | select(.name=="master merge queue") | {id, enforcement}'
+```
+
+If a future API version rejects this shape, the UI fallback is **Settings →
+Rules → New branch ruleset**, target `master`, add the **Merge queue** rule with
+the same parameters; the required-status-checks list stays as the existing three
+contexts.
+
+## Step 3 — verify on the live repo
+
+```bash
+# Open a trivial no-op PR (e.g. a whitespace/docs change), let its required checks pass, then:
+gh pr merge <N> --squash --auto
+gh pr view <N> --json state,mergeStateStatus,autoMergeRequest    # expect it to enter the queue
+gh run list --event merge_group --limit 5                        # the 3 required workflows re-run on the merge_group
+gh pr view <N> --json state                                      # expect MERGED once the merge_group goes green
+```
+
+**Assert the merge_group human-signoff actually enumerated the PR** (turns the
+`(#N)` parse assumption into a checked one — ADR-0072 D3): open the
+`human-signoff` job's `merge_group` run log and confirm it shows
+`merge_group: evaluated 1 PR(s)`, **not** the empty-enumeration
+`::warning:: no PR numbers parsed`. If you see the warning, the `(#N)` parse is
+wrong for this repo's merge method — fix `hs_pr_numbers_in_range` in
+`bin/lib/human-signoff-classifier.sh` before relying on the re-check (entry still
+protects in the meantime).
+
+Also confirm an **unlabeled `feat:` test PR cannot enter the queue** — its
+`human-signoff` is red at entry, so the queue button is unavailable until the
+`human-approved` label is applied.
+
+## Step 4 — only now, merge PR 3
+
+Retire `.github/workflows/rebase-prs.yml` (PR 3). Until then leave it in place.
+
+## Rollback
+
+```bash
+REPO=a-jay85/IBL5
+RULESET_ID=$(gh api repos/$REPO/rulesets --jq '.[] | select(.name=="master merge queue") | .id')
+gh api --method DELETE repos/$REPO/rulesets/$RULESET_ID            # disables the merge queue
+# (optional) restore strict if you want "require up to date" back:
+gh api --method PATCH repos/$REPO/branches/master/protection/required_status_checks --input - <<'JSON'
+{ "strict": true }
+JSON
+```
+
+**Rollback note:** disabling the queue does **not** restore eager rebase — that
+lives in `.github/workflows/rebase-prs.yml`, retired only in PR 3. Because PR 3
+has not merged at runbook time, `rebase-prs.yml` **still exists** and resumes as
+the fallback the moment the queue is off. This is exactly **why PR 3 is sequenced
+after queue confirmation**: a clean rollback = delete the ruleset and the old
+eager-rebase path is still there. (To roll back *after* PR 3 merges, revert PR 3.)
+
+## "Require branches up to date" note
+
+Enabling the merge queue supersedes the per-PR `strict` toggle (the queue does
+just-in-time rebase); Step 1 turns it off.


### PR DESCRIPTION
<!-- no-adr: the genuinely-new tool scripts (bin/lib/human-signoff-classifier.sh + bin/test-human-signoff-classifier) implement the decision recorded in ADR-0072 shipped in THIS PR, so no separate ADR is needed; the other gate-8 flags are false positives — .github/workflows/human-signoff.yml is EDITED not added, and bin/pr-triage + bin/test-postplan-arm-conditions are pre-existing scripts only REFERENCED as patterns -->

Makes GitHub native merge queue **safe to enable** on `master` by wiring the workflow side. Changes **no application code** — only the three required workflows, one new shared shell lib + its harness, one ADR, one runbook doc. All edits are inert while the queue is off (`merge_group` triggers never fire), so this PR merges harmlessly under the current known-good required-check floor; the queue is turned on afterward by the runbook.

**What changes:**
- `.github/workflows/tests.yml`, `e2e-tests.yml`, `human-signoff.yml` — add `on: merge_group:` + force dorny outputs true on merge_group so the heavy jobs run fully (not skip-as-pass)
- `bin/lib/human-signoff-classifier.sh` — sourced lib extracted from `human-signoff.yml`; handles both `pull_request` and `merge_group` events; enumerates every PR in a batched group via `(#N)` subject parsing; fails if any unlabeled `feat:` is present
- `bin/test-human-signoff-classifier` — harness wired into `tests.yml` harness-tests job; exercises all classifier paths under `set -euo pipefail`
- `ibl5/docs/decisions/0072-adopt-github-merge-queue.md` — ADR recording the decision
- `ibl5/docs/runbooks/merge-queue-enablement.md` — exact `gh api` enable/verify/rollback sequence for the human operator
- `ibl5/docs/decisions/README.md` — index row for ADR-0072

## After this PR merges (manual, see runbook)

Full procedure: `ibl5/docs/runbooks/merge-queue-enablement.md`

1. Turn off `strict` ("require branches up to date") — superseded by the queue
2. Create the merge-queue ruleset (the `gh api` call is in the runbook)
3. Verify: open a trivial PR → `gh pr merge --auto` → confirm it queues → confirm `merge_group` CI runs appear → confirm `human-signoff` log shows `evaluated N PR(s)` (not the empty `::warning::`)
4. **Only then, merge PR 3** (retire `rebase-prs.yml`). Until then `rebase-prs.yml` still exists as the rollback fallback.

Rollback: delete the merge-queue ruleset → queue off → `rebase-prs.yml` resumes as eager-rebase fallback (PR 3 has not merged yet).

## Automouse Hold Justification

`auto_merge: false` — **intrinsic self-gating / bootstrap hazard.** This PR rewrites the merge-gate machinery itself (required-check triggers, the `human-signoff` verdict, the branch-protection model). Arming auto-merge would let the just-rewritten gate machinery gate its own change — no self-run check can be trusted when the thing under change *is* the verifier. The queue's real behaviour (entry-gating, merge_group re-runs, JIT rebase) is only observable **after** the queue is enabled on the live repo via the runbook, which happens **after** a human merges this PR under the old, known-good required-check floor. The classifier logic is machine-verified (harness + CI shell job) but queue-enablement is a live-settings step by design.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.