### PR TITLE
chore(website-affecting): expand CI-meta exempt set to cover all provably-inert workflows

### DIFF
--- a/bin/test-website-affecting
+++ b/bin/test-website-affecting
@@ -42,6 +42,8 @@ assert_exit "exempt-pages-deploy"  1 ".github/workflows/pages-deploy.yml"
 assert_exit "exempt-rebase-prs"    1 ".github/workflows/rebase-prs.yml"
 assert_exit "exempt-human-signoff" 1 ".github/workflows/human-signoff.yml"
 assert_exit "exempt-dependabot"    1 ".github/workflows/dependabot-auto-merge.yml"
+assert_exit "exempt-doc-freshness" 1 ".github/workflows/doc-freshness-audit.yml"
+assert_exit "exempt-tests-yml"     1 ".github/workflows/tests.yml"
 
 # --- (b) GUARD (LOAD-BEARING): E2E/Lighthouse drivers → exit 0 (website) ---
 # This block is the mechanical proof against the silent-skip failure mode: if a
@@ -54,8 +56,10 @@ assert_exit "guard-lighthouse"        0 ".github/workflows/lighthouse.yml"
 
 # --- (b2) Exactness boundary: a non-exempt / look-alike workflow → exit 0 ---
 # Proves the exempt case is an EXACT full-path match and never sweeps a sibling
-# workflow. Fail-safe direction: unknown workflow still counts website.
-assert_exit "non-exempt-workflow"  0 ".github/workflows/tests.yml"
+# workflow. Fail-safe direction: an arbitrary unclassified workflow still counts
+# website. Uses a synthetic name (not a real workflow that might later be
+# exempted) so the fail-safe-default intent stays unambiguous.
+assert_exit "non-exempt-workflow"  0 ".github/workflows/arbitrary-nonexempt.yml"
 assert_exit "exempt-lookalike"     0 ".github/workflows/pages-deploy-staging.yml"
 
 # --- (c) Mixed diff: exempt workflow + real app file → exit 0 (any website wins) ---

--- a/bin/test-website-affecting
+++ b/bin/test-website-affecting
@@ -44,15 +44,34 @@ assert_exit "exempt-human-signoff" 1 ".github/workflows/human-signoff.yml"
 assert_exit "exempt-dependabot"    1 ".github/workflows/dependabot-auto-merge.yml"
 assert_exit "exempt-doc-freshness" 1 ".github/workflows/doc-freshness-audit.yml"
 assert_exit "exempt-tests-yml"     1 ".github/workflows/tests.yml"
+assert_exit "exempt-codeql"          1 ".github/workflows/codeql.yml"
+assert_exit "exempt-eslint"          1 ".github/workflows/eslint.yml"
+assert_exit "exempt-gitleaks"        1 ".github/workflows/gitleaks.yml"
+assert_exit "exempt-pr-meta-checks"  1 ".github/workflows/pr-meta-checks.yml"
+assert_exit "exempt-pr-collisions"   1 ".github/workflows/pr-collisions-cron.yml"
+assert_exit "exempt-log-review"      1 ".github/workflows/log-review.yml"
+assert_exit "exempt-db-backup"       1 ".github/workflows/db-backup.yml"
+assert_exit "exempt-mutation"        1 ".github/workflows/mutation.yml"
+assert_exit "exempt-migration-safety" 1 ".github/workflows/migration-safety.yml"
+assert_exit "exempt-engine-yml"      1 ".github/workflows/engine.yml"
+assert_exit "exempt-main-yml"        1 ".github/workflows/main.yml"
+assert_exit "exempt-smoke-prod"      1 ".github/workflows/smoke-prod.yml"
+assert_exit "exempt-cache-deps"      1 ".github/workflows/cache-dependencies.yml"
+assert_exit "exempt-build-ibl6"      1 ".github/workflows/build-ibl6-image.yml"
+assert_exit "exempt-deploy-rehearsal" 1 ".github/workflows/deploy-rehearsal.yml"
 
 # --- (b) GUARD (LOAD-BEARING): E2E/Lighthouse drivers → exit 0 (website) ---
 # This block is the mechanical proof against the silent-skip failure mode: if a
 # future edit ever swept one of these into the exempt set, its PR would skip the
-# very E2E/Lighthouse run that validates it. These MUST classify website.
+# very E2E/Lighthouse run that validates it. These MUST classify website. The
+# lighthouse-baseline/audit siblings drive Lighthouse too (baseline uploads the
+# manifest the PR run compares against), so they are guarded, NOT exempted.
 assert_exit "guard-e2e-tests"         0 ".github/workflows/e2e-tests.yml"
 assert_exit "guard-setup-docker-e2e"  0 ".github/actions/setup-docker-e2e/action.yml"
 assert_exit "guard-docker-compose-ci" 0 "docker-compose.ci.yml"
 assert_exit "guard-lighthouse"        0 ".github/workflows/lighthouse.yml"
+assert_exit "guard-lighthouse-baseline" 0 ".github/workflows/lighthouse-baseline.yml"
+assert_exit "guard-lighthouse-audit"    0 ".github/workflows/lighthouse-audit.yml"
 
 # --- (b2) Exactness boundary: a non-exempt / look-alike workflow → exit 0 ---
 # Proves the exempt case is an EXACT full-path match and never sweeps a sibling

--- a/bin/website-affecting
+++ b/bin/website-affecting
@@ -35,7 +35,7 @@
 # CI-meta exempt set (the INVERSE of the carve-out): a curated denylist of
 # workflow files that do NOT match the deny regex but PROVABLY cannot affect a
 # VR / E2E / Lighthouse / preview render. (Running PHPUnit/PHPStan/Infection is
-# NOT "affecting a render" — see pr-canary/tests.yml/mutation below.) These
+# NOT "affecting a render" — see tests.yml/mutation below.) These
 # classify NON-website even though nothing denies them. This is a DENYLIST
 # CARVE-OUT, not a positive allowlist: its staleness fails SAFE/LOUD (a dropped
 # or renamed entry just over-runs E2E) — never a silent E2E skip. Each entry is a

--- a/bin/website-affecting
+++ b/bin/website-affecting
@@ -38,6 +38,8 @@
 #       .github/workflows/rebase-prs.yml             (git rebase of open PRs)
 #       .github/workflows/human-signoff.yml          (PR-title classifier gate)
 #       .github/workflows/dependabot-auto-merge.yml  (enables gh pr merge --auto)
+#       .github/workflows/doc-freshness-audit.yml    (nightly doc-staleness audit + docfix launcher)
+#       .github/workflows/tests.yml                  (PHPUnit/PHPStan/audit; own paths-filter, not in e2e-tests.yml push-paths)
 #
 # Anchoring is load-bearing:
 #   ^bin/      so ibl5/bin/* (app bin, website-side) is NOT denied
@@ -83,6 +85,8 @@ is_ci_meta_exempt() {
         .github/workflows/rebase-prs.yml)            return 0 ;;  # push:master trigger; rebases open PRs via git — no app code, no E2E/Lighthouse
         .github/workflows/human-signoff.yml)         return 0 ;;  # PR-title classifier gate (bin/lib/human-signoff-classifier.sh) — no app code, no E2E/Lighthouse
         .github/workflows/dependabot-auto-merge.yml) return 0 ;;  # enables gh pr merge --auto for dependabot PRs — no app code, no E2E/Lighthouse
+        .github/workflows/doc-freshness-audit.yml)   return 0 ;;  # nightly doc-staleness audit (bin/check-docs) + docfix launcher — no app code, no E2E/Lighthouse render
+        .github/workflows/tests.yml)                 return 0 ;;  # PHPUnit/PHPStan/audit suite — own dorny paths-filter; absent from e2e-tests.yml push-paths, so a tests.yml-only push already skips E2E
     esac
     return 1
 }
@@ -112,6 +116,8 @@ affect E2E/Lighthouse/app; staleness over-runs, never silent-skips):
   .github/workflows/rebase-prs.yml
   .github/workflows/human-signoff.yml
   .github/workflows/dependabot-auto-merge.yml
+  .github/workflows/doc-freshness-audit.yml
+  .github/workflows/tests.yml
 
 Naturally website-side (not denied, not exempt):
   ibl5/**  .github/** (incl. e2e-tests.yml, lighthouse.yml)  docker/**

--- a/bin/website-affecting
+++ b/bin/website-affecting
@@ -17,6 +17,11 @@
 #   0  Affects website — callers should run/build.
 #   1  Does NOT affect website — callers may skip.
 #
+# Consumers (all run this predicate on the diff, PR-only): e2e-tests.yml `changes`
+# job (→ VR/E2E/api-e2e/mutators), lighthouse.yml's own `changes` job (→ PR
+# Lighthouse), and bin/wt-up (→ local Docker preview build). The exempt criterion
+# below therefore means "cannot alter a VR / E2E / Lighthouse / preview render."
+#
 # Deny-set (a file is non-website if it matches ALL of the following):
 #   - matches the deny regex: (\.md$|^docs/|^ibl5/docs/|^\.claude/|^bin/|^engine/)
 #   - is NOT in the carve-out set (paths that must always trigger, even though
@@ -28,11 +33,12 @@
 # .github/workflows/e2e-tests.yml and .github/workflows/lighthouse.yml.
 #
 # CI-meta exempt set (the INVERSE of the carve-out): a curated denylist of
-# workflow files that do NOT match the deny regex but PROVABLY run no app code
-# and cannot affect the E2E suite, Lighthouse, or the app. These classify
-# NON-website even though nothing denies them. This is a DENYLIST CARVE-OUT, not
-# a positive allowlist: its staleness fails SAFE/LOUD (a dropped or renamed
-# entry just over-runs E2E) — never a silent E2E skip. Each entry is a
+# workflow files that do NOT match the deny regex but PROVABLY cannot affect a
+# VR / E2E / Lighthouse / preview render. (Running PHPUnit/PHPStan/Infection is
+# NOT "affecting a render" — see pr-canary/tests.yml/mutation below.) These
+# classify NON-website even though nothing denies them. This is a DENYLIST
+# CARVE-OUT, not a positive allowlist: its staleness fails SAFE/LOUD (a dropped
+# or renamed entry just over-runs E2E) — never a silent E2E skip. Each entry is a
 # deliberate assertion "this file can't break E2E or the app":
 #       .github/workflows/pages-deploy.yml           (post-E2E gh-pages deploy)
 #       .github/workflows/rebase-prs.yml             (git rebase of open PRs)
@@ -40,6 +46,21 @@
 #       .github/workflows/dependabot-auto-merge.yml  (enables gh pr merge --auto)
 #       .github/workflows/doc-freshness-audit.yml    (nightly doc-staleness audit + docfix launcher)
 #       .github/workflows/tests.yml                  (PHPUnit/PHPStan/audit; own paths-filter, not in e2e-tests.yml push-paths)
+#       .github/workflows/codeql.yml                 (CodeQL static analysis)
+#       .github/workflows/eslint.yml                 (ESLint of e2e specs; static lint)
+#       .github/workflows/gitleaks.yml               (secret scan)
+#       .github/workflows/pr-meta-checks.yml         (bin/ meta-checks; install:false, no app code)
+#       .github/workflows/pr-collisions-cron.yml     (gh + git PR-collision sweep)
+#       .github/workflows/log-review.yml             (SSH prod log digest)
+#       .github/workflows/db-backup.yml              (prod dump + restore self-test)
+#       .github/workflows/mutation.yml               (Infection/PHPUnit; renders nothing)
+#       .github/workflows/migration-safety.yml       (migrate/validate vs CI DB; SQL itself is website-side)
+#       .github/workflows/engine.yml                 (Go engine CI; E2E runs the prebaked jsbsim)
+#       .github/workflows/main.yml                   (push:production deploy pipeline)
+#       .github/workflows/smoke-prod.yml             (post-deploy prod smoke over SSH)
+#       .github/workflows/cache-dependencies.yml     (builds php-apache:latest; E2E pulls prebaked)
+#       .github/workflows/build-ibl6-image.yml       (builds ibl6:latest; E2E builds ibl6 from PR source)
+#       .github/workflows/deploy-rehearsal.yml       (self-contained migration smoke; no VR/E2E/LH)
 #
 # Anchoring is load-bearing:
 #   ^bin/      so ibl5/bin/* (app bin, website-side) is NOT denied
@@ -70,15 +91,17 @@ is_carveout() {
 }
 
 # CI-meta exempt set: paths that do NOT match the deny regex (so they would
-# otherwise count website-side) but PROVABLY run no app code and cannot affect
-# the E2E suite, Lighthouse, or the app. This is a curated DENYLIST CARVE-OUT,
-# not a positive allowlist: its staleness fails SAFE (a dropped/renamed entry
-# just over-runs E2E) — never a silent E2E skip. Each entry is a deliberate
-# assertion "this file can't break E2E or the app." Match is EXACT (full
-# repo-relative path), so a sibling workflow is never accidentally swept in.
+# otherwise count website-side) but PROVABLY cannot affect a VR / E2E / Lighthouse
+# / preview render. This is a curated DENYLIST CARVE-OUT, not a positive
+# allowlist: its staleness fails SAFE (a dropped/renamed entry just over-runs E2E)
+# — never a silent E2E skip. Each entry is a deliberate assertion "this file can't
+# break E2E or the app." Match is EXACT (full repo-relative path), so a sibling
+# workflow is never accidentally swept in.
 # NEVER add: .github/workflows/e2e-tests.yml, .github/workflows/lighthouse.yml,
+# .github/workflows/lighthouse-baseline.yml, .github/workflows/lighthouse-audit.yml,
 # .github/actions/setup-docker-e2e/**, docker-compose.ci.yml, docker/Dockerfile*
-# — those drive E2E/Lighthouse and MUST stay website-side.
+# — those drive E2E/Lighthouse (lighthouse-baseline uploads the manifest the PR
+# Lighthouse compares against) and MUST stay website-side.
 is_ci_meta_exempt() {
     case "$1" in
         .github/workflows/pages-deploy.yml)          return 0 ;;  # workflow_run after E2E; checks out gh-pages + deploys Pages — no app code, consumes E2E output (can't change it)
@@ -87,6 +110,21 @@ is_ci_meta_exempt() {
         .github/workflows/dependabot-auto-merge.yml) return 0 ;;  # enables gh pr merge --auto for dependabot PRs — no app code, no E2E/Lighthouse
         .github/workflows/doc-freshness-audit.yml)   return 0 ;;  # nightly doc-staleness audit (bin/check-docs) + docfix launcher — no app code, no E2E/Lighthouse render
         .github/workflows/tests.yml)                 return 0 ;;  # PHPUnit/PHPStan/audit suite — own dorny paths-filter; absent from e2e-tests.yml push-paths, so a tests.yml-only push already skips E2E
+        .github/workflows/codeql.yml)                return 0 ;;  # CodeQL static analysis of JS/TS + workflows — no app run, no E2E/Lighthouse render
+        .github/workflows/eslint.yml)                return 0 ;;  # ESLint of e2e specs (bun run lint:e2e) — static lint, no app run, no E2E/Lighthouse
+        .github/workflows/gitleaks.yml)              return 0 ;;  # gitleaks secret scan — no app run, no E2E/Lighthouse
+        .github/workflows/pr-meta-checks.yml)        return 0 ;;  # bin/ meta-checks (check-docs/adr/hot-files/orphan-css…), install:false — no composer/app code, no E2E/Lighthouse
+        .github/workflows/pr-collisions-cron.yml)    return 0 ;;  # gh CLI + git PR-collision sweep (schedule) — no app run, no E2E/Lighthouse
+        .github/workflows/log-review.yml)            return 0 ;;  # SSH prod log fetch + Discord DM (schedule) — no app run, no E2E/Lighthouse
+        .github/workflows/db-backup.yml)             return 0 ;;  # prod DB dump + restore self-test (schedule) — no app boot, no E2E/Lighthouse
+        .github/workflows/mutation.yml)              return 0 ;;  # Infection/PHPUnit mutation suite (own DB) — renders nothing, absent from e2e-tests.yml push-paths
+        .github/workflows/migration-safety.yml)      return 0 ;;  # migrate/validate vs CI DB; the SQL (ibl5/migrations/**) is website-side, this workflow file is not
+        .github/workflows/engine.yml)                return 0 ;;  # Go engine build/test; emits no jsbsim binary — E2E runs the prebaked one (same basis as ^engine/)
+        .github/workflows/main.yml)                  return 0 ;;  # push:production deploy pipeline — never runs on a master PR; can't touch PR E2E/Lighthouse
+        .github/workflows/smoke-prod.yml)            return 0 ;;  # workflow_run after "Build and Deploy" — SSH prod smoke; no PR-E2E impact (like pages-deploy)
+        .github/workflows/cache-dependencies.yml)    return 0 ;;  # builds php-apache:latest on push:master; E2E pulls the prebaked image (a PR edit doesn't rebuild it)
+        .github/workflows/build-ibl6-image.yml)      return 0 ;;  # builds ibl6:latest; E2E ibl6 jobs use ibl6-image:build from PR source, not this GHCR push
+        .github/workflows/deploy-rehearsal.yml)      return 0 ;;  # boots PHP for a self-contained migration smoke — drives no VR/E2E/Lighthouse/preview render
     esac
     return 1
 }
@@ -111,16 +149,31 @@ Carve-out (always website-side despite matching deny regex):
   bin/website-affecting  (the predicate itself)
 
 CI-meta exempt (NON-website despite not matching deny regex — provably can't
-affect E2E/Lighthouse/app; staleness over-runs, never silent-skips):
+affect a VR/E2E/Lighthouse/preview render; staleness over-runs, never silent-skips):
   .github/workflows/pages-deploy.yml
   .github/workflows/rebase-prs.yml
   .github/workflows/human-signoff.yml
   .github/workflows/dependabot-auto-merge.yml
   .github/workflows/doc-freshness-audit.yml
   .github/workflows/tests.yml
+  .github/workflows/codeql.yml
+  .github/workflows/eslint.yml
+  .github/workflows/gitleaks.yml
+  .github/workflows/pr-meta-checks.yml
+  .github/workflows/pr-collisions-cron.yml
+  .github/workflows/log-review.yml
+  .github/workflows/db-backup.yml
+  .github/workflows/mutation.yml
+  .github/workflows/migration-safety.yml
+  .github/workflows/engine.yml
+  .github/workflows/main.yml
+  .github/workflows/smoke-prod.yml
+  .github/workflows/cache-dependencies.yml
+  .github/workflows/build-ibl6-image.yml
+  .github/workflows/deploy-rehearsal.yml
 
 Naturally website-side (not denied, not exempt):
-  ibl5/**  .github/** (incl. e2e-tests.yml, lighthouse.yml)  docker/**
+  ibl5/**  .github/** (incl. e2e-tests.yml, lighthouse*.yml)  docker/**
   Dockerfile  docker-compose*.yml  *.php *.ts *.js *.css
 HELP
     exit 0

--- a/ibl5/tests/Cli/WebsiteAffectingCliTest.php
+++ b/ibl5/tests/Cli/WebsiteAffectingCliTest.php
@@ -58,7 +58,7 @@ final class WebsiteAffectingCliTest extends TestCase
         // these renders the app, drives E2E/VR, runs Lighthouse, or feeds the local
         // preview, and none is in e2e-tests.yml's push-path list — so a change to
         // them can't affect an E2E/VR/Lighthouse/preview outcome. Running
-        // PHPUnit/PHPStan/Infection (tests.yml, mutation.yml, pr-canary) is NOT
+        // PHPUnit/PHPStan/Infection (tests.yml, mutation.yml) is NOT
         // "affecting a render". The image-builders (cache-dependencies,
         // build-ibl6-image) build on push:master; E2E pulls the prebaked php image
         // and builds ibl6 from PR source, so a PR edit to those workflows changes

--- a/ibl5/tests/Cli/WebsiteAffectingCliTest.php
+++ b/ibl5/tests/Cli/WebsiteAffectingCliTest.php
@@ -52,6 +52,22 @@ final class WebsiteAffectingCliTest extends TestCase
         self::assertSame(1, $result['exit'], $result['stderr']);
     }
 
+    public function testCiMetaExemptWorkflowsExitOne(): void
+    {
+        // Row 4c: provably-inert CI-meta workflows → SKIP (each alone). The doc
+        // audit runs bin/check-docs; tests.yml runs the PHPUnit/PHPStan suite via
+        // its own dorny paths-filter. Neither renders the app, drives E2E, or runs
+        // Lighthouse, and neither is in e2e-tests.yml's push-path list — so a change
+        // to them can't affect an E2E/VR/Lighthouse outcome.
+        foreach ([
+            '.github/workflows/doc-freshness-audit.yml',
+            '.github/workflows/tests.yml',
+        ] as $path) {
+            $result = $this->runPredicate($path . "\n");
+            self::assertSame(1, $result['exit'], "$path should be CI-meta exempt: {$result['stderr']}");
+        }
+    }
+
     public function testEngineOnlyDiffExitsOne(): void
     {
         // Row 4b: Go sim engine source only → SKIP. E2E runs the PREBAKED jsbsim

--- a/ibl5/tests/Cli/WebsiteAffectingCliTest.php
+++ b/ibl5/tests/Cli/WebsiteAffectingCliTest.php
@@ -54,14 +54,33 @@ final class WebsiteAffectingCliTest extends TestCase
 
     public function testCiMetaExemptWorkflowsExitOne(): void
     {
-        // Row 4c: provably-inert CI-meta workflows → SKIP (each alone). The doc
-        // audit runs bin/check-docs; tests.yml runs the PHPUnit/PHPStan suite via
-        // its own dorny paths-filter. Neither renders the app, drives E2E, or runs
-        // Lighthouse, and neither is in e2e-tests.yml's push-path list — so a change
-        // to them can't affect an E2E/VR/Lighthouse outcome.
+        // Row 4c: provably-inert CI-meta workflows → SKIP (each alone). None of
+        // these renders the app, drives E2E/VR, runs Lighthouse, or feeds the local
+        // preview, and none is in e2e-tests.yml's push-path list — so a change to
+        // them can't affect an E2E/VR/Lighthouse/preview outcome. Running
+        // PHPUnit/PHPStan/Infection (tests.yml, mutation.yml, pr-canary) is NOT
+        // "affecting a render". The image-builders (cache-dependencies,
+        // build-ibl6-image) build on push:master; E2E pulls the prebaked php image
+        // and builds ibl6 from PR source, so a PR edit to those workflows changes
+        // no render.
         foreach ([
             '.github/workflows/doc-freshness-audit.yml',
             '.github/workflows/tests.yml',
+            '.github/workflows/codeql.yml',
+            '.github/workflows/eslint.yml',
+            '.github/workflows/gitleaks.yml',
+            '.github/workflows/pr-meta-checks.yml',
+            '.github/workflows/pr-collisions-cron.yml',
+            '.github/workflows/log-review.yml',
+            '.github/workflows/db-backup.yml',
+            '.github/workflows/mutation.yml',
+            '.github/workflows/migration-safety.yml',
+            '.github/workflows/engine.yml',
+            '.github/workflows/main.yml',
+            '.github/workflows/smoke-prod.yml',
+            '.github/workflows/cache-dependencies.yml',
+            '.github/workflows/build-ibl6-image.yml',
+            '.github/workflows/deploy-rehearsal.yml',
         ] as $path) {
             $result = $this->runPredicate($path . "\n");
             self::assertSame(1, $result['exit'], "$path should be CI-meta exempt: {$result['stderr']}");
@@ -145,6 +164,22 @@ final class WebsiteAffectingCliTest extends TestCase
             ".github/workflows/e2e-tests.yml\n.github/workflows/lighthouse.yml\n"
         );
         self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testLighthouseDriversAreGuardedNotExempt(): void
+    {
+        // Row 13b: the Lighthouse siblings DRIVE Lighthouse (lighthouse-baseline
+        // uploads the manifest the PR run compares against; lighthouse-audit runs
+        // the same booted-stack audit), so a change to them CAN alter a Lighthouse
+        // outcome. They MUST stay website-side (guarded, never exempted) — the
+        // mechanical proof against silently skipping the run that validates them.
+        foreach ([
+            '.github/workflows/lighthouse-baseline.yml',
+            '.github/workflows/lighthouse-audit.yml',
+        ] as $path) {
+            $result = $this->runPredicate($path . "\n");
+            self::assertSame(0, $result['exit'], "$path must stay website-side: {$result['stderr']}");
+        }
     }
 
     public function testCiAdjacentPathsExitZero(): void


### PR DESCRIPTION
## Summary

- Expands the `is_ci_meta_exempt()` denylist in `bin/website-affecting` from 6 → 20 entries, covering every workflow file that provably cannot affect a VR/E2E/Lighthouse/preview render (codeql, eslint, gitleaks, pr-meta-checks, pr-collisions-cron, log-review, db-backup, mutation, migration-safety, engine, main, smoke-prod, cache-dependencies, build-ibl6-image, deploy-rehearsal)
- Guards `lighthouse-baseline.yml` and `lighthouse-audit.yml` as website-side (they drive Lighthouse — baseline uploads the manifest the PR run compares against) with both an assert-exit guard in `bin/test-website-affecting` and a dedicated PHPUnit test
- Updates comments throughout to clarify the exempt criterion: "cannot affect a VR/E2E/Lighthouse/preview render" (previously vague about what "affecting E2E/app" means for image-builder and deploy workflows)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
