### PR TITLE
chore: group github/codeql-action* in dependabot so all sub-actions bump together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "composer"
     directory: "/ibl5"


### PR DESCRIPTION
Fixes the root cause of #1560: Dependabot was bumping `codeql-action/analyze` independently from `init` and `autobuild`, causing a version mismatch that failed CI.

The `groups` stanza ensures all `github/codeql-action*` sub-actions are bumped in a single PR from now on.
