### PR TITLE
chore(agents): pin sonnet-4-6 across review and planning agents

### DIFF
--- a/.claude/agents/plan-architect-sonnet.md
+++ b/.claude/agents/plan-architect-sonnet.md
@@ -1,7 +1,7 @@
 ---
 name: plan-architect-sonnet
 description: Software architect (Sonnet tier) that designs implementation plans for the /plan command from a pre-resolved recipe. Returns a step-by-step plan, identifies the critical files, and weighs architectural trade-offs. Selected by /plan Step 3 ONLY when the source task/backlog entry carries an explicit recipe plus a named existing pattern to copy (the marker-swap / mechanical-sweep class) AND no plan-architect-xhigh trigger (security surface, trust boundary, destructive migration, .claude/skills ship-pipeline invariant) applies. The default Opus plan-architect is used everywhere else.
-model: sonnet
+model: claude-sonnet-4-6
 effort: high
 disallowedTools: Agent, ExitPlanMode, Edit, Write, NotebookEdit
 ---

--- a/.claude/agents/sonnet-4-6.md
+++ b/.claude/agents/sonnet-4-6.md
@@ -1,0 +1,7 @@
+---
+name: sonnet-4-6
+description: Pinned Sonnet 4.6 general-purpose agent. Use `subagent_type: "sonnet-4-6"` (omit model) wherever a skill or plan needs a Sonnet subagent pinned to 4.6 — avoids the `sonnet` alias resolving to Sonnet 5. Full tool access. Appropriate for review agents, backlog housekeeping, manual-test classification, and other judgment tasks that need Edit/Write.
+model: claude-sonnet-4-6
+---
+
+You are a capable general-purpose assistant. Complete the task given in the prompt using all tools available to you. Follow all project rules from the auto-loaded CLAUDE.md files.

--- a/.claude/review-shared/_review-agents.md
+++ b/.claude/review-shared/_review-agents.md
@@ -1,6 +1,6 @@
 ---
 description: Shared code-review agent definitions used by /pr-review and /post-plan.
-last_verified: 2026-05-26
+last_verified: 2026-07-20
 ---
 
 # Code Review Agents (shared definitions)
@@ -11,8 +11,8 @@ Source of truth for code-review agent prompts. Used by `/pr-review` Step 3, and 
 
 Agents are merged by model tier to minimize context overhead (~5K tokens per agent spawn). Three agents instead of six:
 
-- **Agent A (Sonnet):** Architecture + bug detection + DB performance — all require semantic judgment over the same PHP diff
-- **Agent B (Sonnet):** Git history + code comments — both require judgment, different inputs
+- **Agent A (Sonnet 4.6):** Architecture + bug detection + DB performance — all require semantic judgment over the same PHP diff
+- **Agent B (Sonnet 4.6):** Git history + code comments — both require judgment, different inputs
 - **Agent C (Haiku):** Previous PRs — mechanical lookup, no judgment
 
 ## Common preamble (all agents)
@@ -25,7 +25,7 @@ Each agent receives: filtered PR diff, file list, and PR metadata from the paren
 
 ---
 
-## Agent A: Architecture + Bug Detection + DB Performance (Sonnet)
+## Agent A: Architecture + Bug Detection + DB Performance (Sonnet 4.6 — `subagent_type: "sonnet-4-6"`, omit `model`)
 
 You are a **Senior PHP Architect and Staff Engineer** reviewing for architectural fitness, correctness bugs, and database performance. Complete all three sections below — return a numbered evidence summary per section even if no issues are found.
 
@@ -82,7 +82,7 @@ Return issues with the specific CLAUDE.md subsection violated (or anti-pattern m
 
 ---
 
-## Agent B: Git History + Code Comments (Sonnet)
+## Agent B: Git History + Code Comments (Sonnet 4.6 — `subagent_type: "sonnet-4-6"`, omit `model`)
 
 You are a **Senior Software Engineer** reviewing git history for regression risk and checking compliance with in-code guidance. Complete both sections below.
 

--- a/.claude/review-shared/_test-spec-agent.md
+++ b/.claude/review-shared/_test-spec-agent.md
@@ -1,15 +1,15 @@
 ---
 description: Shared E2E spec reviewer agent used by /post-plan Phase 4B Agent D.
-last_verified: 2026-05-23
+last_verified: 2026-07-20
 ---
 
-# Agent D: E2E Spec Reviewer (Sonnet)
+# Agent D: E2E Spec Reviewer (Sonnet 4.6 — `subagent_type: "sonnet-4-6"`, omit `model`)
 
 Semantic reviewer for E2E spec quality. Catches weaknesses that lint cannot — missing POST-effect verification, non-discriminating assertions, and UI branches added without spec coverage.
 
 ## Token-efficiency design
 
-Single Sonnet agent covering all three sections. Sonnet is required because Sections 1-2 need synthesis ("does this assertion discriminate?", "does this prove persistence?"). Section 3 is closer to pattern-match but shares the same prompt to avoid doubling the ~5K per-agent spawn overhead.
+Single Sonnet 4.6 agent covering all three sections. Sonnet is required because Sections 1-2 need synthesis ("does this assertion discriminate?", "does this prove persistence?"). Section 3 is closer to pattern-match but shares the same prompt to avoid doubling the ~5K per-agent spawn overhead.
 
 **Downgrade trigger:** Swap to `model: "haiku"` when the corpus reaches 20+ calibrated examples per category AND the agent's flagged findings track human review with >=80% precision for 4 consecutive weeks.
 

--- a/.claude/rules/agent-tiering-detail.md
+++ b/.claude/rules/agent-tiering-detail.md
@@ -1,6 +1,6 @@
 ---
 description: Read-on-demand detail for agent-tiering — the skip-vs-spawn heuristic, Fable approval-gate procedure, flat-fan-out (nested sub-agent) rationale, orchestrator context economics (delegate-don't-dismiss, split-don't-self-clear), and per-tier prompt style. Loads only when editing workflow orchestration defs.
-last_verified: 2026-07-11
+last_verified: 2026-07-20
 paths:
   - ".claude/skills/**/*.md"
 ---
@@ -76,3 +76,23 @@ The context saving from a sub-agent comes from **delegation, not dismissal**. A 
 **Haiku** (compensate for its tendency to stop at "enough"): lead with a concrete grep/find command · say "list EVERY match" / "do NOT skip files" when exhaustiveness matters · pre-resolve absolute paths · request structured output (table/list) · for checklists, "check EACH pattern, cite file:line or state not found" · never ask it to judge relevance, trace multi-hop flows, or relate a past event to the current context.
 
 **Sonnet**: open-ended exploration, multi-file synthesis, ambiguous queries where the first grep might miss — current style is fine.
+
+## `/plan` orchestrator model
+
+The rows in agent-tiering.md tier sub-agents; the `/plan` session model is a separate call. The `plan-architect` is tiered by Step-3 precedence (xhigh → sonnet → opus) regardless of the orchestrator — a Sonnet `/plan` spawning `plan-architect` still gets an Opus-authored plan.
+
+Tier the orchestrator by the judgment **it** retains:
+
+- **Single backlog item** → **Sonnet** (Steps 2.5/3/4 orchestrator calls are light; same recipe-backed class the "Opus (delegated)" row routes to `plan-architect-sonnet`).
+- **Multiple items in one pass** → **Opus** (cross-item PR decomposition, **dependency ordering**, tier-boundary splits). Cheaper: run each as its own **Sonnet** `/plan` and make only the ordering call yourself.
+
+## Explore Agent Tiering
+
+Tier per prompt — don't default all Explore agents to one tier. Explore itself is pinned to Sonnet 4.6 (see agent-tiering.md § Sonnet 4.6 pins); the choice below is Haiku-vs-Sonnet-4.6 for the Explore *task*.
+
+| Tier | Model param | Use for Explore | Examples |
+|------|-------------|-----------------|---------|
+| **Haiku** | `model: "haiku"` | Enumeration, single-file lookups, grep-and-list | "find all callers of getTeamByName", "does column X exist in migration Y" |
+| **Sonnet 4.6** | *omit `model`* | Multi-hop traces, cross-module synthesis, open-ended investigation | "trace the encoding pipeline from .plr read to Team page" |
+
+**Heuristic:** notice connections / judge relevance / trace data flow → omit `model` (Sonnet 4.6). Answerable by grep + format → `model: "haiku"`.

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,6 +1,6 @@
 ---
-description: Which tier to pick for each sub-agent, including the two Sonnet 4.6 def-pins (Explore + automouse delegates). Skip-vs-spawn heuristic and deeper rationale live in agent-tiering-detail.md.
-last_verified: 2026-07-15
+description: Which tier to pick for each sub-agent, including the Sonnet 4.6 def-pins (Explore, automouse-delegate, sonnet-4-6, plan-architect-sonnet). Skip-vs-spawn heuristic and deeper rationale live in agent-tiering-detail.md.
+last_verified: 2026-07-20
 ---
 
 # Agent Tiering
@@ -12,9 +12,9 @@ Tier every sub-agent (and every agent a plan spawns) by the reasoning the task a
 | Tier | Model param | Use for |
 |------|-------------|---------|
 | **Haiku** | `model: "haiku"` | Command output, pattern-matching named checklists, grep-and-format, mechanical lookups — answerable by running commands and reporting, without judging relevance. |
-| **Sonnet** | `model: "sonnet"` | Synthesis: "is this finding relevant?", cross-file traces, semantic compliance checks, rename sweeps needing call-site judgment. Two surfaces are **pinned to 4.6** — see § Sonnet 4.6 pins. |
+| **Sonnet** | `subagent_type: "sonnet-4-6"`, omit `model` — see § Sonnet 4.6 pins | Synthesis: "is this finding relevant?", cross-file traces, semantic compliance checks, rename sweeps needing call-site judgment, review agents, backlog housekeeping, manual-test classification. Never pass `model: "sonnet"` — the alias now resolves to Sonnet 5. |
 | **Opus** | self (no delegation) | Novel reasoning, FK ordering, rule authoring, ADR writing, ambiguous test failures, final code review, diff-triage. Never delegate understanding. |
-| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3 — three defs selected by ONE ordered precedence (mirrors Step 3): **`plan-architect-xhigh`** (`effort: xhigh`) FIRST for security surfaces, trust boundaries, destructive migrations, or ship-pipeline invariant changes; else **`plan-architect-sonnet`** (`model: sonnet`) when the task is recipe-backed — an explicit recipe plus a named existing pattern to copy — since composing a plan from a pre-resolved recipe is mechanical composition, not novel design (no understanding is delegated, only recipe composition, so it does not breach the Opus (self) row's "never delegate understanding"); else the default **`plan-architect`** (`model: opus` + `effort: high`). Do **not** pass an inline `model` override — each def owns it. |
+| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3 — three defs selected by ONE ordered precedence (mirrors Step 3): **`plan-architect-xhigh`** (`effort: xhigh`) FIRST for security surfaces, trust boundaries, destructive migrations, or ship-pipeline invariant changes; else **`plan-architect-sonnet`** (`model: claude-sonnet-4-6`) when the task is recipe-backed — an explicit recipe plus a named existing pattern to copy — since composing a plan from a pre-resolved recipe is mechanical composition, not novel design (no understanding is delegated, only recipe composition, so it does not breach the Opus (self) row's "never delegate understanding"); else the default **`plan-architect`** (`model: opus` + `effort: high`). Do **not** pass an inline `model` override — each def owns it. |
 | **Fable** | `model: "fable"` — **prompt first, last resort** | Rung above Opus (~2× cost). Use **only** when a task is absolutely critical **and** Fable is 100% necessary to solve it — and **never without prompting the user first** for explicit approval. Default to Opus. Full gate: `.claude/rules/agent-tiering-detail.md`. |
 
 > **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (then the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.
@@ -30,12 +30,18 @@ Tier the orchestrator by the judgment **it** retains:
 
 ## Sonnet 4.6 pins
 
-Two high-volume Sonnet surfaces are pinned to 4.6 via an agent def — the `model` enum can't express a specific version; the def's frontmatter is the only way, and **the pin wins only when `model` is omitted**.
+Sonnet surfaces are pinned to 4.6 via an agent def or skill frontmatter — the `model` enum can't express a specific version; the def/frontmatter is the only way, and **the def-based pin wins only when `model` is omitted**.
 
-| Surface | Def | Spawn with |
-|---------|-----|-----------|
+**Never pass `model: "sonnet"` to Agent()** — that alias now resolves to Sonnet 5.
+
+| Surface | Def / File | Spawn / invoke with |
+|---------|-----------|---------------------|
 | **Explore** | `~/.claude/agents/Explore.md` (machine-local) | `subagent_type: "Explore"`, **omit `model`**. Blocked by `~/.claude/hooks/explore-model-gate.sh` if you pass `model: "sonnet"`. |
 | **Automouse impl delegates** | `.claude/agents/automouse-delegate.md` (in-repo) | `subagent_type: "automouse-delegate"`, **omit `model`**. Fired by `bin/automouse-prompt-impl` for each `### Delegate` packet. |
+| **General Sonnet tasks** (review agents A/B/D, backlog housekeeping, manual-test classification, and any other Sonnet-tier spawn) | `.claude/agents/sonnet-4-6.md` (in-repo) | `subagent_type: "sonnet-4-6"`, **omit `model`**. Full tool access — use wherever a Sonnet spawn previously used `model: "sonnet"`. |
+| **Plan architect (Sonnet tier)** | `.claude/agents/plan-architect-sonnet.md` (in-repo) | `subagent_type: "plan-architect-sonnet"`, **omit `model`**. Selected by `/plan` Step 3 precedence. |
+| **`/pr-review` runner** | `.claude/skills/pr-review/SKILL.md` frontmatter | Pinned via `model: claude-sonnet-4-6` in skill frontmatter. No spawn change needed. |
+| **`/security-audit` runner** | `.claude/skills/security-audit/SKILL.md` frontmatter | Pinned via `model: claude-sonnet-4-6` in skill frontmatter. No spawn change needed. |
 
 ## Explore Agents
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,5 +1,5 @@
 ---
-description: Which tier to pick for each sub-agent, including the Sonnet 4.6 def-pins (Explore, automouse-delegate, sonnet-4-6, plan-architect-sonnet). Skip-vs-spawn heuristic and deeper rationale live in agent-tiering-detail.md.
+description: Which tier to pick for each sub-agent, including the Sonnet 4.6 def-pins. Skip-vs-spawn heuristic and deeper rationale live in agent-tiering-detail.md.
 last_verified: 2026-07-20
 ---
 
@@ -14,23 +14,18 @@ Tier every sub-agent (and every agent a plan spawns) by the reasoning the task a
 | **Haiku** | `model: "haiku"` | Command output, pattern-matching named checklists, grep-and-format, mechanical lookups — answerable by running commands and reporting, without judging relevance. |
 | **Sonnet** | `subagent_type: "sonnet-4-6"`, omit `model` — see § Sonnet 4.6 pins | Synthesis: "is this finding relevant?", cross-file traces, semantic compliance checks, rename sweeps needing call-site judgment, review agents, backlog housekeeping, manual-test classification. Never pass `model: "sonnet"` — the alias now resolves to Sonnet 5. |
 | **Opus** | self (no delegation) | Novel reasoning, FK ordering, rule authoring, ADR writing, ambiguous test failures, final code review, diff-triage. Never delegate understanding. |
-| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3 — three defs selected by ONE ordered precedence (mirrors Step 3): **`plan-architect-xhigh`** (`effort: xhigh`) FIRST for security surfaces, trust boundaries, destructive migrations, or ship-pipeline invariant changes; else **`plan-architect-sonnet`** (`model: claude-sonnet-4-6`) when the task is recipe-backed — an explicit recipe plus a named existing pattern to copy — since composing a plan from a pre-resolved recipe is mechanical composition, not novel design (no understanding is delegated, only recipe composition, so it does not breach the Opus (self) row's "never delegate understanding"); else the default **`plan-architect`** (`model: opus` + `effort: high`). Do **not** pass an inline `model` override — each def owns it. |
+| **Opus (delegated)** | `subagent_type: "plan-architect"` | Implementation **planning** only, via `/plan` Step 3 — three defs selected by ONE ordered precedence (mirrors Step 3): **`plan-architect-xhigh`** (`effort: xhigh`) FIRST for security surfaces, trust boundaries, destructive migrations, or ship-pipeline invariant changes; else **`plan-architect-sonnet`** (`model: claude-sonnet-4-6`) when the task is recipe-backed — an explicit recipe plus a named existing pattern to copy (mechanical composition of a pre-resolved recipe, so no understanding is delegated); else the default **`plan-architect`** (`model: opus` + `effort: high`). Do **not** pass an inline `model` override — each def owns it. |
 | **Fable** | `model: "fable"` — **prompt first, last resort** | Rung above Opus (~2× cost). Use **only** when a task is absolutely critical **and** Fable is 100% necessary to solve it — and **never without prompting the user first** for explicit approval. Default to Opus. Full gate: `.claude/rules/agent-tiering-detail.md`. |
 
 > **The boundary keys on task *type* (judgment vs. mechanical), not raw model capability** — a stronger Sonnet moves nothing across the line. Re-validated 2026-06-30 vs Sonnet 5 (then the `sonnet` alias, native 1M context): unchanged. Why: `agent-tiering-detail.md`.
 
 ## `/plan` orchestrator model
 
-The rows above tier sub-agents; the `/plan` session model is a separate call. The `plan-architect` is tiered by Step-3 precedence (xhigh → sonnet → opus) regardless of the orchestrator — a Sonnet `/plan` spawning `plan-architect` still gets an Opus-authored plan.
-
-Tier the orchestrator by the judgment **it** retains:
-
-- **Single backlog item** → **Sonnet** (Steps 2.5/3/4 orchestrator calls are light; same recipe-backed class the "Opus (delegated)" row routes to `plan-architect-sonnet`).
-- **Multiple items in one pass** → **Opus** (cross-item PR decomposition, **dependency ordering**, tier-boundary splits). Cheaper: run each as its own **Sonnet** `/plan` and make only the ordering call yourself.
+The `/plan` session model is a separate call from the sub-agent rows above. Tier the orchestrator by the judgment it retains — single backlog item → **Sonnet**, multiple items in one pass → **Opus** (cross-item decomposition + dependency ordering). The `plan-architect` is Step-3-tiered (xhigh → sonnet → opus) regardless of orchestrator. Full rationale: `agent-tiering-detail.md` § `/plan` orchestrator model.
 
 ## Sonnet 4.6 pins
 
-Sonnet surfaces are pinned to 4.6 via an agent def or skill frontmatter — the `model` enum can't express a specific version; the def/frontmatter is the only way, and **the def-based pin wins only when `model` is omitted**.
+Sonnet surfaces are pinned to 4.6 via an agent def or skill frontmatter (the `model` enum can't express a specific version) — **the def-based pin wins only when `model` is omitted**.
 
 **Never pass `model: "sonnet"` to Agent()** — that alias now resolves to Sonnet 5.
 
@@ -38,20 +33,12 @@ Sonnet surfaces are pinned to 4.6 via an agent def or skill frontmatter — the 
 |---------|-----------|---------------------|
 | **Explore** | `~/.claude/agents/Explore.md` (machine-local) | `subagent_type: "Explore"`, **omit `model`**. Blocked by `~/.claude/hooks/explore-model-gate.sh` if you pass `model: "sonnet"`. |
 | **Automouse impl delegates** | `.claude/agents/automouse-delegate.md` (in-repo) | `subagent_type: "automouse-delegate"`, **omit `model`**. Fired by `bin/automouse-prompt-impl` for each `### Delegate` packet. |
-| **General Sonnet tasks** (review agents A/B/D, backlog housekeeping, manual-test classification, and any other Sonnet-tier spawn) | `.claude/agents/sonnet-4-6.md` (in-repo) | `subagent_type: "sonnet-4-6"`, **omit `model`**. Full tool access — use wherever a Sonnet spawn previously used `model: "sonnet"`. |
+| **General Sonnet tasks** (review agents, backlog housekeeping, manual-test classification, any Sonnet-tier spawn) | `.claude/agents/sonnet-4-6.md` (in-repo) | `subagent_type: "sonnet-4-6"`, **omit `model`**. Full tool access — use wherever a Sonnet spawn previously used `model: "sonnet"`. |
 | **Plan architect (Sonnet tier)** | `.claude/agents/plan-architect-sonnet.md` (in-repo) | `subagent_type: "plan-architect-sonnet"`, **omit `model`**. Selected by `/plan` Step 3 precedence. |
-| **`/pr-review` runner** | `.claude/skills/pr-review/SKILL.md` frontmatter | Pinned via `model: claude-sonnet-4-6` in skill frontmatter. No spawn change needed. |
-| **`/security-audit` runner** | `.claude/skills/security-audit/SKILL.md` frontmatter | Pinned via `model: claude-sonnet-4-6` in skill frontmatter. No spawn change needed. |
+| **`/pr-review` & `/security-audit` runners** | Their `SKILL.md` frontmatter | Pinned via `model: claude-sonnet-4-6` in skill frontmatter. No spawn change needed. |
 
 ## Explore Agents
 
-Tier per prompt — don't default all Explore agents to one tier. Explore is pinned to Sonnet 4.6 — see § Sonnet 4.6 pins.
-
-| Tier | Model param | Use for Explore | Examples |
-|------|-------------|-----------------|---------|
-| **Haiku** | `model: "haiku"` | Enumeration, single-file lookups, grep-and-list | "find all callers of getTeamByName", "does column X exist in migration Y" |
-| **Sonnet 4.6** | *omit `model`* | Multi-hop traces, cross-module synthesis, open-ended investigation | "trace the encoding pipeline from .plr read to Team page" |
-
-**Heuristic:** notice connections / judge relevance / trace data flow → omit `model` (Sonnet 4.6). Answerable by grep + format → `model: "haiku"`.
+Tier Explore per prompt — don't default all to one tier (Explore itself is pinned to Sonnet 4.6, § Sonnet 4.6 pins). Haiku for enumeration / single-file lookups / grep-and-list; omit `model` (Sonnet 4.6) for multi-hop traces, cross-module synthesis, open-ended investigation. Table + examples: `agent-tiering-detail.md` § Explore Agent Tiering.
 
 Plan-authoring tiering (labeling each phase, mechanical-recipe agents, bulk-sweep patterns) lives in `.claude/skills/plan/_architect-contract.md`, the plan-architect's output contract that `/plan` Step 3 directs the architect to Read.

--- a/.claude/skills/backlog-housekeep/SKILL.md
+++ b/.claude/skills/backlog-housekeep/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: backlog-housekeep
 description: "Ship backlog housekeeping with an implemented backlog item: flip its status, stamp discovered items with provenance, sweep sibling and cross-backlog redundancy, archive done items behind a dated pointer, and reconcile the README index — then self-verify via bin/check-docs."
-last_verified: 2026-07-10
+last_verified: 2026-07-20
 ---
 
 # Backlog Housekeeping
@@ -23,7 +23,7 @@ The base drives both the `--since=<base>` self-verify and, for a PR, the `#<PR>`
 
 **Detect your own tier from your system prompt** — the model executing this skill *is* the caller (there is no runtime model-id API; the orchestrator self-identifies, as `work-triage.md` § Execution routing and `feedback_default_sonnet_execution` assume). If genuinely unsure, default to **inline** — a wrong-way delegation costs more than a same-tier inline pass.
 
-- **Caller is Opus or Fable → delegate; do NOT Read backlog files.** Reason from resident context about *what the work did*: which item it resolved, which items it newly surfaced, which siblings shifted scope. Seed those known effects into the semantic delegation packet (below), then spawn **ONE** Sonnet subagent (`subagent_type: general-purpose`, `model: sonnet`) that Reads the backlog files, runs the cross-backlog redundancy grep sweep (the expensive multi-file read), applies every edit / archive move / index update, self-verifies via `bin/check-docs --since=<base>`, and returns a thin one-line report. The backlog bodies enter the *subagent's* context, never the orchestrator's — that is the entire point of the branch.
+- **Caller is Opus or Fable → delegate; do NOT Read backlog files.** Reason from resident context about *what the work did*: which item it resolved, which items it newly surfaced, which siblings shifted scope. Seed those known effects into the semantic delegation packet (below), then spawn **ONE** Sonnet 4.6 subagent (`subagent_type: "sonnet-4-6"`, omit `model`) that Reads the backlog files, runs the cross-backlog redundancy grep sweep (the expensive multi-file read), applies every edit / archive move / index update, self-verifies via `bin/check-docs --since=<base>`, and returns a thin one-line report. The backlog bodies enter the *subagent's* context, never the orchestrator's — that is the entire point of the branch.
 - **Caller is Sonnet or Haiku (e.g. `/post-plan` runs Sonnet 4.6) → execute inline, no subagent.** Read the backlog files, run the sweep, apply the edits, self-verify — all in the current context. Spawning a same-tier subagent is pure overhead (`feedback_default_sonnet_execution`: if the orchestrator IS Sonnet, edit inline).
 
 Both branches run the identical checklist below; only *who reads the files* differs.

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -4,7 +4,7 @@ description: "Plan an implementation task: enforces a verification matrix, direc
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
-last_verified: 2026-07-16
+last_verified: 2026-07-20
 ---
 
 # /plan — Implementation Planning with Verification Matrix
@@ -43,7 +43,7 @@ Read `.claude/review-shared/_plan-verification.md` and use its full content as `
 Tier per `.claude/rules/agent-tiering.md`:
 
 - Single-module change → 0 agents (direct tools suffice) or 1 Haiku for enumeration
-- Spans 2+ modules → up to 2 agents (Sonnet for cross-module traces, Haiku for file/grep lookups)
+- Spans 2+ modules → up to 2 agents (Explore for cross-module traces — already pinned Sonnet 4.6, use `subagent_type: "Explore"` omit `model`; Haiku for file/grep lookups)
 - Never spawn 3 agents
 
 Provide each agent a single concrete question, pre-resolved paths, and a response cap (under 150 lines). An agent spawned purely for byte isolation must return **distilled pointers** (`path:line` + the load-bearing fact), not pasted file bodies — pasting the contents back defeats the isolation.

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -5,7 +5,7 @@ disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
   - Skill
-last_verified: 2026-07-10
+last_verified: 2026-07-20
 ---
 
 # Post-Plan Orchestrator
@@ -165,7 +165,7 @@ echo "$EXTRACTED"
 
 **Skip this gate when `PLAN_FOUND` and the surviving Manual Testing steps came from the plan's matrix** — `/plan` gates 3, 9, and 12 already classified automatable-vs-manual upstream and authoritatively, so re-litigating it here is wasted. Treat the remaining steps as truly-manual and leave them in the PR. Run the gate below only for plan-less PRs, where no upstream classification occurred.
 
-Launch a **single Sonnet agent** with the QA-classification prompt in `.claude/skills/post-plan/_phase-6-manual-testing.md` (substitute the extracted steps from Step 1 and the changed-file list from Phase 4A). The prompt classifies each surviving manual step into CLI-executable / PHPUnit-replaceable / API-test-replaceable / E2E-replaceable / Visual-regression-replaceable / Truly-manual and returns a JSON array; the full prompt text + JSON schema live in that reference — Read it before spawning.
+Launch a **single Sonnet 4.6 agent** (`subagent_type: "sonnet-4-6"`, omit `model`) with the QA-classification prompt in `.claude/skills/post-plan/_phase-6-manual-testing.md` (substitute the extracted steps from Step 1 and the changed-file list from Phase 4A). The prompt classifies each surviving manual step into CLI-executable / PHPUnit-replaceable / API-test-replaceable / E2E-replaceable / Visual-regression-replaceable / Truly-manual and returns a JSON array; the full prompt text + JSON schema live in that reference — Read it before spawning.
 
 ### Step 3: Execute findings
 

--- a/.claude/skills/post-plan/_phase-4-review-audit.md
+++ b/.claude/skills/post-plan/_phase-4-review-audit.md
@@ -27,10 +27,10 @@ Pass each agent: PR metadata, file list, and filtered `$DIFF`. **No agent calls 
 
 **Model tiers:**
 
-- Agent A (Architecture + Bug detection + DB performance): **Sonnet**
-- Agent B (Git history + Code comments): **Sonnet**
+- Agent A (Architecture + Bug detection + DB performance): **Sonnet 4.6** (`subagent_type: "sonnet-4-6"`, omit `model`)
+- Agent B (Git history + Code comments): **Sonnet 4.6** (`subagent_type: "sonnet-4-6"`, omit `model`)
 - Agent C (Previous PRs): **Haiku**
-- Agent D (E2E specs — POST-effect + assertion discrimination + coverage-branch): **Sonnet**
+- Agent D (E2E specs — POST-effect + assertion discrimination + coverage-branch): **Sonnet 4.6** (`subagent_type: "sonnet-4-6"`, omit `model`)
 
 **Launch gates** (consult Phase 3 variables — skip the launch entirely, don't let the agent exit early):
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -5,8 +5,8 @@ allowed-tools: Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr comment:*),
 name: pr-review
 description: Token-efficient code review for pull requests
 disable-model-invocation: true
-model: sonnet
-last_verified: 2026-07-03
+model: claude-sonnet-4-6
+last_verified: 2026-07-20
 ---
 
 Provide a code review for the given pull request. This command optimizes token usage by fetching the diff once and distributing only what each agent needs.
@@ -65,8 +65,8 @@ Launch applicable agents in parallel. Each agent receives:
 - Directory-specific CLAUDE.md content(s) from Step 2d (if any)
 
 **Model tiers** (see `agent-tiering.md` for rationale):
-- Agent A (Architecture + Bug detection + DB performance): **Sonnet** — skip if no code files; omit DB section if no PHP
-- Agent B (Git history + Code comments): **Sonnet** — skip if no PHP and no code comments in diff
+- Agent A (Architecture + Bug detection + DB performance): **Sonnet 4.6** (`subagent_type: "sonnet-4-6"`, omit `model`) — skip if no code files; omit DB section if no PHP
+- Agent B (Git history + Code comments): **Sonnet 4.6** (`subagent_type: "sonnet-4-6"`, omit `model`) — skip if no PHP and no code comments in diff
 - Agent C (Previous PRs): **Haiku** — skip if no modified (non-added) files
 
 **CRITICAL: No agent should call `gh pr diff`.** The diff was already fetched in Step 2.

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -4,8 +4,8 @@ allowed-tools: Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr comment:*),
 name: security-audit
 description: Token-efficient security audit for pull requests
 disable-model-invocation: true
-model: sonnet
-last_verified: 2026-07-03
+model: claude-sonnet-4-6
+last_verified: 2026-07-20
 ---
 
 Perform a security audit on the given pull request. This command optimizes token usage by fetching the diff once and passing it to a single merged security agent.


### PR DESCRIPTION
## Summary
- Created `.claude/agents/sonnet-4-6.md` agent definition (full tool access for judgment tasks)
- Pinned code-review agents A/B/D to Sonnet 4.6 via `subagent_type: "sonnet-4-6"`
- Pinned `/pr-review` and `/security-audit` skills to `claude-sonnet-4-6` in frontmatter
- Updated `plan-architect-sonnet` and backlog-housekeeping to use new pinning mechanism
- Updated agent-tiering docs to reflect that `model: "sonnet"` alias now resolves to Sonnet 5; all Sonnet spawns must use def-based pins
- No user-facing changes; internal agent configuration only

## Manual Testing

No manual testing needed — verified by automated tests.
