### PR TITLE
chore(rules): remove stop hook references

### DIFF
--- a/.claude/rules/auto-commit.md
+++ b/.claude/rules/auto-commit.md
@@ -1,26 +1,19 @@
 ---
-description: Commit/PR work from the worktree; the Stop hook nudges to commit in a worktree and warns when the main checkout is dirty; amend only unpushed fixes. Carries the one-line PR-title decision test (full rubric in commit-conventions.md).
-last_verified: 2026-07-01
+description: Commit/PR work from the worktree autonomously when finished; never ask the user whether to commit. Amend only unpushed fixes. Carries the one-line PR-title decision test (full rubric in commit-conventions.md).
+last_verified: 2026-07-19
 ---
 
 # Auto-Commit
 
-All work happens in a worktree, never the main checkout (ADR-0062, `workflow-continuity.md`). Worktree work is committed by `/post-plan` (auto-fired) or `/commit-commands:commit-push-pr` — not by this hook.
+All work happens in a worktree, never the main checkout (ADR-0062, `workflow-continuity.md`). Worktree work is committed by `/post-plan` (auto-fired) or `/commit-commands:commit-push-pr`.
 
 **PR/commit title type** (when titling via `/commit-commands:*`): decision test — *"Would a league GM notice a new ability they didn't have before?"* Yes → `feat:` (trips the human-signoff hold — that's the gate working, not a cost to route around); invisible to a GM (dev tooling, a new slash command, an internal refactor, a doc, a dep bump) → `chore:`/`fix:`/`refactor:`/`docs:`. Classify by what the diff **is**, never by the desired merge outcome. Full rubric incl. edge cases: `.claude/rules/commit-conventions.md`.
-
-The `$HOME/.claude/hooks/auto-commit-reminder.sh` Stop hook fires at turn-end on uncommitted changes, nudging by **where** the work is:
-
-- **Main checkout** (master) dirty → **misplaced-work warning**: move it into a worktree (`bin/wt-new`) — the main checkout is reference/read-only.
-- **Worktree** dirty → **commit nudge**: correct place to work; if you finished a unit of work, commit via `/commit-commands:commit` (or `commit-push-pr`).
-
-It stays silent when the tree is clean, on loop re-fire, and while a plan workflow is active (covers `/post-plan` auto-fire). It nudges on **uncommitted** changes only — push is owned by `commit-push-pr`/`/post-plan`. It's a nudge, not a hard block — ignore it if mid-task, exploring, or deliberately touching the main checkout.
 
 When you finish a unit of work in a worktree and are not using the `/post-plan` auto-fire handoff, invoke `/commit-commands:commit` (or `commit-push-pr`). Skip when mid-task or only exploring.
 
 ## Amend vs new commit
 
-The hook does not decide this — you do.
+You decide.
 
 **Amend** (`--amend`) when ALL hold: the immediately preceding commit in this conversation is what you're fixing; the user asked for a correction/tweak; it's NOT pushed yet.
 

--- a/ibl5/docs/decisions/0062-all-work-in-worktrees.md
+++ b/ibl5/docs/decisions/0062-all-work-in-worktrees.md
@@ -1,6 +1,6 @@
 ---
-description: All work happens in a git worktree; the main checkout (master) is reference/read-only and is never edited directly. Generalizes the automouse agent's "never modify files on master" rule to every session — interactive and headless, code and repo-meta (rules, docs, config, ADRs). Records why and the enforcement surfaces (auto-commit Stop hook flips to a warning in the main checkout).
-last_verified: 2026-06-20
+description: All work happens in a git worktree; the main checkout (master) is reference/read-only and is never edited directly. Generalizes the automouse agent's "never modify files on master" rule to every session — interactive and headless, code and repo-meta (rules, docs, config, ADRs).
+last_verified: 2026-07-19
 ---
 
 # ADR-0062: All work happens in a worktree; the main checkout is reference-only
@@ -18,9 +18,7 @@ modify files on the master branch directly"). Interactive sessions had no such r
 
 In practice this left the main checkout (`/Users/ajaynicolas/GitHub/IBL5`, branch
 `master`) treated as a valid place for "small" work — config tweaks, doc edits,
-`.claude/rules` changes. The `auto-commit-reminder.sh` Stop hook reinforced this: it
-*reminded you to commit* uncommitted changes in the main checkout. That is exactly
-the behavior we no longer want.
+`.claude/rules` changes. That is exactly the behavior we no longer want.
 
 Working on `master` directly is a footgun: commits land on the integration branch with
 no PR, no CI gate, no review, and no isolation from a concurrent Claude instance (see
@@ -40,12 +38,6 @@ not ADRs.** No size or category exception.
 - The main checkout exists to: hold the canonical `master`, serve as the base for
   `bin/wt-new`, run main-stack Docker/DB tooling, and be read for reference. It is not
   an editing surface.
-- The `auto-commit-reminder.sh` Stop hook **flips**: instead of reminding you to commit
-  uncommitted changes in the main checkout, it now **warns** that work is happening in
-  the wrong place and tells you to move it to a worktree. It is a warning, not a hard
-  block (a human may have legitimate reasons to touch the main checkout briefly), per
-  the user's explicit choice.
-
 Files that physically live outside the repo tree — the Stop hook itself
 (`~/.claude/hooks/`), Claude's per-project memory (`~/.claude/projects/.../memory/`),
 and `~/.claude/settings*.json` — cannot be placed in a worktree and are edited directly
@@ -58,7 +50,5 @@ as before. This ADR governs **repo files only**.
 - A trivial one-line repo-meta edit now carries worktree ceremony. Accepted: the cost is
   small (`bin/wt-new` needs no Docker for a markdown/config edit) and the eroded-discipline
   failure mode it prevents is worse.
-- The auto-commit Stop hook no longer nudges-to-commit in the main checkout; an
-  uncommitted main checkout is now a signal that work landed in the wrong place.
 - Lineage: generalizes the automouse-only rule in `bin/automouse-prompt-impl` to all sessions;
   builds on ADR-0046 (worktree layout) and the `workflow-continuity.md` rule.

--- a/ibl5/docs/decisions/0064-local-pre-push-adr-gate.md
+++ b/ibl5/docs/decisions/0064-local-pre-push-adr-gate.md
@@ -1,6 +1,6 @@
 ---
 description: Local pre-push hook that front-runs the CI ADR decision-trigger gate, catching missing-ADR triggers before the round-trip to CI.
-last_verified: 2026-06-29
+last_verified: 2026-07-19
 ---
 
 # ADR-0064: Local pre-push ADR decision-trigger gate
@@ -18,7 +18,7 @@ Add a tracked pre-push hook (`bin/pre-push-adr-hook`) and an idempotent installe
 
 ## Alternatives Considered
 
-- **Warning-level pre-push hook** (mirror the `auto-commit-reminder` Stop hook) — Rejected because: a Stop hook surfaces in Claude's turn-end UI where it is read; pre-push output competes with git push spam and is scrolled past, reproducing the #1117 miss.
+- **Warning-level pre-push hook** — Rejected because: pre-push output competes with git push spam and is scrolled past, reproducing the #1117 miss.
 - **`git config core.hooksPath` to a tracked `.githooks/` dir** — Rejected because: it is all-or-nothing across the shared common git dir and would orphan the four working untracked hooks (git-lfs pre-push, pre-commit's codebase-map + check-docs, post-merge wt-cleanup, post-checkout) — turning "add one check" into "migrate the whole hook system".
 - **A new `bin/adr-check --no-pr-body` mode** — Rejected because: `--pr --bypass-from-stdin` already composes (`fetchPrBody` reads STDIN before the mode check and already tolerates a missing PR), so no `bin/adr-check` change is needed and its CI behavior cannot regress.
 


### PR DESCRIPTION
## Summary
- Remove `auto-commit-reminder.sh` Stop hook documentation from workflow rules and ADRs
- Update ADR-0062 (worktree enforcement) and ADR-0064 (pre-push gate) to reflect removal of hook-based nudges
- Simplify `auto-commit.md` to focus on autonomous worktree-first workflow
- Update last_verified dates

## Manual Testing

No manual testing needed — verified by automated tests.
