### PR TITLE
feat: J22 — wire real per-player rl_stl/rl_tov into defQ/offQ composites (PF dispersion)

### DIFF
--- a/engine/internal/backup/assemble.go
+++ b/engine/internal/backup/assemble.go
@@ -227,6 +227,8 @@ func toBundlePlayer(p PlrPlayer, minutes map[int]int) bundle.Player {
 		RealLifeFTA: p.RealLifeFTA,
 		RealLife3GA: p.RealLife3GA,
 		RealLifeORB: p.RealLifeORB,
+		RealLifeSTL: p.RealLifeSTL,
+		RealLifeTVR: p.RealLifeTVR,
 
 		Age:         p.Age,
 		Clutch:      p.Clutch,

--- a/engine/internal/backup/assemble_test.go
+++ b/engine/internal/backup/assemble_test.go
@@ -198,6 +198,59 @@ func TestToBundle_TeamRates(t *testing.T) {
 	}
 }
 
+// TestToBundlePlayer_RealLifeSTLTVR_Mapping: RealLifeSTL/TVR map through assembler correctly;
+// rating fields are not cross-wired into the real-life fields.
+func TestToBundlePlayer_RealLifeSTLTVR_Mapping(t *testing.T) {
+	roster := teamRoster(1)
+	roster[0].RealLifeSTL = 110
+	roster[0].RealLifeTVR = 150
+	// Distinct rating values so we can prove no cross-wiring.
+	roster[0].RatingSTL = 45
+	roster[0].RatingTVR = 55
+	players := append(roster, teamRoster(2)...)
+	sched := []SchGame{{VisitorTeamID: 1, HomeTeamID: 2, Month: 11, Day: 2, Played: true}}
+
+	b, err := ToBundle(players, sched, AssembleOptions{})
+	if err != nil {
+		t.Fatalf("ToBundle: %v", err)
+	}
+	var got bundle.Player
+	for _, p := range b.Players {
+		if p.PID == roster[0].PID {
+			got = p
+		}
+	}
+	if got.RealLifeSTL != 110 || got.RealLifeTVR != 150 {
+		t.Errorf("RealLifeSTL/TVR = %d/%d, want 110/150", got.RealLifeSTL, got.RealLifeTVR)
+	}
+	// Isolation: real-life sums must not equal the rating (they are different sources).
+	if got.RealLifeSTL == got.STL {
+		t.Errorf("RealLifeSTL (%d) must not equal STL rating (%d) — cross-wiring!", got.RealLifeSTL, got.STL)
+	}
+	if got.RealLifeTVR == got.TVR {
+		t.Errorf("RealLifeTVR (%d) must not equal TVR rating (%d) — cross-wiring!", got.RealLifeTVR, got.TVR)
+	}
+}
+
+// TestToBundlePlayer_RealLifeSTLTVR_EndToEnd: ReadPlr → toBundlePlayer carries
+// STL(96)/TVR(100) columns all the way to bundle.Player fields.
+func TestToBundlePlayer_RealLifeSTLTVR_EndToEnd(t *testing.T) {
+	buf := []byte(newPlrRecord(1, 100, 1, 25, "Defender", "SG", 70, 5, 5))
+	plrField(buf, 56, itoaPad(2000, 4)) // RealLifeMIN (> 0 so guard passes)
+	plrField(buf, 96, itoaPad(110, 4))  // RealLifeSTL
+	plrField(buf, 100, itoaPad(150, 4)) // RealLifeTVR
+	plrField(buf, 137, "1")             // CanPlayInGame
+
+	parsed, err := ReadPlr(strings.NewReader(string(buf) + "\r\n"))
+	if err != nil {
+		t.Fatalf("ReadPlr: %v", err)
+	}
+	bp := toBundlePlayer(parsed[0], nil)
+	if bp.RealLifeSTL != 110 || bp.RealLifeTVR != 150 {
+		t.Errorf("end-to-end RealLifeSTL/TVR = %d/%d, want 110/150", bp.RealLifeSTL, bp.RealLifeTVR)
+	}
+}
+
 // --- J9: faithful league 2PA/48 baseline (FUN_004385f0 port), over RAW .plr
 // records (RecordIndex-gated), NOT the assembled bundle player list ----------
 

--- a/engine/internal/backup/plr.go
+++ b/engine/internal/backup/plr.go
@@ -92,6 +92,9 @@ const (
 	offRealLifeFTA = 72 // width 4 — FT attempts (D70 per-player part)
 	offRealLife3GA = 80 // width 4 — 3pt attempts (subtracted from FGA for the 2PA/48 baseline)
 	offRealLifeORB = 84 // width 4 — offensive rebounds (DB8)
+	// not read: DRB=88, AST=92 (defQ/offQ need only STL and TVR — skipped deliberately)
+	offRealLifeSTL = 96  // width 4 — career steals (real-life), PlrLineParser.php:53 substr(line,96,4)
+	offRealLifeTVR = 100 // width 4 — career turnovers (real-life), PlrLineParser.php:54 substr(line,100,4)
 
 	// Per-player IN-SEASON box-score totals (record-relative, width 4 each), the
 	// Branch-B team-rate inputs. JSB's per-half setup (FUN_004cfa50, COMPOSITE_DOUBLES_
@@ -211,6 +214,8 @@ type PlrPlayer struct {
 	RealLifeFTA int
 	RealLife3GA int
 	RealLifeORB int
+	RealLifeSTL int
+	RealLifeTVR int
 
 	// Per-player IN-SEASON box-score totals (offSeasonGP/DRB/AST), the Branch-B
 	// team-rate inputs. Summed per team in assemble.go into bundle.Team.DRBRate/
@@ -300,6 +305,8 @@ func ReadPlr(r io.Reader) ([]PlrPlayer, error) {
 			{&p.RealLifeMIN, offRealLifeMIN, 4}, {&p.RealLifeFGA, offRealLifeFGA, 4},
 			{&p.RealLifeFTA, offRealLifeFTA, 4}, {&p.RealLife3GA, offRealLife3GA, 4},
 			{&p.RealLifeORB, offRealLifeORB, 4},
+			{&p.RealLifeSTL, offRealLifeSTL, 4},
+			{&p.RealLifeTVR, offRealLifeTVR, 4},
 			{&p.SeasonGP, offSeasonGP, 4}, {&p.SeasonDRB, offSeasonDRB, 4},
 			{&p.SeasonAST, offSeasonAST, 4},
 			{&p.RatingFGA, offRating2GA, 3}, {&p.RatingFGP, offRating2GP, 3},

--- a/engine/internal/backup/plr_test.go
+++ b/engine/internal/backup/plr_test.go
@@ -152,6 +152,8 @@ func TestReadPlr_RealLifeBlock(t *testing.T) {
 	plrField(buf, 64, itoaPad(1400, 4)) // realLifeFGA (total FG attempts)
 	plrField(buf, 72, itoaPad(360, 4))  // realLifeFTA
 	plrField(buf, 84, itoaPad(120, 4))  // realLifeORB
+	plrField(buf, 96, itoaPad(137, 4))  // realLifeSTL
+	plrField(buf, 100, itoaPad(205, 4)) // realLifeTVR
 
 	players, err := ReadPlr(strings.NewReader(string(buf) + "\r\n"))
 	if err != nil {
@@ -161,6 +163,38 @@ func TestReadPlr_RealLifeBlock(t *testing.T) {
 	if p.RealLifeMIN != 2520 || p.RealLifeFGA != 1400 || p.RealLifeFTA != 360 || p.RealLifeORB != 120 {
 		t.Errorf("real-life block = MIN%d FGA%d FTA%d ORB%d, want 2520/1400/360/120",
 			p.RealLifeMIN, p.RealLifeFGA, p.RealLifeFTA, p.RealLifeORB)
+	}
+	if p.RealLifeSTL != 137 || p.RealLifeTVR != 205 {
+		t.Errorf("real-life STL/TVR = %d/%d, want 137/205", p.RealLifeSTL, p.RealLifeTVR)
+	}
+}
+
+// TestReadPlr_RealLifeSTLTVR_BlankZero: blank STL/TVR columns (all-spaces) parse to 0, no error.
+func TestReadPlr_RealLifeSTLTVR_BlankZero(t *testing.T) {
+	buf := []byte(newPlrRecord(1, 100, 1, 25, "Rookie", "PG", 70, 5, 5))
+	// Leave offsets 96/100 as spaces (newPlrRecord fills with spaces) — blank field → 0.
+
+	players, err := ReadPlr(strings.NewReader(string(buf) + "\r\n"))
+	if err != nil {
+		t.Fatalf("ReadPlr: %v", err)
+	}
+	p := players[0]
+	if p.RealLifeSTL != 0 || p.RealLifeTVR != 0 {
+		t.Errorf("blank STL/TVR should be 0, got STL=%d TVR=%d", p.RealLifeSTL, p.RealLifeTVR)
+	}
+}
+
+// TestReadPlr_RealLifeSTLTVR_BadField: non-numeric STL field returns ErrBadField, nil record.
+func TestReadPlr_RealLifeSTLTVR_BadField(t *testing.T) {
+	buf := []byte(newPlrRecord(1, 100, 1, 25, "Bad STL", "PG", 70, 5, 5))
+	copy(buf[96:100], "12x4") // non-numeric at offset 96
+
+	_, err := ReadPlr(strings.NewReader(string(buf) + "\r\n"))
+	if !errors.Is(err, ErrBadField) {
+		t.Fatalf("err = %v, want ErrBadField", err)
+	}
+	if !strings.Contains(err.Error(), "96") {
+		t.Errorf("error should name offset 96: %v", err)
 	}
 }
 

--- a/engine/internal/bundle/bundle.go
+++ b/engine/internal/bundle/bundle.go
@@ -99,26 +99,27 @@ type Player struct {
 	Foul int `json:"r_foul"`
 
 	// Real-life / previous-season counting-stat sums — the engine's per-48-MINUTE
-	// shot-volume rate inputs (D88/DB8/D70 = (stat/MIN)×48) for the 2pt-bucket
-	// composite. JSON tags match the PHP PlrParserService rl_* derived columns so the
-	// production bundle-builder (a follow-on PR) maps 1:1. The Go backup assembler
-	// populates them from the static real-life .plr block (offsets 52-111). Absent/
-	// zero MINUTES — a player with no prior-season reference, or a production bundle
-	// not yet wired — falls back to the rating stand-in (sim/bucketweights.go).
-	// RealLifeFGA is total FG attempts (incl. 3PA).
+	// rate inputs. JSON tags match PHP PlrParserService rl_* columns; the Go backup
+	// assembler populates them from the static real-life .plr block (offsets 52-111).
+	// Absent/zero MINUTES — rookie or un-wired bundle — falls back to rating stand-ins.
 	//
-	// RealLifeGP and RealLife3GA feed the league 2PA/48 shot baseline
-	// (sim/shotdecision.go leagueShotBaseline, the FUN_004385f0 league-table
-	// port): GP is the MIN > 2×GP inclusion gate; 3GA isolates pure 2-point
-	// attempts (2PA = RealLifeFGA − RealLife3GA). All-zero (a bundle builder
-	// that has not wired them) simply yields no qualifying players and the
-	// documented constant fallback.
+	// Shot-volume rate inputs (D88/DB8/D70 = (stat/MIN)×48) for the 2pt-bucket
+	// composite: RealLifeMIN/FGA/FTA/3GA/ORB. RealLifeFGA is total FG attempts (incl. 3PA).
+	// RealLifeGP and RealLife3GA also feed the league 2PA/48 shot baseline
+	// (sim/shotdecision.go leagueShotBaseline).
+	//
+	// Quality composite inputs for defQ/offQ (sim/teamquality.go):
+	// RealLifeSTL (STL/MIN×44) and RealLifeTVR (TOV/MIN×48) — the faithful per-player
+	// J22 wiring. PHP PlrParserService already emits rl_stl/rl_tvr; these JSON tags are
+	// the matching Go half. Zero MINUTES → rating stand-in fallback (RealLifeMIN==0 guard).
 	RealLifeGP  int `json:"rl_gp"`
 	RealLifeMIN int `json:"rl_min"`
 	RealLifeFGA int `json:"rl_fga"`
 	RealLifeFTA int `json:"rl_fta"`
 	RealLife3GA int `json:"rl_3ga"`
 	RealLifeORB int `json:"rl_orb"`
+	RealLifeSTL int `json:"rl_stl"`
+	RealLifeTVR int `json:"rl_tvr"`
 
 	// Attributes.
 	Age         int `json:"age"`

--- a/engine/internal/bundle/bundle_test.go
+++ b/engine/internal/bundle/bundle_test.go
@@ -93,6 +93,57 @@ func TestDecode_RealLifeAbsentZero(t *testing.T) {
 	}
 }
 
+// TestPlayer_RealLifeSTLTVR_JSONRoundTrip: rl_stl/rl_tvr decode by tag and survive round-trip.
+func TestPlayer_RealLifeSTLTVR_JSONRoundTrip(t *testing.T) {
+	j := `{"seed":1,"players":[{"pid":1,"teamid":3,"rl_stl":137,"rl_tvr":205}],` +
+		`"schedule":[{"home_team_id":3,"visitor_team_id":7,"date":"d","game_type":2}]}`
+	b, err := Decode([]byte(j))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	p := b.Players[0]
+	if p.RealLifeSTL != 137 || p.RealLifeTVR != 205 {
+		t.Errorf("RealLifeSTL/TVR = %d/%d, want 137/205", p.RealLifeSTL, p.RealLifeTVR)
+	}
+	// Round-trip: marshal → unmarshal → same values.
+	out, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	b2, err := Decode(out)
+	if err != nil {
+		t.Fatalf("re-Decode: %v", err)
+	}
+	if b2.Players[0].RealLifeSTL != 137 || b2.Players[0].RealLifeTVR != 205 {
+		t.Errorf("round-trip RealLifeSTL/TVR = %d/%d, want 137/205", b2.Players[0].RealLifeSTL, b2.Players[0].RealLifeTVR)
+	}
+}
+
+// TestPlayer_RealLifeSTLTVR_ZeroDefault: omitting rl_stl/rl_tvr decodes to 0 (graceful-degradation contract).
+func TestPlayer_RealLifeSTLTVR_ZeroDefault(t *testing.T) {
+	b, err := Decode([]byte(validBundleJSON)) // validBundleJSON has no rl_stl/rl_tvr
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	p := b.Players[0]
+	if p.RealLifeSTL != 0 || p.RealLifeTVR != 0 {
+		t.Errorf("absent rl_stl/rl_tvr should default to 0, got STL=%d TVR=%d", p.RealLifeSTL, p.RealLifeTVR)
+	}
+}
+
+// TestPlayer_RealLifeSTLTVR_WrongKey: wrong key (rl_steals) leaves RealLifeSTL==0.
+func TestPlayer_RealLifeSTLTVR_WrongKey(t *testing.T) {
+	j := `{"seed":1,"players":[{"pid":1,"teamid":3,"rl_steals":99}],` +
+		`"schedule":[{"home_team_id":3,"visitor_team_id":7,"date":"d","game_type":2}]}`
+	b, err := Decode([]byte(j))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if b.Players[0].RealLifeSTL != 0 {
+		t.Errorf("wrong key rl_steals should not bind: RealLifeSTL = %d, want 0", b.Players[0].RealLifeSTL)
+	}
+}
+
 // #3 (boundary) — an unknown game_type value is rejected at decode time.
 func TestDecode_RejectsUnknownGameType(t *testing.T) {
 	for _, gt := range []int{0, 1, 7, 99} {

--- a/engine/internal/sim/teamquality.go
+++ b/engine/internal/sim/teamquality.go
@@ -26,13 +26,12 @@ package sim
 //     is the transition/symmetric case; offQualityWithHCA is the half-court live path.
 //     See bucketweights.go foulBucketWeight for the coupling + faithful redraw.
 //
-// STAND-INS (bundle carries no rl_stl/rl_tov counting sums — only RealLifeMIN/FGA/
-// FTA/ORB): defQ/offQ use the 0-99 STL/TVR RATINGS as per-48 rate stand-ins, mapped
-// through ratingRefScale to the real league per-48 means (leagueSTL48, leagueTOV48).
-// Wiring real rl_stl/rl_tov is a production-bundle follow-on (Out of Scope, J6). Only
-// the defQ/offQ RATIO drives the shrink (both scales cancel a common factor at a
-// balanced matchup — see faithful_scales_derivation_test.go); the foul LEVEL is set
-// by the single foulBucketScale dial (bucketweights.go).
+// Per-player defQ/offQ now use real career STL/TOV composites sourced from
+// bundle.Player.RealLifeSTL/RealLifeTVR (J22): stlRate = STL/MIN×44, tovRate = TOV/MIN×48.
+// The 0-99 STL/TVR ratings are retained as the RealLifeMIN==0 fallback (rookies, un-wired
+// bundles). Only the defQ/offQ RATIO drives the shrink (both scales cancel at a balanced
+// matchup — see faithful_scales_derivation_test.go); the foul LEVEL is set by the single
+// foulBucketScale dial (bucketweights.go).
 
 const (
 	// leagueTOV48 is the real 5.60 league per-48 turnover mean (CEngine[+0x68D8],
@@ -58,10 +57,10 @@ const (
 
 	// stlComposite44 (+0xDD0 = STL/MIN×44, J6 line 51/93, PE 0x66D328) and
 	// tovDivisor48 (+0xDE0 = TOV/MIN×48, J6 line 52, PE 0x669ED0) are the faithful
-	// per-player composite forms. In the RATING stand-in they are folded into the
-	// pinned league means (leagueSTL48 already carries the ×44; leagueTOV48 the /48),
-	// so they are documented provenance for those means — asserted by the recompute
-	// test — not re-applied per player.
+	// per-player composite forms. In the real path (RealLifeMIN>0) they are applied
+	// per player against real minutes. In the rating stand-in fallback they are folded
+	// into the pinned league means (leagueSTL48 already carries the ×44; leagueTOV48
+	// the /48) — asserted by the recompute test.
 	stlComposite44 = 44.0
 	tovDivisor48   = 48.0
 
@@ -74,17 +73,31 @@ const (
 	defQualityCapMultiplier = 1.5
 )
 
-// stlRate maps a defender's 0-99 STL rating to a per-48 steal-rate stand-in (the
-// +0xDD0 STL/MIN×44 composite, whose league mean is leagueSTL48). floor1 floors the
-// rating at 1, so stlRate > 0 always.
+// stlRate returns a defender's per-44 steal composite (the +0xDD0 STL/MIN×44 form).
+// When the player has real career minutes, uses real career STL/MIN×44 (J22 wiring).
+// Falls back to the 0-99 rating stand-in for players with no real minutes (rookie /
+// un-wired bundle); floor1 floors the rating at 1, so stlRate > 0 always.
+// The RealLifeMIN > 0 guard also prevents division by zero.
 func stlRate(p onCourt) float64 {
+	if p.RealLifeMIN > 0 {
+		// Real career steals per-44 composite — the faithful defQ signal (STL/MIN×44).
+		return float64(p.RealLifeSTL) / float64(p.RealLifeMIN) * stlComposite44
+	}
+	// Fallback: rating stand-in for players with no real minutes (rookie / un-wired bundle).
 	return floor1(p.STL) / ratingRefScale * leagueSTL48
 }
 
-// tovRate maps an offensive player's 0-99 TVR rating to a per-48 turnover-rate
-// stand-in (the +0xDE0 TOV/MIN×48 composite, whose league mean is leagueTOV48). NO
-// home/away term (J16 §3). floor1 floors at 1, so tovRate > 0 and offQuality > 0.
+// tovRate returns an offensive player's per-48 turnover composite (the +0xDE0 TOV/MIN×48 form).
+// When the player has real career minutes, uses real career TVR/MIN×48 (J22 wiring).
+// Falls back to the 0-99 rating stand-in for players with no real minutes. NO
+// home/away term (J16 §3). floor1 floors the rating at 1, so tovRate > 0 and offQuality > 0.
+// The RealLifeMIN > 0 guard also prevents division by zero.
 func tovRate(p onCourt) float64 {
+	if p.RealLifeMIN > 0 {
+		// Real career turnovers per-48 composite — the faithful offQ signal (TOV/MIN×48).
+		return float64(p.RealLifeTVR) / float64(p.RealLifeMIN) * tovDivisor48
+	}
+	// Fallback: rating stand-in for players with no real minutes (rookie / un-wired bundle).
 	return floor1(p.TVR) / ratingRefScale * leagueTOV48
 }
 

--- a/engine/internal/sim/teamquality_test.go
+++ b/engine/internal/sim/teamquality_test.go
@@ -71,7 +71,7 @@ func TestDefQuality_SumAndCap(t *testing.T) {
 // depends ONLY on the lineup, never on any home/away input (there is no hca arg).
 func TestOffQuality_SumNoHCA(t *testing.T) {
 	off := fiveStarters(3)
-	// 5 offense at TVR=70 → 5·4.6944002 = 23.472001.
+	// 5 offense at TVR=70, RealLifeMIN=0 → fallback: 5·4.6944002 = 23.472001.
 	if got := offQuality(off); math.Abs(got-23.472001) > teamQualityEps {
 		t.Errorf("offQuality(TVR=70 ×5) = %.5f, want 23.472001", got)
 	}
@@ -80,5 +80,114 @@ func TestOffQuality_SumNoHCA(t *testing.T) {
 	// property that makes the foul bucket produce a ≈1.0 home/away FTA ratio.
 	if offQuality(fiveStarters(3)) != offQuality(fiveStarters(99)) {
 		t.Errorf("offQuality varies with team id — it must depend only on ratings (side-symmetric)")
+	}
+}
+
+// --- J22: real per-player composite path (RealLifeMIN > 0) -------------------
+
+// ocWithReal builds an on-court player with real career stats wired (RealLifeMIN > 0),
+// so stlRate/tovRate use the J22 real-composite path instead of the rating stand-in.
+func ocWithReal(stl, tvr, min int) onCourt {
+	p := mkPlayer(1, 3, slotPG, 48)
+	p.RealLifeSTL = stl
+	p.RealLifeTVR = tvr
+	p.RealLifeMIN = min
+	return oc(slotPG, p)
+}
+
+// TestTeamQuality_RealComposite_HappyPath: stlRate/tovRate with RealLifeMIN>0 equal
+// hand-computed STL/MIN×44 and TOV/MIN×48.
+func TestTeamQuality_RealComposite_HappyPath(t *testing.T) {
+	p := ocWithReal(110, 150, 2000)
+	// stlRate = 110/2000 × 44 = 2.42
+	wantSTL := 110.0 / 2000.0 * 44.0
+	if got := stlRate(p); math.Abs(got-wantSTL) > teamQualityEps {
+		t.Errorf("stlRate(real) = %.6f, want %.6f", got, wantSTL)
+	}
+	// tovRate = 150/2000 × 48 = 3.6
+	wantTOV := 150.0 / 2000.0 * 48.0
+	if got := tovRate(p); math.Abs(got-wantTOV) > teamQualityEps {
+		t.Errorf("tovRate(real) = %.6f, want %.6f", got, wantTOV)
+	}
+}
+
+// TestTeamQuality_DivByZeroGuard: RealLifeSTL>0, RealLifeTVR>0, RealLifeMIN==0
+// returns rating fallback (not NaN/Inf) — guards division by zero.
+func TestTeamQuality_DivByZeroGuard(t *testing.T) {
+	p := mkPlayer(1, 3, slotPG, 48)
+	p.RealLifeSTL = 110
+	p.RealLifeTVR = 150
+	p.RealLifeMIN = 0 // guard must select fallback, not divide by zero
+	oc0 := oc(slotPG, p)
+
+	stl := stlRate(oc0)
+	tov := tovRate(oc0)
+	if math.IsNaN(stl) || math.IsInf(stl, 0) {
+		t.Errorf("stlRate(RealLifeMIN=0) = %v, want finite fallback", stl)
+	}
+	if math.IsNaN(tov) || math.IsInf(tov, 0) {
+		t.Errorf("tovRate(RealLifeMIN=0) = %v, want finite fallback", tov)
+	}
+	// Must equal the rating stand-in (same as mkPlayer's STL=30, TVR=70).
+	wantSTL := floor1(p.STL) / ratingRefScale * leagueSTL48
+	wantTOV := floor1(p.TVR) / ratingRefScale * leagueTOV48
+	if math.Abs(stl-wantSTL) > teamQualityEps {
+		t.Errorf("stlRate fallback = %.6f, want %.6f (rating stand-in)", stl, wantSTL)
+	}
+	if math.Abs(tov-wantTOV) > teamQualityEps {
+		t.Errorf("tovRate fallback = %.6f, want %.6f (rating stand-in)", tov, wantTOV)
+	}
+}
+
+// TestTeamQuality_CapBoundary_RealPath: high-real-STL lineup still hits defQ cap.
+func TestTeamQuality_CapBoundary_RealPath(t *testing.T) {
+	ceiling := defQualityCapMultiplier * defQualityCapTeamMult * leagueSTL48
+	// Very high real STL/MIN ratio → uncapped sum > ceiling → capped.
+	var hi []onCourt
+	for slot := slotPG; slot <= slotC; slot++ {
+		hi = append(hi, ocWithReal(500, 10, 100)) // 500/100×44 = 220 per player
+	}
+	if raw := 5 * (500.0 / 100.0 * 44.0); raw <= ceiling {
+		t.Fatalf("test setup: raw high-real-STL %.3f should exceed ceiling %.3f", raw, ceiling)
+	}
+	if got := defQuality(hi); math.Abs(got-ceiling) > teamQualityEps {
+		t.Errorf("defQuality (real, capped) = %.4f, want ceiling %.4f", got, ceiling)
+	}
+}
+
+// TestTeamQuality_DispersionFlows: mixed-real lineup produces defQ strictly between
+// the min and max single-player contributions — proves real per-player spread flows through.
+func TestTeamQuality_DispersionFlows(t *testing.T) {
+	// Five players with different real STL/MIN ratios.
+	lineup := []onCourt{
+		ocWithReal(50, 100, 2000),  // stlRate = 50/2000×44 = 1.1
+		ocWithReal(100, 100, 2000), // stlRate = 100/2000×44 = 2.2
+		ocWithReal(150, 100, 2000), // stlRate = 150/2000×44 = 3.3
+		ocWithReal(200, 100, 2000), // stlRate = 200/2000×44 = 4.4
+		ocWithReal(250, 100, 2000), // stlRate = 250/2000×44 = 5.5
+	}
+	minContrib := 50.0 / 2000.0 * 44.0
+	maxContrib := 250.0 / 2000.0 * 44.0
+	got := defQuality(lineup)
+	if got <= minContrib || got >= 5*maxContrib {
+		t.Errorf("defQ = %.4f, want strictly between min contrib %.4f and 5×max %.4f — dispersion broken",
+			got, minContrib, 5*maxContrib)
+	}
+	// Specifically, expect sum = (50+100+150+200+250)/2000×44 = 750/2000×44 = 16.5,
+	// but the cap is 13.755 so we get the ceiling.
+	// With different numbers that don't cap:
+	lineup2 := []onCourt{
+		ocWithReal(10, 100, 2000), // 0.22
+		ocWithReal(20, 100, 2000), // 0.44
+		ocWithReal(30, 100, 2000), // 0.66
+		ocWithReal(40, 100, 2000), // 0.88
+		ocWithReal(50, 100, 2000), // 1.1
+	}
+	got2 := defQuality(lineup2)
+	min2 := 10.0 / 2000.0 * 44.0
+	max2 := 50.0 / 2000.0 * 44.0
+	if got2 <= min2 || got2 >= 5*max2+teamQualityEps {
+		t.Errorf("defQ2 = %.4f, want strictly between %.4f and %.4f — dispersion broken",
+			got2, min2, 5*max2)
 	}
 }

--- a/ibl5/docs/backlog/README.md
+++ b/ibl5/docs/backlog/README.md
@@ -1,6 +1,6 @@
 ---
 description: Index of tracked backlogs under docs/backlog/ — one row per LIVE backlog plus the archive pointer, and the canonical status taxonomy shared by all backlogs; and the archive / dated-pointer / supersession housekeeping conventions.
-last_verified: 2026-07-14
+last_verified: 2026-07-16
 ---
 
 # Backlog index

--- a/ibl5/docs/backlog/archive/jsb-native-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/jsb-native-backlog-archive.md
@@ -131,3 +131,12 @@ Full detail: symmetric deterministic base `(2.0 − fatigue)·tovRate(bh)` (corr
 **Finding — mechanism void:** OReb continuations execute inside a single `possession()` call via the `for trip := 0; trip <= maxOffensiveRebounds; trip++` loop (`possession.go:123`). Clock decrement (`gs.clock -= step`) happens once per `possession()` call in `gameloop.go`, AFTER the trip loop completes. Therefore Var(lnPOSS) = f(base_time dispersion) exclusively — no within-possession restructure of any kind can move it. Per-origin putback share was already J4-faithful (engine 12.58% vs J4 12.65%), confirming nothing to re-weight. The real Cov carrier is pace/base_time dispersion, which is J23's domain.
 **Status (2026-07-16):** 🚫 Declined — mechanism void. Evidence pinned at `engine/internal/calibrate/possessioncoupling_archive_test.go:51-64`. Successor: J23 (round-half-up + base_time re-center) targets Var(lnPOSS) toward 0.000721 and Cov(lnPOSS,lnPPS) sign flip. 🧠 Opus.
 
+---
+
+### J22 Per-player rl_stl/rl_tov production-bundle wiring
+*(discovered 2026-07-13 during jsb-native RE-tooling feasibility review)*
+**Location:** `engine/internal/sim/teamquality.go` (`stlRate`/`tovRate`); `engine/internal/bundle/bundle.go` (`RealLifeSTL`/`RealLifeTVR` JSON fields); `engine/internal/backup/plr.go` (offset 96/100); `engine/internal/backup/assemble.go` (RealLife mappings).
+**Problem:** ADR-0084's composites are faithful in **formula** (defQ = Σ STL/MIN×44, offQ = Σ TOV/48) but fed **rating stand-ins**, not real per-player `rl_stl`/`rl_tov`. The engine's PF is under-dispersed — Var(lnPF) ratio ≈ 0.22, PF dispersion ≈ ½ real (J13 monitor; J2 residual context) — because rating stand-ins compress the per-player STL/TOV spread the live composites exist to express.
+**Not the count-axis:** wiring real STL/TOV raises PF *dispersion* — a fidelity fix, **not** a Cov(lnFGA,lnPPS) lever (that is J23's domain).
+**Status (2026-07-16):** ✅ Implemented — PR #1490. Per-player real career STL/TOV composites now feed defQ/offQ (STL/MIN×44, TOV/MIN×48); rating stand-in retained as RealLifeMIN==0 fallback. Backup path via `plr.go`→`bundle`→`assemble`; production path via `bundle.Player` `rl_stl`/`rl_tvr` JSON tags (PHP `PlrParserService` already emitted them). ⚙️ Sonnet.
+

--- a/ibl5/docs/backlog/jsb-native-backlog.md
+++ b/ibl5/docs/backlog/jsb-native-backlog.md
@@ -56,7 +56,7 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 | ⬜ Open | 5 |
 | 📋 Planned | 0 |
 | ◑ Partial | 0 |
-| ✅ Implemented | 16 |
+| ✅ Implemented | 17 |
 | 🚫 Declined | 1 |
 
 ---
@@ -178,11 +178,7 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 ➜ J21 gt=4 playoff-margin overshoot audit — ✅ Implemented (2026-07-14): NO overshoot; engine under-disperses globally; no follow-on fix; see [archive](archive/jsb-native-backlog-archive.md).
 
 ### J22 Per-player rl_stl/rl_tov production-bundle wiring
-*(discovered 2026-07-13 during jsb-native RE-tooling feasibility review)*
-**Location:** `engine/internal/sim/teamquality.go` (`stlRate`/`tovRate`); `engine/internal/bundle/bundle.go` (`RealLifeSTL`/`RealLifeTVR` JSON fields); `engine/internal/backup/plr.go` (offset 96/100); `engine/internal/backup/assemble.go` (RealLife mappings).
-**Problem:** ADR-0084's composites are faithful in **formula** (defQ = Σ STL/MIN×44, offQ = Σ TOV/48) but fed **rating stand-ins**, not real per-player `rl_stl`/`rl_tov`. The engine's PF is under-dispersed — Var(lnPF) ratio ≈ 0.22, PF dispersion ≈ ½ real (J13 monitor; J2 residual context) — because rating stand-ins compress the per-player STL/TOV spread the live composites exist to express.
-**Not the count-axis:** wiring real STL/TOV raises PF *dispersion* — a fidelity fix, **not** a Cov(lnFGA,lnPPS) lever (that is J23's domain).
-**Status:** Done (PR #<n>) — per-player real career STL/TOV composites now feed defQ/offQ (STL/MIN×44, TOV/MIN×48); rating stand-in retained as RealLifeMIN==0 fallback. Backup path via `plr.go`→`bundle`→`assemble`; production path via `bundle.Player` `rl_stl`/`rl_tvr` JSON tags (PHP `PlrParserService` already emitted them).
+➜ J22 Per-player rl_stl/rl_tov production-bundle wiring — ✅ Implemented (2026-07-16): PR #1490; real per-player STL/TOV composites feed defQ/offQ; rating stand-in retained as RealLifeMIN==0 fallback; see [archive](archive/jsb-native-backlog-archive.md).
 
 ### J23 round-half-up + base_time re-center (coupled pace faithful fix)
 *(deferred from J21 pace-dispersion investigation, 2026-07-13, PR #1452)*

--- a/ibl5/docs/backlog/jsb-native-backlog.md
+++ b/ibl5/docs/backlog/jsb-native-backlog.md
@@ -40,7 +40,7 @@ J1 faithful foul pair (✅ 2026-07-10, ADR-0082) ─→ J2 adjudications (✅ 20
               ├─ prerequisite: J16 escape bound re-derived with LIVE AST/48 (J19) — ✅ J19 done
               └─→ J2 verdict: SHIPPABLE with residual → J20 🚫 void (within-possession lever cannot move Var(lnPOSS); pace/base_time dispersion is J23's domain) → J13 (unblocked)
 J17 game-state foul coupling (⬜, new 2026-07-10) — real 5.60 mechanism the engine lacks entirely
-J21 gt=4 playoff-margin audit (✅ 2026-07-14 — no overshoot, engine under-disperses globally) · J22 per-player STL/TOV bundle wiring (⬜, new 2026-07-13) — cut-over-gate fidelity inputs to J13; NEITHER is a Cov(lnFGA,lnPPS) lever
+J21 gt=4 playoff-margin audit (✅ 2026-07-14 — no overshoot, engine under-disperses globally) · J22 per-player STL/TOV bundle wiring (✅ 2026-07-16) — cut-over-gate fidelity inputs to J13; NEITHER is a Cov(lnFGA,lnPPS) lever
 J23 round-half-up + base_time re-center (⬜, new 2026-07-13, #1452) — coupled faithful fix deferred from J21; ADR-0085 records the hold finding; J23 must A/B the recenter alongside the step-rule change
 J18 composite fidelity ports (✅ 2026-07-13 — all divergences merged; f/shrink port declined as documented divergence) · J19 J6-residue RE (✅ 2026-07-12) — both spawned by J6
 ```
@@ -86,7 +86,7 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 | J19 | J6-residue RE (energy operands, rec+0x18 semantics, escape re-derivation, +0xD58) | ✅ Implemented | 🧠 Opus | M |
 | J20 | Empty-FGA / within-possession restructure (Cov possession channel) | 🚫 Declined | 🧠 Opus | L |
 | J21 | gt=4 playoff-margin overshoot audit (playoffNetMultiplier ×1.25) | ✅ Implemented | 🧠 Opus | S |
-| J22 | Per-player rl_stl/rl_tov production-bundle wiring (PF dispersion) | ⬜ Open | 🧠 Opus | M |
+| J22 | Per-player rl_stl/rl_tov production-bundle wiring (PF dispersion) | ✅ Implemented | 🧠 Opus | M |
 | J23 | round-half-up + base_time re-center (coupled pace faithful fix) | ⬜ Open | 🧠 Opus | M |
 
 ### J1 Faithful foul-bucket pair port
@@ -179,11 +179,10 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 
 ### J22 Per-player rl_stl/rl_tov production-bundle wiring
 *(discovered 2026-07-13 during jsb-native RE-tooling feasibility review)*
-**Location:** `engine/internal/sim/teamquality.go:29-32` (the STAND-INS block — "bundle carries no `rl_stl`/`rl_tov` counting sums… defQ/offQ use the 0-99 STL/TVR **ratings** as per-48 rate stand-ins, mapped through `ratingRefScale`"); bundle feed at `engine/internal/backup/assemble.go:215` (`STL: p.RatingSTL` — the 0-99 rating, not a real per-player steal count).
-**Problem:** ADR-0084's composites are faithful in **formula** (defQ = Σ STL/MIN×44, offQ = Σ TOV/48) but fed **rating stand-ins**, not real per-player `rl_stl`/`rl_tov`. The engine's PF is under-dispersed — Var(lnPF) ratio ≈ 0.22, PF dispersion ≈ ½ real (J13 monitor; J2 residual context) — because rating stand-ins compress the per-player STL/TOV spread the live composites exist to express. `teamquality.go:32` already marks this "Out of Scope, J6"; this entry formalizes that deferred follow-on so it is tracked, not just code-commented.
-**Not the count-axis:** wiring real STL/TOV raises PF *dispersion* — a fidelity fix, **not** a Cov(lnFGA,lnPPS) lever (that is J23's domain). File as a dispersion-fidelity follow-on, never a cut-over sign blocker.
-**Direction:** confirm whether the production-bundle SOURCE (`.plr` / real-life stat feed) carries per-player steal/turnover counting sums; if so, add them to the bundle reader + wire into the composites replacing the rating stand-ins; if not, RE where 5.60 sources them. A/B gate = Var(lnPF) ratio toward real, no regression on margin/fta anchors or gt2/gt4 Cov. Sequence before J23 (J20 sequencing constraint removed — J20 🚫 void); J23 reads on this baseline.
-**Status (2026-07-13):** ⬜ Open — new. 🧠 Opus (source question + Var(lnPF) A/B judgment); port ⚙️ Sonnet once source confirmed.
+**Location:** `engine/internal/sim/teamquality.go` (`stlRate`/`tovRate`); `engine/internal/bundle/bundle.go` (`RealLifeSTL`/`RealLifeTVR` JSON fields); `engine/internal/backup/plr.go` (offset 96/100); `engine/internal/backup/assemble.go` (RealLife mappings).
+**Problem:** ADR-0084's composites are faithful in **formula** (defQ = Σ STL/MIN×44, offQ = Σ TOV/48) but fed **rating stand-ins**, not real per-player `rl_stl`/`rl_tov`. The engine's PF is under-dispersed — Var(lnPF) ratio ≈ 0.22, PF dispersion ≈ ½ real (J13 monitor; J2 residual context) — because rating stand-ins compress the per-player STL/TOV spread the live composites exist to express.
+**Not the count-axis:** wiring real STL/TOV raises PF *dispersion* — a fidelity fix, **not** a Cov(lnFGA,lnPPS) lever (that is J23's domain).
+**Status:** Done (PR #<n>) — per-player real career STL/TOV composites now feed defQ/offQ (STL/MIN×44, TOV/MIN×48); rating stand-in retained as RealLifeMIN==0 fallback. Backup path via `plr.go`→`bundle`→`assemble`; production path via `bundle.Player` `rl_stl`/`rl_tvr` JSON tags (PHP `PlrParserService` already emitted them).
 
 ### J23 round-half-up + base_time re-center (coupled pace faithful fix)
 *(deferred from J21 pace-dispersion investigation, 2026-07-13, PR #1452)*


### PR DESCRIPTION
## Summary

Replaces the per-player 0-99 rating stand-ins in `defQ`/`offQ` foul-bucket composites with each player's real career steal/turnover counting sums (STL/MIN×44, TOV/MIN×48). This raises PF **dispersion** — moves `Var(lnPF)_engine` up toward `Var(lnPF)_real` (current ratio ≈ 0.22). Pure Go engine change; no PHP, no SQL, no migration.

**Four-phase implementation:**
1. Extend `engine/internal/backup/plr.go` to parse real-life STL(offset 96)/TVR(offset 100)
2. Add `RealLifeSTL`/`RealLifeTVR` to `bundle.Player` with JSON tags `rl_stl`/`rl_tvr` (completing the production path — `PlrParserService.php` already emits these)
3. Wire the sums through `engine/internal/backup/assemble.go` `toBundlePlayer`
4. Rewrite `stlRate`/`tovRate` in `teamquality.go` with `RealLifeMIN>0` guard; rating stand-in retained as fallback

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.