### PR TITLE
chore(sweep-gate): raise repo-file threshold from 3 to 5

### DIFF
--- a/.claude/rules/work-triage-detail.md
+++ b/.claude/rules/work-triage-detail.md
@@ -22,10 +22,10 @@ The prose routing guidance in `work-triage.md` is a judgment call, and judgment 
 
 ### Gate properties
 
-`~/.claude/hooks/plan-gate-edit.sh` § Check 1 enforces the ≥3-distinct-files rule by **denying** the Edit/Write tool call. Properties worth knowing:
+`~/.claude/hooks/plan-gate-edit.sh` § Check 1 enforces the ≥5-distinct-files rule by **denying** the Edit/Write tool call. The threshold is the hook's `SWEEP_LIMIT` constant — raised from 3 to 5 on 2026-07-22, once repo-scoping had removed the scratch-file false positives and 3 proved to bind on ordinary multi-file changes rather than on sweeps. The self-test reads `SWEEP_LIMIT` from the hook, so retuning it needs no test edit. Properties worth knowing:
 
 - **Sub-agent edits are exempt** (`agent_id` present in the PreToolUse payload). The delegate you spawn in response is never blocked — otherwise the gate would brick the delegation it exists to force. Note sub-agents share the parent's `session_id` *and* `transcript_path`, so `agent_id` is the only usable discriminator.
-- **Per user turn, not per session** (keyed on `prompt_id`). Three unrelated one-file edits across a long session are not a sweep and don't trip it.
+- **Per user turn, not per session** (keyed on `prompt_id`). A handful of unrelated one-file edits spread across a long session is not a sweep and doesn't trip it.
 - **Distinct files, not calls** — editing one file ten times counts once.
 - **Repo files only** — a path counts only when it resolves inside a git working tree; `/tmp` scratch and `~/.claude` hook/settings edits never accrue, so they can't push a later repo file over the line. A new file in a not-yet-created repo subdirectory still counts, because the check walks up to the nearest existing ancestor directory.
 - **Fails open** on a malformed payload; never blocks editing because a field was missing.

--- a/.claude/rules/work-triage.md
+++ b/.claude/rules/work-triage.md
@@ -50,9 +50,9 @@ Stay inline (Opus edits directly) only when:
 
 Either way the routing decision is **stated, not silent** — one line, like the triage verdict. The user should see which way it went and be able to override in the moment.
 
-### The hard trigger: ≥3 distinct files in one turn
+### The hard trigger: ≥5 distinct files in one turn
 
-**The numeric rule: the third distinct repo file you edit on the main thread within one user turn is the handoff point.** Two files is a change; three is a sweep. Route the remainder to one `subagent_type: "sonnet-4-6"` sub-agent (omit `model`) before making that third edit — don't wait to be stopped.
+**The numeric rule: the fifth distinct repo file you edit on the main thread within one user turn is the handoff point.** Four files is a change; five is a sweep. Route the remainder to one `subagent_type: "sonnet-4-6"` sub-agent (omit `model`) before making that fifth edit — don't wait to be stopped.
 
 This is enforced by `~/.claude/hooks/plan-gate-edit.sh` — the hook **denies** the Edit/Write so the gate cannot be read past. Escape hatch: `touch /tmp/claude-sweep-override-<prompt_id>` (example) (say why, out loud). Full gate properties (incl. what counts as a repo file): `work-triage-detail.md` § Hard trigger.
 

--- a/ibl5/docs/decisions/0091-hard-numeric-sweep-delegation-gate.md
+++ b/ibl5/docs/decisions/0091-hard-numeric-sweep-delegation-gate.md
@@ -1,9 +1,9 @@
 ---
-description: Batched main-thread edits are capped at a hard numeric ≥3-distinct-files-per-turn limit, enforced by a PreToolUse deny rather than a warning.
+description: Batched main-thread edits are capped at a hard numeric ≥5-distinct-repo-files-per-turn limit, enforced by a PreToolUse deny rather than a warning.
 last_verified: 2026-07-22
 ---
 
-# ADR-0091: Hard numeric sweep-delegation gate (≥3 files per turn)
+# ADR-0091: Hard numeric sweep-delegation gate (≥5 repo files per turn)
 
 **Status:** Accepted
 **Date:** 2026-07-22
@@ -14,7 +14,7 @@ last_verified: 2026-07-22
 
 ## Decision
 
-The **third distinct file** edited on the main thread within one user turn is the handoff point: route the remainder to one `subagent_type: "sonnet-4-6"` sub-agent. This is enforced, not documented — `~/.claude/hooks/plan-gate-edit.sh` § Check 1 **denies** the `Edit`/`Write` PreToolUse call (exit 2). The gate is scoped by four properties, the first three grounded in an empirical probe of the PreToolUse payload: sub-agent calls are exempt (they carry `agent_id`; main-thread calls do not), state is keyed per user turn on `prompt_id` rather than per session, the count is of distinct files rather than tool calls, and only paths that resolve inside a git working tree accrue (`/tmp` scratch and `~/.claude` hook/settings edits never count, so they cannot push a later repo file over the limit). It fails open on any malformed payload. The escape hatch is `touch /tmp/claude-sweep-override-<prompt_id>` (example), to be used out loud with a stated reason when the edits are genuinely entangled with the design.
+The **fifth distinct repo file** edited on the main thread within one user turn is the handoff point: route the remainder to one `subagent_type: "sonnet-4-6"` sub-agent. This is enforced, not documented — `~/.claude/hooks/plan-gate-edit.sh` § Check 1 **denies** the `Edit`/`Write` PreToolUse call (exit 2). The gate is scoped by four properties, the first three grounded in an empirical probe of the PreToolUse payload: sub-agent calls are exempt (they carry `agent_id`; main-thread calls do not), state is keyed per user turn on `prompt_id` rather than per session, the count is of distinct files rather than tool calls, and only paths that resolve inside a git working tree accrue (`/tmp` scratch and `~/.claude` hook/settings edits never count, so they cannot push a later repo file over the limit). It fails open on any malformed payload. The escape hatch is `touch /tmp/claude-sweep-override-<prompt_id>` (example), to be used out loud with a stated reason when the edits are genuinely entangled with the design.
 
 ## Alternatives Considered
 
@@ -28,11 +28,13 @@ The **third distinct file** edited on the main thread within one user turn is th
 
 - Positive: the routing rule is now unreadable-past. A denied tool call forces the delegation decision to be made explicitly.
 - Positive: the sub-agent exemption is load-bearing and locked in by test — the forced delegate is never itself blocked.
-- Negative: a legitimate multi-file design turn confined to the repo (for example authoring a rule doc, its detail companion, and an ADR together) still trips the gate and needs the override; `SWEEP_LIMIT` is a single constant if the threshold wants raising.
+- Negative: a legitimate design turn touching five or more repo files still trips the gate and needs the override. The threshold is the hook's `SWEEP_LIMIT` constant, retunable in one line; the self-test reads it from the hook rather than hard-coding it, so a change needs no test edit.
+
+**Threshold history.** Shipped at 3 on 2026-07-21, raised to **5** on 2026-07-22. Two things drove the raise: repo-scoping had already removed the scratch-file false positives that made 3 fire spuriously, and 3 proved to bind on ordinary coherent multi-file changes (a rule doc plus its detail companion plus an ADR is three files and one thought) rather than on the 18-file sweep the gate was built for. Five keeps the sweep case caught while leaving normal multi-file work unblocked.
 
 ## References
 
-- `.claude/rules/work-triage.md` — § "The hard trigger: ≥3 distinct files in one turn".
+- `.claude/rules/work-triage.md` — § "The hard trigger: ≥5 distinct files in one turn".
 - `.claude/rules/work-triage-detail.md` — § Hard trigger: full gate properties and the measured incident.
 - `.claude/rules/meta-tooling-bar.md` — the extend-before-add bar that placed this in an existing hook.
 - `~/.claude/hooks/plan-gate-edit.sh` § Check 1 — the enforcement (outside the repo tree).


### PR DESCRIPTION
## Summary
- Raised `SWEEP_LIMIT` in sweep-delegation gate from 3 to 5 distinct repo files per turn
- Updated `.claude/rules/work-triage.md`, `.claude/rules/work-triage-detail.md`, and ADR-0091 to reflect the change
- Rationale: repo-scoping removed scratch-file false positives; 3 proved too restrictive for legitimate multi-file design work (rule doc + detail + ADR = 3 files), while 5 still catches actual sweeps

## Manual Testing

No manual testing needed — verified by automated tests.
