### PR TITLE
docs: add /plan orchestrator model tiering note to agent-tiering rule

### DIFF
--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,6 +1,6 @@
 ---
 description: Which tier to pick for each sub-agent, plus how to tier Explore agents. Skip-vs-spawn heuristic and deeper rationale live in agent-tiering-detail.md.
-last_verified: 2026-07-11
+last_verified: 2026-07-14
 ---
 
 # Agent Tiering
@@ -18,6 +18,16 @@ Tier every sub-agent (and every agent a plan spawns) by the reasoning the task a
 | **Fable** | `model: "fable"` — **prompt first, last resort** | Rung above Opus (~2× cost). Use **only** when a task is absolutely critical **and** Fable is 100% necessary to solve it — and **never without prompting the user first** for explicit approval. Default to Opus. Full gate: `.claude/rules/agent-tiering-detail.md`. |
 
 > **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (then the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.
+
+## `/plan` orchestrator model
+
+The rows above tier the **sub-agents** a plan spawns. The model you run **`/plan` itself** as (the orchestrator session) is a separate call — and it does **not** set the plan's design tier. `/plan` is delegation-terminal: the plan is authored by the `plan-architect` sub-agent in its own window, tiered independently by the Step-3 precedence in the "Opus (delegated)" row (xhigh → sonnet → opus). A Sonnet orchestrator spawning an Opus `plan-architect` still gets an Opus-authored plan.
+
+So tier the orchestrator by the judgment **it** retains, not the architect's:
+
+- **Single backlog item** (known blast radius, a recipe, a named pattern) → **Sonnet**. The orchestrator's own calls — one-PR-vs-split (Step 2.5), architect-tier selection (Step 3), the Step 4 gates — are light for a well-scoped item; this is the same recipe-backed class the "Opus (delegated)" row routes to `plan-architect-sonnet`.
+- **Multiple items in one pass** → **Opus**. Cross-item PR decomposition, **dependency ordering** (the FK-ordering class the Opus (self) row reserves), shared-context seeding, and tier-boundary splits push novel reasoning onto the orchestrator itself.
+  - Cheaper alternative: run each item as its own single-item **Sonnet** `/plan`, and make only the cross-item ordering/stacking call yourself — keeping the per-token-expensive model off the mechanical per-item passes.
 
 ## Explore Agents
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -21,13 +21,12 @@ Tier every sub-agent (and every agent a plan spawns) by the reasoning the task a
 
 ## `/plan` orchestrator model
 
-The rows above tier the **sub-agents** a plan spawns. The model you run **`/plan` itself** as (the orchestrator session) is a separate call — and it does **not** set the plan's design tier. `/plan` is delegation-terminal: the plan is authored by the `plan-architect` sub-agent in its own window, tiered independently by the Step-3 precedence in the "Opus (delegated)" row (xhigh → sonnet → opus). A Sonnet orchestrator spawning an Opus `plan-architect` still gets an Opus-authored plan.
+The rows above tier sub-agents; the `/plan` session model is a separate call. The `plan-architect` is tiered by Step-3 precedence (xhigh → sonnet → opus) regardless of the orchestrator — a Sonnet `/plan` spawning `plan-architect` still gets an Opus-authored plan.
 
-So tier the orchestrator by the judgment **it** retains, not the architect's:
+Tier the orchestrator by the judgment **it** retains:
 
-- **Single backlog item** (known blast radius, a recipe, a named pattern) → **Sonnet**. The orchestrator's own calls — one-PR-vs-split (Step 2.5), architect-tier selection (Step 3), the Step 4 gates — are light for a well-scoped item; this is the same recipe-backed class the "Opus (delegated)" row routes to `plan-architect-sonnet`.
-- **Multiple items in one pass** → **Opus**. Cross-item PR decomposition, **dependency ordering** (the FK-ordering class the Opus (self) row reserves), shared-context seeding, and tier-boundary splits push novel reasoning onto the orchestrator itself.
-  - Cheaper alternative: run each item as its own single-item **Sonnet** `/plan`, and make only the cross-item ordering/stacking call yourself — keeping the per-token-expensive model off the mechanical per-item passes.
+- **Single backlog item** → **Sonnet** (Steps 2.5/3/4 orchestrator calls are light; same recipe-backed class the "Opus (delegated)" row routes to `plan-architect-sonnet`).
+- **Multiple items in one pass** → **Opus** (cross-item PR decomposition, **dependency ordering**, tier-boundary splits). Cheaper: run each as its own **Sonnet** `/plan` and make only the ordering call yourself.
 
 ## Explore Agents
 


### PR DESCRIPTION
## Summary

- Adds a new `## /plan orchestrator model` section to `.claude/rules/agent-tiering.md` clarifying that the session model used to *run* `/plan` is independent from the `plan-architect` sub-agent it spawns
- Documents the orchestrator tiering heuristic: Sonnet for single backlog items (light orchestration decisions), Opus for multi-item passes (cross-item dependency ordering, PR decomposition)
- Bumps `last_verified` to 2026-07-14

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.