### PR TITLE
refactor: Extract & adopt setup-ssh + notify-discord composite GitHub Actions (CI backlog 1.2)

### DIFF
--- a/.github/actions/notify-discord/action.yml
+++ b/.github/actions/notify-discord/action.yml
@@ -1,0 +1,58 @@
+name: 'Notify via Discord DM'
+description: >-
+  Read a pre-built message from a file, wrap it in the IBLbot discordDM payload,
+  and POST it over SSH to the prod box. Assumes a prior Setup SSH step already
+  wrote ~/.ssh/id_deploy.
+inputs:
+  message-file:
+    description: 'Path to a file holding the already-built message body.'
+    required: false
+    default: '/tmp/discord-msg.txt'
+  discord-id:
+    description: 'Recipient Discord user id (secrets.OWNER_DISCORD_ID).'
+    required: true
+  port:
+    description: 'SSH port.'
+    required: true
+  host:
+    description: 'SSH host (the prod box running IBLbot).'
+    required: true
+  username:
+    description: 'SSH username.'
+    required: true
+  fail-on-delivery:
+    description: >-
+      "true" (default): curl -sf with no swallow — a non-2xx or unreachable bot
+      turns the job RED (loud-fail). "false": curl -s + warn-and-continue (soft-fail).
+    required: false
+    default: 'true'
+runs:
+  using: 'composite'
+  steps:
+    - name: Send Discord DM
+      shell: bash
+      env:
+        OWNER_DISCORD_ID: ${{ inputs.discord-id }}
+        MSG_FILE: ${{ inputs.message-file }}
+        PORT: ${{ inputs.port }}
+        HOST: ${{ inputs.host }}
+        USERNAME: ${{ inputs.username }}
+        FAIL_ON_DELIVERY: ${{ inputs.fail-on-delivery }}
+      run: |
+        MSG=$(cat "$MSG_FILE")
+
+        PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
+          '{content: {receivingUserDiscordID: $id, message: $msg}}')
+
+        if [ "$FAIL_ON_DELIVERY" = "true" ]; then
+          # Fail loud: curl -f (non-2xx → exit 22), no `|| echo` swallow — a delivery
+          # failure turns this notify job RED via GitHub's native failure email. A
+          # silently-dropped alert is worse than none.
+          echo "$PAYLOAD" | ssh -p "$PORT" -i ~/.ssh/id_deploy "$USERNAME@$HOST" \
+            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
+        else
+          # Soft-fail: a down bot must not red an advisory cron. Warn and continue.
+          echo "$PAYLOAD" | ssh -p "$PORT" -i ~/.ssh/id_deploy "$USERNAME@$HOST" \
+            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
+            || echo "::warning::IBLbot notification failed (bot may be down)"
+        fi

--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -1,0 +1,50 @@
+name: 'Setup SSH deploy key'
+description: >-
+  Write the deploy private key to ~/.ssh/id_deploy (chmod 600) and keyscan the
+  host into ~/.ssh/known_hosts. Optionally fail loud when any required secret is
+  empty (for workflow_call callers that may forget `secrets: inherit`).
+inputs:
+  host:
+    description: 'SSH host to keyscan (and assert non-empty when require-secrets is true).'
+    required: true
+  port:
+    description: 'SSH port.'
+    required: true
+  private-key:
+    description: 'SSH private key (secrets.PRIVATE_KEY). Written to ~/.ssh/id_deploy.'
+    required: true
+  username:
+    description: 'SSH username — only asserted non-empty when require-secrets is true.'
+    required: false
+    default: ''
+  require-secrets:
+    description: >-
+      When "true", fail loud if PORT/HOST/USERNAME/PRIVATE_KEY are empty.
+    required: false
+    default: 'false'
+runs:
+  using: 'composite'
+  steps:
+    - name: Write deploy key and keyscan host
+      shell: bash
+      env:
+        PORT: ${{ inputs.port }}
+        HOST: ${{ inputs.host }}
+        USERNAME: ${{ inputs.username }}
+        DEPLOY_KEY: ${{ inputs.private-key }}
+        REQUIRE_SECRETS: ${{ inputs.require-secrets }}
+      run: |
+        set -euo pipefail
+        if [ "$REQUIRE_SECRETS" = "true" ]; then
+          # Fail loud if a secret is empty. When the workflow runs via `workflow_call`
+          # the caller MUST pass `secrets: inherit`, or these render empty and `ssh -p`
+          # silently consumes `-i` as its port arg ("Bad port '-i'"). See run 27378437919.
+          : "${PORT:?empty — caller must pass 'secrets: inherit'}"
+          : "${HOST:?empty — caller must pass 'secrets: inherit'}"
+          : "${USERNAME:?empty — caller must pass 'secrets: inherit'}"
+          : "${DEPLOY_KEY:?empty — caller must pass 'secrets: inherit'}"
+        fi
+        mkdir -p ~/.ssh
+        echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
+        chmod 600 ~/.ssh/id_deploy
+        ssh-keyscan -p "$PORT" "$HOST" >> ~/.ssh/known_hosts 2>/dev/null || true

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -61,14 +61,14 @@ jobs:
       REMOTE_DATABASE: iblhoops_ibl5
 
     steps:
+      - uses: actions/checkout@v7
+
       - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} "$BACKUP_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ github.event.inputs.ssh_host_override || secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Dump prod database, rotate, integrity-check
         id: dump
@@ -177,28 +177,26 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - uses: actions/checkout@v7
+
       - name: Setup SSH
         # Always the real prod host — a forced-bad backup host must still alert.
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - name: Send Discord DM
-        env:
-          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
+      - name: Build Discord message
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           MSG=$(printf 'Production DB backup FAILED (%s trigger).\n\nNo verified dump was produced for today. Check the run: %s' "${{ github.event_name }}" "$RUN_URL")
+          printf '%s' "$MSG" > /tmp/discord-msg.txt
 
-          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
-            '{content: {receivingUserDiscordID: $id, message: $msg}}')
-
-          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
-          # delivery failure turns this job RED — surfaced via GitHub's native
-          # scheduled-run failure email. A silently-dropped alert is worse than none.
-          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
+      - name: Send Discord DM
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}

--- a/.github/workflows/deploy-rehearsal.yml
+++ b/.github/workflows/deploy-rehearsal.yml
@@ -98,24 +98,13 @@ jobs:
       # server-side over SSH (the db-backup.yml pattern), reusing the deploy key — no
       # new secrets.
       - name: Setup SSH
-        run: |
-          set -euo pipefail
-          # Fail loud if a secret is empty. When this workflow runs via `workflow_call`
-          # the caller MUST pass `secrets: inherit`, or these render empty and `ssh -p`
-          # silently consumes `-i` as its port arg ("Bad port '-i'"). See run 27378437919.
-          : "${PORT:?empty — caller must pass 'secrets: inherit'}"
-          : "${HOST:?empty — caller must pass 'secrets: inherit'}"
-          : "${USERNAME:?empty — caller must pass 'secrets: inherit'}"
-          : "${DEPLOY_KEY:?empty — caller must pass 'secrets: inherit'}"
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p "$PORT" "$HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          PORT: ${{ secrets.PORT }}
-          HOST: ${{ secrets.HOST }}
-          USERNAME: ${{ secrets.USERNAME }}
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          require-secrets: 'true'
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          username: ${{ secrets.USERNAME }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Clone filtered production data into CI MariaDB
         run: |

--- a/.github/workflows/doc-freshness-audit.yml
+++ b/.github/workflows/doc-freshness-audit.yml
@@ -108,26 +108,27 @@ jobs:
 
       - name: Setup SSH
         if: steps.issue.outputs.notify == 'true'
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - name: Send Discord DM
+      - name: Build Discord message
         if: steps.issue.outputs.notify == 'true'
         env:
-          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
           COUNT: ${{ steps.report.outputs.count }}
         run: |
           MSG=$(printf 'Doc Freshness Audit: %s doc(s) past the 60-day staleness window.\nIssue + details: https://github.com/%s/actions/runs/%s' \
             "$COUNT" "${{ github.repository }}" "${{ github.run_id }}")
+          printf '%s' "$MSG" > /tmp/discord-msg.txt
 
-          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
-            '{content: {receivingUserDiscordID: $id, message: $msg}}')
-
-          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
-            || echo "::warning::IBLbot notification failed (bot may be down)"
+      - name: Send Discord DM
+        if: steps.issue.outputs.notify == 'true'
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          fail-on-delivery: 'false'

--- a/.github/workflows/log-review.yml
+++ b/.github/workflows/log-review.yml
@@ -24,13 +24,11 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Fetch log digest
         id: digest
@@ -85,14 +83,10 @@ jobs:
           } | tee /tmp/discord-msg.txt
 
       - name: Send Discord DM
-        env:
-          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
-        run: |
-          MSG=$(cat /tmp/discord-msg.txt)
-
-          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
-            '{content: {receivingUserDiscordID: $id, message: $msg}}')
-
-          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -s --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-' \
-            || echo "::warning::IBLbot notification failed (bot may be down)"
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          fail-on-delivery: 'false'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,13 +45,11 @@ jobs:
         working-directory: ibl5
 
       - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Stop IBL6 to free resources for deploy
         run: |
@@ -247,14 +245,14 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - uses: actions/checkout@v7
+
       - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Capture deploy state from server
         id: state
@@ -269,9 +267,8 @@ jobs:
           ') || OUTPUT=$'STEP_NAME=unknown\nLAST_MIGRATION=unknown\nDEPLOYED_SHA=unknown'
           echo "$OUTPUT" >> "$GITHUB_OUTPUT"
 
-      - name: Send Discord DM
+      - name: Build Discord message
         env:
-          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
           PREFLIGHT_RESULT: ${{ needs.pre-flight.result }}
           STEP_NAME: ${{ steps.state.outputs.STEP_NAME }}
           LAST_MIGRATION: ${{ steps.state.outputs.LAST_MIGRATION }}
@@ -290,12 +287,12 @@ jobs:
             MSG=$(printf 'Production deploy FAILED at step: %s\n\nCommit: %s\nLast applied migration: %s\nDeployed SHA on box: %s\n\nRun: %s' \
               "$STEP_NAME" "$SHORT_SHA" "$LAST_MIGRATION" "$DEPLOYED_SHA" "$RUN_URL")
           fi
+          printf '%s' "$MSG" > /tmp/discord-msg.txt
 
-          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
-            '{content: {receivingUserDiscordID: $id, message: $msg}}')
-
-          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
-          # delivery failure turns this notify job RED — surfaced via GitHub's native
-          # workflow-failure email. A silently-dropped alert is worse than none.
-          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
+      - name: Send Discord DM
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -275,28 +275,26 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - uses: actions/checkout@v7
+
       - name: Setup SSH
         # Real prod host — the IBLbot Discord-DM endpoint is reachable only there.
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - name: Send Discord DM
-        env:
-          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
+      - name: Build Discord message
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           MSG=$(printf 'Weekly mutation testing FAILED (%s trigger).\n\nMSI dropped below 100%% — an escaped mutant or coverage regression. Check the run: %s' "${{ github.event_name }}" "$RUN_URL")
+          printf '%s' "$MSG" > /tmp/discord-msg.txt
 
-          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
-            '{content: {receivingUserDiscordID: $id, message: $msg}}')
-
-          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
-          # delivery failure turns this job RED — surfaced via GitHub's native
-          # scheduled-run failure email. A silently-dropped alert is worse than none.
-          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
+      - name: Send Discord DM
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}

--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -86,13 +86,11 @@ jobs:
       # (ADR-0039).
       - name: Setup SSH for on-box smoke
         if: steps.guard.outputs.stale != 'true'
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Run IBL5 smoke checks on-box via SSH (gates auto-rollback)
         id: ibl5
@@ -234,22 +232,19 @@ jobs:
           git push origin production
 
       - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - name: Send Discord DM
+      - name: Build Discord message
         env:
           COMMIT_MSG: ${{ steps.check.outputs.commit_msg }}
           COMMIT_SHA: ${{ steps.check.outputs.commit_sha }}
           SHOULD_REVERT: ${{ steps.check.outputs.should_revert }}
           SKIP_REASON: ${{ steps.check.outputs.skip_reason }}
           REVERT_OUTCOME: ${{ steps.revert.outcome }}
-          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SHORT_SHA="${COMMIT_SHA:0:7}"
@@ -263,15 +258,15 @@ jobs:
           else
             MSG=$(printf 'Production smoke test FAILED after deploy. Auto-reverted commit %s. A recovery deploy is in progress.\n\nReverted: %s\nRun: %s' "$SHORT_SHA" "$COMMIT_MSG" "$RUN_URL")
           fi
+          printf '%s' "$MSG" > /tmp/discord-msg.txt
 
-          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
-            '{content: {receivingUserDiscordID: $id, message: $msg}}')
-
-          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
-          # delivery failure turns this notify job RED — surfaced via GitHub's native
-          # workflow-failure email. A silently-dropped alert is worse than none.
-          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
+      - name: Send Discord DM
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
 
   notify-scheduled-failure:
     name: Notify Scheduled Failure
@@ -284,31 +279,29 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+      - uses: actions/checkout@v7
 
-      - name: Send Discord DM
-        env:
-          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
+      - name: Setup SSH
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Build Discord message
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           TRIGGER="${{ github.event_name }}"
           MSG=$(printf 'Production smoke test FAILED (%s trigger — no auto-rollback).\n\nThis may be a transient issue. Check the run for details: %s' "$TRIGGER" "$RUN_URL")
+          printf '%s' "$MSG" > /tmp/discord-msg.txt
 
-          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
-            '{content: {receivingUserDiscordID: $id, message: $msg}}')
-
-          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
-          # delivery failure turns this notify job RED — surfaced via GitHub's native
-          # workflow-failure email. A silently-dropped alert is worse than none.
-          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
+      - name: Send Discord DM
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
 
   notify-ibl6-degradation:
     name: Notify IBL6 Degradation
@@ -322,30 +315,28 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+      - uses: actions/checkout@v7
 
-      - name: Send Discord DM
-        env:
-          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
+      - name: Setup SSH
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Build Discord message
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           MSG=$(printf 'IBL6 smoke FAILED; IBL5 unaffected. No rollback.\n\nRun: %s' "$RUN_URL")
+          printf '%s' "$MSG" > /tmp/discord-msg.txt
 
-          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
-            '{content: {receivingUserDiscordID: $id, message: $msg}}')
-
-          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
-          # delivery failure turns this notify job RED — surfaced via GitHub's native
-          # workflow-failure email. A silently-dropped alert is worse than none.
-          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
+      - name: Send Discord DM
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
 
   notify-inconclusive:
     name: Notify Smoke Inconclusive
@@ -362,18 +353,17 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-        env:
-          DEPLOY_KEY: ${{ secrets.PRIVATE_KEY }}
+      - uses: actions/checkout@v7
 
-      - name: Send Discord DM
+      - name: Setup SSH
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Build Discord message
         env:
-          OWNER_DISCORD_ID: ${{ secrets.OWNER_DISCORD_ID }}
           INCONCLUSIVE_REASON: ${{ needs.smoke.outputs.ibl5_inconclusive_reason }}
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -382,12 +372,12 @@ jobs:
           else
             MSG=$(printf 'IBL5 smoke INCONCLUSIVE (on-box prober hit a uniform WAF-class block). NO rollback; production untouched. Run: %s' "$RUN_URL")
           fi
+          printf '%s' "$MSG" > /tmp/discord-msg.txt
 
-          PAYLOAD=$(jq -n --arg id "$OWNER_DISCORD_ID" --arg msg "$MSG" \
-            '{content: {receivingUserDiscordID: $id, message: $msg}}')
-
-          # Fail loud: no `|| echo` swallow and `curl -f` (non-2xx → exit 22), so a
-          # delivery failure turns this notify job RED — surfaced via GitHub's native
-          # workflow-failure email. A silently-dropped alert is worse than none.
-          echo "$PAYLOAD" | ssh -p ${{ secrets.PORT }} -i ~/.ssh/id_deploy ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-            'curl -sf --max-time 10 -X POST http://localhost:50000/discordDM -H "Content-Type: application/json" -d @-'
+      - name: Send Discord DM
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}

--- a/ibl5/docs/ci-backlog.md
+++ b/ibl5/docs/ci-backlog.md
@@ -48,7 +48,7 @@ last_verified: 2026-06-29
 | # | Title | Status | Automouse | Effort |
 |---|-------|--------|-----------|-------:|
 | 1.1 | Revive + adopt `setup-php-env` composite | ✅ Implemented | 🟩 | M |
-| 1.2 | Extract `notify-discord` composite (SSH + Discord DM) | 📋 Planned | 🟦 | M |
+| 1.2 | Extract `notify-discord` composite (SSH + Discord DM) | ✅ Implemented | 🟦 | M |
 
 ### 1.1 Dead `setup-php-env` composite; PHP setup hand-rolled 16×
 **Location:** `.github/actions/setup-php-env/action.yml` (defined, **used by zero workflows**); duplicated blocks in `.github/workflows/tests.yml` (×5), `migration-safety.yml` (×3), `mutation.yml` (×2), `adr-required.yml`, `refactor-flag.yml`, `doc-freshness.yml`, `doc-freshness-audit.yml`, `deploy-rehearsal.yml`, `cache-dependencies.yml`.
@@ -62,7 +62,7 @@ last_verified: 2026-06-29
 **Problem:** Two structurally identical blocks copy-pasted across the deploy/notify surface; the Discord blocks differ only in the `MSG` string. Each copy is a place a key-handling or endpoint change must be repeated.
 **Suggested direction:** A `notify-discord` composite action taking `message` (and host/secret inputs) that owns both the SSH setup and the DM POST. Callers reduce to one `uses:` + a message string. Note `db-backup.yml`'s notify intentionally targets `secrets.HOST` (not the override) and `deploy-rehearsal.yml`'s SSH setup has a secret-empty guard — the composite must preserve both as inputs/options.
 **Risk if untouched:** A secret rotation or endpoint change touches 12 SSH blocks + 8 DM blocks by hand; the `db-backup` heredoc remote logic is already un-shellchecked.
-**Status (2026-06-28):** 📋 Planned — plan `ci-notify-discord-composite` written + queued for automouse (own PR, split from 1.1). Two composites (`setup-ssh` + `notify-discord`) across the **13 SSH + 9 Discord sites** the plan re-counted on disk. 🟦 `auto_merge: false`: the Discord-send + rollback-alert path runs only against prod (SSH + IBLbot `discordDM`), **unreachable from CI** — `actionlint` proves wiring/syntax but not that a prod DM actually sends; combined with the deploy/secrets surface, a human merges (gate-14 deploy/secrets + gate-15 data-blocked verification gap).
+**Status (2026-06-29):** ✅ Implemented (PR for ci-notify-discord-composite) — two composites (`setup-ssh`, `notify-discord`) extracted and adopted at all 13 SSH + 9 Discord sites; per-caller variants (guard, override-host, loud/soft) preserved. `auto_merge: false` — Discord/rollback-alert path is prod-only, unreachable from CI.
 
 ---
 


### PR DESCRIPTION
## Summary

Extract duplicated SSH setup (13 sites) and Discord notification (9 sites) blocks into two local composite GitHub Actions, and adopt them across all 7 workflows that contain them.

**Composites added:**
- `.github/actions/setup-ssh/action.yml` — SSH deploy key + keyscan + optional empty-secret guard
- `.github/actions/notify-discord/action.yml` — jq payload + ssh-curl POST, loud/soft variants

**Workflows updated:** `smoke-prod`, `main`, `deploy-rehearsal`, `db-backup`, `mutation`, `log-review`, `doc-freshness-audit`

All per-caller variants preserved: secret-empty guard (deploy-rehearsal), override-host (db-backup), loud vs soft Discord (log-review/doc-freshness-audit).

Flips CI backlog item 1.2 to Implemented.

`auto_merge: false` — Discord-delivery + rollback-alert path runs only against prod (SSH to prod box + IBLbot), unreachable from CI. A human git-diff review is required before merge.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.