### PR TITLE
chore(ci): add PHPStan/Playwright result caching and job timeouts

### DIFF
--- a/.github/actions/lighthouse-setup/action.yml
+++ b/.github/actions/lighthouse-setup/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: oven-sh/setup-bun@v2
 
     - name: Cache vendor directory
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ibl5/vendor
         key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
@@ -15,7 +15,7 @@ runs:
           ${{ runner.os }}-vendor-
 
     - name: Cache node_modules
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ibl5/node_modules
         key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}

--- a/.github/workflows/deploy-rehearsal.yml
+++ b/.github/workflows/deploy-rehearsal.yml
@@ -45,6 +45,7 @@ jobs:
   rehearse:
     name: Deploy Rehearsal (composer --no-dev + migrate + validate-schema)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     env:
       DB_HOST: 127.0.0.1

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -22,6 +22,7 @@ jobs:
   idempotency-check:
     name: Bash/PHP Runner Idempotency
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     env:
       DB_HOST: 127.0.0.1
@@ -73,6 +74,7 @@ jobs:
   schema-parity-check:
     name: Bash vs PHP Schema Parity
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     # Only consumed by config.php.example getenv() in `php bin/migrate`; the
     # mysql/mysqldump CLI calls below pass creds via explicit flags, so DB_NAME
@@ -156,6 +158,7 @@ jobs:
   schema-completeness:
     name: Schema Completeness
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     env:
       DB_HOST: 127.0.0.1
@@ -267,6 +270,7 @@ jobs:
   destructive-migration-scan:
     name: Destructive Migration Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -297,6 +301,7 @@ jobs:
     if: always()
     needs: [idempotency-check, schema-parity-check, schema-completeness, destructive-migration-scan]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - run: exit 1
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       pull-requests: read
     outputs:
@@ -70,6 +71,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
     strategy:
@@ -150,6 +152,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - name: Checkout code
@@ -170,6 +173,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - name: Checkout code
@@ -189,6 +193,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.ibl6 == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
     - name: Checkout code
@@ -211,6 +216,14 @@ jobs:
 
     # vite.config forces vitest browser mode (provider: playwright, chromium),
     # so the runner needs the browser binary before test:unit.
+    - name: Cache Playwright browsers
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('IBL6/package-lock.json') }}
+        restore-keys: |
+          playwright-${{ runner.os }}-
+
     - name: Install Playwright Chromium
       working-directory: IBL6
       run: npx playwright install chromium --with-deps
@@ -224,6 +237,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     services:
       mariadb:
@@ -268,6 +282,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - name: Checkout code
@@ -277,6 +292,16 @@ jobs:
       uses: ./.github/actions/setup-php-env
       with:
         create-config: 'false'
+
+    - name: Cache PHPStan result cache
+      uses: actions/cache@v6
+      with:
+        path: |
+          ibl5/tmp
+          ibl5/tmp-tests
+        key: phpstan-${{ hashFiles('ibl5/phpstan.neon', 'ibl5/phpstan-tests.neon', 'ibl5/phpstan-rules/**') }}
+        restore-keys: |
+          phpstan-
 
     - name: Run PHPStan
       working-directory: ibl5
@@ -295,6 +320,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:
@@ -307,6 +333,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -358,6 +385,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -394,6 +422,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -407,6 +436,7 @@ jobs:
     needs: [test, phpstan]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
 
@@ -467,6 +497,7 @@ jobs:
   static-guards:
     name: Static guards
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Folds three unconditional micro-guards into one sequential job to save runner
     # startup overhead (mirrors the PR #1269 meta-checks fold). NO `if:` and NO
     # `needs:` — every check below runs unconditionally because none is covered by a
@@ -500,6 +531,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Each harness builds its own throwaway git repos under mktemp, so the
     # checkout depth and a global git identity are irrelevant.
     steps:
@@ -551,6 +583,7 @@ jobs:
     if: always()
     needs: [changes, test, audit-php, audit-js, ibl6-checks, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, static-guards, harness-tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - run: exit 1
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/ibl5/.gitignore
+++ b/ibl5/.gitignore
@@ -35,6 +35,10 @@ vr-gallery.json
 # Page cache (generated at runtime)
 cache/page/
 
+# PHPStan result cache (tmpDir set in phpstan.neon / phpstan-tests.neon for CI cache persistence)
+/tmp/
+/tmp-tests/
+
 # Security backlog — catalogs unpatched, reachable vulnerabilities (attacker roadmap).
 # Kept in-tree so Claude can read/track it, but MUST NOT be committed.
 docs/security-backlog.md

--- a/ibl5/phpstan-tests.neon
+++ b/ibl5/phpstan-tests.neon
@@ -3,6 +3,7 @@ includes:
     - phpstan-tests-baseline.neon
 
 parameters:
+    tmpDir: tmp-tests
     level: 6
     paths:
         - tests

--- a/ibl5/phpstan.neon
+++ b/ibl5/phpstan.neon
@@ -3,6 +3,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
+    tmpDir: tmp
     level: max
     paths:
         - classes


### PR DESCRIPTION
## Summary
- Bump `actions/cache` to v6 for the lighthouse-setup vendor/node_modules caches.
- Cache PHPStan's result cache (`ibl5/tmp`, `ibl5/tmp-tests`) keyed on config + rules, via new `tmpDir` settings in `phpstan.neon`/`phpstan-tests.neon`.
- Cache Playwright's Chromium browser binaries in the IBL6 unit-test job.
- Add `timeout-minutes` to every CI job so a hung runner fails fast instead of consuming the 6h GitHub default.

## Manual Testing
No manual testing needed — all changes are covered by CI itself (cache hits/misses and timeout behavior are observed on the next few runs).
