### PR TITLE
chore: J13-2 — per-player leaders validation instrument (JSB native engine)

### DIFF
--- a/engine/internal/calibrate/leaders_archive_test.go
+++ b/engine/internal/calibrate/leaders_archive_test.go
@@ -15,13 +15,13 @@ import (
 
 // leadersCheckASummary is the program-wide aggregate written to the artifact.
 type leadersCheckASummary struct {
-	Games          int              `json:"games"`
-	GamesPassed    int              `json:"games_passed"`
-	MismatchCount  int              `json:"mismatch_count"`
-	NegativeCount  int              `json:"negative_count"`
-	DominanceCount int              `json:"dominance_count"`
-	MismatchSample []validate.AMismatch  `json:"mismatch_sample,omitempty"`
-	NegativeSample []validate.ANegative  `json:"negative_sample,omitempty"`
+	Games           int                   `json:"games"`
+	GamesPassed     int                   `json:"games_passed"`
+	MismatchCount   int                   `json:"mismatch_count"`
+	NegativeCount   int                   `json:"negative_count"`
+	DominanceCount  int                   `json:"dominance_count"`
+	MismatchSample  []validate.AMismatch  `json:"mismatch_sample,omitempty"`
+	NegativeSample  []validate.ANegative  `json:"negative_sample,omitempty"`
 	DominanceSample []validate.ADominance `json:"dominance_sample,omitempty"`
 }
 
@@ -185,11 +185,11 @@ func TestLeadersCheckBArchive(t *testing.T) {
 	}
 
 	var (
-		allCorrelations []float64
-		allNegatives    []validate.BNegative
-		totalSkipped    int
+		allCorrelations  []float64
+		allNegatives     []validate.BNegative
+		totalSkipped     int
 		maxAcrossSeasons float64
-		teamSeasons     int
+		teamSeasons      int
 	)
 
 	for _, s := range seasons {

--- a/engine/internal/calibrate/leaders_archive_test.go
+++ b/engine/internal/calibrate/leaders_archive_test.go
@@ -1,0 +1,306 @@
+//go:build archive
+
+package calibrate
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/backup"
+	"github.com/a-jay85/IBL5/engine/internal/validate"
+)
+
+// leadersCheckASummary is the program-wide aggregate written to the artifact.
+type leadersCheckASummary struct {
+	Games          int              `json:"games"`
+	GamesPassed    int              `json:"games_passed"`
+	MismatchCount  int              `json:"mismatch_count"`
+	NegativeCount  int              `json:"negative_count"`
+	DominanceCount int              `json:"dominance_count"`
+	MismatchSample []validate.AMismatch  `json:"mismatch_sample,omitempty"`
+	NegativeSample []validate.ANegative  `json:"negative_sample,omitempty"`
+	DominanceSample []validate.ADominance `json:"dominance_sample,omitempty"`
+}
+
+// leadersCheckBSummary is the aggregate written to the Check B artifact.
+type leadersCheckBSummary struct {
+	TeamSeasons       int                  `json:"team_seasons"`
+	Mean              float64              `json:"mean"`
+	StdDev            float64              `json:"std_dev"`
+	FractionAboveHalf float64              `json:"fraction_above_half"`
+	Skipped           int                  `json:"skipped"`
+	NegativeTeamCount int                  `json:"negative_team_count"`
+	NegativeSample    []validate.BNegative `json:"negative_sample,omitempty"`
+	MaxPlayerAvg      float64              `json:"max_player_avg"`
+}
+
+const maxSample = 20
+
+func writeLeadersArtifact(t *testing.T, name string, v any) {
+	t.Helper()
+	out := filepath.Join("..", "validate", "testdata", name)
+	blob, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal artifact %s: %v", name, err)
+	}
+	if err := os.WriteFile(out, append(blob, '\n'), 0o644); err != nil {
+		t.Fatalf("write artifact %q: %v", out, err)
+	}
+	t.Logf("wrote %s", out)
+}
+
+func appendCapped[T any](dst []T, src []T) []T {
+	for _, v := range src {
+		if len(dst) >= maxSample {
+			break
+		}
+		dst = append(dst, v)
+	}
+	return dst
+}
+
+// TestLeadersCheckAArchive runs Check A over every season's most-complete
+// regular-season zip in the real corpus and asserts data-quality invariants.
+//
+// Invoke:
+//
+//	cd engine && JSB_ARCHIVE_DIR=... go test -tags archive ./internal/calibrate -run TestLeadersCheckAArchive -v -timeout 6h
+func TestLeadersCheckAArchive(t *testing.T) {
+	dir := os.Getenv("JSB_ARCHIVE_DIR")
+	if dir == "" {
+		dir = "/Users/ajaynicolas/GitHub/IBL5/ibl5/backups"
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("archive dir %q not available: %v", dir, err)
+	}
+
+	zips, skips, err := listArchiveZips(dir)
+	if err != nil {
+		t.Fatalf("listArchiveZips: %v", err)
+	}
+	for _, sk := range skips {
+		t.Logf("skip: %s — %s", sk.Path, sk.Reason)
+	}
+
+	seasons, seasonSkips := groupSeasons(zips, dir)
+	for _, sk := range seasonSkips {
+		t.Logf("season skip: %s — %s", sk.Path, sk.Reason)
+	}
+
+	var agg leadersCheckASummary
+
+	for _, s := range seasons {
+		if s.olympics || len(s.regularCandidates) == 0 {
+			continue
+		}
+		best, _, _, selSkips := selectMostComplete(s.regularCandidates, countScoGames)
+		for _, sk := range selSkips {
+			t.Logf("select skip: %s — %s", sk.Path, sk.Reason)
+		}
+		if best == "" {
+			continue
+		}
+
+		tmp, err := os.MkdirTemp("", "jsbcal-leaders-a-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmp) }()
+
+		found, err := extractTriple(best, tmp)
+		if err != nil || !found {
+			t.Logf("extract skip %s: found=%v err=%v", best, found, err)
+			continue
+		}
+
+		scoPath := filepath.Join(tmp, "IBL5.sco")
+		f, err := os.Open(scoPath)
+		if err != nil {
+			t.Logf("open sco %s: %v", scoPath, err)
+			continue
+		}
+		games, err := backup.ReadSco(f)
+		_ = f.Close()
+		if err != nil {
+			t.Logf("ReadSco %s: %v", best, err)
+			continue
+		}
+
+		rep := validate.CheckA(games)
+		agg.Games += rep.Games
+		agg.GamesPassed += rep.GamesPassed
+		agg.MismatchCount += len(rep.Mismatches)
+		agg.NegativeCount += len(rep.Negatives)
+		agg.DominanceCount += len(rep.Dominances)
+		agg.MismatchSample = appendCapped(agg.MismatchSample, rep.Mismatches)
+		agg.NegativeSample = appendCapped(agg.NegativeSample, rep.Negatives)
+		agg.DominanceSample = appendCapped(agg.DominanceSample, rep.Dominances)
+	}
+
+	writeLeadersArtifact(t, "leaders_checkA_archive.json", agg)
+
+	// Invariants.
+	if agg.Games == 0 {
+		t.Fatal("Games==0: walk found no box scores — structural failure")
+	}
+	if agg.NegativeCount != 0 {
+		t.Errorf("Negatives=%d want 0: negative counting stat indicates parser or corpus fault", agg.NegativeCount)
+	}
+	if agg.MismatchCount != 0 {
+		t.Errorf("Mismatches=%d want 0: team-total row must equal player-row sum for every game/team/stat at ±0; see artifact for offending games", agg.MismatchCount)
+	}
+	t.Logf("Games=%d GamesPassed=%d Mismatches=%d Negatives=%d Dominances=%d",
+		agg.Games, agg.GamesPassed, agg.MismatchCount, agg.NegativeCount, agg.DominanceCount)
+}
+
+// TestLeadersCheckBArchive runs Check B over every season's most-complete
+// regular-season zip and asserts rating-vs-.sco correlation invariants.
+//
+// Invoke:
+//
+//	cd engine && JSB_ARCHIVE_DIR=... go test -tags archive ./internal/calibrate -run TestLeadersCheckBArchive -v -timeout 6h
+func TestLeadersCheckBArchive(t *testing.T) {
+	dir := os.Getenv("JSB_ARCHIVE_DIR")
+	if dir == "" {
+		dir = "/Users/ajaynicolas/GitHub/IBL5/ibl5/backups"
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("archive dir %q not available: %v", dir, err)
+	}
+
+	zips, skips, err := listArchiveZips(dir)
+	if err != nil {
+		t.Fatalf("listArchiveZips: %v", err)
+	}
+	for _, sk := range skips {
+		t.Logf("skip: %s — %s", sk.Path, sk.Reason)
+	}
+
+	seasons, seasonSkips := groupSeasons(zips, dir)
+	for _, sk := range seasonSkips {
+		t.Logf("season skip: %s — %s", sk.Path, sk.Reason)
+	}
+
+	var (
+		allCorrelations []float64
+		allNegatives    []validate.BNegative
+		totalSkipped    int
+		maxAcrossSeasons float64
+		teamSeasons     int
+	)
+
+	for _, s := range seasons {
+		if s.olympics || len(s.regularCandidates) == 0 {
+			continue
+		}
+		best, _, _, selSkips := selectMostComplete(s.regularCandidates, countScoGames)
+		for _, sk := range selSkips {
+			t.Logf("select skip: %s — %s", sk.Path, sk.Reason)
+		}
+		if best == "" {
+			continue
+		}
+
+		tmp, err := os.MkdirTemp("", "jsbcal-leaders-b-*")
+		if err != nil {
+			t.Fatalf("MkdirTemp: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmp) }()
+
+		found, err := extractTriple(best, tmp)
+		if err != nil || !found {
+			t.Logf("extract skip %s: found=%v err=%v", best, found, err)
+			continue
+		}
+
+		plrPath := filepath.Join(tmp, "IBL5.plr")
+		scoPath := filepath.Join(tmp, "IBL5.sco")
+
+		fp, err := os.Open(plrPath)
+		if err != nil {
+			t.Logf("open plr %s: %v", plrPath, err)
+			continue
+		}
+		players, err := backup.ReadPlr(fp)
+		_ = fp.Close()
+		if err != nil {
+			t.Logf("ReadPlr %s: %v", best, err)
+			continue
+		}
+
+		fs, err := os.Open(scoPath)
+		if err != nil {
+			t.Logf("open sco %s: %v", scoPath, err)
+			continue
+		}
+		games, err := backup.ReadSco(fs)
+		_ = fs.Close()
+		if err != nil {
+			t.Logf("ReadSco %s: %v", best, err)
+			continue
+		}
+
+		rep := validate.CheckB(players, games, 5)
+		teamSeasons += rep.TeamSeasons
+		totalSkipped += rep.Skipped
+		allCorrelations = append(allCorrelations, rep.Correlations...)
+		allNegatives = appendCapped(allNegatives, rep.NegativeTeams)
+		if rep.MaxPlayerAvg > maxAcrossSeasons {
+			maxAcrossSeasons = rep.MaxPlayerAvg
+		}
+	}
+
+	// Compute aggregate distribution.
+	var mean, stdDev, fracAboveHalf float64
+	if teamSeasons > 0 {
+		var sum float64
+		var aboveHalf int
+		for _, rho := range allCorrelations {
+			sum += rho
+			if rho > 0.5 {
+				aboveHalf++
+			}
+		}
+		mean = sum / float64(teamSeasons)
+		var varSum float64
+		for _, rho := range allCorrelations {
+			d := rho - mean
+			varSum += d * d
+		}
+		stdDev = math.Sqrt(varSum / float64(teamSeasons))
+		fracAboveHalf = float64(aboveHalf) / float64(teamSeasons)
+	}
+
+	agg := leadersCheckBSummary{
+		TeamSeasons:       teamSeasons,
+		Mean:              mean,
+		StdDev:            stdDev,
+		FractionAboveHalf: fracAboveHalf,
+		Skipped:           totalSkipped,
+		NegativeTeamCount: len(allNegatives),
+		NegativeSample:    allNegatives,
+		MaxPlayerAvg:      maxAcrossSeasons,
+	}
+	writeLeadersArtifact(t, "leaders_checkB_archive.json", agg)
+
+	// Invariants.
+	if teamSeasons == 0 {
+		t.Fatal("TeamSeasons==0: no qualifying team-seasons found — structural failure")
+	}
+	for _, rho := range allCorrelations {
+		if math.IsNaN(rho) || math.IsInf(rho, 0) {
+			t.Errorf("non-finite rho in Correlations: %v — CheckB must filter NaNs before returning", rho)
+		}
+	}
+	if maxAcrossSeasons >= 60.0 {
+		t.Errorf("maxAcrossSeasons=%.2f >= 60.0: per-player scoring average too high — ScoGame boxes may be misread as season cumulatives", maxAcrossSeasons)
+	}
+	if mean <= 0 {
+		t.Errorf("aggregate Mean=%.4f <= 0: scoring ratings should on average positively predict .sco scoring — indicates ratings/engine drift or instrument bug", mean)
+	}
+	t.Logf("TeamSeasons=%d Mean=%.4f StdDev=%.4f FractionAboveHalf=%.3f Skipped=%d NegativeTeams=%d MaxPlayerAvg=%.2f",
+		teamSeasons, mean, stdDev, fracAboveHalf, totalSkipped, len(allNegatives), maxAcrossSeasons)
+}

--- a/engine/internal/validate/leaders.go
+++ b/engine/internal/validate/leaders.go
@@ -187,8 +187,8 @@ type BReport struct {
 	TeamSeasons       int       // teams that yielded a finite rho
 	Correlations      []float64 // one finite rho per qualifying team
 	Mean              float64
-	StdDev            float64  // population std dev of Correlations
-	FractionAboveHalf float64  // fraction with rho > 0.5
+	StdDev            float64 // population std dev of Correlations
+	FractionAboveHalf float64 // fraction with rho > 0.5
 	NegativeTeams     []BNegative
 	Skipped           int     // teams dropped: < minPlayers, or degenerate (zero variance)
 	MaxPlayerAvg      float64 // max per-player .sco scoring average (cumulative-misread guardrail)

--- a/engine/internal/validate/leaders.go
+++ b/engine/internal/validate/leaders.go
@@ -1,0 +1,368 @@
+package validate
+
+import (
+	"math"
+	"sort"
+
+	"github.com/a-jay85/IBL5/engine/internal/backup"
+)
+
+// statDef names one of the 13 counting stats Check A reconciles.
+type statDef struct {
+	Name string
+	Get  func(b backup.ScoBox) int
+}
+
+func countingStats() []statDef {
+	return []statDef{
+		{"TwoGM", func(b backup.ScoBox) int { return b.TwoGM }},
+		{"TwoGA", func(b backup.ScoBox) int { return b.TwoGA }},
+		{"FTM", func(b backup.ScoBox) int { return b.FTM }},
+		{"FTA", func(b backup.ScoBox) int { return b.FTA }},
+		{"ThreeGM", func(b backup.ScoBox) int { return b.ThreeGM }},
+		{"ThreeGA", func(b backup.ScoBox) int { return b.ThreeGA }},
+		{"ORB", func(b backup.ScoBox) int { return b.ORB }},
+		{"DRB", func(b backup.ScoBox) int { return b.DRB }},
+		{"AST", func(b backup.ScoBox) int { return b.AST }},
+		{"STL", func(b backup.ScoBox) int { return b.STL }},
+		{"TOV", func(b backup.ScoBox) int { return b.TOV }},
+		{"BLK", func(b backup.ScoBox) int { return b.BLK }},
+		{"PF", func(b backup.ScoBox) int { return b.PF }},
+	}
+}
+
+// AMismatch records a team-total vs player-sum discrepancy for one stat in one game.
+type AMismatch struct {
+	GameIndex int
+	TeamID    int
+	Stat      string
+	TeamTotal int // value on the PlayerID==0 row
+	PlayerSum int // sum over PlayerID>0 rows
+	Delta     int // PlayerSum - TeamTotal
+}
+
+// ANegative records a negative counting stat on a player row.
+type ANegative struct {
+	GameIndex, TeamID, PlayerID int
+	Name, Stat                  string
+	Value                       int
+}
+
+// ADominance records a player whose share of team points exceeds 60%.
+type ADominance struct {
+	GameIndex, TeamID, PlayerID int
+	Name                        string
+	PlayerPoints, TeamPoints    int
+	Share                       float64 // PlayerPoints / TeamPoints
+}
+
+// AReport is the aggregate result of CheckA over a corpus.
+type AReport struct {
+	Games       int
+	GamesPassed int // no mismatch AND no negative (dominance is a flag, not a fail)
+	Mismatches  []AMismatch
+	Negatives   []ANegative
+	Dominances  []ADominance
+}
+
+// ScoPoints returns points scored in a box: 2-pointers, 3-pointers, free throws.
+func ScoPoints(b backup.ScoBox) int { return b.TwoGM*2 + b.ThreeGM*3 + b.FTM }
+
+// CheckA reconciles each game's player rows against its team-total row and
+// flags negative stats and single-player scoring dominance (>60% of team points).
+func CheckA(games []backup.ScoGame) AReport {
+	if len(games) == 0 {
+		return AReport{}
+	}
+	stats := countingStats()
+	var rep AReport
+	for gi, game := range games {
+		rep.Games++
+		// Partition boxes by team.
+		type teamRows struct {
+			total   *backup.ScoBox
+			players []backup.ScoBox
+		}
+		teams := map[int]*teamRows{}
+		for i := range game.Boxes {
+			box := game.Boxes[i]
+			tr := teams[box.TeamID]
+			if tr == nil {
+				tr = &teamRows{}
+				teams[box.TeamID] = tr
+			}
+			if box.PlayerID == 0 {
+				b := box
+				tr.total = &b
+			} else {
+				tr.players = append(tr.players, box)
+			}
+		}
+		gameFailed := false
+		for _, tr := range teams {
+			teamID := 0
+			if len(tr.players) > 0 {
+				teamID = tr.players[0].TeamID
+			} else if tr.total != nil {
+				teamID = tr.total.TeamID
+			}
+			// Summation check.
+			for _, sd := range stats {
+				playerSum := 0
+				for _, p := range tr.players {
+					playerSum += sd.Get(p)
+				}
+				if tr.total == nil {
+					// Missing team-total row with data: surface only when playerSum != 0.
+					// A genuinely empty team (all zero stats) stays silent.
+					if playerSum != 0 {
+						rep.Mismatches = append(rep.Mismatches, AMismatch{
+							GameIndex: gi, TeamID: teamID, Stat: sd.Name,
+							TeamTotal: 0, PlayerSum: playerSum, Delta: playerSum,
+						})
+						gameFailed = true
+					}
+				} else {
+					teamTotal := sd.Get(*tr.total)
+					if playerSum != teamTotal {
+						rep.Mismatches = append(rep.Mismatches, AMismatch{
+							GameIndex: gi, TeamID: teamID, Stat: sd.Name,
+							TeamTotal: teamTotal, PlayerSum: playerSum,
+							Delta: playerSum - teamTotal,
+						})
+						gameFailed = true
+					}
+				}
+			}
+			// Negative check.
+			for _, p := range tr.players {
+				for _, sd := range stats {
+					v := sd.Get(p)
+					if v < 0 {
+						rep.Negatives = append(rep.Negatives, ANegative{
+							GameIndex: gi, TeamID: p.TeamID, PlayerID: p.PlayerID,
+							Name: p.Name, Stat: sd.Name, Value: v,
+						})
+						gameFailed = true
+					}
+				}
+			}
+			// Dominance flag (not a failure).
+			teamPoints := 0
+			for _, p := range tr.players {
+				teamPoints += ScoPoints(p)
+			}
+			if teamPoints > 0 {
+				for _, p := range tr.players {
+					pp := ScoPoints(p)
+					share := float64(pp) / float64(teamPoints)
+					if share > 0.60 {
+						rep.Dominances = append(rep.Dominances, ADominance{
+							GameIndex: gi, TeamID: p.TeamID, PlayerID: p.PlayerID,
+							Name: p.Name, PlayerPoints: pp, TeamPoints: teamPoints,
+							Share: share,
+						})
+					}
+				}
+			}
+		}
+		if !gameFailed {
+			rep.GamesPassed++
+		}
+	}
+	return rep
+}
+
+// -- Check B --
+
+// BNegative records a team-season with a negative rank correlation.
+type BNegative struct {
+	TeamID int
+	Rho    float64
+	N      int // rankable players on the team
+}
+
+// BReport summarizes the distribution of per-team scoring-rank correlations.
+type BReport struct {
+	TeamSeasons       int       // teams that yielded a finite rho
+	Correlations      []float64 // one finite rho per qualifying team
+	Mean              float64
+	StdDev            float64  // population std dev of Correlations
+	FractionAboveHalf float64  // fraction with rho > 0.5
+	NegativeTeams     []BNegative
+	Skipped           int     // teams dropped: < minPlayers, or degenerate (zero variance)
+	MaxPlayerAvg      float64 // max per-player .sco scoring average (cumulative-misread guardrail)
+}
+
+// scoringProxy is a monotone estimate of a player's expected points built from
+// the only scoring ratings the bundle exposes. Ranks are scale-invariant —
+// the only thing Spearman consumes.
+func scoringProxy(p backup.PlrPlayer) float64 {
+	return float64(p.RatingFGA*p.RatingFGP*2 + p.Rating3GA*p.Rating3GP + p.RatingFTA*p.RatingFTP)
+}
+
+// rank returns 1-based average ranks for v, averaging over ties.
+func rank(v []float64) []float64 {
+	n := len(v)
+	idx := make([]int, n)
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(a, b int) bool { return v[idx[a]] < v[idx[b]] })
+	ranks := make([]float64, n)
+	for i := 0; i < n; {
+		j := i + 1
+		for j < n && v[idx[j]] == v[idx[i]] {
+			j++
+		}
+		avg := float64(i+1+j) / 2.0 // average of 1-based positions i+1 .. j
+		for k := i; k < j; k++ {
+			ranks[idx[k]] = avg
+		}
+		i = j
+	}
+	return ranks
+}
+
+// spearman returns the Spearman rank correlation of x and y (equal length).
+// Returns NaN if either variable has zero rank-variance (all tied).
+func spearman(x, y []float64) float64 {
+	rx := rank(x)
+	ry := rank(y)
+	return pearson(rx, ry)
+}
+
+func pearson(x, y []float64) float64 {
+	n := float64(len(x))
+	if n == 0 {
+		return math.NaN()
+	}
+	var mx, my float64
+	for i := range x {
+		mx += x[i]
+		my += y[i]
+	}
+	mx /= n
+	my /= n
+	var num, dx2, dy2 float64
+	for i := range x {
+		dx := x[i] - mx
+		dy := y[i] - my
+		num += dx * dy
+		dx2 += dx * dx
+		dy2 += dy * dy
+	}
+	if dx2 == 0 || dy2 == 0 {
+		return math.NaN()
+	}
+	return num / math.Sqrt(dx2*dy2)
+}
+
+// CheckB correlates, per team, each player's scoring-rating rank against their
+// per-game .sco scoring-average rank, then summarizes the distribution.
+// minPlayers is the minimum rankable players a team needs (recommended: 5).
+func CheckB(players []backup.PlrPlayer, games []backup.ScoGame, minPlayers int) BReport {
+	type key struct{ team, pid int }
+
+	// Build per-player .sco scoring averages (avg points per game where Min > 0).
+	type acc struct{ sum, gp int }
+	scoAcc := map[key]*acc{}
+	for _, game := range games {
+		for _, box := range game.Boxes {
+			if box.PlayerID <= 0 || box.Min <= 0 {
+				continue
+			}
+			k := key{box.TeamID, box.PlayerID}
+			a := scoAcc[k]
+			if a == nil {
+				a = &acc{}
+				scoAcc[k] = a
+			}
+			a.sum += ScoPoints(box)
+			a.gp++
+		}
+	}
+	scoAvg := make(map[key]float64, len(scoAcc))
+	var maxAvg float64
+	for k, a := range scoAcc {
+		if a.gp > 0 {
+			avg := float64(a.sum) / float64(a.gp)
+			scoAvg[k] = avg
+			if avg > maxAvg {
+				maxAvg = avg
+			}
+		}
+	}
+
+	// Build rating proxies.
+	proxy := make(map[key]float64, len(players))
+	for _, p := range players {
+		proxy[key{p.TeamID, p.PID}] = scoringProxy(p)
+	}
+
+	// Collect team IDs.
+	teamSet := map[int]bool{}
+	for k := range proxy {
+		teamSet[k.team] = true
+	}
+	teamIDs := make([]int, 0, len(teamSet))
+	for tid := range teamSet {
+		teamIDs = append(teamIDs, tid)
+	}
+	sort.Ints(teamIDs)
+
+	var rep BReport
+	rep.MaxPlayerAvg = maxAvg
+
+	for _, tid := range teamIDs {
+		var xs, ys []float64
+		for k, px := range proxy {
+			if k.team != tid {
+				continue
+			}
+			avg, ok := scoAvg[k]
+			if !ok {
+				continue
+			}
+			xs = append(xs, px)
+			ys = append(ys, avg)
+		}
+		if len(xs) < minPlayers {
+			rep.Skipped++
+			continue
+		}
+		rho := spearman(xs, ys)
+		if math.IsNaN(rho) {
+			rep.Skipped++
+			continue
+		}
+		rep.Correlations = append(rep.Correlations, rho)
+		rep.TeamSeasons++
+		if rho < 0 {
+			rep.NegativeTeams = append(rep.NegativeTeams, BNegative{TeamID: tid, Rho: rho, N: len(xs)})
+		}
+	}
+
+	if rep.TeamSeasons == 0 {
+		return rep
+	}
+
+	// Compute summary statistics.
+	var sum float64
+	var aboveHalf int
+	for _, rho := range rep.Correlations {
+		sum += rho
+		if rho > 0.5 {
+			aboveHalf++
+		}
+	}
+	rep.Mean = sum / float64(rep.TeamSeasons)
+	var varSum float64
+	for _, rho := range rep.Correlations {
+		d := rho - rep.Mean
+		varSum += d * d
+	}
+	rep.StdDev = math.Sqrt(varSum / float64(rep.TeamSeasons))
+	rep.FractionAboveHalf = float64(aboveHalf) / float64(rep.TeamSeasons)
+	return rep
+}

--- a/engine/internal/validate/leaders_test.go
+++ b/engine/internal/validate/leaders_test.go
@@ -1,0 +1,451 @@
+package validate
+
+import (
+	"math"
+	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/backup"
+)
+
+// boxOf constructs a ScoBox for test cases.
+func boxOf(team, pid, twoGM, threeGM, ftm int) backup.ScoBox {
+	return backup.ScoBox{
+		TeamID:   team,
+		PlayerID: pid,
+		TwoGM:    twoGM,
+		ThreeGM:  threeGM,
+		FTM:      ftm,
+		Min:      20,
+	}
+}
+
+// boxFull constructs a ScoBox with all 13 counting stats set.
+func boxFull(team, pid int, vals [13]int) backup.ScoBox {
+	return backup.ScoBox{
+		TeamID:   team,
+		PlayerID: pid,
+		Min:      20,
+		TwoGM:    vals[0],
+		TwoGA:    vals[1],
+		FTM:      vals[2],
+		FTA:      vals[3],
+		ThreeGM:  vals[4],
+		ThreeGA:  vals[5],
+		ORB:      vals[6],
+		DRB:      vals[7],
+		AST:      vals[8],
+		STL:      vals[9],
+		TOV:      vals[10],
+		BLK:      vals[11],
+		PF:       vals[12],
+	}
+}
+
+// gameOf wraps boxes into a ScoGame.
+func gameOf(boxes ...backup.ScoBox) backup.ScoGame {
+	return backup.ScoGame{Boxes: boxes}
+}
+
+// sumVals sums the 13 counting stat values for a team-total row.
+func sumVals(a, b [13]int) [13]int {
+	var out [13]int
+	for i := range out {
+		out[i] = a[i] + b[i]
+	}
+	return out
+}
+
+func TestCheckA(t *testing.T) {
+	t.Run("happy_consistent", func(t *testing.T) {
+		// Two players per team, team-total == sum of players.
+		p1v := [13]int{3, 6, 2, 3, 1, 2, 1, 2, 3, 1, 2, 0, 2}
+		p2v := [13]int{2, 4, 1, 2, 0, 1, 0, 1, 2, 0, 1, 1, 1}
+		tv := sumVals(p1v, p2v)
+		p3v := [13]int{4, 8, 3, 4, 2, 3, 2, 3, 4, 2, 3, 1, 3}
+		p4v := [13]int{1, 2, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1}
+		tv2 := sumVals(p3v, p4v)
+		game := gameOf(
+			boxFull(1, 0, tv), boxFull(1, 1, p1v), boxFull(1, 2, p2v),
+			boxFull(2, 0, tv2), boxFull(2, 3, p3v), boxFull(2, 4, p4v),
+		)
+		rep := CheckA([]backup.ScoGame{game})
+		if rep.Games != 1 {
+			t.Fatalf("Games=%d want 1", rep.Games)
+		}
+		if rep.GamesPassed != 1 {
+			t.Fatalf("GamesPassed=%d want 1", rep.GamesPassed)
+		}
+		if len(rep.Mismatches) != 0 {
+			t.Fatalf("Mismatches=%v want none", rep.Mismatches)
+		}
+		if len(rep.Negatives) != 0 {
+			t.Fatalf("Negatives=%v want none", rep.Negatives)
+		}
+	})
+
+	t.Run("mismatch_single_stat", func(t *testing.T) {
+		p1v := [13]int{3, 6, 2, 3, 1, 2, 1, 2, 5, 1, 2, 0, 2} // AST=5
+		p2v := [13]int{2, 4, 1, 2, 0, 1, 0, 1, 3, 0, 1, 1, 1} // AST=3
+		tv := sumVals(p1v, p2v)
+		// Bump team-total AST by 1 (index 8).
+		tv[8]++
+		game := gameOf(
+			boxFull(1, 0, tv), boxFull(1, 1, p1v), boxFull(1, 2, p2v),
+		)
+		rep := CheckA([]backup.ScoGame{game})
+		if rep.GamesPassed != 0 {
+			t.Fatalf("GamesPassed=%d want 0", rep.GamesPassed)
+		}
+		astMismatches := 0
+		for _, m := range rep.Mismatches {
+			if m.Stat == "AST" {
+				astMismatches++
+				// Delta = PlayerSum - TeamTotal = 8 - 9 = -1
+				if m.Delta != -1 {
+					t.Errorf("AST Delta=%d want -1", m.Delta)
+				}
+			}
+		}
+		if astMismatches != 1 {
+			t.Fatalf("AST mismatch count=%d want 1; all mismatches: %v", astMismatches, rep.Mismatches)
+		}
+	})
+
+	t.Run("negative_stat", func(t *testing.T) {
+		p1v := [13]int{3, 6, 2, 3, 1, 2, 1, 2, 3, -1, 2, 0, 2} // STL=-1
+		p2v := [13]int{2, 4, 1, 2, 0, 1, 0, 1, 2, 2, 1, 1, 1}
+		tv := sumVals(p1v, p2v)
+		// Correct the team total for STL (use the raw sum which includes -1).
+		// tv[9] = -1+2 = 1 — leave it so no mismatch, only the negative check fires.
+		game := gameOf(
+			boxFull(1, 0, tv), boxFull(1, 1, p1v), boxFull(1, 2, p2v),
+		)
+		rep := CheckA([]backup.ScoGame{game})
+		if rep.GamesPassed != 0 {
+			t.Fatalf("GamesPassed=%d want 0", rep.GamesPassed)
+		}
+		if len(rep.Negatives) != 1 {
+			t.Fatalf("Negatives=%v want 1", rep.Negatives)
+		}
+		if rep.Negatives[0].Stat != "STL" || rep.Negatives[0].Value != -1 {
+			t.Errorf("Negative=%+v want STL=-1", rep.Negatives[0])
+		}
+	})
+
+	t.Run("dominance_over_threshold", func(t *testing.T) {
+		// Player scores 7 pts (2+2+2+1=7), team 11 pts — 7/11 = 0.636 > 0.60.
+		// Player 1: 3*2=6 2pt pts, 0 3pt, 1 FT = 7 total
+		// Player 2: 0 2pt, 0 3pt, 4 FT = 4 total
+		// Team total = 11
+		p1 := backup.ScoBox{TeamID: 1, PlayerID: 1, TwoGM: 3, ThreeGM: 0, FTM: 1, Min: 20}
+		p2 := backup.ScoBox{TeamID: 1, PlayerID: 2, TwoGM: 0, ThreeGM: 0, FTM: 4, Min: 20}
+		// Team total row with matching stats.
+		tot := backup.ScoBox{TeamID: 1, PlayerID: 0, TwoGM: 3, ThreeGM: 0, FTM: 5}
+		game := gameOf(tot, p1, p2)
+		rep := CheckA([]backup.ScoGame{game})
+		// Game still passes (dominance is a flag, not a fail).
+		if rep.GamesPassed != 1 {
+			t.Fatalf("GamesPassed=%d want 1", rep.GamesPassed)
+		}
+		if len(rep.Dominances) != 1 {
+			t.Fatalf("Dominances=%v want 1", rep.Dominances)
+		}
+		if rep.Dominances[0].Share <= 0.60 {
+			t.Errorf("Share=%f want >0.60", rep.Dominances[0].Share)
+		}
+	})
+
+	t.Run("dominance_boundary_exactly_60pct", func(t *testing.T) {
+		// Player 1: 6 pts (TwoGM=3), Player 2: 4 pts (FTM=4) — 6/10 = 0.60 exactly.
+		p1 := backup.ScoBox{TeamID: 1, PlayerID: 1, TwoGM: 3, Min: 20}
+		p2 := backup.ScoBox{TeamID: 1, PlayerID: 2, FTM: 4, Min: 20}
+		tot := backup.ScoBox{TeamID: 1, PlayerID: 0, TwoGM: 3, FTM: 4}
+		game := gameOf(tot, p1, p2)
+		rep := CheckA([]backup.ScoGame{game})
+		if rep.GamesPassed != 1 {
+			t.Fatalf("GamesPassed=%d want 1", rep.GamesPassed)
+		}
+		if len(rep.Dominances) != 0 {
+			t.Fatalf("Dominances=%v want none at exactly 60%%", rep.Dominances)
+		}
+	})
+
+	t.Run("missing_team_total_with_data", func(t *testing.T) {
+		// No PlayerID==0 row; player rows have non-zero stats.
+		p1 := backup.ScoBox{TeamID: 1, PlayerID: 1, TwoGM: 3, AST: 2, Min: 20}
+		p2 := backup.ScoBox{TeamID: 1, PlayerID: 2, TwoGM: 2, AST: 1, Min: 20}
+		game := gameOf(p1, p2)
+		rep := CheckA([]backup.ScoGame{game})
+		if rep.GamesPassed != 0 {
+			t.Fatalf("GamesPassed=%d want 0", rep.GamesPassed)
+		}
+		if len(rep.Mismatches) == 0 {
+			t.Fatal("want mismatches for missing team-total with data")
+		}
+	})
+
+	t.Run("empty_and_nil", func(t *testing.T) {
+		r1 := CheckA(nil)
+		if r1.Games != 0 {
+			t.Errorf("nil: Games=%d want 0", r1.Games)
+		}
+		r2 := CheckA([]backup.ScoGame{})
+		if r2.Games != 0 {
+			t.Errorf("empty: Games=%d want 0", r2.Games)
+		}
+	})
+}
+
+func TestSpearman(t *testing.T) {
+	t.Run("perfect_positive", func(t *testing.T) {
+		got := spearman([]float64{1, 2, 3}, []float64{1, 2, 3})
+		if math.Abs(got-1.0) > 1e-9 {
+			t.Errorf("got %v want 1.0", got)
+		}
+	})
+	t.Run("perfect_negative", func(t *testing.T) {
+		got := spearman([]float64{1, 2, 3}, []float64{3, 2, 1})
+		if math.Abs(got-(-1.0)) > 1e-9 {
+			t.Errorf("got %v want -1.0", got)
+		}
+	})
+	t.Run("tie", func(t *testing.T) {
+		// x=[1,1,2], y=[5,6,7]. x-ranks=[1.5,1.5,3], y-ranks=[1,2,3].
+		// Pre-derived: rho = sqrt(3)/2 ≈ 0.8660254
+		got := spearman([]float64{1, 1, 2}, []float64{5, 6, 7})
+		want := math.Sqrt(3) / 2
+		if math.Abs(got-want) > 1e-9 {
+			t.Errorf("got %v want sqrt(3)/2≈%v", got, want)
+		}
+	})
+	t.Run("zero_variance", func(t *testing.T) {
+		got := spearman([]float64{2, 2, 2}, []float64{1, 2, 3})
+		if !math.IsNaN(got) {
+			t.Errorf("got %v want NaN", got)
+		}
+	})
+}
+
+// plrOf constructs a PlrPlayer with monotone scoring ratings.
+func plrOf(pid, teamID, fga, fgp, tga, tgp, fta, ftp int) backup.PlrPlayer {
+	return backup.PlrPlayer{
+		PID: pid, TeamID: teamID,
+		RatingFGA: fga, RatingFGP: fgp,
+		Rating3GA: tga, Rating3GP: tgp,
+		RatingFTA: fta, RatingFTP: ftp,
+	}
+}
+
+func TestCheckB(t *testing.T) {
+	t.Run("perfect_positive", func(t *testing.T) {
+		// 5 players: proxy ranks match scoAvg ranks exactly.
+		players := []backup.PlrPlayer{
+			plrOf(1, 10, 10, 50, 2, 30, 5, 70), // proxy = 10*50*2+2*30+5*70 = 1000+60+350=1410
+			plrOf(2, 10, 8, 50, 2, 30, 4, 70),  // proxy ≈ 800+60+280=1140
+			plrOf(3, 10, 6, 50, 2, 30, 3, 70),  // proxy ≈ 600+60+210=870
+			plrOf(4, 10, 4, 50, 2, 30, 2, 70),  // proxy ≈ 400+60+140=600
+			plrOf(5, 10, 2, 50, 2, 30, 1, 70),  // proxy ≈ 200+60+70=330
+		}
+		// Build games where scoring avg matches proxy order.
+		boxes := []backup.ScoBox{
+			{TeamID: 10, PlayerID: 1, TwoGM: 10, Min: 20},
+			{TeamID: 10, PlayerID: 2, TwoGM: 8, Min: 20},
+			{TeamID: 10, PlayerID: 3, TwoGM: 6, Min: 20},
+			{TeamID: 10, PlayerID: 4, TwoGM: 4, Min: 20},
+			{TeamID: 10, PlayerID: 5, TwoGM: 2, Min: 20},
+		}
+		games := []backup.ScoGame{{Boxes: boxes}}
+		rep := CheckB(players, games, 5)
+		if rep.TeamSeasons != 1 {
+			t.Fatalf("TeamSeasons=%d want 1", rep.TeamSeasons)
+		}
+		if math.Abs(rep.Correlations[0]-1.0) > 1e-9 {
+			t.Errorf("rho=%v want 1.0", rep.Correlations[0])
+		}
+		if math.Abs(rep.FractionAboveHalf-1.0) > 1e-9 {
+			t.Errorf("FractionAboveHalf=%v want 1.0", rep.FractionAboveHalf)
+		}
+		if len(rep.NegativeTeams) != 0 {
+			t.Errorf("NegativeTeams=%v want none", rep.NegativeTeams)
+		}
+	})
+
+	t.Run("perfect_negative", func(t *testing.T) {
+		// Proxy order is the reverse of scoAvg order.
+		players := []backup.PlrPlayer{
+			plrOf(1, 10, 10, 50, 0, 0, 0, 0), // highest proxy
+			plrOf(2, 10, 8, 50, 0, 0, 0, 0),
+			plrOf(3, 10, 6, 50, 0, 0, 0, 0),
+			plrOf(4, 10, 4, 50, 0, 0, 0, 0),
+			plrOf(5, 10, 2, 50, 0, 0, 0, 0), // lowest proxy
+		}
+		// scoAvg order: pid=5 highest scorer, pid=1 lowest.
+		boxes := []backup.ScoBox{
+			{TeamID: 10, PlayerID: 1, TwoGM: 1, Min: 20}, // lowest avg
+			{TeamID: 10, PlayerID: 2, TwoGM: 2, Min: 20},
+			{TeamID: 10, PlayerID: 3, TwoGM: 3, Min: 20},
+			{TeamID: 10, PlayerID: 4, TwoGM: 4, Min: 20},
+			{TeamID: 10, PlayerID: 5, TwoGM: 5, Min: 20}, // highest avg
+		}
+		games := []backup.ScoGame{{Boxes: boxes}}
+		rep := CheckB(players, games, 5)
+		if rep.TeamSeasons != 1 {
+			t.Fatalf("TeamSeasons=%d want 1", rep.TeamSeasons)
+		}
+		if math.Abs(rep.Correlations[0]-(-1.0)) > 1e-9 {
+			t.Errorf("rho=%v want -1.0", rep.Correlations[0])
+		}
+		if len(rep.NegativeTeams) != 1 {
+			t.Fatalf("NegativeTeams=%v want 1", rep.NegativeTeams)
+		}
+	})
+
+	t.Run("too_few_players", func(t *testing.T) {
+		players := []backup.PlrPlayer{
+			plrOf(1, 10, 10, 50, 0, 0, 0, 0),
+			plrOf(2, 10, 8, 50, 0, 0, 0, 0),
+			plrOf(3, 10, 6, 50, 0, 0, 0, 0),
+			plrOf(4, 10, 4, 50, 0, 0, 0, 0), // only 4 rankable
+		}
+		boxes := []backup.ScoBox{
+			{TeamID: 10, PlayerID: 1, TwoGM: 4, Min: 20},
+			{TeamID: 10, PlayerID: 2, TwoGM: 3, Min: 20},
+			{TeamID: 10, PlayerID: 3, TwoGM: 2, Min: 20},
+			{TeamID: 10, PlayerID: 4, TwoGM: 1, Min: 20},
+		}
+		games := []backup.ScoGame{{Boxes: boxes}}
+		rep := CheckB(players, games, 5)
+		if rep.TeamSeasons != 0 {
+			t.Errorf("TeamSeasons=%d want 0", rep.TeamSeasons)
+		}
+		if rep.Skipped < 1 {
+			t.Errorf("Skipped=%d want >=1", rep.Skipped)
+		}
+	})
+
+	t.Run("degenerate_ties", func(t *testing.T) {
+		// All players have identical ratings — proxy ties → spearman NaN → skipped.
+		players := []backup.PlrPlayer{
+			plrOf(1, 10, 5, 50, 0, 0, 0, 0),
+			plrOf(2, 10, 5, 50, 0, 0, 0, 0),
+			plrOf(3, 10, 5, 50, 0, 0, 0, 0),
+			plrOf(4, 10, 5, 50, 0, 0, 0, 0),
+			plrOf(5, 10, 5, 50, 0, 0, 0, 0),
+		}
+		boxes := []backup.ScoBox{
+			{TeamID: 10, PlayerID: 1, TwoGM: 5, Min: 20},
+			{TeamID: 10, PlayerID: 2, TwoGM: 4, Min: 20},
+			{TeamID: 10, PlayerID: 3, TwoGM: 3, Min: 20},
+			{TeamID: 10, PlayerID: 4, TwoGM: 2, Min: 20},
+			{TeamID: 10, PlayerID: 5, TwoGM: 1, Min: 20},
+		}
+		games := []backup.ScoGame{{Boxes: boxes}}
+		rep := CheckB(players, games, 5)
+		if rep.TeamSeasons != 0 {
+			t.Errorf("TeamSeasons=%d want 0", rep.TeamSeasons)
+		}
+		if rep.Skipped < 1 {
+			t.Errorf("Skipped=%d want >=1 (degenerate NaN)", rep.Skipped)
+		}
+	})
+
+	t.Run("unmatched_pid_excluded", func(t *testing.T) {
+		// pid=99 in .sco but not in players; pid=88 in players but not in .sco.
+		// Correlation computed only over the 5-player intersection.
+		players := []backup.PlrPlayer{
+			plrOf(1, 10, 10, 50, 0, 0, 0, 0),
+			plrOf(2, 10, 8, 50, 0, 0, 0, 0),
+			plrOf(3, 10, 6, 50, 0, 0, 0, 0),
+			plrOf(4, 10, 4, 50, 0, 0, 0, 0),
+			plrOf(5, 10, 2, 50, 0, 0, 0, 0),
+			plrOf(88, 10, 1, 50, 0, 0, 0, 0), // in players, absent from .sco
+		}
+		boxes := []backup.ScoBox{
+			{TeamID: 10, PlayerID: 1, TwoGM: 5, Min: 20},
+			{TeamID: 10, PlayerID: 2, TwoGM: 4, Min: 20},
+			{TeamID: 10, PlayerID: 3, TwoGM: 3, Min: 20},
+			{TeamID: 10, PlayerID: 4, TwoGM: 2, Min: 20},
+			{TeamID: 10, PlayerID: 5, TwoGM: 1, Min: 20},
+			{TeamID: 10, PlayerID: 99, TwoGM: 6, Min: 20}, // in .sco, absent from players
+		}
+		games := []backup.ScoGame{{Boxes: boxes}}
+		rep := CheckB(players, games, 5)
+		// Should get exactly 1 team-season from the 5-player intersection.
+		if rep.TeamSeasons != 1 {
+			t.Errorf("TeamSeasons=%d want 1 (intersection of 5)", rep.TeamSeasons)
+		}
+	})
+
+	t.Run("min_zero_excluded", func(t *testing.T) {
+		// pid=6 appears only with Min==0 — must be excluded from scoAvg map.
+		players := []backup.PlrPlayer{
+			plrOf(1, 10, 10, 50, 0, 0, 0, 0),
+			plrOf(2, 10, 8, 50, 0, 0, 0, 0),
+			plrOf(3, 10, 6, 50, 0, 0, 0, 0),
+			plrOf(4, 10, 4, 50, 0, 0, 0, 0),
+			plrOf(5, 10, 2, 50, 0, 0, 0, 0),
+			plrOf(6, 10, 1, 50, 0, 0, 0, 0), // will appear only in Min==0 boxes
+		}
+		boxes := []backup.ScoBox{
+			{TeamID: 10, PlayerID: 1, TwoGM: 5, Min: 20},
+			{TeamID: 10, PlayerID: 2, TwoGM: 4, Min: 20},
+			{TeamID: 10, PlayerID: 3, TwoGM: 3, Min: 20},
+			{TeamID: 10, PlayerID: 4, TwoGM: 2, Min: 20},
+			{TeamID: 10, PlayerID: 5, TwoGM: 1, Min: 20},
+			{TeamID: 10, PlayerID: 6, TwoGM: 9, Min: 0}, // Min==0 → excluded
+		}
+		games := []backup.ScoGame{{Boxes: boxes}}
+		rep := CheckB(players, games, 5)
+		// pid=6 excluded → only 5-player intersection → 1 team-season.
+		if rep.TeamSeasons != 1 {
+			t.Errorf("TeamSeasons=%d want 1", rep.TeamSeasons)
+		}
+	})
+
+	t.Run("distribution_math", func(t *testing.T) {
+		// Two teams: team 10 → perfect positive (rho=1.0), team 20 → perfect negative (rho=-1.0).
+		// Expected: Mean=0.0, StdDev=1.0, FractionAboveHalf=0.5 (only team 10 is >0.5).
+		players := []backup.PlrPlayer{
+			// team 10: ascending proxy
+			plrOf(1, 10, 10, 50, 0, 0, 0, 0),
+			plrOf(2, 10, 8, 50, 0, 0, 0, 0),
+			plrOf(3, 10, 6, 50, 0, 0, 0, 0),
+			plrOf(4, 10, 4, 50, 0, 0, 0, 0),
+			plrOf(5, 10, 2, 50, 0, 0, 0, 0),
+			// team 20: ascending proxy
+			plrOf(11, 20, 10, 50, 0, 0, 0, 0),
+			plrOf(12, 20, 8, 50, 0, 0, 0, 0),
+			plrOf(13, 20, 6, 50, 0, 0, 0, 0),
+			plrOf(14, 20, 4, 50, 0, 0, 0, 0),
+			plrOf(15, 20, 2, 50, 0, 0, 0, 0),
+		}
+		boxes := []backup.ScoBox{
+			// team 10: scoAvg matches proxy order → rho=1
+			{TeamID: 10, PlayerID: 1, TwoGM: 5, Min: 20},
+			{TeamID: 10, PlayerID: 2, TwoGM: 4, Min: 20},
+			{TeamID: 10, PlayerID: 3, TwoGM: 3, Min: 20},
+			{TeamID: 10, PlayerID: 4, TwoGM: 2, Min: 20},
+			{TeamID: 10, PlayerID: 5, TwoGM: 1, Min: 20},
+			// team 20: scoAvg reverses proxy order → rho=-1
+			{TeamID: 20, PlayerID: 11, TwoGM: 1, Min: 20},
+			{TeamID: 20, PlayerID: 12, TwoGM: 2, Min: 20},
+			{TeamID: 20, PlayerID: 13, TwoGM: 3, Min: 20},
+			{TeamID: 20, PlayerID: 14, TwoGM: 4, Min: 20},
+			{TeamID: 20, PlayerID: 15, TwoGM: 5, Min: 20},
+		}
+		games := []backup.ScoGame{{Boxes: boxes}}
+		rep := CheckB(players, games, 5)
+		if rep.TeamSeasons != 2 {
+			t.Fatalf("TeamSeasons=%d want 2", rep.TeamSeasons)
+		}
+		if math.Abs(rep.Mean-0.0) > 1e-9 {
+			t.Errorf("Mean=%v want 0.0", rep.Mean)
+		}
+		if math.Abs(rep.StdDev-1.0) > 1e-9 {
+			t.Errorf("StdDev=%v want 1.0", rep.StdDev)
+		}
+		if math.Abs(rep.FractionAboveHalf-0.5) > 1e-9 {
+			t.Errorf("FractionAboveHalf=%v want 0.5", rep.FractionAboveHalf)
+		}
+	})
+}

--- a/engine/internal/validate/leaders_test.go
+++ b/engine/internal/validate/leaders_test.go
@@ -7,18 +7,6 @@ import (
 	"github.com/a-jay85/IBL5/engine/internal/backup"
 )
 
-// boxOf constructs a ScoBox for test cases.
-func boxOf(team, pid, twoGM, threeGM, ftm int) backup.ScoBox {
-	return backup.ScoBox{
-		TeamID:   team,
-		PlayerID: pid,
-		TwoGM:    twoGM,
-		ThreeGM:  threeGM,
-		FTM:      ftm,
-		Min:      20,
-	}
-}
-
 // boxFull constructs a ScoBox with all 13 counting stats set.
 func boxFull(team, pid int, vals [13]int) backup.ScoBox {
 	return backup.ScoBox{


### PR DESCRIPTION
## Summary

Builds the J13 per-player leaders validation instrument — two complementary checks:

- **Check A** (`validate.CheckA`): .sco corpus self-consistency — reconciles each game's player rows against the team-total row across all 13 counting stats; flags negative stats and single-player scoring dominance (>60%).
- **Check B** (`validate.CheckB`): rating-vs-.sco rank correlation — computes per-team Spearman ρ between scoring-rating proxy ranks and per-game .sco scoring-average ranks; summarizes the distribution.

Adds real-corpus archive drivers in `engine/internal/calibrate/` (behind `//go:build archive`, so CI never runs them). No engine sim code changes; no GM-visible ability changes.

## Changes

- `engine/internal/validate/leaders.go` (NEW) — Check A + Check B pure computation, `spearman` helper, `scoringProxy` composite
- `engine/internal/validate/leaders_test.go` (NEW) — CI unit tests (exact Spearman values, boundary/negative-path coverage)
- `engine/internal/calibrate/leaders_archive_test.go` (NEW) — two `//go:build archive` real-corpus drivers with invariant assertions

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.