### PR TITLE
docs: refresh stale ADR-0014, ADR-0018, ADR-0019

### DIFF
--- a/ibl5/docs/decisions/0014-centralize-contract-modifier-formulas.md
+++ b/ibl5/docs/decisions/0014-centralize-contract-modifier-formulas.md
@@ -1,6 +1,6 @@
 ---
 description: Centralizes shared contract modifier formulas (winner, tradition, loyalty, playing time) into ContractRules static methods, eliminating three divergent implementations.
-last_verified: 2026-05-04
+last_verified: 2026-07-07
 ---
 
 # ADR-0014: Centralize Contract Modifier Formulas
@@ -10,11 +10,11 @@ last_verified: 2026-05-04
 
 ## Context
 
-Three contract calculators were independently extracted from legacy PHP files in 2025: `ExtensionOfferEvaluator` (PR #49), `NegotiationDemandCalculator` (PR #108), and `FreeAgencyDemandCalculator` (PR #132). Each faithfully ported its legacy source, but the legacy sources had drifted over years of separate maintenance. Winner and tradition used different scaling (raw differential vs normalized win-rate), and playing time had three distinct formulas across the modules. No canonical source was ever established, and the divergence caused incorrect extension evaluations and negotiation demands.
+Three contract calculators were independently extracted from legacy PHP files in 2025: `ExtensionOfferEvaluator` (PR #49), `ExtensionContractDemandCalculator` (PR #108), and `FreeAgencyMarketDemandCalculator` (PR #132). Each faithfully ported its legacy source, but the legacy sources had drifted over years of separate maintenance. Winner and tradition used different scaling (raw differential vs normalized win-rate), and playing time had three distinct formulas across the modules. No canonical source was ever established, and the divergence caused incorrect extension evaluations and negotiation demands.
 
 ## Decision
 
-All shared modifier formulas are centralized as static methods on `ContractRules`: `calculateWinnerModifier`, `calculateTraditionModifier`, `calculateLoyaltyModifier`, and `calculatePlayingTimeModifier`. Consumer classes (`ExtensionOfferEvaluator`, `NegotiationDemandCalculator`, `FreeAgencyDemandCalculator`) delegate to these methods instead of implementing their own formulas. `FreeAgencyDemandCalculator` is the canonical source for the unified formulas. Enforced by `ModifierConsistencyTest` integration test.
+All shared modifier formulas are centralized as static methods on `ContractRules`: `calculateWinnerModifier`, `calculateTraditionModifier`, `calculateLoyaltyModifier`, and `calculatePlayingTimeModifier`. Consumer classes (`ExtensionOfferEvaluator`, `ExtensionContractDemandCalculator`, `FreeAgencyMarketDemandCalculator`) delegate to these methods instead of implementing their own formulas. `FreeAgencyMarketDemandCalculator` is the canonical source for the unified formulas. Enforced by `ModifierConsistencyTest` integration test.
 
 ## Alternatives Considered
 

--- a/ibl5/docs/decisions/0018-coverage-regression-and-baseline-drift-detection.md
+++ b/ibl5/docs/decisions/0018-coverage-regression-and-baseline-drift-detection.md
@@ -1,6 +1,6 @@
 ---
 description: Rationale for adding coverage regression detection and PHPStan baseline drift detection to CI.
-last_verified: 2026-05-04
+last_verified: 2026-07-07
 ---
 
 # ADR-0018: Coverage Regression and Baseline Drift Detection

--- a/ibl5/docs/decisions/0019-mutation-unlock-repositories.md
+++ b/ibl5/docs/decisions/0019-mutation-unlock-repositories.md
@@ -1,6 +1,6 @@
 ---
 description: Rationale for removing the broad *Repository* mutation testing exclusion and adding MariaDB to the mutation CI workflow.
-last_verified: 2026-05-05
+last_verified: 2026-07-07
 ---
 
 # ADR-0019: Mutation Testing Unlock — Repositories
@@ -31,8 +31,7 @@ Plan 15 (Views unlock) removed `*View*` from `infection.json5` but didn't addres
 
 ## Consequences
 
-- 78 of 82 Repository implementations are now subject to the 100% MSI mutation gate.
+- Pass 1 brought all but the four deferred repositories under the 100% MSI mutation gate. Pass 2 has since completed (PR #872), writing direct DB integration tests for the four deferred repositories and removing their per-file excludes. `infection.json5` no longer excludes any Repository — every Repository implementation is now subject to the mutation gate.
 - The mutation CI workflow takes longer (~30s for MariaDB startup + migrations + seed), but this is the same overhead already paid by the `db-integration` job in `tests.yml`.
 - The `phpunit-mutation.xml` config must be kept in sync with `phpunit.xml` when new test suites are added. The testsuites section is identical; only the `<groups>` and `<source>` blocks differ.
 - Running `composer mutation` locally now requires a running MariaDB instance (matching the CI service config) because `testFrameworkOptions` points at `phpunit-mutation.xml`, which includes DB integration tests. Developers without a local MariaDB will see connection failures during coverage generation.
-- Pass 2 (4 remaining repos) requires writing direct DB integration tests before they can be unlocked.


### PR DESCRIPTION
## Summary

- ADR-0014: bump `last_verified` to 2026-07-07; correct class names (`ExtensionContractDemandCalculator`, `FreeAgencyMarketDemandCalculator`) that had drifted from the actual codebase
- ADR-0018: bump `last_verified` to 2026-07-07 (no content changes — content is accurate)
- ADR-0019: bump `last_verified` to 2026-07-07; update Consequences to record Pass 2 completion (PR #872) and remove the now-obsolete "Pass 2 requires..." bullet

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.