### PR TITLE
ci: reduce peak concurrent runner slots per PR (e2e-tests.yml)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -80,6 +80,14 @@ jobs:
               - 'docker-compose.ci.yml'
               - '.github/actions/setup-docker-e2e/**'
               - '.github/workflows/e2e-tests.yml'
+              # ibl6 connects to the SAME shared mariadb/ibl5 DB that
+              # setup-docker-e2e migrates and seeds; ibl6-visual asserts against
+              # seed-driven box-score snapshots. A migration/seed/runner-only PR
+              # must still run ibl6-e2e/ibl6-visual or a DB-driven regression
+              # would skip past the gate.
+              - 'ibl5/migrations/**'
+              - 'ibl5/tests/e2e/fixtures/ci-seed.sql'
+              - 'ibl5/bin/run-migrations-ci.sh'
 
   playwright-version-drift:
     name: Playwright version drift guard

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,6 +45,10 @@ jobs:
       # True only for the `update-baselines` label. Gates the Visual Regression job
       # alone so applying that label reruns baseline regen without a CI storm.
       baseline: ${{ github.event.action == 'labeled' && github.event.label.name == 'update-baselines' }}
+      # True when a change touches IBL6 or the SHARED docker/e2e infra the IBL6 jobs
+      # run inside. Gates ibl6-visual/ibl6-e2e so a pure-ibl5 PR skips them (saving 2
+      # concurrent runner slots) while an IBL6 or shared-infra PR still runs them.
+      ibl6: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.ibl6filter.outputs.ibl6 == 'true' }}
     steps:
       - uses: actions/checkout@v7
         if: github.event_name == 'pull_request' && github.event.action != 'labeled'
@@ -63,6 +67,19 @@ jobs:
           else
             echo "src=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Detect IBL6-affecting changes
+        uses: dorny/paths-filter@v4
+        id: ibl6filter
+        if: github.event_name == 'pull_request' && github.event.action != 'labeled'
+        with:
+          filters: |
+            ibl6:
+              - 'IBL6/**'
+              - 'docker/Dockerfile.ibl6'
+              - 'docker-compose.ci.yml'
+              - '.github/actions/setup-docker-e2e/**'
+              - '.github/workflows/e2e-tests.yml'
 
   playwright-version-drift:
     name: Playwright version drift guard
@@ -360,6 +377,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         shard-index: [1, 2, 3, 4]
         total-shards: [4]
@@ -564,7 +582,7 @@ jobs:
   ibl6-visual:
     name: IBL6 Visual Regression
     needs: [changes]
-    if: needs.changes.outputs.src == 'true' || needs.changes.outputs.baseline == 'true'
+    if: needs.changes.outputs.ibl6 == 'true' || needs.changes.outputs.baseline == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -670,7 +688,7 @@ jobs:
   ibl6-e2e:
     name: IBL6 E2E Tests
     needs: [changes]
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.ibl6 == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary

Shrinks the concurrent-runner-slot footprint of a pure-ibl5 PR in `.github/workflows/e2e-tests.yml`:

- **Change 1 (core):** re-gates `ibl6-e2e` and `ibl6-visual` from the ibl5 `src` detector onto a new IBL6-scoped `ibl6` detector (a `dorny/paths-filter@v4` step mirroring `tests.yml`'s `changes` job). Saves 2 concurrent slots on every non-IBL6 PR with zero latency cost and zero coverage loss — IBL6/shared-infra PRs still run both jobs.
- **Change 2:** adds `max-parallel: 3` to the 4-way `e2e-shards` matrix. Saves 1 concurrent slot for a ~33% shard wall-clock increase.

Combined: the common pure-ibl5 PR drops 3 concurrent runner slots at peak.

Gate safety: the required `E2E Tests` check (`gate` job) fails only on `contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')` — a skipped IBL6 job matches neither, so the gate stays green when IBL6 jobs skip on a pure-ibl5 PR (this run/skip mix is already exercised today on `update-baselines`-labeled events).

## Manual Testing

No manual testing needed — all changes are covered by automated tests.
