### PR TITLE
chore(jsb): J18 pin transitionTriggerDenom=18 (asm-verified jumpshot 5.60)

### DIFF
--- a/engine/internal/sim/testdata/golden.json
+++ b/engine/internal/sim/testdata/golden.json
@@ -1692,19 +1692,22 @@
           "team_id": 7
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 2,
           "clock_seconds": 525,
           "team_id": 7,
-          "player_id": 104
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
-          "kind": "steal",
+          "kind": "shot_make",
           "period": 2,
           "clock_seconds": 525,
           "team_id": 7,
-          "player_id": 104,
-          "defender_id": 203
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
           "kind": "possession_start",
@@ -1713,143 +1716,153 @@
           "team_id": 3
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 2,
           "clock_seconds": 510,
           "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 510,
-          "team_id": 3,
-          "player_id": 201,
-          "defender_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 495,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 480,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 465,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
+          "player_id": 203,
+          "shot_type": "3pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 2,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
+          "clock_seconds": 510,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "3pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 2,
+          "clock_seconds": 510,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 495,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 495,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 495,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 495,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 480,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
           "clock_seconds": 465,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 450,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 450,
           "team_id": 3,
           "player_id": 204
         },
         {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 450,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 450,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 450,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
           "kind": "steal",
           "period": 2,
+          "clock_seconds": 450,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 435,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
           "clock_seconds": 435,
           "team_id": 7,
-          "player_id": 104,
-          "defender_id": 201
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
           "kind": "possession_start",
@@ -1862,88 +1875,64 @@
           "period": 2,
           "clock_seconds": 420,
           "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 405,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 405,
-          "team_id": 7,
-          "player_id": 105,
+          "player_id": 205,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 2,
-          "clock_seconds": 405,
-          "team_id": 7,
-          "player_id": 105,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 205,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 2,
-          "clock_seconds": 405,
-          "team_id": 7,
-          "player_id": 103,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 203,
           "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
           "period": 2,
-          "clock_seconds": 405,
-          "team_id": 7,
-          "player_id": 103,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "oreb_continuation"
         },
         {
           "kind": "shot_make",
           "period": 2,
-          "clock_seconds": 405,
-          "team_id": 7,
-          "player_id": 103,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "oreb_continuation"
         },
         {
           "kind": "possession_start",
           "period": 2,
-          "clock_seconds": 390,
-          "team_id": 3
+          "clock_seconds": 405,
+          "team_id": 7
         },
         {
           "kind": "foul",
           "period": 2,
-          "clock_seconds": 390,
-          "team_id": 7,
-          "player_id": 102
+          "clock_seconds": 405,
+          "team_id": 3,
+          "player_id": 202
         },
         {
           "kind": "free_throw",
           "period": 2,
-          "clock_seconds": 390,
-          "team_id": 3,
-          "player_id": 203,
+          "clock_seconds": 405,
+          "team_id": 7,
+          "player_id": 103,
           "shot_type": "ft",
           "ft_attempts": 2,
           "ft_made": 1
@@ -1951,6 +1940,56 @@
         {
           "kind": "possession_start",
           "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
           "clock_seconds": 375,
           "team_id": 7
         },
@@ -1959,8 +1998,8 @@
           "period": 2,
           "clock_seconds": 375,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
+          "player_id": 101,
+          "shot_type": "3pt",
           "shot_origin": "initial"
         },
         {
@@ -1968,155 +2007,118 @@
           "period": 2,
           "clock_seconds": 375,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
+          "player_id": 101,
+          "shot_type": "3pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 2,
           "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 360,
+          "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 2,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 102,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 205,
           "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 345,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 2,
-          "clock_seconds": 375,
+          "clock_seconds": 345,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 104,
           "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "block",
-          "period": 2,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 102,
-          "defender_id": 205
+          "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 2,
-          "clock_seconds": 375,
+          "clock_seconds": 345,
           "team_id": 3,
           "player_id": 205
         },
         {
           "kind": "possession_start",
           "period": 2,
-          "clock_seconds": 360,
+          "clock_seconds": 330,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 2,
-          "clock_seconds": 360,
+          "clock_seconds": 330,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
           "kind": "shot_miss",
           "period": 2,
-          "clock_seconds": 360,
+          "clock_seconds": 330,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
           "kind": "rebound",
           "period": 2,
-          "clock_seconds": 360,
+          "clock_seconds": 330,
           "team_id": 3,
-          "player_id": 204,
+          "player_id": 201,
           "offensive_rebound": true
         },
         {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 345,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
+          "kind": "turnover",
           "period": 2,
           "clock_seconds": 330,
           "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
+          "player_id": 201
         },
         {
-          "kind": "shot_miss",
+          "kind": "steal",
           "period": 2,
           "clock_seconds": 330,
           "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 7,
-          "player_id": 105
+          "player_id": 201,
+          "defender_id": 104
         },
         {
           "kind": "possession_start",
@@ -2129,14 +2131,14 @@
           "period": 2,
           "clock_seconds": 315,
           "team_id": 7,
-          "player_id": 101
+          "player_id": 105
         },
         {
           "kind": "steal",
           "period": 2,
           "clock_seconds": 315,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 105,
           "defender_id": 204
         },
         {
@@ -2146,19 +2148,22 @@
           "team_id": 3
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 2,
           "clock_seconds": 300,
           "team_id": 3,
-          "player_id": 205
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
-          "kind": "steal",
+          "kind": "shot_make",
           "period": 2,
           "clock_seconds": 300,
           "team_id": 3,
-          "player_id": 205,
-          "defender_id": 104
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
@@ -2191,42 +2196,18 @@
           "team_id": 3
         },
         {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 255,
-          "team_id": 7
-        },
-        {
           "kind": "foul",
           "period": 2,
-          "clock_seconds": 255,
-          "team_id": 3,
-          "player_id": 202
+          "clock_seconds": 270,
+          "team_id": 7,
+          "player_id": 102
         },
         {
           "kind": "free_throw",
           "period": 2,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 102,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 202,
           "shot_type": "ft",
           "ft_attempts": 2,
           "ft_made": 1
@@ -2234,23 +2215,47 @@
         {
           "kind": "possession_start",
           "period": 2,
-          "clock_seconds": 240,
-          "team_id": 3
+          "clock_seconds": 255,
+          "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 2,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 202
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 102
         },
         {
           "kind": "steal",
           "period": 2,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 102,
+          "defender_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 240,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
           "clock_seconds": 240,
           "team_id": 3,
-          "player_id": 202,
-          "defender_id": 104
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
@@ -2263,206 +2268,213 @@
           "period": 2,
           "clock_seconds": 225,
           "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 210,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 202,
+          "player_id": 102,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 2,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 202,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 102,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "block",
           "period": 2,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 102,
+          "defender_id": 202
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 225,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 210,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
           "clock_seconds": 210,
           "team_id": 3,
-          "player_id": 202,
-          "defender_id": 102
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
           "kind": "rebound",
           "period": 2,
           "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 204,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 195,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 104
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 104,
+          "defender_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 180,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 165,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 150,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 150,
           "team_id": 7,
           "player_id": 104
         },
         {
           "kind": "possession_start",
           "period": 2,
-          "clock_seconds": 195,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 104,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 180,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 180,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 180,
-          "team_id": 3,
-          "player_id": 204,
-          "defender_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 165,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 165,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 165,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 150,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 205,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
           "clock_seconds": 135,
           "team_id": 7
         },
@@ -2472,141 +2484,134 @@
           "clock_seconds": 135,
           "team_id": 7,
           "player_id": 101,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 120,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_make",
           "period": 2,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 201,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 101,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
           "period": 2,
-          "clock_seconds": 105,
-          "team_id": 7
+          "clock_seconds": 120,
+          "team_id": 3
         },
         {
           "kind": "foul",
           "period": 2,
-          "clock_seconds": 105,
-          "team_id": 3,
-          "player_id": 201
+          "clock_seconds": 120,
+          "team_id": 7,
+          "player_id": 101
         },
         {
           "kind": "free_throw",
           "period": 2,
-          "clock_seconds": 105,
-          "team_id": 7,
-          "player_id": 103,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 203,
           "shot_type": "ft",
           "ft_attempts": 2
         },
         {
           "kind": "possession_start",
           "period": 2,
-          "clock_seconds": 90,
-          "team_id": 3
+          "clock_seconds": 105,
+          "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 2,
-          "clock_seconds": 90,
-          "team_id": 3,
-          "player_id": 203
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 103
         },
         {
           "kind": "steal",
           "period": 2,
-          "clock_seconds": 90,
-          "team_id": 3,
-          "player_id": 203,
-          "defender_id": 103
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 103,
+          "defender_id": 203
         },
         {
           "kind": "possession_start",
           "period": 2,
-          "clock_seconds": 75,
-          "team_id": 7
+          "clock_seconds": 90,
+          "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 2,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 102,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 2,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 102,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 2,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 103,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 203,
           "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
           "period": 2,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 103,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "oreb_continuation"
         },
         {
           "kind": "shot_make",
           "period": 2,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 103,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 75,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
@@ -2619,49 +2624,49 @@
           "period": 2,
           "clock_seconds": 60,
           "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 60,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 45,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 102,
+          "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 2,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 102,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 2,
+          "clock_seconds": 60,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
           "clock_seconds": 45,
-          "team_id": 3,
-          "player_id": 203
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
@@ -2670,22 +2675,21 @@
           "team_id": 3
         },
         {
-          "kind": "shot_attempt",
+          "kind": "foul",
           "period": 2,
           "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
+          "team_id": 7,
+          "player_id": 105
         },
         {
-          "kind": "shot_make",
+          "kind": "free_throw",
           "period": 2,
           "clock_seconds": 30,
           "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
+          "player_id": 205,
+          "shot_type": "ft",
+          "ft_attempts": 2,
+          "ft_made": 1
         },
         {
           "kind": "possession_start",
@@ -2694,21 +2698,22 @@
           "team_id": 7
         },
         {
-          "kind": "foul",
-          "period": 2,
-          "clock_seconds": 15,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "free_throw",
+          "kind": "shot_attempt",
           "period": 2,
           "clock_seconds": 15,
           "team_id": 7,
-          "player_id": 105,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 1
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 15,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
           "kind": "period_boundary",
@@ -2726,7 +2731,7 @@
           "period": 3,
           "clock_seconds": 720,
           "team_id": 3,
-          "player_id": 204,
+          "player_id": 205,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
@@ -2735,7 +2740,7 @@
           "period": 3,
           "clock_seconds": 720,
           "team_id": 3,
-          "player_id": 204,
+          "player_id": 205,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
@@ -2746,22 +2751,19 @@
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
+          "kind": "turnover",
           "period": 3,
           "clock_seconds": 705,
           "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
+          "player_id": 101
         },
         {
-          "kind": "shot_make",
+          "kind": "steal",
           "period": 3,
           "clock_seconds": 705,
           "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
+          "player_id": 101,
+          "defender_id": 203
         },
         {
           "kind": "possession_start",
@@ -2770,43 +2772,43 @@
           "team_id": 3
         },
         {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 201,
-          "defender_id": 103
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 675,
-          "team_id": 7
-        },
-        {
           "kind": "shot_attempt",
           "period": 3,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 105,
+          "clock_seconds": 690,
+          "team_id": 3,
+          "player_id": 205,
           "shot_type": "3pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_make",
           "period": 3,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 105,
+          "clock_seconds": 690,
+          "team_id": 3,
+          "player_id": 205,
           "shot_type": "3pt",
           "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 675,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 102,
+          "defender_id": 204
         },
         {
           "kind": "possession_start",
@@ -2815,19 +2817,22 @@
           "team_id": 3
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 3,
           "clock_seconds": 660,
           "team_id": 3,
-          "player_id": 202
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
-          "kind": "steal",
+          "kind": "shot_make",
           "period": 3,
           "clock_seconds": 660,
           "team_id": 3,
-          "player_id": 202,
-          "defender_id": 104
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
@@ -2840,49 +2845,46 @@
           "period": 3,
           "clock_seconds": 645,
           "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 630,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 630,
-          "team_id": 3,
-          "player_id": 201,
+          "player_id": 101,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 3,
-          "clock_seconds": 630,
-          "team_id": 3,
-          "player_id": 201,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 101,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 3,
+          "clock_seconds": 645,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
           "clock_seconds": 630,
-          "team_id": 7,
-          "player_id": 104
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 630,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 630,
+          "team_id": 3,
+          "player_id": 205,
+          "defender_id": 102
         },
         {
           "kind": "possession_start",
@@ -2903,7 +2905,7 @@
           "clock_seconds": 615,
           "team_id": 7,
           "player_id": 105,
-          "defender_id": 202
+          "defender_id": 201
         },
         {
           "kind": "possession_start",
@@ -2912,19 +2914,29 @@
           "team_id": 3
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 3,
           "clock_seconds": 600,
           "team_id": 3,
-          "player_id": 205
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
-          "kind": "steal",
+          "kind": "shot_miss",
           "period": 3,
           "clock_seconds": 600,
           "team_id": 3,
-          "player_id": 205,
-          "defender_id": 101
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 600,
+          "team_id": 7,
+          "player_id": 103
         },
         {
           "kind": "possession_start",
@@ -2937,25 +2949,18 @@
           "period": 3,
           "clock_seconds": 585,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 103,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 3,
           "clock_seconds": 585,
           "team_id": 7,
-          "player_id": 102,
+          "player_id": 103,
           "shot_type": "2pt",
           "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 585,
-          "team_id": 3,
-          "player_id": 203
         },
         {
           "kind": "possession_start",
@@ -2968,7 +2973,7 @@
           "period": 3,
           "clock_seconds": 570,
           "team_id": 3,
-          "player_id": 203,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
@@ -2977,7 +2982,7 @@
           "period": 3,
           "clock_seconds": 570,
           "team_id": 3,
-          "player_id": 203,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
@@ -2992,25 +2997,18 @@
           "period": 3,
           "clock_seconds": 555,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 3,
           "clock_seconds": 555,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 102,
           "shot_type": "2pt",
           "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 555,
-          "team_id": 3,
-          "player_id": 204
         },
         {
           "kind": "possession_start",
@@ -3019,52 +3017,55 @@
           "team_id": 3
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 3,
           "clock_seconds": 540,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 540,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 525,
           "team_id": 3,
           "player_id": 205
         },
         {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 540,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
           "kind": "possession_start",
           "period": 3,
           "clock_seconds": 510,
@@ -3075,7 +3076,7 @@
           "period": 3,
           "clock_seconds": 510,
           "team_id": 3,
-          "player_id": 205,
+          "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
@@ -3084,7 +3085,7 @@
           "period": 3,
           "clock_seconds": 510,
           "team_id": 3,
-          "player_id": 205,
+          "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
@@ -3102,19 +3103,22 @@
           "team_id": 7
         },
         {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "steal",
+          "kind": "shot_attempt",
           "period": 3,
           "clock_seconds": 495,
           "team_id": 7,
           "player_id": 101,
-          "defender_id": 201
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 495,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
           "kind": "possession_start",
@@ -3126,78 +3130,134 @@
           "kind": "shot_attempt",
           "period": 3,
           "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 465,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 450,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 450,
           "team_id": 3,
           "player_id": 203,
-          "shot_type": "2pt",
+          "shot_type": "3pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 3,
-          "clock_seconds": 450,
+          "clock_seconds": 480,
           "team_id": 3,
           "player_id": 203,
-          "shot_type": "2pt",
+          "shot_type": "3pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 3,
-          "clock_seconds": 450,
+          "clock_seconds": 480,
           "team_id": 7,
           "player_id": 101
         },
         {
           "kind": "possession_start",
           "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 103,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 450,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 450,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 450,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
           "clock_seconds": 435,
           "team_id": 7
         },
@@ -3206,7 +3266,7 @@
           "period": 3,
           "clock_seconds": 435,
           "team_id": 7,
-          "player_id": 103,
+          "player_id": 105,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
@@ -3215,16 +3275,24 @@
           "period": 3,
           "clock_seconds": 435,
           "team_id": 7,
-          "player_id": 103,
+          "player_id": 105,
           "shot_type": "2pt",
           "shot_origin": "initial"
+        },
+        {
+          "kind": "block",
+          "period": 3,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 105,
+          "defender_id": 201
         },
         {
           "kind": "rebound",
           "period": 3,
           "clock_seconds": 435,
           "team_id": 3,
-          "player_id": 205
+          "player_id": 202
         },
         {
           "kind": "possession_start",
@@ -3237,9 +3305,35 @@
           "period": 3,
           "clock_seconds": 420,
           "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 420,
+          "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
-          "shot_origin": "transition"
+          "shot_origin": "oreb_continuation"
         },
         {
           "kind": "shot_make",
@@ -3248,7 +3342,7 @@
           "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
-          "shot_origin": "transition"
+          "shot_origin": "oreb_continuation"
         },
         {
           "kind": "possession_start",
@@ -3257,29 +3351,19 @@
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
+          "kind": "turnover",
           "period": 3,
           "clock_seconds": 405,
           "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
+          "player_id": 101
         },
         {
-          "kind": "shot_miss",
+          "kind": "steal",
           "period": 3,
           "clock_seconds": 405,
           "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 405,
-          "team_id": 3,
-          "player_id": 202
+          "player_id": 101,
+          "defender_id": 205
         },
         {
           "kind": "possession_start",
@@ -3288,19 +3372,22 @@
           "team_id": 3
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 3,
           "clock_seconds": 390,
           "team_id": 3,
-          "player_id": 202
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
-          "kind": "steal",
+          "kind": "shot_make",
           "period": 3,
           "clock_seconds": 390,
           "team_id": 3,
-          "player_id": 202,
-          "defender_id": 104
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
           "kind": "possession_start",
@@ -3321,7 +3408,7 @@
           "clock_seconds": 375,
           "team_id": 7,
           "player_id": 104,
-          "defender_id": 204
+          "defender_id": 202
         },
         {
           "kind": "possession_start",
@@ -3334,32 +3421,155 @@
           "period": 3,
           "clock_seconds": 360,
           "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 360,
+          "team_id": 3,
           "player_id": 204,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 205,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 315,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 315,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 315,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 300,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_make",
           "period": 3,
-          "clock_seconds": 360,
+          "clock_seconds": 300,
           "team_id": 3,
-          "player_id": 204,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "foul",
           "period": 3,
-          "clock_seconds": 360,
+          "clock_seconds": 300,
           "team_id": 7,
-          "player_id": 102
+          "player_id": 103
         },
         {
           "kind": "free_throw",
           "period": 3,
-          "clock_seconds": 360,
+          "clock_seconds": 300,
           "team_id": 3,
-          "player_id": 204,
+          "player_id": 203,
           "shot_type": "ft",
           "ft_attempts": 1,
           "ft_made": 1
@@ -3367,222 +3577,123 @@
         {
           "kind": "possession_start",
           "period": 3,
-          "clock_seconds": 345,
+          "clock_seconds": 285,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 3,
-          "clock_seconds": 345,
+          "clock_seconds": 285,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
+          "player_id": 105,
+          "shot_type": "3pt",
           "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 103,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
         },
         {
           "kind": "shot_make",
           "period": 3,
-          "clock_seconds": 345,
+          "clock_seconds": 285,
           "team_id": 7,
-          "player_id": 101,
+          "player_id": 103,
           "shot_type": "2pt",
-          "shot_origin": "initial"
+          "shot_origin": "oreb_continuation"
         },
         {
           "kind": "possession_start",
           "period": 3,
-          "clock_seconds": 330,
+          "clock_seconds": 270,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 3,
-          "clock_seconds": 330,
+          "clock_seconds": 270,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 3,
-          "clock_seconds": 330,
+          "clock_seconds": 270,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
           "kind": "rebound",
           "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 101,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 201,
           "offensive_rebound": true
         },
         {
           "kind": "shot_attempt",
           "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 101,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "oreb_continuation"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 101,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "oreb_continuation"
         },
         {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 104,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 104,
-          "defender_id": 201
-        },
-        {
           "kind": "possession_start",
           "period": 3,
-          "clock_seconds": 300,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 300,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 285,
+          "clock_seconds": 255,
           "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 3,
-          "clock_seconds": 285,
+          "clock_seconds": 255,
           "team_id": 7,
           "player_id": 105
         },
         {
           "kind": "steal",
           "period": 3,
-          "clock_seconds": 285,
+          "clock_seconds": 255,
           "team_id": 7,
           "player_id": 105,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 270,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 255,
-          "team_id": 7
-        },
-        {
-          "kind": "foul",
-          "period": 3,
-          "clock_seconds": 255,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "free_throw",
-          "period": 3,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 1
+          "defender_id": 205
         },
         {
           "kind": "possession_start",
@@ -3594,118 +3705,95 @@
           "kind": "shot_attempt",
           "period": 3,
           "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 103,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 104,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 104,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 210,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 210,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 3,
-          "clock_seconds": 210,
+          "clock_seconds": 240,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 203,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 225,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 210,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
           "kind": "possession_start",
           "period": 3,
           "clock_seconds": 195,
@@ -3716,445 +3804,398 @@
           "period": 3,
           "clock_seconds": 195,
           "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 180,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 180,
-          "team_id": 3,
-          "player_id": 203,
+          "player_id": 103,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 3,
-          "clock_seconds": 180,
-          "team_id": 3,
-          "player_id": 203,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 103,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 3,
-          "clock_seconds": 180,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 165,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 165,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 165,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 150,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 150,
+          "clock_seconds": 195,
           "team_id": 3,
           "player_id": 202
         },
         {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 202,
-          "defender_id": 102
-        },
-        {
           "kind": "possession_start",
           "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 135,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 120,
+          "clock_seconds": 180,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 3,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 120,
+          "clock_seconds": 180,
           "team_id": 3,
           "player_id": 204,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 120,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 105,
-          "team_id": 7
-        },
-        {
-          "kind": "foul",
-          "period": 3,
-          "clock_seconds": 105,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "free_throw",
-          "period": 3,
-          "clock_seconds": 105,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 2
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 90,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 90,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
+          "shot_type": "3pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_make",
           "period": 3,
-          "clock_seconds": 90,
+          "clock_seconds": 180,
           "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 75,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 101,
+          "player_id": 204,
           "shot_type": "3pt",
           "shot_origin": "initial"
         },
         {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 104,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 75,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
           "kind": "possession_start",
           "period": 3,
-          "clock_seconds": 60,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 60,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 60,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 60,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 45,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 45,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 30,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 15,
+          "clock_seconds": 165,
           "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 3,
-          "clock_seconds": 15,
+          "clock_seconds": 165,
           "team_id": 7,
-          "player_id": 104
+          "player_id": 101
         },
         {
           "kind": "steal",
           "period": 3,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 101,
+          "defender_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 150,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 201,
+          "defender_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 90,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 90,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 75,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 75,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 30,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 30,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 30,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 105
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 15,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
           "clock_seconds": 15,
           "team_id": 7,
-          "player_id": 104,
-          "defender_id": 205
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 15,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 15,
+          "team_id": 3,
+          "player_id": 202
         },
         {
           "kind": "period_boundary",
@@ -4168,368 +4209,40 @@
           "team_id": 3
         },
         {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
+          "kind": "shot_attempt",
           "period": 4,
           "clock_seconds": 720,
           "team_id": 3,
           "player_id": 205,
-          "defender_id": 103
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 705,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 705,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 705,
-          "team_id": 7,
-          "player_id": 104,
-          "defender_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 690,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 690,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 675,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 105
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 105,
-          "defender_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 660,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 203,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 203,
-          "defender_id": 103
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 645,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 103,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 103,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 205,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 630,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 630,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 630,
-          "team_id": 3,
-          "player_id": 203,
-          "defender_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 615,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 615,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 600,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 600,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 600,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 600,
-          "team_id": 7,
-          "player_id": 105
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 585,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 585,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 585,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 585,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 570,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 570,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 570,
-          "team_id": 3,
-          "player_id": 203,
-          "defender_id": 103
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 555,
+          "clock_seconds": 705,
           "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 555,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 555,
-          "team_id": 7,
-          "player_id": 102,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 540,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 540,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 540,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 540,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 525,
+          "clock_seconds": 705,
           "team_id": 7,
           "player_id": 105
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 525,
+          "clock_seconds": 705,
           "team_id": 7,
           "player_id": 105,
           "defender_id": 202
@@ -4537,819 +4250,67 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 510,
+          "clock_seconds": 690,
           "team_id": 3
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 510,
+          "clock_seconds": 690,
           "team_id": 3,
           "player_id": 205
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 510,
+          "clock_seconds": 690,
           "team_id": 3,
           "player_id": 205,
-          "defender_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 495,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 101,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 480,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 465,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "foul",
-          "period": 4,
-          "clock_seconds": 465,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "free_throw",
-          "period": 4,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "ft",
-          "ft_attempts": 2
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 450,
-          "team_id": 3
-        },
-        {
-          "kind": "foul",
-          "period": 4,
-          "clock_seconds": 450,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "free_throw",
-          "period": 4,
-          "clock_seconds": 450,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 2
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 435,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 420,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 203,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 203,
-          "defender_id": 105
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 405,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 405,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 405,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 390,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 390,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 390,
-          "team_id": 3,
-          "player_id": 201,
-          "defender_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 375,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 102,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 360,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 203,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 203,
           "defender_id": 101
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 345,
+          "clock_seconds": 675,
           "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 103,
+          "offensive_rebound": true
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 104,
-          "defender_id": 205
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "foul",
-          "period": 4,
-          "clock_seconds": 330,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "free_throw",
-          "period": 4,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 2
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 315,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 105,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 103,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 300,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "block",
-          "period": 4,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 202,
-          "defender_id": 105
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 300,
-          "team_id": 7,
-          "player_id": 105
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 285,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 285,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 285,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 270,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 255,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 240,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 225,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 210,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 195,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 195,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 180,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 180,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 180,
-          "team_id": 3,
-          "player_id": 203,
-          "defender_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 165,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 165,
-          "team_id": 7,
-          "player_id": 105
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 165,
-          "team_id": 7,
-          "player_id": 105,
-          "defender_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 150,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 4,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 135,
+          "clock_seconds": 675,
           "team_id": 7,
           "player_id": 103
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 135,
+          "clock_seconds": 675,
           "team_id": 7,
           "player_id": 103,
           "defender_id": 203
@@ -5357,6 +4318,1000 @@
         {
           "kind": "possession_start",
           "period": 4,
+          "clock_seconds": 660,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 645,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 103,
+          "defender_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 630,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 630,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 630,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 630,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 615,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 615,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 615,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 615,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 600,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 600,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 600,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 600,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 585,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 585,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 585,
+          "team_id": 7,
+          "player_id": 103,
+          "defender_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 570,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 570,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 570,
+          "team_id": 3,
+          "player_id": 202,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 555,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 555,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 555,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 555,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 540,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 540,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 540,
+          "team_id": 3,
+          "player_id": 205,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 105,
+          "defender_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 510,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 510,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 510,
+          "team_id": 3,
+          "player_id": 201,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 495,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 495,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 495,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 480,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "foul",
+          "period": 4,
+          "clock_seconds": 480,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "free_throw",
+          "period": 4,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "ft",
+          "ft_attempts": 2
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 465,
+          "team_id": 7
+        },
+        {
+          "kind": "foul",
+          "period": 4,
+          "clock_seconds": 465,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 4,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "ft",
+          "ft_attempts": 2,
+          "ft_made": 2
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 450,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 450,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 450,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 435,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 103,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 103,
+          "defender_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 420,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 405,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 405,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 405,
+          "team_id": 7,
+          "player_id": 101,
+          "defender_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 390,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 375,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 375,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 375,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 375,
+          "team_id": 7,
+          "player_id": 103,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 375,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 375,
+          "team_id": 7,
+          "player_id": 103,
+          "defender_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 360,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 105
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 345,
+          "team_id": 7
+        },
+        {
+          "kind": "foul",
+          "period": 4,
+          "clock_seconds": 345,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 4,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "ft",
+          "ft_attempts": 2,
+          "ft_made": 2
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 315,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 315,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 315,
+          "team_id": 7,
+          "player_id": 102,
+          "defender_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 300,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 285,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 285,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 270,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 255,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 102,
+          "defender_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 240,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 240,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 225,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 102,
+          "defender_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 210,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 195,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 180,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 165,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 203,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 105,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 105,
+          "defender_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
           "clock_seconds": 120,
           "team_id": 3
         },
@@ -5364,6 +5319,51 @@
           "kind": "shot_attempt",
           "period": 4,
           "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 105,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 103,
+          "defender_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 90,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 90,
           "team_id": 3,
           "player_id": 205,
           "shot_type": "3pt",
@@ -5372,7 +5372,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 120,
+          "clock_seconds": 90,
           "team_id": 3,
           "player_id": 205,
           "shot_type": "3pt",
@@ -5381,13 +5381,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 75,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 75,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt",
@@ -5396,7 +5396,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 75,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt",
@@ -5405,20 +5405,20 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 75,
           "team_id": 3,
           "player_id": 202
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 90,
+          "clock_seconds": 60,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 90,
+          "clock_seconds": 60,
           "team_id": 3,
           "player_id": 204,
           "shot_type": "2pt",
@@ -5427,7 +5427,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 90,
+          "clock_seconds": 60,
           "team_id": 3,
           "player_id": 204,
           "shot_type": "2pt",
@@ -5436,27 +5436,27 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 90,
+          "clock_seconds": 60,
           "team_id": 7,
           "player_id": 101
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 75,
+          "clock_seconds": 45,
           "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 75,
+          "clock_seconds": 45,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 75,
+          "clock_seconds": 45,
           "team_id": 7,
           "player_id": 102,
           "defender_id": 205
@@ -5464,20 +5464,20 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 60,
+          "clock_seconds": 30,
           "team_id": 3
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 60,
+          "clock_seconds": 30,
           "team_id": 3,
           "player_id": 203
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 60,
+          "clock_seconds": 30,
           "team_id": 3,
           "player_id": 203,
           "defender_id": 105
@@ -5485,84 +5485,6 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 45,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 45,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 30,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 205,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
           "clock_seconds": 15,
           "team_id": 7
         },
@@ -5572,17 +5494,24 @@
           "clock_seconds": 15,
           "team_id": 7,
           "player_id": 104,
-          "shot_type": "3pt",
+          "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 15,
           "team_id": 7,
           "player_id": 104,
-          "shot_type": "3pt",
+          "shot_type": "2pt",
           "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 15,
+          "team_id": 3,
+          "player_id": 205
         },
         {
           "kind": "period_boundary",
@@ -5595,71 +5524,71 @@
           "pid": 101,
           "pos": "PG",
           "gameMIN": 48,
-          "game2GM": 4,
-          "game2GA": 11,
+          "game2GM": 3,
+          "game2GA": 8,
           "gameFTM": 4,
-          "gameFTA": 6,
+          "gameFTA": 4,
           "game3GM": 1,
-          "game3GA": 5,
-          "gameORB": 2,
-          "gameDRB": 3,
+          "game3GA": 4,
+          "gameORB": 0,
+          "gameDRB": 4,
           "gameAST": 0,
-          "gameSTL": 8,
-          "gameTOV": 5,
+          "gameSTL": 7,
+          "gameTOV": 6,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 3
         },
         {
           "pid": 102,
           "pos": "SG",
           "gameMIN": 48,
           "game2GM": 5,
-          "game2GA": 17,
-          "gameFTM": 1,
+          "game2GA": 11,
+          "gameFTM": 2,
           "gameFTA": 2,
-          "game3GM": 1,
-          "game3GA": 3,
+          "game3GM": 0,
+          "game3GA": 2,
           "gameORB": 3,
           "gameDRB": 4,
           "gameAST": 0,
-          "gameSTL": 4,
-          "gameTOV": 4,
-          "gameBLK": 1,
-          "gamePF": 4
+          "gameSTL": 7,
+          "gameTOV": 7,
+          "gameBLK": 0,
+          "gamePF": 1
         },
         {
           "pid": 103,
           "pos": "SF",
           "gameMIN": 48,
-          "game2GM": 11,
+          "game2GM": 9,
           "game2GA": 18,
           "gameFTM": 1,
-          "gameFTA": 4,
-          "game3GM": 0,
-          "game3GA": 0,
-          "gameORB": 6,
-          "gameDRB": 2,
+          "gameFTA": 2,
+          "game3GM": 1,
+          "game3GA": 1,
+          "gameORB": 7,
+          "gameDRB": 5,
           "gameAST": 0,
-          "gameSTL": 7,
-          "gameTOV": 2,
+          "gameSTL": 2,
+          "gameTOV": 8,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 2
         },
         {
           "pid": 104,
           "pos": "PF",
           "gameMIN": 48,
           "game2GM": 6,
-          "game2GA": 11,
+          "game2GA": 12,
           "gameFTM": 0,
           "gameFTA": 0,
-          "game3GM": 2,
-          "game3GA": 2,
-          "gameORB": 5,
-          "gameDRB": 5,
+          "game3GM": 1,
+          "game3GA": 1,
+          "gameORB": 0,
+          "gameDRB": 2,
           "gameAST": 0,
-          "gameSTL": 10,
-          "gameTOV": 9,
+          "gameSTL": 5,
+          "gameTOV": 3,
           "gameBLK": 0,
           "gamePF": 2
         },
@@ -5667,19 +5596,19 @@
           "pid": 105,
           "pos": "C",
           "gameMIN": 48,
-          "game2GM": 5,
-          "game2GA": 11,
-          "gameFTM": 1,
-          "gameFTA": 2,
-          "game3GM": 2,
-          "game3GA": 2,
-          "gameORB": 1,
-          "gameDRB": 3,
+          "game2GM": 6,
+          "game2GA": 13,
+          "gameFTM": 0,
+          "gameFTA": 0,
+          "game3GM": 1,
+          "game3GA": 3,
+          "gameORB": 2,
+          "gameDRB": 1,
           "gameAST": 0,
-          "gameSTL": 2,
-          "gameTOV": 6,
-          "gameBLK": 1,
-          "gamePF": 0
+          "gameSTL": 3,
+          "gameTOV": 7,
+          "gameBLK": 0,
+          "gamePF": 1
         },
         {
           "pid": 106,
@@ -5703,71 +5632,71 @@
           "pid": 201,
           "pos": "PG",
           "gameMIN": 48,
-          "game2GM": 7,
-          "game2GA": 10,
-          "gameFTM": 3,
+          "game2GM": 8,
+          "game2GA": 12,
+          "gameFTM": 1,
           "gameFTA": 4,
           "game3GM": 0,
           "game3GA": 2,
-          "gameORB": 1,
-          "gameDRB": 2,
+          "gameORB": 4,
+          "gameDRB": 3,
           "gameAST": 0,
-          "gameSTL": 4,
+          "gameSTL": 3,
           "gameTOV": 6,
-          "gameBLK": 0,
-          "gamePF": 3
+          "gameBLK": 1,
+          "gamePF": 1
         },
         {
           "pid": 202,
           "pos": "SG",
           "gameMIN": 48,
-          "game2GM": 5,
-          "game2GA": 9,
-          "gameFTM": 2,
+          "game2GM": 6,
+          "game2GA": 17,
+          "gameFTM": 1,
           "gameFTA": 2,
-          "game3GM": 0,
+          "game3GM": 2,
           "game3GA": 4,
-          "gameORB": 2,
-          "gameDRB": 5,
+          "gameORB": 4,
+          "gameDRB": 8,
           "gameAST": 0,
-          "gameSTL": 8,
-          "gameTOV": 5,
-          "gameBLK": 0,
-          "gamePF": 1
+          "gameSTL": 7,
+          "gameTOV": 3,
+          "gameBLK": 1,
+          "gamePF": 3
         },
         {
           "pid": 203,
           "pos": "SF",
           "gameMIN": 48,
-          "game2GM": 10,
-          "game2GA": 14,
+          "game2GM": 14,
+          "game2GA": 18,
           "gameFTM": 3,
-          "gameFTA": 5,
-          "game3GM": 0,
-          "game3GA": 0,
-          "gameORB": 3,
-          "gameDRB": 6,
+          "gameFTA": 6,
+          "game3GM": 1,
+          "game3GA": 3,
+          "gameORB": 4,
+          "gameDRB": 3,
           "gameAST": 0,
-          "gameSTL": 4,
-          "gameTOV": 9,
+          "gameSTL": 9,
+          "gameTOV": 2,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 0
         },
         {
           "pid": 204,
           "pos": "PF",
           "gameMIN": 48,
-          "game2GM": 8,
-          "game2GA": 15,
-          "gameFTM": 3,
-          "gameFTA": 3,
-          "game3GM": 0,
-          "game3GA": 0,
+          "game2GM": 5,
+          "game2GA": 8,
+          "gameFTM": 2,
+          "gameFTA": 2,
+          "game3GM": 1,
+          "game3GA": 1,
           "gameORB": 3,
-          "gameDRB": 6,
+          "gameDRB": 8,
           "gameAST": 0,
-          "gameSTL": 5,
-          "gameTOV": 3,
+          "gameSTL": 6,
+          "gameTOV": 7,
           "gameBLK": 0,
           "gamePF": 0
         },
@@ -5775,19 +5704,19 @@
           "pid": 205,
           "pos": "C",
           "gameMIN": 48,
-          "game2GM": 9,
-          "game2GA": 13,
-          "gameFTM": 0,
-          "gameFTA": 0,
-          "game3GM": 3,
-          "game3GA": 5,
-          "gameORB": 4,
-          "gameDRB": 7,
+          "game2GM": 8,
+          "game2GA": 11,
+          "gameFTM": 1,
+          "gameFTA": 2,
+          "game3GM": 4,
+          "game3GA": 4,
+          "gameORB": 0,
+          "gameDRB": 6,
           "gameAST": 0,
-          "gameSTL": 5,
-          "gameTOV": 8,
-          "gameBLK": 1,
-          "gamePF": 2
+          "gameSTL": 6,
+          "gameTOV": 6,
+          "gameBLK": 0,
+          "gamePF": 0
         }
       ],
       "team_boxes": [
@@ -5796,44 +5725,44 @@
           "is_home": false,
           "q1": 27,
           "q2": 25,
-          "q3": 18,
-          "q4": 17,
+          "q3": 14,
+          "q4": 11,
           "ot": [],
-          "game2GM": 31,
-          "game2GA": 68,
+          "game2GM": 29,
+          "game2GA": 62,
           "gameFTM": 7,
-          "gameFTA": 14,
-          "game3GM": 6,
-          "game3GA": 12,
-          "gameORB": 17,
-          "gameDRB": 17,
+          "gameFTA": 8,
+          "game3GM": 4,
+          "game3GA": 11,
+          "gameORB": 12,
+          "gameDRB": 16,
           "gameAST": 0,
-          "gameSTL": 31,
-          "gameTOV": 26,
-          "gameBLK": 2,
-          "gamePF": 8
+          "gameSTL": 24,
+          "gameTOV": 31,
+          "gameBLK": 0,
+          "gamePF": 9
         },
         {
           "team_id": 3,
           "is_home": true,
           "q1": 33,
-          "q2": 25,
-          "q3": 23,
-          "q4": 17,
+          "q2": 28,
+          "q3": 30,
+          "q4": 23,
           "ot": [],
-          "game2GM": 39,
-          "game2GA": 61,
-          "gameFTM": 11,
-          "gameFTA": 14,
-          "game3GM": 3,
-          "game3GA": 11,
-          "gameORB": 13,
-          "gameDRB": 26,
+          "game2GM": 41,
+          "game2GA": 66,
+          "gameFTM": 8,
+          "gameFTA": 16,
+          "game3GM": 8,
+          "game3GA": 14,
+          "gameORB": 15,
+          "gameDRB": 28,
           "gameAST": 0,
-          "gameSTL": 26,
-          "gameTOV": 31,
-          "gameBLK": 1,
-          "gamePF": 7
+          "gameSTL": 31,
+          "gameTOV": 24,
+          "gameBLK": 2,
+          "gamePF": 4
         }
       ]
     }

--- a/engine/internal/sim/transition.go
+++ b/engine/internal/sim/transition.go
@@ -9,10 +9,9 @@ import (
 const (
 	// transitionTriggerDenom is the Stage-2 trigger roll domain: a random on-court
 	// starter fires the break iff rand_int(1..transitionTriggerDenom) ≤ its
-	// TransOff rating (00_MASTER_REFERENCE.md L878-896). The denom (20) sits above
-	// the 1-9 TransOff scale so a max roll never fires for a real rating; it stands
-	// in for the unpinned coaching-mod threshold. Documented stand-in.
-	transitionTriggerDenom = 20
+	// TransOff rating (00_MASTER_REFERENCE.md L878-896). Asm-pinned jumpshot 5.60
+	// value (push 0x12 before the rand_int call) — 18.
+	transitionTriggerDenom = 18
 
 	// transitionShotRateDecay / transitionShotRateFloor implement the Stage-3
 	// per-period decay (L912): the team shot-rate threshold drops by 2.0 on each


### PR DESCRIPTION
## Summary

- Replaces the documented stand-in `transitionTriggerDenom = 20` with the asm-pinned value **18** (`push 0x12` before the `rand_int` call in jumpshot 5.60, `00_MASTER_REFERENCE.md` L878–896)
- Updates the golden snapshot to reflect the new denom

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.