### PR TITLE
ci: pin ibl6 to a prebuilt GHCR image in CI E2E

### DIFF
--- a/.github/actions/setup-docker-e2e/action.yml
+++ b/.github/actions/setup-docker-e2e/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Non-admin E2E test password (optional; enables role-gating tests)'
     required: false
     default: ''
+  ibl6-image:
+    description: 'How to obtain the ibl6 image: "pull" the pinned GHCR tag (default) or "build" from PR source (used by the ibl6 jobs so they test PR source, never master).'
+    required: false
+    default: 'pull'
 
 runs:
   using: 'composite'
@@ -91,6 +95,17 @@ runs:
       run: |
         docker compose -f docker-compose.ci.yml exec -T mariadb \
           mariadb -u root -proot ibl5 < ibl5/tests/e2e/fixtures/ci-seed.sql
+
+    - name: Prepare ibl6 image (pull pinned tag, or build from PR source)
+      shell: bash
+      run: |
+        if [ "${{ inputs.ibl6-image }}" = "build" ]; then
+          echo "Building ibl6 from PR source"
+          docker compose -f docker-compose.ci.yml build ibl6
+        else
+          docker pull ghcr.io/a-jay85/ibl5/ibl6:latest || \
+            docker compose -f docker-compose.ci.yml build ibl6
+        fi
 
     - name: Start remaining containers (Apache sees fully-migrated schema)
       shell: bash

--- a/.github/workflows/build-ibl6-image.yml
+++ b/.github/workflows/build-ibl6-image.yml
@@ -1,0 +1,52 @@
+name: Build IBL6 Image
+
+# Publishes ghcr.io/a-jay85/ibl5/ibl6:latest so CI e2e jobs that don't test
+# IBL6 can pull it instead of rebuilding it every run. Mirrors the php-apache
+# GHCR publish in cache-dependencies.yml. Path-scoped so it does NOT fire on
+# ibl5-dependency changes (and cache-dependencies does NOT fire on IBL6 changes).
+
+on:
+  # Rebuild when IBL6 source or its Dockerfile changes on master
+  push:
+    branches:
+      - master
+    paths:
+      - 'IBL6/**'
+      - 'docker/Dockerfile.ibl6'
+
+  # Daily to keep :latest fresh (and to publish it the first time)
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight UTC
+
+  # Allow manual trigger (used by the post-merge watcher and for first publish)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-ibl6-image:
+    name: Build and push IBL6 image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push IBL6 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.ibl6
+          push: true
+          tags: ghcr.io/a-jay85/ibl5/ibl6:latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -633,6 +633,8 @@ jobs:
           cache-dependency-path: IBL6/package-lock.json
 
       - uses: ./.github/actions/setup-docker-e2e
+        with:
+          ibl6-image: build
 
       - name: Wait for ibl6 healthy
         run: |
@@ -736,6 +738,8 @@ jobs:
           cache-dependency-path: IBL6/package-lock.json
 
       - uses: ./.github/actions/setup-docker-e2e
+        with:
+          ibl6-image: build
 
       - name: Wait for ibl6 healthy
         run: |

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -42,6 +42,7 @@ services:
       retries: 10
 
   ibl6:
+    image: ghcr.io/a-jay85/ibl5/ibl6:latest
     build:
       context: .
       dockerfile: docker/Dockerfile.ibl6


### PR DESCRIPTION
## Summary

Pins the `ibl6` service in CI to a prebuilt GHCR image for jobs that don't test IBL6, while the two jobs that actually exercise it (`ibl6-visual`, `ibl6-e2e`) still build from PR source.

- `.github/workflows/build-ibl6-image.yml` (new) — publishes `ghcr.io/a-jay85/ibl5/ibl6:latest`, path-scoped to `IBL6/**` + `docker/Dockerfile.ibl6`, plus daily cron and manual dispatch. Mirrors the existing php-apache GHCR publish in `cache-dependencies.yml`.
- `docker-compose.ci.yml` — `ibl6` service gets an `image:` key alongside the existing `build:` block (same pattern already used for `php`).
- `.github/actions/setup-docker-e2e/action.yml` — new `ibl6-image` input (default `pull`); a conditional prepare step pulls the pinned tag (falling back to a local build pre-first-publish) or builds from PR source when `ibl6-image: build`.
- `.github/workflows/e2e-tests.yml` — `ibl6-visual` and `ibl6-e2e` pass `ibl6-image: build`; all other e2e jobs keep the default `pull` and stop building ibl6 unnecessarily.

Net effect: the many ibl5-only e2e jobs no longer rebuild `ibl6` from source every run; the two jobs that test IBL6 keep testing PR source with zero false-green risk.

## Manual Testing

No manual testing needed — all changes are covered by CI (actionlint, live `ibl6-visual`/`ibl6-e2e` self-verification, and the pull/build fallback behavior).

<!-- no-adr: mirrors existing php-apache GHCR publish pattern; no new architectural decision -->
