### PR TITLE
fix(check-docs): use author tz (%aI) for editCommitDate to avoid UTC day-flip on CI runners

### DIFF
--- a/bin/check-docs
+++ b/bin/check-docs
@@ -513,10 +513,11 @@ function fixDates(array $files, \DateTimeImmutable $today): int
 }
 
 /**
- * Default-tz calendar date (Y-m-d) of the most recent commit in $base..HEAD that
- * touched $rel — the date the change was committed. Read from the author
- * timestamp (%at), an absolute instant, then formatted in the same default
- * timezone as $today so the two share one frame.
+ * Calendar date (Y-m-d) of the most recent commit in $base..HEAD that touched
+ * $rel, in the **author's own timezone**. Read from the author timestamp (%aI,
+ * ISO 8601 with embedded tz offset) so the date reflects the author's calendar
+ * day, not the CI runner's (which is UTC and can be one day ahead for
+ * late-evening commits made in a negative-offset timezone like PDT).
  *
  * Immutable per commit, so comparing last_verified against it is independent of
  * when CI runs: a same-day re-edit of a doc already verified today passes without
@@ -530,7 +531,7 @@ function fixDates(array $files, \DateTimeImmutable $today): int
 function editCommitDate(string $repoRoot, string $base, string $rel): ?string
 {
     $cmd = sprintf(
-        'git -C %s log -1 --format=%%at %s..HEAD -- %s 2>/dev/null',
+        'git -C %s log -1 --format=%%aI %s..HEAD -- %s 2>/dev/null',
         escapeshellarg($repoRoot),
         escapeshellarg($base),
         escapeshellarg($rel)
@@ -538,14 +539,18 @@ function editCommitDate(string $repoRoot, string $base, string $rel): ?string
     $out = [];
     $code = 0;
     exec($cmd, $out, $code);
-    $ts = trim(implode('', $out));
-    if ($code !== 0 || $ts === '' || ctype_digit($ts) === false) {
+    $iso = trim(implode('', $out));
+    if ($code !== 0 || $iso === '') {
         return null;
     }
 
-    return (new \DateTimeImmutable('@' . $ts))
-        ->setTimezone(new \DateTimeZone(date_default_timezone_get()))
-        ->format('Y-m-d');
+    try {
+        // PHP parses the ISO 8601 string preserving the embedded tz offset, so
+        // format('Y-m-d') returns the date in the author's timezone, not UTC.
+        return (new \DateTimeImmutable($iso))->format('Y-m-d');
+    } catch (\Exception $e) {
+        return null;
+    }
 }
 
 /**


### PR DESCRIPTION
GitHub runners use UTC; a commit made late in a negative-offset timezone (e.g. PDT, 23:58 local = next-day UTC) caused `editCommitDate` to return the UTC date, making `last_verified` look stale when it matched the author's local date.

`%aI` embeds the author's tz offset; PHP parses it preserving that offset, so `format('Y-m-d')` returns the author's calendar day regardless of where CI runs.

Reproducer: the jsb-native-backlog.md touch in #1522 was made at 17:xx PDT (= next-day UTC), causing the on-touch check to false-fail on the runner.