### PR TITLE
chore(jsb): re-anchor foulBucketScale 0.40→0.39 after item-2 d70 basis change

### DIFF
--- a/engine/internal/sim/bucketweights.go
+++ b/engine/internal/sim/bucketweights.go
@@ -143,8 +143,16 @@ const (
 	// the Phase-6 weak-coupling claim, which is scoped to gt=2; not re-litigated here.)
 	// See the J15 program / phase2-derivation.md and the Phase-6 (2026-07-11) history
 	// this supersedes for the first re-anchor's story (0.50→22.43, 0.45→20.67,
-	// 0.47→21.36).
-	foulBucketScale = 0.40
+	// 0.47→21.36). Re-anchored a THIRD time (2026-07-13) after J18 item 2 pinned
+	// d70LeagueScalar 1.0→0.6472 (a faithful basis change: it shrank the d70 FTA-rate
+	// term inside twoPtBucketWeight, lowering 2pt bucket mass and raising the foul
+	// share — combined-master FTA/g read 21.82 at the then-current 0.40). 1-D search
+	// on the combined basis: 0.39→21.36, 0.40→21.82 → re-anchored to 0.39 (gap +0.04
+	// vs the .sco 21.32 target). The gt=2 home-margin gap moved +0.498 (at 0.40) →
+	// +0.491 (at 0.39), delta −0.007, within the ~±0.03 noise floor — the dial stayed
+	// side-symmetric and did not disturb the Phase-5 margin lock, consistent with the
+	// weak-coupling claim above.
+	foulBucketScale = 0.39
 
 	// andOneBucketFloor is the verbatim JSB and-one floor (0.03). Ensures the
 	// and-one path cannot be zeroed by a negative matchup quality. Unchanged from

--- a/engine/internal/sim/bucketweights_test.go
+++ b/engine/internal/sim/bucketweights_test.go
@@ -45,7 +45,7 @@ func assembleInputs(foulWeight, hca float64) outcomeInputs {
 // (home's larger 2pt denominator makes foul a marginally smaller share). This test
 // confirms home and away foul shares are NEAR-EQUAL — the property that yields a
 // ≈1.0 home/away FTA ratio, superseding the old home>away asymmetry (ADR-0082).
-// After the Phase-6 re-anchor (foulBucketScale=0.40), the foul share is again a
+// After the Phase-6 re-anchor (foulBucketScale=0.39), the foul share is again a
 // 2pt-dominated realistic minority (~9%), so this test asserts BOTH the structural
 // side-symmetry AND the re-anchored LEVEL band (phase2-derivation.md).
 func TestBucketWeights_FoulPathMix(t *testing.T) {
@@ -82,7 +82,7 @@ func TestBucketWeights_FoulPathMix(t *testing.T) {
 	// ~0.9 share; an unscaled bucket, ~0.01. A minority in [0.03, 0.15] is the faithful
 	// regime this dial was re-anchored to.
 	if homeFoul < 0.03 || homeFoul > 0.15 {
-		t.Errorf("home foul share = %.4f, want a realistic minority in [0.03, 0.15] (level re-anchored, foulBucketScale=0.40)", homeFoul)
+		t.Errorf("home foul share = %.4f, want a realistic minority in [0.03, 0.15] (level re-anchored, foulBucketScale=0.39)", homeFoul)
 	}
 	// Symmetry: home/away foul shares differ ONLY through the ±hca on the 2pt bucket,
 	// so they are near-equal (the discriminator property). NOT the old home>away arm.
@@ -112,7 +112,7 @@ func TestBucketWeights_TwoPtComposite(t *testing.T) {
 	}
 
 	// The foul weight matches the hand-recomputed faithful formula AND — restored after
-	// the Phase-6 re-anchor (foulBucketScale=0.40) — the 2pt composite DOMINATES it
+	// the Phase-6 re-anchor (foulBucketScale=0.39) — the 2pt composite DOMINATES it
 	// (≈16.47 vs ≈2.13 at this fixture), the minority-foul-share invariant the original
 	// +0xD90 characterization pinned.
 	off := fiveStarters(3)

--- a/engine/internal/sim/testdata/golden.json
+++ b/engine/internal/sim/testdata/golden.json
@@ -601,6 +601,24 @@
           "team_id": 3
         },
         {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
           "kind": "foul",
           "period": 1,
           "clock_seconds": 390,
@@ -611,2722 +629,6 @@
           "kind": "free_throw",
           "period": 1,
           "clock_seconds": 390,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 2
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 375,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 375,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 360,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 345,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 345,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 315,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 315,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 300,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 285,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 285,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 285,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 270,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "foul",
-          "period": 1,
-          "clock_seconds": 270,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "free_throw",
-          "period": 1,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "ft",
-          "ft_attempts": 1,
-          "ft_made": 1
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 255,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 240,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 203,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 240,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 225,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 1,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "steal",
-          "period": 1,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 104,
-          "defender_id": 205
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 210,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 210,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 195,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 195,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 180,
-          "team_id": 3
-        },
-        {
-          "kind": "foul",
-          "period": 1,
-          "clock_seconds": 180,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "free_throw",
-          "period": 1,
-          "clock_seconds": 180,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 2
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 165,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 1,
-          "clock_seconds": 165,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "steal",
-          "period": 1,
-          "clock_seconds": 165,
-          "team_id": 7,
-          "player_id": 102,
-          "defender_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 150,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 1,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 1,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 105
-        },
-        {
-          "kind": "steal",
-          "period": 1,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 105,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 120,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 1,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 1,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 105
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 105,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 105,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 105,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 90,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 1,
-          "clock_seconds": 90,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "steal",
-          "period": 1,
-          "clock_seconds": 90,
-          "team_id": 3,
-          "player_id": 204,
-          "defender_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 75,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 75,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 60,
-          "team_id": 3
-        },
-        {
-          "kind": "foul",
-          "period": 1,
-          "clock_seconds": 60,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "free_throw",
-          "period": 1,
-          "clock_seconds": 60,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 2
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 45,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 1,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 30,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 1,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 1,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 1,
-          "clock_seconds": 15,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 1,
-          "clock_seconds": 15,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 1,
-          "clock_seconds": 15,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 1,
-          "clock_seconds": 15,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "period_boundary",
-          "period": 1,
-          "clock_seconds": 0
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 720,
-          "team_id": 3
-        },
-        {
-          "kind": "foul",
-          "period": 2,
-          "clock_seconds": 720,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "free_throw",
-          "period": 2,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 1
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 705,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 705,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 705,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 705,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 690,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 204,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 675,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 660,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 203,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 645,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 630,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 630,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 630,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 103
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 615,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 102,
-          "defender_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 600,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 600,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 600,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 600,
-          "team_id": 3,
-          "player_id": 202,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 600,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 600,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 585,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 585,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 585,
-          "team_id": 7,
-          "player_id": 104,
-          "defender_id": 203
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 570,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 570,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 570,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 555,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 555,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 555,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 555,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 540,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 540,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 540,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 540,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 510,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 510,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 510,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 495,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 104,
-          "defender_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 480,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 465,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 103,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 450,
-          "team_id": 3
-        },
-        {
-          "kind": "foul",
-          "period": 2,
-          "clock_seconds": 450,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "free_throw",
-          "period": 2,
-          "clock_seconds": 450,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 1
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 102,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "block",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 102,
-          "defender_id": 205
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 435,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 420,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 204,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 405,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 405,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 405,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 390,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 390,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 390,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 390,
-          "team_id": 7,
-          "player_id": 105
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 375,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 101,
-          "defender_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 360,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 360,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 345,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 315,
-          "team_id": 7
-        },
-        {
-          "kind": "foul",
-          "period": 2,
-          "clock_seconds": 315,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "free_throw",
-          "period": 2,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 1
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 300,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 202,
-          "defender_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 285,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 285,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 285,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 270,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "block",
-          "period": 2,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 202,
-          "defender_id": 102
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 270,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 255,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 240,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 204,
-          "defender_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 225,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 210,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 210,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 195,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 195,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 180,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 180,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 180,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 165,
-          "team_id": 7
-        },
-        {
-          "kind": "foul",
-          "period": 2,
-          "clock_seconds": 165,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "free_throw",
-          "period": 2,
-          "clock_seconds": 165,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "ft",
-          "ft_attempts": 2
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 150,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 150,
-          "team_id": 3,
-          "player_id": 203,
-          "defender_id": 103
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 103,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 120,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 105,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 105,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 2,
-          "clock_seconds": 105,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 2,
-          "clock_seconds": 105,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 90,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 90,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 90,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 75,
-          "team_id": 7
-        },
-        {
-          "kind": "foul",
-          "period": 2,
-          "clock_seconds": 75,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "free_throw",
-          "period": 2,
-          "clock_seconds": 75,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 1
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 60,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 60,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 60,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 45,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 45,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 30,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 2,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "steal",
-          "period": 2,
-          "clock_seconds": 30,
-          "team_id": 3,
-          "player_id": 201,
-          "defender_id": 103
-        },
-        {
-          "kind": "possession_start",
-          "period": 2,
-          "clock_seconds": 15,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 2,
-          "clock_seconds": 15,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 2,
-          "clock_seconds": 15,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "period_boundary",
-          "period": 2,
-          "clock_seconds": 0
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 720,
-          "team_id": 3,
-          "player_id": 202,
-          "defender_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 705,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 705,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 705,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 690,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 690,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 675,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 105
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 105,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 660,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 645,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 645,
-          "team_id": 3,
-          "player_id": 203
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 630,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 630,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 630,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 615,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 615,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 600,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 600,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 600,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 585,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 585,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 585,
-          "team_id": 7,
-          "player_id": 105,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 585,
-          "team_id": 3,
-          "player_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 570,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 570,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 570,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 570,
-          "team_id": 7,
-          "player_id": 103
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 555,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 555,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 555,
-          "team_id": 7,
-          "player_id": 101,
-          "defender_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 540,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 540,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 540,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 510,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 510,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 510,
-          "team_id": 3,
-          "player_id": 203,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 510,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 495,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 495,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 480,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 480,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 465,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 465,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 465,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 450,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 450,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 450,
-          "team_id": 3,
-          "player_id": 202,
-          "defender_id": 104
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 435,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 435,
-          "team_id": 7,
-          "player_id": 104,
-          "defender_id": 204
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 420,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 420,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "foul",
-          "period": 3,
-          "clock_seconds": 420,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "free_throw",
-          "period": 3,
-          "clock_seconds": 420,
           "team_id": 3,
           "player_id": 204,
           "shot_type": "ft",
@@ -3335,14 +637,14 @@
         },
         {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 405,
+          "period": 1,
+          "clock_seconds": 375,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 405,
+          "period": 1,
+          "clock_seconds": 375,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt",
@@ -3350,8 +652,8 @@
         },
         {
           "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 405,
+          "period": 1,
+          "clock_seconds": 375,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt",
@@ -3359,111 +661,114 @@
         },
         {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 390,
+          "period": 1,
+          "clock_seconds": 360,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 1,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "steal",
+          "period": 1,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 205,
+          "defender_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 345,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 330,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 390,
+          "period": 1,
+          "clock_seconds": 330,
           "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 390,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 375,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 101,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 101,
+          "period": 1,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 101,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "oreb_continuation"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 375,
-          "team_id": 7,
-          "player_id": 104,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 375,
+          "period": 1,
+          "clock_seconds": 330,
           "team_id": 7,
           "player_id": 104
         },
         {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 375,
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 315,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 315,
           "team_id": 7,
-          "player_id": 104,
-          "defender_id": 201
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 315,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 360,
+          "period": 1,
+          "clock_seconds": 300,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 360,
+          "period": 1,
+          "clock_seconds": 300,
           "team_id": 3,
           "player_id": 204,
           "shot_type": "2pt",
@@ -3471,8 +776,8 @@
         },
         {
           "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 360,
+          "period": 1,
+          "clock_seconds": 300,
           "team_id": 3,
           "player_id": 204,
           "shot_type": "2pt",
@@ -3480,311 +785,972 @@
         },
         {
           "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 360,
+          "period": 1,
+          "clock_seconds": 300,
           "team_id": 7,
-          "player_id": 104
+          "player_id": 102
         },
         {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 345,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 105
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 345,
-          "team_id": 7,
-          "player_id": 105,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 330,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 330,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 315,
+          "period": 1,
+          "clock_seconds": 285,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 315,
+          "period": 1,
+          "clock_seconds": 285,
           "team_id": 7,
-          "player_id": 103,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 315,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 315,
-          "team_id": 3,
-          "player_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 300,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 201,
+          "player_id": 102,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 300,
-          "team_id": 3,
-          "player_id": 201,
+          "period": 1,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 102,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 285,
+          "period": 1,
+          "clock_seconds": 270,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 255,
+          "team_id": 7
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 255,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "ft",
+          "ft_attempts": 2,
+          "ft_made": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 240,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 225,
           "team_id": 7
         },
         {
           "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 285,
+          "period": 1,
+          "clock_seconds": 225,
           "team_id": 7,
           "player_id": 101
         },
         {
           "kind": "steal",
-          "period": 3,
-          "clock_seconds": 285,
+          "period": 1,
+          "clock_seconds": 225,
           "team_id": 7,
           "player_id": 101,
-          "defender_id": 202
+          "defender_id": 203
         },
         {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 270,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 270,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 255,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 255,
-          "team_id": 7,
-          "player_id": 104,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 240,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 240,
-          "team_id": 3,
-          "player_id": 201,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 225,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 210,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 210,
           "team_id": 3,
-          "player_id": 203,
+          "player_id": 205,
           "shot_type": "2pt",
-          "shot_origin": "initial"
+          "shot_origin": "transition"
         },
         {
           "kind": "shot_miss",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 210,
           "team_id": 3,
-          "player_id": 203,
+          "player_id": 205,
           "shot_type": "2pt",
-          "shot_origin": "initial"
+          "shot_origin": "transition"
         },
         {
           "kind": "rebound",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 210,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "possession_start",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 195,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
+          "period": 1,
           "clock_seconds": 195,
           "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 195,
+          "team_id": 3,
+          "player_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 180,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 180,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 165,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 165,
+          "team_id": 7,
           "player_id": 105,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 150,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 195,
-          "team_id": 7,
-          "player_id": 105,
+          "period": 1,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 180,
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 135,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 120,
           "team_id": 3
         },
         {
           "kind": "turnover",
-          "period": 3,
-          "clock_seconds": 180,
+          "period": 1,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "steal",
+          "period": 1,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 201,
+          "defender_id": 104
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 105,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 90,
+          "team_id": 3
+        },
+        {
+          "kind": "foul",
+          "period": 1,
+          "clock_seconds": 90,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "free_throw",
+          "period": 1,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "ft",
+          "ft_attempts": 2,
+          "ft_made": 2
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 75,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 1,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "steal",
+          "period": 1,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 101,
+          "defender_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 60,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 1,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 1,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 45,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 1,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 1,
+          "clock_seconds": 45,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 30,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 1,
+          "clock_seconds": 30,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 1,
+          "clock_seconds": 30,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 1,
+          "clock_seconds": 15,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 1,
+          "clock_seconds": 15,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "steal",
+          "period": 1,
+          "clock_seconds": 15,
+          "team_id": 7,
+          "player_id": 103,
+          "defender_id": 202
+        },
+        {
+          "kind": "period_boundary",
+          "period": 1,
+          "clock_seconds": 0
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 720,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 203
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 203,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 705,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 705,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 705,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 705,
+          "team_id": 3,
+          "player_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 690,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 690,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 690,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 675,
+          "team_id": 7
+        },
+        {
+          "kind": "foul",
+          "period": 2,
+          "clock_seconds": 675,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "free_throw",
+          "period": 2,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "ft",
+          "ft_attempts": 2,
+          "ft_made": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 660,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 660,
+          "team_id": 7,
+          "player_id": 104
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 645,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 104,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 630,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 630,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 630,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 615,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 615,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 615,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 615,
+          "team_id": 7,
+          "player_id": 103,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 615,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 615,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 600,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 600,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 600,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 585,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 585,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 585,
+          "team_id": 7,
+          "player_id": 105,
+          "defender_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 570,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 570,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 570,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 570,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 570,
           "team_id": 3,
           "player_id": 202
         },
         {
           "kind": "steal",
-          "period": 3,
-          "clock_seconds": 180,
+          "period": 2,
+          "clock_seconds": 570,
           "team_id": 3,
           "player_id": 202,
-          "defender_id": 102
+          "defender_id": 104
         },
         {
           "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 165,
+          "period": 2,
+          "clock_seconds": 555,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 165,
+          "period": 2,
+          "clock_seconds": 555,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 555,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 555,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 555,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 555,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 540,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 540,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 540,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 103
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 510,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 510,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 510,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 510,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 495,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 495,
           "team_id": 7,
           "player_id": 103,
           "shot_type": "2pt",
@@ -3792,8 +1758,8 @@
         },
         {
           "kind": "shot_miss",
-          "period": 3,
-          "clock_seconds": 165,
+          "period": 2,
+          "clock_seconds": 495,
           "team_id": 7,
           "player_id": 103,
           "shot_type": "2pt",
@@ -3801,27 +1767,700 @@
         },
         {
           "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 165,
+          "period": 2,
+          "clock_seconds": 495,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 480,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 465,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 450,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 450,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 450,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 435,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 420,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 203,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 405,
+          "team_id": 7
+        },
+        {
+          "kind": "foul",
+          "period": 2,
+          "clock_seconds": 405,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "free_throw",
+          "period": 2,
+          "clock_seconds": 405,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "ft",
+          "ft_attempts": 2,
+          "ft_made": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 390,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 375,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 375,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 375,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 375,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 360,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 345,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 345,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 330,
           "team_id": 3,
           "player_id": 201
         },
         {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "defender_id": 104
+        },
+        {
           "kind": "possession_start",
-          "period": 3,
+          "period": 2,
+          "clock_seconds": 315,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 315,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 315,
+          "team_id": 7,
+          "player_id": 105,
+          "defender_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 300,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 285,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 270,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "foul",
+          "period": 2,
+          "clock_seconds": 270,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "free_throw",
+          "period": 2,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "ft",
+          "ft_attempts": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 255,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 240,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 202,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 225,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 225,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 210,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 205,
+          "defender_id": 103
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 195,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 104,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 180,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 203
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 203,
+          "defender_id": 105
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 165,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105,
+          "defender_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
           "clock_seconds": 150,
           "team_id": 3
         },
         {
           "kind": "turnover",
-          "period": 3,
+          "period": 2,
           "clock_seconds": 150,
           "team_id": 3,
           "player_id": 204
         },
         {
           "kind": "steal",
-          "period": 3,
+          "period": 2,
           "clock_seconds": 150,
           "team_id": 3,
           "player_id": 204,
@@ -3829,45 +2468,581 @@
         },
         {
           "kind": "possession_start",
-          "period": 3,
+          "period": 2,
           "clock_seconds": 135,
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
-          "period": 3,
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "steal",
+          "period": 2,
           "clock_seconds": 135,
           "team_id": 7,
           "player_id": 105,
+          "defender_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 120,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 2,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "steal",
+          "period": 2,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 201,
+          "defender_id": 103
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 105,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 105,
+          "team_id": 3,
+          "player_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 90,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 75,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 60,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 45,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 2,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 2,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 103,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 30,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 30,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 30,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "foul",
+          "period": 2,
+          "clock_seconds": 30,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "free_throw",
+          "period": 2,
+          "clock_seconds": 30,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "ft",
+          "ft_attempts": 1,
+          "ft_made": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 2,
+          "clock_seconds": 15,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 2,
+          "clock_seconds": 15,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 2,
+          "clock_seconds": 15,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "period_boundary",
+          "period": 2,
+          "clock_seconds": 0
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 720,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 705,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 705,
+          "team_id": 7,
+          "player_id": 104
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 705,
+          "team_id": 7,
+          "player_id": 104,
+          "defender_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 690,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 690,
+          "team_id": 3,
+          "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 3,
-          "clock_seconds": 135,
-          "team_id": 7,
-          "player_id": 105,
+          "clock_seconds": 690,
+          "team_id": 3,
+          "player_id": 202,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 3,
-          "clock_seconds": 135,
+          "clock_seconds": 690,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 675,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 104,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 104
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 675,
+          "team_id": 7,
+          "player_id": 104,
+          "defender_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 660,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 205,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "foul",
+          "period": 3,
+          "clock_seconds": 660,
+          "team_id": 7,
+          "player_id": 104
+        },
+        {
+          "kind": "free_throw",
+          "period": 3,
+          "clock_seconds": 660,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "ft",
+          "ft_attempts": 1,
+          "ft_made": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 645,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 630,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 630,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 630,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 630,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 615,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 615,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 615,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 615,
           "team_id": 3,
           "player_id": 202
         },
         {
           "kind": "possession_start",
           "period": 3,
-          "clock_seconds": 120,
+          "clock_seconds": 600,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 3,
-          "clock_seconds": 120,
+          "clock_seconds": 600,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "2pt",
@@ -3876,101 +3051,55 @@
         {
           "kind": "shot_miss",
           "period": 3,
-          "clock_seconds": 120,
+          "clock_seconds": 600,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "transition"
         },
         {
-          "kind": "block",
-          "period": 3,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 201,
-          "defender_id": 104
-        },
-        {
           "kind": "rebound",
           "period": 3,
-          "clock_seconds": 120,
+          "clock_seconds": 600,
           "team_id": 3,
           "player_id": 205,
           "offensive_rebound": true
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 3,
-          "clock_seconds": 120,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 3,
-          "clock_seconds": 120,
+          "clock_seconds": 600,
           "team_id": 3,
           "player_id": 205,
-          "defender_id": 104
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 600,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 600,
+          "team_id": 7,
+          "player_id": 104
         },
         {
           "kind": "possession_start",
           "period": 3,
-          "clock_seconds": 105,
+          "clock_seconds": 585,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 3,
-          "clock_seconds": 105,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 105,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 90,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 90,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_make",
-          "period": 3,
-          "clock_seconds": 90,
-          "team_id": 3,
-          "player_id": 205,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "possession_start",
-          "period": 3,
-          "clock_seconds": 75,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 3,
-          "clock_seconds": 75,
+          "clock_seconds": 585,
           "team_id": 7,
           "player_id": 105,
           "shot_type": "2pt",
@@ -3979,7 +3108,7 @@
         {
           "kind": "shot_miss",
           "period": 3,
-          "clock_seconds": 75,
+          "clock_seconds": 585,
           "team_id": 7,
           "player_id": 105,
           "shot_type": "2pt",
@@ -3988,27 +3117,421 @@
         {
           "kind": "rebound",
           "period": 3,
-          "clock_seconds": 75,
+          "clock_seconds": 585,
+          "team_id": 3,
+          "player_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 570,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 570,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 570,
+          "team_id": 3,
+          "player_id": 201,
+          "defender_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 555,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 555,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 555,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 555,
           "team_id": 3,
           "player_id": 205
         },
         {
           "kind": "possession_start",
           "period": 3,
-          "clock_seconds": 60,
+          "clock_seconds": 540,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 540,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 540,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 540,
+          "team_id": 7,
+          "player_id": 104
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 103,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 525,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 510,
           "team_id": 3
         },
         {
           "kind": "turnover",
           "period": 3,
-          "clock_seconds": 60,
+          "clock_seconds": 510,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 510,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 102
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 495,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 495,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 495,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "block",
+          "period": 3,
+          "clock_seconds": 495,
+          "team_id": 7,
+          "player_id": 105,
+          "defender_id": 201
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 495,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 480,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 480,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 465,
+          "team_id": 7,
+          "player_id": 101,
+          "defender_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 450,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 450,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 450,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 435,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 104
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 435,
+          "team_id": 7,
+          "player_id": 104,
+          "defender_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 420,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 204,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 420,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 405,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 405,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 405,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 405,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 390,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 390,
           "team_id": 3,
           "player_id": 205
         },
         {
           "kind": "steal",
           "period": 3,
-          "clock_seconds": 60,
+          "clock_seconds": 390,
           "team_id": 3,
           "player_id": 205,
           "defender_id": 102
@@ -4016,25 +3539,807 @@
         {
           "kind": "possession_start",
           "period": 3,
-          "clock_seconds": 45,
+          "clock_seconds": 375,
           "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 375,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 375,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 360,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
         },
         {
           "kind": "foul",
           "period": 3,
-          "clock_seconds": 45,
-          "team_id": 3,
-          "player_id": 204
+          "clock_seconds": 360,
+          "team_id": 7,
+          "player_id": 103
         },
         {
           "kind": "free_throw",
           "period": 3,
+          "clock_seconds": 360,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "ft",
+          "ft_attempts": 1,
+          "ft_made": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 103,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 345,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 330,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 315,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 315,
+          "team_id": 7,
+          "player_id": 105
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 315,
+          "team_id": 7,
+          "player_id": 105,
+          "defender_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 300,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 203,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 300,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 285,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 285,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 270,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 270,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 255,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 255,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 255,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 240,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 240,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 225,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 225,
+          "team_id": 7,
+          "player_id": 101,
+          "defender_id": 203
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 210,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 210,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 195,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 195,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 195,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 180,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 201
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 180,
+          "team_id": 3,
+          "player_id": 201,
+          "defender_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 165,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 165,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 165,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 150,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 150,
+          "team_id": 7,
+          "player_id": 103
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 135,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 202,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 120,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 102,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 90,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 3,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 204
+        },
+        {
+          "kind": "steal",
+          "period": 3,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 204,
+          "defender_id": 105
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 75,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 105,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 75,
+          "team_id": 3,
+          "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 203,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "foul",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "free_throw",
+          "period": 3,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 203,
+          "shot_type": "ft",
+          "ft_attempts": 1,
+          "ft_made": 1
+        },
+        {
+          "kind": "possession_start",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
           "clock_seconds": 45,
           "team_id": 7,
           "player_id": 104,
-          "shot_type": "ft",
-          "ft_attempts": 2,
-          "ft_made": 2
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 101,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 3,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 101,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
         },
         {
           "kind": "possession_start",
@@ -4052,7 +4357,7 @@
           "shot_origin": "initial"
         },
         {
-          "kind": "shot_miss",
+          "kind": "shot_make",
           "period": 3,
           "clock_seconds": 30,
           "team_id": 3,
@@ -4061,42 +4366,25 @@
           "shot_origin": "initial"
         },
         {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 30,
-          "team_id": 7,
-          "player_id": 101
-        },
-        {
           "kind": "possession_start",
           "period": 3,
           "clock_seconds": 15,
           "team_id": 7
         },
         {
-          "kind": "shot_attempt",
+          "kind": "turnover",
           "period": 3,
           "clock_seconds": 15,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
+          "player_id": 103
         },
         {
-          "kind": "shot_miss",
+          "kind": "steal",
           "period": 3,
           "clock_seconds": 15,
           "team_id": 7,
-          "player_id": 101,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 3,
-          "clock_seconds": 15,
-          "team_id": 3,
-          "player_id": 201
+          "player_id": 103,
+          "defender_id": 204
         },
         {
           "kind": "period_boundary",
@@ -4114,18 +4402,25 @@
           "period": 4,
           "clock_seconds": 720,
           "team_id": 3,
-          "player_id": 205,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
-          "kind": "shot_make",
+          "kind": "shot_miss",
           "period": 4,
           "clock_seconds": 720,
           "team_id": 3,
-          "player_id": 205,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 720,
+          "team_id": 7,
+          "player_id": 104
         },
         {
           "kind": "possession_start",
@@ -4146,7 +4441,7 @@
           "clock_seconds": 705,
           "team_id": 7,
           "player_id": 103,
-          "defender_id": 204
+          "defender_id": 203
         },
         {
           "kind": "possession_start",
@@ -4155,61 +4450,27 @@
           "team_id": 3
         },
         {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 690,
-          "team_id": 3,
-          "player_id": 204,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
+          "kind": "foul",
           "period": 4,
           "clock_seconds": 690,
           "team_id": 7,
-          "player_id": 101
+          "player_id": 104
+        },
+        {
+          "kind": "free_throw",
+          "period": 4,
+          "clock_seconds": 690,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "ft",
+          "ft_attempts": 2,
+          "ft_made": 1
         },
         {
           "kind": "possession_start",
           "period": 4,
           "clock_seconds": 675,
           "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 104,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 675,
-          "team_id": 7,
-          "player_id": 105,
-          "offensive_rebound": true
         },
         {
           "kind": "turnover",
@@ -4224,7 +4485,7 @@
           "clock_seconds": 675,
           "team_id": 7,
           "player_id": 105,
-          "defender_id": 202
+          "defender_id": 204
         },
         {
           "kind": "possession_start",
@@ -4233,337 +4494,133 @@
           "team_id": 3
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 4,
           "clock_seconds": 660,
           "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 660,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 101
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 645,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 103,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 103,
-          "offensive_rebound": true
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 103
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 645,
-          "team_id": 7,
-          "player_id": 103,
-          "defender_id": 203
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 630,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 630,
-          "team_id": 3,
-          "player_id": 203,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 630,
+          "clock_seconds": 660,
           "team_id": 3,
-          "player_id": 203,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 615,
+          "clock_seconds": 645,
           "team_id": 7
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 615,
-          "team_id": 7,
-          "player_id": 103
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 615,
+          "clock_seconds": 645,
           "team_id": 7,
           "player_id": 103,
-          "defender_id": 204
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 645,
+          "team_id": 7,
+          "player_id": 103,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 645,
+          "team_id": 3,
+          "player_id": 203
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 600,
+          "clock_seconds": 630,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 600,
+          "clock_seconds": 630,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 600,
+          "clock_seconds": 630,
           "team_id": 3,
-          "player_id": 202,
+          "player_id": 201,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 600,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 585,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 585,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 585,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "2pt",
-          "shot_origin": "transition"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 585,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 570,
-          "team_id": 3
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 570,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 570,
-          "team_id": 3,
-          "player_id": 202,
-          "shot_type": "2pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 570,
+          "clock_seconds": 630,
           "team_id": 7,
           "player_id": 105
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 555,
+          "clock_seconds": 615,
           "team_id": 7
         },
         {
-          "kind": "turnover",
+          "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 555,
+          "clock_seconds": 615,
           "team_id": 7,
-          "player_id": 103
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
         },
         {
-          "kind": "steal",
+          "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 555,
+          "clock_seconds": 615,
           "team_id": 7,
-          "player_id": 103,
-          "defender_id": 203
+          "player_id": 102,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
         },
         {
-          "kind": "possession_start",
+          "kind": "rebound",
           "period": 4,
-          "clock_seconds": 540,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 540,
+          "clock_seconds": 615,
           "team_id": 3,
           "player_id": 202
         },
         {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 540,
-          "team_id": 3,
-          "player_id": 202,
-          "defender_id": 102
-        },
-        {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 525,
-          "team_id": 7
-        },
-        {
-          "kind": "shot_attempt",
-          "period": 4,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "shot_miss",
-          "period": 4,
-          "clock_seconds": 525,
-          "team_id": 7,
-          "player_id": 102,
-          "shot_type": "3pt",
-          "shot_origin": "initial"
-        },
-        {
-          "kind": "rebound",
-          "period": 4,
-          "clock_seconds": 525,
-          "team_id": 3,
-          "player_id": 201
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 510,
+          "clock_seconds": 600,
           "team_id": 3
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 510,
-          "team_id": 3,
-          "player_id": 205
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 510,
-          "team_id": 3,
-          "player_id": 205,
-          "defender_id": 102
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 495,
-          "team_id": 7
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 105
-        },
-        {
-          "kind": "steal",
-          "period": 4,
-          "clock_seconds": 495,
-          "team_id": 7,
-          "player_id": 105,
-          "defender_id": 202
-        },
-        {
-          "kind": "possession_start",
-          "period": 4,
-          "clock_seconds": 480,
-          "team_id": 3
-        },
-        {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 480,
+          "clock_seconds": 600,
           "team_id": 3,
           "player_id": 201
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 480,
+          "clock_seconds": 600,
           "team_id": 3,
           "player_id": 201,
           "defender_id": 102
@@ -4571,13 +4628,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 465,
+          "clock_seconds": 585,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 465,
+          "clock_seconds": 585,
           "team_id": 7,
           "player_id": 105,
           "shot_type": "2pt",
@@ -4586,7 +4643,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 465,
+          "clock_seconds": 585,
           "team_id": 7,
           "player_id": 105,
           "shot_type": "2pt",
@@ -4595,13 +4652,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 450,
+          "clock_seconds": 570,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 450,
+          "clock_seconds": 570,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
@@ -4610,7 +4667,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 450,
+          "clock_seconds": 570,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
@@ -4619,7 +4676,7 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 450,
+          "clock_seconds": 570,
           "team_id": 3,
           "player_id": 201,
           "offensive_rebound": true
@@ -4627,14 +4684,14 @@
         {
           "kind": "foul",
           "period": 4,
-          "clock_seconds": 450,
+          "clock_seconds": 570,
           "team_id": 7,
           "player_id": 101
         },
         {
           "kind": "free_throw",
           "period": 4,
-          "clock_seconds": 450,
+          "clock_seconds": 570,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "ft",
@@ -4643,20 +4700,20 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 435,
+          "clock_seconds": 555,
           "team_id": 7
         },
         {
           "kind": "foul",
           "period": 4,
-          "clock_seconds": 435,
+          "clock_seconds": 555,
           "team_id": 3,
           "player_id": 202
         },
         {
           "kind": "free_throw",
           "period": 4,
-          "clock_seconds": 435,
+          "clock_seconds": 555,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "ft",
@@ -4666,13 +4723,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 420,
+          "clock_seconds": 540,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 420,
+          "clock_seconds": 540,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -4681,7 +4738,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 420,
+          "clock_seconds": 540,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -4690,13 +4747,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 405,
+          "clock_seconds": 525,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 405,
+          "clock_seconds": 525,
           "team_id": 7,
           "player_id": 104,
           "shot_type": "2pt",
@@ -4705,7 +4762,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 405,
+          "clock_seconds": 525,
           "team_id": 7,
           "player_id": 104,
           "shot_type": "2pt",
@@ -4714,7 +4771,7 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 405,
+          "clock_seconds": 525,
           "team_id": 7,
           "player_id": 103,
           "offensive_rebound": true
@@ -4722,14 +4779,14 @@
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 405,
+          "clock_seconds": 525,
           "team_id": 7,
           "player_id": 103
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 405,
+          "clock_seconds": 525,
           "team_id": 7,
           "player_id": 103,
           "defender_id": 205
@@ -4737,13 +4794,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 390,
+          "clock_seconds": 510,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 390,
+          "clock_seconds": 510,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
@@ -4752,7 +4809,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 390,
+          "clock_seconds": 510,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
@@ -4761,20 +4818,20 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 375,
+          "clock_seconds": 495,
           "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 375,
+          "clock_seconds": 495,
           "team_id": 7,
           "player_id": 101
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 375,
+          "clock_seconds": 495,
           "team_id": 7,
           "player_id": 101,
           "defender_id": 202
@@ -4782,20 +4839,20 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 360,
+          "clock_seconds": 480,
           "team_id": 3
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 360,
+          "clock_seconds": 480,
           "team_id": 3,
           "player_id": 202
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 360,
+          "clock_seconds": 480,
           "team_id": 3,
           "player_id": 202,
           "defender_id": 102
@@ -4803,13 +4860,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 345,
+          "clock_seconds": 465,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 345,
+          "clock_seconds": 465,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt",
@@ -4818,7 +4875,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 345,
+          "clock_seconds": 465,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt",
@@ -4827,7 +4884,7 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 345,
+          "clock_seconds": 465,
           "team_id": 7,
           "player_id": 103,
           "offensive_rebound": true
@@ -4835,14 +4892,14 @@
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 345,
+          "clock_seconds": 465,
           "team_id": 7,
           "player_id": 103
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 345,
+          "clock_seconds": 465,
           "team_id": 7,
           "player_id": 103,
           "defender_id": 201
@@ -4850,20 +4907,20 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 330,
+          "clock_seconds": 450,
           "team_id": 3
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 330,
+          "clock_seconds": 450,
           "team_id": 3,
           "player_id": 204
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 330,
+          "clock_seconds": 450,
           "team_id": 3,
           "player_id": 204,
           "defender_id": 105
@@ -4871,20 +4928,20 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 315,
+          "clock_seconds": 435,
           "team_id": 7
         },
         {
           "kind": "foul",
           "period": 4,
-          "clock_seconds": 315,
+          "clock_seconds": 435,
           "team_id": 3,
           "player_id": 202
         },
         {
           "kind": "free_throw",
           "period": 4,
-          "clock_seconds": 315,
+          "clock_seconds": 435,
           "team_id": 7,
           "player_id": 102,
           "shot_type": "ft",
@@ -4894,13 +4951,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 300,
+          "clock_seconds": 420,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 300,
+          "clock_seconds": 420,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
@@ -4909,7 +4966,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 300,
+          "clock_seconds": 420,
           "team_id": 3,
           "player_id": 202,
           "shot_type": "2pt",
@@ -4918,20 +4975,20 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 285,
+          "clock_seconds": 405,
           "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 285,
+          "clock_seconds": 405,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 285,
+          "clock_seconds": 405,
           "team_id": 7,
           "player_id": 102,
           "defender_id": 202
@@ -4939,13 +4996,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 270,
+          "clock_seconds": 390,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 270,
+          "clock_seconds": 390,
           "team_id": 3,
           "player_id": 205,
           "shot_type": "2pt",
@@ -4954,7 +5011,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 270,
+          "clock_seconds": 390,
           "team_id": 3,
           "player_id": 205,
           "shot_type": "2pt",
@@ -4963,13 +5020,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 255,
+          "clock_seconds": 375,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 255,
+          "clock_seconds": 375,
           "team_id": 7,
           "player_id": 103,
           "shot_type": "2pt",
@@ -4978,7 +5035,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 255,
+          "clock_seconds": 375,
           "team_id": 7,
           "player_id": 103,
           "shot_type": "2pt",
@@ -4987,20 +5044,20 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 255,
+          "clock_seconds": 375,
           "team_id": 3,
           "player_id": 204
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 240,
+          "clock_seconds": 360,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 240,
+          "clock_seconds": 360,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -5009,7 +5066,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 240,
+          "clock_seconds": 360,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -5018,20 +5075,20 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 225,
+          "clock_seconds": 345,
           "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 225,
+          "clock_seconds": 345,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 225,
+          "clock_seconds": 345,
           "team_id": 7,
           "player_id": 102,
           "defender_id": 203
@@ -5039,13 +5096,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 210,
+          "clock_seconds": 330,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 210,
+          "clock_seconds": 330,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "2pt",
@@ -5054,7 +5111,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 210,
+          "clock_seconds": 330,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "2pt",
@@ -5063,27 +5120,27 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 210,
+          "clock_seconds": 330,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 195,
+          "clock_seconds": 315,
           "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 195,
+          "clock_seconds": 315,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 195,
+          "clock_seconds": 315,
           "team_id": 7,
           "player_id": 102,
           "defender_id": 202
@@ -5091,13 +5148,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 180,
+          "clock_seconds": 300,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 180,
+          "clock_seconds": 300,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -5106,7 +5163,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 180,
+          "clock_seconds": 300,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -5115,13 +5172,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 165,
+          "clock_seconds": 285,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 165,
+          "clock_seconds": 285,
           "team_id": 7,
           "player_id": 105,
           "shot_type": "2pt",
@@ -5130,7 +5187,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 165,
+          "clock_seconds": 285,
           "team_id": 7,
           "player_id": 105,
           "shot_type": "2pt",
@@ -5139,13 +5196,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 150,
+          "clock_seconds": 270,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 150,
+          "clock_seconds": 270,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -5154,7 +5211,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 150,
+          "clock_seconds": 270,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -5163,13 +5220,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 135,
+          "clock_seconds": 255,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 135,
+          "clock_seconds": 255,
           "team_id": 7,
           "player_id": 103,
           "shot_type": "3pt",
@@ -5178,7 +5235,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 135,
+          "clock_seconds": 255,
           "team_id": 7,
           "player_id": 103,
           "shot_type": "3pt",
@@ -5187,13 +5244,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 120,
+          "clock_seconds": 240,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 120,
+          "clock_seconds": 240,
           "team_id": 3,
           "player_id": 205,
           "shot_type": "2pt",
@@ -5202,7 +5259,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 120,
+          "clock_seconds": 240,
           "team_id": 3,
           "player_id": 205,
           "shot_type": "2pt",
@@ -5211,7 +5268,7 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 120,
+          "clock_seconds": 240,
           "team_id": 3,
           "player_id": 203,
           "offensive_rebound": true
@@ -5219,7 +5276,7 @@
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 120,
+          "clock_seconds": 240,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -5228,7 +5285,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 120,
+          "clock_seconds": 240,
           "team_id": 3,
           "player_id": 203,
           "shot_type": "2pt",
@@ -5237,20 +5294,20 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 120,
+          "clock_seconds": 240,
           "team_id": 7,
           "player_id": 102
         },
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 225,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 225,
           "team_id": 7,
           "player_id": 105,
           "shot_type": "2pt",
@@ -5259,7 +5316,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 225,
           "team_id": 7,
           "player_id": 105,
           "shot_type": "2pt",
@@ -5268,7 +5325,7 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 225,
           "team_id": 7,
           "player_id": 105,
           "offensive_rebound": true
@@ -5276,14 +5333,14 @@
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 225,
           "team_id": 7,
           "player_id": 105
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 105,
+          "clock_seconds": 225,
           "team_id": 7,
           "player_id": 105,
           "defender_id": 204
@@ -5291,13 +5348,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 90,
+          "clock_seconds": 210,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 90,
+          "clock_seconds": 210,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "2pt",
@@ -5306,7 +5363,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 90,
+          "clock_seconds": 210,
           "team_id": 3,
           "player_id": 201,
           "shot_type": "2pt",
@@ -5315,20 +5372,20 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 75,
+          "clock_seconds": 195,
           "team_id": 7
         },
         {
           "kind": "turnover",
           "period": 4,
-          "clock_seconds": 75,
+          "clock_seconds": 195,
           "team_id": 7,
           "player_id": 103
         },
         {
           "kind": "steal",
           "period": 4,
-          "clock_seconds": 75,
+          "clock_seconds": 195,
           "team_id": 7,
           "player_id": 103,
           "defender_id": 203
@@ -5336,13 +5393,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 60,
+          "clock_seconds": 180,
           "team_id": 3
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 60,
+          "clock_seconds": 180,
           "team_id": 3,
           "player_id": 205,
           "shot_type": "3pt",
@@ -5351,7 +5408,7 @@
         {
           "kind": "shot_make",
           "period": 4,
-          "clock_seconds": 60,
+          "clock_seconds": 180,
           "team_id": 3,
           "player_id": 205,
           "shot_type": "3pt",
@@ -5360,13 +5417,13 @@
         {
           "kind": "possession_start",
           "period": 4,
-          "clock_seconds": 45,
+          "clock_seconds": 165,
           "team_id": 7
         },
         {
           "kind": "shot_attempt",
           "period": 4,
-          "clock_seconds": 45,
+          "clock_seconds": 165,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt",
@@ -5375,7 +5432,7 @@
         {
           "kind": "shot_miss",
           "period": 4,
-          "clock_seconds": 45,
+          "clock_seconds": 165,
           "team_id": 7,
           "player_id": 101,
           "shot_type": "2pt",
@@ -5384,9 +5441,255 @@
         {
           "kind": "rebound",
           "period": 4,
-          "clock_seconds": 45,
+          "clock_seconds": 165,
           "team_id": 3,
           "player_id": 202
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 3,
+          "player_id": 204,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 150,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 135,
+          "team_id": 7,
+          "player_id": 102,
+          "defender_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 120,
+          "team_id": 3
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 203
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 120,
+          "team_id": 3,
+          "player_id": 203,
+          "defender_id": 105
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 105,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 105,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "2pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 105,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 90,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 201,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 205,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 205
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 90,
+          "team_id": 3,
+          "player_id": 205,
+          "defender_id": 101
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 75,
+          "team_id": 7
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 75,
+          "team_id": 7,
+          "player_id": 104,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 60,
+          "team_id": 3
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "shot_miss",
+          "period": 4,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 202,
+          "shot_type": "3pt",
+          "shot_origin": "initial"
+        },
+        {
+          "kind": "rebound",
+          "period": 4,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 205,
+          "offensive_rebound": true
+        },
+        {
+          "kind": "shot_attempt",
+          "period": 4,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 60,
+          "team_id": 3,
+          "player_id": 205,
+          "shot_type": "2pt",
+          "shot_origin": "oreb_continuation"
+        },
+        {
+          "kind": "possession_start",
+          "period": 4,
+          "clock_seconds": 45,
+          "team_id": 7
+        },
+        {
+          "kind": "turnover",
+          "period": 4,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 101
+        },
+        {
+          "kind": "steal",
+          "period": 4,
+          "clock_seconds": 45,
+          "team_id": 7,
+          "player_id": 101,
+          "defender_id": 205
         },
         {
           "kind": "possession_start",
@@ -5399,7 +5702,7 @@
           "period": 4,
           "clock_seconds": 30,
           "team_id": 3,
-          "player_id": 204,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
@@ -5408,7 +5711,7 @@
           "period": 4,
           "clock_seconds": 30,
           "team_id": 3,
-          "player_id": 204,
+          "player_id": 203,
           "shot_type": "2pt",
           "shot_origin": "initial"
         },
@@ -5417,7 +5720,7 @@
           "period": 4,
           "clock_seconds": 30,
           "team_id": 7,
-          "player_id": 101
+          "player_id": 102
         },
         {
           "kind": "possession_start",
@@ -5426,19 +5729,22 @@
           "team_id": 7
         },
         {
-          "kind": "turnover",
-          "period": 4,
-          "clock_seconds": 15,
-          "team_id": 7,
-          "player_id": 102
-        },
-        {
-          "kind": "steal",
+          "kind": "shot_attempt",
           "period": 4,
           "clock_seconds": 15,
           "team_id": 7,
           "player_id": 102,
-          "defender_id": 205
+          "shot_type": "2pt",
+          "shot_origin": "transition"
+        },
+        {
+          "kind": "shot_make",
+          "period": 4,
+          "clock_seconds": 15,
+          "team_id": 7,
+          "player_id": 102,
+          "shot_type": "2pt",
+          "shot_origin": "transition"
         },
         {
           "kind": "period_boundary",
@@ -5452,16 +5758,16 @@
           "pos": "PG",
           "gameMIN": 48,
           "game2GM": 3,
-          "game2GA": 10,
-          "gameFTM": 2,
-          "gameFTA": 2,
-          "game3GM": 1,
-          "game3GA": 3,
-          "gameORB": 2,
-          "gameDRB": 5,
+          "game2GA": 6,
+          "gameFTM": 4,
+          "gameFTA": 6,
+          "game3GM": 2,
+          "game3GA": 5,
+          "gameORB": 1,
+          "gameDRB": 3,
           "gameAST": 0,
-          "gameSTL": 7,
-          "gameTOV": 5,
+          "gameSTL": 8,
+          "gameTOV": 7,
           "gameBLK": 0,
           "gamePF": 3
         },
@@ -5469,73 +5775,73 @@
           "pid": 102,
           "pos": "SG",
           "gameMIN": 48,
-          "game2GM": 2,
+          "game2GM": 7,
           "game2GA": 10,
-          "gameFTM": 3,
-          "gameFTA": 4,
-          "game3GM": 1,
-          "game3GA": 3,
-          "gameORB": 2,
-          "gameDRB": 6,
+          "gameFTM": 2,
+          "gameFTA": 2,
+          "game3GM": 0,
+          "game3GA": 5,
+          "gameORB": 3,
+          "gameDRB": 7,
           "gameAST": 0,
-          "gameSTL": 6,
-          "gameTOV": 6,
-          "gameBLK": 1,
-          "gamePF": 2
+          "gameSTL": 7,
+          "gameTOV": 4,
+          "gameBLK": 0,
+          "gamePF": 1
         },
         {
           "pid": 103,
           "pos": "SF",
           "gameMIN": 48,
-          "game2GM": 5,
-          "game2GA": 14,
-          "gameFTM": 0,
+          "game2GM": 10,
+          "game2GA": 18,
+          "gameFTM": 1,
           "gameFTA": 2,
-          "game3GM": 2,
-          "game3GA": 4,
-          "gameORB": 6,
-          "gameDRB": 1,
+          "game3GM": 1,
+          "game3GA": 2,
+          "gameORB": 7,
+          "gameDRB": 2,
           "gameAST": 0,
           "gameSTL": 3,
-          "gameTOV": 8,
+          "gameTOV": 7,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 2
         },
         {
           "pid": 104,
           "pos": "PF",
           "gameMIN": 48,
-          "game2GM": 7,
-          "game2GA": 13,
-          "gameFTM": 2,
-          "gameFTA": 2,
-          "game3GM": 2,
+          "game2GM": 5,
+          "game2GA": 15,
+          "gameFTM": 0,
+          "gameFTA": 0,
+          "game3GM": 1,
           "game3GA": 2,
-          "gameORB": 2,
-          "gameDRB": 4,
+          "gameORB": 3,
+          "gameDRB": 5,
           "gameAST": 0,
-          "gameSTL": 9,
-          "gameTOV": 6,
-          "gameBLK": 1,
+          "gameSTL": 5,
+          "gameTOV": 3,
+          "gameBLK": 0,
           "gamePF": 2
         },
         {
           "pid": 105,
           "pos": "C",
           "gameMIN": 48,
-          "game2GM": 8,
+          "game2GM": 6,
           "game2GA": 13,
-          "gameFTM": 1,
-          "gameFTA": 2,
+          "gameFTM": 0,
+          "gameFTA": 0,
           "game3GM": 1,
-          "game3GA": 1,
-          "gameORB": 2,
+          "game3GA": 2,
+          "gameORB": 1,
           "gameDRB": 2,
           "gameAST": 0,
-          "gameSTL": 2,
-          "gameTOV": 6,
+          "gameSTL": 4,
+          "gameTOV": 7,
           "gameBLK": 0,
-          "gamePF": 0
+          "gamePF": 1
         },
         {
           "pid": 106,
@@ -5559,35 +5865,35 @@
           "pid": 201,
           "pos": "PG",
           "gameMIN": 48,
-          "game2GM": 9,
-          "game2GA": 13,
+          "game2GM": 10,
+          "game2GA": 17,
           "gameFTM": 2,
-          "gameFTA": 5,
-          "game3GM": 0,
-          "game3GA": 2,
-          "gameORB": 2,
-          "gameDRB": 5,
+          "gameFTA": 4,
+          "game3GM": 1,
+          "game3GA": 3,
+          "gameORB": 5,
+          "gameDRB": 1,
           "gameAST": 0,
-          "gameSTL": 5,
-          "gameTOV": 3,
-          "gameBLK": 0,
-          "gamePF": 1
+          "gameSTL": 2,
+          "gameTOV": 7,
+          "gameBLK": 1,
+          "gamePF": 0
         },
         {
           "pid": 202,
           "pos": "SG",
           "gameMIN": 48,
           "game2GM": 7,
-          "game2GA": 13,
+          "game2GA": 14,
           "gameFTM": 0,
-          "gameFTA": 0,
-          "game3GM": 0,
-          "game3GA": 1,
-          "gameORB": 1,
-          "gameDRB": 6,
+          "gameFTA": 1,
+          "game3GM": 1,
+          "game3GA": 3,
+          "gameORB": 4,
+          "gameDRB": 9,
           "gameAST": 0,
-          "gameSTL": 10,
-          "gameTOV": 6,
+          "gameSTL": 6,
+          "gameTOV": 3,
           "gameBLK": 0,
           "gamePF": 3
         },
@@ -5595,17 +5901,17 @@
           "pid": 203,
           "pos": "SF",
           "gameMIN": 48,
-          "game2GM": 13,
-          "game2GA": 21,
-          "gameFTM": 1,
+          "game2GM": 12,
+          "game2GA": 19,
+          "gameFTM": 2,
           "gameFTA": 2,
-          "game3GM": 0,
-          "game3GA": 0,
-          "gameORB": 3,
-          "gameDRB": 5,
+          "game3GM": 1,
+          "game3GA": 2,
+          "gameORB": 4,
+          "gameDRB": 7,
           "gameAST": 0,
-          "gameSTL": 6,
-          "gameTOV": 2,
+          "gameSTL": 8,
+          "gameTOV": 4,
           "gameBLK": 0,
           "gamePF": 0
         },
@@ -5613,83 +5919,83 @@
           "pid": 204,
           "pos": "PF",
           "gameMIN": 48,
-          "game2GM": 7,
-          "game2GA": 10,
-          "gameFTM": 7,
-          "gameFTA": 7,
-          "game3GM": 0,
-          "game3GA": 0,
-          "gameORB": 2,
-          "gameDRB": 7,
+          "game2GM": 4,
+          "game2GA": 9,
+          "gameFTM": 2,
+          "gameFTA": 3,
+          "game3GM": 2,
+          "game3GA": 2,
+          "gameORB": 1,
+          "gameDRB": 6,
           "gameAST": 0,
-          "gameSTL": 6,
-          "gameTOV": 4,
+          "gameSTL": 5,
+          "gameTOV": 8,
           "gameBLK": 0,
-          "gamePF": 1
+          "gamePF": 2
         },
         {
           "pid": 205,
           "pos": "C",
           "gameMIN": 48,
-          "game2GM": 7,
-          "game2GA": 10,
-          "gameFTM": 0,
-          "gameFTA": 0,
-          "game3GM": 2,
+          "game2GM": 6,
+          "game2GA": 12,
+          "gameFTM": 2,
+          "gameFTA": 2,
+          "game3GM": 3,
           "game3GA": 3,
-          "gameORB": 2,
+          "gameORB": 4,
           "gameDRB": 4,
           "gameAST": 0,
-          "gameSTL": 4,
-          "gameTOV": 12,
-          "gameBLK": 1,
-          "gamePF": 1
+          "gameSTL": 7,
+          "gameTOV": 5,
+          "gameBLK": 0,
+          "gamePF": 0
         }
       ],
       "team_boxes": [
         {
           "team_id": 7,
           "is_home": false,
-          "q1": 24,
-          "q2": 29,
-          "q3": 15,
-          "q4": 11,
+          "q1": 29,
+          "q2": 27,
+          "q3": 12,
+          "q4": 16,
           "ot": [],
-          "game2GM": 25,
-          "game2GA": 60,
-          "gameFTM": 8,
-          "gameFTA": 12,
-          "game3GM": 7,
-          "game3GA": 13,
-          "gameORB": 14,
-          "gameDRB": 18,
+          "game2GM": 31,
+          "game2GA": 62,
+          "gameFTM": 7,
+          "gameFTA": 10,
+          "game3GM": 5,
+          "game3GA": 16,
+          "gameORB": 15,
+          "gameDRB": 19,
           "gameAST": 0,
           "gameSTL": 27,
-          "gameTOV": 31,
-          "gameBLK": 2,
-          "gamePF": 8
+          "gameTOV": 28,
+          "gameBLK": 0,
+          "gamePF": 9
         },
         {
           "team_id": 3,
           "is_home": true,
           "q1": 30,
-          "q2": 28,
-          "q3": 21,
-          "q4": 23,
+          "q2": 26,
+          "q3": 30,
+          "q4": 24,
           "ot": [],
-          "game2GM": 43,
-          "game2GA": 67,
-          "gameFTM": 10,
-          "gameFTA": 14,
-          "game3GM": 2,
-          "game3GA": 6,
-          "gameORB": 10,
+          "game2GM": 39,
+          "game2GA": 71,
+          "gameFTM": 8,
+          "gameFTA": 12,
+          "game3GM": 8,
+          "game3GA": 13,
+          "gameORB": 18,
           "gameDRB": 27,
           "gameAST": 0,
-          "gameSTL": 31,
+          "gameSTL": 28,
           "gameTOV": 27,
           "gameBLK": 1,
-          "gamePF": 6
+          "gamePF": 5
         }
       ]
     }


### PR DESCRIPTION
Third FTA level re-anchor per foulBucketScale's documented maintenance contract (level dial re-found after any faithful basis change — not corpus tuning).

**Trigger:** J18 item 2 (#1436) pinned `d70LeagueScalar` 1.0→0.6472241372826754, shrinking the d70 FTA-rate term in `twoPtBucketWeight` and raising the foul bucket's normalized share. Combined-master FTA/g read **21.82** vs the .sco target **21.32** at the then-current 0.40.

**1-D search (combined basis):** 0.39→21.36, 0.40→21.82 → **0.39** (gap +0.04).

**Margin lock check:** gt=2 home-margin gap +0.498 (0.40) → +0.491 (0.39), delta −0.007, within the ~±0.03 Monte-Carlo noise floor — Phase-5 margin lock undisturbed.

Golden regenerated; full engine suite green (`go build && go vet && go test ./...`).