### PR TITLE
chore(ci): rules byte-budget gate + agent-tiering prose relocation (T2+T7)

### DIFF
--- a/.claude/rules/agent-tiering-detail.md
+++ b/.claude/rules/agent-tiering-detail.md
@@ -1,6 +1,6 @@
 ---
-description: Read-on-demand detail for agent-tiering — Fable approval-gate procedure, flat-fan-out (nested sub-agent) rationale, orchestrator context economics (delegate-don't-dismiss, split-don't-self-clear), and per-tier prompt style. Loads only when editing workflow orchestration defs, where this rationale applies.
-last_verified: 2026-07-07
+description: Read-on-demand detail for agent-tiering — the skip-vs-spawn heuristic, Fable approval-gate procedure, flat-fan-out (nested sub-agent) rationale, orchestrator context economics (delegate-don't-dismiss, split-don't-self-clear), and per-tier prompt style. Loads only when editing workflow orchestration defs.
+last_verified: 2026-07-11
 paths:
   - ".claude/skills/**/*.md"
 ---
@@ -8,8 +8,21 @@ paths:
 # Agent Tiering — Detail
 
 Read-on-demand companion to `agent-tiering.md` (always-loaded). The parent holds the
-operative rules — the Tier table, the Skip-the-Agent heuristic, and Explore tiering.
-This file holds the longer rationale, pulled out of the always-loaded budget.
+operative Tier table and Explore tiering. This file holds the longer rationale — the
+skip-vs-spawn heuristic, the Fable gate, flat-fan-out and orchestrator context economics,
+and prompt style — pulled out of the always-loaded budget.
+
+## Skip the Agent — Direct Tool Calls
+
+Each sub-agent costs ~3–5K tokens (system prompt + rules + memory, loaded before its prompt), and its output re-loads in Opus's context every later turn.
+
+**Run directly (no agent) when ALL hold:** single command/tool call · output under ~50 lines · nothing else to run in parallel · output won't persist across turns.
+
+**Spawn an agent when ANY hold:** output unpredictably verbose (large grep, failing suites with stack traces) and the agent can return a summary · multiple independent verbose tasks run concurrently · the task is multiple sequential tool calls.
+
+**When you spawn, minimize invocation count** — the question is *how many agents are needed*, not *parallel vs. sequential*; token spend outranks wall-clock time. Batch N related tasks into one agent (or do them yourself) — each spawn re-pays the ~3–5K overhead. Separate agents only when each genuinely needs its own context (independent worktrees, isolating verbose output), not because tasks are logically distinct.
+
+**PHPUnit and PHPStan are always direct Bash calls** — passing output is ~5 lines, failures usually under 50; agent overhead dwarfs it. Use `run_in_background` for parallelism without an agent — **but only in the interactive harness**, where a finished background task re-invokes you. In a **headless** run (`claude -p`, e.g. `/post-plan` under automouse) there is no re-invocation: a live background task at turn-end stall-kills the run — run blocking, or poll `BashOutput` to completion in-turn (post-plan `SKILL.md` Phase 5).
 
 ## Fable Approval Gate
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,23 +1,11 @@
 ---
-description: Sub-agent decision rules — when to spawn, when to skip, which model to pick, and how sub-agent delegation keeps orchestrator context low
-last_verified: 2026-07-09
+description: Which tier to pick for each sub-agent, plus how to tier Explore agents. Skip-vs-spawn heuristic and deeper rationale live in agent-tiering-detail.md.
+last_verified: 2026-07-11
 ---
 
 # Agent Tiering
 
 Tier every sub-agent (and every agent a plan spawns) by the reasoning the task actually needs — never default to Opus.
-
-## Skip the Agent — Direct Tool Calls
-
-Each sub-agent costs ~3–5K tokens (system prompt + rules + memory, loaded before its prompt), and its output re-loads in Opus's context every later turn.
-
-**Run directly (no agent) when ALL hold:** single command/tool call · output under ~50 lines · nothing else to run in parallel · output won't persist across turns.
-
-**Spawn an agent when ANY hold:** output unpredictably verbose (large grep, failing suites with stack traces) and the agent can return a summary · multiple independent verbose tasks run concurrently · the task is multiple sequential tool calls.
-
-**When you spawn, minimize invocation count** — the question is *how many agents are needed*, not *parallel vs. sequential*; token spend outranks wall-clock time. Batch N related tasks into one agent (or do them yourself) — each spawn re-pays the ~3–5K overhead. Separate agents only when each genuinely needs its own context (independent worktrees, isolating verbose output), not because tasks are logically distinct.
-
-**PHPUnit and PHPStan are always direct Bash calls** — passing output is ~5 lines, failures usually under 50; agent overhead dwarfs it. Use `run_in_background` for parallelism without an agent — **but only in the interactive harness**, where a finished background task re-invokes you. In a **headless** run (`claude -p`, e.g. `/post-plan` under automouse) there is no re-invocation: a live background task at turn-end stall-kills the run — run blocking, or poll `BashOutput` to completion in-turn (post-plan `SKILL.md` Phase 5).
 
 ## Tiers
 
@@ -30,10 +18,6 @@ Each sub-agent costs ~3–5K tokens (system prompt + rules + memory, loaded befo
 | **Fable** | `model: "fable"` — **prompt first, last resort** | Rung above Opus (~2× cost). Use **only** when a task is absolutely critical **and** Fable is 100% necessary to solve it — and **never without prompting the user first** for explicit approval. Default to Opus. Full gate: `.claude/rules/agent-tiering-detail.md`. |
 
 > **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (then the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.
-
-## Flat fan-out, context economics, and prompt style
-
-Keep **flat fan-out** — the Opus session owns every fan-out and absorbs each agent's output; never nest sub-agents in `/plan`, `/pr-review`, `/security-audit`, `/post-plan`, or automouse. The context win is **delegation, not dismissal** (a sub-agent's intermediate work never enters the orchestrator, so dismissing it reclaims nothing); keep returns **thin** (`path:line`, not file bodies), and since your own context can't self-clear mid-run, **split a too-big run into multiple plans/sessions** rather than nesting orchestrators. Prompt **Haiku** with a concrete grep/find command, "list EVERY match", pre-resolved absolute paths, and structured output — never relevance judgments or multi-hop traces; **Sonnet**'s current style is fine. Full rationale (nested-agent tripwire, the fresh-`Agent()`-vs-`SendMessage` cache tradeoff, per-tier prompt detail): `.claude/rules/agent-tiering-detail.md`.
 
 ## Explore Agents
 

--- a/.claude/rules/work-triage.md
+++ b/.claude/rules/work-triage.md
@@ -1,6 +1,6 @@
 ---
 description: Triage every non-trivial unit of work as ad-hoc vs /plan before starting, with an ad-hoc safety mirror and Sonnet execution-routing for resolved, machine-verifiable edit chunks; the gateway that feeds the deployment funnel (ADR-0067).
-last_verified: 2026-07-07
+last_verified: 2026-07-11
 ---
 
 # Work Triage Rule
@@ -46,7 +46,7 @@ When both hold, **hand off by default — do not pause for permission**: state t
 
 Stay inline (Opus edits directly) only when:
 - the edits and the design are genuinely **entangled** — writing the recipe would mean making each edit-level judgment anyway, so the handoff buys nothing; or
-- the chunk is **trivial** — a one-or-two-edit change where the sub-agent's fixed spawn cost (~3–5K tokens, `agent-tiering.md` § Skip the Agent) exceeds the work being moved.
+- the chunk is **trivial** — a one-or-two-edit change where the sub-agent's fixed spawn cost (~3–5K tokens, `agent-tiering-detail.md` § Skip the Agent) exceeds the work being moved.
 
 Either way the routing decision is **stated, not silent** — one line, like the triage verdict. The user should see which way it went and be able to override in the moment.
 

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -4,7 +4,7 @@ description: "Plan an implementation task: enforces a verification matrix, direc
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
-last_verified: 2026-07-09
+last_verified: 2026-07-11
 ---
 
 # /plan — Implementation Planning with Verification Matrix
@@ -72,7 +72,7 @@ The Plan agent auto-loads CLAUDE.md, all always-loaded rules (agent-tiering, cor
 
 Launch a **single Plan agent** (`subagent_type: "plan-architect"` — its definition carries `model: opus` and `effort: high`; do NOT pass an inline `model` override) with a prompt containing ALL of these. **Escalate to `plan-architect-xhigh` (effort: xhigh) when Step 2 flagged any of: a security surface, a trust boundary (auth/authz-gated route), a destructive migration, or a change to `.claude/skills` ship-pipeline invariants.**
 
-**Run this step inline — never delegate `/plan` itself.** The orchestrating session owns Steps 1–5 directly and spawns exactly **one** `plan-architect` per PR-sized unit. Do NOT hand the whole `/plan` invocation to a `general-purpose`/`claude` sub-agent (or fan it out across several), and do NOT have any such agent fire `/plan` on your behalf. Those agent types carry `Tools: *` — they *can* spawn further agents, so delegating `/plan` to them produces a `general-purpose → plan-architect` nest, exactly the multi-level `plan-architect` tree the flat-fan-out rule forbids (`agent-tiering.md` § Flat fan-out). `plan-architect`/`Plan`/`Explore` cannot cause this themselves — they lack the `Agent` tool — so the only way the nest appears is an orchestrator delegating `/plan` outward. Keep planning one level deep: this session → one `plan-architect`.
+**Run this step inline — never delegate `/plan` itself.** The orchestrating session owns Steps 1–5 directly and spawns exactly **one** `plan-architect` per PR-sized unit. Do NOT hand the whole `/plan` invocation to a `general-purpose`/`claude` sub-agent (or fan it out across several), and do NOT have any such agent fire `/plan` on your behalf. Those agent types carry `Tools: *` — they *can* spawn further agents, so delegating `/plan` to them produces a `general-purpose → plan-architect` nest, exactly the multi-level `plan-architect` tree the flat-fan-out rule forbids (`agent-tiering-detail.md` § Nested Sub-Agents). `plan-architect`/`Plan`/`Explore` cannot cause this themselves — they lack the `Agent` tool — so the only way the nest appears is an orchestrator delegating `/plan` outward. Keep planning one level deep: this session → one `plan-architect`.
 
 1. **Task description** from `$ARGUMENTS` — when the work was split in Step 2.5, scope this to the single PR being planned and state which PR it is and what it depends on
 2. **Exploration results** from Step 2 — file paths, code traces, existing patterns, test coverage findings. **Tell the agent these findings are authoritative and that it must NOT re-explore them.** The agent already ran with `effort: xhigh`, so its instinct is to re-derive everything from scratch — but you've supplied the orientation, and every redundant `grep`/`Read`/agent call extends the run and raises the stall risk (each tool round-trip is another window for the idle timeout to land before the agent reaches its Bash-persist). Instruct it to spend tool calls only on **targeted confirmations** of anything the findings leave genuinely open — cap ~2–3 — then go straight to composing the plan. "Verify everything myself" is the failure mode here, not diligence.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -606,6 +606,12 @@ jobs:
         run: bin/check-workflow-checkout
       - name: Composite behavior contracts
         run: bin/check-composite-contracts
+      # rules-byte-budget: a path-unscoped .claude/rules/*.md file (always loaded
+      # into every session's context) can grow past its token budget via an edit
+      # that no src/shell path-filter covers. bin/check-rules-byte-budget (NEW,
+      # Phase 1) caps it. Backlog: token-spend-backlog T2.
+      - name: Check path-unscoped rules byte budget
+        run: bin/check-rules-byte-budget
 
   harness-tests:
     name: Shell harness regression tests

--- a/bin/check-rules-byte-budget
+++ b/bin/check-rules-byte-budget
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# check-rules-byte-budget — CI gate: cap the byte size of PATH-UNSCOPED
+# (always-loaded) .claude/rules/*.md files. These load into EVERY session's
+# context, so their size is a permanent token cost. Path-scoped rules (those
+# with a `paths:` frontmatter key) load only for matching files and are exempt.
+#
+# Backlog: ibl5/docs/backlog/token-spend-backlog.md T2.
+# Extend-before-add (meta-tooling-bar.md): distinct trigger (size budget) vs
+# bin/check-docs (freshness / dead-refs). ~40 lines bash => no ADR (<50 lines).
+set -euo pipefail
+
+MAX_BYTES="${RULES_BYTE_BUDGET:-5000}"
+RULES_DIR="$(git rev-parse --show-toplevel)/.claude/rules"
+
+fail=0
+for f in "$RULES_DIR"/*.md; do
+  # Frontmatter = lines between the first two `---` markers.
+  fm="$(awk '/^---$/{c++; next} c==1{print} c>=2{exit}' "$f")"
+  # A `paths:` key marks a path-scoped rule -> exempt from the always-loaded budget.
+  if grep -q '^paths:' <<<"$fm"; then
+    continue
+  fi
+  bytes="$(wc -c < "$f")"
+  if (( bytes > MAX_BYTES )); then
+    printf 'FAIL  %s  %d bytes  (budget %d)\n' "$f" "$bytes" "$MAX_BYTES" >&2
+    fail=1
+  fi
+done
+
+if (( fail )); then
+  cat >&2 <<MSG
+
+One or more path-unscoped .claude/rules/*.md files exceed the ${MAX_BYTES}-byte
+budget. These load into EVERY session's context. Trim them, or move detail into
+a path-scoped *-detail.md companion (see agent-tiering-detail.md).
+Override the budget only deliberately: RULES_BYTE_BUDGET=<n> bin/check-rules-byte-budget
+MSG
+  exit 1
+fi
+
+echo "OK: all path-unscoped .claude/rules/*.md within ${MAX_BYTES}-byte budget"

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Token-spend reduction backlog — resident-context diet, caching economics, output-spend guards, and LSP-first navigation for the Claude Code harness, with per-entry status.
-last_verified: 2026-07-09
+last_verified: 2026-07-11
 ---
 
 # Token-Spend Reduction Backlog
@@ -64,7 +64,7 @@ Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive
 **Problem:** The always-loaded surface only ever grows; nothing pushes back. No CI check caps it (verified: no size/budget check in `.github/workflows/` or `bin/check-docs`).
 **Suggested direction:** A small CI job (wired into the `gate` job's `needs:`, per house convention) failing when path-unscoped rules bytes or the MEMORY.md index exceed a budget. MEMORY.md lives outside the repo, so the gate checks rules in CI and the hook surface checks the index locally (pairs with T5).
 **Risk if untouched:** Silent regrowth of the per-turn fixed tax that T7 pays down.
-**Status (2026-07-07):** ⬜ Open.
+**Status (2026-07-11):** ◑ Partial — CI rules byte-budget gate shipped: `bin/check-rules-byte-budget` caps path-unscoped `.claude/rules/*.md` files at 5000 bytes, folded into the `static-guards` job (already in the `gate` `needs:`, so a regrowth fails the required gate). Residual: the local MEMORY.md index-budget hook (out-of-repo, pairs with T5) still deferred.
 
 ### T4 Driver-model downshift for babysitting loops
 **Location:** Interactive workflow — CI-watching, merge-nudging, and re-run loops currently run in the main (Opus/Fable) session.
@@ -85,7 +85,7 @@ Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive
 **Problem:** Every request and every subagent spawn carries the full overlay; on a typical ~35K-token request it is ~27% of the read.
 **Suggested direction:** Prune index lines for finished pipelines and dated status that has expired; merge one-line variants; target ≤ 8KB for the index. Move remaining `agent-tiering.md` prose into the detail file, keeping the tier table + Explore rules. Pairs with E8 in [dev-efficiency-backlog.md](dev-efficiency-backlog.md) (each mechanical gate built lets a memory line retire) and is held in place afterwards by T2/T5.
 **Risk if untouched:** A permanent per-turn tax that compounds across every subagent.
-**Status (2026-07-09):** ◑ Partial — first-pass diet shipped: `agent-tiering.md` collapsed its Flat-fan-out / Context-economics / Prompt-style tail into one combined note (operative content already lives in `agent-tiering-detail.md`); MEMORY.md pruned harness-side (stale `project_authz_gate_deferred` line + backing file dropped now all four IDOR PRs #1107–#1110 are merged; Security-backlog hook corrected 6-queued → 4/6-done). Residual: full ≤8KB MEMORY.md diet + relocating the remaining `agent-tiering.md` prose still deferred.
+**Status (2026-07-11):** ◑ Partial — `agent-tiering.md` relocation now complete: its `## Skip the Agent` heuristic moved into `agent-tiering-detail.md` and the redundant Flat-fan-out / Context-economics / Prompt-style tail removed, leaving only the Tier table + Explore rules in the always-loaded file (down from ~5.9KB to under the 5000-byte T2 budget). Cross-refs in `work-triage.md` and `.claude/skills/plan/SKILL.md` repointed to the detail file. Residual: the full ≤8KB MEMORY.md index diet (out-of-repo, harness-side) still deferred.
 
 ### T9 Lazy-load plan/post-plan skills
 **Location:** `.claude/skills/plan/SKILL.md` (~55KB ≈ 13K tokens) and `.claude/skills/post-plan/SKILL.md` (~68KB ≈ 17K tokens) — each a single file loaded whole at invocation and resident for the entire run.

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -29,9 +29,9 @@ last_verified: 2026-07-11
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 5 |
+| ⬜ Open | 4 |
 | 📋 Planned | 1 |
-| ◑ Partial | 1 |
+| ◑ Partial | 2 |
 | ✅ Implemented | 5 |
 | 🚫 Declined | 0 |
 
@@ -44,7 +44,7 @@ Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive
 | # | Title | Status | Locus | Effort |
 |---|-------|--------|-------|-------:|
 | T1 | Automouse token ledger | ✅ Implemented | repo | M |
-| T2 | Always-loaded context budget gate | ⬜ Open | repo | S |
+| T2 | Always-loaded context budget gate | ◑ Partial | repo | S |
 | T4 | Driver-model downshift for babysitting loops | ⬜ Open | ⌂ | M |
 | T5 | Memory/rules dedup lint | ⬜ Open | ⌂ | S |
 | T7 | Resident-overlay diet (MEMORY.md + rules) | ◑ Partial | both | M |


### PR DESCRIPTION
## Summary

Ships two coupled backlog entries — **T2** (CI byte-budget gate on always-loaded rules) and **T7 residual** (prose relocation in `agent-tiering.md`). They belong together: T2's gate is RED on master today (`agent-tiering.md` ~5.9KB > 5000-byte budget), and T7's relocation is exactly what brings it GREEN.

### T2 — Rules byte-budget gate (`bin/check-rules-byte-budget` + `tests.yml`)
- New script `bin/check-rules-byte-budget`: caps path-unscoped `.claude/rules/*.md` files at 5000 bytes (env-overridable via `RULES_BYTE_BUDGET`). Path-scoped rules (with `paths:` frontmatter) are exempt.
- Folded into the existing `static-guards` job (already in `gate` `needs:`) — adds required-gate status with zero new branch-protection wiring.

### T7 residual — `agent-tiering.md` prose relocation
- Moved `## Skip the Agent — Direct Tool Calls` from always-loaded `agent-tiering.md` into path-scoped `agent-tiering-detail.md` (paths: `.claude/skills/**/*.md`, byte-budget exempt).
- Removed redundant `## Flat fan-out…` tail (already covered in full by detail file's three sections).
- `agent-tiering.md` now holds only the Tier table + Explore rules — down from ~5.9KB to under budget.
- Cross-refs in `work-triage.md` and `.claude/skills/plan/SKILL.md` repointed to detail file.
- Backlog status: T2 `⬜ Open → ◑ Partial`; T7 stays `◑ Partial` with residual narrowed to MEMORY.md diet.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.