### PR TITLE
chore: export CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 for headless runs

### DIFF
--- a/bin/automouse-run
+++ b/bin/automouse-run
@@ -177,6 +177,16 @@ fi
 # Worktree Preview Environment — no human present to verify)
 export CLAUDE_HEADLESS=1
 
+# Headless sessions carry ~44K of fixed context (system prompt + rules +
+# memory + compaction summary). Under the interactive 120K autoCompactWindow
+# pin (~/.claude/settings.json, advisor-timeout fix) that leaves ~44K of
+# working room before the ~73% trigger — a compaction-thrash loop that
+# invalidates the whole prompt cache every few minutes (2026-07-07: 5
+# compactions in 19 min, 21% of the 5h budget, zero edits made). 200K keeps
+# peak context at/below the ~200K degradation and 2x-cost edge while tripling
+# working room. Env var overrides the settings.json pin per-process.
+export CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000
+
 REPO="/Users/ajaynicolas/GitHub/IBL5"
 NIGHTLY_DIR="$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse"
 LOG_DIR="$NIGHTLY_DIR/logs"

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -80,6 +80,8 @@ PROMPT="Invoke the /post-plan skill now on the current git branch. Resolve the p
 # marks the detached run unattended: /post-plan skips the Phase 10 preview rebuild
 # and BLOCKS auto-merge on a golden-snapshot change instead of merely warning.
 # caffeinate -s keeps the Mac awake on AC for the run's duration.
+# CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 lifts the interactive 120K
+# autoCompactWindow pin for this headless run — rationale in bin/automouse-run.
 cat > "$PLIST" <<PLIST_EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -91,7 +93,7 @@ cat > "$PLIST" <<PLIST_EOF
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; CLAUDE_HEADLESS=1 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
+		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>


### PR DESCRIPTION
## Summary

- Headless sessions inherit the interactive 120K `autoCompactWindow` pin from `~/.claude/settings.json` (the advisor-timeout fix), leaving only ~44K of working room before the ~73% compaction trigger
- On 2026-07-07 this caused 5 compactions in 19 min, burning 21% of the nightly budget with zero edits
- `bin/automouse-run` and `bin/post-plan-now`'s plist now export `CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000` to override the settings.json pin per-process, tripling working room while staying ≤200K (the degradation/2× cost edge)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.