### PR TITLE
chore: add impl_model <-> Verification Matrix consistency gate to check-plan + automouse-queue

### DIFF
--- a/bin/automouse-queue
+++ b/bin/automouse-queue
@@ -229,6 +229,25 @@ if [ -e "$QUEUE_DIR/$FILENAME" ]; then
     exit 1
 fi
 
+# impl_model <-> Verification Matrix consistency backstop. bin/check-plan gate
+# 13 catches this at plan-authoring time, but the plan archive predates the
+# gate — an old unmarked plan can still be sitting in ~/.claude/plans/ never
+# having been run through check-plan. Refuse to queue rather than let
+# automouse-run burn a full Opus-default implementation session (or a
+# forbidden Truly-manual-row-under-Sonnet run) on it. Shares the exact rule
+# with check-plan via bin/lib/plan-model-consistency so the two cannot drift.
+LIB_DIR="$(cd "$(dirname "$0")" && pwd)/lib"
+# `if VAR=$(cmd); then` (not a bare assignment) so `set -e` does not abort the
+# script on the script's non-zero exit — the exit code is tested, not thrown.
+if CONSISTENCY_MSG=$("$LIB_DIR/plan-model-consistency" "$SOURCE"); then
+    :
+else
+    echo "Error: $FILENAME fails impl_model <-> Verification Matrix consistency:" >&2
+    echo "  $CONSISTENCY_MSG" >&2
+    echo "Fix the plan's line-1 frontmatter (add/adjust the one-line impl_model: marker), then requeue." >&2
+    exit 1
+fi
+
 evict_dispositions "$FILENAME"
 
 ln -s "$SOURCE" "$QUEUE_DIR/$FILENAME"

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -8,8 +8,11 @@
 # collapse to "run bin/check-plan, fix what it reports" instead of having the
 # Opus orchestrator re-execute them by reading ~40 lines of instructions every
 # invocation. The JUDGMENT gates (negative-path coverage, hot-file extraction,
-# security-surface resolution, impl_model / auto_merge risk) stay in /plan —
-# they need reasoning a script cannot do.
+# security-surface resolution, auto_merge risk) stay in /plan — they need
+# reasoning a script cannot do. impl_model risk used to be on that list too;
+# gate 13 below mechanizes the consistency half of it (does the marker match
+# the matrix?) — whether Sonnet is *trustworthy* for a given plan's content is
+# still Opus judgment at authoring time.
 #
 # Gates implemented (numbering mirrors .claude/skills/plan/SKILL.md Step 4):
 #   1  Matrix exists        — the verification matrix header is present.
@@ -29,6 +32,14 @@
 #                                a new ibl5/migrations/*.sql only when the plan
 #                                text mentions DROP TABLE/COLUMN/INDEX; a
 #                                require/require-dev add to ibl5/composer.json.
+#  13  impl_model consistency — a Truly-manual matrix row forbids
+#                              `impl_model: sonnet`; a zero-manual matrix
+#                              requires a deliberate `impl_model:` marker
+#                              (sonnet, or an explicit opus). Shared with
+#                              bin/automouse-queue's queue-time backstop via
+#                              bin/lib/plan-model-consistency so the two call
+#                              sites cannot drift — see that script for the
+#                              full rule table.
 #
 # Two parts of /plan's Step 4 are DELIBERATELY left in /plan as Opus judgment,
 # because a sweep over the real plan corpus proved them not false-positive-free:
@@ -72,11 +83,12 @@
 #
 # Deliberately NOT linted (kept as /plan Opus judgment): tests-woven-inline,
 # production-comparison classification, test-file-path presence, negative-path
-# coverage, hot-file extraction, security surface,
-# impl_model / auto_merge risk. Edit-anchor snippets are not linted: the real
-# plan corpus quotes them as drifting descriptions ("the Options struct", with
-# file:line refs that go stale), not verbatim lines, so a grep-the-snippet check
-# would false-positive constantly.
+# coverage, hot-file extraction, security surface, auto_merge risk (whether a
+# declared hold's rationale is actually valid — gate H below only checks a
+# justification section is PRESENT). Edit-anchor snippets are not linted: the
+# real plan corpus quotes them as drifting descriptions ("the Options struct",
+# with file:line refs that go stale), not verbatim lines, so a grep-the-snippet
+# check would false-positive constantly.
 #
 # Exit codes: 0 = clean, 1 = one or more violations (printed, prefixed by gate),
 #             2 = usage error / plan file missing.
@@ -289,6 +301,20 @@ if grep -iE 'composer\.json' "$PLAN_FILE" | grep -qiE '\brequire(-dev)?\b'; then
     if [ "$GATE8_RESOLVED" -eq 0 ]; then
         viol "[8] decision-trigger surface ibl5/composer.json (new-dependency) added without an ADR step or no-adr: marker"
     fi
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 13: impl_model <-> Verification Matrix consistency.
+# ---------------------------------------------------------------------------
+# Delegates to bin/lib/plan-model-consistency, which BOTH this gate and
+# bin/automouse-queue's queue-time backstop call — kept in one place so the
+# two cannot drift. That script already skips silently (exit 0, no output)
+# when the plan has no Verification Matrix at all, so this gate never
+# double-reports gate 1's failure.
+GATE13_MSG=$("$SCRIPT_DIR/lib/plan-model-consistency" "$PLAN_FILE")
+GATE13_RC=$?
+if [ "$GATE13_RC" -eq 1 ]; then
+    viol "[13] ${GATE13_MSG}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/bin/lib/plan-model-consistency
+++ b/bin/lib/plan-model-consistency
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/lib/plan-model-consistency — shared impl_model <-> Verification-Matrix
+# consistency check. Used by BOTH bin/check-plan (gate M) and
+# bin/automouse-queue (queue-time backstop) so the two call sites cannot drift.
+#
+# Mechanizes /plan Step-4 gate 13's prose rule: a plan whose Verification Matrix
+# carries zero Truly-manual rows is (by definition) uniformly machine-checkable,
+# so `impl_model: sonnet` is the encouraged choice and its ABSENCE is now a
+# violation (a deliberate opus reason must be recorded instead); a plan carrying
+# at least one Truly-manual row can never declare `impl_model: sonnet` — Sonnet
+# cannot be trusted to self-judge a subjective row.
+#
+#   Truly-manual rows >= 1  AND impl_model: sonnet          -> VIOLATION (forbidden combo)
+#   Truly-manual rows == 0  AND impl_model absent            -> VIOLATION (undeclared default)
+#   Truly-manual rows == 0  AND impl_model: opus (explicit)  -> ok
+#   Truly-manual rows == 0  AND impl_model: sonnet           -> ok (the encouraged case)
+#   Truly-manual rows >= 1  AND impl_model absent or opus    -> ok
+#
+# Deliberately NOT bin/lib/plan-impl-model: that script RESOLVES impl_model to a
+# model id for `claude -p --model`, and its `case` statement collapses explicit
+# `impl_model: opus`, an absent field, and any garbled value to the same
+# `claude-opus-4-8` output (the "safe default" fallback) — so it cannot
+# distinguish "deliberately opus" from "never set," which is exactly the
+# distinction rule (b) above needs. Re-implementing the same line-1-anchored
+# frontmatter parse here (RAW value, not resolved) is the only way to keep that
+# distinction without changing plan-impl-model's contract for automouse-run.
+#
+# Skips silently (exit 0, no output) when the plan carries no Verification
+# Matrix at all — that failure belongs to bin/check-plan gate 1, not this
+# script; a plan with no matrix has nothing for this gate to be consistent
+# about.
+#
+# Usage: bin/lib/plan-model-consistency <plan-file>
+#   exit 0, no output           -> consistent, or nothing to check (no matrix)
+#   exit 1, one line on stdout  -> the violation message (caller prefixes/labels it)
+#   exit 2                      -> usage error (missing arg / file)
+
+set -u
+
+# Force the C locale — same rationale as bin/check-plan: deterministic
+# byte-wise glob/char-class matching across locales.
+export LC_ALL=C
+
+PLAN_FILE="${1:-}"
+if [ -z "$PLAN_FILE" ] || [ ! -e "$PLAN_FILE" ]; then
+    echo "Usage: bin/lib/plan-model-consistency <plan-file>" >&2
+    exit 2
+fi
+
+# No Verification Matrix at all -> not this script's gate to report.
+if ! grep -qiE '\|[[:space:]]*What to verify[[:space:]]*\|' "$PLAN_FILE"; then
+    exit 0
+fi
+
+# Isolate the matrix region and count Truly-manual rows: identical isolation +
+# detection pattern to bin/check-plan gate 3 ("false manuals"), kept in sync
+# deliberately — a row is "Truly-manual" for gate-3 mislabeling purposes and
+# for THIS gate's counting purposes by the exact same text match.
+MANUAL_COUNT=$(awk '
+    /\|[[:space:]]*[Ww]hat to verify[[:space:]]*\|/ { inm=1; next }
+    inm && /^[[:space:]]*\|/ { print; next }
+    inm && !/^[[:space:]]*\|/ { inm=0 }
+' "$PLAN_FILE" | tr '[:upper:]' '[:lower:]' | grep -cE 'truly[- ]manual')
+
+# Parse the RAW impl_model value from ONLY the first line-1-anchored
+# frontmatter block (mirrors bin/lib/plan-impl-model's awk verbatim, but
+# echoes the raw token instead of a resolved model id — see header note for
+# why plan-impl-model itself can't be reused here).
+RAW=$(awk '
+  NR==1 && /^---[[:space:]]*$/ {infm=1; next}
+  infm && /^---[[:space:]]*$/ {infm=0; exit}
+  infm && /^impl_model:[[:space:]]*/ {sub(/^impl_model:[[:space:]]*/,""); gsub(/[[:space:]]/,""); print; exit}
+' "$PLAN_FILE" 2>/dev/null)
+
+if [ "$MANUAL_COUNT" -ge 1 ] && [ "$RAW" = "sonnet" ]; then
+    echo "Truly-manual row forbids impl_model: sonnet — strip the marker or mechanize the row"
+    exit 1
+fi
+
+if [ "$MANUAL_COUNT" -eq 0 ] && [ -z "$RAW" ]; then
+    echo "model must be a deliberate choice: add \`impl_model: sonnet\` (all rows machine-checkable) or an explicit \`impl_model: opus\` with a reason in the plan body"
+    exit 1
+fi
+
+exit 0

--- a/bin/test-automouse-queue
+++ b/bin/test-automouse-queue
@@ -184,6 +184,52 @@ assert_present "row9 queued"                  "$NDIR/queue/plan-i.md"
 echo "ok: row9 — .staleness eviction"
 
 # ===========================================================================
+# impl_model <-> Verification Matrix consistency backstop (bin/lib/
+# plan-model-consistency). The plan archive predates bin/check-plan gate 13,
+# so an old unmarked plan can still be sitting in ~/.claude/plans/ — queuing
+# must refuse it rather than let automouse-run burn a session on it.
+# ===========================================================================
+
+# shellcheck disable=SC2016  # backtick span is a literal markdown code span,
+# not command substitution — single quotes are intentional.
+CLEAN_MATRIX='
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | thing works | PHPUnit | post-impl | `tests/X.php` |
+'
+
+# ---------------------------------------------------------------------------
+# Row 15 — a plan with a clean (zero-manual) matrix and NO impl_model marker
+# is refused at queue time (nonzero exit); it must NOT land in queue/.
+# ---------------------------------------------------------------------------
+setup
+printf '%s\n' "$CLEAN_MATRIX" > "$PDIR/plan-j.md"
+set +e
+out=$(run_queue plan-j 2>&1)
+ec=$?
+set +e
+if [ "$ec" -eq 0 ]; then
+    echo "FAIL: row15 — expected non-zero exit for a plan missing impl_model"
+    FAILED=1
+fi
+if ! echo "$out" | grep -q "impl_model"; then
+    echo "FAIL: row15 — expected an impl_model-consistency error, got: $out"
+    FAILED=1
+fi
+assert_absent "row15 not queued" "$NDIR/queue/plan-j.md"
+echo "ok: row15 — refuses to queue a plan missing impl_model"
+
+# ---------------------------------------------------------------------------
+# Row 16 — the same clean matrix WITH a deliberate `impl_model: sonnet` marker
+# queues normally.
+# ---------------------------------------------------------------------------
+setup
+printf -- '---\nimpl_model: sonnet\n---\n%s\n' "$CLEAN_MATRIX" > "$PDIR/plan-k.md"
+run_queue plan-k >/dev/null 2>&1
+assert_present "row16 queued" "$NDIR/queue/plan-k.md"
+echo "ok: row16 — queues a clean, correctly-marked plan"
+
+# ===========================================================================
 # reorder subcommand — permutation validation + spaced ascending-mtime touch.
 # Order is asserted via `ls -1tr` (oldest-first) — exactly how
 # bin/automouse-run claims the next plan.  GNU ls uses symlink lstat mtime;

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -38,8 +38,21 @@ assert() {
     fi
 }
 
+# Gate 13 (impl_model <-> matrix consistency, assert block further below)
+# requires a deliberate `impl_model:` marker whenever the matrix has zero
+# Truly-manual rows (rule b). Every fixture in this file that predates gate 13
+# and uses a clean 0-manual matrix with no frontmatter needs this minimal
+# prefix so its ORIGINAL gate-under-test attribution survives — exit 0/1 stays
+# attributable to what the fixture's own comment says it tests, not
+# reattributed to gate 13. FM starts at true line 1 (`---` is FM's first byte)
+# so it parses as real frontmatter wherever it is prepended.
+FM='---
+impl_model: sonnet
+---
+'
+
 # A minimal well-formed matrix passes (exit 0). Baseline / no false positives.
-assert "clean-minimal" 0 '
+assert "clean-minimal" 0 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---------------|-----------|--------|---------------------|
 | 1 | cap rejects over-cap trade | PHPUnit | pre-impl | `tests/Trade/TradeValidatorTest.php` |
@@ -51,7 +64,7 @@ assert "no-matrix" 1 'Implementation steps only. No verification table here.'
 
 # Gate 1: 6-column `| PR |` header variant is still recognized as a matrix —
 # combined with valid rows it passes (exit 0). Regression for header detection.
-assert "pr-column-header" 0 '
+assert "pr-column-header" 0 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location | PR |
 |---|---------------|-----------|--------|---------------------|----|
 | 1 | thing works | PHPUnit | post-impl | `tests/X.php` | 1 |
@@ -61,7 +74,7 @@ assert "pr-column-header" 0 '
 # corpus proved the type column open-ended (Go-archive-diagnostic, Documented
 # (domain rule), read-before-cut). So a row with an unusual type must NOT flag
 # on type grounds (exit 0). Left as /plan Opus judgment.
-assert "open-type-not-flagged" 0 '
+assert "open-type-not-flagged" 0 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---------------|-----------|--------|---------------------|
 | 1 | engine attribution | Go-archive-diagnostic | post-impl | `engine/x_test.go` |
@@ -84,14 +97,14 @@ assert "real-manual-ok" 0 '
 '
 
 # Gate 7: a DECIDE token in a table row must flag (exit 1).
-assert "unresolved-decide" 1 '
+assert "unresolved-decide" 1 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---------------|-----------|--------|---------------------|
 | 1 | DECIDE which validator to call | PHPUnit | post-impl | `tests/X.php` |
 '
 
 # Gate 7: TBD token likewise (exit 1).
-assert "unresolved-tbd" 1 '
+assert "unresolved-tbd" 1 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---------------|-----------|--------|---------------------|
 | 1 | TBD which validator | PHPUnit | post-impl | `tests/X.php` |
@@ -100,7 +113,7 @@ assert "unresolved-tbd" 1 '
 # Gate 7: a benign "(or ...)" aside must NOT flag (exit 0). The corpus is full of
 # these (`≤5 (or 0 ideally)`, `(or extend existing)`); "(or " is left to /plan
 # judgment precisely so they do not false-positive here.
-assert "benign-or-aside-ok" 0 '
+assert "benign-or-aside-ok" 0 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---------------|-----------|--------|---------------------|
 | 1 | baseline count is ≤ 5 (or 0 ideally) | CLI-executable | post-impl | `grep -c X file` |
@@ -109,7 +122,7 @@ assert "benign-or-aside-ok" 0 '
 
 # Reuse: a Class::method whose class is absent from ibl5/ (could be Go/external)
 # must NOT flag — the false-positive guard (exit 0).
-assert "reuse-unknown-class-ok" 0 '
+assert "reuse-unknown-class-ok" 0 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---------------|-----------|--------|---------------------|
 | 1 | x | PHPUnit | post-impl | `tests/X.php` |
@@ -119,7 +132,7 @@ assert "reuse-unknown-class-ok" 0 '
 
 # Reuse: a forward-referenced method the plan creates must NOT flag (exit 0),
 # even if it does not exist yet.
-assert "reuse-forward-ref-ok" 0 '
+assert "reuse-forward-ref-ok" 0 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---------------|-----------|--------|---------------------|
 | 1 | x | PHPUnit | post-impl | `tests/X.php` |
@@ -130,7 +143,7 @@ Create a new method `TotallyMadeUpClass::brandNewMethod()` and **reuse** it late
 # Reuse: a `Class::SCREAMING_CASE` token is a class CONSTANT, not a method — it
 # must NOT be method-existence-checked (exit 0). Regression for the corpus false
 # positive on `EngineBundleService::DEFAULT_GAME_TYPE`.
-assert "reuse-constant-not-method" 0 '
+assert "reuse-constant-not-method" 0 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---------------|-----------|--------|---------------------|
 | 1 | x | PHPUnit | post-impl | `tests/X.php` |
@@ -153,26 +166,26 @@ M='
 '
 
 # Gate 8: a new `bin/foo` plus an ADR-step path resolves the trigger (exit 0).
-assert "gate8-bin-with-adr" 0 "$M"'
+assert "gate8-bin-with-adr" 0 "$FM$M"'
 Phase 1 — Create `bin/foo` to do the thing.
 Phase 2 — author the ADR `ibl5/docs/decisions/0099-x.md`.
 '
 
 # Gate 8: a new `.claude/rules/x.md` plus a `no-adr:` bypass marker resolves (exit 0).
-assert "gate8-bypass-marker" 0 "$M"'
+assert "gate8-bypass-marker" 0 "$FM$M"'
 Phase 1 — Create a new file `.claude/rules/x.md`.
 Resolution: no-adr: documented in the existing ADR-0001 already.
 '
 
 # Gate 8: a new `.claude/rules/x.md` with no resolution must flag (exit 1).
 # Load-bearing negative — always-flag path.
-assert "gate8-rule-no-resolution" 1 "$M"'
+assert "gate8-rule-no-resolution" 1 "$FM$M"'
 Phase 1 — Create `.claude/rules/x.md` for the new convention.
 '
 
 # Gate 8: a new `bin/foo` with no resolution must flag (exit 1).
 # Load-bearing negative — conservative bin trigger.
-assert "gate8-bin-no-resolution" 1 "$M"'
+assert "gate8-bin-no-resolution" 1 "$FM$M"'
 Phase 1 — Create `bin/foo` for the new tool.
 '
 
@@ -180,7 +193,7 @@ Phase 1 — Create `bin/foo` for the new tool.
 # verb anywhere, no resolution) must NOT flag (exit 0). This is the discriminating
 # regression for the creation-context include-filter: with `post-impl` in the cue
 # this fixture exits 1; the include-filter deliberately excludes `post-impl`.
-assert "gate8-post-impl-row-not-created" 0 '
+assert "gate8-post-impl-row-not-created" 0 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---------------|-----------|--------|---------------------|
 | 1 | workflow runs green | CLI-executable | post-impl | `.github/workflows/tests.yml` |
@@ -189,19 +202,19 @@ assert "gate8-post-impl-row-not-created" 0 '
 
 # Gate 8: prose merely REFERENCING an existing trigger file (no creation cue) must
 # NOT flag (exit 0) — the include-filter again.
-assert "gate8-referenced-not-created" 0 "$M"'
+assert "gate8-referenced-not-created" 0 "$FM$M"'
 This step references the existing `.github/workflows/tests.yml` workflow.
 '
 
 # Gate 8: a new migration with NO `DROP` in the plan text must NOT flag (exit 0) —
 # conservative migration scoping.
-assert "gate8-migration-no-drop" 0 "$M"'
+assert "gate8-migration-no-drop" 0 "$FM$M"'
 Phase 1 — Create `ibl5/migrations/099_x.sql` to add a nullable column.
 '
 
 # Gate 8: a new migration whose plan text mentions `DROP TABLE`, no resolution,
 # must flag (exit 1) — destructive-migration trigger.
-assert "gate8-migration-drop-no-adr" 1 "$M"'
+assert "gate8-migration-drop-no-adr" 1 "$FM$M"'
 Phase 1 — Create `ibl5/migrations/099_x.sql`.
 The migration runs DROP TABLE foo to remove the legacy store.
 '
@@ -209,27 +222,34 @@ The migration runs DROP TABLE foo to remove the legacy store.
 # Gate 8 regression: a plan that CITES an existing ADR for context (no creation
 # verb on the ADR line) but CREATES a trigger file must still flag (exit 1).
 # Prevents GATE8_RESOLVED from being set by a bare ADR reference.
-assert "gate8-cited-adr-not-authored" 1 "$M"'
+assert "gate8-cited-adr-not-authored" 1 "$FM$M"'
 Phase 1 — Create `bin/foo` for the new tool.
 See ibl5/docs/decisions/0062-worktrees-outside-repo.md for context on the layout.
 '
 
 # Gate 8: a plan that both creates a trigger file AND authors a new ADR (creation
 # verb on the ADR line) must pass (exit 0) — confirms creation-verb check.
-assert "gate8-authored-adr-resolves" 0 "$M"'
+assert "gate8-authored-adr-resolves" 0 "$FM$M"'
 Phase 1 — Create `bin/foo` for the new tool.
 Phase 2 — Create ibl5/docs/decisions/0099-x.md documenting the decision.
 '
 
 # Gate H: a plan whose line-1 frontmatter declares `auto_merge: false` but has NO
-# `## Automouse Hold Justification` section must flag (exit 1).
+# `## Automouse Hold Justification` section must flag (exit 1). Frontmatter
+# also carries impl_model: sonnet so gate 13 (0 manual rows in M, no marker)
+# doesn't co-fire and reattribute this fixture's exit code.
 assert "gateH-hold-no-justification" 1 '---
 auto_merge: false
+impl_model: sonnet
 ---'"$M"
 
 # Gate H: the same hold WITH the justification section passes (exit 0).
+# Frontmatter carries impl_model: sonnet alongside auto_merge: false — without
+# it, gate 13 (0 manual rows, no impl_model marker) would fire rule (b) and
+# reattribute this fixture's exit code away from gate H.
 assert "gateH-hold-with-justification" 0 '---
 auto_merge: false
+impl_model: sonnet
 ---'"$M"'
 ## Automouse Hold Justification
 
@@ -244,32 +264,73 @@ impl_model: sonnet
 
 # Gate H FP-guard: a plan that merely DOCUMENTS the `auto_merge: false` syntax in
 # its body (not in line-1 frontmatter) must NOT flag (exit 0).
-assert "gateH-body-mentions-syntax-only" 0 "$M"'
+assert "gateH-body-mentions-syntax-only" 0 "$FM$M"'
 Note: setting `auto_merge: false` in the line-1 frontmatter holds the merge.
 '
 
 # ---------------------------------------------------------------------------
 # Gate C: context budget.
 # ---------------------------------------------------------------------------
-# Fixtures carry the clean matrix M so exit 0/1 is attributable solely to gate C.
+# All fixtures carry FM (impl_model: sonnet) alongside the clean matrix M so
+# gate 13 (0 manual rows in M, otherwise no marker) never co-fires — gate 13's
+# rule (b) doesn't scale with plan length, so it would fire on the exit-1
+# fixtures below too if FM were omitted, muddying "exit 1 == gate C caught this."
 FILLER="$(yes 'Filler prose line for the context-budget fixture.' | head -520)"
 PHASES11="$(for i in 1 2 3 4 5 6 7 8 9 10 11; do echo "## Phase $i — edit the widget"; done)"
 PHASES12="$PHASES11
 ## Phase 12 — edit the widget"
 
 # Gate C: a >=500-line plan with no marker must flag (exit 1).
-assert "gateC-long-plan-flags" 1 "$M$FILLER"
+assert "gateC-long-plan-flags" 1 "$FM$M$FILLER"
 
 # Gate C: the same long plan WITH a `context-budget:` justification passes (exit 0).
-assert "gateC-long-plan-marker-ok" 0 "$M$FILLER
+assert "gateC-long-plan-marker-ok" 0 "$FM$M$FILLER
 context-budget: length is fenced reference material; 3 phases, small diff.
 "
 
 # Gate C: >=12 numbered phases must flag even under 500 lines (exit 1).
-assert "gateC-many-phases-flags" 1 "$M$PHASES12"
+assert "gateC-many-phases-flags" 1 "$FM$M$PHASES12"
 
 # Gate C boundary: 11 phases and under 500 lines must NOT flag (exit 0).
-assert "gateC-eleven-phases-ok" 0 "$M$PHASES11"
+assert "gateC-eleven-phases-ok" 0 "$FM$M$PHASES11"
+
+# ---------------------------------------------------------------------------
+# Gate 13: impl_model <-> Verification Matrix consistency.
+# ---------------------------------------------------------------------------
+# EXIT-CODE ATTRIBUTION: every fixture here carries the clean minimal matrix
+# M (or a Truly-manual variant of it) with valid rows, no DECIDE/TBD, and no
+# automatable-verb manual row — so exit 0/1 is attributable solely to gate 13,
+# not any other gate.
+M_MANUAL='
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---------------|-----------|--------|---------------------|
+| 1 | does the new dashboard feel polished | Truly-manual | post-impl | n/a |
+'
+
+# (a) A Truly-manual row plus `impl_model: sonnet` is a forbidden combo (exit 1).
+assert "gate13-manual-with-sonnet" 1 '---
+impl_model: sonnet
+---'"$M_MANUAL"
+
+# (b) A clean (zero-manual) matrix with NO impl_model marker at all must flag
+# (exit 1) — the model choice must be deliberate.
+assert "gate13-clean-matrix-absent" 1 "$M"
+
+# (c) A clean matrix with explicit `impl_model: sonnet` passes (exit 0) — the
+# encouraged case this gate exists to surface.
+assert "gate13-clean-sonnet-ok" 0 '---
+impl_model: sonnet
+---'"$M"
+
+# (d) A clean matrix with an explicit `impl_model: opus` passes (exit 0) — a
+# deliberate opus choice is a valid alternative to sonnet.
+assert "gate13-clean-explicit-opus-ok" 0 '---
+impl_model: opus
+---'"$M"
+
+# (e) A Truly-manual row with NO impl_model marker passes (exit 0) — absence
+# defaults to the safe Opus path, which is correct when a row is subjective.
+assert "gate13-manual-absent-ok" 0 "$M_MANUAL"
 
 if [ "$FAILED" -ne 0 ]; then
     echo "RESULT: FAILED"


### PR DESCRIPTION
## Summary

- Introduces `bin/lib/plan-model-consistency` — shared library enforcing the `impl_model` ↔ Verification Matrix consistency rule: Truly-manual rows forbid `impl_model: sonnet`; a zero-manual matrix requires an explicit `impl_model:` marker (sonnet or opus)
- Wires it into `bin/check-plan` as gate 13 — catches violations at plan-authoring time
- Wires it into `bin/automouse-queue` as a queue-time backstop — refuses to queue old pre-gate plans that slipped through the archive
- Updates `bin/test-check-plan` (gate-13 fixtures) and `bin/test-automouse-queue` (rows 15/16) with full coverage of the five rule cases

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.