### PR TITLE
chore: context-budget gate v2 — check-plan [C]/[W], stream-filter peak_ctx, costs.md Peak Ctx column

### DIFF
--- a/bin/automouse-run
+++ b/bin/automouse-run
@@ -328,20 +328,22 @@ model_tier() {
 # cross-phase variable dependency. See .claude/rules/automouse-workflow.md.
 append_cost_row() {
     local plan=$1 phase=$2 log_before=$3 model=${4:-?}
-    local cost report tier
+    local cost report tier peak_raw peak_k
     tier=$(model_tier "$model")
     # `|| true` is load-bearing: under `set -euo pipefail` a killed phase emits no
     # `cost=` line, so grep exits non-zero and this plain assignment would abort the
     # whole automouse loop before the `cost="?"` fallback below. Swallow it and continue.
     cost=$(tail -n +"$((log_before + 1))" "$LOG" | grep -oE 'cost=\$[0-9.]+' | tail -1 | sed 's/cost=\$//') || true
     [ -n "$cost" ] || cost="?"
+    peak_raw=$(tail -n +"$((log_before + 1))" "$LOG" | grep -oE 'peak_ctx=[0-9]+' | tail -1 | sed 's/peak_ctx=//') || true
+    peak_k=$(( ${peak_raw:-0} / 1000 ))
     report="$NIGHTLY_DIR/reports/$(date +%Y-%m-%d)-costs.md"
     mkdir -p "$(dirname "$report")"
     if [ ! -f "$report" ]; then
-        printf '# Automouse cost roll-up — %s\n\n| Plan | Phase | Model | Tier | Cost ($) |\n|---|---|---|---|---|\n' \
+        printf '# Automouse cost roll-up — %s\n\n| Plan | Phase | Model | Tier | Cost ($) | Peak Ctx (K) |\n|---|---|---|---|---|---|\n' \
             "$(date +%Y-%m-%d)" > "$report"
     fi
-    printf '| %s | %s | %s | %s | %s |\n' "$plan" "$phase" "$model" "$tier" "$cost" >> "$report"
+    printf '| %s | %s | %s | %s | %s | %dK |\n' "$plan" "$phase" "$model" "$tier" "$cost" "$peak_k" >> "$report"
     regenerate_weekly_section "$report"
 }
 
@@ -365,7 +367,7 @@ regenerate_weekly_section() {
             d=$(date -v-"${i}"d +%F); f="$reports_dir/$d-costs.md"
             [ -f "$f" ] && sed '/^## Weekly aggregate/,$d' "$f" || true
         done | awk -F'|' '
-            { if (NF==7) {tier=$5; cost=$6}
+            { if (NF==7 || NF==8) {tier=$5; cost=$6}
               else if (NF==5) {tier="(untracked)"; cost=$4}
               else next
               gsub(/^[ \t]+|[ \t]+$/,"",tier); gsub(/^[ \t]+|[ \t]+$/,"",cost)
@@ -382,10 +384,14 @@ regenerate_weekly_section() {
                 if (v ~ /^[0-9]+$/) { if (k=="in") {inp[phase]+=v; inpT+=v}
                   else if (k=="out") {o[phase]+=v; oT+=v}
                   else if (k=="cache") {cr[phase]+=v; crT+=v}
-                  else if (k=="cache_write") {cw[phase]+=v; cwT+=v} } } }
+                  else if (k=="cache_write") {cw[phase]+=v; cwT+=v}
+                  else if (k=="peak_ctx") { v=v+0; if (v>pkmax[phase]) pkmax[phase]=v } } } }
               seen[phase]=1 }
             END { for (p in seen) printf "| %s | %d | %d | %d | %d |\n", p, inp[p], cw[p], cr[p], o[p]
-                  printf "| **Total** | %d | %d | %d | %d |\n", inpT, cwT, crT, oT }'
+                  printf "| **Total** | %d | %d | %d | %d |\n", inpT, cwT, crT, oT
+                  flag=""
+                  for (p in pkmax) if (pkmax[p]>150000) flag=flag " " p "(" int(pkmax[p]/1000) "K)"
+                  if (flag!="") printf "\n> **Split-miss candidates (peak ctx >150K):**%s\n", flag }'
     } >> "$report"
 }
 

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -152,12 +152,14 @@ if [ "$REPO_ROOT" = "/" ]; then
 fi
 
 VIOL_FILE="$(mktemp)"
+WARN_FILE="$(mktemp)"
 MATRIX_FILE="$(mktemp)"
 SEEN_FILE="$(mktemp)"
 GATE8_SEEN="$(mktemp)"
-trap 'rm -f "$VIOL_FILE" "$MATRIX_FILE" "$SEEN_FILE" "$GATE8_SEEN"' EXIT
+trap 'rm -f "$VIOL_FILE" "$WARN_FILE" "$MATRIX_FILE" "$SEEN_FILE" "$GATE8_SEEN"' EXIT
 
 viol() { printf '%s\n' "$1" >> "$VIOL_FILE"; }
+warn() { printf '%s\n' "$1" >> "$WARN_FILE"; }
 
 # ---------------------------------------------------------------------------
 # Gate 1: Matrix exists.
@@ -422,11 +424,94 @@ done < <(grep -iE 'reuse' "$PLAN_FILE" \
 # `context-budget:` marker clears a deliberate exception, mirroring `no-adr:`.
 CB_LINES=$(wc -l < "$PLAN_FILE" | tr -d '[:space:]')
 CB_PHASES=$(grep -cE '^#{2,3}[[:space:]]+([Ss]tep|[Pp]hase)[[:space:]]*[0-9]' "$PLAN_FILE")
+CB_VM_ROWS=$(grep -cE '^\|[[:space:]]*[0-9]' "$PLAN_FILE" || true)
+CB_CF_COUNT=$(awk '
+    /^## Critical Files/{in_cf=1; next}
+    /^## /{in_cf=0}
+    in_cf && /^- `[^`]+`/ {
+        line=$0
+        if (line !~ /\(reference\)/ && line !~ /\(read-only\)/ && \
+            line !~ /\(verify\)/ && line !~ /\(template\)/ && \
+            line !~ /\(no-edit\)/ && line !~ /\(unchanged\)/ && \
+            line !~ /\(context\)/) count++
+    }
+    END {print count+0}
+' "$PLAN_FILE")
 if [ "$CB_LINES" -ge 500 ] || [ "$CB_PHASES" -ge 12 ]; then
     if ! grep -qF 'context-budget:' "$PLAN_FILE"; then
-        viol "[C] marathon-sized plan (${CB_LINES} lines, ${CB_PHASES} numbered phases; flags at >=500 lines or >=12 phases) — split into stacked PR-sized plans (/plan Step 2.5), or justify a deliberate exception with a 'context-budget:' marker"
+        viol "[C] marathon-sized plan (${CB_LINES} lines, ${CB_PHASES} numbered phases, ${CB_VM_ROWS} matrix rows, ${CB_CF_COUNT} critical-file targets; flags at >=500 lines or >=12 phases) — split into stacked PR-sized plans (/plan Step 2.5), or justify a deliberate exception with a 'context-budget:' marker"
     fi
 fi
+
+# ---------------------------------------------------------------------------
+# Gate [W]: Sweep-verb advisory (non-blocking).
+# Fires when a numbered implementation phase body contains a sweep verb
+# ("all call sites", "every occurrence", etc.) AND that phase has no
+# ### Delegate heading — a potential unbounded-scope signal.
+# Advisory only: emits warn(), does not set exit 1.
+# Bash 3.2-compatible: no mapfile, no declare -A, uses temp files for state.
+# ---------------------------------------------------------------------------
+_PHASE_TMP="$(mktemp)"
+awk -v phase_tmp="$_PHASE_TMP" '
+    # Track numbered phase headings (## Phase N / ## Step N)
+    /^#{2,3}[[:space:]]+(Phase|Step|phase|step)[[:space:]]*[0-9]/ {
+        if (in_phase && phase_num != "") {
+            # flush prior phase
+            printf "%s\t%s\t%s\n", phase_num, has_delegate, body > phase_tmp
+        }
+        in_phase = 1
+        phase_num = $0
+        has_delegate = 0
+        body = ""
+        next
+    }
+    # A top-level ## heading that is NOT a numbered phase ends the prior phase
+    /^## / && !/^#{2,3}[[:space:]]+(Phase|Step|phase|step)[[:space:]]*[0-9]/ {
+        if (in_phase && phase_num != "") {
+            printf "%s\t%s\t%s\n", phase_num, has_delegate, body > phase_tmp
+        }
+        in_phase = 0; phase_num = ""; body = ""; has_delegate = 0
+        next
+    }
+    # Detect a delegation packet heading inside this phase
+    in_phase && /^### Delegate/ { has_delegate = 1 }
+    # Skip fenced code blocks
+    in_phase && /^```/ { in_code = !in_code }
+    in_phase && !in_code { body = body " " $0 }
+    END {
+        if (in_phase && phase_num != "") {
+            printf "%s\t%s\t%s\n", phase_num, has_delegate, body > phase_tmp
+        }
+    }
+' "$PLAN_FILE"
+
+while IFS='	' read -r phase_heading has_delegate body; do
+    if [ "$has_delegate" = "0" ]; then
+        # Check for sweep verbs (case-insensitive via tr)
+        body_lower=$(printf '%s' "$body" | tr '[:upper:]' '[:lower:]')
+        matched=""
+        for pattern in \
+            "all call sites" "every occurrence" "all occurrences" \
+            "every caller" "all callers" "all uses" "all instances"; do
+            if printf '%s' "$body_lower" | grep -qF "$pattern"; then
+                matched="$pattern"
+                break
+            fi
+        done
+        # "every file" only matches when NOT followed by "-level"
+        if [ -z "$matched" ]; then
+            if printf '%s' "$body_lower" | grep -q 'every file' \
+               && ! printf '%s' "$body_lower" | grep -q 'every file-level\|every file level'; then
+                matched="every file"
+            fi
+        fi
+        if [ -n "$matched" ]; then
+            short_heading=$(printf '%s' "$phase_heading" | sed 's/^#*[[:space:]]*//')
+            warn "[W] sweep-verb advisory: '${short_heading}' contains '${matched}' without a delegation packet — consider delegating if scope is unbounded (add a ### Delegate block to suppress)"
+        fi
+    fi
+done < "$_PHASE_TMP"
+rm -f "$_PHASE_TMP"
 
 # ---------------------------------------------------------------------------
 # Gate T: below-run-model tier labels are bound (packet or inline marker).
@@ -501,6 +586,10 @@ if [ -s "$VIOL_FILE" ]; then
     echo "check-plan: violations in $PLAN_FILE" >&2
     cat "$VIOL_FILE" >&2
     exit 1
+fi
+if [ -s "$WARN_FILE" ]; then
+    echo "check-plan: advisories in $PLAN_FILE" >&2
+    cat "$WARN_FILE" >&2
 fi
 
 echo "check-plan: OK ($PLAN_FILE)"

--- a/bin/lib/automouse-stream-filter
+++ b/bin/lib/automouse-stream-filter
@@ -7,6 +7,7 @@ CMDPID_FILE="${2:-}"
 SLUG="${3:-}"
 PHASE="${4:-}"
 TOOL_COUNT=0
+PEAK_CTX=0
 TURN_COUNT=1
 START_EPOCH=$(date +%s)
 
@@ -42,6 +43,14 @@ while IFS= read -r line; do
             if [ -n "$tool_name" ]; then
                 TOOL_COUNT=$(( TOOL_COUNT + 1 ))
                 printf '%s tool: %s (#%d, turn %d)\n' "$(line_prefix)" "$tool_name" "$TOOL_COUNT" "$TURN_COUNT"
+            fi
+            ctx=$(printf '%s' "$line" | jq -r '
+                ((.message.usage.input_tokens // 0)|tonumber) +
+                ((.message.usage.cache_read_input_tokens // 0)|tonumber) +
+                ((.message.usage.cache_creation_input_tokens // 0)|tonumber)
+            ' 2>/dev/null) || ctx=0
+            if [ -n "$ctx" ] && [ "$ctx" -gt "${PEAK_CTX:-0}" ] 2>/dev/null; then
+                PEAK_CTX=$ctx
             fi
             ;;
         user)
@@ -88,9 +97,9 @@ while IFS= read -r line; do
             out_tokens=$(printf '%s' "$line" | jq -r '.usage.output_tokens // "?"' 2>/dev/null) || true
             cache_tokens=$(printf '%s' "$line" | jq -r '.usage.cache_read_input_tokens // "?"' 2>/dev/null) || true
             cache_write=$(printf '%s' "$line" | jq -r '.usage.cache_write_input_tokens // .usage.cache_creation_input_tokens // "?"' 2>/dev/null) || true
-            printf '%s exit: stop_reason=%s turns=%s tools=%d duration=%sms cost=$%s in=%s out=%s cache=%s cache_write=%s\n' \
+            printf '%s exit: stop_reason=%s turns=%s tools=%d duration=%sms cost=$%s in=%s out=%s cache=%s cache_write=%s peak_ctx=%d\n' \
                 "$(line_prefix)" "$stop_reason" "$num_turns" "$TOOL_COUNT" "$duration_ms" \
-                "$cost_usd" "$in_tokens" "$out_tokens" "$cache_tokens" "$cache_write"
+                "$cost_usd" "$in_tokens" "$out_tokens" "$cache_tokens" "$cache_write" "${PEAK_CTX:-0}"
             # result is the final stream-json event — terminate claude and exit
             if [ -n "$CMDPID_FILE" ]; then
                 _target_pid=$(cat "$CMDPID_FILE" 2>/dev/null) || true

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -472,6 +472,150 @@ else
     echo "ok: automouse-prompt-impl retains exhaustive-and-pre-resolved tier mandate"
 fi
 
+# ---------------------------------------------------------------------------
+# Gate [W]: sweep-verb advisory tests
+# ---------------------------------------------------------------------------
+
+# Test 4a: [W]-clean-pass — no sweep verbs exits 0 with no advisory
+assert "[W]-clean-pass" 0 "$FM
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | setting renamed correctly | PHPUnit | post-impl | \`tests/ConfigTest.php\` |
+
+## Phase 1: Update the configuration
+
+**Tier:** self
+
+Rename the setting in config.php.
+
+## Critical Files
+
+- \`config.php\`
+"
+
+# Test 4b: [W]-sweep-verb-advisory — sweep verb WITHOUT delegation fires advisory but exits 0
+assert "[W]-sweep-verb-advisory" 0 "$FM
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | helper renamed | PHPUnit | post-impl | \`tests/ServiceTest.php\` |
+
+## Phase 1: Rename all call sites of old helper
+
+**Tier:** self
+
+Update all call sites of \`legacyHelper()\` to use \`newHelper()\` in all PHP files.
+
+## Critical Files
+
+- \`src/Service/OldService.php\`
+"
+
+# Companion: confirm the advisory was emitted
+_body="$FM
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | helper renamed | PHPUnit | post-impl | \`tests/ServiceTest.php\` |
+
+## Phase 1: Rename all call sites of old helper
+
+**Tier:** self
+
+Update all call sites of \`legacyHelper()\` to use \`newHelper()\` in all PHP files.
+
+## Critical Files
+
+- \`src/Service/OldService.php\`
+"
+_f=$(mktemp)
+printf '%s\n' "$_body" > "$_f"
+if ! "$GUARD" "$_f" 2>&1 | grep -q '\[W\]'; then
+    echo "FAIL: [W]-sweep-verb-advisory — expected [W] advisory in stderr, got none"
+    FAILED=1
+else
+    echo "ok: [W]-sweep-verb-advisory advisory emission confirmed"
+fi
+
+# Test 4c: [W]-sweep-verb-with-delegation-pass — sweep verb WITH delegation packet exits 0, no advisory
+_body="$FM
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | helper renamed | PHPUnit | post-impl | \`tests/ServiceTest.php\` |
+
+## Phase 1: Rename all call sites of old helper
+
+**Tier:** Haiku (inline — small single-file sweep, below 15K bar)
+
+### Delegate — rename sweep
+
+- **Tier:** Haiku
+- **Scope:** \`src/Service/OldService.php\` — rename legacyHelper to newHelper
+- **Recipe:** sed replacement on one file
+- **Self-verify:** grep confirms zero remaining old name
+- **Report back:** one-line summary
+
+Update all call sites of \`legacyHelper()\`.
+
+## Critical Files
+
+- \`src/Service/OldService.php\`
+"
+_f=$(mktemp)
+printf '%s\n' "$_body" > "$_f"
+if "$GUARD" "$_f" 2>&1 | grep -q '\[W\]'; then
+    echo "FAIL: [W]-sweep-verb-with-delegation-pass — unexpected [W] advisory"
+    FAILED=1
+else
+    echo "ok: [W]-sweep-verb-with-delegation-pass"
+fi
+
+# Test 4d: [C]-message-contains-proxy-counts — overlong plan violation message includes proxy count fields
+_f=$(mktemp)
+printf '%s\n' \
+  '---' 'title: "Test over-long plan"' 'slug: test-over-long' \
+  'impl_model: sonnet' 'auto_merge: true' '---' '' \
+  '| # | What to verify | Test type | Timing | Test file / location |' \
+  '|---|---|---|---|---|' \
+  '| 1 | Dummy check | PHPUnit | post-impl | tests/DummyTest.php |' '' \
+  '## Phase 1: Do thing' '' '**Tier:** self' '' 'Change file X.' '' \
+  '## Critical Files' '' '- `bin/check-plan`' '' > "$_f"
+yes '# padding line' | head -490 >> "$_f"
+output=$("$GUARD" "$_f" 2>&1)
+if echo "$output" | grep -q '\[C\]' && echo "$output" | grep -q 'matrix rows'; then
+    echo "ok: [C]-message-contains-proxy-counts"
+else
+    echo "FAIL: [C]-message-contains-proxy-counts — expected [C] with 'matrix rows' in output"
+    echo "Got: $output"
+    FAILED=1
+fi
+
+# Negative-path check 4n — sweep verb in Out-of-Scope section does NOT fire advisory
+_f=$(mktemp)
+printf '%s\n' "$FM
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | thing works | PHPUnit | post-impl | \`tests/X.php\` |
+
+## Phase 1: Normal phase
+
+**Tier:** self
+
+Do a thing.
+
+## Out of Scope
+
+Does not touch all call sites of the old API.
+
+## Critical Files
+
+- \`bin/check-plan\`
+" > "$_f"
+if "$GUARD" "$_f" 2>&1 | grep -q '\[W\]'; then
+    echo "FAIL: sweep verb in Out-of-Scope should not fire [W]"
+    FAILED=1
+else
+    echo "ok: Out-of-Scope sweep-verb non-fire confirmed"
+fi
+
 if [ "$FAILED" -ne 0 ]; then
     echo "RESULT: FAILED"
     exit 1

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-07-12
+last_verified: 2026-07-14
 ---
 
 # Loop-Engineering Backlog
@@ -27,8 +27,8 @@ last_verified: 2026-07-12
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 8 |
-| 📋 Planned | 1 |
+| ⬜ Open | 7 |
+| 📋 Planned | 2 |
 | ◑ Partial | 3 |
 | ✅ Implemented | 5 |
 | 🚫 Declined | 0 |
@@ -54,7 +54,7 @@ last_verified: 2026-07-12
 | L13 | Per-phase impl-model routing | ✅ Implemented | — | M |
 | L14 | Escalate-on-retry (Sonnet-first, just-in-time Opus) | ✅ Implemented | — | S |
 | L15 | Sonnet-recipe completeness lint | ⬜ Open | 🟦 | S |
-| L16 | Context-budget gate v2 (work-size proxies + measured calibration) | ⬜ Open | 🟦 | M |
+| L16 | Context-budget gate v2 (work-size proxies + measured calibration) | 📋 Planned | 🟦 | M |
 | L17 | Shared-context artifact for multi-plan splits | ✅ Implemented | — | S |
 
 ### L1 Plan dependency DAG
@@ -151,7 +151,7 @@ last_verified: 2026-07-12
 **Problem:** Two blind spots. (1) Plan size ≠ work size: a 100-line plan phase saying "sweep every call site" triggers a marathon implementation the gate can't see, while a reference-heavy plan false-trips and gets papered over with a `context-budget:` marker. (2) No feedback loop: nothing re-checks the thresholds as plan style evolves, so the gate drifts from the dumb-zone reality it proxies.
 **Suggested direction:** (a) Add work-size proxies — Verification-Matrix row count, Critical-Files change-target count, and sweep-verb detection ("all call sites", "every occurrence") in a phase without a delegation packet. (b) Log peak context tokens per impl run into the T1 ledger (the stream-json usage events already carry them) and add a report correlating plan proxies against measured peaks — recalibrate thresholds from data, and flag any run breaching ~150K as a Step 2.5 split miss for the retro.
 **Risk if untouched:** Dumb-zone breaches keep happening under the gate's radar, and the thresholds stay a one-shot guess.
-**Status (2026-07-08):** ⬜ Open — 🟦. Pairs with T1 in [token-spend-backlog.md](token-spend-backlog.md).
+**Status (2026-07-14):** 📋 Planned — plan slug `context-budget-gate-v2`; ships check-plan [C] proxy counts, [W] sweep-verb advisory, stream-filter peak_ctx tracking, and costs.md Peak Ctx column.
 
 ### L17 Shared-context artifact for multi-plan splits
 ✅ Implemented (2026-07-11) — see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).


### PR DESCRIPTION
## Summary

Extends the automouse context-budget gate toolchain with three improvements:

1. **check-plan [C] gate** — adds proxy count fields (matrix rows, critical-file targets) to the violation message so the author can see *why* the plan is marathon-sized.
2. **check-plan [W] gate** — new non-blocking sweep-verb advisory that fires when a numbered phase contains unbounded-scope verbs ("all call sites", "every occurrence", etc.) without a `### Delegate` packet. Exit 0; advisory-only.
3. **stream-filter peak_ctx** — tracks per-turn three-field context sum (input + cache_read + cache_creation tokens) and emits `peak_ctx=<n>` on the exit line.
4. **automouse-run costs.md** — adds a Peak Ctx (K) column to the daily cost roll-up ledger and a split-miss note in the weekly tokens-by-phase aggregate (phases that peaked >150K).
5. **test-check-plan** — four new tests covering [W] advisory, delegation suppression, and extended [C] message.
6. **backlog** — L16 flipped to 📋 Planned.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.