### PR TITLE
chore: Stale-Docs Auto-Remediation Pipeline

### DIFF
--- a/.github/workflows/doc-freshness-audit.yml
+++ b/.github/workflows/doc-freshness-audit.yml
@@ -19,6 +19,10 @@ jobs:
     name: Repo-wide staleness audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      notify: ${{ steps.issue.outputs.notify }}
+      sig: ${{ steps.report.outputs.sig }}
+      issue-num: ${{ steps.issue.outputs.issue-num }}
 
     steps:
       - name: Checkout code
@@ -98,6 +102,11 @@ jobs:
             echo "notify=true" >> "$GITHUB_OUTPUT"
           fi
 
+          # Re-query the single open stale-docs issue so the docfix job can target it.
+          # gh issue create prints only a URL; both notify=true paths need the number.
+          ISSUE_NUM=$(gh issue list --label stale-docs --state open --json number --jq '.[0].number // empty')
+          echo "issue-num=$ISSUE_NUM" >> "$GITHUB_OUTPUT"
+
       - name: Publish to job summary
         run: |
           if [ "${{ steps.report.outputs.count }}" -gt 0 ]; then
@@ -132,3 +141,13 @@ jobs:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           fail-on-delivery: 'false'
+
+  docfix:
+    name: Fire headless doc-fix on the Mac
+    needs: audit
+    if: needs.audit.outputs.notify == 'true'
+    runs-on: [self-hosted, macOS]
+    timeout-minutes: 10
+    steps:
+      - name: Launch the headless doc-fix run
+        run: /Users/ajaynicolas/GitHub/IBL5/bin/docfix-run "${{ needs.audit.outputs.issue-num }}" "${{ needs.audit.outputs.sig }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -563,6 +563,8 @@ jobs:
         run: bin/test-adr-check
       - name: bin/test-postplan-arm-conditions
         run: bin/test-postplan-arm-conditions
+      - name: bin/test-docfix-run
+        run: bin/test-docfix-run
       - name: bin/test-post-review-findings
         run: bin/test-post-review-findings
       - name: bin/test-human-signoff-classifier

--- a/bin/docfix-run
+++ b/bin/docfix-run
@@ -46,7 +46,7 @@ fi
 # --- 4. Create the worktree (base = master) -----------------------------------
 SLUG="docs-stale-refresh-$(date +%Y%m%d)"
 bin/wt-new "$SLUG"                                   # cwd is $MAIN (step 2)
-WT_IBL5="$(worktrees_parent_dir "$MAIN")/$SLUG/ibl5"
+WT_ROOT="$(worktrees_parent_dir "$MAIN")/$SLUG"
 
 # --- 5. Seed the auto_merge:false hold plan (resolved by slug at post-plan) ----
 PLAN_FILE="$HOME/.claude/plans/$SLUG.md"
@@ -89,12 +89,12 @@ cat > "$PLIST" <<PLIST_EOF
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$WT_IBL5" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
+		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$WT_ROOT" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>WorkingDirectory</key>
-	<string>$WT_IBL5</string>
+	<string>$WT_ROOT</string>
 	<key>StandardOutPath</key>
 	<string>$LOG</string>
 	<key>StandardErrorPath</key>

--- a/bin/docfix-run
+++ b/bin/docfix-run
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# bin/docfix-run <issue-num> <sig> — Mac-side headless stale-docs remediation launcher.
+# Fired by the `docfix` job of .github/workflows/doc-freshness-audit.yml on a
+# self-hosted macOS runner when the nightly audit reports a NEW/CHANGED stale set.
+# Creates a worktree, seeds an auto_merge:false hold plan, and launches a detached
+# headless Claude run that refreshes exactly the stale docs and opens a PR (held for
+# human merge) that Closes the stale-docs issue.
+#
+# Detach mechanism cloned in structure from bin/post-plan-now:71-109 (launchd
+# RunAtLoad one-shot) — a plain `nohup … &` from the runner dies with the job.
+#
+# Usage: bin/docfix-run <issue-num> <sig>
+
+set -euo pipefail
+
+# --- 1. Validate args (negative path) -----------------------------------------
+ISSUE_NUM="${1:-}"
+SIG="${2:-}"
+if [ -z "$ISSUE_NUM" ] || [ -z "$SIG" ]; then
+    echo "docfix-run: usage: bin/docfix-run <issue-num> <sig> (both required)" >&2
+    exit 1
+fi
+
+# --- 2. Anchor to the CANONICAL main checkout (NOT $0) ------------------------
+# The self-hosted runner invokes us from its ephemeral, shallow _work checkout;
+# $0-relative resolution would misroute wt-new under _work (wrong layout, no
+# usable origin/master, reclaimed mid-run). Anchor to the real main checkout —
+# exactly as workflow-continuity says wt-new is run FROM it. IBL5_MAIN override
+# lets bin/test-docfix-run point this at its sandbox.
+MAIN="${IBL5_MAIN:-/Users/ajaynicolas/GitHub/IBL5}"
+cd "$MAIN"
+source "$MAIN/bin/lib/git-helpers.sh"   # worktrees_parent_dir
+
+# --- 3. Dedupe: never stack duplicate doc-fix runs ----------------------------
+if [ -n "$(git -C "$MAIN" branch --list 'docs-stale-refresh-*')" ]; then
+    echo "docfix-run: a docs-stale-refresh-* branch already exists — skipping (no stacking)."
+    exit 0
+fi
+if gh pr list --state open --json headRefName --jq '.[].headRefName' 2>/dev/null \
+     | grep -q '^docs-stale-refresh-'; then
+    echo "docfix-run: an open docs-stale-refresh-* PR is pending human merge — skipping."
+    exit 0
+fi
+
+# --- 4. Create the worktree (base = master) -----------------------------------
+SLUG="docs-stale-refresh-$(date +%Y%m%d)"
+bin/wt-new "$SLUG"                                   # cwd is $MAIN (step 2)
+WT_IBL5="$(worktrees_parent_dir "$MAIN")/$SLUG/ibl5"
+
+# --- 5. Seed the auto_merge:false hold plan (resolved by slug at post-plan) ----
+PLAN_FILE="$HOME/.claude/plans/$SLUG.md"
+cat > "$PLAN_FILE" <<PLAN_EOF
+---
+auto_merge: false
+---
+
+# Stale-docs auto-refresh ($SLUG)
+
+Runtime-seeded hold plan for the autonomous doc-fix run. Refreshes the docs the
+nightly Doc Freshness Audit flagged (issue #$ISSUE_NUM). Held for human merge.
+
+## Automouse Hold Justification
+
+auto_merge: false — this PR is opened autonomously by a self-hosted-runner Claude
+run with no human in the loop, and it modifies documentation a human should read
+before it lands. /post-plan Phase 6.5 condition (7) reads this frontmatter and
+refuses to arm auto-merge, leaving the PR open for a human to merge.
+PLAN_EOF
+
+# --- 6. Launch the detached headless doc-fix run ------------------------------
+TS=$(date +%Y%m%d-%H%M%S)
+LOG="/tmp/docfix-run-$SLUG-$TS.log"
+LABEL="com.ibl5.docfix-run-$SLUG-$TS"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+TODAY="$(date -u +%Y-%m-%d)"
+
+PROMPT="You are refreshing stale documentation with NO human present — never ask questions or wait for input; make the safe choice and continue. Refresh ONLY these docs (comma-separated paths): $SIG. For each: re-verify its content against the current reality of the codebase, correct drifted content, and bump its \`last_verified\` to today ($TODAY). Then run \`bin/check-docs --fix-dates --since=master\` to bump any in-scope doc you changed but did not hand-bump. Do NOT touch any doc outside the list above. Commit with a message whose body contains the line \`Closes #$ISSUE_NUM\`. Then fire \`bin/post-plan-now\` (NOT --auto) to open the PR; the PR body MUST include \`Closes #$ISSUE_NUM\` so merging it closes the stale-docs issue."
+
+# launchd runs a minimal env → same PATH prelude as bin/post-plan-now:94.
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>$LABEL</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-lc</string>
+		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$WT_IBL5" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>WorkingDirectory</key>
+	<string>$WT_IBL5</string>
+	<key>StandardOutPath</key>
+	<string>$LOG</string>
+	<key>StandardErrorPath</key>
+	<string>$LOG</string>
+</dict>
+</plist>
+PLIST_EOF
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+
+echo "docfix-run: fired detached doc-fix run on '$SLUG' (issue #$ISSUE_NUM)."
+echo "  worklist: $SIG"
+echo "  log:      tail -f $LOG"
+echo "  label:    $LABEL   (self-removes when the run finishes)"

--- a/bin/test-docfix-run
+++ b/bin/test-docfix-run
@@ -57,7 +57,7 @@ plan_of()  { ls "$1/home/.claude/plans/docs-stale-refresh-"*.md 2>/dev/null | he
 SB="$(build_sandbox)"
 run_docfix "$SB" "" "" "4242" "ibl5/docs/foo.md,README.md" >/dev/null
 P="$(plist_of "$SB")"; PLAN="$(plan_of "$SB")"
-{ [ -n "$P" ] && grep -q 'cd "'"$SB"'/wts/docs-stale-refresh-.*/ibl5"' "$P" \
+{ [ -n "$P" ] && grep -q 'cd "'"$SB"'/wts/docs-stale-refresh-[^/]*"' "$P" \
     && grep -q 'Closes #4242' "$P" \
     && grep -q 'ibl5/docs/foo.md,README.md' "$P" \
     && grep -q 'claude-sonnet-4-6' "$P"; } \

--- a/bin/test-docfix-run
+++ b/bin/test-docfix-run
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# bin/test-docfix-run — regression guard for bin/docfix-run plumbing (autonomy lever 3).
+# Runs docfix-run in a mktemp sandbox fake-repo against git/gh/launchctl shims and a
+# wt-new stub — nothing real is launched or worktree'd. Asserts plist/prompt/plan
+# composition, dedupe skip, and empty-arg rejection, plus a static gate assertion on
+# the workflow. Run: bin/test-docfix-run  (exit 0 = all pass).
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REAL_DOCFIX="$REPO_ROOT/bin/docfix-run"
+WORKFLOW="$REPO_ROOT/.github/workflows/doc-freshness-audit.yml"
+FAILED=0
+ok()   { echo "ok: $1"; }
+bad()  { echo "FAIL: $1"; FAILED=1; }
+
+# build_sandbox -> prints sandbox path with fake-repo + shims wired.
+build_sandbox() {
+    local SB; SB="$(mktemp -d)"
+    mkdir -p "$SB/bin/lib" "$SB/home/Library/LaunchAgents" "$SB/home/.claude/plans" "$SB/shim"
+    # NOTE: do NOT symlink docfix-run in — the test drives the REAL script with
+    # IBL5_MAIN=$SB, exercising prod's own anchoring code (a $0-relative regression
+    # would then be caught, not masked). Only wt-new + git-helpers are stubbed.
+    printf 'worktrees_parent_dir(){ echo "%s/wts"; }\n' "$SB" > "$SB/bin/lib/git-helpers.sh"
+    cat > "$SB/bin/wt-new" <<'W'
+#!/usr/bin/env bash
+mkdir -p "$(cd "$(dirname "$0")/.." && pwd)/wts/$1/ibl5"
+W
+    chmod +x "$SB/bin/wt-new"
+    # git shim: dedupe consults `git -C <root> branch --list <pat>`
+    cat > "$SB/shim/git" <<'G'
+#!/usr/bin/env bash
+for a in "$@"; do [ "$a" = "branch" ] && { printf '%s' "${SHIM_BRANCH_OUT:-}"; exit 0; }; done
+exit 0
+G
+    # gh shim: dedupe consults `gh pr list … --jq '.[].headRefName'`
+    printf '#!/usr/bin/env bash\nprintf "%%s" "${SHIM_PR_OUT:-}"\nexit 0\n' > "$SB/shim/gh"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$SB/shim/launchctl"
+    chmod +x "$SB/shim/git" "$SB/shim/gh" "$SB/shim/launchctl"
+    printf '%s' "$SB"
+}
+
+# run_docfix <sandbox> <branch-out> <pr-out> <issue> <sig> -> runs, echoes "rc=<code>"
+# Drives the REAL bin/docfix-run with IBL5_MAIN=$SB so prod's anchoring code is
+# what gets exercised (not a $0 accident).
+run_docfix() {
+    local SB="$1"
+    IBL5_MAIN="$SB" HOME="$SB/home" PATH="$SB/shim:$PATH" \
+        SHIM_BRANCH_OUT="$2" SHIM_PR_OUT="$3" \
+        "$REAL_DOCFIX" "$4" "$5" >/dev/null 2>&1
+    echo "rc=$?"
+}
+plist_of() { ls "$1/home/Library/LaunchAgents/"*.plist 2>/dev/null | head -1; }
+plan_of()  { ls "$1/home/.claude/plans/docs-stale-refresh-"*.md 2>/dev/null | head -1; }
+
+# --- Case 1 + 2: happy path composes plist + prompt + hold plan ---------------
+SB="$(build_sandbox)"
+run_docfix "$SB" "" "" "4242" "ibl5/docs/foo.md,README.md" >/dev/null
+P="$(plist_of "$SB")"; PLAN="$(plan_of "$SB")"
+{ [ -n "$P" ] && grep -q 'cd "'"$SB"'/wts/docs-stale-refresh-.*/ibl5"' "$P" \
+    && grep -q 'Closes #4242' "$P" \
+    && grep -q 'ibl5/docs/foo.md,README.md' "$P" \
+    && grep -q 'claude-sonnet-4-6' "$P"; } \
+  && ok "(1) plist carries cd-to-worktree + doc-fix prompt + SIG + Closes #N" \
+  || bad "(1) plist composition"
+{ [ -n "$PLAN" ] && head -1 "$PLAN" | grep -q '^---$' \
+    && grep -q '^auto_merge: false$' "$PLAN" \
+    && grep -q '## Automouse Hold Justification' "$PLAN"; } \
+  && ok "(2) held plan seeded with auto_merge:false + hold section" \
+  || bad "(2) hold plan seeding"
+
+# --- Case 3: dedupe skips (branch OR PR present) — no plist written ------------
+SB="$(build_sandbox)"
+run_docfix "$SB" "docs-stale-refresh-20260704" "" "1" "a.md" >/dev/null
+[ -z "$(plist_of "$SB")" ] && ok "(3a) dedupe-skip on existing branch (no plist)" \
+                           || bad "(3a) dedupe branch skip"
+SB="$(build_sandbox)"
+run_docfix "$SB" "" "docs-stale-refresh-20260703" "1" "a.md" >/dev/null
+[ -z "$(plist_of "$SB")" ] && ok "(3b) dedupe-skip on open PR head (no plist)" \
+                           || bad "(3b) dedupe PR skip"
+
+# --- Case 4 + 5: empty-arg rejection (nonzero, nothing written) ---------------
+SB="$(build_sandbox)"
+[ "$(run_docfix "$SB" "" "" "" "a.md")" != "rc=0" ] && [ -z "$(plist_of "$SB")" ] \
+  && ok "(4) empty issue-num rejected" || bad "(4) empty issue-num not rejected"
+SB="$(build_sandbox)"
+[ "$(run_docfix "$SB" "" "" "42" "")" != "rc=0" ] && [ -z "$(plist_of "$SB")" ] \
+  && ok "(5) empty sig rejected" || bad "(5) empty sig not rejected"
+
+# --- Case 6: workflow-gating static assertion ---------------------------------
+{ grep -q "if: needs.audit.outputs.notify == 'true'" "$WORKFLOW" \
+    && grep -qF 'bin/docfix-run "${{ needs.audit.outputs.issue-num }}" "${{ needs.audit.outputs.sig }}"' "$WORKFLOW" \
+    && grep -qF 'issue-num: ${{ steps.issue.outputs.issue-num }}' "$WORKFLOW"; } \
+  && ok "(6) docfix job gated on notify + passes issue-num & sig; audit exposes issue-num" \
+  || bad "(6) workflow gate/output wiring"
+
+if [ "$FAILED" -eq 0 ]; then echo "All docfix-run checks passed."; else echo "Some docfix-run checks FAILED."; fi
+exit "$FAILED"

--- a/ibl5/docs/decisions/0079-stale-docs-auto-remediation.md
+++ b/ibl5/docs/decisions/0079-stale-docs-auto-remediation.md
@@ -1,0 +1,81 @@
+---
+description: Act on the nightly stale-docs audit automatically — on a NEW/CHANGED stale set, a self-hosted macOS runner fires a headless Claude run that refreshes exactly the stale docs and opens a PR (held for human merge) that Closes the tracker issue.
+last_verified: 2026-07-04
+---
+
+# ADR-0079: Autonomous stale-docs remediation via a self-hosted macOS runner
+
+**Status:** Accepted
+**Date:** 2026-07-04
+
+## Context
+
+`.github/workflows/doc-freshness-audit.yml` runs nightly, computes the in-scope docs whose
+`last_verified` is past the 60-day window, and files/updates ONE idempotent `stale-docs` GitHub
+issue (carrying a `<!-- stale-set: <sig> -->` marker), setting `notify=='true'` only when the
+stale set is NEW or CHANGED. Today that is where the pipeline stops: the issue tracks the drift
+but nothing acts on it, so stale docs linger until a human notices the issue. We want the audit
+to REMEDIATE, not just report.
+
+## Decision
+
+On `notify=='true'`, a second job `docfix` (`needs: audit`, `runs-on: [self-hosted, macOS]`)
+runs one step — `bin/docfix-run "<issue-num>" "<sig>"` — on the owner's Mac. `bin/docfix-run`
+creates a worktree off master, seeds a hold plan, and launches a **detached headless Claude run**
+that refreshes exactly the docs in `<sig>`, then opens a PR that `Closes #<issue-num>`.
+
+1. **Transport = self-hosted macOS runner** (chosen over Tailscale-SSH). The remediation must run
+   on the owner's Mac (that is where the `claude` CLI, its auth, and the dev worktree tooling
+   live). A self-hosted runner is **pull-based**: the Mac polls GitHub over an outbound HTTPS
+   connection, so there is **no inbound networking, no SSH key/ACL to rotate, and no listening
+   service** to secure. Tailscale-SSH (push a command into the Mac from the Actions runner) was
+   rejected: it needs a tailnet, an auth key with rotation, and an ACL granting the CI runner SSH
+   into the dev machine — strictly more attack surface for the same effect.
+2. **The GitHub issue stays the tracker.** Its idempotency (one open issue, marker-diffed stale
+   set) already works; we do not replace it. The only new coupling is that the produced doc-fix
+   PR body carries `Closes #<issue-num>` so merging it closes the issue automatically.
+3. **The fix runs headless via the `bin/post-plan-now` launchd-detach pattern.** A plain
+   `nohup … &` spawned from a runner job shares the job's process group and dies when the job
+   ends; a launchd `RunAtLoad` one-shot (bootstrapped into the user GUI domain) survives the job,
+   exactly as `bin/post-plan-now` and `bin/automouse-run` already rely on. `bin/docfix-run` clones
+   that idiom, differing only in that it first creates the worktree and points the run at it.
+4. **The produced PR is HELD for human merge** (`auto_merge` NOT armed). `bin/docfix-run` seeds a
+   minimal plan at `$HOME/.claude/plans/<slug>.md` with line-1 frontmatter `auto_merge: false`;
+   the fix run ends with `bin/post-plan-now` (NOT `--auto`), and `/post-plan` Phase 6.5 condition
+   (7) reads that frontmatter and refuses to arm auto-merge. A machine-authored doc edit gets a
+   human read before it lands.
+
+## Consequences
+
+- **Positive:** stale docs are refreshed autonomously within a day of the audit flagging them,
+  with a human only in the merge loop. No new inbound network surface; reuses proven launchd and
+  post-plan machinery.
+- **Cost:** the pipeline now depends on the owner's Mac being online and registered as a runner;
+  when it is offline the `docfix` job simply queues/expires and the `stale-docs` issue remains as
+  the fallback tracker (no data loss — the next nightly re-fires on the unchanged set only if it
+  changed, per the `notify` gate).
+- **Security posture:** a self-hosted runner executes workflow code, so it is only acceptable on a
+  **private, single-owner repo** where all workflow code is trusted. Containment: the `docfix` job
+  is reachable ONLY via the `audit` job, which triggers on `schedule`/`workflow_dispatch` — never
+  on `pull_request` — so no untrusted fork PR code ever reaches the runner. The detached run uses
+  the Mac user's own persistent `gh auth login` credential (not the ephemeral Actions
+  `GITHUB_TOKEN`), and every PR it opens is HELD for human merge.
+
+## Operational setup (one-time, OUTSIDE the repo)
+
+Register the Mac as a self-hosted runner and its supporting tools. These are machine-local steps,
+not repo artifacts:
+
+1. Repo → Settings → Actions → Runners → **New self-hosted runner (macOS)**; copy the registration
+   token.
+2. On the Mac, in a runner dir, download the `actions/runner` release and configure it with the
+   labels this workflow selects on:
+   - `./config.sh --url https://github.com/<owner>/<repo> --token <TOKEN> --labels self-hosted,macOS --name ibl5-mac`
+3. Run the runner **as the logged-in user inside the GUI session** (not a root LaunchDaemon), so
+   its jobs inherit the user's login keychain, `PATH`, and `gui/$(id -u)` domain — which
+   `bin/docfix-run`'s `launchctl bootstrap "gui/$(id -u)"` and the detached run's keychain-backed
+   `gh`/`claude` all require. Use the actions/runner service installer under the login user
+   (`./svc.sh install <login-user> && ./svc.sh start`) or launch `./run.sh` in the user session.
+4. Prerequisites on the Mac PATH: the `claude` CLI (authenticated), `gh` (persistent
+   `gh auth login`, able to open PRs), `git` (worktree support), and `caffeinate` — the same tools
+   `bin/post-plan-now` assumes.


### PR DESCRIPTION
## Summary

Adds a fully-automated stale-docs remediation pipeline on top of the existing `doc-freshness-audit` workflow. When the nightly audit reports a new/changed stale set, a second CI job fires `bin/docfix-run` on the self-hosted macOS runner, which creates a worktree, seeds a hold plan, and launches a detached headless Claude run that refreshes exactly the stale docs and opens a PR that `Closes` the tracker issue.

### What changed
- `.github/workflows/doc-freshness-audit.yml` — promotes `notify`/`sig`/`issue-num` to job-level outputs; adds `issue-num` capture after the issue step's if/elif/fi block; appends the new `docfix` job targeting `[self-hosted, macOS]`
- `bin/docfix-run` — new Mac-side headless doc-fix launcher (validates args, dedupes, creates worktree, seeds `auto_merge: false` hold plan, fires launchd RunAtLoad one-shot)
- `bin/test-docfix-run` — mechanical self-check: shimmed sandbox harness, 6 assertion cases (plist/prompt composition, dedupe skip, empty-arg rejection, workflow gate)
- `.github/workflows/tests.yml` — registers `bin/test-docfix-run` in the CI `bin/test-*` suite
- `ibl5/docs/decisions/0079-stale-docs-auto-remediation.md` — ADR covering both `adr-check` triggers (`new-tool-script` + `ci-workflow`)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

## Automouse Hold Justification

`auto_merge: false` — **hold category = intrinsic** (not a reducible verification gap).

This PR stands up a **self-hosted-runner CI code-execution surface**: a macOS runner that executes workflow code on the owner's Mac and launches a headless `claude --dangerously-skip-permissions` run which will autonomously open PRs against the repo. Authorizing that is a one-time trust/security decision a human must make at merge. Every verification item in the matrix is mechanically checked — the hold is the **decision to grant CI code-execution on the dev Mac and let it auto-open PRs**, a governance choice no self-run check can substitute for.
