### PR TITLE
chore(ci): enable GHA layer cache for PHP image build

### DIFF
--- a/.github/workflows/cache-dependencies.yml
+++ b/.github/workflows/cache-dependencies.yml
@@ -126,12 +126,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push PHP image
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           tags: ghcr.io/a-jay85/ibl5/php-apache:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # --- Summary ---
       - name: Cache summary


### PR DESCRIPTION
## Summary
- Adds `docker/setup-buildx-action@v3` so the PHP image build step can use BuildKit's GitHub Actions cache backend.
- Sets `cache-from: type=gha` / `cache-to: type=gha,mode=max` on the `docker/build-push-action@v7` step, letting CI reuse Docker layers across runs instead of rebuilding the image from scratch each time.

## Manual Testing
No manual testing needed — all changes are covered by automated tests.
