### PR TITLE
chore(engine): characterize pace-step distribution; record J21 round-vs-trunc RE finding (ADR-0085)

### DIFF
--- a/engine/internal/calibrate/possessioncoupling_archive_test.go
+++ b/engine/internal/calibrate/possessioncoupling_archive_test.go
@@ -142,6 +142,10 @@ func TestRealArchive_PossessionCoupling(t *testing.T) {
 	t.Logf("  └ Cov(lnPOSS,lnPPS):       engine=%+.6f real=%+.6f", fid.EngineCovLnPossLnPPS, fid.RealCovLnPossLnPPS)
 	t.Logf("  └ Cov(lnFGA/POSS,lnPPS):   engine=%+.6f real=%+.6f", fid.EngineCovLnShotsPerPossLnPPS, fid.RealCovLnShotsPerPossLnPPS)
 	t.Logf("  Var(lnPOSS): engine=%.6f real=%.6f  poss_dispersion=%.2f", fid.EngineVarLnPoss, fid.RealVarLnPoss, fid.PossDispersionRatio)
+	// Budget-mirror term (ADR-0054/J21): widening pace dispersion propagates into
+	// FGA dispersion via Var(lnFGA) ≈ Var(lnPOSS) + Var(ln(FGA/POSS)) + 2·Cov. The
+	// engine value must stay ≤ real (headroom, not overshoot) — the 4th A/B gate term.
+	t.Logf("  Var(lnFGA):  engine=%.6f real=%.6f  (budget-mirror ceiling — engine must stay ≤ real)", fid.EngineVarLnFGA, fid.RealVarLnFGA)
 	t.Logf("VERDICT: the factor whose Cov term carries the wrong sign (engine − vs real +) is where the ADR-0049 build PR must intervene.")
 
 	// Cheap cross-check (advisor): the per-team engine proxy mean should land near the

--- a/engine/internal/sim/possession_pace_pin_test.go
+++ b/engine/internal/sim/possession_pace_pin_test.go
@@ -1,0 +1,170 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/result"
+)
+
+// This file pins the CURRENT (shipped) pace/possession-count behavior — int()
+// TRUNCATION of the base_time -> possession-step mapping (tempo.go possessionTime,
+// gameloop.go clock loop). It is the green-green characterization tripwire for J22,
+// the coupled round-half-up + base_time re-center fix (ADR-0085): when J22 changes
+// the step rule and re-centers base_time, Pin A fires and is re-baselined there.
+//
+//	Pin A (TestPossessionStepDistributionPin_Current) — the UNIT step
+//	  distribution of possessionTime() across a base_time sweep of [13,16].
+//	    - shipped int() truncation: 4 integer buckets, mass ~0.333/0.333/0.333 in
+//	      {13,14,15} and only the closed endpoint (bt==16) in 16 (~1/samples).
+//	    - RE-FAITHFUL round-half-up (FUN_004e42e0, _DAT_00669ef0 = 0.5) would shift
+//	      mass to ~0.167/0.333/0.333/0.167 — the round boundaries at 13.5/14.5/15.5
+//	      hand a half-width of mass to buckets 13 and 16. J21 measured that faithful
+//	      form and HELD it (ADR-0085): shipped alone it does not flip the wrong-
+//	      signed Cov(lnPOSS,lnPPS) and regresses mean pace (the coupled base_time
+//	      re-center is J22). So truncation is retained and pinned here.
+//
+//	Pin B (TestPossessionCountLoopPin_Current) — the full-loop per-team
+//	  possession COUNT over richBundle. This is a characterization + permanent
+//	  invariants, NOT a step-rule tripwire, and deliberately so:
+//	    richBundle's two teams carry IDENTICAL volume ratings (only FGP differs),
+//	    so teamBaseTimeWith yields ONE base_time for the matchup; gameloop.go
+//	    averages the two (identical) team base_times and steps the clock by the
+//	    shared value, and strict offense/defense alternation then hands BOTH
+//	    teams the SAME possession count every seed. Empirically that count is
+//	    exactly 96/team every game (var = 0) — cross-team possession-count
+//	    dispersion is STRUCTURALLY ZERO in this fixed fixture and cannot be
+//	    pinned as a tripwire here. It is also invariant to int/round of the step
+//	    (~15.29 -> 15 either way here). The real cross-team Var(lnPOSS) gate lives
+//	    in the archive test TestRealArchive_PossessionCoupling (internal/calibrate),
+//	    which measures it on the multi-team corpus. So Pin B locks the loop-level
+//	    count characterization (mean 96/team) plus the permanent sanity invariants.
+//
+// See plan jsb-j21-pace-dispersion-fidelity.md Phase 1 (characterization pins) and
+// ADR-0085 (the round-vs-truncate fidelity finding this pin's centers record).
+
+// possessionStepSweep evaluates possessionTime() at `samples` evenly-spaced
+// base_time points across the [baseTimeLow, baseTimeHigh] clamp range and
+// returns the share of results landing in each integer step bucket. Deterministic
+// and self-contained so the pinned shares are reproducible.
+func possessionStepSweep(samples int) map[int]float64 {
+	counts := map[int]int{}
+	for i := 0; i < samples; i++ {
+		bt := baseTimeLow + (baseTimeHigh-baseTimeLow)*float64(i)/float64(samples-1)
+		counts[possessionTime(bt)]++
+	}
+	shares := map[int]float64{}
+	for step, c := range counts {
+		shares[step] = float64(c) / float64(samples)
+	}
+	return shares
+}
+
+func TestPossessionStepDistributionPin_Current(t *testing.T) {
+	const samples = 3001
+	shares := possessionStepSweep(samples)
+
+	const band = 0.02
+	// PIN: re-baseline if a later tempo-step change moves these. Centers read off the
+	// shipped int() truncation sweep: floor partitions [13,16] into 13->[13,14)
+	// 14->[14,15) 15->[15,16) at 1/3 each, and 16 catches only the closed endpoint
+	// bt==16 (a single sample). Under the RE-faithful round-half-up (deferred to J22,
+	// ADR-0085) these become 1/6, 1/3, 1/3, 1/6 — that shift is the J22 tripwire.
+	type bucket struct {
+		step   int
+		center float64
+	}
+	for _, b := range []bucket{
+		{13, 0.333222},
+		{14, 0.333222},
+		{15, 0.333222},
+		{16, 0.000333},
+	} {
+		if got := shares[b.step]; math.Abs(got-b.center) > band {
+			t.Errorf("step %d share drifted: got %.6f, want %.6f ± %.2f", b.step, got, b.center, band)
+		}
+	}
+
+	// Permanent invariants (not pinned/re-baselined): the int-returning mapping
+	// yields exactly the four integers in the [13,16] clamp, and the shares
+	// partition the sweep. Under the shipped truncation, bucket 16 holds only the
+	// closed endpoint (unlike the deferred round-half-up, where all four carry mass).
+	var sum float64
+	for step, share := range shares {
+		if step < int(baseTimeLow) || step > int(baseTimeHigh) {
+			t.Errorf("possessionTime returned step %d outside [%d,%d]", step, int(baseTimeLow), int(baseTimeHigh))
+		}
+		sum += share
+	}
+	if math.Abs(sum-1.0) > 1e-9 {
+		t.Errorf("step shares do not sum to 1.0: got %.9f", sum)
+	}
+	if len(shares) != 4 {
+		t.Errorf("possessionTime must yield exactly 4 integer buckets {13,14,15,16}, got %d: %v", len(shares), shares)
+	}
+}
+
+func TestPossessionCountLoopPin_Current(t *testing.T) {
+	b := richBundle()
+	// Per-team possession counts across the seed sweep (one count per team per game).
+	var perTeam []int
+	for seed := uint64(1); seed <= 40; seed++ {
+		g := Simulate(b, seed).Games[0]
+		byTeam := map[int]int{}
+		for _, e := range g.Events {
+			if e.Kind == result.EventPossessionStart {
+				byTeam[e.TeamID]++
+			}
+		}
+		if len(byTeam) != 2 {
+			t.Fatalf("seed %d: expected 2 teams with possessions, got %d: %v", seed, len(byTeam), byTeam)
+		}
+		// Permanent invariant: both teams must run possessions, and neither may
+		// dominate the other implausibly (strict alternation keeps them equal).
+		var lo, hi, total int
+		first := true
+		for _, c := range byTeam {
+			if c <= 0 {
+				t.Errorf("seed %d: a team ran 0 possessions: %v", seed, byTeam)
+			}
+			if first || c < lo {
+				lo = c
+			}
+			if first || c > hi {
+				hi = c
+			}
+			first = false
+			total += c
+			perTeam = append(perTeam, c)
+		}
+		if lo > 0 && float64(hi)/float64(lo) > 1.25 {
+			t.Errorf("seed %d: per-team possession ratio implausible: %v", seed, byTeam)
+		}
+		// Permanent invariant: total possessions per game in an NBA-plausible band.
+		if total < 150 || total > 230 {
+			t.Errorf("seed %d: total possessions %d outside plausible [150,230]", seed, total)
+		}
+	}
+
+	if len(perTeam) == 0 {
+		t.Fatalf("no possession_start events observed across the sweep")
+	}
+	var mean float64
+	for _, c := range perTeam {
+		mean += float64(c)
+	}
+	mean /= float64(len(perTeam))
+
+	// PIN: characterization of the current loop-level per-team possession count.
+	// This is NOT a step-rule tripwire (richBundle's identical-volume rosters make
+	// cross-team count dispersion structurally zero — see file header; the archive
+	// test owns the real Var(lnPOSS) gate). Re-baseline if a change intentionally
+	// moves the loop-level count on this fixture.
+	const (
+		center = 96.0
+		band   = 2.0 // ~2% of 96
+	)
+	if math.Abs(mean-center) > band {
+		t.Errorf("mean per-team possessions/game drifted: got %.4f, want %.1f ± %.1f", mean, center, band)
+	}
+}

--- a/engine/internal/sim/tempo.go
+++ b/engine/internal/sim/tempo.go
@@ -118,8 +118,25 @@ func teamBaseTimeWith(starters []onCourt, scale float64) float64 {
 	return bt
 }
 
-// possessionTime is the seconds one possession removes from the game clock:
-// (2.0 − factor) × base_time. At factor 1.0 it equals base_time.
+// possessionTime is the integer seconds one possession removes from the game
+// clock: (2.0 − factor) × base_time, truncated. At factor 1.0 it equals base_time.
+//
+// TRUNCATION RETAINED — round-half-up deferred to J22 (ADR-0085). 5.60 rounds this
+// step HALF-UP, it does NOT truncate: FUN_004e42e0 (the possession-clock update,
+// jsb560_decompiled.c:98406-98418) truncates possession_time via __ftol then adds
+// 1 when the fractional part ≥ 0.5 (`_DAT_00669ef0` = 0.5, confirmed from the raw
+// .rdata bytes 0x3fe0000000000000). So Go's int() truncation here IS a confirmed
+// infidelity. But the J21 archive A/B (ADR-0085) showed the faithful round-half-up,
+// shipped ALONE, does NOT flip the wrong-signed Cov(lnPOSS,lnPPS) (Δ within
+// sampling noise) and REGRESSES mean pace: it lengthens the central baseTimeMid =
+// 14.5 step to 15, dropping mean possessions from ~101.9 (trunc) to ~97.6 vs real
+// ~104.6. Truncation's downward bias was accidentally MASKING a base_time-
+// generation miscalibration (engine center 14.5s vs real effective ~13.8s = 1440/
+// 104.6 — base_time ~0.7s too slow). The faithful fix is round-half-up COUPLED with a base_time
+// re-centering (offVolumeNeutral), landing both the step rule and the mean pace
+// correctly — that coupled change is J22. Until then truncation stays: it is the
+// mean-closer of the two imperfect states. See ADR-0085 for the RE evidence, the
+// four-term A/B, and the mean-regression finding.
 func possessionTime(baseTime float64) int {
 	pt := (2.0 - tempoFactor) * baseTime
 	if pt < 1.0 || pt > 24.0 {

--- a/engine/internal/sim/tempo.go
+++ b/engine/internal/sim/tempo.go
@@ -134,7 +134,7 @@ func teamBaseTimeWith(starters []onCourt, scale float64) float64 {
 // generation miscalibration (engine center 14.5s vs real effective ~13.8s = 1440/
 // 104.6 — base_time ~0.7s too slow). The faithful fix is round-half-up COUPLED with a base_time
 // re-centering (offVolumeNeutral), landing both the step rule and the mean pace
-// correctly — that coupled change is J22. Until then truncation stays: it is the
+// correctly — that coupled change is J23. Until then truncation stays: it is the
 // mean-closer of the two imperfect states. See ADR-0085 for the RE evidence, the
 // four-term A/B, and the mean-regression finding.
 func possessionTime(baseTime float64) int {

--- a/engine/internal/sim/tempo.go
+++ b/engine/internal/sim/tempo.go
@@ -121,9 +121,9 @@ func teamBaseTimeWith(starters []onCourt, scale float64) float64 {
 // possessionTime is the integer seconds one possession removes from the game
 // clock: (2.0 − factor) × base_time, truncated. At factor 1.0 it equals base_time.
 //
-// TRUNCATION RETAINED — round-half-up deferred to J22 (ADR-0085). 5.60 rounds this
+// TRUNCATION RETAINED — round-half-up deferred to J23 (ADR-0085). 5.60 rounds this
 // step HALF-UP, it does NOT truncate: FUN_004e42e0 (the possession-clock update,
-// jsb560_decompiled.c:98406-98418) truncates possession_time via __ftol then adds
+// jsb560_decompiled.c:98386-98438) truncates possession_time via __ftol then adds
 // 1 when the fractional part ≥ 0.5 (`_DAT_00669ef0` = 0.5, confirmed from the raw
 // .rdata bytes 0x3fe0000000000000). So Go's int() truncation here IS a confirmed
 // infidelity. But the J21 archive A/B (ADR-0085) showed the faithful round-half-up,

--- a/ibl5/docs/backlog/jsb-native-backlog.md
+++ b/ibl5/docs/backlog/jsb-native-backlog.md
@@ -41,6 +41,7 @@ J1 faithful foul pair (✅ 2026-07-10, ADR-0082) ─→ J2 adjudications (✅ 20
               └─→ J2 verdict: SHIPPABLE with residual → successor = J20 empty-FGA restructure (J4 ✅ 2026-07-12 feeds it) → J13 (unblocked)
 J17 game-state foul coupling (⬜, new 2026-07-10) — real 5.60 mechanism the engine lacks entirely
 J21 gt=4 playoff-margin audit (⬜, new 2026-07-13) · J22 per-player STL/TOV bundle wiring (⬜, new 2026-07-13) — cut-over-gate fidelity inputs to J13; NEITHER is a count-axis (J20) lever
+J23 round-half-up + base_time re-center (⬜, new 2026-07-13, #1452) — coupled faithful fix deferred from J21; ADR-0085 records the hold finding; J23 must A/B the recenter alongside the step-rule change
 J18 composite fidelity ports (✅ 2026-07-13 — all divergences merged; f/shrink port declined as documented divergence) · J19 J6-residue RE (✅ 2026-07-12) — both spawned by J6
 ```
 
@@ -86,6 +87,7 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 | J20 | Empty-FGA / within-possession restructure (Cov possession channel) | ⬜ Open | 🧠 Opus | L |
 | J21 | gt=4 playoff-margin overshoot audit (playoffNetMultiplier ×1.25) | ⬜ Open | 🧠 Opus | S |
 | J22 | Per-player rl_stl/rl_tov production-bundle wiring (PF dispersion) | ⬜ Open | 🧠 Opus | M |
+| J23 | round-half-up + base_time re-center (coupled pace faithful fix) | ⬜ Open | 🧠 Opus | M |
 
 ### J1 Faithful foul-bucket pair port
 ➜ J1 Faithful foul-bucket pair port — ✅ Implemented (2026-07-10): see [archive](archive/jsb-native-backlog-archive.md).
@@ -190,3 +192,10 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 **Not the count-axis:** wiring real STL/TOV raises PF *dispersion* — a fidelity fix, **not** a Cov(lnFGA,lnPPS) lever (that is J20). File as a dispersion-fidelity follow-on, never a cut-over sign blocker.
 **Direction:** confirm whether the production-bundle SOURCE (`.plr` / real-life stat feed) carries per-player steal/turnover counting sums; if so, add them to the bundle reader + wire into the composites replacing the rating stand-ins; if not, RE where 5.60 sources them. A/B gate = Var(lnPF) ratio toward real, no regression on margin/fta anchors or gt2/gt4 Cov. Sequence after J20 (Cov structure first) so the dispersion A/B reads clean.
 **Status (2026-07-13):** ⬜ Open — new. 🧠 Opus (source question + Var(lnPF) A/B judgment); port ⚙️ Sonnet once source confirmed.
+
+### J23 round-half-up + base_time re-center (coupled pace faithful fix)
+*(deferred from J21 pace-dispersion investigation, 2026-07-13, PR #1452)*
+**Location:** `engine/internal/sim/tempo.go` (`possessionTime` function, `offVolumeNeutral` / `defRatingNeutral` constants); `engine/internal/calibrate/possessioncoupling_archive_test.go` (four-term A/B harness).
+**Problem:** ADR-0085 (J21 finding) established two coupled imperfections: (1) `possessionTime` uses `int()` truncation where 5.60 uses round-half-up (`FUN_004e42e0`, `_DAT_00669ef0=0.5` confirmed from `.rdata`); (2) the engine's neutral center `baseTimeMid=14.5s` is ~0.7s too slow (real effective step ≈ 13.8s = 1440/104.6). These partially cancel: truncation's downward bias accidentally compensates the too-slow center. The J21 A/B confirmed shipping round-alone regresses mean pace (101.9→97.6 vs real 104.6) and does not flip the wrong-signed Cov(lnPOSS,lnPPS). The faithful end-state requires both changes together.
+**Direction:** ship round-half-up in `possessionTime` paired with a base_time re-centering (reduce `offVolumeNeutral` and/or adjust `offVolumeScale`/`defRatingScale` so the mean pace lands near real ~104.6); A/B the recenter independently first (it interacts with `Var(lnPOSS)` via the 13s clamp floor); then run the coupled round+recenter A/B on the four-term gate (Cov(lnPOSS,lnPPS) sign flip, Cov(lnFGA,lnPPS) total, Var(lnPOSS) toward 0.000721 without overshoot, Var(lnFGA) ≤ real 0.001330); re-establish the characterization pins from `possession_pace_pin_test.go`. Derive mean/variance targets against the paired `.sco` comparators per the J15/ADR-0084 paired-comparator principle.
+**Status (2026-07-13):** ⬜ Open — deferred from J21. Sequence after J20 (the Cov-structure question) and J22 (STL/TOV bundle wiring). 🧠 Opus (recenter design + four-term adjudication).

--- a/ibl5/docs/backlog/jsb-native-backlog.md
+++ b/ibl5/docs/backlog/jsb-native-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: JSB native-engine backlog — the count-axis cut-over blocker chain, static RE pins, faithful ports, and validation gates, each tagged with the model tier that owns its load-bearing reasoning (Fable-gated items marked).
-last_verified: 2026-07-13
+last_verified: 2026-07-14
 ---
 
 # JSB Native-Engine Backlog

--- a/ibl5/docs/decisions/0085-tempo-step-truncation-retained-round-coupled-recenter-deferred.md
+++ b/ibl5/docs/decisions/0085-tempo-step-truncation-retained-round-coupled-recenter-deferred.md
@@ -1,0 +1,87 @@
+---
+description: J21 finding — 5.60 rounds the possession clock-step half-up (int() truncation is a confirmed infidelity), but the archive A/B shows the faithful round-half-up shipped ALONE fails to flip the wrong-signed Cov(lnPOSS,lnPPS) and regresses mean pace by exposing a base_time-generation miscalibration truncation was masking; truncation is HELD and the faithful round+recenter fix is deferred to J22.
+last_verified: 2026-07-13
+---
+
+# ADR-0085: Tempo step truncation retained; faithful round-half-up + base_time re-center deferred to J22
+
+**Status:** Accepted
+**Date:** 2026-07-13
+
+## Context
+
+The J21 plan (`jsb-j21-pace-dispersion-fidelity`) targeted the two coupled pace-generation defects the ADR-0049 possession-coupling instrument localized on the 20-run archive of record (regular/gt2):
+
+| term | engine (trunc) | real | note |
+|------|--------|------|------|
+| Cov(lnPOSS,lnPPS) [poss-count] | −0.000184 | +0.000241 | wrong sign; 89% of the real positive total — the PRIMARY target |
+| Cov(ln(FGA/POSS),lnPPS) [spp] | −0.000180 | +0.000027 | real ≈ 0 |
+| Var(lnPOSS) | 0.000254 | 0.000721 | engine under-disperses pace ~2.8× — the SECONDARY target |
+
+The design fork the plan opened (Step-3a): is the under-dispersed, wrong-signed possession-count channel a **Go faithfulness bug** in the base_time → possession-step mapping, or an **un-RE'd 5.60 tempo mechanism**? Resolving it required reverse-engineering 5.60's possession-clock update.
+
+### RE finding — 5.60 rounds the step HALF-UP; int() truncation is a confirmed infidelity
+
+`FUN_004e42e0` (the possession-clock update, `jsb560_decompiled.c:98386-98438`) computes the integer clock step by truncating `possession_time` via `__ftol` (`:98407`, `:98411`) and then adding 1 when the fractional part is `≥ _DAT_00669ef0` (`:98412-98414`), before subtracting it from the possession clock at CEngine offset `0x4c24` (`:98425`). That is **round-half-up**.
+
+`_DAT_00669ef0` was confirmed to be **exactly 0.5** from the raw `.rdata` bytes of `jumpshot.exe` (`objdump -s -j .rdata` at VMA `0x669ef0` → little-endian `00000000 0000e03f` = `0x3fe0000000000000` = the IEEE-754 double `0.5`). So the threshold is a half, not some other rounding pivot.
+
+The original Go port used `int()` **truncation** (`engine/internal/sim/tempo.go`, `possessionTime`), which is therefore a **confirmed infidelity** — `floor(pt + 0.5)` is the faithful mirror. This closed the design fork on the "Go faithfulness bug" side.
+
+### But the faithful fix, shipped ALONE, does not help and regresses mean pace
+
+Because the mechanism is a per-possession clock step whose value is quantized to `{13,14,15,16}` (the base_time clamp is `[13,16]` and `tempoFactor = 1.0`), round-half-up **redistributes probability mass between the four buckets** — it does not add granularity. A clean same-config 20-run A/B (both `RUNS=20 STRIDE=1`, seed 20240601, real archive) measured:
+
+| term | trunc (shipped) | round | real | read |
+|------|---|---|---|---|
+| Cov(lnPOSS,lnPPS) (PRIMARY) | −0.000184 | −0.000163 | +0.000241 | **no sign flip**; Δ within sampling noise |
+| Cov(lnFGA,lnPPS) (total) | −0.000364 | −0.000351 | +0.000269 | toward real, still negative |
+| Cov(ln(FGA/POSS),lnPPS) [spp] | −0.000180 | −0.000187 | +0.000027 | ~flat |
+| Var(lnPOSS) (SECONDARY) | 0.000254 | 0.000274 | 0.000721 | +8% (deterministic) but still 2.6× under |
+| Var(lnFGA) (budget mirror) | 0.000792 | 0.000792 | 0.001330 | unchanged — well under the real ceiling |
+| **mean POSS/team** | **101.9** | **97.6** | **104.6** (real `.sco` proxy) | **round regresses the mean ~4 further under** |
+
+Two facts separate the noise from the signal:
+
+- **The Cov(lnPOSS,lnPPS) delta is within sampling noise.** Its sign flipped between the stride-1 (+0.000021) and stride-4 (−0.000018) configs, so it is NOT sign-robust. Round-half-up does not flip the PRIMARY target's wrong sign; the fidelity carries the change, not the metric.
+- **The mean-possession regression is a deterministic mechanism effect, NOT noise.** A neutral matchup averages to `baseTimeMid = 14.5` — exactly on the round boundary — so round-half-up *lengthens* the central step from 14 (trunc) to 15, lowering mean possessions every run. The engine-count mean drops from ~101.9 (trunc) to ~97.6 (round), against a real `.sco`-proxy mean of ~104.63 ± 3.96. Truncation (101.9) is **closer** to the real mean than round (97.6).
+
+### Interpretation — truncation was masking a base_time-generation miscalibration
+
+The engine already under-produces possessions under both rules (real ~104.6; trunc 101.9; round 97.6). The clock model (`gameloop.go`: 4 × `quarterSeconds = 720` = 2880s regulation, stepped on a shared alternating clock ⇒ per-team possessions ≈ 1440 / step) makes a real ~104.6 poss/team imply an effective step of ~13.8s (1440 / 104.6 = 13.76; OT-inclusive games only shrink the gap), versus the engine's neutral center `baseTimeMid = 14.5s` — the engine's base_time generation is **~0.7s too slow**. Truncation's systematic downward bias (`floor` always rounds toward a shorter step ⇒ more possessions) was **accidentally compensating** that too-slow base_time, landing the mean closer to real by luck. The faithful round-half-up removes that accidental compensation and **exposes** the base_time miscalibration.
+
+The base_time neutral reference points (`offVolumeNeutral = 161.0`, `defRatingNeutral = 24.0`) are documented validation-phase stand-ins (see `engine/internal/sim/tempo.go`). Re-centering `offVolumeNeutral` ~0.7s faster is a substantial recalibration of a stand-in that *interacts with the dispersion goal* (a faster center pushes the fast tail toward the 13s clamp floor, which may compress `Var(lnPOSS)` rather than widen it). It therefore needs its own A/B and re-pin — a separate lever, not a Phase-4 bolt-on.
+
+## Decision
+
+**HOLD. Retain `int()` truncation in `possessionTime`; do NOT ship round-half-up alone. Defer the faithful fix — round-half-up COUPLED with a base_time re-centering — to J22.** This ADR is the finding of record.
+
+Rationale, three independent reasons converging:
+
+1. **The plan's own accept gate fails.** Branch-D was pre-registered (plan line 217) as a faithfulness correction that "routes to HOLD, not a defect to chase" if `Var(lnPOSS)` doesn't move materially and the Cov sign doesn't flip. `Var(lnPOSS)` moved only +8%; the PRIMARY Cov sign did not flip (Δ within noise). Both gate conditions land on HOLD.
+2. **Round-alone would ship a regression.** Mean pace — a GM-visible number — moves measurably *away* from real (101.9 → 97.6 vs 104.6) for a marginal, sign-fragile variance gain. Truncation is the mean-closer of the two imperfect states.
+3. **The faithful end-state is a coupled change.** Round-half-up is only correct *together with* a base_time re-center that restores the mean. Shipping the rounding half of a two-part faithful fix — the half that regresses the headline metric — is worse than holding until both land together (J22).
+
+Fidelity-first does not mean shipping each faithful micro-correction in isolation when doing so regresses a headline metric and a *coupled* faithful correction is required; it means the shipped end-state must be faithful. That end-state is round + re-center (J22).
+
+### What ships in this PR (no engine behavior change)
+
+- `engine/internal/sim/tempo.go` — truncation retained; the `possessionTime` docblock records the RE finding, the `_DAT = 0.5` raw-byte confirmation, the mean-regression, and the J22 deferral.
+- `engine/internal/calibrate/possessioncoupling_archive_test.go` — the permanent `Var(lnFGA)` budget-mirror log (build-tag `archive`, never in CI) that emits the fourth A/B term this ADR cites. Kept as the reproducibility instrument for the finding.
+- This ADR.
+
+No change to `possessionTime`'s output, the Pin A characterization, the `tempo_coupling_test.go` fixture, or the committed archive artifact (all remain at the shipped truncation baseline).
+
+## Consequences
+
+- **No pace/possession behavior change.** The engine ships byte-identical possession steps; the archive artifact of record stays the truncation run. `go test ./internal/sim ./internal/calibrate` green.
+- **`auto_merge: false` (honored).** The disposition (accept-vs-hold) was an irreducible human adjudication over an A/B on data unreachable from CI — exactly the reason the plan set `auto_merge: false`. The human chose HOLD; the PR opens for review rather than auto-merging.
+- **Two known-imperfect states remain, both documented.** `int()` truncation is not faithful to 5.60's round-half-up, AND base_time generation is ~0.7s too slow. They partially cancel on the mean today. J22 fixes both together.
+
+## Open follow-on — J22 (the coupled faithful fix)
+
+Ship round-half-up in `possessionTime` **paired with** a base_time re-centering (`offVolumeNeutral`, and/or the `offVolumeScale`/`defRatingScale` calibration) so the faithful step rule lands the mean at ~104.6, then re-run the four-term archive A/B and re-establish the Phase-1 characterization pins. The J22 plan must A/B the recenter on its own (it interacts with `Var(lnPOSS)` via the 13s clamp floor) and re-derive the mean/variance targets against the paired `.sco` comparators on the same sampled games (the J15/ADR-0084 paired-comparator principle).
+
+## Lineage
+
+Extends the ADR-0049 possession-coupling instrument (the four-term decomposition this A/B reads) and the ADR-0054 budget-mirror discipline (`Var(lnFGA) ≈ Var(lnPOSS) + Var(ln(FGA/POSS)) + 2·Cov`, the fourth gate term). Supersedes no prior decision — it records a faithfulness finding and holds. RE grounded in the machine-local decompile `FUN_004e42e0` (`jsb560_decompiled.c:98386-98438`) and the raw `jumpshot.exe` `.rdata` byte confirmation of `_DAT_00669ef0 = 0.5` (git-excluded artifacts).

--- a/ibl5/docs/decisions/0085-tempo-step-truncation-retained-round-coupled-recenter-deferred.md
+++ b/ibl5/docs/decisions/0085-tempo-step-truncation-retained-round-coupled-recenter-deferred.md
@@ -78,9 +78,11 @@ No change to `possessionTime`'s output, the Pin A characterization, the `tempo_c
 - **`auto_merge: false` (honored).** The disposition (accept-vs-hold) was an irreducible human adjudication over an A/B on data unreachable from CI — exactly the reason the plan set `auto_merge: false`. The human chose HOLD; the PR opens for review rather than auto-merging.
 - **Two known-imperfect states remain, both documented.** `int()` truncation is not faithful to 5.60's round-half-up, AND base_time generation is ~0.7s too slow. They partially cancel on the mean today. J22 fixes both together.
 
-## Open follow-on — J22 (the coupled faithful fix)
+## Open follow-on — J23 (the coupled faithful fix)
 
-Ship round-half-up in `possessionTime` **paired with** a base_time re-centering (`offVolumeNeutral`, and/or the `offVolumeScale`/`defRatingScale` calibration) so the faithful step rule lands the mean at ~104.6, then re-run the four-term archive A/B and re-establish the Phase-1 characterization pins. The J22 plan must A/B the recenter on its own (it interacts with `Var(lnPOSS)` via the 13s clamp floor) and re-derive the mean/variance targets against the paired `.sco` comparators on the same sampled games (the J15/ADR-0084 paired-comparator principle).
+Ship round-half-up in `possessionTime` **paired with** a base_time re-centering (`offVolumeNeutral`, and/or the `offVolumeScale`/`defRatingScale` calibration) so the faithful step rule lands the mean at ~104.6, then re-run the four-term archive A/B and re-establish the Phase-1 characterization pins. The J23 plan must A/B the recenter on its own (it interacts with `Var(lnPOSS)` via the 13s clamp floor) and re-derive the mean/variance targets against the paired `.sco` comparators on the same sampled games (the J15/ADR-0084 paired-comparator principle).
+
+(Note: J22 was already assigned to per-player rl_stl/rl_tov production-bundle wiring — STL/TOV PF-dispersion; see the JSB backlog. This follow-on is J23.)
 
 ## Lineage
 


### PR DESCRIPTION
## Summary

- **RE finding:** 5.60 rounds the possession clock step half-up (`FUN_004e42e0`, `_DAT_00669ef0 = 0.5` confirmed from `.rdata` bytes `0x3fe0000000000000`). Go's `int()` truncation in `possessionTime()` is a **confirmed infidelity**.
- **But the faithful fix, alone, fails its own accept gate.** The J21 archive A/B (`RUNS=20 STRIDE=1`) showed round-half-up: (a) does not flip the wrong-signed Cov(lnPOSS,lnPPS) (Δ within sampling noise, sign flip non-robust), and (b) **regresses mean pace** 101.9 → 97.6 vs real 104.6 — truncation was accidentally masking a base_time-generation miscalibration (~0.7s too slow). **HOLD: retain truncation; defer round + base_time re-center to J22.**
- Ships two characterization pins (`possession_pace_pin_test.go`) locking the current truncation behavior as the J22 tripwire, a `possessionTime` docblock recording the RE evidence, and ADR-0085 documenting the finding.

**No engine behavior change.** `go test ./internal/sim ./internal/calibrate` green.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

(The four-term archive A/B adjudication is the intrinsic `auto_merge: false` hold from the plan frontmatter — it was completed and its outcome is documented in ADR-0085. The A/B measurement itself runs locally via `go test -tags archive ./internal/calibrate -run PossessionCoupling`; CI compiles the tagged code but cannot execute it without the ~53 GB corpus. Human merge decision confirms the HOLD disposition.)

## Verification

- `go test ./internal/sim/... -run Pin` — all three pins green (TestPossessionStepDistributionPin_Current, TestPossessionCountLoopPin_Current, TestOriginSharePin_Current)
- `go build ./...` and `go test ./...` — engine suite green
- `bin/check-docs --since=origin/master` — 157 docs verified, no stale-doc block