### PR TITLE
chore(docs): sync token-spend backlog status and xrefs

### DIFF
--- a/ibl5/docs/backlog/token-spend-backlog.md
+++ b/ibl5/docs/backlog/token-spend-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Token-spend reduction backlog — resident-context diet, caching economics, output-spend guards, and LSP-first navigation for the Claude Code harness, with per-entry status.
-last_verified: 2026-07-16
+last_verified: 2026-07-17
 ---
 
 # Token-Spend Reduction Backlog
@@ -77,12 +77,12 @@ First-wave entries (T1–T13) are ✅ Implemented — see the dated pointers bel
 ➜ T12 Sonnet plan-architect for recipe-backed plans — ✅ Implemented (2026-07-11): see [archive](archive/token-spend-backlog-archive.md).
 
 **Token-relevant entries tracked elsewhere:**
-- L18 (tier-default correction — `impl_model:` fails open to Opus) — [loop-engineering-backlog.md](loop-engineering-backlog.md). Supersedes the former L2 token-budget-breaker residual, closed 2026-07-15 as empirically refuted (PR #1477 closed unmerged): impl spend doesn't predict postplan spend, and the measured waste is tier misallocation (~82% of impl spend is Opus; ~$27/week routed to Opus purely by a missing `impl_model:` field), not plan length.
-- L15 (Sonnet-recipe completeness lint) — [loop-engineering-backlog.md](loop-engineering-backlog.md).
-- L16 (context-budget gate v2) — [loop-engineering-backlog.md](loop-engineering-backlog.md).
+- L18 (tier-default correction — `impl_model:` fails open to Opus) — [loop-engineering-backlog.md](loop-engineering-backlog.md). ✅ Implemented (2026-07-16). Supersedes the former L2 token-budget-breaker residual, closed 2026-07-15 as empirically refuted (PR #1477 closed unmerged): impl spend doesn't predict postplan spend, and the measured waste is tier misallocation (~82% of impl spend is Opus; ~$27/week routed to Opus purely by a missing `impl_model:` field), not plan length.
+- L15 (Sonnet-recipe completeness lint) — [loop-engineering-backlog.md](loop-engineering-backlog.md). ✅ Implemented (2026-07-15).
+- L16 (context-budget gate v2) — [loop-engineering-backlog.md](loop-engineering-backlog.md). 📋 Planned.
 - E8 (memory-lines→gates umbrella, pairs with T7) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md). ◑ Partial as of 2026-07-14; one item remains (free-agents teamid write guard).
 - E6 (diff-scoped PHPStan wrapper) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md): every agent verify iteration (local + automouse) drops from O(project) to O(diff) analysis — fewer polling turns and less output per loop. (Cross-referenced 2026-07-14, token-spend sweep.) ✅ Implemented (2026-07-14) — shipped in PR #1362.
-- E3 (PHPStan result-cache in CI) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md): shorter CI runs → fewer CI-watch polling turns per PR. (Cross-referenced 2026-07-14, token-spend sweep.)
+- E3 (PHPStan result-cache in CI) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md). ✅ Implemented (2026-07-03). shorter CI runs → fewer CI-watch polling turns per PR. (Cross-referenced 2026-07-14, token-spend sweep.)
 - E4 (flake-quarantine ledger) — [dev-efficiency-backlog.md](dev-efficiency-backlog.md): removes flake-triggered re-run cycles and lost nightly-queue runs. (Cross-referenced 2026-07-14, token-spend sweep.)
 - 5.1 (build IBLbot TypeScript on the CI runner) — [ci-backlog.md](ci-backlog.md): each droplet-side build failure (2 to date) costs manual-intervention sessions plus CI-watch re-run cycles. (Cross-referenced 2026-07-14, token-spend sweep.)
 


### PR DESCRIPTION
## Summary
- Update last_verified timestamp to 2026-07-17
- Mark L18, L15, E3 as ✅ Implemented with completion dates
- Update L16 status to 📋 Planned

## Manual Testing

No manual testing needed — verified by automated tests.
