### PR TITLE
refactor: Tier-1 module architecture scaffold (Boxscore/Negotiation/Schedule/Navigation)

### DIFF
--- a/ibl5/classes/Boxscore/BoxscoreView.php
+++ b/ibl5/classes/Boxscore/BoxscoreView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Boxscore;
 
+use Boxscore\Contracts\BoxscoreViewInterface;
 use Security\HtmlSanitizer;
 
 /**
@@ -13,7 +14,7 @@ use Security\HtmlSanitizer;
  *
  * @see BoxscoreProcessor For the processing logic
  */
-class BoxscoreView
+class BoxscoreView implements BoxscoreViewInterface
 {
     /**
      * Render parse results log

--- a/ibl5/classes/Boxscore/Contracts/BoxscoreViewInterface.php
+++ b/ibl5/classes/Boxscore/Contracts/BoxscoreViewInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boxscore\Contracts;
+
+/**
+ * BoxscoreViewInterface - Contract for scoParser HTML rendering
+ *
+ * @see \Boxscore\BoxscoreView For the concrete implementation
+ */
+interface BoxscoreViewInterface
+{
+    /**
+     * Render parse results log
+     *
+     * @param array{success: bool, gamesInserted: int, gamesUpdated: int, gamesSkipped: int, linesProcessed: int, messages: list<string>, error?: string} $result
+     * @return string HTML parse log
+     */
+    public function renderParseLog(array $result): string;
+
+    /**
+     * Render All-Star game processing results
+     *
+     * @param array{success: bool, messages: list<string>, skipped?: string} $result
+     * @return string HTML output
+     */
+    public function renderAllStarLog(array $result): string;
+
+    /**
+     * Render the async rename UI for All-Star teams with default placeholder names
+     *
+     * @param list<array{id: int, date: string, name: string, seasonYear: int, teamLabel: string, players: list<string>}> $pendingRenames
+     * @return string HTML output
+     */
+    public function renderAllStarRenameUI(array $pendingRenames): string;
+}

--- a/ibl5/classes/Navigation/Contracts/DesktopNavViewInterface.php
+++ b/ibl5/classes/Navigation/Contracts/DesktopNavViewInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Navigation\Contracts;
+
+/**
+ * Renders the desktop navigation bar: dropdown menus, teams mega-menu,
+ * login/account dropdown, and dev switch.
+ *
+ * @phpstan-import-type NavLink from \Navigation\NavigationConfig
+ * @phpstan-import-type NavMenuData from \Navigation\NavigationConfig
+ * @see \Navigation\Views\DesktopNavView
+ */
+interface DesktopNavViewInterface
+{
+    /**
+     * Render the complete desktop navigation section.
+     *
+     * @param array<string, NavMenuData> $menus
+     * @param NavMenuData|null $myTeamMenu
+     * @param list<array{label: string, url: string, noBoost?: bool}> $accountMenu
+     */
+    public function render(array $menus, ?array $myTeamMenu, array $accountMenu): string;
+
+    /**
+     * Render the dev switch button (only for admin on localhost/production).
+     */
+    public function renderDevSwitch(): string;
+}

--- a/ibl5/classes/Navigation/Contracts/LoginFormViewInterface.php
+++ b/ibl5/classes/Navigation/Contracts/LoginFormViewInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Navigation\Contracts;
+
+/**
+ * Renders the inline login form for both desktop and mobile navigation.
+ * The forms are structurally identical; only CSS sizing classes differ.
+ *
+ * @see \Navigation\Views\LoginFormView
+ */
+interface LoginFormViewInterface
+{
+    /**
+     * Render the login form.
+     *
+     * @param 'desktop'|'mobile' $variant
+     */
+    public function render(string $variant, ?string $requestUri): string;
+}

--- a/ibl5/classes/Navigation/Contracts/MobileNavViewInterface.php
+++ b/ibl5/classes/Navigation/Contracts/MobileNavViewInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Navigation\Contracts;
+
+/**
+ * Renders the mobile sliding panel navigation: user greeting, accordion
+ * sections, teams list, and login form.
+ *
+ * @phpstan-import-type NavLink from \Navigation\NavigationConfig
+ * @phpstan-import-type NavMenuData from \Navigation\NavigationConfig
+ * @see \Navigation\Views\MobileNavView
+ */
+interface MobileNavViewInterface
+{
+    /**
+     * Render the complete mobile navigation panel.
+     *
+     * @param array<string, NavMenuData> $menus
+     * @param NavMenuData|null $myTeamMenu
+     * @param list<array{label: string, url: string, noBoost?: bool}> $accountMenu
+     */
+    public function render(array $menus, ?array $myTeamMenu, array $accountMenu): string;
+}

--- a/ibl5/classes/Navigation/Contracts/NavigationViewInterface.php
+++ b/ibl5/classes/Navigation/Contracts/NavigationViewInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Navigation\Contracts;
+
+/**
+ * Thin orchestrator that composes the full navigation bar from sub-views.
+ *
+ * @see \Navigation\NavigationView
+ */
+interface NavigationViewInterface
+{
+    /**
+     * Render the complete navigation bar (desktop + mobile).
+     */
+    public function render(): string;
+}

--- a/ibl5/classes/Navigation/Contracts/TeamsDropdownViewInterface.php
+++ b/ibl5/classes/Navigation/Contracts/TeamsDropdownViewInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Navigation\Contracts;
+
+/**
+ * Renders the Teams mega-menu/list for both desktop and mobile navigation.
+ *
+ * @phpstan-import-type NavTeamsData from \Navigation\NavigationConfig
+ * @see \Navigation\Views\TeamsDropdownView
+ */
+interface TeamsDropdownViewInterface
+{
+    /**
+     * Render the desktop Teams mega-menu with 2x2 conference/division grid.
+     *
+     * @param NavTeamsData $teamsData
+     */
+    public function renderDesktop(array $teamsData): string;
+
+    /**
+     * Render the mobile Teams collapsible section with division sub-headers.
+     *
+     * @param NavTeamsData $teamsData
+     */
+    public function renderMobile(array $teamsData, ?int $userTeamId): string;
+}

--- a/ibl5/classes/Navigation/NavigationView.php
+++ b/ibl5/classes/Navigation/NavigationView.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Navigation;
 
 use Navigation\Contracts\NavigationMenuBuilderInterface;
+use Navigation\Contracts\NavigationViewInterface;
 use Navigation\Views\DesktopNavView;
 use Navigation\Views\LoginFormView;
 use Navigation\Views\MobileNavView;
@@ -19,7 +20,7 @@ use Security\HtmlSanitizer;
  * @phpstan-import-type NavMenuData from NavigationConfig
  * @phpstan-import-type NavTeamsData from NavigationConfig
  */
-class NavigationView
+class NavigationView implements NavigationViewInterface
 {
     private NavigationConfig $config;
     private NavigationMenuBuilderInterface $menuBuilder;

--- a/ibl5/classes/Navigation/Views/DesktopNavView.php
+++ b/ibl5/classes/Navigation/Views/DesktopNavView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Navigation\Views;
 
+use Navigation\Contracts\DesktopNavViewInterface;
 use Navigation\NavigationConfig;
 use Security\HtmlSanitizer;
 
@@ -14,7 +15,7 @@ use Security\HtmlSanitizer;
  * @phpstan-import-type NavLink from \Navigation\NavigationConfig
  * @phpstan-import-type NavMenuData from \Navigation\NavigationConfig
  */
-class DesktopNavView
+class DesktopNavView implements DesktopNavViewInterface
 {
     private NavigationConfig $config;
     private LoginFormView $loginFormView;

--- a/ibl5/classes/Navigation/Views/LoginFormView.php
+++ b/ibl5/classes/Navigation/Views/LoginFormView.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Navigation\Views;
 
+use Navigation\Contracts\LoginFormViewInterface;
 use Security\HtmlSanitizer;
 
 /**
  * Renders the inline login form for both desktop and mobile navigation.
  * The forms are structurally identical; only CSS sizing classes differ.
  */
-class LoginFormView
+class LoginFormView implements LoginFormViewInterface
 {
     /**
      * Render the login form.

--- a/ibl5/classes/Navigation/Views/MobileNavView.php
+++ b/ibl5/classes/Navigation/Views/MobileNavView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Navigation\Views;
 
+use Navigation\Contracts\MobileNavViewInterface;
 use Navigation\NavigationConfig;
 use Security\HtmlSanitizer;
 
@@ -14,7 +15,7 @@ use Security\HtmlSanitizer;
  * @phpstan-import-type NavLink from \Navigation\NavigationConfig
  * @phpstan-import-type NavMenuData from \Navigation\NavigationConfig
  */
-class MobileNavView
+class MobileNavView implements MobileNavViewInterface
 {
     private NavigationConfig $config;
     private LoginFormView $loginFormView;

--- a/ibl5/classes/Navigation/Views/TeamsDropdownView.php
+++ b/ibl5/classes/Navigation/Views/TeamsDropdownView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Navigation\Views;
 
+use Navigation\Contracts\TeamsDropdownViewInterface;
 use Security\HtmlSanitizer;
 
 /**
@@ -11,7 +12,7 @@ use Security\HtmlSanitizer;
  *
  * @phpstan-import-type NavTeamsData from \Navigation\NavigationConfig
  */
-class TeamsDropdownView
+class TeamsDropdownView implements TeamsDropdownViewInterface
 {
     /**
      * Render the desktop Teams mega-menu with 2x2 conference/division grid.

--- a/ibl5/classes/Negotiation/NegotiationService.php
+++ b/ibl5/classes/Negotiation/NegotiationService.php
@@ -8,6 +8,7 @@ use Negotiation\Contracts\ExtensionContractDemandCalculatorInterface;
 use Negotiation\Contracts\NegotiationRepositoryInterface;
 use Negotiation\Contracts\NegotiationServiceInterface;
 use Negotiation\Contracts\NegotiationValidatorInterface;
+use Negotiation\Views\DemandsBreakdownView;
 use Player\Player;
 
 /**
@@ -53,7 +54,7 @@ class NegotiationService implements NegotiationServiceInterface
 
         if ($bypassOwnership) {
             $breakdown = $this->demandCalculator->calculateDemandsWithBreakdown($player, $teamFactors);
-            $output .= NegotiationDemandsBreakdownView::render($breakdown);
+            $output .= DemandsBreakdownView::render($breakdown);
             return self::wrapInFormContainer($output);
         }
 

--- a/ibl5/classes/Negotiation/Views/DemandsBreakdownView.php
+++ b/ibl5/classes/Negotiation/Views/DemandsBreakdownView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Negotiation;
+namespace Negotiation\Views;
 
 use BasketballStats\StatsFormatter;
 use Negotiation\Contracts\ExtensionContractDemandCalculatorInterface;
@@ -13,7 +13,7 @@ use Security\HtmlSanitizer;
  *
  * @phpstan-import-type DemandsBreakdown from ExtensionContractDemandCalculatorInterface
  */
-class NegotiationDemandsBreakdownView
+class DemandsBreakdownView
 {
     /**
      * @param DemandsBreakdown $breakdown

--- a/ibl5/classes/Schedule/Contracts/ScheduleControllerInterface.php
+++ b/ibl5/classes/Schedule/Contracts/ScheduleControllerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Schedule\Contracts;
+
+/**
+ * ScheduleControllerInterface - Contract for the Schedule module's page controller
+ *
+ * @see \Schedule\ScheduleController For the concrete implementation
+ */
+interface ScheduleControllerInterface
+{
+    /**
+     * Render the schedule page body for a team (if valid) or the league
+     *
+     * @param int $teamid Team ID to render a team-specific schedule for, or 0/invalid for the league schedule
+     * @return string HTML output
+     */
+    public function render(int $teamid): string;
+}

--- a/ibl5/classes/Schedule/ScheduleController.php
+++ b/ibl5/classes/Schedule/ScheduleController.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Schedule;
+
+use LeagueSchedule\LeagueScheduleRepository;
+use LeagueSchedule\LeagueScheduleService;
+use LeagueSchedule\LeagueScheduleView;
+use Repositories\Contracts\TeamIdentityRepositoryInterface;
+use Schedule\Contracts\ScheduleControllerInterface;
+use Standings\StandingsRepository;
+use TeamSchedule\TeamScheduleRepository;
+use TeamSchedule\TeamScheduleService;
+use TeamSchedule\TeamScheduleView;
+
+/**
+ * ScheduleController - Page controller for the Schedule module
+ *
+ * @see \Schedule\Contracts\ScheduleControllerInterface
+ */
+class ScheduleController implements ScheduleControllerInterface
+{
+    public function __construct(
+        private readonly \mysqli $db,
+        private readonly \League\LeagueContext $leagueContext,
+        private readonly TeamIdentityRepositoryInterface $commonRepository,
+    ) {
+    }
+
+    public function render(int $teamid): string
+    {
+        $db = $this->db;
+        $leagueContext = $this->leagueContext;
+
+        $commonRepository = $this->commonRepository;
+        $season = new \Season\Season($db, $leagueContext);
+        $league = new \League\League($db);
+
+        // Load power rankings for SOS tier indicators
+        $standingsRepo = new StandingsRepository($db, $leagueContext);
+        $allStreakData = $standingsRepo->getAllStreakData();
+        /** @var array<int, float> $teamPowerRankings */
+        $teamPowerRankings = [];
+        foreach ($allStreakData as $streakTeamId => $data) {
+            $teamPowerRankings[$streakTeamId] = (float)$data['ranking'];
+        }
+
+        // Validate team ID exists (if provided)
+        $team = null;
+        if ($teamid > 0) {
+            $team = \Team\Team::initialize($db, $teamid);
+        }
+
+        if ($team !== null) {
+            $teamScheduleRepository = new TeamScheduleRepository($db, $leagueContext);
+            $service = new TeamScheduleService($db, $teamScheduleRepository, $teamPowerRankings);
+            $view = new TeamScheduleView();
+
+            $teamStreakData = $allStreakData[$teamid] ?? null;
+            if ($teamStreakData !== null) {
+                $view->setSosSummary([
+                    'remaining_sos' => $teamStreakData['remaining_sos'],
+                    'remaining_sos_rank' => $teamStreakData['remaining_sos_rank'],
+                ]);
+            }
+
+            $games = $service->getProcessedSchedule($teamid, $season);
+            return $view->render($team, $games, $league->getSimLengthInDays(), $season->phase);
+        }
+
+        $repository = new LeagueScheduleRepository($db, $leagueContext);
+        $service = new LeagueScheduleService($repository, $teamPowerRankings);
+        $view = new LeagueScheduleView();
+        $pageData = $service->getSchedulePageData($season, $league, $commonRepository);
+        return $view->render($pageData);
+    }
+}

--- a/ibl5/docs/maintenance-backlog.md
+++ b/ibl5/docs/maintenance-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Long-running backlog of maintenance-cost reduction opportunities, organized by axis. Each item is a candidate for a future plan.
-last_verified: 2026-06-29
+last_verified: 2026-07-02
 ---
 
 # Maintenance-Cost Reduction Backlog
@@ -268,14 +268,14 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 | 2.2 | 🚫 Declined | — | **Status (2026-06-28):** Declined. ActivityTracker + AllStarAppearances `index.php` are single-repo R+V passthrough (one `repo->getX()` → `view->render()`, verified on disk). A Service would be single-implementor pass-through ceremony — no orchestration to house (cf. 2.5/2.8/2.3 passthrough declines). |
 | 2.3 | ◑ Partial | — | FranchiseHistory Service built (#1091); PlayerMovement **declined** (single JOIN, pass-through ceremony). |
 | 2.4 | 🚫 Declined | — | **Status (2026-06-28):** Declined for GMContactList. Its `index.php` is single-repo passthrough (`getAllTeamContacts()` → render). The "match Topics (#1030)" premise is invalid: `TopicsService` orchestrates **two** repos (Topics + Search → `getPageData`) — real aggregation, not uniformity. No equivalent need here. |
-| 2.5 | ◑ Partial | 🟩 | **Status (2026-06-28):** Processor→Service rename **declined** — `BoxscoreProcessor` is a mutating .sco import pipeline (every method drives DB writes; consumed by Updater steps/BulkImport/scripts; no user-facing Boxscore page). Additive `BoxscoreViewInterface` half is 📋 planned in `tier1-module-architecture-scaffold` (staleness-skipped 2026-06-27, re-queue pending). |
+| 2.5 | ◑ Partial | — | BoxscoreViewInterface added (this PR). Processor→Service rename **declined**: BoxscoreProcessor is a mutating .sco import pipeline (cf. 2.8/2.3 pass-through declines; Waivers carries S1+P1). Residual = declined rename. |
 | 2.6 | ✅ Implemented | — | DraftService + DraftController extracted; index.php globals removed; green-green. |
 | 2.7 | ✅ Implemented | — | InjuriesRepository extracted+injected (#970). |
 | 2.8 | 🚫 Declined | — | Search + Standings: pass-through Service = dead code; declined. |
 | 2.9 | 🚫 Declined | — | `*ApiHandler` is the HTMX-fragment convention (9 handlers); rename declined. |
 | 2.10 | ⬜ Open | 🟨 | Extension R+S+P+Vl, no View. Upfront decision (own module vs Player sub-action) **+** extension handler touches #1110 IDOR (sequence). |
 | 2.11 | ✅ Implemented | — | RookieOptionFormView→RookieOptionView (#1031); Service declined. |
-| 2.12 | 📋 Planned | 🟩 | **Planned** in `tier1-module-architecture-scaffold`: consolidate `NegotiationDemandsBreakdownView` into `Views/` (NegotiationOfferView already canonical via 4.22). Skipped by `check-plan-staleness` FP 2026-06-27 (`— NEW` cue unrecognized); re-queue pending. |
+| 2.12 | ✅ Implemented | — | OfferView already canonical (4.22); DemandsBreakdownView moved to Negotiation\Views\ sub-view (this PR). Calculator role tracked under 4.8. |
 | 2.13 | 📋 Planned | 🟨 | Characterization-pins plan queued (`freeagency-2-13-characterization-pins`); the admin/user split touches admin-mutation surface (→ human-merge) **+** collides with #1109 FA IDOR (sequence). |
 | 2.14 | ◑ Partial | 🟨 | TradingController+Service exist (#802) but `maketradeoffer/accepttradeoffer/rejecttradeoffer.php` standalone endpoints remain (verified). Promoting touches trade-mutation surface + collides with #1108 (sequence). |
 | 2.15 | ⬜ Open | 🟨 | `classes/VotingResults/` absent. Upfront decision: merge module dirs vs split namespace. |
@@ -283,11 +283,11 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 | 2.17 | 📋 Planned | 🟦 | News R/S/V extraction = PR #1166 open (queued `extract-news`); held `auto_merge:false` (SQL surface). |
 | 2.18 | ⬜ Open | 🟨 | Static HTML in index.php. Upfront decision: static page outside module vs minimal View. Low risk. |
 | 2.19 | ✅ Implemented | — | **Marker was missing/stale.** `modules/SiteStatistics/` deleted (#733, verified absent). |
-| 2.20 | 📋 Planned | 🟩 | **Planned** in `tier1-module-architecture-scaffold`: extract `ScheduleController::render(int): string` (header/footer stay in index.php). Verified: index.php still branches inline. Skipped by staleness FP 2026-06-27; re-queue pending. |
+| 2.20 | ✅ Implemented | — | ScheduleController owns the branch (this PR); index.php thin; league + team pages byte-identical (E2E). |
 | 2.21 | ⬜ Open | 🟨 | Same root cause as 2.15 (VotingResults namespace); resolve together. |
 | 2.22 | ✅ Implemented | — | `Services/` deleted (2026-05-16). |
 | 2.23 | ✅ Implemented | — | `Shared/` deleted; SalaryConverter→BasketballStats. |
-| 2.24 | 📋 Planned | 🟩 | **Planned** in `tier1-module-architecture-scaffold`: add `NavigationViewInterface` + 4 sub-view ifaces (additive, no constructor retype). Skipped by staleness FP 2026-06-27; re-queue pending. |
+| 2.24 | ✅ Implemented | — | NavigationViewInterface + 4 sub-view interfaces added; views implement them (this PR). |
 | 2.25 | ⬜ Open | 🟨 | index.php still defines `showpage/negotiate/rookieoption/processrookieoption` globals (verified); rookieoption/negotiate touch mutation → collides with #1107 (sequence). showpage extraction alone is green-green. |
 | 2.26 | ✅ Implemented | — | Documented Updater web-POST placement (`classes/Updater/README.md`); audit's "CLI-only" was inaccurate — it is web-only. |
 | 2.27 | ⬜ Open | 🟦 | Root `leagueControlPanel.php`→module bypasses `ModuleAccessControl`; converting changes admin-auth path (security surface) → human-merge. (a11y fix kept standalone deliberately.) |
@@ -338,6 +338,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Rename Processor → Service for read-heavy modules; add ViewInterface.
 **Est. effort:** S
 **Risk if untouched:** Naming confuses new contributors; missing view interface blocks integration tests.
+**Status:** ◑ Partial (2026-06-26) — `BoxscoreViewInterface` added. Processor→Service rename declined: every `BoxscoreProcessor` method mutates (it is a .sco import pipeline used by `Updater\Steps\ProcessBoxscoresStep`), so a Service would be pass-through ceremony (cf. 2.8/2.3). `Processor` is the correct house name (Waivers S1+P1).
 
 ### 2.6 Draft — No Service Layer; Two Legacy Globals + Mis-Named Handler
 **Location:** `classes/Draft/`, `modules/Draft/index.php`
@@ -393,6 +394,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Consolidate `BreakdownView` as a sub-view; document the Player sub-domain relationship.
 **Est. effort:** S
 **Risk if untouched:** Three view-ish files with different conventions confuse the View boundary.
+**Status:** ✅ Implemented (2026-06-26) — `NegotiationOfferView` canonicalized under 4.22; `NegotiationDemandsBreakdownView` → `Negotiation\Views\DemandsBreakdownView` sub-view (this PR). `NegotiationDemandCalculator` is a legitimate Calculator role (see 4.8).
 
 ### 2.13 FreeAgency — 14 Files; Admin Path Not Separated
 **Location:** `classes/FreeAgency/`
@@ -451,6 +453,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Create `Schedule\ScheduleController` that delegates to either service.
 **Est. effort:** S
 **Risk if untouched:** Branching only in `index.php`; untestable; new schedule types bolt onto it.
+**Status:** ✅ Implemented (2026-06-26) — `Schedule\ScheduleController::render(int)` owns the league/team branch; `modules/Schedule/index.php` is now thin glue. League + team pages verified byte-identical via existing E2E flows.
 
 ### 2.21 VotingResults — Namespace/Module Mismatch
 **Location:** `modules/VotingResults/index.php` instantiates `Voting\*` classes
@@ -481,6 +484,7 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Suggested direction:** Add `NavigationViewInterface`; consider sub-view interfaces; rename `Config` if applicable.
 **Est. effort:** S
 **Risk if untouched:** Views unmockable; architecture hard to explain.
+**Status:** ✅ Implemented (2026-06-26) — `NavigationViewInterface` + `DesktopNavViewInterface`/`MobileNavViewInterface`/`LoginFormViewInterface`/`TeamsDropdownViewInterface` added; all five views implement them.
 
 ### 2.25 Player — 42-File Mega-Module; 189-LOC `index.php` With Global Function
 **Location:** `classes/Player/`, `modules/Player/`

--- a/ibl5/infection.json5
+++ b/ibl5/infection.json5
@@ -15,7 +15,6 @@
             // Group-B Views: no output-assertion test yet — honest per-file deferral
             // reasons below; gate 2 in check-infection-excludes fires if a test later
             // appears for one of these and it is not re-included. See ADR 0065.
-            "Negotiation/NegotiationDemandsBreakdownView.php", // no output-assertion test yet — deferred Pass 2
             "Player/Views/PlayerAwardsView.php", // no output-assertion test yet — deferred Pass 2
             "Player/Views/PlayerButtonsView.php", // no output-assertion test yet — deferred Pass 2
             "Player/Views/PlayerMenuView.php", // no output-assertion test yet — deferred Pass 2

--- a/ibl5/modules/Schedule/index.php
+++ b/ibl5/modules/Schedule/index.php
@@ -18,65 +18,14 @@ if (!defined('MODULE_FILE')) {
     die("You can't access this file directly...");
 }
 
-use LeagueSchedule\LeagueScheduleRepository;
-use LeagueSchedule\LeagueScheduleService;
-use LeagueSchedule\LeagueScheduleView;
-use Standings\StandingsRepository;
-use TeamSchedule\TeamScheduleRepository;
-use TeamSchedule\TeamScheduleService;
-use TeamSchedule\TeamScheduleView;
+use Repositories\TeamIdentityRepository;
+use Schedule\ScheduleController;
 
-global $cookie, $mysqli_db, $leagueContext;
+global $mysqli_db, $leagueContext;
 
-$commonRepository = new Repositories\TeamIdentityRepository($mysqli_db);
-$season = new \Season\Season($mysqli_db, $leagueContext);
-$league = new \League\League($mysqli_db);
-
-// Load power rankings for SOS tier indicators
-$standingsRepo = new StandingsRepository($mysqli_db, $leagueContext);
-$allStreakData = $standingsRepo->getAllStreakData();
-/** @var array<int, float> $teamPowerRankings */
-$teamPowerRankings = [];
-foreach ($allStreakData as $teamid => $data) {
-    $teamPowerRankings[$teamid] = (float)$data['ranking'];
-}
-
-// Check for team ID parameter
-$teamid = isset($_GET['teamid']) ? (int)$_GET['teamid'] : 0;
-
-// Validate team ID exists (if provided)
-$isValidTeam = false;
-if ($teamid > 0) {
-    $team = \Team\Team::initialize($mysqli_db, $teamid);
-    $isValidTeam = ($team->teamid > 0);
-}
+$teamid = isset($_GET['teamid']) ? (int) $_GET['teamid'] : 0;
+$controller = new ScheduleController($mysqli_db, $leagueContext, new TeamIdentityRepository($mysqli_db));
 
 PageLayout\PageLayout::header();
-
-if ($isValidTeam) {
-    // Team-specific schedule with colors, logo, and win/loss tracking
-    $teamScheduleRepository = new TeamScheduleRepository($mysqli_db, $leagueContext);
-    $service = new TeamScheduleService($mysqli_db, $teamScheduleRepository, $teamPowerRankings);
-    $view = new TeamScheduleView();
-
-    // Set remaining SOS summary for the team
-    $teamStreakData = $allStreakData[$teamid] ?? null;
-    if ($teamStreakData !== null) {
-        $view->setSosSummary([
-            'remaining_sos' => $teamStreakData['remaining_sos'],
-            'remaining_sos_rank' => $teamStreakData['remaining_sos_rank'],
-        ]);
-    }
-
-    $games = $service->getProcessedSchedule($teamid, $season);
-    echo $view->render($team, $games, $league->getSimLengthInDays(), $season->phase);
-} else {
-    // League-wide schedule
-    $repository = new LeagueScheduleRepository($mysqli_db, $leagueContext);
-    $service = new LeagueScheduleService($repository, $teamPowerRankings);
-    $view = new LeagueScheduleView();
-    $pageData = $service->getSchedulePageData($season, $league, $commonRepository);
-    echo $view->render($pageData);
-}
-
+echo $controller->render($teamid);
 PageLayout\PageLayout::footer();

--- a/ibl5/tests/Boxscore/BoxscoreViewXssTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreViewXssTest.php
@@ -14,7 +14,9 @@ final class BoxscoreViewXssTest extends TestCase
     {
         $view = new BoxscoreView();
 
-        $this->assertInstanceOf(BoxscoreViewInterface::class, $view);
+        $this->assertTrue(
+            (new \ReflectionClass($view))->implementsInterface(BoxscoreViewInterface::class),
+        );
     }
 
     public function testParseLogEscapesXssInMessagesAndError(): void

--- a/ibl5/tests/Boxscore/BoxscoreViewXssTest.php
+++ b/ibl5/tests/Boxscore/BoxscoreViewXssTest.php
@@ -5,10 +5,18 @@ declare(strict_types=1);
 namespace Tests\Boxscore;
 
 use Boxscore\BoxscoreView;
+use Boxscore\Contracts\BoxscoreViewInterface;
 use PHPUnit\Framework\TestCase;
 
 final class BoxscoreViewXssTest extends TestCase
 {
+    public function testImplementsBoxscoreViewInterface(): void
+    {
+        $view = new BoxscoreView();
+
+        $this->assertInstanceOf(BoxscoreViewInterface::class, $view);
+    }
+
     public function testParseLogEscapesXssInMessagesAndError(): void
     {
         $xss = '<script>alert(1)</script>';

--- a/ibl5/tests/Navigation/NavigationViewTest.php
+++ b/ibl5/tests/Navigation/NavigationViewTest.php
@@ -13,13 +13,9 @@ class NavigationViewTest extends TestCase
 {
     public function testImplementsNavigationViewInterface(): void
     {
-        $config = new NavigationConfig(
-            isLoggedIn: false,
-            username: null,
-            currentLeague: 'ibl',
+        $this->assertTrue(
+            (new \ReflectionClass(NavigationView::class))->implementsInterface(NavigationViewInterface::class),
         );
-
-        $this->assertInstanceOf(NavigationViewInterface::class, new NavigationView($config));
     }
 
     /**

--- a/ibl5/tests/Navigation/NavigationViewTest.php
+++ b/ibl5/tests/Navigation/NavigationViewTest.php
@@ -4,12 +4,24 @@ declare(strict_types=1);
 
 namespace Tests\Navigation;
 
+use Navigation\Contracts\NavigationViewInterface;
 use Navigation\NavigationConfig;
 use Navigation\NavigationView;
 use PHPUnit\Framework\TestCase;
 
 class NavigationViewTest extends TestCase
 {
+    public function testImplementsNavigationViewInterface(): void
+    {
+        $config = new NavigationConfig(
+            isLoggedIn: false,
+            username: null,
+            currentLeague: 'ibl',
+        );
+
+        $this->assertInstanceOf(NavigationViewInterface::class, new NavigationView($config));
+    }
+
     /**
      * Render navigation for a logged-in IBL user with the given settings.
      *

--- a/ibl5/tests/Navigation/Views/DesktopNavViewTest.php
+++ b/ibl5/tests/Navigation/Views/DesktopNavViewTest.php
@@ -15,7 +15,9 @@ class DesktopNavViewTest extends TestCase
 {
     public function testImplementsDesktopNavViewInterface(): void
     {
-        $this->assertInstanceOf(DesktopNavViewInterface::class, $this->createView());
+        $this->assertTrue(
+            (new \ReflectionClass(DesktopNavView::class))->implementsInterface(DesktopNavViewInterface::class),
+        );
     }
 
     private function createView(

--- a/ibl5/tests/Navigation/Views/DesktopNavViewTest.php
+++ b/ibl5/tests/Navigation/Views/DesktopNavViewTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Navigation\Views;
 
+use Navigation\Contracts\DesktopNavViewInterface;
 use Navigation\NavigationConfig;
 use Navigation\Views\DesktopNavView;
 use Navigation\Views\LoginFormView;
@@ -12,6 +13,11 @@ use PHPUnit\Framework\TestCase;
 
 class DesktopNavViewTest extends TestCase
 {
+    public function testImplementsDesktopNavViewInterface(): void
+    {
+        $this->assertInstanceOf(DesktopNavViewInterface::class, $this->createView());
+    }
+
     private function createView(
         bool $isLoggedIn = true,
         ?string $username = 'TestUser',

--- a/ibl5/tests/Navigation/Views/LoginFormViewTest.php
+++ b/ibl5/tests/Navigation/Views/LoginFormViewTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Navigation\Views;
 
+use Navigation\Contracts\LoginFormViewInterface;
 use Navigation\Views\LoginFormView;
 use PHPUnit\Framework\TestCase;
 
@@ -14,6 +15,11 @@ class LoginFormViewTest extends TestCase
     protected function setUp(): void
     {
         $this->view = new LoginFormView();
+    }
+
+    public function testImplementsLoginFormViewInterface(): void
+    {
+        $this->assertInstanceOf(LoginFormViewInterface::class, $this->view);
     }
 
     public function testDesktopVariantHasDesktopSizingClasses(): void

--- a/ibl5/tests/Navigation/Views/LoginFormViewTest.php
+++ b/ibl5/tests/Navigation/Views/LoginFormViewTest.php
@@ -19,7 +19,9 @@ class LoginFormViewTest extends TestCase
 
     public function testImplementsLoginFormViewInterface(): void
     {
-        $this->assertInstanceOf(LoginFormViewInterface::class, $this->view);
+        $this->assertTrue(
+            (new \ReflectionClass(LoginFormView::class))->implementsInterface(LoginFormViewInterface::class),
+        );
     }
 
     public function testDesktopVariantHasDesktopSizingClasses(): void

--- a/ibl5/tests/Navigation/Views/MobileNavViewTest.php
+++ b/ibl5/tests/Navigation/Views/MobileNavViewTest.php
@@ -15,7 +15,9 @@ class MobileNavViewTest extends TestCase
 {
     public function testImplementsMobileNavViewInterface(): void
     {
-        $this->assertInstanceOf(MobileNavViewInterface::class, $this->createView());
+        $this->assertTrue(
+            (new \ReflectionClass(MobileNavView::class))->implementsInterface(MobileNavViewInterface::class),
+        );
     }
 
     private function createView(

--- a/ibl5/tests/Navigation/Views/MobileNavViewTest.php
+++ b/ibl5/tests/Navigation/Views/MobileNavViewTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Navigation\Views;
 
+use Navigation\Contracts\MobileNavViewInterface;
 use Navigation\NavigationConfig;
 use Navigation\Views\LoginFormView;
 use Navigation\Views\MobileNavView;
@@ -12,6 +13,11 @@ use PHPUnit\Framework\TestCase;
 
 class MobileNavViewTest extends TestCase
 {
+    public function testImplementsMobileNavViewInterface(): void
+    {
+        $this->assertInstanceOf(MobileNavViewInterface::class, $this->createView());
+    }
+
     private function createView(
         bool $isLoggedIn = true,
         ?string $username = 'TestUser',

--- a/ibl5/tests/Navigation/Views/TeamsDropdownViewTest.php
+++ b/ibl5/tests/Navigation/Views/TeamsDropdownViewTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Navigation\Views;
 
+use Navigation\Contracts\TeamsDropdownViewInterface;
 use Navigation\Views\TeamsDropdownView;
 use PHPUnit\Framework\TestCase;
 

--- a/ibl5/tests/Negotiation/Views/DemandsBreakdownViewTest.php
+++ b/ibl5/tests/Negotiation/Views/DemandsBreakdownViewTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Negotiation\Views;
+
+use Negotiation\Views\DemandsBreakdownView;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization test for DemandsBreakdownView (moved from
+ * Negotiation\NegotiationDemandsBreakdownView during the Tier-1 module
+ * architecture scaffold). Locks the rendered HTML structure so the
+ * namespace/class move stays behavior-preserving.
+ */
+final class DemandsBreakdownViewTest extends TestCase
+{
+    /**
+     * @return array{
+     *     ratings: list<array{name: string, playerValue: int, marketMax: int, rawScore: int}>,
+     *     totalRawScore: int,
+     *     baseline: int,
+     *     adjustedScore: int,
+     *     avgDemands: float|int,
+     *     totalDemands: float|int,
+     *     baseDemands: float|int,
+     *     maxRaise: float|int,
+     *     faPreferences: array{playForWinner: int, tradition: int, loyalty: int, playingTime: int},
+     *     teamFactors: array{wins: int, losses: int, tradition_wins: int, tradition_losses: int, money_committed_at_position: int},
+     *     modifiers: list<array{name: string, formula: string, inputs: string, result: float}>,
+     *     totalModifier: float,
+     *     demands: array{year1: float|int, year2: float|int, year3: float|int, year4: float|int, year5: float|int, year6: int, years: int, total: float|int, modifier: float}
+     * }
+     */
+    private function sampleBreakdown(): array
+    {
+        return [
+            'ratings' => [
+                ['name' => 'Scoring', 'playerValue' => 80, 'marketMax' => 100, 'rawScore' => 60],
+            ],
+            'totalRawScore' => 60,
+            'baseline' => 10,
+            'adjustedScore' => 50,
+            'avgDemands' => 16.6667,
+            'totalDemands' => 83.3335,
+            'baseDemands' => 13.8889,
+            'maxRaise' => 1.3889,
+            'faPreferences' => [
+                'playForWinner' => 5,
+                'tradition' => 5,
+                'loyalty' => 5,
+                'playingTime' => 5,
+            ],
+            'teamFactors' => [
+                'wins' => 41,
+                'losses' => 41,
+                'tradition_wins' => 0,
+                'tradition_losses' => 0,
+                'money_committed_at_position' => 0,
+            ],
+            'modifiers' => [
+                ['name' => 'Play for Winner', 'formula' => '(PFW - 5) * 0.02', 'inputs' => 'PFW=5', 'result' => 0.0],
+            ],
+            'totalModifier' => 1.0,
+            'demands' => [
+                'year1' => 14,
+                'year2' => 15,
+                'year3' => 17,
+                'year4' => 19,
+                'year5' => 21,
+                'year6' => 0,
+                'years' => 5,
+                'total' => 86,
+                'modifier' => 1.0,
+            ],
+        ];
+    }
+
+    public function testRenderProducesStableBreakdownStructure(): void
+    {
+        $html = DemandsBreakdownView::render($this->sampleBreakdown());
+
+        $this->assertStringContainsString('<details class="debug-breakdown">', $html);
+        $this->assertStringContainsString('<summary class="debug-breakdown__summary">Demands Formula Breakdown</summary>', $html);
+        $this->assertStringContainsString('Ratings vs Market', $html);
+        $this->assertStringContainsString('Score Pipeline', $html);
+        $this->assertStringContainsString('Player FA Preferences', $html);
+        $this->assertStringContainsString('Team Factors', $html);
+        $this->assertStringContainsString('Modifier Components', $html);
+        $this->assertStringContainsString('Combined Modifier', $html);
+        $this->assertStringContainsString('Final Demands', $html);
+        $this->assertStringContainsString('<strong>86</strong>', $html);
+        $this->assertStringContainsString('</details>', $html);
+    }
+}

--- a/ibl5/tests/WideUnit/Schedule/ScheduleControllerTest.php
+++ b/ibl5/tests/WideUnit/Schedule/ScheduleControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\WideUnit\Schedule;
+
+use League\LeagueContext;
+use Repositories\TeamIdentityRepository;
+use Schedule\Contracts\ScheduleControllerInterface;
+use Schedule\ScheduleController;
+use Tests\WideUnit\Mocks\TestDataFactory;
+use Tests\WideUnit\WideUnitTestCase;
+
+/**
+ * Tests Schedule\ScheduleController directly (not via the module entry point).
+ *
+ * @see \Tests\Module\EntryPoints\ScheduleEntryPointTest For entry-point / $_GET boundary coverage
+ */
+class ScheduleControllerTest extends WideUnitTestCase
+{
+    public function testImplementsScheduleControllerInterface(): void
+    {
+        $this->assertTrue(
+            (new \ReflectionClass(ScheduleController::class))->implementsInterface(ScheduleControllerInterface::class)
+        );
+    }
+
+    public function testRenderWithValidTeamIdShowsTeamSchedule(): void
+    {
+        $this->mockDb->setMockTeamData([TestDataFactory::createTeam(['teamid' => 1])]);
+        $this->mockDb->setMockData([]);
+
+        $controller = new ScheduleController($this->mockDb, new LeagueContext(), new TeamIdentityRepository($this->mockDb));
+        $output = $controller->render(1);
+
+        $this->assertStringContainsString('schedule-container--team', $output);
+    }
+
+    public function testRenderWithZeroTeamIdShowsLeagueSchedule(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $controller = new ScheduleController($this->mockDb, new LeagueContext(), new TeamIdentityRepository($this->mockDb));
+        $output = $controller->render(0);
+
+        $this->assertStringContainsString('<h1 class="ibl-title">Schedule</h1>', $output);
+    }
+
+    public function testRenderWithUnknownTeamIdThrowsRuntimeException(): void
+    {
+        // Team::initialize() throws when no matching row is found — the
+        // controller reproduces the pre-refactor module's behavior verbatim
+        // (no try/catch), so an invalid teamid propagates the exception
+        // rather than falling back to the league branch.
+        $this->mockDb->setMockTeamData([]);
+        $this->mockDb->setMockData([]);
+
+        $controller = new ScheduleController($this->mockDb, new LeagueContext(), new TeamIdentityRepository($this->mockDb));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Team not found: 99999');
+        $controller->render(99999);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the missing Service/Controller/Interface layers to four existing modules, behavior-preserving (green-green). No new GM-facing ability — pages render byte-identical.

Findings addressed (verified on `master` 2026-06-26): **2.5 Boxscore**, **2.12 Negotiation**, **2.20 Schedule**, **2.24 Navigation** from `ibl5/docs/maintenance-backlog.md`.

- **2.24 Navigation** — Added `NavigationViewInterface` + 4 sub-view interfaces (Desktop/Mobile/Login/TeamsDropdown).
- **2.5 Boxscore** — Added `BoxscoreViewInterface` only. The `Processor → Service` rename was declined: `BoxscoreProcessor` is a mutating import pipeline (not "doing service work"), so the finding's premise doesn't hold on current `master`. Marker → ◑ Partial.
- **2.12 Negotiation** — Extracted `NegotiationDemandsBreakdownView` as a `Views/` sub-view; fixed a PHPStan `alreadyNarrowedType` in view tests.
- **2.20 Schedule** — Extracted `ScheduleController` service/interface layer; `modules/Schedule/index.php` no longer branches inline.
- Backlog doc markers flipped to Implemented for all four findings.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.