### PR TITLE
chore(dev-tooling): auto-heal stale compiled CSS via git hooks

### DIFF
--- a/.claude/rules/css-auto-rebuild.md
+++ b/.claude/rules/css-auto-rebuild.md
@@ -1,17 +1,21 @@
 ---
-description: Tailwind CSS is auto-rebuilt by the ibl5-tailwind container; manual builds are recovery-only.
+description: Tailwind CSS is auto-rebuilt by the ibl5-tailwind container (on save) and by git hooks (after rebase/checkout/merge); manual builds are a last resort.
 paths: "**/*.css"
-last_verified: 2026-05-31
+last_verified: 2026-07-02
 ---
 
 # CSS Auto-Rebuild (Tailwind)
 
 The `ibl5-tailwind` Docker container runs `@tailwindcss/cli --watch=always` continuously. Any saved change to a CSS source file (`.css` in `design/`, or any file Tailwind scans for classes) triggers an automatic rebuild of `themes/IBL/style/style.css`.
 
+## Two auto-rebuild paths (you should never need a manual build)
+
+1. **Editor save → watcher.** The container's `--watch` reacts to the fsevent; compiled output is ready within ~1s. Just reload.
+2. **Git op → hook.** Editor saves propagate, but git BULK file replacement (rebase / checkout / merge / pull rewriting a `design/**` source via rename) is **not reliably delivered** to `@parcel/watcher` through the macOS→Docker bind mount — so the compiled CSS silently goes stale. `bin/install-git-hooks` injects `bin/rebuild-css-if-source-changed` into **post-checkout, post-merge, post-rewrite** to heal that: it is mtime-gated (no-op when the output is already fresh) and backgrounded (git returns at once), rebuilding on the host (`bunx`) with a `docker exec` fallback. `bin/wt-new`/`bin/wt-up` build once at create/up; the hooks cover every git op after that.
+
 ## Rules
 
-- **Do not run manual Tailwind build commands (`bunx @tailwindcss/cli`, `bun run css:build`) as a routine step** — the `ibl5-tailwind` watcher rebuilds `themes/IBL/style/style.css` automatically on save. Never pass `--minify` locally (CI handles minification).
-- **Recovery (the one sanctioned exception):** run a single one-off `bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css` when the watcher misses a change — notably after a `git checkout`/branch switch — or when compiled output is verified stale. Confirm staleness first: `grep -c "your-class" themes/IBL/style/style.css`.
-- After editing CSS source files, the compiled output is available within ~1 second — just reload the page.
-- If the compiled CSS appears stale, check the container is running: `docker compose ps tailwind`. Restart it if needed: `docker compose restart tailwind`.
+- **Do not run manual Tailwind build commands (`bunx @tailwindcss/cli`, `bun run css:build`) as a routine step.** The watcher covers saves; the git hooks cover rebase/checkout/merge. Never pass `--minify` locally (CI handles minification).
+- **Manual build is a last resort** — reach for it only if both auto-paths are unavailable (git hooks not installed — run `bin/install-git-hooks`; or the container is down). Confirm staleness first (`grep -c "your-class" themes/IBL/style/style.css`), then: `bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css`.
+- If the compiled CSS appears stale, check the container is running: `docker compose ps tailwind`. Restart it if needed: `docker compose restart tailwind`. Check the hook log at `~/.cache/ibl5-hooks/css-rebuild.log`.
 - In CI, `css:build` runs as part of the Docker image build — no manual step needed there either.

--- a/bin/install-git-hooks
+++ b/bin/install-git-hooks
@@ -1,21 +1,30 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 #
-# bin/install-git-hooks — install the pre-push ADR decision-trigger gate.
+# bin/install-git-hooks — install the pre-push ADR decision-trigger gate and the
+# CSS auto-heal trigger into the COMMON git hooks dir.
 #
-# Copies a thin shim into the COMMON git hooks dir (git rev-parse
+# Copies thin shims into the COMMON git hooks dir (git rev-parse
 # --git-common-dir), so a single install covers every worktree (worktrees share
-# the common .git). The shim chains git-lfs (preserving LFS pushes) then exec's
-# bin/pre-push-adr-hook, where the gate logic lives version-controlled.
+# the common .git). The pre-push shim chains git-lfs (preserving LFS pushes) then
+# exec's bin/pre-push-adr-hook, where the gate logic lives version-controlled.
+#
+# It also injects a version-controlled CSS auto-heal call into post-checkout,
+# post-merge, and post-rewrite. These git ops bulk-rewrite the working tree in a
+# way the @tailwindcss/cli --watch container does not reliably observe, leaving
+# the compiled stylesheet stale (see bin/rebuild-css-if-source-changed).
 #
 # We deliberately do NOT use core.hooksPath: it is all-or-nothing across the
 # shared common git dir and would orphan the existing untracked hooks (the git-lfs
 # pre-push, pre-commit's codebase-map + check-docs, post-merge wt-cleanup,
-# post-checkout). Copying one shim is surgical.
+# post-checkout). Copying/injecting shims is surgical.
 #
-# Idempotent: re-running detects our sentinel marker and rewrites in place; a
-# pre-existing NON-shim pre-push (the default git-lfs one) is backed up once to
-# pre-push.pre-adr.bak before we overwrite it.
+# Idempotent: re-running detects our sentinel markers and rewrites/skips in
+# place; a pre-existing NON-shim pre-push (the default git-lfs one) is backed up
+# once to pre-push.pre-adr.bak before we overwrite it. The CSS injection is a
+# no-op when its sentinel is already present, and preserves any existing hook
+# body (it inserts our call right after the shebang so it runs before a hook's
+# branch-gated early-exit).
 
 set -euo pipefail
 
@@ -46,3 +55,35 @@ EOF
 chmod 0755 "$SHIM"
 
 echo "Installed pre-push ADR hook: $SHIM"
+
+# --- CSS auto-heal: inject into post-checkout / post-merge / post-rewrite ------
+# These git ops bulk-rewrite the working tree; the --watch container misses that,
+# so the compiled stylesheet goes stale. Our call is placed right after the
+# shebang so it runs BEFORE any branch-gated early-exit already in the hook
+# (post-merge exits early on non-master, but worktrees live on feature branches).
+CSS_SENTINEL='# IBL5-CSS-REBUILD'
+CSS_BLOCK="$CSS_SENTINEL (installed by bin/install-git-hooks)
+\"\$(git rev-parse --show-toplevel 2>/dev/null)/bin/rebuild-css-if-source-changed\" >/dev/null 2>&1 || true"
+
+inject_css_heal() {
+    local hook="$HOOKS_DIR/$1"
+    if [ ! -e "$hook" ]; then
+        printf '#!/bin/sh\n%s\n' "$CSS_BLOCK" > "$hook"
+        chmod 0755 "$hook"
+        echo "Created $1 with CSS auto-heal: $hook"
+        return
+    fi
+    if grep -qF "$CSS_SENTINEL" "$hook"; then
+        return  # already injected
+    fi
+    # Insert our block after the first line (the shebang), preserving the rest.
+    local tmp="$hook.tmp.$$"
+    { head -n 1 "$hook"; printf '%s\n' "$CSS_BLOCK"; tail -n +2 "$hook"; } > "$tmp"
+    chmod 0755 "$tmp"
+    mv "$tmp" "$hook"
+    echo "Injected CSS auto-heal into $1: $hook"
+}
+
+inject_css_heal post-checkout
+inject_css_heal post-merge
+inject_css_heal post-rewrite

--- a/bin/rebuild-css-if-source-changed
+++ b/bin/rebuild-css-if-source-changed
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/rebuild-css-if-source-changed — heal a stale compiled Tailwind stylesheet
+# after a git operation that the --watch container did not observe.
+#
+# The `ibl5-tailwind[-<slug>]` container runs `@tailwindcss/cli --watch`, which
+# reacts to filesystem events. Editor saves propagate (~1s rebuild), but git
+# BULK file replacement (rebase / checkout / merge / pull rewriting a source
+# file via rename) is not reliably delivered to @parcel/watcher through the
+# macOS→Docker bind mount — so the compiled `themes/IBL/style/style.css` silently
+# goes stale relative to `design/**`. `bin/wt-new`/`bin/wt-up` build it once at
+# worktree create/up; this heals the gap for every git op AFTER that.
+#
+# Wired (via bin/install-git-hooks) into post-checkout, post-merge, and
+# post-rewrite — the git ops that bulk-rewrite the working tree. Safe to call
+# unconditionally: it is a no-op when the compiled output is already fresh
+# (mtime-gated), and the rebuild is backgrounded so the git op returns at once.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+IBL5="$REPO_ROOT/ibl5"
+INPUT="$IBL5/design/input.css"
+OUTPUT="$IBL5/themes/IBL/style/style.css"
+DESIGN="$IBL5/design"
+[ -f "$INPUT" ] || exit 0   # not an ibl5 checkout (or design/ absent) — nothing to do
+
+LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/ibl5-hooks"
+mkdir -p "$LOG_DIR"
+LOG="$LOG_DIR/css-rebuild.log"
+
+# Gate: rebuild only when a CSS source under design/ is newer than the compiled
+# output (git sets a rewritten file's mtime to checkout time, so an unchanged op
+# leaves every source older than OUTPUT → no-op). Missing OUTPUT → rebuild.
+if [ -f "$OUTPUT" ] && [ -z "$(find "$DESIGN" -type f -newer "$OUTPUT" -print -quit 2>/dev/null)" ]; then
+    echo "$(date): css fresh, skip ($REPO_ROOT)" >> "$LOG"
+    exit 0
+fi
+
+# Rebuild in the background so the git operation returns immediately.
+(
+    slug="$(basename "$REPO_ROOT")"
+    echo "$(date): css source newer than output — rebuilding ($slug)" >> "$LOG"
+    if command -v bunx >/dev/null 2>&1 &&
+        (cd "$IBL5" && bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css) >> "$LOG" 2>&1; then
+        echo "$(date): css rebuilt on host ($slug)" >> "$LOG"
+    else
+        # Fallback: the tailwind container always has the toolchain. Worktree
+        # stacks are ibl5-tailwind-<slug>; the main stack is ibl5-tailwind.
+        container="ibl5-tailwind-$slug"
+        docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$container" || container="ibl5-tailwind"
+        if docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$container" &&
+            docker exec "$container" bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css >> "$LOG" 2>&1; then
+            echo "$(date): css rebuilt in $container" >> "$LOG"
+        else
+            echo "$(date): css rebuild FAILED — no host bunx and no usable tailwind container ($slug)" >> "$LOG"
+        fi
+    fi
+) &
+disown 2>/dev/null || true
+
+exit 0

--- a/ibl5/docs/decisions/0075-css-auto-heal-via-git-hooks.md
+++ b/ibl5/docs/decisions/0075-css-auto-heal-via-git-hooks.md
@@ -1,0 +1,36 @@
+---
+description: Git hooks (post-checkout/post-merge/post-rewrite) auto-heal stale compiled Tailwind CSS after bulk working-tree rewrites the watcher container misses.
+last_verified: 2026-07-02
+---
+
+# ADR-0075: CSS auto-heal via git hooks
+
+**Status:** Accepted
+**Date:** 2026-07-02
+**Deciders:** A-Jay Nicolas
+
+## Context
+
+The `ibl5-tailwind[-<slug>]` container runs `@tailwindcss/cli --watch=always`, reacting to filesystem events to keep `themes/IBL/style/style.css` in sync with `design/**` source. Editor saves propagate reliably (~1s rebuild). But git operations that bulk-rewrite the working tree — `checkout`, `merge`, `rebase` (via `post-rewrite`) — are not reliably delivered to `@parcel/watcher` through the macOS→Docker bind mount. The compiled stylesheet silently goes stale after a branch switch or merge, and the only prior recovery was a documented manual `bunx @tailwindcss/cli` step — easy to forget, and previously the "one sanctioned exception" in `.claude/rules/css-auto-rebuild.md`.
+
+## Decision
+
+`bin/install-git-hooks` injects a call to `bin/rebuild-css-if-source-changed` into the common git hooks dir's `post-checkout`, `post-merge`, and `post-rewrite`, right after each hook's shebang (so it runs before any branch-gated early exit). The script is mtime-gated (no-op when `design/**` is not newer than the compiled output) and runs the rebuild in the background so the git operation returns immediately; it prefers a host `bunx` and falls back to `docker exec` into the running `ibl5-tailwind[-<slug>]` container. Enforcement: `bin/rebuild-css-if-source-changed`, wired via `bin/install-git-hooks`.
+
+## Alternatives Considered
+
+- **Rely on the editor-save watcher only, document manual rebuild as recovery** — status quo. Rejected because: relies on developer memory and is invisible until a stale-CSS bug is noticed.
+- **`core.hooksPath` pointing at a version-controlled hooks directory** — cleaner single source of truth. Rejected because: all-or-nothing across the shared common git dir; would orphan the existing untracked hooks (git-lfs pre-push, pre-commit's codebase-map + check-docs, post-merge wt-cleanup, post-checkout) that are not being migrated in this change.
+- **Blocking (foreground) rebuild in the hook** — simpler control flow. Rejected because: would add multi-second latency to every checkout/merge/rebase; backgrounding keeps git operations instant while still healing before the next page load in practice.
+
+## Consequences
+
+- Positive: developers and agents no longer need to remember a manual CSS rebuild after switching branches or merging — the common failure mode from the bind-mount gap is closed at the source.
+- Positive: idempotent and low-risk — mtime-gated no-op when output is already fresh, background execution, silent fallback path (host → container) logged to `~/.cache/ibl5-hooks/css-rebuild.log` for diagnosis.
+- Negative: adds a small amount of injected shell to three hook files outside version control (the hooks themselves live in the shared common `.git` dir, not the repo) — `bin/install-git-hooks` must be re-run after any change to the injected block, and the sentinel-based idempotency check is the only guard against duplicate injection.
+
+## References
+
+- `bin/rebuild-css-if-source-changed`
+- `bin/install-git-hooks`
+- `.claude/rules/css-auto-rebuild.md`


### PR DESCRIPTION
## Summary
- Adds `bin/rebuild-css-if-source-changed`, invoked by `bin/install-git-hooks` in `post-checkout`/`post-merge`/`post-rewrite`, to auto-rebuild `themes/IBL/style/style.css` when git bulk-rewrites the working tree in a way the Tailwind watcher container misses (macOS→Docker bind-mount gap in `@parcel/watcher`).
- Mtime-gated no-op when output is already fresh; runs in background so the git operation stays instant; prefers host `bunx`, falls back to `docker exec` into `ibl5-tailwind[-<slug>]`.
- Documents the decision in ADR-0075 and updates `.claude/rules/css-auto-rebuild.md` to describe both auto-rebuild paths.

## Manual Testing
No manual testing needed — all changes are dev-tooling git hooks with no user-facing UI/behavior change.