### PR TITLE
fix: inject throwaway git identity for trial merge so bare CI runners don't abort with "Committer identity unknown"

### DIFF
--- a/bin/pr-canary-check
+++ b/bin/pr-canary-check
@@ -18,7 +18,13 @@ GH_CMD="${GH_CMD:-gh}"
 STICKY_MARKER="<!-- pr-fast-canary -->"
 
 # Test seams — override in tests to inject stub commands without real git/composer.
-do_trial_merge()   { ${CANARY_MERGE_CMD:-git merge --no-commit --no-ff FETCH_HEAD}; }
+# The -c identity is scoped to this one invocation (no global git state mutated).
+# git validates committer identity before preparing a non-fast-forward merge even
+# with --no-commit, so on a bare CI runner (no user.name/email) the merge would
+# abort with "Committer identity unknown" before any real conflict could surface —
+# misreported as a precondition error. The merge is thrown away, so the value is
+# irrelevant; it only has to be non-empty.
+do_trial_merge()   { ${CANARY_MERGE_CMD:-git -c user.email=canary@ci.invalid -c user.name=fast-canary merge --no-commit --no-ff FETCH_HEAD}; }
 do_analyse()       { ( cd "$REPO_ROOT/ibl5" && ${CANARY_ANALYSE_CMD:-composer run analyse}; ); }
 do_test()          { ( cd "$REPO_ROOT/ibl5" && ${CANARY_TEST_CMD:-composer run test}; ); }
 # True when a merge actually began (left a MERGE_HEAD) — i.e. a real content


### PR DESCRIPTION
## Summary

- `bin/pr-canary-check`'s `do_trial_merge()` now passes `-c user.email=canary@ci.invalid -c user.name=fast-canary` to the `git merge` invocation
- On a bare CI runner (GitHub-hosted runners have no global `user.name`/`user.email`) git validates committer identity **before** beginning the merge — even with `--no-commit` — so the merge aborted with `Committer identity unknown` before any real conflict could surface
- This was misreported as a precondition error rather than a conflict, making the canary check unreliable on CI
- The `-c` flags are scoped to the single invocation (no global git config mutation); the identity values are thrown away since `--no-commit` never creates a commit

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.