### PR TITLE
fix: strip weekly section before appending cost row to prevent row erasure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -642,6 +642,8 @@ jobs:
         run: bin/test-automouse-concurrency
       - name: bin/test-automouse-stream-filter
         run: bin/test-automouse-stream-filter
+      - name: bin/test-automouse-cost-rows
+        run: bin/test-automouse-cost-rows
       - name: bin/test-wt-status
         run: bin/test-wt-status
       - name: bin/test-check-plan

--- a/bin/automouse-run
+++ b/bin/automouse-run
@@ -365,6 +365,10 @@ strip_weekly_section() {
     ' "$report" > "$tmp" && mv "$tmp" "$report"
 }
 
+# Return the date N days ago in YYYY-MM-DD format. Works on both BSD (macOS,
+# date -v) and GNU (Linux/CI, date -d) date implementations.
+_date_ago() { date -v-"$1"d +%F 2>/dev/null || date -d "$1 days ago" +%F; }
+
 # Rebuild the trailing-7-days weekly aggregate at the bottom of today's costs
 # report. Idempotent: strips any prior "## Weekly aggregate" section (always the
 # last section) and rewrites it, so re-running per phase keeps it current and it
@@ -381,7 +385,7 @@ regenerate_weekly_section() {
         printf '\n## Weekly aggregate (last 7 days)\n\n'
         printf '### Cost by tier ($)\n\n| Tier | Cost ($) |\n|---|---|\n'
         for i in 0 1 2 3 4 5 6; do
-            d=$(date -v-"${i}"d +%F); f="$reports_dir/$d-costs.md"
+            d=$(_date_ago "$i"); f="$reports_dir/$d-costs.md"
             [ -f "$f" ] && sed '/^## Weekly aggregate/,$d' "$f" || true
         done | awk -F'|' '
             { if (NF==7 || NF==8) {tier=$5; cost=$6}
@@ -393,7 +397,7 @@ regenerate_weekly_section() {
                   printf "| **Total** | %.4f |\n", tot+0 }'
         printf '\n### Tokens by phase\n\n| Phase | Input | Cache-write | Cache-read | Output |\n|---|---|---|---|---|\n'
         for i in 0 1 2 3 4 5 6; do
-            d=$(date -v-"${i}"d +%F); f="$logs_dir/$d.log"
+            d=$(_date_ago "$i"); f="$logs_dir/$d.log"
             [ -f "$f" ] && grep -h 'exit:' "$f" || true
         done | awk '
             { phase="?"; n=split($2,a,"/"); if (n>=2) phase=a[n]

--- a/bin/automouse-run
+++ b/bin/automouse-run
@@ -343,8 +343,26 @@ append_cost_row() {
         printf '# Automouse cost roll-up — %s\n\n| Plan | Phase | Model | Tier | Cost ($) | Peak Ctx (K) |\n|---|---|---|---|---|---|\n' \
             "$(date +%Y-%m-%d)" > "$report"
     fi
+    # Strip the weekly section BEFORE appending, so the row lands at the end of
+    # the per-phase table rather than below the section regenerate_weekly_section
+    # is about to delete — the bug that ate every row but the day's first.
+    strip_weekly_section "$report"
     printf '| %s | %s | %s | %s | %s | %dK |\n' "$plan" "$phase" "$model" "$tier" "$cost" "$peak_k" >> "$report"
     regenerate_weekly_section "$report"
+}
+
+# Truncate a costs report back to its per-phase table: drop the weekly-aggregate
+# section and the blank lines that separate it from the table, leaving the file
+# ending on the last row. Trailing blanks must go too — a blank line between two
+# rows splits the markdown table in half.
+strip_weekly_section() {
+    local report=$1 tmp
+    tmp=$(mktemp)
+    awk '
+        /^## Weekly aggregate/ { exit }
+        /^[[:space:]]*$/       { blanks++; next }
+        { for (i = 0; i < blanks; i++) print ""; blanks = 0; print }
+    ' "$report" > "$tmp" && mv "$tmp" "$report"
 }
 
 # Rebuild the trailing-7-days weekly aggregate at the bottom of today's costs
@@ -352,14 +370,13 @@ append_cost_row() {
 # last section) and rewrites it, so re-running per phase keeps it current and it
 # survives a mid-night run break. Cost-by-tier comes from the reports' Tier
 # column; token totals come from the logs' exit-line tags — each table from its
-# natural source. Every per-file read is piped through the same sed strip so a
-# prior day's weekly rows (which also start with a pipe) are never re-ingested.
+# natural source. Every per-file read strips the weekly section first so a prior
+# day's weekly rows (which also start with a pipe) are never re-ingested.
 regenerate_weekly_section() {
-    local report=$1 reports_dir logs_dir tmp d f i
+    local report=$1 reports_dir logs_dir d f i
     reports_dir=$(dirname "$report")
     logs_dir="$NIGHTLY_DIR/logs"
-    tmp=$(mktemp)
-    sed '/^## Weekly aggregate/,$d' "$report" > "$tmp" && mv "$tmp" "$report"
+    strip_weekly_section "$report"
     {
         printf '\n## Weekly aggregate (last 7 days)\n\n'
         printf '### Cost by tier ($)\n\n| Tier | Cost ($) |\n|---|---|\n'

--- a/bin/test-automouse-cost-rows
+++ b/bin/test-automouse-cost-rows
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-automouse-cost-rows — regression test for automouse-run's cost roll-up.
+#
+# The bug this pins (shipped 2026-07-09 in b42dfb6b2 / #1381, live 6 days):
+# append_cost_row appended the row at EOF — BELOW the "## Weekly aggregate"
+# section — and then called regenerate_weekly_section, whose strip deletes from
+# that header to EOF. Every row but the day's first was written and immediately
+# deleted, leaving one blank line each. Nine phases ran 2026-07-15; the report
+# kept ONE row and nine blank lines, and the weekly total read $9.75 for a ~$120
+# week.
+#
+# The load-bearing assertion is CONTIGUITY, not presence: a blank line between
+# two rows splits the markdown table in half, so "all 3 rows are in the file" can
+# pass while the rendered table is still broken.
+#
+# Run: bin/test-automouse-cost-rows  (exit 0 = all pass, 1 = a case failed)
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+FAILED=0
+
+# assert_eq <actual> <expected> <label>
+assert_eq() {
+    if [ "$1" = "$2" ]; then
+        printf '  ok   %s (%s)\n' "$3" "$1"
+    else
+        printf '  FAIL %s: got %s, expected %s\n' "$3" "$1" "$2"
+        FAILED=1
+    fi
+}
+
+# Sandbox NIGHTLY_DIR so the real roll-up is never touched.
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+mkdir -p "$TMPROOT/reports" "$TMPROOT/logs"
+
+# shellcheck disable=SC2034  # read by the append_cost_row/regenerate_* funcs sourced below
+NIGHTLY_DIR="$TMPROOT"
+LOG="$TMPROOT/logs/$(date +%F).log"
+: > "$LOG"
+
+# Source only the three functions under test — automouse-run is a long-running
+# driver, so extract rather than execute it.
+eval "$(awk '/^model_tier\(\)/,/^}/'             "$REPO_ROOT/bin/automouse-run")"
+eval "$(awk '/^append_cost_row\(\)/,/^}/'        "$REPO_ROOT/bin/automouse-run")"
+eval "$(awk '/^strip_weekly_section\(\)/,/^}/'   "$REPO_ROOT/bin/automouse-run")"
+eval "$(awk '/^regenerate_weekly_section\(\)/,/^}/' "$REPO_ROOT/bin/automouse-run")"
+
+REPORT="$TMPROOT/reports/$(date +%F)-costs.md"
+
+# Three phases, each with its own exit: line — mirrors a real multi-plan night.
+for n in 1 2 3; do
+    before=$(wc -l < "$LOG")
+    printf '[00:0%d:00] plan-%d/impl exit: cost=$%d.5000 peak_ctx=%d000\n' "$n" "$n" "$n" "$((100 + n))" >> "$LOG"
+    append_cost_row "plan-$n.md" "impl" "$before" "claude-sonnet-4-6"
+done
+
+# 1. Every row survives.
+rows=$(grep -c '^| plan-' "$REPORT")
+assert_eq "$rows" 3 "all 3 rows survive"
+
+# 2. THE regression: rows are contiguous — no blank line splits the table.
+gap=$(awk '/^\| plan-/ {if (last && NR-last > 1) bad=1; last=NR} END {print bad+0}' "$REPORT")
+assert_eq "$gap" 0 "rows are contiguous (no table-splitting blanks)"
+
+# 3. The weekly section stays single and last.
+weeklies=$(grep -c '^## Weekly aggregate' "$REPORT")
+assert_eq "$weeklies" 1 "exactly 1 weekly section (idempotent regen)"
+
+# 4. The aggregate totals every row, not just the first ($1.50+$2.50+$3.50).
+total=$(awk -F'|' '/\*\*Total\*\*/ {gsub(/[ \t]/,"",$3); print $3; exit}' "$REPORT")
+assert_eq "$total" "7.5000" "weekly total sums all rows"
+
+# 5. Peak-ctx column is populated (guards the 5-col header regression).
+peaks=$(grep -c '| 10[123]K |' "$REPORT")
+assert_eq "$peaks" 3 "peak-ctx column carries all 3 peaks"
+
+exit "$FAILED"

--- a/bin/test-automouse-cost-rows
+++ b/bin/test-automouse-cost-rows
@@ -42,9 +42,10 @@ NIGHTLY_DIR="$TMPROOT"
 LOG="$TMPROOT/logs/$(date +%F).log"
 : > "$LOG"
 
-# Source only the three functions under test — automouse-run is a long-running
+# Source only the functions under test — automouse-run is a long-running
 # driver, so extract rather than execute it.
 eval "$(awk '/^model_tier\(\)/,/^}/'             "$REPO_ROOT/bin/automouse-run")"
+eval "$(awk '/^_date_ago\(\)/,/^}/'              "$REPO_ROOT/bin/automouse-run")"
 eval "$(awk '/^append_cost_row\(\)/,/^}/'        "$REPO_ROOT/bin/automouse-run")"
 eval "$(awk '/^strip_weekly_section\(\)/,/^}/'   "$REPO_ROOT/bin/automouse-run")"
 eval "$(awk '/^regenerate_weekly_section\(\)/,/^}/' "$REPO_ROOT/bin/automouse-run")"


### PR DESCRIPTION
## Summary

Fixes a bug where `append_cost_row` was losing all but the first cost row per day.

**Root cause:** `append_cost_row` appended the new row at EOF — below the `## Weekly aggregate` section — then called `regenerate_weekly_section`, which strips everything from that header to EOF. Every row after the first was written and immediately erased, leaving one blank line each.

**Observed impact (2026-07-15):** Nine phases ran; the report kept ONE row and nine blank lines. Weekly total read $9.75 for a ~$120 week.

## Fix

- Call `strip_weekly_section` **before** appending the row, so the new row always lands at the end of the per-phase table.
- Extract `strip_weekly_section` as a named function (reused by `regenerate_weekly_section`, which previously had an inline version via `sed`).

## Tests

`bin/test-automouse-cost-rows` (new) — regression test pinning:
1. All 3 rows survive (not erased)
2. Rows are contiguous — no blank line splits the markdown table
3. Exactly 1 weekly section (idempotent regen)
4. Aggregate total sums all rows
5. Peak-ctx column is populated

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.

<!-- no-adr: regression test for existing automouse cost-roll-up function -->