### PR TITLE
chore: flip T15 to implemented, update rollup, append archive entry

### DIFF
--- a/ibl5/docs/backlog/archive/token-spend-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/token-spend-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed token-spend reduction entries, extracted from token-spend-backlog.md.
-last_verified: 2026-07-14
+last_verified: 2026-07-16
 ---
 
 # Token-Spend Reduction Backlog — Archive
@@ -73,3 +73,8 @@ Read-only historical record of ✅ Implemented entries. For OPEN items see ../to
 **Location:** `.claude/skills/plan/SKILL.md` (~55KB ≈ 13K tokens) and `.claude/skills/post-plan/SKILL.md` (~68KB ≈ 17K tokens) — each a single file loaded whole at invocation and resident for the entire run.
 **Problem (was):** A long post-plan run re-reads ~17K tokens every turn, plus a fresh cache write per nightly session.
 **Status (2026-07-14):** ✅ Implemented — both restructures shipped. Post-plan (#1389, merged 2026-07-09): `.claude/skills/post-plan/SKILL.md` cut from ~68KB to ~30KB, split into seven `_phase-*.md` reference files read on phase entry. Plan-skill (#1363, merged 2026-07-08): `.claude/skills/plan/SKILL.md` Step 3 slimmed (Regions A/B removed, contract pointer wired), extracting the architect contract into on-demand `.claude/skills/plan/_architect-contract.md`. The two restructures were deliberately different shapes: plan-skill did not mirror post-plan's per-phase orchestrator split — instead it moved the architect contract into the plan-architect subagent's throwaway context, since the orchestrator's Steps 1–4 are too interdependent/reasoning-heavy to split. That contract extraction was the complete intended optimization for plan-skill, not a partial step toward a fuller split — both halves of T9 are done.
+
+### T15 Read-payload accretion guard
+**Location:** `$HOME/.claude/hooks/output-guard.sh` (Check E, PreToolUse warn-only); `~/GitHub/IBL5/.claude/settings.local.json` (new `"Read"` matcher entry).
+**Problem (was):** Read results injected 17.3M chars (~4.3M tokens) into contexts over 7 days — 67% of all tool-result bytes. A full-file Read early in a long session is the compounding version of the T10 problem: its tokens are re-billed as cache-read on every subsequent call. The Read tool supports `offset`/`limit` but nothing pushed back on a no-limit Read of a large file.
+**Status (2026-07-16):** ✅ Implemented — `output-guard.sh` extended with Check E: PreToolUse warn when a Read call targets a file over 500 lines with no `offset`/`limit` parameter. Advisory names the LSP-first rule and Explore sub-agent delegation as cheaper paths. Warn-only; skips subagents (their contexts are discarded at SubagentStop). Wired via a new `"Read"` matcher entry in `settings.local.json`. Harness extended with 6 new tests (18–23). Plan: `$HOME/.claude/plans/t15-read-payload-accretion-guard.md`.

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -54,15 +54,6 @@ First-wave entries (T1–T13) are ✅ Implemented — see the dated pointers bel
 **Provenance:** discovered 2026-07-16 during the post-backlog re-measure (advisory session).
 **Status (2026-07-16):** ⬜ Open.
 
-### T15 Read-payload accretion guard
-**Locus:** ⌂ harness-local. **Effort:** S.
-**Location:** `$HOME/.claude/hooks/output-guard.sh` guards unbounded **Bash** output (T10) — the **Read** tool is unguarded.
-**Problem:** Measured 2026-07-16: Read results injected **17.3M chars (~4.3M tokens) into contexts over 7 days — 67% of all tool-result bytes** (next largest: Bash at 8.0M). A full-file Read early in a long session is the compounding version of the T10 problem: its tokens are re-billed as cache-read on every subsequent call, so a 5K-token Read at call 50 of a 500-call session costs ~2.25M cache-read tokens by session end. The Read tool supports `offset`/`limit` and the harness guidance says "read only the part you need," but nothing pushes back on a no-limit Read of a large file.
-**Suggested direction:** Extend `$HOME/.claude/hooks/output-guard.sh` (same family as T10, an extend not an add): PreToolUse warn when a Read call targets a file over ~500 lines with no `offset`/`limit` — advisory names the LSP-first rule (symbol questions) and Explore/fork delegation (multi-file surveys) as the cheaper paths. Warn-only; skip subagents (their contexts are discarded, which is exactly where big reads *should* go).
-**Risk if untouched:** The dominant tool-result payload keeps feeding T14's accretion; the two entries compound.
-**Provenance:** discovered 2026-07-16 during the post-backlog re-measure (advisory session).
-**Status (2026-07-16):** ✅ Implemented (2026-07-16) — `output-guard.sh` Check E: warns on Read of >500-line file with no offset/limit; skips subagents. See [archive](archive/token-spend-backlog-archive.md).
-
 ### T16 Poll-shaped Bash round-trips → background/Monitor routing
 **Locus:** ⌂ harness-local (hook or rule line). **Effort:** S.
 **Problem:** Measured 2026-07-16: **329 `gh pr`/`gh run` calls plus ~120 nightly-queue status checks in 7 days**, largely poll loops (run, read, run again). At the measured ~81K-token average context per call, each poll is a full-window cache re-read just to ask "is it done yet" — order of 30M+ cache-read tokens/week spent on waiting. The harness already has the cheap substitutes (`run_in_background` + Monitor re-invokes on completion; `/loop` self-pacing with matched intervals; ScheduleWakeup's own guidance says one ~480s check beats eight 60s ones), but adoption is norm-level and the poll pattern persists in transcripts.

--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -31,10 +31,10 @@ last_verified: 2026-07-16
 
 | Status | Count |
 |--------|------:|
-| ⬜ Open | 3 |
+| ⬜ Open | 2 |
 | 📋 Planned | 0 |
 | ◑ Partial | 0 |
-| ✅ Implemented | 13 |
+| ✅ Implemented | 14 |
 | 🚫 Declined | 0 |
 
 Archived entries (✅ Implemented): see [token-spend-backlog-archive.md](archive/token-spend-backlog-archive.md).
@@ -61,7 +61,7 @@ First-wave entries (T1–T13) are ✅ Implemented — see the dated pointers bel
 **Suggested direction:** Extend `$HOME/.claude/hooks/output-guard.sh` (same family as T10, an extend not an add): PreToolUse warn when a Read call targets a file over ~500 lines with no `offset`/`limit` — advisory names the LSP-first rule (symbol questions) and Explore/fork delegation (multi-file surveys) as the cheaper paths. Warn-only; skip subagents (their contexts are discarded, which is exactly where big reads *should* go).
 **Risk if untouched:** The dominant tool-result payload keeps feeding T14's accretion; the two entries compound.
 **Provenance:** discovered 2026-07-16 during the post-backlog re-measure (advisory session).
-**Status (2026-07-16):** ⬜ Open.
+**Status (2026-07-16):** ✅ Implemented (2026-07-16) — `output-guard.sh` Check E: warns on Read of >500-line file with no offset/limit; skips subagents. See [archive](archive/token-spend-backlog-archive.md).
 
 ### T16 Poll-shaped Bash round-trips → background/Monitor routing
 **Locus:** ⌂ harness-local (hook or rule line). **Effort:** S.
@@ -76,6 +76,7 @@ First-wave entries (T1–T13) are ✅ Implemented — see the dated pointers bel
 ➜ T4 Driver-model downshift for babysitting loops — ✅ Implemented (2026-07-14): resolved by substitution (L6+L8+post-plan-Sonnet+`/loop`); residual measured empty. See [archive](archive/token-spend-backlog-archive.md).
 
 ➜ T13 Aggregate always-loaded rules budget — ✅ Implemented (2026-07-14): see [archive](archive/token-spend-backlog-archive.md).
+➜ T15 Read-payload accretion guard — ✅ Implemented (2026-07-16): see [archive](archive/token-spend-backlog-archive.md).
 
 ➜ T7 Resident-overlay diet (MEMORY.md + rules) — ✅ Implemented (2026-07-14): see [archive](archive/token-spend-backlog-archive.md).
 


### PR DESCRIPTION
## Summary

Backlog housekeeping for T15 Read-payload accretion guard.

Implementation (machine-local, outside repo):
- `output-guard.sh` extended with Check E: warns when a Read call targets a file >500 lines with no `offset`/`limit` parameter
- `test-output-guard.sh` extended with 6 new tests (18–23) — harness passes 23/23
- `settings.local.json` wired with a new `"Read"` matcher entry in the `PreToolUse` array

This PR (repo diff):
- `ibl5/docs/backlog/token-spend-backlog.md`: flip T15 ⬜→✅, rollup Open 3→2 / Implemented 13→14, add dated pointer
- `ibl5/docs/backlog/archive/token-spend-backlog-archive.md`: append T15 archive entry, bump `last_verified`

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.