### PR TITLE
chore: add BanSqlStringConcatenationRule + test + baseline (28 safe builder-result sites baselined)

### DIFF
--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -4,6 +4,7 @@
         "ibl.directHeader": 1,
         "ibl.directTime": 13,
         "ibl.hardcodedEnvString": 8,
+        "ibl.sqlStringConcatenation": 10,
         "ibl.sqlStringInterpolation": 31
     },
     "phpstan-tests-baseline.neon": {

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -7,6 +7,12 @@ parameters:
 			path: classes/Api/Controller/HealthController.php
 
 		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 2
+			path: classes/Api/Repository/ApiGameRepository.php
+
+		-
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringInterpolation
 			count: 2
@@ -109,6 +115,12 @@ parameters:
 			path: classes/Extension/ExtensionService.php
 
 		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 3
+			path: classes/FranchiseRecordBook/FranchiseRecordBookRepository.php
+
+		-
 			rawMessage: 'Direct now-returning time call is banned outside the Clock seam. Inject Clock\ClockInterface (constructor for instance classes; settable static clock with factory fallback for static classes) and call $clock->now(). Pass an explicit timestamp to date()/strtotime() for deterministic formatting.'
 			identifier: ibl.directTime
 			count: 1
@@ -157,6 +169,12 @@ parameters:
 			path: classes/JsbParser/PlayerIdResolver.php
 
 		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 1
+			path: classes/LastSimRecap/LastSimRecapRepository.php
+
+		-
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringInterpolation
 			count: 1
@@ -173,6 +191,12 @@ parameters:
 			identifier: ibl.directTime
 			count: 1
 			path: classes/League/LeagueContext.php
+
+		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 1
+			path: classes/LeagueSchedule/LeagueScheduleRepository.php
 
 		-
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
@@ -265,6 +289,12 @@ parameters:
 			path: classes/PlayerDatabase/PlayerDatabaseRepository.php
 
 		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 3
+			path: classes/PlrParser/PlrBoxScoreRepository.php
+
+		-
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringInterpolation
 			count: 1
@@ -313,6 +343,12 @@ parameters:
 			path: classes/SeasonLeaderboards/SeasonLeaderboardsRepository.php
 
 		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 4
+			path: classes/Standings/StandingsRepository.php
+
+		-
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringInterpolation
 			count: 10
@@ -323,6 +359,12 @@ parameters:
 			identifier: ibl.sqlStringInterpolation
 			count: 2
 			path: classes/Statistics/TeamStatsCalculator.php
+
+		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 3
+			path: classes/Team/SplitStatsRepository.php
 
 		-
 			rawMessage: 'Table-qualified column ''ibl_standings.league_record'' must be wrapped in backticks (`ibl_standings`.`league_record`) for PHPStan rename safety.'
@@ -349,10 +391,28 @@ parameters:
 			path: classes/Team/Team.php
 
 		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 2
+			path: classes/Team/TeamQueryRepository.php
+
+		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 8
+			path: classes/TeamOffDefStats/TeamOffDefStatsRepository.php
+
+		-
 			rawMessage: 'SQL string uses variable interpolation. Splicing a variable into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringInterpolation
 			count: 2
 			path: classes/TeamOffDefStats/TeamOffDefStatsRepository.php
+
+		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 1
+			path: classes/TeamSchedule/TeamScheduleRepository.php
 
 		-
 			rawMessage: 'Direct now-returning time call is banned outside the Clock seam. Inject Clock\ClockInterface (constructor for instance classes; settable static clock with factory fallback for static classes) and call $clock->now(). Pass an explicit timestamp to date()/strtotime() for deterministic formatting.'

--- a/ibl5/phpstan-rules/BanSqlStringConcatenationRule.php
+++ b/ibl5/phpstan-rules/BanSqlStringConcatenationRule.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Type;
+
+/**
+ * Bans `.`-concatenation of non-constant values into SQL string literals.
+ *
+ * This rule is the direct sibling of BanSqlStringInterpolationRule, which bans
+ * `"...$var..."` interpolation. That rule explicitly excludes `.`-concatenation
+ * in its own docblock — this rule closes that gap.
+ *
+ * Type-aware predicate: an operand is injection-inert (not flagged) iff PHPStan
+ * can prove its type is int, float, or a constant string. Everything else —
+ * general `string`, `mixed`, nullable, `int|string` union, a string-returning
+ * method call — is flagged as a risk.
+ *
+ * Chain-nesting / per-`->right` traversal: PHPStan visits every Concat node.
+ * In a left-associative chain `"SELECT" . $a . $b`, parsed as
+ * `Concat(Concat("SELECT", $a), $b)`, each operand is the `->right` of exactly
+ * one Concat node, and the chain's leftmost leaf is never anyone's `->right`.
+ * The rule type-checks only `$node->right` at each visited Concat, so every
+ * operand is visited exactly once — no `getAttribute('parent')` and no duplicate
+ * errors.
+ *
+ * The `classes/` path guard prevents the rule from analyzing itself or test
+ * fixtures, avoiding a bootstrap/self-gating hazard.
+ *
+ * Unsound residual NOT covered by this rule (human-at-merge remains the control):
+ * (a) Dynamic identifier injection — table/column/ORDER-BY names cannot be bound
+ *     by prepared statements; safety depends on a match()/allowlist being correct,
+ *     a judgment call this rule cannot make.
+ * (b) Second-order / stored injection — tainted data stored safely then
+ *     concatenated into a different query whose sink is outside the analyzed file.
+ * (c) Parameterized-but-wrong authz-in-query (IDOR) — a perfectly bound query
+ *     with a WHERE clause that trusts a client-supplied id.
+ *
+ * @implements Rule<Concat>
+ */
+final class BanSqlStringConcatenationRule implements Rule
+{
+    /**
+     * Matches a literal that *begins* (after leading whitespace) with a SQL DML verb
+     * or a SQL clause keyword. Anchoring at the start is what distinguishes a real
+     * query/fragment from prose that merely mentions a keyword.
+     */
+    private const SQL_STATEMENT_PATTERN = '/^\s*(SELECT|INSERT\s+INTO|UPDATE|DELETE\s+FROM|REPLACE\s+INTO|WHERE|ORDER\s+BY|GROUP\s+BY|HAVING|LEFT\s+JOIN|RIGHT\s+JOIN|INNER\s+JOIN)\b/i';
+
+    public function getNodeType(): string
+    {
+        return Concat::class;
+    }
+
+    /**
+     * @param Concat $node
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $file = $scope->getFile();
+
+        if (!str_contains($file, DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR)) {
+            return [];
+        }
+
+        // Walk to the leftmost leaf of the Concat subtree.
+        $left = $node->left;
+        while ($left instanceof Concat) {
+            $left = $left->left;
+        }
+
+        // Only flag chains whose leftmost leaf is a plain SQL keyword string literal.
+        // If the leftmost leaf is an InterpolatedString, BanSqlStringInterpolationRule owns it.
+        if (!$left instanceof String_) {
+            return [];
+        }
+
+        if (preg_match(self::SQL_STATEMENT_PATTERN, $left->value) !== 1) {
+            return [];
+        }
+
+        // Check only the ->right operand of this Concat node (see chain-nesting note above).
+        $right = $node->right;
+
+        // A plain String_ literal on the right is always inert (constant author-controlled text).
+        if ($right instanceof String_) {
+            return [];
+        }
+
+        if ($this->isInjectionInert($scope->getType($right))) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'SQL string concatenates a non-constant value. Concatenating a runtime '
+                . 'value into query text risks SQL injection. Use bound parameters (?) for values, '
+                . 'and a validated allowlist/match() for identifiers (table/column names).'
+            )
+                ->identifier('ibl.sqlStringConcatenation')
+                ->line($right->getStartLine())
+                ->build(),
+        ];
+    }
+
+    private function isInjectionInert(Type $type): bool
+    {
+        return $type->isInteger()->yes()
+            || $type->isFloat()->yes()
+            || $type->getConstantStrings() !== [];
+    }
+}

--- a/ibl5/phpstan.neon
+++ b/ibl5/phpstan.neon
@@ -149,6 +149,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: PHPStanRules\BanSqlStringConcatenationRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: PHPStanRules\BanDuplicateModifierMethodRule
         tags:
             - phpstan.rules.rule

--- a/ibl5/tests/PHPStanRules/BanSqlStringConcatenationRuleTest.php
+++ b/ibl5/tests/PHPStanRules/BanSqlStringConcatenationRuleTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStanRules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanRules\BanSqlStringConcatenationRule;
+
+/**
+ * @extends RuleTestCase<BanSqlStringConcatenationRule>
+ */
+final class BanSqlStringConcatenationRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new BanSqlStringConcatenationRule();
+    }
+
+    public function testFlagsNonConstantConcatenationIntoSql(): void
+    {
+        $message = 'SQL string concatenates a non-constant value. Concatenating a runtime '
+            . 'value into query text risks SQL injection. Use bound parameters (?) for values, '
+            . 'and a validated allowlist/match() for identifiers (table/column names).';
+
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/SqlStringConcatenation.php'],
+            [
+                [$message, 11],
+                [$message, 17],
+            ],
+        );
+    }
+}

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/SqlStringConcatenation.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/SqlStringConcatenation.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+const CONCAT_MAX_ID = 100;
+
+function buildConcatenatedQueries(string $name, int $count, int $teamId): array
+{
+    // KNOWN-BAD: a string variable concatenated into a SELECT/WHERE — injection-shaped.
+    $bad1 = "SELECT * FROM ibl_plr WHERE name = '"
+        . $name
+        . "'";
+    // KNOWN-BAD: a string variable concatenated mid-chain, after an int-safe operand.
+    $bad2 = "SELECT * FROM ibl_plr WHERE tid = "
+        . $teamId
+        . " AND city = '"
+        . $name
+        . "'";
+    // KNOWN-GOOD: any integer is injection-inert (digits only).
+    $good1 = "SELECT * FROM ibl_plr WHERE pid = " . $count;
+    // KNOWN-GOOD: a constant resolves to a literal value known at analysis time.
+    $good2 = "SELECT * FROM ibl_plr WHERE pid < " . CONCAT_MAX_ID . " ORDER BY pid";
+    // KNOWN-GOOD: fully parameterized literal — not a Concat node at all.
+    $good3 = "SELECT * FROM ibl_plr WHERE name = ?";
+    // KNOWN-GOOD: non-SQL prose — leftmost literal does not begin with a SQL keyword.
+    $good4 = "Hello " . $name . ", welcome";
+
+    return [$bad1, $bad2, $good1, $good2, $good3, $good4];
+}


### PR DESCRIPTION
## Summary

Adds `BanSqlStringConcatenationRule` — the direct sibling of `BanSqlStringInterpolationRule` (which explicitly excludes `.`-concatenation). The new rule closes the one remaining first-order SQL-injection gap in the syntactic defense: **string concatenation (`.` operator) of a non-literal value into a SQL string**.

The rule is **type-aware**: it flags only operands whose PHPStan type is NOT provably injection-inert (not int, not float, not a constant string). The 28 existing safe builder-result concat sites in `classes/` are baselined.

## CRITICAL FRAMING

1. **This rule NARROWS REVIEW SCOPE, NOT HOLD FREQUENCY.** Gate-14(b) keeps firing on *every* SQL-touching PR — auto-merge stays held for SQL changes. The rule does not auto-arm any SQL PR and does not change how many PRs are held. What it changes: CI now mechanically proves the *first-order* concat/interpolation slice is absent, so the human reviewer can focus on the diff-undetectable residual. **This PR is rule-only — does NOT edit `plan.md` gate-14(b) or `/post-plan` Phase 6.5.**

2. **Unsound residual the gate does NOT cover** (documented in rule docblock):
   - (a) **Dynamic identifier injection** — table/column/ORDER-BY names cannot be bound by prepared statements; safety depends on a `match()`/allowlist being correct, a judgment call.
   - (b) **Second-order / stored injection** — tainted data stored safely then concatenated into a *different* query whose sink is outside the analyzed file.
   - (c) **Parameterized-but-wrong authz-in-query (IDOR)** — a perfectly bound query with a WHERE clause that trusts a client-supplied id.

   None are detectable by this rule. The human-at-merge remains the control.

## Design

- **Node type:** `PhpParser\Node\Expr\BinaryOp\Concat`
- **Keyword anchor:** recurse `->left` to the leftmost leaf; fire only when it's a `String_` matching `SQL_STATEMENT_PATTERN` (verbatim from the interpolation rule).
- **Per-`->right`-operand traversal** (no `getAttribute('parent')` needed): in `"SELECT" . $a . $b`, each operand is the `->right` of exactly one Concat node → every operand visited exactly once, no duplicates.
- **Injection-inert predicate:** `isInteger()->yes() || isFloat()->yes() || getConstantStrings() !== []`
- **Path scope:** `classes/` guard (same as the interpolation rule) → never analyzes itself.

## Baselined sites

28 sites in `TeamOffDefStatsRepository.php` (builder-result concats: each builds a fixed SQL template with bound `?` placeholders; interpolated parts are int-only from `array_map('intval', ...)` or hardcoded literal strings). Verified: no raw-var/superglobal-derived site was silently baselined.

<!-- no-adr: extends existing SQL-injection lint family (BanSqlStringInterpolationRule sibling); enforces established prepared-statement boundary, no new architectural decision -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.