### PR TITLE
chore(ci): surface new VR screens inline at top of PR body

### DIFF
--- a/.claude/rules/visual-review-prs.md
+++ b/.claude/rules/visual-review-prs.md
@@ -6,17 +6,20 @@ paths:
   - "ibl5/tests/e2e/vr-coverage-map.ts"
   - "ibl5/tests/e2e/vr-gallery.ts"
   - "ibl5/tests/e2e/vr-review-comment.ts"
+  - "ibl5/tests/e2e/vr-pr-body.ts"
   - "bin/vr-changed-coverage"
   - "bin/vr-build-gallery"
   - "bin/vr-review-comment"
-last_verified: 2026-06-30
+last_verified: 2026-07-02
 ---
 
 # Visual-review PRs
 
-See ADR-0068, ADR-0069, ADR-0073, and ADR-0074 for the decisions and rationale. ADR-0074 is the
-current model: the gallery is **change-driven** (built from rows whose PR render differs from
-master's committed baseline), not failure-driven.
+See ADR-0068, ADR-0069, ADR-0073, ADR-0074, and ADR-0076 for the decisions and rationale. ADR-0074
+is the current gallery-selection model: the gallery is **change-driven** (built from rows whose PR
+render differs from master's committed baseline), not failure-driven. ADR-0076 extends it: brand-new
+views (`gallery.newCells`) are additionally published inline at the top of the PR body, not only in
+the sticky comment.
 
 ## What runs
 
@@ -89,6 +92,26 @@ Each cell is captured twice — render A (`.a.png`) and a reload render B (`.b.p
 whose reload `.b.png` is missing is likewise demoted to infra. See ADR-0073 for the
 infra-vs-pixel-diff labeling this reuses.
 
+## New screens in the PR body
+
+In addition to the sticky comment, brand-new views (`gallery.newCells`) are published inline at the
+top of the PR body itself (ADR-0076) — no click required to see a first render. Two extra workflow
+steps run after "Deploy gallery to per-SHA Pages" and "Post sticky comment":
+
+- **Copy new-screen renders** — `bin/vr-review-comment --copy-new-screens=DEST` copies each new
+  cell's first-render PNG into a `new-screens/` subdirectory of the Pages deploy tree.
+- **Splice into the PR body** — `bin/vr-review-comment --update-pr-body=<PR#>` polls the first
+  new-screen image URL for readiness (bounded, ~30s), then splices a marker-delimited
+  (`<!-- vr-new-screens:begin/end -->`), idempotent block at offset 0 of the PR body via
+  `gh pr edit --body-file`. The block self-removes once `newCells` is empty (baseline committed via
+  `update-baselines`), so it never goes stale. `--dry-run` exercises the splice without mutating a
+  real PR.
+
+Both steps are `continue-on-error: true` — a failure here degrades to "no inline image," it never
+fails the VR job or blocks the sticky comment. The pure splice/copy-plan logic lives in
+`ibl5/tests/e2e/vr-pr-body.ts` (unit-tested in `ibl5/tests/ts-unit/vr-pr-body.test.ts`); only `gh`/
+`fetch`/`fs` I/O lives in the `bin/vr-review-comment` glue layer.
+
 ## Modifying the selection logic
 
 Gallery cell selection lives in `bin/vr-build-gallery` and `ibl5/tests/e2e/vr-gallery.ts`
@@ -98,7 +121,10 @@ comment markup lives in `ibl5/tests/e2e/vr-review-comment.ts` (`buildComment`). 
 unit-tested (`ibl5/tests/ts-unit/vr-gallery.test.ts`, `ibl5/tests/ts-unit/vr-coverage-map.test.ts`,
 `ibl5/tests/ts-unit/vr-review-comment.test.ts`, run via `bun run test:unit` from `ibl5/`). Per-row
 source overrides use the optional `sourceGlobs` field on `VrRow`. **Changing this selection logic is
-a mechanical-enforcement surface and requires an ADR** (current: ADR-0074).
+a mechanical-enforcement surface and requires an ADR** (current: ADR-0074). The PR-body new-screens
+publishing surface (`--copy-new-screens`/`--update-pr-body` on `bin/vr-review-comment`,
+`ibl5/tests/e2e/vr-pr-body.ts`, `ibl5/tests/ts-unit/vr-pr-body.test.ts`) is likewise a
+mechanical-enforcement surface, covered by **ADR-0076**.
 
 ## One-time deployment prerequisite
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -187,6 +187,14 @@ jobs:
             --gallery-json=ibl5/vr-gallery.json
           cat ibl5/vr-gallery.json
 
+      - name: Copy new-screen renders into gallery deploy tree
+        if: always() && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'update-baselines')
+        continue-on-error: true
+        run: |
+          bin/vr-review-comment \
+            --gallery=ibl5/vr-gallery.json \
+            --copy-new-screens=ibl5/vr-gallery/new-screens
+
       - name: Deploy VR gallery to per-SHA GitHub Pages
         id: vr-pages
         if: always() && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'update-baselines')
@@ -216,6 +224,17 @@ jobs:
         with:
           header: visual-review
           path: vr-review-comment.md
+
+      - name: Splice new-screen images into PR body
+        if: always() && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'update-baselines')
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bin/vr-review-comment \
+            --gallery=ibl5/vr-gallery.json \
+            --pages-url=https://a-jay85.github.io/IBL5/${{ github.sha }}/visual-review/ \
+            --update-pr-body=${{ github.event.pull_request.number }}
 
       # --- Auto-update baselines when label is present ---
       - name: Regenerate visual regression baselines

--- a/bin/vr-review-comment
+++ b/bin/vr-review-comment
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
-// bin/vr-review-comment — build the sticky `visual-review` PR comment markdown.
+// bin/vr-review-comment — build the sticky `visual-review` PR comment markdown,
+// and (additive) publish brand-new VR screens inline at the top of the PR body.
 //
 // Reads the change-driven gallery JSON (bin/vr-build-gallery output — cells are
 // already classified changed/new/flake against master's committed baseline), the
@@ -8,10 +9,16 @@
 // marocchino/sticky-pull-request-comment in .github/workflows/e2e-tests.yml).
 // Models bin/lighthouse-comment.
 //
+// Additive modes (see ADR-0076):
+//   --copy-new-screens=DEST   copy each newCells render into DEST, then exit.
+//   --update-pr-body=N        splice a new-screens image section into PR #N's
+//                             body (offset 0, marker-delimited), then exit.
+//
 // Usage:
 //   bin/vr-review-comment --gallery=ibl5/vr-gallery.json --coverage=coverage.json \
 //     --pages-url=https://a-jay85.github.io/IBL5/<sha>/visual-review/ --out=vr-review-comment.md
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -19,20 +26,34 @@ const __dir = dirname(fileURLToPath(import.meta.url));
 const ibl5Dir = resolve(__dir, '..', 'ibl5');
 
 const { buildComment } = await import(resolve(ibl5Dir, 'tests/e2e/vr-review-comment.ts'));
+const { buildCopyPlan, buildNewScreensSection, newScreenUrl, normalizeBody, spliceBody } =
+  await import(resolve(ibl5Dir, 'tests/e2e/vr-pr-body.ts'));
 
 const USAGE =
-  'Usage: bin/vr-review-comment --gallery=PATH --coverage=PATH --pages-url=URL [--out=PATH]';
+  'Usage: bin/vr-review-comment --gallery=PATH --coverage=PATH --pages-url=URL [--out=PATH]\n' +
+  '   or: bin/vr-review-comment --gallery=PATH --copy-new-screens=DEST [--renders-dir=SRC]\n' +
+  '   or: bin/vr-review-comment --gallery=PATH --pages-url=URL --update-pr-body=N [--dry-run] [--body-file-in=PATH]';
 
 let galleryPath: string | null = null;
 let coveragePath: string | null = null;
 let pagesUrl: string | null = null;
 let outPath: string | null = null;
+let copyDest: string | null = null;
+let rendersDir = 'ibl5/vr-gallery';
+let updatePr: string | null = null;
+let dryRun = false;
+let bodyFileIn: string | null = null;
 
 for (const arg of process.argv.slice(2)) {
   if (arg.startsWith('--gallery=')) galleryPath = arg.slice('--gallery='.length);
   else if (arg.startsWith('--coverage=')) coveragePath = arg.slice('--coverage='.length);
   else if (arg.startsWith('--pages-url=')) pagesUrl = arg.slice('--pages-url='.length);
   else if (arg.startsWith('--out=')) outPath = arg.slice('--out='.length);
+  else if (arg.startsWith('--copy-new-screens=')) copyDest = arg.slice('--copy-new-screens='.length);
+  else if (arg.startsWith('--renders-dir=')) rendersDir = arg.slice('--renders-dir='.length);
+  else if (arg.startsWith('--update-pr-body=')) updatePr = arg.slice('--update-pr-body='.length);
+  else if (arg === '--dry-run') dryRun = true;
+  else if (arg.startsWith('--body-file-in=')) bodyFileIn = arg.slice('--body-file-in='.length);
   else if (arg === '--help') {
     process.stdout.write(USAGE + '\n');
     process.exit(0);
@@ -42,10 +63,79 @@ for (const arg of process.argv.slice(2)) {
   }
 }
 
+// Change-driven gallery JSON — cells are PRE-CLASSIFIED by bin/vr-build-gallery
+// (changed/new vs master's committed baseline; flake = self-disagreeing render).
+// Absent/garbled ⇒ no diff/infra cells (the uncovered/global sections still
+// render from coverage). No git ls-files here: the builder already did the
+// tracked-index check (ADR-0069) when it resolved `git show <base.sha>:…`.
+// Loaded here (right after arg parsing) because copy mode needs it but not a
+// pages URL.
+type LeanCell = { module: string; viewport: 'desktop' | 'mobile'; title: string };
+let gallery: { changedCells?: LeanCell[]; newCells?: LeanCell[]; flakeCells?: LeanCell[] } = {};
+if (galleryPath !== null && existsSync(galleryPath)) {
+  try {
+    gallery = JSON.parse(readFileSync(galleryPath, 'utf-8'));
+  } catch {
+    // keep empty gallery
+  }
+}
+const rawNewCells: LeanCell[] = gallery.newCells ?? [];
+
+// Copy mode — publish each NEW cell's first render into the deploy tree, then exit.
+if (copyDest !== null) {
+  const plan = buildCopyPlan(rawNewCells, rendersDir, copyDest);
+  if (plan.length > 0) mkdirSync(copyDest, { recursive: true });
+  for (const { src, dest } of plan) {
+    if (existsSync(src)) copyFileSync(src, dest);
+    else process.stderr.write(`vr-review-comment: missing render ${src}\n`); // defensive skip
+  }
+  process.stdout.write(`vr-review-comment: copied ${plan.length} new-screen render(s)\n`);
+  process.exit(0);
+}
+
 if (pagesUrl === null) {
   process.stderr.write(`--pages-url is required\n${USAGE}\n`);
   process.exit(2);
 }
+
+// Bounded readiness poll (I/O — glue only). Returns after first 200 or the cap.
+async function waitForFirstScreen(url: string): Promise<boolean> {
+  for (let i = 0; i < 6; i++) {
+    // ~6 attempts, hard cap ~30s
+    try {
+      const r = await fetch(url, { method: 'HEAD' });
+      if (r.ok) return true;
+    } catch {
+      // treat as not-ready; keep polling
+    }
+    await new Promise((res) => setTimeout(res, i < 5 ? 5000 : 0)); // 5s backoff, no tail wait
+  }
+  return false; // timed out -> proceed anyway
+}
+
+// Update-body mode — splice the new-screens section into the PR body, then exit.
+if (updatePr !== null) {
+  const section = buildNewScreensSection(rawNewCells, pagesUrl);
+  if (dryRun) {
+    const cur = bodyFileIn !== null && existsSync(bodyFileIn) ? readFileSync(bodyFileIn, 'utf-8') : '';
+    process.stdout.write(spliceBody(normalizeBody(cur), section));
+    process.exit(0);
+  }
+  if (rawNewCells.length > 0) {
+    const ok = await waitForFirstScreen(newScreenUrl(pagesUrl, rawNewCells[0].title));
+    if (!ok) process.stderr.write('vr-review-comment: new-screen URL not live; editing anyway\n');
+  }
+  const raw = execFileSync('gh', ['pr', 'view', updatePr, '--json', 'body', '-q', '.body'], {
+    encoding: 'utf-8',
+  });
+  const next = spliceBody(normalizeBody(raw), section);
+  const tmp = resolve(process.cwd(), 'vr-pr-body.tmp.md');
+  writeFileSync(tmp, next + '\n');
+  execFileSync('gh', ['pr', 'edit', updatePr, '--body-file', tmp], { stdio: 'inherit' });
+  process.exit(0);
+}
+
+// Comment mode (default) — reached only when neither new mode fired above.
 
 // Coverage JSON — fail safe to "review everything" if absent/garbled.
 let coverage = { coveredRows: [] as string[], uncoveredChangedPaths: [] as string[], globalChange: true };
@@ -54,21 +144,6 @@ if (coveragePath !== null && existsSync(coveragePath)) {
     coverage = JSON.parse(readFileSync(coveragePath, 'utf-8'));
   } catch {
     // keep the fail-safe default
-  }
-}
-
-// Change-driven gallery JSON — cells are PRE-CLASSIFIED by bin/vr-build-gallery
-// (changed/new vs master's committed baseline; flake = self-disagreeing render).
-// Absent/garbled ⇒ no diff/infra cells (the uncovered/global sections still
-// render from coverage). No git ls-files here: the builder already did the
-// tracked-index check (ADR-0069) when it resolved `git show <base.sha>:…`.
-type LeanCell = { module: string; viewport: 'desktop' | 'mobile'; title: string };
-let gallery: { changedCells?: LeanCell[]; newCells?: LeanCell[]; flakeCells?: LeanCell[] } = {};
-if (galleryPath !== null && existsSync(galleryPath)) {
-  try {
-    gallery = JSON.parse(readFileSync(galleryPath, 'utf-8'));
-  } catch {
-    // keep empty gallery
   }
 }
 

--- a/ibl5/docs/decisions/0076-vr-new-screens-in-pr-body.md
+++ b/ibl5/docs/decisions/0076-vr-new-screens-in-pr-body.md
@@ -1,0 +1,110 @@
+---
+description: Brand-new VR views (gallery.newCells) are published inline at the top of the PR body — not only inside the sticky visual-review comment — via a marker-delimited, offset-0, idempotent managed block spliced in with `gh pr edit --body-file`, after a bounded readiness poll against the first new-screen image URL.
+last_verified: 2026-07-02
+---
+
+# ADR-0076: Publish first-render screenshots of new VR views in the PR body
+
+**Status:** Accepted
+**Date:** 2026-07-02
+
+## Lineage
+
+Extends **ADR-0074** (change-driven gallery, the source of `gallery.json`'s pre-classified
+`newCells`) — does NOT supersede it. ADR-0074 decided *how* new-vs-changed cells are classified;
+this ADR decides an *additional surface* those already-classified new cells are published to.
+
+## Context
+
+A brand-new VR view (`gallery.newCells`) has no prior baseline, so there is nothing to diff — the
+only useful review artifact is the first render itself. Today that render is reachable only via the
+sticky `visual-review` comment and the per-SHA Pages gallery link, both a click away. A reviewer
+scanning the PR body (the default landing view on GitHub, and what most reviewers glance at first)
+sees no visual signal at all that a new screen was added, let alone what it looks like — they must
+already know to open the comment.
+
+Publishing the first-render images directly at the top of the PR body removes that extra click and
+surfaces new-screen additions where reviewers are already looking. This is additive to, not a
+replacement for, the sticky comment (which still carries the full changed/flake breakdown).
+
+This adds a new bin-script surface (`--copy-new-screens`, `--update-pr-body` on
+`bin/vr-review-comment`), a new pure module (`ibl5/tests/e2e/vr-pr-body.ts`), and a workflow rewire
+in `.github/workflows/e2e-tests.yml` — a mechanical-enforcement surface per
+`.claude/rules/visual-review-prs.md` — so an ADR is required. This ADR resolves the `bin/adr-check`
+decision-trigger for those files; no `no-adr` bypass is needed.
+
+## Decision
+
+- **Selection**: only `gallery.newCells` (already pre-classified by `bin/vr-build-gallery` per
+  ADR-0074) are published to the PR body. Changed and flake cells are not — they remain
+  comment-only, since a changed/flake cell needs the before/after/diff triptych the gallery page
+  provides, not a single image.
+- **Managed block, offset 0, idempotent**: the new-screens section is wrapped in
+  `<!-- vr-new-screens:begin -->` / `<!-- vr-new-screens:end -->` markers and always spliced at
+  offset 0 (the very top of the body). `spliceBody` (`ibl5/tests/e2e/vr-pr-body.ts`) replaces an
+  existing block found at offset 0, leaves a marker found elsewhere in the body untouched (treated as
+  human prose, not the managed block), and removes the block entirely (restoring bare prose) when
+  `newCells` is empty on a later run — so a screen that stops being "new" (baseline committed via
+  `update-baselines`) cleans up after itself instead of leaving a stale block behind.
+- **Deploy-tree copy**: `--copy-new-screens=DEST` copies each new cell's `<title>.after.png` from the
+  gallery render tree into a `new-screens/` subdirectory of the Pages deploy tree, so the PR-body
+  image URL (`https://a-jay85.github.io/IBL5/<sha>/visual-review/new-screens/<title>.png`) resolves
+  once Pages finishes deploying.
+- **Bounded readiness poll**: because the Pages deploy and the PR-body edit are separate workflow
+  steps racing the same `peaceiris/actions-gh-pages` publish, `--update-pr-body` first polls the
+  first new-screen image URL (HEAD request, up to 6 attempts, 5s backoff, ~30s cap) before editing
+  the PR body. On timeout it edits anyway (stderr-warns "not live; editing anyway") rather than
+  silently dropping the block — a briefly-404ing image that resolves moments later is preferable to
+  never surfacing the new screen at all.
+- **`--dry-run`**: prints the spliced body to stdout with no network calls (no poll, no `gh`
+  invocation) — the only way to safely exercise the splice/strip logic against a real PR number
+  without mutating it.
+- **Both steps `continue-on-error: true`**: a copy or splice failure (e.g. a transient `gh` API
+  error) must not fail the VR job or block the sticky comment step, since the PR-body block is a
+  convenience surface, not the primary review artifact.
+
+## Alternatives Considered
+
+- **Only link to the gallery from the PR body (no inline image).** Rejected: reintroduces the
+  extra-click problem this ADR exists to remove — a link doesn't let a reviewer see the render
+  without navigating away from the PR body.
+- **Publish all cells (changed + new) to the PR body, not just new ones.** Rejected: changed/flake
+  cells need before/after/diff, which doesn't fit a single inline image; the gallery page already
+  serves that comparison well. Scope creep into a redundant, worse-rendered copy of the sticky
+  comment.
+- **Append the block at the bottom of the body instead of offset 0.** Rejected: a reviewer's first
+  glance is the top of the body; appending at the bottom reintroduces the "you have to already know
+  to scroll" friction this ADR is meant to fix.
+- **Overwrite the whole PR body unconditionally instead of a managed, offset-0 block.** Rejected:
+  would clobber the PR author's own description text every run. The marker-delimited splice
+  preserves everything the author wrote.
+
+## Consequences
+
+- **Positive:** New-screen renders are visible on the PR body itself, with zero extra clicks —
+  reviewers see what changed as they read the description.
+- **Positive:** The block is self-cleaning — once a new screen's baseline is committed
+  (`update-baselines`), the next run's empty `newCells` strips the block automatically, so the PR
+  body never accumulates stale first-render images.
+- **Positive:** Splice/strip logic (`spliceBody`, `normalizeBody`, `buildNewScreensSection`,
+  `buildCopyPlan`, `newScreenUrl`) is pure and unit-tested
+  (`ibl5/tests/ts-unit/vr-pr-body.test.ts`, 18 cases) — the only I/O (`gh pr view`/`gh pr edit`,
+  `fetch`, `fs` copy) lives in the `bin/vr-review-comment` glue layer.
+- **Negative:** The readiness poll adds up to ~30s to the workflow's critical path when Pages is
+  slow to publish (bounded, and `continue-on-error` means a timeout degrades to a possibly-404
+  image rather than failing the job).
+- **Negative:** A second I/O surface (`gh pr edit`) against the PR object itself, distinct from the
+  existing sticky-comment surface — a bug here mutates the PR body, not just a comment, which is
+  harder for an author to simply delete and ignore. Mitigated by the idempotent, marker-scoped
+  splice (never touches text outside the managed block) and by `--dry-run` for safe local testing.
+
+## References
+
+- `bin/vr-review-comment` — `--copy-new-screens`/`--renders-dir` (copy mode) and
+  `--update-pr-body`/`--dry-run`/`--body-file-in` (update-body mode).
+- `ibl5/tests/e2e/vr-pr-body.ts` — pure `buildCopyPlan`, `buildNewScreensSection`, `newScreenUrl`,
+  `normalizeBody`, `spliceBody`.
+- `ibl5/tests/ts-unit/vr-pr-body.test.ts` — unit coverage for the pure module.
+- `.github/workflows/e2e-tests.yml` — "Copy new-screen renders into gallery deploy tree" and
+  "Splice new-screen images into PR body" steps.
+- `ibl5/docs/decisions/0074-vr-change-driven-review.md` — source of `gallery.json`'s `newCells`.

--- a/ibl5/tests/e2e/vr-pr-body.ts
+++ b/ibl5/tests/e2e/vr-pr-body.ts
@@ -1,0 +1,77 @@
+// Pure builder for the top-of-PR-body "new VR screens" section. No I/O — the
+// bin/vr-review-comment wrapper reads the change-driven gallery JSON
+// (bin/vr-build-gallery output) and calls these functions, plus does the
+// fs copy + `gh pr edit` glue (tests/ts-unit/vr-pr-body.test.ts covers this
+// module; the CLI-executable checks in the plan cover the glue).
+//
+// Sibling of vr-review-comment.ts, same no-I/O contract. Reuses its
+// base-URL normalization + encodeURIComponent pattern (reportLink) and its
+// module-grouping / localeCompare / title-sort pattern (renderModuleSection).
+import type { Viewport } from './vr-manifest';
+
+export type LeanCell = { module: string; viewport: Viewport; title: string };
+
+export const PR_BODY_MARKER_BEGIN = '<!-- vr-new-screens:begin -->';
+export const PR_BODY_MARKER_END = '<!-- vr-new-screens:end -->';
+
+// URL under the per-SHA Pages tree; mirrors reportLink's slash-normalization + encoding.
+export function newScreenUrl(pagesUrl: string, title: string): string {
+  const base = pagesUrl.endsWith('/') ? pagesUrl : pagesUrl + '/';
+  return `${base}new-screens/${encodeURIComponent(title)}.png`;
+}
+
+// Deterministic copy plan (no I/O). src = <renders>/<title>.after.png ; dest = <dest>/<title>.png
+export function buildCopyPlan(
+  newCells: LeanCell[],
+  rendersDir: string,
+  destDir: string
+): { src: string; dest: string }[] {
+  return newCells.map((c) => ({
+    src: `${rendersDir}/${c.title}.after.png`,
+    dest: `${destDir}/${c.title}.png`,
+  }));
+}
+
+// Managed section markdown, grouped by module (localeCompare), cells sorted by title.
+// Empty newCells => '' (splice will strip the block).
+export function buildNewScreensSection(newCells: LeanCell[], pagesUrl: string): string {
+  if (newCells.length === 0) return '';
+
+  const byModule = new Map<string, LeanCell[]>();
+  for (const cell of newCells) {
+    const group = byModule.get(cell.module);
+    if (group) group.push(cell);
+    else byModule.set(cell.module, [cell]);
+  }
+
+  const lines: string[] = [PR_BODY_MARKER_BEGIN, '', '### 🆕 New VR screens', ''];
+  const modules = [...byModule.keys()].sort((a, b) => a.localeCompare(b));
+  for (const moduleName of modules) {
+    const cells = byModule.get(moduleName)!.slice().sort((a, b) => a.title.localeCompare(b.title));
+    lines.push(`**${moduleName}**`, '');
+    for (const c of cells) {
+      lines.push(`![${c.title} — ${c.viewport}](${newScreenUrl(pagesUrl, c.title)})`);
+    }
+    lines.push('');
+  }
+  lines.push(PR_BODY_MARKER_END);
+  return lines.join('\n');
+}
+
+// "null"/nullish -> ""; strip trailing newlines.
+export function normalizeBody(raw: string | null | undefined): string {
+  const b = raw == null || raw === 'null' ? '' : raw;
+  return b.replace(/\n+$/, '');
+}
+
+// Offset-0-only, clobber-safe splice. currentBody must already be normalized.
+export function spliceBody(currentBody: string, section: string): string {
+  let human = currentBody;
+  if (currentBody.startsWith(PR_BODY_MARKER_BEGIN)) {
+    const end = currentBody.indexOf(PR_BODY_MARKER_END);
+    if (end !== -1) human = currentBody.slice(end + PR_BODY_MARKER_END.length).replace(/^\s+/, '');
+    // BEGIN-at-0 but no END => malformed (never written by us); leave human = currentBody.
+  }
+  if (section === '') return human; // strip case
+  return human === '' ? section : `${section}\n\n${human}`;
+}

--- a/ibl5/tests/ts-unit/vr-pr-body.test.ts
+++ b/ibl5/tests/ts-unit/vr-pr-body.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PR_BODY_MARKER_BEGIN,
+  PR_BODY_MARKER_END,
+  newScreenUrl,
+  buildCopyPlan,
+  buildNewScreensSection,
+  normalizeBody,
+  spliceBody,
+  type LeanCell,
+} from '../e2e/vr-pr-body';
+
+const PAGES_URL = 'https://a-jay85.github.io/IBL5/deadbeef/visual-review/';
+
+describe('newScreenUrl', () => {
+  it('1a: appends new-screens/<title>.png under the pages URL', () => {
+    expect(newScreenUrl(PAGES_URL, 'standings')).toBe(`${PAGES_URL}new-screens/standings.png`);
+  });
+
+  it('1b: adds a trailing slash when pagesUrl lacks one', () => {
+    const noSlash = 'https://a-jay85.github.io/IBL5/deadbeef/visual-review';
+    expect(newScreenUrl(noSlash, 'standings')).toBe(`${noSlash}/new-screens/standings.png`);
+  });
+
+  it('1c: encodeURIComponent is applied to the title', () => {
+    expect(newScreenUrl(PAGES_URL, 'standings mobile')).toBe(
+      `${PAGES_URL}new-screens/${encodeURIComponent('standings mobile')}.png`
+    );
+  });
+});
+
+describe('buildCopyPlan', () => {
+  it('2a: maps each cell to {src: <renders>/<title>.after.png, dest: <dest>/<title>.png}', () => {
+    const cells: LeanCell[] = [{ module: 'standings', viewport: 'desktop', title: 'standings' }];
+    expect(buildCopyPlan(cells, 'ibl5/vr-gallery', 'ibl5/vr-gallery/new-screens')).toEqual([
+      { src: 'ibl5/vr-gallery/standings.after.png', dest: 'ibl5/vr-gallery/new-screens/standings.png' },
+    ]);
+  });
+
+  it('2b: empty newCells -> [] (boundary)', () => {
+    expect(buildCopyPlan([], 'ibl5/vr-gallery', 'ibl5/vr-gallery/new-screens')).toEqual([]);
+  });
+});
+
+describe('buildNewScreensSection', () => {
+  it('3a: empty newCells -> "" (boundary/negative)', () => {
+    expect(buildNewScreensSection([], PAGES_URL)).toBe('');
+  });
+
+  it('3b: non-empty section starts with BEGIN and ends with END markers', () => {
+    const cells: LeanCell[] = [{ module: 'standings', viewport: 'desktop', title: 'standings' }];
+    const section = buildNewScreensSection(cells, PAGES_URL);
+    expect(section.startsWith(PR_BODY_MARKER_BEGIN)).toBe(true);
+    expect(section.endsWith(PR_BODY_MARKER_END)).toBe(true);
+  });
+
+  it('3c: contains one image per cell, linking via newScreenUrl', () => {
+    const cells: LeanCell[] = [
+      { module: 'standings', viewport: 'desktop', title: 'standings' },
+      { module: 'standings', viewport: 'mobile', title: 'standings-mobile' },
+    ];
+    const section = buildNewScreensSection(cells, PAGES_URL);
+    expect(section).toContain(`![standings — desktop](${newScreenUrl(PAGES_URL, 'standings')})`);
+    expect(section).toContain(
+      `![standings-mobile — mobile](${newScreenUrl(PAGES_URL, 'standings-mobile')})`
+    );
+  });
+
+  it('3d: modules are ordered by localeCompare', () => {
+    const cells: LeanCell[] = [
+      { module: 'zebra', viewport: 'desktop', title: 'zebra' },
+      { module: 'alpha', viewport: 'desktop', title: 'alpha' },
+    ];
+    const section = buildNewScreensSection(cells, PAGES_URL);
+    expect(section.indexOf('alpha')).toBeLessThan(section.indexOf('zebra'));
+  });
+});
+
+describe('normalizeBody', () => {
+  it("4a: 'null' -> ''", () => {
+    expect(normalizeBody('null')).toBe('');
+  });
+
+  it("4b: strips trailing newlines: 'x\\n\\n' -> 'x'", () => {
+    expect(normalizeBody('x\n\n')).toBe('x');
+  });
+
+  it("4c: '' -> ''", () => {
+    expect(normalizeBody('')).toBe('');
+  });
+
+  it('4d: null -> "" (negative)', () => {
+    expect(normalizeBody(null)).toBe('');
+    expect(normalizeBody(undefined)).toBe('');
+  });
+});
+
+describe('spliceBody', () => {
+  it('5a: empty body + section -> section only, no leading blank', () => {
+    const section = buildNewScreensSection(
+      [{ module: 'standings', viewport: 'desktop', title: 'standings' }],
+      PAGES_URL
+    );
+    expect(spliceBody('', section)).toBe(section);
+  });
+
+  it('5b: human-prose body (no marker) + section -> section\\n\\nprose, prose intact', () => {
+    const section = buildNewScreensSection(
+      [{ module: 'standings', viewport: 'desktop', title: 'standings' }],
+      PAGES_URL
+    );
+    const prose = 'Human prose here.';
+    expect(spliceBody(prose, section)).toBe(`${section}\n\n${prose}`);
+  });
+
+  it('5c: a well-formed block at offset 0 is replaced, prose preserved, and the result is idempotent', () => {
+    const cellsA: LeanCell[] = [{ module: 'standings', viewport: 'desktop', title: 'standings' }];
+    const cellsB: LeanCell[] = [{ module: 'roster', viewport: 'desktop', title: 'roster' }];
+    const sectionA = buildNewScreensSection(cellsA, PAGES_URL);
+    const sectionB = buildNewScreensSection(cellsB, PAGES_URL);
+    const prose = 'Human prose here.';
+
+    const once = spliceBody(spliceBody(prose, sectionA), sectionB);
+    expect(once).toBe(`${sectionB}\n\n${prose}`);
+    expect(once).not.toContain('standings');
+
+    const twice = spliceBody(once, sectionB);
+    expect(twice).toBe(once);
+  });
+
+  it('5d: a BEGIN marker mid-body (not offset 0) is NOT stripped and is preserved verbatim after prepend', () => {
+    const section = buildNewScreensSection(
+      [{ module: 'standings', viewport: 'desktop', title: 'standings' }],
+      PAGES_URL
+    );
+    const midBodyBegin = `Some prose.\n\n${PR_BODY_MARKER_BEGIN}\nnot really a managed block\n${PR_BODY_MARKER_END}`;
+    const result = spliceBody(midBodyBegin, section);
+    expect(result).toBe(`${section}\n\n${midBodyBegin}`);
+  });
+
+  it('5e: strip case — block at offset 0 + section === "" removes the block, prose preserved', () => {
+    const section = buildNewScreensSection(
+      [{ module: 'standings', viewport: 'desktop', title: 'standings' }],
+      PAGES_URL
+    );
+    const prose = 'Human prose here.';
+    const withBlock = spliceBody(prose, section);
+    expect(spliceBody(withBlock, '')).toBe(prose);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces brand-new visual-regression views inline at the top of the PR body so a reviewer sees new screenshots without scrolling to the buried sticky `visual-review` comment. Changed-view before/after stays in the sticky comment — only NEW cells (no committed baseline) go in the body.

Builds on ADR-0074's change-driven gallery pipeline without touching its selection logic.

## What changed

1. **`ibl5/tests/e2e/vr-pr-body.ts`** (new) — pure, no-I/O module: URL builder, section builder (marker-delimited, module-grouped), deterministic copy plan, body normalizer, offset-0-only clobber-safe splice.
2. **`ibl5/tests/ts-unit/vr-pr-body.test.ts`** (new) — vitest unit tests for every export, including boundary/negative cases (empty newCells, mid-body marker not clobbered, idempotent splice).
3. **`bin/vr-review-comment`** — additive flags: `--copy-new-screens=DEST`, `--renders-dir=SRC`, `--update-pr-body=N`, `--dry-run`, `--body-file-in=PATH`. Default comment path (`--out`/stdout) is unchanged.
4. **`.github/workflows/e2e-tests.yml`** — two new `continue-on-error: true` steps: copy new-screen renders into the existing gallery deploy tree (between "Build VR gallery" and the Pages deploy), and splice the new-screens section into the PR body (after "Post sticky visual-review comment", using the default `GITHUB_TOKEN` for loop-safety).
5. **`ibl5/docs/decisions/0076-vr-new-screens-in-pr-body.md`** (new ADR, Lineage → ADR-0074).
6. **`.claude/rules/visual-review-prs.md`** — `paths:` + prose + `last_verified` bump.

## Safety

- **Loop-safety**: `gh pr edit --body` fires an `edited` event not in `e2e-tests.yml`'s trigger types, and `GITHUB_TOKEN`-initiated events don't retrigger workflows.
- **Clobber-safety**: the managed block is only recognized/stripped when it sits at body offset 0 as a well-formed `BEGIN…END` pair; human prose is never touched.
- **camo-cached-404**: `--update-pr-body` polls the first new-screen URL (bounded ~6 attempts, ~30s cap) before editing, then proceeds regardless on timeout.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
