### PR TITLE
chore(jsb): J9 faithful league-baseline port — compute 2PA/48 from raw .plr records (ADR-0085)

### DIFF
--- a/engine/internal/backup/assemble.go
+++ b/engine/internal/backup/assemble.go
@@ -23,6 +23,48 @@ const (
 	teamASTRateBase = 44.0
 )
 
+// leagueShotBaselineMaxRecordIndex is the FUN_004385f0 league-table scan
+// boundary: JSB 5.60 computes the league 2PA/48 baseline over .plr file
+// RECORDS 1-959 only, at league-select time — records 960+ (which hold
+// hundreds more named players on a full IBL5.plr) are outside that scan and
+// must never leak into the sum (see jsb-native/re-artifacts/jsb-J9-baseline-
+// pin-20260712.md, exact-reproduction pin 19.78050919336985, n=376).
+const leagueShotBaselineMaxRecordIndex = 959
+
+// computeLeagueShotBaseline is the faithful FUN_004385f0 league-table port
+// for the CEngine+0x6638 row: the league's 2-point attempts per 48 player-
+// minutes, (Σ2PA / ΣMIN) × 48 over qualifying RAW .plr records — deliberately
+// NOT over the assembled bundle player list, which is a different (and
+// larger) population. A record qualifies when its RecordIndex is within the
+// scan (≤ leagueShotBaselineMaxRecordIndex), it carries a non-empty Name, and
+// RealLifeMIN > 2×RealLifeGP (the decompile's inclusion gate). 2PA = FGA −
+// 3GA, since RealLifeFGA is the combined FG-attempts total. The ratio is of
+// ACCUMULATED SUMS, never a mean of per-player rates (write loop,
+// jsb560_decompiled.c:27124-27175). An empty qualifying population (e.g. a
+// synthetic/short test roster, or degenerate ΣMIN/Σ2PA) returns 0 — the
+// engine-side documented constant fallback lives in sim/shotdecision.go
+// (leagueBaselineFallback) and applies when it reads a zero
+// bundle.LeagueShotBaseline (sim/state.go shotBaselineOrFallback), never here.
+func computeLeagueShotBaseline(players []PlrPlayer) float64 {
+	var sum2PA, sumMIN float64
+	for _, p := range players {
+		if p.RecordIndex > leagueShotBaselineMaxRecordIndex {
+			continue
+		}
+		if p.Name == "" {
+			continue
+		}
+		if p.RealLifeMIN > 2*p.RealLifeGP {
+			sum2PA += float64(p.RealLifeFGA - p.RealLife3GA)
+			sumMIN += float64(p.RealLifeMIN)
+		}
+	}
+	if sumMIN <= 0 || sum2PA <= 0 {
+		return 0
+	}
+	return sum2PA / sumMIN * 48.0
+}
+
 // AssembleOptions carries the bundle-level metadata the backup files do not
 // themselves provide. The .sch has no game type, so the caller supplies one;
 // the zero value defaults to a regular-season game.
@@ -133,11 +175,12 @@ func ToBundle(players []PlrPlayer, sched []SchGame, opts AssembleOptions) (bundl
 	}
 
 	return bundle.Bundle{
-		LeagueID: opts.LeagueID,
-		Seed:     opts.Seed,
-		Teams:    teams,
-		Players:  bundlePlayers,
-		Schedule: games,
+		LeagueID:           opts.LeagueID,
+		Seed:               opts.Seed,
+		Teams:              teams,
+		Players:            bundlePlayers,
+		Schedule:           games,
+		LeagueShotBaseline: computeLeagueShotBaseline(players),
 	}, nil
 }
 
@@ -174,10 +217,15 @@ func toBundlePlayer(p PlrPlayer, minutes map[int]int) bundle.Player {
 		BLK: p.RatingBLK,
 		// Foul: no .plr source -> 0.
 
-		// Real-life / previous-season sums -> the per-48-minute rate composite inputs.
+		// Real-life / previous-season sums -> the per-48-minute rate composite
+		// inputs. GP/3GA are ALSO read directly off the raw PlrPlayer records
+		// (not this bundle.Player copy) by computeLeagueShotBaseline above, which
+		// runs over a different, narrower population (RecordIndex ≤ 959 + name).
+		RealLifeGP:  p.RealLifeGP,
 		RealLifeMIN: p.RealLifeMIN,
 		RealLifeFGA: p.RealLifeFGA,
 		RealLifeFTA: p.RealLifeFTA,
+		RealLife3GA: p.RealLife3GA,
 		RealLifeORB: p.RealLifeORB,
 
 		Age:         p.Age,

--- a/engine/internal/backup/assemble_test.go
+++ b/engine/internal/backup/assemble_test.go
@@ -198,6 +198,135 @@ func TestToBundle_TeamRates(t *testing.T) {
 	}
 }
 
+// --- J9: faithful league 2PA/48 baseline (FUN_004385f0 port), over RAW .plr
+// records (RecordIndex-gated), NOT the assembled bundle player list ----------
+
+// mkBaselinePlr builds a minimal PlrPlayer carrying only the fields
+// computeLeagueShotBaseline reads: the raw-record scan gate (RecordIndex,
+// Name) and the real-life rate inputs (RealLifeGP/MIN/FGA/3GA).
+func mkBaselinePlr(recordIndex int, name string, gp, min, fga, tga int) PlrPlayer {
+	return PlrPlayer{
+		RecordIndex: recordIndex, Name: name,
+		RealLifeGP: gp, RealLifeMIN: min, RealLifeFGA: fga, RealLife3GA: tga,
+	}
+}
+
+// TestComputeLeagueShotBaseline pins the faithful computation on a synthetic
+// fixture: the RecordIndex ≤ 959 scan boundary (959 included, 960 excluded),
+// the non-empty-name gate, the MIN > 2×GP inclusion gate (strict >, so
+// MIN == 2×GP is excluded), the ratio-of-accumulated-sums arithmetic
+// (explicitly NOT the mean of per-player rates — the decompile write loop,
+// jsb560_decompiled.c:27124-27175, divides pre-accumulated sums), the
+// 2PA = FGA − 3GA subtraction, and the empty-population zero result (the
+// engine-side constant fallback is sim/shotdecision.go's concern, not this
+// function's — see TestShotBaselineOrFallback in the sim package).
+func TestComputeLeagueShotBaseline(t *testing.T) {
+	// Two qualifying players with DIFFERENT per-minute rates plus one gated-out
+	// player whose huge rate would poison the result if the gate leaked.
+	//   A: GP 70, MIN 2400 (> 140) — 2PA = 1000 − 200 = 800  → rate 16.0/48min
+	//   B: GP 80, MIN 1200 (> 160) — 2PA = 700 − 100  = 600  → rate 24.0/48min
+	//   C: GP 60, MIN 120 (NOT > 120 — boundary MIN == 2×GP fails a strict >),
+	//      2PA = 119 (would shift the sums if included)
+	base := []PlrPlayer{
+		mkBaselinePlr(1, "A", 70, 2400, 1000, 200),
+		mkBaselinePlr(2, "B", 80, 1200, 700, 100),
+		mkBaselinePlr(3, "C", 60, 120, 119, 0),
+	}
+
+	// Ratio of sums: (800+600)/(2400+1200) × 48 = 1400/3600 × 48 = 18.666…
+	want := 1400.0 / 3600.0 * 48.0
+	got := computeLeagueShotBaseline(base)
+	if math.Abs(got-want) > 1e-12 {
+		t.Errorf("computeLeagueShotBaseline = %v, want %v (ratio of sums)", got, want)
+	}
+	// Mean of per-player rates would be (16+24)/2 = 20.0 — must NOT match.
+	meanOfRates := (800.0/2400.0*48.0 + 600.0/1200.0*48.0) / 2.0
+	if math.Abs(got-meanOfRates) < 1e-9 {
+		t.Errorf("computeLeagueShotBaseline = %v equals the mean of per-player rates %v — must be the ratio of accumulated sums", got, meanOfRates)
+	}
+
+	// MIN==2×GP boundary gate: flipping C to qualifying (MIN 121 > 120) must
+	// change the result — proves the strict-> gate, not an off-by-one artifact.
+	incl := make([]PlrPlayer, len(base))
+	copy(incl, base)
+	incl[2] = mkBaselinePlr(3, "C", 60, 121, 119, 0)
+	if inc := computeLeagueShotBaseline(incl); math.Abs(inc-got) < 1e-9 {
+		t.Errorf("gate fixture too weak: including C (MIN 121 > 120) left the baseline at %v", inc)
+	}
+
+	// RecordIndex scan boundary: a record at 959 is IN the scan; the identical
+	// record at 960 is OUT — the FUN_004385f0 league-select loop bound.
+	at959 := append(append([]PlrPlayer{}, base...), mkBaselinePlr(959, "D", 70, 2400, 1000, 200))
+	at960 := append(append([]PlrPlayer{}, base...), mkBaselinePlr(960, "D", 70, 2400, 1000, 200))
+	got959 := computeLeagueShotBaseline(at959)
+	got960 := computeLeagueShotBaseline(at960)
+	if math.Abs(got959-got960) < 1e-9 {
+		t.Errorf("RecordIndex 959 vs 960 gave the same baseline (%v == %v) — scan boundary not enforced", got959, got960)
+	}
+	if math.Abs(got960-got) > 1e-9 {
+		t.Errorf("RecordIndex 960 leaked into the sum: got %v, want unchanged base %v", got960, got)
+	}
+	// (959 should differ from base since D is a qualifying additional record.)
+	if math.Abs(got959-got) < 1e-9 {
+		t.Error("RecordIndex 959 fixture too weak: record D did not affect the baseline")
+	}
+
+	// Empty-name gate: a record within the scan with no name is excluded even
+	// though its stats would otherwise qualify.
+	noName := append(append([]PlrPlayer{}, base...), mkBaselinePlr(4, "", 70, 2400, 1000, 200))
+	if got4 := computeLeagueShotBaseline(noName); math.Abs(got4-got) > 1e-9 {
+		t.Errorf("empty-name record leaked into the sum: got %v, want unchanged base %v", got4, got)
+	}
+
+	// Empty population → 0 (never leagueBaselineFallback — that constant is the
+	// sim package's concern, applied by shotBaselineOrFallback on a zero field).
+	if got := computeLeagueShotBaseline(nil); got != 0 {
+		t.Errorf("nil population baseline = %v, want 0", got)
+	}
+	allZero := []PlrPlayer{mkBaselinePlr(1, "E", 0, 0, 0, 0), mkBaselinePlr(2, "F", 0, 0, 0, 0)}
+	if got := computeLeagueShotBaseline(allZero); got != 0 {
+		t.Errorf("all-zero population baseline = %v, want 0", got)
+	}
+	// Qualifying minutes but zero attempts (degenerate Σ2PA) → 0, never a zero
+	// divisor downstream in shotValue2pt.
+	noShots := []PlrPlayer{mkBaselinePlr(1, "G", 10, 500, 0, 0)}
+	if got := computeLeagueShotBaseline(noShots); got != 0 {
+		t.Errorf("zero-attempt population baseline = %v, want 0", got)
+	}
+}
+
+// TestToBundle_LeagueShotBaseline confirms ToBundle wires computeLeagueShotBaseline's
+// result onto the assembled bundle's LeagueShotBaseline field — the end-to-end
+// path gameloop.go's gs.shotBaseline = b.LeagueShotBaseline depends on. teamRoster's
+// makePlayer sets no real-life sums, so an unwired roster assembles to the
+// empty-population zero (the sim-side fallback then applies via
+// shotBaselineOrFallback, not exercised here).
+func TestToBundle_LeagueShotBaseline(t *testing.T) {
+	players := append(teamRoster(1), teamRoster(2)...)
+	sched := []SchGame{{VisitorTeamID: 1, HomeTeamID: 2, Month: 11, Day: 2, Played: true}}
+
+	b, err := ToBundle(players, sched, AssembleOptions{})
+	if err != nil {
+		t.Fatalf("ToBundle: %v", err)
+	}
+	if b.LeagueShotBaseline != 0 {
+		t.Errorf("LeagueShotBaseline = %v, want 0 (no roster player has real-life sums wired)", b.LeagueShotBaseline)
+	}
+
+	roster := teamRoster(1)
+	roster[0].RecordIndex = 1
+	roster[0].RealLifeGP, roster[0].RealLifeMIN, roster[0].RealLifeFGA, roster[0].RealLife3GA = 70, 2400, 1000, 200
+	players2 := append(roster, teamRoster(2)...)
+	b2, err := ToBundle(players2, sched, AssembleOptions{})
+	if err != nil {
+		t.Fatalf("ToBundle: %v", err)
+	}
+	want := 800.0 / 2400.0 * 48.0
+	if math.Abs(b2.LeagueShotBaseline-want) > 1e-9 {
+		t.Errorf("LeagueShotBaseline = %v, want %v", b2.LeagueShotBaseline, want)
+	}
+}
+
 // Row #12: an unknown team and empty inputs are typed errors, not silent empty
 // bundles.
 func TestToBundle_Errors(t *testing.T) {

--- a/engine/internal/backup/plr.go
+++ b/engine/internal/backup/plr.go
@@ -80,9 +80,17 @@ const (
 	// here citing "offsets 88/92" was wrong: 88/92 are not the DRB/AST source; the
 	// faithful JSB team rate is (Σ_player season_DRB / Σ_player season_GP)×48 — see
 	// offSeasonGP and assemble.go.)
+	//
+	// offRealLifeGP and offRealLife3GA feed the league 2PA/48 shot baseline
+	// (assemble.go computeLeagueShotBaseline, the FUN_004385f0 league-table
+	// port, over raw RECORDS — RecordIndex ≤ 959, not the bundle player list):
+	// GP is the MIN > 2×GP inclusion gate, and 3GA isolates pure 2-point attempts
+	// (2PA = FGA_total − 3GA, since offRealLifeFGA is the combined total).
+	offRealLifeGP  = 52 // width 4 — games played (league-baseline inclusion gate)
 	offRealLifeMIN = 56 // width 4 — minutes played (the per-48 rate divisor)
 	offRealLifeFGA = 64 // width 4 — total FG attempts (D88)
 	offRealLifeFTA = 72 // width 4 — FT attempts (D70 per-player part)
+	offRealLife3GA = 80 // width 4 — 3pt attempts (subtracted from FGA for the 2PA/48 baseline)
 	offRealLifeORB = 84 // width 4 — offensive rebounds (DB8)
 
 	// Per-player IN-SEASON box-score totals (record-relative, width 4 each), the
@@ -164,6 +172,19 @@ type PlrPlayer struct {
 	Age     int
 	Peak    int
 
+	// RecordIndex is the 1-based position of this player's line in the raw .plr
+	// file (every CRLF-separated line counts, including short/padding rows and
+	// pid==0 team-summary rows that never become a PlrPlayer — the parse is
+	// sequential, so this is simply the loop position, NOT the roster-slot
+	// Ordinal above). It is the FUN_004385f0 league-table scan boundary: JSB
+	// 5.60 computes the league 2PA/48 baseline over records 1-959 ONLY (records
+	// 960+ hold hundreds more named players outside that scan). Ordinal
+	// happens to coincide with RecordIndex on some files but is a DIFFERENT
+	// concept (a roster slot the .plr text itself carries) and must not be
+	// used as the gate — see jsb-native/re-artifacts/jsb-J9-baseline-pin-
+	// 20260712.md.
+	RecordIndex int
+
 	Clutch        int
 	Consistency   int
 	Talent        int
@@ -181,9 +202,14 @@ type PlrPlayer struct {
 	// the 2pt-bucket composite reads ((stat/MIN)×48; RealLifeFGA is total FG attempts
 	// incl. 3PA). Zero MINUTES means no prior-season reference (e.g. a rookie); the
 	// engine falls back to the rating stand-in (sim/bucketweights.go twoPtBucketWeight).
+	// RealLifeGP (the MIN > 2×GP inclusion gate) and RealLife3GA (2PA = FGA − 3GA)
+	// feed the league 2PA/48 shot baseline (assemble.go computeLeagueShotBaseline),
+	// gated jointly with RecordIndex ≤ 959 and a non-empty Name.
+	RealLifeGP  int
 	RealLifeMIN int
 	RealLifeFGA int
 	RealLifeFTA int
+	RealLife3GA int
 	RealLifeORB int
 
 	// Per-player IN-SEASON box-score totals (offSeasonGP/DRB/AST), the Branch-B
@@ -251,7 +277,11 @@ func ReadPlr(r io.Reader) ([]PlrPlayer, error) {
 			continue // team-summary row (pid==0) or padding slot
 		}
 
-		p := PlrPlayer{Ordinal: ordinal, PID: pid, Name: decodeCP1252(plrSlice(line, offName, 32))}
+		// RecordIndex is the 1-based position of THIS line in the raw file (i is
+		// the index into every CRLF-separated line, including skipped short/
+		// padding/team-summary rows before it) — the FUN_004385f0 scan boundary,
+		// deliberately independent of Ordinal (see the PlrPlayer doc comment).
+		p := PlrPlayer{Ordinal: ordinal, PID: pid, RecordIndex: i + 1, Name: decodeCP1252(plrSlice(line, offName, 32))}
 		p.Pos = strings.TrimSpace(plrSlice(line, offPos, 2))
 
 		// Parse every numeric field; the first non-numeric one short-circuits.
@@ -266,8 +296,10 @@ func ReadPlr(r io.Reader) ([]PlrPlayer, error) {
 			{&p.CanPlayInGame, offCanPlayInGame, 1},
 			{&p.PGDepth, offPGDepth, 1}, {&p.SGDepth, offSGDepth, 1}, {&p.SFDepth, offSFDepth, 1},
 			{&p.PFDepth, offPFDepth, 1}, {&p.CDepth, offCDepth, 1},
+			{&p.RealLifeGP, offRealLifeGP, 4},
 			{&p.RealLifeMIN, offRealLifeMIN, 4}, {&p.RealLifeFGA, offRealLifeFGA, 4},
-			{&p.RealLifeFTA, offRealLifeFTA, 4}, {&p.RealLifeORB, offRealLifeORB, 4},
+			{&p.RealLifeFTA, offRealLifeFTA, 4}, {&p.RealLife3GA, offRealLife3GA, 4},
+			{&p.RealLifeORB, offRealLifeORB, 4},
 			{&p.SeasonGP, offSeasonGP, 4}, {&p.SeasonDRB, offSeasonDRB, 4},
 			{&p.SeasonAST, offSeasonAST, 4},
 			{&p.RatingFGA, offRating2GA, 3}, {&p.RatingFGP, offRating2GP, 3},

--- a/engine/internal/backup/plr_test.go
+++ b/engine/internal/backup/plr_test.go
@@ -197,6 +197,43 @@ func TestReadPlr_SeasonBadField(t *testing.T) {
 	}
 }
 
+// TestReadPlr_RecordIndex pins RecordIndex to the 1-based position of a
+// player's line in the RAW file — counting every CRLF-separated line,
+// including a too-short padding row and a pid==0 team-summary row that never
+// become a PlrPlayer — NOT the post-filter position among appended players
+// and NOT the Ordinal roster-slot field. This is the FUN_004385f0 league-
+// table scan boundary computeLeagueShotBaseline (assemble.go) gates on.
+func TestReadPlr_RecordIndex(t *testing.T) {
+	short := "   1 short line under two hundred bytes"                       // line 1: skipped, still a record
+	teamRow := newPlrRecord(0, 0, 1, 0, "", "", 0, 0, 0)                     // line 2: pid==0, skipped
+	r1 := newPlrRecord(999, 100, 1, 25, "First Real Player", "PG", 70, 5, 5) // line 3
+	r2 := newPlrRecord(1, 200, 1, 30, "Second Real Player", "SG", 60, 4, 4)  // line 4
+	data := short + "\r\n" + teamRow + "\r\n" + r1 + "\r\n" + r2 + "\r\n"
+
+	players, err := ReadPlr(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadPlr: %v", err)
+	}
+	if len(players) != 2 {
+		t.Fatalf("player count = %d, want 2", len(players))
+	}
+	// r1 is the 3rd raw line (short + teamRow precede it) -> RecordIndex 3,
+	// despite carrying Ordinal 999 -- the two must NOT be conflated.
+	if players[0].RecordIndex != 3 {
+		t.Errorf("player0 RecordIndex = %d, want 3 (short line + team row both count)", players[0].RecordIndex)
+	}
+	if players[0].Ordinal != 999 {
+		t.Errorf("player0 Ordinal = %d, want 999 (unchanged by RecordIndex)", players[0].Ordinal)
+	}
+	// r2 is the 4th raw line -> RecordIndex 4, despite carrying Ordinal 1.
+	if players[1].RecordIndex != 4 {
+		t.Errorf("player1 RecordIndex = %d, want 4", players[1].RecordIndex)
+	}
+	if players[1].Ordinal != 1 {
+		t.Errorf("player1 Ordinal = %d, want 1 (unchanged by RecordIndex)", players[1].Ordinal)
+	}
+}
+
 // Row 3: a non-numeric real-life field yields ErrBadField naming the offset
 // (boundary — the same guard every numeric field uses, now over the new block).
 func TestReadPlr_RealLifeBadField(t *testing.T) {

--- a/engine/internal/bundle/bundle.go
+++ b/engine/internal/bundle/bundle.go
@@ -106,9 +106,18 @@ type Player struct {
 	// zero MINUTES — a player with no prior-season reference, or a production bundle
 	// not yet wired — falls back to the rating stand-in (sim/bucketweights.go).
 	// RealLifeFGA is total FG attempts (incl. 3PA).
+	//
+	// RealLifeGP and RealLife3GA feed the league 2PA/48 shot baseline
+	// (sim/shotdecision.go leagueShotBaseline, the FUN_004385f0 league-table
+	// port): GP is the MIN > 2×GP inclusion gate; 3GA isolates pure 2-point
+	// attempts (2PA = RealLifeFGA − RealLife3GA). All-zero (a bundle builder
+	// that has not wired them) simply yields no qualifying players and the
+	// documented constant fallback.
+	RealLifeGP  int `json:"rl_gp"`
 	RealLifeMIN int `json:"rl_min"`
 	RealLifeFGA int `json:"rl_fga"`
 	RealLifeFTA int `json:"rl_fta"`
+	RealLife3GA int `json:"rl_3ga"`
 	RealLifeORB int `json:"rl_orb"`
 
 	// Attributes.
@@ -145,12 +154,24 @@ type Game struct {
 }
 
 // Bundle is the complete engine input for one sim run.
+//
+// LeagueShotBaseline is the league 2PA-per-48-player-minutes shot baseline
+// (CEngine+0x6638, the FUN_004385f0 league-table port — sim/shotdecision.go
+// shotValue2pt/shotValue3pt). It is assembled ONCE per snapshot from the raw
+// .plr records (backup.ToBundle's computeLeagueShotBaseline), NOT from the
+// bundle's player list: the qualifying population is .plr file records 1-959
+// with a non-empty name and RealLifeMIN > 2×RealLifeGP, which is narrower than
+// (and record-position-gated relative to) the assembled Players slice. A
+// bundle that has not wired this field (e.g. a hand-built test bundle) leaves
+// it 0, and the sim degrades to the documented constant fallback
+// (sim/state.go shotBaselineOrFallback) rather than dividing by zero.
 type Bundle struct {
-	LeagueID int      `json:"league_id"`
-	Seed     uint64   `json:"seed"`
-	Teams    []Team   `json:"teams"`
-	Players  []Player `json:"players"`
-	Schedule []Game   `json:"schedule"`
+	LeagueID           int      `json:"league_id"`
+	Seed               uint64   `json:"seed"`
+	Teams              []Team   `json:"teams"`
+	Players            []Player `json:"players"`
+	Schedule           []Game   `json:"schedule"`
+	LeagueShotBaseline float64  `json:"league_shot_baseline"`
 }
 
 // Validation errors surfaced at the contract boundary.

--- a/engine/internal/sim/bucketweights.go
+++ b/engine/internal/sim/bucketweights.go
@@ -15,11 +15,15 @@ import "github.com/a-jay85/IBL5/engine/internal/rng"
 //     is the dominant, field-goal-heavy path. Net-free (net lives only in
 //     shot_value, not the bucket — so the playoff ×1.25 multiplier never amplifies
 //     the bucket).
-//   - 3pt (threePtBucketWeight) = the 2pt composite × the player's 3pt propensity.
-//     JSB's +0xDB0 is DEAD (always 0) and 3pt is decided upstream in the ball-
-//     handler stage (COMPOSITE_DOUBLES_TRACE.md §RESOLUTION); the Go engine folds
-//     3pt into the play-outcome pick at the propensity rate — functionally
-//     equivalent, kept on the same O(10s) basis as 2pt so 3pt does not vanish.
+//   - 3pt (threePtBucketWeight) = the recovered +0xDB0 composite (FUN_004cfa50's
+//     stack-built player record; copied into the league record by FUN_00405970 —
+//     the same provenance chain as +0xDC8/+0xD70): the player's season 3GA/MIN×48,
+//     an f-projected per-48-minute three-point-attempt rate. LIVE, not dead: the J6
+//     RE session (2026-07-10) overturned COMPOSITE_DOUBLES_TRACE.md §RESOLUTION's
+//     "always 0" finding — FUN_004e1ba0's Σ(de0+db0+d90) play-outcome normalization
+//     reads it directly. Faithful when the bundle carries real-life minutes; falls
+//     back to the previous derived stand-in (2pt composite × 3pt propensity)
+//     otherwise — see threePtBucketWeight.
 //   - and-one (andOneBucketWeight) = matchup×0.25 + made-rate, floored to 0.03
 //     (the verbatim JSB floor, _DAT…→0.03). A small minority of plays, as in JSB.
 //   - foul (foulBucketWeight) = the faithful JSB 5.60 foul bucket with a symmetric
@@ -201,13 +205,29 @@ func twoPtBucketWeight(p onCourt) float64 {
 	return d88 - (d88/(d70+d88))*db8*makeShare
 }
 
-// threePtBucketWeight keeps the 3pt path on the same O(10s) basis as the 2pt
-// composite, scaled by the player's 3pt propensity. JSB's +0xDB0 is dead and 3pt
-// is gated upstream in the ball-handler stage; folding it into the play-outcome
-// pick at the propensity rate is functionally equivalent (COMPOSITE_DOUBLES_
-// TRACE.md §RESOLUTION). Scaling off the 2pt composite (rather than a fixed O(1)
-// constant) prevents 3pt attempts from vanishing now that 2pt is O(10s).
+// threePtBucketWeight is the recovered +0xDB0 composite (FUN_004cfa50's
+// stack-built player record; copied into the league record by FUN_00405970 — the
+// same provenance chain as +0xDC8/+0xD70): the player's season 3GA/MIN×48, an
+// f-projected per-48-minute three-point-attempt rate. LIVE, not dead: the J6 RE
+// session (2026-07-10) overturned COMPOSITE_DOUBLES_TRACE.md §RESOLUTION's "always
+// 0" finding — FUN_004e1ba0's Σ(de0+db0+d90) play-outcome normalization reads it
+// directly. When the bundle carries real-life minutes (RealLifeMIN > 0) the weight
+// is the FAITHFUL per48Min(RealLife3GA, RealLifeMIN) rate — a non-shooter correctly
+// gets a zero 3pt bucket, mirroring 5.60. Absent real-life minutes (rookie / unwired
+// production bundle) it falls back to the previous derived stand-in (2pt composite ×
+// 3pt propensity), preserved byte-for-byte for the no-reference case — the same
+// two-branch shape as twoPtBucketWeight.
+//
+// Legacy-serialized-bundle caveat: a bundle written before this port's rl_3ga field
+// existed deserializes RealLife3GA as 0 while RealLifeMIN > 0 carries over, zeroing
+// the 3pt bucket for that player. Acceptable: bundles are assembled fresh from .plr
+// at runtime rather than persisted across ports — the same caveat the J9
+// LeagueShotBaseline field (RealLifeFGA) already carries for an identical
+// field-addition case.
 func threePtBucketWeight(p onCourt) float64 {
+	if p.RealLifeMIN > 0 {
+		return per48Min(p.RealLife3GA, p.RealLifeMIN)
+	}
 	return twoPtBucketWeight(p) * threePtPropensity(p)
 }
 

--- a/engine/internal/sim/bucketweights_test.go
+++ b/engine/internal/sim/bucketweights_test.go
@@ -421,3 +421,57 @@ func TestBucketWeights_RealLifeZeroFGA(t *testing.T) {
 		t.Errorf("zero-FGA limit = %v, want 0 (d88)", got)
 	}
 }
+
+// --- J18 item 1: threePtBucketWeight faithful to the recovered +0xDB0 composite --
+
+// Row 12: with real-life minutes, threePtBucketWeight equals the faithful
+// per48Min(RealLife3GA, RealLifeMIN) rate directly — the recovered +0xDB0 composite
+// (FUN_004cfa50 stack-record store, copied by FUN_00405970), NOT the derived
+// 2pt-composite × propensity stand-in.
+func TestBucketWeights_RealLifeThreePt(t *testing.T) {
+	pl := mkPlayer(1, 3, slotPG, 48)
+	pl.RealLifeMIN = 2000
+	pl.RealLife3GA = 200 // per48Min(200, 2000) = 4.8
+	p := oc(slotPG, pl)
+
+	want := per48Min(200, 2000)
+	if got := threePtBucketWeight(p); math.Abs(got-want) > 1e-9 {
+		t.Errorf("threePtBucketWeight = %.6f, want faithful per48Min(RealLife3GA, RealLifeMIN) = %.6f", got, want)
+	}
+	if standin := twoPtBucketWeight(p) * threePtPropensity(p); math.Abs(want-standin) < 1e-9 {
+		t.Fatalf("test setup: faithful rate %.6f coincides with the derived stand-in %.6f — case does not discriminate", want, standin)
+	}
+}
+
+// Row 13 (boundary): RealLifeMIN>0 with RealLife3GA==0 (played real minutes, never
+// attempted a three) must yield an EXACT zero 3pt bucket — faithful to 5.60, which
+// gives a non-shooter a zero +0xDB0 weight, not a small propensity-derived residual.
+func TestBucketWeights_RealLifeThreePtZeroAttempts(t *testing.T) {
+	pl := mkPlayer(1, 3, slotPG, 48)
+	pl.RealLifeMIN, pl.RealLife3GA = 1800, 0
+	got := threePtBucketWeight(oc(slotPG, pl))
+
+	if got != 0 {
+		t.Errorf("non-shooter (RealLife3GA==0) 3pt bucket = %v, want exactly 0 (faithful to 5.60)", got)
+	}
+}
+
+// Row 14 (unchanged stand-in): with no real-life minutes (RealLifeMIN==0),
+// threePtBucketWeight still equals the previous derived stand-in — 2pt composite ×
+// 3pt propensity — byte-for-byte, the no-reference fallback this port preserves.
+func TestBucketWeights_ThreePtFallbackUnchanged(t *testing.T) {
+	p := oc(slotPG, mkPlayer(1, 3, slotPG, 48)) // RealLifeMIN==0 → fallback
+
+	want := twoPtBucketWeight(p) * threePtPropensity(p)
+	if got := threePtBucketWeight(p); math.Abs(got-want) > 1e-9 {
+		t.Errorf("fallback threePtBucketWeight = %.6f, want twoPtBucketWeight×threePtPropensity = %.6f", got, want)
+	}
+
+	// Sums present but MIN==0 → still the fallback (MIN gates the real path, same as
+	// twoPtBucketWeight's real-rate gate).
+	p2 := p
+	p2.RealLife3GA = 9999
+	if got := threePtBucketWeight(p2); math.Abs(got-want) > 1e-9 {
+		t.Errorf("MIN==0 with RealLife3GA set engaged the real path: got %.6f, want %.6f", got, want)
+	}
+}

--- a/engine/internal/sim/freeze.go
+++ b/engine/internal/sim/freeze.go
@@ -86,8 +86,9 @@ type FreezeConfig struct {
 //   - FoulWeight: mean foulBucketWeight output
 //   - MakeVal2pt: mean PRE-clutch shotValue2pt output (per-mille)
 //
-// The 3pt make-value is a team-invariant constant (shotValue3pt = leagueBaseline×1.5),
-// so it carries no cross-team variance and the Make arm freezes only the 2pt channel.
+// The 3pt make-value is team-invariant within a snapshot (shotValue3pt =
+// gs.shotBaseline×1.5, league-constant per bundle), so it carries no cross-team
+// variance and the Make arm freezes only the 2pt channel.
 type FreezeMeans struct {
 	OrebProb   float64
 	TurnProb   float64
@@ -380,7 +381,7 @@ func (gs *gameState) makeValue2pt(net float64, fgp int, origin result.ShotOrigin
 	// freeze against the NEW baseline. The UnfaithfulPutback escape hatch restores the
 	// old net-coupled value for the ADR-0055 OFF walk only. OriginInitial and
 	// OriginTransition are unchanged (transition putback faithfulness is OOS — ADR-0055).
-	v := shotValue2pt(net, fgp, false)
+	v := shotValue2pt(net, fgp, false, gs.shotBaselineOrFallback())
 	if origin == result.OriginOffReb && !gs.freeze.UnfaithfulPutback {
 		v = putbackValue2pt(fgp)
 	}

--- a/engine/internal/sim/freeze_test.go
+++ b/engine/internal/sim/freeze_test.go
@@ -184,7 +184,7 @@ func TestMakePutback_OriginScoped(t *testing.T) {
 	const fgp = 50
 	net := 5.0
 	live := shotValue2pt(net, fgp, false, leagueBaselineFallback) // initial/transition live value
-	putback := putbackValue2pt(fgp)       // faithful OriginOffReb live value (ADR-0055)
+	putback := putbackValue2pt(fgp)                               // faithful OriginOffReb live value (ADR-0055)
 	mean := 111.0
 
 	cases := []struct {

--- a/engine/internal/sim/freeze_test.go
+++ b/engine/internal/sim/freeze_test.go
@@ -42,7 +42,7 @@ func TestFreeze_SubstitutesAndAccumulates(t *testing.T) {
 	// wrapper's accumulated rounding exactly.
 	careless, pressure := 60.0, 100.0
 	wantTurn := stealTurnoverScale * careless * pressure // below the clamp
-	wantMake := shotValue2pt(5, 50, false)
+	wantMake := shotValue2pt(5, 50, false, leagueBaselineFallback)
 
 	if got := base.orebProb(100, 100); got != wantOreb {
 		t.Errorf("baseline orebProb = %v, want live %v", got, wantOreb)
@@ -81,7 +81,7 @@ func TestFreeze_NoCrossConfound(t *testing.T) {
 	liveOreb := gate1Probability(120, 80, 0) // gs.gateBaseline is 0 in these cases
 	careless, pressure := 60.0, 100.0
 	liveTurn := stealTurnoverScale * careless * pressure // runtime eval, below the clamp
-	liveMake := shotValue2pt(5, 50, false)
+	liveMake := shotValue2pt(5, 50, false, leagueBaselineFallback)
 	// Symmetric bucket: this single-defender/single-offense fixture drives the
 	// coupling factor negative (defQ from one defender sits far below the 5-man-
 	// normalized baseline), so foulBucketWeight redraws — seed each gs the same so
@@ -183,7 +183,7 @@ func TestFreeze_MisconfigErrors(t *testing.T) {
 func TestMakePutback_OriginScoped(t *testing.T) {
 	const fgp = 50
 	net := 5.0
-	live := shotValue2pt(net, fgp, false) // initial/transition live value
+	live := shotValue2pt(net, fgp, false, leagueBaselineFallback) // initial/transition live value
 	putback := putbackValue2pt(fgp)       // faithful OriginOffReb live value (ADR-0055)
 	mean := 111.0
 

--- a/engine/internal/sim/gameloop.go
+++ b/engine/internal/sim/gameloop.go
@@ -59,6 +59,13 @@ func simGameWith(b bundle.Bundle, g bundle.Game, r *rng.RNG, opts Options) (resu
 	} else {
 		gs.gateBaseline = leagueReboundBaseline(b)
 	}
+	// The shot baseline (league 2PA/48, CEngine+0x6638) is likewise league-
+	// constant: it is assembled ONCE per snapshot at bundle-build time, over
+	// raw .plr records 1-959 (backup.ToBundle's computeLeagueShotBaseline) —
+	// NOT over the bundle's player list, which is a different, larger
+	// population. A zero/unwired field (e.g. a hand-built test bundle) falls
+	// back to leagueBaselineFallback via shotBaselineOrFallback below.
+	gs.shotBaseline = b.LeagueShotBaseline
 
 	// One shared possession length per game: the average of the two teams' base
 	// times (factor 1.0). Each team's base_time now carries its offensive volume

--- a/engine/internal/sim/possession.go
+++ b/engine/internal/sim/possession.go
@@ -188,7 +188,7 @@ func possession(gs *gameState, offense, defense *teamState, periodIdx int, fbPen
 			}
 			return false // made shot
 		case outcome3pt:
-			if made, _ := gs.shotAttempt(offense, defense, bh, shotValue3pt(), result.ShotThree, origin, periodIdx); !made {
+			if made, _ := gs.shotAttempt(offense, defense, bh, shotValue3pt(gs.shotBaselineOrFallback()), result.ShotThree, origin, periodIdx); !made {
 				gs.creditBlock(offense, defense, bh, def)
 				if cont, next := gs.rebound(offense, defense, periodIdx); cont {
 					bh = next

--- a/engine/internal/sim/putbackfaithful_test.go
+++ b/engine/internal/sim/putbackfaithful_test.go
@@ -23,7 +23,7 @@ import (
 func TestPutbackFaithful_MakeValueOriginScoped(t *testing.T) {
 	const fgp = 50
 	net := 5.0
-	normal := shotValue2pt(net, fgp, false)
+	normal := shotValue2pt(net, fgp, false, leagueBaselineFallback)
 	putback := putbackValue2pt(fgp)
 	if putback == normal {
 		t.Fatalf("fixture too weak: putbackValue2pt(%d)=%v equals the normal value %v — cannot distinguish the forms", fgp, putback, normal)
@@ -56,7 +56,7 @@ func TestPutbackFaithful_MakeValueOriginScoped(t *testing.T) {
 func TestPutbackFaithful_HarvestUsesNewBaseline(t *testing.T) {
 	const fgp = 50
 	net := 5.0
-	normal := shotValue2pt(net, fgp, false)
+	normal := shotValue2pt(net, fgp, false, leagueBaselineFallback)
 	putback := putbackValue2pt(fgp)
 
 	accPut := &FreezeAccum{}
@@ -86,7 +86,7 @@ func TestPutbackFaithful_HarvestUsesNewBaseline(t *testing.T) {
 func TestPutbackFaithful_EscapeHatchRestoresMaster(t *testing.T) {
 	const fgp = 50
 	net := 5.0
-	normal := shotValue2pt(net, fgp, false)
+	normal := shotValue2pt(net, fgp, false, leagueBaselineFallback)
 
 	gs := &gameState{freeze: FreezeConfig{UnfaithfulPutback: true}}
 	if got := gs.makeValue2pt(net, fgp, result.OriginOffReb); got != normal {

--- a/engine/internal/sim/shotdecision.go
+++ b/engine/internal/sim/shotdecision.go
@@ -1,21 +1,46 @@
 package sim
 
-import "github.com/a-jay85/IBL5/engine/internal/rng"
+import (
+	"github.com/a-jay85/IBL5/engine/internal/rng"
+)
 
 // Make-value calibration constants. The decompile assembles shot_value on a
 // per-mille scale (the make roll compares it to rand_int(1,1000)) using
-// league_baseline (CEngine+0x6638, the historical league-wide 2P%) and per-player
-// per-game bases (player[+0xD64] 2pt, +0xD68 FT). None of those league/per-game
-// values exist before validation phase, so the engine derives them from the
-// bundle's FGP/FTP ratings and a named league baseline. fgpToPermille and
-// leagueBaseline were calibrated against the .sco archive (ADR-0045): 2pt% ≈ 49.8%
-// and 3pt% ≈ 37.2% (the JSB 3pt make = baseline×1.5, so leagueBaseline = sco 3pt%
-// × 666.7 ≈ 248). Documented validation-phase stand-ins, same class as
-// offVolumeScale / foulBucketScale.
+// league_baseline (CEngine+0x6638) and per-player per-game bases (player[+0xD64]
+// 2pt, +0xD68 FT).
+//
+// league_baseline's true identity is NOT a shooting percentage — it is the
+// league's 2-point attempts per 48 player-minutes: bucket 0 (ALL positions) of
+// the 6-double-per-stat table FUN_004385f0 writes at CEngine+0x6638, computed
+// as (Σ2PA / ΣMIN) × 48 over qualifying players (ratio of accumulated sums, not
+// a mean of per-player rates — see the write loop, jsb560_decompiled.c
+// :27124-27175, e.g. pdVar11[0xc] = (Σ2PA/ΣMIN)×_DAT_00669ed0 at :27131).
+// Qualifying players are .plr records 1-959 with MIN > 2×GP. Consumption sites
+// confirm the identity byte-for-byte: 2pt normal shot_value divides by
+// *(double*)(param_1+0x6638) at :93886-93887, and 3pt shot_value multiplies it
+// by 1.5 at :94025 — exactly the shotValue3pt() = leagueBaseline×1.5 form
+// below. (Prior comment here mislabeled it "the historical league-wide 2P%";
+// corrected 2026-07-12 per jsb-native/00_MASTER_REFERENCE.md and the J5
+// RE artifact's offset row-map — both pin +0x6638 as the 2PA/48 row, and the
+// true 2P%/FG% table lives at a different offset, +0x6698.)
+//
+// The baseline is now assembled ONCE per snapshot at bundle-build time
+// (backup.ToBundle's computeLeagueShotBaseline, over raw .plr records 1-959 —
+// NOT the bundle's player list, a different and larger population) and
+// carried on bundle.Bundle.LeagueShotBaseline; gameloop.go copies it onto
+// gameState.shotBaseline, read here via shotBaselineOrFallback (state.go).
+// leagueBaselineFallback is the documented fallback when a snapshot has no
+// qualifying records (e.g. a synthetic test bundle that never wired
+// LeagueShotBaseline): it is the prior .sco-calibrated stand-in (ADR-0045):
+// 2pt% ≈ 49.8% and 3pt% ≈ 37.2% (JSB 3pt make = baseline×1.5, so fallback =
+// sco 3pt% × 666.7 ≈ 248) — a different scale than the true ~19.78 (IBL5.plr)
+// 2PA/48 volume-rate value, since it was fit to reproduce output shooting-%,
+// not to be a faithful port of the raw attempt-rate. fgpToPermille shares
+// that calibration.
 const (
-	leagueBaseline = 250.0 // per-mille; 3pt make = baseline×1.5 = 375‰ (~37.5%, sco-implied)
-	fgpToPermille  = 9.4   // base 2pt make = FGP × this (calibrated to 2pt% ≈ 50%)
-	ftpToPermille  = 10.0  // FT make = FTP × this  (FTP 75 → 750‰)
+	leagueBaselineFallback = 250.0 // per-mille stand-in; 3pt make = fallback×1.5 = 375‰ (~37.5%, sco-implied)
+	fgpToPermille          = 9.4   // base 2pt make = FGP × this (calibrated to 2pt% ≈ 50%)
+	ftpToPermille          = 10.0  // FT make = FTP × this  (FTP 75 → 750‰)
 
 	netToShotValue   = 500.0 // _DAT_00669ef0 (0.5) × _DAT_0066ac40 (1000.0)
 	shotClock2ptMult = 1.3333333333
@@ -30,11 +55,12 @@ func base2pt(fgp int) float64 { return float64(fgp) * fgpToPermille }
 // shotValue2pt assembles the 2-point make value. Normal:
 // net × 500 / baseline + base_2pt. Shot clock: base_2pt × 1.3333 (the corrected
 // per-player +0xD60 form — a rushed look ignores the matchup net advantage).
-func shotValue2pt(net float64, fgp int, shotClock bool) float64 {
+// baseline is the per-snapshot league 2PA/48 (gameState.shotBaseline).
+func shotValue2pt(net float64, fgp int, shotClock bool, baseline float64) float64 {
 	if shotClock {
 		return base2pt(fgp) * shotClock2ptMult
 	}
-	return net*netToShotValue/leagueBaseline + base2pt(fgp)
+	return net*netToShotValue/baseline + base2pt(fgp)
 }
 
 // putbackValue2pt is the JSB 5.60 putback (OReb-continuation) 2pt make-value:
@@ -47,10 +73,11 @@ func putbackValue2pt(fgp int) float64 {
 	return base2pt(fgp) * shotClock2ptMult
 }
 
-// shotValue3pt is league-baseline × 1.5 — deliberately independent of net
-// advantage. ODPT ratings decide whether a 3pt is *attempted*, but once
-// attempted, make probability is identical for all players.
-func shotValue3pt() float64 { return leagueBaseline * 1.5 }
+// shotValue3pt is league-baseline × 1.5 (decompile :94025, ×_DAT_0066d388) —
+// deliberately independent of net advantage. ODPT ratings decide whether a 3pt
+// is *attempted*, but once attempted, make probability is identical for all
+// players. baseline is the per-snapshot league 2PA/48 (gameState.shotBaseline).
+func shotValue3pt(baseline float64) float64 { return baseline * 1.5 }
 
 // shotValueFT is the per-attempt free-throw value: the FTP rating, per-mille.
 func shotValueFT(ftp int) float64 { return float64(ftp) * ftpToPermille }

--- a/engine/internal/sim/shotdecision_test.go
+++ b/engine/internal/sim/shotdecision_test.go
@@ -11,18 +11,18 @@ import (
 
 func TestShotValue_Assembly(t *testing.T) {
 	// 2pt normal: net × 500 / baseline + FGP × 9
-	want2 := 2.0*netToShotValue/leagueBaseline + 50*fgpToPermille
-	if got := shotValue2pt(2.0, 50, false); math.Abs(got-want2) > 1e-9 {
+	want2 := 2.0*netToShotValue/leagueBaselineFallback + 50*fgpToPermille
+	if got := shotValue2pt(2.0, 50, false, leagueBaselineFallback); math.Abs(got-want2) > 1e-9 {
 		t.Errorf("2pt = %v, want %v", got, want2)
 	}
 	// 2pt shot clock: FGP × 9 × 1.3333 (ignores net)
 	wantSC := 50 * fgpToPermille * shotClock2ptMult
-	if got := shotValue2pt(999.0, 50, true); math.Abs(got-wantSC) > 1e-6 {
+	if got := shotValue2pt(999.0, 50, true, leagueBaselineFallback); math.Abs(got-wantSC) > 1e-6 {
 		t.Errorf("2pt shot-clock = %v, want %v", got, wantSC)
 	}
 	// 3pt: baseline × 1.5
-	if got := shotValue3pt(); math.Abs(got-leagueBaseline*1.5) > 1e-9 {
-		t.Errorf("3pt = %v, want %v", got, leagueBaseline*1.5)
+	if got := shotValue3pt(leagueBaselineFallback); math.Abs(got-leagueBaselineFallback*1.5) > 1e-9 {
+		t.Errorf("3pt = %v, want %v", got, leagueBaselineFallback*1.5)
 	}
 	// FT: FTP × 10
 	if got := shotValueFT(75); math.Abs(got-750) > 1e-9 {
@@ -48,20 +48,20 @@ func TestShotValue2pt_Calibration(t *testing.T) {
 	// make-value for an average shooter (FGP 47) with a small positive net sits in a
 	// realistic ~44–56% band — neither degenerate-low (the pre-0045 underfit) nor
 	// absurd-high.
-	if v := shotValue2pt(5, 47, false); v < 440 || v > 560 {
+	if v := shotValue2pt(5, 47, false, leagueBaselineFallback); v < 440 || v > 560 {
 		t.Errorf("avg-FGP 2pt make-value = %.1f‰, want a realistic ~44–56%% band", v)
 	}
 	// Boundary FGP=0 → base2pt 0; a neutral-net value stays ≥ 0 (no underflow).
 	if got := base2pt(0); got != 0 {
 		t.Errorf("base2pt(0) = %v, want 0", got)
 	}
-	if v := shotValue2pt(0, 0, false); v < 0 {
+	if v := shotValue2pt(0, 0, false, leagueBaselineFallback); v < 0 {
 		t.Errorf("shotValue2pt(0,0) = %v, want ≥ 0 (no underflow)", v)
 	}
 	// The 3pt make-value is unchanged by the 2pt recalibration (depends only on
-	// leagueBaseline, which is set so 3pt% stays faithful ≈37.5%).
-	if got := shotValue3pt(); got != leagueBaseline*1.5 {
-		t.Errorf("3pt value = %v, want %v (unchanged by 2pt recalibration)", got, leagueBaseline*1.5)
+	// the baseline, whose fallback is set so 3pt% stays faithful ≈37.5%).
+	if got := shotValue3pt(leagueBaselineFallback); got != leagueBaselineFallback*1.5 {
+		t.Errorf("3pt value = %v, want %v (unchanged by 2pt recalibration)", got, leagueBaselineFallback*1.5)
 	}
 }
 
@@ -69,8 +69,26 @@ func TestShotValue2pt_Calibration(t *testing.T) {
 
 func TestShotValue3pt_IgnoresNet(t *testing.T) {
 	// There is no net parameter; the value is constant regardless of matchup.
-	if shotValue3pt() != leagueBaseline*1.5 {
+	if shotValue3pt(leagueBaselineFallback) != leagueBaselineFallback*1.5 {
 		t.Error("3pt shot value must be league-baseline×1.5, independent of net advantage")
+	}
+}
+
+// TestShotBaselineOrFallback pins the guard gameloop.go's gs.shotBaseline =
+// b.LeagueShotBaseline depends on: bundle.Bundle.LeagueShotBaseline is now
+// assembled at bundle-build time (backup.ToBundle's computeLeagueShotBaseline),
+// so a bundle whose builder never wired it (or whose raw .plr population had
+// no qualifying records) leaves gameState.shotBaseline at the Go zero value —
+// this must degrade to leagueBaselineFallback, never a zero divisor for
+// shotValue2pt/3pt.
+func TestShotBaselineOrFallback(t *testing.T) {
+	var zero gameState
+	if got := zero.shotBaselineOrFallback(); got != leagueBaselineFallback {
+		t.Errorf("zero-value gameState.shotBaselineOrFallback() = %v, want fallback %v", got, leagueBaselineFallback)
+	}
+	wired := gameState{shotBaseline: 19.7805}
+	if got := wired.shotBaselineOrFallback(); got != 19.7805 {
+		t.Errorf("wired gameState.shotBaselineOrFallback() = %v, want 19.7805 (pass-through)", got)
 	}
 }
 

--- a/engine/internal/sim/state.go
+++ b/engine/internal/sim/state.go
@@ -148,9 +148,31 @@ type gameState struct {
 	// leaves the read-only instrument inert.
 	gateCont     *GateContAccum
 	gateBaseline float64
+
+	// shotBaseline is the league 2PA-per-48-player-minutes shot baseline
+	// (CEngine+0x6638), copied ONCE per game from bundle.Bundle.LeagueShotBaseline
+	// (gameloop.go) — assembled at bundle-build time over raw .plr records
+	// (backup.ToBundle's computeLeagueShotBaseline), league-constant within a
+	// snapshot, like gateBaseline. It feeds shotValue2pt's net term and
+	// shotValue3pt (= baseline×1.5).
+	shotBaseline float64
 }
 
 func (g *gameState) emit(e result.Event) { g.events = append(g.events, e) }
+
+// shotBaselineOrFallback returns the per-game league 2PA/48 shot baseline, or
+// leagueBaselineFallback when unset — a zero-value gameState constructed
+// directly (as unit tests do), OR a bundle whose LeagueShotBaseline was never
+// wired (a hand-built test bundle, or computeLeagueShotBaseline finding no
+// qualifying raw records). This guards the shotValue2pt zero divisor: an
+// unset baseline must degrade to the documented constant, never to ±Inf
+// make-values.
+func (g *gameState) shotBaselineOrFallback() float64 {
+	if g.shotBaseline > 0 {
+		return g.shotBaseline
+	}
+	return leagueBaselineFallback
+}
 
 // fatigueFactor is the shared JSB fatigue curve: (energy/30 + 100) × 0.01,
 // capped at 1.0. Because PR3a energy is non-negative base stamina, this is


### PR DESCRIPTION
## Summary

- Ports FUN_004385f0 CEngine+0x6638: league shot baseline is 2-point-attempts per 48 player-minutes (ratio of accumulated sums over .plr records 1–959 with MIN > 2×GP), not a shooting percentage as previously labeled
- `computeLeagueShotBaseline` in `backup/assemble.go` computes the value at bundle-build time from raw `PlrPlayer` records; `bundle.Bundle.LeagueShotBaseline` carries it; `gameloop.go` copies it to `gameState.shotBaseline`
- `shotValue2pt` and `shotValue3pt` now take `baseline float64` as a param; `shotBaselineOrFallback()` on `gameState` provides the `leagueBaselineFallback=250` stand-in for test bundles with no raw .plr data
- Corrects the prior misidentification in `shotdecision.go` comments (the constant was labeled "historical league-wide 2P%" — the RE analysis and the J5 artifact's offset row-map both pin +0x6638 as the 2PA/48 row, not the 2P% table which is at +0x6698)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.