### PR TITLE
docs: token-spend backlog housekeeping — T2 and T5 implemented, archive

### DIFF
--- a/ibl5/docs/backlog/archive/token-spend-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/token-spend-backlog-archive.md
@@ -14,10 +14,20 @@ Read-only historical record of ✅ Implemented entries. For OPEN items see ../to
 **Problem (was):** The nightly queue was pure spend mechanism with only partial measurement: per-phase cost rows existed, but there was no tier breakdown, no weekly aggregate, and no equivalent report for interactive sessions (the origin 7-day analysis was done by hand).
 **Status (2026-07-09):** ✅ Implemented — `bin/lib/automouse-stream-filter` now emits `cache_write` on the exit line; `bin/automouse-run` cost rows carry Model + Tier columns and a per-phase-rebuilt `## Weekly aggregate (last 7 days)` section (cost-by-tier + tokens-by-phase); new `bin/token-report` runs the interactive-session token analysis on demand.
 
+### T2 Always-loaded context budget gate
+**Location:** `bin/check-rules-byte-budget` (CI per-file rules cap) + `$HOME/.claude/hooks/memory-expiry.py` (SessionStart MEMORY.md byte-budget check).
+**Problem (was):** The always-loaded surface (path-unscoped `.claude/rules/*.md` + the `MEMORY.md` index) only ever grew; nothing pushed back, and no CI or hook check capped it.
+**Status (2026-07-14):** ✅ Implemented — CI rules byte-budget gate shipped first (`bin/check-rules-byte-budget`, 5000-byte per-file cap, folded into the `static-guards` job). Residual local MEMORY.md index-budget check now closed: `memory-expiry.py` warns when the index exceeds an 8192-byte budget (ratcheted to hold the T7 diet; index was dieted to ~6.1KB the same day). Pairs with T5 (same hook).
+
 ### T3 Wire PHP LSP + LSP-first rule
 **Location:** `.claude/rules/lsp-first.md`; intelephense via the php-lsp plugin.
 **Problem (was):** Symbol navigation ran as grep-and-read-whole-file chains — the largest read-token sink in a 275K-line PHP codebase.
 **Status (2026-07-07):** ✅ Implemented — intelephense wired and the LSP-first rule shipped (measured ~10–30× cheaper than the grep-and-read path on `CsrfGuard::validateSubmittedToken`: ~320 tokens vs ~3–10K). Sub-item **SessionStart index warm-up: 🚫 Declined** — a `--stdio` server can't be reached by a shell hook (verified 2026-07-07); the tool blocks until indexed and the rule carries retry-once guidance instead.
+
+### T5 Memory/rules dedup lint
+**Location:** `$HOME/.claude/hooks/memory-expiry.py` (SessionStart hook).
+**Problem (was):** The "MEMORY.md never duplicates `.claude/rules/`" norm was manual discipline; overlap could silently re-grow in the always-loaded index.
+**Status (2026-07-14):** ✅ Implemented — added a dedup check to the SessionStart hook: each index line is scored against every rule's signature (description + headings) and near-exact overlaps surface for retirement. Thresholds (overlap-coef ≥0.6 ∧ shared ≥5 ∧ Jaccard ≥0.35) were calibrated on the real corpus — silent on the current clean index (top coincidental overlap oc 0.50), fires on a genuine duplicate (oc 1.0). Pairs with T2 (same hook).
 
 ### T6 Re-cap runtime context window
 **Location:** `$HOME/.claude/settings.json` — `autoCompactWindow: 200000`.

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -29,10 +29,10 @@ last_verified: 2026-07-14
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 3 |
+| ⬜ Open | 2 |
 | 📋 Planned | 0 |
-| ◑ Partial | 2 |
-| ✅ Implemented | 8 |
+| ◑ Partial | 1 |
+| ✅ Implemented | 10 |
 | 🚫 Declined | 0 |
 
 Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive/token-spend-backlog-archive.md).
@@ -43,18 +43,9 @@ Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive
 
 | # | Title | Status | Locus | Effort |
 |---|-------|--------|-------|-------:|
-| T2 | Always-loaded context budget gate | ◑ Partial | repo | S |
 | T4 | Driver-model downshift for babysitting loops | ⬜ Open | ⌂ | M |
-| T5 | Memory/rules dedup lint | ⬜ Open | ⌂ | S |
 | T7 | Resident-overlay diet (MEMORY.md + rules) | ◑ Partial | both | M |
 | T13 | Aggregate always-loaded rules budget | ⬜ Open | repo | S |
-
-### T2 Always-loaded context budget gate
-**Location:** `.claude/rules/*.md` (path-unscoped subset ≈ 19KB) + the memory index (`MEMORY.md`, ≈ 16KB) — together ~9K tokens on every request and every subagent spawn.
-**Problem:** The always-loaded surface only ever grows; nothing pushes back. No CI check caps it (verified: no size/budget check in `.github/workflows/` or `bin/check-docs`).
-**Suggested direction:** A small CI job (wired into the `gate` job's `needs:`, per house convention) failing when path-unscoped rules bytes or the MEMORY.md index exceed a budget. MEMORY.md lives outside the repo, so the gate checks rules in CI and the hook surface checks the index locally (pairs with T5).
-**Risk if untouched:** Silent regrowth of the per-turn fixed tax that T7 pays down.
-**Status (2026-07-11):** ◑ Partial — CI rules byte-budget gate shipped: `bin/check-rules-byte-budget` caps path-unscoped `.claude/rules/*.md` files at 5000 bytes, folded into the `static-guards` job (already in the `gate` `needs:`, so a regrowth fails the required gate). Residual: the local MEMORY.md index-budget hook (out-of-repo, pairs with T5) still deferred.
 
 ### T4 Driver-model downshift for babysitting loops
 **Location:** Interactive workflow — CI-watching, merge-nudging, and re-run loops currently run in the main (Opus/Fable) session.
@@ -62,13 +53,6 @@ Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive
 **Suggested direction:** A Sonnet wrapper session (or `/loop`-driven routine) for watch/nudge phases, reserving the top-tier session for design and review. Partially substituted by L6/L8 in [loop-engineering-backlog.md](loop-engineering-backlog.md), which remove the need to babysit at all.
 **Risk if untouched:** Top-tier token burn on mechanical polling.
 **Status (2026-07-07):** ⬜ Open. **(2026-07-14):** L6/L8 in [loop-engineering-backlog.md](loop-engineering-backlog.md) have both since shipped ✅ Implemented, so nightly babysitting is largely removed; residual scope narrows to interactive CI-watch/merge-nudge sessions.
-
-### T5 Memory/rules dedup lint
-**Location:** `$HOME/.claude/hooks/memory-expiry.py` (SessionStart hook; currently expiry-only).
-**Problem:** The "MEMORY.md never duplicates `.claude/rules/`" norm is manual discipline; overlap can silently re-grow in the always-loaded index.
-**Suggested direction:** Add a similarity check (index hooks vs rule headings/bodies) to the existing hook, surfacing suspected duplicates the way expiry lines are surfaced.
-**Risk if untouched:** Redundant always-loaded lines dilute recall and re-inflate the T7 surface.
-**Status (2026-07-07):** ⬜ Open.
 
 ### T7 Resident-overlay diet (MEMORY.md + rules)
 **Location:** Memory index `MEMORY.md` (18.1KB measured 2026-07-14, up from ~16KB/181 files on 2026-07-07, ~90 lines, 191 topic files behind it); `.claude/rules/agent-tiering.md` (~6.6KB, with an existing overflow file `.claude/rules/agent-tiering-detail.md`).
@@ -85,6 +69,10 @@ Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive
 **Status (2026-07-14):** ⬜ Open (discovered 2026-07-14 during token-spend-triage).
 
 ➜ T1 Automouse token ledger — ✅ Implemented (2026-07-09): see [archive](archive/token-spend-backlog-archive.md).
+
+➜ T2 Always-loaded context budget gate — ✅ Implemented (2026-07-14): see [archive](archive/token-spend-backlog-archive.md).
+
+➜ T5 Memory/rules dedup lint — ✅ Implemented (2026-07-14): see [archive](archive/token-spend-backlog-archive.md).
 
 ➜ T9 Lazy-load plan/post-plan skills — ✅ Implemented (2026-07-14): see [archive](archive/token-spend-backlog-archive.md).
 


### PR DESCRIPTION
## Summary

- T2 (Always-loaded context budget gate): ◑ Partial → ✅ Implemented — MEMORY.md index-budget check closed via `memory-expiry.py` byte-budget warning (pairs with T5, same hook)
- T5 (Memory/rules dedup lint): ⬜ Open → ✅ Implemented — dedup similarity check added to `memory-expiry.py` SessionStart hook; calibrated thresholds (overlap-coef ≥0.6 ∧ shared ≥5 ∧ Jaccard ≥0.35) pass the clean index, fire on genuine duplicates
- Archive both entries; reconcile roll-up counts (Open: 3→2, Partial: 2→1, Implemented: 8→10)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.