### PR TITLE
chore(wt): fetch+sync base branch in wt-new; block un-rebased pushes in pre-push hook

### DIFF
--- a/bin/pre-push-adr-hook
+++ b/bin/pre-push-adr-hook
@@ -49,8 +49,26 @@ fi
 # adr-check gate (in pr-meta-checks.yml) remains the backstop, and blocking a legitimate push here
 # would be worse than deferring to CI.
 if ! git -C "$REPO_ROOT" rev-parse --verify origin/master >/dev/null 2>&1; then
-    echo "pre-push-adr-hook: origin/master not found; skipping ADR gate (CI still enforces it)." >&2
+    echo "pre-push-adr-hook: origin/master not found; skipping gates (CI still enforces them)." >&2
     exit 0
+fi
+
+# Block pushes where the branch hasn't been rebased onto origin/master. No fetch here —
+# keep push latency low; wt-new already syncs at creation time. If origin/master has
+# advanced since then, `git fetch origin master && git rebase origin/master` or
+# `bin/wt-rebase` brings the branch current.
+CURRENT_BRANCH=$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || true)
+if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "master" ]; then
+    if ! git -C "$REPO_ROOT" merge-base --is-ancestor origin/master HEAD 2>/dev/null; then
+        cat >&2 <<'EOF'
+
+pre-push-adr-hook: branch is not rebased onto origin/master.
+Fetch and rebase before pushing:
+  git fetch origin master && git rebase origin/master
+  # or rebase all active worktrees at once: bin/wt-rebase
+EOF
+        exit 1
+    fi
 fi
 
 # Pipe the branch's commit-message blob to adr-check. Run inside REPO_ROOT so both

--- a/bin/wt-new
+++ b/bin/wt-new
@@ -48,6 +48,18 @@ if [ -d "$WT_ROOT" ]; then
     exit 1
 fi
 
+# Sync local $BASE_BRANCH with origin before branching — avoids forking from a stale tip.
+echo "Fetching origin/$BASE_BRANCH..."
+if git -C "$REPO_ROOT" fetch origin "$BASE_BRANCH" --quiet 2>/dev/null; then
+    BEHIND=$(git -C "$REPO_ROOT" rev-list --count "$BASE_BRANCH..origin/$BASE_BRANCH" 2>/dev/null || echo 0)
+    if [ "$BEHIND" -gt 0 ]; then
+        echo "Fast-forwarding local $BASE_BRANCH ($BEHIND commit(s) behind origin)..."
+        git -C "$REPO_ROOT" merge --ff-only "origin/$BASE_BRANCH" --quiet
+    fi
+else
+    echo "Warning: could not reach origin; creating worktree from local $BASE_BRANCH." >&2
+fi
+
 # Create worktree + branch in one step
 echo "Creating worktree '$NAME' from $BASE_BRANCH..."
 git -C "$REPO_ROOT" worktree add "$WT_ROOT" -b "$NAME" "$BASE_BRANCH"


### PR DESCRIPTION
## Summary

- `bin/wt-new`: fetches and fast-forwards the local base branch from origin before creating a worktree, so new worktrees start from the latest master rather than a stale local tip.
- `bin/pre-push-adr-hook`: adds a rebase-gate that blocks pushes where the branch hasn't been rebased onto `origin/master`, with a clear error message pointing to `git fetch origin master && git rebase origin/master` or `bin/wt-rebase`.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.