### PR TITLE
fix: escalate /plan failures to needs_human + add scope_estimate size gate

### DIFF
--- a/bin/bug-pipeline-gather-prompt
+++ b/bin/bug-pipeline-gather-prompt
@@ -11,6 +11,10 @@ schema; no prose.
   and the acceptance outcome are all clear enough to plan against; else false.
 - When enough_info=false, put ONE concise, specific follow-up question in
   next_question (the single most useful thing still missing). Omit it when true.
+- `scope_estimate` (optional string, omit when uncertain): set to `"single_pr"` when the
+  request clearly fits one focused PR, or `"multi_pr"` when it spans multiple independent
+  subsystems or would require multiple sequential PRs. Omit entirely when you cannot
+  estimate from the request text.
 <untrusted>
 ORIGINAL REQUEST: {{original_text}}
 THREAD TRANSCRIPT (oldest->newest): {{transcript}}

--- a/bin/bug-pipeline-tick
+++ b/bin/bug-pipeline-tick
@@ -121,7 +121,7 @@ park_blocked() { # id status
 
 # ── The classifier Haiku call (locked-down: schema-constrained, tool-starved) ─
 CLASSIFY_SCHEMA='{"type":"object","additionalProperties":false,"required":["class"],"properties":{"class":{"enum":["bug","feature","not_a_thing"]},"bug_has_enough_info":{"type":"boolean"},"feature_is_regression":{"type":"boolean"},"clarifying_question":{"type":"string"},"issue_title":{"type":"string","maxLength":70},"severity":{"enum":["low","medium","high"]}}}'
-GATHER_SCHEMA='{"type":"object","additionalProperties":false,"required":["enough_info"],"properties":{"enough_info":{"type":"boolean"},"next_question":{"type":"string"}}}'
+GATHER_SCHEMA='{"type":"object","additionalProperties":false,"required":["enough_info"],"properties":{"enough_info":{"type":"boolean"},"next_question":{"type":"string"},"scope_estimate":{"enum":["single_pr","multi_pr"]}}}'
 
 # run_structured_call <prompt> <schema> ; sets CJ_RC, CJ_OUT (raw envelope), CJ_ERR
 run_structured_call() {
@@ -326,8 +326,14 @@ drive_feature_row() { # row_json
             log "gather $id: asked follow-up, stays gathering"
     else
         # enough_info=true → ping @A-Jay for a ✅ and record the ping message id.
+        local scope_est ping_text
+        scope_est="$(printf '%s' "$result" | jq -r 'if has("scope_estimate") then .scope_estimate else "missing" end' 2>/dev/null)"
+        ping_text="Feature ready for a plan — react ✅ to approve."
+        if [ "$scope_est" = "multi_pr" ]; then
+            ping_text="Feature ready for a plan — react ✅ to approve. ⚠️ looks multi-PR — consider planning this interactively instead of reacting ✅"
+        fi
         local mid
-        mid="$(bot_mention "$thread_id" "$BUG_PIPELINE_APPROVER_ID" "Feature ready for a plan — react ✅ to approve.")"
+        mid="$(bot_mention "$thread_id" "$BUG_PIPELINE_APPROVER_ID" "$ping_text")"
         if [ -n "$mid" ]; then
             cli transition "$id" awaiting_ajay --approval-message-id="$mid" $clear_opt >/dev/null && \
                 log "gather $id: enough info → awaiting_ajay (approval msg $mid)"
@@ -372,7 +378,14 @@ drive_ready_for_plan() { # row id thread_id original_text issue_number clear_opt
         cli transition "$id" planned $clear_opt >/dev/null && log "feature $id → planned ($new_plan) — STOP"
         bpgh_comment "$issue_number" "Plan queued: $new_plan"
     else
-        log "feature $id: /plan did not produce a new plan (rc=$rc) — stays ready-for-plan, retry next tick"
+        log "feature $id: /plan did not produce a new plan (rc=$rc) — escalating to needs_human"
+        cli transition "$id" needs_human $clear_opt >/dev/null && \
+            log "feature $id → needs_human"
+        [ -n "$thread_id" ] && bot_post_to_thread "$thread_id" \
+            "Auto-planning failed — this looks too big for the pipeline; let's plan it together"
+        bpgh_add_label "$issue_number" "needs-human" || true
+        bpgh_comment "$issue_number" \
+            "Auto-planning failed — /plan did not produce a plan (rc=$rc); transitioning to needs_human for interactive planning." || true
     fi
 }
 

--- a/bin/test-bug-pipeline-feature
+++ b/bin/test-bug-pipeline-feature
@@ -49,17 +49,39 @@ fi
 bpt_reset; bpt_set_actionable "$READY"; bpt_set_claude_rc 1
 bpt_run
 bpt_log_lacks "$STUB" transition.log "planned" "plan non-zero exit → not planned"
+bpt_log_has   "$STUB" transition.log "needs_human"  "plan non-zero exit → needs_human"
+bpt_log_has   "$STUB" calls.log     "POST_TO_THREAD" "plan failure posts to thread"
+bpt_log_has   "$STUB" calls.log     "GH"             "plan failure best-effort gh label/comment"
 
 # ── ★ NEG (b): /plan exits 0 but creates NO plan file → NOT planned ───────────
 bpt_reset; bpt_set_actionable "$READY"   # STUB_MAKE_PLAN unset → no plan file
 bpt_run
 bpt_log_lacks "$STUB" transition.log "planned" "plan exit 0 but no new file → not planned"
+bpt_log_has   "$STUB" transition.log "needs_human"  "plan exit 0 no file → needs_human"
+bpt_log_has   "$STUB" calls.log     "POST_TO_THREAD" "plan exit 0 no file posts to thread"
+bpt_log_has   "$STUB" calls.log     "GH"             "plan exit 0 no file gh label/comment"
 
 # ── ★ NEG (c): /plan usage-limit → blocked_until, NOT planned ─────────────────
 bpt_reset; bpt_set_actionable "$READY"; bpt_set_claude_raw 'api error: 429 rate_limit_error'
 bpt_run
 bpt_log_lacks "$STUB" transition.log "planned" "usage-limit → not planned"
 bpt_log_has   "$STUB" transition.log "awaiting_ajay --blocked-until=" "usage-limit → blocked_until in place"
+
+# ── scope_estimate=multi_pr → warning appended to mention ping ────────────────
+bpt_reset; bpt_set_actionable "$GATHERING"
+bpt_set_claude_result '{"enough_info":true,"scope_estimate":"multi_pr"}'
+STUB_MESSAGE_ID=1420098765432109877 bpt_run
+bpt_log_has   "$STUB" curl.log "looks multi-PR" "scope_estimate=multi_pr appends warning to ping"
+bpt_log_has   "$STUB" transition.log "awaiting_ajay --approval-message-id=" \
+    "scope_estimate=multi_pr still transitions awaiting_ajay normally"
+
+# ── scope_estimate absent → ping text unchanged (off-shape guard) ──────────────
+bpt_reset; bpt_set_actionable "$GATHERING"
+bpt_set_claude_result '{"enough_info":true}'
+STUB_MESSAGE_ID=1420098765432109878 bpt_run
+bpt_log_lacks "$STUB" curl.log "looks multi-PR" "scope_estimate absent → ping unchanged"
+bpt_log_has   "$STUB" transition.log "awaiting_ajay --approval-message-id=" \
+    "scope_estimate absent still transitions awaiting_ajay normally"
 
 echo "----"
 [ "$FAILED" -eq 0 ] && echo "ALL PASS" || echo "FAILURES"


### PR DESCRIPTION
## Summary

Fixes two gaps in the Discord bug-pipeline:

1. **Plan-failure escalation:** When `drive_ready_for_plan`'s `/plan` call exits non-zero (or exits 0 but produces no new plan file), the row now transitions to `needs_human` on first failure instead of silently retrying on the next tick. The Discord thread receives a plain-language message and the GitHub issue gets a best-effort `needs-human` label + comment. The `claude_env_error` → `park_blocked` path is unchanged.

2. **Size gate:** `GATHER_SCHEMA` gains an optional `scope_estimate` field (`"single_pr"` | `"multi_pr"`). The gather prompt instructs Haiku to set it when estimable. When `enough_info=true` and `scope_estimate=="multi_pr"`, the ✅ approval ping carries a fixed literal warning suffix; off-shape or absent `scope_estimate` leaves the ping unchanged.

## Changes

- `bin/bug-pipeline-tick`: Extend GATHER_SCHEMA, add scope_est extraction + conditional ping text in `drive_feature_row`, replace else-branch in `drive_ready_for_plan`
- `bin/bug-pipeline-gather-prompt`: Add `scope_estimate` instruction bullet
- `bin/test-bug-pipeline-feature`: Extend NEG(a)/NEG(b) assertions, add two gather cases

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.