### PR TITLE
chore(cron): Route errors to Discord, prevent email spam

### DIFF
--- a/ibl5/bin/ibl6-healthcheck
+++ b/ibl5/bin/ibl6-healthcheck
@@ -1,0 +1,17 @@
+#!/bin/bash
+# IBL6 pm2 watchdog. Redirects all output to the pm2 healthcheck log so cron
+# never sends email. Connection-refused errors are transient (pm2 restarted);
+# pm2 start/save output is informational. Neither warrants a notification.
+set -euo pipefail
+
+LOG=/home/iblhoops/.pm2/healthcheck.log
+NVM_PM2=/home/iblhoops/.nvm/versions/node/v22.7.0/bin/pm2
+IBL6=/home/iblhoops/public_html/IBL6
+
+exec >> "$LOG" 2>&1
+
+if ! curl -fsS --max-time 5 -o /dev/null http://127.0.0.1:3001/; then
+    cd "$IBL6"
+    "$NVM_PM2" start ecosystem.config.cjs --update-env
+    "$NVM_PM2" save
+fi

--- a/ibl5/bin/rebuild-record-holders-cache
+++ b/ibl5/bin/rebuild-record-holders-cache
@@ -16,43 +16,32 @@ require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/vendor/autoload.php';
 include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/config.php';
 include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/db/db.php';
 
+\Discord\Discord::init($_SERVER['SERVER_NAME']);
+
 /** @var \mysqli $mysqli_db */
 
-echo "Record Holders cache rebuild started\n";
+try {
+    $recordHoldersRepository = new \RecordHolders\RecordHoldersRepository($mysqli_db);
+    $lastAnnouncedDate = $recordHoldersRepository->getLastAnnouncedDate();
+    $newDates = $recordHoldersRepository->getUnannouncedGameDates($lastAnnouncedDate);
 
-// --- Detect broken/tied records for new game dates ---
-
-$recordHoldersRepository = new \RecordHolders\RecordHoldersRepository($mysqli_db);
-$lastAnnouncedDate = $recordHoldersRepository->getLastAnnouncedDate();
-$newDates = $recordHoldersRepository->getUnannouncedGameDates($lastAnnouncedDate);
-
-if ($newDates !== []) {
-    $latestDate = $newDates[count($newDates) - 1];
-    echo 'Checking ' . count($newDates) . ' game date(s) for records (' . $newDates[0] . ' to ' . $latestDate . ")\n";
-
-    $detector = new \RecordHolders\RecordBreakingDetector($recordHoldersRepository);
-    $announcements = $detector->detectAndAnnounce($newDates);
-
-    if ($announcements !== []) {
-        foreach ($announcements as $msg) {
-            echo "  RECORD: {$msg}\n";
-        }
-    } else {
-        echo "  No records broken or tied\n";
+    if ($newDates !== []) {
+        $latestDate = $newDates[count($newDates) - 1];
+        $detector = new \RecordHolders\RecordBreakingDetector($recordHoldersRepository);
+        $detector->detectAndAnnounce($newDates);
+        $recordHoldersRepository->markAnnouncementsProcessed($latestDate);
     }
 
-    $recordHoldersRepository->markAnnouncementsProcessed($latestDate);
-} else {
-    echo "No new game dates to check\n";
+    $innerService = new \RecordHolders\RecordHoldersService($recordHoldersRepository);
+    $cache = new \Cache\DatabaseCache($mysqli_db);
+    $cachedService = new \RecordHolders\CachedRecordHoldersService($innerService, $cache);
+    $cachedService->rebuildCache();
+} catch (\Throwable $e) {
+    try {
+        \Discord\Discord::sendDM('283183467804491776', 'rebuild-record-holders-cache failed: ' . $e->getMessage());
+    } catch (\Throwable) {
+        // DM delivery failed; fall through to stderr
+    }
+    fwrite(STDERR, 'rebuild-record-holders-cache failed: ' . $e->getMessage() . "\n");
+    exit(1);
 }
-
-// --- Rebuild the cache atomically ---
-
-echo "Rebuilding cache...\n";
-
-$innerService = new \RecordHolders\RecordHoldersService($recordHoldersRepository);
-$cache = new \Cache\DatabaseCache($mysqli_db);
-$cachedService = new \RecordHolders\CachedRecordHoldersService($innerService, $cache);
-$cachedService->rebuildCache();
-
-echo "Cache rebuilt successfully\n";


### PR DESCRIPTION
## Summary
- Add pm2 healthcheck script to suppress transient connection errors from cron
- Refactor rebuild-record-holders-cache: route errors to Discord DM instead of cron email
- Consolidate error handling with graceful fallback to stderr

## Manual Testing

No manual testing needed — verified by automated tests.
