### PR TITLE
chore: collapse clean PR-comment results under <details>

### DIFF
--- a/.github/scripts/summarize-e2e-results.mjs
+++ b/.github/scripts/summarize-e2e-results.mjs
@@ -227,7 +227,8 @@ function generateSectionMarkdown(label, report, screenshotsDir) {
   const flakyCount = results.flaky.length;
 
   if (failCount === 0 && flakyCount === 0) {
-    lines.push(`### ${label} — All ${results.total} tests passed`);
+    // Clean section collapses to a one-line <details> summary to save PR scroll.
+    lines.push(`<details><summary>✅ ${label} — all ${results.total} tests passed</summary></details>`);
   } else {
     const parts = [];
     if (failCount > 0) parts.push(`${failCount} failed`);

--- a/bin/lib/post-review-findings.sh
+++ b/bin/lib/post-review-findings.sh
@@ -127,6 +127,8 @@ ${PRF_FOOTER}"
 #   Posts a single issue comment for the no-issues path (no findings survived the
 #   filter).  The heading and footer are emitted by this function; callers pass
 #   only the evidence body (e.g. "No issues found. Architecture clean.").
+#   This is always the clean path, so the comment is wrapped in a collapsed
+#   <details> (affirmative one-line summary) to save PR scroll space.
 post_review_summary() {
     local pr="$1" title="$2" body="$3"
     local tmp; tmp="$(mktemp -d)"
@@ -134,6 +136,7 @@ post_review_summary() {
     trap "rm -rf '$tmp'" RETURN
 
     local out="$tmp/summary.txt"
-    printf '### %s\n\n%s\n\n%s\n' "$title" "$body" "$PRF_FOOTER" > "$out"
+    printf '<details><summary>✅ %s — no issues found</summary>\n\n### %s\n\n%s\n\n%s\n\n</details>\n' \
+        "$title" "$title" "$body" "$PRF_FOOTER" > "$out"
     "$GH_CMD" pr comment "$pr" --body-file "$out"
 }

--- a/bin/test-post-review-findings
+++ b/bin/test-post-review-findings
@@ -120,6 +120,14 @@ assert_absent() { # label file
     fi
 }
 
+assert_not_contains() { # label file text
+    if grep -qF "$3" "$2" 2>/dev/null; then
+        fail "$1 should NOT contain '$3' but does"
+    else
+        ok "$1 correctly omits '$3'"
+    fi
+}
+
 # ── case 1: on-diff ───────────────────────────────────────────────────────────
 # Finding anchored on a line that IS in the diff (line 12).
 # Expect: $REVIEW_OUT posted as batch review; $COMMENT_OUT absent.
@@ -137,6 +145,7 @@ assert_jq       "case1: side RIGHT"      '.comments[0].side == "RIGHT"'         
 assert_jq       "case1: body has Bug X"  '.comments[0].body | contains("Bug X")'              "$REVIEW_OUT"
 assert_jq       "case1: score marker"    '.comments[0].body | contains("<!-- score: 85 -->")' "$REVIEW_OUT"
 assert_absent   "case1: no fallback"     "$COMMENT_OUT"
+assert_not_contains "case1: review body not collapsed" "$REVIEW_OUT" "<details>"
 
 # ── case 2: out-of-diff (NEGATIVE) ───────────────────────────────────────────
 # Finding on line NOT in the diff (line 999).
@@ -150,6 +159,7 @@ assert_contains "case2: heading"         "$COMMENT_OUT" "### Code review"
 assert_contains "case2: Bug Y present"   "$COMMENT_OUT" "Bug Y"
 assert_contains "case2: score marker 90" "$COMMENT_OUT" "<!-- score: 90 -->"
 assert_absent   "case2: no review POST"  "$REVIEW_OUT"
+assert_not_contains "case2: issues comment not collapsed" "$COMMENT_OUT" "<details>"
 
 # ── case 3: mixed ─────────────────────────────────────────────────────────────
 # Two findings: line 12 on-diff, line 999 out-of-diff.
@@ -172,6 +182,16 @@ assert_contains "case4: heading"   "$COMMENT_OUT" "### Code review"
 assert_contains "case4: body"      "$COMMENT_OUT" "No issues found."
 assert_contains "case4: footer"    "$COMMENT_OUT" "Generated with [Claude Code]"
 assert_absent   "case4: no review" "$REVIEW_OUT"
+assert_contains "case4: collapsed details" "$COMMENT_OUT" "<details><summary>"
+assert_contains "case4: summary verdict"   "$COMMENT_OUT" "✅ Code review — no issues found"
+assert_contains "case4: details close"     "$COMMENT_OUT" "</details>"
+
+# case 4b: SAME function collapses for Security audit (proves one change covers both)
+reset_outputs
+post_review_summary 99 "Security audit" "No security issues found. Inputs validated."
+assert_contains "case4b: security collapsed" "$COMMENT_OUT" "<details><summary>"
+assert_contains "case4b: security verdict"   "$COMMENT_OUT" "✅ Security audit — no issues found"
+assert_contains "case4b: security heading"   "$COMMENT_OUT" "### Security audit"
 
 # ── case 6: BOUNDARY — empty findings ────────────────────────────────────────
 reset_outputs

--- a/ibl5/classes/Cli/LighthouseCommentFormatter.php
+++ b/ibl5/classes/Cli/LighthouseCommentFormatter.php
@@ -83,8 +83,17 @@ final class LighthouseCommentFormatter
         $body .= "\u{1F7E1} = below warn threshold or regression > 0.03 vs baseline\n";
         $body .= "\u{1F534} = below error threshold\n";
 
+        // Clean audits (no error-level violation) collapse under <details> to save
+        // PR scroll space; failing audits stay expanded. The wrapComment() marker
+        // stays outside the <details> so sticky-comment detection still finds it.
+        $markdown = $hasErrorViolation
+            ? $body
+            : "<details><summary>\u{2705} Lighthouse Audit \u{2014} no failing audits</summary>\n\n"
+                . $body
+                . "\n</details>\n";
+
         return [
-            'markdown' => $this->wrapComment($body),
+            'markdown' => $this->wrapComment($markdown),
             'hasErrorViolation' => $hasErrorViolation,
         ];
     }

--- a/ibl5/tests/Cli/LighthouseCommentFormatterTest.php
+++ b/ibl5/tests/Cli/LighthouseCommentFormatterTest.php
@@ -38,6 +38,17 @@ final class LighthouseCommentFormatterTest extends TestCase
         $tableRows = $this->extractTableRows($result['markdown']);
         self::assertStringNotContainsString("\u{1F534}", $tableRows);
         self::assertStringNotContainsString("\u{1F7E1}", $tableRows);
+        // Clean audit collapses; the lighthouse-comment marker stays outside <details>.
+        self::assertStringContainsString(
+            "<details><summary>\u{2705} Lighthouse Audit \u{2014} no failing audits</summary>",
+            $result['markdown']
+        );
+        self::assertStringContainsString('</details>', $result['markdown']);
+        self::assertTrue(
+            strpos($result['markdown'], '<!-- lighthouse-comment -->')
+                < strpos($result['markdown'], '<details>'),
+            'lighthouse-comment marker must precede the <details> wrapper'
+        );
     }
 
     /** Case 2: All scores pass, with baseline (no regression) — delta column shows ±0.00 */
@@ -66,6 +77,8 @@ final class LighthouseCommentFormatterTest extends TestCase
         self::assertStringContainsString("\u{1F7E1}", $result['markdown']);
         self::assertStringContainsString('0.55', $result['markdown']);
         self::assertStringContainsString('-0.05', $result['markdown']);
+        // Warn-level regression with no error violation still collapses.
+        self::assertStringContainsString('<details>', $result['markdown']);
     }
 
     /** Case 4: One URL fails error threshold — shows red marker, hasErrorViolation true */
@@ -78,6 +91,8 @@ final class LighthouseCommentFormatterTest extends TestCase
         self::assertTrue($result['hasErrorViolation']);
         self::assertStringContainsString("\u{1F534}", $result['markdown']);
         self::assertStringContainsString('0.75', $result['markdown']);
+        // Failing audit stays expanded — reviewers see the red row inline.
+        self::assertStringNotContainsString('<details>', $result['markdown']);
     }
 
     /** Case 5: Baseline file absent (null) — comment includes "No master baseline yet" */
@@ -99,6 +114,8 @@ final class LighthouseCommentFormatterTest extends TestCase
         self::assertFalse($result['hasErrorViolation']);
         self::assertStringContainsString('<!-- lighthouse-comment -->', $result['markdown']);
         self::assertStringContainsString('Lighthouse skipped', $result['markdown']);
+        // The one-line skip path is left expanded (collapsing a one-liner is noise).
+        self::assertStringNotContainsString('<details>', $result['markdown']);
     }
 
     /** Case 7: bin/lighthouse-comment exits 2 on missing --manifest */

--- a/ibl5/tests/ts-unit/summarize-e2e-results.test.ts
+++ b/ibl5/tests/ts-unit/summarize-e2e-results.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { resolve } from 'path';
+
+// summarize-e2e-results.mjs has no importable exports (it runs main at the top
+// level), so we drive it as a CLI exactly as .github/workflows/e2e-tests.yml does
+// and assert on stdout. Mirrors the CLI-end-to-end block in vr-review-comment.test.ts.
+
+const repoRoot = resolve(__dirname, '../../..');
+const SCRIPT = '.github/scripts/summarize-e2e-results.mjs';
+
+function runSummary(report: unknown): string {
+  const fixture = `${tmpdir()}/summarize-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}.json`;
+  writeFileSync(fixture, JSON.stringify(report));
+  return execFileSync('node', [SCRIPT, `--functional=${fixture}`], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+  });
+}
+
+const ALL_PASSED = {
+  suites: [{ specs: [{ title: 'loads home', tests: [{ status: 'expected', results: [] }] }] }],
+};
+
+const ONE_FAILED = {
+  suites: [
+    {
+      specs: [
+        {
+          title: 'broken form',
+          tests: [
+            {
+              status: 'unexpected',
+              results: [{ errors: [{ message: 'expected true to be false' }], attachments: [] }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('summarize-e2e-results.mjs collapse', () => {
+  it('clean → all-passed section collapses under a <details> summary', () => {
+    const md = runSummary(ALL_PASSED);
+    expect(md).toContain('<details><summary>✅ Functional E2E — all 1 tests passed</summary></details>');
+  });
+
+  it('failures → section header stays expanded (no ✅ collapse summary)', () => {
+    const md = runSummary(ONE_FAILED);
+    expect(md).toContain('### Functional E2E — 1 failed (1 total)');
+    expect(md).not.toContain('✅ Functional E2E');
+  });
+});


### PR DESCRIPTION
## Summary

When a PR-comment-leaving job finds nothing actionable, wrap its result in a collapsed `<details>` with a one-line affirmative `<summary>` to save PR scroll space; when there ARE issues, leave the comment expanded exactly as today.

Changes the three cleanly-testable comment generators (each already has a real test seam):
- `post_review_summary` bash helper (covers Code review + Security audit)
- `LighthouseCommentFormatter::format()` PHP class
- `summarize-e2e-results.mjs` Node script (per-section)

The three YAML-inline generators (mutation / orphan-css / hot-files) are scoped out to keep this PR to unit-testable surfaces.

### Collapsed-shape convention

```
<details><summary>✅ <Surface> — <affirmative verdict></summary>

<full existing body, unchanged>

</details>
```

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.