### PR TITLE
feat: runnerless Mac poll for stale-docs auto-remediation (ADR-0086)

### DIFF
--- a/.github/workflows/doc-freshness-audit.yml
+++ b/.github/workflows/doc-freshness-audit.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: read
 
 concurrency:
   group: doc-freshness-audit
@@ -19,11 +20,6 @@ jobs:
     name: Repo-wide staleness audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    outputs:
-      notify: ${{ steps.issue.outputs.notify }}
-      sig: ${{ steps.report.outputs.sig }}
-      issue-num: ${{ steps.issue.outputs.issue-num }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -60,6 +56,7 @@ jobs:
             echo "**Remediation:** re-verify each doc against reality, then bump its \`last_verified\` to today and commit (on a branch that touches the doc, \`bin/check-docs --fix-dates --since=master\` bumps the changed-but-unbumped ones)."
             echo ""
             echo "<!-- stale-set: ${{ steps.report.outputs.sig }} -->"
+            echo "<!-- stale-since: $(date -u +%Y-%m-%dT%H:%M:%SZ) -->"
           } > /tmp/issue-body.md
 
       - name: Ensure stale-docs label exists
@@ -115,8 +112,16 @@ jobs:
             echo "No stale docs — all in-scope docs are within the 60-day window." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Evaluate refresh-pipeline health
+        id: health
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ steps.issue.outputs.issue-num }}
+        run: |
+          bin/docfix-poll --health-report "$ISSUE_NUM" | tee -a "$GITHUB_OUTPUT"
+
       - name: Setup SSH
-        if: steps.issue.outputs.notify == 'true'
+        if: steps.health.outputs.alert == 'true'
         uses: ./.github/actions/setup-ssh
         with:
           host: ${{ secrets.HOST }}
@@ -124,30 +129,20 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Build Discord message
-        if: steps.issue.outputs.notify == 'true'
+        if: steps.health.outputs.alert == 'true'
         env:
           COUNT: ${{ steps.report.outputs.count }}
+          DETAIL: ${{ steps.health.outputs.detail }}
         run: |
-          MSG=$(printf 'Doc Freshness Audit: %s doc(s) past the 60-day staleness window.\nIssue + details: https://github.com/%s/actions/runs/%s' \
-            "$COUNT" "${{ github.repository }}" "${{ github.run_id }}")
+          MSG=$(printf 'Doc refresh needs you: %s doc(s) are stale and the pipeline could not clear them on its own.\n%s\nRun: https://github.com/%s/actions/runs/%s' \
+            "$COUNT" "$DETAIL" "${{ github.repository }}" "${{ github.run_id }}")
           printf '%s' "$MSG" > /tmp/discord-msg.txt
 
       - name: Send Discord DM
-        if: steps.issue.outputs.notify == 'true'
+        if: steps.health.outputs.alert == 'true'
         uses: ./.github/actions/notify-discord
         with:
           discord-id: ${{ secrets.OWNER_DISCORD_ID }}
           port: ${{ secrets.PORT }}
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
-          fail-on-delivery: 'false'
-
-  docfix:
-    name: Fire headless doc-fix on the Mac
-    needs: audit
-    if: needs.audit.outputs.notify == 'true'
-    runs-on: [self-hosted, macOS]
-    timeout-minutes: 10
-    steps:
-      - name: Launch the headless doc-fix run
-        run: /Users/ajaynicolas/GitHub/IBL5/bin/docfix-run "${{ needs.audit.outputs.issue-num }}" "${{ needs.audit.outputs.sig }}"

--- a/.github/workflows/docs-refreshed-notify.yml
+++ b/.github/workflows/docs-refreshed-notify.yml
@@ -1,0 +1,70 @@
+name: Docs Refreshed Notify
+
+# Fires when a pull_request is opened or reopened. The job below guards on
+# same-repo origin AND a docs-stale-refresh-* head ref, so only doc-fix PRs
+# opened from this repo send a DM.
+#
+# Why this trigger fires at all (load-bearing fact): a PR opened by the default
+# Actions GITHUB_TOKEN does NOT trigger pull_request workflows. This one fires
+# because bin/docfix-run opens its PR from the Mac with the owner's persistent
+# `gh` PAT, so GitHub attributes it to a real user. That same fact is the
+# anti-recursion guarantee.
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read      # `gh pr view --json files` for the refreshed file list
+
+concurrency:
+  group: docs-refreshed-notify-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  notify-refreshed:
+    # Guard: BOTH conditions ANDed.
+    #  - same-repo: a FORK PR is skipped. This repo is PUBLIC, the event fires for
+    #    fork PRs, and a fork can name its branch docs-stale-refresh-x to pass a
+    #    head-ref-only guard. (Not an RCE — pull_request is read-only and secretless —
+    #    but it is fork-triggerable noise, gated out at the source.)
+    #  - head.ref prefix: only doc-refresh PRs send a DM.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'docs-stale-refresh-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build Discord message
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # PR_NUMBER travels via env, never interpolated inline — prevents shell injection.
+          # PR title is deliberately excluded: it is author-controlled text.
+          FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path')
+          {
+            printf 'Claude refreshed your stale docs — ready for your review. PR #%s:\n' "$PR_NUMBER"
+            echo "$FILES" | sed 's/^/  /'
+            printf 'Review and merge: %s\n' "$PR_URL"
+          } > /tmp/discord-msg.txt
+
+      - name: Setup SSH
+        uses: ./.github/actions/setup-ssh
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Send Discord DM
+        uses: ./.github/actions/notify-discord
+        with:
+          discord-id: ${{ secrets.OWNER_DISCORD_ID }}
+          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}

--- a/bin/docfix-poll
+++ b/bin/docfix-poll
@@ -180,7 +180,7 @@ issue_episode_epoch() {   # $1 = issue number
 # a report, not a gate, mirroring `check-docs --staleness-report`. The audit
 # workflow appends them to $GITHUB_OUTPUT verbatim.
 health_report() {
-    local alert=false kind="" detail="" report count pr_json pr_num red orphan age_h
+    local alert=false kind="" detail="" report count pr_json pr_num red orphan age_h episode
     report="$(mktemp)"; trap 'rm -f "$report"' RETURN
     "$MAIN/bin/check-docs" --staleness-report > "$report" \
         || { printf 'alert=false\nkind=\ndetail=\n'; return 0; }
@@ -188,15 +188,21 @@ health_report() {
     local issue_num="${1:-}"
 
     if [ "${count:-0}" -gt 0 ] && [ -n "$issue_num" ]; then
+        # `|| var=""` on every bare gh assignment: set -e is live in this function
+        # body, so an unguarded transient gh failure (rate limit, network) would
+        # abort before the final printf — the exact silent-skip the guard above
+        # exists to prevent. Fail-quiet, same contract as the check-docs guard.
         pr_json="$(gh pr list --state open --json number,headRefName,url \
-          --jq '[.[] | select(.headRefName | startswith("docs-stale-refresh-"))] | .[0] // empty')"
+          --jq '[.[] | select(.headRefName | startswith("docs-stale-refresh-"))] | .[0] // empty')" \
+          || pr_json=""
         if [ -n "$pr_json" ]; then
             # An open PR is the DESIGNED steady state (auto_merge:false — the user
             # reviews it). Only a RED check is a failure; green/pending stay silent.
             pr_num="$(jq -r .number <<<"$pr_json")"
             red="$(gh pr view "$pr_num" --json statusCheckRollup \
               --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT"
-                     or .conclusion == "CANCELLED" or .conclusion == "ACTION_REQUIRED")] | length')"
+                     or .conclusion == "CANCELLED" or .conclusion == "ACTION_REQUIRED")] | length')" \
+              || red=""
             if [ "${red:-0}" -gt 0 ]; then
                 alert=true; kind="ci-red"
                 detail="Refresh PR $(jq -r .url <<<"$pr_json") has ${red} failing check(s) — the doc refresh needs a fix before you can merge it."
@@ -207,7 +213,12 @@ health_report() {
             alert=true; kind="died"
             detail="Refresh branch ${orphan} is on origin with no PR — the doc-fix run died mid-flight. Log: ls -t /tmp/docfix-run-*.log | head -1"
         else
-            age_h=$(( ( $(date -u +%s) - $(issue_episode_epoch "$issue_num") ) / 3600 ))
+            # gh dying inside issue_episode_epoch yields empty output, and an empty
+            # arithmetic operand is a syntax error that kills the function. Fall back
+            # to "now" (age 0 → no alert) — fail-quiet like every guard above.
+            episode="$(issue_episode_epoch "$issue_num")" && [ -n "$episode" ] \
+                || episode="$(date -u +%s)"
+            age_h=$(( ( $(date -u +%s) - episode ) / 3600 ))
             if [ "$age_h" -ge 36 ]; then
                 alert=true; kind="never-ran"
                 detail="No refresh PR has been opened in ${age_h}h. The Mac poll is probably not installed: cd ~/GitHub/IBL5 && git pull && bin/docfix-poll --install-schedule"

--- a/bin/docfix-poll
+++ b/bin/docfix-poll
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+#
+# bin/docfix-poll — Runnerless Mac poll for stale-docs auto-remediation (ADR-0086).
+# Replaces the deleted `docfix` job in doc-freshness-audit.yml: GitHub schedules
+# nothing on this Mac (no self-hosted runner is registered — the public-repo runner
+# security constraint, stated in ADR-0086, makes that permanently unsafe). Instead,
+# launchd drives this poller from the owner's Mac at 09:17 local daily.
+#
+# Install AFTER this PR lands on master: the launchd Program points at the MAIN
+# checkout's copy of this file, so a pre-merge install silently runs a stale version.
+#
+# Usage:
+#   bin/docfix-poll                    # nightly poll (run by launchd)
+#   bin/docfix-poll --install-schedule   # install the 09:17 launchd job (post-merge)
+#   bin/docfix-poll --uninstall-schedule # remove the launchd job (rollback)
+#   bin/docfix-poll --print-schedule     # emit plist to stdout — test seam, no side effect
+#   bin/docfix-poll --health-report [ISSUE_NUM]  # print 3 key=value lines; always exits 0
+#   bin/docfix-poll -h                 # this help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- MAIN checkout derivation (Divergence 1 from backups-sync-setup template) ---
+# IBL5_MAIN lets bin/test-docfix-run sandbox this script without touching the real
+# checkout. Falls back to the worktree-list awk (mirrors bin/docfix-run:31).
+MAIN="${IBL5_MAIN:-}"
+if [ -z "$MAIN" ]; then
+    MAIN="$(git -C "$SCRIPT_DIR/.." worktree list --porcelain 2>/dev/null \
+             | awk '/^worktree / {print $2; exit}')"
+fi
+[ -n "$MAIN" ] || MAIN="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SCHEDULE_ACTION=""
+HEALTH_ISSUE_ARG=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --install-schedule)   SCHEDULE_ACTION="install";   shift ;;
+        --uninstall-schedule) SCHEDULE_ACTION="uninstall"; shift ;;
+        --print-schedule)     SCHEDULE_ACTION="print";     shift ;;
+        --health-report)      SCHEDULE_ACTION="health";    shift
+                              [ $# -gt 0 ] && { HEALTH_ISSUE_ARG="$1"; shift; } || true ;;
+        -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0"; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# --- Schedule management (launchd) -------------------------------------------
+PLIST_LABEL="com.ibl5.docfix-poll"
+PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+PROGRAM="$MAIN/bin/docfix-poll"
+LOG_DIR="$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/docfix-poll/logs"
+
+# Single source of truth for the plist — shared by --print-schedule and
+# --install-schedule, so the MAIN-checkout derivation is exercised by tests.
+build_plist() {
+    cat <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${PLIST_LABEL}</string>
+	<key>Program</key>
+	<string>${PROGRAM}</string>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>9</integer>
+		<key>Minute</key>
+		<integer>17</integer>
+	</dict>
+	<key>WorkingDirectory</key>
+	<string>${MAIN}</string>
+	<key>StandardOutPath</key>
+	<string>${LOG_DIR}/launchd-stdout.log</string>
+	<key>StandardErrorPath</key>
+	<string>${LOG_DIR}/launchd-stderr.log</string>
+</dict>
+</plist>
+PLIST
+}
+
+if [ -n "$SCHEDULE_ACTION" ] && [ "$SCHEDULE_ACTION" != "health" ]; then
+    case "$SCHEDULE_ACTION" in
+        print)
+            build_plist
+            ;;
+        install)
+            # Fail-closed guard (Divergence 2): launchd accepts a plist whose Program
+            # does not exist and then silently never runs it — the exact silent-failure
+            # class that killed this pipeline the first time. Refuse rather than install
+            # a job that can never fire, and name the fix.
+            if [ ! -x "$PROGRAM" ]; then
+                echo "FAILED: $PROGRAM is not an executable file." >&2
+                echo "  The launchd job runs the MAIN checkout's copy, so merge this PR first:" >&2
+                echo "    cd \"$MAIN\" && git pull && bin/docfix-poll --install-schedule" >&2
+                exit 1
+            fi
+            mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
+            launchctl bootout "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true
+            build_plist > "$PLIST_PATH"
+            launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+            if ! launchctl print "gui/$(id -u)/${PLIST_LABEL}" >/dev/null 2>&1; then
+                echo "FAILED: ${PLIST_LABEL} did not load." >&2
+                exit 1
+            fi
+            echo "Installed ${PLIST_LABEL} (daily 09:17 local). Program: $PROGRAM"
+            ;;
+        uninstall)
+            launchctl bootout "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true
+            rm -f "$PLIST_PATH"
+            echo "Uninstalled ${PLIST_LABEL}."
+            ;;
+    esac
+    exit 0
+fi
+
+# --- Shared helpers (poll and --health-report both use these) -----------------
+
+iso_to_epoch() {
+    # BSD (macOS) and GNU date disagree on the parsing flag; try both.
+    date -u -d "$1" +%s 2>/dev/null || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$1" +%s
+}
+
+# The ONE definition of "a human already declined a refresh covering these docs".
+# Coverage, not equality: --fix-dates can make the PR touch more docs than the
+# worklist, and if the stale set later grows beyond what was declined the pipeline
+# resumes on its own.
+uncovered_count() {   # $1 = path to a --staleness-report JSON file
+    local declined
+    declined="$(gh pr list --state closed --limit 20 --json headRefName,mergedAt,files \
+      --jq '[.[] | select(.headRefName | startswith("docs-stale-refresh-"))
+                 | select(.mergedAt == null)] | .[0].files // [] | map(.path)' 2>/dev/null || echo '[]')"
+    jq -r --argjson d "$declined" '[.[].path] - $d | length' "$1"
+}
+
+# Seam for the `died` branch: shimmed in bin/test-docfix-run so the git ls-remote
+# call is testable without hitting the network. Do NOT inline this call.
+git_remote_refresh_branches() {
+    git ls-remote --heads origin 'refs/heads/docs-stale-refresh-*' | sed 's#.*refs/heads/##'
+}
+
+# A branch on origin with NO PR of ANY state = a run that pushed and then died
+# before opening one. NOT merely "a branch exists": nothing ever deletes a DECLINED
+# PR's remote branch (bin/cleanup only READS origin/<branch> at :174 — GitHub's
+# delete_branch_on_merge reaps the MERGED case, and there is no closed-unmerged
+# equivalent), so a lingering branch is the normal residue of a decline. Keying on
+# branch-existence alone would fire `died` forever on every later stale set.
+# Verified against bin/cleanup 2026-07-15.
+orphaned_refresh_branch() {   # echoes the first branch with no PR at all; empty if none
+    local b
+    while read -r b; do
+        [ -z "$b" ] && continue
+        if [ "$(gh pr list --state all --head "$b" --json number --jq 'length' 2>/dev/null || echo 1)" -eq 0 ]; then
+            printf '%s' "$b"; return
+        fi
+    done < <(git_remote_refresh_branches)
+}
+
+# Epoch at which the CURRENT stale set was first filed. NOT the issue's createdAt:
+# the audit keeps ONE long-lived `stale-docs` issue (workflow :77-103 — created only
+# when none is open, EDITED when the signature changes, closed only at count 0), so
+# createdAt marks the FIRST episode ever, possibly weeks stale. The audit rebuilds
+# the body exactly when an episode starts, so a body marker carries the right
+# timestamp. Fallback to createdAt covers the pre-existing issue whose body predates
+# the marker: there the fallback is CORRECT — an old createdAt with no PR is a
+# genuinely uninstalled poll, which is the bootstrap alert this plan needs on day one.
+issue_episode_epoch() {   # $1 = issue number
+    local since
+    since="$(gh issue view "$1" --json body --jq .body 2>/dev/null | tr -d '\r' \
+             | sed -n 's/.*<!-- stale-since: \(.*\) -->.*/\1/p' | head -1)"
+    [ -z "$since" ] && since="$(gh issue view "$1" --json createdAt --jq .createdAt)"
+    iso_to_epoch "$since"
+}
+
+# --- --health-report: is the refresh pipeline broken? -------------------------
+# Emits three `key=value` lines on stdout (alert/kind/detail); always exits 0 —
+# a report, not a gate, mirroring `check-docs --staleness-report`. The audit
+# workflow appends them to $GITHUB_OUTPUT verbatim.
+health_report() {
+    local alert=false kind="" detail="" report count pr_json pr_num red orphan age_h
+    report="$(mktemp)"; trap 'rm -f "$report"' RETURN
+    "$MAIN/bin/check-docs" --staleness-report > "$report"
+    count="$(jq 'length' "$report")"
+    local issue_num="${1:-}"
+
+    if [ "${count:-0}" -gt 0 ] && [ -n "$issue_num" ]; then
+        pr_json="$(gh pr list --state open --json number,headRefName,url \
+          --jq '[.[] | select(.headRefName | startswith("docs-stale-refresh-"))] | .[0] // empty')"
+        if [ -n "$pr_json" ]; then
+            # An open PR is the DESIGNED steady state (auto_merge:false — the user
+            # reviews it). Only a RED check is a failure; green/pending stay silent.
+            pr_num="$(jq -r .number <<<"$pr_json")"
+            red="$(gh pr view "$pr_num" --json statusCheckRollup \
+              --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT"
+                     or .conclusion == "CANCELLED" or .conclusion == "ACTION_REQUIRED")] | length')"
+            if [ "${red:-0}" -gt 0 ]; then
+                alert=true; kind="ci-red"
+                detail="Refresh PR $(jq -r .url <<<"$pr_json") has ${red} failing check(s) — the doc refresh needs a fix before you can merge it."
+            fi
+        elif [ "$(uncovered_count "$report")" -eq 0 ]; then
+            : # a human declined a refresh covering these docs — stay quiet
+        elif orphan="$(orphaned_refresh_branch)"; [ -n "$orphan" ]; then
+            alert=true; kind="died"
+            detail="Refresh branch ${orphan} is on origin with no PR — the doc-fix run died mid-flight. Log: ls -t /tmp/docfix-run-*.log | head -1"
+        else
+            age_h=$(( ( $(date -u +%s) - $(issue_episode_epoch "$issue_num") ) / 3600 ))
+            if [ "$age_h" -ge 36 ]; then
+                alert=true; kind="never-ran"
+                detail="No refresh PR has been opened in ${age_h}h. The Mac poll is probably not installed: cd ~/GitHub/IBL5 && git pull && bin/docfix-poll --install-schedule"
+            fi
+        fi
+    fi
+    printf 'alert=%s\nkind=%s\ndetail=%s\n' "$alert" "$kind" "$detail"
+}
+
+if [ "$SCHEDULE_ACTION" = "health" ]; then
+    health_report "${HEALTH_ISSUE_ARG:-}"
+    exit 0
+fi
+
+# --- The poll -----------------------------------------------------------------
+cd "$MAIN"
+
+REPORT="$(mktemp)"
+trap 'rm -f "$REPORT"' EXIT
+"$MAIN/bin/check-docs" --staleness-report > "$REPORT"
+COUNT="$(jq 'length' "$REPORT")"
+SIG="$(jq -r '.[].path' "$REPORT" | sort | paste -sd, -)"
+[ "$COUNT" -eq 0 ] && { echo "docfix-poll: no stale docs — nothing to do."; exit 0; }
+
+# Reap leftovers whose PR is finished (merged or declined). An OPEN PR's branch
+# stays: it is waiting on the user's review, which is the designed steady state.
+while IFS= read -r branch; do
+    [ -n "$branch" ] || continue
+    state="$(gh pr view "$branch" --json state -q .state 2>/dev/null || true)"
+    case "$state" in
+        MERGED|CLOSED)
+            # Named mode needs the worktree DIRECTORY (bin/cleanup:695-704 → exit 1
+            # without it). post-plan leaves it in place, so that's the happy path;
+            # tolerate a nonzero exit and let the nightly alert report a real stall.
+            "$MAIN/bin/cleanup" "$branch" \
+                && echo "docfix-poll: reaped '$branch' (PR $state)." \
+                || echo "docfix-poll: could not reap '$branch' — leaving it." >&2 ;;
+        *)  echo "docfix-poll: leaving '$branch' (PR state: ${state:-none})." ;;
+    esac
+done < <(git -C "$MAIN" branch --list 'docs-stale-refresh-*' --format='%(refname:short)')
+
+# Did a human already decline a refresh COVERING this exact stale set?
+UNCOVERED="$(uncovered_count "$REPORT")"
+if [ "$UNCOVERED" -eq 0 ]; then
+    echo "docfix-poll: a human declined a refresh covering all $COUNT stale doc(s) — staying quiet."
+    exit 0
+fi
+
+ISSUE_NUM="$(gh issue list --label stale-docs --state open --json number \
+              --jq '.[0].number // empty')"
+if [ -z "$ISSUE_NUM" ]; then
+    echo "docfix-poll: $COUNT stale doc(s) but no open stale-docs issue — the audit owns issue creation; skipping."
+    exit 0
+fi
+
+echo "docfix-poll: $COUNT stale doc(s), issue #$ISSUE_NUM — firing bin/docfix-run."
+"$MAIN/bin/docfix-run" "$ISSUE_NUM" "$SIG"   # no `exec`: it would skip the EXIT trap

--- a/bin/docfix-poll
+++ b/bin/docfix-poll
@@ -182,7 +182,8 @@ issue_episode_epoch() {   # $1 = issue number
 health_report() {
     local alert=false kind="" detail="" report count pr_json pr_num red orphan age_h
     report="$(mktemp)"; trap 'rm -f "$report"' RETURN
-    "$MAIN/bin/check-docs" --staleness-report > "$report"
+    "$MAIN/bin/check-docs" --staleness-report > "$report" \
+        || { printf 'alert=false\nkind=\ndetail=\n'; return 0; }
     count="$(jq 'length' "$report")"
     local issue_num="${1:-}"
 

--- a/bin/docfix-run
+++ b/bin/docfix-run
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 #
 # bin/docfix-run <issue-num> <sig> — Mac-side headless stale-docs remediation launcher.
-# Fired by the `docfix` job of .github/workflows/doc-freshness-audit.yml on a
-# self-hosted macOS runner when the nightly audit reports a NEW/CHANGED stale set.
-# Creates a worktree, seeds an auto_merge:false hold plan, and launches a detached
-# headless Claude run that refreshes exactly the stale docs and opens a PR (held for
-# human merge) that Closes the stale-docs issue.
+# Fired by bin/docfix-poll (launchd, daily) when the nightly audit has flagged a
+# stale set. Creates a worktree, seeds an auto_merge:false hold plan, and launches
+# a detached headless Claude run that refreshes exactly the stale docs and opens a
+# PR (held for human merge) that Closes the stale-docs issue.
 #
 # Detach mechanism cloned in structure from bin/post-plan-now:71-109 (launchd
-# RunAtLoad one-shot) — a plain `nohup … &` from the runner dies with the job.
+# RunAtLoad one-shot) — a plain `nohup … &` from the poll dies with it.
 #
 # Usage: bin/docfix-run <issue-num> <sig>
 
@@ -23,11 +22,10 @@ if [ -z "$ISSUE_NUM" ] || [ -z "$SIG" ]; then
 fi
 
 # --- 2. Anchor to the CANONICAL main checkout (NOT $0) ------------------------
-# The self-hosted runner invokes us from its ephemeral, shallow _work checkout;
-# $0-relative resolution would misroute wt-new under _work (wrong layout, no
-# usable origin/master, reclaimed mid-run). Anchor to the real main checkout —
-# exactly as workflow-continuity says wt-new is run FROM it. IBL5_MAIN override
-# lets bin/test-docfix-run point this at its sandbox.
+# The poller invokes us from $MAIN itself, but launchd sets an arbitrary cwd, and
+# bin/test-docfix-run needs the IBL5_MAIN override. Anchor to the real main
+# checkout — exactly as workflow-continuity says wt-new is run FROM it. IBL5_MAIN
+# override lets bin/test-docfix-run point this at its sandbox.
 MAIN="${IBL5_MAIN:-/Users/ajaynicolas/GitHub/IBL5}"
 cd "$MAIN"
 source "$MAIN/bin/lib/git-helpers.sh"   # worktrees_parent_dir
@@ -62,7 +60,7 @@ nightly Doc Freshness Audit flagged (issue #$ISSUE_NUM). Held for human merge.
 
 ## Automouse Hold Justification
 
-auto_merge: false — this PR is opened autonomously by a self-hosted-runner Claude
+auto_merge: false — this PR is opened autonomously by a launchd-scheduled Claude
 run with no human in the loop, and it modifies documentation a human should read
 before it lands. /post-plan Phase 6.5 condition (7) reads this frontmatter and
 refuses to arm auto-merge, leaving the PR open for a human to merge.

--- a/bin/test-docfix-run
+++ b/bin/test-docfix-run
@@ -1,59 +1,124 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
-# bin/test-docfix-run — regression guard for bin/docfix-run plumbing (autonomy lever 3).
-# Runs docfix-run in a mktemp sandbox fake-repo against git/gh/launchctl shims and a
-# wt-new stub — nothing real is launched or worktree'd. Asserts plist/prompt/plan
-# composition, dedupe skip, and empty-arg rejection, plus a static gate assertion on
-# the workflow. Run: bin/test-docfix-run  (exit 0 = all pass).
+# bin/test-docfix-run — regression guard for bin/docfix-run and bin/docfix-poll
+# (autonomy lever 3). Runs both scripts in a mktemp sandbox against shims —
+# nothing real is launched or worktree'd. Guards: plist/prompt/plan composition,
+# dedupe skip, empty-arg rejection, poll logic (reap, decline, fire), and the
+# health predicate (all three ALERT branches + every silent one).
+# Run: bin/test-docfix-run  (exit 0 = all pass).
 set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 REAL_DOCFIX="$REPO_ROOT/bin/docfix-run"
+REAL_POLL="$REPO_ROOT/bin/docfix-poll"
 WORKFLOW="$REPO_ROOT/.github/workflows/doc-freshness-audit.yml"
+NOTIFY_WORKFLOW="$REPO_ROOT/.github/workflows/docs-refreshed-notify.yml"
 FAILED=0
 ok()   { echo "ok: $1"; }
 bad()  { echo "FAIL: $1"; FAILED=1; }
 
 # build_sandbox -> prints sandbox path with fake-repo + shims wired.
+# Shim convention: every SHIM_* variable holds POST-jq output — the shims ignore
+# --jq entirely. A shim that must return nothing returns "" not "[]".
 build_sandbox() {
     local SB; SB="$(mktemp -d)"
     mkdir -p "$SB/bin/lib" "$SB/home/Library/LaunchAgents" "$SB/home/.claude/plans" "$SB/shim"
     # NOTE: do NOT symlink docfix-run in — the test drives the REAL script with
-    # IBL5_MAIN=$SB, exercising prod's own anchoring code (a $0-relative regression
-    # would then be caught, not masked). Only wt-new + git-helpers are stubbed.
+    # IBL5_MAIN=$SB, exercising prod's own anchoring code.
     printf 'worktrees_parent_dir(){ echo "%s/wts"; }\n' "$SB" > "$SB/bin/lib/git-helpers.sh"
     cat > "$SB/bin/wt-new" <<'W'
 #!/usr/bin/env bash
 mkdir -p "$(cd "$(dirname "$0")/.." && pwd)/wts/$1/ibl5"
 W
     chmod +x "$SB/bin/wt-new"
-    # git shim: dedupe consults `git -C <root> branch --list <pat>`
+
+    # Stubs for helpers the poll calls via "$MAIN/bin/<name>".
+    # check-docs: prints SHIM_STALE_JSON (post-jq: a JSON array of {path} objects).
+    printf '#!/usr/bin/env bash\nprintf "%%s" "${SHIM_STALE_JSON:-[]}"\n' \
+        > "$SB/bin/check-docs"
+    # cleanup: logs branch to cleanup-calls, exits SHIM_CLEANUP_RC (default 0).
+    printf '#!/usr/bin/env bash\necho "$1" >> "%s/cleanup-calls"\nexit "${SHIM_CLEANUP_RC:-0}"\n' \
+        "$SB" > "$SB/bin/cleanup"
+    # docfix-run: logs "issue|sig" to docfix-calls.
+    printf '#!/usr/bin/env bash\necho "$1|$2" >> "%s/docfix-calls"\n' \
+        "$SB" > "$SB/bin/docfix-run"
+    chmod +x "$SB/bin/check-docs" "$SB/bin/cleanup" "$SB/bin/docfix-run"
+
+    # git shim: seam for ls-remote (died branch) AND branch --list (reap + dedupe).
+    # branch: printf with newline so `while IFS= read -r` picks up the last line.
+    # ls-remote: printf without newline when empty = no branches (a bare \n would
+    #   give orphaned_refresh_branch a spurious empty branch to check).
     cat > "$SB/shim/git" <<'G'
 #!/usr/bin/env bash
-for a in "$@"; do [ "$a" = "branch" ] && { printf '%s' "${SHIM_BRANCH_OUT:-}"; exit 0; }; done
-exit 0
+if [ "$1" = "ls-remote" ]; then
+    [ -n "${SHIM_LS_REMOTE:-}" ] && printf '%s\n' "$SHIM_LS_REMOTE" || true
+    exit 0
+fi
+for a in "$@"; do
+    [ "$a" = "branch" ] && { [ -n "${SHIM_BRANCH_OUT:-}" ] && printf '%s\n' "$SHIM_BRANCH_OUT" || true; exit 0; }
+done
+exec /usr/bin/git "$@"
 G
-    # gh shim: dedupe consults `gh pr list … --jq '.[].headRefName'`
-    printf '#!/usr/bin/env bash\nprintf "%%s" "${SHIM_PR_OUT:-}"\nexit 0\n' > "$SB/shim/gh"
+
+    # gh shim: every SHIM_* holds post-jq output; the shim ignores --jq.
+    cat > "$SB/shim/gh" <<'H'
+#!/usr/bin/env bash
+args="$*"
+case "$1 $2" in
+  "issue list") printf '%s' "${SHIM_ISSUE_OUT:-}" ;;
+  "issue view")
+      case "$args" in
+        *"--json body"*) printf '%s' "${SHIM_ISSUE_BODY:-}" ;;
+        *)               printf '%s' "${SHIM_ISSUE_CREATED:-}" ;;
+      esac ;;
+  "pr list")
+      case "$args" in
+        *"--state all"*)    printf '%s' "${SHIM_PR_FOR_BRANCH:-0}" ;;
+        *"--state closed"*) printf '%s' "${SHIM_PR_CLOSED:-[]}" ;;
+        *)                  printf '%s' "${SHIM_PR_OPEN:-}" ;;
+      esac ;;
+  "pr view")
+      case "$args" in
+        *statusCheckRollup*) printf '%s' "${SHIM_PR_ROLLUP:-0}" ;;
+        *)                   printf '%s' "${SHIM_PR_STATE:-}" ;;
+      esac ;;
+esac
+exit 0
+H
     printf '#!/usr/bin/env bash\nexit 0\n' > "$SB/shim/launchctl"
     chmod +x "$SB/shim/git" "$SB/shim/gh" "$SB/shim/launchctl"
     printf '%s' "$SB"
 }
 
-# run_docfix <sandbox> <branch-out> <pr-out> <issue> <sig> -> runs, echoes "rc=<code>"
-# Drives the REAL bin/docfix-run with IBL5_MAIN=$SB so prod's anchoring code is
-# what gets exercised (not a $0 accident).
+# run_docfix: drives the REAL bin/docfix-run with IBL5_MAIN=$SB.
+# $2=SHIM_BRANCH_OUT  $3=SHIM_PR_OPEN (renamed from old SHIM_PR_OUT)
 run_docfix() {
     local SB="$1"
     IBL5_MAIN="$SB" HOME="$SB/home" PATH="$SB/shim:$PATH" \
-        SHIM_BRANCH_OUT="$2" SHIM_PR_OUT="$3" \
+        SHIM_BRANCH_OUT="$2" SHIM_PR_OPEN="$3" \
         "$REAL_DOCFIX" "$4" "$5" >/dev/null 2>&1
     echo "rc=$?"
 }
+
+# run_poll: drives the REAL bin/docfix-poll (poll path) with IBL5_MAIN=$SB.
+# Caller sets SHIM_* vars before calling (they're inherited by the subshell).
+run_poll() {
+    local SB="$1"
+    ( IBL5_MAIN="$SB" HOME="$SB/home" PATH="$SB/shim:$SB/bin:$PATH" \
+      "$REAL_POLL" >/dev/null 2>&1 ) || true
+}
+
+# run_health: drives bin/docfix-poll --health-report <issue>; prints output.
+run_health() {
+    local SB="$1" ISSUE="${2:-}"
+    IBL5_MAIN="$SB" HOME="$SB/home" PATH="$SB/shim:$SB/bin:$PATH" \
+        "$REAL_POLL" --health-report "$ISSUE" 2>/dev/null
+}
+
 plist_of() { ls "$1/home/Library/LaunchAgents/"*.plist 2>/dev/null | head -1; }
 plan_of()  { ls "$1/home/.claude/plans/docs-stale-refresh-"*.md 2>/dev/null | head -1; }
 
-# --- Case 1 + 2: happy path composes plist + prompt + hold plan ---------------
+# --- Cases 1-5: bin/docfix-run launcher ----------------------------------------
 SB="$(build_sandbox)"
 run_docfix "$SB" "" "" "4242" "ibl5/docs/foo.md,README.md" >/dev/null
 P="$(plist_of "$SB")"; PLAN="$(plan_of "$SB")"
@@ -69,7 +134,6 @@ P="$(plist_of "$SB")"; PLAN="$(plan_of "$SB")"
   && ok "(2) held plan seeded with auto_merge:false + hold section" \
   || bad "(2) hold plan seeding"
 
-# --- Case 3: dedupe skips (branch OR PR present) — no plist written ------------
 SB="$(build_sandbox)"
 run_docfix "$SB" "docs-stale-refresh-20260704" "" "1" "a.md" >/dev/null
 [ -z "$(plist_of "$SB")" ] && ok "(3a) dedupe-skip on existing branch (no plist)" \
@@ -79,7 +143,6 @@ run_docfix "$SB" "" "docs-stale-refresh-20260703" "1" "a.md" >/dev/null
 [ -z "$(plist_of "$SB")" ] && ok "(3b) dedupe-skip on open PR head (no plist)" \
                            || bad "(3b) dedupe PR skip"
 
-# --- Case 4 + 5: empty-arg rejection (nonzero, nothing written) ---------------
 SB="$(build_sandbox)"
 [ "$(run_docfix "$SB" "" "" "" "a.md")" != "rc=0" ] && [ -z "$(plist_of "$SB")" ] \
   && ok "(4) empty issue-num rejected" || bad "(4) empty issue-num not rejected"
@@ -87,12 +150,253 @@ SB="$(build_sandbox)"
 [ "$(run_docfix "$SB" "" "" "42" "")" != "rc=0" ] && [ -z "$(plist_of "$SB")" ] \
   && ok "(5) empty sig rejected" || bad "(5) empty sig not rejected"
 
-# --- Case 6: workflow-gating static assertion ---------------------------------
-{ grep -q "if: needs.audit.outputs.notify == 'true'" "$WORKFLOW" \
-    && grep -qF 'bin/docfix-run "${{ needs.audit.outputs.issue-num }}" "${{ needs.audit.outputs.sig }}"' "$WORKFLOW" \
-    && grep -qF 'issue-num: ${{ steps.issue.outputs.issue-num }}' "$WORKFLOW"; } \
-  && ok "(6) docfix job gated on notify + passes issue-num & sig; audit exposes issue-num" \
-  || bad "(6) workflow gate/output wiring"
+# --- Case 6: doc-freshness-audit.yml static assertions (NEGATIVE) -------------
+{ ! grep -q 'self-hosted' "$WORKFLOW" \
+    && ! grep -q 'docfix:' "$WORKFLOW" \
+    && ! grep -qF 'bin/docfix-run' "$WORKFLOW" \
+    && grep -q 'pull-requests: read' "$WORKFLOW" \
+    && grep -qF "steps.health.outputs.alert == 'true'" "$WORKFLOW" \
+    && ! grep -qF "notify == 'true'" "$WORKFLOW" \
+    && ! grep -q "fail-on-delivery" "$WORKFLOW"; } \
+  && ok "(6) audit: no self-hosted/docfix/docfix-run; health.alert gate; pull-requests:read; no fail-on-delivery" \
+  || bad "(6) audit static assertions"
+
+# --- Case 7: docs-refreshed-notify.yml static assertion -----------------------
+{ grep -q "github.event.pull_request.head.repo.full_name == github.repository" "$NOTIFY_WORKFLOW" \
+    && grep -q "startsWith(github.event.pull_request.head.ref, 'docs-stale-refresh-')" "$NOTIFY_WORKFLOW"; } \
+  && ok "(7) docs-refreshed-notify ANDs same-repo guard and head prefix" \
+  || bad "(7) docs-refreshed-notify static assertion"
+
+# --- Case 8: carry-forward — bin/docfix-run still has auto_merge:false --------
+{ grep -q '^auto_merge: false$' "$REAL_DOCFIX" \
+    && grep -q '## Automouse Hold Justification' "$REAL_DOCFIX"; } \
+  && ok "(8) bin/docfix-run: auto_merge:false and hold section preserved" \
+  || bad "(8) carry-forward check"
+
+# --- Case 9: --print-schedule -------------------------------------------------
+SB="$(build_sandbox)"
+SCHED="$(IBL5_MAIN="$SB" HOME="$SB/home" PATH="$SB/shim:$PATH" \
+    "$REAL_POLL" --print-schedule 2>&1)"
+{ echo "$SCHED" | grep -q 'StartCalendarInterval' \
+    && echo "$SCHED" | grep -q '<integer>9</integer>' \
+    && echo "$SCHED" | grep -q '<integer>17</integer>' \
+    && echo "$SCHED" | grep -qF "<string>$SB/bin/docfix-poll</string>"; } \
+  && ok "(9) --print-schedule emits Hour 9 / Minute 17 and MAIN-checkout Program" \
+  || bad "(9) --print-schedule"
+
+# --- Case 10: --install-schedule / --uninstall-schedule -----------------------
+SB="$(build_sandbox)"
+PLIST_F="$SB/home/Library/LaunchAgents/com.ibl5.docfix-poll.plist"
+# Negative: no executable at $SB/bin/docfix-poll
+IBL5_MAIN="$SB" HOME="$SB/home" PATH="$SB/shim:$PATH" \
+    "$REAL_POLL" --install-schedule >/dev/null 2>&1 && _RC=0 || _RC=$?
+{ [ "$_RC" -ne 0 ] && [ ! -f "$PLIST_F" ]; } \
+  && ok "(10) --install-schedule exits nonzero and writes no plist without executable" \
+  || bad "(10) --install-schedule negative"
+# Positive: create executable
+printf '#!/usr/bin/env bash\n' > "$SB/bin/docfix-poll"; chmod +x "$SB/bin/docfix-poll"
+IBL5_MAIN="$SB" HOME="$SB/home" PATH="$SB/shim:$PATH" \
+    "$REAL_POLL" --install-schedule >/dev/null 2>&1 && _RC=0 || _RC=$?
+{ [ "$_RC" -eq 0 ] && [ -f "$PLIST_F" ]; } \
+  && ok "(10) --install-schedule exits 0 and writes plist when program exists" \
+  || bad "(10) --install-schedule positive"
+# Uninstall
+IBL5_MAIN="$SB" HOME="$SB/home" PATH="$SB/shim:$PATH" \
+    "$REAL_POLL" --uninstall-schedule >/dev/null 2>&1
+[ ! -f "$PLIST_F" ] \
+  && ok "(10) --uninstall-schedule removes plist (idempotent)" \
+  || bad "(10) --uninstall-schedule"
+
+# --- Poll cases: shared stale fixture -----------------------------------------
+STALE_TWO='[{"path":"b.md"},{"path":"a.md"}]'
+STALE_ONE='[{"path":"a.md"}]'
+
+# Case 11: happy path — fires launcher with SELF-DERIVED sig and issue number
+SB="$(build_sandbox)"
+SHIM_STALE_JSON="$STALE_TWO" SHIM_ISSUE_OUT="77" SHIM_PR_CLOSED='[]' \
+    run_poll "$SB"
+{ [ -f "$SB/docfix-calls" ] && grep -qF "77|a.md,b.md" "$SB/docfix-calls"; } \
+  && ok "(11) poll fires launcher with self-derived sig (sorted) and issue number" \
+  || bad "(11) poll happy path"
+
+# Case 12: NEGATIVE — empty staleness report (exit 0 from check-docs) fires nothing
+SB="$(build_sandbox)"
+SHIM_STALE_JSON='[]' SHIM_ISSUE_OUT="77" run_poll "$SB"
+[ ! -f "$SB/docfix-calls" ] \
+  && ok "(12) poll fires nothing when staleness report is empty (exit 0 is not a gate)" \
+  || bad "(12) poll empty report"
+
+# Case 13: NEGATIVE — no open stale-docs issue → fires nothing, no empty issue-num
+SB="$(build_sandbox)"
+SHIM_STALE_JSON="$STALE_ONE" SHIM_ISSUE_OUT="" SHIM_PR_CLOSED='[]' run_poll "$SB"
+[ ! -f "$SB/docfix-calls" ] \
+  && ok "(13) poll fires nothing when no open stale-docs issue exists" \
+  || bad "(13) poll no-issue guard"
+
+# Case 14: NEGATIVE, decline-respect — closed PR covers full stale set → quiet
+SB="$(build_sandbox)"
+SHIM_STALE_JSON="$STALE_ONE" SHIM_ISSUE_OUT="77" SHIM_PR_CLOSED='["a.md"]' \
+    run_poll "$SB"
+[ ! -f "$SB/docfix-calls" ] \
+  && ok "(14) poll stays silent when a declined PR covers all stale docs" \
+  || bad "(14) poll decline-respect"
+
+# Case 15: auto-resume — stale set grown beyond declined set → fires
+SB="$(build_sandbox)"
+SHIM_STALE_JSON="$STALE_TWO" SHIM_ISSUE_OUT="77" SHIM_PR_CLOSED='["a.md"]' \
+    run_poll "$SB"
+{ [ -f "$SB/docfix-calls" ] && grep -qF "77|" "$SB/docfix-calls"; } \
+  && ok "(15) poll resumes when stale set grows beyond the declined set" \
+  || bad "(15) poll auto-resume"
+
+# Case 16a: reap MERGED branch
+SB="$(build_sandbox)"
+SHIM_STALE_JSON="$STALE_ONE" SHIM_ISSUE_OUT="77" SHIM_PR_CLOSED='[]' \
+SHIM_BRANCH_OUT="docs-stale-refresh-merged" SHIM_PR_STATE="MERGED" \
+    run_poll "$SB"
+{ [ -f "$SB/cleanup-calls" ] && grep -q "docs-stale-refresh-merged" "$SB/cleanup-calls"; } \
+  && ok "(16a) poll reaps a MERGED leftover branch" \
+  || bad "(16a) reap MERGED"
+
+# Case 16b: reap CLOSED-unmerged branch
+SB="$(build_sandbox)"
+SHIM_STALE_JSON="$STALE_ONE" SHIM_ISSUE_OUT="77" SHIM_PR_CLOSED='[]' \
+SHIM_BRANCH_OUT="docs-stale-refresh-closed" SHIM_PR_STATE="CLOSED" \
+    run_poll "$SB"
+{ [ -f "$SB/cleanup-calls" ] && grep -q "docs-stale-refresh-closed" "$SB/cleanup-calls"; } \
+  && ok "(16b) poll reaps a CLOSED-unmerged leftover branch" \
+  || bad "(16b) reap CLOSED"
+
+# Case 16c: NEGATIVE — OPEN PR's branch is never reaped; poll still reaches launcher
+SB="$(build_sandbox)"
+SHIM_STALE_JSON="$STALE_ONE" SHIM_ISSUE_OUT="77" SHIM_PR_CLOSED='[]' \
+SHIM_BRANCH_OUT="docs-stale-refresh-open" SHIM_PR_STATE="OPEN" \
+    run_poll "$SB"
+{ [ ! -f "$SB/cleanup-calls" ] && [ -f "$SB/docfix-calls" ]; } \
+  && ok "(16c) OPEN PR's branch is not reaped; poll still reaches launcher" \
+  || bad "(16c) no-reap OPEN + launcher reaches"
+
+# Case 16d: failed cleanup does not abort the poll; launcher still fires
+SB="$(build_sandbox)"
+SHIM_STALE_JSON="$STALE_ONE" SHIM_ISSUE_OUT="77" SHIM_PR_CLOSED='[]' \
+SHIM_BRANCH_OUT="docs-stale-refresh-fail" SHIM_PR_STATE="CLOSED" SHIM_CLEANUP_RC=1 \
+    run_poll "$SB"
+{ [ -f "$SB/cleanup-calls" ] && [ -f "$SB/docfix-calls" ]; } \
+  && ok "(16d) failed cleanup (rc=1) does not abort poll; launcher still fires" \
+  || bad "(16d) cleanup failure tolerated"
+
+# --- Health-report helper: generate portable timestamps -----------------------
+_ts_ago() {  # $1=seconds_ago -> ISO-8601 UTC timestamp
+    local epoch; epoch=$(( $(date -u +%s) - $1 ))
+    date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ
+}
+TS_40H="$(_ts_ago $(( 40*3600 )))"
+TS_20H="$(_ts_ago $(( 20*3600 )))"
+TS_2H="$(_ts_ago $(( 2*3600 )))"
+TS_30D="$(_ts_ago $(( 30*24*3600 )))"
+
+PR_OBJ='{"number":42,"headRefName":"docs-stale-refresh-test","url":"https://example.com/pull/42"}'
+
+# --- Cases 17a-17e: --health-report alert branches ---------------------------
+
+# Case 17a: ALERT ci-red — open PR with failing checks
+SB="$(build_sandbox)"
+OUT="$(SHIM_STALE_JSON="$STALE_ONE" SHIM_PR_OPEN="$PR_OBJ" SHIM_PR_ROLLUP=2 \
+    run_health "$SB" 77)"
+{ echo "$OUT" | grep -q 'alert=true' \
+    && echo "$OUT" | grep -q 'kind=ci-red' \
+    && echo "$OUT" | grep -q 'https://example.com/pull/42'; } \
+  && ok "(17a) health: ALERT ci-red on open PR with failing checks" \
+  || bad "(17a) health ci-red"
+
+# Case 17b: NEGATIVE no-nag — open PR with green CI stays silent
+SB="$(build_sandbox)"
+OUT="$(SHIM_STALE_JSON="$STALE_ONE" SHIM_PR_OPEN="$PR_OBJ" SHIM_PR_ROLLUP=0 \
+    run_health "$SB" 77)"
+{ echo "$OUT" | grep -q 'alert=false'; } \
+  && ok "(17b) health: no alert on green/pending open PR (no-nag property)" \
+  || bad "(17b) health no-nag"
+
+# Case 17c: ALERT died — refresh branch on origin has no PR of any state
+SB="$(build_sandbox)"
+LS="abcdef123	refs/heads/docs-stale-refresh-x"
+OUT="$(SHIM_STALE_JSON="$STALE_ONE" SHIM_PR_OPEN="" SHIM_PR_CLOSED='[]' \
+    SHIM_LS_REMOTE="$LS" SHIM_PR_FOR_BRANCH=0 \
+    run_health "$SB" 77)"
+{ echo "$OUT" | grep -q 'alert=true' \
+    && echo "$OUT" | grep -q 'kind=died' \
+    && echo "$OUT" | grep -q 'docs-stale-refresh-x'; } \
+  && ok "(17c) health: ALERT died on orphan branch with no PR" \
+  || bad "(17c) health died"
+
+# Case 17d: ALERT never-ran — no PR, no branch, stale-since 40h ago
+SB="$(build_sandbox)"
+BODY="<!-- stale-since: $TS_40H -->"
+OUT="$(SHIM_STALE_JSON="$STALE_ONE" SHIM_PR_OPEN="" SHIM_PR_CLOSED='[]' \
+    SHIM_LS_REMOTE="" SHIM_ISSUE_BODY="$BODY" \
+    run_health "$SB" 77)"
+{ echo "$OUT" | grep -q 'alert=true' \
+    && echo "$OUT" | grep -q 'kind=never-ran' \
+    && echo "$OUT" | grep -q 'install-schedule'; } \
+  && ok "(17d) health: ALERT never-ran after 36h grace (40h marker)" \
+  || bad "(17d) health never-ran"
+
+# Case 17e: NEGATIVE — same as 17d but 20h marker stays below grace
+SB="$(build_sandbox)"
+BODY="<!-- stale-since: $TS_20H -->"
+OUT="$(SHIM_STALE_JSON="$STALE_ONE" SHIM_PR_OPEN="" SHIM_PR_CLOSED='[]' \
+    SHIM_LS_REMOTE="" SHIM_ISSUE_BODY="$BODY" \
+    run_health "$SB" 77)"
+{ echo "$OUT" | grep -q 'alert=false'; } \
+  && ok "(17e) health: no alert within 36h grace (20h marker)" \
+  || bad "(17e) health grace"
+
+# --- Cases 18a-18d: false-alarm negatives -------------------------------------
+
+# Case 18a: NEGATIVE — empty stale set → alert=false regardless of everything else
+SB="$(build_sandbox)"
+OUT="$(SHIM_STALE_JSON='[]' SHIM_PR_OPEN="$PR_OBJ" SHIM_PR_ROLLUP=99 \
+    run_health "$SB" 77)"
+{ echo "$OUT" | grep -q 'alert=false'; } \
+  && ok "(18a) health: no alert on empty stale set" \
+  || bad "(18a) health empty set"
+
+# Case 18b: NEGATIVE, decline-respect — declined branch present but set covered → quiet
+# Decline-before-died ordering: if decline check short-circuits, the orphan branch
+# must NOT trigger a died alert.
+SB="$(build_sandbox)"
+LS="abcdef123	refs/heads/docs-stale-refresh-declined"
+OUT="$(SHIM_STALE_JSON="$STALE_ONE" SHIM_PR_OPEN="" SHIM_PR_CLOSED='["a.md"]' \
+    SHIM_LS_REMOTE="$LS" \
+    run_health "$SB" 77)"
+{ echo "$OUT" | grep -q 'alert=false'; } \
+  && ok "(18b) health: no alert when declined PR covers set even with lingering branch" \
+  || bad "(18b) health decline-before-died ordering"
+
+# Case 18c: NEGATIVE — declined branch (partial decline) has a closed PR; not orphaned
+# The stale set grew past the decline, so uncovered_count > 0, but the branch still
+# has a PR → not orphaned → died must NOT fire. stale-since ~1h → never-ran silent.
+SB="$(build_sandbox)"
+LS="abcdef123	refs/heads/docs-stale-refresh-partial"
+BODY1H="<!-- stale-since: $TS_2H -->"
+OUT="$(SHIM_STALE_JSON="$STALE_TWO" SHIM_PR_OPEN="" SHIM_PR_CLOSED='["a.md"]' \
+    SHIM_LS_REMOTE="$LS" SHIM_PR_FOR_BRANCH=1 SHIM_ISSUE_BODY="$BODY1H" \
+    run_health "$SB" 77)"
+{ echo "$OUT" | grep -q 'alert=false'; } \
+  && ok "(18c) health: no false died on declined PR's lingering branch (has closed PR)" \
+  || bad "(18c) health died must not fire on declined branch"
+
+# Case 18d: NEGATIVE, episode anchor — 2h stale-since marker beats 30d createdAt
+# A long-lived issue with a recent episode start must not fire never-ran.
+SB="$(build_sandbox)"
+BODY2H="<!-- stale-since: $TS_2H -->"
+OUT="$(SHIM_STALE_JSON="$STALE_ONE" SHIM_PR_OPEN="" SHIM_PR_CLOSED='[]' \
+    SHIM_LS_REMOTE="" SHIM_ISSUE_BODY="$BODY2H" SHIM_ISSUE_CREATED="$TS_30D" \
+    run_health "$SB" 77)"
+{ echo "$OUT" | grep -q 'alert=false'; } \
+  && ok "(18d) health: stale-since marker (2h) beats createdAt (30d) — no false never-ran" \
+  || bad "(18d) health episode anchor"
 
 if [ "$FAILED" -eq 0 ]; then echo "All docfix-run checks passed."; else echo "Some docfix-run checks FAILED."; fi
 exit "$FAILED"

--- a/bin/test-docfix-run
+++ b/bin/test-docfix-run
@@ -33,8 +33,9 @@ W
     chmod +x "$SB/bin/wt-new"
 
     # Stubs for helpers the poll calls via "$MAIN/bin/<name>".
-    # check-docs: prints SHIM_STALE_JSON (post-jq: a JSON array of {path} objects).
-    printf '#!/usr/bin/env bash\nprintf "%%s" "${SHIM_STALE_JSON:-[]}"\n' \
+    # check-docs: prints SHIM_STALE_JSON (post-jq: a JSON array of {path} objects);
+    # exits SHIM_CHECKDOCS_RC (default 0) for the health fail-quiet contract cases.
+    printf '#!/usr/bin/env bash\nprintf "%%s" "${SHIM_STALE_JSON:-[]}"\nexit "${SHIM_CHECKDOCS_RC:-0}"\n' \
         > "$SB/bin/check-docs"
     # cleanup: logs branch to cleanup-calls, exits SHIM_CLEANUP_RC (default 0).
     printf '#!/usr/bin/env bash\necho "$1" >> "%s/cleanup-calls"\nexit "${SHIM_CLEANUP_RC:-0}"\n' \
@@ -63,6 +64,8 @@ G
     # gh shim: every SHIM_* holds post-jq output; the shim ignores --jq.
     cat > "$SB/shim/gh" <<'H'
 #!/usr/bin/env bash
+# SHIM_GH_FAIL: simulate a transient gh outage (rate limit/network) — every call fails.
+[ -n "${SHIM_GH_FAIL:-}" ] && exit 1
 args="$*"
 case "$1 $2" in
   "issue list") printf '%s' "${SHIM_ISSUE_OUT:-}" ;;
@@ -397,6 +400,28 @@ OUT="$(SHIM_STALE_JSON="$STALE_ONE" SHIM_PR_OPEN="" SHIM_PR_CLOSED='[]' \
 { echo "$OUT" | grep -q 'alert=false'; } \
   && ok "(18d) health: stale-since marker (2h) beats createdAt (30d) — no false never-ran" \
   || bad "(18d) health episode anchor"
+
+# --- Cases 18e-18f: the always-exits-0 contract under set -euo pipefail -------
+# health_report must emit all 3 key=value lines and exit 0 even when a dependency
+# dies mid-function — otherwise steps.health.outputs.alert is never written and
+# every downstream DM step is silently skipped.
+
+# Case 18e: check-docs itself fails → guarded early-return (alert=false, 3 lines, rc 0)
+SB="$(build_sandbox)"
+OUT="$(SHIM_CHECKDOCS_RC=1 run_health "$SB" 77)"; RC=$?
+{ [ "$RC" -eq 0 ] && [ "$(printf '%s\n' "$OUT" | grep -c '^')" -eq 3 ] \
+    && printf '%s\n' "$OUT" | grep -q '^alert=false$'; } \
+  && ok "(18e) health: check-docs failure still prints 3 lines + exits 0" \
+  || bad "(18e) health check-docs failure contract"
+
+# Case 18f: every gh call fails mid-function (stale set nonempty, so the gh
+# branches are reached) → still 3 lines, rc 0, fail-quiet alert=false
+SB="$(build_sandbox)"
+OUT="$(SHIM_STALE_JSON="$STALE_ONE" SHIM_GH_FAIL=1 run_health "$SB" 77)"; RC=$?
+{ [ "$RC" -eq 0 ] && [ "$(printf '%s\n' "$OUT" | grep -c '^')" -eq 3 ] \
+    && printf '%s\n' "$OUT" | grep -q '^alert=false$'; } \
+  && ok "(18f) health: gh outage mid-function still prints 3 lines + exits 0" \
+  || bad "(18f) health gh outage contract"
 
 if [ "$FAILED" -eq 0 ]; then echo "All docfix-run checks passed."; else echo "Some docfix-run checks FAILED."; fi
 exit "$FAILED"

--- a/ibl5/docs/decisions/0079-stale-docs-auto-remediation.md
+++ b/ibl5/docs/decisions/0079-stale-docs-auto-remediation.md
@@ -1,11 +1,12 @@
 ---
 description: Act on the nightly stale-docs audit automatically — on a NEW/CHANGED stale set, a self-hosted macOS runner fires a headless Claude run that refreshes exactly the stale docs and opens a PR (held for human merge) that Closes the tracker issue.
-last_verified: 2026-07-04
+last_verified: 2026-07-15
 ---
 
 # ADR-0079: Autonomous stale-docs remediation via a self-hosted macOS runner
 
 **Status:** Accepted
+**Superseded by:** ADR-0086 (transport only — its human-merge posture is carried forward and still governs)
 **Date:** 2026-07-04
 
 ## Context

--- a/ibl5/docs/decisions/0086-runnerless-mac-poll-for-stale-docs-remediation.md
+++ b/ibl5/docs/decisions/0086-runnerless-mac-poll-for-stale-docs-remediation.md
@@ -1,0 +1,160 @@
+---
+description: Replace ADR-0079's self-hosted macOS runner with a launchd-scheduled Mac poll — the repo is public, so a runner label is addressable by any workflow including a fork's; the Mac pulls work from GitHub instead of GitHub pushing work onto the Mac.
+last_verified: 2026-07-15
+---
+
+# ADR-0086: Runnerless Mac poll for stale-docs remediation
+
+**Status:** Accepted
+**Date:** 2026-07-15
+**Supersedes:** ADR-0079 *Autonomous stale-docs remediation via a self-hosted macOS runner*
+(`0079-stale-docs-auto-remediation.md`) — transport only; its human-merge posture is carried forward
+deliberately.
+
+> **Numbering note.** The number 0079 is **duplicated on master**: this ADR supersedes
+> `0079-stale-docs-auto-remediation.md` (2026-07-04), **not** `0079-sha-pin-github-actions.md`
+> (2026-07-05), which is untouched and still in force. Every unqualified "ADR-0079" below means the
+> stale-docs one. The collision is pre-existing and repo-wide (0032, 0062, 0065, 0069, 0079, 0081, and
+> 0085 are each used twice); fixing it is out of scope here — renumbering would break inbound links
+> from rules and PHPStan rules that cite these numbers.
+
+## Context
+
+ADR-0079 (*stale-docs auto-remediation*) designed a pipeline: on a new or changed stale set, a `docfix`
+job running on a self-hosted macOS runner invokes `bin/docfix-run`, which launches a detached headless
+Claude run that refreshes the flagged docs and opens a PR held for human merge.
+
+**The pipeline has never fired.** No runner was ever registered — `gh api
+repos/a-jay85/IBL5/actions/runners` returns `total_count: 0` — so every `docfix` job queues until
+GitHub cancels it (runs `29334100558` and `29255223423` cancelled; `29417207057` queued). ADR-0079's
+"Operational setup" section was never executed. Zero doc-fix PRs have ever been produced; the owner
+receives a "N docs stale" DM instead of a refresh. The pipeline's *code* merged (PR #1329,
+2026-07-06); its *transport* never existed.
+
+Completing the missing install step was the obvious fix, and it is the wrong one.
+
+### ADR-0079's containment premise is false
+
+ADR-0079 states its own precondition plainly: a self-hosted runner "is only acceptable on a
+**private, single-owner repo** where all workflow code is trusted." **This repo is public**
+(`isPrivate: false`, `forkCount: 1`). The premise was false when 0079 was written, so its security
+conclusion never held.
+
+Its containment argument does not survive the correction, and it fails for a reason worth naming
+precisely, because the reasoning error is easy to repeat. ADR-0079 argued the `docfix` job is
+reachable ONLY via the `audit` job, which triggers on `schedule`/`workflow_dispatch` and never on
+`pull_request` — "so no untrusted fork PR code ever reaches the runner." That reasoning is about the
+reachability of *one job*. It is not the property that matters.
+
+**A registered runner is addressable by its labels, and labels are a repo-wide resource.** Once a
+runner is registered with `[self-hosted, macOS]`, *any* workflow in the repo can target it — including
+a workflow that does not exist yet. On a public repo, a fork PR can add a workflow declaring
+`on: pull_request` and `runs-on: [self-hosted, macOS]`, and that workflow executes arbitrary code on
+the owner's Mac. Nothing in the `audit` → `docfix` dependency constrains this; the attacker never
+touches `docfix` at all. GitHub's default fork protection requires approval only for **first-time**
+contributors — a single merged typo fix promotes a contributor permanently, after which their fork
+PRs run without further approval.
+
+The mitigations one would reach for are unavailable, verified 2026-07-15:
+
+- `actions/permissions/access` → HTTP 422: *"Access policy only applies to internal and private
+  repositories."* The very control that would scope runner access is unavailable **because** the repo
+  is public — the API refusing the request is itself confirmation of the premise error.
+- Repo-level runner groups, which could restrict which workflows may target a runner, are an
+  organization feature; this repo is owned by a personal account (`a-jay85`).
+
+Deliberately NOT cited as aggravating, though each is factually true of this repo: `allowed_actions:
+"all"`, `sha_pinning_required: false`, and `default_workflow_permissions: "write"`. None of them bear
+on this threat. A fork's workflow needs no marketplace action to run `curl … | sh` on the runner, so an
+allowlist is irrelevant; SHA-pinning **is** in fact enforced on PRs by the `pinact-check` drift-guard
+in the `gate` aggregator (ADR-0079, *SHA-pin all external GitHub Actions* — the other ADR numbered
+0079), and in any case a self-hosted runner executes a fork's job *before* any gate verdict exists, so
+a CI lint cannot prevent code execution; and a fork PR receives a read-only `GITHUB_TOKEN` regardless
+of the default-permissions setting. The vulnerability rests on label addressability alone. Listing
+unrelated settings beside it would inflate the case and invite a reader to reject the whole argument
+when one decoration is shown not to matter.
+
+## Decision
+
+**1. Transport = a launchd-scheduled poll on the Mac. The Mac pulls; GitHub never pushes.**
+
+`bin/docfix-poll` runs daily from a launchd `StartCalendarInterval` agent, derives the stale set
+locally via `bin/check-docs --staleness-report`, reads the open `stale-docs` tracker issue, and
+invokes `bin/docfix-run` itself. The `docfix` job is deleted from
+`.github/workflows/doc-freshness-audit.yml`.
+
+This **eliminates the vulnerability class rather than mitigating it**: with no runner registered,
+there is no label to target, so no workflow — fork-authored or otherwise — can schedule anything onto
+the Mac. There is no allowlist to maintain, no approval setting to get right, and no first-time-
+contributor promotion to reason about. The Mac's outbound `gh` calls are the only coupling.
+
+This is a **third option ADR-0079 never considered.** It weighed exactly two transports — self-hosted
+runner versus Tailscale-SSH — and chose the runner because it is pull-based: no inbound networking, no
+SSH key to rotate, no listening service. That reasoning was sound and is preserved here. A launchd
+poll is *also* pull-based and shares every one of those properties, while additionally requiring no
+GitHub-side execution grant at all. Against Tailscale-SSH, 0079's rejection stands unchanged (a
+tailnet, a rotating auth key, and an ACL granting CI SSH into the dev machine remain strictly more
+surface for the same effect).
+
+**2. The human-merge posture is PRESERVED — a deliberate carry-forward, not an oversight.**
+
+ADR-0079 decision (4) holds in full: `bin/docfix-run` is unchanged, still seeding line-1
+`auto_merge: false` into the runtime hold plan, and `/post-plan` Phase 6.5 condition (7) still reads
+that frontmatter and refuses to arm auto-merge. A machine-authored doc edit still gets a human read
+before it lands.
+
+Auto-merging doc-refresh PRs was considered and rejected in favour of this posture. Two reasons.
+First, `bin/lib/pr-armable.sh` condition (10) establishes an unconditional floor — a PR opened by an
+autonomous pipeline "ALWAYS holds for a human merge," with no override label — and doc-refresh PRs are
+squarely that class; they evade the label today only because nothing applies it, which is an unclosed
+hole rather than a grant. Second, the human review **is** the bound on what an unattended
+`--dangerously-skip-permissions` run can land. Preserving it is what keeps this change small: no
+mechanical docs-only gate is needed, so this ADR adds no new gate and leaves condition (10) and the
+shared predicate untouched.
+
+**3. Only genuine failures alert; the pipeline self-heals.**
+
+The alert discriminates on PR state and CI status rather than on staleness alone. A leftover branch
+from a merged PR is reaped automatically. An open PR with green CI is the **expected steady state** —
+it means the pipeline did its job and the owner has already been told to review it — and is silent;
+alerting on it would nag the owner for not having merged yet. A declined PR goes quiet without any
+manual cleanup. Only a run that died before opening a PR, a PR whose CI is red, or a poll that never
+fired will DM. `bin/cleanup` is never surfaced as an owner remedy.
+
+This preserves the constraint that motivated the redesign — a broken pipeline must still ping, never
+fail silently — while removing every DM that merely asks the owner to do maintenance.
+
+**4. Nothing to revoke.**
+
+Because no runner was ever registered, superseding 0079's transport requires no decommissioning: no
+token to revoke, no runner to unregister, no `actions/runner` install to remove. ADR-0079's
+"Operational setup" section is void, never having been performed.
+
+## Consequences
+
+- **Positive.** The fork-PR code-execution class is eliminated by construction, not mitigated by
+  configuration. The pipeline gains an owner-visible schedule it never had, and it now actually runs.
+  The reaping step fixes a latent wedge in which a single leftover `docs-stale-refresh-*` branch would
+  have stopped the pipeline forever after its first PR (`bin/docfix-run:36-39`).
+- **Cost.** Remediation latency is now bounded by the poll interval rather than firing immediately
+  after the audit. Scheduling moves from a GitHub-visible workflow to a machine-local launchd agent,
+  so a failure of the *poller itself* is not visible in the Actions UI — which is precisely why the
+  never-fired alert exists.
+- **Cost.** The launchd agent must be installed once on the Mac, after this change merges, via
+  `bin/docfix-poll --install-schedule`. It cannot ship pre-installed: the agent's `Program` must point
+  at the main checkout's copy of the script, which does not exist until merge. If the owner skips the
+  install, the alert fires — the install step is self-enforcing rather than reliant on memory.
+- **Security posture.** No inbound network surface, consistent with 0079's goal. No GitHub-side
+  execution grant of any kind. The detached run continues to use the Mac user's own persistent
+  `gh auth login` credential (not the ephemeral Actions `GITHUB_TOKEN`) — which is also what makes the
+  pipeline function at all, since a PR opened with the default token does not trigger `pull_request`
+  workflows. Every PR it opens remains held for human merge.
+
+## What ADR-0079 got right
+
+Carried forward unchanged: the GitHub issue remains the idempotent tracker, marker-diffed on the
+stale-set signature, with the doc-fix PR carrying `Closes #<issue-num>` (0079 decision 2). The fix
+still runs headless via the `bin/post-plan-now` launchd-detach idiom, because a `nohup … &` shares its
+parent's process group and dies with it (0079 decision 3). The produced PR is still held for human
+merge (0079 decision 4). Only decision 1 — the transport — is superseded, and only because its stated
+precondition was not true of this repo.


### PR DESCRIPTION
## Summary

Replaces the never-fired `docfix` GitHub Actions job with a launchd-scheduled Mac poller (`bin/docfix-poll`). The `docfix` job queued 3 times and was cancelled each time — no self-hosted runner was ever registered, and registering one on this public repo is an RCE-class risk (fork PRs can address `[self-hosted, macOS]` runners; lab guard only covers first-time contributors). The poll eliminates the class: GitHub schedules nothing on the Mac.

**Behavior unchanged:** `bin/docfix-run`'s `auto_merge: false` seed and the human-merge posture are preserved. This swaps the transport only.

### Changes
- **New:** `bin/docfix-poll` — launchd schedule management (`--install-schedule`, `--uninstall-schedule`, `--print-schedule`) + nightly poll path + `--health-report` predicate the audit workflow calls
- **New:** `.github/workflows/docs-refreshed-notify.yml` — Discord DM when a refresh PR is opened for review
- **Edit:** `.github/workflows/doc-freshness-audit.yml` — delete the `docfix` job; add `pull-requests: read`; re-predicate DMs onto health alert; add episode-start marker to issue body
- **Edit:** `bin/test-docfix-run` — retire case (6); add 22 new cases for poll, reap, decline, health-alert
- **Edit:** `bin/docfix-run` — comments only (4 stale self-hosted-runner claims corrected)
- **New:** `ibl5/docs/decisions/0086-runnerless-mac-poll-for-stale-docs-remediation.md`
- **Edit:** `ibl5/docs/decisions/0079-stale-docs-auto-remediation.md` — add `Superseded by:` marker; bump `last_verified`

## Post-merge install (required — run once after merging)

```bash
cd ~/GitHub/IBL5 && git pull && bin/docfix-poll --install-schedule
```

The script refuses to install if the program isn't executable at the MAIN checkout's path — silent-fail is the exact bug this plan fixes, so it's fail-closed.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
