### PR TITLE
chore: add mechanical backlog-housekeeping mechanism

### DIFF
--- a/.claude/rules/backlog-housekeep.md
+++ b/.claude/rules/backlog-housekeep.md
@@ -1,0 +1,21 @@
+---
+description: When you implement or discover a backlog item, ship backlog housekeeping with the change via /backlog-housekeep; bin/check-docs is the backstop.
+paths: ibl5/docs/backlog/**/*.md
+last_verified: 2026-07-10
+---
+
+# Backlog Housekeeping
+
+**Trigger.** When this change implements or resolves a backlog item — or surfaces new ones — backlog housekeeping ships **with** it, in the same PR, not as a follow-up.
+
+**How.** Run `/backlog-housekeep`. Inside `/post-plan` (which cannot call the Skill tool), Read `.claude/skills/backlog-housekeep/SKILL.md` and follow it inline — `/post-plan` Phase 2.5 wires this.
+
+**What it does** (one line each — detail lives in the skill, not here):
+
+- flips the resolved item's status glyph with today's date;
+- stamps each newly-surfaced item `(discovered YYYY-MM-DD during <ref>)`;
+- sweeps sibling and cross-backlog redundancy, stamping each superseded item `**Superseded by:** <ref> — <reason>`;
+- archives done items behind a dated pointer into `archive/`;
+- reconciles the `ibl5/docs/backlog/README.md` index and counts.
+
+**Backstop.** `bin/check-docs --since=<base>` fails a PR that archives an item without its sibling archive file or its dated pointer, or that marks a body-status item done inline without archiving it. It is diff-scoped (changed backlog files only) — the skill does the reasoning; the gate is the false-positive-free structural check. Do not restate its rules here.

--- a/.claude/skills/backlog-housekeep/SKILL.md
+++ b/.claude/skills/backlog-housekeep/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: backlog-housekeep
+description: "Ship backlog housekeeping with an implemented backlog item: flip its status, stamp discovered items with provenance, sweep sibling and cross-backlog redundancy, archive done items behind a dated pointer, and reconcile the README index — then self-verify via bin/check-docs."
+last_verified: 2026-07-10
+---
+
+# Backlog Housekeeping
+
+Run this when a unit of work (a PR or a plan) just **implemented, resolved, or surfaced** a backlog item under `ibl5/docs/backlog/`. It performs the full housekeeping pass so the bookkeeping ships **with** the change, then self-verifies via the `bin/check-docs` backstop.
+
+It is both a slash command (`/backlog-housekeep`) and a procedure another skill can **Read and follow inline** — `/post-plan` Phase 2.5 cannot call the Skill tool, so it Reads this file and executes the checklist directly. Write nothing here that depends on `$ARGUMENTS`-only wiring; the steps below are self-contained.
+
+## Inputs
+
+`$ARGUMENTS` optionally carries the provenance ref (`<PR-number|plan-slug>`) and the diff base. When absent, derive:
+
+- **Base:** `git merge-base HEAD master` (the PR's `baseRefName` for a stacked PR).
+- **Provenance `<ref>`:** the open PR number (`gh pr view --json number --jq .number`), else the branch slug (`basename "$(git rev-parse --show-toplevel)"`).
+
+The base drives both the `--since=<base>` self-verify and, for a PR, the `#<PR>` used in provenance/supersession stamps.
+
+## Caller-tier branch (the token-efficiency core)
+
+**Detect your own tier from your system prompt** — the model executing this skill *is* the caller (there is no runtime model-id API; the orchestrator self-identifies, as `work-triage.md` § Execution routing and `feedback_default_sonnet_execution` assume). If genuinely unsure, default to **inline** — a wrong-way delegation costs more than a same-tier inline pass.
+
+- **Caller is Opus or Fable → delegate; do NOT Read backlog files.** Reason from resident context about *what the work did*: which item it resolved, which items it newly surfaced, which siblings shifted scope. Seed those known effects into the semantic delegation packet (below), then spawn **ONE** Sonnet subagent (`subagent_type: general-purpose`, `model: sonnet`) that Reads the backlog files, runs the cross-backlog redundancy grep sweep (the expensive multi-file read), applies every edit / archive move / index update, self-verifies via `bin/check-docs --since=<base>`, and returns a thin one-line report. The backlog bodies enter the *subagent's* context, never the orchestrator's — that is the entire point of the branch.
+- **Caller is Sonnet or Haiku (e.g. `/post-plan` runs Sonnet 4.6) → execute inline, no subagent.** Read the backlog files, run the sweep, apply the edits, self-verify — all in the current context. Spawning a same-tier subagent is pure overhead (`feedback_default_sonnet_execution`: if the orchestrator IS Sonnet, edit inline).
+
+Both branches run the identical checklist below; only *who reads the files* differs.
+
+## Housekeeping checklist (7 operations)
+
+1. **Source-backlog status flip.** In the backlog that owns the implemented item, flip its status glyph to the resolved state (`✅ Implemented` / `🚫 Declined`) with today's date on its `**Status (YYYY-MM-DD):**` line.
+2. **Provenance-stamped discoveries.** For each item surfaced *during* this work, add a new backlog entry stamped `(discovered YYYY-MM-DD during <ref>)` so its origin is greppable.
+3. **Sibling-scope edits.** Edit sibling items in the same backlog whose scope shifted because of this change (narrowed, split, or now-blocked), noting the shift in the entry.
+4. **Cross-backlog redundancy sweep.** Grep the OTHER backlogs for items this change makes redundant; on each, add the greppable field `**Superseded by:** <ref> — <reason>` (verbatim format — `<ref>` = this PR/plan, `<reason>` = one clause). Do NOT delete the superseded item; the stamp is the audit trail.
+5. **Archive move + dated pointer.** For every item now done or declined in a **body-status** backlog: move its body into the sibling archive file `archive/<x>-backlog-archive.md` (create it if absent — the gate's (b) invariant requires the canonical sibling), and replace the LIVE entry with a one-line dated pointer into that archive. Table-status backlogs (`maintenance-backlog.md`) keep their glyphs in-place per row — no archive move.
+6. **README index/count reconciliation.** Update `ibl5/docs/backlog/README.md` counts and any index rows affected by the flips/additions/archives, and bump its `last_verified` to today (the convention this step follows is codified in that README).
+7. **Self-verify (mandatory gate).** Run `bin/check-docs --since=<base>` — the backstop that catches an unresolved pointer, a missing sibling, or an inline-done item. Fix every diagnostic before returning. This is the machine check that the housekeeping is internally consistent.
+
+If nothing qualifies (no flip, no discovery, no archive), **no-op** and say so in one line — never fabricate edits.
+
+## Delegation-packet shape (Opus/Fable branch)
+
+Author the packet in the format at `.claude/skills/plan/_architect-contract.md` **§ Delegation packets for verbose phases** (the canonical heading). Fill each field **semantically** (domain facts, not file line-edits — the subagent resolves those by Reading):
+
+- **Scope:** "housekeep the backlog(s) for `<item>` resolved by `<ref>`."
+- **Recipe:** the seeded known-effects from resident context — the item to flip, discovered items to stamp, siblings that shifted scope, backlogs to sweep for redundancy, items to archive.
+- **Self-verify the subagent MUST run before returning:** `bin/check-docs --since=<base>` green (plus full `composer test` only if it touched anything under `ibl5/` — backlog docs do not, so the gate alone suffices).
+- **Report-back (thin):** one line — `flipped <n>, discovered <n>, superseded <n>, archived <n>; check-docs green`.

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: post-plan
-description: Single orchestrator for the post-plan workflow. Runs commit/push/PR, diff classification, code review, security audit, verification, CI monitoring, retrospective, worktree teardown, and background process cleanup as one uninterrupted sequence.
+description: Single orchestrator for the post-plan workflow. Runs commit/push/PR, backlog housekeeping, diff classification, code review, security audit, verification, CI monitoring, retrospective, worktree teardown, and background process cleanup as one uninterrupted sequence.
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
   - Skill
-last_verified: 2026-07-09
+last_verified: 2026-07-10
 ---
 
 # Post-Plan Orchestrator
@@ -31,7 +31,7 @@ if ! git diff --cached --quiet; then
 fi
 ```
 
-Phase 2 makes the initial commit and opens the PR. Phases that may modify files after Phase 2 (Phase 4D follow-up fixes if review identifies real bugs, Phase 5 fix-and-rerun loops, Phase 6 test writing, Phase 7 CI fixes) MUST checkpoint before continuing. The squash-merge armed in Phase 6.5 collapses the chain.
+Phase 2 makes the initial commit and opens the PR. Phases that may modify files after Phase 2 (Phase 2.5 backlog housekeeping, Phase 4D follow-up fixes if review identifies real bugs, Phase 5 fix-and-rerun loops, Phase 6 test writing, Phase 7 CI fixes) MUST checkpoint before continuing. The squash-merge armed in Phase 6.5 collapses the chain.
 
 ---
 
@@ -93,6 +93,26 @@ If the working tree is clean and `git diff origin/master...HEAD` is also empty (
 2. **If no PR exists for the current branch:** create one with `gh pr create`. **Stacked PRs:** If branched from a feature branch (not `master`), use `--base <parent-branch>`. Skip if a PR already exists. **Merge-order dependency:** When this PR shares files with, or must merge after, a sibling PR that is also based on `master` (so stacking via `--base` is unavailable / fragile under squash-merge), add a `Depends-on: #<n>[, #<n>...]` line to the PR body — **on its own line** (the parser anchors to start-of-line, so an inline prose mention of the marker is ignored). Phase 6.5 condition (6) reads it and refuses to arm auto-merge until every named PR is `MERGED`, so the series cannot ship out of order. Use this rather than stacking when the repo squash-merges (a squash collapses the parent's commits, leaving a stacked child's branch carrying the pre-squash commits → conflict on auto-retarget).
 3. **Manual testing in PR description:** Check the plan file for a Verification Matrix. If one exists, copy only the rows classified as `Truly-manual` into the PR's `## Manual Testing` section. If the matrix has zero truly-manual rows (or the plan says "All verification is automated"), write: `No manual testing needed — all changes are covered by unit and E2E tests.` If no plan file or no matrix exists, fall back to the original rule: list only steps requiring subjective human judgment on new or redesigned UI/UX ("does this look/feel good?", "does this flow work well?"). Production comparison and "does output still match?" are visual-regression-replaceable, not manual. Do NOT list CLI commands or script invocations — Phase 6 executes those.
 4. Use Haiku agents for commit message generation if delegating
+
+---
+
+## Phase 2.5: Backlog Housekeeping
+
+If the shipped work implemented or resolved a backlog item, backlog housekeeping ships in **THIS** PR — not as a follow-up. The PR exists (Phase 2), so provenance stamps can reference `#<PR>`. Running here (before Phase 3 classifies and Phase 6.5 arms auto-merge) is what puts the housekeeping edits in the diff that gets reviewed and merged.
+
+**Detect (run once — the PR gives the correct base):**
+
+```bash
+BL_TOUCHED=$(gh pr diff --name-only 2>/dev/null | grep -E '^ibl5/docs/backlog/[^/]+-backlog\.md$' || true)
+```
+
+Also treat housekeeping as triggered if the plan file (`$PLAN_FILE` from Phase 1) declares a resolved or discovered backlog item (a `## Backlog` / tracking-doc status-update section, per `.claude/skills/plan/_architect-contract.md`). The regex **excludes** `README.md` (no `-backlog.md` suffix) and anything under `archive/` (`[^/]+` cannot cross `/`), so a README-only or archive-only diff does **not** trigger.
+
+**If neither signal fires:** print `Phase 2.5: no backlog item resolved — skipping.` and continue to Phase 3.
+
+**If triggered — run INLINE, no subagent.** Post-plan runs as **Sonnet 4.6** and its `disallowed-tools` includes **`Skill`**, so it **cannot** call `/backlog-housekeep`. Instead **Read `.claude/skills/backlog-housekeep/SKILL.md` and follow it inline**, taking that skill's **Sonnet/Haiku caller branch** (execute inline — a same-tier subagent spawn is pure overhead per `feedback_default_sonnet_execution`). Apply its housekeeping checklist with `#<PR>` as the `<ref>` and the PR base as the `--since` base (default `origin/master`; the PR's `baseRefName` for a stacked PR).
+
+**Self-verify + checkpoint (mandatory):** run `bin/check-docs --since=origin/master` (substitute the PR base for a stacked PR), fix any diagnostic, then **commit + push** the housekeeping edits. Per Incremental Checkpoints, this phase modifies files, so the edits must be committed and pushed before Phase 3 — they belong in the diff that Phase 3 classifies and Phase 6.5 arms on.
 
 ---
 

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -48,6 +48,19 @@ const REFERENCE_ALLOWLIST = [
     'ibl5/vr-gallery',                  // gitignored — per-run generated gallery scratch dir (written at CI runtime, never committed)
 ];
 
+// Backlogs that mark items done with a table-cell glyph (e.g. `| C1 | … | ✅ |`)
+// rather than a `**Status:** ✅ Implemented` body line. They keep resolved rows
+// in place instead of archiving them, so the (c) done→archive invariant in
+// checkBacklogTransitions() does not apply to them. Empirically (2026-07-10)
+// both maintenance-backlog.md and a11y-backlog.md are pure table-status; only
+// maintenance is listed here because the (c) check is anchored strictly to
+// `**Status:**`-shaped lines, so a table-cell flip never trips it regardless —
+// keeping the set minimal preserves the catch if a11y-backlog.md ever grows a
+// real body `**Status:**` line without archiving.
+const TABLE_STATUS_BACKLOGS = [
+    'maintenance-backlog.md',
+];
+
 function usage(): string
 {
     return <<<USAGE
@@ -663,6 +676,111 @@ function iterChangedDocs(string $base, string $repoRoot): array
     return $docs;
 }
 
+/**
+ * Diff-scoped backlog archive-transition invariants (--since mode only).
+ *
+ * Body-status backlogs (docs/backlog/<x>-backlog.md) mark an item ✅ Implemented /
+ * 🚫 Declined and archive the resolved body behind a dated `archive/…` pointer so the
+ * LIVE file stays short. This enforces that pairing at PR time, ONLY on files the diff
+ * actually changed — never a full-scan corpus migration. Three transition invariants:
+ *
+ *   (a) Every `archive/<x>-backlog-archive.md` link present in the head body must
+ *       resolve to an existing file.
+ *   (b) When the head body ADDS an archive pointer the base body lacked (a
+ *       done→archived transition), the canonical sibling derived from the LIVE
+ *       filename (archive/<stem>-backlog-archive.md) must exist. Derived from the
+ *       filename, not the link text, so it also catches a pointer that links the
+ *       wrong archive file.
+ *   (c) Body-status backlogs only: when the diff ADDS a `**Status:** ✅ Implemented`
+ *       / `🚫 Declined` line the base lacked, the same file must also add an archive
+ *       pointer. Anchored to `**Status:**`-shaped lines, so a table-cell status flip
+ *       (maintenance/a11y style) never trips it. Files in TABLE_STATUS_BACKLOGS are
+ *       exempt belt-and-suspenders.
+ *
+ * README.md (the index) and archive/ files are out of scope for all three. Base-missing
+ * (added) files read as an empty base body, matching iterChangedDocs' base-blob fetch.
+ *
+ * @return list<string>
+ */
+function checkBacklogTransitions(string $base, string $repoRoot): array
+{
+    $escapedRoot = escapeshellarg($repoRoot);
+    $escapedBase = escapeshellarg($base);
+    $archiveDir = 'ibl5/docs/backlog/archive/';
+    $pointerRe = '/\]\(archive\/([A-Za-z0-9._-]+-backlog-archive\.md)\)/';
+    $doneRe = '/^\s*\*\*Status[^*]*:\*\*\s*(?:✅ Implemented|🚫 Declined)/m';
+
+    $issues = [];
+    foreach (iterChangedDocs($base, $repoRoot) as $doc) {
+        $rel = $doc['rel'];
+        if (!str_starts_with($rel, 'ibl5/docs/backlog/')) {
+            continue;
+        }
+        $name = basename($rel);
+        // The index and archived history are out of scope — only LIVE item files.
+        if ($name === 'README.md' || str_contains($rel, '/archive/') || !str_ends_with($name, '-backlog.md')) {
+            continue;
+        }
+
+        $headBody = is_file($doc['abs']) ? (string) file_get_contents($doc['abs']) : '';
+        // Base blob: fails when the file did not exist at $base (added) => empty base.
+        $showCmd = sprintf('git -C %s show %s:%s 2>/dev/null', $escapedRoot, $escapedBase, escapeshellarg($rel));
+        $baseOut = [];
+        $baseCode = 0;
+        exec($showCmd, $baseOut, $baseCode);
+        $baseBody = $baseCode === 0 ? implode("\n", $baseOut) : '';
+
+        $headPointers = preg_match_all($pointerRe, $headBody, $m) > 0 ? array_values(array_unique($m[1])) : [];
+        $basePointers = preg_match_all($pointerRe, $baseBody, $m) > 0 ? array_values(array_unique($m[1])) : [];
+        $newPointers = array_diff($headPointers, $basePointers);
+
+        // (a) Every archive pointer in the head body must resolve.
+        foreach ($headPointers as $ptr) {
+            if (!is_file($repoRoot . '/' . $archiveDir . $ptr)) {
+                $issues[] = sprintf(
+                    '%s: archive pointer `archive/%s` does not resolve — %s%s is missing (commit the sibling archive file or fix the link)',
+                    $rel,
+                    $ptr,
+                    $archiveDir,
+                    $ptr
+                );
+            }
+        }
+
+        // (b) A newly-added pointer signals a done→archived transition; the canonical
+        // sibling derived from the LIVE filename must exist.
+        if ($newPointers !== []) {
+            $canonical = substr($name, 0, -strlen('-backlog.md')) . '-backlog-archive.md';
+            if (!is_file($repoRoot . '/' . $archiveDir . $canonical)) {
+                $issues[] = sprintf(
+                    '%s: archived an item but its canonical archive sibling %s%s is missing — create it (LIVE %s pairs with archive/%s)',
+                    $rel,
+                    $archiveDir,
+                    $canonical,
+                    $name,
+                    $canonical
+                );
+            }
+        }
+
+        // (c) Body-status backlogs: a newly-added done Status line must be paired with a
+        // newly-added archive pointer (move the body out, leave a dated pointer).
+        if (!in_array($name, TABLE_STATUS_BACKLOGS, true)) {
+            $headDone = preg_match_all($doneRe, $headBody, $m) > 0 ? $m[0] : [];
+            $baseDone = preg_match_all($doneRe, $baseBody, $m) > 0 ? $m[0] : [];
+            if (array_diff($headDone, $baseDone) !== [] && $newPointers === []) {
+                $issues[] = sprintf(
+                    '%s: item marked done inline (`**Status:** ✅ Implemented` / `🚫 Declined`) but no archive pointer added — move the resolved body into archive/%s-backlog-archive.md and replace the LIVE entry with a dated pointer',
+                    $rel,
+                    substr($name, 0, -strlen('-backlog.md'))
+                );
+            }
+        }
+    }
+
+    return $issues;
+}
+
 // --- main ---
 
 $opts = ['fix_dates' => false, 'include_memory' => false, 'verbose' => false, 'since' => null, 'no_staleness' => false, 'staleness_report' => false];
@@ -732,6 +850,9 @@ if ($opts['since'] !== null) {
     }
 
     $issues = checkChanged($opts['since'], $root, $today);
+    // Diff-scoped backlog archive-transition invariants — --since mode only, never
+    // full-scan (avoids forcing a corpus migration of pre-existing backlog history).
+    $issues = array_merge($issues, checkBacklogTransitions($opts['since'], $root));
     if ($issues === []) {
         echo "On-touch doc check passed (changed files vs {$opts['since']}).\n";
         exit(0);

--- a/ibl5/docs/backlog/README.md
+++ b/ibl5/docs/backlog/README.md
@@ -1,6 +1,6 @@
 ---
-description: Index of tracked backlogs under docs/backlog/ — one row per LIVE backlog plus the archive pointer, and the canonical status taxonomy shared by all backlogs.
-last_verified: 2026-07-08
+description: Index of tracked backlogs under docs/backlog/ — one row per LIVE backlog plus the archive pointer, and the canonical status taxonomy shared by all backlogs; and the archive / dated-pointer / supersession housekeeping conventions.
+last_verified: 2026-07-10
 ---
 
 # Backlog index
@@ -38,11 +38,31 @@ The canonical five-glyph status set used by every backlog in this directory:
 Domain-specific **automouse-readiness** legends (🟩/🟦/🟨/🟥) and **effort scales** (S/M/L) stay defined
 per-file — their semantics vary by domain.
 
+## Housekeeping conventions
+
+- **Discovered-item provenance:** a backlog item surfaced while implementing another change is stamped
+  `(discovered YYYY-MM-DD during <ref>)`, where `<ref>` is the PR number or plan slug — a greppable origin.
+- **Cross-backlog supersession:** when a change makes an item in *another* backlog redundant, stamp that
+  item `**Superseded by:** <ref> — <reason>` (verbatim, greppable). Do not delete it — the stamp is the audit trail.
+- **Ship it with the work:** run `/backlog-housekeep` (the `.claude/rules/backlog-housekeep.md` rule surfaces
+  this when you touch a backlog file); it applies the flips, stamps, archive moves, and README reconciliation,
+  then self-verifies via `bin/check-docs`.
+
 ## Archive
 
 [`archive/`](archive/) holds the read-only historical record of ✅ Implemented / 🚫 Declined findings,
-extracted out of `maintenance-backlog.md` so the LIVE file stays short. Not governed by `bin/check-docs`
-(historical dead refs are tolerated there).
+extracted out of the LIVE backlogs so they stay short. Not governed by `bin/check-docs` (historical dead
+refs are tolerated there).
+
+- **Sibling pairing:** each LIVE `<x>-backlog.md` pairs with `archive/<x>-backlog-archive.md` (e.g.
+  `token-spend-backlog.md` ↔ `archive/token-spend-backlog-archive.md`).
+- **Archiving an item:** when an item reaches ✅ Implemented or 🚫 Declined in a **body-status** backlog,
+  move its body into the sibling archive and replace the LIVE entry with a one-line **dated pointer**, e.g.
+  `➜ <id> <title> — ✅ Implemented (YYYY-MM-DD): see [archive](archive/<x>-backlog-archive.md).`
+- **Table-status backlogs** (`maintenance-backlog.md`) keep their glyphs in-place per row — no per-item
+  pointer; bulk-resolved sections still extract to the archive.
+- **Enforced by** `bin/check-docs --since=<base>`: a newly-added archive pointer must resolve to its
+  sibling, and a body-status item flipped done must become a pointer (the diff-scoped backstop).
 
 ## Not part of this directory
 

--- a/ibl5/tests/Cli/CheckDocsCliTest.php
+++ b/ibl5/tests/Cli/CheckDocsCliTest.php
@@ -386,4 +386,124 @@ final class CheckDocsCliTest extends TestCase
         $this->assertIsArray($report, $output);
         $this->assertCount(0, $report);
     }
+
+    // --- Phase 5: --since backlog transitions gate ---
+
+    #[Test]
+    public function sinceBodyStatusDoneWithoutPointerExitsOne(): void
+    {
+        $this->commitFile(
+            'ibl5/docs/backlog/ci-backlog.md',
+            $this->doc($this->freshDate(), "### 1 Item\n\n**Status (2026-07-01):** ⬜ Open — an item.\n"),
+            'base'
+        );
+        $base = $this->currentSha();
+        $this->commitFile(
+            'ibl5/docs/backlog/ci-backlog.md',
+            $this->doc($this->freshDate(0), "### 1 Item\n\n**Status (2026-07-10):** ✅ Implemented — an item.\n"),
+            'mark done inline'
+        );
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(1, $code, $output);
+        $this->assertStringContainsString('marked done inline', $output);
+    }
+
+    #[Test]
+    public function sinceArchivePointerTargetMissingExitsOne(): void
+    {
+        $this->commitFile(
+            'ibl5/docs/backlog/e2e-backlog.md',
+            $this->doc($this->freshDate(), "### 1 Item\n\n**Status (2026-07-01):** ⬜ Open — an item.\n"),
+            'base'
+        );
+        $base = $this->currentSha();
+        $this->commitFile(
+            'ibl5/docs/backlog/e2e-backlog.md',
+            $this->doc($this->freshDate(0), "See [archive](archive/e2e-backlog-archive.md).\n"),
+            'add dead pointer'
+        );
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(1, $code, $output);
+        $this->assertStringContainsString('does not resolve', $output);
+    }
+
+    #[Test]
+    public function sinceNewPointerCanonicalSiblingMissingExitsOne(): void
+    {
+        $this->commitFile('ibl5/docs/backlog/archive/maintenance-backlog-archive.md', "archive\n", 'existing archive');
+        $this->commitFile(
+            'ibl5/docs/backlog/token-spend-backlog.md',
+            $this->doc($this->freshDate(), "### 1 Item\n\n**Status (2026-07-01):** ⬜ Open — an item.\n"),
+            'base'
+        );
+        $base = $this->currentSha();
+        $this->commitFile(
+            'ibl5/docs/backlog/token-spend-backlog.md',
+            $this->doc($this->freshDate(0), "See [archive](archive/maintenance-backlog-archive.md).\n"),
+            'add pointer to wrong sibling'
+        );
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(1, $code, $output);
+        $this->assertStringContainsString('canonical archive sibling', $output);
+    }
+
+    #[Test]
+    public function sinceArchivedWithSiblingAndPointerExitsZero(): void
+    {
+        $this->commitFile(
+            'ibl5/docs/backlog/a11y-backlog.md',
+            $this->doc($this->freshDate(), "### 1 Item\n\n**Status (2026-07-01):** ⬜ Open — an item.\n"),
+            'base'
+        );
+        $base = $this->currentSha();
+
+        @mkdir($this->tmpDir . '/ibl5/docs/backlog/archive', 0o777, true);
+        file_put_contents($this->tmpDir . '/ibl5/docs/backlog/archive/a11y-backlog-archive.md', "archive\n");
+        $this->commitFile(
+            'ibl5/docs/backlog/a11y-backlog.md',
+            $this->doc($this->freshDate(0), "➜ 1 Item — ✅ Implemented (2026-07-10): see [archive](archive/a11y-backlog-archive.md).\n"),
+            'archive item'
+        );
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(0, $code, $output);
+    }
+
+    #[Test]
+    public function sinceMaintenanceTableStatusDoneExemptExitsZero(): void
+    {
+        $this->commitFile(
+            'ibl5/docs/backlog/maintenance-backlog.md',
+            $this->doc($this->freshDate(), "| ID | Item | Status |\n|----|------|--------|\n| C1 | Foo | ⬜ |\n"),
+            'base'
+        );
+        $base = $this->currentSha();
+        $this->commitFile(
+            'ibl5/docs/backlog/maintenance-backlog.md',
+            $this->doc($this->freshDate(0), "| ID | Item | Status |\n|----|------|--------|\n| C1 | Foo | ✅ |\n"),
+            'flip row done'
+        );
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(0, $code, $output);
+    }
+
+    #[Test]
+    public function sinceUnchangedBadBacklogNotInDiffExitsZero(): void
+    {
+        $this->commitFile(
+            'ibl5/docs/backlog/jsb-native-backlog.md',
+            $this->doc($this->freshDate(), "### 1 Item\n\n**Status (2026-07-01):** ✅ Implemented — no pointer, deliberately bad.\n"),
+            'bad backlog'
+        );
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($this->freshDate(), 'Original body.'), 'unrelated doc');
+        $base = $this->currentSha();
+        $this->commitFile('ibl5/docs/sample.md', $this->doc($this->freshDate(0), 'Edited body.'), 'edit unrelated');
+
+        [$code, $output] = $this->runScript('--since=' . $base);
+        $this->assertSame(0, $code, $output);
+    }
 }


### PR DESCRIPTION
## What

Adds a **mechanical backlog-housekeeping mechanism** so backlog bookkeeping ships **with** the change that resolves a backlog item, not as a drifting follow-up.

Three cooperating parts:

- **`bin/check-docs` gains `checkBacklogTransitions()`** — a **diff-scoped (`--since` only)** structural backstop that asserts, on changed `ibl5/docs/backlog/*-backlog.md` files:
  - **(a)** every archive pointer resolves to a real file (`does not resolve`);
  - **(b)** a newly-archived item has its canonical sibling archive file (`canonical archive sibling`);
  - **(c)** a **body-status** item marked done inline must add an archive pointer (`marked done inline`).
  - Table-status backlogs (`maintenance-backlog.md`) are exempt from (c). **Full-scan mode is unchanged** — no forced migration of the existing corpus.
- **`/backlog-housekeep` skill** (+ path-scoped `.claude/rules/backlog-housekeep.md` reminder that loads only when a backlog file is touched) — the 7-operation checklist with a **caller-tier branch**: Opus/Fable delegate the file reads to one Sonnet subagent; Sonnet/Haiku execute inline.
- **`/post-plan` Phase 2.5** wires it into the ship pipeline — post-plan Reads the skill and runs it inline (it can't call the Skill tool). No-ops on a README-only or archive-only diff.

## Tests

6 new `CheckDocsCliTest` cases cover all three invariants, the table-status exemption, and diff-scoping (an unchanged bad backlog outside the diff must pass). Full suite green: `OK (6463 tests, 32488 assertions)` (24 pre-existing vendor deprecations + 1 hygiene-allowed skip, none introduced here).

## Merge handling

**`auto_merge: false`** — this PR edits ship-pipeline machinery (`/post-plan` SKILL.md, `bin/check-docs`), so per the plan's frontmatter it is held for **human review + manual merge**; auto-merge is deliberately not armed. Branch is behind master; rebase/update-branch at merge time.

<!-- no-adr: backlog-housekeep is an operational-convention pointer extending the existing backlog/archive convention; enforcement lives in the /backlog-housekeep skill + check-docs backstop, no new architectural constraint -->
