### PR TITLE
docs: E6 backlog housekeeping — archive diff-scoped PHPStan wrapper entry

### DIFF
--- a/ibl5/docs/backlog/archive/dev-efficiency-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/dev-efficiency-backlog-archive.md
@@ -1,0 +1,15 @@
+---
+description: Historical archive: completed development-efficiency backlog entries, extracted from dev-efficiency-backlog.md.
+last_verified: 2026-07-14
+---
+
+# Development-Efficiency Backlog — Archive
+
+Read-only historical record of ✅ Implemented / 🚫 Declined entries. For OPEN items see ../dev-efficiency-backlog.md. Not governed by bin/check-docs (historical dead refs tolerated).
+
+---
+
+### E6 Diff-scoped PHPStan wrapper
+**Location:** `ibl5/bin/analyse-diff`.
+**What shipped:** `bin/analyse-diff` runs PHPStan only on `.php` files changed vs a base ref (default: `master`), routing them through `composer run analyse` / `composer run analyse:tests` so it inherits the exact `--memory-limit`/`--autoload-file` flags and honors baselines. Covers committed branch changes, staged/unstaged edits, and untracked new files. Full-project run remains the CI gate.
+**Status (2026-07-14):** ✅ Implemented — shipped in PR #1362.

--- a/ibl5/docs/backlog/dev-efficiency-backlog.md
+++ b/ibl5/docs/backlog/dev-efficiency-backlog.md
@@ -27,10 +27,10 @@ last_verified: 2026-07-14
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 5 |
+| ⬜ Open | 4 |
 | 📋 Planned | 2 |
 | ◑ Partial | 2 |
-| ✅ Implemented | 2 |
+| ✅ Implemented | 3 |
 | 🚫 Declined | 0 |
 
 ---
@@ -44,7 +44,7 @@ last_verified: 2026-07-14
 | E3 | PHPStan result-cache in CI | ⬜ Open | 🟩 | S |
 | E4 | Flake-quarantine ledger | ⬜ Open | 🟨 | M |
 | E5 | Scheduled stale-worktree GC | ◑ Partial | 🟨 | S |
-| E6 | Diff-scoped PHPStan wrapper | ⬜ Open | 🟩 | S |
+| E6 | Diff-scoped PHPStan wrapper | ✅ Implemented | — | S |
 | E7 | Parallel PHPUnit | ✅ Implemented | — | M |
 | E8 | Memory lines → mechanical gates (umbrella) | ◑ Partial | 🟨 | M |
 | E9 | Meta-tooling growth bar | 📋 Planned | 🟦 | S |
@@ -86,12 +86,7 @@ last_verified: 2026-07-14
 **Risk if untouched:** Disk/RAM held by dead Docker stacks; stale worktrees confuse session coordination.
 **Status (2026-07-07):** ◑ Partial — sweep + classifier merged; scheduling absent. 🟨 (the schedule itself is host-local, not PR-shippable).
 
-### E6 Diff-scoped PHPStan wrapper
-**Location:** `ibl5/composer.json` — only full-project `analyse` scripts exist; nothing diff-scoped in `bin/`.
-**Problem:** Inner-loop iteration pays a full-project analysis for a 3-file change.
-**Suggested direction:** An `analyse-diff` wrapper under `bin/`: `git diff --name-only master... -- '*.php'` fed to PHPStan with the same memory-limit/autoload flags the composer scripts set. Full run remains the CI gate.
-**Risk if untouched:** Slow verify step in every mechanical-sweep loop, local and automouse.
-**Status (2026-07-07):** ⬜ Open — 🟩.
+➜ E6 Diff-scoped PHPStan wrapper — ✅ Implemented (2026-07-14): see [archive](archive/dev-efficiency-backlog-archive.md).
 
 ### E7 Parallel PHPUnit
 **Location:** `ibl5/composer.json:17,21` — `brianium/paratest ^7.23`; `composer run test` runs paratest.

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -74,7 +74,7 @@ Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive
 - L15 (Sonnet-recipe completeness lint) — [loop-engineering-backlog.md](loop-engineering-backlog.md).
 - L16 (context-budget gate v2) — [loop-engineering-backlog.md](loop-engineering-backlog.md).
 - E8 (memory-lines→gates umbrella, pairs with T7) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md). ◑ Partial as of 2026-07-14; one item remains (free-agents teamid write guard).
-- E6 (diff-scoped PHPStan wrapper) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md): every agent verify iteration (local + automouse) drops from O(project) to O(diff) analysis — fewer polling turns and less output per loop. (Cross-referenced 2026-07-14, token-spend sweep.)
+- E6 (diff-scoped PHPStan wrapper) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md): every agent verify iteration (local + automouse) drops from O(project) to O(diff) analysis — fewer polling turns and less output per loop. (Cross-referenced 2026-07-14, token-spend sweep.) ✅ Implemented (2026-07-14) — shipped in PR #1362.
 - E3 (PHPStan result-cache in CI) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md): shorter CI runs → fewer CI-watch polling turns per PR. (Cross-referenced 2026-07-14, token-spend sweep.)
 - E4 (flake-quarantine ledger) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md): removes flake-triggered re-run cycles and lost nightly-queue runs. (Cross-referenced 2026-07-14, token-spend sweep.)
 - 5.1 (build IBLbot TypeScript on the CI runner) — [ci-backlog.md](ci-backlog.md): each droplet-side build failure (2 to date) costs manual-intervention sessions plus CI-watch re-run cycles. (Cross-referenced 2026-07-14, token-spend sweep.)


### PR DESCRIPTION
## Summary

- Archives E6 (Diff-scoped PHPStan wrapper) in `dev-efficiency-backlog.md`: moves body to the new `archive/dev-efficiency-backlog-archive.md` sibling and replaces the live entry with a dated pointer
- Creates `archive/dev-efficiency-backlog-archive.md` (new archive sibling for this backlog)
- Annotates the E6 cross-reference in `token-spend-backlog.md` as implemented
- Roll-up counts updated: Open 5→4, Implemented 2→3

The implementation shipped in PR #1362 (`chore: add analyse-diff bin script for per-file PHPStan in dev loop`).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.