### PR TITLE
chore: hardcode site h1 title on home page

### DIFF
--- a/ibl5/modules/News/index.php
+++ b/ibl5/modules/News/index.php
@@ -38,7 +38,7 @@ function theindex($new_topic = "0")
     PageLayout\PageLayout::header();
 
     if (defined('HOME_FILE')) {
-        echo '<h1 class="ibl-title">' . \Security\HtmlSanitizer::e((string) $sitename) . '</h1>';
+        echo '<h1 class="ibl-title">IBL: Internet Basketball League</h1>';
     } else {
         echo '<h1 class="ibl-title">News</h1>';
     }


### PR DESCRIPTION
## Summary
- Replaces dynamic `$sitename` variable in the News module home H1 with the hardcoded string `IBL: Internet Basketball League`
- Removes the `HtmlSanitizer::e()` escaping call since the value is now a static literal

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
