### PR TITLE
chore: CI-meta workflow carve-out for bin/website-affecting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -543,6 +543,8 @@ jobs:
         run: bin/test-check-workflow-checkout
       - name: bin/test-check-composite-contracts
         run: bin/test-check-composite-contracts
+      - name: bin/test-website-affecting
+        run: bin/test-website-affecting
 
   gate:
     name: Tests and Analysis

--- a/bin/test-website-affecting
+++ b/bin/test-website-affecting
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-website-affecting — regression harness for bin/website-affecting.
+#
+# Pipes newline-separated repo-relative paths into bin/website-affecting and
+# asserts the EXIT CODE (0 = affects website / BUILD, 1 = non-website / SKIP).
+# Pins: the CI-meta exempt set (exit 1), the E2E/Lighthouse driver GUARD set
+# (exit 0 — the load-bearing anti-silent-skip proof), any-website-file-wins on a
+# mixed diff, and existing-behavior regressions (deny regex, app php, carve-out,
+# fail-safe empty diff).
+#
+# Run: bin/test-website-affecting  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GUARD="$SCRIPT_DIR/website-affecting"
+
+FAILED=0
+
+pass()     { echo "ok: $1"; }
+failcase() { echo "FAIL: $1"; FAILED=1; }
+
+# assert_exit <name> <expected-exit> <path> [path...]
+# Feeds each path on its own line (trailing newline each, so `while read` sees
+# the final line) into the classifier and asserts its exit code.
+assert_exit() {
+    local name="$1" expected="$2"; shift 2
+    local actual
+    printf '%s\n' "$@" | "$GUARD" >/dev/null 2>&1
+    actual=$?
+    if [ "$actual" -eq "$expected" ]; then
+        pass "$name (exit $actual)"
+    else
+        failcase "$name — expected exit $expected, got $actual"
+    fi
+}
+
+# --- (a) CI-meta exempt set: each alone → exit 1 (non-website / SKIP) ---
+assert_exit "exempt-pages-deploy"  1 ".github/workflows/pages-deploy.yml"
+assert_exit "exempt-rebase-prs"    1 ".github/workflows/rebase-prs.yml"
+assert_exit "exempt-human-signoff" 1 ".github/workflows/human-signoff.yml"
+assert_exit "exempt-dependabot"    1 ".github/workflows/dependabot-auto-merge.yml"
+
+# --- (b) GUARD (LOAD-BEARING): E2E/Lighthouse drivers → exit 0 (website) ---
+# This block is the mechanical proof against the silent-skip failure mode: if a
+# future edit ever swept one of these into the exempt set, its PR would skip the
+# very E2E/Lighthouse run that validates it. These MUST classify website.
+assert_exit "guard-e2e-tests"         0 ".github/workflows/e2e-tests.yml"
+assert_exit "guard-setup-docker-e2e"  0 ".github/actions/setup-docker-e2e/action.yml"
+assert_exit "guard-docker-compose-ci" 0 "docker-compose.ci.yml"
+assert_exit "guard-lighthouse"        0 ".github/workflows/lighthouse.yml"
+
+# --- (b2) Exactness boundary: a non-exempt / look-alike workflow → exit 0 ---
+# Proves the exempt case is an EXACT full-path match and never sweeps a sibling
+# workflow. Fail-safe direction: unknown workflow still counts website.
+assert_exit "non-exempt-workflow"  0 ".github/workflows/tests.yml"
+assert_exit "exempt-lookalike"     0 ".github/workflows/pages-deploy-staging.yml"
+
+# --- (c) Mixed diff: exempt workflow + real app file → exit 0 (any website wins) ---
+assert_exit "mixed-exempt-plus-app" 0 \
+    ".github/workflows/pages-deploy.yml" "ibl5/index.php"
+
+# --- (d) Existing-behavior regression pins ---
+assert_exit "pin-markdown"      1 "README.md"          # \.md$ deny regex
+assert_exit "pin-app-php"       0 "ibl5/index.php"     # app code, website-side
+assert_exit "pin-carveout-self" 0 "bin/website-affecting"  # is_carveout forces website
+
+# Empty stdin → exit 0 (fail-safe BUILD). Tested with genuinely empty input.
+printf '' | "$GUARD" >/dev/null 2>&1
+empty_exit=$?
+if [ "$empty_exit" -eq 0 ]; then
+    pass "pin-empty-stdin (exit 0)"
+else
+    failcase "pin-empty-stdin — expected exit 0, got $empty_exit"
+fi
+
+# --- Results ---
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0

--- a/bin/website-affecting
+++ b/bin/website-affecting
@@ -23,9 +23,21 @@
 #     they match the deny regex):
 #       bin/website-affecting  (the predicate itself — changing the gate must trigger it)
 #
-# Workflow files (.github/workflows/e2e-tests.yml, .github/workflows/lighthouse.yml)
-# are naturally website-side (none of their paths match the deny regex) — no
-# explicit carve-out needed.
+# Most naturally website-side files (they do NOT match the deny regex) always
+# count website — INCLUDING E2E/Lighthouse drivers like
+# .github/workflows/e2e-tests.yml and .github/workflows/lighthouse.yml.
+#
+# CI-meta exempt set (the INVERSE of the carve-out): a curated denylist of
+# workflow files that do NOT match the deny regex but PROVABLY run no app code
+# and cannot affect the E2E suite, Lighthouse, or the app. These classify
+# NON-website even though nothing denies them. This is a DENYLIST CARVE-OUT, not
+# a positive allowlist: its staleness fails SAFE/LOUD (a dropped or renamed
+# entry just over-runs E2E) — never a silent E2E skip. Each entry is a
+# deliberate assertion "this file can't break E2E or the app":
+#       .github/workflows/pages-deploy.yml           (post-E2E gh-pages deploy)
+#       .github/workflows/rebase-prs.yml             (git rebase of open PRs)
+#       .github/workflows/human-signoff.yml          (PR-title classifier gate)
+#       .github/workflows/dependabot-auto-merge.yml  (enables gh pr merge --auto)
 #
 # Anchoring is load-bearing:
 #   ^bin/      so ibl5/bin/* (app bin, website-side) is NOT denied
@@ -48,6 +60,26 @@ is_carveout() {
     return 1
 }
 
+# CI-meta exempt set: paths that do NOT match the deny regex (so they would
+# otherwise count website-side) but PROVABLY run no app code and cannot affect
+# the E2E suite, Lighthouse, or the app. This is a curated DENYLIST CARVE-OUT,
+# not a positive allowlist: its staleness fails SAFE (a dropped/renamed entry
+# just over-runs E2E) — never a silent E2E skip. Each entry is a deliberate
+# assertion "this file can't break E2E or the app." Match is EXACT (full
+# repo-relative path), so a sibling workflow is never accidentally swept in.
+# NEVER add: .github/workflows/e2e-tests.yml, .github/workflows/lighthouse.yml,
+# .github/actions/setup-docker-e2e/**, docker-compose.ci.yml, docker/Dockerfile*
+# — those drive E2E/Lighthouse and MUST stay website-side.
+is_ci_meta_exempt() {
+    case "$1" in
+        .github/workflows/pages-deploy.yml)          return 0 ;;  # workflow_run after E2E; checks out gh-pages + deploys Pages — no app code, consumes E2E output (can't change it)
+        .github/workflows/rebase-prs.yml)            return 0 ;;  # push:master trigger; rebases open PRs via git — no app code, no E2E/Lighthouse
+        .github/workflows/human-signoff.yml)         return 0 ;;  # PR-title classifier gate (bin/lib/human-signoff-classifier.sh) — no app code, no E2E/Lighthouse
+        .github/workflows/dependabot-auto-merge.yml) return 0 ;;  # enables gh pr merge --auto for dependabot PRs — no app code, no E2E/Lighthouse
+    esac
+    return 1
+}
+
 if [ "${1:-}" = "--help" ]; then
     cat <<'HELP'
 bin/website-affecting — classify changed files as website-affecting or not.
@@ -66,8 +98,16 @@ Deny-set (non-website if matched and not in carve-out):
 Carve-out (always website-side despite matching deny regex):
   bin/website-affecting  (the predicate itself)
 
-Naturally website-side (not denied, no carve-out needed):
-  ibl5/**  .github/**  docker/**  Dockerfile  docker-compose*.yml  *.php *.ts *.js *.css
+CI-meta exempt (NON-website despite not matching deny regex — provably can't
+affect E2E/Lighthouse/app; staleness over-runs, never silent-skips):
+  .github/workflows/pages-deploy.yml
+  .github/workflows/rebase-prs.yml
+  .github/workflows/human-signoff.yml
+  .github/workflows/dependabot-auto-merge.yml
+
+Naturally website-side (not denied, not exempt):
+  ibl5/**  .github/** (incl. e2e-tests.yml, lighthouse.yml)  docker/**
+  Dockerfile  docker-compose*.yml  *.php *.ts *.js *.css
 HELP
     exit 0
 fi
@@ -88,8 +128,14 @@ while IFS= read -r line; do
         fi
         # else: denied and not in carve-out — non-website, don't increment WEBSITE_COUNT
     else
-        # Does not match deny regex → website-affecting
-        WEBSITE_COUNT=$((WEBSITE_COUNT + 1))
+        # Does not match deny regex → website-side by DEFAULT, unless the path is
+        # in the curated CI-meta exempt set (workflow files that provably can't
+        # affect the E2E suite, Lighthouse, or the app). Fail-safe: anything not
+        # explicitly exempt still counts website.
+        if ! is_ci_meta_exempt "$line"; then
+            WEBSITE_COUNT=$((WEBSITE_COUNT + 1))
+        fi
+        # else: CI-meta exempt — non-website, don't increment WEBSITE_COUNT
     fi
 done
 


### PR DESCRIPTION
## Summary

Adds a curated CI-meta exempt set to `bin/website-affecting` so that changes to four workflow files that provably run no app code (`pages-deploy.yml`, `rebase-prs.yml`, `human-signoff.yml`, `dependabot-auto-merge.yml`) no longer trigger the full E2E/Lighthouse suite. Design is a denylist carve-out (fails safe/loud — over-runs E2E rather than silently skipping it), not a positive allowlist.

- `bin/website-affecting`: new `is_ci_meta_exempt()` helper + rewired else-branch; updated header doc block and `--help` heredoc.
- `bin/test-website-affecting`: new regression harness pinning the exempt set, the load-bearing GUARD set (E2E/Lighthouse drivers must stay website-side), exactness boundary, mixed-diff behavior, and existing-behavior regressions.
- `.github/workflows/tests.yml`: wires the new harness into the `harness-tests` job.

<!-- no-adr: regression harness for bin/website-affecting; introduces no architecture -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
