### PR TITLE
chore: re-gate calibrated bands on post-J18 engine

### DIFF
--- a/engine/internal/validate/bands.go
+++ b/engine/internal/validate/bands.go
@@ -81,6 +81,21 @@ type Band struct {
 // │ AbsFloor=11 (in-band 0.977). RelPct kept at the committed (wider) values   │
 // │ per rationale 3 above — the proposal (0.596/0.600) would only tighten.     │
 // │ Gate is reference-only (no CI workflow invokes jsbcalibrate).              │
+// │                                                                            │
+// │ ── J18 UPDATE (2026-07-13, post-J18 formula-divergence re-gate) ──────────│
+// │ jsbcalibrate --mode gate re-run on the post-J15 + post-J18 engine (six    │
+// │ formula-divergence fixes: #1433, #1435-1437, #1440, #1443, #1444). Run    │
+// │ params match J15: --runs 20 --sample-stride 50 --selection season,        │
+// │ coverage 0.95, min-rate 0.90, corpus ibl5/backups.                        │
+// │ RESULT: PASS overall. Per-stat in-band rates (non-1.000 shown):           │
+// │   gt2: tgm=0.985, tga=0.970, ast=0.976, stl=0.990, tov=0.984,            │
+// │        blk=0.983, pf=0.946 (all others 1.000)                             │
+// │   gt4: tgm=0.976, tga=0.959, reb=0.994, ast=0.941, stl=0.965,            │
+// │        tov=0.976, pf=0.959 (all others 1.000)                             │
+// │ Literals: UNCHANGED — all stats in-band both game types.                  │
+// │ RelPct never re-derived (rationale 3); AbsFloor updated only when the     │
+// │ calibrate proposal is LOWER than committed.                                │
+// │ date: 2026-07-13                                                          │
 // └──────────────────────────────────────────────────────────────────────────┘
 
 // regularBands holds the calibrated regular-season (game_type 2) tolerances.

--- a/ibl5/docs/backlog/jsb-native-backlog.md
+++ b/ibl5/docs/backlog/jsb-native-backlog.md
@@ -138,7 +138,7 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 **Location:** `engine/internal/validate/bands.go` (placeholder ±15%, explicitly non-authoritative); per-player leaders validation (never built); the standings-residual gate (floor ≈ 3–5 wins / ~0 ppg); Var(lnPPS) sits ~2% under real as a monitor-only watch item.
 **Problem:** Even with the dispersion blocker resolved, cut-over needs authoritative bands derived from the archive, a per-player sanity layer, and the actual go/no-go decision (env-flag swap of the jumpshot.exe invocation, `.sco` import path kept for one-command rollback; SHADOW as the live distributional check).
 **Direction:** Gated on the J2 verdict. Band derivation and the leaders instrument are ⚙️-delegable; the acceptance judgment and the cut-over ADR are 🧠.
-**Status (2026-07-12):** ⬜ Open — **unblocked** (J2 verdict in: SHIPPABLE with documented residual). Band derivation and per-player instrument are ⚙️-delegable; the acceptance judgment and cut-over ADR are 🧠.
+**Status (2026-07-13):** ⬜ Open — **bands sub-item VERIFIED post-J18** (`jsbcalibrate --mode gate` re-run on the post-J15+J18 engine, runs=20 stride=50: PASS, no literal change; provenance in `engine/internal/validate/bands.go` J18 block). Leaders instrument (J13-2) + cut-over ADR (J13-3) still open. Band derivation and per-player instrument are ⚙️-delegable; the acceptance judgment and cut-over ADR are 🧠.
 
 ### J14 AutoResearch eval-harness ADR (loop L9 companion)
 **Location:** No harness exists; instrumentation groundwork (calibration walk ≈ 8 min full-corpus, freeze arms, channel-split tests) is merged. Cross-ref: [loop-engineering-backlog.md](loop-engineering-backlog.md) L9.


### PR DESCRIPTION
Re-runs `jsbcalibrate --mode gate` on the post-J15 + post-J18 engine (six formula-divergence fixes: #1433, #1435–#1437, #1440, #1443, #1444) and records the re-gate in the `bands.go` provenance header and the JSB native backlog.

**Gate result:** PASS — all stats in-band both game types (exit 0). No literal changes to `regularBands` or `playoffBands`. Provenance header updated with J18 block (per-stat rates, run params). Backlog J13 status line updated with bands-verified note.

## Changes

- `engine/internal/validate/bands.go` — J18 provenance block added (no literal changes to band maps)
- `ibl5/docs/backlog/jsb-native-backlog.md` — J13 Status-line bands-verified note + `last_verified` bump

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.