### PR TITLE
chore: improve check-docs ## Supersedes error message with ## Lineage hint

### DIFF
--- a/bin/check-docs
+++ b/bin/check-docs
@@ -451,11 +451,12 @@ function checkAdrTransitions(string $repoRoot): array
             $yClaim = $claims[$y] ?? ['supersededBy' => null];
             if ($yClaim['supersededBy'] !== $num) {
                 $issues[] = sprintf(
-                    '%s: ## Supersedes references ADR-%s, but ADR-%s Status line does not say "Superseded by ADR-%s"',
+                    '%s: ## Supersedes references ADR-%s, but ADR-%s Status line does not say "Superseded by ADR-%s" (if ADR-%s is not genuinely superseded, rename the section to ## Lineage)',
                     $rel,
                     $y,
                     $y,
-                    $num
+                    $num,
+                    $y
                 );
             }
         }


### PR DESCRIPTION
## Summary
- Improves the `check-docs` error message when a `## Supersedes` section references an ADR whose Status line doesn't say "Superseded by ADR-N"
- Adds a hint in the error message suggesting `## Lineage` as an alternative section name when the ADR isn't genuinely superseded

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)