### PR TITLE
chore: revert automouse/post-plan model pin from Sonnet 5 to Sonnet 4.6

### DIFF
--- a/.claude/rules/agent-tiering-detail.md
+++ b/.claude/rules/agent-tiering-detail.md
@@ -1,6 +1,6 @@
 ---
 description: Read-on-demand detail for agent-tiering — Fable approval-gate procedure, flat-fan-out (nested sub-agent) rationale, orchestrator context economics (delegate-don't-dismiss, split-don't-self-clear), and per-tier prompt style. Loads only when editing workflow orchestration defs, where this rationale applies.
-last_verified: 2026-07-03
+last_verified: 2026-07-04
 paths:
   - ".claude/skills/**/*.md"
   - ".claude/skills/**/SKILL.md"
@@ -30,7 +30,7 @@ Absent approval, proceed on Opus (or the correct lower tier) — flag and contin
 
 ## Boundary keys on task type, not model capability
 
-Re-validated 2026-06-30 against Sonnet 5 (now the `sonnet` alias, native 1M context). The
+Re-validated 2026-06-30 against Sonnet 5 (then the `sonnet` alias, native 1M context). The
 Opus-only column (final code review, diff-triage, rule/ADR authoring, novel reasoning,
 ambiguous failures) stays Opus because **"never delegate understanding" is a *delegation*
 rule, not a "wait for a smarter model" rule** — a more capable Sonnet does not make

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,6 +1,6 @@
 ---
 description: Sub-agent decision rules — when to spawn, when to skip, which model to pick, and how sub-agent delegation keeps orchestrator context low
-last_verified: 2026-07-03
+last_verified: 2026-07-04
 ---
 
 # Agent Tiering
@@ -29,7 +29,7 @@ Each sub-agent costs ~3–5K tokens (system prompt + rules + memory, loaded befo
 | **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3. The def pins `model: opus` + `effort: xhigh`, so planning runs at Opus depth in a clean sub-context. Do **not** pass an inline `model` override — the def owns it. |
 | **Fable** | `model: "fable"` — **prompt first, last resort** | Opt-in rung above Opus. Use **only** when a task is absolutely critical **and** Fable is 100% necessary to solve it — and **never without prompting the user first** for explicit approval. Default to Opus; treat Fable as a last resort, not a routine capability upgrade. Full gate: `.claude/rules/agent-tiering-detail.md`. |
 
-> **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (now the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.
+> **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (then the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.
 
 ## Flat fan-out (no nested sub-agents)
 

--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -1,6 +1,6 @@
 ---
 description: All work happens in a worktree (never the main checkout); worktree setup and the implementation→/post-plan handoff (auto-fired in a detached fresh session) for any verified-complete worktree work, plan-driven or ad-hoc.
-last_verified: 2026-07-01
+last_verified: 2026-07-04
 ---
 
 # Workflow Continuity Rule
@@ -39,7 +39,7 @@ bin/post-plan-now --auto
 
 (Ad-hoc branch with no plan file → post-plan runs plan-blind; expected, not an error. The merge-arming decision still happens at `/post-plan` Phase 6.5, so auto-opening the PR never auto-merges a `feat:`/`auto_merge: false`/visual PR without human signoff.)
 
-This spawns a detached, fresh **Sonnet 5** `/post-plan` on this branch (launchd-supervised, so it survives you closing Claude Code). Notes:
+This spawns a detached, fresh **Sonnet 4.6** `/post-plan` on this branch (launchd-supervised, so it survives you closing Claude Code). Notes:
 
 - **Do NOT commit first.** Leave the worktree **dirty** — `/post-plan` commits the uncommitted tree in Phase 2 and opens the PR. Committing here changes what it ships.
 - **Only fire when verification passed.** If implementation did **not** verify clean (failing tests, unresolved blocker, you stopped to ask the user something), do **not** fire — leave the worktree dirty and hand off in prose. Turn-end ≠ done; that judgment is yours.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -2,7 +2,7 @@
 name: ship
 description: "Commit, push, and open a PR via /post-plan, which decides whether auto-merge arms; /ship never arms directly."
 disable-model-invocation: true
-last_verified: 2026-07-03
+last_verified: 2026-07-04
 ---
 
 # /ship — Commit, push, PR via /post-plan
@@ -37,7 +37,7 @@ Then the actions:
 
 - **Do NOT commit.** Leave the worktree **dirty** — `/post-plan` Phase 2 commits the uncommitted tree and opens the PR; committing first would change what ships (see `.claude/rules/workflow-continuity.md`).
 - Fire **`bin/post-plan-now`** (bare, **not** `--auto`): a human invoking `/ship` IS the decision to ship; `--auto` only matters inside headless, which the Step 1 precondition already rejected.
-- Report: post-plan fired (detached Sonnet 5, launchd-supervised); the PR / code review / CI / auto-merge progress all land on the PR; list any predicted holds from the advisory step.
+- Report: post-plan fired (detached Sonnet 4.6, launchd-supervised); the PR / code review / CI / auto-merge progress all land on the PR; list any predicted holds from the advisory step.
 
 ## Decision-table recap
 

--- a/bin/automouse-run
+++ b/bin/automouse-run
@@ -675,7 +675,7 @@ PLAN_FILE=$PLAN_NAME" \
 
 PLAN_FILE=$PLAN_NAME" \
                 --dangerously-skip-permissions \
-                --model claude-sonnet-5 \
+                --model claude-sonnet-4-6 \
                 --effort high \
                 --output-format stream-json \
                 --verbose \

--- a/bin/lib/plan-impl-model
+++ b/bin/lib/plan-impl-model
@@ -25,7 +25,7 @@ RAW=$(awk '
 ' "$PLAN_FILE" 2>/dev/null)
 
 case "$RAW" in
-  sonnet) echo "claude-sonnet-5" ;;
+  sonnet) echo "claude-sonnet-4-6" ;;
   haiku)  echo "claude-haiku-4-5"  ;;
   *)      echo "claude-opus-4-8"   ;;   # opus, empty, garbled, or unknown → safe default
 esac

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# bin/post-plan-now — fire a fresh, detached Sonnet 5 /post-plan session on the
+# bin/post-plan-now — fire a fresh, detached Sonnet 4.6 /post-plan session on the
 # current worktree's branch, replacing the manual "open a new session and hand
 # off" step. The run is supervised by launchd (RunAtLoad one-shot), so it
 # survives closing Claude Code or the terminal — a plain `nohup … &` launched
@@ -91,7 +91,7 @@ cat > "$PLIST" <<PLIST_EOF
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-5 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
+		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
@@ -108,7 +108,7 @@ PLIST_EOF
 launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$PLIST"
 
-echo "post-plan-now: fired a detached Sonnet 5 /post-plan on branch '$SLUG'."
+echo "post-plan-now: fired a detached Sonnet 4.6 /post-plan on branch '$SLUG'."
 echo "  supervised by launchd — survives closing Claude Code / the terminal"
 echo "  log:    tail -f $LOG"
 echo "  label:  $LABEL   (self-removes when post-plan finishes)"

--- a/bin/test-automouse-impl-model
+++ b/bin/test-automouse-impl-model
@@ -40,7 +40,7 @@ assert() {
 }
 
 # c1 — line-1 frontmatter selects sonnet
-assert "c1-sonnet" "claude-sonnet-5" '---
+assert "c1-sonnet" "claude-sonnet-4-6" '---
 impl_model: sonnet
 ---
 # Plan
@@ -72,7 +72,7 @@ impl_model: opus
 # Plan'
 
 # c5 — leading/trailing whitespace around the value is tolerated
-assert "c5-whitespace" "claude-sonnet-5" '---
+assert "c5-whitespace" "claude-sonnet-4-6" '---
 impl_model:   sonnet
 ---
 # Plan'


### PR DESCRIPTION
## Summary

- Reverts `--model` flag in `bin/automouse-run`, `bin/post-plan-now` from `claude-sonnet-5` → `claude-sonnet-4-6`
- Updates `bin/lib/plan-impl-model` resolver: `sonnet` alias now maps to `claude-sonnet-4-6`
- Updates `bin/test-automouse-impl-model` assertions to match
- Updates prose references in `.claude/rules/` and `.claude/skills/ship/SKILL.md` (wording: "now the \`sonnet\` alias" → "then the \`sonnet\` alias"; `last_verified` dates bumped)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)