### PR TITLE
docs(runbook): note resolved IBLbot deploy OOM (#905)

### DIFF
--- a/ibl5/docs/OPERATIONS_RUNBOOK.md
+++ b/ibl5/docs/OPERATIONS_RUNBOOK.md
@@ -1,6 +1,6 @@
 ---
 description: Production operations runbook — deploy, rollback, DB restore, sim-file recovery, logs, and running the app without the Claude Code harness.
-last_verified: 2026-06-08
+last_verified: 2026-07-05
 ---
 
 # IBL5 Operations Runbook
@@ -33,6 +33,8 @@ git push origin <your-branch>:production
    - OPcache flush
    - IBL6 restart (pm2)
 3. **Post-deploy smoke** (`.github/workflows/smoke-prod.yml`) — curls `https://www.iblhoops.net` from the production box's own IP to avoid WAF bans. On real failure, auto-reverts the `production` branch and DMs Discord.
+
+> **Note — IBLbot slash-command OOM (resolved, #905):** registering IBLbot slash commands during deploy previously ran `tsx src/...`, which transpiles TypeScript through esbuild at runtime. On this memory-tight server the esbuild service was `SIGKILL`ed (`TransformError: The service was stopped`), failing the deploy. Fixed by running the compiled output (`npm run deploy-commands:prod` → `node dist/deploy-commands.js`, no runtime esbuild). The OOM path is gone — not a recurring failure. See the inline comment at `.github/workflows/main.yml` (IBLbot deploy step).
 
 ### Manual deploy (if GitHub Actions is unavailable)
 


### PR DESCRIPTION
## Summary

- Adds a callout note in the Deploy section documenting the now-resolved IBLbot slash-command OOM error (`TransformError: The service was stopped`) that previously occurred during deploys
- Notes the root cause (esbuild runtime transpile via `tsx` on a memory-tight server) and fix (`npm run deploy-commands:prod` → compiled `node dist/deploy-commands.js`)
- Points to the inline comment in `.github/workflows/main.yml` for context
- Bumps `last_verified` to 2026-07-05

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)