### PR TITLE
chore: skip Lighthouse/E2E/VR CI for PHPUnit-test-only changes

### DIFF
--- a/bin/test-website-affecting
+++ b/bin/test-website-affecting
@@ -90,6 +90,23 @@ assert_exit "pin-markdown"      1 "README.md"          # \.md$ deny regex
 assert_exit "pin-app-php"       0 "ibl5/index.php"     # app code, website-side
 assert_exit "pin-carveout-self" 0 "bin/website-affecting"  # is_carveout forces website
 
+# --- (e) ^ibl5/tests/ deny + browser-spec carve-out ---
+# SAFE (exit 0 / stays website): the real Playwright/API browser specs must keep
+# triggering E2E/VR despite matching the new ^ibl5/tests/ deny — is_carveout wins.
+assert_exit "tests-e2e-spec"       0 "ibl5/tests/e2e/foo.spec.ts"          # carve-out ibl5/tests/e2e/*
+assert_exit "tests-api-e2e-spec"   0 "ibl5/tests/api-e2e/bar.ts"           # carve-out ibl5/tests/api-e2e/*
+assert_exit "tests-e2e-ci-seed"    0 "ibl5/tests/e2e/fixtures/ci-seed.sql" # seed under e2e/ → carved
+assert_exit "tests-e2e-nested"     0 "ibl5/tests/e2e/smoke/foo.spec.ts"    # case-glob * spans '/', nested covered
+# DANGEROUS (exit 1 / now SKIPs): PHPUnit test-only .php — never executed by the
+# app-under-test, so it cannot alter any render (Module/ entry-point tests only
+# ASSERT the render, never produce it).
+assert_exit "tests-cli-php"        1 "ibl5/tests/Cli/Foo.php"                        # ^ibl5/tests/ deny
+assert_exit "tests-dbintegration"  1 "ibl5/tests/DatabaseIntegration/Bar.php"        # ^ibl5/tests/ deny
+assert_exit "tests-module-entry"   1 "ibl5/tests/Module/EntryPoints/BazEntryPointTest.php"  # HTML-asserting but assert-only
+# BOUNDARY (exit 1): the e2e-helpers sibling must NOT match the ibl5/tests/e2e/*
+# carve-out (trailing-slash glob) — proves ^ibl5/tests/ deny still applies.
+assert_exit "tests-e2e-sibling"    1 "ibl5/tests/e2e-helpers/x.ts"         # sibling ≠ e2e/* carve-out
+
 # Empty stdin → exit 0 (fail-safe BUILD). Tested with genuinely empty input.
 printf '' | "$GUARD" >/dev/null 2>&1
 empty_exit=$?

--- a/bin/website-affecting
+++ b/bin/website-affecting
@@ -23,10 +23,12 @@
 # below therefore means "cannot alter a VR / E2E / Lighthouse / preview render."
 #
 # Deny-set (a file is non-website if it matches ALL of the following):
-#   - matches the deny regex: (\.md$|^docs/|^ibl5/docs/|^\.claude/|^bin/|^engine/)
+#   - matches the deny regex: (\.md$|^docs/|^ibl5/docs/|^\.claude/|^bin/|^engine/|^ibl5/tests/)
 #   - is NOT in the carve-out set (paths that must always trigger, even though
 #     they match the deny regex):
 #       bin/website-affecting  (the predicate itself — changing the gate must trigger it)
+#       ibl5/tests/e2e/*       (Playwright browser specs — drive real renders)
+#       ibl5/tests/api-e2e/*   (API E2E specs — drive real requests)
 #
 # Most naturally website-side files (they do NOT match the deny regex) always
 # count website — INCLUDING E2E/Lighthouse drivers like
@@ -75,17 +77,33 @@
 #              touches docker/** or the image build (website-side, not denied), so
 #              those still trigger E2E. Note ibl5/bin/jsbsim (the baked binary) is
 #              under ^ibl5/, never matched by ^engine/.
+#   ^ibl5/tests/ PHPUnit test-only PHP (Cli/, Module/, DatabaseIntegration/, …).
+#              A PHPUnit .php test is never executed by the app-under-test, so
+#              changing one cannot alter any render — even HTML-rendering Module/
+#              entry-point tests only ASSERT the app's render, never produce it.
+#              CARVE-OUT: ibl5/tests/e2e/* and ibl5/tests/api-e2e/* are the real
+#              browser specs (Playwright) — they DRIVE renders, so they stay
+#              website-side. Prefix globs (…/e2e/*, NOT …/e2e*) so a sibling like
+#              ibl5/tests/e2e-helpers/ is NOT carved out; the case glob's * spans
+#              '/', so nested specs (…/e2e/smoke/foo.spec.ts) are covered.
+#              Conscious over-run: a .md-only change under ibl5/tests/e2e/ (e.g.
+#              ibl5/tests/e2e/README.md) now flips skip→RUN — the carve-out wins
+#              over \.md$. Rare and SAFE (extra E2E run, never a silent skip).
 #
 # shellcheck shell=bash
 
 set -u
 
-DENY_REGEX='(\.md$|^docs/|^ibl5/docs/|^\.claude/|^bin/|^engine/)'
+DENY_REGEX='(\.md$|^docs/|^ibl5/docs/|^\.claude/|^bin/|^engine/|^ibl5/tests/)'
 
-# Carve-out: paths that match the deny regex but must still trigger (exact match).
+# Carve-out: paths that match the deny regex but must still trigger. Exact match
+# for the predicate itself; prefix globs for the real browser-spec dirs (they
+# DRIVE renders, so they stay website-side despite matching ^ibl5/tests/).
 is_carveout() {
     case "$1" in
         bin/website-affecting) return 0 ;;
+        ibl5/tests/e2e/*)      return 0 ;;
+        ibl5/tests/api-e2e/*)  return 0 ;;
     esac
     return 1
 }
@@ -145,9 +163,12 @@ Deny-set (non-website if matched and not in carve-out):
   ^\.claude/     local .claude rules/commands
   ^bin/          host repo bin/ scripts
   ^engine/       Go sim engine source (own CI; E2E runs the prebaked binary)
+  ^ibl5/tests/   PHPUnit test-only PHP (never executed by the app-under-test)
 
 Carve-out (always website-side despite matching deny regex):
   bin/website-affecting  (the predicate itself)
+  ibl5/tests/e2e/*       (Playwright browser specs — drive real renders)
+  ibl5/tests/api-e2e/*   (API E2E specs — drive real requests)
 
 CI-meta exempt (NON-website despite not matching deny regex — provably can't
 affect a VR/E2E/Lighthouse/preview render; staleness over-runs, never silent-skips):

--- a/ibl5/tests/Cli/WebsiteAffectingCliTest.php
+++ b/ibl5/tests/Cli/WebsiteAffectingCliTest.php
@@ -97,6 +97,36 @@ final class WebsiteAffectingCliTest extends TestCase
         self::assertSame(1, $result['exit'], $result['stderr']);
     }
 
+    public function testTestsCliDirDiffExitsOne(): void
+    {
+        // PHPUnit Cli test .php → SKIP (^ibl5/tests/ deny; never run by app-under-test)
+        $result = $this->runPredicate("ibl5/tests/Cli/Foo.php\n");
+        self::assertSame(1, $result['exit'], $result['stderr']);
+    }
+
+    public function testTestsDatabaseIntegrationDirExitsOne(): void
+    {
+        // PHPUnit DatabaseIntegration test .php → SKIP (^ibl5/tests/ deny)
+        $result = $this->runPredicate("ibl5/tests/DatabaseIntegration/Bar.php\n");
+        self::assertSame(1, $result['exit'], $result['stderr']);
+    }
+
+    public function testTestsModuleEntryPointDirExitsOne(): void
+    {
+        // Module entry-point test renders HTML but only ASSERTS the app's render,
+        // never produces it → SKIP (^ibl5/tests/ deny).
+        $result = $this->runPredicate("ibl5/tests/Module/EntryPoints/BazEntryPointTest.php\n");
+        self::assertSame(1, $result['exit'], $result['stderr']);
+    }
+
+    public function testTestsE2eSiblingDirExitsOne(): void
+    {
+        // BOUNDARY: e2e-helpers sibling must NOT match the ibl5/tests/e2e/* carve-out
+        // (trailing-slash glob) → still denied by ^ibl5/tests/ → SKIP.
+        $result = $this->runPredicate("ibl5/tests/e2e-helpers/x.ts\n");
+        self::assertSame(1, $result['exit'], $result['stderr']);
+    }
+
     // =========================================================================
     // RUN cases (exit 0 — website-affecting)
     // =========================================================================
@@ -126,6 +156,34 @@ final class WebsiteAffectingCliTest extends TestCase
     {
         // Row 8: ibl5/tests/e2e/ → RUN (E2E test dir stays website-side)
         $result = $this->runPredicate("ibl5/tests/e2e/foo.spec.ts\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testTestsE2eDirStaysWebsite(): void
+    {
+        // Real Playwright spec under ibl5/tests/e2e/ → RUN via is_carveout (drives renders)
+        $result = $this->runPredicate("ibl5/tests/e2e/roster.spec.ts\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testTestsApiE2eDirStaysWebsite(): void
+    {
+        // API E2E spec under ibl5/tests/api-e2e/ → RUN via is_carveout (drives requests)
+        $result = $this->runPredicate("ibl5/tests/api-e2e/standings.ts\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testTestsE2eNestedPathStaysWebsite(): void
+    {
+        // Nested spec proves the case-glob * spans '/': ibl5/tests/e2e/* covers subdirs → RUN
+        $result = $this->runPredicate("ibl5/tests/e2e/smoke/foo.spec.ts\n");
+        self::assertSame(0, $result['exit'], $result['stderr']);
+    }
+
+    public function testCiSeedUnderE2eStaysWebsite(): void
+    {
+        // The E2E seed fixture lives under e2e/ → carved in → RUN (VR/E2E depend on it)
+        $result = $this->runPredicate("ibl5/tests/e2e/fixtures/ci-seed.sql\n");
         self::assertSame(0, $result['exit'], $result['stderr']);
     }
 
@@ -205,6 +263,7 @@ final class WebsiteAffectingCliTest extends TestCase
         self::assertStringContainsString('^docs/', $result['output']);
         self::assertStringContainsString('^\.claude/', $result['output']);
         self::assertStringContainsString('^engine/', $result['output']);
+        self::assertStringContainsString('^ibl5/tests/', $result['output']);
         self::assertStringContainsString('bin/website-affecting', $result['output']);
     }
 


### PR DESCRIPTION
Adds `^ibl5/tests/` to the `website-affecting` deny regex so PHPUnit-test-only diffs no longer trigger the Lighthouse, E2E, and VR CI jobs. Browser spec directories that drive real renders (`ibl5/tests/e2e/*`, `ibl5/tests/api-e2e/*`) are carved back to website-side.

## What changed

- `bin/website-affecting` — adds `^ibl5/tests/` as the final `DENY_REGEX` alternative; extends `is_carveout()` with `ibl5/tests/e2e/*` and `ibl5/tests/api-e2e/*` prefix arms; updates header comment block and `--help` heredoc to document the new deny entry + the two spec-dir carve-outs.
- `bin/test-website-affecting` — adds `(e)` block: 4 SAFE→exit-0 pins (e2e spec, api-e2e spec, e2e ci-seed, nested e2e path proving `*` spans `/`), 3 DANGEROUS→exit-1 pins (Cli/, DatabaseIntegration/, Module/EntryPoints/ `.php`), and 1 boundary→exit-1 pin (`e2e-helpers/` sibling).
- `ibl5/tests/Cli/WebsiteAffectingCliTest.php` — adds 8 PHPUnit methods mirroring the bash harness pins; extends `testHelpExitsZeroAndPrintsDenySet` to assert `^ibl5/tests/` in `--help`.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
