### PR TITLE
chore: add bin/test dispatcher and bin/test-test companion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -620,6 +620,8 @@ jobs:
         run: bin/test-check-pr-collisions
       - name: bin/test-check-phpunit-hygiene
         run: bin/test-check-phpunit-hygiene
+      - name: bin/test-test
+        run: bin/test-test
       - name: bin/test-refactor-flag
         run: bin/test-refactor-flag
       - name: bin/test-automouse-queue

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test — route a test invocation to the correct runner/container.
+#
+#   bin/test [unit]      host PHPUnit:   cd ibl5 && vendor/bin/phpunit
+#   bin/test db          DB-integration via bin/db-test-up (worktree-aware)
+#   bin/test e2e         Playwright via bin/e2e-wt.sh / ibl5/bin/e2e-local.sh
+#
+# Flags (must precede the subcommand):
+#   -n, --dry-run   print the command that would run; do not execute
+#   -h, --help      show this help
+# Any args after the subcommand are forwarded verbatim to the delegated runner
+# (e.g. bin/test unit --filter Foo ; bin/test -n e2e --headed).
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SELF_DIR/.." && pwd)"
+source "$SELF_DIR/lib/git-helpers.sh"   # provides is_in_worktree
+
+usage() {
+    cat <<'USAGE'
+Usage: bin/test [-n|--dry-run] [unit|db|e2e] [-- runner-args...]
+
+  unit   (default)  Host PHPUnit: cd ibl5 && vendor/bin/phpunit
+  db                DB-integration tests (worktree-aware) via bin/db-test-up
+  e2e               Playwright E2E (worktree-aware) via bin/e2e-wt.sh /
+                    ibl5/bin/e2e-local.sh
+
+  -n, --dry-run     Print the command that would run; do not execute.
+  -h, --help        Show this help.
+USAGE
+}
+
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -n|--dry-run) DRY_RUN=1; shift ;;
+        -h|--help)    usage; exit 0 ;;
+        --)           shift; break ;;
+        -*)           printf 'Unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+        *)            break ;;
+    esac
+done
+SUB="${1:-unit}"
+[ $# -gt 0 ] && shift
+FORWARD=("$@")
+
+emit() {   # print (dry-run) or exec the argv
+    if [ "$DRY_RUN" -eq 1 ]; then echo "${*}"; else exec "$@"; fi
+}
+
+case "$SUB" in
+    unit)
+        CMD=(vendor/bin/phpunit ${FORWARD[@]+"${FORWARD[@]}"})
+        if [ "$DRY_RUN" -eq 1 ]; then
+            echo "cd $REPO_ROOT/ibl5 && ${CMD[*]}"
+        else
+            cd "$REPO_ROOT/ibl5" && exec "${CMD[@]}"
+        fi
+        ;;
+    db)
+        if is_in_worktree; then
+            # show-toplevel returns the worktree root dir (e.g. IBL5-worktrees/<slug>);
+            # basename of that IS the slug — not dirname, which climbs one level too high.
+            WT_NAME="$(basename "$(git rev-parse --show-toplevel)")"
+            emit "$SELF_DIR/db-test-up" "$WT_NAME" ${FORWARD[@]+"${FORWARD[@]}"}
+        else
+            emit "$SELF_DIR/db-test-up" ${FORWARD[@]+"${FORWARD[@]}"}
+        fi
+        ;;
+    e2e)
+        if is_in_worktree; then
+            WT_NAME="$(basename "$(git rev-parse --show-toplevel)")"
+            emit "$SELF_DIR/e2e-wt.sh" "$WT_NAME" ${FORWARD[@]+"${FORWARD[@]}"}
+        else
+            emit "$REPO_ROOT/ibl5/bin/e2e-local.sh" ${FORWARD[@]+"${FORWARD[@]}"}
+        fi
+        ;;
+    *)
+        printf 'Unknown subcommand: %s\n' "$SUB" >&2
+        usage >&2
+        exit 2
+        ;;
+esac

--- a/bin/test-test
+++ b/bin/test-test
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-test — regression tests for bin/test dispatcher.
+#
+# Exercises routing via --dry-run so no docker/host infrastructure is needed.
+# Mirrors the structure of bin/test-check-phpunit-hygiene.
+#
+# Run: bin/test-test  (exit 0 = all pass, non-zero = a case failed)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DISPATCHER="$SCRIPT_DIR/test"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" 2>/dev/null' EXIT
+FAILED=0
+pass()     { echo "ok: $1"; }
+failcase() { echo "FAIL: $1"; FAILED=1; }
+
+# Fresh non-worktree repo (main-checkout-like: git-dir == git-common-dir).
+mk_main() {
+    local d; d="$(mktemp -d "$TMP/main.XXXXXX")"
+    git init -q "$d" >/dev/null 2>&1
+    git -C "$d" config user.email t@example.com >/dev/null 2>&1
+    git -C "$d" config user.name tester >/dev/null 2>&1
+    git -C "$d" config commit.gpgsign false >/dev/null 2>&1
+    echo "$d"
+}
+
+# Real linked worktree whose root basename == <slug> (git-dir != git-common-dir).
+# Each call uses a unique base + unique parent dir so the fixed slug never collides.
+mk_worktree() {
+    local slug="$1" base parent wt
+    base="$(mktemp -d "$TMP/base.XXXXXX")"
+    git init -q "$base" >/dev/null 2>&1
+    git -C "$base" config user.email t@example.com >/dev/null 2>&1
+    git -C "$base" config user.name tester >/dev/null 2>&1
+    git -C "$base" config commit.gpgsign false >/dev/null 2>&1
+    git -C "$base" commit --allow-empty -q -m init >/dev/null 2>&1   # HEAD for worktree add
+    parent="$(mktemp -d "$TMP/wtp.XXXXXX")"
+    wt="$parent/$slug"
+    git -C "$base" worktree add -q "$wt" -b "b-$slug" >/dev/null 2>&1
+    echo "$wt"
+}
+
+# run_case <name> <ctx-dir> <want-exit> <want-regex|-> -- <dispatcher-args...>
+run_case() {
+    local name="$1" ctx="$2" want="$3" want_re="$4"; shift 4
+    [ "${1:-}" = "--" ] && shift
+    local out rc
+    out="$( ( cd "$ctx" && "$DISPATCHER" "$@" ) 2>&1 )"
+    rc=$?
+    if [ "$rc" -ne "$want" ]; then
+        failcase "$name — expected exit $want, got $rc"
+        printf '%s\n' "$out" | sed 's/^/    /'; return
+    fi
+    if [ "$want_re" != "-" ] && ! printf '%s' "$out" | grep -qE "$want_re"; then
+        failcase "$name — output did not match: $want_re"
+        printf '%s\n' "$out" | sed 's/^/    /'; return
+    fi
+    pass "$name (exit $rc)"
+}
+
+# --- Cases --------------------------------------------------------------------
+
+MAIN="$(mk_main)"
+WT_DB="$(mk_worktree db-slug)"
+WT_E2E="$(mk_worktree e2e-slug)"
+
+run_case "unit-explicit"         "$MAIN"   0 'cd .*/ibl5 && vendor/bin/phpunit'     -- --dry-run unit
+run_case "unit-default-no-sub"   "$MAIN"   0 'vendor/bin/phpunit'                   -- --dry-run
+run_case "db-worktree-derives-name" "$WT_DB"  0 'db-test-up[[:space:]]+db-slug([[:space:]]|$)'  -- --dry-run db
+run_case "db-main-no-arg"        "$MAIN"   0 'db-test-up[[:space:]]*$'              -- --dry-run db
+run_case "e2e-worktree"          "$WT_E2E" 0 'e2e-wt\.sh[[:space:]]+e2e-slug'       -- --dry-run e2e
+run_case "e2e-main"              "$MAIN"   0 'e2e-local\.sh([[:space:]]|$)'          -- --dry-run e2e
+run_case "unknown-subcommand"    "$MAIN"   2 'Usage|Unknown subcommand'              -- --dry-run bogus
+run_case "unknown-option"        "$MAIN"   2 'Unknown option|Usage'                  -- --bogus
+
+# --- Result -------------------------------------------------------------------
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
## Summary

- New `bin/test` dispatcher routes `unit`/`db`/`e2e` subcommands to the correct runner with worktree awareness (reuses `is_in_worktree` from `bin/lib/git-helpers.sh`)
- New `bin/test-test` companion exercises all routing via `--dry-run` (no docker/host infra needed); 8 cases covering positive and negative paths
- Wires `bin/test-test` into the existing `harness-tests` CI job (already `gate.needs`-blocked)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: bin/test mechanizes existing bin/db-test-up + bin/e2e-wt.sh + bin/e2e-local.sh routing already covered by ADR-0046/0062; no new architectural decision -->