### PR TITLE
docs: add plan decomposition backlog entries (L13-L17, T11-T12)

### DIFF
--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
-description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-07-07
+description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
+last_verified: 2026-07-08
 ---
 
 # Loop-Engineering Backlog
@@ -27,7 +27,7 @@ last_verified: 2026-07-07
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 6 |
+| ⬜ Open | 11 |
 | 📋 Planned | 2 |
 | ◑ Partial | 3 |
 | ✅ Implemented | 1 |
@@ -51,6 +51,11 @@ last_verified: 2026-07-07
 | L10 | Discord intake loop | ◑ Partial | 🟦 | L |
 | L11 | Comprehension-debt digest | ⬜ Open | 🟦 | S |
 | L12 | Autonomy contracts in plan frontmatter | ◑ Partial | 🟦 | M |
+| L13 | Per-phase impl-model routing | ⬜ Open | 🟦 | M |
+| L14 | Escalate-on-retry (Sonnet-first, just-in-time Opus) | ⬜ Open | 🟦 | S |
+| L15 | Sonnet-recipe completeness lint | ⬜ Open | 🟦 | S |
+| L16 | Context-budget gate v2 (work-size proxies + measured calibration) | ⬜ Open | 🟦 | M |
+| L17 | Shared-context artifact for multi-plan splits | ⬜ Open | 🟦 | S |
 
 ### L1 Plan dependency DAG
 **Location:** `bin/automouse-queue` — queue order is symlink mtime (`ls -1tr`); `bin/automouse-queue-reorder-ui` re-touches mtimes by hand. No `depends_on` anywhere (verified).
@@ -128,6 +133,41 @@ last_verified: 2026-07-07
 **Suggested direction:** Per-plan `stop_condition` / `evidence` frontmatter fields that post-plan verification checks mechanically — goal, scope, stop condition, evidence, per the autonomy-contract framing.
 **Risk if untouched:** Autonomy increases (L1–L8) without a matching declared-contract surface.
 **Status (2026-07-07):** ◑ Partial — the one-bit levers + gates exist; structured contract fields don't. 🟦.
+
+### L13 Per-phase impl-model routing
+**Location:** `bin/automouse-run` (single `--model` per plan, resolved once by `bin/lib/plan-impl-model`); plans already label every phase Sonnet / Haiku / self per `.claude/skills/plan/_architect-contract.md` § Agent-tiering guidance — nothing consumes those labels at run time (verified 2026-07-08).
+**Problem:** Model selection is whole-run: a mixed plan runs every mechanical phase at the top tier, and the only relief is a tier-boundary split (T11 in [token-spend-backlog.md](token-spend-backlog.md)), which can't reach plans whose judgment and mechanical phases interleave.
+**Suggested direction:** Make the in-plan tier labels binding rather than advisory: the impl orchestrator MUST delegate a Sonnet/Haiku-labeled phase as a sub-agent per its delegation packet (mechanism exists; today it's agent discretion). Bulk spend moves down-tier AND out of the orchestrator's context — dumb-zone relief and tier savings from the same change. A runner-driven per-phase `claude -p` sequence with a state handoff is the heavier fallback if in-run delegation proves unreliable.
+**Risk if untouched:** Per-phase tiering stays a plan-authoring ritual with no runtime effect; mixed plans pay top-tier for mechanical sweeps.
+**Status (2026-07-08):** ⬜ Open — 🟦.
+
+### L14 Escalate-on-retry (Sonnet-first, just-in-time Opus)
+**Location:** `bin/automouse-run` — `MAX_ATTEMPTS=3`, every attempt at the same `impl_model`; genuine failures park the plan in `skipped/` after 3.
+**Problem:** `impl_model: sonnet` adoption is throttled by its downside: a plan that turns out to need judgment burns all three attempts on the same model, then a queue slot. The rational response is conservative labeling — Opus-by-default — which is the exact spend the marker exists to avoid.
+**Suggested direction:** On a genuine (non-environmental) failure of a Sonnet-model plan, escalate the final retry to Opus, feeding the prior attempt's failure report into the retry context (the L8 sidecar pattern already persists it). Cheap plans stay cheap; hard plans get Opus exactly when the evidence demands it. Once proven, this makes Sonnet-first safe enough to consider as the *default* for unmarked plans, inverting today's Opus-by-omission.
+**Risk if untouched:** Gate 13(b)'s Sonnet default stays capped at "obviously mechanical" plans; every borderline plan pre-commits to Opus.
+**Status (2026-07-08):** ⬜ Open — 🟦.
+
+### L15 Sonnet-recipe completeness lint
+**Location:** `bin/check-plan` — gates cover matrix presence, forbidden tokens, staleness, and size; none check *recipe completeness*. Gate 13 judges Sonnet-eligibility by verification (a machine check fails on a wrong edit) only.
+**Problem:** "Sonnet-capable" has two halves and only one is enforced: verifiable, but not *specified* — a Sonnet plan whose phases lack edit anchors, reuse notes, or self-verify commands passes `bin/check-plan`, then flails at 2am on judgment calls the plan never resolved. Those burned attempts read as model failure and push labeling back toward Opus.
+**Suggested direction:** A new gate for `impl_model: sonnet` plans: every numbered phase that edits an existing file must carry an edit-anchor cue (quoted snippet per the architect contract), and every delegation packet a Self-verify line; violations name the phase. Heuristic by nature, so support a clearing marker mirroring the existing `no-adr:` / `context-budget:` pattern.
+**Risk if untouched:** Sonnet-labeled plans fail for specification gaps, mis-attributed to model capability.
+**Status (2026-07-08):** ⬜ Open — 🟦.
+
+### L16 Context-budget gate v2 (work-size proxies + measured calibration)
+**Location:** `bin/check-plan` gate `[C]` (≥ 500 lines OR ≥ 12 numbered phases — thresholds hand-set once from the 2026-07-07 automouse-corpus audit); the T1 per-phase cost rows carry no peak-context column.
+**Problem:** Two blind spots. (1) Plan size ≠ work size: a 100-line plan phase saying "sweep every call site" triggers a marathon implementation the gate can't see, while a reference-heavy plan false-trips and gets papered over with a `context-budget:` marker. (2) No feedback loop: nothing re-checks the thresholds as plan style evolves, so the gate drifts from the dumb-zone reality it proxies.
+**Suggested direction:** (a) Add work-size proxies — Verification-Matrix row count, Critical-Files change-target count, and sweep-verb detection ("all call sites", "every occurrence") in a phase without a delegation packet. (b) Log peak context tokens per impl run into the T1 ledger (the stream-json usage events already carry them) and add a report correlating plan proxies against measured peaks — recalibrate thresholds from data, and flag any run breaching ~150K as a Step 2.5 split miss for the retro.
+**Risk if untouched:** Dumb-zone breaches keep happening under the gate's radar, and the thresholds stay a one-shot guess.
+**Status (2026-07-08):** ⬜ Open — 🟦. Pairs with T1 in [token-spend-backlog.md](token-spend-backlog.md).
+
+### L17 Shared-context artifact for multi-plan splits
+**Location:** `/plan` Step 2.5 multi-PR path (`.claude/skills/plan/SKILL.md`) — Steps 3–5 run once per unit, each plan fully self-contained; the Discord bug pipeline hand-rolled a shared-context spec file to avoid exactly this.
+**Problem:** When a task splits into N plans, each plan-architect run and each implementation session re-derives the shared orientation (blast radius, patterns, front-loaded decisions) independently — N× the exploration spend — and each plan re-inlines the shared background, inflating it toward gate `[C]`. This is a tax on splitting, i.e. a disincentive against the very decomposition the context-budget gate demands.
+**Suggested direction:** Formalize the pattern the Discord pipeline improvised: when Step 2.5 splits, persist Step 2's exploration pointers (`path:line` + load-bearing fact, never file bodies) plus recorded Step 3.5 decisions once to `$HOME/.claude/plans/<program>-shared-context.md`; each split plan references it instead of restating it. Plans get smaller, and each architect run becomes targeted confirmation instead of re-exploration.
+**Risk if untouched:** Splitting stays expensive, so plans skew large — working against L16/T11.
+**Status (2026-07-08):** ⬜ Open — 🟦.
 
 ---
 

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -29,7 +29,7 @@ last_verified: 2026-07-08
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 4 |
+| ⬜ Open | 6 |
 | 📋 Planned | 1 |
 | ◑ Partial | 1 |
 | ✅ Implemented | 0 |
@@ -49,6 +49,8 @@ Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive
 | T5 | Memory/rules dedup lint | ⬜ Open | ⌂ | S |
 | T7 | Resident-overlay diet (MEMORY.md + rules) | ⬜ Open | both | M |
 | T9 | Lazy-load plan/post-plan skills | 📋 Planned | repo | M |
+| T11 | Tier-boundary plan splitting | ⬜ Open | repo | S |
+| T12 | Sonnet plan-architect for recipe-backed plans | ⬜ Open | repo | M |
 
 ### T1 Automouse token ledger
 **Location:** `bin/lib/automouse-stream-filter` (parses `total_cost_usd` + token counts from the stream-json `result` event); `bin/automouse-run` (appends a per-plan, per-phase row to `automouse/reports/YYYY-MM-DD-costs.md`).
@@ -91,6 +93,20 @@ Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive
 **Suggested direction:** Thin orchestrator SKILL.md + per-phase reference files read on phase entry. Both restructures are planned: `$HOME/.claude/plans/lazy-load-plan-skill.md` and `$HOME/.claude/plans/lazy-load-post-plan-skill.md` (the post-plan one is in the automouse queue).
 **Risk if untouched:** ~20K tokens of dead weight resident in every `/plan` and `/post-plan` run.
 **Status (2026-07-07):** 📋 Planned — post-plan restructure queued; plan-skill restructure planned, not yet queued.
+
+### T11 Tier-boundary plan splitting
+**Location:** `.claude/skills/plan/SKILL.md` — Step 2.5 (split criteria) and Step 4 gate 13 (`impl_model` criterion).
+**Problem:** Gate 13's Sonnet criterion is all-or-nothing per plan: a single judgment phase or `Truly-manual` row drops the *entire* implementation to Opus (~1.7× per-token) even when the other 90% of phases are mechanical. Step 2.5's split criteria (review size, rollback boundary, context budget) never consider the model-tier boundary, so mixed plans are never restructured to isolate the Opus-forcing part.
+**Suggested direction:** Add a Step 2.5 split criterion: when a plan's Opus-tier phases (novel design, migration authoring, judgment sweeps) are *separable* from its mechanical phases, split at the tier boundary — a small Opus plan plus stacked `impl_model: sonnet` plan(s) carrying the bulk of the edits. Pairs with L13 in [loop-engineering-backlog.md](loop-engineering-backlog.md) (per-phase routing), which covers the *interleaved* case a split can't reach.
+**Risk if untouched:** Mixed plans keep running whole-hog at Opus; the gate-13(b) default only helps uniformly-mechanical plans.
+**Status (2026-07-08):** ⬜ Open.
+
+### T12 Sonnet plan-architect for recipe-backed plans
+**Location:** `.claude/agents/plan-architect.md` (pins `model: opus` + `effort: xhigh`); `/plan` Step 3 spawns it for every plan.
+**Problem:** Every plan pays an Opus-xhigh architect run even when the design was already resolved upstream — a backlog entry that names the recipe, the files, and the pattern to copy (the marker-swap / mechanical-sweep class). By the house tiering rule (task *type*, not model capability), composing a plan from a pre-resolved recipe is mechanical composition, not novel design.
+**Suggested direction:** A second architect def at Sonnet, selected in Step 3 only when the source backlog entry carries an explicit recipe + named existing pattern; Opus stays the default everywhere else. Gate rollout on measurement (T1 tier ledger + `bin/check-plan` failure rate per architect tier) so a plan-quality regression is visible before the cheap path becomes habit.
+**Risk if untouched:** Opus-xhigh spend on plans whose only hard thinking already happened in the backlog audit.
+**Status (2026-07-08):** ⬜ Open.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds five new loop-engineering backlog entries (L13–L17) covering per-phase impl-model routing, escalate-on-retry Sonnet→Opus, Sonnet-recipe completeness lint, context-budget gate v2, and shared-context artifacts for multi-plan splits
- Adds two token-spend backlog entries (T11–T12) covering tier-boundary plan splitting and Sonnet plan-architect for recipe-backed plans
- Updates summaries, open-count stats, and cross-references between the two backlogs

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.