### PR TITLE
docs: L2 close as implemented, add L18 tier-default correction backlog entry

### DIFF
--- a/ibl5/docs/backlog/archive/loop-engineering-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/loop-engineering-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed autonomous-loop engineering entries, extracted from loop-engineering-backlog.md.
-last_verified: 2026-07-12
+last_verified: 2026-07-15
 ---
 
 # Autonomous-Loop Engineering Backlog — Archive
@@ -29,3 +29,15 @@ Read-only historical record of ✅ Implemented entries. For OPEN items see ../lo
 **Suggested direction (was):** Make the in-plan tier labels binding rather than advisory: the impl orchestrator MUST delegate a Sonnet/Haiku-labeled phase as a sub-agent per its delegation packet (packet-carrying phases were already bound from 2026-06-07; the residual gap was bare sub-tier labels carrying no packet). Bulk spend moves down-tier AND out of the orchestrator's context — dumb-zone relief and tier savings from the same change. A runner-driven per-phase `claude -p` sequence with a state handoff is the heavier fallback if in-run delegation proves unreliable.
 **Risk if untouched (was):** Per-phase tiering stays a plan-authoring ritual with no runtime effect; mixed plans pay top-tier for mechanical sweeps.
 **Status (2026-07-11):** ✅ Implemented — in-plan sub-tier labels are now binding: `.claude/skills/plan/_architect-contract.md` requires a `### Delegate` packet or an explicit `(inline — …)` marker on every below-run-model phase, `bin/check-plan` gate `[T]` enforces it, and `bin/automouse-prompt-impl` binds each case at run time. Packet-carrying phases were already bound (2026-06-07); this closes the bare-label gap. The heavier runner-driven per-phase `claude -p` fallback was not needed.
+
+### L2 Per-plan circuit breaker
+**Location:** `bin/automouse-run` — per-phase `timeout` caps (`MAX_IMPL_SECS`/`MAX_PP_SECS` = 3600s), outer `MAX_ELAPSED` ≈ 4h45m, `MAX_ATTEMPTS=3` then the plan is parked in `skipped/` with a report.
+**Problem (was):** One runaway plan could eat the night.
+**Residual (token-budget breaker) — ✖ Won't do, empirically refuted.** Built as PR #1477 (`MAX_PLAN_COST_USD`, default $5.00, parks the plan in `skipped/` before postplan), then **closed unmerged 2026-07-15**. Measured against 47 `exit:` lines (2026-07-07→07-15):
+- **Keys on the wrong variable.** Impl cost does not predict postplan cost — the most expensive impl in the dataset (`ibl6-retirement-1-boxscore-php-port`, $18.72) had nearly the *cheapest* postplan ($1.95), while the three most expensive postplans ($5.68, $5.41, $4.22) all rode cheap impls that never trip the cap. Correlation across 17 paired plans r ≈ 0.08 (noisy at n=17; the inversions are the robust signal).
+- **Destroys completed work.** The breaker is gated on `$HANDOFF_FILE`, so it fires *only on impls that succeeded*, then `mv`s the plan away and `rm`s the handoff. At $5.00 it would discard ~$83.49 of working implementation across 7 of 28 runs to avoid postplans averaging ~$3.35; recovery means re-running impl, spending model-hours twice to save a notional figure once.
+- **Wrong unit.** automouse runs on subscription auth (bare `claude -p`, no `ANTHROPIC_API_KEY`), so `cost=$X` is an API list-price equivalent, not spend. Weekly automouse load is ~10.4 model-hours — a small fraction of a Max 5x weekly cap. Long overnight impls are *desirable* use of otherwise-idle budget, not waste.
+- **Doesn't bound the real constraint.** A per-plan cap can't bound a queue total: on 2026-07-11 the queue ran 5.8 model-hours (breaching a 5-hour session window) and this breaker would have fired once, saving ~14 minutes.
+
+**Superseded by:** L18 (tier-default correction) — the measured waste is tier misallocation, not plan length.
+**Status (2026-07-15):** ✅ Implemented — wall-clock + attempts breakers live and sufficient; the token-cap residual is closed as refuted (above), not deferred. Surfaced L18 as the real measured cost driver. PR #1481.

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-07-14
+last_verified: 2026-07-15
 ---
 
 # Loop-Engineering Backlog
@@ -40,7 +40,7 @@ last_verified: 2026-07-14
 | # | Title | Status | Automouse | Effort |
 |---|-------|--------|-----------|-------:|
 | L1 | Plan dependency DAG | ⬜ Open | 🟦 | M |
-| L2 | Per-plan circuit breaker | ◑ Partial | 🟦 | S |
+| L2 | Per-plan circuit breaker | ✅ Implemented | — | S |
 | L3 | Morning digest | ⬜ Open | 🟦 | S |
 | L4 | Retro-miner | ⬜ Open | 🟥 | M |
 | L5 | Master-canary between runs | ⬜ Open | 🟦 | M |
@@ -56,6 +56,7 @@ last_verified: 2026-07-14
 | L15 | Sonnet-recipe completeness lint | ⬜ Open | 🟦 | S |
 | L16 | Context-budget gate v2 (work-size proxies + measured calibration) | 📋 Planned | 🟦 | M |
 | L17 | Shared-context artifact for multi-plan splits | ✅ Implemented | — | S |
+| L18 | Tier-default correction (`impl_model:` fails open to Opus) | ⬜ Open | 🟦 | S |
 
 ### L1 Plan dependency DAG
 **Location:** `bin/automouse-queue` — queue order is symlink mtime (`ls -1tr`); `bin/automouse-queue-reorder-ui` re-touches mtimes by hand. No `depends_on` anywhere (verified).
@@ -67,9 +68,14 @@ last_verified: 2026-07-14
 ### L2 Per-plan circuit breaker
 **Location:** `bin/automouse-run` — per-phase `timeout` caps (`MAX_IMPL_SECS`/`MAX_PP_SECS` = 3600s), outer `MAX_ELAPSED` ≈ 4h45m, `MAX_ATTEMPTS=3` then the plan is parked in `skipped/` with a report.
 **Problem (was):** One runaway plan could eat the night.
-**Suggested direction (residual):** Add a token-budget breaker alongside the wall-clock one — the cost data is already parsed per phase (T1 in [token-spend-backlog.md](token-spend-backlog.md)); breach parks the plan as needs-human and continues the queue.
-**Risk if untouched:** A plan can stay under the time cap while burning an outsized token budget.
-**Status (2026-07-07):** ◑ Partial — wall-clock + attempts breakers live; token cap absent. 🟦.
+**Residual (token-budget breaker) — ✖ Won't do, empirically refuted.** Built as PR #1477 (`MAX_PLAN_COST_USD`, default $5.00, parks the plan in `skipped/` before postplan), then **closed unmerged 2026-07-15**. Measured against 47 `exit:` lines (2026-07-07→07-15):
+- **Keys on the wrong variable.** Impl cost does not predict postplan cost — the most expensive impl in the dataset (`ibl6-retirement-1-boxscore-php-port`, $18.72) had nearly the *cheapest* postplan ($1.95), while the three most expensive postplans ($5.68, $5.41, $4.22) all rode cheap impls that never trip the cap. Correlation across 17 paired plans r ≈ 0.08 (noisy at n=17; the inversions are the robust signal).
+- **Destroys completed work.** The breaker is gated on `$HANDOFF_FILE`, so it fires *only on impls that succeeded*, then `mv`s the plan away and `rm`s the handoff. At $5.00 it would discard ~$83.49 of working implementation across 7 of 28 runs to avoid postplans averaging ~$3.35; recovery means re-running impl, spending model-hours twice to save a notional figure once.
+- **Wrong unit.** automouse runs on subscription auth (bare `claude -p`, no `ANTHROPIC_API_KEY`), so `cost=$X` is an API list-price equivalent, not spend. Weekly automouse load is ~10.4 model-hours — a small fraction of a Max 5x weekly cap. Long overnight impls are *desirable* use of otherwise-idle budget, not waste.
+- **Doesn't bound the real constraint.** A per-plan cap can't bound a queue total: on 2026-07-11 the queue ran 5.8 model-hours (breaching a 5-hour session window) and this breaker would have fired once, saving ~14 minutes.
+
+**Superseded by:** L18 (tier-default correction) — the measured waste is tier misallocation, not plan length.
+**Status (2026-07-15):** ✅ Implemented — wall-clock + attempts breakers live and sufficient; the token-cap residual is closed as refuted (above), not deferred. 🟦.
 
 ### L3 Morning digest
 **Location:** `bin/automouse-run` writes per-run reports (`done`/`skipped`/`env-stop`/`error`) plus a daily costs table; nothing aggregates or notifies (verified).
@@ -155,6 +161,14 @@ last_verified: 2026-07-14
 
 ### L17 Shared-context artifact for multi-plan splits
 ✅ Implemented (2026-07-11) — see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).
+
+### L18 Tier-default correction (`impl_model:` fails open to Opus)
+**Location:** `bin/lib/plan-impl-model` — resolves a plan's impl model from line-1-anchored `impl_model:` frontmatter. Its fallthrough is `*) echo "claude-opus-4-8" ;; # opus, empty, garbled, or unknown → safe default`. `bin/lib/automouse-escalate-model` already escalates any non-Opus base → Opus on the final attempt (ADR-0085); `bin/check-plan` gate `[T]` enforces per-phase sub-tier labels but does **not** require the top-level `impl_model:` field.
+**Problem:** The default is the *most expensive* model, so a plan that omits `impl_model:` silently buys Opus at ~5.4× Sonnet's per-run cost. Measured 2026-07-07→07-15 (28 impl runs): Opus 13 runs / $99.11 total / $7.62 avg vs Sonnet 15 runs / $21.33 / $1.42 avg — Opus is **82% of impl spend**. Two plans reached the queue with no `impl_model:` field at all and were silently routed to Opus: `ibl6-retirement-1-boxscore-php-port` ($18.72 — the single most expensive run in the dataset) and `mobile-target-size-a11y-sitewide` ($7.38 + $0.94 retry). Both are mechanical work (a PHP port; a sitewide a11y sweep) — textbook Sonnet jobs. That's **~$27, ~15% of the week, spent on Opus because a YAML field was absent** — nobody ever made a tier decision.
+**Suggested direction:** Invert the fallthrough so the ladder starts at its bottom rung, since the Opus safety net already exists above it. Either (a) **fail closed** — `bin/check-plan` rejects a plan with no `impl_model:`, forcing an explicit tier decision at authoring time; or (b) **fail cheap** — default to `claude-sonnet-4-6` and let `automouse-escalate-model` promote to Opus on the final attempt. (b) is self-correcting and needs no new gate: a wrongly-Sonnet'd plan costs ~$1.42 + $7.62 ≈ $9 worst case versus $7.62 guaranteed today, while every correctly-Sonnet'd plan drops from $7.62 to $1.42. Prefer (b), optionally with (a)'s lint as a nudge. Keep `garbled/unknown → Opus` distinct from `missing → Sonnet`; only the *absent* case should fail cheap.
+**Risk if untouched:** Every plan authored without the field silently bills top-tier for mechanical work — the exact failure `.claude/rules/agent-tiering.md` ("never default to Opus") forbids for sub-agents, reproduced in the runner's own default.
+**Provenance:** Surfaced 2026-07-15 while reviewing L2/PR #1477; the cost telemetry gathered to refute the token-budget breaker located the real waste here.
+**Status (2026-07-15):** ⬜ Open — 🟦.
 
 ---
 

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -66,16 +66,7 @@ last_verified: 2026-07-15
 **Status (2026-07-07):** ⬜ Open — 🟦.
 
 ### L2 Per-plan circuit breaker
-**Location:** `bin/automouse-run` — per-phase `timeout` caps (`MAX_IMPL_SECS`/`MAX_PP_SECS` = 3600s), outer `MAX_ELAPSED` ≈ 4h45m, `MAX_ATTEMPTS=3` then the plan is parked in `skipped/` with a report.
-**Problem (was):** One runaway plan could eat the night.
-**Residual (token-budget breaker) — ✖ Won't do, empirically refuted.** Built as PR #1477 (`MAX_PLAN_COST_USD`, default $5.00, parks the plan in `skipped/` before postplan), then **closed unmerged 2026-07-15**. Measured against 47 `exit:` lines (2026-07-07→07-15):
-- **Keys on the wrong variable.** Impl cost does not predict postplan cost — the most expensive impl in the dataset (`ibl6-retirement-1-boxscore-php-port`, $18.72) had nearly the *cheapest* postplan ($1.95), while the three most expensive postplans ($5.68, $5.41, $4.22) all rode cheap impls that never trip the cap. Correlation across 17 paired plans r ≈ 0.08 (noisy at n=17; the inversions are the robust signal).
-- **Destroys completed work.** The breaker is gated on `$HANDOFF_FILE`, so it fires *only on impls that succeeded*, then `mv`s the plan away and `rm`s the handoff. At $5.00 it would discard ~$83.49 of working implementation across 7 of 28 runs to avoid postplans averaging ~$3.35; recovery means re-running impl, spending model-hours twice to save a notional figure once.
-- **Wrong unit.** automouse runs on subscription auth (bare `claude -p`, no `ANTHROPIC_API_KEY`), so `cost=$X` is an API list-price equivalent, not spend. Weekly automouse load is ~10.4 model-hours — a small fraction of a Max 5x weekly cap. Long overnight impls are *desirable* use of otherwise-idle budget, not waste.
-- **Doesn't bound the real constraint.** A per-plan cap can't bound a queue total: on 2026-07-11 the queue ran 5.8 model-hours (breaching a 5-hour session window) and this breaker would have fired once, saving ~14 minutes.
-
-**Superseded by:** L18 (tier-default correction) — the measured waste is tier misallocation, not plan length.
-**Status (2026-07-15):** ✅ Implemented — wall-clock + attempts breakers live and sufficient; the token-cap residual is closed as refuted (above), not deferred. 🟦.
+➜ L2 Per-plan circuit breaker — ✅ Implemented (2026-07-15): see [loop-engineering-backlog-archive.md](archive/loop-engineering-backlog-archive.md).
 
 ### L3 Morning digest
 **Location:** `bin/automouse-run` writes per-run reports (`done`/`skipped`/`env-stop`/`error`) plus a daily costs table; nothing aggregates or notifies (verified).

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Token-spend reduction backlog — resident-context diet, caching economics, output-spend guards, and LSP-first navigation for the Claude Code harness, with per-entry status.
-last_verified: 2026-07-14
+last_verified: 2026-07-15
 ---
 
 # Token-Spend Reduction Backlog
@@ -62,7 +62,7 @@ All entries are ✅ Implemented — see the dated pointers below and [token-spen
 ➜ T12 Sonnet plan-architect for recipe-backed plans — ✅ Implemented (2026-07-11): see [archive](archive/token-spend-backlog-archive.md).
 
 **Token-relevant entries tracked elsewhere:**
-- L2 residual (token-budget circuit breaker) — [loop-engineering-backlog.md](loop-engineering-backlog.md).
+- L18 (tier-default correction — `impl_model:` fails open to Opus) — [loop-engineering-backlog.md](loop-engineering-backlog.md). Supersedes the former L2 token-budget-breaker residual, closed 2026-07-15 as empirically refuted (PR #1477 closed unmerged): impl spend doesn't predict postplan spend, and the measured waste is tier misallocation (~82% of impl spend is Opus; ~$27/week routed to Opus purely by a missing `impl_model:` field), not plan length.
 - L15 (Sonnet-recipe completeness lint) — [loop-engineering-backlog.md](loop-engineering-backlog.md).
 - L16 (context-budget gate v2) — [loop-engineering-backlog.md](loop-engineering-backlog.md).
 - E8 (memory-lines→gates umbrella, pairs with T7) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md). ◑ Partial as of 2026-07-14; one item remains (free-agents teamid write guard).


### PR DESCRIPTION
## Summary

- Closes L2 (per-plan circuit breaker) as ✅ Implemented — the token-budget breaker residual is retired as empirically refuted by PR #1477 (closed unmerged 2026-07-15): impl cost does not predict postplan cost (r≈0.08 across 17 paired plans), and the breaker would discard ~\$83.49 of working implementations to avoid postplans averaging ~\$3.35
- Adds L18 (tier-default correction) as the real measured waste: `impl_model:` absent → silent Opus default → 82% of impl spend at 5.4× Sonnet price for mechanical work (~\$27/week attributable to missing `impl_model:` fields)
- Updates token-spend-backlog cross-reference to point to L18 instead of the retired L2 residual

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.