### PR TITLE
chore(docs): refresh documentation and decision records

### DIFF
--- a/.claude/rules/contract-rules.md
+++ b/.claude/rules/contract-rules.md
@@ -8,7 +8,7 @@ paths:
   - "ibl5/classes/Player/Contract/**/*"
   - "ibl5/classes/Waivers/**/*"
   - "ibl5/classes/ContractList/**/*"
-last_verified: 2026-05-16
+last_verified: 2026-07-22
 ---
 
 # IBL Contract Rules (CBA)
@@ -50,9 +50,14 @@ Player must play **3+ consecutive years** with the same team.
 ## Key Methods
 
 ```php
-ContractRules::hasBirdRights(int $yearsWithTeam): bool
-ContractRules::getMaxRaisePercentage(int $yearsWithTeam): float  // 0.10 or 0.125
+ContractRules::hasBirdRights(int $birdYears): bool
+ContractRules::getMaxRaisePercentage(int $birdYears): float  // 0.10 or 0.125
+ContractRules::calculateMaxRaise(int $yearOneOffer, int $birdYears): int
 ContractRules::getVeteranMinimumSalary(int $experience): int
 ContractRules::getMaxContractSalary(int $experience): int
 ContractRules::getMLEOffers(int $years): array
 ```
+
+All raise calculations (validators, preset buttons, display hints) MUST go through
+`calculateMaxRaise()` — it `floor()`s the result, so bypassing it reintroduces
+off-by-one rounding inconsistencies between the UI and the validator.

--- a/ibl5/docs/API_GUIDE.md
+++ b/ibl5/docs/API_GUIDE.md
@@ -1,11 +1,11 @@
 ---
-description: REST API architectural overview — auth, rate limiting, ETag caching, controller inventory.
-last_verified: 2026-05-19
+description: REST API architectural overview — auth, rate limiting, ETag caching, controller inventory, route table.
+last_verified: 2026-07-22
 ---
 
 # API Guide
 
-**Status:** Implemented ✅ — 17 controllers, API key auth, rate limiting, ETag caching, pagination, CSV export.
+**Status:** Implemented ✅ — 24 controllers, API key auth, rate limiting, ETag caching, pagination, CSV export.
 
 ## Architecture
 
@@ -14,34 +14,89 @@ ibl5/classes/Api/
 ├── Router.php                     # Route dispatch
 ├── Cache/
 │   └── ETagHandler.php            # HTTP ETag caching
-├── Controller/                    # 17 endpoint controllers
+├── Contracts/                     # API interfaces
+│   ├── AuthenticatorInterface.php
+│   ├── ControllerInterface.php
+│   ├── RateLimiterInterface.php
+│   ├── RouterInterface.php
+│   └── TransformerInterface.php
+├── Controller/                    # 24 controllers
+│   ├── EnqueueController.php
 │   ├── GameBoxscoreController.php
 │   ├── GameDetailController.php
 │   ├── GameListController.php
+│   ├── HealthController.php
 │   ├── InjuriesController.php
+│   ├── LastSeenController.php
 │   ├── LeadersController.php
+│   ├── PipelineStateController.php
 │   ├── PlayerDetailController.php
 │   ├── PlayerExportController.php
 │   ├── PlayerHistoryController.php
 │   ├── PlayerListController.php
 │   ├── PlayerStatsController.php
+│   ├── ReactionController.php
 │   ├── SeasonController.php
 │   ├── StandingsController.php
 │   ├── TeamDetailController.php
 │   ├── TeamListController.php
 │   ├── TeamRosterController.php
+│   ├── ThreadByPrController.php
+│   ├── ThreadReplyController.php
 │   ├── TradeAcceptController.php
 │   └── TradeDeclineController.php
-└── Middleware/
-    ├── Contracts/
-    ├── ApiKeyAuthenticator.php    # API key validation
-    ├── RateLimiter.php            # Per-key rate limiting
-    └── SystemClock.php
+├── Middleware/
+│   ├── ApiKeyAuthenticator.php    # API key validation
+│   └── RateLimiter.php            # Per-key rate limiting
+├── Pagination/
+│   └── Paginator.php
+├── Repository/                    # Data access layer
+├── Response/                      # JSON, CSV, HTML responders
+└── Transformer/                   # Response shape transformers
 ```
+
+## Route Inventory
+
+All routes are registered in `ibl5/classes/Api/Router.php`.
+
+### GET routes (API key required except `health`)
+
+| Route | Controller |
+|-------|------------|
+| `health` | `HealthController` — public, no auth |
+| `players` | `PlayerListController` |
+| `players/export` | `PlayerExportController` |
+| `players/{uuid}` | `PlayerDetailController` |
+| `players/{uuid}/stats` | `PlayerStatsController` |
+| `players/{uuid}/history` | `PlayerHistoryController` |
+| `teams` | `TeamListController` |
+| `teams/{uuid}` | `TeamDetailController` |
+| `teams/{uuid}/roster` | `TeamRosterController` |
+| `standings` | `StandingsController` |
+| `standings/{conference}` | `StandingsController` |
+| `games` | `GameListController` |
+| `games/{uuid}` | `GameDetailController` |
+| `games/{uuid}/boxscore` | `GameBoxscoreController` |
+| `stats/leaders` | `LeadersController` |
+| `injuries` | `InjuriesController` |
+| `season` | `SeasonController` |
+
+### POST routes (API key required)
+
+| Route | Controller |
+|-------|------------|
+| `trades/{offerId}/accept` | `TradeAcceptController` |
+| `trades/{offerId}/decline` | `TradeDeclineController` |
+| `bug-pipeline/enqueue` | `EnqueueController` |
+| `bug-pipeline/thread-reply` | `ThreadReplyController` |
+| `bug-pipeline/reaction` | `ReactionController` |
+| `bug-pipeline/last-seen` | `LastSeenController` |
+| `bug-pipeline/state` | `PipelineStateController` |
+| `bug-pipeline/thread-by-pr` | `ThreadByPrController` |
 
 ## Features
 
-- **Authentication:** API key validation via `ApiKeyAuthenticator`
+- **Authentication:** API key validation via `ApiKeyAuthenticator` (the `health` route is public — no key required)
 - **Rate Limiting:** Per-key enforcement via `RateLimiter`
 - **Caching:** HTTP ETag support via `ETagHandler` using `updated_at` timestamps
 - **Pagination:** Built into list controllers

--- a/ibl5/docs/DOCKER_SETUP.md
+++ b/ibl5/docs/DOCKER_SETUP.md
@@ -1,6 +1,6 @@
 ---
 description: Docker Compose setup for local PHP-Apache + MariaDB stack.
-last_verified: 2026-05-22
+last_verified: 2026-07-22
 ---
 
 # Docker Development Setup
@@ -40,7 +40,7 @@ The site is available at **http://main.localhost/ibl5/**.
 | PHP-Apache | http://main.localhost/ibl5/ | Application |
 | MariaDB | localhost:3306 | Database |
 | Mailpit | http://localhost:8025 | Email testing UI |
-| Adminer | http://localhost:8082 | Database browser |
+| Adminer | http://adminer.localhost/ | Database browser |
 | Traefik Dashboard | http://localhost:8081 | Reverse proxy routes |
 
 ### Adminer Login
@@ -172,7 +172,7 @@ bin/wt-down --all --volumes
 
 ### Adminer Access
 
-Connect to any worktree's database via Adminer at http://localhost:8082:
+Connect to any worktree's database via Adminer at http://adminer.localhost/ (routes through Traefik):
 - Server: `ibl5-db-<slug>` (e.g., `ibl5-db-my-feature`)
 - Username: `root`
 - Password: `root`

--- a/ibl5/docs/STRATEGIC_PRIORITIES.md
+++ b/ibl5/docs/STRATEGIC_PRIORITIES.md
@@ -1,6 +1,6 @@
 ---
 description: Post-refactoring roadmap and priority queue.
-last_verified: 2026-05-19
+last_verified: 2026-07-22
 ---
 
 # Strategic Development Priorities for IBL5
@@ -11,22 +11,22 @@ IBL5 has completed its full-stack modernization from a PHP-Nuke monolith to an i
 
 ### What's Built
 
-- **All IBL modules** follow Repository/Service/View pattern with `Contracts/` interfaces
-- **REST API** with 17 controllers, API key auth, rate limiting, ETag caching, pagination, CSV export
+- **IBL modules** follow the Repository/Service/View pattern with `Contracts/` interfaces (newer namespaces such as `SimRecap` and `BugPipeline` are not yet fully interface-backed)
+- **REST API** with 24 controllers, API key auth, rate limiting, ETag caching, pagination, CSV export
 - **Security stack**: CSP + HSTS + X-Frame-Options headers, CSRF on all forms, `HtmlSanitizer::e()` on all output, prepared statements everywhere
 - **HTMX frontend**: boosted navigation (SPA-like), tab switching via `hx-get`, partial-page loading, form boost
 - **Test pyramid**: PHPUnit (unit + integration + module entry point), Playwright E2E (functional + visual regression), Infection mutation testing at 100% MSI
 - **CI/CD**: PHPUnit + PHPStan + Playwright + Lighthouse + CodeQL + migration safety + mutation testing + production smoke tests + auto-rebase
 - **Docker dev environment**: multi-worktree with Traefik routing, isolated DBs, automated migration runner
-- **IBL6 SvelteKit frontend** in early development (`IBL6/`)
+- **IBL6 SvelteKit frontend** in early development — a separate sibling repo (`~/GitHub/IBL6`), not a subdirectory of this one; its container image is built here by `.github/workflows/build-ibl6-image.yml`
 
 ### Quality Gates (enforced by CI)
 
 - PHPStan level `max` with `strict-rules` and `bleedingEdge` — zero errors
 - PHPUnit — full suite green, zero skips
-- Coverage threshold — 70% (ratcheted; actual ~80%)
+- Coverage threshold — 80% floor (`ibl5/bin/check-coverage`), plus a no-regression check against `ibl5/coverage-baseline.json` (actual 84.26%)
 - Mutation testing — 100% MSI / 100% Covered MSI (weekly + on-demand)
-- Playwright E2E — 4-shard parallel, visual regression baselines
+- Playwright E2E — single shard (was 4; collapsed to fit free-tier runner caps), visual regression baselines
 - Lighthouse — performance audits on every PR
 
 ---
@@ -65,29 +65,34 @@ HTMX is partially adopted — boosted navigation, tab switching, and form boost 
 
 ### 4. Test Coverage Expansion
 
-Coverage is at ~80% with the 70% CI threshold. The test suite is mature (PHPUnit, Playwright, mutation testing all enforced), but there are still gaps in integration test coverage for some modules.
+Coverage is at 84.26% with an 80% CI floor plus a no-regression check. The test suite is mature (PHPUnit, Playwright, mutation testing all enforced), but there are still gaps in integration test coverage for some modules.
 
 **Remaining work:**
-- Ratchet coverage threshold as new tests are added (next target: 75%)
+- Ratchet the coverage floor upward as new tests are added (the floor is manual — set in the `Check coverage threshold` step of `.github/workflows/tests.yml`)
 - Add module entry point tests for untested modules (using `ModuleEntryPointTestCase`)
 - Expand E2E coverage for form submission flows that currently only have read-only tests
 
 ### 5. API Maturation
 
-The REST API has 17 controllers covering players, teams, games, standings, schedule, leaders, injuries, trade actions, and CSV export. Auth (API keys), rate limiting, ETag caching, and pagination are all in place.
+The REST API has 24 controllers covering players (list/detail/stats/history/export), teams (list/detail/roster), games (list/detail/boxscore), standings, seasons, leaders, injuries, trade actions, PR threads/reactions, and pipeline/health/enqueue operations. Auth (API keys), rate limiting, ETag caching, and pagination are all in place.
 
 **Remaining work:**
 - OpenAPI/Swagger documentation generation
 - Additional endpoints as IBL6 frontend needs arise
 - Consider JWT auth alongside API keys for user-scoped operations
 
+### 6. JSB Native Sim Engine (Go)
+
+A native Go re-implementation of the jumpshot 5.60 sim engine lives under `engine/`, scaffolded May 2026. The goal is cut-over fidelity with the legacy Windows binary so simulation stops depending on it.
+
+**Remaining work:** tracked item-by-item in [backlog/jsb-native-backlog.md](backlog/jsb-native-backlog.md) — the count-axis cut-over blocker chain, static RE pins, faithful ports, and validation gates. That backlog is the single source of truth for engine status; do not duplicate item state here.
+
 ---
 
 ## Lower Priority / Future
 
 - **Performance optimization**: Query analysis, Redis caching layer, page fragment caching. Not urgent — current page loads are acceptable.
-- **PowerRankings module**: The only display module without `Contracts/` interfaces. Low impact, refactor opportunistically.
-- **Generic PHP-Nuke modules** (Web_Links, Your_Account, News, Content, etc.): Will be replaced by IBL6 SvelteKit equivalents rather than refactored in PHP.
+- **Generic PHP-Nuke modules**: `Web_Links` and `Content` are already gone; `News`, `Topics`, and `YourAccount` remain and will be replaced by IBL6 SvelteKit equivalents rather than refactored in PHP.
 
 ---
 
@@ -97,3 +102,4 @@ The REST API has 17 controllers covering players, teams, games, standings, sched
 - **Jan 2026**: 80% test coverage target achieved; all display modules refactored
 - **Feb 2026**: REST API launched with auth, rate limiting, caching
 - **Mar 2026**: HTMX frontend phases 1-3 shipped; mutation testing at 100% MSI; legacy `nuke_*` tables reduced to 10 (from 30+); TradingRepository god class split; CSV player export; production deploy smoke tests; worktree Docker simplification
+- **Apr – Jul 2026**: coverage floor ratcheted 70% → 80% (actual 84.26%) with a no-regression baseline check; REST API grown 17 → 24 controllers (PR threads/reactions, pipeline state, health, enqueue); native Go sim engine scaffolded under `engine/` (May 2026); E2E resharded 4 → 1 to fit free-tier runner caps

--- a/ibl5/docs/decisions/0004-docker-only-dev-environment.md
+++ b/ibl5/docs/decisions/0004-docker-only-dev-environment.md
@@ -1,6 +1,6 @@
 ---
 description: Why IBL5 local dev is Docker-only, with MAMP sunset and native PHP stacks rejected.
-last_verified: 2026-05-22
+last_verified: 2026-07-22
 ---
 
 # ADR-0004: Docker-only development environment
@@ -27,7 +27,7 @@ Local development uses Docker Compose only. `docker compose up -d` starts PHP-Ap
 
 - Positive: every contributor runs identical PHP version, MariaDB version, Apache config, and request routing. "Works on my machine" is no longer a legitimate diagnosis.
 - Positive: git worktrees can run in parallel — each worktree gets an isolated Docker stack via `bin/wt-up`.
-- Positive: CI parity is automatic. The same `docker-compose.yml` that CI uses is what developers use locally, so PHPUnit and Playwright behave the same in both environments.
+- Positive: CI parity is automatic. Local dev uses `docker-compose.yml` (full stack: Traefik, MariaDB 10.11, Mailpit, Adminer). CI PHPUnit uses GitHub Actions native `services:` containers (same MariaDB 10.11 image); CI E2E Playwright uses the minimal `docker-compose.ci.yml` (no Traefik/Mailpit/Adminer). All three share the same MariaDB 10.11 image, achieving the parity the decision aimed for. *Update 2026-07-22: the original claim "The same docker-compose.yml that CI uses is what developers use locally" was imprecise; CI has always used separate service definitions. The underlying parity (matching MariaDB and PHP versions) holds.*
 - Positive: Playwright E2E tests can rely on `http://main.localhost/ibl5/` being the single canonical URL.
 - Negative: Docker Desktop is a heavyweight prerequisite for onboarding. Accepted because the alternative was worse.
 - Negative: First-time setup requires creating the shared `ibl5-proxy` Docker network manually. Documented in `ibl5/docs/DOCKER_SETUP.md`.
@@ -37,7 +37,8 @@ Local development uses Docker Compose only. `docker compose up -d` starts PHP-Ap
 ## References
 
 - `ibl5/docs/DOCKER_SETUP.md` — the step-by-step onboarding guide.
-- `docker-compose.yml` — the canonical service definition.
+- `docker-compose.yml` — the canonical local dev service definition (full stack).
+- `docker-compose.ci.yml` — the minimal CI E2E stack (no Traefik/Mailpit/Adminer).
 - `bin/wt-new`, `bin/wt-up`, `bin/wt-down` — worktree lifecycle commands that assume Docker.
 - `docker/Dockerfile.tailwind` — the Tailwind CSS watcher sidecar image.
 - `.claude/rules/workflow-continuity.md` — the agent-facing worktree rule (cites this ADR).

--- a/ibl5/docs/decisions/0005-strict-types-enforcement.md
+++ b/ibl5/docs/decisions/0005-strict-types-enforcement.md
@@ -1,6 +1,6 @@
 ---
 description: Why PHPStan level max plus strict-rules plus RequireStrictTypesRule is the non-negotiable type floor.
-last_verified: 2026-05-14
+last_verified: 2026-07-22
 ---
 
 # ADR-0005: Strict types + typed properties enforcement
@@ -21,7 +21,7 @@ Every PHP file inside `ibl5/classes/` must begin with `declare(strict_types=1);`
 - **Strict equality:** always `===` / `!==`, never `==` / `!=`.
 - **Null handling:** nullable types (`?string`) and null coalescing (`??`), no implicit null-to-empty.
 
-The rule fires in PostToolUse during editing and in CI via `tests.yml` PHPStan job.
+The rule fires in PostToolUse on task completion (not per-edit) and in CI via `tests.yml` PHPStan job.
 
 ## Alternatives Considered
 

--- a/ibl5/docs/decisions/0009-unify-cross-table-column-names.md
+++ b/ibl5/docs/decisions/0009-unify-cross-table-column-names.md
@@ -1,6 +1,6 @@
 ---
 description: Rationale for unifying turnover, 3-pointer rating, and team-id column names across the schema (Tier 2 of the sql-column-naming audit), enforced by a new PHPStan rule.
-last_verified: 2026-05-20
+last_verified: 2026-07-22
 ---
 
 # ADR-0009: Unify Cross-Table Column Names

--- a/ibl5/docs/decisions/0012-archive-first-jsb-reading.md
+++ b/ibl5/docs/decisions/0012-archive-first-jsb-reading.md
@@ -1,6 +1,6 @@
 ---
 description: JSB file reading uses archive-first strategy via JsbSourceResolver — reads all JSB file types directly from backup ZIP without extracting to disk.
-last_verified: 2026-05-15
+last_verified: 2026-07-22
 ---
 
 # ADR-0012: Archive-first JSB file reading

--- a/ibl5/docs/decisions/0020-mutation-unlock-controllers-handlers.md
+++ b/ibl5/docs/decisions/0020-mutation-unlock-controllers-handlers.md
@@ -1,6 +1,6 @@
 ---
 description: Rationale for removing the broad *Controller* and *Handler* mutation testing exclusions and refining overly broad module-level excludes.
-last_verified: 2026-05-13
+last_verified: 2026-07-22
 ---
 
 # ADR-0020: Mutation Testing Unlock — Controllers + Handlers
@@ -35,3 +35,5 @@ last_verified: 2026-05-13
 - All 998 mutations are killed by existing tests — no backfill was needed.
 - The `Cache`, `SiteStatistics`, and `Discord` module exclusions are now file-specific, avoiding accidental shadowing of files in other modules.
 - Pass 2 (14 untested files) remains deferred with specific per-file excludes.
+
+*Update 2026-07-22: Pass 2 is complete. The 14 per-file Controller/Handler excludes listed above have been removed from `ibl5/infection.json5`; direct test files now exist for the previously deferred classes (confirmed: `PlayerPageControllerTest.php`, `UpdaterControllerTest.php`). The `Cache`/`SiteStatistics`/`Discord` file-specific excludes are also no longer present in `infection.json5`. ADR-0065 (2026-06-18) made the `mutation-pr` job a required merge gate — see `ibl5/docs/decisions/0065-mutation-testing-required-gate.md`.*

--- a/ibl5/docs/decisions/0022-lighthouse-pr-comments.md
+++ b/ibl5/docs/decisions/0022-lighthouse-pr-comments.md
@@ -1,6 +1,6 @@
 ---
 description: ADR for Lighthouse PR sticky comments with per-URL scores and deltas vs master baseline
-last_verified: 2026-05-13
+last_verified: 2026-07-22
 ---
 
 # ADR-0022: Lighthouse PR Comments
@@ -28,6 +28,8 @@ Post a sticky PR comment with per-URL scores, deltas against master, and direct 
 - Positive: Direct report links in the comment eliminate the hunt-the-storage-URL friction.
 - Negative: `pull-requests: write` permission added to the Lighthouse workflow (small attack surface increase).
 - Negative: Third-party action dependency (`marocchino/sticky-pull-request-comment@v2`).
+
+**Update 2026-07-22:** The action has been upgraded to v3.0.5 (pin `5770ad5eb8f42dd2c4f34da00c94c5381e49af88`). The sticky-comment behaviour is unchanged.
 - Negative: `numberOfRuns: 3` increases CI wall-clock time from ~5 min to ~12 min for the Lighthouse job.
 
 ## References

--- a/ibl5/docs/decisions/0023-deploy-rehearsal-pre-flight-gate.md
+++ b/ibl5/docs/decisions/0023-deploy-rehearsal-pre-flight-gate.md
@@ -1,6 +1,6 @@
 ---
-description: Deploy rehearsal workflow gates production deploys by dry-running composer --no-dev, migrations, and schema validation against a disposable MariaDB before SSH steps touch prod.
-last_verified: 2026-05-13
+description: Deploy rehearsal workflow gates production deploys by dry-running composer --no-dev, migrations, and schema validation against a prod-cloned disposable MariaDB before SSH steps touch prod.
+last_verified: 2026-07-22
 ---
 
 # ADR-0023: Deploy Rehearsal Pre-Flight Gate
@@ -35,3 +35,5 @@ A reusable workflow `.github/workflows/deploy-rehearsal.yml` mirrors the exact `
 - `.github/workflows/migration-safety.yml` — template for MariaDB service + tracker-seed pattern
 - `ibl5/bin/validate-schema` — schema assertion runner
 - `ibl5/config/schema-assertions.php` — assertion definitions
+
+**Update 2026-07-22:** The deploy rehearsal no longer runs migrations against a fresh/empty MariaDB schema. Following a live production failure (migration 144, FK on real orphan rows — see ADR-0059), the rehearsal was changed to clone production data into the CI MariaDB via `bin/rehearsal-prod-dump` over SSH. The `composer install --no-dev` + `php bin/migrate` + `php bin/validate-schema` sequence and the `needs: pre-flight` gate in `main.yml` are unchanged; only the database seed changed from a snapshot to a prod clone. The MariaDB image remains 10.11.

--- a/ibl5/docs/decisions/0024-deploy-telemetry-and-backup-freshness.md
+++ b/ibl5/docs/decisions/0024-deploy-telemetry-and-backup-freshness.md
@@ -1,6 +1,6 @@
 ---
 description: Adds deploy-step sentinel telemetry, enriched failure notifications, and a deploy-rehearsal HTTP probe to CI/CD workflows.
-last_verified: 2026-05-14
+last_verified: 2026-07-22
 ---
 
 # ADR-0024: Deploy Telemetry and Rehearsal HTTP Probe

--- a/ibl5/docs/decisions/0025-ban-bare-table-identifiers.md
+++ b/ibl5/docs/decisions/0025-ban-bare-table-identifiers.md
@@ -1,6 +1,6 @@
 ---
 description: ADR for BanBareTableIdentifierRule PHPStan custom rule enforcing backtick-quoted table names
-last_verified: 2026-05-15
+last_verified: 2026-07-22
 ---
 
 # ADR-0025: Ban Bare Table Identifiers
@@ -34,6 +34,8 @@ The sweep is split into two PRs:
 - Positive: Future table renames get significant static-analysis coverage once PR B lands (see Known Gaps below).
 - Negative: 133 baseline entries added (temporary — PR B will remove them).
 - Negative: Test assertions that match SQL strings must include backticks, adding minor friction.
+
+**Update 2026-07-22:** `phpstan-baseline.neon` now contains **0** `ibl.bareTableIdentifier` entries (measured 2026-07-22). The PR B high-touch module sweep has been completed and the baseline entries removed. Remaining grep hits for `FROM/JOIN/UPDATE/INTO/DELETE FROM ibl_*` without backticks in `classes/` are in PHPDoc comments, docblocks, and `.md` files — outside the `String_`-node scope the rule scans, so they are not caught (and not in the baseline). The rule and its file-scope restriction (`str_contains($file, '/classes/')`) are unchanged.
 
 ## Known Gaps
 

--- a/ibl5/docs/decisions/0027-ban-direct-common-mysqli-instantiation.md
+++ b/ibl5/docs/decisions/0027-ban-direct-common-mysqli-instantiation.md
@@ -1,6 +1,6 @@
 ---
-description: ADR for BanDirectCommonMysqliInstantiationRule enforcing constructor injection of CommonMysqliRepositoryInterface
-last_verified: 2026-05-16
+description: ADR for BanDirectCommonMysqliInstantiationRule enforcing constructor injection of the split CommonMysqli repository interfaces
+last_verified: 2026-07-22
 ---
 
 # ADR-0027: Ban Direct CommonMysqliRepository Instantiation
@@ -37,3 +37,5 @@ Add `BanDirectCommonMysqliInstantiationRule` (`ibl5/phpstan-rules/BanDirectCommo
 - Positive: New class code cannot instantiate `CommonMysqliRepository` directly — must inject the interface.
 - Positive: Enables future caching decorator (Plan B) and class splitting without touching call sites.
 - Negative: Module `index.php` files must create the instance and wire it down manually.
+
+**Update 2026-07-22:** `CommonMysqliRepository` and `CommonMysqliRepositoryInterface` were deleted when `Services/` was removed (ADR-0028, PR #777). The class was split into three narrow repositories: `Repositories\TeamIdentityRepository`, `Repositories\PlayerLookupRepository`, and `Repositories\SalaryCapRepository` (see `.claude/rules/core-coding.md` for their method signatures). The rule class `BanDirectCommonMysqliInstantiationRule` still exists and is still registered in `ibl5/phpstan.neon`, but it was updated to ban direct instantiation of those three split classes. The rule identifier changed from `ibl.directCommonMysqliInstantiation` to `ibl.directRepoInstantiation`. The allowed-patterns list gained `/Bootstrap/` in addition to the original four patterns (`modules/`, `tests/`, `scripts/`, `mainfile.php`, `api.php`). The anti-pattern-prevention goal is unchanged.

--- a/ibl5/docs/decisions/0028-services-and-shared-deletion.md
+++ b/ibl5/docs/decisions/0028-services-and-shared-deletion.md
@@ -1,6 +1,6 @@
 ---
 description: ADR recording deletion of Services/ and Shared/ catch-all namespaces
-last_verified: 2026-05-16
+last_verified: 2026-07-22
 ---
 
 # ADR-0028: Delete Services/ and Shared/ Namespaces

--- a/ibl5/docs/decisions/0029-bootstrap-wiring-web.md
+++ b/ibl5/docs/decisions/0029-bootstrap-wiring-web.md
@@ -1,6 +1,6 @@
 ---
 description: ADR for wiring Bootstrap\Application as mainfile.php composition root (web mode)
-last_verified: 2026-05-17
+last_verified: 2026-07-22
 ---
 
 # 0029 — Bootstrap\Application wired as mainfile.php composition root (web)

--- a/ibl5/docs/decisions/0030-bootstrap-unified-composition.md
+++ b/ibl5/docs/decisions/0030-bootstrap-unified-composition.md
@@ -1,6 +1,6 @@
 ---
 description: ADR for completing Bootstrap\Application as the single composition root for web, api, and test entry points
-last_verified: 2026-05-17
+last_verified: 2026-07-22
 ---
 
 # 0030 — Bootstrap unified composition (web/api/test)
@@ -29,7 +29,7 @@ Three bootstrap paths (mainfile.php / api.php / tests/bootstrap.php) each contai
 
 - New bootstrap concerns are added as a Step class registered in one or more factories. No duplicate code paths.
 - `LegacyFunctions.php` is the authoritative source for legacy globals (`include_secure`, `filter`, `blocks`, etc.).
-- mainfile.php reduced from 410 to 65 lines; tests/bootstrap.php from 96 to 7 lines (+ worktree autoloader).
+- mainfile.php reduced from 410 to 65 lines; tests/bootstrap.php from 96 to 7 lines (+ worktree autoloader). (Update 2026-07-22: both files subsequently grew as worktree autoloader blocks were added. Current counts: mainfile.php 72 lines, tests/bootstrap.php 40 lines.)
 - Test path benefits from the same container pipeline (future test parity wins).
 - The `blocks()` function now uses `real_escape_string()` in production (previously only the unused LegacyFunctions copy did).
 

--- a/ibl5/docs/decisions/0031-xss-zero-floor-ratchet.md
+++ b/ibl5/docs/decisions/0031-xss-zero-floor-ratchet.md
@@ -1,6 +1,6 @@
 ---
 description: Zero-floor ratchet mechanism for RequireEscapedOutputRule prevents XSS regression in cleaned files.
-last_verified: 2026-05-17
+last_verified: 2026-07-22
 ---
 
 # ADR-0031: XSS Zero-Floor Ratchet

--- a/ibl5/docs/decisions/0032-ban-implicit-superglobals.md
+++ b/ibl5/docs/decisions/0032-ban-implicit-superglobals.md
@@ -1,6 +1,6 @@
 ---
 description: PHPStan rules ban implicit superglobals and global keyword outside bootstrap, enforcing constructor injection.
-last_verified: 2026-05-17
+last_verified: 2026-07-22
 ---
 
 # ADR-0032: Ban Implicit Superglobals and Global Keyword

--- a/ibl5/docs/decisions/0032-cookie-before-header-zero-floor.md
+++ b/ibl5/docs/decisions/0032-cookie-before-header-zero-floor.md
@@ -1,6 +1,6 @@
 ---
 description: Zero-floor ratchet for ibl.cookieBeforeHeader PHPStan rule, preventing baseline regression in cleaned controllers
-last_verified: 2026-05-17
+last_verified: 2026-07-22
 ---
 
 # ADR-0032: Zero-Floor Ratchet for `ibl.cookieBeforeHeader`
@@ -21,12 +21,12 @@ Without a ratchet, future baseline regeneration could silently re-suppress a new
 
 Apply the zero-floor pattern established in [ADR-0031](0031-xss-zero-floor-ratchet.md) to `PageLayoutHeaderBeforeCookieRule`:
 
-- A `ZERO_FLOOR_FILES` constant lists the four cleaned controllers.
+- A `ZERO_FLOOR_FILES` constant lists the four cleaned controllers. (Update 2026-07-22: WaiversController was subsequently added; the list now covers five controllers.)
 - Errors in zero-floor files are emitted with `->nonIgnorable()`, bypassing baseline suppression.
 - A tip message identifies the file as zero-floored.
 
 ## Consequences
 
-- New `$cookie[...]` reads before `PageLayout::header()` in these four files will fail PHPStan unconditionally.
+- New `$cookie[...]` reads before `PageLayout::header()` in these five files will fail PHPStan unconditionally. (Update 2026-07-22: WaiversController was added after the initial decision; the list grew from four to five.)
 - Other files not in the zero-floor list remain baseline-suppressible (backwards-compatible).
 - Future controller cleanups can add files to the list incrementally.

--- a/ibl5/docs/decisions/0032-xss-burndown-retrospective.md
+++ b/ibl5/docs/decisions/0032-xss-burndown-retrospective.md
@@ -1,6 +1,6 @@
 ---
-description: Retrospective ADR documenting the complete XSS burndown across Plans A, B, and C — 186+ instances eliminated, 17 view files now in zero-floor.
-last_verified: 2026-05-17
+description: Retrospective ADR documenting the complete XSS burndown across Plans A, B, and C — 315 baseline suppressions eliminated, 17 view files now in zero-floor.
+last_verified: 2026-07-22
 ---
 
 # ADR-0032: XSS Burndown Retrospective


### PR DESCRIPTION
## Summary

- Updated `last_verified` dates across 21 documentation files to 2026-07-22
- Refreshed API_GUIDE with expanded controller inventory (17 → 24 controllers) and new route tables
- Updated Strategic Priorities with current metrics: coverage 84.26%, E2E resharding, native Go engine scaffolding
- Clarified Docker setup: Adminer routes through Traefik at `http://adminer.localhost/`
- Added updates to ADRs documenting recent changes (ADR-0023 prod-clone deploy rehearsal, ADR-0025 bare-table identifiers completed, ADR-0027 CommonMysqli split, etc.)
- Refined contract-rules method signatures and added guidance on `calculateMaxRaise()` centralization

## Manual Testing

No manual testing needed — verified by automated tests.
