### PR TITLE
docs(jsb): close out J8+J11, record J18 merge completion + third fta re-anchor

### DIFF
--- a/ibl5/docs/backlog/archive/jsb-native-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/jsb-native-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed JSB native-engine backlog entries (J-items), extracted from jsb-native-backlog.md.
-last_verified: 2026-07-12
+last_verified: 2026-07-13
 ---
 
 # JSB Native-Engine Backlog — Archive
@@ -77,3 +77,24 @@ Full detail: symmetric deterministic base `(2.0 − fatigue)·tovRate(bh)` (corr
 ### J19 J6-residue RE (energy operands, rec+0x18 semantics, escape re-derivation, +0xD58)
 
 **Status (2026-07-12):** ✅ Implemented — the load-bearing item (1), J16's escape-bound re-derivation with live AST/48, was resolved inside the J15 program (ADR-0084: the deterministic home arm is effectively-not-perfectly non-positive; live +0xDC8 AST48 shaved the barrier ~15%, residual 57.16 → 48.42, redraw still dominant for any realistic roster). Bounded residue spun forward as a follow-on objdump session — item (2) rec[+0x18] in-season decay semantics, (3) energy-formula operand identities (asm 4d4711–4d4774), (4) +0xD58 dead-vs-reader confirm, plus the +0xDA0/+0xDA8 transition-retention re-trace. 🧠 Opus (🔮 only if the asm hits the NaN/FPU-flag class).
+
+---
+
+### J8 Transition trigger denominator 18
+
+**Status (2026-07-13):** ✅ Implemented — PR #1433 ported the asm-confirmed `transitionTriggerDenom = 18` (was 20). ⚙️ Sonnet.
+
+**Location:** `engine/internal/sim/transition.go` `transitionTriggerDenom = 20` (comment admits "unpinned stand-in") vs asm-confirmed 5.60 value **18** (`push 0x12` before the rand_int call).
+**Problem:** Engine under-fires transition ~11% with a ~10%-too-shallow TransOff slope. Like J7 this corrects fidelity while nudging the count-axis headline the WRONG way (more transition volume → more dilution).
+**Direction:** One-constant port + A/B (expect a small negative headline nudge; ship on fidelity grounds with the A/B in the PR). Sequence after the J2 verdict.
+
+---
+
+### J11 Season-selection min-GP guard
+
+**Status (2026-07-13):** ✅ Verified already-implemented — the verify-first check found the guard shipped in PR #975: `minSeasonMedianGP = 70` with a proxy-medGP (2·games/teams) pre-sim skip in `engine/internal/calibrate/season.go`, exactly the truncated-season protection this item wanted. No further work. ⚙️ Sonnet.
+
+**Location:** `engine/internal/calibrate` season selection (season.go) — picked TRUNCATED snapshots for 5/19 seasons (medGP 3–46 instead of ~82) when last measured.
+**Problem:** Silently biases any committed standings gate that walks the archive.
+**Direction:** Verify first — later corpus-completeness work (era-dependent complete-season counts, medGP normalization) may already cover it; if not, add the guard + a regression test. Measurement recipes in the re-artifacts assume it is still open.
+

--- a/ibl5/docs/backlog/jsb-native-backlog.md
+++ b/ibl5/docs/backlog/jsb-native-backlog.md
@@ -40,7 +40,7 @@ J1 faithful foul pair (✅ 2026-07-10, ADR-0082) ─→ J2 adjudications (✅ 20
               ├─ prerequisite: J16 escape bound re-derived with LIVE AST/48 (J19) — ✅ J19 done
               └─→ J2 verdict: SHIPPABLE with residual → successor = J20 empty-FGA restructure (J4 ✅ 2026-07-12 feeds it) → J13 (unblocked)
 J17 game-state foul coupling (⬜, new 2026-07-10) — real 5.60 mechanism the engine lacks entirely
-J18 composite fidelity ports (◑ — formula divergences shipped; f/shrink pending) · J19 J6-residue RE (✅ 2026-07-12) — both spawned by J6
+J18 composite fidelity ports (◑ — all divergences merged; f/shrink question pending) · J19 J6-residue RE (✅ 2026-07-12) — both spawned by J6
 ```
 
 The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dominant carrier** (J2 session 1, 2026-07-10): a mechanical Cov injection from unfaithful foul share. PPS = PF/FGA counts FT points in the numerator while foul plays displace FGA from the denominator, so excess foul-share level/dispersion injects negative Cov directly; the engine ran foul share at **1.8× real** (37.8 vs 20.65 FTA/g, a pre-ADR-0082 legacy). Zeroing defQ moved gt2 Cov **−0.000774 → −0.000340** (real +0.000269) — 56% of the residual, ~15× any prior single lever; that A/B stands as measurement. **But J6 (same day) overturned the static premise underneath it:** J5's "defQ ≡ 0" was a store-enumeration blindspot — 5.60 builds the player record on the STACK (FUN_004cfa50 → FUN_00405970 write-back), so +0xDD0 (STL/MIN×44), +0xDE0 (usage-shrunk TOV/48), and +0xDC8 (AST/48) are all **live**. The faithful foul coupling is therefore roster-VARYING (defQ = Σ defenders' STL/MIN×44; offQ = Σ offense TOV/48 − HCA, TOV-coupled not volume-neutral), and J2's "symmetric U[0,0.6) both sides" verdict plus the J15 program must be re-adjudicated against the live-composite semantics before any port ships. "Mapped carriers exhausted" stays refuted; the map had a foul-path hole — and a method hole (see J6's caveat).
@@ -51,10 +51,10 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 7 |
+| ⬜ Open | 5 |
 | 📋 Planned | 0 |
 | ◑ Partial | 1 |
-| ✅ Implemented | 12 |
+| ✅ Implemented | 14 |
 | 🚫 Declined | 0 |
 
 ---
@@ -70,10 +70,10 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 | J5 | Unpinnable-claims sweep + static closures | ✅ Implemented | 🔮 Fable | M |
 | J6 | Composite-scale pins (+0xD90/+0xDB0, `f`, full player formula map) | ✅ Implemented | 🔮 Fable | M |
 | J7 | Turnover volume-coupling fidelity RE | ⬜ Open | 🧠 Opus | M |
-| J8 | Transition trigger denominator 18 | ⬜ Open | ⚙️ Sonnet | S |
+| J8 | Transition trigger denominator 18 | ✅ Implemented | ⚙️ Sonnet | S |
 | J9 | League-baseline faithful port (FUN_004385f0) | ✅ Implemented | ⚙️ Sonnet | S |
 | J10 | `.plb` minutes reader + stamina=100 bundle fix | ✅ Implemented | ⚙️ Sonnet | S |
-| J11 | Season-selection min-GP guard | ⬜ Open | ⚙️ Sonnet | S |
+| J11 | Season-selection min-GP guard | ✅ Implemented | ⚙️ Sonnet | S |
 | J12 | HCA re-homing to basis-scaled site-2 (absorbed into J15) | ✅ Implemented | 🧠 Opus | M |
 | J13 | Cut-over package: bands, leaders, decision | ⬜ Open | 🧠 Opus | L |
 | J14 | AutoResearch eval-harness ADR (loop L9 companion) | ⬜ Open | 🧠 Opus | L |
@@ -109,10 +109,7 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 **Status (2026-07-08):** ⬜ Open. 🧠 Opus (RE + verdict); port likely ⚙️ Sonnet.
 
 ### J8 Transition trigger denominator 18
-**Location:** `engine/internal/sim/transition.go` `transitionTriggerDenom = 20` (comment admits "unpinned stand-in") vs asm-confirmed 5.60 value **18** (`push 0x12` before the rand_int call).
-**Problem:** Engine under-fires transition ~11% with a ~10%-too-shallow TransOff slope. Like J7 this corrects fidelity while nudging the count-axis headline the WRONG way (more transition volume → more dilution).
-**Direction:** One-constant port + A/B (expect a small negative headline nudge; ship on fidelity grounds with the A/B in the PR). Sequence after the J2 verdict.
-**Status (2026-07-08):** ⬜ Open. ⚙️ Sonnet build + 🧠 Opus A/B sign-off.
+➜ J8 Transition trigger denominator 18 — ✅ Implemented (2026-07-13): PR #1433 (`transitionTriggerDenom` 20→18, asm-verified); see [archive](archive/jsb-native-backlog-archive.md).
 
 ### J9 League-baseline faithful port (FUN_004385f0)
 ➜ J9 League-baseline faithful port — ✅ Implemented (2026-07-12): PR #1437; see [archive](archive/jsb-native-backlog-archive.md).
@@ -124,10 +121,7 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 **Status (2026-07-12):** ✅ Implemented. Merged via PR #949 (`engine/internal/backup/plb.go` + `assemble.go`) — confirmed still live; archive regression re-run clean. ⚙️ Sonnet.
 
 ### J11 Season-selection min-GP guard
-**Location:** `engine/internal/calibrate` season selection (season.go) — picked TRUNCATED snapshots for 5/19 seasons (medGP 3–46 instead of ~82) when last measured.
-**Problem:** Silently biases any committed standings gate that walks the archive.
-**Direction:** Verify first — later corpus-completeness work (era-dependent complete-season counts, medGP normalization) may already cover it; if not, add the guard + a regression test. Measurement recipes in the re-artifacts assume it is still open.
-**Status (2026-07-08):** ⬜ Open (verify-first). ⚙️ Sonnet.
+➜ J11 Season-selection min-GP guard — ✅ Verified already-implemented (2026-07-13): guard shipped in PR #975 (`minSeasonMedianGP = 70` + proxy-medGP skip, `engine/internal/calibrate/season.go`); see [archive](archive/jsb-native-backlog-archive.md).
 
 ### J12 HCA re-homing to basis-scaled site-2 (absorbed into J15)
 **Location:** `engine/internal/sim/possession.go` `s2 + hca` (the site-2 2pt-composite nudge).
@@ -167,8 +161,8 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 **Location:** `engine/internal/sim/bucketweights.go` + `teamquality.go` — every divergence from the J6-pinned formulas, now enumerable against `jsb-native/re-artifacts/jsb-J6-composite-scales-20260710.md` §2/§6.
 **Problem:** J6 turned "unpinned stand-in" into "known-divergent." Confirmed divergences: (1) `bucketweights.go` comments (~:19, ~:180) assert "+0xDB0 is DEAD (always 0)" — false, it's usage-shrunk 3GA/MIN×48, so `threePtBucketWeight` needs re-derivation from the live composite (also a candidate for J2's residual: FTADisp 1.51, and the 3pt weight sits in the foul-share denominator); (2) `d70LeagueScalar = 1.0` (~:77) where 5.60 uses **S = (leaguePF48×5 − leagueTOV48×0.5)/(leagueFTA48×5)**, exactly computable from the FUN_004385f0 table the engine already models; (3) `d88` (~:159) uses `RealLifeFGA` where 5.60 uses **2PA** (and f-projected inputs); (4) the "+0xDE0 dead ⇒ foul floors" comment (~:85) premise is wrong; (5) `teamquality.go` faithful formulas per J15; (6) the `param_6` net-advantage foul shrink `e80 ×= 1 − param_6/(4·leagueTOV48)` (J16 exact identity, applied in 5.60 after the coupling and before the ≤0 redraw, both param_5 paths) — ✅ PORTED 2026-07-12 (jsb-j2s2-j18-composites). Provenance correction from the port: 5.60's `param_6` at the FUN_004e1ba0 site is FUN_004e3860's return (`:93276-93293` fVar22→dVar1→double arg), i.e. the Go **`matchupQuality`** — NOT the ODPT `netAdvantage` ADR-0084 Decision 2 assumed (whose O(10s) scale would trip the 13.4126 redraw threshold every possession). With matchupQuality's Phase 3/4 aggregates stubbed to 0, mq spans ~[−0.5,+0.8] so the shrink is a ±few-% modulation that matures when those aggregates land. Open modeling question: whether to port the `f = (Confidence + rec[+0x18] + 95)/200` ±2% projection modulation and the pass-2 usage shrink, or accept them as documented divergences (they need Confidence + the +0x18 marker in the bundle).
 **Direction:** Foul-adjacent pieces (2)(4)(5) execute inside J15. The shot-mix pieces (1)(3) and the f/shrink question are a follow-on A/B'd PR — each changes bucket weights globally, so headline Cov + Var gates must be re-measured per change, not batched blind. Comment corrections ride the first PR that touches each file.
-**Update (2026-07-12):** All enumerated divergences ported/fixed, each individually A/B'd: (1) threePtBucketWeight = faithful 3GA/MIN×48 (PR #1438); (2) d70LeagueScalar = 0.6472241372826754, S computed exactly from the J9-validated league table (PR #1436); (3) d88 = 2PA/48 (PR #1439); (4) fixed in J15 (#1432); (5) in J15; (6, discovered during J16) :97164 mq foul shrink (PR #1435). Cov unchanged in every A/B — confirming the J2 s2 finding that shot-mix ports are fidelity work, not Cov levers. Follow-up shipped: foulBucketScale re-anchored 0.47 → 0.40 (PR #1440, its documented maintenance contract after the basis shrink); one more anchor check needed after the two stacks (#1436 vs #1437-40) merge. Ports live on two stacks and both edit `bucketweights.go` — expect a merge conflict.
-**Status (2026-07-12):** ◑ Partial — all six formula divergences shipped (PRs #1435–#1440, stacked, pending merge); remaining: the f = (Confidence + rec[+0x18] + 95)/200 projection-modulation / pass-2 usage-shrink port-vs-document question (🧠 user decision — J19's rec[+0x18] evidence favors documenting as divergence).
+**Update (2026-07-12):** All enumerated divergences ported/fixed, each individually A/B'd: (1) threePtBucketWeight = faithful 3GA/MIN×48 (PR #1438); (2) d70LeagueScalar = 0.6472241372826754, S computed exactly from the J9-validated league table (PR #1436); (3) d88 = 2PA/48 (PR #1439); (4) fixed in J15 (#1432); (5) in J15; (6, discovered during J16) :97164 mq foul shrink (PR #1435). Cov unchanged in every A/B — confirming the J2 s2 finding that shot-mix ports are fidelity work, not Cov levers. All ports MERGED to master 2026-07-13: (1) via #1437 (stack parent, absorbing #1438); (3) via #1443 (replacement PR — #1439 was auto-closed when its stacked base branch was deleted); (2) #1436; (6) #1435; denom18 #1433. foulBucketScale maintenance contract executed twice: 0.47→0.40 (PR #1440, post-items-1+3 basis) and 0.40→0.39 (PR #1444, after item 2's d70 pin landed — combined-master check read FTA/g 21.82 vs the .sco 21.32 target; 1-D search 0.39→21.36, 0.40→21.82; gt=2 margin gap +0.498→+0.491, within the ±0.03 noise floor, Phase-5 margin lock intact).
+**Status (2026-07-13):** ◑ Partial — all six formula divergences MERGED (#1433, #1435–#1437, #1440, #1443, #1444); combined FTA anchor verified on final master (21.36 vs .sco 21.32). Remaining: the f = (Confidence + rec[+0x18] + 95)/200 projection-modulation / pass-2 usage-shrink port-vs-document question (🧠 user decision — J19's rec[+0x18] evidence favors documenting as divergence).
 
 ### J19 J6-residue RE (energy operands, rec+0x18 semantics, escape re-derivation, +0xD58)
 **Location:** `jsb-native/` decompile + PE; open items recorded in `jsb-native/re-artifacts/jsb-J6-composite-scales-20260710.md` § still-open.


### PR DESCRIPTION
End-of-session backlog reconciliation after the J18 engine-PR stack merged (#1433, #1435–#1437, #1440, #1443, #1444).

- **J8 → ✅** — `transitionTriggerDenom` 20→18 merged via PR #1433; body archived.
- **J11 → ✅** — verify-first resolved: the min-GP guard already shipped in PR #975 (`minSeasonMedianGP = 70` + proxy-medGP skip in `season.go`); body archived.
- **J18** — Update/Status record the merged PR mapping and the third foulBucketScale re-anchor (0.40→0.39, PR #1444; combined-master FTA 21.36 vs .sco target 21.32). Stays ◑: the f/pass-2 usage-shrink port-vs-document question is an explicit user decision.
- Roll-up: ⬜ 7→5, ✅ 12→14.