### PR TITLE
chore(automouse): add bin/automouse-run plan <slug> single-plan mode

### DIFF
--- a/.claude/rules/automouse-workflow.md
+++ b/.claude/rules/automouse-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: Automouse autonomous workflow (formerly "nightly") — launchd fires claude -p on a recurring schedule, running two context-isolated agents per plan (implementation + post-plan) with time guards and incremental checkpoints.
-last_verified: 2026-06-28
+last_verified: 2026-07-10
 paths: "bin/automouse-*"
 ---
 
@@ -8,7 +8,7 @@ paths: "bin/automouse-*"
 
 > **"Automouse" is this pipeline — the autonomous plan-execution machinery (`bin/automouse-*`, this rule).** It was **formerly called "nightly"**; the term was renamed because the user runs it outside nighttime too, so "nightly" was a misnomer that sent people hunting through `cron` / `/schedule` / `CronCreate` / launchd-by-hand. When you read "automouse" (or legacy "nightly") referring to autonomous plan execution, it means **`bin/automouse-run` fired by launchd**, draining the queue built by `bin/automouse-queue` — *not* a generic scheduler. (The macOS `launchd` agent is the scheduling substrate, but the concept lives in these scripts.)
 
-A headless `claude -p` process runs on a recurring schedule via macOS `launchd`. It loops through queued plans — two `claude -p` invocations per plan (implementation, then post-plan) — until the queue is empty or the time guard is exceeded.
+A headless `claude -p` process runs on a recurring schedule via macOS `launchd`. It loops through queued plans — two `claude -p` invocations per plan (implementation, then post-plan) — until the queue is empty or the time guard is exceeded. For a single watched run, `bin/automouse-run plan <slug>` executes exactly one named plan (auto-queuing it if absent) with the same guard machinery, then stops — leaving the rest of the queue untouched.
 
 ## Quick Reference
 
@@ -20,6 +20,7 @@ A headless `claude -p` process runs on a recurring schedule via macOS `launchd`.
 | Check morning results | `ls ~/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse/reports/` |
 | Cancel the next run | `rm ~/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse/queue/*.md` |
 | Schedule a one-shot run | `bin/automouse-run schedule "2026-05-28 20:00 PDT"` (self-cleaning launchd agent; TZ optional) |
+| Run one plan (one-off, foreground) | `bin/automouse-run plan <slug>` (impl + post-plan for exactly one named plan, then stops; auto-queues if absent, leaves the rest of the queue untouched) |
 | Disable the automouse job | `launchctl unload ~/Library/LaunchAgents/com.ibl5.automouse.plist` |
 | Re-enable the automouse job | `launchctl load ~/Library/LaunchAgents/com.ibl5.automouse.plist` |
 | Force-trigger now | `launchctl start com.ibl5.automouse` |

--- a/bin/automouse-run
+++ b/bin/automouse-run
@@ -191,6 +191,7 @@ REPO="/Users/ajaynicolas/GitHub/IBL5"
 NIGHTLY_DIR="$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/automouse"
 LOG_DIR="$NIGHTLY_DIR/logs"
 QUEUE_DIR="$NIGHTLY_DIR/queue"
+PLANS_DIR="${PLANS_DIR:-$HOME/.claude/plans}"
 MAX_ELAPSED=17100  # ~4h45m — stops around 4:45am, leaves headroom in the 5h usage window
 MAX_ATTEMPTS=3     # per-plan retry cap within one night (covers impl + postplan phases)
 MAX_IMPL_SECS=3600   # per-phase cap: impl gets at most 1h
@@ -211,6 +212,37 @@ MIN_VIABLE_SECS=60   # a real impl/postplan never finishes (pass OR fail) under 
 
 HANDOFF_DIR="$NIGHTLY_DIR/handoff"
 mkdir -p "$LOG_DIR" "$QUEUE_DIR" "$HANDOFF_DIR"
+
+# One-off single-plan mode: bin/automouse-run plan <slug>
+# Runs impl + post-plan for exactly ONE named plan, then stops. Reuses all
+# guard machinery (heartbeat/stall-kill, env-breaker, handoff resume, cost
+# roll-up, reports, lock). Foreground, streams to the dated log like a manual run.
+SINGLE_PLAN=""
+if [ "${1:-}" = "plan" ]; then
+    slug="${2:-}"
+    if [ -z "$slug" ]; then
+        echo "usage: bin/automouse-run plan <slug>" >&2
+        exit 1
+    fi
+    FILENAME="${slug%.md}.md"
+    if [ ! -e "$QUEUE_DIR/$FILENAME" ]; then
+        # Not already queued — queue it now, reusing automouse-queue's
+        # resolution (INPUT / $PLANS_DIR/$INPUT / $PLANS_DIR/$INPUT.md) and its
+        # evict_dispositions() cleanup of stale skipped/ + done/ sidecars.
+        if ! NIGHTLY_DIR="$NIGHTLY_DIR" PLANS_DIR="$PLANS_DIR" \
+                "$REPO/bin/automouse-queue" "$slug"; then
+            echo "automouse-run plan: cannot resolve or queue '$slug' — " \
+                 "no such plan under $PLANS_DIR" >&2
+            exit 1
+        fi
+    fi
+    if [ ! -e "$QUEUE_DIR/$FILENAME" ]; then
+        echo "automouse-run plan: '$slug' did not land in the queue after " \
+             "queuing — aborting" >&2
+        exit 1
+    fi
+    SINGLE_PLAN="$FILENAME"
+fi
 
 WATCHER_PID=""
 CURRENT_LOCK=""   # claim-lock dir held for the plan this runner is processing
@@ -472,6 +504,7 @@ claim_next_plan() {
     while IFS= read -r plan; do
         [ -n "$plan" ] || continue
         plan_name=$(basename "$plan")
+        [ -n "${SINGLE_PLAN:-}" ] && [ "$plan_name" != "$SINGLE_PLAN" ] && continue
         lock="$QUEUE_DIR/${plan_name}.lock"
         # Fast path: unlocked plan — claim atomically.
         if mkdir "$lock" 2>/dev/null; then
@@ -529,18 +562,24 @@ git -C "$REPO" merge --ff-only origin/master >> "$LOG" 2>&1 || true
 # archival so a marked plan isn't swept into skipped.archive/ first. Non-fatal
 # (|| true): a self-heal hiccup must never abort the night (mirrors the || true
 # on the archive_stale block).
-"$REPO/bin/automouse-self-heal" >> "$LOG" 2>&1 || true
+# Skipped in single-plan mode: requeuing other staleness-skipped plans would
+# violate "leaves the rest of the queue untouched".
+if [ -z "${SINGLE_PLAN:-}" ]; then
+    "$REPO/bin/automouse-self-heal" >> "$LOG" 2>&1 || true
+fi
 
 # Startup archival: shrink the accumulating output dirs by moving entries idle
 # for $ARCHIVE_AGE_DAYS into sibling `.archive/` folders. queue/ (pending work,
 # iterated below) and handoff/ (transient, cleaned at loop end) are excluded by
 # design. Whole block guarded so an archival hiccup never stops the night.
-{
-    archive_stale logs
-    archive_stale reports
-    archive_stale "done"
-    archive_stale skipped
-} || true
+if [ -z "${SINGLE_PLAN:-}" ]; then
+    {
+        archive_stale logs
+        archive_stale reports
+        archive_stale "done"
+        archive_stale skipped
+    } || true
+fi
 
 while true; do
     # Check if queue has plans
@@ -567,7 +606,11 @@ while true; do
     # If every queued plan is already claimed, there's nothing for us to do.
     NEXT_PLAN=$(claim_next_plan) || NEXT_PLAN=""
     if [ -z "$NEXT_PLAN" ]; then
-        echo "All queued plans are claimed by a concurrent runner — nothing to do." >> "$LOG"
+        if [ -n "${SINGLE_PLAN:-}" ]; then
+            echo "Plan ${SINGLE_PLAN%.md} is being processed by another runner — nothing to do." >> "$LOG"
+        else
+            echo "All queued plans are claimed by a concurrent runner — nothing to do." >> "$LOG"
+        fi
         break
     fi
     PLAN_NAME=$(basename "$NEXT_PLAN")
@@ -799,6 +842,10 @@ PLAN_FILE=$PLAN_NAME" \
         rm -rf "$CURRENT_LOCK" 2>/dev/null || true
         CURRENT_LOCK=""
     fi
+
+    # Single-plan mode: exactly one attempt, then stop — predictable for a
+    # watched one-off. A genuine failure does NOT retry to MAX_ATTEMPTS.
+    [ -n "${SINGLE_PLAN:-}" ] && break
 done
 
 # Clean up any leftover attempt files for plans that completed

--- a/bin/test-automouse-single
+++ b/bin/test-automouse-single
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-automouse-single — characterization + regression test for the
+# bin/automouse-run plan <slug> single-plan mode.
+#
+# Verifies: selection guard (only the named plan runs), untouched-queue contract,
+# self-heal gated OFF in single mode, auto-queue-if-absent, hard-fail on
+# unresolvable slug, and already-queued tolerance.
+#
+# macOS-only: automouse-run depends on launchd/BSD tools (caffeinate, stat -f, BSD date).
+#
+# Run: bin/test-automouse-single  (exit 0 = pass/skip, 1 = any assertion failed)
+
+set -u
+
+if [ "$(uname)" != "Darwin" ]; then
+    echo "SKIP: test-automouse-single is macOS-only (automouse-run depends on launchd/BSD tools)."
+    exit 0
+fi
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(mktemp -d)"
+trap 'rm -rf "$ROOT"' EXIT
+
+NDIR="$ROOT/automouse"
+PDIR="$ROOT/plans"
+STUBDIR="$ROOT/stub"
+mkdir -p "$NDIR/queue" "$NDIR/handoff" "$NDIR/logs" "$NDIR/reports" \
+         "$NDIR/done" "$NDIR/skipped" "$PDIR" "$STUBDIR"
+
+FAILED=0
+
+assert_present() {
+    local desc="$1" path="$2"
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        echo "FAIL: $desc — expected present: $path"
+        FAILED=1
+    fi
+}
+
+assert_absent() {
+    local desc="$1" path="$2"
+    if [ -e "$path" ]; then
+        echo "FAIL: $desc — expected absent (exists): $path"
+        FAILED=1
+        return
+    fi
+    if [ -L "$path" ]; then
+        echo "FAIL: $desc — expected absent (dangling symlink): $path"
+        FAILED=1
+    fi
+}
+
+# --- Stub claude ------------------------------------------------------------
+# First call per plan (no handoff) = impl: writes handoff JSON.
+# Second call (handoff present) = postplan: moves plan to done/, clears handoff.
+# Emits a stream-json success result event. sleep 2 keeps runtime above the
+# sub-minute fast-fail threshold (MIN_VIABLE_SECS=60) without tripping it:
+# impl is safe because the handoff is written (should_impl_env_stop returns 1);
+# postplan is safe because the handoff is deleted before the sub-minute check.
+cat > "$STUBDIR/claude" <<STUB
+#!/usr/bin/env bash
+set -u
+NDIR="$NDIR"
+plan="\$(printf '%s\n' "\$*" | grep -oE 'PLAN_FILE=[^[:space:]]+' | tail -1 | cut -d= -f2)"
+sleep 2
+if [ -n "\$plan" ]; then
+    hf="\$NDIR/handoff/\$plan.json"
+    if [ ! -f "\$hf" ]; then
+        printf '{"branch":"x","plan":"%s"}\n' "\$plan" > "\$hf"
+    else
+        mv "\$NDIR/queue/\$plan" "\$NDIR/done/\$plan" 2>/dev/null || true
+        rm -f "\$hf" "\$NDIR/queue/\$plan.attempts" 2>/dev/null || true
+    fi
+fi
+printf '{"type":"result","subtype":"success","stop_reason":"end_turn","num_turns":1,"duration_ms":2000,"total_cost_usd":0.001,"usage":{"input_tokens":1,"output_tokens":1}}\n'
+exit 0
+STUB
+chmod +x "$STUBDIR/claude"
+
+# --- Copy real runner; redirect NIGHTLY_DIR + stub PATH --------------------
+RUNNER="$ROOT/automouse-run"
+sed -e "s#^NIGHTLY_DIR=.*#NIGHTLY_DIR=\"$NDIR\"#" \
+    -e "s#^export PATH=.*#export PATH=\"$STUBDIR:/usr/local/bin:/opt/homebrew/bin:\$PATH\"#" \
+    "$REPO/bin/automouse-run" > "$RUNNER"
+chmod +x "$RUNNER"
+
+# --- Helpers ---------------------------------------------------------------
+seed_plan() {
+    local slug="$1"
+    printf '# %s\n\nimpl_model: sonnet\n' "$slug" > "$PDIR/$slug.md"
+    ln -s "$PDIR/$slug.md" "$NDIR/queue/$slug.md"
+}
+
+run_single() {
+    PLANS_DIR="$PDIR" "$RUNNER" plan "$1" > "$ROOT/run.out" 2>&1
+}
+
+reset_state() {
+    rm -rf "$NDIR/queue" "$NDIR/handoff" "$NDIR/done" "$NDIR/skipped" \
+           "$NDIR/logs" "$NDIR/reports" "$PDIR"
+    mkdir -p "$NDIR/queue" "$NDIR/handoff" "$NDIR/logs" "$NDIR/reports" \
+             "$NDIR/done" "$NDIR/skipped" "$PDIR"
+}
+
+# ===========================================================================
+# Case 1 — only the named plan runs; others remain untouched (Phases 2 & 4)
+# ===========================================================================
+echo "--- case 1: named plan runs, others untouched ---"
+reset_state
+seed_plan plan-1
+seed_plan plan-2
+seed_plan plan-3
+run_single plan-2
+
+assert_present "case1 plan-2 completed"  "$NDIR/done/plan-2.md"
+assert_absent  "case1 plan-2 left queue" "$NDIR/queue/plan-2.md"
+for other in plan-1 plan-3; do
+    assert_present "case1 $other still queued"    "$NDIR/queue/$other.md"
+    assert_absent  "case1 $other not done"        "$NDIR/done/$other.md"
+    assert_absent  "case1 $other no lock"         "$NDIR/queue/$other.md.lock"
+    assert_absent  "case1 $other no attempts"     "$NDIR/queue/$other.md.attempts"
+    assert_absent  "case1 $other no handoff"      "$NDIR/handoff/$other.md.json"
+done
+
+# ===========================================================================
+# Case 2 — self-heal gated OFF in single mode (Phase 3)
+# ===========================================================================
+echo "--- case 2: self-heal gated off ---"
+reset_state
+seed_plan plan-run
+# plan-skip: no repo-path tokens → check-plan-staleness exits 0 → self-heal
+# would requeue it if not gated. Positive control proves this below.
+printf '# plan-skip\n\nimpl_model: sonnet\n' > "$PDIR/plan-skip.md"
+ln -s "$PDIR/plan-skip.md" "$NDIR/skipped/plan-skip.md"
+touch "$NDIR/skipped/plan-skip.md.staleness"
+
+# Positive control: verify self-heal WOULD requeue plan-skip without the gate.
+# Clone the state to a temp copy and run self-heal on it.
+CLONE="$ROOT/clone-case2"
+cp -r "$NDIR" "$CLONE"
+if NIGHTLY_DIR="$CLONE" PLANS_DIR="$PDIR" "$REPO/bin/automouse-self-heal" >/dev/null 2>&1; then
+    if [ -e "$CLONE/queue/plan-skip.md" ]; then
+        echo "positive-control: self-heal WOULD requeue plan-skip — fixture is non-vacuous."
+    else
+        echo "WARN: positive-control inconclusive (self-heal ran but plan-skip not in clone queue/)"
+    fi
+else
+    echo "WARN: positive-control self-heal exited non-zero — fixture may be vacuous"
+fi
+rm -rf "$CLONE"
+
+run_single plan-run
+assert_present "case2 plan-run completed"    "$NDIR/done/plan-run.md"
+assert_present "case2 skip still skipped"    "$NDIR/skipped/plan-skip.md"
+assert_present "case2 staleness marker kept" "$NDIR/skipped/plan-skip.md.staleness"
+assert_absent  "case2 skip NOT resurrected"  "$NDIR/queue/plan-skip.md"
+
+# ===========================================================================
+# Case 3 — auto-queue-if-absent (Phase 1)
+# ===========================================================================
+echo "--- case 3: auto-queue-if-absent ---"
+reset_state
+seed_plan plan-other
+printf '# plan-x\n\nimpl_model: sonnet\n' > "$PDIR/plan-x.md"   # NOT in queue/
+run_single plan-x
+
+assert_present "case3 plan-x auto-queued+ran" "$NDIR/done/plan-x.md"
+assert_present "case3 plan-other untouched"   "$NDIR/queue/plan-other.md"
+assert_absent  "case3 plan-other not done"    "$NDIR/done/plan-other.md"
+assert_absent  "case3 plan-other no lock"     "$NDIR/queue/plan-other.md.lock"
+
+# ===========================================================================
+# Case 4 — unresolvable slug hard-fails before the loop (Phases 1 & 4)
+# ===========================================================================
+echo "--- case 4: unresolvable slug hard-fails ---"
+reset_state
+set +e
+out=$(PLANS_DIR="$PDIR" "$RUNNER" plan nonexistent-slug 2>&1); exit_code=$?
+set -e
+[ "$exit_code" -ne 0 ] || { echo "FAIL: case4 expected non-zero exit, got 0"; FAILED=1; }
+echo "$out" | grep -qi "cannot resolve\|no such plan\|nonexistent-slug" \
+    || { echo "FAIL: case4 expected a loud unresolved-slug message, got: $out"; FAILED=1; }
+assert_absent "case4 no no-queue report" \
+    "$NDIR/reports/$(date +%Y-%m-%d)-no-queue.md"
+
+# ===========================================================================
+# Case 5 — already-queued tolerance (Phase 1 pre-check)
+# ===========================================================================
+echo "--- case 5: already-queued tolerance ---"
+reset_state
+seed_plan plan-dup            # writes $PDIR/plan-dup.md AND queue/ symlink
+run_single plan-dup           # must NOT abort on the already-queued symlink
+assert_present "case5 plan-dup completed"  "$NDIR/done/plan-dup.md"
+assert_absent  "case5 plan-dup left queue" "$NDIR/queue/plan-dup.md"
+grep -qi "already queued" "$ROOT/run.out" \
+    && { echo "FAIL: case5 leaked an 'already queued' error"; FAILED=1; }
+
+# ===========================================================================
+echo ""
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: all passed"
+exit 0


### PR DESCRIPTION
## Summary

- Adds `bin/automouse-run plan <slug>` subcommand: runs impl + post-plan for exactly one named plan, then stops, reusing all existing guard machinery (heartbeat/stall-kill, env-breaker, handoff resume, cost roll-up, reports, lock/concurrency)
- Foreground execution (streams to the dated log like a manual `bin/automouse-run`); auto-queues the named plan if not already queued; leaves the rest of the queue untouched
- New test harness `bin/test-automouse-single` covers 5 cases: untouched-queue contract, self-heal gated off, auto-queue-if-absent, hard-fail on unresolvable slug, already-queued tolerance

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: test harness for existing automouse tooling, no new architectural constraint -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)