### PR TITLE
fix(ci): remove --no-output so --testdox-summary output appears in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,7 +275,7 @@ jobs:
         DB_USER: root
         DB_PASS: root
         DB_NAME: ibl5
-      run: vendor/bin/phpunit --group database --no-progress --no-output --testdox-summary
+      run: vendor/bin/phpunit --group database --no-progress --testdox-summary
 
   phpstan:
     name: PHPStan Analysis


### PR DESCRIPTION
## Summary

- Removes `--no-output` from the PHPUnit database integration job in `tests.yml`
- `--no-output` suppresses all PHPUnit output including the testdox summary, defeating `--testdox-summary` entirely
- With the flag removed, CI now shows the testdox summary as intended

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.