### PR TITLE
chore: serve VR gallery via Actions workflow_run deploy (ADR-0078)

### DIFF
--- a/.claude/rules/visual-review-prs.md
+++ b/.claude/rules/visual-review-prs.md
@@ -2,6 +2,7 @@
 description: On a visual-change PR, the visual-regression run builds a change-driven before/after gallery (rows whose render differs from master's committed baseline) and posts a sticky visual-review PR comment grouped by module, with a "changed but NOT covered" coverage-gap section.
 paths:
   - ".github/workflows/e2e-tests.yml"
+  - ".github/workflows/pages-deploy.yml"
   - "ibl5/tests/e2e/vr-manifest.ts"
   - "ibl5/tests/e2e/vr-coverage-map.ts"
   - "ibl5/tests/e2e/vr-gallery.ts"
@@ -41,13 +42,18 @@ They are skipped only during baseline regen (the `update-baselines` label).
    (`changedCells`/`newCells`/`flakeCells`).
 3. **Deploy gallery to per-SHA Pages** — pushes `ibl5/vr-gallery` to the `gh-pages` branch under
    `<sha>/visual-review/` (multiple open PRs/SHAs coexist). The Playwright HTML report (traces) is
-   preserved under `<sha>/visual-review/playwright-report/`.
+   preserved under `<sha>/visual-review/playwright-report/`. The `gh-pages` branch is only the
+   durable accumulator; the site is **served** by `.github/workflows/pages-deploy.yml` (Pages
+   source = GitHub Actions, no Jekyll), which fires on `E2E Tests` completion and re-publishes the
+   whole tree.
 4. **Build comment** — `bin/vr-review-comment` consumes the pre-classified `gallery.json` and renders
    the sticky markdown.
 5. **Post sticky comment** — `marocchino/sticky-pull-request-comment@v3`, header `visual-review`.
 
 A `vr-pages-cleanup` job (push-to-master only, not part of the required gate) prunes
-per-SHA gallery dirs whose newest commit is older than 14 days.
+per-SHA gallery dirs whose newest commit is older than 14 days. Its `gh-pages` push is unchanged;
+a prune reaches the served site when `pages-deploy.yml` next re-publishes the tree (on the master
+run's `E2E Tests` completion).
 
 ## Reading the comment
 
@@ -128,11 +134,16 @@ mechanical-enforcement surface, covered by **ADR-0076**.
 
 ## One-time deployment prerequisite
 
-GitHub Pages must be enabled with source = the `gh-pages` branch, once, after the branch
-first exists (owner action — Pages is otherwise 404):
+GitHub Pages must be set to source = **GitHub Actions** (`build_type: workflow`) — a one-time
+owner action. The gallery is served by `.github/workflows/pages-deploy.yml`, which uploads the
+whole `gh-pages` tree as the Pages artifact; the `gh-pages` branch stays the durable per-SHA
+accumulator. Repo Settings → Pages → Build and deployment → Source → GitHub Actions, or:
 
 ```bash
-gh api -X POST repos/a-jay85/IBL5/pages -f 'source[branch]=gh-pages' -f 'source[path]=/'
+gh api --method PUT repos/a-jay85/IBL5/pages -f build_type=workflow
 ```
 
-(or repo Settings → Pages).
+Until the source is flipped, the `Deploy VR gallery to Pages` runs go red at the deploy step
+(expected; self-clears once flipped). After flipping, trigger one re-serve immediately via the
+workflow's `workflow_dispatch` (Actions → Deploy VR gallery to Pages → Run workflow) instead of
+waiting for the next PR.

--- a/.claude/rules/visual-review-prs.md
+++ b/.claude/rules/visual-review-prs.md
@@ -11,7 +11,7 @@ paths:
   - "bin/vr-changed-coverage"
   - "bin/vr-build-gallery"
   - "bin/vr-review-comment"
-last_verified: 2026-07-02
+last_verified: 2026-07-03
 ---
 
 # Visual-review PRs

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,69 @@
+name: Deploy VR gallery to Pages
+
+on:
+  workflow_run:
+    workflows: ["E2E Tests"]
+    types: [completed]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Serialize Pages deploys and NEVER cancel an in-flight one (a cancelled deploy can leave the
+# site half-published). Concurrent PR/master runs queue and each re-serves the whole tree.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout gh-pages (the durable per-SHA accumulator)
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Upload the whole gh-pages tree as the Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Assert a per-SHA gallery serves HTTP 200
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="${{ steps.deployment.outputs.page_url }}"
+          base="${base%/}"
+          # newest committed <sha>/visual-review/ dir on the checked-out gh-pages tree
+          newest=""
+          newest_ct=0
+          for d in */ ; do
+            [ -f "${d}visual-review/index.html" ] || continue
+            ct=$(git log -1 --format=%ct -- "$d" 2>/dev/null || echo 0)
+            if [ "$ct" -gt "$newest_ct" ]; then newest_ct="$ct"; newest="${d%/}"; fi
+          done
+          if [ -z "$newest" ]; then
+            echo "No <sha>/visual-review/index.html present yet — nothing to assert."
+            exit 0
+          fi
+          url="${base}/${newest}/visual-review/index.html"
+          echo "Asserting HTTP 200 for ${url}"
+          for i in $(seq 1 10); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$url" || echo 000)
+            echo "attempt ${i}: HTTP ${code}"
+            [ "$code" = "200" ] && exit 0
+            sleep 20
+          done
+          echo "::error::VR gallery did not serve HTTP 200 at ${url} after retries"
+          exit 1

--- a/ibl5/docs/decisions/0068-visual-review-pr-publishing.md
+++ b/ibl5/docs/decisions/0068-visual-review-pr-publishing.md
@@ -1,6 +1,6 @@
 ---
 description: Publish the Playwright visual-regression HTML report to per-SHA GitHub Pages and post a sticky PR comment (grouped by module, with a coverage-gap section) so visual-change PRs are reviewed from the PR itself.
-last_verified: 2026-06-22
+last_verified: 2026-07-02
 ---
 
 # ADR-0068: Visual-review publishing for visual-change PRs
@@ -41,18 +41,21 @@ before/after (ordering invariant). Changed-files → manifest-coverage selection
 are pure, unit-tested functions; changing that selection logic is itself a
 mechanical-enforcement surface and requires a future ADR.
 
-Per-SHA hosting uses `peaceiris/actions-gh-pages@v4` with `keep_files: true` and
-`destination_dir: <sha>/visual-review`. `actions/deploy-pages` was rejected because it
-replaces the whole site with a single latest deploy, so it cannot host concurrent SHAs.
+Per-SHA accumulation uses `peaceiris/actions-gh-pages@v4` with `keep_files: true` and
+`destination_dir: <sha>/visual-review` to push each commit's gallery onto the `gh-pages`
+branch, which is the durable accumulator of every open PR's gallery. Serving is via GitHub
+Actions (Pages source = GitHub Actions, `build_type: workflow`) — see ADR-0078, which amends
+the serving layer of this decision.
 
 ## Alternatives Considered
 
 - **Hosted visual-review SaaS (Percy/Argos/Chromatic)** — Rejected: lower build effort
   but adds an external dependency and egresses screenshots, against the repo's
   self-hosted/Docker posture (ADR-0046/0062 lineage).
-- **`actions/deploy-pages` instead of a `gh-pages` branch** — Rejected: it replaces the
-  whole Pages site with one latest deploy, defeating the per-SHA requirement that lets
-  multiple open PRs/SHAs coexist.
+- **`actions/deploy-pages` uploading only the current run's gallery** — Rejected: a single
+  fresh-artifact deploy of just this SHA's output replaces the whole site and cannot host
+  concurrent SHAs. ADR-0078 instead uploads the ENTIRE `gh-pages` tree as the artifact, so
+  `actions/deploy-pages` serves every accumulated SHA at once — coexistence is preserved.
 - **A new opt-in `visual-review` label to trigger publishing** — Rejected: the comment is
   only built when VR detects diffing cells, so it is self-scoping; a label would add a
   step the reviewer must remember.
@@ -63,10 +66,11 @@ replaces the whole site with a single latest deploy, so it cannot host concurren
   off from the PR instead of loading each page in the Docker preview.
 - Positive: the coverage-gap section makes a changed-but-unreviewed page impossible to miss.
 - Negative: visual-change PRs sit red until a human applies `update-baselines` (by design).
-- Negative: a `gh-pages` branch is introduced and must be set as the Pages source — a
-  one-time owner enablement (Pages is currently disabled / 404). After the branch first
-  exists: `gh api -X POST repos/a-jay85/IBL5/pages -f 'source[branch]=gh-pages' -f 'source[path]=/'`
-  (or repo Settings → Pages).
+- Negative: the Pages source must be set to **GitHub Actions** (`build_type: workflow`) — a
+  one-time owner action (repo Settings → Pages → Build and deployment → Source → GitHub Actions,
+  or `gh api --method PUT repos/a-jay85/IBL5/pages -f build_type=workflow`). See ADR-0078. Until
+  it is flipped, the `Deploy VR gallery to Pages` `workflow_run` runs go red at the deploy step
+  (expected; self-clears once flipped).
 - Negative: fork PRs receive a read-only token with no secrets and cannot post the comment
   or push Pages — acceptable for this single-owner repo (consistent with the existing
   secrets-in-`pull_request` E2E model). The steps no-op there.
@@ -75,6 +79,9 @@ replaces the whole site with a single latest deploy, so it cannot host concurren
 
 - `.github/workflows/e2e-tests.yml` — the `e2e` job's publish/comment steps (gated to the
   review run, before regen) and the `vr-pages-cleanup` retention job.
+- `.github/workflows/pages-deploy.yml`, `ibl5/docs/decisions/0078-vr-pages-actions-serving.md` —
+  the `workflow_run`-triggered Actions deploy that serves the whole `gh-pages` tree, and the ADR
+  that amends this decision's serving layer.
 - `ibl5/tests/e2e/vr-coverage-map.ts` — pure changed-files → manifest-coverage mapper.
 - `ibl5/tests/e2e/vr-review-comment.ts` — pure sticky-comment markdown builder.
 - `bin/vr-changed-coverage`, `bin/vr-review-comment` — CLI wrappers consumed by the workflow.

--- a/ibl5/docs/decisions/0068-visual-review-pr-publishing.md
+++ b/ibl5/docs/decisions/0068-visual-review-pr-publishing.md
@@ -1,6 +1,6 @@
 ---
 description: Publish the Playwright visual-regression HTML report to per-SHA GitHub Pages and post a sticky PR comment (grouped by module, with a coverage-gap section) so visual-change PRs are reviewed from the PR itself.
-last_verified: 2026-07-02
+last_verified: 2026-07-03
 ---
 
 # ADR-0068: Visual-review publishing for visual-change PRs

--- a/ibl5/docs/decisions/0078-vr-pages-actions-serving.md
+++ b/ibl5/docs/decisions/0078-vr-pages-actions-serving.md
@@ -1,0 +1,76 @@
+---
+description: Serve the accumulated per-SHA visual-review gh-pages tree via a workflow_run-triggered GitHub Actions Pages deploy (build_type: workflow), replacing the stuck legacy Jekyll branch-build that 404'd.
+last_verified: 2026-07-02
+---
+
+# ADR-0078: Serve the VR gallery via Actions (workflow_run → deploy-pages), not legacy Jekyll
+
+**Status:** Accepted
+**Date:** 2026-07-02
+
+## Context
+
+ADR-0068 publishes each PR's visual-review gallery to a `gh-pages` branch under
+`<sha>/visual-review/` (via `peaceiris/actions-gh-pages@v4`, `keep_files: true`) and set the
+Pages **source to the `gh-pages` branch** (legacy `build_type`). That legacy Jekyll branch-build
+got stuck (`status: building`) and returned **404** for the site root and every
+`<sha>/visual-review/` URL — the accumulated per-SHA content was intact, but the serving layer
+was dead. ADR-0068 also recorded "`actions/deploy-pages` rejected because it replaces the whole
+site with one latest deploy" — true only when the artifact is one run's output.
+
+## Decision
+
+Set the Pages source to **GitHub Actions** (`build_type: workflow`) and serve the **whole
+`gh-pages` tree — no Jekyll** — via a new `.github/workflows/pages-deploy.yml`. It is triggered by
+`workflow_run` on the `E2E Tests` workflow completing (plus `workflow_dispatch`), checks out
+`gh-pages`, uploads the **entire** tree as the Pages artifact (`actions/upload-pages-artifact`,
+`path: .`), and deploys it (`actions/deploy-pages`) — so **every** accumulated
+`<sha>/visual-review/` is served at once. The `gh-pages` branch stays the durable per-SHA
+accumulator; the `peaceiris` push and the `vr-pages-cleanup` prune job are unchanged; the per-SHA
+URL scheme (`https://a-jay85.github.io/IBL5/<sha>/visual-review/`) is unchanged.
+
+## Alternatives Considered
+
+- **Keep the legacy `gh-pages` branch build** — Rejected: the Jekyll build stalls on a large
+  branch and serves 404; it is the reported bug.
+- **`actions/deploy-pages` uploading only the current run's gallery** — Rejected: a single
+  fresh-artifact deploy of one SHA replaces the whole site and cannot host concurrent SHAs (this
+  is ADR-0068's original rejection). Uploading the ENTIRE `gh-pages` tree instead preserves
+  per-SHA coexistence.
+- **A `push: [gh-pages]`-triggered deploy workflow** — Rejected: `gh-pages` is a `peaceiris`
+  orphan branch with no `.github/workflows/` directory, so a push there never runs a workflow (a
+  push-triggered workflow is read from the pushed ref); a push-context run would also violate the
+  `github-pages` environment's default-branch protection. `workflow_run` runs from the default
+  branch, sidesteps both, and needs no `CI_PAT`.
+- **In-job serve inside the required `e2e` job** — Rejected: it puts `environment: github-pages`
+  (which GitHub serializes) on the required gate, coupling gate latency to Pages deploys and
+  turning every pre-flip PR gate red. `workflow_run` keeps serving out of the required gate.
+
+## Consequences
+
+- Positive: the VR gallery serves again, with every open PR's `<sha>/visual-review/` coexisting.
+- Positive: no Jekyll build to stall; each deploy re-publishes the current accumulated tree, so
+  `vr-pages-cleanup` prunes reach the served site on the next master-run deploy.
+- Negative: the Pages source must be flipped to **GitHub Actions** (`build_type: workflow`) once,
+  by the owner (`gh api --method PUT repos/a-jay85/IBL5/pages -f build_type=workflow`, or Settings
+  → Pages). `workflow_run` reads the workflow from the default branch, so `pages-deploy.yml` only
+  runs after it is on `master`; pre-flip runs go red at the deploy step (expected; self-clears).
+
+## Lineage
+
+Amends the **serving-layer** decision of ADR-0068 (Visual-review publishing). ADR-0068 otherwise
+stands in full — change-driven gallery selection, per-SHA `peaceiris` accumulation onto `gh-pages`,
+the sticky comment, and the `update-baselines` sign-off are all unchanged. This ADR replaces only
+"Pages source = the `gh-pages` branch (legacy build)" with "Pages source = GitHub Actions serving
+the whole `gh-pages` tree," and retires ADR-0068's "`actions/deploy-pages` rejected" reasoning
+(which assumed a single-run artifact). Deliberately NOT modeled as `## Supersedes`: ADR-0068 is not
+retired, only its serving mechanism is amended, so no reciprocal `Status: Superseded by` is claimed.
+
+## References
+
+- `.github/workflows/pages-deploy.yml` — the `workflow_run`-triggered Actions deploy that serves
+  the whole `gh-pages` tree (this ADR).
+- `ibl5/docs/decisions/0068-visual-review-pr-publishing.md` — the amended decision.
+- `.github/workflows/e2e-tests.yml` — the `peaceiris` push and `vr-pages-cleanup` job that
+  accumulate/prune the `gh-pages` tree, both unchanged.
+- `.claude/rules/visual-review-prs.md` — operator-facing rule (Pages-source prerequisite, serve path).

--- a/ibl5/docs/decisions/0078-vr-pages-actions-serving.md
+++ b/ibl5/docs/decisions/0078-vr-pages-actions-serving.md
@@ -1,6 +1,6 @@
 ---
 description: Serve the accumulated per-SHA visual-review gh-pages tree via a workflow_run-triggered GitHub Actions Pages deploy (build_type: workflow), replacing the stuck legacy Jekyll branch-build that 404'd.
-last_verified: 2026-07-02
+last_verified: 2026-07-03
 ---
 
 # ADR-0078: Serve the VR gallery via Actions (workflow_run → deploy-pages), not legacy Jekyll


### PR DESCRIPTION
## Summary

Migrates VR gallery Pages serving off the stuck legacy Jekyll branch-build onto GitHub Actions
(`workflow_run` → `deploy-pages`). The legacy Jekyll build was stuck (`status: building`) and
returned 404 for every `<sha>/visual-review/` URL even though the accumulated per-SHA content on
`gh-pages` was intact.

- New `.github/workflows/pages-deploy.yml`: triggered by `workflow_run` on `E2E Tests` completing
  (plus `workflow_dispatch`), checks out `gh-pages`, uploads the **entire** tree as the Pages
  artifact, deploys via `actions/deploy-pages`, and self-asserts the newest per-SHA gallery
  returns HTTP 200.
- New ADR-0078 (renumbered from the plan's 0077 — 0077 was taken by the htmlsanitizer ADR in the
  interim; see note below) records the serving-layer decision and backlinks ADR-0068 via
  `## Lineage`.
- ADR-0068 amended: `last_verified` bump, corrected "`actions/deploy-pages` rejected" reasoning
  (true only for a single-run artifact; uploading the whole `gh-pages` tree preserves per-SHA
  coexistence), forward-pointer to ADR-0078.
- `.claude/rules/visual-review-prs.md` updated: new Pages-source prerequisite, the serve path,
  prune-propagation note, `paths` entry.

The `gh-pages` branch stays the durable per-SHA accumulator; the existing `peaceiris` publish step
and `vr-pages-cleanup` prune job in `e2e-tests.yml` are unchanged. Per-SHA URL scheme is unchanged.

## One-time owner action required after merge

GitHub Pages must be flipped from source = `gh-pages` branch (legacy) to source = **GitHub
Actions** (`build_type: workflow`). Sequence:

1. Merge this PR (puts `pages-deploy.yml` on `master` — `workflow_run` reads it from the default
   branch, so the deploy cannot run pre-merge).
2. Flip the Pages source:
   `gh api --method PUT repos/a-jay85/IBL5/pages -f build_type=workflow` (or Settings → Pages →
   Build and deployment → Source → GitHub Actions).
3. Actions → **Deploy VR gallery to Pages** → **Run workflow** (`workflow_dispatch`) to re-serve
   immediately rather than waiting for the next PR.
4. Confirm a per-SHA gallery URL returns HTTP 200, and that two distinct already-accumulated SHA
   dirs both return 200 simultaneously (proves the whole-tree upload preserves multi-PR
   coexistence).

This is why `auto_merge: false` is set in the plan — the flip is an owner-only action that can only
happen after merge, and the only true end-to-end proof (a live 200) is only exercisable
post-merge-and-post-flip. Auto-merge must not race ahead of that sequence.

## Note: ADR renumbering

The plan specified ADR-0077, but by automouse run time 0077 had been taken by the htmlsanitizer
ADR (merged in the interim). Per the plan's `bin/next-adr` instruction, this ships as ADR-0078
instead — same content, backlink, and Lineage relationship to ADR-0068.

## Manual Testing

No manual testing needed — all changes are covered by automated checks (YAML validity, ADR/doc
CI gates) and the workflow's own self-asserting 200 check; the live post-merge verification (V6/V7
in the plan's Verification Matrix) requires the owner's one-time Pages-source flip above and is not
a step Claude can perform.
