### PR TITLE
chore: bug pipeline worktrees use descriptive slugs

### DIFF
--- a/bin/bug-pipeline-tick
+++ b/bin/bug-pipeline-tick
@@ -586,7 +586,7 @@ give_up_needs_human() { # claimed hunt_id wt_appdir [override_finding]
     bpgh_assign "$issue" a-jay85
     # Terminal + release the lease so no stale `hunting` row is left owned forever (Phase 1 flag).
     cli transition "$hunt_id" needs_human --release-lease >/dev/null
-    log "hunt $hunt_id -> needs_human; lease released; worktree bug-$hunt_id left for human inspection"
+    log "hunt $hunt_id -> needs_human; lease released; worktree $(basename "$(dirname "$wt_appdir")") left for human inspection"
 }
 
 # Usage-limit park (Phase 7): status → blocked, lease KEPT (owner unchanged), attempt UNCHANGED.
@@ -597,6 +597,19 @@ park_hunt_blocked() { # hunt_id
     log "hunt $1 hit usage limit -> blocked until $until (attempt count unchanged)"
 }
 
+# Derive the worktree/branch slug: bug-<id>-<kebab-from-original_text>.
+# Deterministic (pure function of the immutable row) so reclaim/resume/reconcile
+# all recompute the identical slug. SECURITY: original_text is UNTRUSTED GM text —
+# strict [a-z0-9-] allowlist output only; always a valid git ref / Docker hostname.
+bug_slug() { # id original_text
+    local id="$1" desc
+    desc="$(printf '%s' "$2" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr -cs 'a-z0-9' '-')"
+    desc="${desc#-}"
+    desc="$(printf '%.30s' "$desc")"
+    desc="${desc%-}"
+    if [ -n "$desc" ]; then printf 'bug-%s-%s' "$id" "$desc"; else printf 'bug-%s' "$id"; fi
+}
+
 # Drive a claimed hunt: create/reuse the worktree, climb the ladder up to the attempt cap,
 # then ship (fixed) / park (blocked) / give up (escalate+cap or terminal). Foreground —
 # the tick blocks until the hunt returns, so overlapping ticks can't double-hunt (invariant 1).
@@ -604,7 +617,10 @@ drive_hunt_row() { # claimed_row_json
     local claimed="$1" hunt_id slug wt_root wt_appdir attempts terminal
     hunt_id="$(printf '%s' "$claimed" | jq -r '.id')"
     attempts="$(printf '%s' "$claimed" | jq -r '.hunt_attempts // 0')"
-    slug="bug-${hunt_id}"; wt_root="$WT_BASE/$slug"; wt_appdir="$wt_root/ibl5"
+    slug="$(bug_slug "$hunt_id" "$(printf '%s' "$claimed" | jq -r '.original_text // empty')")"
+    # Legacy cutover: a pre-rename hunt left a bug-<id> worktree — reuse it, don't fork a second one.
+    if [ ! -d "$WT_BASE/$slug" ] && [ -d "$WT_BASE/bug-${hunt_id}" ]; then slug="bug-${hunt_id}"; fi
+    wt_root="$WT_BASE/$slug"; wt_appdir="$wt_root/ibl5"
 
     if [ ! -d "$wt_root" ]; then
         if ! "$WT_NEW_BIN" "$slug" >> "$HUNT_LOG" 2>&1; then
@@ -655,7 +671,10 @@ resume_blocked_hunt() { # row_json (surfaced by the enumerator, blocked_until al
     if [ -z "$resumed" ]; then
         log "resume: $id already resumed by another tick — skip"; return 0
     fi
-    slug="bug-${id}"; wt_root="$WT_BASE/$slug"
+    slug="$(bug_slug "$id" "$(printf '%s' "$row" | jq -r '.original_text // empty')")"
+    # Legacy cutover: a pre-rename hunt left a bug-<id> worktree — reuse it, don't fork a second one.
+    if [ ! -d "$WT_BASE/$slug" ] && [ -d "$WT_BASE/bug-${id}" ]; then slug="bug-${id}"; fi
+    wt_root="$WT_BASE/$slug"
     if [ ! -d "$wt_root" ]; then
         log "resume: worktree $wt_root gone — recreating"
         if ! "$WT_NEW_BIN" "$slug" >> "$HUNT_LOG" 2>&1; then
@@ -678,9 +697,13 @@ reconcile_pr_open_rows() {
         id="$(printf '%s' "$row" | jq -r '.id')"
         pr="$(printf '%s' "$row" | jq -r '.pr_number // empty')"
         issue="$(printf '%s' "$row" | jq -r '.issue_number // empty')"
-        branch="bug-${id}"
+        branch="$(bug_slug "$id" "$(printf '%s' "$row" | jq -r '.original_text // empty')")"
         if [ -z "$pr" ] || [ "$pr" = "null" ]; then
             n="$("$GH_BIN" pr list --repo "$BUG_PIPELINE_CODE_REPO" --head "$branch" --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+            # Legacy cutover: a pre-rename hunt shipped under the bare bug-<id> branch name.
+            if [ -z "$n" ] && [ "$branch" != "bug-${id}" ]; then
+                n="$("$GH_BIN" pr list --repo "$BUG_PIPELINE_CODE_REPO" --head "bug-${id}" --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+            fi
             if [ -n "$n" ]; then
                 cli transition "$id" pr_open --pr="$n" >/dev/null && log "reconcile: $id pr_number=$n"
                 # Trusted-cron seam is the only actor allowed to touch gh, so the

--- a/bin/lib/bug-pipeline-test-stubs.sh
+++ b/bin/lib/bug-pipeline-test-stubs.sh
@@ -102,7 +102,18 @@ echo "GH $*" >> "$STUB/calls.log"
 printf '%s\n' "$@" >> "$STUB/gh.args.log"   # one arg per line — proves title is a single argv element
 case "$*" in
   *"issue create"*) [ "${GH_FAIL:-0}" = 1 ] && exit 1; echo "https://github.com/${BUG_PIPELINE_ISSUE_REPO}/issues/${STUB_ISSUE_NUMBER:-4242}" ;;
-  *"pr list"*)      [ "${GH_FAIL:-0}" = 1 ] && exit 1; cat "$STUB/gh-pr-list.out" 2>/dev/null || true ;;  # driver's --jq already applied → emit the final value
+  *"pr list"*)
+      [ "${GH_FAIL:-0}" = 1 ] && exit 1
+      # Vary output by --head so a case can encode "this head has no PR, but the legacy
+      # head does" (PR #1487 cutover). Falls back to the head-agnostic gh-pr-list.out.
+      head=""; prev=""
+      for a in "$@"; do [ "$prev" = "--head" ] && head="$a"; prev="$a"; done
+      if [ -n "$head" ] && [ -f "$STUB/gh-pr-list-$head.out" ]; then
+          cat "$STUB/gh-pr-list-$head.out"
+      else
+          cat "$STUB/gh-pr-list.out" 2>/dev/null || true   # driver's --jq already applied → emit the final value
+      fi
+      ;;
   *"pr view"*)      [ "${GH_FAIL:-0}" = 1 ] && exit 1; cat "$STUB/gh-pr-view.out" 2>/dev/null || true ;;
   *) [ "${GH_FAIL:-0}" = 1 ] && exit 1; : ;;
 esac
@@ -195,7 +206,7 @@ bpt_reset() {
           "$STUB"/claim-next-resume.out "$STUB"/list-pr-open.out "$STUB"/plans/*.md \
           "$STUB"/result*.json "$STUB"/envfail* "$STUB"/make-dirty \
           "$STUB"/verdicts "$STUB"/verdict-idx \
-          "$STUB"/gh-pr-list.out "$STUB"/gh-pr-view.out 2>/dev/null
+          "$STUB"/gh-pr-list.out "$STUB"/gh-pr-list-*.out "$STUB"/gh-pr-view.out 2>/dev/null
     rm -rf "$STUB"/wt/* 2>/dev/null
     printf '[]' > "$STUB/actionable.json"
     unset GH_FAIL STUB_THREAD_ID STUB_MESSAGE_ID STUB_ISSUE_NUMBER WT_NEW_FAIL
@@ -218,6 +229,7 @@ bpt_set_verdicts()     { printf '%s\n' "$@" > "$STUB/verdicts"; }             # 
 bpt_hunt_dirty()       { : > "$STUB/make-dirty"; }                            # ship path sees a real diff
 bpt_envfail()          { : > "$STUB/envfail${1:+-$1}"; }                      # [model] usage-limit at a tier
 bpt_set_gh_pr_list()   { printf '%s' "$1" > "$STUB/gh-pr-list.out"; }
+bpt_set_gh_pr_list_for() { printf '%s' "$2" > "$STUB/gh-pr-list-$1.out"; }   # <head> <value>
 bpt_set_gh_pr_view()   { printf '%s' "$1" > "$STUB/gh-pr-view.out"; }
 # bpt_count <name> <want> <file>  — assert a stub log has exactly <want> non-blank lines
 # (grep -c prints 0 and exits 1 on no-match, so read its stdout and default empty→0; no `|| echo`).

--- a/bin/test-bug-pipeline-hunt
+++ b/bin/test-bug-pipeline-hunt
@@ -40,13 +40,34 @@ bpt_expect_eq   "r5: exit 0" 0 "$BPT_RC"
 bpt_file_absent "$STUB/claude.sentinel" "r5: empty claim spawns zero hunter"
 bpt_log_has     "$STUB" tick.out "no actionable rows" "r5: falls through to cheap exit"
 
-# ── Row 8 — wt-new called once as bug-<id>; worktree created ──
+# ── Row 8 — wt-new called once as bug-<id>-<descriptive-slug>; worktree created ──
+# Full-line exact match (not bpt_log_has substring) so a legacy "wt-new bug-7" run
+# can never false-green this: it would fail the exact comparison below.
 bpt_reset
 bpt_set_claim "$CLAIM"; bpt_set_result '{"verdict":"fixed"}'; bpt_hunt_dirty
 bpt_run
-bpt_count   "r8: wt-new called exactly once" 1 "$STUB/wt-new.log"
-bpt_log_has "$STUB" wt-new.log "wt-new bug-7" "r8: worktree slug is bug-<id>"
-if [ -d "$STUB/wt/bug-7/ibl5" ]; then bpt_ok "r8: worktree tree created"; else bpt_fail "r8: worktree tree missing"; fi
+bpt_count "r8: wt-new called exactly once" 1 "$STUB/wt-new.log"
+r8_line="$(cat "$STUB/wt-new.log" 2>/dev/null)"
+bpt_expect_eq "r8: worktree slug is bug-<id>-<descriptive-slug> (exact)" \
+    "wt-new bug-7-the-trade-button-is-broken" "$r8_line"
+if [ -d "$STUB/wt/bug-7-the-trade-button-is-broken/ibl5" ]; then bpt_ok "r8: worktree tree created"; else bpt_fail "r8: worktree tree missing"; fi
+
+# ── sanity — bug_slug() unit rows, exercised directly against the driver's own function
+# (not a re-implementation) via a fresh subshell that sources $DRIVER. $0 is deliberately
+# NOT set to $DRIVER (must differ from the sourced BASH_SOURCE[0]) — the driver's
+# `[ "${BASH_SOURCE[0]}" = "${0}" ]` tail guard would otherwise match and auto-run main().
+# All env-seam vars main() would need are already exported by bpt_setup, so the
+# REPO_ROOT-derived fallbacks this mismatched $0 skips are never actually consulted.
+bpt_bug_slug() { bash -c 'source "$1"; bug_slug "$2" "$3"' bpt-unit-shim "$DRIVER" "$1" "$2" 2>/dev/null; }
+bpt_expect_eq "sanity: empty original_text → bug-<id> fallback" \
+    "bug-9" "$(bpt_bug_slug 9 "")"
+bpt_expect_eq "sanity: emoji-only original_text → bug-<id> fallback" \
+    "bug-9" "$(bpt_bug_slug 9 "🎉🎉🎉")"
+bpt_expect_eq "sanity: long text → 30-char cap, no trailing hyphen" \
+    "bug-1-nav-dropdown-re-triggers-stagg" \
+    "$(bpt_bug_slug 1 "nav dropdown re-triggers staggered animation")"
+bpt_expect_eq "sanity: mixed-case/punctuation squeezes to single hyphens" \
+    "bug-3-a-b-c" "$(bpt_bug_slug 3 "A!! b__C")"
 
 # ── Row 10 — NEG wt-new failure → re-queue + release-lease, no hunter, exit 0 ──
 bpt_reset
@@ -115,6 +136,24 @@ bpt_run
 bpt_log_lacks "$STUB" transition.log "pr_open --pr" "r17: no pr found → no transition (reconcile again later)"
 bpt_log_lacks "$STUB" gh.log "pr edit" "r17: no pr found → no label attempt"
 
+# ── Row 17 — PR #1487 cutover: pre-rename hunt row shipped under the bare bug-<id> branch.
+# gh pr list against the NEW descriptive head returns empty, but the LEGACY bug-1 head
+# still has the PR (opened before the rename) → reconcile must fall back and backfill it.
+bpt_reset
+bpt_set_list_pr_open '[{"id":"1","status":"pr_open","pr_number":null,"issue_number":"9","original_text":"nav dropdown re-triggers staggered animation"}]'
+bpt_set_gh_pr_list_for "bug-1-nav-dropdown-re-triggers-stagg" ''
+bpt_set_gh_pr_list_for "bug-1" '77'
+bpt_run
+bpt_log_has "$STUB" gh.log "pr list --repo test/code-fake --head bug-1-nav-dropdown-re-triggers-stagg" \
+    "r17-cutover: reconcile first tries the NEW descriptive head"
+# NOTE: "--head bug-1 --json" (not bare "--head bug-1") — bug-1 is a PREFIX of the
+# descriptive head above, so an un-anchored substring match would false-green here
+# even without the fallback query actually firing.
+bpt_log_has "$STUB" gh.log "pr list --repo test/code-fake --head bug-1 --json" \
+    "r17-cutover: falls back to the legacy bare bug-<id> head"
+bpt_log_has "$STUB" transition.log "transition 1 pr_open --pr=77" \
+    "r17-cutover: backfills pr_number from the legacy-head PR"
+
 # ── Row 18 — SECURITY grep: post-plan-now absent from the prompt AND from run_hunter_agent ──
 if grep -qi 'post-plan-now' "$PROMPT"; then bpt_fail "r18: post-plan-now leaked into hunter prompt"; else bpt_ok "r18: post-plan-now absent from hunter prompt"; fi
 rha_body="$(awk '/^run_hunter_agent\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$DRIVER")"
@@ -174,17 +213,35 @@ bpt_file_absent "$STUB/claude.sentinel" "r26: future-blocked row spawns no hunte
 bpt_count       "r26: no wt-new for an unresumed row" 0 "$STUB/wt-new.log"
 
 # ── Row 27 — ripe blocked row → atomic blocked→hunting, EXISTING worktree reused (no wt-new) ──
+# original_text must match on BOTH fixtures: resume_blocked_hunt derives its slug from $row
+# (the enumerator's listActiveConversations row) to decide reuse-vs-create, but then hands off
+# to drive_hunt_row($resumed) which independently recomputes from claim-next --resume's row
+# (findById). Both are `SELECT *` on the SAME db row in production, so original_text always
+# agrees there — the fixture must mirror that or the two slug computations diverge.
+bpt_reset
+R27_SLUG="bug-7-roster-page-throws-a-fatal-err"
+mkdir -p "$STUB/wt/$R27_SLUG/ibl5"
+git -C "$STUB/wt/$R27_SLUG" init -q; git -C "$STUB/wt/$R27_SLUG" config user.email t@t; git -C "$STUB/wt/$R27_SLUG" config user.name t
+printf 'base\n' > "$STUB/wt/$R27_SLUG/ibl5/hunted.txt"
+git -C "$STUB/wt/$R27_SLUG" add -A; git -C "$STUB/wt/$R27_SLUG" commit -qm base
+bpt_set_actionable '[{"id":"7","status":"blocked","class":"bug","original_text":"roster page throws a fatal error"}]'
+bpt_set_resume '{"id":"7","status":"hunting","class":"bug","hunt_attempts":1,"issue_number":"4242","original_text":"roster page throws a fatal error"}'
+bpt_set_result '{"verdict":"fixed"}'; bpt_hunt_dirty
+bpt_run
+if grep -q . "$STUB/hunt-models.log" 2>/dev/null; then bpt_ok "r27: ripe blocked row is re-hunted"; else bpt_fail "r27: ripe blocked row was not hunted"; fi
+bpt_count "r27: existing worktree reused (no wt-new)" 0 "$STUB/wt-new.log"
+
+# ── NEW — legacy-worktree-reuse (hunt path): claim row WITH original_text, but only the
+# LEGACY bug-<id> dir pre-exists → drive_hunt_row must reuse it, never fork a second worktree.
 bpt_reset
 mkdir -p "$STUB/wt/bug-7/ibl5"
 git -C "$STUB/wt/bug-7" init -q; git -C "$STUB/wt/bug-7" config user.email t@t; git -C "$STUB/wt/bug-7" config user.name t
 printf 'base\n' > "$STUB/wt/bug-7/ibl5/hunted.txt"
 git -C "$STUB/wt/bug-7" add -A; git -C "$STUB/wt/bug-7" commit -qm base
-bpt_set_actionable '[{"id":"7","status":"blocked","class":"bug"}]'
-bpt_set_resume '{"id":"7","status":"hunting","class":"bug","hunt_attempts":1,"issue_number":"4242"}'
-bpt_set_result '{"verdict":"fixed"}'; bpt_hunt_dirty
+bpt_set_claim "$CLAIM"; bpt_set_result '{"verdict":"fixed"}'; bpt_hunt_dirty
 bpt_run
-if grep -q . "$STUB/hunt-models.log" 2>/dev/null; then bpt_ok "r27: ripe blocked row is re-hunted"; else bpt_fail "r27: ripe blocked row was not hunted"; fi
-bpt_count "r27: existing worktree reused (no wt-new)" 0 "$STUB/wt-new.log"
+bpt_count "r-legacy: no wt-new call (legacy dir reused)" 0 "$STUB/wt-new.log"
+bpt_log_has "$STUB" transition.log "transition 7 pr_open" "r-legacy: hunt still ships using the reused legacy worktree"
 
 # ── Row 32 — RCA labels on ship: area/root_cause slugs → ensure+add label against the issue ──
 bpt_reset

--- a/bin/test-bug-pipeline-hunt
+++ b/bin/test-bug-pipeline-hunt
@@ -95,7 +95,7 @@ bpt_reset
 bpt_set_claim "$CLAIM"; bpt_set_result '{"verdict":"fixed"}'; bpt_hunt_dirty
 bpt_run
 bpt_count "r12: cron fired post-plan-now once" 1 "$STUB/post-plan-now.log"
-if git -C "$STUB/wt/bug-7" diff --quiet 2>/dev/null; then bpt_fail "r12: worktree unexpectedly clean at handoff"; else bpt_ok "r12: worktree DIRTY at handoff (post-plan-now commits it)"; fi
+if git -C "$STUB/wt/bug-7-the-trade-button-is-broken" diff --quiet 2>/dev/null; then bpt_fail "r12: worktree unexpectedly clean at handoff"; else bpt_ok "r12: worktree DIRTY at handoff (post-plan-now commits it)"; fi
 
 # ── Row 13 / Row 23 — all tiers escalate → needs_human; post-plan-now NEVER fired, never pr_open ──
 bpt_reset


### PR DESCRIPTION
## Summary

Adds a `bug_slug()` function that appends a kebab-case excerpt of
the hunt's `original_text` to the worktree/branch name, making them
human-readable at a glance (`bug-7-the-trade-button-is-broken`
instead of `bug-7`).

### Slug rules
- lowercase; non-alphanumeric runs → single `-`; max 30 chars of desc
- trailing hyphen stripped; empty slug falls back to bare `bug-<id>`
- strict `[a-z0-9-]` allowlist — `original_text` is untrusted GM input

### Legacy cutover (no orphaned hunts)
- `drive_hunt_row` / `resume_blocked_hunt`: if the new descriptive
  dir doesn't exist but the bare `bug-<id>` dir does, reuse it in place
- `reconcile_pr_open_rows`: if the descriptive head has no open PR,
  falls back to query the bare `bug-<id>` head (covers PRs opened before
  the rename)

### Test coverage
- `bpt_set_gh_pr_list_for <head> <value>` helper in test stubs
- Unit rows for `bug_slug()`: empty/emoji-only fallback, 30-char cap,
  punct/case squeezing
- r8 exact-match asserts the new descriptive slug (not just substring)
- r17-cutover: reconcile backfills `pr_number` from legacy head
- r-legacy: drive path reuses legacy `bug-<id>` dir, no second wt-new
- r27 split into two: one with `original_text` (named slug) and one
  without (bare-id fallback)

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.