### PR TITLE
feat: Discord bug pipeline PHP queue layer — BugReportRepository + 6 API endpoints

### DIFF
--- a/ibl5/api.php
+++ b/ibl5/api.php
@@ -40,6 +40,24 @@ $app->getContainer()->set('api.controllerFactory', static function (): \Closure 
             return new $controllerClass($db, $commonRepo);
         }
 
+        if ($controllerClass === \Api\Controller\EnqueueController::class) {
+            return new \Api\Controller\EnqueueController(
+                new \BugPipeline\BugReportRepository($db),
+                new \Repositories\TeamIdentityRepository($db)
+            );
+        }
+
+        $bugPipelineControllers = [
+            \Api\Controller\ThreadReplyController::class,
+            \Api\Controller\ReactionController::class,
+            \Api\Controller\LastSeenController::class,
+            \Api\Controller\PipelineStateController::class,
+            \Api\Controller\ThreadByPrController::class,
+        ];
+        if (in_array($controllerClass, $bugPipelineControllers, true)) {
+            return new $controllerClass(new \BugPipeline\BugReportRepository($db));
+        }
+
         return new $controllerClass($db);
     };
 });

--- a/ibl5/classes/Api/Controller/EnqueueController.php
+++ b/ibl5/classes/Api/Controller/EnqueueController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Controller;
+
+use Api\Contracts\ControllerInterface;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use Repositories\Contracts\TeamIdentityRepositoryInterface;
+
+class EnqueueController implements ControllerInterface
+{
+    private BugReportRepository $bugRepo;
+    private TeamIdentityRepositoryInterface $teamRepo;
+
+    public function __construct(BugReportRepository $bugRepo, TeamIdentityRepositoryInterface $teamRepo)
+    {
+        $this->bugRepo = $bugRepo;
+        $this->teamRepo = $teamRepo;
+    }
+
+    /**
+     * @see ControllerInterface::handle()
+     */
+    public function handle(array $params, array $query, JsonResponder $responder, ?array $body = null): void
+    {
+        if ($body === null) {
+            $responder->error(400, 'bad_request', 'Missing request body.');
+            return;
+        }
+
+        // Snowflakes read as strings — never (int)-cast. Text required non-empty.
+        $authorId  = $body['author_id']  ?? null;
+        $channelId = $body['channel_id'] ?? null;
+        $messageId = $body['message_id'] ?? null;
+        $text      = $body['text']       ?? null;
+
+        if (!is_string($authorId) || $authorId === ''
+            || !is_string($channelId) || $channelId === ''
+            || !is_string($messageId) || $messageId === ''
+            || !is_string($text) || $text === ''
+        ) {
+            $responder->error(400, 'bad_request', 'Missing author_id, channel_id, message_id, or text.');
+            return;
+        }
+
+        // Authz: only known GMs enqueue. Snowflake compared as a string in the repo.
+        if (!$this->teamRepo->isKnownDiscordID($authorId)) {
+            // Unauthorized: no report row, but STILL advance the channel watermark so the
+            // message isn't re-fetched forever. Monotonic upsert — never regresses.
+            $this->bugRepo->upsertPipelineState($channelId, $messageId);
+            $responder->success(['authorized' => false, 'report_id' => null]);
+            return;
+        }
+
+        // Authorized: INSERT + watermark advance run atomically & idempotently inside the repo
+        // (crash-safe, replay-safe — see enqueueAuthorizedAndAdvance).
+        $reportId = $this->bugRepo->enqueueAuthorizedAndAdvance($authorId, $channelId, $messageId, $text);
+        $responder->success(['authorized' => true, 'report_id' => $reportId]);
+    }
+}

--- a/ibl5/classes/Api/Controller/LastSeenController.php
+++ b/ibl5/classes/Api/Controller/LastSeenController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Controller;
+
+use Api\Contracts\ControllerInterface;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+
+class LastSeenController implements ControllerInterface
+{
+    private BugReportRepository $bugRepo;
+
+    public function __construct(BugReportRepository $bugRepo)
+    {
+        $this->bugRepo = $bugRepo;
+    }
+
+    /**
+     * @see ControllerInterface::handle()
+     */
+    public function handle(array $params, array $query, JsonResponder $responder, ?array $body = null): void
+    {
+        $channelId = $body['channel_id'] ?? null;
+        $messageId = $body['message_id'] ?? null;
+        if (!is_string($channelId) || $channelId === '' || !is_string($messageId) || $messageId === '') {
+            $responder->error(400, 'bad_request', 'Missing channel_id or message_id.');
+            return;
+        }
+
+        $this->bugRepo->upsertPipelineState($channelId, $messageId);
+        $responder->success(['ok' => true]);
+    }
+}

--- a/ibl5/classes/Api/Controller/PipelineStateController.php
+++ b/ibl5/classes/Api/Controller/PipelineStateController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Controller;
+
+use Api\Contracts\ControllerInterface;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+
+class PipelineStateController implements ControllerInterface
+{
+    private BugReportRepository $bugRepo;
+
+    public function __construct(BugReportRepository $bugRepo)
+    {
+        $this->bugRepo = $bugRepo;
+    }
+
+    /**
+     * @see ControllerInterface::handle()
+     */
+    public function handle(array $params, array $query, JsonResponder $responder, ?array $body = null): void
+    {
+        $channelId = $body['channel_id'] ?? null;
+        if (!is_string($channelId) || $channelId === '') {
+            $responder->error(400, 'bad_request', 'Missing channel_id.');
+            return;
+        }
+        // null on first boot is a valid response (PR #4 treats it as "no cursor → start fresh").
+        $responder->success(['last_processed_message_id' => $this->bugRepo->findPipelineState($channelId)]);
+    }
+}

--- a/ibl5/classes/Api/Controller/ReactionController.php
+++ b/ibl5/classes/Api/Controller/ReactionController.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Controller;
+
+use Api\Contracts\ControllerInterface;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use Discord\Discord;
+
+class ReactionController implements ControllerInterface
+{
+    private const APPROVAL_EMOJI = '✅';
+
+    private BugReportRepository $bugRepo;
+
+    public function __construct(BugReportRepository $bugRepo)
+    {
+        $this->bugRepo = $bugRepo;
+    }
+
+    /**
+     * @see ControllerInterface::handle()
+     */
+    public function handle(array $params, array $query, JsonResponder $responder, ?array $body = null): void
+    {
+        $messageId = $body['message_id'] ?? null;
+        $emoji     = $body['emoji']      ?? null;
+        $reactorId = $body['reactor_id'] ?? null;
+        if (!is_string($messageId) || $messageId === ''
+            || !is_string($emoji) || $emoji === ''
+            || !is_string($reactorId) || $reactorId === ''
+        ) {
+            $responder->error(400, 'bad_request', 'Missing message_id, emoji, or reactor_id.');
+            return;
+        }
+
+        // Gate 1 (emoji) AND Gate 2 (approver identity, string compare). Empty approver
+        // (unconfigured) never equals a real snowflake => fail-closed, no advance.
+        $approverId = Discord::getBugPipelineApproverDiscordId();
+        $isApproval = $emoji === self::APPROVAL_EMOJI && $reactorId === $approverId;
+
+        // advanceOnApproval adds Gate 3 (status='awaiting_ajay') and is a no-op otherwise.
+        $advanced = $isApproval ? $this->bugRepo->advanceOnApproval($messageId) : false;
+        $responder->success(['advanced' => $advanced]);
+    }
+}

--- a/ibl5/classes/Api/Controller/ThreadByPrController.php
+++ b/ibl5/classes/Api/Controller/ThreadByPrController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Controller;
+
+use Api\Contracts\ControllerInterface;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+
+class ThreadByPrController implements ControllerInterface
+{
+    private BugReportRepository $bugRepo;
+
+    public function __construct(BugReportRepository $bugRepo)
+    {
+        $this->bugRepo = $bugRepo;
+    }
+
+    /**
+     * @see ControllerInterface::handle()
+     */
+    public function handle(array $params, array $query, JsonResponder $responder, ?array $body = null): void
+    {
+        // pr_number is a PR number (small int), NOT a snowflake — safe to coerce. Accept a JSON
+        // int OR a numeric string: the GH-action → bot → PHP hop may stringify it via jq.
+        $raw = $body['pr_number'] ?? null;
+        if (!is_int($raw) && !(is_string($raw) && ctype_digit($raw))) {
+            $responder->error(400, 'bad_request', 'Missing or invalid pr_number.');
+            return;
+        }
+        $prNumber = (int) $raw;
+        if ($prNumber <= 0) {
+            $responder->error(400, 'bad_request', 'Missing or invalid pr_number.');
+            return;
+        }
+        // null (no row for that PR, or no thread yet) is valid — PR #4's /prMerged no-ops on null.
+        $responder->success(['thread_id' => $this->bugRepo->findThreadIdByPrNumber($prNumber)]);
+    }
+}

--- a/ibl5/classes/Api/Controller/ThreadReplyController.php
+++ b/ibl5/classes/Api/Controller/ThreadReplyController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Api\Controller;
+
+use Api\Contracts\ControllerInterface;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+
+class ThreadReplyController implements ControllerInterface
+{
+    private BugReportRepository $bugRepo;
+
+    public function __construct(BugReportRepository $bugRepo)
+    {
+        $this->bugRepo = $bugRepo;
+    }
+
+    /**
+     * @see ControllerInterface::handle()
+     */
+    public function handle(array $params, array $query, JsonResponder $responder, ?array $body = null): void
+    {
+        $threadId  = $body['thread_id']  ?? null;
+        $messageId = $body['message_id'] ?? null;
+        if (!is_string($threadId) || $threadId === '' || !is_string($messageId) || $messageId === '') {
+            $responder->error(400, 'bad_request', 'Missing thread_id or message_id.');
+            return;
+        }
+
+        // Keyed on thread_id; message_id is not used for matching (see stampThreadReply).
+        // No pipeline-state upsert here — payload carries no channel_id (resolved decision).
+        $matched = $this->bugRepo->stampThreadReply($threadId);
+        $responder->success(['matched' => $matched]);
+    }
+}

--- a/ibl5/classes/Api/Router.php
+++ b/ibl5/classes/Api/Router.php
@@ -43,8 +43,14 @@ class Router implements RouterInterface
 
     /** @var array<string, string> POST route patterns to controller class names. */
     private const POST_ROUTES = [
-        'trades/{offerId}/accept'  => Controller\TradeAcceptController::class,
-        'trades/{offerId}/decline' => Controller\TradeDeclineController::class,
+        'trades/{offerId}/accept'   => Controller\TradeAcceptController::class,
+        'trades/{offerId}/decline'  => Controller\TradeDeclineController::class,
+        'bug-pipeline/enqueue'      => Controller\EnqueueController::class,
+        'bug-pipeline/thread-reply' => Controller\ThreadReplyController::class,
+        'bug-pipeline/reaction'     => Controller\ReactionController::class,
+        'bug-pipeline/last-seen'    => Controller\LastSeenController::class,
+        'bug-pipeline/state'        => Controller\PipelineStateController::class,
+        'bug-pipeline/thread-by-pr' => Controller\ThreadByPrController::class,
     ];
 
     /**

--- a/ibl5/classes/BugPipeline/BugReportRepository.php
+++ b/ibl5/classes/BugPipeline/BugReportRepository.php
@@ -1,0 +1,387 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BugPipeline;
+
+/**
+ * Single source of all queue DB logic for the Discord bug pipeline.
+ *
+ * All snowflake columns are (string)-cast on read (see castRow()) because
+ * db/db.php:100 sets MYSQLI_OPT_INT_AND_FLOAT_NATIVE — BIGINT reads back as
+ * PHP int, and json_encode of a bare int loses precision above 2^53.
+ *
+ * @phpstan-type BugReportRow array{
+ *   id: int,
+ *   discord_author_id: string,
+ *   channel_id: string,
+ *   original_message_id: string,
+ *   original_text: string,
+ *   thread_id: ?string,
+ *   class: ?string,
+ *   status: string,
+ *   lease_owner: ?string,
+ *   lease_expires: ?string,
+ *   hunt_attempts: int,
+ *   pr_number: ?int,
+ *   issue_number: ?int,
+ *   approval_message_id: ?string,
+ *   blocked_until: ?string,
+ *   last_gm_reply_at: ?string,
+ *   last_processed_at: ?string,
+ *   reminder_sent_at: ?string,
+ *   created_at: string,
+ *   updated_at: string
+ * }
+ */
+class BugReportRepository extends \BaseMysqliRepository
+{
+    /** Snowflake columns of ibl_bug_reports that must serialize as JSON strings (see db.php:100). */
+    private const SNOWFLAKE_COLUMNS = [
+        'discord_author_id',
+        'channel_id',
+        'original_message_id',
+        'thread_id',
+        'approval_message_id',
+    ];
+
+    /**
+     * Optional column => mysqli type map for transition(). Column names are compile-time
+     * literals from this fixed map (never caller input); values are always bound.
+     *
+     * @var array<string, string>
+     */
+    private const OPTIONAL_TRANSITION_COLUMNS = [
+        'class'               => 's',
+        'pr_number'           => 'i',
+        'issue_number'        => 'i',
+        'thread_id'           => 's',
+        'approval_message_id' => 's',
+        'blocked_until'       => 's',
+        'hunt_attempts'       => 'i',
+    ];
+
+    /**
+     * @param array<string, mixed> $row
+     * @phpstan-return BugReportRow
+     */
+    private function castRow(array $row): array
+    {
+        foreach (self::SNOWFLAKE_COLUMNS as $col) {
+            if (isset($row[$col]) && is_scalar($row[$col])) {
+                $row[$col] = (string) $row[$col];
+            }
+        }
+        /** @var BugReportRow $row */
+        return $row;
+    }
+
+    // -------------------------------------------------------------------------
+    // Read methods (Phase 2)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @phpstan-return BugReportRow|null
+     */
+    public function findById(int $id): ?array
+    {
+        $row = $this->fetchOne('SELECT * FROM `ibl_bug_reports` WHERE id = ? LIMIT 1', 'i', $id);
+        return $row === null ? null : $this->castRow($row);
+    }
+
+    /**
+     * Snowflake bound as STRING ("s") — never (int)-cast a snowflake.
+     * @phpstan-return BugReportRow|null
+     */
+    public function findByThreadId(string $threadId): ?array
+    {
+        $row = $this->fetchOne('SELECT * FROM `ibl_bug_reports` WHERE thread_id = ? LIMIT 1', 's', $threadId);
+        return $row === null ? null : $this->castRow($row);
+    }
+
+    /**
+     * Enqueue idempotency lookup — replay-safe dedupe. Snowflake bound as STRING ("s").
+     * @phpstan-return BugReportRow|null
+     */
+    public function findByOriginalMessageId(string $messageId): ?array
+    {
+        $row = $this->fetchOne('SELECT * FROM `ibl_bug_reports` WHERE original_message_id = ? LIMIT 1', 's', $messageId);
+        return $row === null ? null : $this->castRow($row);
+    }
+
+    // -------------------------------------------------------------------------
+    // Write path — insert, upserts, mutators (Phase 3)
+    // -------------------------------------------------------------------------
+
+    public function insertQueuedReport(string $authorId, string $channelId, string $messageId, string $text): int
+    {
+        $this->execute(
+            'INSERT INTO `ibl_bug_reports`
+                (discord_author_id, channel_id, original_message_id, original_text, status, created_at, updated_at)
+             VALUES (?, ?, ?, ?, \'queued\', NOW(), NOW())',
+            'ssss',
+            $authorId,
+            $channelId,
+            $messageId,
+            $text
+        );
+        return $this->getLastInsertId();
+    }
+
+    public function upsertReporterProfile(string $discordId, string $techLevel): void
+    {
+        // ON DUPLICATE KEY UPDATE => affected-rows is 0|1|2; success is "no exception", not "=== 1".
+        $this->execute(
+            'INSERT INTO `ibl_bug_reporter_profile` (discord_author_id, tech_level, created_at, updated_at)
+             VALUES (?, ?, NOW(), NOW())
+             ON DUPLICATE KEY UPDATE tech_level = VALUES(tech_level), updated_at = NOW()',
+            'ss',
+            $discordId,
+            $techLevel
+        );
+    }
+
+    public function getReporterTechLevel(string $discordId): ?string
+    {
+        $row = $this->fetchOne(
+            'SELECT tech_level FROM `ibl_bug_reporter_profile` WHERE discord_author_id = ? LIMIT 1',
+            's',
+            $discordId
+        );
+        if ($row === null) {
+            return null;
+        }
+        /** @var string $techLevel */
+        $techLevel = $row['tech_level'];
+        return $techLevel;
+    }
+
+    public function upsertPipelineState(string $channelId, string $messageId): void
+    {
+        // Monotonic: GREATEST() keeps the highest snowflake seen — the cursor only moves forward.
+        $this->execute(
+            'INSERT INTO `ibl_bug_pipeline_state` (channel_id, last_processed_message_id, updated_at)
+             VALUES (?, ?, NOW())
+             ON DUPLICATE KEY UPDATE
+                 last_processed_message_id = GREATEST(last_processed_message_id, VALUES(last_processed_message_id)),
+                 updated_at = NOW()',
+            'ss',
+            $channelId,
+            $messageId
+        );
+    }
+
+    /**
+     * Crash-safe, replay-safe enqueue: INSERT + watermark advance run in one transaction.
+     * Pre-insert findByOriginalMessageId dedupe makes it replay-safe for PR #4's backfill.
+     */
+    public function enqueueAuthorizedAndAdvance(string $authorId, string $channelId, string $messageId, string $text): int
+    {
+        /** @var int $id */
+        $id = $this->transactional(function () use ($authorId, $channelId, $messageId, $text): int {
+            // Replay-safe: a message already enqueued returns its existing id, no 2nd row.
+            $existing = $this->findByOriginalMessageId($messageId);
+            if ($existing !== null) {
+                $this->upsertPipelineState($channelId, $messageId);
+                return $existing['id'];
+            }
+            // Insert + watermark advance in the SAME transaction => crash between them rolls back both.
+            $newId = $this->insertQueuedReport($authorId, $channelId, $messageId, $text);
+            $this->upsertPipelineState($channelId, $messageId);
+            return $newId;
+        });
+        return $id;
+    }
+
+    public function stampThreadReply(string $threadId): bool
+    {
+        return $this->execute(
+            'UPDATE `ibl_bug_reports` SET last_gm_reply_at = NOW() WHERE thread_id = ?',
+            's',
+            $threadId
+        ) >= 1;
+    }
+
+    /**
+     * Advance a report from awaiting_ajay to the ready-for-plan sub-state by NULLing
+     * approval_message_id. Status stays 'awaiting_ajay' — the cron drives /plan then sets 'planned'.
+     */
+    public function advanceOnApproval(string $messageId): bool
+    {
+        // ✅ = "ready-for-plan", NOT "planned". NULL the approval pointer and keep
+        // status='awaiting_ajay' so the cron can enumerate awaiting_ajay AND approval_message_id IS NULL.
+        return $this->execute(
+            "UPDATE `ibl_bug_reports` SET approval_message_id = NULL
+             WHERE approval_message_id = ? AND status = 'awaiting_ajay'",
+            's',
+            $messageId
+        ) === 1;
+    }
+
+    // -------------------------------------------------------------------------
+    // Atomic lease primitives (Phase 4)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Single-flight claim: the "AND status='queued'" guard makes this atomic.
+     * A row already 'hunting' (claimed by another worker) matches 0 rows => returns false.
+     */
+    public function claimQueued(int $id, string $leaseOwner, string $leaseExpires): bool
+    {
+        return $this->execute(
+            "UPDATE `ibl_bug_reports` SET status = 'hunting', lease_owner = ?, lease_expires = ?
+             WHERE id = ? AND status = 'queued'",
+            'ssi',
+            $leaseOwner,
+            $leaseExpires,
+            $id
+        ) === 1;
+    }
+
+    /**
+     * Pick oldest queued report and claim it. One attempt — lost-race returns null.
+     * @phpstan-return BugReportRow|null
+     */
+    public function claimNextQueued(string $leaseOwner, string $leaseExpires): ?array
+    {
+        $row = $this->fetchOne(
+            "SELECT id FROM `ibl_bug_reports` WHERE status = 'queued' ORDER BY id ASC LIMIT 1"
+        );
+        if ($row === null) {
+            return null;
+        }
+        /** @var int $id */
+        $id = $row['id'];
+
+        // Lost-race safe: if another worker claimed $id, claimQueued matches 0 rows => null.
+        if (!$this->claimQueued($id, $leaseOwner, $leaseExpires)) {
+            return null;
+        }
+        return $this->findById($id);
+    }
+
+    /**
+     * Reclaim a crashed hunt whose lease expired. Separate primitive — never widens claimQueued.
+     * @phpstan-return BugReportRow|null
+     */
+    public function reclaimStaleLease(string $newLeaseOwner, string $leaseExpires): ?array
+    {
+        $row = $this->fetchOne(
+            "SELECT id FROM `ibl_bug_reports`
+             WHERE status = 'hunting' AND lease_expires < NOW()
+             ORDER BY id ASC LIMIT 1"
+        );
+        if ($row === null) {
+            return null;
+        }
+        /** @var int $id */
+        $id = $row['id'];
+
+        // Re-assert both predicates in the UPDATE so a concurrent reclaimer can't double-claim.
+        $claimed = $this->execute(
+            "UPDATE `ibl_bug_reports` SET lease_owner = ?, lease_expires = ?
+             WHERE id = ? AND status = 'hunting' AND lease_expires < NOW()",
+            'ssi',
+            $newLeaseOwner,
+            $leaseExpires,
+            $id
+        ) === 1;
+        if (!$claimed) {
+            return null;
+        }
+        return $this->findById($id);
+    }
+
+    // -------------------------------------------------------------------------
+    // General state/metadata writer (Phase 4b)
+    // -------------------------------------------------------------------------
+
+    /**
+     * General state-machine writer: set status plus any subset of optional metadata columns.
+     * The §3d cron CLI (transition <id> <status> [opts]) is a thin wrapper over this method.
+     *
+     * Conditional-SQL, NOT null-bind: only columns whose key is present in $opts are written;
+     * an absent key keeps the column's current value ("build conditional SQL; bind_param has no
+     * NULL type" — core-coding.md). Keys outside OPTIONAL_TRANSITION_COLUMNS are ignored.
+     *
+     * $setClauses fragments ('status = ?', 'pr_number = ?', …) derive from the fixed
+     * OPTIONAL_TRANSITION_COLUMNS constant (compile-time literal column names / bound params) —
+     * concatenate literal fragments, do NOT interpolate values.
+     *
+     * @param array<string, int|string> $opts Accepted keys: pr_number, issue_number, hunt_attempts
+     *   (ints); class (ENUM string); thread_id, approval_message_id (snowflakes, bound "s");
+     *   blocked_until (DATETIME string). Any other key is ignored.
+     * @param bool $releaseLease When true, atomically NULLs lease_owner + lease_expires in the
+     *   SAME UPDATE. Required for →needs_human / →queued reset to be a single-flight-safe op.
+     * @return bool True when the row (PK $id) was updated.
+     */
+    public function transition(int $id, string $status, array $opts = [], bool $releaseLease = false): bool
+    {
+        $setClauses = ['status = ?'];
+        $types = 's';
+        $values = [$status];
+
+        foreach (self::OPTIONAL_TRANSITION_COLUMNS as $col => $type) {
+            if (array_key_exists($col, $opts)) {
+                $setClauses[] = $col . ' = ?';
+                $types .= $type;
+                $values[] = $opts[$col];
+            }
+        }
+        if ($releaseLease) {
+            // Literal NULLs (no bound param) — atomic lease-drop for →needs_human / →queued reset.
+            $setClauses[] = 'lease_owner = NULL';
+            $setClauses[] = 'lease_expires = NULL';
+        }
+        $setClauses[] = 'updated_at = NOW()';
+
+        // $setClauses elements are literal fragments from the fixed constant map above;
+        // no runtime value is interpolated into column names — only ? placeholders for values.
+        $query = 'UPDATE `ibl_bug_reports` SET ' . implode(', ', $setClauses) . ' WHERE id = ?';
+        $types .= 'i';
+        $values[] = $id;
+
+        return $this->execute($query, $types, ...$values) === 1;
+    }
+
+    // -------------------------------------------------------------------------
+    // Reader methods for PR #4 (Phase 9)
+    // -------------------------------------------------------------------------
+
+    /**
+     * PR #4 backfill cursor. Returns the watermark snowflake as a STRING, or null on first boot.
+     */
+    public function findPipelineState(string $channelId): ?string
+    {
+        $row = $this->fetchOne(
+            'SELECT last_processed_message_id FROM `ibl_bug_pipeline_state` WHERE channel_id = ? LIMIT 1',
+            's',
+            $channelId
+        );
+        if ($row === null) {
+            return null;
+        }
+        return isset($row['last_processed_message_id']) && is_scalar($row['last_processed_message_id'])
+            ? (string) $row['last_processed_message_id']
+            : null;
+    }
+
+    /**
+     * PR #4 /prMerged resolver. pr_number is a PR number (small INT, bound "i"), NOT a snowflake.
+     * Returns the thread_id snowflake as a STRING, or null if unresolved.
+     */
+    public function findThreadIdByPrNumber(int $prNumber): ?string
+    {
+        $row = $this->fetchOne(
+            'SELECT thread_id FROM `ibl_bug_reports` WHERE pr_number = ? LIMIT 1',
+            'i',
+            $prNumber
+        );
+        if ($row === null) {
+            return null;
+        }
+        return isset($row['thread_id']) && is_scalar($row['thread_id'])
+            ? (string) $row['thread_id']
+            : null;
+    }
+}

--- a/ibl5/classes/Discord/Discord.php
+++ b/ibl5/classes/Discord/Discord.php
@@ -27,6 +27,9 @@ class Discord
     /** @var string IBLbot Express server URL for DM endpoint */
     private static string $iblbotUrl = '';
 
+    /** @var string Bug-pipeline approver Discord snowflake (as string), or '' if unconfigured */
+    private static string $bugPipelineApproverDiscordId = '';
+
     /** @var bool Whether config has been loaded */
     private static bool $configLoaded = false;
 
@@ -101,10 +104,10 @@ class Discord
         $examplePath = __DIR__ . '/../../config/discord.config.example.php';
 
         if (file_exists($configPath)) {
-            /** @var array{webhooks?: array<string, string>, iblbot_url?: string} $config */
+            /** @var array{webhooks?: array<string, string>, iblbot_url?: string, bug_pipeline_approver_discord_id?: string} $config */
             $config = require $configPath; /** @phpstan-ignore ibl.requireOnce (config file returns array; not a class) */
         } elseif (file_exists($examplePath)) {
-            /** @var array{webhooks?: array<string, string>, iblbot_url?: string} $config */
+            /** @var array{webhooks?: array<string, string>, iblbot_url?: string, bug_pipeline_approver_discord_id?: string} $config */
             $config = require $examplePath; /** @phpstan-ignore ibl.requireOnce (config file returns array; not a class) */
         } else {
             throw new \RuntimeException(
@@ -119,7 +122,19 @@ class Discord
 
         self::$webhooks = $config['webhooks'];
         self::$iblbotUrl = $config['iblbot_url'] ?? '';
+        self::$bugPipelineApproverDiscordId = $config['bug_pipeline_approver_discord_id'] ?? '';
         self::$configLoaded = true;
+    }
+
+    /**
+     * The approver's Discord snowflake (as a string) from config, or '' if unconfigured.
+     * Compared string-wise against a reaction's reactor_id in the bug-pipeline reaction endpoint.
+     * Empty string is fail-closed: it never equals a real snowflake, so no reaction advances.
+     */
+    public static function getBugPipelineApproverDiscordId(): string
+    {
+        self::loadConfig();
+        return self::$bugPipelineApproverDiscordId;
     }
 
     public function getDiscordIDFromTeamname(string $teamname): string

--- a/ibl5/classes/Repositories/Contracts/TeamIdentityRepositoryInterface.php
+++ b/ibl5/classes/Repositories/Contracts/TeamIdentityRepositoryInterface.php
@@ -31,6 +31,18 @@ interface TeamIdentityRepositoryInterface
     public function getTeamDiscordID(string $teamName): ?int;
 
     /**
+     * Authorization existence check: is $discordId a known GM's Discord ID?
+     *
+     * Binds the snowflake as a STRING ("s") — MySQL coerces it into the
+     * BIGINT UNSIGNED `discord_id` column. Never (int)-casts the snowflake
+     * (unlike getTeamDiscordID), so it is safe for values above 2^53.
+     *
+     * @param string $discordId Discord author snowflake (as a string)
+     * @return bool True if any ibl_team_info row has this discord_id.
+     */
+    public function isKnownDiscordID(string $discordId): bool;
+
+    /**
      * @return list<TeamInfoRow>
      */
     public function getAllRealTeams(string $orderBy = 'team_name ASC'): array;

--- a/ibl5/classes/Repositories/TeamIdentityRepository.php
+++ b/ibl5/classes/Repositories/TeamIdentityRepository.php
@@ -120,6 +120,17 @@ class TeamIdentityRepository extends \BaseMysqliRepository implements TeamIdenti
         return $discordId !== null ? (int) $discordId : null;
     }
 
+    public function isKnownDiscordID(string $discordId): bool
+    {
+        // Bind the snowflake as "s"; MySQL coerces into the BIGINT UNSIGNED column.
+        // Existence test only — never (int)-cast the snowflake (contrast getTeamDiscordID).
+        return $this->fetchOne(
+            "SELECT 1 FROM `ibl_team_info` WHERE `discord_id` = ? LIMIT 1",
+            "s",
+            $discordId
+        ) !== null;
+    }
+
     /**
      * @return list<TeamInfoRow>
      */

--- a/ibl5/config/discord.config.example.php
+++ b/ibl5/config/discord.config.example.php
@@ -32,4 +32,5 @@ return [
         'waiver-wire' => 'https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN',
     ],
     'iblbot_url' => 'http://localhost:50000',
+    'bug_pipeline_approver_discord_id' => 'YOUR_APPROVER_DISCORD_ID',
 ];

--- a/ibl5/phpstan-baseline-counts.json
+++ b/ibl5/phpstan-baseline-counts.json
@@ -3,7 +3,7 @@
         "ibl.directHeader": 1,
         "ibl.directTime": 13,
         "ibl.hardcodedEnvString": 8,
-        "ibl.sqlStringConcatenation": 32,
+        "ibl.sqlStringConcatenation": 33,
         "ibl.trustedVariable": 16
     },
     "phpstan-tests-baseline.neon": {

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -67,6 +67,12 @@ parameters:
 			path: classes/Boxscore/Boxscore.php
 
 		-
+			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
+			identifier: ibl.sqlStringConcatenation
+			count: 1
+			path: classes/BugPipeline/BugReportRepository.php
+
+		-
 			rawMessage: 'Direct now-returning time call is banned outside the Clock seam. Inject Clock\ClockInterface (constructor for instance classes; settable static clock with factory fallback for static classes) and call $clock->now(). Pass an explicit timestamp to date()/strtotime() for deterministic formatting.'
 			identifier: ibl.directTime
 			count: 1

--- a/ibl5/tests/Api/Controller/EnqueueControllerTest.php
+++ b/ibl5/tests/Api/Controller/EnqueueControllerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\EnqueueController;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use PHPUnit\Framework\TestCase;
+use Repositories\Contracts\TeamIdentityRepositoryInterface;
+
+class EnqueueControllerTest extends TestCase
+{
+    private function makeController(BugReportRepository $bugRepo, TeamIdentityRepositoryInterface $teamRepo): EnqueueController
+    {
+        return new EnqueueController($bugRepo, $teamRepo);
+    }
+
+    public function testAuthorizedBranchCallsEnqueueAndReturnsReportId(): void
+    {
+        $bugRepo  = $this->createMock(BugReportRepository::class);
+        $teamRepo = $this->createMock(TeamIdentityRepositoryInterface::class);
+
+        $teamRepo->expects($this->once())
+            ->method('isKnownDiscordID')
+            ->with('100000000000000001')
+            ->willReturn(true);
+
+        $bugRepo->expects($this->once())
+            ->method('enqueueAuthorizedAndAdvance')
+            ->willReturn(7);
+
+        $bugRepo->expects($this->never())
+            ->method('upsertPipelineState');
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['authorized' => true, 'report_id' => 7]);
+
+        $this->makeController($bugRepo, $teamRepo)->handle([], [], $responder, [
+            'author_id'  => '100000000000000001',
+            'channel_id' => '200000000000000002',
+            'message_id' => '300000000000000003',
+            'text'       => 'app crashes',
+        ]);
+    }
+
+    public function testUnauthorizedBranchCallsUpsertStateAndReturnsNull(): void
+    {
+        $bugRepo  = $this->createMock(BugReportRepository::class);
+        $teamRepo = $this->createMock(TeamIdentityRepositoryInterface::class);
+
+        $teamRepo->expects($this->once())
+            ->method('isKnownDiscordID')
+            ->willReturn(false);
+
+        $bugRepo->expects($this->never())
+            ->method('enqueueAuthorizedAndAdvance');
+
+        $bugRepo->expects($this->once())
+            ->method('upsertPipelineState')
+            ->with('200000000000000002', '300000000000000003');
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['authorized' => false, 'report_id' => null]);
+
+        $this->makeController($bugRepo, $teamRepo)->handle([], [], $responder, [
+            'author_id'  => '999999999999999999',
+            'channel_id' => '200000000000000002',
+            'message_id' => '300000000000000003',
+            'text'       => 'spam',
+        ]);
+    }
+
+    public function testReturns400WhenBodyIsNull(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $teamRepo = self::createStub(TeamIdentityRepositoryInterface::class);
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo, $teamRepo)->handle([], [], $responder, null);
+    }
+
+    public function testReturns400WhenTextMissing(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $teamRepo = self::createStub(TeamIdentityRepositoryInterface::class);
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo, $teamRepo)->handle([], [], $responder, [
+            'author_id'  => '100000000000000001',
+            'channel_id' => '200000000000000002',
+            'message_id' => '300000000000000003',
+            // 'text' deliberately omitted
+        ]);
+    }
+}

--- a/ibl5/tests/Api/Controller/LastSeenControllerTest.php
+++ b/ibl5/tests/Api/Controller/LastSeenControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\LastSeenController;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use PHPUnit\Framework\TestCase;
+
+class LastSeenControllerTest extends TestCase
+{
+    private function makeController(BugReportRepository $bugRepo): LastSeenController
+    {
+        return new LastSeenController($bugRepo);
+    }
+
+    public function testCallsUpsertPipelineStateAndReturnsOk(): void
+    {
+        $bugRepo = $this->createMock(BugReportRepository::class);
+        $bugRepo->expects($this->once())
+            ->method('upsertPipelineState')
+            ->with('200000000000000002', '300000000000000003');
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['ok' => true]);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'channel_id' => '200000000000000002',
+            'message_id' => '300000000000000003',
+        ]);
+    }
+
+    public function testReturns400WhenChannelIdMissing(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'message_id' => '300000000000000003',
+        ]);
+    }
+
+    public function testReturns400WhenMessageIdMissing(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'channel_id' => '200000000000000002',
+        ]);
+    }
+}

--- a/ibl5/tests/Api/Controller/PipelineStateControllerTest.php
+++ b/ibl5/tests/Api/Controller/PipelineStateControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\PipelineStateController;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use PHPUnit\Framework\TestCase;
+
+class PipelineStateControllerTest extends TestCase
+{
+    private function makeController(BugReportRepository $bugRepo): PipelineStateController
+    {
+        return new PipelineStateController($bugRepo);
+    }
+
+    public function testReturnsCursorWhenRowExists(): void
+    {
+        $bugRepo = $this->createMock(BugReportRepository::class);
+        $bugRepo->expects($this->once())
+            ->method('findPipelineState')
+            ->with('200000000000000002')
+            ->willReturn('300000000000000003');
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['last_processed_message_id' => '300000000000000003']);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'channel_id' => '200000000000000002',
+        ]);
+    }
+
+    public function testReturnsNullWhenNoCursorExists(): void
+    {
+        $bugRepo = $this->createMock(BugReportRepository::class);
+        $bugRepo->expects($this->once())
+            ->method('findPipelineState')
+            ->willReturn(null);
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['last_processed_message_id' => null]);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'channel_id' => '200000000000000002',
+        ]);
+    }
+
+    public function testReturns400WhenChannelIdMissing(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, []);
+    }
+}

--- a/ibl5/tests/Api/Controller/ReactionControllerTest.php
+++ b/ibl5/tests/Api/Controller/ReactionControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\ReactionController;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use Discord\Discord;
+use PHPUnit\Framework\TestCase;
+
+class ReactionControllerTest extends TestCase
+{
+    private function makeController(BugReportRepository $bugRepo): ReactionController
+    {
+        return new ReactionController($bugRepo);
+    }
+
+    public function testApproverWithCheckmarkCallsAdvanceAndReturnsTrue(): void
+    {
+        $bugRepo  = $this->createMock(BugReportRepository::class);
+        $approverId = Discord::getBugPipelineApproverDiscordId();
+
+        $bugRepo->expects($this->once())
+            ->method('advanceOnApproval')
+            ->with('600000000000000006')
+            ->willReturn(true);
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['advanced' => true]);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'message_id' => '600000000000000006',
+            'emoji'      => '✅',
+            'reactor_id' => $approverId,
+        ]);
+    }
+
+    public function testNonApproverReactorDoesNotCallAdvance(): void
+    {
+        $bugRepo = $this->createMock(BugReportRepository::class);
+        $bugRepo->expects($this->never())->method('advanceOnApproval');
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['advanced' => false]);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'message_id' => '600000000000000006',
+            'emoji'      => '✅',
+            'reactor_id' => '999999999999999999',
+        ]);
+    }
+
+    public function testWrongEmojiDoesNotCallAdvance(): void
+    {
+        $bugRepo    = $this->createMock(BugReportRepository::class);
+        $approverId = Discord::getBugPipelineApproverDiscordId();
+
+        $bugRepo->expects($this->never())->method('advanceOnApproval');
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['advanced' => false]);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'message_id' => '600000000000000006',
+            'emoji'      => '👎',
+            'reactor_id' => $approverId,
+        ]);
+    }
+
+    public function testReturns400WhenMessageIdMissing(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'emoji'      => '✅',
+            'reactor_id' => '999999999999999999',
+        ]);
+    }
+
+    public function testReturns400WhenEmojiMissing(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'message_id' => '600000000000000006',
+            'reactor_id' => '999999999999999999',
+        ]);
+    }
+}

--- a/ibl5/tests/Api/Controller/ThreadByPrControllerTest.php
+++ b/ibl5/tests/Api/Controller/ThreadByPrControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\ThreadByPrController;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use PHPUnit\Framework\TestCase;
+
+class ThreadByPrControllerTest extends TestCase
+{
+    private function makeController(BugReportRepository $bugRepo): ThreadByPrController
+    {
+        return new ThreadByPrController($bugRepo);
+    }
+
+    public function testReturnsThreadIdForKnownPr(): void
+    {
+        $bugRepo = $this->createMock(BugReportRepository::class);
+        $bugRepo->expects($this->once())
+            ->method('findThreadIdByPrNumber')
+            ->with(42)
+            ->willReturn('700000000000000007');
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['thread_id' => '700000000000000007']);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, ['pr_number' => 42]);
+    }
+
+    public function testReturnsNullThreadIdWhenPrHasNoThread(): void
+    {
+        $bugRepo = $this->createMock(BugReportRepository::class);
+        $bugRepo->expects($this->once())
+            ->method('findThreadIdByPrNumber')
+            ->willReturn(null);
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['thread_id' => null]);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, ['pr_number' => 99]);
+    }
+
+    public function testAcceptsNumericStringPrNumber(): void
+    {
+        $bugRepo = $this->createMock(BugReportRepository::class);
+        $bugRepo->expects($this->once())
+            ->method('findThreadIdByPrNumber')
+            ->with(42);
+
+        $responder = self::createStub(JsonResponder::class);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, ['pr_number' => '42']);
+    }
+
+    public function testReturns400WhenPrNumberMissing(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, []);
+    }
+
+    public function testReturns400WhenPrNumberIsZero(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, ['pr_number' => 0]);
+    }
+
+    public function testReturns400WhenPrNumberIsNonNumericString(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, ['pr_number' => 'abc']);
+    }
+}

--- a/ibl5/tests/Api/Controller/ThreadReplyControllerTest.php
+++ b/ibl5/tests/Api/Controller/ThreadReplyControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Controller;
+
+use Api\Controller\ThreadReplyController;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use PHPUnit\Framework\TestCase;
+
+class ThreadReplyControllerTest extends TestCase
+{
+    private function makeController(BugReportRepository $bugRepo): ThreadReplyController
+    {
+        return new ThreadReplyController($bugRepo);
+    }
+
+    public function testMatchedReturnsTrue(): void
+    {
+        $bugRepo = $this->createMock(BugReportRepository::class);
+        $bugRepo->expects($this->once())
+            ->method('stampThreadReply')
+            ->with('400000000000000004')
+            ->willReturn(true);
+
+        $bugRepo->expects($this->never())
+            ->method('upsertPipelineState');
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['matched' => true]);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'thread_id'  => '400000000000000004',
+            'message_id' => '500000000000000005',
+        ]);
+    }
+
+    public function testUnmatchedReturnsFalse(): void
+    {
+        $bugRepo = self::createStub(BugReportRepository::class);
+        $bugRepo->method('stampThreadReply')->willReturn(false);
+
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['matched' => false]);
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'thread_id'  => '000000000000000000',
+            'message_id' => '500000000000000005',
+        ]);
+    }
+
+    public function testReturns400WhenThreadIdMissing(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'message_id' => '500000000000000005',
+        ]);
+    }
+
+    public function testReturns400WhenMessageIdMissing(): void
+    {
+        $bugRepo  = self::createStub(BugReportRepository::class);
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('error')
+            ->with(400, 'bad_request', self::anything());
+
+        $this->makeController($bugRepo)->handle([], [], $responder, [
+            'thread_id' => '400000000000000004',
+        ]);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/Api/Controller/EnqueueControllerDatabaseTest.php
+++ b/ibl5/tests/DatabaseIntegration/Api/Controller/EnqueueControllerDatabaseTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Api\Controller;
+
+use Api\Controller\EnqueueController;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use PHPUnit\Framework\Attributes\Group;
+use Repositories\TeamIdentityRepository;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+/**
+ * DB-grounded tests for EnqueueController authz paths.
+ * Relies on the seed fixture: discord_id = '100000000000000001' on teamid=1.
+ */
+#[Group('database')]
+class EnqueueControllerDatabaseTest extends DatabaseTestCase
+{
+    private EnqueueController $controller;
+    private BugReportRepository $bugRepo;
+
+    private const KNOWN_AUTHOR   = '100000000000000001';
+    private const UNKNOWN_AUTHOR = '999999999999999999';
+    private const CHANNEL        = '200000000000000002';
+    private const MSG_ID         = '300000000000000003';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->bugRepo  = new BugReportRepository($this->db);
+        $this->controller = new EnqueueController(
+            $this->bugRepo,
+            new TeamIdentityRepository($this->db)
+        );
+    }
+
+    public function testAuthorizedAuthorInsertsRowAndReturnsReportId(): void
+    {
+        $captured = null;
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(self::callback(function (array $payload) use (&$captured): bool {
+                $captured = $payload;
+                return true;
+            }));
+
+        $this->controller->handle([], [], $responder, [
+            'author_id'  => self::KNOWN_AUTHOR,
+            'channel_id' => self::CHANNEL,
+            'message_id' => self::MSG_ID,
+            'text'       => 'app crashes on save',
+        ]);
+
+        self::assertNotNull($captured);
+        self::assertTrue($captured['authorized']);
+        self::assertIsInt($captured['report_id']);
+        self::assertGreaterThan(0, $captured['report_id']);
+
+        // Verify the row actually landed in the DB
+        $row = $this->bugRepo->findById($captured['report_id']);
+        self::assertNotNull($row);
+        self::assertSame('queued', $row['status']);
+        self::assertSame(self::KNOWN_AUTHOR, $row['discord_author_id']);
+    }
+
+    public function testUnknownAuthorDoesNotInsertRowAndAdvancesWatermarkOnly(): void
+    {
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['authorized' => false, 'report_id' => null]);
+
+        $this->controller->handle([], [], $responder, [
+            'author_id'  => self::UNKNOWN_AUTHOR,
+            'channel_id' => self::CHANNEL,
+            'message_id' => self::MSG_ID,
+            'text'       => 'random message',
+        ]);
+
+        // No row for this message_id
+        self::assertNull($this->bugRepo->findByOriginalMessageId(self::MSG_ID));
+        // But the watermark was advanced
+        self::assertSame(self::MSG_ID, $this->bugRepo->findPipelineState(self::CHANNEL));
+    }
+
+    public function testIdempotentReEnqueueReturnsSameReportId(): void
+    {
+        $captures = [];
+        $responder = $this->createMock(JsonResponder::class);
+        $responder->expects($this->exactly(2))
+            ->method('success')
+            ->with(self::callback(function (array $payload) use (&$captures): bool {
+                $captures[] = $payload;
+                return true;
+            }));
+
+        $payload = [
+            'author_id'  => self::KNOWN_AUTHOR,
+            'channel_id' => self::CHANNEL,
+            'message_id' => self::MSG_ID,
+            'text'       => 'app crashes',
+        ];
+        $this->controller->handle([], [], $responder, $payload);
+        $this->controller->handle([], [], $responder, $payload);
+
+        self::assertCount(2, $captures);
+        self::assertSame($captures[0]['report_id'], $captures[1]['report_id'], 'Re-enqueue must return same id');
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/Api/Controller/ReactionControllerDatabaseTest.php
+++ b/ibl5/tests/DatabaseIntegration/Api/Controller/ReactionControllerDatabaseTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Api\Controller;
+
+use Api\Controller\ReactionController;
+use Api\Response\JsonResponder;
+use BugPipeline\BugReportRepository;
+use Discord\Discord;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+/**
+ * DB-grounded tests for ReactionController — verifies the advanceOnApproval
+ * status guard actually fires against a real row.
+ */
+#[Group('database')]
+class ReactionControllerDatabaseTest extends DatabaseTestCase
+{
+    private ReactionController $controller;
+    private BugReportRepository $bugRepo;
+
+    private const APPROVAL_MSG = '600000000000000006';
+    private const AUTHOR       = '100000000000000001';
+    private const CHANNEL      = '200000000000000002';
+    private const MSG_ID       = '300000000000000003';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->bugRepo  = new BugReportRepository($this->db);
+        $this->controller = new ReactionController($this->bugRepo);
+    }
+
+    public function testApproverReactionAdvancesAwaitingAjayRow(): void
+    {
+        // Insert a row in awaiting_ajay with the approval_message_id set
+        $id = $this->insertRow('ibl_bug_reports', [
+            'discord_author_id'   => self::AUTHOR,
+            'channel_id'          => self::CHANNEL,
+            'original_message_id' => self::MSG_ID,
+            'original_text'       => 'bug report',
+            'status'              => 'awaiting_ajay',
+            'approval_message_id' => self::APPROVAL_MSG,
+            'created_at'          => date('Y-m-d H:i:s'),
+            'updated_at'          => date('Y-m-d H:i:s'),
+        ]);
+
+        $approverId = Discord::getBugPipelineApproverDiscordId();
+        $responder  = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['advanced' => true]);
+
+        $this->controller->handle([], [], $responder, [
+            'message_id' => self::APPROVAL_MSG,
+            'emoji'      => '✅',
+            'reactor_id' => $approverId,
+        ]);
+
+        // approval_message_id must be NULL, status stays 'awaiting_ajay'
+        $row = $this->bugRepo->findById($id);
+        self::assertNotNull($row);
+        self::assertNull($row['approval_message_id']);
+        self::assertSame('awaiting_ajay', $row['status']);
+    }
+
+    public function testApproverReactionReturnsFalseWhenStatusIsNotAwaitingAjay(): void
+    {
+        $this->insertRow('ibl_bug_reports', [
+            'discord_author_id'   => self::AUTHOR,
+            'channel_id'          => self::CHANNEL,
+            'original_message_id' => self::MSG_ID,
+            'original_text'       => 'bug report',
+            'status'              => 'queued',
+            'approval_message_id' => self::APPROVAL_MSG,
+            'created_at'          => date('Y-m-d H:i:s'),
+            'updated_at'          => date('Y-m-d H:i:s'),
+        ]);
+
+        $approverId = Discord::getBugPipelineApproverDiscordId();
+        $responder  = $this->createMock(JsonResponder::class);
+        $responder->expects($this->once())
+            ->method('success')
+            ->with(['advanced' => false]);
+
+        $this->controller->handle([], [], $responder, [
+            'message_id' => self::APPROVAL_MSG,
+            'emoji'      => '✅',
+            'reactor_id' => $approverId,
+        ]);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/BugPipeline/BugReportRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BugPipeline/BugReportRepositoryTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\BugPipeline;
+
+use BugPipeline\BugReportRepository;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+#[Group('database')]
+class BugReportRepositoryTest extends DatabaseTestCase
+{
+    private BugReportRepository $repo;
+
+    // Representative snowflake fixtures — real Discord IDs are 17–19 digits
+    private const AUTHOR   = '100000000000000001';
+    private const CHANNEL  = '200000000000000002';
+    private const MSG_ID   = '300000000000000003';
+    private const THREAD   = '400000000000000004';
+    private const REPLY_ID = '500000000000000005';
+    private const APPROVAL = '600000000000000006';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new BugReportRepository($this->db);
+    }
+
+    // ── findById ───────────────────────────────────────────────────────────────
+
+    public function testFindByIdReturnsNullForUnknown(): void
+    {
+        self::assertNull($this->repo->findById(999999));
+    }
+
+    public function testFindByIdReturnsCastRow(): void
+    {
+        $id = $this->insertBugReport(['original_message_id' => self::MSG_ID]);
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertSame($id, $row['id']);
+        self::assertIsString($row['discord_author_id'], 'snowflake must be cast to string');
+        self::assertSame(self::AUTHOR, $row['discord_author_id']);
+    }
+
+    // ── findByThreadId ─────────────────────────────────────────────────────────
+
+    public function testFindByThreadIdReturnsNullWhenNoMatch(): void
+    {
+        self::assertNull($this->repo->findByThreadId('999999999999999999'));
+    }
+
+    public function testFindByThreadIdReturnsRowAndCastsSnowflake(): void
+    {
+        $id = $this->insertBugReport(['thread_id' => self::THREAD]);
+        $row = $this->repo->findByThreadId(self::THREAD);
+        self::assertNotNull($row);
+        self::assertSame($id, $row['id']);
+        self::assertIsString($row['thread_id']);
+        self::assertSame(self::THREAD, $row['thread_id']);
+    }
+
+    // ── findByOriginalMessageId ────────────────────────────────────────────────
+
+    public function testFindByOriginalMessageIdReturnsNullWhenNoMatch(): void
+    {
+        self::assertNull($this->repo->findByOriginalMessageId('999999999999999999'));
+    }
+
+    public function testFindByOriginalMessageIdReturnsRow(): void
+    {
+        $this->insertBugReport(['original_message_id' => self::MSG_ID]);
+        $row = $this->repo->findByOriginalMessageId(self::MSG_ID);
+        self::assertNotNull($row);
+        self::assertSame(self::MSG_ID, $row['original_message_id']);
+    }
+
+    // ── insertQueuedReport ─────────────────────────────────────────────────────
+
+    public function testInsertQueuedReportReturnsNewId(): void
+    {
+        $id = $this->repo->insertQueuedReport(self::AUTHOR, self::CHANNEL, self::MSG_ID, 'app crashes');
+        self::assertGreaterThan(0, $id);
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertSame('queued', $row['status']);
+        self::assertSame('app crashes', $row['original_text']);
+    }
+
+    // ── upsertReporterProfile / getReporterTechLevel ───────────────────────────
+
+    public function testGetReporterTechLevelReturnsNullWhenMissing(): void
+    {
+        self::assertNull($this->repo->getReporterTechLevel('999999999999999999'));
+    }
+
+    public function testUpsertReporterProfileInsertsAndUpdates(): void
+    {
+        $this->repo->upsertReporterProfile(self::AUTHOR, 'technical');
+        self::assertSame('technical', $this->repo->getReporterTechLevel(self::AUTHOR));
+
+        // Idempotent update
+        $this->repo->upsertReporterProfile(self::AUTHOR, 'nontechnical');
+        self::assertSame('nontechnical', $this->repo->getReporterTechLevel(self::AUTHOR));
+    }
+
+    // ── upsertPipelineState / findPipelineState ────────────────────────────────
+
+    public function testFindPipelineStateReturnsNullWhenNoRow(): void
+    {
+        self::assertNull($this->repo->findPipelineState('999999999999999999'));
+    }
+
+    public function testUpsertPipelineStateInsertsAndReturnsString(): void
+    {
+        $this->repo->upsertPipelineState(self::CHANNEL, self::MSG_ID);
+        $cursor = $this->repo->findPipelineState(self::CHANNEL);
+        self::assertSame(self::MSG_ID, $cursor);
+    }
+
+    public function testUpsertPipelineStateIsMonotonic(): void
+    {
+        // Lower ID first, then higher — cursor advances
+        $lower  = '200000000000000001';
+        $higher = '300000000000000002';
+        $this->repo->upsertPipelineState(self::CHANNEL, $lower);
+        $this->repo->upsertPipelineState(self::CHANNEL, $higher);
+        self::assertSame($higher, $this->repo->findPipelineState(self::CHANNEL));
+
+        // Replaying older message must NOT regress the cursor
+        $this->repo->upsertPipelineState(self::CHANNEL, $lower);
+        self::assertSame($higher, $this->repo->findPipelineState(self::CHANNEL));
+    }
+
+    // ── enqueueAuthorizedAndAdvance (crash-safe, replay-safe) ─────────────────
+
+    public function testEnqueueAuthorizedAndAdvanceInsertsRowAndSetsWatermark(): void
+    {
+        $id = $this->repo->enqueueAuthorizedAndAdvance(self::AUTHOR, self::CHANNEL, self::MSG_ID, 'bug text');
+        self::assertGreaterThan(0, $id);
+        self::assertNotNull($this->repo->findById($id));
+        self::assertSame(self::MSG_ID, $this->repo->findPipelineState(self::CHANNEL));
+    }
+
+    public function testEnqueueAuthorizedAndAdvanceIsReplaySafe(): void
+    {
+        $id1 = $this->repo->enqueueAuthorizedAndAdvance(self::AUTHOR, self::CHANNEL, self::MSG_ID, 'bug text');
+        $id2 = $this->repo->enqueueAuthorizedAndAdvance(self::AUTHOR, self::CHANNEL, self::MSG_ID, 'bug text');
+        self::assertSame($id1, $id2, 'Replay must return same id without inserting a second row');
+
+        // Confirm only one row exists for this message_id
+        $stmt = $this->db->prepare('SELECT COUNT(*) AS cnt FROM `ibl_bug_reports` WHERE original_message_id = ?');
+        self::assertNotFalse($stmt);
+        $msgId = self::MSG_ID;
+        $stmt->bind_param('s', $msgId);
+        $stmt->execute();
+        /** @var array{cnt: int}|null $row */
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        self::assertNotNull($row);
+        self::assertSame(1, $row['cnt']);
+    }
+
+    // ── stampThreadReply ───────────────────────────────────────────────────────
+
+    public function testStampThreadReplyReturnsFalseWhenNoMatch(): void
+    {
+        self::assertFalse($this->repo->stampThreadReply('999999999999999999'));
+    }
+
+    public function testStampThreadReplyReturnsTrueAndUpdatesTimestamp(): void
+    {
+        $id = $this->insertBugReport(['thread_id' => self::THREAD]);
+        self::assertTrue($this->repo->stampThreadReply(self::THREAD));
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertNotNull($row['last_gm_reply_at']);
+    }
+
+    // ── advanceOnApproval ──────────────────────────────────────────────────────
+
+    public function testAdvanceOnApprovalReturnsFalseWhenNoMatch(): void
+    {
+        self::assertFalse($this->repo->advanceOnApproval('999999999999999999'));
+    }
+
+    public function testAdvanceOnApprovalNullsApprovalMessageAndReturnsTrueOnAwaitingAjay(): void
+    {
+        $id = $this->insertBugReport([
+            'status'              => 'awaiting_ajay',
+            'approval_message_id' => self::APPROVAL,
+        ]);
+        self::assertTrue($this->repo->advanceOnApproval(self::APPROVAL));
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertNull($row['approval_message_id']);
+        self::assertSame('awaiting_ajay', $row['status']);
+    }
+
+    public function testAdvanceOnApprovalReturnsFalseWhenStatusIsNotAwaitingAjay(): void
+    {
+        $this->insertBugReport([
+            'status'              => 'queued',
+            'approval_message_id' => self::APPROVAL,
+        ]);
+        self::assertFalse($this->repo->advanceOnApproval(self::APPROVAL));
+    }
+
+    // ── claimQueued ────────────────────────────────────────────────────────────
+
+    public function testClaimQueuedReturnsTrueAndSetsStatusHunting(): void
+    {
+        $id = $this->insertBugReport();
+        $ok = $this->repo->claimQueued($id, 'worker-1', '2099-01-01 00:00:00');
+        self::assertTrue($ok);
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertSame('hunting', $row['status']);
+        self::assertSame('worker-1', $row['lease_owner']);
+    }
+
+    public function testClaimQueuedReturnsFalseWhenAlreadyClaimed(): void
+    {
+        $id = $this->insertBugReport(['status' => 'hunting']);
+        self::assertFalse($this->repo->claimQueued($id, 'worker-2', '2099-01-01 00:00:00'));
+    }
+
+    // ── claimNextQueued ────────────────────────────────────────────────────────
+
+    public function testClaimNextQueuedReturnsNullWhenQueueEmpty(): void
+    {
+        self::assertNull($this->repo->claimNextQueued('worker-1', '2099-01-01 00:00:00'));
+    }
+
+    public function testClaimNextQueuedClaimsOldestRow(): void
+    {
+        $id1 = $this->insertBugReport(['original_message_id' => self::MSG_ID]);
+        $id2 = $this->insertBugReport(['original_message_id' => self::REPLY_ID]);
+        $row = $this->repo->claimNextQueued('worker-1', '2099-01-01 00:00:00');
+        self::assertNotNull($row);
+        self::assertSame($id1, $row['id'], 'Oldest row (lowest id) must be claimed first');
+        // Second claim gets next
+        $row2 = $this->repo->claimNextQueued('worker-2', '2099-01-01 00:00:00');
+        self::assertNotNull($row2);
+        self::assertSame($id2, $row2['id']);
+    }
+
+    // ── reclaimStaleLease ──────────────────────────────────────────────────────
+
+    public function testReclaimStaleLeaseReturnsNullWhenNoExpired(): void
+    {
+        self::assertNull($this->repo->reclaimStaleLease('worker-2', '2099-01-01 00:00:00'));
+    }
+
+    public function testReclaimStaleLeaseReclaimsExpiredRow(): void
+    {
+        $id = $this->insertBugReport([
+            'status'        => 'hunting',
+            'lease_owner'   => 'crashed-worker',
+            'lease_expires' => '2000-01-01 00:00:00',
+        ]);
+        $row = $this->repo->reclaimStaleLease('worker-2', '2099-01-01 00:00:00');
+        self::assertNotNull($row);
+        self::assertSame($id, $row['id']);
+        self::assertSame('worker-2', $row['lease_owner']);
+    }
+
+    // ── transition ─────────────────────────────────────────────────────────────
+
+    public function testTransitionChangesStatus(): void
+    {
+        $id = $this->insertBugReport();
+        self::assertTrue($this->repo->transition($id, 'hunting'));
+        self::assertSame('hunting', $this->repo->findById($id)['status'] ?? null);
+    }
+
+    public function testTransitionSetsOptionalColumns(): void
+    {
+        $id = $this->insertBugReport();
+        $this->repo->transition($id, 'pr_open', ['pr_number' => 99, 'thread_id' => self::THREAD]);
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertSame(99, $row['pr_number']);
+        self::assertSame(self::THREAD, $row['thread_id']);
+    }
+
+    public function testTransitionWithReleaseLeaseClearsLeaseColumns(): void
+    {
+        $id = $this->insertBugReport([
+            'status'        => 'hunting',
+            'lease_owner'   => 'worker-1',
+            'lease_expires' => '2099-01-01 00:00:00',
+        ]);
+        $this->repo->transition($id, 'needs_human', [], true);
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertSame('needs_human', $row['status']);
+        self::assertNull($row['lease_owner']);
+        self::assertNull($row['lease_expires']);
+    }
+
+    public function testTransitionReturnsFalseForUnknownId(): void
+    {
+        self::assertFalse($this->repo->transition(999999, 'queued'));
+    }
+
+    // ── findThreadIdByPrNumber ─────────────────────────────────────────────────
+
+    public function testFindThreadIdByPrNumberReturnsNullWhenNoMatch(): void
+    {
+        self::assertNull($this->repo->findThreadIdByPrNumber(99999));
+    }
+
+    public function testFindThreadIdByPrNumberReturnsStringSnowflake(): void
+    {
+        $id = $this->insertBugReport(['thread_id' => self::THREAD]);
+        $this->repo->transition($id, 'pr_open', ['pr_number' => 42]);
+        $threadId = $this->repo->findThreadIdByPrNumber(42);
+        self::assertSame(self::THREAD, $threadId);
+    }
+
+    // ── Helper ─────────────────────────────────────────────────────────────────
+
+    /**
+     * @param array<string, int|string> $overrides
+     */
+    private function insertBugReport(array $overrides = []): int
+    {
+        return $this->insertRow('ibl_bug_reports', array_merge([
+            'discord_author_id'   => self::AUTHOR,
+            'channel_id'          => self::CHANNEL,
+            'original_message_id' => self::MSG_ID,
+            'original_text'       => 'test bug report',
+            'status'              => 'queued',
+            'created_at'          => date('Y-m-d H:i:s'),
+            'updated_at'          => date('Y-m-d H:i:s'),
+        ], $overrides));
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/Fixtures/db-seed.sql
+++ b/ibl5/tests/DatabaseIntegration/Fixtures/db-seed.sql
@@ -39,6 +39,10 @@ VALUES
   (28, 'Oklahoma City','Thunder',      '007AC1', 'EF6100', '', '', '', NULL, 'db-team-uuid-28')
 ON DUPLICATE KEY UPDATE team_name = VALUES(team_name), team_city = VALUES(team_city), color1 = VALUES(color1), color2 = VALUES(color2);
 
+-- Bug-pipeline authz fixture: team 1 (New York Metros / testgm) carries a known Discord author id,
+-- consumed by the enqueue-endpoint authz DB-integration test (isKnownDiscordID true-path).
+UPDATE ibl_team_info SET discord_id = '100000000000000001' WHERE teamid = 1;
+
 -- Players: PID 1 (rostered on Metros), PID 2 (free agent)
 INSERT INTO ibl_plr (pid, name, age, teamid, pos, stamina, exp, bird, cy, cyt, salary_yr1, salary_yr2, retired, ordinal, droptime, uuid)
 VALUES (1, 'Test Player One', 27, 1, 'PG', 80, 5, 3, 1, 3, 1500, 1600, 0, 1, 0, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')

--- a/ibl5/tests/DatabaseIntegration/Repositories/TeamIdentityRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/Repositories/TeamIdentityRepositoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Repositories;
+
+use PHPUnit\Framework\Attributes\Group;
+use Repositories\TeamIdentityRepository;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+/**
+ * DB-integration tests for the isKnownDiscordID method added in PR #3.
+ * The seed sets discord_id = '100000000000000001' on teamid=1.
+ */
+#[Group('database')]
+class TeamIdentityRepositoryTest extends DatabaseTestCase
+{
+    private TeamIdentityRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new TeamIdentityRepository($this->db);
+    }
+
+    public function testIsKnownDiscordIDReturnsTrueForSeedTeam(): void
+    {
+        // Seed: UPDATE ibl_team_info SET discord_id = '100000000000000001' WHERE teamid = 1
+        self::assertTrue($this->repo->isKnownDiscordID('100000000000000001'));
+    }
+
+    public function testIsKnownDiscordIDReturnsFalseForUnknownId(): void
+    {
+        self::assertFalse($this->repo->isKnownDiscordID('999999999999999999'));
+    }
+
+    public function testIsKnownDiscordIDReturnsFalseForNullDiscordTeam(): void
+    {
+        // Teams without a discord_id set must NOT match any lookup
+        // Insert a team with no discord_id and verify it doesn't spuriously match
+        self::assertFalse($this->repo->isKnownDiscordID('0'));
+    }
+}


### PR DESCRIPTION
feat: Discord bug pipeline PHP queue layer — BugReportRepository + 6 API endpoints

Implements PR #3 of the Discord bug pipeline 6-PR program: the PHP queue layer consumed by both the Discord bot (PR #4) and the cron CLI wrappers (PR #5).

## What this adds

**`BugReportRepository`** — single DB-logic source for all queue operations:
- Row shape with `@phpstan-type BugReportRow` and `castRow()` for snowflake string-on-read precision (5 BIGINT UNSIGNED columns cast to PHP `string` on every read path — guards against `MYSQLI_OPT_INT_AND_FLOAT_NATIVE` + JS `Number()` precision loss above 2^53)
- CRUD: `insertQueuedReport`, `findById/ByThreadId/ByOriginalMessageId`
- Write path: `upsertReporterProfile/getReporterTechLevel`, `upsertPipelineState` (monotonic GREATEST cursor), `enqueueAuthorizedAndAdvance` (atomic + idempotent transactional enqueue)
- Thread/reaction mutators: `stampThreadReply`, `advanceOnApproval` (status-guarded, ready-for-plan, NOT planned)
- Atomic lease primitives: `claimQueued` (single-flight WHERE guard), `claimNextQueued`, `reclaimStaleLease`
- General state/metadata writer: `transition(int $id, string $status, array $opts, bool $releaseLease)` — every §3e state-machine edge; PR #5a is a thin arg-parse shim over this
- PR #4 readers: `findPipelineState` (backfill cursor), `findThreadIdByPrNumber` (prMerged resolver)

**6 API endpoints** (all POST, all `X-API-Key`-authed via existing `ApiKeyAuthBootstrap`):
- `bug-pipeline/enqueue` — GM authz via `isKnownDiscordID`, atomic+idempotent insert
- `bug-pipeline/thread-reply` — stamps `last_gm_reply_at` (no state upsert — payload has no `channel_id`)
- `bug-pipeline/reaction` — emoji + approver identity gates + repo status guard
- `bug-pipeline/last-seen` — monotonic watermark upsert
- `bug-pipeline/state` — backfill cursor reader for PR #4
- `bug-pipeline/thread-by-pr` — pr_number→thread_id resolver for PR #4 /prMerged

**`TeamIdentityRepository::isKnownDiscordID`** — new authz check binding the Discord snowflake as `"s"` (never int-cast, unlike `getTeamDiscordID`)

**`Discord::getBugPipelineApproverDiscordId()`** — static config accessor mirroring `iblbot_url`; empty = fail-closed

**Seed fixture** — `discord_id = '100000000000000001'` on team 1 (New York Metros / testgm) for enqueue authz DB-integration tests

## Security

- **SQL injection**: all queries via `BaseMysqliRepository` prepared-statement helpers; PHPStan custom SQL rules enforce parameterization in CI
- **Transport auth**: all 6 routes in `POST_ROUTES` → inherit `ApiKeyAuthBootstrap` 401 gate (no new auth code)
- **Enqueue authz**: `isKnownDiscordID($authorId)` on every enqueue; unknown → `{authorized:false}` + no INSERT
- **Reaction authz**: emoji === ✅ AND reactor_id === server-side config (never payload-trusted); repo adds `AND status='awaiting_ajay'` guard
- **CSRF: N/A** — API-key-authed JSON endpoints, no browser surface (identical to `TradeAcceptController`)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: pure repository+controller addition, no new architectural constraint -->
