### PR TITLE
chore(automouse): tag log lines with impl/postplan phase

### DIFF
--- a/bin/automouse-run
+++ b/bin/automouse-run
@@ -583,7 +583,7 @@ PLAN_FILE=$PLAN_NAME" \
                 --verbose \
                 --name "automouse-impl-$(date +%Y-%m-%d-%H%M)" \
             2> >(grep -v 'thinking.type=enabled' >> "$LOG") \
-            | bin/lib/automouse-stream-filter "$HEARTBEAT_FILE" "$CMDPID_FILE" "$PLAN_SLUG" \
+            | bin/lib/automouse-stream-filter "$HEARTBEAT_FILE" "$CMDPID_FILE" "$PLAN_SLUG" impl \
             >> "$LOG" || IMPL_STATUS=$?
 
         kill "$WATCHER_PID" 2>/dev/null || true
@@ -681,7 +681,7 @@ PLAN_FILE=$PLAN_NAME" \
                 --verbose \
                 --name "automouse-postplan-$(date +%Y-%m-%d-%H%M)" \
             2> >(grep -v 'thinking.type=enabled' >> "$LOG") \
-            | bin/lib/automouse-stream-filter "$HEARTBEAT_FILE" "$CMDPID_FILE" "$PLAN_SLUG" \
+            | bin/lib/automouse-stream-filter "$HEARTBEAT_FILE" "$CMDPID_FILE" "$PLAN_SLUG" postplan \
             >> "$LOG" || PP_STATUS=$?
 
         kill "$WATCHER_PID" 2>/dev/null || true

--- a/bin/lib/automouse-stream-filter
+++ b/bin/lib/automouse-stream-filter
@@ -1,23 +1,28 @@
 #!/bin/bash
-# Usage: claude ... --output-format stream-json | automouse-stream-filter <heartbeat_file> [<cmdpid_file>] [<slug>]
+# Usage: claude ... --output-format stream-json | automouse-stream-filter <heartbeat_file> [<cmdpid_file>] [<slug>] [<phase>]
 set -euo pipefail
 
-HEARTBEAT_FILE="${1:?Usage: automouse-stream-filter <heartbeat_file> [<cmdpid_file>] [<slug>]}"
+HEARTBEAT_FILE="${1:?Usage: automouse-stream-filter <heartbeat_file> [<cmdpid_file>] [<slug>] [<phase>]}"
 CMDPID_FILE="${2:-}"
 SLUG="${3:-}"
+PHASE="${4:-}"
 TOOL_COUNT=0
 TURN_COUNT=1
 START_EPOCH=$(date +%s)
 
 # Line prefix: the elapsed timestamp, plus the active plan slug when one was
 # passed. Concurrent runners interleave into per-day logs, so the slug column
-# right after the timestamp says which plan each line belongs to.
+# right after the timestamp says which plan each line belongs to. When a phase
+# (impl/postplan) is passed it is appended as `<slug>/<phase>`, so the two
+# phases of one plan are distinguishable within the interleaved day log.
 line_prefix() {
-    local now diff
+    local now diff tag
     now=$(date +%s)
     diff=$(( now - START_EPOCH ))
-    if [ -n "$SLUG" ]; then
-        printf '[%02d:%02d:%02d] %s' $(( diff / 3600 )) $(( (diff % 3600) / 60 )) $(( diff % 60 )) "$SLUG"
+    tag="$SLUG"
+    [ -n "$SLUG" ] && [ -n "$PHASE" ] && tag="$SLUG/$PHASE"
+    if [ -n "$tag" ]; then
+        printf '[%02d:%02d:%02d] %s' $(( diff / 3600 )) $(( (diff % 3600) / 60 )) $(( diff % 60 )) "$tag"
     else
         printf '[%02d:%02d:%02d]' $(( diff / 3600 )) $(( (diff % 3600) / 60 )) $(( diff % 60 ))
     fi

--- a/bin/test-automouse-stream-filter
+++ b/bin/test-automouse-stream-filter
@@ -32,6 +32,12 @@ run_filter() {
     printf '%s' "$1" | "$FILTER" "$hb" "" "test-plan" 2>/dev/null
 }
 
+# run_filter_phase <phase> <ndjson-on-stdin> → captured filter stdout, phase tagged
+run_filter_phase() {
+    local hb="$TMP/hb"
+    printf '%s' "$2" | "$FILTER" "$hb" "" "test-plan" "$1" 2>/dev/null
+}
+
 # assert_contains <name> <output> <needle>
 assert_contains() {
     local name="$1" out="$2" needle="$3"
@@ -88,6 +94,20 @@ OUT=$(run_filter '{"type":"assistant","message":{"content":[{"type":"tool_use","
 ')
 assert_contains "c5a-tool-still-emits" "$OUT" "tool: Bash (#1, turn 1)"
 assert_contains "c5b-exit-still-emits" "$OUT" "exit: stop_reason=end_turn"
+
+# c6 — a passed phase is tagged onto the slug column as `<slug>/<phase>`
+OUT=$(run_filter_phase impl '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}
+'"$RESULT_LINE"'
+')
+assert_contains "c6a-phase-tags-tool" "$OUT" "test-plan/impl tool: Bash"
+assert_contains "c6b-phase-tags-exit" "$OUT" "test-plan/impl exit: stop_reason=end_turn"
+
+# c7 (back-compat, negative) — no phase arg → bare slug, no trailing slash
+OUT=$(run_filter '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}
+'"$RESULT_LINE"'
+')
+assert_contains "c7a-noPhase-bare-slug" "$OUT" "test-plan tool: Bash"
+assert_not_contains "c7b-noPhase-no-slash" "$OUT" "test-plan/"
 
 if [ "$FAILED" -ne 0 ]; then
     echo "RESULT: FAILED"


### PR DESCRIPTION
## Summary
- `bin/lib/automouse-stream-filter` now accepts an optional 4th arg (`<phase>`, e.g. `impl`/`postplan`) and tags the slug column as `<slug>/<phase>` when passed, so interleaved per-day logs distinguish the two phases of one plan run.
- `bin/automouse-run` passes `impl` and `postplan` respectively at its two call sites.
- Back-compat preserved: no phase arg → bare slug, no trailing slash (covered by new negative test c7).

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.