### PR TITLE
fix(adr-check): stop false-triggering new-dependency on version bumps

### DIFF
--- a/bin/adr-check
+++ b/bin/adr-check
@@ -83,6 +83,37 @@ function diffAddedLines(string $mode, string $file): array
     return $added;
 }
 
+/** @return list<string> */
+function diffRemovedLines(string $mode, string $file): array
+{
+    $range = gitDiffRange($mode);
+    [$lines] = runCmd(sprintf('git diff %s -- %s', escapeshellarg($range), escapeshellarg($file)));
+    $removed = [];
+    foreach ($lines as $line) {
+        if (str_starts_with($line, '-') && !str_starts_with($line, '---')) {
+            $removed[] = substr($line, 1);
+        }
+    }
+    return $removed;
+}
+
+/**
+ * Extract Composer "vendor/package" keys from require/require-dev diff lines.
+ *
+ * @param list<string> $lines
+ * @return list<string>
+ */
+function composerPackageKeys(array $lines): array
+{
+    $keys = [];
+    foreach ($lines as $line) {
+        if (preg_match('#"([a-z0-9._-]+/[a-z0-9._-]+)"\s*:\s*"#i', $line, $m) === 1) {
+            $keys[] = strtolower($m[1]);
+        }
+    }
+    return $keys;
+}
+
 /**
  * Read the full contents of a file from the git object store (index for --staged,
  * HEAD for --pr). Returns [line_count, first_line].
@@ -149,11 +180,15 @@ function detectTriggers(string $mode): array
         if ($file !== 'ibl5/composer.json') {
             continue;
         }
-        foreach (diffAddedLines($mode, $file) as $line) {
-            if (preg_match('#"[a-z0-9._-]+/[a-z0-9._-]+"\s*:\s*"#i', $line) === 1) {
-                $triggers[] = ['type' => 'new-dependency', 'file' => $file];
-                break;
-            }
+        // A version bump modifies an existing require line: the same package key
+        // appears on both the added and removed sides. Only a genuinely new
+        // dependency has an added key with no removed counterpart. Diff the keys
+        // rather than scanning added lines alone, so dependabot/manual bumps
+        // don't false-trigger the gate.
+        $addedKeys = composerPackageKeys(diffAddedLines($mode, $file));
+        $removedKeys = composerPackageKeys(diffRemovedLines($mode, $file));
+        if (array_diff($addedKeys, $removedKeys) !== []) {
+            $triggers[] = ['type' => 'new-dependency', 'file' => $file];
         }
     }
 

--- a/ibl5/tests/Cli/AdrCheckCliTest.php
+++ b/ibl5/tests/Cli/AdrCheckCliTest.php
@@ -10,18 +10,141 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('cli')]
 final class AdrCheckCliTest extends TestCase
 {
+    private string $binPath;
+
+    protected function setUp(): void
+    {
+        $bin = realpath(__DIR__ . '/../../../bin/adr-check');
+        self::assertIsString($bin, 'bin/adr-check must exist');
+        $this->binPath = $bin;
+    }
+
     public function testHelpFlagPrintsUsageAndExitsZero(): void
     {
         $output = [];
         $exit = 0;
-        exec(escapeshellcmd(realpath(__DIR__ . '/../../../bin/adr-check')) . ' --help 2>&1', $output, $exit);
+        exec(escapeshellcmd($this->binPath) . ' --help 2>&1', $output, $exit);
         self::assertSame(0, $exit);
         self::assertStringContainsString('Decision-trigger gate', implode("\n", $output));
     }
 
     public function testUnknownFlagExitsTwo(): void
     {
-        exec(escapeshellcmd(realpath(__DIR__ . '/../../../bin/adr-check')) . ' --bogus 2>&1', $unused, $exit);
+        exec(escapeshellcmd($this->binPath) . ' --bogus 2>&1', $unused, $exit);
         self::assertSame(2, $exit);
+    }
+
+    /**
+     * A dependency version bump modifies an existing require line — same package
+     * key on both sides of the diff — so it must NOT trip the new-dependency
+     * trigger. This is the dependabot-bump false-positive that motivated the
+     * key-diff detection (PR #1293).
+     */
+    public function testVersionBumpDoesNotTriggerNewDependency(): void
+    {
+        $before = $this->composerJson(['infection/infection' => '^0.33.2']);
+        $after = $this->composerJson(['infection/infection' => '^0.34.0']);
+
+        [$exit, $output] = $this->runStagedAgainst($before, $after);
+
+        self::assertSame(0, $exit, "version bump should pass, got:\n{$output}");
+        self::assertStringContainsString('ADR not required', $output);
+    }
+
+    /**
+     * Adding a genuinely new require entry (a key with no removed counterpart)
+     * must still trip the trigger and fail without an accompanying ADR.
+     */
+    public function testNewDependencyTriggersWithoutAdr(): void
+    {
+        $before = $this->composerJson(['infection/infection' => '^0.34.0']);
+        $after = $this->composerJson([
+            'infection/infection' => '^0.34.0',
+            'vendor/newpackage' => '^1.0',
+        ]);
+
+        [$exit, $output] = $this->runStagedAgainst($before, $after);
+
+        self::assertSame(1, $exit, "new dependency should fail, got:\n{$output}");
+        self::assertStringContainsString('new-dependency', $output);
+    }
+
+    /**
+     * A bump that also happens to reorder or reformat unrelated require lines
+     * must still pass: no key is added-without-removed.
+     */
+    public function testBumpAlongsideRemovedDependencyStillPasses(): void
+    {
+        $before = $this->composerJson([
+            'infection/infection' => '^0.33.2',
+            'vendor/dropme' => '^1.0',
+        ]);
+        $after = $this->composerJson(['infection/infection' => '^0.34.0']);
+
+        [$exit, $output] = $this->runStagedAgainst($before, $after);
+
+        self::assertSame(0, $exit, "bump + removal should pass, got:\n{$output}");
+    }
+
+    /**
+     * @param array<string, string> $requireDev
+     */
+    private function composerJson(array $requireDev): string
+    {
+        return (string) json_encode(
+            ['name' => 'ibl5/test', 'require-dev' => $requireDev],
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+        ) . "\n";
+    }
+
+    /**
+     * Build a throwaway git repo, commit `ibl5/composer.json` with $before, stage
+     * $after, and run `bin/adr-check --staged` from the repo root.
+     *
+     * @return array{0: int, 1: string}
+     */
+    private function runStagedAgainst(string $before, string $after): array
+    {
+        $repo = sys_get_temp_dir() . '/adr-check-test-' . bin2hex(random_bytes(6));
+        mkdir($repo . '/ibl5', 0o777, true);
+        $composer = $repo . '/ibl5/composer.json';
+
+        $git = 'git -C ' . escapeshellarg($repo)
+            . ' -c user.email=test@example.com -c user.name=test'
+            . ' -c commit.gpgsign=false';
+
+        file_put_contents($composer, $before);
+        exec("{$git} init -q 2>&1");
+        exec("{$git} add ibl5/composer.json 2>&1");
+        exec("{$git} commit -q -m initial 2>&1");
+
+        file_put_contents($composer, $after);
+        exec("{$git} add ibl5/composer.json 2>&1");
+
+        $output = [];
+        $exit = 0;
+        exec(
+            'cd ' . escapeshellarg($repo) . ' && '
+            . escapeshellcmd($this->binPath) . ' --staged 2>&1',
+            $output,
+            $exit,
+        );
+
+        $this->rrmdir($repo);
+
+        return [$exit, implode("\n", $output)];
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            /** @var \SplFileInfo $item */
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
     }
 }


### PR DESCRIPTION
## Summary
- `adr-check`'s new-dependency trigger scanned only added diff lines in `ibl5/composer.json`, so a dependabot/manual version bump (which modifies an existing require line) false-triggered the ADR gate.
- Now diffs added vs. removed package keys — a key only trips the trigger when it's added with no removed counterpart (i.e. genuinely new).

## Test plan
- [x] `testVersionBumpDoesNotTriggerNewDependency` — bump passes without ADR
- [x] `testNewDependencyTriggersWithoutAdr` — genuinely new dependency still fails without ADR
- [x] `testBumpAlongsideRemovedDependencyStillPasses` — bump + unrelated removal still passes

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
