### PR TITLE
chore(ops): add IBLbot healthcheck and Discord error notifications

### DIFF
--- a/ibl5/bin/iblbot-healthcheck
+++ b/ibl5/bin/iblbot-healthcheck
@@ -1,0 +1,17 @@
+#!/bin/bash
+# IBLbot pm2 watchdog. Redirects all output to the IBLbot healthcheck log so
+# cron never sends email. Connection-refused errors are transient (pm2 restarted);
+# pm2 start/save output is informational. Neither warrants a notification.
+set -euo pipefail
+
+LOG=/home/iblhoops/.pm2/iblbot-healthcheck.log
+NVM_PM2=/home/iblhoops/.nvm/versions/node/v22.7.0/bin/pm2
+IBLBOT=/home/iblhoops/public_html/ibl5/IBLbot
+
+exec >> "$LOG" 2>&1
+
+if ! curl -fsS --max-time 5 -o /dev/null http://127.0.0.1:50000/; then
+    cd "$IBLBOT"
+    "$NVM_PM2" start ecosystem.config.cjs --update-env
+    "$NVM_PM2" save
+fi

--- a/ibl5/bin/warm-cache
+++ b/ibl5/bin/warm-cache
@@ -11,47 +11,61 @@ if (php_sapi_name() !== 'cli') {
 set_time_limit(0);
 
 $_SERVER['DOCUMENT_ROOT'] = dirname(__DIR__, 2);
-$_SERVER['SERVER_NAME'] = 'localhost'; // Set for CLI context
+$_SERVER['SERVER_NAME'] = (isset($argv) && in_array('--production', $argv, true))
+    ? 'iblhoops.net'
+    : 'localhost';
 require $_SERVER['DOCUMENT_ROOT'] . '/ibl5/vendor/autoload.php';
 include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/config.php';
 include $_SERVER['DOCUMENT_ROOT'] . '/ibl5/db/db.php';
 
+\Discord\Discord::init($_SERVER['SERVER_NAME']);
+
 /** @var \mysqli $mysqli_db */
 
-echo "Cache warming started at " . date('Y-m-d H:i:s') . "\n";
+try {
+    echo "Cache warming started at " . date('Y-m-d H:i:s') . "\n";
 
-// --- Career Leaderboards ---
+    // --- Career Leaderboards ---
 
-echo "\nWarming Career Leaderboards cache...\n";
+    echo "\nWarming Career Leaderboards cache...\n";
 
-$dbCache = new \Cache\DatabaseCache($mysqli_db);
-$innerRepository = new \CareerLeaderboards\CareerLeaderboardsRepository($mysqli_db);
-$cachedRepository = new \CareerLeaderboards\CachedCareerLeaderboardsRepository($innerRepository, $dbCache);
-$cachedRepository->rebuildCache();
+    $dbCache = new \Cache\DatabaseCache($mysqli_db);
+    $innerRepository = new \CareerLeaderboards\CareerLeaderboardsRepository($mysqli_db);
+    $cachedRepository = new \CareerLeaderboards\CachedCareerLeaderboardsRepository($innerRepository, $dbCache);
+    $cachedRepository->rebuildCache();
 
-echo "Career Leaderboards cache warmed (8 table keys)\n";
+    echo "Career Leaderboards cache warmed (8 table keys)\n";
 
-// --- Season Leaderboards ---
+    // --- Season Leaderboards ---
 
-echo "\nWarming Season Leaderboards cache...\n";
+    echo "\nWarming Season Leaderboards cache...\n";
 
-$innerSeasonRepo = new \SeasonLeaderboards\SeasonLeaderboardsRepository($mysqli_db);
-$cachedSeasonRepo = new \SeasonLeaderboards\CachedSeasonLeaderboardsRepository($innerSeasonRepo, $dbCache);
-$cachedSeasonRepo->rebuildCache();
+    $innerSeasonRepo = new \SeasonLeaderboards\SeasonLeaderboardsRepository($mysqli_db);
+    $cachedSeasonRepo = new \SeasonLeaderboards\CachedSeasonLeaderboardsRepository($innerSeasonRepo, $dbCache);
+    $cachedSeasonRepo->rebuildCache();
 
-echo "Season Leaderboards cache warmed (leaders, years, teams)\n";
+    echo "Season Leaderboards cache warmed (leaders, years, teams)\n";
 
-// --- Record Holders ---
+    // --- Record Holders ---
 
-echo "\nWarming Record Holders cache...\n";
+    echo "\nWarming Record Holders cache...\n";
 
-$recordHoldersRepository = new \RecordHolders\RecordHoldersRepository($mysqli_db);
-$innerService = new \RecordHolders\RecordHoldersService($recordHoldersRepository);
-$cachedService = new \RecordHolders\CachedRecordHoldersService($innerService, $dbCache);
-$cachedService->rebuildCache();
+    $recordHoldersRepository = new \RecordHolders\RecordHoldersRepository($mysqli_db);
+    $innerService = new \RecordHolders\RecordHoldersService($recordHoldersRepository);
+    $cachedService = new \RecordHolders\CachedRecordHoldersService($innerService, $dbCache);
+    $cachedService->rebuildCache();
 
-echo "Record Holders cache warmed\n";
+    echo "Record Holders cache warmed\n";
 
-// --- Done ---
+    // --- Done ---
 
-echo "\nAll caches warmed successfully at " . date('Y-m-d H:i:s') . "\n";
+    echo "\nAll caches warmed successfully at " . date('Y-m-d H:i:s') . "\n";
+} catch (\Throwable $e) {
+    try {
+        \Discord\Discord::sendDM('283183467804491776', 'warm-cache failed: ' . $e->getMessage());
+    } catch (\Throwable) {
+        // DM delivery failed; fall through to stderr
+    }
+    fwrite(STDERR, 'warm-cache failed: ' . $e->getMessage() . "\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- Add IBLbot pm2 healthcheck script to monitor process and restart if unreachable
- Redirect cron output to log file to suppress email notifications for transient errors
- Support production mode in warm-cache for proper domain configuration
- Add Discord DM alerts when warm-cache fails; gracefully fall back to stderr
- Wrap cache warming in try-catch for structured error reporting

## Manual Testing

No manual testing needed — verified by automated tests.
