### PR TITLE
chore: scope sweep-gate file counter to repo paths only

### DIFF
--- a/.claude/rules/work-triage-detail.md
+++ b/.claude/rules/work-triage-detail.md
@@ -27,8 +27,9 @@ The prose routing guidance in `work-triage.md` is a judgment call, and judgment 
 - **Sub-agent edits are exempt** (`agent_id` present in the PreToolUse payload). The delegate you spawn in response is never blocked — otherwise the gate would brick the delegation it exists to force. Note sub-agents share the parent's `session_id` *and* `transcript_path`, so `agent_id` is the only usable discriminator.
 - **Per user turn, not per session** (keyed on `prompt_id`). Three unrelated one-file edits across a long session are not a sweep and don't trip it.
 - **Distinct files, not calls** — editing one file ten times counts once.
+- **Repo files only** — a path counts only when it resolves inside a git working tree; `/tmp` scratch and `~/.claude` hook/settings edits never accrue, so they can't push a later repo file over the line. A new file in a not-yet-created repo subdirectory still counts, because the check walks up to the nearest existing ancestor directory.
 - **Fails open** on a malformed payload; never blocks editing because a field was missing.
-- **Escape hatch, deliberately loud:** `touch /tmp/claude-sweep-override-<prompt_id>` (example) releases it for that turn. Legitimate when the edits are genuinely *entangled* with the design — for example authoring a hook, its test, and its rule doc together. Using it silently defeats the gate: **say out loud that you're overriding and why**, in the same turn.
+- **Escape hatch, deliberately loud:** `touch /tmp/claude-sweep-override-<prompt_id>` (example) releases it for that turn. Legitimate when the edits are genuinely *entangled* with the design — for example authoring a rule doc, its detail companion, and the ADR recording the decision together. Using it silently defeats the gate: **say out loud that you're overriding and why**, in the same turn.
 
 ## Repeat-polling
 

--- a/.claude/rules/work-triage.md
+++ b/.claude/rules/work-triage.md
@@ -52,9 +52,9 @@ Either way the routing decision is **stated, not silent** — one line, like the
 
 ### The hard trigger: ≥3 distinct files in one turn
 
-**The numeric rule: the third distinct file you edit on the main thread within one user turn is the handoff point.** Two files is a change; three is a sweep. Route the remainder to one `subagent_type: "sonnet-4-6"` sub-agent (omit `model`) before making that third edit — don't wait to be stopped.
+**The numeric rule: the third distinct repo file you edit on the main thread within one user turn is the handoff point.** Two files is a change; three is a sweep. Route the remainder to one `subagent_type: "sonnet-4-6"` sub-agent (omit `model`) before making that third edit — don't wait to be stopped.
 
-This is enforced by `~/.claude/hooks/plan-gate-edit.sh` — the hook **denies** the Edit/Write so the gate cannot be read past. Escape hatch: `touch /tmp/claude-sweep-override-<prompt_id>` (example) (say why, out loud). Full properties (sub-agent exemption, per-turn scoping, fail-open): `work-triage-detail.md` § Hard trigger.
+This is enforced by `~/.claude/hooks/plan-gate-edit.sh` — the hook **denies** the Edit/Write so the gate cannot be read past. Escape hatch: `touch /tmp/claude-sweep-override-<prompt_id>` (example) (say why, out loud). Full gate properties (incl. what counts as a repo file): `work-triage-detail.md` § Hard trigger.
 
 Self-test: `bash ~/.claude/hooks/test-plan-gate-edit.sh`.
 

--- a/ibl5/docs/decisions/0091-hard-numeric-sweep-delegation-gate.md
+++ b/ibl5/docs/decisions/0091-hard-numeric-sweep-delegation-gate.md
@@ -14,7 +14,7 @@ last_verified: 2026-07-22
 
 ## Decision
 
-The **third distinct file** edited on the main thread within one user turn is the handoff point: route the remainder to one `subagent_type: "sonnet-4-6"` sub-agent. This is enforced, not documented — `~/.claude/hooks/plan-gate-edit.sh` § Check 1 **denies** the `Edit`/`Write` PreToolUse call (exit 2). The gate is scoped by three properties, each grounded in an empirical probe of the PreToolUse payload: sub-agent calls are exempt (they carry `agent_id`; main-thread calls do not), state is keyed per user turn on `prompt_id` rather than per session, and the count is of distinct files rather than tool calls. It fails open on any malformed payload. The escape hatch is `touch /tmp/claude-sweep-override-<prompt_id>` (example), to be used out loud with a stated reason when the edits are genuinely entangled with the design.
+The **third distinct file** edited on the main thread within one user turn is the handoff point: route the remainder to one `subagent_type: "sonnet-4-6"` sub-agent. This is enforced, not documented — `~/.claude/hooks/plan-gate-edit.sh` § Check 1 **denies** the `Edit`/`Write` PreToolUse call (exit 2). The gate is scoped by four properties, the first three grounded in an empirical probe of the PreToolUse payload: sub-agent calls are exempt (they carry `agent_id`; main-thread calls do not), state is keyed per user turn on `prompt_id` rather than per session, the count is of distinct files rather than tool calls, and only paths that resolve inside a git working tree accrue (`/tmp` scratch and `~/.claude` hook/settings edits never count, so they cannot push a later repo file over the limit). It fails open on any malformed payload. The escape hatch is `touch /tmp/claude-sweep-override-<prompt_id>` (example), to be used out loud with a stated reason when the edits are genuinely entangled with the design.
 
 ## Alternatives Considered
 
@@ -28,7 +28,7 @@ The **third distinct file** edited on the main thread within one user turn is th
 
 - Positive: the routing rule is now unreadable-past. A denied tool call forces the delegation decision to be made explicitly.
 - Positive: the sub-agent exemption is load-bearing and locked in by test — the forced delegate is never itself blocked.
-- Negative: the limit counts *any* path, including `/tmp` scratch and out-of-repo hook edits, so legitimate 3-file design turns (authoring a hook, its test, and its rule doc together) trip it and need the override. `SWEEP_LIMIT` is a single constant if the threshold wants raising.
+- Negative: a legitimate multi-file design turn confined to the repo (for example authoring a rule doc, its detail companion, and an ADR together) still trips the gate and needs the override; `SWEEP_LIMIT` is a single constant if the threshold wants raising.
 
 ## References
 


### PR DESCRIPTION
## Summary

Narrows the ≥3-distinct-files hard-trigger gate so only paths that resolve inside a git working tree accrue toward the limit. Out-of-repo writes — `/tmp` scratch files and `~/.claude` hook/settings edits — no longer count and cannot push a later repo file over the threshold.

**Changes:**
- `work-triage.md`: "third distinct file" → "third distinct **repo** file"; routes detail to companion doc
- `work-triage-detail.md`: adds "Repo files only" bullet with full semantics (git-working-tree check, new-subdir handling)
- `ibl5/docs/decisions/0091-hard-numeric-sweep-delegation-gate.md`: updates Decision paragraph and Consequences to reflect the four-property scope

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.