### PR TITLE
chore: J14 — AutoResearch eval-harness (build)

### DIFF
--- a/engine/cmd/jsbcalibrate/main.go
+++ b/engine/cmd/jsbcalibrate/main.go
@@ -58,7 +58,7 @@ func runWith(args []string, stdout, stderr io.Writer, c collectors) int {
 	fs := flag.NewFlagSet("jsbcalibrate", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	archive := fs.String("archive", "", "root dir of JSB backup zips (required)")
-	mode := fs.String("mode", "calibrate", "calibrate | gate | measure")
+	mode := fs.String("mode", "calibrate", "calibrate | gate | measure | research")
 	selection := fs.String("selection", "season", "snapshot selection: season (one regular snapshot/season, clean regular bucket) | flat (every zip, type by filename)")
 	runs := fs.Int("runs", 50, "seeded engine runs per corpus game")
 	seed := fs.Uint64("seed", 0, "base seed; per-game seeds derive deterministically from it")
@@ -77,8 +77,8 @@ func runWith(args []string, stdout, stderr io.Writer, c collectors) int {
 		_, _ = fmt.Fprintln(stderr, "jsbcalibrate: --archive <dir> is required")
 		return 2
 	}
-	if *mode != "calibrate" && *mode != "gate" && *mode != "measure" {
-		_, _ = fmt.Fprintf(stderr, "jsbcalibrate: invalid --mode %q (valid: calibrate, gate, measure)\n", *mode)
+	if *mode != "calibrate" && *mode != "gate" && *mode != "measure" && *mode != "research" {
+		_, _ = fmt.Fprintf(stderr, "jsbcalibrate: invalid --mode %q (valid: calibrate, gate, measure, research)\n", *mode)
 		return 2
 	}
 	var collect collectFunc
@@ -102,6 +102,15 @@ func runWith(args []string, stdout, stderr io.Writer, c collectors) int {
 		MakePutbackHalf: *makePutbackHalf,
 		UnfaithfulOreb:  *unfaithfulOreb,
 		Progress:        stderr,
+	}
+	if *mode == "research" {
+		rep, err := calibrate.RunResearch(*archive, opts)
+		if err != nil {
+			_, _ = fmt.Fprintln(stderr, "jsbcalibrate:", err)
+			return 1
+		}
+		calibrate.WriteResearchReport(stdout, rep)
+		return 0
 	}
 	reports, skips, err := collect(*archive, opts)
 	if err != nil {

--- a/engine/cmd/jsbcalibrate/main_test.go
+++ b/engine/cmd/jsbcalibrate/main_test.go
@@ -140,6 +140,21 @@ func TestRun_InvalidMode(t *testing.T) {
 	}
 }
 
+// J14: --mode research is accepted (passes the mode-validation gate, does NOT
+// exit 2) even when the archive dir does not exist (it exits 1 from the walk
+// error, which is the normal non-existent-archive path). Negative row: --mode
+// bogus still exits 2 (covered by TestRun_InvalidMode above).
+func TestRun_ResearchModeAccepted(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	// /tmp/jsbcal-nonexistent-dir-for-test is guaranteed absent; RunResearch will
+	// fail to walk it → exit 1, not exit 2 (the invalid-mode exit).
+	code := runWith([]string{"--archive", "/tmp/jsbcal-nonexistent-dir-for-test", "--mode", "research"},
+		&out, &errBuf, stubCollectors(nil, nil))
+	if code == 2 {
+		t.Fatalf("--mode research treated as invalid (exit 2), want exit 0 or 1; stderr: %q", errBuf.String())
+	}
+}
+
 // Negative: an invalid --selection is a usage error (exit 2).
 func TestRun_InvalidSelection(t *testing.T) {
 	var out, errBuf bytes.Buffer

--- a/engine/internal/calibrate/research.go
+++ b/engine/internal/calibrate/research.go
@@ -1,0 +1,349 @@
+package calibrate
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/a-jay85/IBL5/engine/internal/backup"
+	"github.com/a-jay85/IBL5/engine/internal/result"
+	"github.com/a-jay85/IBL5/engine/internal/sim"
+)
+
+// fidelityTerms is the ordered set of fidelity terms researchWalk returns.
+// The fixed order makes ResearchReport.Points deterministic regardless of map
+// iteration order.
+var fidelityTerms = []string{
+	"cov_poss_pps",
+	"cov_shots_per_poss_pps",
+	"steal_share",
+	"non_steal_to_share",
+}
+
+// LeveragePoint is one stand-in × value × fidelity-term observation: how much
+// value v for the named stand-in moves the fidelity term relative to baseline,
+// and whether the move exceeds the empirical noise floor.
+//
+// Note: the packet draft types Value as string, but Sweep values are float64 and
+// WriteResearchReport formats with %g; Value is float64 here for lossless
+// round-trip and to match Apply's func(o *Options, v float64) signature.
+type LeveragePoint struct {
+	StandInID  string
+	Value      float64
+	Term       string
+	Delta      float64
+	NoiseFloor float64
+	AboveNoise bool
+}
+
+// ResearchReport is the full leverage readout from one RunResearch call:
+// an empirical per-term noise floor (derived from two same-config
+// different-seed baseline walks) plus every (stand-in, value, term)
+// delta observation.
+type ResearchReport struct {
+	NoiseFloor map[string]float64
+	Points     []LeveragePoint
+}
+
+// researchWalkFn is the walk-function type injected into runResearch as a test
+// seam. The real implementation is researchWalk; tests substitute a closure that
+// returns fixed maps without touching the archive.
+type researchWalkFn func(root string, opts Options, apply func(*Options)) (map[string]float64, error)
+
+// teamBoxPts returns a TeamBox's total points scored: Q1+Q2+Q3+Q4+ΣOT.
+//
+// IMPORTANT: this is "points for" (PF in basketball-statistics parlance).
+// TeamBox.GamePF is personal FOULS — a different field entirely. Using GamePF
+// here would silently produce plausible-but-wrong covariances.
+func teamBoxPts(tb result.TeamBox) float64 {
+	pts := tb.Q1 + tb.Q2 + tb.Q3 + tb.Q4
+	for _, ot := range tb.OT {
+		pts += ot
+	}
+	return float64(pts)
+}
+
+// researchWalk is the real archive-walking fidelity-term collector.
+//
+// It applies the stand-in override by calling apply on a copy of opts, then
+// walks every zip in root (strided by opts.SampleStride), extracts each
+// backup triple, and simulates opts.Runs games per zip. From each simulation
+// it accumulates:
+//
+//   - per-(season,team) box stats for the Dean-Oliver possession proxy and the
+//     possRow/decomposePossCoupling path; and
+//   - per-possession ending-mix counts for steal_share / non_steal_to_share.
+//
+// Returns a map keyed by the four fidelityTerms.
+func researchWalk(root string, opts Options, apply func(*Options)) (map[string]float64, error) {
+	// Apply the override to a private copy — opts itself is the original baseline.
+	optsCopy := opts
+	apply(&optsCopy)
+
+	runs := optsCopy.Runs
+	if runs < 1 {
+		runs = 1
+	}
+	stride := optsCopy.SampleStride
+	if stride < 1 {
+		stride = 1
+	}
+	seed := optsCopy.Seed
+
+	simOpts := sim.Options{
+		BaseTimeMid:           optsCopy.BaseTimeMid,
+		StealTurnoverScale:    optsCopy.StealTurnoverScale,
+		NonStealTurnoverScale: optsCopy.NonStealTurnoverScale,
+	}
+
+	zips, _, err := listArchiveZips(root)
+	if err != nil {
+		return nil, err
+	}
+
+	// Per-(season,team) box accumulator for the possRow path.
+	type teamKey struct {
+		season string
+		teamID int
+	}
+	type teamAcc struct {
+		games  int
+		sumPF  float64 // total points-for (Q1+Q2+Q3+Q4+OT), NOT personal fouls
+		sumFGA float64 // 2-pt + 3-pt field-goal attempts
+		sumFTA float64 // free-throw attempts
+		sumORB float64 // offensive rebounds
+		sumTOV float64 // turnovers
+	}
+	accs := map[teamKey]*teamAcc{}
+
+	// Global ending-mix counts for steal_share / non_steal_to_share.
+	var counts sim.EndingMixCounts
+
+	for idx, zipPath := range zips {
+		if idx%stride != 0 {
+			continue
+		}
+
+		sname := seasonName(root, zipPath)
+
+		tmp, mkErr := os.MkdirTemp("", "jsbres-*")
+		if mkErr != nil {
+			continue // skip: can't create temp dir
+		}
+
+		found, exErr := extractTriple(zipPath, tmp)
+		if exErr != nil || !found {
+			_ = os.RemoveAll(tmp)
+			continue
+		}
+
+		plrFile, err := os.Open(filepath.Join(tmp, "IBL5.plr"))
+		if err != nil {
+			_ = os.RemoveAll(tmp)
+			continue
+		}
+		players, err := backup.ReadPlr(plrFile)
+		_ = plrFile.Close()
+		if err != nil {
+			_ = os.RemoveAll(tmp)
+			continue
+		}
+
+		schFile, err := os.Open(filepath.Join(tmp, "IBL5.sch"))
+		if err != nil {
+			_ = os.RemoveAll(tmp)
+			continue
+		}
+		sched, err := backup.ReadSch(schFile)
+		_ = schFile.Close()
+		_ = os.RemoveAll(tmp)
+		if err != nil {
+			continue
+		}
+
+		b, err := backup.ToBundle(players, sched, backup.AssembleOptions{})
+		if err != nil {
+			continue
+		}
+
+		for run := 0; run < runs; run++ {
+			res, simErr := sim.SimulateWith(b, seed+uint64(run), simOpts)
+			if simErr != nil {
+				continue
+			}
+			for _, g := range res.Games {
+				// Box-score accumulation for possRow / decomposePossCoupling.
+				for _, tb := range g.TeamBoxes {
+					k := teamKey{sname, tb.TeamID}
+					a := accs[k]
+					if a == nil {
+						a = &teamAcc{}
+						accs[k] = a
+					}
+					a.games++
+					a.sumPF += teamBoxPts(tb) // points-for, not personal fouls
+					a.sumFGA += float64(tb.Game2GA + tb.Game3GA)
+					a.sumFTA += float64(tb.GameFTA)
+					a.sumORB += float64(tb.GameORB)
+					a.sumTOV += float64(tb.GameTOV)
+				}
+
+				// Ending-mix segmentation loop (verbatim from TestEndingMixBaseline).
+				counts.Games++
+				var cur []result.Event
+				for _, e := range g.Events {
+					if e.Kind == result.EventPossessionStart {
+						sim.ClassifyPossession(cur, &counts)
+						cur = cur[:0]
+						continue
+					}
+					cur = append(cur, e)
+				}
+				sim.ClassifyPossession(cur, &counts) // trailing partial possession
+			}
+		}
+	}
+
+	// Build one possRow per (season, team) from per-game averages.
+	rows := make([]possRow, 0, len(accs))
+	for k, a := range accs {
+		if a.games == 0 {
+			continue
+		}
+		g := float64(a.games)
+		pfPG := a.sumPF / g
+		fgaPG := a.sumFGA / g
+		ftaPG := a.sumFTA / g
+		orbPG := a.sumORB / g
+		tovPG := a.sumTOV / g
+		// Dean-Oliver possession proxy (symmetric with standings.go):
+		//   POSS ≈ FGA + 0.44·FTA + TOV − ORB
+		possPG := fgaPG + 0.44*ftaPG + tovPG - orbPG
+		rows = append(rows, possRow{
+			season: k.season,
+			pf:     pfPG,
+			fga:    fgaPG,
+			poss:   possPG,
+		})
+	}
+
+	_, covPossPPS, covShotsPerPossPPS := decomposePossCoupling(rows)
+
+	terms := map[string]float64{
+		"cov_poss_pps":           covPossPPS,
+		"cov_shots_per_poss_pps": covShotsPerPossPPS,
+	}
+	if counts.Possessions > 0 {
+		terms["steal_share"] = float64(counts.EndSteal) / float64(counts.Possessions)
+		terms["non_steal_to_share"] = float64(counts.EndTOInd) / float64(counts.Possessions)
+	} else {
+		terms["steal_share"] = 0
+		terms["non_steal_to_share"] = 0
+	}
+
+	return terms, nil
+}
+
+// runResearch is the internal entry point for the research walk. It accepts a
+// researchWalkFn seam so unit tests can exercise the noise-floor, delta, and
+// AboveNoise logic without accessing the real archive.
+//
+// It runs three phases:
+//  1. Noise floor: two baseline walks (seeds opts.Seed and opts.Seed+1) to
+//     estimate per-term measurement variance.
+//  2. Sweep: for each stand-in in StandInRegistry(), for each non-first
+//     (non-baseline) Sweep value, one walk with the override applied.
+//  3. Assemble: for every (stand-in, value, term) compute Delta = result −
+//     baseline and AboveNoise = |Delta| > noise floor.
+func runResearch(root string, opts Options, walkFn researchWalkFn) (ResearchReport, error) {
+	if opts.Runs < 1 {
+		opts.Runs = 1
+	}
+	if opts.SampleStride < 1 {
+		opts.SampleStride = 1
+	}
+
+	noApply := func(*Options) {}
+
+	// Baseline run 1 — used as the reference for Delta computation.
+	opts1 := opts
+	base1, err := walkFn(root, opts1, noApply)
+	if err != nil {
+		return ResearchReport{}, fmt.Errorf("research baseline run 1: %w", err)
+	}
+
+	// Baseline run 2 — different seed, same config → empirical noise floor.
+	opts2 := opts
+	opts2.Seed = opts.Seed + 1
+	base2, err := walkFn(root, opts2, noApply)
+	if err != nil {
+		return ResearchReport{}, fmt.Errorf("research baseline run 2: %w", err)
+	}
+
+	// Noise floor: |run2[term] − run1[term]| per term.
+	noiseFloor := make(map[string]float64, len(fidelityTerms))
+	for _, term := range fidelityTerms {
+		noiseFloor[term] = math.Abs(base2[term] - base1[term])
+	}
+
+	report := ResearchReport{NoiseFloor: noiseFloor}
+
+	// Sweep every stand-in's non-baseline values in registry order, iterating
+	// the fixed fidelityTerms slice so Points order is deterministic.
+	for _, si := range StandInRegistry() {
+		for _, v := range si.Sweep[1:] { // Sweep[0] is the baseline value
+			apply := si.Apply
+			vv := v
+			res, wErr := walkFn(root, opts, func(o *Options) { apply(o, vv) })
+			if wErr != nil {
+				continue
+			}
+			for _, term := range fidelityTerms {
+				delta := res[term] - base1[term]
+				nf := noiseFloor[term]
+				report.Points = append(report.Points, LeveragePoint{
+					StandInID:  si.ID,
+					Value:      v,
+					Term:       term,
+					Delta:      delta,
+					NoiseFloor: nf,
+					AboveNoise: math.Abs(delta) > nf,
+				})
+			}
+		}
+	}
+
+	return report, nil
+}
+
+// RunResearch runs the full research walk over the backup archive at root.
+// It establishes an empirical noise floor from two baseline passes at
+// opts.Seed and opts.Seed+1, then sweeps every registered stand-in's
+// non-baseline values and assembles a ResearchReport.
+func RunResearch(root string, opts Options) (ResearchReport, error) {
+	return runResearch(root, opts, researchWalk)
+}
+
+// WriteResearchReport writes a leverage summary to w. All points are ranked by
+// |Delta| (largest first). Each line has the form:
+//
+//	<stand-in> <value> <term>: delta=<±v> noise=<v> [ABOVE NOISE]
+//	<stand-in> <value> <term>: delta=<±v> noise=<v> [sub-noise]
+func WriteResearchReport(w io.Writer, r ResearchReport) {
+	pts := make([]LeveragePoint, len(r.Points))
+	copy(pts, r.Points)
+	sort.Slice(pts, func(i, j int) bool {
+		return math.Abs(pts[i].Delta) > math.Abs(pts[j].Delta)
+	})
+	for _, p := range pts {
+		tag := "[sub-noise]"
+		if p.AboveNoise {
+			tag = "[ABOVE NOISE]"
+		}
+		_, _ = fmt.Fprintf(w, "%s %g %s: delta=%+g noise=%g %s\n",
+			p.StandInID, p.Value, p.Term, p.Delta, p.NoiseFloor, tag)
+	}
+}

--- a/engine/internal/calibrate/research_archive_test.go
+++ b/engine/internal/calibrate/research_archive_test.go
@@ -1,0 +1,146 @@
+//go:build archive
+
+// TestResearchSelfValidation is an archive-gated self-validation test for
+// RunResearch. It checks that the registered stand-ins move the fidelity terms
+// they are hypothesized to move (above the empirical noise floor), and that
+// orthogonal stand-ins do NOT move unrelated terms above noise (isolation arm).
+//
+// Run manually (archive dir required):
+//
+//	cd engine && JSB_ARCHIVE_DIR=/Users/ajaynicolas/GitHub/IBL5/ibl5/backups \
+//	  go test -tags archive ./internal/calibrate -run TestResearchSelfValidation -v
+//
+// Adjust JSB_ARCHIVE_STRIDE (default 500) and JSB_ARCHIVE_SEED (default 20240601)
+// to trade runtime for fidelity.
+package calibrate
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+// envIntArchive reads an integer from the named environment variable, returning
+// def when the variable is unset or cannot be parsed. Named to avoid collision
+// with envInt (realarchive_test.go, same build tag, same package).
+func envIntArchive(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// findPoints filters rep.Points to those matching both standInID and term.
+func findPoints(rep ResearchReport, standInID, term string) []LeveragePoint {
+	var out []LeveragePoint
+	for _, p := range rep.Points {
+		if p.StandInID == standInID && p.Term == term {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func TestResearchSelfValidation(t *testing.T) {
+	dir := os.Getenv("JSB_ARCHIVE_DIR")
+	if dir == "" {
+		t.Skip("JSB_ARCHIVE_DIR not set — archive dir not available")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("archive dir %q not available: %v", dir, err)
+	}
+
+	stride := envIntArchive("JSB_ARCHIVE_STRIDE", 500)
+	seed := uint64(envIntArchive("JSB_ARCHIVE_SEED", 20240601))
+
+	opts := Options{
+		Seed:         seed,
+		SampleStride: stride,
+		Runs:         4,
+	}
+
+	rep, err := RunResearch(dir, opts)
+	if err != nil {
+		t.Fatalf("RunResearch: %v", err)
+	}
+
+	// Log full report for diagnostic visibility.
+	t.Logf("=== ResearchReport: noise floors ===")
+	for term, nf := range rep.NoiseFloor {
+		t.Logf("  noise floor %s: %g", term, nf)
+	}
+	t.Logf("=== ResearchReport: leverage points ===")
+	for _, p := range rep.Points {
+		tag := "[sub-noise]"
+		if p.AboveNoise {
+			tag = "[ABOVE NOISE]"
+		}
+		t.Logf("  %s %g %s: delta=%+g noise=%g %s",
+			p.StandInID, p.Value, p.Term, p.Delta, p.NoiseFloor, tag)
+	}
+
+	// --- base_time arm ---
+	// The base_time_mid stand-in should move cov_poss_pps above noise (it is
+	// the pace lever — PR #1495 / ADR-0087 §4).
+	btPoss := findPoints(rep, "base_time_mid", "cov_poss_pps")
+	if len(btPoss) == 0 {
+		t.Fatal("base_time arm: no LeveragePoints for (base_time_mid, cov_poss_pps) — " +
+			"stand-in missing or sweep produced no non-baseline values")
+	}
+	var btPossAbove bool
+	for _, p := range btPoss {
+		if p.AboveNoise {
+			btPossAbove = true
+			break
+		}
+	}
+	if !btPossAbove {
+		t.Errorf("base_time arm: expected at least one (base_time_mid, cov_poss_pps) point "+
+			"AboveNoise==true (base_time sweep must move possession↔efficiency covariance above "+
+			"empirical noise floor), got %d point(s) all sub-noise", len(btPoss))
+	}
+
+	// Isolation arm: base_time_mid should NOT move steal_share above noise
+	// (pace change ≠ steal-rate change).
+	for _, p := range findPoints(rep, "base_time_mid", "steal_share") {
+		if p.AboveNoise {
+			t.Errorf("base_time isolation arm: (base_time_mid, steal_share) point "+
+				"value=%g has AboveNoise==true — base_time changing pace should not "+
+				"move steal-share fraction above noise (possible isolation failure or "+
+				"noise floor too low); delta=%+g noise=%g", p.Value, p.Delta, p.NoiseFloor)
+		}
+	}
+
+	// --- steal-scale arm ---
+	// The steal_turnover_scale stand-in should move steal_share above noise.
+	stPts := findPoints(rep, "steal_turnover_scale", "steal_share")
+	if len(stPts) == 0 {
+		t.Fatal("steal-scale arm: no LeveragePoints for (steal_turnover_scale, steal_share) — " +
+			"stand-in missing or sweep produced no non-baseline values")
+	}
+	var stAbove bool
+	for _, p := range stPts {
+		if p.AboveNoise {
+			stAbove = true
+			break
+		}
+	}
+	if !stAbove {
+		t.Errorf("steal-scale arm: expected at least one (steal_turnover_scale, steal_share) "+
+			"point AboveNoise==true (steal-scale sweep must move steal-share fraction above "+
+			"empirical noise floor), got %d point(s) all sub-noise", len(stPts))
+	}
+
+	// Isolation arm: steal_turnover_scale should NOT move cov_poss_pps above noise
+	// (steal rate changes TO rate, not pace — should not couple into possession↔efficiency covariance).
+	for _, p := range findPoints(rep, "steal_turnover_scale", "cov_poss_pps") {
+		if p.AboveNoise {
+			t.Errorf("steal-scale isolation arm: (steal_turnover_scale, cov_poss_pps) point "+
+				"value=%g has AboveNoise==true — steal-scale changes TO rate, not pace, and "+
+				"should not move possession-count coupling above noise; delta=%+g noise=%g",
+				p.Value, p.Delta, p.NoiseFloor)
+		}
+	}
+}

--- a/engine/internal/calibrate/research_test.go
+++ b/engine/internal/calibrate/research_test.go
@@ -1,9 +1,84 @@
 package calibrate
 
 import (
+	"bytes"
 	"math"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/a-jay85/IBL5/engine/internal/result"
 )
+
+// TestTeamBoxPts verifies the points-for helper sums Q1–Q4 plus OT correctly.
+func TestTeamBoxPts(t *testing.T) {
+	tb := result.TeamBox{Q1: 20, Q2: 18, Q3: 24, Q4: 15, OT: []int{5, 3}}
+	want := float64(20 + 18 + 24 + 15 + 5 + 3)
+	if got := teamBoxPts(tb); got != want {
+		t.Errorf("teamBoxPts = %v, want %v", got, want)
+	}
+	// No OT — should not panic.
+	if got := teamBoxPts(result.TeamBox{Q1: 10, Q2: 10, Q3: 10, Q4: 10}); got != 40 {
+		t.Errorf("teamBoxPts no-OT = %v, want 40", got)
+	}
+}
+
+// TestWriteResearchReport verifies the writer emits one line per LeveragePoint
+// with the correct ABOVE NOISE / sub-noise tag and sorts by |Delta| descending.
+func TestWriteResearchReport(t *testing.T) {
+	rep := ResearchReport{
+		NoiseFloor: map[string]float64{"steal_share": 0.001},
+		Points: []LeveragePoint{
+			{StandInID: "steal_turnover_scale", Value: 1.8e-5, Term: "steal_share", Delta: 0.005, NoiseFloor: 0.001, AboveNoise: true},
+			{StandInID: "steal_turnover_scale", Value: 1.8e-5, Term: "cov_poss_pps", Delta: 0.0001, NoiseFloor: 0.002, AboveNoise: false},
+		},
+	}
+	var buf bytes.Buffer
+	WriteResearchReport(&buf, rep)
+	out := buf.String()
+	if !strings.Contains(out, "[ABOVE NOISE]") {
+		t.Errorf("WriteResearchReport missing [ABOVE NOISE]: %q", out)
+	}
+	if !strings.Contains(out, "[sub-noise]") {
+		t.Errorf("WriteResearchReport missing [sub-noise]: %q", out)
+	}
+	// Sorted by |Delta| descending: steal_share (0.005) before cov_poss_pps (0.0001).
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "steal_share") {
+		t.Errorf("first line should be steal_share (largest |Delta|): %q", lines[0])
+	}
+}
+
+// TestRunResearch_EmptyRoot calls RunResearch against a temp dir with no zip
+// files. researchWalk should list zero zips, return zero terms for every walk,
+// and RunResearch should return a valid ResearchReport (not error).
+func TestRunResearch_EmptyRoot(t *testing.T) {
+	dir, err := os.MkdirTemp("", "jsbresearch-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	rep, err := RunResearch(dir, Options{Runs: 1, SampleStride: 1})
+	if err != nil {
+		t.Fatalf("RunResearch empty root: %v", err)
+	}
+	// With no games simulated all terms are zero.
+	for term, nf := range rep.NoiseFloor {
+		if nf != 0 {
+			t.Errorf("NoiseFloor[%q] = %v, want 0 (no archive)", term, nf)
+		}
+	}
+	// No above-noise points since all deltas are zero.
+	for _, p := range rep.Points {
+		if p.AboveNoise {
+			t.Errorf("unexpected AboveNoise=true from empty archive: %+v", p)
+		}
+	}
+}
 
 // copyTermMap returns a shallow copy of a fidelity-term map.
 func copyTermMap(m map[string]float64) map[string]float64 {

--- a/engine/internal/calibrate/research_test.go
+++ b/engine/internal/calibrate/research_test.go
@@ -1,0 +1,131 @@
+package calibrate
+
+import (
+	"math"
+	"testing"
+)
+
+// copyTermMap returns a shallow copy of a fidelity-term map.
+func copyTermMap(m map[string]float64) map[string]float64 {
+	c := make(map[string]float64, len(m))
+	for k, v := range m {
+		c[k] = v
+	}
+	return c
+}
+
+// TestResearchWalk_ZeroDelta exercises the runResearch orchestration logic via
+// the researchWalkFn seam — no archive access required. It uses a synthetic
+// walk function that returns fixed term maps so the test covers:
+//
+//	(a) When both baseline walks and all sweep walks return identical maps,
+//	    every LeveragePoint has Delta==0 and AboveNoise==false.
+//
+//	(b) When the two baseline walks differ slightly (establishing a non-zero
+//	    noise floor) and one stand-in's sweep walks return a value that
+//	    exceeds the noise floor, those LeveragePoints have AboveNoise==true.
+func TestResearchWalk_ZeroDelta(t *testing.T) {
+	t.Run("zero_delta_identical_walks", func(t *testing.T) {
+		fixed := map[string]float64{
+			"cov_poss_pps":           0.010,
+			"cov_shots_per_poss_pps": -0.005,
+			"steal_share":            0.085,
+			"non_steal_to_share":     0.049,
+		}
+
+		// Every call returns the same values: both baselines are identical, so
+		// noise floor == 0 for every term; all sweep deltas are also 0.
+		fakeFn := func(_ string, _ Options, _ func(*Options)) (map[string]float64, error) {
+			return copyTermMap(fixed), nil
+		}
+
+		rep, err := runResearch("", Options{Runs: 1, SampleStride: 1}, fakeFn)
+		if err != nil {
+			t.Fatalf("runResearch: %v", err)
+		}
+		if len(rep.Points) == 0 {
+			t.Fatal("no Points produced — StandInRegistry must have at least one non-baseline Sweep entry")
+		}
+		for term, nf := range rep.NoiseFloor {
+			if nf != 0 {
+				t.Errorf("NoiseFloor[%q] = %v, want 0 (identical baselines)", term, nf)
+			}
+		}
+		for _, p := range rep.Points {
+			if p.Delta != 0 {
+				t.Errorf("%s/%g/%s: Delta = %v, want 0", p.StandInID, p.Value, p.Term, p.Delta)
+			}
+			if p.AboveNoise {
+				t.Errorf("%s/%g/%s: AboveNoise = true, want false (delta == 0, noise floor == 0)",
+					p.StandInID, p.Value, p.Term)
+			}
+		}
+	})
+
+	t.Run("above_noise_detected", func(t *testing.T) {
+		// base1: the reference baseline.
+		base1 := map[string]float64{
+			"cov_poss_pps":           0.010,
+			"cov_shots_per_poss_pps": -0.005,
+			"steal_share":            0.0850,
+			"non_steal_to_share":     0.049,
+		}
+		// base2: tiny steal_share nudge → noise floor steal_share = 0.0001.
+		base2 := map[string]float64{
+			"cov_poss_pps":           0.010,
+			"cov_shots_per_poss_pps": -0.005,
+			"steal_share":            0.0851,
+			"non_steal_to_share":     0.049,
+		}
+		// sweepResult: large steal_share delta (0.005) >> noise floor (0.0001).
+		sweepResult := map[string]float64{
+			"cov_poss_pps":           0.010,
+			"cov_shots_per_poss_pps": -0.005,
+			"steal_share":            0.0900,
+			"non_steal_to_share":     0.049,
+		}
+
+		// call counts the number of walkFn invocations so we can distinguish the
+		// two baseline calls from the subsequent sweep calls.
+		call := 0
+		fakeFn := func(_ string, o Options, apply func(*Options)) (map[string]float64, error) {
+			call++
+			if call == 1 {
+				return copyTermMap(base1), nil // baseline run 1 (seed opts.Seed)
+			}
+			if call == 2 {
+				return copyTermMap(base2), nil // baseline run 2 (seed opts.Seed+1)
+			}
+			// Sweep call: check whether the apply closure set StealTurnoverScale.
+			probe := o
+			apply(&probe)
+			if probe.StealTurnoverScale != nil {
+				return copyTermMap(sweepResult), nil
+			}
+			return copyTermMap(base1), nil // all other sweeps → no change from baseline
+		}
+
+		rep, err := runResearch("", Options{Runs: 1, SampleStride: 1, Seed: 42}, fakeFn)
+		if err != nil {
+			t.Fatalf("runResearch: %v", err)
+		}
+
+		// Noise floor for steal_share must equal |base2 − base1|.
+		wantNF := math.Abs(base2["steal_share"] - base1["steal_share"])
+		if got := rep.NoiseFloor["steal_share"]; math.Abs(got-wantNF) > 1e-15 {
+			t.Errorf("NoiseFloor[steal_share] = %v, want %v", got, wantNF)
+		}
+
+		// At least one steal_turnover_scale × steal_share point must be AboveNoise.
+		foundAbove := false
+		for _, p := range rep.Points {
+			if p.StandInID == "steal_turnover_scale" && p.Term == "steal_share" && p.AboveNoise {
+				foundAbove = true
+				break
+			}
+		}
+		if !foundAbove {
+			t.Error("want at least one steal_turnover_scale × steal_share LeveragePoint with AboveNoise = true")
+		}
+	})
+}

--- a/engine/internal/calibrate/season.go
+++ b/engine/internal/calibrate/season.go
@@ -289,10 +289,12 @@ func (o Options) makePutbackActive() bool { return o.MakePutback || o.MakePutbac
 func validateWithArms(opts Options, validateFn func(string, int, uint64, bundle.GameType, sim.Options) (validate.Report, error)) ValidateFunc {
 	return func(dir string, runs int, seed uint64, gt bundle.GameType) (validate.Report, error) {
 		base := sim.Options{}
-		base.BaseTimeMid = opts.BaseTimeMid                    // J23 sweep seam: nil ⇒ const path; survives both the early-return and two-pass paths below
-		base.GateBaseline = opts.GateBaseline                  // ADR-0058 gate-baseline sweep seam: nil ⇒ bundle-derived baseline; survives both paths below
-		base.Freeze.UnfaithfulPutback = opts.UnfaithfulPutback // ADR-0055 OFF walk: restore master's coupled putback; survives both paths (copied into harvest/frozen)
-		base.Freeze.UnfaithfulOreb = opts.UnfaithfulOreb       // ADR-0058 OFF walk: restore linear gate-2 ORB continuation; survives both paths
+		base.BaseTimeMid = opts.BaseTimeMid                     // J23 sweep seam: nil ⇒ const path; survives both the early-return and two-pass paths below
+		base.StealTurnoverScale = opts.StealTurnoverScale       // J14 research turnover-scale sweep seam
+		base.NonStealTurnoverScale = opts.NonStealTurnoverScale // J14 research turnover-scale sweep seam
+		base.GateBaseline = opts.GateBaseline                   // ADR-0058 gate-baseline sweep seam: nil ⇒ bundle-derived baseline; survives both paths below
+		base.Freeze.UnfaithfulPutback = opts.UnfaithfulPutback  // ADR-0055 OFF walk: restore master's coupled putback; survives both paths (copied into harvest/frozen)
+		base.Freeze.UnfaithfulOreb = opts.UnfaithfulOreb        // ADR-0058 OFF walk: restore linear gate-2 ORB continuation; survives both paths
 		if opts.BranchB {
 			base.Freeze.BranchB = true
 			base.BranchBAccum = opts.BranchBAccum

--- a/engine/internal/calibrate/season_test.go
+++ b/engine/internal/calibrate/season_test.go
@@ -107,6 +107,60 @@ func TestValidateWithArms_BaseTimeMid(t *testing.T) {
 	})
 }
 
+// TestValidateWithArms_TurnoverScale (J14): StealTurnoverScale / NonStealTurnoverScale
+// are propagated onto the base sim.Options by validateWithArms (row 6 of J14 matrix).
+// A non-nil pointer must arrive intact; a nil pointer must stay nil (const path).
+func TestValidateWithArms_TurnoverScale(t *testing.T) {
+	capture := func(got *sim.Options) func(string, int, uint64, bundle.GameType, sim.Options) (validate.Report, error) {
+		return func(_ string, _ int, _ uint64, _ bundle.GameType, o sim.Options) (validate.Report, error) {
+			*got = o
+			return validate.Report{}, nil
+		}
+	}
+	ptr := func(f float64) *float64 { return &f }
+
+	t.Run("set pointer reaches base (steal)", func(t *testing.T) {
+		var got sim.Options
+		fn := validateWithArms(Options{StealTurnoverScale: ptr(1.5e-5)}, capture(&got))
+		if _, err := fn("dir", 5, 99, bundle.GameTypeRegular); err != nil {
+			t.Fatalf("fn: %v", err)
+		}
+		if got.StealTurnoverScale == nil || *got.StealTurnoverScale != 1.5e-5 {
+			t.Fatalf("StealTurnoverScale=%v, want *1.5e-5", got.StealTurnoverScale)
+		}
+	})
+	t.Run("nil stays nil (steal const path)", func(t *testing.T) {
+		var got sim.Options
+		fn := validateWithArms(Options{}, capture(&got))
+		if _, err := fn("dir", 5, 99, bundle.GameTypeRegular); err != nil {
+			t.Fatalf("fn: %v", err)
+		}
+		if got.StealTurnoverScale != nil {
+			t.Fatalf("StealTurnoverScale=%v, want nil", got.StealTurnoverScale)
+		}
+	})
+	t.Run("set pointer reaches base (non-steal)", func(t *testing.T) {
+		var got sim.Options
+		fn := validateWithArms(Options{NonStealTurnoverScale: ptr(0.002)}, capture(&got))
+		if _, err := fn("dir", 5, 99, bundle.GameTypeRegular); err != nil {
+			t.Fatalf("fn: %v", err)
+		}
+		if got.NonStealTurnoverScale == nil || *got.NonStealTurnoverScale != 0.002 {
+			t.Fatalf("NonStealTurnoverScale=%v, want *0.002", got.NonStealTurnoverScale)
+		}
+	})
+	t.Run("nil stays nil (non-steal const path)", func(t *testing.T) {
+		var got sim.Options
+		fn := validateWithArms(Options{}, capture(&got))
+		if _, err := fn("dir", 5, 99, bundle.GameTypeRegular); err != nil {
+			t.Fatalf("fn: %v", err)
+		}
+		if got.NonStealTurnoverScale != nil {
+			t.Fatalf("NonStealTurnoverScale=%v, want nil", got.NonStealTurnoverScale)
+		}
+	})
+}
+
 // TestResolveValidate_InjectedSeamIgnoresScale: when an Options.Validate seam is
 // injected, resolveValidate returns it directly — bypassing validateWithArms, where
 // BaseTimeMid lives. The injected ValidateFunc has no sim.Options parameter, so the

--- a/engine/internal/calibrate/standinregistry.go
+++ b/engine/internal/calibrate/standinregistry.go
@@ -1,0 +1,63 @@
+package calibrate
+
+// StandIn describes one perturbable engine parameter: why it is a stand-in
+// (not a pin), what values to sweep, and how to apply a candidate value to a
+// calibrate.Options so the research walk can exercise it. The registry is
+// default-DENY / safe-by-omission (ADR-0087 §2): only explicitly registered
+// stand-ins are swept; everything else is pinned by its package const.
+type StandIn struct {
+	ID            string                      // stable key, e.g. "steal_turnover_scale"
+	Term          string                      // fidelity term it is hypothesized to move
+	Justification string                      // REQUIRED non-empty (ADR-0087 §2): why perturbable
+	Sweep         []float64                   // candidate values (baseline first)
+	Apply         func(o *Options, v float64) // writes the override pointer onto Options
+}
+
+// StandInRegistry returns the full set of currently-registered stand-ins.
+// The list is the source of truth for the research walk (RunResearch) and its
+// Justification CI gate (TestStandInRegistryJustified). To register a new
+// stand-in: add an entry here with a non-empty Justification, at least two
+// Sweep values (baseline first), and an Apply closure that sets the matching
+// Options pointer. Do NOT register a stand-in without a Justification — the CI
+// gate rejects it.
+func StandInRegistry() []StandIn {
+	ptr := func(v float64) *float64 { return &v }
+	return []StandIn{
+		{
+			ID:   "steal_turnover_scale",
+			Term: "steal_share",
+			Justification: "stealTurnoverScale (steal.go) is the dominant per-possession steal " +
+				"probability coefficient. Calibrated from the J3 corpus target (8.9 steals/team " +
+				"→ 1.69e-5) but plausibly off by ±15%: the archive gate is 17.8±0.7/g (both " +
+				"teams) and the ending-mix steal-share gate is [8.0%, 9.0%]. Perturbable as a " +
+				"research lever — the harness can quantify how much this scale moves the steal " +
+				"ending-share and the TO-rate fidelity terms without re-running the full calibration.",
+			Sweep: []float64{1.69e-5, 1.5e-5, 1.85e-5},
+			Apply: func(o *Options, v float64) { o.StealTurnoverScale = ptr(v) },
+		},
+		{
+			ID:   "non_steal_turnover_scale",
+			Term: "non_steal_to_share",
+			Justification: "nonStealTurnoverScale (steal.go) drives independent (non-steal) " +
+				"turnovers. Calibrated to 0.00175 to target non-steal TO endings ≈ 4.9±0.5% of " +
+				"possessions, but the independent-TO rate is harder to measure from the J3 corpus " +
+				"(it conflates offensive fouls). Perturbable as a research lever — the harness " +
+				"isolates how this constant moves the non-steal ending-share independently of the " +
+				"steal rate.",
+			Sweep: []float64{0.00175, 0.00140, 0.00210},
+			Apply: func(o *Options, v float64) { o.NonStealTurnoverScale = ptr(v) },
+		},
+		{
+			ID:   "base_time_mid",
+			Term: "pace",
+			Justification: "baseTimeMid (tempo.go) is the per-game constant possession-clock center " +
+				"(ADR-0085, J23 re-center sweep). Provisional value 16.0 is calibrated to the " +
+				"faithful JSB 5.60 possession-clock; the archive sweep PR #1495 confirmed it as " +
+				"the pace lever. Perturbable as a research lever — the harness can reproduce the " +
+				"direction and rough magnitude of the #1495 sweep as a self-validation arm " +
+				"(ADR-0087 §4 base_time arm).",
+			Sweep: []float64{16.0, 15.0, 17.0},
+			Apply: func(o *Options, v float64) { o.BaseTimeMid = ptr(v) },
+		},
+	}
+}

--- a/engine/internal/calibrate/standinregistry_test.go
+++ b/engine/internal/calibrate/standinregistry_test.go
@@ -1,0 +1,27 @@
+package calibrate
+
+import "testing"
+
+// TestStandInRegistryJustified is the ADR-0087 §2 CI gate: every registered
+// StandIn must carry a non-empty Justification (safe-by-omission enforcement).
+// A blank Justification means an un-reviewed parameter is being swept — reject at
+// go test time rather than silently producing an unjustified leverage report.
+func TestStandInRegistryJustified(t *testing.T) {
+	registry := StandInRegistry()
+	seen := make(map[string]bool, len(registry))
+	for _, si := range registry {
+		if si.Justification == "" {
+			t.Errorf("StandIn %q: Justification is empty (ADR-0087 §2 requires non-empty)", si.ID)
+		}
+		if si.ID == "" {
+			t.Errorf("StandIn with Term=%q: ID is empty", si.Term)
+		}
+		if len(si.Sweep) < 2 {
+			t.Errorf("StandIn %q: len(Sweep)=%d, want >=2 (baseline + at least one perturbation)", si.ID, len(si.Sweep))
+		}
+		if seen[si.ID] {
+			t.Errorf("StandIn %q: duplicate ID in registry", si.ID)
+		}
+		seen[si.ID] = true
+	}
+}

--- a/engine/internal/calibrate/walk.go
+++ b/engine/internal/calibrate/walk.go
@@ -104,6 +104,14 @@ type Options struct {
 	// const path). The pointer distinguishes "unset" (nil ⇒ const) from a real value.
 	BaseTimeMid *float64
 
+	// StealTurnoverScale / NonStealTurnoverScale, when non-nil, override the sim
+	// package turnover-scale consts in the default (non-injected) engine runs — the
+	// J14 research turnover-scale sweep. Threaded into sim.Options by validateWithArms
+	// (an injected Options.Validate test seam ignores them). nil ⇒ const path, so every
+	// existing caller stays byte-identical.
+	StealTurnoverScale    *float64
+	NonStealTurnoverScale *float64
+
 	// GateBaseline, when non-nil, overrides the L1 gate-1 baseline term (the league
 	// offensive-rebound share × 100) in the default (non-injected) engine runs — the
 	// ADR-0058 gate-continuation baseline sensitivity sweep. Threaded into sim.Options by

--- a/engine/internal/sim/endingmix.go
+++ b/engine/internal/sim/endingmix.go
@@ -1,0 +1,99 @@
+package sim
+
+import "github.com/a-jay85/IBL5/engine/internal/result"
+
+// EndingMixCounts is one accumulation bucket of per-possession endings and
+// event tallies (both teams pooled, like the J3 corpus numbers).
+type EndingMixCounts struct {
+	Games       int `json:"games"`
+	Possessions int `json:"possessions"`
+
+	// Possession endings (each possession classified exactly once).
+	EndSteal   int `json:"end_steal"`    // EventSteal present (steal IS the turnover)
+	EndTOInd   int `json:"end_to_ind"`   // EventTurnover without a steal (independent check)
+	EndDReb    int `json:"end_dreb"`     // defensive rebound (always trip-terminal)
+	EndMade    int `json:"end_made"`     // made FG, no FT sequence
+	EndFT      int `json:"end_ft"`       // FT sequence last (and-one or foul-only; engine FTs never rebound)
+	EndOther   int `json:"end_other"`    // OREB-cap exhaustion / empty possession
+	ORebCont   int `json:"oreb_cont"`    // offensive-rebound CONTINUATIONS (not endings)
+	AndOneSeqs int `json:"and_one_seqs"` // and-one FT sequences (FTAttempts==1) inside EndFT
+
+	// Event tallies for the sub-model rate decomposition.
+	FGA    int `json:"fga"` // all shot attempts (2pt+3pt, all origins)
+	FGM    int `json:"fgm"`
+	FGA3   int `json:"fga3"`
+	FGM3   int `json:"fgm3"`
+	OReb   int `json:"oreb"`
+	DReb   int `json:"dreb"`
+	Steals int `json:"steals"`
+	TOs    int `json:"turnovers"` // all EventTurnover (steal-driven + independent)
+	FTA    int `json:"fta"`
+	FTM    int `json:"ftm"`
+	Fouls  int `json:"fouls"`
+}
+
+// ClassifyPossession tallies one possession's events into c. Priority mirrors
+// the trip structure: a steal is the dominant turnover and ends the trip; an
+// independent EventTurnover (no steal) likewise; a defensive rebound is always
+// trip-terminal; otherwise the possession ended on a make or an FT sequence.
+func ClassifyPossession(evs []result.Event, c *EndingMixCounts) {
+	if len(evs) == 0 {
+		return
+	}
+	c.Possessions++
+	var hasSteal, hasTO, hasDReb, hasMake, hasFT bool
+	var lastFTAttempts int
+	for _, e := range evs {
+		switch e.Kind {
+		case result.EventShotAttempt:
+			c.FGA++
+			if e.ShotType == result.ShotThree {
+				c.FGA3++
+			}
+		case result.EventShotMake:
+			c.FGM++
+			hasMake = true
+			if e.ShotType == result.ShotThree {
+				c.FGM3++
+			}
+		case result.EventRebound:
+			if e.OffensiveRebound {
+				c.OReb++
+				c.ORebCont++
+			} else {
+				c.DReb++
+				hasDReb = true
+			}
+		case result.EventSteal:
+			c.Steals++
+			hasSteal = true
+		case result.EventTurnover:
+			c.TOs++
+			hasTO = true
+		case result.EventFreeThrow:
+			c.FTA += e.FTAttempts
+			c.FTM += e.FTMade
+			hasFT = true
+			lastFTAttempts = e.FTAttempts
+		case result.EventFoul:
+			c.Fouls++
+		}
+	}
+	switch {
+	case hasSteal:
+		c.EndSteal++
+	case hasTO:
+		c.EndTOInd++
+	case hasDReb:
+		c.EndDReb++
+	case hasFT:
+		c.EndFT++
+		if lastFTAttempts == 1 {
+			c.AndOneSeqs++
+		}
+	case hasMake:
+		c.EndMade++
+	default:
+		c.EndOther++
+	}
+}

--- a/engine/internal/sim/endingmix_share_archive_test.go
+++ b/engine/internal/sim/endingmix_share_archive_test.go
@@ -42,102 +42,6 @@ import (
 	"github.com/a-jay85/IBL5/engine/internal/result"
 )
 
-// endingMixCounts is one accumulation bucket of per-possession endings and
-// event tallies (both teams pooled, like the J3 corpus numbers).
-type endingMixCounts struct {
-	Games       int `json:"games"`
-	Possessions int `json:"possessions"`
-
-	// Possession endings (each possession classified exactly once).
-	EndSteal   int `json:"end_steal"`    // EventSteal present (steal IS the turnover)
-	EndTOInd   int `json:"end_to_ind"`   // EventTurnover without a steal (independent check)
-	EndDReb    int `json:"end_dreb"`     // defensive rebound (always trip-terminal)
-	EndMade    int `json:"end_made"`     // made FG, no FT sequence
-	EndFT      int `json:"end_ft"`       // FT sequence last (and-one or foul-only; engine FTs never rebound)
-	EndOther   int `json:"end_other"`    // OREB-cap exhaustion / empty possession
-	ORebCont   int `json:"oreb_cont"`    // offensive-rebound CONTINUATIONS (not endings)
-	AndOneSeqs int `json:"and_one_seqs"` // and-one FT sequences (FTAttempts==1) inside EndFT
-
-	// Event tallies for the sub-model rate decomposition.
-	FGA    int `json:"fga"` // all shot attempts (2pt+3pt, all origins)
-	FGM    int `json:"fgm"`
-	FGA3   int `json:"fga3"`
-	FGM3   int `json:"fgm3"`
-	OReb   int `json:"oreb"`
-	DReb   int `json:"dreb"`
-	Steals int `json:"steals"`
-	TOs    int `json:"turnovers"` // all EventTurnover (steal-driven + independent)
-	FTA    int `json:"fta"`
-	FTM    int `json:"ftm"`
-	Fouls  int `json:"fouls"`
-}
-
-// classifyPossession tallies one possession's events into c. Priority mirrors
-// the trip structure: a steal is the dominant turnover and ends the trip; an
-// independent EventTurnover (no steal) likewise; a defensive rebound is always
-// trip-terminal; otherwise the possession ended on a make or an FT sequence.
-func classifyPossession(evs []result.Event, c *endingMixCounts) {
-	if len(evs) == 0 {
-		return
-	}
-	c.Possessions++
-	var hasSteal, hasTO, hasDReb, hasMake, hasFT bool
-	var lastFTAttempts int
-	for _, e := range evs {
-		switch e.Kind {
-		case result.EventShotAttempt:
-			c.FGA++
-			if e.ShotType == result.ShotThree {
-				c.FGA3++
-			}
-		case result.EventShotMake:
-			c.FGM++
-			hasMake = true
-			if e.ShotType == result.ShotThree {
-				c.FGM3++
-			}
-		case result.EventRebound:
-			if e.OffensiveRebound {
-				c.OReb++
-				c.ORebCont++
-			} else {
-				c.DReb++
-				hasDReb = true
-			}
-		case result.EventSteal:
-			c.Steals++
-			hasSteal = true
-		case result.EventTurnover:
-			c.TOs++
-			hasTO = true
-		case result.EventFreeThrow:
-			c.FTA += e.FTAttempts
-			c.FTM += e.FTMade
-			hasFT = true
-			lastFTAttempts = e.FTAttempts
-		case result.EventFoul:
-			c.Fouls++
-		}
-	}
-	switch {
-	case hasSteal:
-		c.EndSteal++
-	case hasTO:
-		c.EndTOInd++
-	case hasDReb:
-		c.EndDReb++
-	case hasFT:
-		c.EndFT++
-		if lastFTAttempts == 1 {
-			c.AndOneSeqs++
-		}
-	case hasMake:
-		c.EndMade++
-	default:
-		c.EndOther++
-	}
-}
-
 // endingMixArtifact is the committed diagnostic output from one archive pass.
 type endingMixArtifact struct {
 	Generated string          `json:"generated"`
@@ -145,7 +49,7 @@ type endingMixArtifact struct {
 	Runs      int             `json:"runs"`
 	Seed      uint64          `json:"seed"`
 	Snapshots int             `json:"snapshots"`
-	Counts    endingMixCounts `json:"counts"`
+	Counts    EndingMixCounts `json:"counts"`
 
 	// Derived shares (% of possessions).
 	StealSharePct float64 `json:"end_steal_share_pct"`
@@ -192,7 +96,7 @@ func TestEndingMixBaseline(t *testing.T) {
 		t.Skipf("no .zip snapshots under %q", dir)
 	}
 
-	var c endingMixCounts
+	var c EndingMixCounts
 	snapshots := 0
 
 	for i := 0; i < len(zips); i += stride {
@@ -214,13 +118,13 @@ func TestEndingMixBaseline(t *testing.T) {
 				var cur []result.Event
 				for _, e := range g.Events {
 					if e.Kind == result.EventPossessionStart {
-						classifyPossession(cur, &c)
+						ClassifyPossession(cur, &c)
 						cur = cur[:0]
 						continue
 					}
 					cur = append(cur, e)
 				}
-				classifyPossession(cur, &c)
+				ClassifyPossession(cur, &c)
 			}
 		}
 		snapshots++

--- a/engine/internal/sim/freeze.go
+++ b/engine/internal/sim/freeze.go
@@ -248,6 +248,13 @@ type Options struct {
 	// down to the faithful 16.0. See the tempo.go NO-GO block and ADR-0085.
 	BaseTimeMid *float64
 
+	// StealTurnoverScale / NonStealTurnoverScale override the package consts
+	// stealTurnoverScale / nonStealTurnoverScale (steal.go) for the J14 research
+	// turnover-scale sweep. nil → use the const (a zero Options stays byte-identical
+	// to Simulate); non-nil → use the pointed-to value. Always a valid float when set.
+	StealTurnoverScale    *float64
+	NonStealTurnoverScale *float64
+
 	// GateCont, when non-nil, harvests the L1 gate-1 decomposition instrument
 	// (ADR-0057/0058) across the run: at every offensive-rebound resolution it records
 	// the gate-1 P (live since ADR-0058), the linear gate-2 P, and their product, keyed
@@ -361,7 +368,7 @@ func (gs *gameState) accumulateGateCont(offTeamID int, off, def float64) {
 // Cov(lnFGA,lnPPS) (the ADR-0045 Cov re-run). The caller draws its gs.rng.Float64()
 // roll unconditionally, so live and frozen passes consume the RNG identically.
 func (gs *gameState) turnoverProb(careless, pressure float64) float64 {
-	p := stealTurnoverScale * careless * pressure
+	p := gs.stealTurnoverScale * careless * pressure
 	if p < 0 {
 		p = 0
 	}

--- a/engine/internal/sim/freeze_test.go
+++ b/engine/internal/sim/freeze_test.go
@@ -36,7 +36,7 @@ func TestFreeze_SubstitutesAndAccumulates(t *testing.T) {
 	def := []onCourt{oc(slotPG, mkPlayer(2, 3, slotPG, 50))}
 	bh := off[0]
 	wantFoul := foulBucketWeight(bh, off, def, 0, 0, rng.New(foulSeed))
-	base := &gameState{accum: acc, rng: rng.New(foulSeed)}
+	base := &gameState{accum: acc, rng: rng.New(foulSeed), stealTurnoverScale: stealTurnoverScale, nonStealTurnoverScale: nonStealTurnoverScale}
 	wantOreb := gate1Probability(100, 100, base.gateBaseline) // live faithful gate-1 (base.gateBaseline is 0)
 	// float64 vars force runtime (not constant-folded) evaluation, matching the
 	// wrapper's accumulated rounding exactly.
@@ -102,7 +102,7 @@ func TestFreeze_NoCrossConfound(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			gs := &gameState{freeze: c.cfg, rng: rng.New(foulSeed)}
+			gs := &gameState{freeze: c.cfg, rng: rng.New(foulSeed), stealTurnoverScale: stealTurnoverScale, nonStealTurnoverScale: nonStealTurnoverScale}
 			gotOreb := gs.orebProb(120, 80)
 			gotTurn := gs.turnoverProb(60, 100)
 			gotMake := gs.makeValue2pt(5, bh, 0, result.OriginInitial, 0, 0)

--- a/engine/internal/sim/gameloop.go
+++ b/engine/internal/sim/gameloop.go
@@ -36,6 +36,19 @@ func resolveBaseTimeMid(opts Options) float64 {
 	return baseTimeMid
 }
 
+func resolveStealTurnoverScale(opts Options) float64 {
+	if opts.StealTurnoverScale != nil {
+		return *opts.StealTurnoverScale
+	}
+	return stealTurnoverScale
+}
+func resolveNonStealTurnoverScale(opts Options) float64 {
+	if opts.NonStealTurnoverScale != nil {
+		return *opts.NonStealTurnoverScale
+	}
+	return nonStealTurnoverScale
+}
+
 // simGameWith is simGame plus the freeze/accumulation Options (freeze.go). A zero
 // Options leaves every possession decision byte-identical to simGame; a non-zero
 // Options either harvests league-mean derived values (opts.Accum) or substitutes a
@@ -80,6 +93,8 @@ func simGameWith(b bundle.Bundle, g bundle.Game, r *rng.RNG, opts Options) (resu
 	// DRB-push (Phase 4) fast classes widen the mix further, drawn off the
 	// PRIOR possession's outcome below.
 	baseTime := resolveBaseTimeMid(opts)
+	gs.stealTurnoverScale = resolveStealTurnoverScale(opts)
+	gs.nonStealTurnoverScale = resolveNonStealTurnoverScale(opts)
 
 	// Tip-off winner starts on offense; possessions strictly alternate.
 	offense, defense := visitor, home

--- a/engine/internal/sim/gameloop_test.go
+++ b/engine/internal/sim/gameloop_test.go
@@ -1,0 +1,33 @@
+package sim
+
+import "testing"
+
+func TestResolveStealTurnoverScale_NilUsesConst(t *testing.T) {
+	got := resolveStealTurnoverScale(Options{})
+	if got != stealTurnoverScale {
+		t.Errorf("resolveStealTurnoverScale(nil) = %v, want const %v", got, stealTurnoverScale)
+	}
+}
+
+func TestResolveStealTurnoverScale_NonNilOverrides(t *testing.T) {
+	v := 3.14e-5
+	got := resolveStealTurnoverScale(Options{StealTurnoverScale: &v})
+	if got != v {
+		t.Errorf("resolveStealTurnoverScale(override) = %v, want %v", got, v)
+	}
+}
+
+func TestResolveNonStealTurnoverScale_NilUsesConst(t *testing.T) {
+	got := resolveNonStealTurnoverScale(Options{})
+	if got != nonStealTurnoverScale {
+		t.Errorf("resolveNonStealTurnoverScale(nil) = %v, want const %v", got, nonStealTurnoverScale)
+	}
+}
+
+func TestResolveNonStealTurnoverScale_NonNilOverrides(t *testing.T) {
+	v := 0.0025
+	got := resolveNonStealTurnoverScale(Options{NonStealTurnoverScale: &v})
+	if got != v {
+		t.Errorf("resolveNonStealTurnoverScale(override) = %v, want %v", got, v)
+	}
+}

--- a/engine/internal/sim/state.go
+++ b/engine/internal/sim/state.go
@@ -112,6 +112,12 @@ type gameState struct {
 	// Game2GM/Game3GM are now derived from the event stream by aggregateBoxes.
 	madeFG map[int]int
 
+	// stealTurnoverScale / nonStealTurnoverScale are the per-possession turnover
+	// scales for THIS run: the package const on a live run, or the Options override
+	// (J14 research sweep). Populated once per game in simGameWith.
+	stealTurnoverScale    float64
+	nonStealTurnoverScale float64
+
 	// transitionShotRate is the Stage-3 decaying team shot-rate threshold for
 	// fast-break steal-success (00_MASTER_REFERENCE.md L900-914). It is seeded
 	// once per period on the first possession that carries the fast-break pending

--- a/engine/internal/sim/steal.go
+++ b/engine/internal/sim/steal.go
@@ -104,7 +104,7 @@ func (gs *gameState) stealTurnover(offense, defense *teamState, victim onCourt) 
 // since there is no stealer). A gs.rng.Float64() roll is drawn unconditionally
 // so the RNG stream is deterministic regardless of outcome.
 func (gs *gameState) nonStealTurnover(offense *teamState, victim onCourt) bool {
-	prob := nonStealTurnoverScale * turnoverCarelessness(victim.TVR)
+	prob := gs.nonStealTurnoverScale * turnoverCarelessness(victim.TVR)
 	if prob > maxTurnoverProb {
 		prob = maxTurnoverProb
 	}

--- a/engine/internal/sim/steal_test.go
+++ b/engine/internal/sim/steal_test.go
@@ -47,7 +47,7 @@ func countStealTurnovers(victimTVR, defenderSTL int, seeds uint64) int {
 	count := 0
 	for s := uint64(1); s <= seeds; s++ {
 		off, def := stealLineups(victimTVR, defenderSTL)
-		gs := &gameState{rng: rng.New(s), period: 1, clock: 500}
+		gs := &gameState{rng: rng.New(s), period: 1, clock: 500, stealTurnoverScale: stealTurnoverScale, nonStealTurnoverScale: nonStealTurnoverScale}
 		if gs.stealTurnover(off, def, off.players[0]) {
 			count++
 		}
@@ -121,7 +121,7 @@ func TestStealTurnover_AllZeroSTLNoTurnover(t *testing.T) {
 func TestTurnoverProb_NoNaNOnEmptyRatings(t *testing.T) {
 	// All-zero TVR (carelessness = base) and all-zero STL (pressure 0): the weight
 	// must be finite, never NaN/Inf, and exactly 0 (no pressure).
-	gs := &gameState{}
+	gs := &gameState{stealTurnoverScale: stealTurnoverScale, nonStealTurnoverScale: nonStealTurnoverScale}
 	pressure := teamStealPressure(newTeamState(stealLineupPlayers(3, 0, 0), 3, true))
 	p := gs.turnoverProb(turnoverCarelessness(0), pressure)
 	if math.IsNaN(p) || math.IsInf(p, 0) {
@@ -143,7 +143,7 @@ func TestStealTurnover_CreditsDefenderVictimKeepsTOV(t *testing.T) {
 	for seed := uint64(1); seed < 200; seed++ {
 		offense, defense := stealLineups(10, 45)
 		victim := offense.players[0]
-		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500, stealTurnoverScale: stealTurnoverScale, nonStealTurnoverScale: nonStealTurnoverScale}
 		if !gs.stealTurnover(offense, defense, victim) {
 			continue
 		}
@@ -193,7 +193,7 @@ func countNonStealTurnovers(tvr int, seeds uint64) int {
 	count := 0
 	for s := uint64(1); s <= seeds; s++ {
 		off, _ := stealLineups(tvr, 30)
-		gs := &gameState{rng: rng.New(s), period: 1, clock: 500}
+		gs := &gameState{rng: rng.New(s), period: 1, clock: 500, stealTurnoverScale: stealTurnoverScale, nonStealTurnoverScale: nonStealTurnoverScale}
 		if gs.nonStealTurnover(off, off.players[0]) {
 			count++
 		}
@@ -227,7 +227,7 @@ func TestNonStealTurnover_NoEventSteal(t *testing.T) {
 	offense, _ := stealLineups(0, 30) // TVR=0: max carelessness for high probability
 	victim := offense.players[0]
 	for seed := uint64(1); seed < 500; seed++ {
-		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500, stealTurnoverScale: stealTurnoverScale, nonStealTurnoverScale: nonStealTurnoverScale}
 		if !gs.nonStealTurnover(offense, victim) {
 			continue
 		}

--- a/engine/internal/sim/transition_test.go
+++ b/engine/internal/sim/transition_test.go
@@ -258,7 +258,7 @@ func TestPossession_FastBreakFlagMatchesEnding(t *testing.T) {
 	var seenMade, seenDReb, seenSteal bool
 	for seed := uint64(1); seed <= 400; seed++ {
 		offense, defense := twoTeams()
-		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500}
+		gs := &gameState{rng: rng.New(seed), period: 1, clock: 500, stealTurnoverScale: stealTurnoverScale, nonStealTurnoverScale: nonStealTurnoverScale}
 		outcome := possession(gs, offense, defense, 0, possNormal)
 		dreb, steal, made := classifyEnding(gs.events)
 		var want possOutcome

--- a/ibl5/docs/backlog/archive/jsb-native-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/jsb-native-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed JSB native-engine backlog entries (J-items), extracted from jsb-native-backlog.md.
-last_verified: 2026-07-16
+last_verified: 2026-07-20
 ---
 
 # JSB Native-Engine Backlog — Archive
@@ -148,3 +148,11 @@ Full detail: symmetric deterministic base `(2.0 − fatigue)·tovRate(bh)` (corr
 **Problem:** ADR-0085 (J21 finding) established two coupled imperfections: (1) `possessionTime` uses `int()` truncation where 5.60 uses round-half-up (`FUN_004e42e0`, `_DAT_00669ef0=0.5` confirmed from `.rdata`); (2) the engine's neutral center `baseTimeMid=14.5s` is ~0.7s too slow (real effective step ≈ 13.8s = 1440/104.6). These partially cancel: truncation's downward bias accidentally compensates the too-slow center. The J21 A/B confirmed shipping round-alone regresses mean pace (101.9→97.6 vs real 104.6) and does not flip the wrong-signed Cov(lnPOSS,lnPPS). The faithful end-state requires both changes together.
 **Direction:** ship round-half-up in `possessionTime` paired with a base_time re-centering via `baseTimeMid` directly (the direct neutral-center knob, NOT `offVolumeNeutral` — see ADR-0085 Update and plan Architectural trade-offs); run coupled round+recenter A/B on the four-term gate; re-establish the characterization pins from `possession_pace_pin_test.go`.
 **Status (2026-07-16):** ✅ Implemented — PR #1495. Round-half-up (`int(pt+0.5)`) in `possessionTime` COUPLED with `baseTimeMid` re-centered 14.5→13.65 (20-run archive sweep selected 13.65 as closest to real ~104.6 poss/g). Mean pace ~104.5 poss/g restored (was ~101.9 truncation / ~97.6 round-alone). Four-term gate (20-run archive of record): Cov(lnPOSS,lnPPS) documented-null — sign flip NOT achieved (Cov carrier is cross-team pace-dispersion subsystem per J20 finding, consistent with `possessioncoupling_archive_test.go:51-64`); Var(lnPOSS) 0.000339 (toward 0.000721, no overshoot ✓); Cov(lnFGA,lnPPS) total −0.000347 (improved from −0.000364 ✓); Var(lnFGA) within ≤0.001330 ceiling ✓. Pins re-established (Pin A ~1/6,1/3,1/3,~1/6 round-half-up buckets; Pin B re-baselined 96→104 — step dropped 15→14 at re-centered base_time). ADR-0085 hold lifted. 🧠 Opus.
+
+---
+
+### J14 AutoResearch eval-harness ADR (loop L9 companion)
+**Location:** No harness prior to this PR; instrumentation groundwork (calibration walk ≈ 8 min full-corpus, freeze arms, channel-split tests) is merged. Cross-ref: [loop-engineering-backlog.md](loop-engineering-backlog.md) L9.
+**Problem:** Engine iteration is human-paced despite an objective metric. The unresolved design tension — and why this is an ADR, not a script — is that a "perturb params, keep improvements" loop **conflicts with the faithfulness bar** (every shipped change must be RE-grounded in 5.60, not tuned to the corpus): the search space must be constrained to admitted stand-in constants and instrument-only measurements, never RE-pinned formulas.
+**Direction:** ADR defining metric, legal parameter space (stand-ins only), acceptance rule, and how trial results feed RE prioritization rather than direct commits. Harness build is ⚙️ Sonnet-executable once the ADR is written.
+**Status (2026-07-20):** ✅ Implemented — ADR-0087 (metric = ADR-0049 four-term + ending-mix bands; legal param space = default-deny stand-in allowlist; acceptance = leverage report for RE prioritization, never auto-commit; harness self-validation vs J23/J26 A/Bs) + eval harness shipped (`engine/internal/calibrate/research.go`, `standinregistry.go`; `jsbcalibrate --mode research`; archive-gated self-validation in `research_archive_test.go`). Loop orchestration / automouse wiring is L9's separate residual.

--- a/ibl5/docs/backlog/jsb-native-backlog.md
+++ b/ibl5/docs/backlog/jsb-native-backlog.md
@@ -79,7 +79,7 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 | J11 | Season-selection min-GP guard | ✅ Implemented | ⚙️ Sonnet | S |
 | J12 | HCA re-homing to basis-scaled site-2 (absorbed into J15) | ✅ Implemented | 🧠 Opus | M |
 | J13 | Cut-over package: bands, leaders, decision | ⬜ Open | 🧠 Opus | L |
-| J14 | AutoResearch eval-harness ADR (loop L9 companion) | ⬜ Open | 🧠 Opus | L |
+| J14 | AutoResearch eval-harness ADR (loop L9 companion) | ✅ Implemented | 🧠 Opus | L |
 | J15 | Faithful foul-bucket program (live composites + HCA re-homing + level re-anchor) | ✅ Implemented | 🧠 Opus | L |
 | J16 | FUN_004e3860 net-advantage formula via objdump | ✅ Implemented | 🔮 Fable | S |
 | J17 | Game-state foul coupling port (param_8 desperation + late-game fouling) | ⬜ Open | 🧠 Opus | M |
@@ -148,10 +148,7 @@ The cut-over blocker — the wrong-signed Cov(lnFGA,lnPPS) — has a **named dom
 **Status (2026-07-13):** ⬜ Open — **bands sub-item VERIFIED post-J18** (`jsbcalibrate --mode gate` re-run on the post-J15+J18 engine, runs=20 stride=50: PASS, no literal change; provenance in `engine/internal/validate/bands.go` J18 block). **Leaders instrument (J13-2) SHIPPED** (2026-07-14, PR #1463 `6899910ea` — per-player leaders validation instrument); **cut-over ADR (J13-3) still open** — the only remaining J13 sub-item. Band derivation and per-player instrument are ⚙️-delegable; the acceptance judgment and cut-over ADR are 🧠.
 
 ### J14 AutoResearch eval-harness ADR (loop L9 companion)
-**Location:** No harness exists; instrumentation groundwork (calibration walk ≈ 8 min full-corpus, freeze arms, channel-split tests) is merged. Cross-ref: [loop-engineering-backlog.md](loop-engineering-backlog.md) L9.
-**Problem:** Engine iteration is human-paced despite an objective metric. The unresolved design tension — and why this is an ADR, not a script — is that a "perturb params, keep improvements" loop **conflicts with the faithfulness bar** (every shipped change must be RE-grounded in 5.60, not tuned to the corpus): the search space must be constrained to admitted stand-in constants and instrument-only measurements, never RE-pinned formulas.
-**Direction:** ADR defining metric, legal parameter space (stand-ins only), acceptance rule, and how trial results feed RE prioritization rather than direct commits. Harness build afterward is ⚙️.
-**Status (2026-07-20):** ◑ Partial — ADR-0087 shipped (metric = ADR-0049 four-term + ending-mix bands; legal param space = default-deny stand-in allowlist; acceptance = leverage report for RE prioritization, never auto-commit; harness self-validation vs J23/J26 A/Bs). ⚙️ harness build deferred.
+➜ J14 AutoResearch eval-harness ADR (loop L9 companion) — ✅ Implemented (2026-07-20): see [archive](archive/jsb-native-backlog-archive.md).
 
 ### J15 Faithful foul-bucket program (live composites + HCA re-homing + level re-anchor)
 **Location:** `engine/internal/sim/bucketweights.go` `foulBucketWeight` + `teamquality.go` `defQuality`/`offQuality` + `possession.go` site-2 HCA + `engine/internal/validate` bands/goldens. Measured ground: `jsb-native/re-artifacts/jsb-J2-adjudication-20260710.md` §4/§6; faithful formulas: `jsb-J6-composite-scales-20260710.md`.

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -47,7 +47,7 @@ last_verified: 2026-07-20
 | L6 | Auto-update-branch unsticker | ✅ Implemented | — | S |
 | L7 | Queue-add shift-left preflight | 📋 Planned | 🟦 | S |
 | L8 | Failure self-heal / requeue | ✅ Implemented | — | M |
-| L9 | JSB AutoResearch loop | ⬜ Open | 🟥 | L |
+| L9 | JSB AutoResearch loop | ◑ Partial | 🟥 | L |
 | L10 | Discord intake loop | ◑ Partial | 🟦 | L |
 | L11 | Comprehension-debt digest | ⬜ Open | 🟦 | S |
 | L12 | Autonomy contracts in plan frontmatter | ◑ Partial | 🟦 | M |
@@ -109,7 +109,7 @@ last_verified: 2026-07-20
 **Problem:** Engine-parameter tuning is human-paced despite having exactly what a self-improvement loop needs: an objective metric (simulated stat distributions vs real targets).
 **Suggested direction:** An eval harness that perturbs engine params in a worktree, sims N seasons, scores distribution error, keeps only improvements, and logs each trial — overnight, hundreds of trials. Wants an ADR (metric definition, param search space, acceptance rule).
 **Risk if untouched:** RE convergence stays bottlenecked on human iteration bandwidth.
-**Status (2026-07-07):** ⬜ Open — 🟥 (the loop design itself is the judgment).
+**Status (2026-07-20):** ◑ Partial — harness shipped (J14); loop orchestration / automouse wiring remains. 🟥.
 **ADR:** satisfied by ADR-0087 (2026-07-20) — metric/legal-space/acceptance rule defined; harness build remains open.
 
 ### L10 Discord intake loop

--- a/ibl5/docs/decisions/0087-autoresearch-eval-harness-faithfulness-constrained-loop.md
+++ b/ibl5/docs/decisions/0087-autoresearch-eval-harness-faithfulness-constrained-loop.md
@@ -135,7 +135,10 @@ generalize.** Its acceptance test is:
   the leverage it reports matches the hand-run sweep within the noise floor.
 - Re-run the **J26 ceiling probe** (zeroing a Phase-4 term moved FG% +2.83pp in
   the manual prototype) and confirm the harness recovers the same lever
-  magnitude.
+  magnitude. *(Steal/non-steal turnover-scale arm: automated by the J14 harness —
+  `steal_turnover_scale` and `non_steal_turnover_scale` are registered stand-ins in
+  `StandInRegistry()` (`engine/internal/calibrate/standinregistry.go`); the sweep
+  runs automatically via `jsbcalibrate --mode research`.)*
 
 Seed/determinism is controlled via the freeze arms so these are exact
 comparisons, not eyeballed. A harness that cannot reproduce a known A/B is not


### PR DESCRIPTION
## Summary

Builds the AutoResearch eval-harness (ADR-0087): a faithfulness-constrained leverage report over an allowlisted stand-in registry.

**Changes:**
- `engine/internal/sim/endingmix.go` — extracted, exported `EndingMixCounts` + `ClassifyPossession` from archive test
- `engine/internal/sim/freeze.go` / `gameloop.go` / `state.go` / `steal.go` — turnover-scale override-pointer seam (mirrors `BaseTimeMid`)
- `engine/internal/calibrate/standinregistry.go` — default-frozen stand-in registry with CI Justification gate
- `engine/internal/calibrate/research.go` — single-pass research walk + leverage report (`RunResearch` / `WriteResearchReport`)
- `engine/cmd/jsbcalibrate/main.go` — `--mode research` dispatch
- `engine/internal/calibrate/research_archive_test.go` — self-validation archive test (base_time + steal-scale arms)
- `ibl5/docs/backlog/jsb-native-backlog.md` — J14 → ✅ Implemented
- `ibl5/docs/backlog/loop-engineering-backlog.md` — L9 → ◑ Partial
- `ibl5/docs/decisions/0087-autoresearch-eval-harness-faithfulness-constrained-loop.md` — §4 supersession annotation

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.