### PR TITLE
chore(deps): add immutable@4.3.9

### DIFF
--- a/ibl5/package-lock.json
+++ b/ibl5/package-lock.json
@@ -4398,12 +4398,11 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "3.8.3",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",

--- a/ibl5/package.json
+++ b/ibl5/package.json
@@ -37,6 +37,7 @@
     "socket.io-adapter": "2.5.7",
     "uuid": "14.0.0",
     "ws": "8.21.0",
+    "immutable": "4.3.9",
     "eslint": {
       "brace-expansion": "5.0.7"
     }


### PR DESCRIPTION
## Summary
- Add immutable@4.3.9 to ibl5/package.json
- Resolves npm audit findings related to immutable package

## Manual Testing

No manual testing needed — verified by automated tests.
