### PR TITLE
chore: repoint automouse/post-plan model alias from sonnet-4-6 to sonnet-5

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,6 +1,6 @@
 ---
 description: "Commit, push, and open a PR via /post-plan, which decides whether auto-merge arms; /ship never arms directly."
-last_verified: 2026-06-22
+last_verified: 2026-06-30
 ---
 
 # /ship — Commit, push, PR via /post-plan
@@ -35,7 +35,7 @@ Then the actions:
 
 - **Do NOT commit.** Leave the worktree **dirty** — `/post-plan` Phase 2 commits the uncommitted tree and opens the PR; committing first would change what ships (see `.claude/rules/workflow-continuity.md`).
 - Fire **`bin/post-plan-now`** (bare, **not** `--auto`): a human invoking `/ship` IS the decision to ship; `--auto` only matters inside headless, which the Step 1 precondition already rejected.
-- Report: post-plan fired (detached Sonnet 4.6, launchd-supervised); the PR / code review / CI / auto-merge progress all land on the PR; list any predicted holds from the advisory step.
+- Report: post-plan fired (detached Sonnet 5, launchd-supervised); the PR / code review / CI / auto-merge progress all land on the PR; list any predicted holds from the advisory step.
 
 ## Decision-table recap
 

--- a/.claude/rules/agent-tiering-detail.md
+++ b/.claude/rules/agent-tiering-detail.md
@@ -1,6 +1,6 @@
 ---
 description: Read-on-demand detail for agent-tiering — full Fable approval-gate procedure, flat-fan-out (nested sub-agent) rationale, and per-tier prompt style. Loads only when editing workflow orchestration defs, where this rationale applies.
-last_verified: 2026-06-27
+last_verified: 2026-06-30
 paths:
   - ".claude/commands/**/*.md"
   - ".claude/skills/**/SKILL.md"
@@ -25,6 +25,21 @@ This file holds the longer rationale, pulled out of the always-loaded budget.
 - **Recommendation**: a clear "I'd use Fable here" / "Opus is probably fine, flagging it" — not a neutral survey.
 
 Absent approval, proceed on Opus (or the correct lower tier) — flag and continue, don't block. Approval covers that one task; a new task re-triggers the gate. Use `AskUserQuestion` only when it's a genuine fork; otherwise inline the suggestion and keep going.
+
+## Boundary keys on task type, not model capability
+
+Re-validated 2026-06-30 against Sonnet 5 (now the `sonnet` alias, native 1M context). The
+Opus-only column (final code review, diff-triage, rule/ADR authoring, novel reasoning,
+ambiguous failures) stays Opus because **"never delegate understanding" is a *delegation*
+rule, not a "wait for a smarter model" rule** — a more capable Sonnet does not make
+delegating the judgment safe, because the cost was never Sonnet's raw ability, it was that
+the Opus session loses the findings it would otherwise filter (see the flat-fan-out
+rationale below, and `feedback_sonnet_proving_negatives` / `feedback_review_agent_full_diff`).
+Sonnet 5's larger context window only **strengthens** the existing "spawn Sonnet to absorb
+verbose output" rationale; it is not a reason to push understanding-class work down a tier.
+**Tripwire to revisit:** a model generation where the *delegation* failure mode itself
+changes (e.g. a coordinator that can surface its own filtered-out findings), not merely a
+higher per-task capability score.
 
 ## Nested Sub-Agents — Available, Deliberately Unused
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,6 +1,6 @@
 ---
 description: Sub-agent decision rules — when to spawn, when to skip, and which model to pick
-last_verified: 2026-06-27
+last_verified: 2026-06-30
 ---
 
 # Agent Tiering
@@ -28,6 +28,8 @@ Each sub-agent pays fixed overhead (~3–5K tokens: system prompt + rules + memo
 | **Opus** | self (no delegation) | Novel reasoning, FK ordering, rule authoring, ADR writing, ambiguous test failures, final code review, diff-triage. Never delegate understanding. |
 | **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3. The def pins `model: opus` + `effort: xhigh` (the built-in Plan agent has no per-call effort override; A/B proved them equivalent), so planning runs at Opus depth in a clean sub-context. Do **not** pass an inline `model` override — the def owns it. |
 | **Fable** | **unavailable — do not select** | Currently inaccessible; never pick `model: "fable"`. When access returns it is the opt-in rung above Opus (ceiling-binding tasks), gated behind explicit approval — full procedure in `.claude/rules/agent-tiering-detail.md`. |
+
+> **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — so a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 against Sonnet 5 (now the `sonnet` alias, native 1M context): boundary unchanged. Why a more-capable Sonnet doesn't shift work down a tier: `agent-tiering-detail.md`.
 
 ## Flat fan-out (no nested sub-agents)
 

--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -1,6 +1,6 @@
 ---
 description: All work happens in a worktree (never the main checkout); worktree setup and the implementation→/post-plan handoff (auto-fired in a detached fresh session) for any verified-complete worktree work, plan-driven or ad-hoc.
-last_verified: 2026-06-28
+last_verified: 2026-06-30
 ---
 
 # Workflow Continuity Rule
@@ -39,7 +39,7 @@ bin/post-plan-now --auto
 
 (On an ad-hoc branch with no plan file, post-plan runs plan-blind — that's expected, not an error. The merge-arming decision still happens at `/post-plan` Phase 6.5, so auto-opening the PR never means auto-merging a `feat:`/`auto_merge: false`/visual PR without human signoff.)
 
-This spawns a detached, fresh **Sonnet 4.6** `/post-plan` on this branch (supervised by launchd, so it survives you closing Claude Code). It removes the manual "open a new session and hand off" step. Notes:
+This spawns a detached, fresh **Sonnet 5** `/post-plan` on this branch (supervised by launchd, so it survives you closing Claude Code). It removes the manual "open a new session and hand off" step. Notes:
 
 - **Do NOT commit first.** Leave the worktree **dirty** — `/post-plan` commits the uncommitted tree in its Phase 2 and opens the PR. Committing here would change what it ships.
 - **Only fire when verification passed.** If implementation did **not** verify clean (failing tests, unresolved blocker, you stopped to ask the user something), do **not** run it — leave the worktree dirty and hand off in prose instead. Turn-end ≠ done; that judgment is yours.

--- a/bin/automouse-run
+++ b/bin/automouse-run
@@ -675,7 +675,7 @@ PLAN_FILE=$PLAN_NAME" \
 
 PLAN_FILE=$PLAN_NAME" \
                 --dangerously-skip-permissions \
-                --model claude-sonnet-4-6 \
+                --model claude-sonnet-5 \
                 --effort high \
                 --output-format stream-json \
                 --verbose \

--- a/bin/lib/plan-impl-model
+++ b/bin/lib/plan-impl-model
@@ -25,7 +25,7 @@ RAW=$(awk '
 ' "$PLAN_FILE" 2>/dev/null)
 
 case "$RAW" in
-  sonnet) echo "claude-sonnet-4-6" ;;
+  sonnet) echo "claude-sonnet-5" ;;
   haiku)  echo "claude-haiku-4-5"  ;;
   *)      echo "claude-opus-4-8"   ;;   # opus, empty, garbled, or unknown → safe default
 esac

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# bin/post-plan-now — fire a fresh, detached Sonnet 4.6 /post-plan session on the
+# bin/post-plan-now — fire a fresh, detached Sonnet 5 /post-plan session on the
 # current worktree's branch, replacing the manual "open a new session and hand
 # off" step. The run is supervised by launchd (RunAtLoad one-shot), so it
 # survives closing Claude Code or the terminal — a plain `nohup … &` launched
@@ -91,7 +91,7 @@ cat > "$PLIST" <<PLIST_EOF
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
+		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-5 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
@@ -108,7 +108,7 @@ PLIST_EOF
 launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$PLIST"
 
-echo "post-plan-now: fired a detached Sonnet 4.6 /post-plan on branch '$SLUG'."
+echo "post-plan-now: fired a detached Sonnet 5 /post-plan on branch '$SLUG'."
 echo "  supervised by launchd — survives closing Claude Code / the terminal"
 echo "  log:    tail -f $LOG"
 echo "  label:  $LABEL   (self-removes when post-plan finishes)"

--- a/bin/test-automouse-impl-model
+++ b/bin/test-automouse-impl-model
@@ -40,7 +40,7 @@ assert() {
 }
 
 # c1 — line-1 frontmatter selects sonnet
-assert "c1-sonnet" "claude-sonnet-4-6" '---
+assert "c1-sonnet" "claude-sonnet-5" '---
 impl_model: sonnet
 ---
 # Plan
@@ -72,7 +72,7 @@ impl_model: opus
 # Plan'
 
 # c5 — leading/trailing whitespace around the value is tolerated
-assert "c5-whitespace" "claude-sonnet-4-6" '---
+assert "c5-whitespace" "claude-sonnet-5" '---
 impl_model:   sonnet
 ---
 # Plan'


### PR DESCRIPTION
## Summary
- Sonnet 5 has superseded 4.6 as the `sonnet` alias; updates hardcoded `claude-sonnet-4-6` strings to `claude-sonnet-5` in `bin/automouse-run`, `bin/post-plan-now`, `bin/lib/plan-impl-model`, and the matching test (`bin/test-automouse-impl-model`).
- Bumps `last_verified` dates and doc prose (`ship.md`, `workflow-continuity.md`, `agent-tiering.md`) to reflect the new model name.
- Adds a re-validation note to `agent-tiering-detail.md`: the Opus/Sonnet task-type boundary is unchanged under Sonnet 5's larger context window — the boundary keys on task type, not raw model capability.

## Manual Testing
No manual testing needed — all changes are covered by automated tests.