### PR TITLE
fix: surface trial-merge output and distinguish conflict vs precondition error in pr-canary-check

### DIFF
--- a/bin/pr-canary-check
+++ b/bin/pr-canary-check
@@ -18,9 +18,12 @@ GH_CMD="${GH_CMD:-gh}"
 STICKY_MARKER="<!-- pr-fast-canary -->"
 
 # Test seams — override in tests to inject stub commands without real git/composer.
-do_trial_merge() { ${CANARY_MERGE_CMD:-git merge --no-commit --no-ff FETCH_HEAD}; }
-do_analyse()     { ( cd "$REPO_ROOT/ibl5" && ${CANARY_ANALYSE_CMD:-composer run analyse}; ); }
-do_test()        { ( cd "$REPO_ROOT/ibl5" && ${CANARY_TEST_CMD:-composer run test}; ); }
+do_trial_merge()   { ${CANARY_MERGE_CMD:-git merge --no-commit --no-ff FETCH_HEAD}; }
+do_analyse()       { ( cd "$REPO_ROOT/ibl5" && ${CANARY_ANALYSE_CMD:-composer run analyse}; ); }
+do_test()          { ( cd "$REPO_ROOT/ibl5" && ${CANARY_TEST_CMD:-composer run test}; ); }
+# True when a merge actually began (left a MERGE_HEAD) — i.e. a real content
+# conflict, as opposed to a precondition error where the merge never started.
+merge_in_progress() { ${CANARY_MERGE_STATE_CMD:-git rev-parse -q --verify MERGE_HEAD}; }
 
 usage() {
     cat <<'EOF'
@@ -76,10 +79,22 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 # Trial-merge: only fetch for real when the merge cmd is not injected
 merge=clean
+merge_log=""
 [ -z "${CANARY_MERGE_CMD:-}" ] && git fetch --no-tags origin "refs/pull/${PR_NUM}/head"
 if ! do_trial_merge >/tmp/canary-merge.log 2>&1; then
-    merge=conflict
-    git merge --abort || true
+    # Capture the real git output so a failure is debuggable from the PR comment
+    # and the CI run log — not silently swallowed.
+    merge_log="$(tail -n 60 /tmp/canary-merge.log 2>/dev/null || true)"
+    # Distinguish a genuine content conflict (the merge began, leaving a
+    # MERGE_HEAD / unmerged paths) from a precondition error where the merge
+    # never started (dirty tree, unrelated histories, unresolvable ref, …).
+    # Both fail the canary, but only the former is an actual merge conflict.
+    if merge_in_progress >/dev/null 2>&1; then
+        merge=conflict
+    else
+        merge=error
+    fi
+    git merge --abort >/dev/null 2>&1 || true
 fi
 
 # set -e-safe capture: run checks only when the merge was clean
@@ -96,6 +111,7 @@ render_body() {
     case "$merge" in
         clean)    merge_status="clean" ;;
         conflict) merge_status="CONFLICT" ;;
+        error)    merge_status="ERROR (trial-merge could not start — not a content conflict)" ;;
         *)        merge_status="$merge" ;;
     esac
 
@@ -113,7 +129,7 @@ render_body() {
         *)       test_status="$test" ;;
     esac
 
-    if [ "$merge" = conflict ] || [ "$analyse" = fail ] || [ "$test" = fail ]; then
+    if [ "$merge" != clean ] || [ "$analyse" = fail ] || [ "$test" = fail ]; then
         overall="FAIL"
     else
         overall="PASS"
@@ -126,6 +142,9 @@ render_body() {
 
     printf '## PR Fast-Canary\n\n'
     printf '**Merge:** %s\n\n' "$merge_status"
+    if [[ -n "$merge_log" ]]; then
+        printf '<details><summary>Trial-merge output</summary>\n\n```\n%s\n```\n\n</details>\n\n' "$merge_log"
+    fi
     printf '**PHPStan (`composer run analyse`):** %s\n\n' "$analyse_status"
     printf '**PHPUnit (`composer run test`):** %s\n\n' "$test_status"
     printf '**Overall:** %s\n\n' "$overall"

--- a/bin/test-pr-canary-check
+++ b/bin/test-pr-canary-check
@@ -92,6 +92,15 @@ STUB
 
 chmod +x "$STUBBIN/gh"
 
+# Stub merge command: emits a recognizable error to stderr and fails, so we can
+# assert the canary surfaces the real trial-merge output in the rendered body.
+cat > "$STUBBIN/mergefail" <<'STUB'
+#!/usr/bin/env bash
+echo "SIMULATED-MERGE-OUTPUT: boom" >&2
+exit 1
+STUB
+chmod +x "$STUBBIN/mergefail"
+
 # Shorthand: run canary with stub gh and injected seams, capture stdout + exit code
 run_canary() {
     # Usage: run_canary [extra env vars...] -- [args to pass to pr-canary-check]
@@ -128,17 +137,30 @@ run_canary_rc -- --unknown-flag && failcase "row1-unknown-flag-exits2" || {
 
 run_canary_rc -- --help && pass "row1-help-exits0" || failcase "row1-help-exits0 (got exit $?)"
 
-# --- Row 2: Merge conflict ---
+# --- Row 2: Real merge conflict (merge began — MERGE_HEAD present) ---
 
-body_conflict="$(run_canary "CANARY_MERGE_CMD=false" "CANARY_ANALYSE_CMD=false" "CANARY_TEST_CMD=false" -- --pr 42)"
+conflict_env=("CANARY_MERGE_CMD=$STUBBIN/mergefail" "CANARY_MERGE_STATE_CMD=true" "CANARY_ANALYSE_CMD=false" "CANARY_TEST_CMD=false")
+body_conflict="$(run_canary "${conflict_env[@]}" -- --pr 42)"
 rc_conflict=0
-run_canary_rc "CANARY_MERGE_CMD=false" "CANARY_ANALYSE_CMD=false" "CANARY_TEST_CMD=false" -- --pr 42 || rc_conflict=$?
+run_canary_rc "${conflict_env[@]}" -- --pr 42 || rc_conflict=$?
 
-assert_match "row2-conflict-body-says-CONFLICT" 'CONFLICT' "$body_conflict"
+assert_match "row2-conflict-body-says-CONFLICT" 'Merge:\*\* CONFLICT' "$body_conflict"
+assert_match "row2-conflict-surfaces-merge-log" 'SIMULATED-MERGE-OUTPUT: boom' "$body_conflict"
+assert_match "row2-conflict-has-details-block"  'Trial-merge output' "$body_conflict"
 assert_match "row2-conflict-phpstan-skipped"    'PHPStan.*skipped' "$body_conflict"
 assert_match "row2-conflict-phpunit-skipped"    'PHPUnit.*skipped' "$body_conflict"
 assert_match "row2-conflict-overall-FAIL"       'Overall.*FAIL' "$body_conflict"
 [ "$rc_conflict" -eq 0 ] && pass "row2-conflict-exits0" || failcase "row2-conflict-exits0 (got $rc_conflict)"
+
+# --- Row 2b: Precondition error (merge never started — no MERGE_HEAD) ---
+
+error_env=("CANARY_MERGE_CMD=$STUBBIN/mergefail" "CANARY_MERGE_STATE_CMD=false" "CANARY_ANALYSE_CMD=false" "CANARY_TEST_CMD=false")
+body_error="$(run_canary "${error_env[@]}" -- --pr 42)"
+
+assert_match  "row2b-error-body-says-ERROR"      'Merge:\*\* ERROR' "$body_error"
+assert_absent "row2b-error-not-labeled-conflict" 'Merge:\*\* CONFLICT' "$body_error"
+assert_match  "row2b-error-surfaces-merge-log"   'SIMULATED-MERGE-OUTPUT: boom' "$body_error"
+assert_match  "row2b-error-overall-FAIL"         'Overall.*FAIL' "$body_error"
 
 # --- Row 3: PHPStan FAIL (set-e-safe capture) ---
 


### PR DESCRIPTION
## Summary

- `bin/pr-canary-check` silently swallowed trial-merge failure details. Now captures the last 60 lines of `git merge` output and embeds them in the PR comment under a `<details>` block, making conflicts debuggable without diving into the CI run log.
- Distinguishes a real content conflict (MERGE_HEAD present after the merge began) from a precondition error where the merge never started (dirty tree, unresolvable ref, etc.). Both fail the canary but are now reported with distinct labels (`CONFLICT` vs `ERROR`).
- `render_body` overall FAIL logic updated to `merge != clean` (covers both conflict and error states).
- `bin/test-pr-canary-check` updated: row 2 now uses a proper stub that emits recognizable output to stderr; adds row 2b for the precondition-error path; asserts the merge log is surfaced in the rendered body.

## Manual Testing

No manual testing needed — all changes are covered by automated tests.