### PR TITLE
chore: automouse queue reorder UI — drag-and-drop browser tool

### DIFF
--- a/bin/automouse-queue
+++ b/bin/automouse-queue
@@ -116,6 +116,88 @@ if [ "$1" = "requeue" ]; then
     exit 0
 fi
 
+# Reorder the queue by re-touching the TARGET plan files with ascending mtimes.
+# automouse-run claims the oldest-mtime plan first (`ls -1tr`, which dereferences
+# the queue symlinks), so first arg = oldest = runs first. The argument list must
+# be an EXACT permutation of the current queue: every arg queued, none repeated,
+# counts equal. Validation is a full first pass — no mtime is touched unless it
+# passes, so a rejected reorder leaves the queue untouched.
+if [ "$1" = "reorder" ]; then
+    shift
+    if [ $# -lt 1 ]; then
+        echo "Error: reorder requires the full queue in the desired order." >&2
+        echo "Usage: bin/automouse-queue reorder <slug1> <slug2> ... <slugN>" >&2
+        exit 1
+    fi
+
+    # Current queue basenames, space-wrapped for membership tests (" a.md b.md ").
+    queued=" "
+    queued_count=0
+    while IFS= read -r f; do
+        queued="$queued$(basename "$f") "
+        queued_count=$((queued_count + 1))
+    done < <(ls -1tr "$QUEUE_DIR"/*.md 2>/dev/null)
+
+    if [ "$queued_count" -eq 0 ]; then
+        echo "Error: the queue is empty; nothing to reorder." >&2
+        exit 1
+    fi
+
+    # Validate (touch nothing this pass). $ordered collects normalized names.
+    seen=" "
+    ordered=""
+    given_count=0
+    for arg in "$@"; do
+        # basename strips any leading path -> path-traversal / arbitrary-file defense.
+        name=$(basename "$arg")
+        case "$name" in
+            *.md) ;;
+            *) name="${name}.md" ;;
+        esac
+        case "$queued" in
+            *" $name "*) ;;
+            *)
+                echo "Error: $name is not in the queue." >&2
+                show_queue >&2
+                exit 1 ;;
+        esac
+        case "$seen" in
+            *" $name "*)
+                echo "Error: $name given more than once." >&2
+                exit 1 ;;
+        esac
+        seen="$seen$name "
+        ordered="$ordered$name "
+        given_count=$((given_count + 1))
+    done
+
+    # Membership + no-dup + equal counts ⟹ exact permutation (no adds/drops).
+    if [ "$given_count" -ne "$queued_count" ]; then
+        echo "Error: reorder needs an exact permutation of the queue" \
+             "($queued_count queued, $given_count given)." >&2
+        show_queue >&2
+        exit 1
+    fi
+
+    # Apply: distinct mtimes 60s apart, computed from one clock snapshot so
+    # loop drift can't tie two stamps (a same-second tie lets `ls` fall back to
+    # filename order and scramble the request). First arg = oldest = runs first.
+    now=$(date +%s)
+    base=$(( now - given_count * 60 ))
+    i=0
+    for name in $ordered; do
+        target=$(readlink "$QUEUE_DIR/$name")
+        stamp=$(date -r $(( base + i * 60 )) +%Y%m%d%H%M.%S)   # BSD/macOS: -r = epoch
+        touch -t "$stamp" "$target"
+        i=$((i + 1))
+    done
+
+    echo "Reordered $given_count plan(s)."
+    echo ""
+    show_queue
+    exit 0
+fi
+
 INPUT="$1"
 
 # Resolve the plan file path

--- a/bin/automouse-queue
+++ b/bin/automouse-queue
@@ -191,7 +191,10 @@ if [ "$1" = "reorder" ]; then
         # BSD (-r epoch) fallback for the macOS automouse host.
         epoch=$(( base + i * 60 ))
         stamp=$(date -d "@$epoch" +%Y%m%d%H%M.%S 2>/dev/null || date -r "$epoch" +%Y%m%d%H%M.%S)
-        touch -t "$stamp" "$target"
+        # GNU ls -1tr sorts by symlink lstat mtime; BSD ls sorts by target stat mtime.
+        # Touch both so the reorder is visible on both Linux CI and macOS dev.
+        touch -h -t "$stamp" "$QUEUE_DIR/$name"
+        touch    -t "$stamp" "$target"
         i=$((i + 1))
     done
 

--- a/bin/automouse-queue
+++ b/bin/automouse-queue
@@ -187,7 +187,10 @@ if [ "$1" = "reorder" ]; then
     i=0
     for name in $ordered; do
         target=$(readlink "$QUEUE_DIR/$name")
-        stamp=$(date -r $(( base + i * 60 )) +%Y%m%d%H%M.%S)   # BSD/macOS: -r = epoch
+        # epoch -> touch stamp, portable: GNU (-d @epoch) first for Linux CI,
+        # BSD (-r epoch) fallback for the macOS automouse host.
+        epoch=$(( base + i * 60 ))
+        stamp=$(date -d "@$epoch" +%Y%m%d%H%M.%S 2>/dev/null || date -r "$epoch" +%Y%m%d%H%M.%S)
         touch -t "$stamp" "$target"
         i=$((i + 1))
     done

--- a/bin/automouse-queue-reorder-ui
+++ b/bin/automouse-queue-reorder-ui
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Open a local drag-and-drop page to reorder the automouse plan queue.
+#
+# Spawns an ephemeral `php -S` server bound to 127.0.0.1 ONLY, opens the browser,
+# and waits for a single Save (which shells out to `bin/automouse-queue reorder`)
+# or for Ctrl-C / a timeout. The server is always torn down on exit. All queue
+# mutation and validation live in the `reorder` engine — this launcher owns only
+# the server lifecycle.
+#
+# Usage: bin/automouse-queue-reorder-ui
+
+set -euo pipefail
+
+: "${NIGHTLY_DIR:=$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse}"
+: "${PLANS_DIR:=$HOME/.claude/plans}"
+QUEUE_DIR="$NIGHTLY_DIR/queue"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+QUEUE_CMD="$SCRIPT_DIR/automouse-queue"                # sibling engine
+ROUTER="$SCRIPT_DIR/lib/automouse-reorder-router.php"  # sibling router + page
+
+command -v php >/dev/null 2>&1 || { echo "Error: php not found on PATH." >&2; exit 1; }
+[ -f "$ROUTER" ] || { echo "Error: router not found: $ROUTER" >&2; exit 1; }
+
+# Current run order (ls -1tr = target mtime, oldest-first = runs-first).
+# `|| true`: an empty queue makes `ls *.md` error, which pipefail + set -e would
+# otherwise abort on before the empty-check below.
+order="$(ls -1tr "$QUEUE_DIR"/*.md 2>/dev/null | while IFS= read -r f; do basename "$f"; done || true)"
+if [ -z "$order" ]; then
+    echo "Queue empty, nothing to reorder."
+    exit 0
+fi
+
+# Pick a free loopback port (small TOCTOU window is acceptable for a local tool;
+# the readiness probe below fails cleanly if the bind lost the race).
+pick_port() {
+    local p
+    for _ in $(seq 1 25); do
+        p=$(( (RANDOM % 10000) + 20000 ))          # 20000–29999
+        if ! nc -z 127.0.0.1 "$p" >/dev/null 2>&1; then echo "$p"; return 0; fi
+    done
+    echo "Error: could not find a free loopback port." >&2
+    return 1
+}
+PORT="$(pick_port)"
+
+WORKDIR="$(mktemp -d)"
+SENTINEL="$WORKDIR/result"        # router writes this ONLY on a successful apply
+PHP_PID=""
+cleanup() {
+    [ -n "$PHP_PID" ] && kill "$PHP_PID" 2>/dev/null || true
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT INT TERM
+
+# Launch — bind 127.0.0.1 ONLY (never 0.0.0.0 / never bare :PORT).
+AUTOMOUSE_QUEUE_ORDER="$order" \
+AUTOMOUSE_QUEUE_CMD="$QUEUE_CMD" \
+AUTOMOUSE_SENTINEL="$SENTINEL" \
+NIGHTLY_DIR="$NIGHTLY_DIR" PLANS_DIR="$PLANS_DIR" \
+php -S 127.0.0.1:"$PORT" "$ROUTER" >/dev/null 2>&1 &
+PHP_PID=$!
+
+# Wait for the server to accept connections.
+ready=0
+for _ in $(seq 1 40); do
+    if nc -z 127.0.0.1 "$PORT" >/dev/null 2>&1; then ready=1; break; fi
+    if ! kill -0 "$PHP_PID" 2>/dev/null; then echo "Error: server failed to start." >&2; exit 1; fi
+    sleep 0.25
+done
+[ "$ready" = 1 ] || { echo "Error: server not ready on 127.0.0.1:$PORT." >&2; exit 1; }
+
+echo "Reorder UI: http://127.0.0.1:$PORT/  (drag to reorder, click Save; Ctrl-C to cancel)"
+command -v open >/dev/null 2>&1 && open "http://127.0.0.1:$PORT/" || true
+
+# Wait for Save (sentinel appears) or timeout / server death.
+timeout_halfsecs=1200            # ~10 min
+elapsed=0
+while [ ! -f "$SENTINEL" ]; do
+    if ! kill -0 "$PHP_PID" 2>/dev/null; then echo "Error: server exited before Save." >&2; exit 1; fi
+    sleep 0.5
+    elapsed=$((elapsed + 1))
+    if [ "$elapsed" -ge "$timeout_halfsecs" ]; then
+        echo "Timed out waiting for Save; no changes applied." >&2
+        exit 1
+    fi
+done
+
+# Save succeeded. Give php a moment to flush its HTTP response to the browser
+# before the EXIT trap kills it (the router writes the sentinel just before
+# echoing its JSON reply; without this grace the kill can clip that reply and
+# the page shows a spurious "Request failed" despite a successful reorder).
+sleep 0.3
+
+# cleanup() (EXIT trap) kills php + removes WORKDIR.
+echo ""
+echo "New run order (next to run first):"
+i=1
+while IFS= read -r f; do
+    printf "  %2d. %s\n" "$i" "$(basename "$f")"
+    i=$((i + 1))
+done < <(ls -1tr "$QUEUE_DIR"/*.md 2>/dev/null)

--- a/bin/lib/automouse-reorder-router.php
+++ b/bin/lib/automouse-reorder-router.php
@@ -1,0 +1,223 @@
+<?php
+// Router for `php -S 127.0.0.1:<port> bin/lib/automouse-reorder-router.php`,
+// spawned by bin/automouse-queue-reorder-ui. Serves a self-contained
+// drag-and-drop page (GET /) and applies a reorder (POST /apply) by shelling
+// out to the tested `bin/automouse-queue reorder` engine — this layer holds no
+// validation of its own. Inputs arrive via inherited env from the launcher:
+//   AUTOMOUSE_QUEUE_ORDER  newline-separated queue basenames, ls -1tr order
+//   AUTOMOUSE_QUEUE_CMD    absolute path to bin/automouse-queue
+//   AUTOMOUSE_SENTINEL     file the router writes ONLY on a successful apply
+//   NIGHTLY_DIR / PLANS_DIR  inherited so the shelled-out engine sees the same queue
+//
+// NOTE: this is a local-only dev-ops tool served on 127.0.0.1, outside the
+// ibl5/ PHPStan scope — the app's CsrfGuard / XSS rules do not apply here.
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$uri    = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+
+if ($method === 'POST' && $uri === '/apply') {
+    apply_reorder();
+    return;
+}
+serve_page();
+
+function queue_slugs(): array
+{
+    $raw = getenv('AUTOMOUSE_QUEUE_ORDER');
+    if ($raw === false || trim($raw) === '') {
+        return [];
+    }
+    return array_values(array_filter(array_map('trim', explode("\n", $raw)), 'strlen'));
+}
+
+function apply_reorder(): void
+{
+    header('Content-Type: application/json');
+    $body = json_decode(file_get_contents('php://input'), true);
+    $order = is_array($body) && isset($body['order']) ? $body['order'] : null;
+    if (!is_array($order) || $order === []) {
+        http_response_code(400);
+        echo json_encode(['ok' => false, 'output' => 'Bad request: expected {order:[...]}.']);
+        return;
+    }
+    foreach ($order as $slug) {
+        if (!is_string($slug) || $slug === '') {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'output' => 'Bad request: order must be non-empty strings.']);
+            return;
+        }
+    }
+
+    $queueCmd = getenv('AUTOMOUSE_QUEUE_CMD') ?: 'automouse-queue';
+    // escapeshellarg every token (defense-in-depth on top of the engine's own
+    // permutation validation); 2>&1 so the engine's error text flows back.
+    $cmd = escapeshellarg($queueCmd) . ' reorder '
+         . implode(' ', array_map('escapeshellarg', $order)) . ' 2>&1';
+    exec($cmd, $out, $ret);
+    $output = implode("\n", $out);
+
+    if ($ret === 0) {
+        $sentinel = getenv('AUTOMOUSE_SENTINEL');
+        if ($sentinel !== false && $sentinel !== '') {
+            file_put_contents($sentinel, $output);   // signal the launcher to tear down
+        }
+        echo json_encode(['ok' => true, 'exit' => 0, 'output' => $output]);
+        return;
+    }
+    // Rejection: no sentinel, server stays up so the user can retry.
+    echo json_encode(['ok' => false, 'exit' => $ret, 'output' => $output]);
+}
+
+function serve_page(): void
+{
+    $slugs = queue_slugs();
+    header('Content-Type: text/html; charset=utf-8');
+
+    $items = '';
+    foreach ($slugs as $i => $slug) {
+        $safe  = htmlspecialchars($slug, ENT_QUOTES, 'UTF-8');           // data-slug (engine accepts .md or not)
+        $label = htmlspecialchars(preg_replace('/\.md$/', '', $slug), ENT_QUOTES, 'UTF-8');  // human-facing, no .md
+        $pos   = $i + 1;
+        $items .= <<<LI
+      <li class="row" draggable="true" data-slug="{$safe}">
+        <span class="handle" aria-hidden="true">⠿</span>
+        <span class="pos">{$pos}</span>
+        <span class="slug">{$label}</span>
+      </li>
+
+LI;
+    }
+
+    $empty = $slugs === [];
+    $emptyNote = $empty
+        ? '<p class="empty">The queue is empty — nothing to reorder.</p>'
+        : '';
+    $saveDisabled = $empty ? 'disabled' : '';
+
+    echo <<<HTML
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Automouse queue — reorder</title>
+<style>
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; }
+  body {
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    margin: 0; padding: 2rem 1rem; background: #f4f5f7; color: #1c1e21;
+  }
+  main { max-width: 720px; margin: 0 auto; }
+  h1 { font-size: 1.25rem; margin: 0 0 .25rem; }
+  p.sub { margin: 0 0 1.25rem; color: #606770; }
+  ol#queue { list-style: none; margin: 0; padding: 0; }
+  li.row {
+    display: flex; align-items: center; gap: .75rem;
+    background: #fff; border: 1px solid #dcdfe3; border-radius: 8px;
+    padding: .7rem .9rem; margin: 0 0 .5rem;
+    cursor: grab; user-select: none;
+    box-shadow: 0 1px 2px rgba(0,0,0,.04);
+  }
+  li.row:active { cursor: grabbing; }
+  li.row.dragging { opacity: .4; border-style: dashed; }
+  .handle { color: #b0b3b8; font-size: 1.1rem; }
+  .pos {
+    min-width: 1.6rem; height: 1.6rem; display: inline-flex;
+    align-items: center; justify-content: center;
+    background: #eef0f2; border-radius: 50%; font-size: .8rem;
+    color: #606770; font-variant-numeric: tabular-nums;
+  }
+  li.row:first-child .pos { background: #d6f0d8; color: #1a7f37; }
+  .slug { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .92rem; }
+  .actions { margin-top: 1.25rem; display: flex; align-items: center; gap: 1rem; }
+  button {
+    font: inherit; font-weight: 600; color: #fff; background: #1a7f37;
+    border: 0; border-radius: 8px; padding: .55rem 1.1rem; cursor: pointer;
+  }
+  button:disabled { background: #9db0a3; cursor: default; }
+  #msg { font-size: .9rem; }
+  #msg.ok  { color: #1a7f37; }
+  #msg.err { color: #c0392b; white-space: pre-wrap; font-family: ui-monospace, Menlo, monospace; }
+  .hint { color: #8a8d91; font-size: .82rem; margin-top: 1.5rem; }
+  .empty { color: #606770; font-style: italic; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Automouse queue — drag to reorder</h1>
+  <p class="sub">Top of the list runs <strong>next</strong>. Drag rows, then Save.</p>
+  {$emptyNote}
+  <ol id="queue">
+{$items}  </ol>
+  <div class="actions">
+    <button id="save" {$saveDisabled}>Save order</button>
+    <span id="msg"></span>
+  </div>
+  <p class="hint">Save applies the new order and shuts this server down. Close the tab or press Ctrl-C in the terminal to cancel with no changes.</p>
+</main>
+<script>
+const list = document.getElementById('queue');
+let dragEl = null;
+
+list.addEventListener('dragstart', e => {
+  dragEl = e.target.closest('li');
+  if (dragEl) dragEl.classList.add('dragging');
+  e.dataTransfer.effectAllowed = 'move';
+});
+list.addEventListener('dragend', () => {
+  if (dragEl) dragEl.classList.remove('dragging');
+  dragEl = null;
+  renumber();
+});
+list.addEventListener('dragover', e => {
+  e.preventDefault();
+  if (!dragEl) return;
+  const after = afterElement(list, e.clientY);
+  if (after == null) list.appendChild(dragEl);
+  else list.insertBefore(dragEl, after);
+});
+function afterElement(container, y) {
+  const els = [...container.querySelectorAll('li:not(.dragging)')];
+  return els.reduce((closest, child) => {
+    const box = child.getBoundingClientRect();
+    const offset = y - box.top - box.height / 2;
+    return (offset < 0 && offset > closest.offset) ? { offset, element: child } : closest;
+  }, { offset: -Infinity }).element;
+}
+function renumber() {
+  [...list.children].forEach((li, i) => { li.querySelector('.pos').textContent = (i + 1); });
+}
+
+const saveBtn = document.getElementById('save');
+saveBtn && saveBtn.addEventListener('click', async () => {
+  const order = [...list.querySelectorAll('li')].map(li => li.dataset.slug);
+  const msg = document.getElementById('msg');
+  msg.className = ''; msg.textContent = 'Applying…';
+  saveBtn.disabled = true;
+  try {
+    const res = await fetch('/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order })
+    });
+    const data = await res.json();
+    if (data.ok) {
+      msg.className = 'ok';
+      msg.textContent = 'Queue reordered. You can close this tab — the server is shutting down.';
+    } else {
+      msg.className = 'err';
+      msg.textContent = data.output || 'Reorder rejected.';
+      saveBtn.disabled = false;   // let the user fix and retry
+    }
+  } catch (err) {
+    msg.className = 'err';
+    msg.textContent = 'Request failed: ' + err;
+    saveBtn.disabled = false;
+  }
+});
+</script>
+</body>
+</html>
+HTML;
+}

--- a/bin/test-automouse-queue
+++ b/bin/test-automouse-queue
@@ -185,8 +185,9 @@ echo "ok: row9 — .staleness eviction"
 
 # ===========================================================================
 # reorder subcommand — permutation validation + spaced ascending-mtime touch.
-# Order is asserted via `ls -1tr` (target mtime, oldest-first) — exactly how
-# bin/automouse-run claims the next plan.
+# Order is asserted via `ls -1tr` (oldest-first) — exactly how
+# bin/automouse-run claims the next plan.  GNU ls uses symlink lstat mtime;
+# BSD ls uses target stat mtime.  reorder touches both, so results agree.
 # ===========================================================================
 
 # basenames of queue entries in ls -1tr (oldest-first = runs-first) order, space-joined

--- a/bin/test-automouse-queue
+++ b/bin/test-automouse-queue
@@ -155,7 +155,9 @@ ln -s "$PDIR/plan-h.md" "$NDIR/skipped/plan-h.md"
 set +e
 out=$(run_queue plan-h 2>&1)
 exit_code=$?
-set -e
+# Restore the top-level state (set -u only, never -e): a leaked `set -e` here
+# would silently abort rows 9-14 on any non-zero return instead of recording a
+# FAIL — which is exactly how the CI failure masqueraded as an early exit.
 if [ "$exit_code" -eq 0 ]; then
     echo "FAIL: row8 — expected non-zero exit for already-queued plan, got 0"
     FAILED=1
@@ -202,8 +204,12 @@ assert_order() {
         FAILED=1
     fi
 }
-# epoch mtime of a queue entry's readlink target (BSD/macOS stat)
-target_mtime() { stat -f %m "$(readlink "$NDIR/queue/$1")"; }
+# epoch mtime of a queue entry's readlink target, portable: GNU (-c %Y) first
+# for Linux CI, BSD (-f %m) fallback for macOS (mirrors bin/wt-status).
+target_mtime() {
+    local t; t="$(readlink "$NDIR/queue/$1")"
+    stat -c %Y "$t" 2>/dev/null || stat -f %m "$t"
+}
 
 # ---------------------------------------------------------------------------
 # Row 10 — happy path: reorder >=3 plans -> ls -1tr matches requested order
@@ -245,7 +251,7 @@ touch "$PDIR/plan-a.md" "$PDIR/plan-b.md" "$PDIR/plan-c.md"
 run_queue plan-a >/dev/null 2>&1; run_queue plan-b >/dev/null 2>&1; run_queue plan-c >/dev/null 2>&1
 run_queue reorder plan-a plan-b plan-c >/dev/null 2>&1
 before="$(queue_order)"
-set +e; out=$(run_queue reorder plan-a plan-b plan-z 2>&1); ec=$?; set -e
+set +e; out=$(run_queue reorder plan-a plan-b plan-z 2>&1); ec=$?; set +e
 [ "$ec" -eq 0 ] && { echo "FAIL: row12 — expected non-zero exit for unqueued slug"; FAILED=1; }
 echo "$out" | grep -q "not in the queue" || { echo "FAIL: row12 — missing not-in-queue error: $out"; FAILED=1; }
 assert_order "row12 order unchanged after reject" "$before"
@@ -260,11 +266,11 @@ run_queue plan-a >/dev/null 2>&1; run_queue plan-b >/dev/null 2>&1; run_queue pl
 run_queue reorder plan-a plan-b plan-c >/dev/null 2>&1
 before="$(queue_order)"
 # (a) missing entry -> count mismatch
-set +e; out=$(run_queue reorder plan-a plan-b 2>&1); ec=$?; set -e
+set +e; out=$(run_queue reorder plan-a plan-b 2>&1); ec=$?; set +e
 [ "$ec" -eq 0 ] && { echo "FAIL: row13a — expected non-zero for missing entry"; FAILED=1; }
 assert_order "row13a order unchanged" "$before"
 # (b) duplicate-as-extra -> dup rejection
-set +e; out=$(run_queue reorder plan-a plan-b plan-b 2>&1); ec=$?; set -e
+set +e; out=$(run_queue reorder plan-a plan-b plan-b 2>&1); ec=$?; set +e
 [ "$ec" -eq 0 ] && { echo "FAIL: row13b — expected non-zero for duplicate entry"; FAILED=1; }
 assert_order "row13b order unchanged" "$before"
 echo "ok: row13 — reject non-permutation (missing/extra)"
@@ -277,7 +283,7 @@ touch "$PDIR/plan-a.md" "$PDIR/plan-b.md" "$PDIR/plan-c.md"
 run_queue plan-a >/dev/null 2>&1; run_queue plan-b >/dev/null 2>&1; run_queue plan-c >/dev/null 2>&1
 run_queue reorder plan-a plan-b plan-c >/dev/null 2>&1
 a0=$(target_mtime plan-a.md); b0=$(target_mtime plan-b.md); c0=$(target_mtime plan-c.md)
-set +e; run_queue reorder plan-c plan-a plan-z >/dev/null 2>&1; set -e   # rejected: plan-z not queued
+set +e; run_queue reorder plan-c plan-a plan-z >/dev/null 2>&1; set +e   # rejected: plan-z not queued
 a1=$(target_mtime plan-a.md); b1=$(target_mtime plan-b.md); c1=$(target_mtime plan-c.md)
 if [ "$a0" != "$a1" ] || [ "$b0" != "$b1" ] || [ "$c0" != "$c1" ]; then
     echo "FAIL: row14 — target mtimes changed on a rejected reorder"

--- a/bin/test-automouse-queue
+++ b/bin/test-automouse-queue
@@ -181,6 +181,110 @@ assert_absent  "row9 staleness marker gone"  "$NDIR/skipped/plan-i.md.staleness"
 assert_present "row9 queued"                  "$NDIR/queue/plan-i.md"
 echo "ok: row9 — .staleness eviction"
 
+# ===========================================================================
+# reorder subcommand — permutation validation + spaced ascending-mtime touch.
+# Order is asserted via `ls -1tr` (target mtime, oldest-first) — exactly how
+# bin/automouse-run claims the next plan.
+# ===========================================================================
+
+# basenames of queue entries in ls -1tr (oldest-first = runs-first) order, space-joined
+queue_order() {
+    local out="" f
+    while IFS= read -r f; do out="$out $(basename "$f")"; done \
+        < <(ls -1tr "$NDIR/queue"/*.md 2>/dev/null)
+    echo "${out# }"
+}
+assert_order() {
+    local desc="$1" expected="$2" actual
+    actual="$(queue_order)"
+    if [ "$actual" != "$expected" ]; then
+        echo "FAIL: $desc — expected order [$expected], got [$actual]"
+        FAILED=1
+    fi
+}
+# epoch mtime of a queue entry's readlink target (BSD/macOS stat)
+target_mtime() { stat -f %m "$(readlink "$NDIR/queue/$1")"; }
+
+# ---------------------------------------------------------------------------
+# Row 10 — happy path: reorder >=3 plans -> ls -1tr matches requested order
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-a.md" "$PDIR/plan-b.md" "$PDIR/plan-c.md"
+run_queue plan-a >/dev/null 2>&1
+run_queue plan-b >/dev/null 2>&1
+run_queue plan-c >/dev/null 2>&1
+run_queue reorder plan-c plan-a plan-b >/dev/null 2>&1
+assert_order "row10 reorder applies requested order" "plan-c.md plan-a.md plan-b.md"
+echo "ok: row10 — reorder happy path"
+
+# ---------------------------------------------------------------------------
+# Row 11 — ordering: mtimes end >=1 min apart, no same-second tie-scramble.
+# Start from an identical-mtime state and request a non-alphabetical order —
+# a same-second touch loop would let `ls` filename-tiebreak and scramble it.
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-a.md" "$PDIR/plan-b.md" "$PDIR/plan-c.md"
+run_queue plan-a >/dev/null 2>&1
+run_queue plan-b >/dev/null 2>&1
+run_queue plan-c >/dev/null 2>&1
+touch -t 202601010000.00 "$PDIR/plan-a.md" "$PDIR/plan-b.md" "$PDIR/plan-c.md"
+run_queue reorder plan-c plan-b plan-a >/dev/null 2>&1
+assert_order "row11 non-alpha order survives identical start" "plan-c.md plan-b.md plan-a.md"
+m1=$(target_mtime plan-c.md); m2=$(target_mtime plan-b.md); m3=$(target_mtime plan-a.md)
+if [ $((m2 - m1)) -lt 60 ] || [ $((m3 - m2)) -lt 60 ]; then
+    echo "FAIL: row11 — target mtimes not >=60s apart: $m1 $m2 $m3"
+    FAILED=1
+fi
+echo "ok: row11 — spaced ascending mtimes, no tie-scramble"
+
+# ---------------------------------------------------------------------------
+# Row 12 — reject a slug not currently queued (non-zero exit, order unchanged)
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-a.md" "$PDIR/plan-b.md" "$PDIR/plan-c.md"
+run_queue plan-a >/dev/null 2>&1; run_queue plan-b >/dev/null 2>&1; run_queue plan-c >/dev/null 2>&1
+run_queue reorder plan-a plan-b plan-c >/dev/null 2>&1
+before="$(queue_order)"
+set +e; out=$(run_queue reorder plan-a plan-b plan-z 2>&1); ec=$?; set -e
+[ "$ec" -eq 0 ] && { echo "FAIL: row12 — expected non-zero exit for unqueued slug"; FAILED=1; }
+echo "$out" | grep -q "not in the queue" || { echo "FAIL: row12 — missing not-in-queue error: $out"; FAILED=1; }
+assert_order "row12 order unchanged after reject" "$before"
+echo "ok: row12 — reject unqueued slug"
+
+# ---------------------------------------------------------------------------
+# Row 13 — reject a non-permutation: missing entry AND duplicate-as-extra
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-a.md" "$PDIR/plan-b.md" "$PDIR/plan-c.md"
+run_queue plan-a >/dev/null 2>&1; run_queue plan-b >/dev/null 2>&1; run_queue plan-c >/dev/null 2>&1
+run_queue reorder plan-a plan-b plan-c >/dev/null 2>&1
+before="$(queue_order)"
+# (a) missing entry -> count mismatch
+set +e; out=$(run_queue reorder plan-a plan-b 2>&1); ec=$?; set -e
+[ "$ec" -eq 0 ] && { echo "FAIL: row13a — expected non-zero for missing entry"; FAILED=1; }
+assert_order "row13a order unchanged" "$before"
+# (b) duplicate-as-extra -> dup rejection
+set +e; out=$(run_queue reorder plan-a plan-b plan-b 2>&1); ec=$?; set -e
+[ "$ec" -eq 0 ] && { echo "FAIL: row13b — expected non-zero for duplicate entry"; FAILED=1; }
+assert_order "row13b order unchanged" "$before"
+echo "ok: row13 — reject non-permutation (missing/extra)"
+
+# ---------------------------------------------------------------------------
+# Row 14 — touch-nothing-on-rejection: target mtimes unchanged after a reject
+# ---------------------------------------------------------------------------
+setup
+touch "$PDIR/plan-a.md" "$PDIR/plan-b.md" "$PDIR/plan-c.md"
+run_queue plan-a >/dev/null 2>&1; run_queue plan-b >/dev/null 2>&1; run_queue plan-c >/dev/null 2>&1
+run_queue reorder plan-a plan-b plan-c >/dev/null 2>&1
+a0=$(target_mtime plan-a.md); b0=$(target_mtime plan-b.md); c0=$(target_mtime plan-c.md)
+set +e; run_queue reorder plan-c plan-a plan-z >/dev/null 2>&1; set -e   # rejected: plan-z not queued
+a1=$(target_mtime plan-a.md); b1=$(target_mtime plan-b.md); c1=$(target_mtime plan-c.md)
+if [ "$a0" != "$a1" ] || [ "$b0" != "$b1" ] || [ "$c0" != "$c1" ]; then
+    echo "FAIL: row14 — target mtimes changed on a rejected reorder"
+    FAILED=1
+fi
+echo "ok: row14 — touch-nothing on rejection"
+
 # ---------------------------------------------------------------------------
 if [ "$FAILED" -ne 0 ]; then
     echo "RESULT: FAILED"


### PR DESCRIPTION
## Summary
- Adds `bin/automouse-queue reorder` subcommand with exact-permutation validation (no-touch on reject) and spaced-mtime apply (60s gaps, no same-second tie-scramble)
- Extends `bin/test-automouse-queue` with Rows 10–14 covering happy path, ordering guarantee, and three rejection paths
- New `bin/lib/automouse-reorder-router.php`: self-contained `php -S` router with native HTML5 drag-and-drop page; shells to the engine on POST
- New `bin/automouse-queue-reorder-ui`: launcher that binds `127.0.0.1`-only, opens the browser, waits for Save sentinel, then tears down

## Manual Testing

| # | Step |
|---|------|
| 8 | Run `bin/automouse-queue-reorder-ui` with ≥2 plans queued. Does the drag-and-drop reorder page feel smooth and legible? Does dragging a plan to the top of the list clearly read as "runs next"? |

<!-- no-adr: local dev-ops queue-reorder tool; no new architectural constraint -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)