### PR TITLE
chore: trim always-on rules to cut context token overhead

### DIFF
--- a/.claude/rules/agent-tiering-detail.md
+++ b/.claude/rules/agent-tiering-detail.md
@@ -1,6 +1,6 @@
 ---
 description: Read-on-demand detail for agent-tiering — full Fable approval-gate procedure, flat-fan-out (nested sub-agent) rationale, and per-tier prompt style. Loads only when editing workflow orchestration defs, where this rationale applies.
-last_verified: 2026-06-30
+last_verified: 2026-07-01
 paths:
   - ".claude/commands/**/*.md"
   - ".claude/skills/**/SKILL.md"
@@ -14,8 +14,10 @@ This file holds the longer rationale, pulled out of the always-loaded budget.
 
 ## Fable Approval Gate
 
-> **Status: Fable is currently unavailable — never select it** (see the parent's Tier
-> table). This full procedure applies *if* Fable access returns; until then it is dormant.
+> **Status: Fable is available again (2026-07-01) but tightly gated.** Never select it on
+> your own; use it *only* when a task is absolutely critical **and** Fable is 100% necessary
+> to solve it, and *only* after an explicit user yes. Default to Opus — treat Fable as a last
+> resort, not a routine capability upgrade.
 
 **Claude must never select Fable on its own** — neither the session model nor a `model: "fable"` sub-agent. When a task matches the Fable row, do not silently run on Opus *and* do not switch; **surface a suggestion** and wait for an explicit yes. The suggestion states:
 
@@ -24,7 +26,7 @@ This file holds the longer rationale, pulled out of the always-loaded budget.
 - **Cons**: ~2× cost ($10/$50 vs $5/$25 per MTok); Opus is *likely sufficient* (most tasks are); the gain is a ceiling-raise, not a guarantee.
 - **Recommendation**: a clear "I'd use Fable here" / "Opus is probably fine, flagging it" — not a neutral survey.
 
-Absent approval, proceed on Opus (or the correct lower tier) — flag and continue, don't block. Approval covers that one task; a new task re-triggers the gate. Use `AskUserQuestion` only when it's a genuine fork; otherwise inline the suggestion and keep going.
+Absent approval, proceed on Opus (or the correct lower tier) — flag and continue, don't block. Approval covers that one task; a new task re-triggers the gate. Because Fable is a last resort, any actual intent to run on Fable is itself a genuine fork — **always** use `AskUserQuestion` to get the explicit yes *before* selecting it; never proceed on Fable from an inline suggestion alone.
 
 ## Boundary keys on task type, not model capability
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -27,7 +27,7 @@ Each sub-agent costs ~3–5K tokens (system prompt + rules + memory, loaded befo
 | **Sonnet** | `model: "sonnet"` | Synthesis: "is this finding relevant?", cross-file traces, semantic compliance checks, rename sweeps needing call-site judgment. |
 | **Opus** | self (no delegation) | Novel reasoning, FK ordering, rule authoring, ADR writing, ambiguous test failures, final code review, diff-triage. Never delegate understanding. |
 | **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3. The def pins `model: opus` + `effort: xhigh`, so planning runs at Opus depth in a clean sub-context. Do **not** pass an inline `model` override — the def owns it. |
-| **Fable** | **unavailable — do not select** | Inaccessible; never pick `model: "fable"`. When access returns it is the opt-in rung above Opus, gated behind explicit approval — see `.claude/rules/agent-tiering-detail.md`. |
+| **Fable** | `model: "fable"` — **prompt first, last resort** | Opt-in rung above Opus. Use **only** when a task is absolutely critical **and** Fable is 100% necessary to solve it — and **never without prompting the user first** for explicit approval. Default to Opus; treat Fable as a last resort, not a routine capability upgrade. Full gate: `.claude/rules/agent-tiering-detail.md`. |
 
 > **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (now the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -15,7 +15,7 @@ Each sub-agent costs ~3–5K tokens (system prompt + rules + memory, loaded befo
 
 **Spawn an agent when ANY hold:** output unpredictably verbose (large grep, failing suites with stack traces) and the agent can return a summary · multiple independent verbose tasks run concurrently · the task is multiple sequential tool calls.
 
-**When you spawn, minimize invocation count** — batch N related tasks into one agent (or do them yourself), not one agent per task; each spawn re-pays the ~3–5K overhead. Separate agents only when each genuinely needs its own context (independent worktrees, isolating verbose output), not merely because tasks are logically distinct.
+**When you spawn, minimize invocation count** — the question is *how many agents are actually needed*, not *parallel vs. sequential*. Token spend is valued over wall-clock time, and parallel fan-out usually costs more than running sequentially — so weigh the ROI before assigning a fleet. Batch N related tasks into one agent (or do them yourself), not one agent per task; each spawn re-pays the ~3–5K overhead. Separate agents only when each genuinely needs its own context (independent worktrees, isolating verbose output), not merely because tasks are logically distinct.
 
 **PHPUnit and PHPStan are always direct Bash calls** — passing output is ~5 lines, failures usually under 50; agent overhead dwarfs it. Use `run_in_background` for parallelism without an agent — **but only in the interactive harness**, where a finished background task re-invokes you. In a **headless** run (`claude -p`, e.g. `/post-plan` under automouse) there is no re-invocation: a live background task at turn-end stall-kills the run — run blocking, or poll `BashOutput` to completion in-turn (post-plan `SKILL.md` Phase 5).
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,6 +1,6 @@
 ---
 description: Sub-agent decision rules — when to spawn, when to skip, and which model to pick
-last_verified: 2026-06-30
+last_verified: 2026-07-01
 ---
 
 # Agent Tiering
@@ -9,15 +9,15 @@ Tier every sub-agent (and every agent a plan spawns) by the reasoning the task a
 
 ## Skip the Agent — Direct Tool Calls
 
-Each sub-agent pays fixed overhead (~3–5K tokens: system prompt + rules + memory, loaded before it reads its prompt), and every token of its output is re-sent in Opus's context each subsequent turn. Justified only when the agent absorbs verbose output, runs in parallel, or needs multi-step reasoning.
+Each sub-agent costs ~3–5K tokens (system prompt + rules + memory, loaded before its prompt), and its output re-loads in Opus's context every later turn.
 
-**Run directly (no agent) when ALL hold:** single command/tool call · output under ~50 lines · nothing else needs to run in parallel · output won't persist across many turns.
+**Run directly (no agent) when ALL hold:** single command/tool call · output under ~50 lines · nothing else to run in parallel · output won't persist across turns.
 
-**Spawn an agent when ANY hold:** output unpredictably verbose (large grep, failing suites with stack traces) and the agent can return a summary · multiple independent verbose tasks can run concurrently · the task is multiple sequential tool calls.
+**Spawn an agent when ANY hold:** output unpredictably verbose (large grep, failing suites with stack traces) and the agent can return a summary · multiple independent verbose tasks run concurrently · the task is multiple sequential tool calls.
 
-**When you do spawn, minimize the invocation count — the question is "how many agents are actually needed," not "parallel vs sequential."** Each spawn re-pays the ~3–5K overhead, so batch N related tasks into one agent (or do them yourself) rather than one agent per task. Separate agents are justified only when each genuinely needs its own context (independent worktrees, isolating verbose output) — not merely because the tasks are logically distinct.
+**When you spawn, minimize invocation count** — batch N related tasks into one agent (or do them yourself), not one agent per task; each spawn re-pays the ~3–5K overhead. Separate agents only when each genuinely needs its own context (independent worktrees, isolating verbose output), not merely because tasks are logically distinct.
 
-**PHPUnit and PHPStan are always direct Bash calls** — passing output is ~5 lines, failures usually under 50; agent overhead dwarfs it. Use `run_in_background` for parallelism without an agent — **but only in the interactive harness, where a finished background task re-invokes you.** In a **headless** run (`claude -p`, e.g. `/post-plan` under automouse) there is no re-invocation: ending the turn with a background task alive stall-kills the run. There, either run blocking, or poll `BashOutput` to completion in-turn before ending the turn (see post-plan `SKILL.md` Phase 5).
+**PHPUnit and PHPStan are always direct Bash calls** — passing output is ~5 lines, failures usually under 50; agent overhead dwarfs it. Use `run_in_background` for parallelism without an agent — **but only in the interactive harness**, where a finished background task re-invokes you. In a **headless** run (`claude -p`, e.g. `/post-plan` under automouse) there is no re-invocation: a live background task at turn-end stall-kills the run — run blocking, or poll `BashOutput` to completion in-turn (post-plan `SKILL.md` Phase 5).
 
 ## Tiers
 
@@ -26,18 +26,18 @@ Each sub-agent pays fixed overhead (~3–5K tokens: system prompt + rules + memo
 | **Haiku** | `model: "haiku"` | Command output, pattern-matching named checklists, grep-and-format, mechanical lookups — answerable by running commands and reporting, without judging relevance. |
 | **Sonnet** | `model: "sonnet"` | Synthesis: "is this finding relevant?", cross-file traces, semantic compliance checks, rename sweeps needing call-site judgment. |
 | **Opus** | self (no delegation) | Novel reasoning, FK ordering, rule authoring, ADR writing, ambiguous test failures, final code review, diff-triage. Never delegate understanding. |
-| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3. The def pins `model: opus` + `effort: xhigh` (the built-in Plan agent has no per-call effort override; A/B proved them equivalent), so planning runs at Opus depth in a clean sub-context. Do **not** pass an inline `model` override — the def owns it. |
-| **Fable** | **unavailable — do not select** | Currently inaccessible; never pick `model: "fable"`. When access returns it is the opt-in rung above Opus (ceiling-binding tasks), gated behind explicit approval — full procedure in `.claude/rules/agent-tiering-detail.md`. |
+| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3. The def pins `model: opus` + `effort: xhigh`, so planning runs at Opus depth in a clean sub-context. Do **not** pass an inline `model` override — the def owns it. |
+| **Fable** | **unavailable — do not select** | Inaccessible; never pick `model: "fable"`. When access returns it is the opt-in rung above Opus, gated behind explicit approval — see `.claude/rules/agent-tiering-detail.md`. |
 
-> **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — so a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 against Sonnet 5 (now the `sonnet` alias, native 1M context): boundary unchanged. Why a more-capable Sonnet doesn't shift work down a tier: `agent-tiering-detail.md`.
+> **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (now the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.
 
 ## Flat fan-out (no nested sub-agents)
 
-Sub-agents *can* spawn sub-agents (5 deep), but we keep **flat fan-out**: the Opus session owns every fan-out and absorbs every agent's output. Do **not** nest in the recurring workflows (`/plan`, `/pr-review`, `/security-audit`, `/post-plan`, automouse). Rationale + the tripwire to revisit: `.claude/rules/agent-tiering-detail.md`.
+Sub-agents *can* nest (5 deep), but we keep **flat fan-out**: the Opus session owns every fan-out and absorbs every agent's output. Do **not** nest in `/plan`, `/pr-review`, `/security-audit`, `/post-plan`, or automouse. Rationale + tripwire: `.claude/rules/agent-tiering-detail.md`.
 
 ## Prompt style
 
-When prompting **Haiku**, compensate for its tendency to stop at "enough": concrete grep/find command, "list EVERY match", pre-resolved absolute paths, structured output, and never ask it to judge relevance or trace multi-hop flows. **Sonnet**'s current style is fine. Full guidance: `.claude/rules/agent-tiering-detail.md`.
+Prompting **Haiku**: compensate for its tendency to stop at "enough" — concrete grep/find command, "list EVERY match", pre-resolved absolute paths, structured output; never ask it to judge relevance or trace multi-hop flows. **Sonnet**'s current style is fine. Full guidance: `.claude/rules/agent-tiering-detail.md`.
 
 ## Explore Agents
 
@@ -50,4 +50,4 @@ Tier per prompt — don't default all Explore agents to one tier.
 
 **Heuristic:** notice connections / judge relevance / trace data flow → Sonnet. Answerable by grep + format → Haiku.
 
-Plan-authoring tiering (labeling each phase Sonnet/Haiku/self, mechanical-recipe agents, bulk-sweep patterns) lives in `.claude/commands/plan.md` Step 3.
+Plan-authoring tiering (labeling each phase, mechanical-recipe agents, bulk-sweep patterns) lives in `.claude/commands/plan.md` Step 3.

--- a/.claude/rules/auto-commit.md
+++ b/.claude/rules/auto-commit.md
@@ -1,6 +1,6 @@
 ---
-description: Commit/PR work from the worktree; the Stop hook nudges to commit in a worktree and warns if the main checkout is dirty (work landed in the wrong place); amend when fixing unpushed work. Carries the one-line PR-title decision test (full rubric in commit-conventions.md).
-last_verified: 2026-06-27
+description: Commit/PR work from the worktree; the Stop hook nudges to commit in a worktree and warns when the main checkout is dirty; amend only unpushed fixes. Carries the one-line PR-title decision test (full rubric in commit-conventions.md).
+last_verified: 2026-07-01
 ---
 
 # Auto-Commit
@@ -9,14 +9,14 @@ All work happens in a worktree, never the main checkout (ADR-0062, `workflow-con
 
 **PR/commit title type** (when titling via `/commit-commands:*`): decision test — *"Would a league GM notice a new ability they didn't have before?"* Yes → `feat:` (trips the human-signoff hold — that's the gate working, not a cost to route around); invisible to a GM (dev tooling, a new slash command, an internal refactor, a doc, a dep bump) → `chore:`/`fix:`/`refactor:`/`docs:`. Classify by what the diff **is**, never by the desired merge outcome. Full rubric incl. edge cases: `.claude/rules/commit-conventions.md`.
 
-The `$HOME/.claude/hooks/auto-commit-reminder.sh` Stop hook fires at turn-end when there are uncommitted changes, and nudges the right action depending on **where** the work is:
+The `$HOME/.claude/hooks/auto-commit-reminder.sh` Stop hook fires at turn-end on uncommitted changes, nudging by **where** the work is:
 
-- **Main checkout** (master) dirty → **misplaced-work warning**: the work landed in the wrong place; move it into a worktree (`bin/wt-new`) — the main checkout is reference/read-only.
-- **Worktree** dirty → **commit nudge**: this is the correct place to work; if you finished a unit of work, commit it via `/commit-commands:commit` (or `commit-push-pr`).
+- **Main checkout** (master) dirty → **misplaced-work warning**: move it into a worktree (`bin/wt-new`) — the main checkout is reference/read-only.
+- **Worktree** dirty → **commit nudge**: correct place to work; if you finished a unit of work, commit via `/commit-commands:commit` (or `commit-push-pr`).
 
-It stays silent when the tree is clean, on loop re-fire, and while a plan workflow is active (which covers `/post-plan` auto-fire committing in a worktree). It nudges on **uncommitted** changes only — push is owned by `commit-push-pr`/`/post-plan`. It is a nudge, not a hard block — ignore it if you are mid-task, just exploring, or have a deliberate reason to be touching the main checkout.
+It stays silent when the tree is clean, on loop re-fire, and while a plan workflow is active (covers `/post-plan` auto-fire). It nudges on **uncommitted** changes only — push is owned by `commit-push-pr`/`/post-plan`. It's a nudge, not a hard block — ignore it if mid-task, exploring, or deliberately touching the main checkout.
 
-When you finish a unit of work in a worktree (impl, fix, refactor, config, docs) and are not using the `/post-plan` auto-fire handoff, invoke `/commit-commands:commit` (or `commit-push-pr`). Skip it when mid-task or when the user is only exploring.
+When you finish a unit of work in a worktree and are not using the `/post-plan` auto-fire handoff, invoke `/commit-commands:commit` (or `commit-push-pr`). Skip when mid-task or only exploring.
 
 ## Amend vs new commit
 

--- a/.claude/rules/browser-login.md
+++ b/.claude/rules/browser-login.md
@@ -1,17 +1,17 @@
 ---
 description: Localhost browsing is logged-out by default; set an `_auto_login=1` cookie to auto-authenticate via DEV_AUTO_LOGIN. Identity matrix for all test layers.
-last_verified: 2026-06-19
+last_verified: 2026-07-01
 ---
 
 # Browser Auto-Login
 
-On localhost (`main.localhost`, `localhost`, `127.0.0.1`, `<slug>.localhost`), manual browsing is **logged-out by default**. Dev auto-login is opt-in: it only fires when an `_auto_login=1` cookie is present AND `DEV_AUTO_LOGIN` is set in `ibl5/.env.test`.
+On localhost (`main.localhost`, `localhost`, `127.0.0.1`, `<slug>.localhost`), manual browsing is **logged-out by default**. Dev auto-login is opt-in: it fires only when an `_auto_login=1` cookie is present AND `DEV_AUTO_LOGIN` is set in `ibl5/.env.test`.
 
 To auto-authenticate as the `.env.test` `DEV_AUTO_LOGIN` user:
 - **curl:** `curl --cookie "_auto_login=1" http://<slug>.localhost/ibl5/...`
 - **Playwright:** `page.context().addCookies([{ name: '_auto_login', value: '1', domain, path: '/' }])`
 
-Without the cookie you will see the login form — that is expected, not a misconfiguration.
+Without the cookie you see the login form — expected, not a misconfiguration.
 
 A separate `_e2e=1` cookie gates PageCache-skip for unauthenticated E2E browser contexts (no auth effect).
 
@@ -23,4 +23,4 @@ A separate `_e2e=1` cookie gates PageCache-skip for unauthenticated E2E browser 
 | CI E2E browser | Configured at runtime | `secrets.IBL_TEST_USER` / `IBL_TEST_PASS` | Playwright in CI |
 | DatabaseIntegration tests | testadmin / testgm | `tests/DatabaseIntegration/Fixtures/db-seed.sql` | PHPUnit `#[Group('database')]` tests |
 
-These layers do not need to share usernames. Each is independently scoped.
+These layers do not need to share usernames — each is independently scoped.

--- a/.claude/rules/work-triage.md
+++ b/.claude/rules/work-triage.md
@@ -1,6 +1,6 @@
 ---
 description: Triage every non-trivial unit of work as ad-hoc vs /plan before starting, with an ad-hoc safety mirror; the gateway that feeds the deployment funnel (ADR-0067).
-last_verified: 2026-06-27
+last_verified: 2026-07-01
 ---
 
 # Work Triage Rule
@@ -13,7 +13,7 @@ This is the **gateway** of the deployment funnel (ADR-0067): triage decides plan
 
 ## The ad-hoc bar
 
-Work is ad-hoc-safe only when **all** hold:
+Ad-hoc-safe only when **all** hold:
 - **Known blast radius** — you can name every file/behavior it touches.
 - **An existing pattern to copy** — not novel infrastructure.
 - **No multi-phase reasoning** — a single coherent change, not a sequence with intermediate decisions.
@@ -25,7 +25,7 @@ If any are open, it wants a `/plan`.
 
 ## Ad-hoc safety mirror
 
-Even when the bar above says ad-hoc, run a quick safety check — the same surfaces `/plan` Step 4 gate 14 holds for. If the change touches any of:
+Even when the bar says ad-hoc, run a quick safety check — the same surfaces `/plan` Step 4 gate 14 holds for. If the change touches any of:
 - a **security surface** (SQL, POST/form endpoint, auth/authz-gated route, user-facing output rendering),
 - a **destructive or schema-tightening migration**,
 - **new or redesigned user-visible UI/UX**, or
@@ -35,6 +35,6 @@ then prefer `/plan`, so the defense and its verification are designed up front. 
 
 ## Calibration
 
-Surface the verdict only when scope is **non-trivial or borderline**. Skip the ritual for obviously trivial edits (typo, one-line fix) — just do them; don't add ceremony.
+Surface the verdict only when scope is **non-trivial or borderline**. Skip the ritual for obviously trivial edits (typo, one-line fix). 
 
 **Headless:** no-op under headless/automouse (no user to recommend `/plan` to; automouse runs only pre-vetted plans). Governs interactive work-start only.

--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -1,15 +1,15 @@
 ---
 description: All work happens in a worktree (never the main checkout); worktree setup and the implementation→/post-plan handoff (auto-fired in a detached fresh session) for any verified-complete worktree work, plan-driven or ad-hoc.
-last_verified: 2026-06-30
+last_verified: 2026-07-01
 ---
 
 # Workflow Continuity Rule
 
 ## All work happens in a worktree
 
-**Never edit the main checkout (`/Users/ajaynicolas/GitHub/IBL5`, branch `master`) directly** — not code, not migrations, not docs, not `.claude/rules`, not config, not ADRs. No size or category exception (ADR-0062). The main checkout is reference/read-only: it holds canonical `master`, is the base for `bin/wt-new`, and runs main-stack Docker/DB tooling.
+**Never edit the main checkout (`/Users/ajaynicolas/GitHub/IBL5`, branch `master`) directly** — not code, migrations, docs, `.claude/rules`, config, or ADRs. No size or category exception (ADR-0062). The main checkout is reference/read-only: it holds canonical `master`, is the base for `bin/wt-new`, and runs main-stack Docker/DB tooling.
 
-The only files exempt are those that physically live **outside** the repo tree and cannot go in a worktree: the Claude hooks (`~/.claude/hooks/`), per-project memory (`~/.claude/projects/.../memory/`), and `~/.claude/settings*.json`. Edit those in place as usual.
+Exempt — files that physically live **outside** the repo tree: Claude hooks (`~/.claude/hooks/`), per-project memory (`~/.claude/projects/.../memory/`), and `~/.claude/settings*.json`. Edit those in place.
 
 ## Planning
 
@@ -17,32 +17,32 @@ Use `/plan <task description>` for implementation planning.
 
 ## Worktree Setup
 
-Before touching any repo file, make sure you are in a worktree. Create one unless it already exists for this task:
+Before touching any repo file, be in a worktree. Create one unless it already exists for this task:
 
 ```bash
 bin/wt-new <slug>   # slug = kebab-case branch name derived from the plan
 ```
 
-Use `--base <branch>` for stacked PRs. Work in `IBL5-worktrees/<slug>/ibl5/` (worktrees live outside the repo — ADR-0046). The only reason to skip creation is that the worktree for this task already exists (or the plan names an existing one) — never because "this edit is small enough to do on master."
+Use `--base <branch>` for stacked PRs. Work in `IBL5-worktrees/<slug>/ibl5/` (worktrees live outside the repo — ADR-0046). Skip creation only when this task's worktree already exists (or the plan names one) — never because "this edit is small enough for master."
 
 ## Post-Plan
 
-Never run `/post-plan` **inline** in this session — it re-reads the full implementation context on every phase, so an inline run after a long implementation session (especially on Opus) costs several times a fresh run. It must run in a **fresh** session, with **cwd = this worktree**.
+Never run `/post-plan` **inline** — it re-reads full implementation context every phase, so an inline run after a long session (especially Opus) costs several times a fresh run. Run it in a **fresh** session, cwd = this worktree.
 
 ### Interactive sessions — auto-fire the handoff
 
-This applies to **any** verified-complete unit of work in a worktree — plan-driven **or ad-hoc**. When the work has verified clean and the only thing left is the mechanical push + open-PR to land it, that ship step does **not** need a confirmation prompt — do **not** ask "want me to push and open the PR?". The global "confirm before outward-facing actions" default is **durably overridden here**: shipping verified-complete worktree work is pre-authorized. Your **final action** is:
+For **any** verified-complete unit of work in a worktree — plan-driven **or ad-hoc**. When it has verified clean and only the mechanical push + open-PR remains, that ship step needs **no** confirmation prompt — do **not** ask "want me to push and open the PR?". The global "confirm before outward-facing actions" default is **durably overridden here**: shipping verified-complete worktree work is pre-authorized. Final action:
 
 ```bash
 bin/post-plan-now --auto
 ```
 
-(On an ad-hoc branch with no plan file, post-plan runs plan-blind — that's expected, not an error. The merge-arming decision still happens at `/post-plan` Phase 6.5, so auto-opening the PR never means auto-merging a `feat:`/`auto_merge: false`/visual PR without human signoff.)
+(Ad-hoc branch with no plan file → post-plan runs plan-blind; expected, not an error. The merge-arming decision still happens at `/post-plan` Phase 6.5, so auto-opening the PR never auto-merges a `feat:`/`auto_merge: false`/visual PR without human signoff.)
 
-This spawns a detached, fresh **Sonnet 5** `/post-plan` on this branch (supervised by launchd, so it survives you closing Claude Code). It removes the manual "open a new session and hand off" step. Notes:
+This spawns a detached, fresh **Sonnet 5** `/post-plan` on this branch (launchd-supervised, so it survives you closing Claude Code). Notes:
 
-- **Do NOT commit first.** Leave the worktree **dirty** — `/post-plan` commits the uncommitted tree in its Phase 2 and opens the PR. Committing here would change what it ships.
-- **Only fire when verification passed.** If implementation did **not** verify clean (failing tests, unresolved blocker, you stopped to ask the user something), do **not** run it — leave the worktree dirty and hand off in prose instead. Turn-end ≠ done; that judgment is yours.
-- **No deadlock.** `/post-plan` resolves the plan from the branch slug (no handoff file needed); the detached child is reparented under launchd, so it clears its own plan-gate independently of this session.
+- **Do NOT commit first.** Leave the worktree **dirty** — `/post-plan` commits the uncommitted tree in Phase 2 and opens the PR. Committing here changes what it ships.
+- **Only fire when verification passed.** If implementation did **not** verify clean (failing tests, unresolved blocker, you stopped to ask the user something), do **not** fire — leave the worktree dirty and hand off in prose. Turn-end ≠ done; that judgment is yours.
+- **No deadlock.** `/post-plan` resolves the plan from the branch slug (no handoff file needed); the detached child reparents under launchd and clears its own plan-gate independently.
 
-`--auto` adds one safety gate (a bare `bin/post-plan-now` skips it — running it by hand IS the decision to ship): it **skips** when already inside a headless/automouse run (the automouse runner fires post-plan itself). It no longer holds post-plan for a "risky" plan — post-plan **always** runs and opens the PR. Whether the PR then **auto-merges** is decided at `/post-plan` Phase 6.5, which honors a plan's `auto_merge: false` (see `/plan` Step 4) and refuses to arm auto-merge, leaving the PR open for a human to merge after review.
+`--auto` adds one safety gate (a bare `bin/post-plan-now` skips it — running it by hand IS the decision to ship): it **skips** when already inside a headless/automouse run (the automouse runner fires post-plan itself). It no longer holds post-plan for a "risky" plan — post-plan **always** runs and opens the PR. Whether the PR then **auto-merges** is decided at `/post-plan` Phase 6.5, which honors a plan's `auto_merge: false` (see `/plan` Step 4) and otherwise leaves the PR open for a human to merge.

--- a/.claude/rules/worktree-hostname.md
+++ b/.claude/rules/worktree-hostname.md
@@ -1,31 +1,29 @@
 ---
 description: How to derive the correct Docker hostname for the current worktree or main repo. Prevents using stale slugs.
-last_verified: 2026-06-27
+last_verified: 2026-07-01
 ---
 
 # Worktree Hostname
 
 ## Main repo
 
-The main checkout (`/Users/ajaynicolas/GitHub/IBL5/ibl5/`) is reference/read-only (ADR-0062 — see `workflow-continuity.md`). Its Docker hostname is `main.localhost`, used for reading/serving the canonical `master` stack and main-stack DB tooling, not for developing a change.
+The main checkout (`/Users/ajaynicolas/GitHub/IBL5/ibl5/`) is reference/read-only (ADR-0062 — see `workflow-continuity.md`). Its Docker hostname `main.localhost` serves the canonical `master` stack and main-stack DB tooling, not development of a change.
 
 ## Worktrees
 
-Worktrees live OUTSIDE the repo at `IBL5-worktrees/<slug>/ibl5/` — a canonical-case
-sibling of the main checkout (see `ibl5/docs/decisions/0046-worktrees-outside-repo.md`
-for why). The Docker hostname is `<slug>.localhost`.
+Worktrees live OUTSIDE the repo at `IBL5-worktrees/<slug>/ibl5/` — a canonical-case sibling of the main checkout (see `ibl5/docs/decisions/0046-worktrees-outside-repo.md`). Docker hostname: `<slug>.localhost`.
 
-To derive the slug at runtime from anywhere inside a worktree:
+Derive the slug at runtime from anywhere inside a worktree:
 
 ```bash
 basename "$(git rev-parse --show-toplevel)"
 ```
 
-This returns the worktree directory name, which matches the Traefik route configured by `bin/wt-up`.
+This returns the worktree directory name, matching the Traefik route `bin/wt-up` configures.
 
 ## URL paths
 
-Always navigate to `/ibl5/` paths — never the bare root (`/`). The application lives under `/ibl5/`, and the root directory returns a redirect (or 403 if the Docker image hasn't been rebuilt). Going to root wastes a round-trip; go directly to `/ibl5/` or a deeper path.
+Always navigate to `/ibl5/` paths — never the bare root (`/`). The app lives under `/ibl5/`; root returns a redirect (or 403 if the Docker image hasn't been rebuilt) and wastes a round-trip.
 
 ```
 # Wrong


### PR DESCRIPTION
## What

Compresses verbose prose in the **6 always-on** `.claude/rules/*.md` (files with no `paths:` glob load into *every* session's context) while preserving every directive, path reference, and semantic distinction. Also shortens overlong frontmatter `description:` fields (they load into context too) and bumps `last_verified` per the doc-freshness on-touch rule.

`phpstan-invocation.md` left untouched — already minimal.

## Savings

| File | Before | After |
|------|-------:|------:|
| agent-tiering | 5215 | 4603 |
| workflow-continuity | 4140 | 3741 |
| auto-commit | 2697 | 2448 |
| work-triage | 2491 | 2441 |
| worktree-hostname | 1547 | 1421 |
| browser-login | 1483 | 1473 |
| **total** | **17,573** | **16,127** (−1,446 B) |

Paired with a MEMORY.md index rewrite (in the exempt `~/.claude` path, not in this PR): together ~1.5k tokens off the always-loaded overhead.

## Review focus

This trims prose that loads into every session — **verify no directive/precision was lost**, not just that it reads cleanly. Diff is prose-only; no path tokens added.

## Notes

- Not auto-merge-armed on purpose — held for human review (rules quality affects every future session).
- CI `check-docs` (`--no-staleness` + on-touch) passes. A local full-staleness hook flags an **unrelated** pre-existing stale ADR (0017, 62d); not addressed here.