### PR TITLE
chore: add plan-architect-xhigh agent; tier plan-architect effort high/xhigh

### DIFF
--- a/.claude/agents/plan-architect-xhigh.md
+++ b/.claude/agents/plan-architect-xhigh.md
@@ -1,8 +1,8 @@
 ---
-name: plan-architect
-description: Software architect that designs implementation plans for the /plan command. Returns a step-by-step plan, identifies the critical files, and weighs architectural trade-offs. Runs at high effort. Use only as the Step-3 planning agent invoked by /plan; see plan-architect-xhigh for security/destructive/ship-pipeline tasks.
+name: plan-architect-xhigh
+description: Software architect for high-stakes implementation plans — tasks touching a security surface, trust boundary (auth/authz-gated route), destructive migration, or .claude/skills ship-pipeline invariants. Runs at xhigh effort. Use only as the Step-3 escalated planning agent invoked by /plan.
 model: opus
-effort: high
+effort: xhigh
 disallowedTools: Agent, ExitPlanMode, Edit, Write, NotebookEdit
 ---
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,6 +1,6 @@
 ---
 description: Sub-agent decision rules — when to spawn, when to skip, which model to pick, and how sub-agent delegation keeps orchestrator context low
-last_verified: 2026-07-07
+last_verified: 2026-07-09
 ---
 
 # Agent Tiering
@@ -26,7 +26,7 @@ Each sub-agent costs ~3–5K tokens (system prompt + rules + memory, loaded befo
 | **Haiku** | `model: "haiku"` | Command output, pattern-matching named checklists, grep-and-format, mechanical lookups — answerable by running commands and reporting, without judging relevance. |
 | **Sonnet** | `model: "sonnet"` | Synthesis: "is this finding relevant?", cross-file traces, semantic compliance checks, rename sweeps needing call-site judgment. |
 | **Opus** | self (no delegation) | Novel reasoning, FK ordering, rule authoring, ADR writing, ambiguous test failures, final code review, diff-triage. Never delegate understanding. |
-| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3. The def pins `model: opus` + `effort: xhigh`, so planning runs at Opus depth in a clean sub-context. Do **not** pass an inline `model` override — the def owns it. |
+| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3. The def pins `model: opus` + `effort: high`; escalate to `plan-architect-xhigh` (`effort: xhigh`) for security surfaces, trust boundaries, destructive migrations, or ship-pipeline invariant changes. Do **not** pass an inline `model` override — the def owns it. |
 | **Fable** | `model: "fable"` — **prompt first, last resort** | Rung above Opus (~2× cost). Use **only** when a task is absolutely critical **and** Fable is 100% necessary to solve it — and **never without prompting the user first** for explicit approval. Default to Opus. Full gate: `.claude/rules/agent-tiering-detail.md`. |
 
 > **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (then the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -4,7 +4,7 @@ description: "Plan an implementation task: enforces a verification matrix, direc
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
-last_verified: 2026-07-07
+last_verified: 2026-07-09
 ---
 
 # /plan — Implementation Planning with Verification Matrix
@@ -70,7 +70,7 @@ Run this step once per PR-sized unit identified in Step 2.5. Each run plans exac
 
 The Plan agent auto-loads CLAUDE.md, all always-loaded rules (agent-tiering, core-coding, etc.), and user memory. Do NOT re-inject any of these into the prompt — only supply what the agent cannot get on its own.
 
-Launch a **single Plan agent** (`subagent_type: "plan-architect"` — its definition carries `model: opus` and `effort: xhigh`; do NOT pass an inline `model` override) with a prompt containing ALL of these:
+Launch a **single Plan agent** (`subagent_type: "plan-architect"` — its definition carries `model: opus` and `effort: high`; do NOT pass an inline `model` override) with a prompt containing ALL of these. **Escalate to `plan-architect-xhigh` (effort: xhigh) when Step 2 flagged any of: a security surface, a trust boundary (auth/authz-gated route), a destructive migration, or a change to `.claude/skills` ship-pipeline invariants.**
 
 **Run this step inline — never delegate `/plan` itself.** The orchestrating session owns Steps 1–5 directly and spawns exactly **one** `plan-architect` per PR-sized unit. Do NOT hand the whole `/plan` invocation to a `general-purpose`/`claude` sub-agent (or fan it out across several), and do NOT have any such agent fire `/plan` on your behalf. Those agent types carry `Tools: *` — they *can* spawn further agents, so delegating `/plan` to them produces a `general-purpose → plan-architect` nest, exactly the multi-level `plan-architect` tree the flat-fan-out rule forbids (`agent-tiering.md` § Flat fan-out). `plan-architect`/`Plan`/`Explore` cannot cause this themselves — they lack the `Agent` tool — so the only way the nest appears is an orchestrator delegating `/plan` outward. Keep planning one level deep: this session → one `plan-architect`.
 


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/plan-architect-xhigh.md` — a dedicated planning agent running at `effort: xhigh` for high-stakes tasks (security surfaces, trust boundaries, destructive migrations, ship-pipeline invariant changes)
- Drops default `plan-architect` from `effort: xhigh` → `effort: high` for standard planning (reduces cost on routine tasks)
- Updates `agent-tiering.md` and `/plan SKILL.md` to route escalation: Step 2 flags any of the four surfaces → use `plan-architect-xhigh`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.