### PR TITLE
chore: migrate slash commands to skills format

### DIFF
--- a/.claude/rules/agent-tiering-detail.md
+++ b/.claude/rules/agent-tiering-detail.md
@@ -1,8 +1,8 @@
 ---
 description: Read-on-demand detail for agent-tiering — Fable approval-gate procedure, flat-fan-out (nested sub-agent) rationale, orchestrator context economics (delegate-don't-dismiss, split-don't-self-clear), and per-tier prompt style. Loads only when editing workflow orchestration defs, where this rationale applies.
-last_verified: 2026-07-02
+last_verified: 2026-07-03
 paths:
-  - ".claude/commands/**/*.md"
+  - ".claude/skills/**/*.md"
   - ".claude/skills/**/SKILL.md"
 ---
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,6 +1,6 @@
 ---
 description: Sub-agent decision rules — when to spawn, when to skip, which model to pick, and how sub-agent delegation keeps orchestrator context low
-last_verified: 2026-07-02
+last_verified: 2026-07-03
 ---
 
 # Agent Tiering
@@ -54,4 +54,4 @@ Tier per prompt — don't default all Explore agents to one tier.
 
 **Heuristic:** notice connections / judge relevance / trace data flow → Sonnet. Answerable by grep + format → Haiku.
 
-Plan-authoring tiering (labeling each phase, mechanical-recipe agents, bulk-sweep patterns) lives in `.claude/commands/plan.md` Step 3.
+Plan-authoring tiering (labeling each phase, mechanical-recipe agents, bulk-sweep patterns) lives in `.claude/skills/plan/SKILL.md` Step 3.

--- a/.claude/rules/doc-freshness.md
+++ b/.claude/rules/doc-freshness.md
@@ -1,6 +1,6 @@
 ---
 description: Frontmatter schema, 60-day staleness policy, on-touch verification rule, and dead-reference rules enforced by bin/check-docs
-last_verified: 2026-06-04
+last_verified: 2026-07-03
 paths: "**/*.md"
 ---
 
@@ -8,7 +8,7 @@ paths: "**/*.md"
 
 ## Frontmatter Schema
 
-Every in-scope `.md` file (README.md, `.claude/rules/`, `.claude/skills/**/SKILL.md`, `.claude/commands/`, `ibl5/docs/`, `ibl5/docs/decisions/`) must open with:
+Every in-scope `.md` file (README.md, `.claude/rules/`, `.claude/skills/**/SKILL.md`, `ibl5/docs/`, `ibl5/docs/decisions/`) must open with:
 
 ```yaml
 ---

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,10 +1,11 @@
 ---
+name: plan
 description: "Plan an implementation task: enforces a verification matrix, directs code reuse, flags security surfaces, and requires negative-path tests so plans drive clean, secure, well-tested implementations."
+disable-model-invocation: true
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
 last_verified: 2026-07-03
-
 ---
 
 # /plan — Implementation Planning with Verification Matrix

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -226,7 +226,7 @@ Each Bash tool call runs in a fresh shell, so the classification flags are **not
 
 ## Phase 4: Code Review + Security Audit
 
-Agent definitions and scoring rubric live in shared include files under `.claude/commands/` so this skill, `/pr-review`, and `/security-audit` all share one source of truth. Read them as instructed below — do NOT inline the definitions or duplicate them.
+Agent definitions and scoring rubric live in shared include files under `.claude/review-shared/` so this skill, `/pr-review`, and `/security-audit` all share one source of truth. Read them as instructed below — do NOT inline the definitions or duplicate them.
 
 ### 4A: Fetch PR data (shared by both)
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,7 +2,9 @@
 allowed-tools: Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr comment:*),
   Bash(gh issue view:*), Bash(gh search:*), Bash(gh pr list:*), Bash(gh api:*),
   Bash(git log:*), Bash(git rev-parse:*), Bash(git show:*), Bash(source:*)
+name: pr-review
 description: Token-efficient code review for pull requests
+disable-model-invocation: true
 model: sonnet
 last_verified: 2026-07-03
 ---

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -1,7 +1,9 @@
 ---
 allowed-tools: Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr comment:*),
   Bash(gh api:*), Bash(git rev-parse:*), Bash(source:*)
+name: security-audit
 description: Token-efficient security audit for pull requests
+disable-model-invocation: true
 model: sonnet
 last_verified: 2026-07-03
 ---

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: ship
 description: "Commit, push, and open a PR via /post-plan, which decides whether auto-merge arms; /ship never arms directly."
-last_verified: 2026-06-30
+disable-model-invocation: true
+last_verified: 2026-07-03
 ---
 
 # /ship — Commit, push, PR via /post-plan

--- a/.claude/skills/update-cc/SKILL.md
+++ b/.claude/skills/update-cc/SKILL.md
@@ -1,7 +1,9 @@
 ---
 allowed-tools: Bash(curl:*)
+name: update-cc
 description: Check the latest Claude Code release for anything actionable in our workflow
-last_verified: 2026-06-10
+disable-model-invocation: true
+last_verified: 2026-07-03
 ---
 
 Answer: **"Is there anything actionable for us in the latest version of Claude Code?"**
@@ -16,7 +18,7 @@ Outputs just the top `## <version>` section. Do not fetch more.
 
 ## Step 2: Assess against our setup
 
-Judge each bullet against IBL5's workflow (CLAUDE.md, `.claude/rules/`, `.claude/commands/`, `.claude/settings.json`, `bin/` scripts, hooks, memory, worktree usage). For each bullet, silently classify as **irrelevant** or **actionable**.
+Judge each bullet against IBL5's workflow (CLAUDE.md, `.claude/rules/`, `.claude/skills/`, `.claude/settings.json`, `bin/` scripts, hooks, memory, worktree usage). For each bullet, silently classify as **irrelevant** or **actionable**.
 
 Actionable = the change unlocks, improves, or invalidates something we actually do (hook, script, command, setting, rule, workflow habit).
 

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -15,7 +15,6 @@ const IN_SCOPE_GLOBS = [
     'README.md',
     '.claude/rules/*.md',
     '.claude/skills/*/SKILL.md',
-    '.claude/commands/*.md',
     'ibl5/docs/*.md',
     'ibl5/docs/backlog/*.md',
     'ibl5/docs/decisions/*.md',

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -11,7 +11,7 @@
 # security-surface resolution, impl_model / auto_merge risk) stay in /plan —
 # they need reasoning a script cannot do.
 #
-# Gates implemented (numbering mirrors .claude/commands/plan.md Step 4):
+# Gates implemented (numbering mirrors .claude/skills/plan/SKILL.md Step 4):
 #   1  Matrix exists        — the verification matrix header is present.
 #   3  No false manuals      — a Truly-manual row whose text uses an automatable
 #                              verb (verify / check that / confirm / ensure) is an

--- a/bin/test-post-review-findings
+++ b/bin/test-post-review-findings
@@ -205,8 +205,8 @@ assert_absent "case6: no comment on empty"  "$COMMENT_OUT"
 # ── structural case 7: all 3 callers reference the helper ────────────────────
 for f in \
     "$REPO_ROOT/.claude/skills/post-plan/SKILL.md" \
-    "$REPO_ROOT/.claude/commands/pr-review.md" \
-    "$REPO_ROOT/.claude/commands/security-audit.md"
+    "$REPO_ROOT/.claude/skills/pr-review/SKILL.md" \
+    "$REPO_ROOT/.claude/skills/security-audit/SKILL.md"
 do
     name="$(basename "$f")"
     if grep -q 'post-review-findings.sh' "$f" 2>/dev/null; then
@@ -221,8 +221,8 @@ done
 # prior posting as a review body (not just an issue comment) is detected.
 # Assert "reviews" (plural) appears in the Step 1 → Step 2 region of each file.
 for f in \
-    "$REPO_ROOT/.claude/commands/pr-review.md" \
-    "$REPO_ROOT/.claude/commands/security-audit.md"
+    "$REPO_ROOT/.claude/skills/pr-review/SKILL.md" \
+    "$REPO_ROOT/.claude/skills/security-audit/SKILL.md"
 do
     name="$(basename "$f")"
     step1=$(awk '/^## Step 1/,/^## Step 2/' "$f" 2>/dev/null)

--- a/ibl5/docs/decisions/0067-unified-deployment-funnel.md
+++ b/ibl5/docs/decisions/0067-unified-deployment-funnel.md
@@ -1,6 +1,6 @@
 ---
 description: Unifies the deployment funnel so every PR-opening path flows through /post-plan; triage is a loaded rule, /plan auto-queues, /ship drops merge-intent tokens.
-last_verified: 2026-06-22
+last_verified: 2026-07-03
 ---
 
 # ADR-0067: Unified deployment funnel — one pipeline through /post-plan
@@ -36,7 +36,7 @@ Collapse the funnel to a single pipeline with one variable:
 
 - `.claude/rules/work-triage.md` — the triage gateway rule (added in this PR).
 - `.claude/rules/workflow-continuity.md` — the implementation → `/post-plan` auto-fire handoff.
-- `.claude/commands/plan.md` — `/plan` (auto-queue added in PR B).
-- `.claude/commands/ship.md` — `/ship` (simplified in PR C).
+- `.claude/skills/plan/SKILL.md` — `/plan` (auto-queue added in PR B).
+- `.claude/skills/ship/SKILL.md` — `/ship` (simplified in PR C).
 - `.claude/skills/post-plan/SKILL.md` — Phase 6.5, the single arming authority.
 - `bin/automouse-queue` — the queue command `/plan` invokes.


### PR DESCRIPTION
## Summary
- Renames `.claude/commands/*.md` (plan, pr-review, security-audit, ship, update-cc) to `.claude/skills/<name>/SKILL.md`, each carrying `name:` + `disable-model-invocation: true` frontmatter so they stay explicit-invoke-only rather than auto-triggering.
- Updates every cross-reference in `.claude/rules/*.md`, `bin/check-docs`, `bin/check-plan`, `bin/test-post-review-findings`, and `ibl5/docs/decisions/0067-unified-deployment-funnel.md` to point at the new skill paths.
- `bin/check-docs` in-scope globs drop the now-empty `.claude/commands/*.md` pattern (skills glob already covers the new location).

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.