### PR TITLE
docs: E3 backlog housekeeping — mark PHPStan CI cache implemented, archive entry

### DIFF
--- a/ibl5/docs/backlog/archive/dev-efficiency-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/dev-efficiency-backlog-archive.md
@@ -13,3 +13,8 @@ Read-only historical record of ✅ Implemented / 🚫 Declined entries. For OPEN
 **Location:** `ibl5/bin/analyse-diff`.
 **What shipped:** `bin/analyse-diff` runs PHPStan only on `.php` files changed vs a base ref (default: `master`), routing them through `composer run analyse` / `composer run analyse:tests` so it inherits the exact `--memory-limit`/`--autoload-file` flags and honors baselines. Covers committed branch changes, staged/unstaged edits, and untracked new files. Full-project run remains the CI gate.
 **Status (2026-07-14):** ✅ Implemented — shipped in PR #1362.
+
+### E3 PHPStan result-cache in CI
+**Location:** `.github/workflows/tests.yml` (the `phpstan` job).
+**What shipped:** A `Cache PHPStan result cache` step (`actions/cache` v6.1.0) persists `ibl5/tmp` + `ibl5/tmp-tests` (the `phpstan.neon`/`phpstan-tests.neon` `tmpDir`s where PHPStan writes `resultCache.php`), keyed on the phpstan config files + `phpstan-rules/**`. PHPStan's own file-hash invalidation keeps results correct across restores. Only `tests.yml` runs `composer run analyse`/`analyse:tests`; `pr-meta-checks.yml`/`mutation.yml` don't invoke PHPStan.
+**Status (2026-07-03):** ✅ Implemented — shipped in PR #1309 (predates the entry's own 2026-07-07 "verified" claim; the entry was stale).

--- a/ibl5/docs/backlog/dev-efficiency-backlog.md
+++ b/ibl5/docs/backlog/dev-efficiency-backlog.md
@@ -27,10 +27,10 @@ last_verified: 2026-07-14
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 4 |
+| ⬜ Open | 3 |
 | 📋 Planned | 2 |
 | ◑ Partial | 2 |
-| ✅ Implemented | 3 |
+| ✅ Implemented | 4 |
 | 🚫 Declined | 0 |
 
 ---
@@ -41,7 +41,7 @@ last_verified: 2026-07-14
 |---|-------|--------|-----------|-------:|
 | E1 | Warm-standby worktree pool | ⬜ Open | 🟨 | M |
 | E2 | Dependabot grouping | ⬜ Open | 🟩 | S |
-| E3 | PHPStan result-cache in CI | ⬜ Open | 🟩 | S |
+| E3 | PHPStan result-cache in CI | ✅ Implemented | — | S |
 | E4 | Flake-quarantine ledger | ⬜ Open | 🟨 | M |
 | E5 | Scheduled stale-worktree GC | ◑ Partial | 🟨 | S |
 | E6 | Diff-scoped PHPStan wrapper | ✅ Implemented | — | S |
@@ -65,12 +65,7 @@ last_verified: 2026-07-14
 **Risk if untouched:** ~5× redundant CI runs per bump wave.
 **Status (2026-07-07):** ⬜ Open — 🟩.
 
-### E3 PHPStan result-cache in CI
-**Location:** `.github/workflows/` — no `resultCache` persistence (verified); every PR re-analyzes the world.
-**Problem:** Most PRs touch a handful of files but pay a full-project PHPStan run.
-**Suggested direction:** Persist `resultCachePath` via `actions/cache` keyed on `composer.lock` + the phpstan config; PHPStan's own file-hash invalidation keeps it correct.
-**Risk if untouched:** The longest single step in the most-run workflow stays O(project) instead of O(diff).
-**Status (2026-07-07):** ⬜ Open — 🟩.
+➜ E3 PHPStan result-cache in CI — ✅ Implemented (2026-07-03): see [archive](archive/dev-efficiency-backlog-archive.md).
 
 ### E4 Flake-quarantine ledger
 **Location:** E2E CI (`.github/workflows/`) — no quarantine mechanism (verified; "flake" mentions are VR-specific).


### PR DESCRIPTION
## Summary
- E3 (PHPStan result-cache in CI) shipped in PR #1309 but the backlog entry was stale (still marked ⬜ Open with inaccurate description claiming no cache existed)
- Stamps E3 ✅ Implemented, archives the body with provenance, updates status-table counts (Open 4→3, Implemented 3→4), adds redirect pointer in the main backlog

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)