### PR TITLE
chore: wire IBL5 TS unit tests into CI gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
       src: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.src == 'true' }}
       shell: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.shell == 'true' }}
       ibl6: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.ibl6 == 'true' }}
+      ibl5ts: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.ibl5ts == 'true' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
@@ -64,6 +65,17 @@ jobs:
               - '.github/workflows/human-signoff.yml'
             ibl6:
               - 'IBL6/**'
+              - '.github/workflows/tests.yml'
+            ibl5ts:
+              # Everything the ibl5 TS unit suite executes or imports
+              # (tests/ts-unit/ specs cover the pure VR-review helpers and
+              # the E2E summarizer script — see ibl5/vitest.unit.config.ts).
+              - 'ibl5/tests/ts-unit/**'
+              - 'ibl5/tests/e2e/vr-*.ts'
+              - '.github/scripts/summarize-e2e-results.mjs'
+              - 'ibl5/vitest.unit.config.ts'
+              - 'ibl5/package.json'
+              - 'ibl5/bun.lock'
               - '.github/workflows/tests.yml'
 
   test:
@@ -231,6 +243,29 @@ jobs:
     - name: Unit tests (vitest)
       working-directory: IBL6
       run: npm run test:unit -- --run
+
+  ibl5-ts-unit:
+    name: IBL5 TS Unit Tests
+    needs: [changes]
+    if: needs.changes.outputs.ibl5ts == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+    - name: Install dependencies
+      working-directory: ibl5
+      run: bun install
+
+    # Pure-unit vitest config (tests/ts-unit/, no DB/browser/env) — the fast
+    # suite locking the VR-review helper and E2E-summarizer contracts.
+    - name: TS unit tests (vitest)
+      working-directory: ibl5
+      run: bun run test:unit
 
   db-integration:
     name: Database Integration Tests
@@ -613,7 +648,7 @@ jobs:
   gate:
     name: Tests and Analysis
     if: always()
-    needs: [changes, test, audit-php, audit-js, ibl6-checks, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, static-guards, harness-tests, pinact-check]
+    needs: [changes, test, audit-php, audit-js, ibl6-checks, ibl5-ts-unit, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, static-guards, harness-tests, pinact-check]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/ibl5/bun.lock
+++ b/ibl5/bun.lock
@@ -8,14 +8,14 @@
         "@axe-core/playwright": "^4.12.1",
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "1.61.1",
-        "@tailwindcss/cli": "^4.3.1",
+        "@tailwindcss/cli": "^4.3.2",
         "browser-sync": "^3.0.4",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "eslint-plugin-playwright": "^2.10.4",
-        "pixelmatch": "^6.0.0",
+        "pixelmatch": "^7.2.0",
         "pngjs": "^7.0.0",
         "tailwindcss": "^4.3.1",
-        "typescript-eslint": "^8.62.0",
+        "typescript-eslint": "^8.62.1",
         "vitest": "^4.1.9",
       },
     },
@@ -782,7 +782,7 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "pixelmatch": ["pixelmatch@6.0.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g=="],
+    "pixelmatch": ["pixelmatch@7.2.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg=="],
 
     "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 


### PR DESCRIPTION
## Summary

- Adds `ibl5-ts-unit` CI job that runs `bun install` + `bun run test:unit` (vitest) on `ubuntu-latest`
- Gates on `ibl5ts` paths filter covering `tests/ts-unit/**`, `tests/e2e/vr-*.ts`, `summarize-e2e-results.mjs`, `vitest.unit.config.ts`, `package.json`, and `bun.lock`
- Wires `ibl5-ts-unit` into the `gate` job's `needs:` so the suite is required to pass before merge
- Includes dep bumps in `bun.lock` (`@tailwindcss/cli`, `eslint`, `pixelmatch`, `typescript-eslint`)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
