### PR TITLE
chore: in-PR PHP image build (paths-filtered runtime detector)

### DIFF
--- a/.github/actions/setup-docker-e2e/action.yml
+++ b/.github/actions/setup-docker-e2e/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'How to obtain the ibl6 image: "pull" the pinned GHCR tag (default) or "build" from PR source (used by the ibl6 jobs so they test PR source, never master).'
     required: false
     default: 'pull'
+  php-image:
+    description: 'How to obtain the PHP image: "pull" the pinned GHCR :latest tag (default) or "build" from PR source against the gha layer cache (used when a PR touches runtime-affecting files so E2E tests the PR''s own runtime).'
+    required: false
+    default: 'pull'
 
 runs:
   using: 'composite'
@@ -63,10 +67,25 @@ runs:
       run: bunx @tailwindcss/cli -i design/input.css -o themes/IBL/style/style.css
 
     - name: Pull or build PHP image
+      if: inputs.php-image != 'build'
       shell: bash
       run: |
         docker pull ghcr.io/a-jay85/ibl5/php-apache:latest || \
         docker build -t ghcr.io/a-jay85/ibl5/php-apache:latest .
+
+    - name: Set up Docker Buildx
+      if: inputs.php-image == 'build'
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    - name: Build PHP image from PR source
+      if: inputs.php-image == 'build'
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: .
+        push: false
+        load: true
+        tags: ghcr.io/a-jay85/ibl5/php-apache:latest
+        cache-from: type=gha
 
     - name: Start MariaDB first (schema must be ready before Apache serves)
       shell: bash

--- a/.github/workflows/cache-dependencies.yml
+++ b/.github/workflows/cache-dependencies.yml
@@ -14,6 +14,9 @@ on:
   # Run when dependencies change
   push:
     paths:
+      # Keep in sync with e2e-tests.yml `changes` job `runtime:` filter — the in-PR
+      # build trigger. This list rebuilds php-apache:latest; that list decides when a
+      # PR builds the image in-PR. Drift → a runtime PR tests against a stale image.
       - 'ibl5/composer.json'
       - 'ibl5/composer.lock'
       - 'ibl5/bun.lock'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,6 +49,17 @@ jobs:
       # run inside. Gates ibl6-visual/ibl6-e2e so a pure-ibl5 PR skips them (saving 2
       # concurrent runner slots) while an IBL6 or shared-infra PR still runs them.
       ibl6: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.ibl6filter.outputs.ibl6 == 'true' }}
+      # True when a PR touches a runtime-affecting dep — the same 7-entry set that
+      # cache-dependencies.yml rebuilds `:latest` from (kept in sync; see Phase 5).
+      # Consumed by setup-docker-e2e (Phase 2): when true the six e2e jobs build the
+      # PHP image from the PR's Dockerfile/deps instead of pulling the stale `:latest`.
+      # NOTE the deliberate absence of the `push || dependabot` disjunction that `src`
+      # and `ibl6` carry: on a `push` event the runtimefilter step below is SKIPPED
+      # (pull_request-only guard) → this output is empty → falsy → jobs pull `:latest`
+      # (status quo; cache-dependencies already rebuilt it on that push). A dependabot
+      # runtime PR is a normal pull_request event, so the filter detects it with no
+      # special-case. Both fall-throughs are intended.
+      runtime: ${{ steps.runtimefilter.outputs.runtime == 'true' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: github.event_name == 'pull_request' && github.event.action != 'labeled'
@@ -88,6 +99,36 @@ jobs:
               - 'ibl5/migrations/**'
               - 'ibl5/tests/e2e/fixtures/ci-seed.sql'
               - 'ibl5/bin/run-migrations-ci.sh'
+
+      - name: Detect runtime-affecting changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: runtimefilter
+        # Unlike ibl6filter, this fires on ALL pull_request events INCLUDING `labeled`
+        # — do NOT copy ibl6filter's `&& github.event.action != 'labeled'` guard. A
+        # runtime PR that gets the `update-baselines` label fires a `labeled` event; if
+        # we skipped on it, `runtime` would default false and VR baselines would
+        # regenerate against the stale `:latest` instead of the PR's freshly-built
+        # image. The head SHA is unchanged on a label event, so the base…head diff —
+        # and thus the filter result — is identical to the prior synchronize; firing on
+        # labeled is safe and correct. dorny/paths-filter needs NO checkout for
+        # pull_request events (it diffs base…head via the GitHub compare API, which the
+        # job's existing `pull-requests: read` permission authorizes) — this matters
+        # because the `changes` job's checkout step is itself skipped on `labeled`.
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            runtime:
+              # Keep in sync with cache-dependencies.yml `push: paths` (lines 17-23) —
+              # the 7-entry set that rebuilds php-apache:latest. If these two lists
+              # drift, a runtime-affecting PR may test against a stale image (the exact
+              # gap this feature closes), or over-build. Update BOTH together.
+              - 'ibl5/composer.json'
+              - 'ibl5/composer.lock'
+              - 'ibl5/bun.lock'
+              - 'ibl5/package.json'
+              - 'Dockerfile'
+              - 'docker/opcache.ini'
+              - 'docker/entrypoint.sh'
 
   playwright-version-drift:
     name: Playwright version drift guard
@@ -157,6 +198,7 @@ jobs:
       # --- Docker E2E Setup ---
       - uses: ./.github/actions/setup-docker-e2e
         with:
+          php-image: ${{ needs.changes.outputs.runtime == 'true' && 'build' || 'pull' }}
           build-css: 'true'
           with-playwright: 'true'
           test-user: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
@@ -373,6 +415,8 @@ jobs:
 
       # --- Docker E2E Setup ---
       - uses: ./.github/actions/setup-docker-e2e
+        with:
+          php-image: ${{ needs.changes.outputs.runtime == 'true' && 'build' || 'pull' }}
 
       - name: Run API E2E tests
         working-directory: ibl5
@@ -446,6 +490,7 @@ jobs:
       # --- Docker E2E Setup ---
       - uses: ./.github/actions/setup-docker-e2e
         with:
+          php-image: ${{ needs.changes.outputs.runtime == 'true' && 'build' || 'pull' }}
           build-css: 'true'
           with-playwright: 'true'
           test-user: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
@@ -566,6 +611,7 @@ jobs:
       # --- Docker E2E Setup (fresh, dedicated DB for this job) ---
       - uses: ./.github/actions/setup-docker-e2e
         with:
+          php-image: ${{ needs.changes.outputs.runtime == 'true' && 'build' || 'pull' }}
           build-css: 'true'
           with-playwright: 'true'
           test-user: ${{ secrets.IBL_TEST_USER || 'ci-e2e-user' }}
@@ -650,6 +696,7 @@ jobs:
       - uses: ./.github/actions/setup-docker-e2e
         with:
           ibl6-image: build
+          php-image: ${{ needs.changes.outputs.runtime == 'true' && 'build' || 'pull' }}
 
       - name: Wait for ibl6 healthy
         run: |
@@ -755,6 +802,7 @@ jobs:
       - uses: ./.github/actions/setup-docker-e2e
         with:
           ibl6-image: build
+          php-image: ${{ needs.changes.outputs.runtime == 'true' && 'build' || 'pull' }}
 
       - name: Wait for ibl6 healthy
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ WORKDIR /src/engine
 COPY engine/ /src/engine
 RUN CGO_ENABLED=0 go build -o /opt/jsbsim ./cmd/jsbsim
 
+# This runtime stage IS the CI `php-apache:latest` image. On master/cron pushes,
+# cache-dependencies.yml rebuilds and publishes it; on a PR that touches a
+# runtime-affecting file (Dockerfile, docker/opcache.ini, docker/entrypoint.sh,
+# composer.json/lock, bun.lock, package.json) e2e-tests.yml builds it in-PR from
+# this source against the gha layer cache (setup-docker-e2e `php-image: build`),
+# so E2E exercises the PR's own runtime instead of the stale published tag.
 FROM php:8.5-apache
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

- Adds a `runtimefilter` `dorny/paths-filter` step and `runtime` output to the `changes` job in `e2e-tests.yml`, computing `true` when a PR touches any of the 7 runtime-affecting paths (Dockerfile, `docker/opcache.ini`, `docker/entrypoint.sh`, `composer.json/lock`, `bun.lock`, `package.json`).
- Adds a `php-image` input (default `'pull'`) to `setup-docker-e2e/action.yml` with a gated build branch: `if: inputs.php-image == 'build'` → `docker/setup-buildx-action` + `docker/build-push-action` with `load: true`, `cache-from: type=gha`, no push, no registry login.
- Wires `php-image: ${{ needs.changes.outputs.runtime == 'true' && 'build' || 'pull' }}` into all six `setup-docker-e2e` call sites (including `api-e2e`, which gains a new `with:` block).
- Adds a permanent Dockerfile comment (bootstrapping self-test: this PR touches a runtime path → `runtime==true` → CI exercises the build branch end-to-end).
- Adds reciprocal drift-guard cross-reference comments in both `e2e-tests.yml` and `cache-dependencies.yml` so the two 7-entry path lists stay in sync.

<!-- no-adr: CI plumbing: in-PR PHP image build mirrors cache-dependencies.yml build recipe + ibl6filter paths-filter; no new enforcement policy -->

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
