### PR TITLE
chore(ci): ignore npm audit fix exit code

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -58,7 +58,7 @@ jobs:
           # major bump). Loop every lockfile directory.
           for dir in ibl5 IBL6 ibl5/IBLbot; do
             echo "::group::npm audit fix — $dir"
-            ( cd "$dir" && npm ci && npm audit fix )
+            ( cd "$dir" && npm ci && npm audit fix || true )
             echo "::endgroup::"
           done
 


### PR DESCRIPTION
## Summary
- Add `|| true` to prevent npm audit fix failures from breaking the workflow
- Allows CI job to continue even if vulnerabilities cannot be auto-fixed

## Manual Testing

No manual testing needed — verified by automated tests.
