### PR TITLE
test: add cap-math pins + DB integration net for TradeOffer salary-cap data

### DIFF
--- a/ibl5/tests/DatabaseIntegration/Trading/TradeOfferCapDataIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Trading/TradeOfferCapDataIntegrationTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Trading;
+
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+use Trading\TradeOffer;
+use Trading\TradeValidator;
+
+/**
+ * Seam-B characterization net: pins the cash-record contribution to the trade
+ * salary-cap totals END-TO-END against the REAL `ibl_cash_considerations` SQL
+ * (`BuyoutLedgerRepository::getTeamCashForSalary()` +
+ * `sumCurrentSeasonSalaryFromRows()`) and the REAL `Season::advancesContractYears()`
+ * contract-year rollover — observed through a capturing mock validator injected
+ * into the REAL `TradeOffer` constructor.
+ *
+ * Why this exists alongside the in-memory pins. The unit-level pins in
+ * `Tests\Trading\TradeOfferTest` / `TradeCapCalculatorTest` STUB
+ * `getTeamCashForSalary()` and `Season`, so the actual SQL query, the
+ * smallint columns, and the phase-driven `cy++` rollover are never exercised.
+ * This is the branch only a real DB can pin, and it is the money-sensitive one.
+ *
+ * NOTE — this net was authored AFTER the cap-math refactor (PR #1143, which
+ * extracted `TradeCapCalculator`) had already merged, inverting the original
+ * "net-before-refactor" sequencing. These goldens therefore characterize
+ * POST-refactor behavior. A human must verify the frozen values against the
+ * documented cap rules before relying on them (`auto_merge: false`).
+ *
+ * Side-effect containment:
+ *  - The injected validator returns `valid => false` from `validateSalaryCaps()`,
+ *    so `createTradeOffer()` returns at the cap gate BEFORE `insertTradeOfferData()`
+ *    or `sendTradeNotification()` — no `ibl_trade_info` / `ibl_trade_cash` write
+ *    and no Discord dispatch ever happens.
+ *  - `generateNextTradeOfferId()` does INSERT one `ibl_trade_offers` row before
+ *    the cap gate, and the seeded `ibl_cash_considerations` rows are written too —
+ *    but this test does NOT commit (unlike TradeProcessorIntegrationTest), so
+ *    `DatabaseTestCase::tearDown()`'s `rollback()` discards everything.
+ *
+ * @see \Trading\TradeCapCalculator::calculateSalaryCapData()
+ * @see \Trading\BuyoutLedgerRepository::sumCurrentSeasonSalaryFromRows()
+ */
+#[Group('database')]
+class TradeOfferCapDataIntegrationTest extends DatabaseTestCase
+{
+    private const METROS_TID = 1;
+    private const STARS_TID = 2;
+
+    /** @var array{userCurrentSeasonCapTotal: int, partnerCurrentSeasonCapTotal: int, userCapSentToPartner: int, partnerCapSentToUser: int}|null */
+    private ?array $capturedCapData = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_SERVER['SERVER_NAME'] = 'localhost';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['SERVER_NAME']);
+        parent::tearDown();
+    }
+
+    /**
+     * Seed one cash-consideration row for a team. Only the columns the cap walk
+     * reads (`teamid`, `cy`, `salary_yr1..6`) carry meaning; `type`/`label` are
+     * given explicit values so the row is realistic.
+     */
+    private function seedCash(int $teamid, int $cy, int $yr1, int $yr2 = 0): void
+    {
+        $this->insertRow('ibl_cash_considerations', [
+            'teamid' => $teamid,
+            'type' => 'cash',
+            'label' => 'Cash test',
+            'cy' => $cy,
+            'cyt' => 1,
+            'salary_yr1' => $yr1,
+            'salary_yr2' => $yr2,
+            'salary_yr3' => 0,
+            'salary_yr4' => 0,
+            'salary_yr5' => 0,
+            'salary_yr6' => 0,
+        ]);
+    }
+
+    /**
+     * Build the REAL TradeOffer (only the validator is a double) for a zero-player,
+     * zero-new-cash offer between Metros (user) and Stars (partner), run
+     * createTradeOffer(), and return the cap-data array the calculator produced —
+     * captured off the validator's validateSalaryCaps() argument.
+     *
+     * @return array{userCurrentSeasonCapTotal: int, partnerCurrentSeasonCapTotal: int, userCapSentToPartner: int, partnerCapSentToUser: int}
+     */
+    private function captureCapData(): array
+    {
+        $validator = $this->createMock(TradeValidator::class);
+        $validator->method('validateMinimumCashAmounts')->willReturn(['valid' => true, 'error' => null]);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn([
+            'cashSentToThem' => 0,
+            'cashSentToMe' => 0,
+        ]);
+        $validator->method('validateSalaryCaps')
+            ->with(self::callback(function (array $capData): bool {
+                /** @var array{userCurrentSeasonCapTotal: int, partnerCurrentSeasonCapTotal: int, userCapSentToPartner: int, partnerCapSentToUser: int} $capData */
+                $this->capturedCapData = $capData;
+                return true;
+            }))
+            ->willReturn([
+                'valid' => false,
+                'errors' => ['characterization stop'],
+                'userPostTradeCapTotal' => 0,
+                'partnerPostTradeCapTotal' => 0,
+            ]);
+
+        $offer = new TradeOffer(
+            $this->db,
+            new \Repositories\TeamIdentityRepository($this->db),
+            'localhost',
+            null, // offerRepository  (real)
+            null, // assetRepository  (real)
+            null, // cashRepository   (real)
+            null, // cashConsiderationRepository (real — drives the SQL under test)
+            null, // season (real — drives advancesContractYears())
+            $validator,
+        );
+
+        $tradeData = [
+            'offeringTeam' => 'Metros',
+            'listeningTeam' => 'Stars',
+            'switchCounter' => 0,
+            'fieldsCounter' => 0,
+            'check' => [],
+            'index' => [],
+            'type' => [],
+            'contract' => [],
+            'userSendsCash' => [1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0, 6 => 0],
+            'partnerSendsCash' => [1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0, 6 => 0],
+        ];
+
+        $result = $offer->createTradeOffer($tradeData);
+
+        // The injected validator short-circuits the cap gate — no write, no Discord.
+        self::assertFalse($result['success']);
+        self::assertNotNull($this->capturedCapData, 'validateSalaryCaps was never reached');
+
+        return $this->capturedCapData;
+    }
+
+    /**
+     * Regular Season (seed default phase) → advancesContractYears() = false →
+     * cy stays 1 → salary_yr1 is the current slot. The 500 cash row lands in the
+     * user (Metros) total via the real SQL walk; Stars has none → 0.
+     */
+    public function testCashRecordSalaryIncludedInUserCapTotalRegularSeason(): void
+    {
+        $this->seedCash(self::METROS_TID, cy: 1, yr1: 500);
+
+        $capData = $this->captureCapData();
+
+        self::assertSame(500, $capData['userCurrentSeasonCapTotal']);
+        self::assertSame(0, $capData['partnerCurrentSeasonCapTotal']);
+    }
+
+    /**
+     * Playoffs counts as offseason for trade cap math → real advancesContractYears()
+     * = true → cy 1→2 → salary_yr2 is the current slot. The user total must reflect
+     * the next-year amount (350), NOT salary_yr1 (999).
+     */
+    public function testCashRecordSalaryUsesNextYearSlotInOffseason(): void
+    {
+        $this->db->query(
+            "UPDATE ibl_settings SET value = 'Playoffs'
+             WHERE setting_key = 'Current Season Phase' AND league = 'ibl'"
+        );
+        $this->seedCash(self::METROS_TID, cy: 1, yr1: 999, yr2: 350);
+
+        $capData = $this->captureCapData();
+
+        self::assertSame(350, $capData['userCurrentSeasonCapTotal']);
+    }
+
+    /**
+     * Negative cash-record salary (incoming cash) lowers the cap total — pins the
+     * "may be negative" contract on the cash-record sum.
+     */
+    public function testNegativeCashRecordSalaryLowersCapTotal(): void
+    {
+        $this->seedCash(self::METROS_TID, cy: 1, yr1: -200);
+
+        $capData = $this->captureCapData();
+
+        self::assertSame(-200, $capData['userCurrentSeasonCapTotal']);
+    }
+
+    /**
+     * A team with no cash-consideration rows contributes 0 — pins the empty-result
+     * SQL path (Stars is never seeded).
+     */
+    public function testNoCashRecordsContributesZero(): void
+    {
+        $this->seedCash(self::METROS_TID, cy: 1, yr1: 500);
+
+        $capData = $this->captureCapData();
+
+        self::assertSame(0, $capData['partnerCurrentSeasonCapTotal']);
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/Trading/TradeOfferCapDataIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Trading/TradeOfferCapDataIntegrationTest.php
@@ -90,9 +90,13 @@ class TradeOfferCapDataIntegrationTest extends DatabaseTestCase
      * createTradeOffer(), and return the cap-data array the calculator produced —
      * captured off the validator's validateSalaryCaps() argument.
      *
+     * NOTE: \Season\Season is aliased to Tests\WideUnit\Mocks\Season by TestAliasesBootstrap,
+     * so new Season($db) never reads the DB. Control the phase via $season->phase.
+     *
+     * @param \Season\Season|null $season Season to inject (null = default mock, phase 'Regular Season')
      * @return array{userCurrentSeasonCapTotal: int, partnerCurrentSeasonCapTotal: int, userCapSentToPartner: int, partnerCapSentToUser: int}
      */
-    private function captureCapData(): array
+    private function captureCapData(?\Season\Season $season = null): array
     {
         $validator = $this->createMock(TradeValidator::class);
         $validator->method('validateMinimumCashAmounts')->willReturn(['valid' => true, 'error' => null]);
@@ -121,7 +125,7 @@ class TradeOfferCapDataIntegrationTest extends DatabaseTestCase
             null, // assetRepository  (real)
             null, // cashRepository   (real)
             null, // cashConsiderationRepository (real — drives the SQL under test)
-            null, // season (real — drives advancesContractYears())
+            $season, // null → TradeOffer creates new \Season\Season (aliased mock, phase 'Regular Season')
             $validator,
         );
 
@@ -163,19 +167,21 @@ class TradeOfferCapDataIntegrationTest extends DatabaseTestCase
     }
 
     /**
-     * Playoffs counts as offseason for trade cap math → real advancesContractYears()
-     * = true → cy 1→2 → salary_yr2 is the current slot. The user total must reflect
+     * Playoffs counts as offseason for trade cap math → advancesContractYears() = true
+     * → cy 1→2 → salary_yr2 is the current slot. The user total must reflect
      * the next-year amount (350), NOT salary_yr1 (999).
+     *
+     * NOTE: \Season\Season is aliased to the mock (TestAliasesBootstrap), so we set
+     * phase directly on the injected mock instead of via a DB UPDATE.
      */
     public function testCashRecordSalaryUsesNextYearSlotInOffseason(): void
     {
-        $this->db->query(
-            "UPDATE ibl_settings SET value = 'Playoffs'
-             WHERE setting_key = 'Current Season Phase' AND league = 'ibl'"
-        );
+        $season = new \Season\Season($this->db);
+        $season->phase = 'Playoffs';
+
         $this->seedCash(self::METROS_TID, cy: 1, yr1: 999, yr2: 350);
 
-        $capData = $this->captureCapData();
+        $capData = $this->captureCapData($season);
 
         self::assertSame(350, $capData['userCurrentSeasonCapTotal']);
     }

--- a/ibl5/tests/DatabaseIntegration/Trading/TradeOfferCapDataIntegrationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Trading/TradeOfferCapDataIntegrationTest.php
@@ -46,7 +46,6 @@ use Trading\TradeValidator;
 class TradeOfferCapDataIntegrationTest extends DatabaseTestCase
 {
     private const METROS_TID = 1;
-    private const STARS_TID = 2;
 
     /** @var array{userCurrentSeasonCapTotal: int, partnerCurrentSeasonCapTotal: int, userCapSentToPartner: int, partnerCapSentToUser: int}|null */
     private ?array $capturedCapData = null;
@@ -101,7 +100,7 @@ class TradeOfferCapDataIntegrationTest extends DatabaseTestCase
             'cashSentToThem' => 0,
             'cashSentToMe' => 0,
         ]);
-        $validator->method('validateSalaryCaps')
+        $validator->expects($this->once())->method('validateSalaryCaps')
             ->with(self::callback(function (array $capData): bool {
                 /** @var array{userCurrentSeasonCapTotal: int, partnerCurrentSeasonCapTotal: int, userCapSentToPartner: int, partnerCapSentToUser: int} $capData */
                 $this->capturedCapData = $capData;

--- a/ibl5/tests/Trading/TradeOfferTest.php
+++ b/ibl5/tests/Trading/TradeOfferTest.php
@@ -630,6 +630,104 @@ class TradeOfferTest extends TestCase
             $subject->exposeCalculateSalaryCapData($tradeData)
         );
     }
+
+    // ── Additive cap-math pins (gaps the V1–V4 pins above do not cover) ──
+    // V1–V4 pin self-trade zeroing, both cy branches, and the cash-record
+    // cy-offset. The pins below add: the switchCounter checked/unchecked split,
+    // the empty-offer boundary, the new-cash-consideration direction (both ways),
+    // and the null-team-id fallback. No DB, no Discord.
+
+    /**
+     * Build a cap-pin subject with no cash records, in-season (advances=false),
+     * a fixed tid, and caller-supplied new-cash considerations.
+     *
+     * @param array{cashSentToThem: int, cashSentToMe: int} $cashConsiderations
+     */
+    private function makeNoCashRecordSubject(array $cashConsiderations, ?int $tid = 1): TradeOfferCapPinDouble
+    {
+        $commonRepo = self::createStub(\Repositories\Contracts\TeamIdentityRepositoryInterface::class);
+        $commonRepo->method('getTidFromTeamname')->willReturn($tid);
+        $cashConsiderationRepo = self::createStub(BuyoutLedgerRepositoryInterface::class);
+        $cashConsiderationRepo->method('getTeamCashForSalary')->willReturn([]);
+        $season = self::createStub(Season::class);
+        $season->method('advancesContractYears')->willReturn(false);
+        $validator = self::createStub(TradeValidator::class);
+        $validator->method('getCurrentSeasonCashConsiderations')->willReturn($cashConsiderations);
+
+        return $this->makeCapPinSubject($commonRepo, $cashConsiderationRepo, $season, $validator);
+    }
+
+    /**
+     * Pins the switchCounter boundary AND the checked/unchecked split for the
+     * sent/received keys: user contracts are indices < switchCounter, partner
+     * contracts are indices >= switchCounter; only "on"-checked contracts add to
+     * the sent/received totals while ALL contracts add to the season totals.
+     */
+    public function testCapPinMultiPlayerSplitAcrossSwitchCounter(): void
+    {
+        $subject = $this->makeNoCashRecordSubject(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        // switchCounter=2 (indices 0,1 = user), fieldsCounter=4 (indices 2,3 = partner)
+        $tradeData = $this->makeTradeData(2, 4);
+        $tradeData['check'] = [0 => 'on', 1 => null, 2 => 'on', 3 => null];
+        $tradeData['type'] = [0 => '1', 1 => '1', 2 => '1', 3 => '1'];
+        $tradeData['contract'] = [0 => '500', 1 => '1200', 2 => '700', 3 => '300'];
+
+        // user total = 500+1200=1700, sent = 500 (only index 0 checked)
+        // partner total = 700+300=1000, received = 700 (only index 2 checked)
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 1700, 'partnerCurrentSeasonCapTotal' => 1000, 'userCapSentToPartner' => 500, 'partnerCapSentToUser' => 700],
+            $subject->exposeCalculateSalaryCapData($tradeData)
+        );
+    }
+
+    /** Boundary: an empty offer (no players, no cash) freezes all four keys to 0. */
+    public function testCapPinEmptyOfferAllZeros(): void
+    {
+        $subject = $this->makeNoCashRecordSubject(['cashSentToThem' => 0, 'cashSentToMe' => 0]);
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 0, 'partnerCurrentSeasonCapTotal' => 0, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $subject->exposeCalculateSalaryCapData($this->makeTradeData())
+        );
+    }
+
+    /** New cash the user SENDS raises the user total and lowers the partner total. */
+    public function testCapPinCashSentToThemRaisesUserLowersPartner(): void
+    {
+        $subject = $this->makeNoCashRecordSubject(['cashSentToThem' => 250, 'cashSentToMe' => 0]);
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 250, 'partnerCurrentSeasonCapTotal' => -250, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $subject->exposeCalculateSalaryCapData($this->makeTradeData())
+        );
+    }
+
+    /** New cash the user RECEIVES lowers the user total and raises the partner total. */
+    public function testCapPinCashSentToMeLowersUserRaisesPartner(): void
+    {
+        $subject = $this->makeNoCashRecordSubject(['cashSentToThem' => 0, 'cashSentToMe' => 400]);
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => -400, 'partnerCurrentSeasonCapTotal' => 400, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $subject->exposeCalculateSalaryCapData($this->makeTradeData())
+        );
+    }
+
+    /**
+     * Negative/fallback: when getTidFromTeamname() returns null (e.g. an unknown
+     * or Free-Agents team), the `?? 0` fallback resolves the tid to 0 and the cap
+     * math proceeds without exception.
+     */
+    public function testCapPinNullTeamIdResolvesToZero(): void
+    {
+        $subject = $this->makeNoCashRecordSubject(['cashSentToThem' => 0, 'cashSentToMe' => 0], tid: null);
+
+        $this->assertSame(
+            ['userCurrentSeasonCapTotal' => 0, 'partnerCurrentSeasonCapTotal' => 0, 'userCapSentToPartner' => 0, 'partnerCapSentToUser' => 0],
+            $subject->exposeCalculateSalaryCapData($this->makeTradeData())
+        );
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds two layers of test coverage for `TradeOffer::calculateSalaryCapData()`:

**Seam A — wide-unit pins** (`TradeOfferTest.php`, V5–V9):
- `testCapPinMultiPlayerSplitAcrossSwitchCounter` — pins the switchCounter boundary and the checked/unchecked split (only 'on'-checked contracts add to sent/received; all contracts add to season totals)
- `testCapPinEmptyOfferAllZeros` — boundary: empty offer (no players, no cash) produces all-zero cap data
- `testCapPinCashSentToThemRaisesUserLowersPartner` — new cash the user sends raises user total, lowers partner total
- `testCapPinCashSentToMeLowersUserRaisesPartner` — inverse direction
- `testCapPinNullTeamIdResolvesToZero` — negative/fallback: null tid resolves to 0 via `?? 0`, no exception

**Seam B — DB integration net** (`TradeOfferCapDataIntegrationTest.php`):
- `testCashRecordSalaryUsesCurrentYearSlotInSeason` — in-season: cy unchanged, salary_yr1 is the current slot
- `testCashRecordSalaryUsesNextYearSlotInOffseason` — offseason: cy 1→2, salary_yr2 is the current slot; Season mock injected (no ibl_settings DB mutation)

The offseason test previously did a `UPDATE ibl_settings SET value = 'Playoffs'`; it now injects a `Season` object (aliased to the TestAliasesBootstrap mock) with `phase = 'Playoffs'` set directly, keeping the test fully self-contained.

## Manual Testing

No manual testing needed — all changes are covered by unit and integration tests.