### PR TITLE
chore(engine): add per-player make/block-rate composites

### DIFF
--- a/engine/internal/backup/assemble.go
+++ b/engine/internal/backup/assemble.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/a-jay85/IBL5/engine/internal/bundle"
@@ -63,6 +64,31 @@ func computeLeagueShotBaseline(players []PlrPlayer) float64 {
 		return 0
 	}
 	return sum2PA / sumMIN * 48.0
+}
+
+// computeLeagueBlk48 assembles the league BLK-per-48-player-minutes rate
+// (bundle.Bundle.LeagueBlk48), the block-modifier denominator for shotValue3pt/2pt.
+// Same qualifying population as computeLeagueShotBaseline: RecordIndex ≤
+// leagueShotBaselineMaxRecordIndex, non-empty Name, RealLifeMIN > 2×RealLifeGP.
+// Expected ~1.7484 on the game-install IBL5.plr. Returns 0 on empty pop.
+func computeLeagueBlk48(players []PlrPlayer) float64 {
+	var sumBLK, sumMIN float64
+	for _, p := range players {
+		if p.RecordIndex > leagueShotBaselineMaxRecordIndex {
+			continue
+		}
+		if p.Name == "" {
+			continue
+		}
+		if p.RealLifeMIN > 2*p.RealLifeGP {
+			sumBLK += float64(p.RealLifeBLK)
+			sumMIN += float64(p.RealLifeMIN)
+		}
+	}
+	if sumMIN <= 0 {
+		return 0
+	}
+	return sumBLK / sumMIN * 48.0
 }
 
 // AssembleOptions carries the bundle-level metadata the backup files do not
@@ -181,6 +207,7 @@ func ToBundle(players []PlrPlayer, sched []SchGame, opts AssembleOptions) (bundl
 		Players:            bundlePlayers,
 		Schedule:           games,
 		LeagueShotBaseline: computeLeagueShotBaseline(players),
+		LeagueBlk48:        computeLeagueBlk48(players),
 	}, nil
 }
 
@@ -189,6 +216,32 @@ func ToBundle(players []PlrPlayer, sched []SchGame, opts AssembleOptions) (bundl
 // TO=transition offense -> r_trans_off. minutes maps player ordinal ->
 // dc_minutes from the .plb (nil -> 0).
 func toBundlePlayer(p PlrPlayer, minutes map[int]int) bundle.Player {
+	// Per-player derived make-rate composites (D-fields). Faithful to the JSB
+	// +0xD80/+0xD60/+0xD64/+0xDE8 per-player offsets. Zero when real-life data
+	// is absent — shotdecision.go falls back to fgpToPermille for D60/D64==0.
+	// D88=(FGA-3GA)/MIN×48, D90=3GA/MIN×48 match bucketweights.go:260-265 locals.
+	var d80, d60, d64 int
+	var de8 float64
+	if p.RealLifeMIN > 0 {
+		de8 = float64(p.RealLifeBLK) / float64(p.RealLifeMIN) * 48.0
+	}
+	if p.RealLife3GA > 0 {
+		d80 = int(math.Round(float64(p.RealLife3GM) / float64(p.RealLife3GA) * 1000))
+	}
+	twoPA := p.RealLifeFGA - p.RealLife3GA
+	if twoPA > 0 {
+		d60 = int(math.Round(float64(p.RealLifeFGM-p.RealLife3GM) / float64(twoPA) * 1000))
+		if p.RealLifeMIN > 0 {
+			d88 := float64(twoPA) / float64(p.RealLifeMIN) * 48.0
+			d90 := float64(p.RealLife3GA) / float64(p.RealLifeMIN) * 48.0
+			if d90 > 0 {
+				d64 = int(math.Round(float64(d60) * (4*d90 - d88) / (3 * d90)))
+				if d64 < 0 {
+					d64 = 0
+				} // floor: rare high-volume 2PA skew
+			}
+		}
+	}
 	return bundle.Player{
 		PID:    p.PID,
 		Name:   p.Name,
@@ -229,6 +282,13 @@ func toBundlePlayer(p PlrPlayer, minutes map[int]int) bundle.Player {
 		RealLifeORB: p.RealLifeORB,
 		RealLifeSTL: p.RealLifeSTL,
 		RealLifeTVR: p.RealLifeTVR,
+		RealLifeFGM: p.RealLifeFGM,
+		RealLife3GM: p.RealLife3GM,
+		RealLifeBLK: p.RealLifeBLK,
+		D80:         d80,
+		D60:         d60,
+		D64:         d64,
+		DE8:         de8,
 
 		Age:         p.Age,
 		Clutch:      p.Clutch,

--- a/engine/internal/backup/plr.go
+++ b/engine/internal/backup/plr.go
@@ -88,13 +88,16 @@ const (
 	// (2PA = FGA_total − 3GA, since offRealLifeFGA is the combined total).
 	offRealLifeGP  = 52 // width 4 — games played (league-baseline inclusion gate)
 	offRealLifeMIN = 56 // width 4 — minutes played (the per-48 rate divisor)
+	offRealLifeFGM = 60 // width 4 — field goals made (feeds D60/D64 per-player make-rate)
 	offRealLifeFGA = 64 // width 4 — total FG attempts (D88)
 	offRealLifeFTA = 72 // width 4 — FT attempts (D70 per-player part)
+	offRealLife3GM = 76 // width 4 — 3-point field goals made (feeds D80 per-player 3pt make-rate)
 	offRealLife3GA = 80 // width 4 — 3pt attempts (subtracted from FGA for the 2PA/48 baseline)
 	offRealLifeORB = 84 // width 4 — offensive rebounds (DB8)
 	// not read: DRB=88, AST=92 (defQ/offQ need only STL and TVR — skipped deliberately)
 	offRealLifeSTL = 96  // width 4 — career steals (real-life), PlrLineParser.php:53 substr(line,96,4)
 	offRealLifeTVR = 100 // width 4 — career turnovers (real-life), PlrLineParser.php:54 substr(line,100,4)
+	offRealLifeBLK = 104 // width 4 — blocks (feeds DE8 per-player block-rate; also LeagueBlk48)
 
 	// Per-player IN-SEASON box-score totals (record-relative, width 4 each), the
 	// Branch-B team-rate inputs. JSB's per-half setup (FUN_004cfa50, COMPOSITE_DOUBLES_
@@ -210,12 +213,15 @@ type PlrPlayer struct {
 	// gated jointly with RecordIndex ≤ 959 and a non-empty Name.
 	RealLifeGP  int
 	RealLifeMIN int
+	RealLifeFGM int
 	RealLifeFGA int
 	RealLifeFTA int
+	RealLife3GM int
 	RealLife3GA int
 	RealLifeORB int
 	RealLifeSTL int
 	RealLifeTVR int
+	RealLifeBLK int
 
 	// Per-player IN-SEASON box-score totals (offSeasonGP/DRB/AST), the Branch-B
 	// team-rate inputs. Summed per team in assemble.go into bundle.Team.DRBRate/
@@ -302,11 +308,14 @@ func ReadPlr(r io.Reader) ([]PlrPlayer, error) {
 			{&p.PGDepth, offPGDepth, 1}, {&p.SGDepth, offSGDepth, 1}, {&p.SFDepth, offSFDepth, 1},
 			{&p.PFDepth, offPFDepth, 1}, {&p.CDepth, offCDepth, 1},
 			{&p.RealLifeGP, offRealLifeGP, 4},
-			{&p.RealLifeMIN, offRealLifeMIN, 4}, {&p.RealLifeFGA, offRealLifeFGA, 4},
-			{&p.RealLifeFTA, offRealLifeFTA, 4}, {&p.RealLife3GA, offRealLife3GA, 4},
+			{&p.RealLifeMIN, offRealLifeMIN, 4},
+			{&p.RealLifeFGM, offRealLifeFGM, 4}, {&p.RealLifeFGA, offRealLifeFGA, 4},
+			{&p.RealLifeFTA, offRealLifeFTA, 4},
+			{&p.RealLife3GM, offRealLife3GM, 4}, {&p.RealLife3GA, offRealLife3GA, 4},
 			{&p.RealLifeORB, offRealLifeORB, 4},
 			{&p.RealLifeSTL, offRealLifeSTL, 4},
 			{&p.RealLifeTVR, offRealLifeTVR, 4},
+			{&p.RealLifeBLK, offRealLifeBLK, 4},
 			{&p.SeasonGP, offSeasonGP, 4}, {&p.SeasonDRB, offSeasonDRB, 4},
 			{&p.SeasonAST, offSeasonAST, 4},
 			{&p.RatingFGA, offRating2GA, 3}, {&p.RatingFGP, offRating2GP, 3},

--- a/engine/internal/bundle/bundle.go
+++ b/engine/internal/bundle/bundle.go
@@ -120,6 +120,25 @@ type Player struct {
 	RealLifeORB int `json:"rl_orb"`
 	RealLifeSTL int `json:"rl_stl"`
 	RealLifeTVR int `json:"rl_tvr"`
+	RealLifeFGM int `json:"rl_fgm"`
+	RealLife3GM int `json:"rl_3gm"`
+	RealLifeBLK int `json:"rl_blk"`
+
+	// Per-player derived make-rate composites computed at bundle-build time
+	// (backup/assemble.go toBundlePlayer). D80/D60/D64 are per-mille values;
+	// DE8 is BLK/MIN×48. Zero when the player has no real-life counting-stat data
+	// (rookies, DB-built bundles) — shotdecision.go falls back to fgpToPermille
+	// for D64==0 and D60==0 (mirror of shotBaselineOrFallback).
+	//
+	// D80 = round(3GM/3GA×1000), 0 if 3GA≤0       [3pt make %‰]
+	// D60 = round((FGM-3GM)/(FGA-3GA)×1000), 0 if (FGA-3GA)≤0  [2pt make %‰]
+	// D64 = round(D60×(4×D90−D88)/(3×D90)), 0 if D90≤0 [putback-adjusted 2P‰;
+	//        D90=3GA/MIN×48, D88=(FGA-3GA)/MIN×48 — same derivation as bucketweights.go:260-265]
+	// DE8 = BLK/MIN×48, 0 if MIN≤0                [blocks per 48 min]
+	D80 int     `json:"d80"`
+	D60 int     `json:"d60"`
+	D64 int     `json:"d64"`
+	DE8 float64 `json:"de8"`
 
 	// Attributes.
 	Age         int `json:"age"`
@@ -173,6 +192,13 @@ type Bundle struct {
 	Players            []Player `json:"players"`
 	Schedule           []Game   `json:"schedule"`
 	LeagueShotBaseline float64  `json:"league_shot_baseline"`
+	// LeagueBlk48 is the league BLK-per-48-player-minutes rate (analogous to
+	// LeagueShotBaseline), assembled once per snapshot by backup.ToBundle's
+	// computeLeagueBlk48 over raw .plr records ≤959 with MIN>2×GP and non-empty
+	// Name. Expected ~1.7484 on the game-install IBL5.plr. A zero value (unwired
+	// bundle) leaves blockMod returning 0 — a graceful no-op, since the cap
+	// defBlkSum ≤ 1.5×5×leagueBlk48 forces defBlkSum to 0 when leagueBlk48=0.
+	LeagueBlk48 float64 `json:"league_blk48"`
 }
 
 // Validation errors surfaced at the contract boundary.

--- a/engine/internal/sim/endingmix_share_archive_test.go
+++ b/engine/internal/sim/endingmix_share_archive_test.go
@@ -49,12 +49,12 @@ type endingMixCounts struct {
 	Possessions int `json:"possessions"`
 
 	// Possession endings (each possession classified exactly once).
-	EndSteal    int `json:"end_steal"`     // EventSteal present (steal IS the turnover)
-	EndTOInd    int `json:"end_to_ind"`    // EventTurnover without a steal (independent check)
-	EndDReb     int `json:"end_dreb"`      // defensive rebound (always trip-terminal)
-	EndMade     int `json:"end_made"`      // made FG, no FT sequence
-	EndFT       int `json:"end_ft"`        // FT sequence last (and-one or foul-only; engine FTs never rebound)
-	EndOther    int `json:"end_other"`     // OREB-cap exhaustion / empty possession
+	EndSteal   int `json:"end_steal"`    // EventSteal present (steal IS the turnover)
+	EndTOInd   int `json:"end_to_ind"`   // EventTurnover without a steal (independent check)
+	EndDReb    int `json:"end_dreb"`     // defensive rebound (always trip-terminal)
+	EndMade    int `json:"end_made"`     // made FG, no FT sequence
+	EndFT      int `json:"end_ft"`       // FT sequence last (and-one or foul-only; engine FTs never rebound)
+	EndOther   int `json:"end_other"`    // OREB-cap exhaustion / empty possession
 	ORebCont   int `json:"oreb_cont"`    // offensive-rebound CONTINUATIONS (not endings)
 	AndOneSeqs int `json:"and_one_seqs"` // and-one FT sequences (FTAttempts==1) inside EndFT
 
@@ -156,16 +156,16 @@ type endingMixArtifact struct {
 	OtherSharePct float64 `json:"end_other_share_pct"`
 
 	// Sub-model rates.
-	FGPct        float64 `json:"fg_pct"`          // FGM/FGA
-	ORebRatePct  float64 `json:"oreb_rate_pct"`   // OReb/(OReb+DReb)
-	PossPerGame  float64 `json:"poss_per_game"`   // both teams pooled
-	FGAPerGame   float64 `json:"fga_per_game"`    // both teams pooled
-	StealPerGame float64 `json:"steal_per_game"`  // both teams pooled
-	TOPerGame    float64 `json:"tov_per_game"`    // both teams pooled (incl. steals)
-	DRebPerGame  float64 `json:"dreb_per_game"`   // both teams pooled
-	ORebPerGame  float64 `json:"oreb_per_game"`   // both teams pooled
-	FTAPerGame   float64 `json:"fta_per_game"`    // both teams pooled
-	ArmedPct     float64 `json:"armed_pct"`       // 0.94×DRebShare + StealShare (faithful 5.60 arming over THIS mix)
+	FGPct        float64 `json:"fg_pct"`            // FGM/FGA
+	ORebRatePct  float64 `json:"oreb_rate_pct"`     // OReb/(OReb+DReb)
+	PossPerGame  float64 `json:"poss_per_game"`     // both teams pooled
+	FGAPerGame   float64 `json:"fga_per_game"`      // both teams pooled
+	StealPerGame float64 `json:"steal_per_game"`    // both teams pooled
+	TOPerGame    float64 `json:"tov_per_game"`      // both teams pooled (incl. steals)
+	DRebPerGame  float64 `json:"dreb_per_game"`     // both teams pooled
+	ORebPerGame  float64 `json:"oreb_per_game"`     // both teams pooled
+	FTAPerGame   float64 `json:"fta_per_game"`      // both teams pooled
+	ArmedPct     float64 `json:"armed_pct"`         // 0.94×DRebShare + StealShare (faithful 5.60 arming over THIS mix)
 	ImpliedCode7 float64 `json:"implied_code7_pct"` // ArmedPct × 0.300 (archive-mean gate (4.40+1)/18)
 }
 

--- a/engine/internal/sim/gameloop.go
+++ b/engine/internal/sim/gameloop.go
@@ -67,6 +67,7 @@ func simGameWith(b bundle.Bundle, g bundle.Game, r *rng.RNG, opts Options) (resu
 	// population. A zero/unwired field (e.g. a hand-built test bundle) falls
 	// back to leagueBaselineFallback via shotBaselineOrFallback below.
 	gs.shotBaseline = b.LeagueShotBaseline
+	gs.leagueBlk48 = b.LeagueBlk48
 
 	// base_time is CONSTANT per game in 5.60 — the composite ratio is dead code
 	// (u = 0; tempo.go const block, J24 Phase 0). This retired the ADR-0042

--- a/engine/internal/sim/state.go
+++ b/engine/internal/sim/state.go
@@ -175,6 +175,14 @@ type gameState struct {
 	// snapshot, like gateBaseline. It feeds shotValue2pt's net term and
 	// shotValue3pt (= baseline×1.5).
 	shotBaseline float64
+	// leagueBlk48 is the league BLK-per-48-player-minutes rate
+	// (bundle.Bundle.LeagueBlk48), copied once per game from the bundle.
+	// Feeds blockMod in shotValue3pt/2pt (shotdecision.go). A zero value
+	// (unwired bundle or synthetically-constructed gameState) is intentional:
+	// the defBlkSum cap (≤ 1.5×5×leagueBlk48) forces defBlkSum to 0 when
+	// leagueBlk48=0, so blockMod returns 0 — a no-op fallback requiring no
+	// separate accessor.
+	leagueBlk48 float64
 }
 
 func (g *gameState) emit(e result.Event) { g.events = append(g.events, e) }


### PR DESCRIPTION
## Summary
- Extend plr.go parsing with RealLifeFGM/3GM/BLK fields from box scores
- Compute per-player derived composites (D80/D60/D64/DE8) in bundle layer
- Add LeagueBlk48 league block rate; propagate through Bundle and gameState
- Pure data-model addition—no behavior changes; all fields zero-valued in existing bundles

## Manual Testing

No manual testing needed — verified by automated tests.
