### PR TITLE
chore(plan): allow model-invocable /plan skill

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: plan
 description: "Plan an implementation task: enforces a verification matrix, directs code reuse, flags security surfaces, and requires negative-path tests so plans drive clean, secure, well-tested implementations."
-disable-model-invocation: true
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode


### PR DESCRIPTION
## Summary
- Removes `disable-model-invocation: true` from the plan skill frontmatter so Claude can invoke `/plan` directly when appropriate, not only when the user types the slash command.

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.