### PR TITLE
fix(migration-safety): reduce column-rename-sweep false positives

### DIFF
--- a/bin/check-column-rename-sweep
+++ b/bin/check-column-rename-sweep
@@ -40,7 +40,7 @@ SCAN_PATHS="ibl5/scripts/ ibl5/bin/ ibl5/api.php"
 # Common English / short SQL-reserved words. When a renamed old-name is one of these,
 # require an unambiguous SQL context (backtick- or quote-wrapped) to avoid matching the
 # word in comments, shell/PHP variables, and prose. See ADR-0071.
-COMMON_WORD_DENYLIST=" from to key name value line order set group by select table column index type status date id "
+COMMON_WORD_DENYLIST=" from to key name value line order set group by select table column index type status date id do old new home year "
 
 usage() {
     cat <<'EOF'
@@ -168,6 +168,14 @@ trap cleanup EXIT
 while IFS= read -r migfile; do
     migbase="$(basename "$migfile")"
     while IFS= read -r line; do
+        # Strip SQL comments before parsing (D4). A migration that *describes*
+        # `RENAME COLUMN old TO new` in prose is not performing one — without this,
+        # 113_rename_reserved_word_rating_columns.sql:31 registers a phantom
+        # `old` -> `new` rename that then matches $row['old'], "old path", etc.
+        # A column name can never contain `--` or `#`, so truncating is lossless.
+        line="${line%%--*}"
+        line="${line%%#*}"
+
         old_name=""
         new_name=""
 
@@ -218,8 +226,11 @@ fi
 HITS=""
 while IFS='	' read -r old_name mig_basename; do
     [ -n "$old_name" ] || continue
-    # Skip if old_name is still in the live schema (FP-filter, D2)
-    if grep -qxF "$old_name" "$TMP_COLUMNS_FILE" 2>/dev/null; then
+    # Skip if old_name is still in the live schema (FP-filter, D2).
+    # Case-insensitive (D5): MySQL column names are case-insensitive, so a
+    # pure case change such as `Sim` -> `sim` (120_misc_snake_case_cleanup.sql)
+    # is not a rename that can leave a stale reference behind.
+    if grep -qixF "$old_name" "$TMP_COLUMNS_FILE" 2>/dev/null; then
         continue
     fi
     # Choose match expression: denylisted words require backtick- or quote-wrapped token.

--- a/ibl5/docs/decisions/0071-column-rename-sweep-matching-precision.md
+++ b/ibl5/docs/decisions/0071-column-rename-sweep-matching-precision.md
@@ -1,6 +1,6 @@
 ---
 description: Per-column matching strictness in check-column-rename-sweep to eliminate bareword false positives for common English / SQL-reserved words.
-last_verified: 2026-06-28
+last_verified: 2026-07-22
 ---
 
 # ADR-0071: Column-rename sweep matching precision (denylist design)
@@ -39,7 +39,13 @@ Introduce **per-column matching strictness** keyed on a common-word denylist.
 
 A bash variable `COMMON_WORD_DENYLIST` lists common English words and short SQL reserved
 words: `from`, `to`, `key`, `name`, `value`, `line`, `order`, `set`, `group`, `by`,
-`select`, `table`, `column`, `index`, `type`, `status`, `date`, `id`.
+`select`, `table`, `column`, `index`, `type`, `status`, `date`, `id`, `do`, `old`, `new`,
+`home`, `year`.
+
+`do` is a real rename in `ibl5/migrations/113_rename_reserved_word_rating_columns.sql`
+(`do` → `r_drive_off`) and also the shell loop keyword, so bareword matching hit every
+`; do` in `ibl5/bin/`. `old`/`new`/`home`/`year` are defensive: common English words that
+appear in prose far more often than as unquoted column references.
 
 ### Matching rule
 
@@ -51,6 +57,24 @@ words: `from`, `to`, `key`, `name`, `value`, `line`, `order`, `set`, `group`, `b
 - **Old name is NOT in the denylist** — keep the existing bareword `\b${old_name}\b` match,
   so an unquoted `SELECT legacyZorp FROM …` in a `scripts/` file is still caught (the PR
   #637 blind spot this gate exists to defend).
+
+### D4 — SQL comments are not rename statements
+
+The rename-map parser strips everything from the first `--` or `#` on each migration line
+before matching. A column name can never contain either token, so the truncation is
+lossless. Without it, prose such as
+`` -- is now `RENAME COLUMN IF EXISTS old TO new` followed by a guarded … ``
+(`ibl5/migrations/113_rename_reserved_word_rating_columns.sql`) registered a phantom
+`old` → `new` rename, which then matched `$change['old']`, `// old path`, and similar.
+
+### D5 — the live-schema filter is case-insensitive
+
+MySQL column names are case-insensitive, so a pure case change such as `Sim` → `sim`
+(`ibl5/migrations/120_misc_snake_case_cleanup.sql`) cannot leave a stale reference behind.
+The D2 filter therefore compares against `information_schema.COLUMNS` with `grep -qixF`.
+Previously the case-sensitive compare made `Sim` look absent from the live schema, so it
+fell through to bareword matching and hit English prose ("Sim date update", a Discord
+notification label).
 
 ### Accepted residual
 
@@ -70,11 +94,15 @@ genuine edge cases not covered by this rule.
   per-PR bypass markers.
 - Non-denylisted column renames (the typical case) continue to be caught by the bareword
   match — the PR #637 blind spot remains defended.
-- Six new PHPUnit tests in `CheckColumnRenameSweepCliTest` cover the four false-positive
-  cases (exit 0) and two true-positive cases (exit 1) introduced by this rule.
-- The implementation is confined to `bin/check-column-rename-sweep` (denylist constant +
-  one conditional before the grep call); the surrounding rename-map / D2-filter logic is
-  unchanged.
+- `CheckColumnRenameSweepCliTest` covers each false-positive case (exit 0) and its matching
+  true-positive counterpart (exit 1): the six denylist cases from the original rule, plus
+  the commented-rename (D4), case-only-rename (D5), and shell-keyword `do` cases.
+- The implementation is confined to `bin/check-column-rename-sweep`: the denylist constant,
+  one conditional before the grep call, a comment strip in the rename-map parser (D4), and
+  a `-i` flag on the D2 membership test (D5).
+- D4/D5 (added 2026-07-22) close the residual that left `master` red on `Migration Safety`
+  after PR #1583 merged: PR runs could bypass via the PR-body marker, but `push` events
+  carry no PR body and so had no escape hatch.
 
 ## Lineage
 

--- a/ibl5/tests/Cli/CheckColumnRenameSweepCliTest.php
+++ b/ibl5/tests/Cli/CheckColumnRenameSweepCliTest.php
@@ -291,6 +291,87 @@ final class CheckColumnRenameSweepCliTest extends TestCase
         self::assertStringContainsString('from', $result['output']);
     }
 
+    public function testRenameDescribedInSqlCommentIsNotParsed(): void
+    {
+        // A migration that *describes* a rename in prose performs none. Parsing the
+        // comment harvested a phantom `old` -> `new` rename that matched English prose.
+        $this->writeMigration(
+            '113_rename_rating.sql',
+            "-- The guarded form is `RENAME COLUMN IF EXISTS old TO new` followed by a check.\n"
+            . "# Also not a rename: CHANGE COLUMN legacyZorp new_zorp\n"
+            . "ALTER TABLE ibl_plr RENAME COLUMN `r_to` TO `r_tvr`;\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/scripts/foo.php',
+            "echo \$change['old'] . ' -> ' . \$change['new'];  // old path\n"
+            . "echo legacyZorp;\n"
+        );
+        $colFile = $this->writeColumnsFile(['r_tvr']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No stale renamed-column references detected', $result['output']);
+    }
+
+    public function testCaseOnlyRenameIsNotFlagged(): void
+    {
+        // MySQL column names are case-insensitive, so `Sim` -> `sim` cannot leave a
+        // stale reference behind — the live-schema filter must match case-insensitively.
+        $this->writeMigration(
+            '120_misc_snake_case_cleanup.sql',
+            "ALTER TABLE ibl_sim_summaries CHANGE COLUMN `Sim` `sim` INT;\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/scripts/foo.php',
+            "echo \"Sim {\$sim} recap is ready for review.\";\n"
+        );
+        $colFile = $this->writeColumnsFile(['sim', 'other_col']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No stale renamed-column references detected', $result['output']);
+    }
+
+    public function testShellKeywordRenameNotFlaggedAsBareword(): void
+    {
+        // `do` is a real column rename in migration 113 but also a shell keyword.
+        $this->writeMigration(
+            '113_rename_rating.sql',
+            "ALTER TABLE ibl_plr RENAME COLUMN `do` TO `r_drive_off`;\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/bin/foo',
+            "for f in \"\$DIR\"/*; do :; done\n"
+        );
+        $colFile = $this->writeColumnsFile(['r_drive_off']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(0, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('No stale renamed-column references detected', $result['output']);
+    }
+
+    public function testShellKeywordRenameStillFlaggedWhenBackticked(): void
+    {
+        // Denylisting `do` must not blind the check to a genuine SQL reference.
+        $this->writeMigration(
+            '113_rename_rating.sql',
+            "ALTER TABLE ibl_plr RENAME COLUMN `do` TO `r_drive_off`;\n"
+        );
+        file_put_contents(
+            $this->tmpDir . '/ibl5/scripts/ratings.php',
+            "\$sql = 'SELECT `do` FROM ibl_plr';\n"
+        );
+        $colFile = $this->writeColumnsFile(['r_drive_off']);
+
+        $result = $this->runScript(['--columns-file=' . $colFile]);
+
+        self::assertSame(1, $result['exit'], "Output: {$result['output']}");
+        self::assertStringContainsString('113_rename_rating.sql', $result['output']);
+    }
+
     /**
      * @param list<string> $args
      * @return array{output: string, exit: int}


### PR DESCRIPTION
## Summary
- Strip SQL comments before parsing rename statements to avoid phantom renames from prose descriptions (D4)
- Make live-schema filter case-insensitive to handle case-only renames like `Sim` → `sim` (D5)
- Expand denylist with `do`, `old`, `new`, `home`, `year` to reduce bareword false matches
- Add three PHPUnit tests covering SQL comments, case-only renames, and shell keyword edge cases