### PR TITLE
docs: reverify ADR-0017 (dependabot full CI and auto-merge)

### DIFF
--- a/ibl5/docs/decisions/0017-dependabot-full-ci-and-auto-merge.md
+++ b/ibl5/docs/decisions/0017-dependabot-full-ci-and-auto-merge.md
@@ -1,6 +1,6 @@
 ---
 description: Rationale for forcing all CI checks on Dependabot PRs and enabling squash auto-merge.
-last_verified: 2026-05-01
+last_verified: 2026-07-02
 ---
 
 # ADR-0017: Dependabot Full CI and Auto-Merge


### PR DESCRIPTION
## Summary
- Bumps `last_verified` on ADR-0017 (dependabot full CI and auto-merge) — content re-checked against current CI/auto-merge configuration and confirmed still accurate, no doc changes needed.

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.