### PR TITLE
feat(sim-recap): admin viewer page, view class and listAll() repository query

### DIFF
--- a/ibl5/classes/SimRecap/SimSummariesView.php
+++ b/ibl5/classes/SimRecap/SimSummariesView.php
@@ -24,10 +24,11 @@ class SimSummariesView
     /**
      * @param list<array<string, mixed>> $rows         From SimSummaryRepository::listAll()
      * @param array<string, mixed>|null  $recap        From SimSummaryRepository::find(), or null
+     * @param list<array<string, mixed>> $gameRecaps   From SimSummaryRepository::findDisplayableGameRecaps(), sorted by sort_order
      * @param string|null                $error        'malformed' | 'notfound' | null
      * @param int|null                   $requestedSim The validated sim behind a 'notfound' notice
      */
-    public function render(array $rows, ?array $recap, ?string $error, ?int $requestedSim = null): string
+    public function render(array $rows, ?array $recap, array $gameRecaps, ?string $error, ?int $requestedSim = null): string
     {
         ob_start();
         ?>
@@ -90,6 +91,29 @@ class SimSummariesView
 <?php if (!is_string($body)): ?>
         <p id="recap-missing">No recap text stored yet — status: <?= HtmlSanitizer::e($recap['status'] ?? '') ?>.</p>
 <?php else: ?>
+<?php $intro = $recap['intro_text'] ?? null; ?>
+<?php if (is_string($intro) && $intro !== ''): ?>
+        <p id="recap-intro"><?= HtmlSanitizer::e($intro) ?></p>
+<?php endif; ?>
+<?php if ($gameRecaps !== []): ?>
+        <ol id="recap-games">
+<?php foreach ($gameRecaps as $game): ?>
+<?php
+            $gDate = $game['game_date'] ?? null;
+            $gVid  = $game['visitor_teamid'] ?? null;
+            $gHid  = $game['home_teamid'] ?? null;
+?>
+            <li class="recap-game">
+                <span class="recap-game__meta"><?= HtmlSanitizer::e(is_string($gDate) ? $gDate : '') ?> · team <?= HtmlSanitizer::e(is_scalar($gVid) ? (string) $gVid : '') ?> at team <?= HtmlSanitizer::e(is_scalar($gHid) ? (string) $gHid : '') ?></span>
+                <p class="recap-game__text"><?= HtmlSanitizer::e($game['recap_text'] ?? '') ?></p>
+            </li>
+<?php endforeach; ?>
+        </ol>
+<?php endif; ?>
+<?php $outro = $recap['outro_text'] ?? null; ?>
+<?php if (is_string($outro) && $outro !== ''): ?>
+        <p id="recap-outro"><?= HtmlSanitizer::e($outro) ?></p>
+<?php endif; ?>
         <textarea id="recap-body" readonly rows="24" cols="100"><?= HtmlSanitizer::e($body) ?></textarea>
         <p>
             <button type="button" id="recap-copy">Copy</button>

--- a/ibl5/classes/SimRecap/SimSummariesView.php
+++ b/ibl5/classes/SimRecap/SimSummariesView.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimRecap;
+
+use PageLayout\PageLayout;
+use Security\HtmlSanitizer;
+
+/**
+ * Admin viewer for the sim recap queue — index table plus one optional recap panel.
+ *
+ * Every dynamic byte is escaped with HtmlSanitizer::e(). `trusted()` is used for
+ * exactly one thing here: PageLayout::renderFontPreconnectLinks(), markup this
+ * codebase pre-renders itself. Nothing that came out of `ibl_sim_summaries` ever
+ * goes through it — `recap_text` is LLM-generated prose and untrusted by provenance.
+ *
+ * The class emits no headers and never calls exit; the `format=txt` export lives in
+ * the top-level page, where BanDirectHeaderCallRule and BanDieExitInProductionRule
+ * do not apply.
+ */
+class SimSummariesView
+{
+    /**
+     * @param list<array<string, mixed>> $rows         From SimSummaryRepository::listAll()
+     * @param array<string, mixed>|null  $recap        From SimSummaryRepository::find(), or null
+     * @param string|null                $error        'malformed' | 'notfound' | null
+     * @param int|null                   $requestedSim The validated sim behind a 'notfound' notice
+     */
+    public function render(array $rows, ?array $recap, ?string $error, ?int $requestedSim = null): string
+    {
+        ob_start();
+        ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sim Recaps</title>
+    <?= HtmlSanitizer::trusted(PageLayout::renderFontPreconnectLinks()) // @phpstan-ignore ibl.trustedVariable (three literal <link> tags built from string constants in PageLayout — no parameters, no interpolation, no request or DB data) ?>
+    <link rel="stylesheet" href="/ibl5/themes/IBL/style/style.css">
+</head>
+<body>
+<div class="updater">
+    <h1 class="updater__title">Sim Recaps</h1>
+
+<?php if ($error === 'malformed'): ?>
+    <p class="ibl-card" id="recap-error">Invalid sim number.</p>
+<?php elseif ($error === 'notfound'): ?>
+    <p class="ibl-card" id="recap-error">No recap stored for sim <?= HtmlSanitizer::e($requestedSim ?? '') ?>.</p>
+<?php endif; ?>
+
+    <table class="ibl-data-table">
+        <thead>
+            <tr>
+                <th>Sim</th>
+                <th>Status</th>
+                <th>Attempts</th>
+                <th>Generated</th>
+                <th>Created</th>
+                <th>Body</th>
+            </tr>
+        </thead>
+        <tbody>
+<?php if ($rows === []): ?>
+            <tr>
+                <td colspan="6">No sim recaps have been generated yet.</td>
+            </tr>
+<?php else: ?>
+<?php foreach ($rows as $row): ?>
+            <tr>
+                <td><a href="simSummaries.php?sim=<?= HtmlSanitizer::e($row['sim'] ?? '') ?>"><?= HtmlSanitizer::e($row['sim'] ?? '') ?></a></td>
+                <td><?= HtmlSanitizer::e($row['status'] ?? '') ?></td>
+                <td><?= HtmlSanitizer::e($row['attempts'] ?? '') ?></td>
+                <td><?= HtmlSanitizer::e($row['generated_at'] ?? '—') ?></td>
+                <td><?= HtmlSanitizer::e($row['created_at'] ?? '—') ?></td>
+                <td><?= HtmlSanitizer::e($this->formatBodyLength($row)) ?></td>
+            </tr>
+<?php endforeach; ?>
+<?php endif; ?>
+        </tbody>
+    </table>
+
+<?php if ($recap !== null): ?>
+    <section class="ibl-card" id="recap-panel">
+        <h2 class="ibl-title">Sim <?= HtmlSanitizer::e($recap['sim'] ?? '') ?></h2>
+        <p>Status: <?= HtmlSanitizer::e($recap['status'] ?? '') ?> · Attempts: <?= HtmlSanitizer::e($recap['attempts'] ?? '') ?> · Generated: <?= HtmlSanitizer::e($recap['generated_at'] ?? '—') ?></p>
+        <p id="recap-themes">Themes: <?= HtmlSanitizer::e($this->themeSummary($recap)) ?></p>
+<?php $body = $recap['recap_text'] ?? null; ?>
+<?php if (!is_string($body)): ?>
+        <p id="recap-missing">No recap text stored yet — status: <?= HtmlSanitizer::e($recap['status'] ?? '') ?>.</p>
+<?php else: ?>
+        <textarea id="recap-body" readonly rows="24" cols="100"><?= HtmlSanitizer::e($body) ?></textarea>
+        <p>
+            <button type="button" id="recap-copy">Copy</button>
+            <span id="recap-copied" hidden>Copied</span>
+            <a id="recap-download" href="simSummaries.php?sim=<?= HtmlSanitizer::e($recap['sim'] ?? '') ?>&amp;format=txt">Download raw text</a>
+        </p>
+        <script>
+            document.getElementById('recap-copy').addEventListener('click', function () {
+                navigator.clipboard.writeText(document.getElementById('recap-body').value);
+                document.getElementById('recap-copied').hidden = false;
+            });
+        </script>
+<?php endif; ?>
+    </section>
+<?php endif; ?>
+
+    <a href="/ibl5/index.php" class="updater__return underline">Return to IBL</a>
+</div>
+</body>
+</html>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * The index shows body size, never the body — `listAll()` does not select it.
+     *
+     * @param array<string, mixed> $row
+     */
+    private function formatBodyLength(array $row): string
+    {
+        $length = $row['recap_length'] ?? null;
+
+        return is_numeric($length) ? ((string) (int) $length) . ' bytes' : '—';
+    }
+
+    /**
+     * `themes_used` is a JSON column and is never rendered raw. The return value
+     * is plain text that the caller escapes — nothing here is pre-rendered HTML,
+     * so `trusted()` never touches a recap value. A payload that does not decode
+     * to a non-empty array renders as a literal em dash; unit 1's
+     * `recentThemesToleratesMalformedJson()` proves such rows exist.
+     *
+     * @param array<string, mixed> $recap
+     */
+    private function themeSummary(array $recap): string
+    {
+        $raw = $recap['themes_used'] ?? null;
+        if (!is_string($raw) || $raw === '') {
+            return '—';
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return '—';
+        }
+
+        if (!is_array($decoded)) {
+            return '—';
+        }
+
+        $parts = [];
+        foreach ($decoded as $theme) {
+            if (is_scalar($theme)) {
+                $parts[] = (string) $theme;
+            }
+        }
+
+        return $parts === [] ? '—' : implode(', ', $parts);
+    }
+}

--- a/ibl5/classes/SimRecap/SimSummaryRepository.php
+++ b/ibl5/classes/SimRecap/SimSummaryRepository.php
@@ -360,4 +360,40 @@ class SimSummaryRepository extends \BaseMysqliRepository
         /** @var list<array<string, mixed>> */
         return $this->fetchAll($sql);
     }
+
+    /**
+     * Per-game recap rows for one sim that have a verified archived box score,
+     * sorted by sort_order ascending — the admin viewer's display read.
+     *
+     * Distinct from findGameRecaps(), which is the unfiltered write-verification
+     * read. The INNER JOIN here is an existence filter: only games with an
+     * archived box-score record are displayed. Join partner is
+     * `ibl_box_scores_teams`, NOT `ibl_schedule` (shared-context decision 51 —
+     * `ibl_schedule` is churned on every sim upload and is an unreliable archive
+     * source). Returns an empty array when no per-game rows qualify; the View
+     * must handle that case.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findDisplayableGameRecaps(int $sim): array
+    {
+        // EXISTS, not INNER JOIN: ibl_box_scores_teams stores one row per TEAM
+        // side, so a join on the game's natural key matches twice and would
+        // render every per-game recap twice.
+        $sql = "SELECT gr.`game_date`, gr.`visitor_teamid`, gr.`home_teamid`,"
+            . " gr.`game_of_that_day`, gr.`sort_order`, gr.`recap_text`"
+            . " FROM `ibl_sim_game_recaps` gr"
+            . " WHERE gr.`sim` = ?"
+            . " AND EXISTS ("
+            . "     SELECT 1 FROM `ibl_box_scores_teams` bst"
+            . "     WHERE bst.`game_date` = gr.`game_date`"
+            . "       AND bst.`visitor_teamid` = gr.`visitor_teamid`"
+            . "       AND bst.`home_teamid` = gr.`home_teamid`"
+            . "       AND COALESCE(bst.`game_of_that_day`, 0) = gr.`game_of_that_day`"
+            . " )"
+            . " ORDER BY gr.`sort_order` ASC, gr.`id` ASC";
+
+        /** @var list<array<string, mixed>> */
+        return $this->fetchAll($sql, 'i', $sim);
+    }
 }

--- a/ibl5/classes/SimRecap/SimSummaryRepository.php
+++ b/ibl5/classes/SimRecap/SimSummaryRepository.php
@@ -342,4 +342,22 @@ class SimSummaryRepository extends \BaseMysqliRepository
             $limit
         );
     }
+
+    /**
+     * Every recap row, newest sim first, for the admin viewer index.
+     *
+     * `recap_text` is deliberately excluded: the index renders metadata only,
+     * and the bodies are MEDIUMTEXT.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function listAll(): array
+    {
+        $sql = "SELECT `sim`, `status`, `attempts`, `generated_at`, `created_at`,"
+            . " CHAR_LENGTH(`recap_text`) AS `recap_length`"
+            . " FROM `ibl_sim_summaries`"
+            . " ORDER BY `sim` DESC"; // @phpstan-ignore ibl.orderByMissingTiebreaker (sim is the PK of ibl_sim_summaries — inherently unique)
+        /** @var list<array<string, mixed>> */
+        return $this->fetchAll($sql);
+    }
 }

--- a/ibl5/simSummaries.php
+++ b/ibl5/simSummaries.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/mainfile.php';
+
+// Auth guard
+if (!is_user($user)) {
+    $_SESSION['redirect_after_login_path'] = 'simSummaries.php';
+    \Utilities\HtmxHelper::redirect('modules.php?name=YourAccount');
+}
+
+if (!is_admin()) {
+    http_response_code(403);
+    echo 'Access denied. Administrator privileges required.';
+    exit;
+}
+
+const SIM_MAX = 4294967295; // INT UNSIGNED ceiling of ibl_sim_summaries.sim
+
+// A non-string `sim` (e.g. `?sim[]=1`) is treated as malformed rather than cast.
+$simParam = $_GET['sim'] ?? null;
+$rawSim   = is_string($simParam) ? $simParam : ($simParam === null ? '' : 'invalid');
+$wantsTxt = (($_GET['format'] ?? '') === 'txt');
+
+$simError = null;   // 'malformed' | 'notfound' | null
+$sim      = null;   // int, only ever set from a fully validated value
+$row      = null;
+
+if ($rawSim !== '') {
+    if (!ctype_digit($rawSim) || strlen($rawSim) > 10) {
+        $simError = 'malformed';
+    } else {
+        $candidate = (int) $rawSim;
+        if ($candidate < 1 || $candidate > SIM_MAX) {
+            $simError = 'malformed';
+        } else {
+            $sim = $candidate;
+        }
+    }
+}
+
+$repo = new \SimRecap\SimSummaryRepository($mysqli_db);
+if ($sim !== null) {
+    $row = $repo->find($sim);          // bound int parameter, never string concatenation
+    if ($row === null) {
+        $simError = 'notfound';
+    }
+}
+
+// Plain-text export of a single recap body
+if ($wantsTxt) {
+    if ($sim === null || $row === null || $row['recap_text'] === null) {
+        http_response_code($simError === 'malformed' || $sim === null ? 400 : 404);
+        header('Content-Type: text/plain; charset=utf-8');
+        echo "No recap text available.\n";
+        exit;
+    }
+
+    header('Content-Type: text/plain; charset=utf-8');
+    header('Content-Disposition: attachment; filename="sim-' . $sim . '-recap.txt"');
+    header('X-Content-Type-Options: nosniff');
+    echo (string) $row['recap_text'];
+    exit;
+}
+
+$rows = $repo->listAll();
+
+if ($simError === 'malformed') {
+    http_response_code(400);
+} elseif ($simError === 'notfound') {
+    http_response_code(404);
+}
+
+// $sim is passed so the 'notfound' notice can name the sim it could not find.
+echo (new \SimRecap\SimSummariesView())->render($rows, $row, $simError, $sim);

--- a/ibl5/simSummaries.php
+++ b/ibl5/simSummaries.php
@@ -66,6 +66,13 @@ if ($wantsTxt) {
 
 $rows = $repo->listAll();
 
+// Per-game recaps only accompany a stored envelope body; a pending/failed row
+// renders its status message instead of a game list (plan Phase 3b).
+$gameRecaps = [];
+if ($sim !== null && $row !== null && $row['recap_text'] !== null) {
+    $gameRecaps = $repo->findDisplayableGameRecaps($sim);
+}
+
 if ($simError === 'malformed') {
     http_response_code(400);
 } elseif ($simError === 'notfound') {
@@ -73,4 +80,4 @@ if ($simError === 'malformed') {
 }
 
 // $sim is passed so the 'notfound' notice can name the sim it could not find.
-echo (new \SimRecap\SimSummariesView())->render($rows, $row, $simError, $sim);
+echo (new \SimRecap\SimSummariesView())->render($rows, $row, $gameRecaps, $simError, $sim);

--- a/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
@@ -372,6 +372,39 @@ final class SimSummaryRepositoryTest extends DatabaseTestCase
         );
     }
 
+    // ── findDisplayableGameRecaps tests ──────────────────────────────────────────
+
+    public function testFindDisplayableGameRecapsReturnsOnlyGamesWithBoxScores(): void
+    {
+        // Two game recaps: gotd=1 (will have a matching box score) and gotd=2 (will not).
+        $games = [
+            $this->gameRecap(sortOrder: 0, gameOfThatDay: 1),
+            $this->gameRecap(sortOrder: 1, gameOfThatDay: 2),
+        ];
+        $this->repo->markDone(999001, 'Intro.', 'Outro.', 'Recap.', $games, null);
+
+        // Two team-side rows for gotd=1 only (unique key includes `name`, so both persist).
+        $this->db->query(
+            "INSERT INTO `ibl_box_scores_teams` (`game_date`, `visitor_teamid`, `home_teamid`, `game_of_that_day`, `name`)" .
+            " VALUES ('2025-01-01', 1, 2, 1, 'Metros'), ('2025-01-01', 1, 2, 1, 'Stars')"
+        );
+
+        $displayable = $this->repo->findDisplayableGameRecaps(999001);
+
+        self::assertCount(1, $displayable, 'Only games with a matching box score are returned');
+        self::assertSame(1, $displayable[0]['game_of_that_day'], 'The returned game is the one backed by a box score');
+    }
+
+    public function testFindDisplayableGameRecapsReturnsEmptyArrayWhenNoBoxScoresExist(): void
+    {
+        // Store one game recap with no corresponding ibl_box_scores_teams row.
+        $this->repo->markDone(999001, 'Intro.', 'Outro.', 'Recap.', [$this->gameRecap(sortOrder: 0)], null);
+
+        $displayable = $this->repo->findDisplayableGameRecaps(999001);
+
+        self::assertSame([], $displayable, 'No box score match → no displayable game recaps');
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
 
     /**

--- a/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php
@@ -248,6 +248,46 @@ final class SimSummaryRepositoryTest extends DatabaseTestCase
         self::assertTrue($found, 'Malformed JSON must be returned as-is without throwing');
     }
 
+    // ── listAll() — the admin viewer index ─────────────────────────────────────
+
+    public function testListAllReturnsEveryRowNewestSimFirst(): void
+    {
+        $this->clearSummaries();
+        $this->repo->queuePendingIfAbsent(999001);
+        $this->repo->queuePendingIfAbsent(999003);
+        $this->repo->markDone(999003, 'Intro three.', 'Outro three.', 'Body three.', [], null);
+        $this->repo->queuePendingIfAbsent(999002);
+        $this->db->query("UPDATE `ibl_sim_summaries` SET `status` = 'failed' WHERE `sim` = 999002");
+
+        $rows = $this->repo->listAll();
+
+        self::assertCount(3, $rows);
+        self::assertSame([999003, 999002, 999001], array_map(
+            static fn (array $row): int => (int) $row['sim'],
+            $rows
+        ));
+    }
+
+    public function testListAllExposesRecapLengthWithoutTheBody(): void
+    {
+        $this->clearSummaries();
+        $this->repo->queuePendingIfAbsent(999003);
+        $this->repo->markDone(999003, 'Intro three.', 'Outro three.', 'Body three.', [], null);
+
+        $rows = $this->repo->listAll();
+
+        self::assertCount(1, $rows);
+        self::assertSame(11, (int) $rows[0]['recap_length']);
+        self::assertArrayNotHasKey('recap_text', $rows[0], 'The index must never load MEDIUMTEXT bodies');
+    }
+
+    public function testListAllReturnsAnEmptyArrayWhenNoRowsExist(): void
+    {
+        $this->clearSummaries();
+
+        self::assertSame([], $this->repo->listAll());
+    }
+
     // ── findGameRecaps tests ───────────────────────────────────────────────────
 
     public function testMarkDoneStoresGameRecapsInSortOrder(): void
@@ -333,6 +373,17 @@ final class SimSummaryRepositoryTest extends DatabaseTestCase
     }
 
     // ── Private helpers ────────────────────────────────────────────────────────
+
+    /**
+     * Migration 155 seeds one `done` row (MAX(ibl_sim_dates.sim)) into every
+     * migrated database, so any test asserting an exact row set must clear the
+     * table first. DELETE (not TRUNCATE) — TRUNCATE auto-commits in MySQL and
+     * would break DatabaseTestCase's per-test transaction rollback.
+     */
+    private function clearSummaries(): void
+    {
+        $this->db->query('DELETE FROM `ibl_sim_summaries`');
+    }
 
     /**
      * Build a minimal valid game recap array for markDone's $gameRecaps parameter.

--- a/ibl5/tests/WideUnit/Scripts/SimSummariesGuardTest.php
+++ b/ibl5/tests/WideUnit/Scripts/SimSummariesGuardTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\WideUnit\Scripts;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source-assertion guard test for the admin recap viewer entry point.
+ *
+ * simSummaries.php cannot be included in a unit test (it boots mainfile.php),
+ * so its security properties are asserted against the raw source: both auth
+ * guards present, both ahead of any repository use, and no raw SQL.
+ */
+final class SimSummariesGuardTest extends TestCase
+{
+    private string $src;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $source = file_get_contents(__DIR__ . '/../../../simSummaries.php');
+        self::assertIsString($source, 'simSummaries.php must exist and be readable');
+        $this->src = $source;
+    }
+
+    public function testBothGuardsArePresent(): void
+    {
+        self::assertStringContainsString('if (!is_user($user))', $this->src, 'Login guard must be present');
+        self::assertStringContainsString('if (!is_admin())', $this->src, 'Admin guard must be present');
+        self::assertStringContainsString('http_response_code(403)', $this->src, 'Non-admins must get a 403');
+    }
+
+    public function testTheGuardsPrecedeAnyRepositoryUse(): void
+    {
+        $adminGuard = strpos($this->src, 'is_admin()');
+        self::assertIsInt($adminGuard);
+
+        foreach (['SimSummaryRepository', 'listAll', 'find('] as $needle) {
+            $offset = strpos($this->src, $needle);
+            self::assertIsInt($offset, sprintf('Expected %s in simSummaries.php', $needle));
+            self::assertGreaterThan(
+                $adminGuard,
+                $offset,
+                sprintf('%s must appear after the admin guard, never before it', $needle)
+            );
+        }
+    }
+
+    public function testNoRawSqlAndNoDirectDbCall(): void
+    {
+        self::assertStringNotContainsString('->query(', $this->src, 'All database access goes through the repository');
+        self::assertStringNotContainsString('SELECT ', $this->src, 'No raw SQL belongs in the entry point');
+    }
+
+    /**
+     * `.htaccess` is inert in the Docker/CI stack (AllowOverride None), so an
+     * Apache-level rule would falsely imply protection. The pre-existing
+     * `ibl5/.htaccess` is a bot IP blocklist and must stay free of any rule for
+     * this page; no sibling `.htaccess` belongs in the SimRecap class directory.
+     */
+    public function testNoHtaccessProtectsThisPage(): void
+    {
+        $htaccess = file_get_contents(__DIR__ . '/../../../.htaccess');
+        self::assertIsString($htaccess);
+        self::assertStringNotContainsString(
+            'simSummaries',
+            $htaccess,
+            'Access control for simSummaries.php lives in the PHP guards, not in an inert .htaccess'
+        );
+
+        self::assertFileDoesNotExist(__DIR__ . '/../../../classes/SimRecap/.htaccess');
+    }
+}

--- a/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
+++ b/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\WideUnit\SimRecap;
+
+use PHPUnit\Framework\TestCase;
+use SimRecap\SimSummariesView;
+
+/**
+ * The View is a pure function of its arguments — no DB, no superglobals.
+ */
+final class SimSummariesViewTest extends TestCase
+{
+    private SimSummariesView $view;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->view = new SimSummariesView();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function indexRow(int $sim, ?int $length = 42): array
+    {
+        return [
+            'sim'          => $sim,
+            'status'       => $length === null ? 'pending' : 'done',
+            'attempts'     => 1,
+            'generated_at' => '2026-02-22 10:05:00',
+            'created_at'   => '2026-02-22 09:00:00',
+            'recap_length' => $length,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function recapRow(?string $text, ?string $themes = null): array
+    {
+        return [
+            'sim'           => 689,
+            'status'        => $text === null ? 'pending' : 'done',
+            'recap_text'    => $text,
+            'themes_used'   => $themes,
+            'attempts'      => 1,
+            'claimed_at'    => null,
+            'blocked_until' => null,
+            'generated_at'  => '2026-03-01 10:05:00',
+        ];
+    }
+
+    public function testRendersEveryRowInTheOrderGiven(): void
+    {
+        $html = $this->view->render(
+            [$this->indexRow(689), $this->indexRow(688), $this->indexRow(687)],
+            null,
+            null
+        );
+
+        self::assertSame(4, substr_count($html, '<tr>'), 'One header row plus three data rows');
+        $first  = strpos($html, 'sim=689');
+        $second = strpos($html, 'sim=688');
+        $third  = strpos($html, 'sim=687');
+        self::assertIsInt($first);
+        self::assertIsInt($second);
+        self::assertIsInt($third);
+        self::assertLessThan($second, $first, 'The View must not re-sort the rows it is given');
+        self::assertLessThan($third, $second, 'The View must not re-sort the rows it is given');
+    }
+
+    public function testEscapesRecapTextInsteadOfEmittingIt(): void
+    {
+        $html = $this->view->render(
+            [],
+            $this->recapRow('</textarea><script>alert(1)</script>'),
+            null
+        );
+
+        // The only <script> in the output is the View's own copy-button script.
+        self::assertStringNotContainsString('<script>alert(1)</script>', $html);
+        self::assertStringNotContainsString('</textarea><script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testNeverRendersRawThemesJson(): void
+    {
+        $html = $this->view->render(
+            [],
+            $this->recapRow('Body.', '["<img src=x onerror=alert(1)>"]'),
+            null
+        );
+
+        self::assertStringNotContainsString('onerror=alert(1)>', $html, 'Themes must be escaped, never raw');
+        self::assertStringContainsString('&lt;img src=x onerror=alert(1)&gt;', $html);
+
+        $malformed = $this->view->render([], $this->recapRow('Body.', '"not-an-array"'), null);
+        self::assertStringContainsString('Themes: —', $malformed);
+        self::assertStringNotContainsString('not-an-array', $malformed);
+    }
+
+    public function testRendersTheEmptyState(): void
+    {
+        $html = $this->view->render([], null, null);
+
+        self::assertStringContainsString('No sim recaps have been generated yet.', $html);
+        self::assertStringNotContainsString('simSummaries.php?sim=', $html, 'No data rows means no sim links');
+    }
+
+    public function testOmitsTheDownloadLinkWhenRecapTextIsNull(): void
+    {
+        $html = $this->view->render([], $this->recapRow(null), null);
+
+        self::assertStringNotContainsString('format=txt', $html);
+        self::assertStringNotContainsString('<textarea', $html);
+        self::assertStringContainsString('No recap text stored yet — status: pending.', $html);
+    }
+
+    public function testRendersTheErrorNotices(): void
+    {
+        self::assertStringContainsString('Invalid sim number.', $this->view->render([], null, 'malformed'));
+        self::assertStringContainsString(
+            'No recap stored for sim 999999.',
+            $this->view->render([], null, 'notfound', 999999)
+        );
+    }
+
+    public function testRendersTheIndexBodyLengthWithoutTheBody(): void
+    {
+        $html = $this->view->render([$this->indexRow(689, 42), $this->indexRow(688, null)], null, null);
+
+        self::assertStringContainsString('42 bytes', $html);
+        self::assertStringContainsString('<td>—</td>', $html);
+    }
+}

--- a/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
+++ b/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
@@ -38,13 +38,15 @@ final class SimSummariesViewTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private function recapRow(?string $text, ?string $themes = null): array
+    private function recapRow(?string $text, ?string $themes = null, ?string $introText = null, ?string $outroText = null): array
     {
         return [
             'sim'           => 689,
             'status'        => $text === null ? 'pending' : 'done',
             'recap_text'    => $text,
             'themes_used'   => $themes,
+            'intro_text'    => $introText,
+            'outro_text'    => $outroText,
             'attempts'      => 1,
             'claimed_at'    => null,
             'blocked_until' => null,
@@ -57,6 +59,7 @@ final class SimSummariesViewTest extends TestCase
         $html = $this->view->render(
             [$this->indexRow(689), $this->indexRow(688), $this->indexRow(687)],
             null,
+            [],
             null
         );
 
@@ -76,6 +79,7 @@ final class SimSummariesViewTest extends TestCase
         $html = $this->view->render(
             [],
             $this->recapRow('</textarea><script>alert(1)</script>'),
+            [],
             null
         );
 
@@ -90,20 +94,21 @@ final class SimSummariesViewTest extends TestCase
         $html = $this->view->render(
             [],
             $this->recapRow('Body.', '["<img src=x onerror=alert(1)>"]'),
+            [],
             null
         );
 
         self::assertStringNotContainsString('onerror=alert(1)>', $html, 'Themes must be escaped, never raw');
         self::assertStringContainsString('&lt;img src=x onerror=alert(1)&gt;', $html);
 
-        $malformed = $this->view->render([], $this->recapRow('Body.', '"not-an-array"'), null);
+        $malformed = $this->view->render([], $this->recapRow('Body.', '"not-an-array"'), [], null);
         self::assertStringContainsString('Themes: —', $malformed);
         self::assertStringNotContainsString('not-an-array', $malformed);
     }
 
     public function testRendersTheEmptyState(): void
     {
-        $html = $this->view->render([], null, null);
+        $html = $this->view->render([], null, [], null);
 
         self::assertStringContainsString('No sim recaps have been generated yet.', $html);
         self::assertStringNotContainsString('simSummaries.php?sim=', $html, 'No data rows means no sim links');
@@ -111,7 +116,7 @@ final class SimSummariesViewTest extends TestCase
 
     public function testOmitsTheDownloadLinkWhenRecapTextIsNull(): void
     {
-        $html = $this->view->render([], $this->recapRow(null), null);
+        $html = $this->view->render([], $this->recapRow(null), [], null);
 
         self::assertStringNotContainsString('format=txt', $html);
         self::assertStringNotContainsString('<textarea', $html);
@@ -120,18 +125,71 @@ final class SimSummariesViewTest extends TestCase
 
     public function testRendersTheErrorNotices(): void
     {
-        self::assertStringContainsString('Invalid sim number.', $this->view->render([], null, 'malformed'));
+        self::assertStringContainsString('Invalid sim number.', $this->view->render([], null, [], 'malformed'));
         self::assertStringContainsString(
             'No recap stored for sim 999999.',
-            $this->view->render([], null, 'notfound', 999999)
+            $this->view->render([], null, [], 'notfound', 999999)
         );
     }
 
     public function testRendersTheIndexBodyLengthWithoutTheBody(): void
     {
-        $html = $this->view->render([$this->indexRow(689, 42), $this->indexRow(688, null)], null, null);
+        $html = $this->view->render([$this->indexRow(689, 42), $this->indexRow(688, null)], null, [], null);
 
         self::assertStringContainsString('42 bytes', $html);
         self::assertStringContainsString('<td>—</td>', $html);
+    }
+
+    public function testEscapesAllLlmFieldsInsteadOfEmittingThem(): void
+    {
+        $xss = '<script>alert(1)</script>';
+        $gameRecap = [
+            'game_date'        => '2025-01-01',
+            'visitor_teamid'   => 1,
+            'home_teamid'      => 2,
+            'game_of_that_day' => 1,
+            'sort_order'       => 0,
+            'recap_text'       => $xss,
+        ];
+        $html = $this->view->render(
+            [],
+            $this->recapRow('Body.', null, $xss, $xss),
+            [$gameRecap],
+            null
+        );
+
+        // None of the LLM-sourced payloads may appear unescaped anywhere in the output.
+        self::assertStringNotContainsString('<script>alert(1)</script>', $html);
+        // All three occurrences (intro, game recap, outro) must be entity-encoded.
+        self::assertSame(3, substr_count($html, '&lt;script&gt;alert(1)&lt;/script&gt;'));
+    }
+
+    public function testOmitsPerGameListWhenRecapTextIsNull(): void
+    {
+        // When a row has no recap_text the caller passes [] for $gameRecaps;
+        // the view must not render the game list regardless.
+        $html = $this->view->render([], $this->recapRow(null), [], null);
+
+        self::assertStringNotContainsString('id="recap-games"', $html);
+        self::assertStringNotContainsString('<ol', $html);
+    }
+
+    public function testRendersPerGameRecapsInTheOrderGiven(): void
+    {
+        $recaps = [
+            ['game_date' => '2025-01-01', 'visitor_teamid' => 1, 'home_teamid' => 2, 'game_of_that_day' => 1, 'sort_order' => 0, 'recap_text' => 'First game recap.'],
+            ['game_date' => '2025-01-02', 'visitor_teamid' => 3, 'home_teamid' => 4, 'game_of_that_day' => 1, 'sort_order' => 1, 'recap_text' => 'Second game recap.'],
+            ['game_date' => '2025-01-03', 'visitor_teamid' => 5, 'home_teamid' => 6, 'game_of_that_day' => 1, 'sort_order' => 2, 'recap_text' => 'Third game recap.'],
+        ];
+        $html = $this->view->render([], $this->recapRow('Body.'), $recaps, null);
+
+        $firstPos  = strpos($html, 'First game recap.');
+        $secondPos = strpos($html, 'Second game recap.');
+        $thirdPos  = strpos($html, 'Third game recap.');
+        self::assertIsInt($firstPos);
+        self::assertIsInt($secondPos);
+        self::assertIsInt($thirdPos);
+        self::assertLessThan($secondPos, $firstPos, 'Game recaps must appear in the order the caller provides');
+        self::assertLessThan($thirdPos, $secondPos, 'Game recaps must appear in the order the caller provides');
     }
 }

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -62,6 +62,19 @@ INSERT INTO ibl_sim_dates (sim, start_date, end_date) VALUES
   (689, '2026-03-01', '2026-03-07');
 
 -- ============================================================
+-- Sim recap summaries (admin viewer — simSummaries.php)
+-- Cleared first: migration 155 seeds MAX(ibl_sim_dates.sim) as a
+-- done row with recap_text NULL, which would make the viewer's
+-- row count and newest-first assertions nondeterministic.
+-- ============================================================
+DELETE FROM ibl_sim_summaries;
+INSERT INTO ibl_sim_summaries (sim, status, recap_text, themes_used, attempts, generated_at, created_at) VALUES
+  (686, 'failed',  NULL, NULL, 2, NULL, '2026-02-08 09:00:00'),
+  (687, 'pending', NULL, NULL, 0, NULL, '2026-02-15 09:00:00'),
+  (688, 'done',    'Sim 688 recap: a wire-to-wire blowout behind a 41-point night from the rookie.', '["blowout","rookie"]', 1, '2026-02-22 10:05:00', '2026-02-22 09:00:00'),
+  (689, 'done',    'Sim 689 recap: the Cannons erased a nine-point fourth-quarter deficit to win by three.', '["comeback"]', 1, '2026-03-01 10:05:00', '2026-03-01 09:00:00');
+
+-- ============================================================
 -- Teams (28 real franchises + Free Agents)
 -- Only columns required by the app; others use table defaults.
 -- ============================================================

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -67,12 +67,15 @@ INSERT INTO ibl_sim_dates (sim, start_date, end_date) VALUES
 -- done row with recap_text NULL, which would make the viewer's
 -- row count and newest-first assertions nondeterministic.
 -- ============================================================
+DELETE FROM ibl_sim_game_recaps;
 DELETE FROM ibl_sim_summaries;
-INSERT INTO ibl_sim_summaries (sim, status, recap_text, themes_used, attempts, generated_at, created_at) VALUES
-  (686, 'failed',  NULL, NULL, 2, NULL, '2026-02-08 09:00:00'),
-  (687, 'pending', NULL, NULL, 0, NULL, '2026-02-15 09:00:00'),
-  (688, 'done',    'Sim 688 recap: a wire-to-wire blowout behind a 41-point night from the rookie.', '["blowout","rookie"]', 1, '2026-02-22 10:05:00', '2026-02-22 09:00:00'),
-  (689, 'done',    'Sim 689 recap: the Cannons erased a nine-point fourth-quarter deficit to win by three.', '["comeback"]', 1, '2026-03-01 10:05:00', '2026-03-01 09:00:00');
+INSERT INTO ibl_sim_summaries (sim, status, recap_text, intro_text, outro_text, themes_used, attempts, generated_at, created_at) VALUES
+  (686, 'failed',  NULL, NULL, NULL, NULL, 2, NULL, '2026-02-08 09:00:00'),
+  (687, 'pending', NULL, NULL, NULL, NULL, 0, NULL, '2026-02-15 09:00:00'),
+  (688, 'done',    'Sim 688 recap: a wire-to-wire blowout behind a 41-point night from the rookie.', NULL, NULL, '["blowout","rookie"]', 1, '2026-02-22 10:05:00', '2026-02-22 09:00:00'),
+  (689, 'done',    'Sim 689 recap: the Cannons erased a nine-point fourth-quarter deficit to win by three.', 'Another week of IBL action delivered drama from tip-off to the final buzzer.', 'The Cannons are one to watch as the season reaches its final stretch.', '["comeback"]', 1, '2026-03-01 10:05:00', '2026-03-01 09:00:00');
+-- The per-game rows are inserted further down, after ibl_team_info: they carry
+-- FKs to ibl_team_info(teamid), so inserting them here aborts the whole seed.
 
 -- ============================================================
 -- Teams (28 real franchises + Free Agents)
@@ -109,6 +112,16 @@ INSERT INTO ibl_team_info (teamid, team_city, team_name, color1, color2, uuid) V
   (26, 'Indiana',      'Pacers',       '002D62', 'FDBB30', 'b0000000-0000-0000-0000-000000000026'),
   (27, 'Utah',         'Jazz',         '002B5C', '00471B', 'b0000000-0000-0000-0000-000000000027'),
   (28, 'Oklahoma City','Thunder',      '007AC1', 'EF6100', 'b0000000-0000-0000-0000-000000000028');
+
+-- Per-game recaps for sim 689 (see the sim-summaries block above). Deferred to
+-- here because ibl_sim_game_recaps FKs visitor_teamid/home_teamid to
+-- ibl_team_info(teamid). Each natural key below has a matching pair of
+-- ibl_box_scores_teams rows further down, so all three pass the admin viewer's
+-- archived-box-score existence filter.
+INSERT INTO ibl_sim_game_recaps (sim, season_year, game_date, visitor_teamid, home_teamid, game_of_that_day, box_id, sort_order, recap_text) VALUES
+  (689, 2026, '2026-02-20', 1, 2, 1, NULL, 0, 'The Metros dominated from the opening tip, cruising to a 105-98 victory.'),
+  (689, 2026, '2026-03-03', 1, 3, 1, NULL, 1, 'A balanced offensive attack lifted the Metros past the Cougars in a tightly contested game.'),
+  (689, 2026, '2026-03-05', 2, 1, 1, NULL, 2, 'The Stars held off a late Metros rally to steal a road win, 95-88.');
 
 -- ============================================================
 -- Standings (28 teams — FK to ibl_team_info)

--- a/ibl5/tests/e2e/flows/role-gating-non-admin.spec.ts
+++ b/ibl5/tests/e2e/flows/role-gating-non-admin.spec.ts
@@ -49,6 +49,21 @@ test.describe('Admin entry-point scripts: non-admin gets 403', () => {
     expect(response?.status()).toBe(403);
   });
 
+  test('simSummaries.php returns 403', async ({ page }) => {
+    const response = await page.goto('simSummaries.php');
+    expect(response?.status()).toBe(403);
+  });
+
+  test('simSummaries.php?sim=689&format=txt returns 403 without leaking the recap', async ({
+    request,
+  }) => {
+    const response = await request.get('simSummaries.php?sim=689&format=txt');
+    expect(response.status()).toBe(403);
+    // Seeded body of sim 689 (tests/e2e/fixtures/ci-seed.sql) — a 403 that still
+    // wrote the payload would pass a status-only assertion.
+    expect(await response.text()).not.toContain('the Cannons erased a nine-point');
+  });
+
   test('leagueControlPanel.php returns 403', async ({ page }) => {
     const response = await page.goto('leagueControlPanel.php');
     expect(response?.status()).toBe(403);

--- a/ibl5/tests/e2e/smoke/auth-redirect.spec.ts
+++ b/ibl5/tests/e2e/smoke/auth-redirect.spec.ts
@@ -34,3 +34,24 @@ test.describe('Unauthenticated redirect tests', () => {
     });
   }
 });
+
+// Top-level admin scripts guard with is_user() BEFORE is_admin(), so an
+// unauthenticated request redirects to login rather than returning 403.
+test.describe('Unauthenticated redirect tests: admin entry-point scripts', () => {
+  test('simSummaries.php redirects unauthenticated users to login', async ({ page }) => {
+    await page.goto('simSummaries.php');
+
+    await page.waitForURL(/name=YourAccount/, { timeout: 10_000 });
+    await expect(page.locator('#login-username'), 'YourAccount login form must render after redirect').toBeVisible();
+  });
+
+  test('simSummaries.php?sim=689&format=txt redirects unauthenticated users to login', async ({
+    page,
+  }) => {
+    // The plain-text export sits behind the same guard — it cannot bypass it.
+    await page.goto('simSummaries.php?sim=689&format=txt');
+
+    await page.waitForURL(/name=YourAccount/, { timeout: 10_000 });
+    await expect(page.locator('#login-username'), 'YourAccount login form must render after redirect').toBeVisible();
+  });
+});

--- a/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
+++ b/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
@@ -42,6 +42,18 @@ test.describe('Sim recap admin viewer', () => {
     expect(response?.status()).toBe(200);
     await expect(page.locator('#recap-body')).toHaveValue(SIM_689_BODY);
     await expect(page.locator('#recap-themes')).toContainText('comeback');
+    await expect(page.locator('#recap-intro')).toContainText(
+      'Another week of IBL action delivered drama from tip-off to the final buzzer.',
+    );
+    await expect(page.locator('#recap-outro')).toContainText(
+      'The Cannons are one to watch as the season reaches its final stretch.',
+    );
+    const gameItems = page.locator('#recap-games li');
+    await expect(gameItems).toHaveCount(3);
+    // Games must appear in sort_order order: 2026-02-20 → 2026-03-03 → 2026-03-05.
+    await expect(gameItems.nth(0)).toContainText('2026-02-20');
+    await expect(gameItems.nth(1)).toContainText('2026-03-03');
+    await expect(gameItems.nth(2)).toContainText('2026-03-05');
     await assertNoPhpErrors(page);
   });
 
@@ -62,6 +74,7 @@ test.describe('Sim recap admin viewer', () => {
     expect(response?.status()).toBe(200);
     await expect(page.locator('#recap-body')).toHaveCount(0);
     await expect(page.locator('#recap-download')).toHaveCount(0);
+    await expect(page.locator('#recap-games')).toHaveCount(0);
     await expect(page.locator('#recap-missing')).toContainText('pending');
     await assertNoPhpErrors(page);
   });

--- a/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
+++ b/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
@@ -75,6 +75,14 @@ test.describe('Sim recap admin viewer', () => {
     await assertNoPhpErrors(page);
   });
 
+  test('a signed sim is rejected before any cast', async ({ page }) => {
+    // The sign character fails ctype_digit(), so no cast and no query happen.
+    const response = await page.goto('simSummaries.php?sim=-3');
+
+    expect(response?.status()).toBe(400);
+    await expect(page.locator('#recap-error')).toHaveText('Invalid sim number.');
+  });
+
   test('sim=0 is rejected by the lower bound', async ({ page }) => {
     // All digits, so ctype_digit() passes — the `< 1` floor is what rejects it.
     const response = await page.goto('simSummaries.php?sim=0');
@@ -116,6 +124,9 @@ test.describe('Sim recap plain-text export', () => {
     expect(response.status()).toBe(200);
     expect(response.headers()['content-type']).toMatch(/^text\/plain/);
     expect(response.headers()['content-disposition']).toContain('sim-689-recap.txt');
+    // nosniff is re-asserted by the export itself, so a recap body containing
+    // markup is displayed as text rather than sniffed as HTML.
+    expect(response.headers()['x-content-type-options']).toBe('nosniff');
     expect(await response.text()).toBe(SIM_689_BODY);
   });
 

--- a/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
+++ b/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '../fixtures/auth';
+import { assertNoPhpErrors } from '../helpers/php-errors';
+
+/**
+ * Admin viewer for the sim recap queue (`simSummaries.php`).
+ *
+ * Every count, order and string below is bound to the `ibl_sim_summaries`
+ * block in `tests/e2e/fixtures/ci-seed.sql`, which seeds exactly four rows
+ * (686 failed, 687 pending, 688 done, 689 done) after clearing the single
+ * row migration 155 plants. Sim 999999 is deliberately left unseeded so the
+ * "valid but absent" path has a stable fixture.
+ */
+
+// Byte-exact `recap_text` of the newest seeded row — the download/copy paths
+// must reproduce it without HTML wrapping or entity encoding.
+const SIM_689_BODY =
+  'Sim 689 recap: the Cannons erased a nine-point fourth-quarter deficit to win by three.';
+
+const SEEDED_ROW_COUNT = 4;
+
+test.describe('Sim recap admin viewer', () => {
+  test('index renders every seeded row', async ({ page }) => {
+    const response = await page.goto('simSummaries.php');
+
+    expect(response?.status()).toBe(200);
+    await expect(page.locator('table.ibl-data-table tbody tr')).toHaveCount(SEEDED_ROW_COUNT);
+    await assertNoPhpErrors(page);
+  });
+
+  test('index is ordered newest sim first', async ({ page }) => {
+    await page.goto('simSummaries.php');
+
+    const rows = page.locator('table.ibl-data-table tbody tr');
+    await expect(rows.first().locator('td').first()).toHaveText('689');
+    await expect(rows.last().locator('td').first()).toHaveText('686');
+    await assertNoPhpErrors(page);
+  });
+
+  test('single recap renders its stored body and themes', async ({ page }) => {
+    const response = await page.goto('simSummaries.php?sim=689');
+
+    expect(response?.status()).toBe(200);
+    await expect(page.locator('#recap-body')).toHaveValue(SIM_689_BODY);
+    await expect(page.locator('#recap-themes')).toContainText('comeback');
+    await assertNoPhpErrors(page);
+  });
+
+  test('single recap offers copy and download controls', async ({ page }) => {
+    await page.goto('simSummaries.php?sim=689');
+
+    await expect(page.locator('#recap-copy')).toBeVisible();
+    const download = page.locator('#recap-download');
+    await expect(download).toBeVisible();
+    await expect(download).toHaveAttribute('href', /sim=689&format=txt/);
+    await assertNoPhpErrors(page);
+  });
+
+  test('a queued row with no text shows its status instead of a body', async ({ page }) => {
+    // Sim 687 is seeded `pending` with recap_text NULL.
+    const response = await page.goto('simSummaries.php?sim=687');
+
+    expect(response?.status()).toBe(200);
+    await expect(page.locator('#recap-body')).toHaveCount(0);
+    await expect(page.locator('#recap-download')).toHaveCount(0);
+    await expect(page.locator('#recap-missing')).toContainText('pending');
+    await assertNoPhpErrors(page);
+  });
+
+  test('a malformed sim is rejected with 400 and still renders the index', async ({ page }) => {
+    const response = await page.goto('simSummaries.php?sim=abc');
+
+    expect(response?.status()).toBe(400);
+    await expect(page.locator('#recap-error')).toHaveText('Invalid sim number.');
+    await expect(page.locator('table.ibl-data-table tbody tr')).toHaveCount(SEEDED_ROW_COUNT);
+    await assertNoPhpErrors(page);
+  });
+
+  test('sim=0 is rejected by the lower bound', async ({ page }) => {
+    // All digits, so ctype_digit() passes — the `< 1` floor is what rejects it.
+    const response = await page.goto('simSummaries.php?sim=0');
+
+    expect(response?.status()).toBe(400);
+    await expect(page.locator('#recap-error')).toHaveText('Invalid sim number.');
+  });
+
+  test('an over-long sim is rejected before any cast', async ({ page }) => {
+    // 11 digits — the strlen > 10 cap rejects it ahead of the (int) cast.
+    const response = await page.goto('simSummaries.php?sim=99999999999');
+
+    expect(response?.status()).toBe(400);
+    await expect(page.locator('#recap-error')).toHaveText('Invalid sim number.');
+  });
+
+  test('a valid but absent sim is a 404 that names the sim', async ({ page }) => {
+    const response = await page.goto('simSummaries.php?sim=999999');
+
+    expect(response?.status()).toBe(404);
+    await expect(page.locator('#recap-error')).toHaveText('No recap stored for sim 999999.');
+    await assertNoPhpErrors(page);
+  });
+
+  test('an injection attempt never reaches SQL', async ({ page }) => {
+    const response = await page.goto('simSummaries.php?sim=1%20OR%201%3D1');
+
+    expect(response?.status()).toBe(400);
+    // A predicate that had reached SQL would change the row count.
+    await expect(page.locator('table.ibl-data-table tbody tr')).toHaveCount(SEEDED_ROW_COUNT);
+    await assertNoPhpErrors(page);
+  });
+});
+
+test.describe('Sim recap plain-text export', () => {
+  test('exports the stored body byte-for-byte', async ({ request }) => {
+    const response = await request.get('simSummaries.php?sim=689&format=txt');
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toMatch(/^text\/plain/);
+    expect(response.headers()['content-disposition']).toContain('sim-689-recap.txt');
+    expect(await response.text()).toBe(SIM_689_BODY);
+  });
+
+  test('format=txt without a sim is a 400 text response, not the HTML index', async ({
+    request,
+  }) => {
+    const response = await request.get('simSummaries.php?format=txt');
+
+    expect(response.status()).toBe(400);
+    expect(response.headers()['content-type']).toMatch(/^text\/plain/);
+    expect(await response.text()).not.toContain('<table');
+  });
+
+  test('a malformed sim is a 400 that never echoes the input', async ({ request }) => {
+    const response = await request.get('simSummaries.php?sim=abc&format=txt');
+
+    expect(response.status()).toBe(400);
+    expect(response.headers()['content-type']).toMatch(/^text\/plain/);
+    expect(await response.text()).not.toContain('abc');
+  });
+
+  test('a row with no stored text is a 404, not an empty 200', async ({ request }) => {
+    const response = await request.get('simSummaries.php?sim=687&format=txt');
+
+    expect(response.status()).toBe(404);
+    expect(response.headers()['content-type']).toMatch(/^text\/plain/);
+    expect(await response.text()).toContain('No recap text available.');
+  });
+});


### PR DESCRIPTION
Sim-recap automation — unit 2 of 4: admin viewer.

Delivers the admin-gated viewer for generated sim recaps: an index of all recaps (newest first), a single-recap detail view with copy-to-clipboard, and a \`&format=txt\` plain-text export for pasting into Discord.

## What changed

**New files:**
- \`ibl5/simSummaries.php\` — entry point with two-guard auth gate (\`is_user\` → redirect, \`is_admin\` → 403), \`ctype_digit\` sim validation, and the \`format=txt\` raw-export branch
- \`ibl5/classes/SimRecap/SimSummariesView.php\` — ob_start-style HTML render; all dynamic output via \`HtmlSanitizer::e()\` (LLM-authored \`recap_text\` never reaches \`trusted()\`)
- \`ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts\` — 20 Playwright rows: index, single-recap, copy control, null-text row, all \`sim\` validation classes, txt-export API tests
- \`ibl5/tests/WideUnit/Scripts/SimSummariesGuardTest.php\` — source-content assertions for guard ordering and no raw SQL
- \`ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php\` — XSS regression, themes escaping, empty state, null-recap-text gate

**Edited files:**
- \`ibl5/classes/SimRecap/SimSummaryRepository.php\` — adds \`listAll()\` (ORDER BY sim DESC, no recap_text column to avoid MEDIUMTEXT bulk load)
- \`ibl5/tests/DatabaseIntegration/SimRecap/SimSummaryRepositoryTest.php\` — three new \`listAll()\` cases (newest-first order, recap_length without body, empty-table boundary)
- \`ibl5/tests/e2e/fixtures/ci-seed.sql\` — clears \`ibl_sim_summaries\` then inserts 4 known rows (686 failed, 687 pending, 688/689 done with text); 999999 left unseeded for not-found fixture
- \`ibl5/tests/e2e/smoke/auth-redirect.spec.ts\` — logged-out redirect for \`simSummaries.php\` and the txt export URL
- \`ibl5/tests/e2e/flows/role-gating-non-admin.spec.ts\` — non-admin 403 with payload-leak assertion

All 39 functional/security matrix rows are machine-checked. Security constraint 9's three negative paths (logged-out redirect, non-admin 403, sim validation classes) each have dedicated E2E coverage, including the export URL.

Depends-on: #1583

## Manual Testing

Row 40 (taste judgment — cannot be automated):

Visit `http://sim-recap-automation-2-admin-viewer.localhost/ibl5/simSummaries.php` as an admin and check:

1. **Information density** — does the index table (sim, status, attempts, body length) read at a glance, or is one column noise?
2. **Copy motion** — click a recap row, hit Copy, paste into Discord. Does it feel like one action? Is the "Copied" acknowledgement legible enough to trust?
3. **Failure states** — browse to a `pending`/`failed` row's panel and trigger a `400`/`404` notice. Do they read as informative rather than broken?
