### PR TITLE
chore(ci): skip vendor/node_modules install steps on cache hit

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -128,6 +128,7 @@ jobs:
       # --- Dependency Caching ---
       - name: Cache vendor directory
         uses: actions/cache@v6
+        id: vendor-cache
         with:
           path: ibl5/vendor
           key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
@@ -136,6 +137,7 @@ jobs:
 
       - name: Cache node_modules
         uses: actions/cache@v6
+        id: node-modules-cache
         with:
           path: ibl5/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
@@ -143,10 +145,12 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install JS dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: bun install
 
       - name: Install Composer dependencies
+        if: steps.vendor-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
 
@@ -341,6 +345,7 @@ jobs:
 
       - name: Cache vendor directory
         uses: actions/cache@v6
+        id: vendor-cache
         with:
           path: ibl5/vendor
           key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
@@ -349,6 +354,7 @@ jobs:
 
       - name: Cache node_modules
         uses: actions/cache@v6
+        id: node-modules-cache
         with:
           path: ibl5/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
@@ -356,10 +362,12 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install JS dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: bun install
 
       - name: Install Composer dependencies
+        if: steps.vendor-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
 
@@ -408,6 +416,7 @@ jobs:
       # --- Dependency Caching ---
       - name: Cache vendor directory
         uses: actions/cache@v6
+        id: vendor-cache
         with:
           path: ibl5/vendor
           key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
@@ -416,6 +425,7 @@ jobs:
 
       - name: Cache node_modules
         uses: actions/cache@v6
+        id: node-modules-cache
         with:
           path: ibl5/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
@@ -423,10 +433,12 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install JS dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: bun install
 
       - name: Install Composer dependencies
+        if: steps.vendor-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
 
@@ -510,6 +522,7 @@ jobs:
       # --- Dependency Caching ---
       - name: Cache vendor directory
         uses: actions/cache@v6
+        id: vendor-cache
         with:
           path: ibl5/vendor
           key: ${{ runner.os }}-vendor-${{ hashFiles('ibl5/composer.lock') }}
@@ -518,6 +531,7 @@ jobs:
 
       - name: Cache node_modules
         uses: actions/cache@v6
+        id: node-modules-cache
         with:
           path: ibl5/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
@@ -525,10 +539,12 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install JS dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: bun install
 
       - name: Install Composer dependencies
+        if: steps.vendor-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
 
@@ -786,7 +802,17 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Cache node_modules
+        uses: actions/cache@v6
+        id: node-modules-cache
+        with:
+          path: ibl5/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('ibl5/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install JS dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         working-directory: ibl5
         run: bun install
 


### PR DESCRIPTION
## Summary
- Add `id: vendor-cache` / `id: node-modules-cache` to each `actions/cache@v6` step in `e2e-tests.yml`
- Gate the corresponding `bun install` / `composer install` steps with `if: steps.<cache-id>.outputs.cache-hit != 'true'`
- Adds the missing node_modules cache step to the job that previously always ran `bun install` unconditionally

Skips redundant dependency installs when the cache already has an exact key match, cutting wasted runner-minutes on the free-tier pool.

## Manual Testing
No manual testing needed — all changes are covered by CI (the workflow itself runs on this PR and will demonstrate cache-hit skip behavior once cache entries exist).
