### PR TITLE
fix: harden VR pipeline — nav-flake self-heal, trace policy, infra-vs-pixel labeling

### DIFF
--- a/.claude/rules/visual-review-prs.md
+++ b/.claude/rules/visual-review-prs.md
@@ -7,7 +7,7 @@ paths:
   - "ibl5/tests/e2e/vr-review-comment.ts"
   - "bin/vr-changed-coverage"
   - "bin/vr-review-comment"
-last_verified: 2026-06-24
+last_verified: 2026-06-29
 ---
 
 # Visual-review PRs
@@ -59,6 +59,17 @@ approval mechanism.
 
 - Fork PR: the read-only token has no secrets, so the publish/comment steps no-op (expected).
 - No pixel diffs: VR passes, nothing to review, no comment.
+
+## Infra/render failures vs pixel diffs
+
+A failed VR cell is a **pixel diff** only when it carries a `*-diff.png` screenshot attachment.
+A cell that failed before a screenshot could be taken — a `page.goto` navigation timeout, a blank
+render, an error — carries no triplet and is labeled an **infra/render failure** in a separate
+`⚠️ … failed to render` comment section whose remedy is **re-run the VR job**, NOT
+`update-baselines` (which cannot fix a timeout). The "changed pixels" headline and the global-change
+banner appear only when ≥1 genuine pixel diff exists. The VR spec uses `gotoWithRetry`
+(`tests/e2e/helpers/navigation.ts`) so transient navigation timeouts self-heal rather than
+producing these cells. See ADR-0073.
 
 ## Modifying the selection logic
 

--- a/bin/vr-review-comment
+++ b/bin/vr-review-comment
@@ -18,7 +18,7 @@ const __dir = dirname(fileURLToPath(import.meta.url));
 const ibl5Dir = resolve(__dir, '..', 'ibl5');
 
 const { VR_MANIFEST } = await import(resolve(ibl5Dir, 'tests/e2e/vr-manifest.ts'));
-const { buildComment, extractDiffCells, classifyCells } = await import(
+const { buildComment, extractCells, classifyCells } = await import(
   resolve(ibl5Dir, 'tests/e2e/vr-review-comment.ts')
 );
 
@@ -70,7 +70,7 @@ if (resultsPath !== null && existsSync(resultsPath)) {
   }
 }
 
-const diffCells = extractDiffCells(report, VR_MANIFEST);
+const { diffCells, infraCells } = extractCells(report, VR_MANIFEST);
 
 // Classify NEW (no committed baseline) vs CHANGED (committed baseline = real
 // diff). Signal: `git ls-files <snapshot path>` reads the TRACKED INDEX, not the
@@ -110,6 +110,7 @@ const classifiedCells = classifyCells(diffCells, trackedTitles);
 
 const markdown = buildComment({
   diffCells: classifiedCells,
+  infraCells,
   uncoveredChangedPaths: coverage.uncoveredChangedPaths ?? [],
   globalChange: coverage.globalChange ?? false,
   pagesUrl,

--- a/ibl5/docs/decisions/0073-vr-infra-vs-pixel-failure-labeling.md
+++ b/ibl5/docs/decisions/0073-vr-infra-vs-pixel-failure-labeling.md
@@ -1,0 +1,83 @@
+---
+description: The visual-review comment classifies a failed VR cell as a genuine pixel diff only when it carries a *-diff.png screenshot attachment; failed cells with no triplet are labeled navigation/render failures with a re-run remedy, never "changed pixels / apply update-baselines".
+last_verified: 2026-06-29
+---
+
+# ADR-0073: Distinguish infra/render failures from pixel diffs in the visual-review comment
+
+**Status:** Accepted
+**Date:** 2026-06-28
+
+## Lineage
+
+Extends **ADR-0068** (per-SHA Pages publishing) and **ADR-0069** (NEW-vs-CHANGED comment
+classification) — does NOT supersede them. Those decisions assumed every failing VR cell is a
+pixel change. This ADR adds a prior split: pixel diff vs infra/render failure.
+
+## Context
+
+The `visual-review` comment keyed solely on `spec.ok === false`, so ANY failed VR cell —
+including a `page.goto` navigation timeout (the PHP built-in server intermittently returns blank
+HTML under load) — was rendered as a "changed pixels" cell under a headline instructing the
+reviewer to apply the `update-baselines` label. For a navigation timeout this is wrong twice: the
+run captured no before/after/diff images (the screenshot step never ran), and regenerating
+baselines cannot fix a timeout. PR #1107's stale report showed all 12 "changed views" were in fact
+identical `page.goto` timeouts with zero pixel-diff attachments.
+
+The Playwright JSON report already distinguishes the two: a genuine screenshot mismatch attaches
+`<title>-expected.png` / `<title>-actual.png` / `<title>-diff.png`, while a navigation/error
+failure attaches only `error-context`. The bot was not reading attachments.
+
+This changes the comment selection/markup logic, a mechanical-enforcement surface per
+`.claude/rules/visual-review-prs.md`, so an ADR is required.
+
+## Decision
+
+Classify each failed VR cell by its attachments:
+
+- **Pixel diff** ⇔ the cell carries a `*-diff.png` attachment. These render in the existing
+  per-module "changed view(s)" / "new view(s)" sections under the "This PR changed pixels … apply
+  `update-baselines`" headline.
+- **Infra/render failure** ⇔ failed but with attachments and no `*-diff.png`. These render in a
+  separate `⚠️ N view(s) failed to render (navigation/error — not a pixel change)` section whose
+  remedy is **re-run the VR job**, explicitly NOT regenerating baselines.
+- **Legacy fallback:** a failed spec with no attachment data at all is treated as a pixel diff,
+  preserving the prior `{title, ok}`-only behavior. Real reports always attach ≥1 artifact on
+  failure, so this affects only synthetic test fixtures.
+
+The "This PR changed pixels" headline and the "Global change detected" banner render only when at
+least one genuine pixel-diff cell exists, so an infra-only failure never points the reviewer at the
+wrong remedy.
+
+This is paired with a navigation-robustness change: the VR spec swaps raw `page.goto` for the
+existing non-masking `gotoWithRetry` helper, so transient navigation timeouts self-heal to green
+rather than producing infra-failure cells at all. The classifier handles the residue. VR still goes
+red on any genuine failure (a non-transient broken page exhausts the retries; a real pixel diff
+fails the comparison) — neither the retry nor the relabeling auto-greens a real failure.
+
+## Alternatives Considered
+
+- **Add Playwright `retries` instead of `gotoWithRetry`.** Rejected: a screenshot-comparison retry
+  re-runs `toHaveScreenshot` and can mask a flaky-render pixel diff; the codebase already
+  standardized on the non-masking `gotoWithRetry` for navigation robustness.
+- **Auto-pass VR on an infra failure.** Rejected: it would hide a genuinely broken page. VR staying
+  red on a real failure is correct; the fix is fewer false reds plus the right remedy message.
+- **A new standalone bin script.** Rejected: `bin/vr-review-comment` already owns the report parse;
+  the classifier extends the existing pure `vr-review-comment.ts` seam.
+
+## Consequences
+
+- **Positive:** A navigation timeout is labeled as flake with a re-run remedy, never as a pixel
+  change demanding baseline regeneration.
+- **Positive:** The classifier is pure and unit-tested; the gating is mechanized, not trusted.
+- **Negative:** The classifier depends on Playwright's attachment naming (`*-diff.png`); a future
+  Playwright change to attachment names would need a corresponding update (covered by the unit
+  tests, which would go red).
+
+## References
+
+- `ibl5/tests/e2e/vr-review-comment.ts` — `extractCells`, `specHasPixelDiff`, `buildComment`.
+- `ibl5/tests/ts-unit/vr-review-comment.test.ts` — classification + gating tests.
+- `ibl5/tests/e2e/smoke/visual-regression.spec.ts` — `gotoWithRetry` navigation.
+- `ibl5/playwright.visual.config.ts` — `trace: 'retain-on-failure'`.
+- `ibl5/docs/decisions/0069-vr-comment-new-vs-changed.md` — the classification this extends.

--- a/ibl5/playwright.visual.config.ts
+++ b/ibl5/playwright.visual.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
     baseURL: process.env.BASE_URL || 'http://main.localhost/ibl5/',
     actionTimeout: 10_000,
     navigationTimeout: 20_000,
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     viewport: { width: 1280, height: 900 },
     reducedMotion: 'reduce',

--- a/ibl5/tests/e2e/smoke/visual-regression.spec.ts
+++ b/ibl5/tests/e2e/smoke/visual-regression.spec.ts
@@ -1,11 +1,10 @@
-// Do NOT swap page.goto for gotoWithRetry in this PR — that's a behavior
-// change; defer to a follow-up.
 import type { Locator, Page } from '@playwright/test';
 import { test as publicTest } from '../fixtures/public';
 import { test as authTest } from '../fixtures/auth';
 import { test as authRegularTest } from '../fixtures/auth-regular';
 import { expect } from '../fixtures/base';
 import { assertNoPhpErrors } from '../helpers/php-errors';
+import { gotoWithRetry } from '../helpers/navigation';
 import {
   VR_MANIFEST,
   DEFAULT_STATE,
@@ -37,7 +36,7 @@ async function captureSnapshot(
   if (viewport === 'mobile') {
     await page.setViewportSize({ width: 375, height: 812 });
   }
-  await page.goto(row.url);
+  await gotoWithRetry(page, row.url);
   await assertNoPhpErrors(page, `on ${row.url}`);
   await page.waitForLoadState('networkidle');
   const anchor = page.locator(row.anchor).first();

--- a/ibl5/tests/e2e/vr-review-comment.ts
+++ b/ibl5/tests/e2e/vr-review-comment.ts
@@ -24,9 +24,35 @@ export type DiffCell = {
 };
 
 // ── Playwright JSON report (only the fields we read) ─────────────────────────
-type PwSpec = { title?: string; ok?: boolean };
+type PwAttachment = { name?: string; contentType?: string; path?: string };
+type PwResult = { status?: string; attachments?: PwAttachment[]; error?: { message?: string }; errors?: Array<{ message?: string }> };
+type PwTest = { results?: PwResult[] };
+type PwSpec = { title?: string; ok?: boolean; tests?: PwTest[] };
 type PwSuite = { specs?: PwSpec[]; suites?: PwSuite[] };
 type PwReport = { suites?: PwSuite[] };
+
+/** A failed cell that carries no screenshot triplet — a navigation/render/error
+ *  failure, NOT a pixel change. */
+export type InfraCell = { module: string; viewport: Viewport; title: string; error?: string };
+
+/** All attachments across a spec's results. */
+function specAttachments(spec: PwSpec): PwAttachment[] {
+  const out: PwAttachment[] = [];
+  for (const t of spec.tests ?? []) for (const r of t.results ?? []) for (const a of r.attachments ?? []) out.push(a);
+  return out;
+}
+/** A genuine screenshot mismatch attaches `<title>-diff.png`. */
+function specHasPixelDiff(spec: PwSpec): boolean {
+  return specAttachments(spec).some((a) => (a.name ?? '').endsWith('-diff.png'));
+}
+/** First error line, if the report carried one (for the infra section). */
+function specError(spec: PwSpec): string | undefined {
+  for (const t of spec.tests ?? []) for (const r of t.results ?? []) {
+    const m = r.error?.message ?? r.errors?.[0]?.message;
+    if (m) return m.split('\n')[0].slice(0, 140);
+  }
+  return undefined;
+}
 
 /** Flatten the nested suite tree into a flat spec list. */
 function collectSpecs(suite: PwSuite, out: PwSpec[]): void {
@@ -54,21 +80,44 @@ function titleViewport(title: string): Viewport {
   return title.endsWith('-mobile') ? 'mobile' : 'desktop';
 }
 
-/** Parse the Playwright JSON report into the failing (diffing) cells. */
-export function extractDiffCells(report: PwReport, manifest: VrRow[]): DiffCell[] {
+/**
+ * Parse the Playwright JSON report into failing cells, split by failure KIND:
+ *  - diffCells  — genuine pixel mismatches (carry a `*-diff.png` attachment).
+ *  - infraCells — failed but with NO screenshot triplet (navigation/timeout/error).
+ *
+ * Legacy fallback: a failed spec with NO attachment info at all (the historical
+ * `{title, ok}`-only fixture shape) is treated as a pixel diff, preserving prior
+ * behavior. Real Playwright reports always attach ≥1 artifact on failure
+ * (`error-context` at minimum), so this fallback only affects synthetic fixtures.
+ */
+export function extractCells(report: PwReport, manifest: VrRow[]): { diffCells: DiffCell[]; infraCells: InfraCell[] } {
   const specs: PwSpec[] = [];
   for (const suite of report.suites ?? []) collectSpecs(suite, specs);
 
-  const cells: DiffCell[] = [];
+  const diffCells: DiffCell[] = [];
+  const infraCells: InfraCell[] = [];
   for (const spec of specs) {
-    if (spec.ok !== false) continue; // only failed screenshot comparisons
+    if (spec.ok !== false) continue; // only failed specs
     const title = spec.title;
     if (!title) continue;
     const module = titleToModule(title, manifest);
     if (module === null) continue; // not a VR cell (defensive)
-    cells.push({ module, viewport: titleViewport(title), title });
+    const viewport = titleViewport(title);
+    const atts = specAttachments(spec);
+    if (specHasPixelDiff(spec)) {
+      diffCells.push({ module, viewport, title });
+    } else if (atts.length > 0) {
+      infraCells.push({ module, viewport, title, error: specError(spec) });
+    } else {
+      diffCells.push({ module, viewport, title }); // legacy fallback (no attachment info)
+    }
   }
-  return cells;
+  return { diffCells, infraCells };
+}
+
+/** Back-compat: callers that only want pixel-diff cells. */
+export function extractDiffCells(report: PwReport, manifest: VrRow[]): DiffCell[] {
+  return extractCells(report, manifest).diffCells;
 }
 
 /**
@@ -83,6 +132,7 @@ export function classifyCells(cells: DiffCell[], trackedTitles: Set<string>): Di
 
 export type BuildCommentInput = {
   diffCells: DiffCell[];
+  infraCells?: InfraCell[];
   uncoveredChangedPaths: string[];
   globalChange: boolean;
   /** Per-SHA Pages base URL, e.g. https://a-jay85.github.io/IBL5/<sha>/visual-review/ */
@@ -104,21 +154,33 @@ function reportLink(pagesUrl: string, title: string): string {
  */
 export function buildComment(input: BuildCommentInput): string {
   const { diffCells, uncoveredChangedPaths, globalChange, pagesUrl } = input;
+  const infraCells = input.infraCells ?? [];
+  const hasPixelWork = diffCells.length > 0; // changed + new are both DiffCells
   const lines: string[] = [];
 
   lines.push(`## ${COMMENT_HEADER}`);
   lines.push('');
-  lines.push(
-    'This PR changed pixels. Review the before/after/diff below, then **apply the ' +
-      '`update-baselines` label** to approve — that regenerates the baselines and ' +
-      'the auto-commit is the durable sign-off. The VR check stays red until then.',
-  );
-  lines.push('');
 
-  if (globalChange) {
+  if (hasPixelWork) {
     lines.push(
-      '> 🌐 **Global change detected** (shared CSS / theme / class) — every VR row ' +
-        'is treated as potentially affected; review broadly.',
+      'This PR changed pixels. Review the before/after/diff below, then **apply the ' +
+        '`update-baselines` label** to approve — that regenerates the baselines and ' +
+        'the auto-commit is the durable sign-off. The VR check stays red until then.',
+    );
+    lines.push('');
+    if (globalChange) {
+      lines.push(
+        '> 🌐 **Global change detected** (shared CSS / theme / class) — every VR row ' +
+          'is treated as potentially affected; review broadly.',
+      );
+      lines.push('');
+    }
+  } else if (infraCells.length > 0) {
+    lines.push(
+      '⚠️ **The VR run failed to render — this is NOT a pixel change.** ' +
+        'The view(s) below errored on navigation/timeout, so there is no before/after to ' +
+        'review. **Re-run the VR job** — regenerating baselines cannot fix a render failure, ' +
+        'so do **not** apply the baseline-regeneration label.',
     );
     lines.push('');
   }
@@ -169,11 +231,28 @@ export function buildComment(input: BuildCommentInput): string {
   if (
     changedCells.length === 0 &&
     newCells.length === 0 &&
+    infraCells.length === 0 &&
     !globalChange &&
     uncoveredChangedPaths.length === 0
   ) {
     // Boundary: nothing diffed, nothing new, nothing uncovered — safe no-diff body.
     lines.push('_No visual diffs detected and no changed page falls outside VR coverage._');
+    lines.push('');
+  }
+
+  if (infraCells.length > 0) {
+    lines.push(
+      `### ⚠️ ${infraCells.length} view(s) failed to render (navigation/error — not a pixel change)`,
+    );
+    lines.push('');
+    lines.push(
+      'These cells errored before a screenshot could be taken, so there is **no before/after**. ' +
+        'Re-run the VR job; this is a flake/infra failure, **not** a baseline issue.',
+    );
+    lines.push('');
+    for (const cell of [...infraCells].sort((a, b) => a.title.localeCompare(b.title))) {
+      lines.push(`- \`${cell.title}\` — ${cell.viewport}${cell.error ? ` (${cell.error})` : ''}`);
+    }
     lines.push('');
   }
 

--- a/ibl5/tests/ts-unit/vr-review-comment.test.ts
+++ b/ibl5/tests/ts-unit/vr-review-comment.test.ts
@@ -7,9 +7,11 @@ import type { VrRow } from '../e2e/vr-manifest';
 import {
   buildComment,
   classifyCells,
+  extractCells,
   extractDiffCells,
   titleToModule,
   type DiffCell,
+  type InfraCell,
 } from '../e2e/vr-review-comment';
 
 const PAGES_URL = 'https://a-jay85.github.io/IBL5/deadbeef/visual-review/';
@@ -66,8 +68,15 @@ describe('buildComment', () => {
     expect(md).not.toContain('<details>');
   });
 
-  it('renders the global-change banner when globalChange is true', () => {
-    const md = buildComment({ diffCells: [], uncoveredChangedPaths: [], globalChange: true, pagesUrl: PAGES_URL });
+  it('renders the global-change banner when globalChange is true AND there is pixel work', () => {
+    // The banner is gated behind pixel work (ADR-0073): a global change with no
+    // pixel diffs has nothing to review, so the banner only renders alongside diff cells.
+    const md = buildComment({
+      diffCells: [{ module: 'standings', viewport: 'desktop', title: 'standings' }],
+      uncoveredChangedPaths: [],
+      globalChange: true,
+      pagesUrl: PAGES_URL,
+    });
     expect(md).toContain('Global change detected');
   });
 });
@@ -210,6 +219,127 @@ describe('buildComment — NEW vs CHANGED', () => {
   });
 });
 
+describe('extractCells / infra-vs-pixel classification', () => {
+  const infraSpec = {
+    title: 'draft-history',
+    ok: false,
+    tests: [
+      {
+        results: [
+          {
+            status: 'failed',
+            attachments: [{ name: 'error-context', contentType: 'text/markdown' }],
+            error: { message: 'TimeoutError: page.goto exceeded\nat captureSnapshot' },
+          },
+        ],
+      },
+    ],
+  };
+  const pixelSpec = {
+    title: 'standings',
+    ok: false,
+    tests: [
+      {
+        results: [
+          {
+            status: 'failed',
+            attachments: [
+              { name: 'standings-expected.png', contentType: 'image/png' },
+              { name: 'standings-actual.png', contentType: 'image/png' },
+              { name: 'standings-diff.png', contentType: 'image/png' },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const legacySpec = { title: 'player-movement', ok: false };
+
+  const MANIFEST: VrRow[] = [
+    { name: 'standings', auth: 'public', url: 'modules.php?name=Standings', anchor: '.t' },
+    { name: 'player-movement', auth: 'public', url: 'modules.php?name=PlayerMovement', anchor: '.t' },
+    { name: 'draft-history', auth: 'public', url: 'modules.php?name=DraftHistory', anchor: '.t' },
+  ];
+
+  it('row 2 (NEG infra): a failed spec with only an error-context attachment classifies as infra, not diff', () => {
+    const report = { suites: [{ specs: [infraSpec] }] };
+    const { diffCells, infraCells } = extractCells(report, MANIFEST);
+    expect(diffCells).toHaveLength(0);
+    expect(infraCells).toHaveLength(1);
+    expect(infraCells[0]).toMatchObject({ module: 'draft-history', viewport: 'desktop', title: 'draft-history' });
+    expect(infraCells[0].error).toContain('TimeoutError');
+  });
+
+  it('row 3: a failed spec carrying <title>-diff.png classifies as a pixel diff, not infra', () => {
+    const report = { suites: [{ specs: [pixelSpec] }] };
+    const { diffCells, infraCells } = extractCells(report, MANIFEST);
+    expect(infraCells).toHaveLength(0);
+    expect(diffCells).toHaveLength(1);
+    expect(diffCells[0]).toMatchObject({ module: 'standings', viewport: 'desktop', title: 'standings' });
+  });
+
+  it('row 4 (back-compat): a legacy {title, ok:false} spec with no tests classifies as a pixel diff; infraCells empty', () => {
+    const report = { suites: [{ specs: [legacySpec] }] };
+    const { diffCells, infraCells } = extractCells(report, MANIFEST);
+    expect(infraCells).toHaveLength(0);
+    expect(diffCells).toHaveLength(1);
+    expect(diffCells[0]).toMatchObject({ module: 'player-movement', title: 'player-movement' });
+  });
+
+  it('mixed: pixel + infra + legacy split correctly', () => {
+    const report = { suites: [{ specs: [infraSpec, pixelSpec, legacySpec] }] };
+    const { diffCells, infraCells } = extractCells(report, MANIFEST);
+    expect(infraCells.map((c) => c.title)).toEqual(['draft-history']);
+    expect(diffCells.map((c) => c.title).sort()).toEqual(['player-movement', 'standings']);
+  });
+
+  it('extractDiffCells back-compat wrapper returns only diffCells', () => {
+    const report = { suites: [{ specs: [infraSpec, pixelSpec] }] };
+    const cells = extractDiffCells(report, MANIFEST);
+    expect(cells.map((c) => c.title)).toEqual(['standings']);
+  });
+});
+
+describe('buildComment — infra-vs-pixel gating', () => {
+  const oneInfra: InfraCell = {
+    module: 'draft-history',
+    viewport: 'desktop',
+    title: 'draft-history',
+    error: 'TimeoutError: page.goto exceeded',
+  };
+  const oneDiff: DiffCell = { module: 'standings', viewport: 'desktop', title: 'standings', isNew: false };
+
+  it('row 5 (NEG suppression): infra-only with globalChange:true omits pixel headline/banner/update-baselines, includes failed-to-render + title', () => {
+    const md = buildComment({
+      diffCells: [],
+      infraCells: [oneInfra],
+      uncoveredChangedPaths: [],
+      globalChange: true,
+      pagesUrl: PAGES_URL,
+    });
+    expect(md).not.toContain('This PR changed pixels');
+    expect(md).not.toContain('Global change detected');
+    expect(md).not.toContain('update-baselines');
+    expect(md).toContain('failed to render');
+    expect(md).toContain('draft-history');
+    expect(md).not.toContain('No visual diffs detected');
+  });
+
+  it('row 6 (mixed): 1 pixel diff + 1 infra contains BOTH the changed-pixels headline AND the failed-to-render section', () => {
+    const md = buildComment({
+      diffCells: [oneDiff],
+      infraCells: [oneInfra],
+      uncoveredChangedPaths: [],
+      globalChange: false,
+      pagesUrl: PAGES_URL,
+    });
+    expect(md).toContain('This PR changed pixels');
+    expect(md).toContain('failed to render');
+    expect(md).toContain('draft-history');
+    expect(md).toContain('standings');
+  });
+});
+
 describe('CLI end-to-end (bin/vr-review-comment against real git index)', () => {
   it('3 (CLI row): classifies committed-baseline title as CHANGED and uncommitted title as NEW', () => {
     // standings.png is a committed baseline; standings-nobaselinexyz.png is not.
@@ -251,5 +381,55 @@ describe('CLI end-to-end (bin/vr-review-comment against real git index)', () => 
     expect(changedSectionEnd).toBeGreaterThan(-1);
     const standsNoBaselineInChanged = stdout.substring(0, changedSectionEnd).indexOf('standings-nobaselinexyz');
     expect(standsNoBaselineInChanged).toBe(-1);
+  });
+
+  it('row 7 (CLI infra-only): an infra-only report produces the "failed to render" comment, not "changed pixels"', () => {
+    const repoRoot = resolve(__dirname, '../../..');
+    const tmpResults = `${tmpdir()}/vr-review-comment-infra-${Date.now()}.json`;
+    const fakeReport = {
+      suites: [
+        {
+          specs: [],
+          suites: [
+            {
+              specs: [
+                {
+                  title: 'standings',
+                  ok: false,
+                  tests: [
+                    {
+                      results: [
+                        {
+                          status: 'failed',
+                          attachments: [{ name: 'error-context', contentType: 'text/markdown' }],
+                          error: { message: 'TimeoutError: page.goto exceeded' },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    writeFileSync(tmpResults, JSON.stringify(fakeReport));
+
+    const stdout = execFileSync(
+      'bun',
+      [
+        'bin/vr-review-comment',
+        `--results=${tmpResults}`,
+        '--coverage=/nonexistent',
+        '--pages-url=https://example/IBL5/deadbeef/visual-review/',
+      ],
+      { cwd: repoRoot, encoding: 'utf-8' },
+    );
+
+    expect(stdout).toContain('failed to render');
+    expect(stdout).toContain('standings');
+    expect(stdout).not.toContain('This PR changed pixels');
+    expect(stdout).not.toContain('update-baselines');
   });
 });


### PR DESCRIPTION
Fixes three coupled defects surfaced by PR #1107's stale visual-review comment:

1. **Nav flake (Defect 1):** VR spec swapped raw `page.goto` → `gotoWithRetry` (5-attempt, blank-body + HTTP≥400 retry, non-masking — reused verbatim from `tests/e2e/helpers/navigation.ts`). Transient PHP-server timeouts self-heal to green; a real broken page still exhausts the retries and goes red.

2. **Trace gap (Defect 2):** `playwright.visual.config.ts` trace policy changed `'on-first-retry'` → `'retain-on-failure'` (`retries: 0` unchanged). Genuine failures now capture a trace even with zero retries.

3. **Mislabeling (Defect 3):** `vr-review-comment.ts` now reads `specs[].tests[].results[].attachments[]` and classifies each failed cell: a failed cell WITH a `*-diff.png` attachment = pixel diff (existing headline + `update-baselines` instruction); WITHOUT the triplet = infra/render failure (`⚠️ N view(s) failed to render` section + re-run remedy). The "changed pixels" headline and global-change banner render only when ≥1 genuine pixel diff exists. Legacy `{title, ok}` fixtures fall back to pixel-diff (back-compat).

**Also:**
- `bin/vr-review-comment` threads `infraCells` from `extractCells` into `buildComment`
- 184-line vitest suite covering all classifier + comment-gating cases (rows 2–7)
- ADR-0073 documents the selection-logic change (required by `.claude/rules/visual-review-prs.md`)
- `.claude/rules/visual-review-prs.md` updated with the infra-vs-pixel behavior

No workflow change. No SQL, POST/form endpoint, auth/authz route, output rendering, migration, or dependency change — this is TS test tooling, Playwright config, a CI comment builder, an ADR, and a doc.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
