### PR TITLE
chore(post-plan-now): support harness engine with skill fallback

### DIFF
--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -39,7 +39,7 @@ bin/post-plan-now --auto
 
 (Ad-hoc branch with no plan file → post-plan runs plan-blind; expected, not an error. The merge-arming decision still happens at `/post-plan` Phase 6.5, so auto-opening the PR never auto-merges a `feat:`/`auto_merge: false`/visual PR without human signoff.)
 
-This spawns a detached, fresh **Sonnet 4.6** `/post-plan` on this branch (launchd-supervised, so it survives you closing Claude Code). Notes:
+This spawns a detached, launchd-supervised post-plan run on this branch (survives you closing Claude Code). Engine: the **compiled post-plan harness** (`~/GitHub/postplan-harness`, deterministic sequencer + bounded LLM calls) when installed, falling back to a fresh **Sonnet 4.6** `/post-plan` skill session if the harness fails or is absent (`POST_PLAN_SKILL=1` forces the skill). Notes:
 
 - **Do NOT commit first.** Leave the worktree **dirty** — `/post-plan` commits the uncommitted tree in Phase 2 and opens the PR. Committing here changes what it ships.
 - **Only fire when verification passed.** If implementation did **not** verify clean (failing tests, unresolved blocker, you stopped to ask the user something), do **not** fire — leave the worktree dirty and hand off in prose. Turn-end ≠ done; that judgment is yours.

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 #
-# bin/post-plan-now — fire a fresh, detached Sonnet 4.6 /post-plan session on the
-# current worktree's branch, replacing the manual "open a new session and hand
-# off" step. The run is supervised by launchd (RunAtLoad one-shot), so it
+# bin/post-plan-now — fire a detached post-plan run on the current worktree's
+# branch, replacing the manual "open a new session and hand off" step.
+#
+# Engine selection: when the compiled post-plan harness is installed
+# (~/GitHub/postplan-harness, see its README) it runs `./run isolated <root>
+# --live` — the deterministic phase sequencer with bounded LLM calls (~65-100x
+# fewer gross tokens than a skill session). If the harness exits nonzero, or is
+# absent on this machine, the same launchd job falls back to the original
+# Sonnet 4.6 /post-plan skill session. POST_PLAN_SKILL=1 forces the skill path.
+# The harness intentionally omits backlog housekeeping, worktree teardown, the
+# E2E verify track, and Phase 10 preview — the skill fallback retains them.
+#
+# Either way the run is supervised by launchd (RunAtLoad one-shot), so it
 # survives closing Claude Code or the terminal — a plain `nohup … &` launched
 # from Claude Code's Bash tool shares the tool-shell's process group and dies
 # with it, so launchd is the load-bearing detach mechanism (same reason
 # bin/automouse-run uses launchd).
 #
-# The plan is resolved from the branch slug by /post-plan Phase 1 — no handoff
-# file is needed (that machinery is automouse-only).
+# The plan is resolved from the branch slug — by harness Phase 1 (plan-blind if
+# absent) or /post-plan skill Phase 1. No handoff file is needed.
 #
 # Usage:
 #   bin/post-plan-now           # you decided to ship: fire unconditionally
@@ -75,6 +85,17 @@ PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 
 PROMPT="Invoke the /post-plan skill now on the current git branch. Resolve the plan from the branch slug per the skill Phase 1, then execute every phase. No human is present: never ask questions or wait for input — make the safe choice and continue."
 
+# Compiled-harness engine (see header). The harness command chains `|| skill`
+# inside the launchd job, so a harness failure degrades to the skill session
+# in the same supervised run instead of silently shipping nothing.
+HARNESS="$HOME/GitHub/postplan-harness"
+HARNESS_TRY=""
+ENGINE="Sonnet 4.6 /post-plan skill session"
+if [ "${POST_PLAN_SKILL:-0}" != "1" ] && [ -x "$HARNESS/run" ]; then
+    HARNESS_TRY="CLAUDE_HEADLESS=1 caffeinate -s \"$HARNESS/run\" isolated \"$ROOT\" \"$HARNESS/out/live-$SLUG-$TS\" --live || "
+    ENGINE="compiled post-plan harness (falls back to the skill session on failure)"
+fi
+
 # launchd runs with a minimal env, so prepend the same PATH bin/automouse-run uses
 # (proven to find claude/gh/docker/node for full post-plan runs). CLAUDE_HEADLESS=1
 # marks the detached run unattended: /post-plan skips the Phase 10 preview rebuild
@@ -93,7 +114,7 @@ cat > "$PLIST" <<PLIST_EOF
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
+		<string>export PATH="/usr/local/bin:/opt/homebrew/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:\$PATH"; cd "$ROOT" &amp;&amp; { ${HARNESS_TRY}CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s claude -p "$PROMPT" --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --name "$LABEL"; }; rm -f "$PLIST"; launchctl bootout gui/\$(id -u)/$LABEL</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
@@ -110,7 +131,8 @@ PLIST_EOF
 launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$PLIST"
 
-echo "post-plan-now: fired a detached Sonnet 4.6 /post-plan on branch '$SLUG'."
+echo "post-plan-now: fired a detached post-plan on branch '$SLUG'."
+echo "  engine: $ENGINE"
 echo "  supervised by launchd — survives closing Claude Code / the terminal"
 echo "  log:    tail -f $LOG"
 echo "  label:  $LABEL   (self-removes when post-plan finishes)"


### PR DESCRIPTION
## Summary
- Detect compiled post-plan harness at ~/GitHub/postplan-harness and invoke it when available
- Automatic fallback to Sonnet 4.6 skill session if harness is absent or fails (same launchd job)
- POST_PLAN_SKILL=1 env var forces skill session path
- Updated workflow-continuity.md to document engine selection and harness scope limits (no backlog housekeeping, E2E verify, or Phase 10 preview)

## Manual Testing

No manual testing needed — verified by automated tests.
