### PR TITLE
chore: add CI lint gates for workflow checkout ordering and composite behavior contracts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -488,6 +488,23 @@ jobs:
         working-directory: ibl5
         run: bin/check-csrf-field-name
 
+  workflow-lint:
+    name: Workflow composite-action lint
+    runs-on: ubuntu-latest
+    # Runs unconditionally: a job that `uses:` a local ./.github/actions/* action
+    # without a prior checkout fails only at runtime (and reusable cron/deploy jobs
+    # aren't exercised on the PR), and a composite that drops a pinned behavior
+    # contract fails silently — neither is covered by any path-filter. Both checks
+    # are a few seconds of bash with no dependencies. NOTE: no working-directory —
+    # these live in repo-root bin/ and scan repo-root .github/.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Local-action checkout ordering
+        run: bin/check-workflow-checkout
+      - name: Composite behavior contracts
+        run: bin/check-composite-contracts
+
   harness-tests:
     name: Shell harness regression tests
     needs: [changes]
@@ -528,6 +545,10 @@ jobs:
         run: bin/test-playwright-version
       - name: bin/test-pr-canary-check
         run: bin/test-pr-canary-check
+      - name: bin/test-check-workflow-checkout
+        run: bin/test-check-workflow-checkout
+      - name: bin/test-check-composite-contracts
+        run: bin/test-check-composite-contracts
 
   gate:
     name: Tests and Analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -553,7 +553,7 @@ jobs:
   gate:
     name: Tests and Analysis
     if: always()
-    needs: [changes, test, audit-php, audit-js, ibl6-checks, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, infection-excludes, csrf-field-name, harness-tests]
+    needs: [changes, test, audit-php, audit-js, ibl6-checks, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, infection-excludes, csrf-field-name, harness-tests, workflow-lint]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1

--- a/bin/check-composite-contracts
+++ b/bin/check-composite-contracts
@@ -1,0 +1,61 @@
+#!/bin/bash
+# bin/check-composite-contracts — pins two behavior contracts of the shared CI
+# composites that CI itself cannot exercise (the prod SSH + IBLbot Discord path is
+# unreachable from CI, so actionlint proves wiring but not these semantics).
+#
+#   setup-ssh:      the host keyscan must keep its `|| true` guard, so a transient
+#                   keyscan failure never aborts a deploy/backup/smoke job.
+#   notify-discord: `fail-on-delivery` must DEFAULT to 'true' (loud-fail), so a
+#                   caller that omits it keeps alert-delivery failures RED. (This
+#                   pins the default only; it does NOT verify that no caller passes
+#                   fail-on-delivery: false on an alert path — that intent is not
+#                   mechanizable from the composite alone.)
+#
+# Conditional by design: each check is SKIPPED (visibly) when its composite file is
+# absent, so this no-ops on a branch without the composites and auto-activates the
+# moment they land. The visible "skipped" line means a path typo can't silently turn
+# the gate into a vacuous pass.
+#
+# Usage: bin/check-composite-contracts [actions-dir]   (default: .github/actions)
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ACTIONS="${1:-$ROOT/.github/actions}"
+
+fail=0
+
+ssh_file="$ACTIONS/setup-ssh/action.yml"
+if [ -f "$ssh_file" ]; then
+  if grep -qE 'ssh-keyscan.*\|\| true' "$ssh_file"; then
+    echo "composite-contracts: setup-ssh keyscan guard present"
+  else
+    echo "composite-contracts: setup-ssh is MISSING its 'ssh-keyscan ... || true' guard — a transient keyscan failure must not abort the job ($ssh_file)" >&2
+    fail=1
+  fi
+else
+  echo "composite-contracts: setup-ssh absent — skipped"
+fi
+
+nd_file="$ACTIONS/notify-discord/action.yml"
+if [ -f "$nd_file" ]; then
+  # Read the default of the fail-on-delivery input specifically: enter its block on
+  # the bare 2-space key, leave on the next bare 2-space key, capture default within.
+  # This reads the RIGHT block's default even when fail-on-delivery is not last and
+  # other inputs also define a default.
+  default_raw="$(awk '
+    /^  fail-on-delivery:[[:space:]]*$/ { inblk=1; next }
+    inblk && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { inblk=0 }
+    inblk && /^[[:space:]]*default:/ { sub(/^[[:space:]]*default:[[:space:]]*/, ""); print; exit }
+  ' "$nd_file")"
+  default="$(printf '%s' "$default_raw" | tr -d "\"' ")"
+  if [ "$default" = "true" ]; then
+    echo "composite-contracts: notify-discord fail-on-delivery defaults to 'true' (loud-fail)"
+  else
+    echo "composite-contracts: notify-discord fail-on-delivery default is '${default:-<unset>}', expected 'true' (loud-fail) ($nd_file)" >&2
+    fail=1
+  fi
+else
+  echo "composite-contracts: notify-discord absent — skipped"
+fi
+
+exit "$fail"

--- a/bin/check-workflow-checkout
+++ b/bin/check-workflow-checkout
@@ -1,0 +1,58 @@
+#!/bin/bash
+# bin/check-workflow-checkout — CI gate: any workflow job that `uses:` a LOCAL
+# composite action (./.github/actions/...) must run actions/checkout FIRST in that
+# job. GitHub resolves a local action from the checked-out tree, so without a prior
+# checkout the step fails at runtime with "Can't find '…/action.yml'". actionlint
+# does not model step ordering, so it never catches this — this gate fills that gap.
+#
+# Reusable-workflow calls (uses: ./.github/workflows/*.yml) are JOB-level and need
+# NO checkout (GitHub fetches them itself), so they are deliberately NOT flagged —
+# only ./.github/actions/ uses are.
+#
+# Usage: bin/check-workflow-checkout [file ...]   (default: .github/workflows/*.yml)
+set -eu
+
+if [ "$#" -gt 0 ]; then
+  set -- "$@"
+else
+  set --
+  for f in .github/workflows/*.yml; do
+    [ -f "$f" ] && set -- "$@" "$f"
+  done
+fi
+
+[ "$#" -gt 0 ] || { echo "check-workflow-checkout: no workflow files to scan" >&2; exit 0; }
+
+rc=0
+awk '
+  # Reset per file so state never leaks across workflows.
+  FNR==1 { injobs=0; seen=0; job="" }
+
+  # Enter the jobs: map; any later top-level key closes it.
+  /^jobs:[[:space:]]*$/ { injobs=1; next }
+  injobs && /^[^[:space:]#]/ { injobs=0 }
+
+  # A job header is the only 2-space-indented bare key under jobs:. Reset checkout
+  # state for the new job.
+  injobs && /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ { job=$0; sub(/:.*/, "", job); gsub(/[[:space:]]/, "", job); seen=0 }
+
+  # A checkout step (any version) satisfies the requirement for the rest of the job.
+  # Leading "- " allows the inline list-item form.
+  injobs && /^[[:space:]]*(- )?uses:[[:space:]]*actions\/checkout/ { seen=1 }
+
+  # A local composite-action use with no prior checkout in this job is a violation.
+  injobs && /^[[:space:]]*(- )?uses:[[:space:]]*\.\/\.github\/actions\// {
+    if (!seen) {
+      printf "%s:%d: job \"%s\" uses a local action before any actions/checkout step\n", FILENAME, FNR, job
+      fail = 1
+    }
+  }
+
+  END { exit (fail ? 1 : 0) }
+' "$@" || rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  echo "check-workflow-checkout: a job uses a local ./.github/actions/* action without a prior actions/checkout step — add 'uses: actions/checkout@v7' before it (GitHub cannot resolve a local action without the repo checked out)." >&2
+  exit 1
+fi
+exit 0

--- a/bin/test-check-composite-contracts
+++ b/bin/test-check-composite-contracts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-check-composite-contracts — regression test for the composite-contract
+# gate. Builds throwaway .github/actions trees and asserts the check's exit code and
+# skip/active behavior. Verifies the logic even while the live composites are absent
+# on master (the check is dormant there, but its logic must already be correct so it
+# is sound the moment the composites land).
+#
+# Run: bin/test-check-composite-contracts  (exit 0 = all pass, 1 = a case failed)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$SCRIPT_DIR/check-composite-contracts"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILED=0
+
+# fresh_actions → echoes a new empty actions dir. Uses mktemp (not a counter): this
+# runs in a $(...) subshell at the call site, so a counter increment would not
+# persist and every call would reuse one dir, leaking state across cases.
+fresh_actions() {
+  mktemp -d "$TMP/actions.XXXXXX"
+}
+
+put_ssh() { # dir, guarded(1|0)
+  mkdir -p "$1/setup-ssh"
+  # $PORT/$HOST are intentionally literal in the fixture YAML, not shell-expanded.
+  # shellcheck disable=SC2016
+  if [ "$2" -eq 1 ]; then
+    printf 'runs:\n  steps:\n    - run: ssh-keyscan -p "$PORT" "$HOST" >> ~/.ssh/known_hosts 2>/dev/null || true\n' > "$1/setup-ssh/action.yml"
+  else
+    printf 'runs:\n  steps:\n    - run: ssh-keyscan -p "$PORT" "$HOST" >> ~/.ssh/known_hosts\n' > "$1/setup-ssh/action.yml"
+  fi
+}
+
+# put_nd <dir> <fail-on-delivery-default> [extra-input-with-default]
+# Writes a notify-discord action.yml. When the 3rd arg is "lead", an UNRELATED input
+# with its own default is placed BEFORE fail-on-delivery, and fail-on-delivery is not
+# last — proving the parser reads the right block's default.
+put_nd() {
+  mkdir -p "$1/notify-discord"
+  local f="$1/notify-discord/action.yml"
+  {
+    echo 'inputs:'
+    if [ "${3:-}" = "lead" ]; then
+      echo '  message-file:'
+      echo '    description: msg'
+      echo "    default: '/tmp/x.txt'"
+    fi
+    echo '  fail-on-delivery:'
+    echo '    description: loud or soft'
+    echo '    required: false'
+    echo "    default: '$2'"
+    echo '  port:'
+    echo '    description: port'
+    echo '    required: true'
+  } > "$f"
+}
+
+expect() { # name want got
+  if [ "$3" -eq "$2" ]; then
+    echo "ok: $1 (exit $3)"
+  else
+    echo "FAIL: $1 — expected exit $2, got $3"
+    FAILED=1
+  fi
+}
+
+# --- both absent → pass, both skipped (visibly) --------------------------------
+d="$(fresh_actions)"
+out="$("$CHECK" "$d" 2>&1)"; rc=$?
+expect "both-absent-pass" 0 "$rc"
+if printf '%s' "$out" | grep -q 'setup-ssh absent — skipped' \
+   && printf '%s' "$out" | grep -q 'notify-discord absent — skipped'; then
+  echo "ok: absent-skips-are-visible"
+else
+  echo "FAIL: absent-skips-are-visible — output: $out"; FAILED=1
+fi
+
+# --- setup-ssh guarded → pass --------------------------------------------------
+d="$(fresh_actions)"; put_ssh "$d" 1
+"$CHECK" "$d" >/dev/null 2>&1; expect "ssh-guard-present" 0 $?
+
+# --- setup-ssh missing guard → fail --------------------------------------------
+d="$(fresh_actions)"; put_ssh "$d" 0
+"$CHECK" "$d" >/dev/null 2>&1; expect "ssh-guard-missing" 1 $?
+
+# --- notify-discord default true → pass ----------------------------------------
+d="$(fresh_actions)"; put_nd "$d" true
+"$CHECK" "$d" >/dev/null 2>&1; expect "nd-default-true" 0 $?
+
+# --- notify-discord default false → fail ---------------------------------------
+d="$(fresh_actions)"; put_nd "$d" false
+"$CHECK" "$d" >/dev/null 2>&1; expect "nd-default-false" 1 $?
+
+# --- right-block parsing: a leading input also has a default; fail-on-delivery
+#     (true) is not last → must still pass (reads the correct block) -------------
+d="$(fresh_actions)"; put_nd "$d" true lead
+"$CHECK" "$d" >/dev/null 2>&1; expect "nd-reads-correct-block-true" 0 $?
+
+# --- same shape but fail-on-delivery=false with a leading true default → fail ---
+d="$(fresh_actions)"; put_nd "$d" false lead
+"$CHECK" "$d" >/dev/null 2>&1; expect "nd-reads-correct-block-false" 1 $?
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "RESULT: FAILED"
+  exit 1
+fi
+echo "RESULT: all passed"
+exit 0

--- a/bin/test-check-workflow-checkout
+++ b/bin/test-check-workflow-checkout
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-check-workflow-checkout — regression test for the local-action checkout
+# gate. Each case writes a throwaway workflow file and asserts the check's exit code
+# (and, where it matters, which job is named in the output).
+#
+# Run: bin/test-check-workflow-checkout  (exit 0 = all pass, 1 = a case failed)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$SCRIPT_DIR/check-workflow-checkout"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILED=0
+
+# write_wf <body>  → echoes the path of a fresh workflow file holding <body>. Uses
+# mktemp (not a counter): this runs in a $(...) subshell, so a counter would not
+# persist and every call would reuse one path.
+write_wf() {
+  # X's must be the trailing chars (BSD mktemp rejects a suffix). The check reads any
+  # path given as an arg, so the missing .yml extension is irrelevant here.
+  local f
+  f="$(mktemp "$TMP/wf.XXXXXX")"
+  printf '%s\n' "$1" > "$f"
+  printf '%s' "$f"
+}
+
+expect() { # name want-exit got-exit
+  if [ "$3" -eq "$2" ]; then
+    echo "ok: $1 (exit $3)"
+  else
+    echo "FAIL: $1 — expected exit $2, got $3"
+    FAILED=1
+  fi
+}
+
+# --- good: checkout precedes local action -------------------------------------
+f="$(write_wf 'name: ok
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-ssh')"
+"$CHECK" "$f" >/dev/null 2>&1; expect "checkout-before-local-action" 0 $?
+
+# --- bad: local action, no checkout -------------------------------------------
+f="$(write_wf 'name: bad
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup-ssh')"
+"$CHECK" "$f" >/dev/null 2>&1; expect "local-action-no-checkout" 1 $?
+
+# --- bad: checkout AFTER the local action (order matters) ----------------------
+f="$(write_wf 'name: order
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup-ssh
+      - uses: actions/checkout@v7')"
+"$CHECK" "$f" >/dev/null 2>&1; expect "checkout-after-local-action" 1 $?
+
+# --- good: reusable-workflow call needs no checkout (must NOT be flagged) -------
+f="$(write_wf 'name: reusable
+on: [pull_request]
+jobs:
+  call:
+    uses: ./.github/workflows/deploy-rehearsal.yml
+    secrets: inherit')"
+"$CHECK" "$f" >/dev/null 2>&1; expect "reusable-workflow-no-flag" 0 $?
+
+# --- good: keyed (non-list) uses with prior checkout ---------------------------
+f="$(write_wf 'name: keyed
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup
+        uses: ./.github/actions/setup-ssh')"
+"$CHECK" "$f" >/dev/null 2>&1; expect "keyed-form-with-checkout" 0 $?
+
+# --- per-job reset: job A clean, job B violates → fail, and only B is named -----
+f="$(write_wf 'name: twojobs
+on: [pull_request]
+jobs:
+  alpha:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-ssh
+  bravo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/notify-discord')"
+out="$("$CHECK" "$f" 2>&1)"; rc=$?
+expect "two-jobs-second-violates" 1 "$rc"
+if printf '%s' "$out" | grep -q '"bravo"' && ! printf '%s' "$out" | grep -q '"alpha"'; then
+  echo "ok: only-violating-job-named"
+else
+  echo "FAIL: only-violating-job-named — output: $out"
+  FAILED=1
+fi
+
+# --- comment mentioning uses: must not false-trigger ---------------------------
+f="$(write_wf 'name: comment
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # uses: ./.github/actions/setup-ssh  (documentation only)
+      - uses: actions/checkout@v7')"
+"$CHECK" "$f" >/dev/null 2>&1; expect "commented-uses-ignored" 0 $?
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "RESULT: FAILED"
+  exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
## Summary

- Adds `bin/check-workflow-checkout`: CI gate that flags any workflow job using a local `./.github/actions/*` action without a prior `actions/checkout` step (actionlint does not model step ordering, so this gap was previously uncaught)
- Adds `bin/check-composite-contracts`: pins two behavior contracts actionlint cannot enforce — the `setup-ssh` keyscan `|| true` guard and `notify-discord` `fail-on-delivery` loud-fail default
- Wires both checks into a new `workflow-lint` CI job (unconditional — no path filter, since the bugs are timing/ordering issues that path filters can't catch) and adds their regression tests to the existing `harness-tests` job

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: new CI lint scripts enforcing actionlint-invisible workflow invariants, no architectural decision required -->