### PR TITLE
chore(ci): merge idempotency-check into schema-completeness

### DIFF
--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -19,57 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  idempotency-check:
-    name: Bash/PHP Runner Idempotency
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    env:
-      DB_HOST: 127.0.0.1
-      DB_USER: root
-      DB_PASS: root
-      DB_NAME: iblhoops_ibl5
-
-    services:
-      mariadb:
-        image: mariadb:10.11
-        env:
-          MARIADB_ROOT_PASSWORD: root
-          MARIADB_DATABASE: iblhoops_ibl5
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mariadb-admin ping -proot"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-    # config.php.example reads DB creds from getenv(); the job-level DB_* env
-    # vars point it at the CI MariaDB service.
-    - name: Setup PHP environment
-      uses: ./.github/actions/setup-php-env
-
-    - name: Apply migrations via bash runner
-      run: ibl5/bin/run-migrations-ci.sh -h 127.0.0.1 -u root -proot iblhoops_ibl5
-
-    - name: Seed PHP migration tracker
-      working-directory: ibl5
-      run: php bin/migrate-seed
-
-    - name: Assert PHP runner sees nothing pending
-      working-directory: ibl5
-      run: |
-        output=$(php bin/migrate --status)
-        echo "$output"
-        if [ "$output" != "Nothing to migrate." ]; then
-          echo "FAIL: PHP runner has pending migrations after bash runner applied all."
-          echo "This means the bash and PHP runners disagree on which files exist."
-          exit 1
-        fi
 
   schema-parity-check:
     name: Bash vs PHP Schema Parity
@@ -193,6 +142,21 @@ jobs:
       run: |
         chmod +x ibl5/bin/run-migrations-ci.sh
         ibl5/bin/run-migrations-ci.sh -h 127.0.0.1 -u root -proot ibl5_completeness
+
+    - name: Seed PHP migration tracker
+      working-directory: ibl5
+      run: php bin/migrate-seed
+
+    - name: Assert PHP runner sees nothing pending
+      working-directory: ibl5
+      run: |
+        output=$(php bin/migrate --status)
+        echo "$output"
+        if [ "$output" != "Nothing to migrate." ]; then
+          echo "FAIL: PHP runner has pending migrations after bash runner applied all."
+          echo "This means the bash and PHP runners disagree on which files exist."
+          exit 1
+        fi
 
     - name: Check for stale renamed-column references
       env:
@@ -356,7 +320,7 @@ jobs:
   gate:
     name: Migration Safety
     if: always()
-    needs: [idempotency-check, schema-parity-check, schema-completeness, destructive-migration-scan]
+    needs: [schema-parity-check, schema-completeness, destructive-migration-scan]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/ibl5/docs/backlog/archive/ci-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/ci-backlog-archive.md
@@ -9,6 +9,13 @@ Read-only historical record of ✅ Implemented / 🚫 Declined findings. For OPE
 
 ---
 
+### 2.2 migration-safety.yml — three jobs each rebuild a full DB stack
+**Location:** `.github/workflows/migration-safety.yml` — jobs `idempotency-check`, `schema-parity-check`, `schema-completeness`.
+**Problem:** All three spin up an independent MariaDB 10.11 service, run an independent composer install, and apply the full migration stack from zero. `idempotency-check` and `schema-completeness` both apply the same full stack; the latter just adds FK/table/column assertions afterward.
+**Suggested direction:** Merge `idempotency-check` into `schema-completeness` (one DB build, then both sets of assertions). Keep `schema-parity-check` separate — it needs two DBs by design. Costs some intra-workflow parallelism; nets fewer runner-minutes and one fewer composer install.
+**Risk if untouched:** Three full migration runs per push to a migrations file; setup duplication (mitigated once 1.1 lands).
+**Status (2026-07-11):** ✅ Implemented — folded `idempotency-check`'s bash-apply→PHP-seed→`migrate --status` idempotency assertion into `schema-completeness` (shared MariaDB service + `setup-php-env`); removed the standalone job and dropped it from the `gate` job's `needs`. `schema-parity-check` kept separate (two DBs). Green-green — all assertions preserved. (#1422)
+
 ### 3.1 audit-js — `npm audit` without a prior install
 **Location:** `.github/workflows/tests.yml`, job `audit-js`.
 **Problem:** Runs `npm audit --audit-level=high` with no `npm ci`/`npm install` first, relying on the bare runner Node — it may pass vacuously (no lockfile-resolved tree to scan). This is a **correctness** gap, not just tidiness.

--- a/ibl5/docs/backlog/ci-backlog.md
+++ b/ibl5/docs/backlog/ci-backlog.md
@@ -29,9 +29,9 @@ last_verified: 2026-07-11
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 3 |
+| ⬜ Open | 2 |
 | 📋 Planned | 0 |
-| ✅ Implemented | 6 |
+| ✅ Implemented | 7 |
 | 🚫 Declined | 0 |
 
 > The 4 "verified-not-redundant" entries in Axis 4 are **decisions to keep**, not open work — they exist so a future audit does not re-flag them. Not counted above.
@@ -66,7 +66,7 @@ last_verified: 2026-07-11
 | # | Title | Status | Automouse | Effort |
 |---|-------|--------|-----------|-------:|
 | 2.1 | Collapse smoke-prod's 4 notify jobs into one | ⬜ Open | 🟦 | S |
-| 2.2 | Merge migration-safety `idempotency-check` + `schema-completeness` | ⬜ Open | 🟩 | M |
+| 2.2 | Merge migration-safety `idempotency-check` + `schema-completeness` | ✅ Implemented | 🟩 | M |
 
 ### 2.1 smoke-prod.yml — four near-identical notify jobs
 **Location:** `.github/workflows/smoke-prod.yml` — jobs `rollback-and-notify`, `notify-scheduled-failure`, `notify-ibl6-degradation`, `notify-inconclusive`.
@@ -80,7 +80,7 @@ last_verified: 2026-07-11
 **Problem:** All three spin up an independent MariaDB 10.11 service, run an independent composer install, and apply the full migration stack from zero. `idempotency-check` and `schema-completeness` both apply the same full stack; the latter just adds FK/table/column assertions afterward.
 **Suggested direction:** Merge `idempotency-check` into `schema-completeness` (one DB build, then both sets of assertions). Keep `schema-parity-check` separate — it needs two DBs by design. Costs some intra-workflow parallelism; nets fewer runner-minutes and one fewer composer install.
 **Risk if untouched:** Three full migration runs per push to a migrations file; setup duplication (mitigated once 1.1 lands).
-**Status (2026-06-28):** ⬜ Open — green-green (gate job unchanged, assertions preserved) → 🟩.
+**Status (2026-07-11):** ✅ Implemented — folded `idempotency-check`'s bash-apply→PHP-seed→`migrate --status` idempotency assertion into `schema-completeness` (shared MariaDB service + `setup-php-env`); removed the standalone job and dropped it from the `gate` job's `needs`. `schema-parity-check` kept separate (two DBs). Green-green — all assertions preserved.
 
 ---
 

--- a/ibl5/docs/backlog/ci-backlog.md
+++ b/ibl5/docs/backlog/ci-backlog.md
@@ -75,12 +75,7 @@ last_verified: 2026-07-11
 **Risk if untouched:** Notify logic forks across 4 jobs; a message-format change is repeated.
 **Status (2026-06-28):** ⬜ Open — sequence after 1.2. Deploy/notify surface → 🟦.
 
-### 2.2 migration-safety.yml — three jobs each rebuild a full DB stack
-**Location:** `.github/workflows/migration-safety.yml` — jobs `idempotency-check`, `schema-parity-check`, `schema-completeness`.
-**Problem:** All three spin up an independent MariaDB 10.11 service, run an independent composer install, and apply the full migration stack from zero. `idempotency-check` and `schema-completeness` both apply the same full stack; the latter just adds FK/table/column assertions afterward.
-**Suggested direction:** Merge `idempotency-check` into `schema-completeness` (one DB build, then both sets of assertions). Keep `schema-parity-check` separate — it needs two DBs by design. Costs some intra-workflow parallelism; nets fewer runner-minutes and one fewer composer install.
-**Risk if untouched:** Three full migration runs per push to a migrations file; setup duplication (mitigated once 1.1 lands).
-**Status (2026-07-11):** ✅ Implemented — folded `idempotency-check`'s bash-apply→PHP-seed→`migrate --status` idempotency assertion into `schema-completeness` (shared MariaDB service + `setup-php-env`); removed the standalone job and dropped it from the `gate` job's `needs`. `schema-parity-check` kept separate (two DBs). Green-green — all assertions preserved.
+➜ 2.2 migration-safety.yml — ✅ Implemented (2026-07-11): see [archive](archive/ci-backlog-archive.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Folds the `idempotency-check` job's three functional steps (bash-runner apply, PHP-tracker seed, `--status` assertion) into the existing `schema-completeness` job, then drops `idempotency-check` from the `gate` job's `needs:` list.

Both jobs already boot one MariaDB 10.11 and run the identical bash runner (`ibl5/bin/run-migrations-ci.sh`). The merge is a pure consolidation: one fewer MariaDB service boot and one fewer PHP-env setup, with every assertion preserved.

Resolves ci-backlog finding 2.2.

## Changes

- Delete standalone `idempotency-check` job (52 lines removed)
- Splice two idempotency PHP steps (`migrate-seed` + `migrate --status` assertion) into `schema-completeness` after "Apply all migrations" and before "Check for stale renamed-column references"
- Drop `idempotency-check` from `gate` job `needs:` array
- Flip ci-backlog 2.2 to ✅ Implemented, bump `last_verified`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.