### PR TITLE
chore: add gate S (Sonnet-recipe completeness) to bin/check-plan + close L15

### DIFF
--- a/bin/check-plan
+++ b/bin/check-plan
@@ -101,15 +101,29 @@
 #                              .claude/skills/plan/_architect-contract.md Binding
 #                              rule; whether a given tier CHOICE is correct stays
 #                              Opus judgment — this only binds the label to an act.
+#   S  Sonnet-recipe completeness — for impl_model: sonnet plans only, checks the
+#                              "specified" half of Sonnet-eligibility gate 13
+#                              ignores: (1) every ### Delegate packet carries a
+#                              **Self-verify:** line (fence-aware, reusing gate T's
+#                              4-backtick parse; violations name the packet phase),
+#                              and (2) a phased plan carries >=1 edit-anchor SIGNAL
+#                              (Anchor keyword, a `line NN` ref, or a 4-backtick
+#                              fence) somewhere in the body — a plan-LEVEL presence
+#                              check, not per-phase verbatim matching. A
+#                              `sonnet-recipe:` marker clears the whole gate,
+#                              mirroring no-adr: / context-budget:.
 #
 # Deliberately NOT linted (kept as /plan Opus judgment): tests-woven-inline,
 # production-comparison classification, test-file-path presence, negative-path
 # coverage, hot-file extraction, security surface, auto_merge risk (whether a
 # declared hold's rationale is actually valid — gate H below only checks a
-# justification section is PRESENT). Edit-anchor snippets are not linted: the
-# real plan corpus quotes them as drifting descriptions ("the Options struct",
-# with file:line refs that go stale), not verbatim lines, so a grep-the-snippet
-# check would false-positive constantly.
+# justification section is PRESENT). Edit-anchor snippet VERBATIM matching is
+# still not linted: the real plan corpus quotes anchors as drifting descriptions
+# ("the Options struct", with file:line refs that go stale), not verbatim lines,
+# so a grep-the-snippet check would false-positive constantly. Gate S adds only a
+# weaker plan-LEVEL presence check (impl_model: sonnet plans) — that the plan
+# carries at least one anchor SIGNAL somewhere — never that a given phase's
+# snippet matches a source line.
 #
 # Exit codes: 0 = clean, 1 = one or more violations (printed, prefixed by gate),
 #             2 = usage error / plan file missing.
@@ -578,6 +592,69 @@ done < <(awk -v run_rank="$RUN_RANK" '
     }
     END { flush_region() }
 ' "$PLAN_FILE")
+
+# ---------------------------------------------------------------------------
+# Gate S: Sonnet-recipe completeness (impl_model: sonnet plans only).
+# ---------------------------------------------------------------------------
+# gate 13 checks a Sonnet plan is machine-executable in principle; gate S checks
+# the plan actually SPECIFIES the recipe: (1) every ### Delegate packet carries a
+# **Self-verify:** line, and (2) the plan body carries an edit-anchor signal
+# (Phase 2). A `sonnet-recipe:` marker anywhere clears the whole gate (mirrors
+# no-adr: / context-budget:). $RUN_MODEL was resolved above for gate T; reuse it.
+case "$RUN_MODEL" in
+    *sonnet*)
+        if ! grep -qF 'sonnet-recipe:' "$PLAN_FILE"; then
+            # Sub-check 1: every ### Delegate packet needs a **Self-verify:** line.
+            while IFS= read -r sviol; do
+                [ -n "$sviol" ] && viol "$sviol"
+            done < <(awk -v q="'" '
+                function fence_ticks(s,   t) {
+                    if (match(s, /^[ \t]*`+/)) {
+                        t = substr(s, RSTART, RLENGTH); gsub(/[^`]/, "", t); return length(t)
+                    }
+                    return 0
+                }
+                function report(   msg) {
+                    if (in_packet && !has_sv) {
+                        msg = "[S] delegation packet " q pname q " lacks a **Self-verify:** line (required for impl_model: sonnet plans)"
+                        print msg
+                    }
+                }
+                BEGIN { infence=0; fence_len=0; in_packet=0; has_sv=0; pname="" }
+                {
+                    # Delegate heading lives INSIDE the 4-backtick fence; match raw.
+                    if ($0 ~ /^[ \t]*###[ \t]+Delegate/) {
+                        report()          # a prior unterminated packet, if any
+                        in_packet=1; has_sv=0; pname=$0
+                        sub(/^[ \t]*###[ \t]+Delegate[^A-Za-z0-9]*/, "", pname)
+                        if (pname == "") pname = "(unnamed)"
+                    }
+                    if (in_packet && $0 ~ /\*\*Self-verify:\*\*/) has_sv=1
+                    nt = fence_ticks($0)
+                    if (infence) {
+                        if (nt >= fence_len && $0 ~ /^[ \t]*`+[ \t]*$/) {
+                            infence=0; fence_len=0
+                            report(); in_packet=0; has_sv=0; pname=""
+                        }
+                        next
+                    }
+                    if (nt >= 3) { infence=1; fence_len=nt; next }
+                }
+                END { report() }
+            ' "$PLAN_FILE")
+            # Sub-check 2: a phased Sonnet plan must carry >=1 edit-anchor signal.
+            # $CB_PHASES was counted by gate C (line ~424) with the shared
+            # #{2,3} Step/Phase detector — reuse it, do not recount. A plan with
+            # zero phase headings (creation-only / prose) is exempt.
+            if [ "${CB_PHASES:-0}" -ge 1 ]; then
+                if ! grep -qiE 'anchor|line [0-9]' "$PLAN_FILE" \
+                   && ! grep -qE '^[[:space:]]*`{4,}' "$PLAN_FILE"; then
+                    viol "[S] impl_model: sonnet plan has no edit-anchor signal (Anchor keyword, 'line NN' reference, or 4-backtick fence); add anchors or suppress with 'sonnet-recipe: ...'"
+                fi
+            fi
+        fi
+        ;;
+esac
 
 # ---------------------------------------------------------------------------
 # Report.

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -647,7 +647,7 @@ case "$RUN_MODEL" in
             # #{2,3} Step/Phase detector — reuse it, do not recount. A plan with
             # zero phase headings (creation-only / prose) is exempt.
             if [ "${CB_PHASES:-0}" -ge 1 ]; then
-                if ! grep -qiE 'anchor|line [0-9]' "$PLAN_FILE" \
+                if ! grep -qiE 'anchor|\bline [0-9]' "$PLAN_FILE" \
                    && ! grep -qE '^[[:space:]]*`{4,}' "$PLAN_FILE"; then
                     viol "[S] impl_model: sonnet plan has no edit-anchor signal (Anchor keyword, 'line NN' reference, or 4-backtick fence); add anchors or suppress with 'sonnet-recipe: ...'"
                 fi

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -51,6 +51,11 @@ impl_model: sonnet
 ---
 '
 
+FM_OPUS='---
+impl_model: opus
+---
+'
+
 # A minimal well-formed matrix passes (exit 0). Baseline / no false positives.
 assert "clean-minimal" 0 "$FM"'
 | # | What to verify | Test type | Timing | Test file / location |
@@ -582,7 +587,8 @@ fi
 # ---------------------------------------------------------------------------
 
 # Test 4a: [W]-clean-pass — no sweep verbs exits 0 with no advisory
-assert "[W]-clean-pass" 0 "$FM
+# Uses FM_OPUS (impl_model: opus) so gate S (sonnet-recipe completeness) does not apply.
+assert "[W]-clean-pass" 0 "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | setting renamed correctly | PHPUnit | post-impl | \`tests/ConfigTest.php\` |
@@ -599,7 +605,8 @@ Rename the setting in config.php.
 "
 
 # Test 4b: [W]-sweep-verb-advisory — sweep verb WITHOUT delegation fires advisory but exits 0
-assert "[W]-sweep-verb-advisory" 0 "$FM
+# Uses FM_OPUS so gate S does not interfere with the [W] advisory check.
+assert "[W]-sweep-verb-advisory" 0 "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | helper renamed | PHPUnit | post-impl | \`tests/ServiceTest.php\` |
@@ -616,7 +623,7 @@ Update all call sites of \`legacyHelper()\` to use \`newHelper()\` in all PHP fi
 "
 
 # Companion: confirm the advisory was emitted
-_body="$FM
+_body="$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | helper renamed | PHPUnit | post-impl | \`tests/ServiceTest.php\` |

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -291,8 +291,12 @@ context-budget: length is fenced reference material; 3 phases, small diff.
 # Gate C: >=12 numbered phases must flag even under 500 lines (exit 1).
 assert "gateC-many-phases-flags" 1 "$FM$M$PHASES12"
 
-# Gate C boundary: 11 phases and under 500 lines must NOT flag (exit 0).
-assert "gateC-eleven-phases-ok" 0 "$FM$M$PHASES11"
+# Gate C boundary: 11 phases and under 500 lines must NOT flag (exit 0). The
+# sonnet-recipe: marker clears the new gate S (these synthetic phases carry no
+# edit anchors), keeping exit 0 attributable to gate C alone.
+assert "gateC-eleven-phases-ok" 0 "$FM$M$PHASES11
+sonnet-recipe: gate-C size fixture; recipe completeness not under test.
+"
 
 # ---------------------------------------------------------------------------
 # Gate 13: impl_model <-> Verification Matrix consistency.
@@ -448,6 +452,100 @@ assert "gateT-nested-fence-packet-ok" 0 "$TFM$M"'
 git mv a b
 ```
 - **Self-verify:** composer run analyse
+- **Report back:** one line
+````
+'
+
+# ---------------------------------------------------------------------------
+# Gate S: Sonnet-recipe completeness (impl_model: sonnet only).
+# ---------------------------------------------------------------------------
+# (S1) A ### Delegate packet WITH a **Self-verify:** line passes (exit 0). The
+# 4-backtick fence doubles as the anchor signal, so only Self-verify is under test.
+assert "gateS-selfverify-present-ok" 0 "$FM$M"'
+## Phase 1 — edit the report block
+Anchor: the change lands at the report block.
+
+````
+### Delegate — Phase 1
+- **Tier:** Sonnet
+- **Scope:** bin/check-plan
+- **Recipe:** insert the gate
+- **Self-verify:** bin/test-check-plan
+- **Report back:** one line
+````
+'
+
+# (S2) The same packet MISSING its **Self-verify:** line flags (exit 1). Anchor
+# present (fence + Anchor keyword) so exit 1 is attributable to the Self-verify
+# sub-check alone; the fenced ### Delegate suppresses any gate T co-fire.
+assert "gateS-selfverify-missing-flags" 1 "$FM$M"'
+## Phase 1 — edit the report block
+Anchor: the change lands at the report block.
+
+````
+### Delegate — Phase 1
+- **Tier:** Sonnet
+- **Scope:** bin/check-plan
+- **Recipe:** insert the gate
+- **Report back:** one line
+````
+'
+
+# (S3) A phased plan with an Anchor keyword and no packet passes (exit 0).
+assert "gateS-anchor-keyword-ok" 0 "$FM$M"'
+## Phase 1 — edit the widget
+Anchor: the unique surrounding snippet is quoted here.
+'
+
+# (S4) A phased Sonnet plan with NO anchor signal and no packet flags (exit 1) —
+# the anchor sub-check. No below-model tier, short, clean matrix => gate S alone.
+assert "gateS-anchor-missing-flags" 1 "$FM$M"'
+## Phase 1 — edit the widget
+Change the report block to add the gate.
+'
+
+# (S5) A `sonnet-recipe:` marker suppresses the WHOLE gate — a packet missing
+# Self-verify (would be exit 1) passes (exit 0) with the marker present.
+assert "gateS-clearing-marker-suppresses" 0 "$FM$M"'
+## Phase 1 — edit the report block
+
+sonnet-recipe: mechanical gate edit; recipe completeness cleared deliberately.
+
+````
+### Delegate — Phase 1
+- **Tier:** Sonnet
+- **Recipe:** do it
+- **Report back:** one line
+````
+'
+
+# (S6) A phases-less Sonnet plan with no anchor is EXEMPT (exit 0) — the anchor
+# sub-check keys on $CB_PHASES >= 1, so creation-only / prose plans never flag.
+assert "gateS-no-phase-heading-ok" 0 "$FM$M"'
+Prose plan with no phase headings and no delegation packets. A creation note.
+'
+
+# (S7) Gate S is impl_model-gated: an OPUS plan, phased, anchor-less, no
+# Self-verify, still passes (exit 0) — gate S runs only for impl_model: sonnet.
+assert "gateS-opus-plan-exempt" 0 "$TFM$M"'
+## Phase 1 — edit the widget
+Edits the report block; opus run, no packet.
+'
+
+# (S8) A valid packet whose **Recipe:** holds a nested 3-backtick fence, with the
+# **Self-verify:** line AFTER it, passes (exit 0) — the inner 3-tick fence must
+# NOT close the outer 4-tick packet (guards nt >= fence_len). Mirrors gate T's T8.
+assert "gateS-nested-fence-selfverify-ok" 0 "$FM$M"'
+## Phase 1 — edit the report block
+Anchor: change lands at the report block.
+
+````
+### Delegate — Phase 1
+- **Recipe:**
+```
+sed -i s/a/b/ file.txt
+```
+- **Self-verify:** bin/test-check-plan
 - **Report back:** one line
 ````
 '

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -550,6 +550,13 @@ sed -i s/a/b/ file.txt
 ````
 '
 
+# (S9) Word-boundary guard: a plan with "baseline 1" in the body (no standalone
+# "line NN" ref) still flags (exit 1) — "baseline 1" must NOT match \bline [0-9].
+assert "gateS-anchor-word-boundary-flags" 1 "$FM$M"'
+## Phase 1 — edit the widget
+The baseline 1 approach handles this; see guideline 5 for reference.
+'
+
 # ---------------------------------------------------------------------------
 # Directive presence: the runtime prompt (bin/automouse-prompt-impl) must keep
 # BOTH the packet-delegation instruction AND the exhaustive-and-pre-resolved

--- a/ibl5/docs/backlog/archive/loop-engineering-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/loop-engineering-backlog-archive.md
@@ -41,3 +41,8 @@ Read-only historical record of ✅ Implemented entries. For OPEN items see ../lo
 
 **Superseded by:** L18 (tier-default correction) — the measured waste is tier misallocation, not plan length.
 **Status (2026-07-15):** ✅ Implemented — wall-clock + attempts breakers live and sufficient; the token-cap residual is closed as refuted (above), not deferred. Surfaced L18 as the real measured cost driver. PR #1481.
+
+### L15 Sonnet-recipe completeness lint
+**Location:** `bin/check-plan` — gates cover matrix presence, forbidden tokens, staleness, and size; none check *recipe completeness*. Gate 13 judges Sonnet-eligibility by verification (a machine check fails on a wrong edit) only.
+**Problem (was):** "Sonnet-capable" has two halves and only one is enforced: verifiable, but not *specified*.
+**Status (2026-07-15):** ✅ Implemented — `bin/check-plan` gate `[S]` now checks, for `impl_model: sonnet` plans only: every `### Delegate` packet carries a `**Self-verify:**` line (fence-aware, reusing gate T's parse), and a phased plan carries >=1 edit-anchor signal (Anchor keyword / `line NN` ref / 4-backtick fence). A `sonnet-recipe:` marker clears the gate. Tested in `bin/test-check-plan` (gateS-* cases).

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -53,7 +53,7 @@ last_verified: 2026-07-15
 | L12 | Autonomy contracts in plan frontmatter | ◑ Partial | 🟦 | M |
 | L13 | Per-phase impl-model routing | ✅ Implemented | — | M |
 | L14 | Escalate-on-retry (Sonnet-first, just-in-time Opus) | ✅ Implemented | — | S |
-| L15 | Sonnet-recipe completeness lint | ⬜ Open | 🟦 | S |
+| L15 | Sonnet-recipe completeness lint | ✅ Implemented | — | S |
 | L16 | Context-budget gate v2 (work-size proxies + measured calibration) | 📋 Planned | 🟦 | M |
 | L17 | Shared-context artifact for multi-plan splits | ✅ Implemented | — | S |
 | L18 | Tier-default correction (`impl_model:` fails open to Opus) | ⬜ Open | 🟦 | S |
@@ -137,11 +137,7 @@ last_verified: 2026-07-15
 ✅ Implemented (2026-07-11) — see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).
 
 ### L15 Sonnet-recipe completeness lint
-**Location:** `bin/check-plan` — gates cover matrix presence, forbidden tokens, staleness, and size; none check *recipe completeness*. Gate 13 judges Sonnet-eligibility by verification (a machine check fails on a wrong edit) only.
-**Problem:** "Sonnet-capable" has two halves and only one is enforced: verifiable, but not *specified* — a Sonnet plan whose phases lack edit anchors, reuse notes, or self-verify commands passes `bin/check-plan`, then flails at 2am on judgment calls the plan never resolved. Those burned attempts read as model failure and push labeling back toward Opus.
-**Suggested direction:** A new gate for `impl_model: sonnet` plans: every numbered phase that edits an existing file must carry an edit-anchor cue (quoted snippet per the architect contract), and every delegation packet a Self-verify line; violations name the phase. Heuristic by nature, so support a clearing marker mirroring the existing `no-adr:` / `context-budget:` pattern.
-**Risk if untouched:** Sonnet-labeled plans fail for specification gaps, mis-attributed to model capability.
-**Status (2026-07-08):** ⬜ Open — 🟦.
+✅ Implemented (2026-07-15) — see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).
 
 ### L16 Context-budget gate v2 (work-size proxies + measured calibration)
 **Location:** `bin/check-plan` gate `[C]` (≥ 500 lines OR ≥ 12 numbered phases — thresholds hand-set once from the 2026-07-07 automouse-corpus audit); the T1 per-phase cost rows carry no peak-context column.


### PR DESCRIPTION
## Summary

Adds **gate S** to `bin/check-plan`: for `impl_model: sonnet` plans only, verifies that:
1. Every `### Delegate` packet carries a `**Self-verify:**` line (fence-aware awk, reusing gate T's 4-backtick parse)
2. A phased plan carries at least one edit-anchor signal (Anchor keyword, `line NN` reference, or 4-backtick fence)

A `sonnet-recipe:` marker clears the whole gate, mirroring the established `no-adr:`/`context-budget:` suppression pattern. Closes L15 (loop-engineering backlog).

**Why:** Gate 13 checks a Sonnet plan is *verifiable* (machine check fails on wrong edit); gate S checks the *specified* half — that the recipe is actually written down. Without it, Sonnet plans can pass `bin/check-plan` while lacking anchors/self-verify, causing 2am failures mis-attributed to model capability.

## Changes

- `bin/check-plan`: Gate S block (sub-checks 1 + 2), updated gate-list header, corrected "not linted" comment
- `bin/test-check-plan`: 8 new `gateS-*` fixtures + `gateC-eleven-phases-ok` regression fix (`sonnet-recipe:` clear)
- `ibl5/docs/backlog/loop-engineering-backlog.md`: L15 pointer + `last_verified` bump
- `ibl5/docs/backlog/archive/loop-engineering-backlog-archive.md`: archived L15 block

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.