### PR TITLE
chore(jsb): J18 item 1 — faithful 3pt bucket from recovered +0xDB0 composite

### DIFF
--- a/engine/internal/calibrate/measure_baseline_archive_test.go
+++ b/engine/internal/calibrate/measure_baseline_archive_test.go
@@ -95,7 +95,7 @@ func TestMeasureBaseline_Archive(t *testing.T) {
 	// but accumulates FTA via ftaFor instead of points via pointsFor, and
 	// reads the ENGINE value (EngineMean) on both sides — the same accessor
 	// CollectHomeMargins uses for its engine margin — never ScoVal.
-	var sumHomeFTA, sumAwayFTA float64      // ENGINE split
+	var sumHomeFTA, sumAwayFTA float64       // ENGINE split
 	var scoSumHomeFTA, scoSumAwayFTA float64 // REAL (.sco) split — the sign the engine must match
 	var nSplit int
 	for _, rep := range reports {

--- a/engine/internal/sim/bucketweights.go
+++ b/engine/internal/sim/bucketweights.go
@@ -15,11 +15,15 @@ import "github.com/a-jay85/IBL5/engine/internal/rng"
 //     is the dominant, field-goal-heavy path. Net-free (net lives only in
 //     shot_value, not the bucket — so the playoff ×1.25 multiplier never amplifies
 //     the bucket).
-//   - 3pt (threePtBucketWeight) = the 2pt composite × the player's 3pt propensity.
-//     JSB's +0xDB0 is DEAD (always 0) and 3pt is decided upstream in the ball-
-//     handler stage (COMPOSITE_DOUBLES_TRACE.md §RESOLUTION); the Go engine folds
-//     3pt into the play-outcome pick at the propensity rate — functionally
-//     equivalent, kept on the same O(10s) basis as 2pt so 3pt does not vanish.
+//   - 3pt (threePtBucketWeight) = the recovered +0xDB0 composite (FUN_004cfa50's
+//     stack-built player record; copied into the league record by FUN_00405970 —
+//     the same provenance chain as +0xDC8/+0xD70): the player's season 3GA/MIN×48,
+//     an f-projected per-48-minute three-point-attempt rate. LIVE, not dead: the J6
+//     RE session (2026-07-10) overturned COMPOSITE_DOUBLES_TRACE.md §RESOLUTION's
+//     "always 0" finding — FUN_004e1ba0's Σ(de0+db0+d90) play-outcome normalization
+//     reads it directly. Faithful when the bundle carries real-life minutes; falls
+//     back to the previous derived stand-in (2pt composite × 3pt propensity)
+//     otherwise — see threePtBucketWeight.
 //   - and-one (andOneBucketWeight) = matchup×0.25 + made-rate, floored to 0.03
 //     (the verbatim JSB floor, _DAT…→0.03). A small minority of plays, as in JSB.
 //   - foul (foulBucketWeight) = the faithful JSB 5.60 foul bucket with a symmetric
@@ -201,13 +205,29 @@ func twoPtBucketWeight(p onCourt) float64 {
 	return d88 - (d88/(d70+d88))*db8*makeShare
 }
 
-// threePtBucketWeight keeps the 3pt path on the same O(10s) basis as the 2pt
-// composite, scaled by the player's 3pt propensity. JSB's +0xDB0 is dead and 3pt
-// is gated upstream in the ball-handler stage; folding it into the play-outcome
-// pick at the propensity rate is functionally equivalent (COMPOSITE_DOUBLES_
-// TRACE.md §RESOLUTION). Scaling off the 2pt composite (rather than a fixed O(1)
-// constant) prevents 3pt attempts from vanishing now that 2pt is O(10s).
+// threePtBucketWeight is the recovered +0xDB0 composite (FUN_004cfa50's
+// stack-built player record; copied into the league record by FUN_00405970 — the
+// same provenance chain as +0xDC8/+0xD70): the player's season 3GA/MIN×48, an
+// f-projected per-48-minute three-point-attempt rate. LIVE, not dead: the J6 RE
+// session (2026-07-10) overturned COMPOSITE_DOUBLES_TRACE.md §RESOLUTION's "always
+// 0" finding — FUN_004e1ba0's Σ(de0+db0+d90) play-outcome normalization reads it
+// directly. When the bundle carries real-life minutes (RealLifeMIN > 0) the weight
+// is the FAITHFUL per48Min(RealLife3GA, RealLifeMIN) rate — a non-shooter correctly
+// gets a zero 3pt bucket, mirroring 5.60. Absent real-life minutes (rookie / unwired
+// production bundle) it falls back to the previous derived stand-in (2pt composite ×
+// 3pt propensity), preserved byte-for-byte for the no-reference case — the same
+// two-branch shape as twoPtBucketWeight.
+//
+// Legacy-serialized-bundle caveat: a bundle written before this port's rl_3ga field
+// existed deserializes RealLife3GA as 0 while RealLifeMIN > 0 carries over, zeroing
+// the 3pt bucket for that player. Acceptable: bundles are assembled fresh from .plr
+// at runtime rather than persisted across ports — the same caveat the J9
+// LeagueShotBaseline field (RealLifeFGA) already carries for an identical
+// field-addition case.
 func threePtBucketWeight(p onCourt) float64 {
+	if p.RealLifeMIN > 0 {
+		return per48Min(p.RealLife3GA, p.RealLifeMIN)
+	}
 	return twoPtBucketWeight(p) * threePtPropensity(p)
 }
 

--- a/engine/internal/sim/bucketweights_test.go
+++ b/engine/internal/sim/bucketweights_test.go
@@ -229,6 +229,7 @@ func TestBucketWeights_FoulDivisor(t *testing.T) {
 //     itself anti-home. Its magnitude is bounded FAR below leg B — the defQ cap
 //     (defQualityCapMultiplier·defQualityCapTeamMult·leagueSTL48 ≈ 13.76) keeps
 //     (defQ − baseline) too small for leg C to ever rival leg B.
+//
 // Leg B (a ~6% shift on the ~3.35 base) dominates leg C (a sub-1% shift on the
 // ~1.09 factor) by roughly an order of magnitude (measured ≈9.5× here), so the NET
 // is anti-home REGARDLESS of leg C's sign: the home foul weight is LOWER than the

--- a/engine/internal/sim/bucketweights_test.go
+++ b/engine/internal/sim/bucketweights_test.go
@@ -420,3 +420,57 @@ func TestBucketWeights_RealLifeZeroFGA(t *testing.T) {
 		t.Errorf("zero-FGA limit = %v, want 0 (d88)", got)
 	}
 }
+
+// --- J18 item 1: threePtBucketWeight faithful to the recovered +0xDB0 composite --
+
+// Row 12: with real-life minutes, threePtBucketWeight equals the faithful
+// per48Min(RealLife3GA, RealLifeMIN) rate directly — the recovered +0xDB0 composite
+// (FUN_004cfa50 stack-record store, copied by FUN_00405970), NOT the derived
+// 2pt-composite × propensity stand-in.
+func TestBucketWeights_RealLifeThreePt(t *testing.T) {
+	pl := mkPlayer(1, 3, slotPG, 48)
+	pl.RealLifeMIN = 2000
+	pl.RealLife3GA = 200 // per48Min(200, 2000) = 4.8
+	p := oc(slotPG, pl)
+
+	want := per48Min(200, 2000)
+	if got := threePtBucketWeight(p); math.Abs(got-want) > 1e-9 {
+		t.Errorf("threePtBucketWeight = %.6f, want faithful per48Min(RealLife3GA, RealLifeMIN) = %.6f", got, want)
+	}
+	if standin := twoPtBucketWeight(p) * threePtPropensity(p); math.Abs(want-standin) < 1e-9 {
+		t.Fatalf("test setup: faithful rate %.6f coincides with the derived stand-in %.6f — case does not discriminate", want, standin)
+	}
+}
+
+// Row 13 (boundary): RealLifeMIN>0 with RealLife3GA==0 (played real minutes, never
+// attempted a three) must yield an EXACT zero 3pt bucket — faithful to 5.60, which
+// gives a non-shooter a zero +0xDB0 weight, not a small propensity-derived residual.
+func TestBucketWeights_RealLifeThreePtZeroAttempts(t *testing.T) {
+	pl := mkPlayer(1, 3, slotPG, 48)
+	pl.RealLifeMIN, pl.RealLife3GA = 1800, 0
+	got := threePtBucketWeight(oc(slotPG, pl))
+
+	if got != 0 {
+		t.Errorf("non-shooter (RealLife3GA==0) 3pt bucket = %v, want exactly 0 (faithful to 5.60)", got)
+	}
+}
+
+// Row 14 (unchanged stand-in): with no real-life minutes (RealLifeMIN==0),
+// threePtBucketWeight still equals the previous derived stand-in — 2pt composite ×
+// 3pt propensity — byte-for-byte, the no-reference fallback this port preserves.
+func TestBucketWeights_ThreePtFallbackUnchanged(t *testing.T) {
+	p := oc(slotPG, mkPlayer(1, 3, slotPG, 48)) // RealLifeMIN==0 → fallback
+
+	want := twoPtBucketWeight(p) * threePtPropensity(p)
+	if got := threePtBucketWeight(p); math.Abs(got-want) > 1e-9 {
+		t.Errorf("fallback threePtBucketWeight = %.6f, want twoPtBucketWeight×threePtPropensity = %.6f", got, want)
+	}
+
+	// Sums present but MIN==0 → still the fallback (MIN gates the real path, same as
+	// twoPtBucketWeight's real-rate gate).
+	p2 := p
+	p2.RealLife3GA = 9999
+	if got := threePtBucketWeight(p2); math.Abs(got-want) > 1e-9 {
+		t.Errorf("MIN==0 with RealLife3GA set engaged the real path: got %.6f, want %.6f", got, want)
+	}
+}

--- a/engine/internal/sim/freeze_test.go
+++ b/engine/internal/sim/freeze_test.go
@@ -184,7 +184,7 @@ func TestMakePutback_OriginScoped(t *testing.T) {
 	const fgp = 50
 	net := 5.0
 	live := shotValue2pt(net, fgp, false, leagueBaselineFallback) // initial/transition live value
-	putback := putbackValue2pt(fgp)       // faithful OriginOffReb live value (ADR-0055)
+	putback := putbackValue2pt(fgp)                               // faithful OriginOffReb live value (ADR-0055)
 	mean := 111.0
 
 	cases := []struct {

--- a/engine/internal/sim/possession.go
+++ b/engine/internal/sim/possession.go
@@ -66,6 +66,7 @@ func threePtPropensity(p onCourt) float64 {
 //     (leg A): +hcaScaled home / −hcaScaled away on the O(10s) 2pt bucket.
 //   - hca (RAW ±0.2) feeds the foul bucket, where the base (leg B) and offQ (leg C)
 //     carry the raw delta on the faithful CEngine TOV48 basis — see foulBucketWeight.
+//
 // Callers pass 0 for both on the transition path (param_5==0, fully symmetric) and
 // for ASG (hcaDelta returns 0). The and-one leg D (e90 inherits e88's +hca) is added
 // by the caller to andOneWeight, since that bucket is assembled outside playBuckets.


### PR DESCRIPTION
## Summary

Implements J18 item 1 from the JSB native backlog: replaces the derived 3pt bucket stand-in (2pt composite × propensity) with the faithful +0xDB0 composite recovered in the J6 RE session.

- `threePtBucketWeight` now reads `RealLifeMIN`/`RealLife3GA` from the `onCourt` struct when real-life minutes are available, computing `per48Min(RealLife3GA, RealLifeMIN)` — the player's season 3GA/MIN×48 rate, matching JSB's FUN_004cfa50 stack-record store (copied by FUN_00405970 into the league record)
- Non-shooters with `RealLife3GA==0` correctly receive an exact-zero 3pt bucket weight (faithful to 5.60), rather than a small propensity-derived residual
- Fallback to the previous derived stand-in is preserved byte-for-byte for rookies and unwired bundles (`RealLifeMIN==0`)
- Comments updated to document the J6 RE overturn of COMPOSITE_DOUBLES_TRACE.md §RESOLUTION's "always 0" finding

Tests added (rows 12–14 in `bucketweights_test.go`):
- Row 12: faithful `per48Min(RealLife3GA, RealLifeMIN)` path when `RealLifeMIN > 0`
- Row 13: exact-zero result for a player with real minutes but zero 3-point attempts
- Row 14: stand-in path unchanged when `RealLifeMIN == 0`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.