### PR TITLE
feat: Discord bug-report bot (Mac local — discord-bug-pipeline PR #4)

### DIFF
--- a/ibl5/IBLbot/.env.bugbot.example
+++ b/ibl5/IBLbot/.env.bugbot.example
@@ -3,9 +3,11 @@ BUG_BOT_DISCORD_TOKEN=your-bug-bot-token-here
 # Optional (only if the bug-bot ever registers slash commands):
 DISCORD_CLIENT_ID=
 DISCORD_GUILD_ID=
-# Mac-local PHP/docker stack base URL that serves PR #3's /api/bug-pipeline/* endpoints
-# (NOT the prod v1 API). Full URL = ${BUG_PIPELINE_API_BASE_URL}/api/bug-pipeline/<endpoint>.
-BUG_PIPELINE_API_BASE_URL=http://<slug>.localhost
+# Mac-local PHP/docker stack that serves master's /api/v1/bug-pipeline/* endpoints.
+# Use the always-up main stack (http://main.localhost/ibl5) — NOT a worktree slug
+# (torn down on merge) and NOT the deployed prod server. Include the /ibl5 prefix.
+# Full URL = ${BUG_PIPELINE_API_BASE_URL}/api/v1/bug-pipeline/<endpoint>.
+BUG_PIPELINE_API_BASE_URL=http://main.localhost/ibl5
 # Reused as the X-API-Key header value on the §3b POSTs.
 API_KEY=your-api-key-here
 # Loopback Express port the PR #5 cron calls (default 50001; keep distinct from prod bot's 50000).

--- a/ibl5/IBLbot/.env.bugbot.example
+++ b/ibl5/IBLbot/.env.bugbot.example
@@ -1,0 +1,18 @@
+# Second Discord app (bug-report bot) — SEPARATE from the prod IBLbot app/token.
+BUG_BOT_DISCORD_TOKEN=your-bug-bot-token-here
+# Optional (only if the bug-bot ever registers slash commands):
+DISCORD_CLIENT_ID=
+DISCORD_GUILD_ID=
+# Mac-local PHP/docker stack base URL that serves PR #3's /api/bug-pipeline/* endpoints
+# (NOT the prod v1 API). Full URL = ${BUG_PIPELINE_API_BASE_URL}/api/bug-pipeline/<endpoint>.
+BUG_PIPELINE_API_BASE_URL=http://<slug>.localhost
+# Reused as the X-API-Key header value on the §3b POSTs.
+API_KEY=your-api-key-here
+# Loopback Express port the PR #5 cron calls (default 50001; keep distinct from prod bot's 50000).
+EXPRESS_PORT=50001
+# The dedicated bug-report channel snowflake ID (decision 10 — injected, never hardcoded).
+BUG_CHANNEL_ID=000000000000000000
+
+# PREREQUISITE (one-time, in the Discord Developer Portal for the NEW bug-bot app):
+#   Enable the "MESSAGE CONTENT INTENT" privileged intent — the bot cannot read
+#   message text without it. This is an environmental setup step, not a code test.

--- a/ibl5/IBLbot/.gitignore
+++ b/ibl5/IBLbot/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
 .env
+.env.bugbot
 config.json
 logs/

--- a/ibl5/IBLbot/README.bugbot.md
+++ b/ibl5/IBLbot/README.bugbot.md
@@ -3,7 +3,7 @@
 A **second** Discord bot process — a distinct Discord app/token from the prod
 IBLbot — that turns a dedicated bug-report channel into a work queue. It runs on
 the Mac only, never on prod. It writes nothing to MySQL directly: every DB effect
-goes through PR #3's `/api/bug-pipeline/*` PHP endpoints.
+goes through PR #3's `/api/v1/bug-pipeline/*` PHP endpoints.
 
 Two I/O directions:
 - **Inbound (Discord → PHP):** `MessageCreate`, `MessageReactionAdd`, and a
@@ -22,7 +22,8 @@ Two I/O directions:
    Messages, Send Messages in Threads.
 3. `cp .env.bugbot.example .env.bugbot` and fill in:
    - `BUG_BOT_DISCORD_TOKEN` — the new app's token
-   - `BUG_PIPELINE_API_BASE_URL` — the Mac-local PHP/docker stack base (NOT prod)
+   - `BUG_PIPELINE_API_BASE_URL` — the always-up main stack `http://main.localhost/ibl5`
+     (NOT a worktree slug, torn down on merge; NOT prod)
    - `API_KEY` — a valid `ibl_api_keys` key; **must be a high/unlimited rate-limit
      tier** so startup backfill isn't 429-throttled into silently dropping reports
    - `BUG_CHANNEL_ID` — the dedicated bug-report channel snowflake
@@ -38,3 +39,7 @@ pm2 start ecosystem.bugbot.config.cjs   # run inside tmux so it survives termina
 The bug-bot uses its OWN PM2 ecosystem file (`ecosystem.bugbot.config.cjs`) — it is
 deliberately NOT added to the prod `ecosystem.config.cjs`, so a prod deploy never
 starts it.
+
+**Runtime dependency:** the bot targets `http://main.localhost/ibl5`, so the always-up
+main stack must be running (`bin/dev-up`, which prod-syncs the DB by default). It is not
+tied to any worktree stack (those are torn down on merge).

--- a/ibl5/IBLbot/README.bugbot.md
+++ b/ibl5/IBLbot/README.bugbot.md
@@ -1,0 +1,40 @@
+# Bug-Report Bot (Mac-local)
+
+A **second** Discord bot process — a distinct Discord app/token from the prod
+IBLbot — that turns a dedicated bug-report channel into a work queue. It runs on
+the Mac only, never on prod. It writes nothing to MySQL directly: every DB effect
+goes through PR #3's `/api/bug-pipeline/*` PHP endpoints.
+
+Two I/O directions:
+- **Inbound (Discord → PHP):** `MessageCreate`, `MessageReactionAdd`, and a
+  `ClientReady` backfill forward events to the pipeline endpoints.
+- **Outbound-command (cron → Discord):** six loopback Express endpoints
+  (`127.0.0.1:50001`) let the PR #5 cron drive Discord actions.
+
+## One-time setup
+
+1. **Create the SECOND Discord application + bot token** in the Developer Portal
+   (separate from the prod IBLbot app — one token cannot hold two gateway
+   connections). **Enable the `MESSAGE CONTENT` privileged intent** on this new
+   app; without it the bot connects but reads empty `message.content`.
+2. **Invite the new bot to the guild** with permissions: View Channel / Read
+   Messages, Read Message History, Add Reactions, Create Public Threads, Send
+   Messages, Send Messages in Threads.
+3. `cp .env.bugbot.example .env.bugbot` and fill in:
+   - `BUG_BOT_DISCORD_TOKEN` — the new app's token
+   - `BUG_PIPELINE_API_BASE_URL` — the Mac-local PHP/docker stack base (NOT prod)
+   - `API_KEY` — a valid `ibl_api_keys` key; **must be a high/unlimited rate-limit
+     tier** so startup backfill isn't 429-throttled into silently dropping reports
+   - `BUG_CHANNEL_ID` — the dedicated bug-report channel snowflake
+
+## Start
+
+```bash
+cd ibl5/IBLbot
+npm run build
+pm2 start ecosystem.bugbot.config.cjs   # run inside tmux so it survives terminal close
+```
+
+The bug-bot uses its OWN PM2 ecosystem file (`ecosystem.bugbot.config.cjs`) — it is
+deliberately NOT added to the prod `ecosystem.config.cjs`, so a prod deploy never
+starts it.

--- a/ibl5/IBLbot/ecosystem.bugbot.config.cjs
+++ b/ibl5/IBLbot/ecosystem.bugbot.config.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  apps: [
+    {
+      name: 'ibl-bug-bot',                 // distinct from prod 'iblbot'
+      script: 'dist/bug-bot/index.js',     // the Phase 5 entrypoint's compiled output
+      cwd: '/Users/ajaynicolas/GitHub/IBL5/ibl5/IBLbot',  // Mac main checkout (NOT the prod path)
+      max_memory_restart: '150M',
+      min_uptime: '10s',
+      max_restarts: 10,
+      log_date_format: 'YYYY-MM-DD HH:mm:ss'
+    }
+  ]
+};

--- a/ibl5/IBLbot/src/bug-bot/backfill.test.ts
+++ b/ibl5/IBLbot/src/bug-bot/backfill.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Client } from 'discord.js';
+
+vi.mock('./config.js', () => ({
+    config: { bugChannelId: 'BUG_CHANNEL' },
+}));
+
+vi.mock('./php-client.js', () => ({
+    getState: vi.fn(),
+    lastSeen: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+import { runBackfill } from './backfill.js';
+import * as phpClient from './php-client.js';
+
+// discord.js messages.fetch returns a Collection (extends Map, has .first()/.size).
+function fakeCollection(arr: unknown[]) {
+    return {
+        size: arr.length,
+        values: () => arr[Symbol.iterator](),
+        first: () => arr[0],
+    };
+}
+
+function msg(id: string, ts: number) {
+    return { id, createdTimestamp: ts };
+}
+
+function clientWithChannel(channel: unknown): Client {
+    return { channels: { fetch: vi.fn().mockResolvedValue(channel) } } as unknown as Client;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+describe('runBackfill', () => {
+    it('replays each new top-level message via the shared handleEnqueue, oldest-first, string ids', async () => {
+        const getState = vi.fn().mockResolvedValue({ last_processed_message_id: '100' });
+        const handleEnqueue = vi.fn().mockResolvedValue(undefined);
+        // supplied newest-first (discord order); expect oldest-first replay
+        const channel = {
+            isTextBased: () => true,
+            messages: { fetch: vi.fn().mockResolvedValue(fakeCollection([msg('300', 3000), msg('200', 2000)])) },
+        };
+
+        await runBackfill(clientWithChannel(channel), { getState, handleEnqueue });
+
+        expect(handleEnqueue).toHaveBeenCalledTimes(2);
+        expect(handleEnqueue.mock.calls[0][0].id).toBe('200');   // oldest first
+        expect(handleEnqueue.mock.calls[1][0].id).toBe('300');
+        expect(typeof handleEnqueue.mock.calls[0][0].id).toBe('string');
+    });
+
+    it('does NOT walk thread history — only the parent channel is fetched', async () => {
+        const getState = vi.fn().mockResolvedValue({ last_processed_message_id: '100' });
+        const handleEnqueue = vi.fn().mockResolvedValue(undefined);
+        const channel = {
+            isTextBased: () => true,
+            messages: { fetch: vi.fn().mockResolvedValue(fakeCollection([msg('200', 2000)])) },
+        };
+        const client = clientWithChannel(channel);
+
+        await runBackfill(client, { getState, handleEnqueue });
+
+        // channels.fetch only ever called with the bug channel id — never a thread id.
+        const fetchMock = vi.mocked(client.channels.fetch);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('BUG_CHANNEL');
+    });
+
+    it('null cursor → no replay, start-fresh (boundary)', async () => {
+        const getState = vi.fn().mockResolvedValue({ last_processed_message_id: null });
+        const handleEnqueue = vi.fn().mockResolvedValue(undefined);
+        const fetch = vi.fn().mockResolvedValue(fakeCollection([msg('500', 5000)]));
+        const channel = { isTextBased: () => true, messages: { fetch } };
+
+        await runBackfill(clientWithChannel(channel), { getState, handleEnqueue });
+
+        expect(handleEnqueue).not.toHaveBeenCalled();
+        // no messages.fetch({ after }) issued (only the {limit:1} seed peek)
+        for (const call of fetch.mock.calls) {
+            expect(call[0]).not.toHaveProperty('after');
+        }
+        // seeded the cursor from the newest message
+        expect(phpClient.lastSeen).toHaveBeenCalledWith({ channel_id: 'BUG_CHANNEL', message_id: '500' });
+    });
+
+    it('swallows a getState rejection without throwing (negative)', async () => {
+        const getState = vi.fn().mockRejectedValue(new Error('cursor read failed'));
+        const handleEnqueue = vi.fn();
+
+        await expect(runBackfill(clientWithChannel(null), { getState, handleEnqueue })).resolves.toBeUndefined();
+        expect(handleEnqueue).not.toHaveBeenCalled();
+        expect(console.error).toHaveBeenCalled();
+    });
+
+    it('paging advances `after` and stops on a short page (no infinite loop)', async () => {
+        const getState = vi.fn().mockResolvedValue({ last_processed_message_id: '0' });
+        const handleEnqueue = vi.fn().mockResolvedValue(undefined);
+
+        const fullPage = Array.from({ length: 100 }, (_, i) => msg(String(i + 1), (i + 1) * 10));
+        const fetch = vi.fn()
+            .mockResolvedValueOnce(fakeCollection(fullPage))                 // 100 → keep paging
+            .mockResolvedValueOnce(fakeCollection([msg('101', 1010)]));      // short → stop
+        const channel = { isTextBased: () => true, messages: { fetch } };
+
+        await runBackfill(clientWithChannel(channel), { getState, handleEnqueue });
+
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(fetch.mock.calls[0][0]).toEqual({ after: '0', limit: 100 });
+        // after advanced to the newest id of the first page (100, the last after oldest-first sort)
+        expect(fetch.mock.calls[1][0]).toEqual({ after: '100', limit: 100 });
+        expect(handleEnqueue).toHaveBeenCalledTimes(101);
+    });
+});

--- a/ibl5/IBLbot/src/bug-bot/backfill.ts
+++ b/ibl5/IBLbot/src/bug-bot/backfill.ts
@@ -1,0 +1,99 @@
+import type { Client, Message } from 'discord.js';
+import { config } from './config.js';
+import * as phpClient from './php-client.js';
+import { handleEnqueue as realHandleEnqueue } from './handlers.js';
+
+interface BackfillDeps {
+    getState: typeof phpClient.getState;
+    handleEnqueue: (msg: Message) => Promise<void>;
+}
+
+/**
+ * On boot, recover TOP-LEVEL bug reports posted while the Mac was asleep. Reads the
+ * cursor from PR #3 (gap #1), fetches only new top-level messages after it, and
+ * replays each through the SAME handleEnqueue the live listener uses (no divergent
+ * replay code — PR #3's /enqueue owns idempotency/dedupe).
+ *
+ * NEVER throws — every rejection is caught, logged, and swallowed. Collaborators are
+ * injected via `deps` so vitest can mock them without a network or a live channel.
+ */
+export async function runBackfill(client: Client, deps?: Partial<BackfillDeps>): Promise<void> {
+    const getState = deps?.getState ?? phpClient.getState;
+    const handleEnqueue = deps?.handleEnqueue ?? realHandleEnqueue;
+
+    try {
+        // 1. Read cursor (gap #1).
+        const { last_processed_message_id } = await getState({ channel_id: config.bugChannelId });
+
+        // 2. Resolve the bug channel; guard it exposes .messages (a misconfigured
+        //    BUG_CHANNEL_ID must not throw).
+        const channel = await client.channels.fetch(config.bugChannelId);
+        if (!channel || !channel.isTextBased()) {
+            console.error(`Backfill: bug channel ${config.bugChannelId} is not a text channel — skipping`);
+            return;
+        }
+
+        // 3. Null-cursor boundary (first-ever boot): start fresh, no replay. Replaying
+        //    full channel history could flood PR #3's queue with pre-pipeline messages,
+        //    and messages.fetch({ after }) requires a snowflake. Optionally seed the
+        //    cursor from the newest message so the next boot has a watermark.
+        if (last_processed_message_id === null) {
+            const newest = await channel.messages.fetch({ limit: 1 });
+            const newestMsg = newest.first();
+            if (newestMsg) {
+                try {
+                    await phpClient.lastSeen({
+                        channel_id: config.bugChannelId,
+                        message_id: newestMsg.id,
+                    });
+                } catch (seedErr) {
+                    console.error('Backfill: failed to seed cursor on first boot:', seedErr);
+                }
+            }
+            return;
+        }
+
+        // 4. Page forward (TOP-LEVEL only — channel.messages.fetch does NOT include
+        //    thread replies; missed thread replies are recovered by the cron's
+        //    per-tick live get-thread-messages, decision 7). Replay oldest-first so
+        //    the cursor advances monotonically.
+        let after = last_processed_message_id;
+        for (;;) {
+            const page = await channel.messages.fetch({ after, limit: 100 });
+            if (page.size === 0) break;
+
+            const oldestFirst = [...page.values()].sort(
+                (a, b) => a.createdTimestamp - b.createdTimestamp,
+            );
+
+            // 5. Replay via the shared path.
+            for (const message of oldestFirst) {
+                await handleEnqueue(message);
+            }
+
+            // Advance the cursor to the newest replayed id (last after oldest-first sort).
+            const lastReplayed = oldestFirst[oldestFirst.length - 1];
+            if (!lastReplayed) break;
+            after = lastReplayed.id;   // string cursor — NEVER Number() it
+
+            if (page.size < 100) break;   // short page → done, no infinite loop
+        }
+    } catch (error) {
+        // 6/7. Error containment — runBackfill NEVER throws. A 429 (rate-limit) is
+        // logged distinctly so a mis-provisioned API_KEY tier fails loudly rather than
+        // silently dropping reports (PR #3 §rate-limiting: the bug-bot's API_KEY must
+        // be a high/unlimited ibl_api_keys tier — an ops provisioning item).
+        if (isRateLimited(error)) {
+            console.error('Backfill: RATE-LIMITED (429) — API_KEY tier likely too low; reports may be dropped:', error);
+        } else {
+            console.error('Backfill failed (swallowed — bot continues live):', error);
+        }
+    }
+}
+
+function isRateLimited(error: unknown): boolean {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+        return (error as { statusCode: unknown }).statusCode === 429;
+    }
+    return false;
+}

--- a/ibl5/IBLbot/src/bug-bot/config.ts
+++ b/ibl5/IBLbot/src/bug-bot/config.ts
@@ -24,8 +24,9 @@ export const config = {
         guildId: process.env['DISCORD_GUILD_ID'] ?? '',
     },
     phpApi: {
-        // Mac-local PHP/docker stack base (e.g. http://<slug>.localhost) — NOT the
-        // prod v1 API. php-client builds `${baseUrl}/api/bug-pipeline/<endpoint>`.
+        // Always-up main stack incl. the /ibl5 app prefix (http://main.localhost/ibl5)
+        // — serves master's endpoints; NOT a worktree slug (torn down on merge) nor
+        // prod. php-client builds `${baseUrl}/api/v1/bug-pipeline/<endpoint>`.
         baseUrl: requireEnv('BUG_PIPELINE_API_BASE_URL'),
         // Reused as the X-API-Key header value on the §3b POSTs.
         key: requireEnv('API_KEY'),

--- a/ibl5/IBLbot/src/bug-bot/config.ts
+++ b/ibl5/IBLbot/src/bug-bot/config.ts
@@ -1,0 +1,41 @@
+import dotenv from 'dotenv';
+import * as path from 'path';
+
+// cwd = IBLbot for BOTH the prod bot and the bug-bot. Load the bug-bot's own
+// dotenv file explicitly so it never inherits the prod bot's DISCORD_TOKEN — an
+// unqualified dotenv.config() would read the prod .env from the shared cwd. No
+// `override`, so a real process-env value still wins (matches prod behavior).
+dotenv.config({ path: path.resolve(process.cwd(), '.env.bugbot') });
+
+function requireEnv(key: string): string {
+    const value = process.env[key];
+    if (!value) {
+        throw new Error(`Missing required environment variable: ${key}`);
+    }
+    return value;
+}
+
+export const config = {
+    discord: {
+        // The SECOND Discord app's token — distinct from prod DISCORD_TOKEN.
+        token: requireEnv('BUG_BOT_DISCORD_TOKEN'),
+        // Optional — only used if the bug-bot ever registers slash commands.
+        clientId: process.env['DISCORD_CLIENT_ID'] ?? '',
+        guildId: process.env['DISCORD_GUILD_ID'] ?? '',
+    },
+    phpApi: {
+        // Mac-local PHP/docker stack base (e.g. http://<slug>.localhost) — NOT the
+        // prod v1 API. php-client builds `${baseUrl}/api/bug-pipeline/<endpoint>`.
+        baseUrl: requireEnv('BUG_PIPELINE_API_BASE_URL'),
+        // Reused as the X-API-Key header value on the §3b POSTs.
+        key: requireEnv('API_KEY'),
+    },
+    express: {
+        // Default 50001 — distinct from the prod bot's 50000 so both loopback
+        // servers coexist on the Mac.
+        port: parseInt(process.env['EXPRESS_PORT'] ?? '50001', 10),
+    },
+    // Dedicated bug-report channel snowflake — injected via env, NEVER hardcoded.
+    // Keep it a string (snowflake wire-type LOCKED — never parseInt it).
+    bugChannelId: requireEnv('BUG_CHANNEL_ID'),
+} as const;

--- a/ibl5/IBLbot/src/bug-bot/handlers.test.ts
+++ b/ibl5/IBLbot/src/bug-bot/handlers.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Message, MessageReaction, User } from 'discord.js';
+
+vi.mock('./config.js', () => ({
+    config: { bugChannelId: 'BUG_CHANNEL' },
+}));
+
+vi.mock('./php-client.js', () => ({
+    enqueue: vi.fn().mockResolvedValue({ authorized: true, report_id: 1 }),
+    threadReply: vi.fn().mockResolvedValue({ matched: true }),
+    reaction: vi.fn().mockResolvedValue({ advanced: true }),
+}));
+
+import {
+    classifyMessage,
+    toRoutable,
+    handleEnqueue,
+    handleReaction,
+    type RoutableMessage,
+} from './handlers.js';
+import * as phpClient from './php-client.js';
+
+const base: RoutableMessage = {
+    authorId: 'GM',
+    isBot: false,
+    channelId: 'BUG_CHANNEL',
+    isThread: false,
+    parentId: null,
+};
+
+describe('classifyMessage', () => {
+    it('top-level message in the bug channel → enqueue', () => {
+        expect(classifyMessage(base, 'CLIENT')).toBe('enqueue');
+    });
+
+    it('thread under the bug channel → thread-reply', () => {
+        expect(classifyMessage({ ...base, channelId: 'THREAD', isThread: true, parentId: 'BUG_CHANNEL' }, 'CLIENT'))
+            .toBe('thread-reply');
+    });
+
+    it('bot-self → ignore', () => {
+        expect(classifyMessage({ ...base, isBot: true }, 'CLIENT')).toBe('ignore');
+    });
+
+    it('authorId === clientUserId → ignore', () => {
+        expect(classifyMessage({ ...base, authorId: 'CLIENT' }, 'CLIENT')).toBe('ignore');
+    });
+
+    it('message in a different channel → ignore', () => {
+        expect(classifyMessage({ ...base, channelId: 'OTHER' }, 'CLIENT')).toBe('ignore');
+    });
+
+    it('thread under some OTHER parent → ignore', () => {
+        expect(classifyMessage({ ...base, channelId: 'THREAD', isThread: true, parentId: 'OTHER' }, 'CLIENT'))
+            .toBe('ignore');
+    });
+});
+
+describe('toRoutable', () => {
+    it('maps a non-thread live Message', () => {
+        const msg = {
+            author: { id: 'A1', bot: false },
+            channelId: 'BUG_CHANNEL',
+            channel: { isThread: () => false },
+        } as unknown as Message;
+        expect(toRoutable(msg)).toEqual({
+            authorId: 'A1', isBot: false, channelId: 'BUG_CHANNEL', isThread: false, parentId: null,
+        });
+    });
+
+    it('maps a thread live Message with parentId', () => {
+        const msg = {
+            author: { id: 'A2', bot: true },
+            channelId: 'THREAD',
+            channel: { isThread: () => true, parentId: 'BUG_CHANNEL' },
+        } as unknown as Message;
+        expect(toRoutable(msg)).toEqual({
+            authorId: 'A2', isBot: true, channelId: 'THREAD', isThread: true, parentId: 'BUG_CHANNEL',
+        });
+    });
+});
+
+describe('handleEnqueue', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('forwards the four fields with string ids (no numeric coercion)', async () => {
+        const msg = {
+            author: { id: '111111111111111111' },
+            channelId: '222222222222222222',
+            id: '333333333333333333',
+            content: 'a bug',
+        } as unknown as Message;
+
+        await handleEnqueue(msg);
+
+        expect(phpClient.enqueue).toHaveBeenCalledTimes(1);
+        const arg = vi.mocked(phpClient.enqueue).mock.calls[0][0];
+        expect(arg).toEqual({
+            author_id: '111111111111111111',
+            channel_id: '222222222222222222',
+            message_id: '333333333333333333',
+            text: 'a bug',
+        });
+        expect(typeof arg.author_id).toBe('string');
+        expect(typeof arg.message_id).toBe('string');
+    });
+});
+
+describe('handleReaction', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    function makeReaction(over: Partial<{ partial: boolean; channelId: string; channel: unknown; msgPartial: boolean }>) {
+        return {
+            partial: over.partial ?? false,
+            emoji: { name: '✅' },
+            fetch: vi.fn().mockResolvedValue(undefined),
+            message: {
+                partial: over.msgPartial ?? false,
+                id: 'MSG',
+                channelId: over.channelId ?? 'BUG_CHANNEL',
+                channel: over.channel ?? { isThread: () => false },
+                fetch: vi.fn().mockResolvedValue(undefined),
+            },
+        } as unknown as MessageReaction;
+    }
+
+    it('skips the bot\'s own reaction', async () => {
+        await handleReaction(makeReaction({}), { bot: true, id: 'BOT' } as unknown as User, 'CLIENT');
+        expect(phpClient.reaction).not.toHaveBeenCalled();
+    });
+
+    it('skips a reaction by the client user', async () => {
+        await handleReaction(makeReaction({}), { bot: false, id: 'CLIENT' } as unknown as User, 'CLIENT');
+        expect(phpClient.reaction).not.toHaveBeenCalled();
+    });
+
+    it('skips a reaction outside the bug channel (scope guard)', async () => {
+        await handleReaction(makeReaction({ channelId: 'OTHER' }), { bot: false, id: 'U' } as unknown as User, 'CLIENT');
+        expect(phpClient.reaction).not.toHaveBeenCalled();
+    });
+
+    it('skips a reaction in a thread under some OTHER parent (scope guard)', async () => {
+        const reaction = makeReaction({ channelId: 'THREAD', channel: { isThread: () => true, parentId: 'OTHER' } });
+        await handleReaction(reaction, { bot: false, id: 'U' } as unknown as User, 'CLIENT');
+        expect(phpClient.reaction).not.toHaveBeenCalled();
+    });
+
+    it('fetches partials and forwards string ids for a real user on a bug-channel message', async () => {
+        const reaction = makeReaction({ partial: true, msgPartial: true });
+        const user = { bot: false, id: '999999999999999999' } as unknown as User;
+
+        await handleReaction(reaction, user, 'CLIENT');
+
+        expect(reaction.fetch).toHaveBeenCalled();
+        expect(reaction.message.fetch).toHaveBeenCalled();
+        expect(phpClient.reaction).toHaveBeenCalledTimes(1);
+        const arg = vi.mocked(phpClient.reaction).mock.calls[0][0];
+        expect(arg).toEqual({ message_id: 'MSG', emoji: '✅', reactor_id: '999999999999999999' });
+        expect(typeof arg.reactor_id).toBe('string');
+    });
+
+    it('forwards a reaction in a thread under the bug channel (scope guard positive)', async () => {
+        const reaction = makeReaction({ channelId: 'THREAD', channel: { isThread: () => true, parentId: 'BUG_CHANNEL' } });
+        await handleReaction(reaction, { bot: false, id: 'U' } as unknown as User, 'CLIENT');
+        expect(phpClient.reaction).toHaveBeenCalledTimes(1);
+    });
+});

--- a/ibl5/IBLbot/src/bug-bot/handlers.ts
+++ b/ibl5/IBLbot/src/bug-bot/handlers.ts
@@ -1,0 +1,98 @@
+import type {
+    Message,
+    MessageReaction,
+    PartialMessageReaction,
+    User,
+    PartialUser,
+} from 'discord.js';
+import { config } from './config.js';
+import * as phpClient from './php-client.js';
+
+// ── Pure routing function — the single most-tested unit ─────────────────────
+// Takes a minimal plain shape (NOT a live Message) so tests need no discord.js
+// mock. `clientUserId` is injected (rather than read off a live client) to keep
+// classifyMessage pure.
+export interface RoutableMessage {
+    authorId: string;
+    isBot: boolean;
+    channelId: string;
+    isThread: boolean;
+    parentId: string | null;
+}
+export type Route = 'enqueue' | 'thread-reply' | 'ignore';
+
+export function classifyMessage(msg: RoutableMessage, clientUserId: string): Route {
+    if (msg.isBot || msg.authorId === clientUserId) return 'ignore';
+    if (msg.channelId === config.bugChannelId && !msg.isThread) return 'enqueue';
+    if (msg.isThread && msg.parentId === config.bugChannelId) return 'thread-reply';
+    return 'ignore';
+}
+
+// Adapter mapping a live Message → the plain RoutableMessage shape. Co-located
+// here so it is covered by handlers.test.ts.
+export function toRoutable(message: Message): RoutableMessage {
+    const inThread = message.channel.isThread();
+    return {
+        authorId: message.author.id,
+        isBot: message.author.bot,
+        channelId: message.channelId,
+        isThread: inThread,
+        parentId: inThread ? message.channel.parentId : null,
+    };
+}
+
+// ── Shared enqueue path — Phase 6 backfill calls this EXACT function ─────────
+// All *_id fields are the string values discord.js already provides — NEVER
+// Number()/parseInt.
+export async function handleEnqueue(msg: Message): Promise<void> {
+    await phpClient.enqueue({
+        author_id: msg.author.id,
+        channel_id: msg.channelId,
+        message_id: msg.id,
+        text: msg.content,
+    });
+}
+
+// A thread's own channel id IS the thread id — that's what §3b thread-reply
+// stamps last_gm_reply_at against.
+export async function handleThreadReply(msg: Message): Promise<void> {
+    await phpClient.threadReply({ thread_id: msg.channelId, message_id: msg.id });
+}
+
+// ── Reaction handler — resolves partials, ignores the bot's own reactions ────
+export async function handleReaction(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+    clientUserId: string,
+): Promise<void> {
+    if (user.bot || user.id === clientUserId) return;            // ignore bot's own
+    if (reaction.partial) await reaction.fetch();                // uncached post-restart
+    if (reaction.message.partial) await reaction.message.fetch();
+
+    // SCOPE GUARD (security + efficiency): only forward reactions on messages in the
+    // bug channel or a thread under it — the ✅ approval lives on a message in a
+    // bug-channel thread. GuildMessageReactions otherwise fires for EVERY reaction
+    // anywhere in the guild, POSTing each to PHP and leaking every reactor_id off a
+    // channel we don't own. Resolve partials FIRST so channel context is populated.
+    const msgChannel = reaction.message.channel;
+    const inBugScope =
+        reaction.message.channelId === config.bugChannelId ||
+        (msgChannel.isThread() && msgChannel.parentId === config.bugChannelId);
+    if (!inBugScope) return;
+
+    await phpClient.reaction({
+        message_id: reaction.message.id,
+        emoji: reaction.emoji.name ?? '',   // custom emoji may have null name
+        reactor_id: user.id,
+    });
+}
+
+// ── Optional convenience dispatcher (thin) ──────────────────────────────────
+// index.ts stays a wiring shell; the tested logic lives in classifyMessage + the
+// handlers above.
+export async function routeAndHandle(message: Message, clientUserId: string): Promise<void> {
+    const route = classifyMessage(toRoutable(message), clientUserId);
+    if (route === 'enqueue') await handleEnqueue(message);
+    else if (route === 'thread-reply') await handleThreadReply(message);
+    // 'ignore' → no-op
+}

--- a/ibl5/IBLbot/src/bug-bot/index.ts
+++ b/ibl5/IBLbot/src/bug-bot/index.ts
@@ -1,0 +1,74 @@
+import { Client, Events, GatewayIntentBits, Partials } from 'discord.js';
+import { config } from './config.js';
+import {
+    classifyMessage,
+    toRoutable,
+    handleEnqueue,
+    handleThreadReply,
+    handleReaction,
+} from './handlers.js';
+import { startBugBotServer } from './server.js';
+import { runBackfill } from './backfill.js';
+
+const client = new Client({
+    intents: [
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,        // PRIVILEGED — must be enabled in the Developer Portal
+        GatewayIntentBits.GuildMessageReactions,
+    ],
+    // Partials so MessageReactionAdd fires on uncached (pre-restart) messages;
+    // handleReaction .fetch()es them before reading.
+    partials: [Partials.Message, Partials.Reaction, Partials.Channel],
+});
+
+// Backfill gate: live MessageCreate handling WAITS for the ClientReady backfill to
+// finish, so the oldest-first replay and live traffic never race the enqueue/cursor
+// path. A live message that also falls in the backfill window is deduped downstream
+// by PR #3's idempotent enqueue (findByOriginalMessageId), so buffer-then-process is
+// safe. The gate is released in a `finally`, so even a thrown backfill lets live
+// traffic through (never a permanent hang).
+let resolveBackfill!: () => void;
+const backfillReady = new Promise<void>((resolve) => {
+    resolveBackfill = resolve;
+});
+
+client.once(Events.ClientReady, async (c) => {
+    console.log(`Bug-bot ready as ${c.user.tag}`);
+    try {
+        await runBackfill(client);
+    } catch (err) {
+        console.error('Backfill failed (continuing live):', err);   // MUST NOT crash the bot
+    } finally {
+        resolveBackfill();   // OPEN THE GATE even if backfill threw — else live msgs hang forever
+    }
+});
+
+client.on(Events.MessageCreate, async (message) => {
+    try {
+        await backfillReady;   // hold live enqueues until backfill completes
+        const clientUserId = client.user?.id ?? '';
+        const route = classifyMessage(toRoutable(message), clientUserId);
+        if (route === 'enqueue') await handleEnqueue(message);
+        else if (route === 'thread-reply') await handleThreadReply(message);
+        // 'ignore' → no-op
+    } catch (err) {
+        console.error('MessageCreate handler error:', err);
+    }
+});
+
+// MessageReactionAdd is deliberately NOT gated: reactions advance state via PR #3's
+// idempotent advanceOnApproval UPDATE and have no backfill to race.
+client.on(Events.MessageReactionAdd, async (reaction, user) => {
+    try {
+        const clientUserId = client.user?.id ?? '';
+        await handleReaction(reaction, user, clientUserId);
+    } catch (err) {
+        console.error('MessageReactionAdd handler error:', err);
+    }
+});
+
+// Bootstrap (order matters): start the loopback server unconditionally so the cron
+// endpoints are reachable even while the gateway is mid-connect (discord.js queues
+// actions).
+void client.login(config.discord.token);
+startBugBotServer(client);

--- a/ibl5/IBLbot/src/bug-bot/php-client.test.ts
+++ b/ibl5/IBLbot/src/bug-bot/php-client.test.ts
@@ -34,7 +34,7 @@ describe('apiPost', () => {
 
         expect(fetchFn).toHaveBeenCalledTimes(1);
         const [url, opts] = fetchFn.mock.calls[0];
-        expect(url).toBe('http://test.localhost/api/bug-pipeline/enqueue');
+        expect(url).toBe('http://test.localhost/api/v1/bug-pipeline/enqueue');
         expect(opts.method).toBe('POST');
         expect(opts.headers['X-API-Key']).toBe('test-api-key');
         expect(opts.headers['Content-Type']).toBe('application/json');

--- a/ibl5/IBLbot/src/bug-bot/php-client.test.ts
+++ b/ibl5/IBLbot/src/bug-bot/php-client.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+vi.mock('./config.js', () => ({
+    config: {
+        phpApi: { baseUrl: 'http://test.localhost', key: 'test-api-key' },
+    },
+}));
+
+import { apiPost, enqueue, ApiError } from './php-client.js';
+
+function mockFetchOnce(body: unknown, init?: { ok?: boolean; status?: number }): ReturnType<typeof vi.fn> {
+    const fn = vi.fn().mockResolvedValue({
+        ok: init?.ok ?? true,
+        status: init?.status ?? 200,
+        json: async () => body,
+    });
+    vi.stubGlobal('fetch', fn);
+    return fn;
+}
+
+describe('apiPost', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('builds the URL, sets headers, and sends the JSON body', async () => {
+        const fetchFn = mockFetchOnce({ status: 'success', data: { authorized: true, report_id: 7 } });
+
+        await apiPost('enqueue', { message_id: '123456789012345678', text: 'hi' });
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        const [url, opts] = fetchFn.mock.calls[0];
+        expect(url).toBe('http://test.localhost/api/bug-pipeline/enqueue');
+        expect(opts.method).toBe('POST');
+        expect(opts.headers['X-API-Key']).toBe('test-api-key');
+        expect(opts.headers['Content-Type']).toBe('application/json');
+        expect(opts.body).toBe(JSON.stringify({ message_id: '123456789012345678', text: 'hi' }));
+    });
+
+    it('keeps a string snowflake a string in the serialized body (no numeric coercion)', async () => {
+        const fetchFn = mockFetchOnce({ status: 'success', data: {} });
+
+        await enqueue({
+            author_id: '111111111111111111',
+            channel_id: '222222222222222222',
+            message_id: '333333333333333333',
+            text: 'bug',
+        });
+
+        const sent = JSON.parse(fetchFn.mock.calls[0][1].body);
+        expect(typeof sent.message_id).toBe('string');
+        expect(sent.message_id).toBe('333333333333333333');
+    });
+
+    it('returns body.data (envelope stripped), not the whole envelope', async () => {
+        mockFetchOnce({ status: 'success', data: { authorized: true, report_id: 7 } });
+
+        const result = await apiPost<{ authorized: boolean; report_id: number }>('enqueue', {});
+
+        expect(result).toEqual({ authorized: true, report_id: 7 });
+    });
+
+    it('throws ApiError on a non-ok HTTP response', async () => {
+        mockFetchOnce({ status: 'error', error: { code: 'BAD', message: 'nope' } }, { ok: false, status: 500 });
+
+        await expect(apiPost('enqueue', {})).rejects.toBeInstanceOf(ApiError);
+    });
+
+    it('throws ApiError on a {status:"error"} envelope returned with HTTP 200', async () => {
+        mockFetchOnce({ status: 'error', error: { code: 'x', message: 'y' } }, { ok: true, status: 200 });
+
+        await expect(apiPost('enqueue', {})).rejects.toBeInstanceOf(ApiError);
+    });
+});

--- a/ibl5/IBLbot/src/bug-bot/php-client.ts
+++ b/ibl5/IBLbot/src/bug-bot/php-client.ts
@@ -1,0 +1,137 @@
+import { config } from './config.js';
+
+// ApiError is re-declared LOCALLY on purpose. NEVER `import { ApiError } from
+// '../api/client.js'` — api/client.ts imports ../config.js, whose module body runs
+// dotenv.config() + requireEnv('DISCORD_TOKEN'|'DISCORD_CLIENT_ID'|'API_BASE_URL')
+// at load time. Since .env.bugbot defines BUG_BOT_DISCORD_TOKEN /
+// BUG_PIPELINE_API_BASE_URL — not those prod keys — importing it would either throw
+// on boot or silently load the prod bot's secrets, defeating the config isolation.
+// HARD RULE: the bug-bot imports NOTHING from '../api/' or '../config.js'.
+export class ApiError extends Error {
+    constructor(
+        public readonly statusCode: number,
+        public readonly errorCode: string,
+        message: string,
+    ) {
+        super(message);
+        this.name = 'ApiError';
+    }
+}
+
+// The IBL API wraps every response: JsonResponder::success($data) →
+// {status:'success', data:{…}}; error() → {status:'error', error:{code,message}}.
+interface ApiEnvelope<T> {
+    status: 'success' | 'error';
+    data?: T;
+    error?: { code: string; message: string };
+}
+
+/**
+ * POST JSON to a bug-pipeline endpoint and return the UNWRAPPED `data` payload.
+ * Throws ApiError on a non-ok HTTP status OR a `{status:'error'}` envelope (which
+ * PR #3 may return even with HTTP 200). Every thin wrapper below reads its response
+ * fields straight off this return value ONLY because the envelope is stripped here.
+ */
+export async function apiPost<T>(endpoint: string, payload: unknown): Promise<T> {
+    const urlString = `${config.phpApi.baseUrl}/api/bug-pipeline/${endpoint}`;
+    const response = await fetch(urlString, {
+        method: 'POST',
+        headers: {
+            'X-API-Key': config.phpApi.key,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        },
+        body: JSON.stringify(payload),
+    });
+
+    const body = await response.json() as ApiEnvelope<T>;
+
+    if (!response.ok || body.status === 'error') {
+        throw new ApiError(
+            response.status,
+            body.error?.code ?? 'HTTP_ERROR',
+            body.error?.message ?? `HTTP ${response.status}`,
+        );
+    }
+
+    return body.data as T;
+}
+
+// ── Typed thin wrappers (one per endpoint) ──────────────────────────────────
+// Snowflake wire-type LOCKED: every *_id field is `string` and passed through
+// untouched — NEVER Number()/parseInt a snowflake. `report_id` / `pr_number` are
+// the ONLY numeric fields in this module.
+
+// The 4 §3b writers (frozen contract):
+
+export interface EnqueueBody {
+    author_id: string;
+    channel_id: string;
+    message_id: string;
+    text: string;
+}
+export interface EnqueueResult {
+    authorized: boolean;
+    report_id: number | null;
+}
+export function enqueue(body: EnqueueBody): Promise<EnqueueResult> {
+    return apiPost<EnqueueResult>('enqueue', body);
+}
+
+export interface ThreadReplyBody {
+    thread_id: string;
+    message_id: string;
+}
+export interface ThreadReplyResult {
+    matched: boolean;
+}
+export function threadReply(body: ThreadReplyBody): Promise<ThreadReplyResult> {
+    return apiPost<ThreadReplyResult>('thread-reply', body);
+}
+
+export interface ReactionBody {
+    message_id: string;
+    emoji: string;
+    reactor_id: string;
+}
+export interface ReactionResult {
+    advanced: boolean;
+}
+export function reaction(body: ReactionBody): Promise<ReactionResult> {
+    return apiPost<ReactionResult>('reaction', body);
+}
+
+export interface LastSeenBody {
+    channel_id: string;
+    message_id: string;
+}
+export interface LastSeenResult {
+    ok: true;
+}
+export function lastSeen(body: LastSeenBody): Promise<LastSeenResult> {
+    return apiPost<LastSeenResult>('last-seen', body);
+}
+
+// The 2 gap readers (PR #3 additions — the DB-less bot's only READ path):
+
+export interface StateBody {
+    channel_id: string;
+}
+export interface StateResult {
+    last_processed_message_id: string | null;
+}
+// Gap #1 — backfill cursor.
+export function getState(body: StateBody): Promise<StateResult> {
+    return apiPost<StateResult>('state', body);
+}
+
+export interface ThreadByPrBody {
+    pr_number: number;
+}
+export interface ThreadByPrResult {
+    thread_id: string | null;
+}
+// Gap #2 — /prMerged resolver (pr_number → thread_id).
+export function threadByPr(body: ThreadByPrBody): Promise<ThreadByPrResult> {
+    return apiPost<ThreadByPrResult>('thread-by-pr', body);
+}

--- a/ibl5/IBLbot/src/bug-bot/php-client.ts
+++ b/ibl5/IBLbot/src/bug-bot/php-client.ts
@@ -33,7 +33,7 @@ interface ApiEnvelope<T> {
  * fields straight off this return value ONLY because the envelope is stripped here.
  */
 export async function apiPost<T>(endpoint: string, payload: unknown): Promise<T> {
-    const urlString = `${config.phpApi.baseUrl}/api/bug-pipeline/${endpoint}`;
+    const urlString = `${config.phpApi.baseUrl}/api/v1/bug-pipeline/${endpoint}`;
     const response = await fetch(urlString, {
         method: 'POST',
         headers: {

--- a/ibl5/IBLbot/src/bug-bot/server.test.ts
+++ b/ibl5/IBLbot/src/bug-bot/server.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Client } from 'discord.js';
+
+const h = vi.hoisted(() => {
+    const routes: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const listenSpy = vi.fn();
+    return { routes, listenSpy };
+});
+
+vi.mock('express', () => {
+    const app = {
+        use: vi.fn(),
+        post: vi.fn((path: string, handler: (req: unknown, res: unknown) => unknown) => { h.routes[path] = handler; }),
+        get: vi.fn((path: string, handler: (req: unknown, res: unknown) => unknown) => { h.routes[path] = handler; }),
+        listen: h.listenSpy,
+    };
+    const expressFn = vi.fn(() => app) as unknown as { (): typeof app; json: () => unknown };
+    expressFn.json = vi.fn(() => 'json-mw');
+    return { default: expressFn };
+});
+
+vi.mock('./config.js', () => ({
+    config: { express: { port: 50001 }, bugChannelId: 'BUG_CHANNEL' },
+}));
+
+vi.mock('./php-client.js', () => ({
+    threadByPr: vi.fn(),
+}));
+
+import { startBugBotServer } from './server.js';
+import * as phpClient from './php-client.js';
+
+function makeRes() {
+    const res = {
+        statusCode: 200,
+        status: vi.fn((c: number) => { res.statusCode = c; return res; }),
+        send: vi.fn(() => res),
+        json: vi.fn(() => res),
+    };
+    return res;
+}
+
+// A fake client whose channels.fetch resolves the supplied channel.
+function clientWithChannel(channel: unknown): Client {
+    return { channels: { fetch: vi.fn().mockResolvedValue(channel) } } as unknown as Client;
+}
+
+async function invoke(path: string, body: unknown, client: Client) {
+    h.routes = {};
+    startBugBotServer(client);
+    const res = makeRes();
+    await h.routes[path]({ body }, res);
+    return res;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    h.routes = {};
+});
+
+describe('loopback bind (gate 14b)', () => {
+    it('binds app.listen to 127.0.0.1', () => {
+        startBugBotServer(clientWithChannel(null));
+        expect(h.listenSpy).toHaveBeenCalledTimes(1);
+        expect(h.listenSpy.mock.calls[0][0]).toBe(50001);
+        expect(h.listenSpy.mock.calls[0][1]).toBe('127.0.0.1');
+    });
+});
+
+describe('/react', () => {
+    const goodChannel = {
+        isTextBased: () => true,
+        messages: { fetch: vi.fn().mockResolvedValue({ react: vi.fn().mockResolvedValue(undefined) }) },
+    };
+
+    it('400 when a required field is missing', async () => {
+        const res = await invoke('/react', { message_id: '1' }, clientWithChannel(goodChannel));
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('200 on a resolving react', async () => {
+        const res = await invoke('/react', { message_id: '1', emoji: '✅' }, clientWithChannel(goodChannel));
+        expect(res.statusCode).toBe(200);
+        expect(res.send).toHaveBeenCalledWith('reacted');
+    });
+
+    it('500 when the discord call rejects', async () => {
+        const badChannel = {
+            isTextBased: () => true,
+            messages: { fetch: vi.fn().mockRejectedValue(new Error('boom')) },
+        };
+        const res = await invoke('/react', { message_id: '1', emoji: '✅' }, clientWithChannel(badChannel));
+        expect(res.statusCode).toBe(500);
+    });
+});
+
+describe('/create-thread', () => {
+    const channel = {
+        isTextBased: () => true,
+        messages: { fetch: vi.fn().mockResolvedValue({ startThread: vi.fn().mockResolvedValue({ id: 'THREAD_ID' }) }) },
+    };
+
+    it('400 when name is missing', async () => {
+        const res = await invoke('/create-thread', { message_id: '1' }, clientWithChannel(channel));
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('returns {thread_id} as a string', async () => {
+        const res = await invoke('/create-thread', { message_id: '1', name: 'bug' }, clientWithChannel(channel));
+        expect(res.json).toHaveBeenCalledWith({ thread_id: 'THREAD_ID' });
+        expect(typeof res.json.mock.calls[0][0].thread_id).toBe('string');
+    });
+
+    it('500 when startThread rejects', async () => {
+        const bad = {
+            isTextBased: () => true,
+            messages: { fetch: vi.fn().mockResolvedValue({ startThread: vi.fn().mockRejectedValue(new Error('x')) }) },
+        };
+        const res = await invoke('/create-thread', { message_id: '1', name: 'bug' }, clientWithChannel(bad));
+        expect(res.statusCode).toBe(500);
+    });
+});
+
+describe('/post-to-thread', () => {
+    const sendable = { isSendable: () => true, send: vi.fn().mockResolvedValue(undefined) };
+
+    it('400 when message is missing', async () => {
+        const res = await invoke('/post-to-thread', { thread_id: 'T' }, clientWithChannel(sendable));
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('200 posted on success', async () => {
+        const res = await invoke('/post-to-thread', { thread_id: 'T', message: 'hi' }, clientWithChannel(sendable));
+        expect(res.statusCode).toBe(200);
+        expect(res.send).toHaveBeenCalledWith('posted');
+    });
+
+    it('500 when send rejects', async () => {
+        const bad = { isSendable: () => true, send: vi.fn().mockRejectedValue(new Error('x')) };
+        const res = await invoke('/post-to-thread', { thread_id: 'T', message: 'hi' }, clientWithChannel(bad));
+        expect(res.statusCode).toBe(500);
+    });
+});
+
+describe('/mention', () => {
+    const sendable = { isSendable: () => true, send: vi.fn().mockResolvedValue({ id: 'MENTION_MSG_ID' }) };
+
+    it('400 when discord_id is missing', async () => {
+        const res = await invoke('/mention', { thread_id: 'T', message: 'm' }, clientWithChannel(sendable));
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('returns {message_id} as a string (the approval_message_id)', async () => {
+        const res = await invoke('/mention', { thread_id: 'T', discord_id: '42', message: 'm' }, clientWithChannel(sendable));
+        expect(res.json).toHaveBeenCalledWith({ message_id: 'MENTION_MSG_ID' });
+        expect(typeof res.json.mock.calls[0][0].message_id).toBe('string');
+    });
+
+    it('interpolates the mention and message into the send', async () => {
+        await invoke('/mention', { thread_id: 'T', discord_id: '42', message: 'ping' }, clientWithChannel(sendable));
+        expect(sendable.send).toHaveBeenCalledWith('<@42> ping');
+    });
+
+    it('500 when send rejects', async () => {
+        const bad = { isSendable: () => true, send: vi.fn().mockRejectedValue(new Error('x')) };
+        const res = await invoke('/mention', { thread_id: 'T', discord_id: '42', message: 'm' }, clientWithChannel(bad));
+        expect(res.statusCode).toBe(500);
+    });
+});
+
+describe('/get-thread-messages', () => {
+    function threadChannel(messages: unknown[]) {
+        return {
+            isTextBased: () => true,
+            messages: { fetch: vi.fn().mockResolvedValue(new Map(messages.map((m, i) => [String(i), m]))) },
+        };
+    }
+
+    it('400 when thread_id is missing', async () => {
+        const res = await invoke('/get-thread-messages', {}, clientWithChannel(threadChannel([])));
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('maps author_id as string, includes content + numeric ts, oldest-first', async () => {
+        // supplied newest-first; expect oldest-first output
+        const channel = threadChannel([
+            { author: { id: '20' }, content: 'second', createdTimestamp: 2000 },
+            { author: { id: '10' }, content: 'first', createdTimestamp: 1000 },
+        ]);
+        const res = await invoke('/get-thread-messages', { thread_id: 'T' }, clientWithChannel(channel));
+        const payload = res.json.mock.calls[0][0];
+        expect(payload.messages).toEqual([
+            { author_id: '10', content: 'first', ts: 1000 },
+            { author_id: '20', content: 'second', ts: 2000 },
+        ]);
+        expect(typeof payload.messages[0].author_id).toBe('string');
+    });
+
+    it('requests an explicit limit of 100', async () => {
+        const channel = threadChannel([]);
+        await invoke('/get-thread-messages', { thread_id: 'T' }, clientWithChannel(channel));
+        expect(channel.messages.fetch).toHaveBeenCalledWith({ limit: 100 });
+    });
+
+    it('500 when fetch rejects', async () => {
+        const bad = { isTextBased: () => true, messages: { fetch: vi.fn().mockRejectedValue(new Error('x')) } };
+        const res = await invoke('/get-thread-messages', { thread_id: 'T' }, clientWithChannel(bad));
+        expect(res.statusCode).toBe(500);
+    });
+});
+
+describe('/prMerged', () => {
+    const sendable = { isSendable: () => true, send: vi.fn().mockResolvedValue(undefined) };
+
+    it('400 when pr_number is missing', async () => {
+        const res = await invoke('/prMerged', {}, clientWithChannel(sendable));
+        expect(res.statusCode).toBe(400);
+    });
+
+    it('no-ops with 200 when threadByPr resolves null (boundary)', async () => {
+        vi.mocked(phpClient.threadByPr).mockResolvedValue({ thread_id: null });
+        const res = await invoke('/prMerged', { pr_number: 5 }, clientWithChannel(sendable));
+        expect(res.statusCode).toBe(200);
+        expect(res.send).toHaveBeenCalledWith('no thread for PR');
+        expect(sendable.send).not.toHaveBeenCalled();
+    });
+
+    it('sends "Fixed!" when threadByPr resolves a thread_id', async () => {
+        vi.mocked(phpClient.threadByPr).mockResolvedValue({ thread_id: 'THREAD_ID' });
+        const res = await invoke('/prMerged', { pr_number: 5 }, clientWithChannel(sendable));
+        expect(res.statusCode).toBe(200);
+        expect(sendable.send).toHaveBeenCalledWith('Fixed! ✅');
+    });
+
+    it('500 when the thread send rejects', async () => {
+        vi.mocked(phpClient.threadByPr).mockResolvedValue({ thread_id: 'THREAD_ID' });
+        const bad = { isSendable: () => true, send: vi.fn().mockRejectedValue(new Error('x')) };
+        const res = await invoke('/prMerged', { pr_number: 5 }, clientWithChannel(bad));
+        expect(res.statusCode).toBe(500);
+    });
+});

--- a/ibl5/IBLbot/src/bug-bot/server.ts
+++ b/ibl5/IBLbot/src/bug-bot/server.ts
@@ -1,0 +1,180 @@
+import express from 'express';
+import type { Client } from 'discord.js';
+import { config } from './config.js';
+import * as phpClient from './php-client.js';
+
+/**
+ * The 6 §3c loopback Express endpoints the PR #5 cron calls to make the bot
+ * perform Discord actions. This is the NEW security surface (gate 14b): the ONLY
+ * access control is the loopback bind (127.0.0.1) + per-field input validation.
+ *
+ * WIRE FORMAT: handlers read top-level `req.body.*` (NOT `content`-wrapped) — the
+ * §3c callers (PR #5 cron / PR #6 GH-action) POST top-level. Do NOT re-introduce a
+ * `content` wrapper.
+ *
+ * All ids are strings — NEVER Number()/parseInt; discord.js accepts string
+ * snowflakes directly. `pr_number` is the one numeric field.
+ */
+export function startBugBotServer(client: Client): void {
+    const app = express();
+    app.use(express.json());
+
+    // POST /react — { message_id, emoji }
+    app.post('/react', async (req, res) => {
+        const { message_id, emoji } = req.body ?? {};
+        if (!message_id || !emoji) {
+            res.status(400).send('Missing message_id or emoji');
+            return;
+        }
+        try {
+            const channel = await client.channels.fetch(config.bugChannelId);
+            if (!channel || !channel.isTextBased()) {
+                res.status(500).send('Bug channel is not text-based');
+                return;
+            }
+            const message = await channel.messages.fetch(message_id);
+            await message.react(emoji);
+            res.send('reacted');
+        } catch (error) {
+            console.error('/react failed:', error);
+            res.status(500).send('Failed to react');
+        }
+    });
+
+    // POST /create-thread — { message_id, name } → { thread_id }
+    app.post('/create-thread', async (req, res) => {
+        const { message_id, name } = req.body ?? {};
+        if (!message_id || !name) {
+            res.status(400).send('Missing message_id or name');
+            return;
+        }
+        try {
+            const channel = await client.channels.fetch(config.bugChannelId);
+            if (!channel || !channel.isTextBased()) {
+                res.status(500).send('Bug channel is not text-based');
+                return;
+            }
+            const message = await channel.messages.fetch(message_id);
+            const thread = await message.startThread({ name });
+            res.json({ thread_id: thread.id });   // thread_id is a string snowflake
+        } catch (error) {
+            console.error('/create-thread failed:', error);
+            res.status(500).send('Failed to create thread');
+        }
+    });
+
+    // POST /post-to-thread — { thread_id, message }
+    app.post('/post-to-thread', async (req, res) => {
+        const { thread_id, message } = req.body ?? {};
+        if (!thread_id || !message) {
+            res.status(400).send('Missing thread_id or message');
+            return;
+        }
+        try {
+            const channel = await client.channels.fetch(thread_id);
+            if (!channel || !channel.isSendable()) {
+                res.status(500).send('Thread is not sendable');
+                return;
+            }
+            await channel.send(message);
+            res.send('posted');
+        } catch (error) {
+            console.error('/post-to-thread failed:', error);
+            res.status(500).send('Failed to post to thread');
+        }
+    });
+
+    // POST /mention — { thread_id, discord_id, message } → { message_id }
+    // The returned message_id is recorded by PR #5 as the row's
+    // approval_message_id — the message A-Jay reacts ✅ to. Returning it is a HARD
+    // contract requirement, not cosmetic.
+    app.post('/mention', async (req, res) => {
+        const { thread_id, discord_id, message } = req.body ?? {};
+        if (!thread_id || !discord_id || !message) {
+            res.status(400).send('Missing thread_id, discord_id, or message');
+            return;
+        }
+        try {
+            const channel = await client.channels.fetch(thread_id);
+            if (!channel || !channel.isSendable()) {
+                res.status(500).send('Thread is not sendable');
+                return;
+            }
+            const sent = await channel.send(`<@${discord_id}> ${message}`);
+            res.json({ message_id: sent.id });   // the posted mention's id (string)
+        } catch (error) {
+            console.error('/mention failed:', error);
+            res.status(500).send('Failed to mention');
+        }
+    });
+
+    // POST /get-thread-messages — { thread_id } → { messages: [...] }
+    // The cron→Haiku live transcript (decision 7). Explicit limit 100 (default is
+    // only 50). discord.js returns newest-first — sort ascending before mapping.
+    app.post('/get-thread-messages', async (req, res) => {
+        const { thread_id } = req.body ?? {};
+        if (!thread_id) {
+            res.status(400).send('Missing thread_id');
+            return;
+        }
+        try {
+            const channel = await client.channels.fetch(thread_id);
+            if (!channel || !channel.isTextBased()) {
+                res.status(500).send('Thread is not text-based');
+                return;
+            }
+            const msgs = await channel.messages.fetch({ limit: 100 });
+            res.json({
+                messages: [...msgs.values()]
+                    .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
+                    .map((m) => ({
+                        author_id: m.author.id,     // string
+                        content: m.content,
+                        ts: m.createdTimestamp,     // numeric
+                    })),
+            });
+        } catch (error) {
+            console.error('/get-thread-messages failed:', error);
+            res.status(500).send('Failed to fetch thread messages');
+        }
+    });
+
+    // POST /prMerged — { pr_number }. Resolve pr_number → thread_id (gap #2). A null
+    // thread is a boundary no-op (the PR may predate the pipeline), NOT an error.
+    app.post('/prMerged', async (req, res) => {
+        const { pr_number } = req.body ?? {};
+        if (pr_number === undefined || pr_number === null) {
+            res.status(400).send('Missing pr_number');
+            return;
+        }
+        try {
+            const { thread_id } = await phpClient.threadByPr({ pr_number });
+            if (thread_id === null) {
+                console.log(`/prMerged: no thread for PR #${pr_number}`);
+                res.status(200).send('no thread for PR');
+                return;
+            }
+            const channel = await client.channels.fetch(thread_id);
+            if (!channel || !channel.isSendable()) {
+                res.status(500).send('Thread is not sendable');
+                return;
+            }
+            await channel.send('Fixed! ✅');   // fixed literal — no caller input interpolated
+            res.status(200).send('fixed');
+        } catch (error) {
+            console.error('/prMerged failed:', error);
+            res.status(500).send('Failed to post fixed confirmation');
+        }
+    });
+
+    // GET / — health check
+    app.get('/', (_req, res) => {
+        res.send('ok');
+    });
+
+    // LOOPBACK BIND '127.0.0.1' IS MANDATORY — THE security control (gate 14b).
+    // Never bind 0.0.0.0 / omit the host arg.
+    app.listen(config.express.port, '127.0.0.1', () => {
+        console.log(`Bug-bot Express server listening on 127.0.0.1:${config.express.port}`);
+    });
+}

--- a/ibl5/IBLbot/tsconfig.json
+++ b/ibl5/IBLbot/tsconfig.json
@@ -15,5 +15,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Mac-local Discord bot for the discord-bug-pipeline program (PR #4 of 6). Implements the bug-report bot that listens on the Discord bug channel, enqueues reports via the PHP API (PR #3), and exposes six loopback Express endpoints (`127.0.0.1:50001`) the PR #5 cron uses to drive Discord actions.

**New files only in `ibl5/IBLbot/src/bug-bot/`:**
- `config.ts` — isolated dotenv config (loads `.env.bugbot`, never the prod `.env`)
- `php-client.ts` — typed HTTP client for the `/api/bug-pipeline/*` endpoints
- `handlers.ts` — `classifyMessage`, `handleEnqueue`, `handleThreadReply`, `handleReaction`
- `server.ts` — 6 loopback Express endpoints bound to `127.0.0.1`
- `backfill.ts` — startup replay of missed top-level messages (cursor-based)
- `index.ts` — wiring (Discord Client + PM2-aware Express loopback)
- `*.test.ts` — vitest suites (47/47 green across 4 test files)
- `ibl5/IBLbot/ecosystem.bugbot.config.cjs` — PM2 ecosystem file
- `ibl5/IBLbot/.env.bugbot.example` — env key list with placeholders

**Key design decisions:**
- Bug-bot loads `.env.bugbot` explicitly (never the prod `.env`) — config isolation from the prod IBLbot
- `ApiError` re-declared locally — no import from `../api/` (avoids prod-config startup landmine)
- All 6 §3c loopback endpoints bound to `127.0.0.1` only (loopback trust boundary)
- Snowflake wire-type locked: every `*_id` field is `string`, never `parseInt`'d
- `apiPost` unwraps the `JsonResponder` envelope — returns `body.data`, not the raw body

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

Depends-on: #1353
