### PR TITLE
ci: drop shard index from E2E job/step names

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -386,7 +386,7 @@ jobs:
         run: docker compose -f docker-compose.ci.yml down
 
   e2e-shards:
-    name: E2E Tests (shard ${{ matrix.shard-index }}/${{ matrix.total-shards }})
+    name: E2E Tests
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
@@ -453,7 +453,7 @@ jobs:
           test-pass-regular: ${{ secrets.IBL_TEST_PASS_REGULAR || 'e2e-regular-pass' }}
 
       # --- Run Sharded Tests ---
-      - name: Run E2E tests (shard ${{ matrix.shard-index }}/${{ matrix.total-shards }})
+      - name: Run E2E tests
         env:
           IBL_TEST_USER: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
           IBL_TEST_PASS: ${{ secrets.IBL_TEST_PASS || 'ci-e2e-pass-not-secret' }}


### PR DESCRIPTION
## Summary
- Drops the `(shard N/M)` matrix interpolation from the E2E job and step display names in `.github/workflows/e2e-tests.yml`, simplifying the GitHub Actions UI labels for sharded E2E runs.

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.
