### PR TITLE
chore(.claude/rules): trim backlog-housekeep rule

### DIFF
--- a/.claude/rules/backlog-housekeep.md
+++ b/.claude/rules/backlog-housekeep.md
@@ -1,7 +1,7 @@
 ---
 description: When you implement or discover a backlog item, ship backlog housekeeping with the change via /backlog-housekeep; bin/check-docs is the backstop.
 paths: ibl5/docs/backlog/**/*.md
-last_verified: 2026-07-10
+last_verified: 2026-07-13
 ---
 
 # Backlog Housekeeping
@@ -10,12 +10,6 @@ last_verified: 2026-07-10
 
 **How.** Run `/backlog-housekeep`. Inside `/post-plan` (which cannot call the Skill tool), Read `.claude/skills/backlog-housekeep/SKILL.md` and follow it inline — `/post-plan` Phase 2.5 wires this.
 
-**What it does** (one line each — detail lives in the skill, not here):
-
-- flips the resolved item's status glyph with today's date;
-- stamps each newly-surfaced item `(discovered YYYY-MM-DD during <ref>)`;
-- sweeps sibling and cross-backlog redundancy, stamping each superseded item `**Superseded by:** <ref> — <reason>`;
-- archives done items behind a dated pointer into `archive/`;
-- reconciles the `ibl5/docs/backlog/README.md` index and counts.
+**What it does.** Flips the resolved item's status, stamps newly-surfaced items with provenance, sweeps sibling and cross-backlog redundancy, archives done items behind a dated pointer, and reconciles the `ibl5/docs/backlog/README.md` index — the 7-op checklist lives in the skill, not here.
 
 **Backstop.** `bin/check-docs --since=<base>` fails a PR that archives an item without its sibling archive file or its dated pointer, or that marks a body-status item done inline without archiving it. It is diff-scoped (changed backlog files only) — the skill does the reasoning; the gate is the false-positive-free structural check. Do not restate its rules here.


### PR DESCRIPTION
## Summary

- Consolidates the 5-bullet \"What it does\" list into a single prose sentence — the detail lives in the skill, not the rule
- Bumps `last_verified` to 2026-07-13

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.