### PR TITLE
perf(RecordHolders): safe cache-miss path — serve-stale-first + single-flight GET_LOCK

### DIFF
--- a/ibl5/classes/Cache/Contracts/DatabaseCacheInterface.php
+++ b/ibl5/classes/Cache/Contracts/DatabaseCacheInterface.php
@@ -42,4 +42,38 @@ interface DatabaseCacheInterface
      * @param string $key Cache key
      */
     public function delete(string $key): void;
+
+    /**
+     * Retrieve a cached value by key, IGNORING expiration.
+     *
+     * Returns the stored value even when past its expiration timestamp, so callers can
+     * serve a stale-but-valid payload while an out-of-band refresh (e.g. cron) rebuilds.
+     * Returns null only on a genuine miss, corrupt JSON, or database error.
+     *
+     * @param string $key Cache key
+     * @return array<mixed>|null Decoded array if a row exists (fresh or stale), null otherwise
+     */
+    public function getStale(string $key): ?array;
+
+    /**
+     * Acquire a named single-flight lock, blocking up to $timeoutSeconds for it.
+     *
+     * Used to ensure only one request rebuilds an expensive cache entry at a time
+     * (stampede / thundering-herd guard). Returns false on timeout or database error,
+     * so a failed acquire must degrade safely (serve stale/empty, do not rebuild).
+     *
+     * @param string $key Lock name
+     * @param int $timeoutSeconds Seconds to wait for the lock
+     * @return bool True if the lock was acquired, false on timeout or error
+     */
+    public function acquireLock(string $key, int $timeoutSeconds): bool;
+
+    /**
+     * Release a named lock previously taken with acquireLock().
+     *
+     * Silently fails on database errors.
+     *
+     * @param string $key Lock name
+     */
+    public function releaseLock(string $key): void;
 }

--- a/ibl5/classes/Cache/DatabaseCache.php
+++ b/ibl5/classes/Cache/DatabaseCache.php
@@ -34,6 +34,41 @@ class DatabaseCache extends \BaseMysqliRepository implements DatabaseCacheInterf
      */
     public function get(string $key): ?array
     {
+        $row = $this->fetchRow($key);
+        if ($row === null) {
+            return null; // cache miss or DB error — already logged in fetchRow on error
+        }
+
+        if ($row['expiration'] < $this->clock->now()) {
+            return null; // expired — not an error (getStale() ignores this branch)
+        }
+
+        return $this->decodeValue($key, $row['value']);
+    }
+
+    /**
+     * @see DatabaseCacheInterface::getStale()
+     *
+     * @return array<mixed>|null
+     */
+    public function getStale(string $key): ?array
+    {
+        $row = $this->fetchRow($key);
+        if ($row === null) {
+            return null; // absent or DB error — already logged in fetchRow on error
+        }
+
+        // Deliberately IGNORE $row['expiration']: return the stored value even if stale.
+        return $this->decodeValue($key, $row['value']);
+    }
+
+    /**
+     * Fetch the raw cache row for a key, or null on miss / database error.
+     *
+     * @return array{value: string, expiration: int}|null
+     */
+    private function fetchRow(string $key): ?array
+    {
         try {
             $row = $this->fetchOne(
                 "SELECT `value`, `expiration` FROM `cache` WHERE `cache_key` = ?",
@@ -50,13 +85,19 @@ class DatabaseCache extends \BaseMysqliRepository implements DatabaseCacheInterf
         }
 
         /** @var array{value: string, expiration: int} $row */
-        if ($row['expiration'] < $this->clock->now()) {
-            return null; // expired — not an error
-        }
+        return $row;
+    }
 
+    /**
+     * Decode a stored JSON cache value into an array, or null on corrupt JSON.
+     *
+     * @return array<mixed>|null
+     */
+    private function decodeValue(string $key, string $value): ?array
+    {
         try {
             /** @var mixed $decoded */
-            $decoded = json_decode($row['value'], true, 512, JSON_THROW_ON_ERROR);
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
             $this->channelLogger->warning('cache_corrupt_json', ['cache_key' => $key, 'error' => $e->getMessage()]);
             return null;
@@ -106,6 +147,39 @@ class DatabaseCache extends \BaseMysqliRepository implements DatabaseCacheInterf
             $this->execute("DELETE FROM `cache` WHERE `cache_key` = ?", 's', $key);
         } catch (\RuntimeException $e) {
             $this->channelLogger->error('cache_delete_failed', ['cache_key' => $key, 'error' => $e->getMessage()]);
+        }
+    }
+
+    /**
+     * @see DatabaseCacheInterface::acquireLock()
+     */
+    public function acquireLock(string $key, int $timeoutSeconds): bool
+    {
+        try {
+            $row = $this->fetchOne("SELECT GET_LOCK(?, ?) AS got", 'si', $key, $timeoutSeconds);
+        } catch (\RuntimeException $e) {
+            $this->channelLogger->error('cache_lock_acquire_failed', ['lock_key' => $key, 'error' => $e->getMessage()]);
+            return false;
+        }
+
+        if ($row === null) {
+            return false; // GET_LOCK returned NULL (error/killed) — do not rebuild
+        }
+
+        /** @var array{got: int|string|null} $row */
+        return (int) ($row['got'] ?? 0) === 1;
+    }
+
+    /**
+     * @see DatabaseCacheInterface::releaseLock()
+     */
+    public function releaseLock(string $key): void
+    {
+        try {
+            // DO (not SELECT) avoids leaving an unconsumed result set → "commands out of sync".
+            $this->execute("DO RELEASE_LOCK(?)", 's', $key);
+        } catch (\RuntimeException $e) {
+            $this->channelLogger->error('cache_lock_release_failed', ['lock_key' => $key, 'error' => $e->getMessage()]);
         }
     }
 }

--- a/ibl5/classes/RecordHolders/CachedRecordHoldersService.php
+++ b/ibl5/classes/RecordHolders/CachedRecordHoldersService.php
@@ -20,6 +20,8 @@ class CachedRecordHoldersService implements RecordHoldersServiceInterface
 {
     private const CACHE_KEY = 'record_holders';
     private const TTL_SECONDS = 86400; // 24 hours
+    private const LOCK_KEY = 'record_holders_rebuild';
+    private const LOCK_TIMEOUT_SECONDS = 10;
 
     private RecordHoldersServiceInterface $inner;
     private DatabaseCacheInterface $cache;
@@ -31,20 +33,86 @@ class CachedRecordHoldersService implements RecordHoldersServiceInterface
     }
 
     /**
+     * Serve-stale-first, single-flight cold build.
+     *
+     * 1. Fresh hit → return it.
+     * 2. Expired entry present → serve the stale value immediately; the cron (rebuildCache)
+     *    is the refresher, so no heavy inline rebuild happens on a user's request.
+     * 3. Cold/empty → only the request that wins the single-flight lock rebuilds inline;
+     *    concurrent requests fall through to an empty structure (thundering-herd guard).
+     *
      * @return AllRecordsData
      */
     public function getAllRecords(): array
     {
-        $cached = $this->cache->get(self::CACHE_KEY);
-        if ($cached !== null) {
-            /** @var AllRecordsData $cached */
-            return $cached;
+        $fresh = $this->cache->get(self::CACHE_KEY);
+        if ($fresh !== null) {
+            /** @var AllRecordsData $fresh */
+            return $fresh;
         }
 
-        $records = $this->inner->getAllRecords();
-        $this->cache->set(self::CACHE_KEY, $records, self::TTL_SECONDS);
+        $stale = $this->cache->getStale(self::CACHE_KEY);
+        if ($stale !== null) {
+            /** @var AllRecordsData $stale */
+            return $stale;
+        }
 
-        return $records;
+        if ($this->cache->acquireLock(self::LOCK_KEY, self::LOCK_TIMEOUT_SECONDS)) {
+            try {
+                // Another request may have built the entry while we waited for the lock.
+                $again = $this->cache->get(self::CACHE_KEY);
+                if ($again !== null) {
+                    /** @var AllRecordsData $again */
+                    return $again;
+                }
+
+                $records = $this->inner->getAllRecords();
+                $this->cache->set(self::CACHE_KEY, $records, self::TTL_SECONDS);
+
+                return $records;
+            } finally {
+                $this->cache->releaseLock(self::LOCK_KEY);
+            }
+        }
+
+        // Lock timed out — degrade: serve whatever a concurrent builder produced, else empty.
+        $again = $this->cache->get(self::CACHE_KEY);
+        if ($again !== null) {
+            /** @var AllRecordsData $again */
+            return $again;
+        }
+
+        return $this->emptyRecords();
+    }
+
+    /**
+     * Empty AllRecordsData structure served when the cache is cold and the single-flight
+     * lock could not be acquired (a concurrent request is already rebuilding).
+     *
+     * @return AllRecordsData
+     */
+    private function emptyRecords(): array
+    {
+        return [
+            'playerSingleGame' => [
+                'regularSeason' => [],
+                'playoffs' => [],
+                'heat' => [],
+            ],
+            'quadrupleDoubles' => [],
+            'allStarRecord' => [
+                'name' => '',
+                'pid' => null,
+                'teams' => '',
+                'teamTids' => '',
+                'amount' => 0,
+                'years' => '',
+            ],
+            'playerFullSeason' => [],
+            'teamGameRecords' => [],
+            'teamSeasonRecords' => [],
+            'teamFranchise' => [],
+        ];
     }
 
     /**

--- a/ibl5/classes/RecordHolders/RecordHoldersRepository.php
+++ b/ibl5/classes/RecordHolders/RecordHoldersRepository.php
@@ -491,30 +491,41 @@ class RecordHoldersRepository extends \BaseMysqliRepository implements RecordHol
             $safeLabel = str_replace("'", "''", $label);
             $unions[] = "(SELECT
                     '" . $safeLabel . "' AS stat_type,
-                    bs.pid,
+                    cand.pid,
                     p.name,
                     h.teamid AS teamid,
                     h.team AS team_name,
-                    bs.game_date AS `date`,
+                    cand.game_date AS `date`,
                     COALESCE(sch.box_id, 0) AS box_id,
                     COALESCE(bst.game_of_that_day, 0) AS game_of_that_day,
-                    CASE WHEN h.teamid = bs.visitor_teamid THEN bs.home_teamid ELSE bs.visitor_teamid END AS oppTid,
+                    CASE WHEN h.teamid = cand.visitor_teamid THEN cand.home_teamid ELSE cand.visitor_teamid END AS oppTid,
                     opp.team_name AS opp_team_name,
-                    " . $expression . " AS value
-                FROM `ibl_box_scores` bs
-                JOIN `ibl_plr` p ON p.pid = bs.pid
-                JOIN `ibl_hist` h ON h.pid = bs.pid AND h.year = (" . self::SEASON_YEAR_EXPRESSION . ")
-                LEFT JOIN `ibl_schedule` sch ON sch.game_date = bs.game_date
-                    AND sch.visitor_teamid = bs.visitor_teamid AND sch.home_teamid = bs.home_teamid
-                LEFT JOIN _game_of_day bst ON bst.game_date = bs.game_date
-                    AND bst.visitor_teamid = bs.visitor_teamid AND bst.home_teamid = bs.home_teamid
+                    cand.value
+                FROM (
+                    SELECT
+                        bs.pid,
+                        bs.game_date,
+                        bs.visitor_teamid,
+                        bs.home_teamid,
+                        (" . self::SEASON_YEAR_EXPRESSION . ") AS season_year,
+                        " . $expression . " AS value
+                    FROM `ibl_box_scores` bs
+                    WHERE " . $dateFilter . "
+                        AND bs.visitor_teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
+                        AND bs.home_teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
+                    ORDER BY " . $expression . " DESC
+                    LIMIT 500
+                ) cand
+                JOIN `ibl_plr` p ON p.pid = cand.pid
+                JOIN `ibl_hist` h ON h.pid = cand.pid AND h.year = cand.season_year
+                LEFT JOIN `ibl_schedule` sch ON sch.game_date = cand.game_date
+                    AND sch.visitor_teamid = cand.visitor_teamid AND sch.home_teamid = cand.home_teamid
+                LEFT JOIN _game_of_day bst ON bst.game_date = cand.game_date
+                    AND bst.visitor_teamid = cand.visitor_teamid AND bst.home_teamid = cand.home_teamid
                 LEFT JOIN `ibl_team_info` opp ON opp.teamid = CASE
-                    WHEN h.teamid = bs.visitor_teamid THEN bs.home_teamid
-                    ELSE bs.visitor_teamid END
-                WHERE " . $dateFilter . "
-                    AND bs.visitor_teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
-                    AND bs.home_teamid BETWEEN 1 AND " . League::MAX_REAL_TEAMID . "
-                ORDER BY value DESC, bs.game_date ASC
+                    WHEN h.teamid = cand.visitor_teamid THEN cand.home_teamid
+                    ELSE cand.visitor_teamid END
+                ORDER BY cand.value DESC, cand.game_date ASC
                 LIMIT 5)";
         }
 

--- a/ibl5/tests/Cache/DatabaseCacheTest.php
+++ b/ibl5/tests/Cache/DatabaseCacheTest.php
@@ -289,6 +289,116 @@ final class DatabaseCacheTest extends TestCase
 
         $this->assertFalse($mockDb->wasWriteCalled());
     }
+
+    public function testGetStaleReturnsExpiredValue(): void
+    {
+        // getStale must return a row even when its expiration is in the past.
+        $mockDb = new MockCacheDb();
+        $cache = new DatabaseCache($mockDb, null, new FixedClock(1_000_000));
+
+        $data = [['pid' => 7, 'name' => 'Stale Player']];
+        $mockDb->setCacheData('stale_key', (string) json_encode($data), 999_999); // expired
+
+        $this->assertNull($cache->get('stale_key'), 'sanity: get() treats it as expired');
+        $this->assertSame($data, $cache->getStale('stale_key'));
+    }
+
+    public function testGetStaleReturnsNullOnMiss(): void
+    {
+        $mockDb = new MockCacheDb();
+        $cache = new DatabaseCache($mockDb);
+
+        $this->assertNull($cache->getStale('absent_key'));
+    }
+
+    public function testGetStaleReturnsNullOnCorruptJson(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('warning')->with('cache_corrupt_json', \PHPUnit\Framework\Assert::anything());
+        $cache = new DatabaseCache($mockDb, $logger, new FixedClock(1_000_000));
+
+        $mockDb->setCacheData('corrupt_key', '{not valid json', 2_000_000);
+
+        $this->assertNull($cache->getStale('corrupt_key'));
+    }
+
+    public function testAcquireLockReturnsTrueWhenLockGranted(): void
+    {
+        $mockDb = new MockCacheDb();
+        $cache = new DatabaseCache($mockDb);
+
+        $mockDb->setLockResult(1);
+
+        $this->assertTrue($cache->acquireLock('rebuild_lock', 10));
+    }
+
+    public function testAcquireLockReturnsFalseOnTimeout(): void
+    {
+        $mockDb = new MockCacheDb();
+        $cache = new DatabaseCache($mockDb);
+
+        $mockDb->setLockResult(0);
+
+        $this->assertFalse($cache->acquireLock('rebuild_lock', 10));
+    }
+
+    public function testAcquireLockReturnsFalseWhenLockResultNull(): void
+    {
+        $mockDb = new MockCacheDb();
+        $cache = new DatabaseCache($mockDb);
+
+        $mockDb->setLockResult(null); // GET_LOCK returned NULL (error/killed)
+
+        $this->assertFalse($cache->acquireLock('rebuild_lock', 10));
+    }
+
+    public function testAcquireLockReturnsFalseOnPrepareFailure(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with('cache_lock_acquire_failed', \PHPUnit\Framework\Assert::anything());
+        $cache = new DatabaseCache($mockDb, $logger);
+
+        $mockDb->setPrepareShouldFail(true);
+
+        $this->assertFalse($cache->acquireLock('rebuild_lock', 10));
+    }
+
+    public function testReleaseLockExecutesReleaseStatement(): void
+    {
+        $mockDb = new MockCacheDb();
+        $cache = new DatabaseCache($mockDb);
+
+        $cache->releaseLock('rebuild_lock');
+
+        $this->assertTrue($mockDb->wasReleaseLockCalled());
+    }
+
+    public function testReleaseLockLogsOnPrepareFailure(): void
+    {
+        $mockDb = new MockCacheDb();
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with('cache_lock_release_failed', \PHPUnit\Framework\Assert::anything());
+        $cache = new DatabaseCache($mockDb, $logger);
+
+        $mockDb->setPrepareShouldFail(true);
+        $cache->releaseLock('rebuild_lock');
+
+        $this->assertFalse($mockDb->wasReleaseLockCalled());
+    }
+
+    public function testLockSqlIsParameterized(): void
+    {
+        // Security: the lock name must NEVER be interpolated into the SQL string.
+        // GET_LOCK/RELEASE_LOCK must use bound placeholders (?), not string concat.
+        $source = (string) file_get_contents(__DIR__ . '/../../classes/Cache/DatabaseCache.php');
+
+        $this->assertStringContainsString('GET_LOCK(?, ?)', $source);
+        $this->assertStringContainsString('RELEASE_LOCK(?)', $source);
+        $this->assertStringNotContainsString('GET_LOCK(\'', $source);
+        $this->assertStringNotContainsString('RELEASE_LOCK(\'', $source);
+    }
 }
 
 /**
@@ -305,6 +415,9 @@ class MockCacheDb extends \mysqli
     private bool $deleteCalled = false;
     private bool $prepareShouldFail = false;
     private int $lastWrittenExpiration = 0;
+    /** Value GET_LOCK returns: 1 = acquired, 0 = timeout, null = error/killed. */
+    private ?int $lockResult = 1;
+    private bool $releaseLockCalled = false;
 
     public function __construct()
     {
@@ -331,6 +444,26 @@ class MockCacheDb extends \mysqli
     public function wasDeleteCalled(): bool
     {
         return $this->deleteCalled;
+    }
+
+    public function setLockResult(?int $result): void
+    {
+        $this->lockResult = $result;
+    }
+
+    public function getLockResult(): ?int
+    {
+        return $this->lockResult;
+    }
+
+    public function markReleaseLockCalled(): void
+    {
+        $this->releaseLockCalled = true;
+    }
+
+    public function wasReleaseLockCalled(): bool
+    {
+        return $this->releaseLockCalled;
     }
 
     public function getLastWrittenExpiration(): int
@@ -422,11 +555,19 @@ class MockCacheStmt
             $this->db->markDeleteCalled();
             $this->db->deleteKey($this->boundKey);
         }
+        if (str_contains($this->query, 'RELEASE_LOCK')) {
+            $this->db->markReleaseLockCalled();
+        }
         return true;
     }
 
     public function get_result(): MockCacheResult
     {
+        if (str_contains($this->query, 'GET_LOCK')) {
+            $lock = $this->db->getLockResult();
+            return new MockCacheResult($lock === null ? null : ['got' => $lock]);
+        }
+
         $entry = $this->db->getCacheEntry($this->boundKey);
         return new MockCacheResult($entry);
     }
@@ -438,12 +579,12 @@ class MockCacheStmt
 
 class MockCacheResult
 {
-    /** @var array{value: string, expiration: int}|null */
+    /** @var array<string, int|string>|null */
     private ?array $data;
     private bool $fetched = false;
 
     /**
-     * @param array{value: string, expiration: int}|null $data
+     * @param array<string, int|string>|null $data
      */
     public function __construct(?array $data)
     {
@@ -451,7 +592,7 @@ class MockCacheResult
     }
 
     /**
-     * @return array{value: string, expiration: int}|null
+     * @return array<string, int|string>|null
      */
     public function fetch_assoc(): ?array
     {

--- a/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/CareerLeaderboards/CachedCareerLeaderboardsRepositoryTest.php
@@ -282,4 +282,21 @@ class InMemoryCache implements DatabaseCacheInterface
     {
         unset($this->store[$key]);
     }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getStale(string $key): ?array
+    {
+        return $this->store[$key]['data'] ?? null;
+    }
+
+    public function acquireLock(string $key, int $timeoutSeconds): bool
+    {
+        return true;
+    }
+
+    public function releaseLock(string $key): void
+    {
+    }
 }

--- a/ibl5/tests/DatabaseIntegration/RecordHoldersRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/RecordHoldersRepositoryTest.php
@@ -431,6 +431,153 @@ class RecordHoldersRepositoryTest extends DatabaseTestCase
         self::assertArrayHasKey('value', $pointsRecord);
     }
 
+    public function testGetTopPlayerSingleGameBatchOrdersDescAndCapsAtFive(): void
+    {
+        // 6 players with distinct calc_points (70..65); LIMIT 5 must drop the lowest.
+        // calc_points = game_2gm * 2 + game_ftm + game_3gm * 3.
+        $players = [
+            [200090510, 35, 0], // 70
+            [200090511, 34, 1], // 69
+            [200090512, 34, 0], // 68
+            [200090513, 33, 1], // 67
+            [200090514, 33, 0], // 66
+            [200090515, 32, 1], // 65 -> dropped
+        ];
+        foreach ($players as [$pid, $twos, $fts]) {
+            $name = 'Pts' . $pid; // varchar(16): keep <= 16 chars
+            $this->insertTestPlayer($pid, $name);
+            $this->insertHistRow($pid, $name, 2099);
+            $this->insertPlayerBoxscoreRow(
+                '2099-03-03', $pid, $name, 'PG', 2, 1, 1,
+                points2m: $twos, ftm: $fts, points3m: 0,
+            );
+        }
+
+        $result = $this->repo->getTopPlayerSingleGameBatch(
+            ['Most Points in a Single Game' => 'bs.calc_points'],
+            "bs.game_date = '2099-03-03' AND bs.game_type = 1"
+        );
+
+        $records = $result['Most Points in a Single Game'];
+        self::assertCount(5, $records);
+        self::assertSame(200090510, (int) $records[0]['pid']);
+        self::assertSame(
+            [70, 69, 68, 67, 66],
+            array_map(static fn (array $r): int => (int) $r['value'], $records),
+        );
+    }
+
+    public function testGetTopPlayerSingleGameBatchDropsRowsMissingHistSnapshot(): void
+    {
+        // Player X: highest value but NO ibl_hist snapshot -> dropped by the INNER JOIN.
+        $this->insertTestPlayer(200090520, 'NoHist X');
+        $this->insertPlayerBoxscoreRow(
+            '2099-03-10', 200090520, 'NoHist X', 'PG', 2, 1, 1,
+            points2m: 35, ftm: 0, points3m: 0, // 70
+        );
+        // Player Y: lower value but WITH snapshot -> occupies the slot.
+        $this->insertTestPlayer(200090521, 'HasHist Y');
+        $this->insertHistRow(200090521, 'HasHist Y', 2099);
+        $this->insertPlayerBoxscoreRow(
+            '2099-03-10', 200090521, 'HasHist Y', 'PG', 2, 1, 1,
+            points2m: 34, ftm: 1, points3m: 0, // 69
+        );
+
+        $result = $this->repo->getTopPlayerSingleGameBatch(
+            ['Most Points in a Single Game' => 'bs.calc_points'],
+            "bs.game_date = '2099-03-10' AND bs.game_type = 1"
+        );
+
+        $pids = array_map(
+            static fn (array $r): int => (int) $r['pid'],
+            $result['Most Points in a Single Game'],
+        );
+        self::assertNotContains(200090520, $pids);
+        self::assertContains(200090521, $pids);
+    }
+
+    public function testGetTopPlayerSingleGameBatchExcludesNonRealTeamRows(): void
+    {
+        // Row on a non-real team (All-Star Away, teamid 50 > MAX_REAL_TEAMID) -> excluded by
+        // the guard. Must reference an existing ibl_team_info row (FK fk_boxscore_home); 29
+        // does not exist, so 50 is used as a real >MAX_REAL_TEAMID team.
+        $this->insertTestPlayer(200090530, 'FakeTeam');
+        $this->insertHistRow(200090530, 'FakeTeam', 2099);
+        $this->insertPlayerBoxscoreRow(
+            '2099-03-12', 200090530, 'FakeTeam', 'PG', 2, 1, 1,
+            points2m: 35, ftm: 0, points3m: 0, // 70
+            overrides: ['home_teamid' => 50],
+        );
+        // Real-team row with a lower value.
+        $this->insertTestPlayer(200090531, 'RealTeam');
+        $this->insertHistRow(200090531, 'RealTeam', 2099);
+        $this->insertPlayerBoxscoreRow(
+            '2099-03-12', 200090531, 'RealTeam', 'PG', 2, 1, 1,
+            points2m: 34, ftm: 1, points3m: 0, // 69
+        );
+
+        $result = $this->repo->getTopPlayerSingleGameBatch(
+            ['Most Points in a Single Game' => 'bs.calc_points'],
+            "bs.game_date = '2099-03-12' AND bs.game_type = 1"
+        );
+
+        $pids = array_map(
+            static fn (array $r): int => (int) $r['pid'],
+            $result['Most Points in a Single Game'],
+        );
+        self::assertNotContains(200090530, $pids);
+        self::assertContains(200090531, $pids);
+    }
+
+    public function testGetTopPlayerSingleGameBatchPreservesGameDateTiebreak(): void
+    {
+        // Same value; earlier game_date must rank first (value DESC, game_date ASC).
+        $this->insertTestPlayer(200090540, 'Earlier');
+        $this->insertHistRow(200090540, 'Earlier', 2099);
+        $this->insertPlayerBoxscoreRow(
+            '2099-04-01', 200090540, 'Earlier', 'PG', 2, 1, 1,
+            points2m: 35, ftm: 0, points3m: 0, // 70
+        );
+        $this->insertTestPlayer(200090541, 'Later');
+        $this->insertHistRow(200090541, 'Later', 2099);
+        $this->insertPlayerBoxscoreRow(
+            '2099-04-02', 200090541, 'Later', 'PG', 2, 1, 1,
+            points2m: 35, ftm: 0, points3m: 0, // 70
+        );
+
+        $result = $this->repo->getTopPlayerSingleGameBatch(
+            ['Most Points in a Single Game' => 'bs.calc_points'],
+            "bs.game_date IN ('2099-04-01','2099-04-02') AND bs.game_type = 1"
+        );
+
+        $pids = array_map(
+            static fn (array $r): int => (int) $r['pid'],
+            $result['Most Points in a Single Game'],
+        );
+        self::assertSame([200090540, 200090541], $pids);
+    }
+
+    public function testGetTopPlayerSingleGameBatchReturnsFewerThanFiveWhenLimitNotReached(): void
+    {
+        // Only 3 qualifying rows -> the LIMIT 5 is never reached.
+        foreach ([200090550, 200090551, 200090552] as $i => $pid) {
+            $name = 'Few ' . $pid;
+            $this->insertTestPlayer($pid, $name);
+            $this->insertHistRow($pid, $name, 2099);
+            $this->insertPlayerBoxscoreRow(
+                '2099-04-05', $pid, $name, 'PG', 2, 1, 1,
+                points2m: 30 - $i, ftm: 0, points3m: 0,
+            );
+        }
+
+        $result = $this->repo->getTopPlayerSingleGameBatch(
+            ['Most Points in a Single Game' => 'bs.calc_points'],
+            "bs.game_date = '2099-04-05' AND bs.game_type = 1"
+        );
+
+        self::assertCount(3, $result['Most Points in a Single Game']);
+    }
+
     // --- Team Single Game Batch ---
 
     public function testGetTopTeamSingleGameBatchReturnsGroupedResults(): void

--- a/ibl5/tests/DatabaseIntegration/RecordHoldersRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/RecordHoldersRepositoryTest.php
@@ -460,10 +460,10 @@ class RecordHoldersRepositoryTest extends DatabaseTestCase
 
         $records = $result['Most Points in a Single Game'];
         self::assertCount(5, $records);
-        self::assertSame(200090510, (int) $records[0]['pid']);
+        self::assertSame(200090510, $records[0]['pid']);
         self::assertSame(
             [70, 69, 68, 67, 66],
-            array_map(static fn (array $r): int => (int) $r['value'], $records),
+            array_map(static fn (array $r): int => $r['value'], $records),
         );
     }
 

--- a/ibl5/tests/Module/EntryPoints/RecordHoldersEntryPointTest.php
+++ b/ibl5/tests/Module/EntryPoints/RecordHoldersEntryPointTest.php
@@ -11,6 +11,8 @@ class RecordHoldersEntryPointTest extends ModuleEntryPointTestCase
         parent::setUp();
         $this->mockDb->setMockData([]);
         $this->mockDb->onQuery('cache', []);
+        // Cold cache → single-flight rebuild: the request must win GET_LOCK to build inline.
+        $this->mockDb->onQuery('GET_LOCK', [['got' => 1]]);
     }
 
     public function testRendersAllThreeRecordCategories(): void

--- a/ibl5/tests/RecordHolders/CachedRecordHoldersServiceTest.php
+++ b/ibl5/tests/RecordHolders/CachedRecordHoldersServiceTest.php
@@ -50,25 +50,67 @@ final class CachedRecordHoldersServiceTest extends TestCase
         $this->assertNotNull($this->cache->get('record_holders'));
     }
 
-    public function testExpiredCacheTriggersRefresh(): void
+    public function testExpiredCacheServesStaleWithoutCallingInner(): void
     {
+        // Serve-stale-first contract: an expired entry is returned as-is; the cron
+        // (rebuildCache) is the refresher, so no inline rebuild runs on a user request.
         $mockInner = $this->createMock(RecordHoldersServiceInterface::class);
         $service = new CachedRecordHoldersService($mockInner, $this->cache);
 
         $staleRecords = $this->createSampleRecords();
-        $freshRecords = $this->createSampleRecords();
-        $freshRecords['playerSingleGame']['regularSeason'] = [];
 
-        // Set with negative TTL to simulate expired entry
+        // Set with a past expiration timestamp to simulate an expired entry.
         $this->cache->setWithExpiration('record_holders', $staleRecords, time() - 100);
 
-        $mockInner->expects($this->once())
-            ->method('getAllRecords')
-            ->willReturn($freshRecords);
+        $mockInner->expects($this->never())->method('getAllRecords');
+
+        $result = $service->getAllRecords();
+
+        $this->assertSame($staleRecords, $result);
+    }
+
+    public function testColdCacheWithoutLockReturnsEmptyWithoutCallingInner(): void
+    {
+        // Cold cache + lock NOT acquired (a concurrent request is rebuilding):
+        // degrade to an empty structure, never call the expensive inner build.
+        $mockInner = $this->createMock(RecordHoldersServiceInterface::class);
+        $this->cache->lockAcquirable = false;
+        $service = new CachedRecordHoldersService($mockInner, $this->cache);
+
+        $mockInner->expects($this->never())->method('getAllRecords');
 
         $result = $service->getAllRecords();
 
         $this->assertSame([], $result['playerSingleGame']['regularSeason']);
+        $this->assertSame([], $result['playerSingleGame']['playoffs']);
+        $this->assertSame([], $result['playerSingleGame']['heat']);
+        $this->assertSame([], $result['quadrupleDoubles']);
+        $this->assertSame('', $result['allStarRecord']['name']);
+        $this->assertNull($result['allStarRecord']['pid']);
+        $this->assertSame([], $result['playerFullSeason']);
+        $this->assertSame([], $result['teamGameRecords']);
+        $this->assertSame([], $result['teamSeasonRecords']);
+        $this->assertSame([], $result['teamFranchise']);
+    }
+
+    public function testColdCacheWithLockCallsInnerOnceAndCachesAndReleasesLock(): void
+    {
+        // Cold cache + lock acquired: this request rebuilds inline exactly once,
+        // stores the result, and releases the lock afterward.
+        $mockInner = $this->createMock(RecordHoldersServiceInterface::class);
+        $service = new CachedRecordHoldersService($mockInner, $this->cache);
+
+        $records = $this->createSampleRecords();
+
+        $mockInner->expects($this->once())
+            ->method('getAllRecords')
+            ->willReturn($records);
+
+        $result = $service->getAllRecords();
+
+        $this->assertSame($records, $result);
+        $this->assertNotNull($this->cache->get('record_holders'));
+        $this->assertSame(1, $this->cache->releaseLockCount);
     }
 
     public function testCorruptCacheReturnsNullFromGet(): void
@@ -176,6 +218,12 @@ class RecordHoldersInMemoryCache implements DatabaseCacheInterface
     /** @var array<string, array{data: array<mixed>, expiration: int}> */
     private array $store = [];
 
+    /** Controls what acquireLock() returns (defaults to acquired). */
+    public bool $lockAcquirable = true;
+
+    /** Number of times releaseLock() was invoked. */
+    public int $releaseLockCount = 0;
+
     /**
      * @return array<mixed>|null
      */
@@ -186,11 +234,31 @@ class RecordHoldersInMemoryCache implements DatabaseCacheInterface
         }
 
         if ($this->store[$key]['expiration'] < time()) {
-            unset($this->store[$key]);
+            // Expired: return null WITHOUT deleting — mirrors the real DatabaseCache,
+            // so getStale() can still recover the row.
             return null;
         }
 
         return $this->store[$key]['data'];
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getStale(string $key): ?array
+    {
+        // Ignore expiration entirely — return the stored value if a row exists.
+        return $this->store[$key]['data'] ?? null;
+    }
+
+    public function acquireLock(string $key, int $timeoutSeconds): bool
+    {
+        return $this->lockAcquirable;
+    }
+
+    public function releaseLock(string $key): void
+    {
+        $this->releaseLockCount++;
     }
 
     /**

--- a/ibl5/tests/SeasonLeaderboards/CachedSeasonLeaderboardsRepositoryTest.php
+++ b/ibl5/tests/SeasonLeaderboards/CachedSeasonLeaderboardsRepositoryTest.php
@@ -190,4 +190,21 @@ class SeasonLeaderboardsInMemoryCache implements DatabaseCacheInterface
     {
         unset($this->store[$key]);
     }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getStale(string $key): ?array
+    {
+        return $this->store[$key]['data'] ?? null;
+    }
+
+    public function acquireLock(string $key, int $timeoutSeconds): bool
+    {
+        return true;
+    }
+
+    public function releaseLock(string $key): void
+    {
+    }
 }


### PR DESCRIPTION
## Summary

Rewrites `RecordHoldersRepository::getTopPlayerSingleGameBatch` so each of the 9 stat UNION-ALL branches first selects candidate box-score rows from `ibl_box_scores` ALONE (index-ordered, LIMIT 500), then joins the other tables to only those candidates. Previously driven from `ibl_plr` with a full 550K-row filesort; regular-season batch was ~471s. Now ~1s (measured).

Also makes `CachedRecordHoldersService::getAllRecords()` cache-miss path safe: serve-stale-first for expired entries + single-flight `GET_LOCK` for cold-empty case, eliminating the thundering herd.

### Changes
- `RecordHoldersRepository.php`: rewrite `getTopPlayerSingleGameBatch` — index-ordered inner subquery on `ibl_box_scores`, LIMIT 500 buffer, 5-join outer
- `DatabaseCacheInterface.php` + `DatabaseCache.php`: add `getStale()`, `acquireLock()`, `releaseLock()`
- `CachedRecordHoldersService.php`: A+B hybrid miss path (stale-first + `GET_LOCK` single-flight)
- Tests: characterization DB-integration tests (pre/post rewrite), Phase 3 service/cache unit tests

All verification is automated — no new/redesigned UI/UX.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.