### PR TITLE
feat: GM feedback ack + thread on bug fast path

### DIFF
--- a/bin/bug-pipeline-tick
+++ b/bin/bug-pipeline-tick
@@ -239,7 +239,18 @@ classify_row() { # row_json
     case "$effective_class" in
         bug)
             if [ "$enough" = "true" ]; then
-                cli transition "$id" queued --class=bug $issue_opt $clear_opt >/dev/null && \
+                local tid="$thread_id"
+                if [ -z "$tid" ] || [ "$tid" = "null" ]; then
+                    tid="$(bot_create_thread "$(printf '%s' "$row" | jq -r '.original_message_id')" "Bug: ${issue_title:-report}")"
+                fi
+                local thread_opt=""
+                if [ -n "$tid" ]; then
+                    bot_post_to_thread "$tid" "Looks like a bug — I'm on it 🔍"
+                    thread_opt="--thread-id=$tid"
+                else
+                    log "bug $id: create-thread failed — proceeding without thread (hunt not blocked)"
+                fi
+                cli transition "$id" queued --class=bug $issue_opt $clear_opt $thread_opt >/dev/null && \
                     log "bug $id classified enough — awaiting hunter (#5b)"
             else
                 open_thread_and_ask "$row" "$id" "$thread_id" "$question" bug "$issue_opt" "$clear_opt" "$issue_number"
@@ -689,7 +700,7 @@ resume_blocked_hunt() { # row_json (surfaced by the enumerator, blocked_until al
 # and on merge transition pr_open→fixed + close the tracking issue. The cron IS the trusted actor
 # and MAY read/write gh here — categorically distinct from the starved hunter (no gh at all).
 reconcile_pr_open_rows() {
-    local rows row id pr issue branch n state
+    local rows row id pr issue branch n state thread_id
     rows="$(cli list-pr-open 2>/dev/null)"
     printf '%s' "$rows" | jq -e 'type == "array"' >/dev/null 2>&1 || return 0
     while IFS= read -r row; do
@@ -697,6 +708,7 @@ reconcile_pr_open_rows() {
         id="$(printf '%s' "$row" | jq -r '.id')"
         pr="$(printf '%s' "$row" | jq -r '.pr_number // empty')"
         issue="$(printf '%s' "$row" | jq -r '.issue_number // empty')"
+        thread_id="$(printf '%s' "$row" | jq -r '.thread_id // empty')"
         branch="$(bug_slug "$id" "$(printf '%s' "$row" | jq -r '.original_text // empty')")"
         if [ -z "$pr" ] || [ "$pr" = "null" ]; then
             n="$("$GH_BIN" pr list --repo "$BUG_PIPELINE_CODE_REPO" --head "$branch" --json number --jq '.[0].number // empty' 2>/dev/null || true)"
@@ -711,6 +723,9 @@ reconcile_pr_open_rows() {
                 "$GH_BIN" pr edit "$n" --repo "$BUG_PIPELINE_CODE_REPO" --add-label pipeline-authored \
                     >/dev/null 2>&1 || log "reconcile: $id pipeline-authored label failed (best-effort)"
                 [ -n "$issue" ] && bpgh_comment "$issue" "PR opened: https://github.com/${BUG_PIPELINE_CODE_REPO}/pull/$n"
+                if [ -n "$thread_id" ] && [ "$thread_id" != "null" ]; then
+                    bot_post_to_thread "$thread_id" "Opened a fix PR: https://github.com/${BUG_PIPELINE_CODE_REPO}/pull/$n"
+                fi
             fi
         else
             state="$("$GH_BIN" pr view "$pr" --repo "$BUG_PIPELINE_CODE_REPO" --json state,mergedAt --jq '.state' 2>/dev/null || true)"

--- a/bin/lib/bug-pipeline-test-stubs.sh
+++ b/bin/lib/bug-pipeline-test-stubs.sh
@@ -87,7 +87,13 @@ SH
 echo "curl $*" >> "$STUB/curl.log"
 case "$*" in *create-thread*) echo "CREATE_THREAD" >> "$STUB/calls.log";; *post-to-thread*) echo "POST_TO_THREAD" >> "$STUB/calls.log";; *mention*) echo "MENTION" >> "$STUB/calls.log";; esac
 case "$*" in
-  *create-thread*)       echo '{"thread_id":"'"${STUB_THREAD_ID:-880000000000000001}"'"}' ;;
+  *create-thread*)
+    if [ "${STUB_CREATE_THREAD_FAIL:-0}" = 1 ]; then
+      echo '{}'   # no thread_id key → bot_create_thread's `jq -r '.thread_id // empty'` yields empty
+    else
+      echo '{"thread_id":"'"${STUB_THREAD_ID:-880000000000000001}"'"}'
+    fi
+    ;;
   *mention*)             echo '{"message_id":"'"${STUB_MESSAGE_ID:-1420098765432109876}"'"}' ;;
   *get-thread-messages*) cat "$STUB/transcript.json" 2>/dev/null || echo '{"messages":[]}' ;;
   *)                     echo '{}' ;;
@@ -209,7 +215,7 @@ bpt_reset() {
           "$STUB"/gh-pr-list.out "$STUB"/gh-pr-list-*.out "$STUB"/gh-pr-view.out 2>/dev/null
     rm -rf "$STUB"/wt/* 2>/dev/null
     printf '[]' > "$STUB/actionable.json"
-    unset GH_FAIL STUB_THREAD_ID STUB_MESSAGE_ID STUB_ISSUE_NUMBER WT_NEW_FAIL
+    unset GH_FAIL STUB_THREAD_ID STUB_MESSAGE_ID STUB_ISSUE_NUMBER WT_NEW_FAIL STUB_CREATE_THREAD_FAIL
 }
 
 bpt_set_actionable()  { printf '%s' "$1" > "$STUB/actionable.json"; }

--- a/bin/test-bug-pipeline-classify
+++ b/bin/test-bug-pipeline-classify
@@ -23,13 +23,35 @@ bpt_run
 bpt_log_has  "$STUB" transition.log "dropped --class=not_a_thing" "not_a_thing → dropped"
 bpt_log_lacks "$STUB" calls.log "POST_TO_THREAD" "not_a_thing posts nothing to Discord"
 
-# ── bug + enough → queued --class=bug, no thread opened, NEVER hunting ─────────
+# ── bug + enough → thread opened, ack posted, thread_id persisted, NEVER hunting ──
 bpt_reset; bpt_set_actionable "$QUEUED"
 bpt_set_claude_result '{"class":"bug","bug_has_enough_info":true,"issue_title":"Box score wrong","severity":"medium"}'
 bpt_run
+bpt_log_has  "$STUB" calls.log "CREATE_THREAD" "bug+enough opens a thread"
+bpt_log_has  "$STUB" curl.log "Looks like a bug" "bug+enough posts the pickup ack"
 bpt_log_has  "$STUB" transition.log "queued --class=bug" "bug+enough → queued --class=bug"
-bpt_log_lacks "$STUB" calls.log "CREATE_THREAD" "bug+enough opens no thread"
+bpt_log_has  "$STUB" transition.log "--thread-id=880000000000000001" "bug+enough persists thread_id on the transition"
 bpt_log_lacks "$STUB" transition.log "hunting" "bug+enough never emits hunting"
+
+# ── ★ bug-fast-path ordering: create-thread → post-ack → queued transition ────
+bpt_reset; bpt_set_actionable "$QUEUED"
+bpt_set_claude_result '{"class":"bug","bug_has_enough_info":true,"issue_title":"Box score wrong","severity":"medium"}'
+bpt_run
+ct="$(order_of CREATE_THREAD)"; pt="$(order_of POST_TO_THREAD)"; tr_line="$(order_of TRANSITION)"
+if [ -n "$ct" ] && [ -n "$pt" ] && [ -n "$tr_line" ] && [ "$ct" -lt "$pt" ] && [ "$pt" -lt "$tr_line" ]; then
+    bpt_ok "bug-fast-path order: create-thread < post-ack < queued transition"
+else
+    bpt_fail "bug-fast-path order wrong (create=$ct post=$pt transition=$tr_line)"
+fi
+
+# ── ★ NEGATIVE — create-thread fails → transition still proceeds, no --thread-id ──
+bpt_reset; bpt_set_actionable "$QUEUED"
+bpt_set_claude_result '{"class":"bug","bug_has_enough_info":true,"issue_title":"Box score wrong","severity":"medium"}'
+STUB_CREATE_THREAD_FAIL=1 bpt_run
+bpt_log_has  "$STUB" calls.log "CREATE_THREAD" "create-thread was attempted"
+bpt_log_lacks "$STUB" calls.log "POST_TO_THREAD" "no thread_id → no ack posted"
+bpt_log_has  "$STUB" transition.log "queued --class=bug" "create-thread failure does NOT block the queued transition"
+bpt_log_lacks "$STUB" transition.log "--thread-id=" "create-thread failure → transition carries no --thread-id"
 
 # ── feature + new → create-thread then gathering ──────────────────────────────
 bpt_reset; bpt_set_actionable "$QUEUED"

--- a/bin/test-bug-pipeline-hunt
+++ b/bin/test-bug-pipeline-hunt
@@ -128,6 +128,7 @@ bpt_run
 bpt_log_has "$STUB" transition.log "transition 7 pr_open --pr=42" "r17: backfills pr_number from gh pr list"
 bpt_log_has "$STUB" gh.log "pr edit 42 --repo test/code-fake --add-label pipeline-authored" "r17: applies pipeline-authored label at reconcile"
 bpt_log_has "$STUB" gh.log "issue comment 4242" "r17: comments PR url on the tracking issue once"
+bpt_log_lacks "$STUB" calls.log "POST_TO_THREAD" "r17: row has no thread_id → no PR-opened thread post"
 # empty gh pr list → no transition, no label, still reconcilable next tick
 bpt_reset
 bpt_set_list_pr_open '[{"id":"7","status":"pr_open","pr_number":null,"issue_number":"4242"}]'
@@ -153,6 +154,15 @@ bpt_log_has "$STUB" gh.log "pr list --repo test/code-fake --head bug-1 --json" \
     "r17-cutover: falls back to the legacy bare bug-<id> head"
 bpt_log_has "$STUB" transition.log "transition 1 pr_open --pr=77" \
     "r17-cutover: backfills pr_number from the legacy-head PR"
+
+# ── Row 17b — PR-opened thread post: row carries thread_id → posts "Opened a fix PR" to it ──
+bpt_reset
+bpt_set_list_pr_open '[{"id":"7","status":"pr_open","pr_number":null,"issue_number":"4242","thread_id":"880000000000000001"}]'
+bpt_set_gh_pr_list '42'
+bpt_run
+bpt_log_has "$STUB" transition.log "transition 7 pr_open --pr=42" "r17b: backfills pr_number same as r17"
+bpt_log_has "$STUB" calls.log "POST_TO_THREAD" "r17b: thread_id present → posts to the thread"
+bpt_log_has "$STUB" curl.log "Opened a fix PR: https://github.com/test/code-fake/pull/42" "r17b: PR-opened message names the exact PR URL"
 
 # ── Row 18 — SECURITY grep: post-plan-now absent from the prompt AND from run_hunter_agent ──
 if grep -qi 'post-plan-now' "$PROMPT"; then bpt_fail "r18: post-plan-now leaked into hunter prompt"; else bpt_ok "r18: post-plan-now absent from hunter prompt"; fi

--- a/ibl5/IBLbot/src/bug-bot/handlers.test.ts
+++ b/ibl5/IBLbot/src/bug-bot/handlers.test.ts
@@ -89,6 +89,7 @@ describe('handleEnqueue', () => {
             channelId: '222222222222222222',
             id: '333333333333333333',
             content: 'a bug',
+            react: vi.fn().mockResolvedValue(undefined),
         } as unknown as Message;
 
         await handleEnqueue(msg);
@@ -103,6 +104,41 @@ describe('handleEnqueue', () => {
         });
         expect(typeof arg.author_id).toBe('string');
         expect(typeof arg.message_id).toBe('string');
+    });
+
+    it('reacts ✴️ to the original message after a successful enqueue', async () => {
+        const msg = {
+            author: { id: '111111111111111111' },
+            channelId: '222222222222222222',
+            id: '333333333333333333',
+            content: 'a bug',
+            react: vi.fn().mockResolvedValue(undefined),
+        } as unknown as Message;
+
+        await handleEnqueue(msg);
+
+        expect(phpClient.enqueue).toHaveBeenCalledTimes(1);
+        expect(msg.react).toHaveBeenCalledTimes(1);
+        expect(msg.react).toHaveBeenCalledWith('✴️');
+        // enqueue must complete before the ack react fires
+        const enqueueOrder = vi.mocked(phpClient.enqueue).mock.invocationCallOrder[0];
+        const reactOrder = vi.mocked(msg.react).mock.invocationCallOrder[0];
+        expect(enqueueOrder).toBeLessThan(reactOrder);
+    });
+
+    it('swallows a react() rejection — handleEnqueue still resolves, enqueue still fired', async () => {
+        const msg = {
+            author: { id: '111111111111111111' },
+            channelId: '222222222222222222',
+            id: '333333333333333333',
+            content: 'a bug',
+            react: vi.fn().mockRejectedValue(new Error('Missing Permissions')),
+        } as unknown as Message;
+
+        await expect(handleEnqueue(msg)).resolves.toBeUndefined();
+
+        expect(phpClient.enqueue).toHaveBeenCalledTimes(1);
+        expect(msg.react).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/ibl5/IBLbot/src/bug-bot/handlers.ts
+++ b/ibl5/IBLbot/src/bug-bot/handlers.ts
@@ -51,6 +51,17 @@ export async function handleEnqueue(msg: Message): Promise<void> {
         message_id: msg.id,
         text: msg.content,
     });
+    // Instant ack (bot-side of "ack + thread"): react ✴️ so a GM sees pickup with no
+    // cron round-trip. Also fires for Phase-6 backfilled messages (same shared path) —
+    // desirable: it signals the bot picked the report up on catch-up, not just live.
+    // Must never throw past this handler — Phase-6 backfill (backfill.ts) awaits
+    // handleEnqueue in a plain loop with no per-message try/catch, so an uncaught
+    // react rejection here would abort replay of every message after it.
+    try {
+        await msg.react('✴️');
+    } catch (err) {
+        console.error('handleEnqueue: react ack failed (swallowed):', err);
+    }
 }
 
 // A thread's own channel id IS the thread id — that's what §3b thread-reply

--- a/ibl5/IBLbot/src/bug-bot/index.ts
+++ b/ibl5/IBLbot/src/bug-bot/index.ts
@@ -9,6 +9,7 @@ import {
 } from './handlers.js';
 import { startBugBotServer } from './server.js';
 import { runBackfill } from './backfill.js';
+import { logBugChannelPermissionPreflight } from './preflight.js';
 
 const client = new Client({
     intents: [
@@ -34,6 +35,13 @@ const backfillReady = new Promise<void>((resolve) => {
 
 client.once(Events.ClientReady, async (c) => {
     console.log(`Bug-bot ready as ${c.user.tag}`);
+    // Diagnostic only — reports missing bug-channel permissions, never gates anything.
+    // Own try/catch so it can't skip backfill (it already swallows internally).
+    try {
+        await logBugChannelPermissionPreflight(client);
+    } catch (err) {
+        console.error('Permission preflight errored (continuing):', err);
+    }
     try {
         await runBackfill(client);
     } catch (err) {

--- a/ibl5/IBLbot/src/bug-bot/preflight.test.ts
+++ b/ibl5/IBLbot/src/bug-bot/preflight.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PermissionsBitField } from 'discord.js';
+import type { Client } from 'discord.js';
+
+vi.mock('./config.js', () => ({
+    config: { express: { port: 50001 }, bugChannelId: 'BUG_CHANNEL' },
+}));
+
+import {
+    checkBugChannelPermissions,
+    logBugChannelPermissionPreflight,
+    REQUIRED_BUG_CHANNEL_PERMISSIONS,
+} from './preflight.js';
+
+const ALL = Object.values(REQUIRED_BUG_CHANNEL_PERMISSIONS);
+
+// A channel whose permissionsFor reports exactly the supplied flags. Shaped like a
+// real GuildTextChannel on the no-Guilds-intent path: the code must roles.fetch() and
+// members.fetchMe() before permissionsFor can resolve anything (verified live).
+function channelHolding(flags: bigint[]) {
+    return {
+        guild: {
+            roles: { fetch: vi.fn().mockResolvedValue(undefined) },
+            members: { fetchMe: vi.fn().mockResolvedValue({ id: 'BOT' }) },
+        },
+        permissionsFor: vi.fn(() => ({ has: (flag: bigint) => flags.includes(flag) })),
+    };
+}
+
+function clientWith(channel: unknown): Client {
+    return {
+        user: { id: 'BOT', tag: 'bug-bot#0001' },
+        channels: { fetch: vi.fn().mockResolvedValue(channel) },
+    } as unknown as Client;
+}
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('checkBugChannelPermissions', () => {
+    it('ok when every required permission is held', async () => {
+        const res = await checkBugChannelPermissions(clientWith(channelHolding(ALL)));
+        expect(res).toEqual({ status: 'ok' });
+    });
+
+    it('names AddReactions when only that one is missing — the ✴️ ack case', async () => {
+        const withoutReact = ALL.filter((f) => f !== PermissionsBitField.Flags.AddReactions);
+        const res = await checkBugChannelPermissions(clientWith(channelHolding(withoutReact)));
+        expect(res).toEqual({ status: 'missing', missing: ['AddReactions'] });
+    });
+
+    it('lists every missing permission, not just the first', async () => {
+        const res = await checkBugChannelPermissions(clientWith(channelHolding([])));
+        expect(res.status).toBe('missing');
+        expect(res.status === 'missing' && res.missing).toEqual(Object.keys(REQUIRED_BUG_CHANNEL_PERMISSIONS));
+    });
+
+    it('unknown (not missing) when the channel does not resolve', async () => {
+        const res = await checkBugChannelPermissions(clientWith(null));
+        expect(res.status).toBe('unknown');
+    });
+
+    it('unknown when the channel has no permissionsFor (DM/group)', async () => {
+        const res = await checkBugChannelPermissions(clientWith({ isTextBased: () => true }));
+        expect(res.status).toBe('unknown');
+    });
+
+    it('unknown when permissionsFor returns null', async () => {
+        const channel = { ...channelHolding([]), permissionsFor: vi.fn(() => null) };
+        const res = await checkBugChannelPermissions(clientWith(channel));
+        expect(res.status).toBe('unknown');
+    });
+
+    // Regression, found live 2026-07-24: the bot has no GatewayIntentBits.Guilds, so
+    // neither roles nor its own member are cached. Skipping either fetch made the
+    // preflight permanently INCONCLUSIVE (or throw) in production while every mocked
+    // test still passed.
+    it('fetches roles and its own member before resolving permissions', async () => {
+        const channel = channelHolding(ALL);
+        await checkBugChannelPermissions(clientWith(channel));
+        expect(channel.guild.roles.fetch).toHaveBeenCalledTimes(1);
+        expect(channel.guild.members.fetchMe).toHaveBeenCalledTimes(1);
+        // and it asks about the fetched member, not client.user
+        expect(channel.permissionsFor).toHaveBeenCalledWith({ id: 'BOT' });
+    });
+
+    it('unknown when roles.fetch rejects', async () => {
+        const channel = channelHolding(ALL);
+        channel.guild.roles.fetch = vi.fn().mockRejectedValue(new Error('rest 403'));
+        const res = await checkBugChannelPermissions(clientWith(channel));
+        expect(res.status).toBe('unknown');
+    });
+
+    it('never throws when channels.fetch rejects', async () => {
+        const client = {
+            user: { id: 'BOT' },
+            channels: { fetch: vi.fn().mockRejectedValue(new Error('boom')) },
+        } as unknown as Client;
+        await expect(checkBugChannelPermissions(client)).resolves.toMatchObject({ status: 'unknown' });
+    });
+
+    it('unknown when client.user is not populated', async () => {
+        const client = { user: null, channels: { fetch: vi.fn() } } as unknown as Client;
+        const res = await checkBugChannelPermissions(client);
+        expect(res.status).toBe('unknown');
+    });
+});
+
+describe('logBugChannelPermissionPreflight', () => {
+    it('console.errors on a missing permission — the whole point is visibility', async () => {
+        const withoutReact = ALL.filter((f) => f !== PermissionsBitField.Flags.AddReactions);
+        await logBugChannelPermissionPreflight(clientWith(channelHolding(withoutReact)));
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(String(vi.mocked(console.error).mock.calls[0][0])).toContain('AddReactions');
+    });
+
+    it('logs (not errors) when everything is held', async () => {
+        await logBugChannelPermissionPreflight(clientWith(channelHolding(ALL)));
+        expect(console.error).not.toHaveBeenCalled();
+        expect(console.log).toHaveBeenCalledTimes(1);
+    });
+
+    it('warns as inconclusive rather than claiming failure', async () => {
+        await logBugChannelPermissionPreflight(clientWith(null));
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.error).not.toHaveBeenCalled();
+    });
+});

--- a/ibl5/IBLbot/src/bug-bot/preflight.ts
+++ b/ibl5/IBLbot/src/bug-bot/preflight.ts
@@ -1,0 +1,83 @@
+import { PermissionsBitField } from 'discord.js';
+import type { Client } from 'discord.js';
+import { config } from './config.js';
+
+// Every Discord permission the bug-bot's own surfaces need in the bug channel.
+// Deliberately the ACTUAL set, not a generous one — a false alarm here trains
+// people to ignore the log line. The bot never posts top-level in the channel
+// (all output goes into threads), so SendMessages is NOT required.
+export const REQUIRED_BUG_CHANNEL_PERMISSIONS: Record<string, bigint> = {
+    // backfill + handlers read the channel at all
+    ViewChannel: PermissionsBitField.Flags.ViewChannel,
+    // backfill's messages.fetch over the replay window
+    ReadMessageHistory: PermissionsBitField.Flags.ReadMessageHistory,
+    // the ✴️ ack on a GM report (handlers.ts) and POST /react
+    AddReactions: PermissionsBitField.Flags.AddReactions,
+    // POST /create-thread — message.startThread()
+    CreatePublicThreads: PermissionsBitField.Flags.CreatePublicThreads,
+    // POST /post-to-thread, /mention, /prMerged
+    SendMessagesInThreads: PermissionsBitField.Flags.SendMessagesInThreads,
+};
+
+export type PreflightResult =
+    | { status: 'ok' }
+    | { status: 'missing'; missing: string[] }
+    | { status: 'unknown'; reason: string };
+
+/**
+ * Resolve which of REQUIRED_BUG_CHANNEL_PERMISSIONS the bot actually holds in the
+ * bug channel. Never throws — an undeterminable answer is 'unknown', not an error,
+ * because this runs on the ClientReady path and MUST NOT be able to abort startup.
+ */
+export async function checkBugChannelPermissions(client: Client): Promise<PreflightResult> {
+    try {
+        if (!client.user) return { status: 'unknown', reason: 'client.user is not populated yet' };
+
+        const channel = await client.channels.fetch(config.bugChannelId);
+        if (!channel) return { status: 'unknown', reason: `channel ${config.bugChannelId} did not resolve` };
+        // DM/group channels have no permission overwrites to read.
+        if (!('permissionsFor' in channel) || typeof channel.permissionsFor !== 'function' || !('guild' in channel)) {
+            return { status: 'unknown', reason: 'channel is not a guild channel' };
+        }
+
+        // Both fetches are REQUIRED, and both are REST calls that need no extra intent.
+        // The bot runs without GatewayIntentBits.Guilds, so neither the guild's roles
+        // nor its own member are cached — verified live 2026-07-24: without roles.fetch()
+        // permissionsFor THROWS on an undefined role, and without fetchMe() it returns
+        // null. Passing client.user directly hits the same empty member cache.
+        await channel.guild.roles.fetch();
+        const me = await channel.guild.members.fetchMe();
+
+        const perms = channel.permissionsFor(me);
+        if (!perms) return { status: 'unknown', reason: 'permissionsFor returned null' };
+
+        const missing = Object.entries(REQUIRED_BUG_CHANNEL_PERMISSIONS)
+            .filter(([, flag]) => !perms.has(flag))
+            .map(([name]) => name);
+
+        return missing.length === 0 ? { status: 'ok' } : { status: 'missing', missing };
+    } catch (err) {
+        return { status: 'unknown', reason: `permission check threw: ${String(err)}` };
+    }
+}
+
+/**
+ * The startup half: log the result loudly. This exists because a missing permission
+ * is otherwise INVISIBLE — handlers.ts swallows react/thread failures on purpose so a
+ * single bad message can't abort backfill, which means a mis-scoped role degrades the
+ * pipeline silently. One line at boot turns that into something you can see in
+ * `pm2 logs ibl-bug-bot`.
+ */
+export async function logBugChannelPermissionPreflight(client: Client): Promise<PreflightResult> {
+    const result = await checkBugChannelPermissions(client);
+
+    if (result.status === 'ok') {
+        console.log(`Permission preflight OK — bug channel ${config.bugChannelId}: ${Object.keys(REQUIRED_BUG_CHANNEL_PERMISSIONS).join(', ')}`);
+    } else if (result.status === 'missing') {
+        console.error(`Permission preflight FAILED — bug channel ${config.bugChannelId} is MISSING: ${result.missing.join(', ')}. The pipeline will fail SILENTLY on the affected step (ack/thread/post). Fix the bot role in Discord, then restart.`);
+    } else {
+        console.warn(`Permission preflight INCONCLUSIVE — ${result.reason}. Could not confirm bug-channel permissions.`);
+    }
+
+    return result;
+}

--- a/ibl5/IBLbot/src/bug-bot/server.live.test.ts
+++ b/ibl5/IBLbot/src/bug-bot/server.live.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+
+// Opt-in live smoke against the RUNNING pm2 bug-bot. Everything in
+// server.test.ts runs against a mocked discord.js, so it proves handler LOGIC
+// only — it can never prove the deployed bot's Discord role actually holds
+// Add Reactions in the bug channel. That is an environment fact, and the ✴️
+// ack depends on it: handlers.ts swallows a react failure so backfill can't
+// abort, so a missing permission fails SILENTLY in production.
+//
+// Default-SKIP (same shape as bin/test-bug-pipeline-hunt's BUG_PIPELINE_HUNT_LIVE
+// row) because this touches live Discord. There is no /unreact endpoint, so a
+// run leaves a real reaction on a real message — point BUG_BOT_LIVE_MESSAGE_ID
+// at a message the bot has ALREADY ✴️-acked and the run adds no visible state.
+//
+//   BUG_BOT_LIVE=1 BUG_BOT_LIVE_MESSAGE_ID=957965952618758154 npm test
+//
+// That id is a known-good target: it already carries the bot's ✴️ (verified
+// green 2026-07-24), so re-running adds nothing visible to the channel.
+//
+// config.js is deliberately NOT imported: it throws on missing env, which would
+// break the default-skip path in CI.
+const LIVE = process.env.BUG_BOT_LIVE === '1';
+const MESSAGE_ID = process.env.BUG_BOT_LIVE_MESSAGE_ID ?? '';
+const BASE = `http://127.0.0.1:${process.env.BUG_BOT_LIVE_PORT ?? '50001'}`;
+
+async function post(path: string, body: unknown) {
+    const res = await fetch(`${BASE}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+    return { status: res.status, text: await res.text() };
+}
+
+describe.runIf(LIVE && MESSAGE_ID !== '')('live bug-bot /react (opt-in)', () => {
+    it('reacts to a real bug-channel message — proves the role holds Add Reactions', async () => {
+        const res = await post('/react', { message_id: MESSAGE_ID, emoji: '✴️' });
+        expect(res.status).toBe(200);
+        expect(res.text).toBe('reacted');
+    });
+
+    // Negative control: without this, a stub that always answers 'reacted'
+    // would pass the row above and prove nothing.
+    it('500s on a message id that does not exist in the bug channel', async () => {
+        const res = await post('/react', { message_id: '1', emoji: '✴️' });
+        expect(res.status).toBe(500);
+    });
+});
+
+describe.skipIf(LIVE && MESSAGE_ID !== '')('live bug-bot /react (opt-in)', () => {
+    it.skip('SKIP: set BUG_BOT_LIVE=1 + BUG_BOT_LIVE_MESSAGE_ID=<snowflake> (posts a real ✴️; no /unreact exists)', () => {});
+});


### PR DESCRIPTION
## Summary

Live E2E testing (2026-07-16) found a silent gap in the bug-pipeline's GM feedback loop:
- A GM reporting a bug saw no acknowledgement until the cron tick's next classification pass
- The bug fast path (`class=bug`/`bug_has_enough_info=true`) never opened a Discord thread, so the "fix PR opened" signal had nowhere to post

This PR closes both gaps with the smallest change that reuses existing infrastructure:

1. **Instant ✴️ ack** in the shared `handleEnqueue` path (live traffic AND Phase-6 startup backfill get it for free)
2. **Thread on bug fast path**: cron-side thread opened on `class=bug`+enough_info, posting "Looks like a bug — I'm on it 🔍"; thread_id persisted on the `queued --class=bug` transition; create-thread failure never blocks the transition (thread is comms, not control flow, on this path)
3. **PR-opened post**: `reconcile_pr_open_rows` posts "Opened a fix PR" to the row's thread when it discovers `pr_number`, reusing the `thread_id` the row already carries

## Changes

- `ibl5/IBLbot/src/bug-bot/handlers.ts`: `handleEnqueue` gains ✴️ react with internal try/catch
- `ibl5/IBLbot/src/bug-bot/handlers.test.ts`: existing mock fixed + 2 new handleEnqueue cases (happy path + negative/swallow)
- `bin/lib/bug-pipeline-test-stubs.sh`: `STUB_CREATE_THREAD_FAIL` toggle added to shared curl stub
- `bin/bug-pipeline-tick`: `classify_row` bug arm (thread+ack+persist) + `reconcile_pr_open_rows` (PR-opened thread post)
- `bin/test-bug-pipeline-classify`: flipped "no thread" → thread-opened assertions; new ordering + negative cases
- `bin/test-bug-pipeline-hunt`: extended Row 17 negative assertion; new Row 17b positive case

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
