### PR TITLE
chore: ignore ibl5/.bug-pipeline/ scratch dir written by bug-pipeline-tick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ibl5/*.dra
 ibl5/*.ret
 ibl5/*.hof
 ibl5/*.plb
+
+# Bug-pipeline hunter scratch (bin/bug-pipeline-tick writes hunt-result.json into the worktree)
+ibl5/.bug-pipeline/


### PR DESCRIPTION
## Summary

Adds `.gitignore` entry for `ibl5/.bug-pipeline/`, a scratch directory written by `bin/bug-pipeline-tick` (stores `hunt-result.json` between ticks). Without this, the directory shows as untracked noise in any worktree running the live bug-pipeline.

## Manual Testing

No manual testing needed — all changes are covered by automated tests.
