### PR TITLE
fix(e2e): stop asserting shared-session success flash in depth chart spec

### DIFF
--- a/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
@@ -123,17 +123,24 @@ test.describe('Depth Chart submission', () => {
     await firstPg.selectOption(before === '3' ? '4' : '3');
 
     await page.locator('.depth-chart-buttons .depth-chart-submit-btn').click();
-    // PRG redirect completed (back on the module URL, not op=submit). The success
-    // flash is intentionally not asserted here — see the shared-session note at the
-    // top of this file. This test's contract is token rotation, asserted below.
-    await page.waitForURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/, { timeout: 15_000 });
-
-    const tokenAfter = await page
-      .locator('input[name="_csrf_token"]')
-      .first()
-      .getAttribute('value');
+    // Do NOT rely on page.waitForURL here: beforeEach already navigated to a URL
+    // that matches this same regex, so waitForURL can resolve immediately against
+    // the pre-submit document — before the PRG redirect's new document has actually
+    // loaded — and a one-shot getAttribute() right after would then read the STALE
+    // pre-submit token (this is exactly what broke when the old success-flash
+    // .toBeVisible() wait — which only exists in the NEW document — was removed for
+    // the shared-session flash-steal race; see the note at the top of this file).
+    // Poll for the token to actually change instead, which only becomes true once
+    // the new document has loaded, without depending on the racy shared-session flash.
+    let tokenAfter: string | null = null;
+    await expect(async () => {
+      tokenAfter = await page
+        .locator('input[name="_csrf_token"]')
+        .first()
+        .getAttribute('value');
+      expect(tokenAfter).not.toBe(tokenBefore);
+    }).toPass({ timeout: 15_000 });
     expect(tokenAfter).toMatch(/^[a-f0-9]{64}$/);
-    expect(tokenAfter).not.toBe(tokenBefore);
   });
 
   test('back-to-depth-chart after submit still allows resubmit (regression)', async ({ page }) => {
@@ -149,8 +156,18 @@ test.describe('Depth Chart submission', () => {
       .locator('.depth-chart-table select[name^="pg"]')
       .first();
     await firstPg.selectOption('3');
-    await page.locator('.depth-chart-buttons .depth-chart-submit-btn').click();
-    await page.waitForURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/, { timeout: 15_000 });
+    // Set up the URL wait BEFORE clicking (Promise.all), not after: beforeEach
+    // already navigated to a URL matching this same pattern, so a wait started
+    // AFTER the click can observe the still-current pre-submit URL as an
+    // immediate "match" and resolve before the PRG redirect actually lands —
+    // which then let the very next page.goto() below abort that still-in-flight
+    // navigation (net::ERR_ABORTED). Starting the wait first ties it to the
+    // navigation the click triggers, not to whatever URL happened to be current.
+    await Promise.all([
+      page.waitForURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/, { timeout: 15_000 }),
+      page.locator('.depth-chart-buttons .depth-chart-submit-btn').click(),
+    ]);
+    await page.waitForLoadState('networkidle');
 
     // Leave the depth chart page and come back — minimal reliable repro of
     // the "user returns to the form later" pattern.
@@ -163,8 +180,10 @@ test.describe('Depth Chart submission', () => {
       .locator('.depth-chart-table select[name^="pg"]')
       .first()
       .selectOption('4');
-    await page.locator('.depth-chart-buttons .depth-chart-submit-btn').click();
-    await page.waitForURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/, { timeout: 15_000 });
+    await Promise.all([
+      page.waitForURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/, { timeout: 15_000 }),
+      page.locator('.depth-chart-buttons .depth-chart-submit-btn').click(),
+    ]);
 
     // The pre-PRG regression symptom: a stale-token resubmit rendered this error.
     // Redirected back to the module URL (asserted above) with that error absent is

--- a/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
+++ b/ibl5/tests/e2e/flows/depth-chart-entry-submission.spec.ts
@@ -12,6 +12,22 @@ import { submitFormAndAssertEffect } from '../helpers/submit-form';
 // the logged-in user's team to Monarchs (tid=8). The Monarchs roster has
 // exactly 12 active players with proper depth coverage (seeded in ci-seed.sql)
 // and is not referenced by any other spec, so parallel workers cannot pollute it.
+//
+// Why we do NOT assert the ".ibl-alert--success / depth chart saved" flash here:
+// the success flash lives in $_SESSION['flash_success'] and is single-use — the
+// FIRST PageLayout::header() render for that session consumes (unset)s it. All
+// authenticated E2E workers share ONE pinned server-side PHPSESSID (see
+// playwright-tests.md "Shared server session"), so any parallel worker that
+// renders any module in the ~ms window between this spec's submit-POST and its
+// redirect-GET can render the flash into ITS page and clear it, leaving this
+// spec's GET flash-less. That race made these tests intermittently red. The
+// flash render + single-use consumption is already unit-covered by
+// tests/Unit/PageLayout/PageLayoutTest.php, so here we assert the DURABLE proof
+// of success instead — the submitted depth value persisted to the DB (readable
+// back on the redirected form). (The ".ibl-alert--error" validation-failure test
+// below is NOT affected: its flash key `_ibl_depth_chart_flash` is module-scoped
+// and only this serial spec ever renders DepthChartEntry, so no parallel worker
+// can steal it.)
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Depth Chart submission', () => {
@@ -61,7 +77,7 @@ test.describe('Depth Chart submission', () => {
     }
   });
 
-  test('submit redirects back to module URL with success flash and fresh form', async ({ page }) => {
+  test('submit redirects back to module URL with a fresh form and persisted change', async ({ page }) => {
     await expect(page.locator('.depth-chart-form')).toBeVisible({ timeout: 15000 });
 
     const firstPg = page
@@ -74,8 +90,10 @@ test.describe('Depth Chart submission', () => {
         await page.locator('.depth-chart-buttons .depth-chart-submit-btn').click();
       },
       expectSameSpot: async () => {
+        // PRG landed us back on the module URL (not op=submit) with a fresh form.
+        // The success flash is deliberately NOT asserted — see the shared-session
+        // note at the top of this file; the durable success proof is the readBack.
         await expect(page).toHaveURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/);
-        await expect(page.locator('.ibl-alert--success', { hasText: /depth chart saved/i })).toBeVisible({ timeout: 15000 });
         await expect(page.locator('.depth-chart-form')).toBeVisible();
         await assertNoPhpErrors(page, 'after depth chart submission');
       },
@@ -105,8 +123,10 @@ test.describe('Depth Chart submission', () => {
     await firstPg.selectOption(before === '3' ? '4' : '3');
 
     await page.locator('.depth-chart-buttons .depth-chart-submit-btn').click();
+    // PRG redirect completed (back on the module URL, not op=submit). The success
+    // flash is intentionally not asserted here — see the shared-session note at the
+    // top of this file. This test's contract is token rotation, asserted below.
     await page.waitForURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/, { timeout: 15_000 });
-    await expect(page.locator('.ibl-alert--success', { hasText: /depth chart saved/i })).toBeVisible({ timeout: 15000 });
 
     const tokenAfter = await page
       .locator('input[name="_csrf_token"]')
@@ -131,7 +151,6 @@ test.describe('Depth Chart submission', () => {
     await firstPg.selectOption('3');
     await page.locator('.depth-chart-buttons .depth-chart-submit-btn').click();
     await page.waitForURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/, { timeout: 15_000 });
-    await expect(page.locator('.ibl-alert--success', { hasText: /depth chart saved/i })).toBeVisible({ timeout: 15000 });
 
     // Leave the depth chart page and come back — minimal reliable repro of
     // the "user returns to the form later" pattern.
@@ -147,7 +166,12 @@ test.describe('Depth Chart submission', () => {
     await page.locator('.depth-chart-buttons .depth-chart-submit-btn').click();
     await page.waitForURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/, { timeout: 15_000 });
 
-    await expect(page.locator('.ibl-alert--success', { hasText: /depth chart saved/i })).toBeVisible({ timeout: 15000 });
+    // The pre-PRG regression symptom: a stale-token resubmit rendered this error.
+    // Redirected back to the module URL (asserted above) with that error absent is
+    // the exact regression proof. Success flash intentionally not asserted, and no
+    // read-back reload added here — value-persistence is already covered by the
+    // first submit test and the IDOR test, and a bare goto under parallel load is a
+    // blank-page flake vector we deliberately avoid (see the shared-session note).
     await expect(page.getByText(/Invalid or expired/i)).not.toBeVisible();
   });
 
@@ -253,7 +277,12 @@ test.describe('Depth Chart submission', () => {
     // Resubmit — must now pass validation with the fresh token.
     await page.locator('.depth-chart-buttons .depth-chart-submit-btn').click();
 
-    await expect(page.locator('.ibl-alert--success', { hasText: /depth chart saved/i })).toBeVisible();
+    // Both success and validation-failure take the PRG redirect, so the durable
+    // discriminator for "resubmit succeeded" is: we redirected back to the module
+    // URL AND no validation-error alert rendered. The success flash is not asserted
+    // (shared-session steal — see the note at the top of this file); the error flash
+    // key is module-scoped, so its absence here is not racy.
+    await page.waitForURL(/modules\.php\?name=DepthChartEntry(?!.*op=submit)/, { timeout: 15_000 });
     await expect(page.locator('.ibl-alert--error')).not.toBeVisible();
   });
 
@@ -349,13 +378,12 @@ test.describe('Depth Chart submission', () => {
     await page.locator('.depth-chart-buttons .depth-chart-submit-btn').click();
 
     // Treated as a normal Monarchs submission (Team_Name ignored): PRG back to
-    // the module with the success flash, and the change persisted on Monarchs.
+    // the module, and the change persisted on Monarchs. The success flash is not
+    // asserted (shared-session steal — see the note at the top of this file); the
+    // durable proof the write landed on Monarchs is the read-back below.
     await expect(page).toHaveURL(
       /modules\.php\?name=DepthChartEntry(?!.*op=submit)/,
     );
-    await expect(
-      page.locator('.ibl-alert--success', { hasText: /depth chart saved/i }),
-    ).toBeVisible({ timeout: 15000 });
     await expect(
       page.locator('.depth-chart-table select[name^="pg"]').first(),
     ).toHaveValue('3');


### PR DESCRIPTION
## Summary
- The depth chart E2E spec asserted `.ibl-alert--success` (flash message) after each submit, but the success flash lives in single-use, session-scoped `$_SESSION['flash_success']`. All authenticated E2E workers share one pinned server-side PHPSESSID, so a parallel worker rendering any module in the redirect window can consume/steal the flash before this spec's GET reads it — causing intermittent (flaky) red failures.
- Replaces each success-flash assertion with a durable proof of success instead: persisted value read-back, PRG-redirect landing on the module URL, and absence of the module-scoped error flash (which is NOT subject to this race, since only this serial spec renders DepthChartEntry).
- The flash render + single-use consumption behavior itself remains covered by `tests/Unit/PageLayout/PageLayoutTest.php`.

## Manual Testing
No manual testing needed — all changes are covered by E2E tests.
