### PR TITLE
chore(sim-recap): add Mac-side poll daemon and prompt builder

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -686,6 +686,8 @@ jobs:
         run: bin/test-bug-pipeline-issue
       - name: bin/test-bug-pipeline-hunt
         run: bin/test-bug-pipeline-hunt
+      - name: bin/test-sim-recap-tick
+        run: bin/test-sim-recap-tick
 
   gate:
     name: Tests and Analysis

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -28,6 +28,10 @@ regexes = [
   # tests/Logging/PiiRedactionProcessorTest.php.
   '''ibl_(test|headerkey|abcdef|abc12345)''',
 
+  # Sentinel value used in bin/test-sim-recap-tick to verify passwords are never
+  # logged — deliberately fake, never a real credential.
+  '''hunter2_sentinel_xyz''',
+
   # Sequential placeholder Discord snowflake IDs in test fixtures
   # (tests/Discord/*, tests/Team/TeamViewTest.php).
   '''123456789012345678''',

--- a/bin/lib/sim-recap-exemplar.txt
+++ b/bin/lib/sim-recap-exemplar.txt
@@ -1,0 +1,267 @@
+IBL SIM RECAPS — Feb 26 – Mar 4, 2008 (46 games)
+Voice: Bill Simmons. Records/standings are current post-sim.
+Format per game: score header, then GM Discord mentions (away · home).
+================================================================================
+
+WHERE THINGS STAND
+
+Utah is still Utah. The Jazz sit at 48-13, the best record in the league by a comfortable margin, and they spent this week doing exactly what the best team is supposed to do: beat the teams beneath them and go home early. Behind them the Clippers have quietly turned into a monster. LA is 45-15 now, they hung 162 on Chicago and 139 on Golden State in the same week, and Stephen Curry is out here handing out assists like campaign flyers. The Braves (45-20) keep winning because Devin Booker keeps scoring 40, which at this point is just weather. The Knicks (42-16), Bullets (40-16) and Hawks (41-20) round out a top tier that is deep and mean, and James Harden dropping 40, 35 and 32 in the same week is the reason Washington won't go away.
+
+The Central is a street fight. Atlanta (41-20) and Charlotte (39-19) are separated by half a game and a bad mood. And then, as always, we descend into the basement, where the ping-pong balls are getting a real workout. The Pacers are 5-51. Five. Fifty-one. That's not a season, that's a cry for help. Portland is 8-50 with a 7-foot Latvian who occasionally forgets the team around him is terrible. The Wolves are 11-48, the Raptors 11-45. The lone bright spot down there belongs to the Celtics, who are 10-48 and pulled off the single most improbable result of the week, an upset so unlikely it gets its own paragraph later, because miracles should not be buried in the middle of a recap. On to the games.
+
+================================================================================
+
+
+================================ Feb 26 =========================================
+
+**Boston Celtics 100 @ Miami Heat 114**
+<@518041859881304074> · <@493176245652291584>
+
+Miami keeps winning games in the ugliest, most satisfying way possible: by making you hate offense. The Heat held Boston to 100 and cruised 114, and the frontcourt of Nate Thurmond (16 and 18) and Bill Laimbeer (14 and 19) grabbed 37 rebounds between them, which is less a stat and more a warning label. Laimbeer collecting boards and presumably committing a few tasteful felonies is my favorite recurring bit in this league. Danny Granger added 25, Jrue Holiday chipped in 21. Boston got 24 from Nick Van Exel, who never met a shot clock he respected. The Heat are 32-22 and built to strangle you in April.
+
+**Houston Rockets 103 @ Washington Bullets 139**
+<@667455847189970964> · <@511987457798045706>
+
+Washington won by 36 and it wasn't that close. James Harden went for 31 and Ramon Fernandez matched him with 31 of his own while adding SEVEN steals, which means half of Houston's possessions ended with the ball going the other way. Nick Richards added 18 and 13 with four blocks. The Bullets are 37-16 and playing like a team that believes it. The one dark cloud: Washington lost Jean-Paul Beugnot to a bone bruise on his right knee, three games out. When you win by 36 and still leave with a guy in a boot, the basketball gods are just showing off their sense of humor.
+
+**Phoenix Suns 135 @ Minnesota Timberwolves 133**
+<@669635704862539786> · <@667176455599554570>
+
+Minnesota put four guys in the 20s and lost by two, which is the kind of night that makes you want to throw your remote into a lake. Sue Bird went 24 and 11 assists, Christian Laettner had 24 and 10, Chris Kaman posted 24 and 18, Stephon Marbury added 23 and 12 dimes, and it added up to a two-point loss. Phoenix survived behind LaMelo Ball's 30-8-8 and 28 from Alex English, whose scoring touch apparently ages like fine wine. The Wolves are 11-46 and can't catch a break. They did everything but the last thing.
+
+**Dallas Mavericks 153 @ Portland Trail Blazers 130**
+<@317185882262208517> · <@339503038232395776>
+
+Dallas hung 153 and it still somehow felt routine. Penny Hardaway ran the show with 34, Peja Stojakovic dropped 29, and Shaquille O'Neal did the dad-at-the-barbecue thing with 15, 15 and four blocks. Even Paul Reed got in on it with 20 and 11 off the bench. Kristaps Porzingis answered with 33 and 10 for Portland, which is the Blazers' whole existence in one line: the Unicorn is spectacular, the scoreboard doesn't care. The bad news for Dallas is real, though. Amir Johnson strained his right hip and is out four games. Winning by 23 and losing a rotation big is a very Mavericks way to spend an evening.
+
+**Detroit Pistons 128 @ New Orleans Pelicans 123**
+<@774632927978848306> · <@669349908989345802>
+
+Chris Paul posted a 25-12-12 triple-double, because CP3 has been quietly stuffing box scores in this league since before some of these franchises existed. Vince Carter added 28, Kirk Hinrich buried 22, and Detroit held on 128-123. New Orleans made them sweat: Mel Daniels went 28 and 13, Tyrese Haliburton had 27, 12 and 7, and Artis Gilmore added a 20-12 for good measure. The Pelicans had the firepower and still lost by five, which usually means somebody forgot to guard somebody. Detroit will take it and not ask questions.
+
+**Las Vegas Aces 105 @ Orlando Magic 119**
+<@454639880245477377> · <@830100995676569600>
+
+Mario Hezonja scored 36, buried three triples, and looked like a man who found a cheat code, and Orlando handled Las Vegas 119-105. The number to circle belongs to Angel Reese, who grabbed 21 rebounds, which is not a typo and not a rec-league stat padding session, just relentless work on the glass. Elgin Baylor added 15 and 11 assists. Vegas got 24 and 13 from Kareem Abdul-Jabbar and a nice 16-9-9 from Lindsay Whalen, but the Aces are 16-36 and this was never really theirs. Reese on the boards is becoming appointment viewing.
+
+**New Jersey Nets 104 @ Charlotte Sting 112**
+<@419729887427952654> · <@710928347403780156>
+
+Robert Parish went for 22 and 19 with five blocks, and I need everyone to remember that Parish is, in basketball years, older than the sport itself. LeBron chipped in 26-7-9 because he was bored and decided to be great again, and Bobby Portis added 23 and 17 as Charlotte took it 112-104. New Jersey got 25 from Jamal Mashburn and a 23-12-six-blocks night from Jermaine O'Neal, plus a 16-16 from Arturas Karnisovas, and it wasn't enough. The Sting are 38-17 and have the best player in almost every building they walk into. Parish grabbing 19 boards is a bit that never gets old. Neither does he, apparently.
+
+
+================================ Feb 27 =========================================
+
+**New Jersey Nets 109 @ Denver Nuggets 130**
+<@419729887427952654> · <@205798824185167872>
+
+Jamal Mashburn scored 39 and lost by 21, which is the basketball version of winning an argument nobody was having. Denver spread it around and rolled 130-109 behind 29 from Leandro Barbosa, a 22-14 from Chamique Holdsclaw, and 21 and 14 from Alonzo Mourning. Jermaine O'Neal had 12 and 17 with five blocks for the Nets and could only watch Mashburn heat-check his way to nothing. The Nuggets are 35-22 and hanging around the Midwest race. When your best player scores 39 and you get run off the floor, the other four starters need to check in.
+
+**Miami Heat 109 @ Orlando Magic 126**
+<@493176245652291584> · <@830100995676569600>
+
+Elgin Baylor went for 28, 20 and 7, Angel Reese grabbed 22 rebounds again, and Orlando won its second straight, 126-109. Reese pulling down 22 boards on back-to-back nights means she's just decided rebounds are hers now and the rest of us can file a complaint. Hezonja added 25 with six steals. The lone Miami highlight was terrifying in its own way: Nate Thurmond blocked TEN shots. Ten. He also had 16 and 16. That's a man treating the rim like it owes him money, and his team still lost by 17. The Magic are cooking. Miami's defense finally met an offense it couldn't slow.
+
+**Houston Rockets 118 @ Charlotte Sting 137**
+<@667455847189970964> · <@710928347403780156>
+
+Robert Parish, ageless wonder, dropped 30 and 11, and Charlotte handled Houston 137-118. LeBron added 23-7-7 with four steals because he treats passing lanes like a personal toll booth. Bobby Portis had 23 and 16. Houston actually got a real effort, 29 and 8 assists from Tim Hardaway and a wild defensive night from the bigs (Sean Marks four blocks, Andrew Bogut seven), but the 20-38 Rockets don't have the horses to hang with the Sting. Parish scoring 30 at his age should require a birth certificate check at the scorer's table.
+
+**Atlanta Hawks 142 @ Minnesota Timberwolves 129**
+<@666988022751035397> · <@667176455599554570>
+
+Shareef Abdur-Rahim went for 40 and 12, Pete Maravich added 23 with the usual assortment of passes that shouldn't be legal, and Atlanta beat Minnesota 142-129. The Hawks are 39-20 and have that scary "we can outscore anyone" thing going. Minnesota fought, they always fight: Laettner had 26 and 14, Marbury 24 and 11 dimes, Kaman 22 and 18. The Wolves are 11-47 and stuck in the league's cruelest tier, good enough to make it interesting, not good enough to win it. Shareef going for 40 is just a Tuesday in this league. Wild sentence, true sentence.
+
+**Las Vegas Aces 109 @ LA Lakers 127**
+<@454639880245477377> · <@997197206085963837>
+
+The Lakers had five guys in double figures and handled Vegas 127-109, which is what 34-win teams do to 16-win teams. Chris Webber led with 26 and 10, Tyrese Maxey added 22 and 12 assists, and Myles Turner posted 22, 11 and four blocks. John Stockton chipped in 11, six dimes and five steals because Stockton is physically incapable of playing a game without pickpocketing somebody. Clyde Drexler gave Vegas 26 and 9, but the Aces are 16-37 and this was chalk. LA is rounding into a real problem out West.
+
+**Washington Bullets 144 @ Detroit Pistons 130**
+<@511987457798045706> · <@774632927978848306>
+
+James Harden posted a 32-11-13 triple-double, DeMar DeRozan added 29, and Washington kept rolling with a 144-130 win. The Bullets are 38-16 and Harden is playing MVP-level basketball, the kind where the step-back comes with its own sound effect. The subplot: Chris Paul went for 42, eight and nine in the loss, a genuinely absurd night that bought Detroit nothing. Two point guards traded haymakers and only one got a win. CP3 dropped 42 and got a pat on the back and a long shower. Harden got the triple-double and the standings bump. Advantage: the Beard.
+
+**Vancouver Grizzlies 122 @ LA Clippers 137**
+<@395705560068259840> · <@667058444880052247>
+
+The Clippers keep winning, and here's the twist: GM Brandon Tomyoy suited himself up and dropped 13 points and 10 assists, the ultimate flex. Imagine being the boss, the guy who signs everybody's checks, AND running the offense. Stephen Curry added 28 and 11 dimes, and Dejan Milojevic went for 25, 16 and five steals. Vancouver got a monster from A'Ja Wilson (28, 13 and six blocks) and 24 from David West, but LA is 43-15 and looks the part. Curry and Milojevic combined for 41 assists worth of gravity. The owner got a double-double. This franchise is annoyingly good at everything.
+
+
+================================ Feb 28 =========================================
+
+**Washington Bullets 134 @ Buffalo Braves 130**
+<@511987457798045706> · <@371146882883518486>
+
+Two of the East's best went at it and Washington left with a 134-130 statement. James Harden scored 40, because apparently 32 the night before was a warm-up. The Bullets are 39-16 and Harden is on a heater that should come with a fire marshal. Buffalo did Buffalo things: Devin Booker went for 33, seven assists and five steals, Tani Cohen-Mintz added 20 and 14, Nneka Ogwumike had 21. Two teams that could meet in May, and Washington got the early word in. When Harden and Booker both go off and your team is the one that scored 134 and lost, you tip your cap and get on the plane.
+
+**Vancouver Grizzlies 111 @ Miami Heat 115**
+<@395705560068259840> · <@493176245652291584>
+
+Miami won another rock fight, 115-111, and the box score looked like a defensive clinic that forgot to invite the offense. Nate Thurmond had 16, 19 and three blocks, Marcus Camby added seven blocks off the bench, David West had SEVEN blocks too, and Vancouver's A'Ja Wilson chipped in five of her own. That's a lot of rejected layups for one gym. Danny Granger led Miami with 26, Jrue Holiday added 24 and nine. The Heat are 33-23 and have quietly assembled a defense that turns good offenses into slideshows. Vancouver scored 111 and it felt like 80.
+
+**Las Vegas Aces 117 @ Portland Trail Blazers 141**
+<@454639880245477377> · <@339503038232395776>
+
+Portland actually won a game, and the world kept spinning. Norman Powell led the way with 33, Bob McAdoo added 24 and 16, and the Blazers handled Vegas 141-117. For one night they looked like an actual basketball team instead of a lottery projection with a nice frontcourt. Las Vegas got 25 from Damir Mulaomerovic and 24 and 12 from Don Nelson, but the 16-38 Aces couldn't match Portland's size. The Blazers are still 7-48. Enjoy the wins when they come, Portland. They arrive roughly as often as Halley's Comet.
+
+**Denver Nuggets 137 @ Golden State Warriors 134**
+<@205798824185167872> · <@667121639552450560>
+
+Alonzo Mourning blocked EIGHT shots and added 30 and 12, and Denver edged Golden State 137-134 in a shootout that Zo apparently decided to referee personally at the rim. Bayley Martinez had 27, eight and 12 assists, Barbosa added 22 with seven steals, and Holdsclaw grabbed 21 and 15. Golden State got a monster from Dwyane Wade (41 points, five threes) and 29 and 18 from Dwight Howard, and still fell by three. Wade dropping 41 in a loss is the recurring Warriors tragedy this season. He does everything. It buys a highlight tape and a handshake line.
+
+**Chicago Bulls 99 @ New Orleans Pelicans 152**
+<@336682769583177730> · <@669349908989345802>
+
+New Orleans 152, Chicago 99. That's not a final score, that's a math error someone should investigate. The Pelicans won by 53 behind 32 and 14 from Mel Daniels, a 30-12-six-blocks night from Artis Gilmore, and a 22-11-seven-steals gem from Tyrese Haliburton. Even Prince, yes the artist formerly known as scoring 22, got in on it. The 13-43 Bulls got outscored by roughly a touchdown-and-two-field-goals and never had a pulse. One sour note for New Orleans: they lost Jason Williams to a sprained thumb, six games out. A 53-point win with a casualty. Only in this league.
+
+**Orlando Magic 133 @ Charlotte Sting 114**
+<@830100995676569600> · <@710928347403780156>
+
+Orlando won its third straight, 133-114, and Ricky Rubio dropped 18 assists, which is less a stat line than a public service. Rubio was flinging passes into windows that hadn't opened yet. Mario Hezonja poured in 38, Riccardo Pittis added 23 with seven steals, and the Magic frontcourt (Angel Reese and Elgin Baylor combined for 32 rebounds) owned the glass. Charlotte got 28 and 10 from Bobby Portis and a 20-20 from Robert Parish, who continues to refuse the concept of aging, and still lost by 19. Orlando is 31-28 and suddenly looks like a team nobody wants to see.
+
+**Milwaukee Bucks 139 @ Detroit Pistons 114**
+<@483483037128982528> · <@774632927978848306>
+
+Milwaukee's two shooting guards are Michael Jordan and Kobe Bryant, which is deeply unfair and also extremely fun to watch happen to other teams. MJ went for 36 and seven, Kobe added 32, 10 and four steals, and the Bucks buried Detroit 139-114. Atanas Golomeev chipped in a 19-19 for good measure. Chris Paul kept the Pistons breathing with 33, but you can't out-score Jordan and Kobe on the same roster. That's not a rotation, that's a fantasy draft that went too well. Detroit never had a chance and probably knew it during warmups.
+
+
+================================ Mar 1 =========================================
+
+**Buffalo Braves 134 @ Minnesota Timberwolves 129**
+<@371146882883518486> · <@667176455599554570>
+
+Devin Booker scored 40, because of course he did, and Buffalo held off Minnesota 134-129. Booker dropping 40 has stopped being news and started being a utility bill. Nneka Ogwumike added 25 and 11, Andris Biedrins had 21 and 15, and the Braves needed all of it. Minnesota, forever the honorable loser, got 26 and 14 from Chris Kaman, 21 and 10 from Laettner, and 18 with 12 assists from Sue Bird. The Wolves are 11-48 and keep losing games they nearly win. Booker cooks, the Braves survive, the sun rises in the east. Some things you can set a clock by.
+
+**Boston Celtics 103 @ Orlando Magic 122**
+<@518041859881304074> · <@830100995676569600>
+
+Orlando made it four straight, and Riccardo Pittis had the night: 29 points, 10 boards, eight assists and SEVEN steals, a stat line that looks like he was playing a different, easier sport. Elgin Baylor added 25 and 10, Hezonja had 23 and 10, and the Magic rolled 122-103. Boston got 27 and 12 from Montrezl Harrell and 17 and 14 from David Lee, but the Celtics are 9-47 and mostly playing for June's ping-pong balls. Orlando is legitimately hot right now, and Pittis stealing the ball seven times is the kind of thing that ruins a team's whole evening.
+
+**Miami Heat 125 @ Milwaukee Bucks 119**
+<@493176245652291584> · <@483483037128982528>
+
+Danny Granger went for 34 and Miami won a track meet for once, beating Milwaukee 125-119. Notable, because the Heat winning a game in the 120s is like a vegetarian ordering a steak. Jrue Holiday added 18 and eight. Milwaukee got 32 and 12 from Atanas Golomeev and a 19-8-10 from Michael Jordan, who apparently moonlights as a point guard when the mood strikes. The Bucks are 28-30 and can't quite get over .500, which for a team with Jordan and Kobe feels like a plot hole. Miami climbed to 34-23 and did it by, of all things, scoring.
+
+**New York Knicks 135 @ Dallas Mavericks 128**
+<@669365599184617473> · <@317185882262208517>
+
+Shaquille O'Neal blocked NINE shots and grabbed 21 rebounds and lost, which is the most Shaq way imaginable to have a monster night. He added 29 points, Peja Stojakovic had 28, and Penny Hardaway dished 16 assists, and Dallas still fell 135-128. Mavs GM Mel Baltazar suited up for 19. New York countered with a balanced beatdown: Drazen Dalipagic 33, Immanuel Quickley 28, Tyreke Evans 20 and 12 dimes, and Erick Dampier controlling the paint with 18 boards and five blocks. The Knicks are 41-16. Shaq did everything a center can do except win. Sometimes the box score lies about who won. This time it told the truth in fine print.
+
+**LA Lakers 128 @ Detroit Pistons 112**
+<@997197206085963837> · <@774632927978848306>
+
+The Lakers pounded the glass and beat Detroit 128-112, with Myles Turner (22 and 15), Chris Webber (22 and 12) and Shawn Kemp (20 and 16) combining to make the paint a construction zone. John Stockton added 17 and 12 assists because he's Stockton and that's the deal. Detroit got a heroic 22 and 18 assists from Chris Paul, who is having a spectacular, deeply unrewarded week, plus 24 and 11 from Zion Williamson. The Pistons are 24-31 and keep getting great individual games in losing efforts. CP3 with 18 dimes in an L is this team's brand now.
+
+**LA Clippers 162 @ Chicago Bulls 120**
+<@667058444880052247> · <@336682769583177730>
+
+The Clippers scored 162 points. One hundred and sixty-two. Against a real, professional basketball team. LA beat Chicago by 42, hung 49 in the third quarter alone, and Stephen Curry orchestrated it with 37, 10 assists and five steals like a man conducting an orchestra of dunks. Deni Avdija and Dejan Milojevic each added 26. The 13-44 Bulls got 22 from Modestas Paulauskas and were otherwise scenery. The only Clippers downside: Zaza Pachulia went down with a migraine, out three games, and honestly, watching your team score 162, who could blame him. LA is 44-15 and terrifying.
+
+**Toronto Raptors 127 @ Portland Trail Blazers 124**
+<@194057659878604800> · <@339503038232395776>
+
+Two of the league's saddest teams played a legitimately entertaining game, and Toronto won 127-124 in a battle for basement dignity. DeJuan Blair grabbed 20 rebounds and added 20 points, Zydrunas Ilgauskas had 24 and 18, Mike Bibby ran it with 22 and 12 assists, and Brandy Reed led the way with 30. Portland got 31 and eight from Kristaps Porzingis, the one guy on that roster worth the price of admission. When the 11-45 Raptors and the 7-49 Blazers meet, someone has to win. Toronto drew the short straw and the long one at the same time. Enjoy the win. Study the draft board after.
+
+
+================================ Mar 2 =========================================
+
+**Houston Rockets 129 @ Portland Trail Blazers 133**
+<@667455847189970964> · <@339503038232395776>
+
+Portland won two in a week, which for this franchise is basically a parade. The Blazers edged Houston 133-129 behind 32 from Jamal Crawford and a 26-11-four-blocks night from Porzingis, who buried four threes just to remind you he's a 7-footer who shoots like a guard. Andrew Bogut had a monster 21 rebounds and six blocks in the loss. This one hurt Houston twice, though: they lost Tim Hardaway to a knee contusion (three games) and Allie Quigley to a sore knee (six games) in the same night. Winning by four is nice. Losing two rotation guys getting there is the Rockets tax.
+
+**Milwaukee Bucks 138 @ Sacramento Kings 127**
+<@483483037128982528> · <@792231509872476161>
+
+Jordan and Kobe again, and again it worked. Kobe scored 30, MJ added 27, nine assists and four steals, Atanas Golomeev grabbed a 25-19, and Milwaukee beat Sacramento 138-127. Having the two best shooting guards in the sport on one roster remains a cheat code the Bucks refuse to apologize for. Sacramento fought behind 27, 10 and seven from Nancy Lieberman and 25 from Ray Allen, who still can't miss a three even on the wrong side of history. The Kings are 32-24 and stuck in the West's crowded middle. You can play great against Milwaukee. You just can't guard two Hall of Fame two-guards at once.
+
+**LA Lakers 125 @ Miami Heat 114**
+<@997197206085963837> · <@493176245652291584>
+
+Chris Webber went for 37 and 15 with four steals and four blocks, a do-everything night, and the Lakers handled Miami 125-114. C-Webb stuffing every column while Tyrese Maxey adds 27 is a nice recipe. Shawn Kemp chipped in 19 and 15. Miami got 23 and 21 from Bill Laimbeer, who grabs rebounds and administers hard fouls with the same joyless efficiency, but the Heat's usual defensive smother never showed up. LA is 36-18 and has quietly stacked a strong week. When the Lakers get 37 and 15 from their power forward, they're a bad matchup for anybody.
+
+**Golden State Warriors 128 @ LA Clippers 139**
+<@667121639552450560> · <@667058444880052247>
+
+Stephen Curry dished 19 assists, GM Brandon Tomyoy suited up for 33 points and five threes, and the Clippers beat Golden State 139-128. Yes, the owner led his team in scoring. Yes, that's insane. Yes, LA is 45-15 and doing whatever it wants. Deni Avdija added 25 and 10. Golden State kept it respectable behind 28 and eight from Darius Garland and a 26-12-10 triple-double from Dwyane Wade, but the Warriors are 38-24 and just ran into the West's freight train. Curry with 19 dimes and the boss dropping 33 is the most Clippers box score of the year. This franchise is showing off now.
+
+**Atlanta Hawks 131 @ New Jersey Nets 112**
+<@666988022751035397> · <@419729887427952654>
+
+Jamal Mashburn scored 44 and lost by 19, which continues his personal genre: the magnificent, pointless explosion. Atlanta beat New Jersey 131-112 without needing anything ridiculous, just 29 from Pete Maravich and 26 with five steals from Shareef Abdur-Rahim. The Nets got Mashburn's 44 and a 22 from Sergio Llull and not much resistance elsewhere. New Jersey is 27-34 and running out of season. Mashburn is having a week where he scores 39, then 44, then 38, and his team keeps losing anyway. Somewhere there's a lesson about teammates. He's not listening, and honestly, good for him.
+
+**Dallas Mavericks 113 @ Utah Jazz 132**
+<@317185882262208517> · <@283183467804491776>
+
+The best team in the league reminded everyone why, beating Dallas 132-113. Utah spread the wealth: Andrew Gaze had 28, Takenori Akagi added 26 and 16, Bobby Hurley ran it with 22 and nine assists, and George Mikan turned in a gloriously old-school 16, 17 and SEVEN blocks, dominating with two-handed set shots and the serene confidence of a man who invented the position. Dallas got 26 from Peja and 25 from Penny but couldn't keep up. The Jazz are 48-13. This is what a wagon does to a good-not-great team. Business trip, expensed, done.
+
+**Boston Celtics 113 @ Washington Bullets 139**
+<@518041859881304074> · <@511987457798045706>
+
+James Harden scored 35 with 10 assists, and Washington kept its hot streak alive with a 139-113 win. The Bullets are 40-16 and Harden is having the kind of month where you start checking his MVP odds. Boston got 22 apiece from Nick Van Exel and Montrezl Harrell, plus a nostalgic 12 and 10 assists from Magic Johnson, but the Celtics are 9-48 and this was a scheduled tune-up. Washington treated it like one. Beat the worst team in the East, rest the starters, enjoy the flight. Harden barely had to sweat, which is its own kind of scary.
+
+
+================================ Mar 3 =========================================
+
+**New Orleans Pelicans 116 @ Golden State Warriors 133**
+<@669349908989345802> · <@667121639552450560>
+
+Golden State needed a win after a rough stretch and got one, beating New Orleans 133-116 behind a monster Dwyane Wade night: 36 points, 10 rebounds, seven assists and four blocks. Wade doing literally everything is the Warriors' entire offensive plan and defensive plan rolled into one guy. Dwight Howard added 21 and 16. New Orleans got 33 from Anthony Edwards and a 28-18 from Mel Daniels but couldn't stop the bleeding. The Warriors are 39-24 and needed this one to steady the ship. Wade carrying a team on his back is starting to leave a mark.
+
+**Orlando Magic 113 @ New York Knicks 139**
+<@830100995676569600> · <@669365599184617473>
+
+Erick Dampier blocked ELEVEN shots. Eleven! That's not rim protection, that's a permit violation. He added 13 boards and turned the paint into a place where layups go to file for hazard pay, and New York ended Orlando's four-game win streak 139-113. Tyreke Evans and Immanuel Quickley each had 27, Drazen Dalipagic added 22. The Magic, so hot all week, ran into a buzzsaw and got 28 from Hezonja and little else. The Knicks are 42-16 and back atop the Atlantic. Dampier with 11 blocks means the Magic spent the second half checking whether the rim was legal. It was. He just wasn't letting them use it.
+
+**Dallas Mavericks 113 @ Las Vegas Aces 138**
+<@317185882262208517> · <@454639880245477377>
+
+The 17-38 Aces beat a good team, and they should frame it and hang it over the bar. Vegas handled Dallas 138-113 behind 26 and six from Clyde Drexler and 24 and 14 from Don Nelson. The wild part: Shaquille O'Neal blocked NINE shots for the second time in a week, added 16 and 17, and still lost by 25. Shaq is out here rejecting everything and getting nothing for it. Mavs GM Mel Baltazar had 24 in the loss. Dallas is 36-25 and just got its doors blown off by a lottery team. Some nights the schedule owes you back. This was the Aces cashing the check.
+
+**New Jersey Nets 110 @ LA Lakers 144**
+<@419729887427952654> · <@997197206085963837>
+
+Los Angeles ran the Nets out of the building 144-110, and Myles Turner turned the rim into a rejection center with seven blocks to go with 20 and 14. Tyrese Maxey led the scoring with 29, Chris Webber added 25, and John Stockton had 21, nine assists and seven steals because Stockton stealing the ball seven times is just his resting state. New Jersey got, you guessed it, 38 from Jamal Mashburn, his fourth monster scoring night of the week in a fourth loss. The Lakers are 37-18 and steamrolling. Mashburn's individual brilliance is becoming basketball's saddest running joke.
+
+**Denver Nuggets 119 @ Phoenix Suns 127**
+<@205798824185167872> · <@669635704862539786>
+
+LaMelo Ball went for 33, nine and eight, and Phoenix held off Denver 127-119. Brittney Griner added 26 with three blocks, Alex English had 25, and Vin Baker chipped in 20 and 15. Denver kept it close behind 27 and 16 from Chamique Holdsclaw and a 18-11-10 triple-double from Bayley Martinez, but the Nuggets couldn't get the road stop when they needed it. Phoenix is 27-28 and can't afford to drop these if it wants to sniff the playoffs. LaMelo filling the box score is exactly the kind of night the Suns needed. Barely, but they'll take barely.
+
+**Sacramento Kings 131 @ Vancouver Grizzlies 148**
+<@792231509872476161> · <@395705560068259840>
+
+A'Ja Wilson posted 31 and 16 with five blocks, and Vancouver outgunned Sacramento 148-131. Wilson is a nightly double-double machine who also protects the rim, which feels greedy. Taiga Kagami added 28 and 14, David West had 26 and 12, and, yes, that is baseball legend Tony Gwynn scoring 26 with five steals for the Grizzlies, and no, I will not be taking questions about how this league works. Sacramento got 35 from Nancy Lieberman and a 21-16 from Maurice Stokes but couldn't match Vancouver's frontcourt. The Grizzlies are 37-19 and jockeying for Pacific position. Gwynn dropping 26 is my favorite sentence of the week.
+
+**Charlotte Sting 117 @ Boston Celtics 130**
+<@710928347403780156> · <@518041859881304074>
+
+Stop everything. The Boston Celtics, owners of a 9-48 record, beat the 39-19 Charlotte Sting 130-117, and it wasn't a fluke, it was a beating. Luol Deng had 26 and nine, Montrezl Harrell added 24 and 15, and David Lee posted a 19-18 as Boston built a lead and never gave it back. Charlotte got 25 from LeBron and 20 from Robert Parish and simply got outworked by a team with nothing to play for except pride, which turns out to be a decent motivator. This is why they play the games. Boston's tenth win of the season came against one of the East's best, and every Celtics fan (both of them) should savor it. Charlotte should burn the tape.
+
+
+================================ Mar 4 =========================================
+
+**Atlanta Hawks 137 @ Indiana Pacers 132**
+<@666988022751035397> · <@667321452080660480>
+
+Give the Pacers this: they made a good team sweat. Atlanta escaped Indiana 137-132, and it took 33 and 17 from Karl-Anthony Towns and 33 from Pete Maravich to hold off the 5-51 disaster. Stepas Butautas added 28, Shareef had 25. The Pacers, historically bad and playing for nothing, got 24, 11 and seven from Carmelo Anthony, a 20-11 from Willy Hernangomez, and 19 apiece from Milos Teodosic and Glen Rice, and pushed the Hawks to the wire. When you're 5-51, losing by five to a 41-win team is basically a moral victory, and moral victories are all Indiana has left. Take the effort. Ignore the record. It's the only way.
+
+**Miami Heat 124 @ New Orleans Pelicans 114**
+<@493176245652291584> · <@669349908989345802>
+
+Miami won another one in the trenches, beating New Orleans 124-114, and the blocked-shot festival continued: Artis Gilmore rejected ELEVEN shots for the Pelicans and still lost, while Bill Laimbeer posted a 20-20 for the Heat and presumably left a few bruises as souvenirs. Danny Granger led Miami with 31, Jrue Holiday added 25 and eight. New Orleans got 30 from Anthony Edwards and Gilmore's 11-block masterpiece, which bought a highlight reel and a loss. The Heat are 35-24 and just keep grinding out wins in the 120s and below. Laimbeer with a 20-20 is exactly the kind of thing that makes you check if it's still 1988.
+
+**Portland Trail Blazers 96 @ Buffalo Braves 139**
+<@339503038232395776> · <@371146882883518486>
+
+Buffalo hammered Portland 139-96, a 43-point demolition, and Devin Booker did it the easy way with 33 points and seven threes. Booker raining seven triples in a blowout is like ordering a third dessert. Nobody needed it. He did it anyway. Andris Biedrins added 16 and 14, Nneka Ogwumike had 18. Portland, which had briefly resembled a basketball team, got 24 and 16 from Bob McAdoo, but Porzingis was a non-factor with just six points, and without the Unicorn there's no reason to watch this team. The Blazers are 8-50. The Braves are 45-20 and have the most bankable bucket-getter in the league. This was never a contest.
+
+**Sacramento Kings 120 @ Las Vegas Aces 122**
+<@792231509872476161> · <@454639880245477377>
+
+The Aces closed the week with another upset, holding off Sacramento 122-120 behind a 29-15 from Spencer Haywood and 24 and 10 from Don Nelson. Vegas beating a winning team twice in one week is a genuine feel-good story for a 18-38 club that doesn't get many. Sacramento was terrific and lost anyway: Blake Griffin went for 33 and 13, Ray Allen added 26, and Nancy Lieberman had 20 and nine assists, and it came down to the final possession. The Kings are 32-26 and this one stings because they did enough to win on most nights. Just not this one. The Aces earned their party.
+
+
+================================================================================
+END — 46 games. Feb 26 – Mar 4, 2008.

--- a/bin/sim-recap-cron-setup
+++ b/bin/sim-recap-cron-setup
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# One-time setup for the sim recap poll cron (Phase 6 of sim-recap-automation plan).
+#
+# Installs a Mac-local launchd LaunchAgent (com.ibl5.sim-recap-poll) that fires
+# the poll-only bash driver bin/sim-recap-tick every 300s via StartInterval —
+# host-durable, poll-only, cheap on empty ticks (zero claude spawns when no new
+# sims are present). The plist Program/WorkingDirectory point at the durable MAIN
+# checkout (never a worktree, which gets torn down after its PR merges).
+#
+# Usage:
+#   bin/sim-recap-cron-setup --print-schedule      # emit the plist to stdout (no side effect; masks DB password)
+#   bin/sim-recap-cron-setup --install-schedule    # install + load the LaunchAgent
+#   bin/sim-recap-cron-setup --uninstall-schedule  # unload + remove the LaunchAgent
+#
+# Install AFTER this lands on master — the launchd Program points at the main
+# checkout's bin/sim-recap-tick, which must exist there.
+#
+# Environment variables read at generation time (must be exported before running
+# --install-schedule):
+#   SIM_RECAP_SSH_HOST      remote host running the sim database
+#   SIM_RECAP_REMOTE_ROOT   root path on the remote host
+#   SIM_RECAP_DB_USER       MySQL user on the remote host
+#   SIM_RECAP_DB_NAME       MySQL database name
+#   SIM_RECAP_DB_PASSWORD   MySQL password (REQUIRED for --install-schedule)
+#
+# No API-key env var is needed — claude uses ambient CLI auth, exactly as the
+# bug-pipeline plist does.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ACTION=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --install-schedule)   ACTION="install";   shift ;;
+    --uninstall-schedule) ACTION="uninstall"; shift ;;
+    --print-schedule)     ACTION="print";     shift ;;
+    -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0"; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+[ -n "$ACTION" ] || { echo "No action given. See --help." >&2; exit 1; }
+
+# --- Durable MAIN-checkout derivation -----------------------------------------
+# Program/WorkingDirectory MUST point at the main checkout, never this worktree
+# (a worktree gets torn down — the LaunchAgent would then point at a dead path).
+# The first `git worktree list` entry is the main working tree.
+MAIN_WT="$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+[ -n "$MAIN_WT" ] || MAIN_WT="$REPO_ROOT"   # fallback: not in a git tree
+
+PLIST_LABEL="com.ibl5.sim-recap-poll"
+PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+LOG_DIR="$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5/sim-recap/logs"
+PROGRAM="$MAIN_WT/bin/sim-recap-tick"
+
+# Single source of truth for the plist — used by both --print-schedule and
+# --install-schedule, so the MAIN-checkout derivation is exercised by tests.
+# $1 = value to embed for SIM_RECAP_DB_PASSWORD ("***" for --print-schedule,
+#      the real value for --install-schedule).
+build_plist() {
+  local db_pw="$1"
+  cat <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${PLIST_LABEL}</string>
+	<key>Program</key>
+	<string>${PROGRAM}</string>
+	<!-- StartInterval: the correct launchd primitive for a repeating poll.
+	     300s is frozen by the decisions digest (D6) — do NOT change it here.
+	     Do NOT "fix" this to a calendar-interval key — that is calendar-only. -->
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>WorkingDirectory</key>
+	<string>${MAIN_WT}</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<!-- launchd agents start with a minimal PATH that omits Homebrew; claude, ssh,
+		     mysql, git must resolve. No API-key env var — claude uses ambient CLI auth. -->
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+		<key>SIM_RECAP_SSH_HOST</key>
+		<string>${SIM_RECAP_SSH_HOST:-}</string>
+		<key>SIM_RECAP_REMOTE_ROOT</key>
+		<string>${SIM_RECAP_REMOTE_ROOT:-}</string>
+		<key>SIM_RECAP_DB_USER</key>
+		<string>${SIM_RECAP_DB_USER:-}</string>
+		<key>SIM_RECAP_DB_NAME</key>
+		<string>${SIM_RECAP_DB_NAME:-}</string>
+		<key>SIM_RECAP_DB_PASSWORD</key>
+		<string>${db_pw}</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>${LOG_DIR}/launchd-stdout.log</string>
+	<key>StandardErrorPath</key>
+	<string>${LOG_DIR}/launchd-stderr.log</string>
+</dict>
+</plist>
+PLIST
+}
+
+case "$ACTION" in
+  print)
+    build_plist "***"
+    ;;
+  install)
+    # Refusal 1 (checked first so both guards are testable from the worktree):
+    # SIM_RECAP_DB_PASSWORD must be set — don't install a job that fails every 300s.
+    if [ -z "${SIM_RECAP_DB_PASSWORD:-}" ]; then
+      echo "Error: SIM_RECAP_DB_PASSWORD is unset. Export it before running --install-schedule." >&2
+      exit 1
+    fi
+    # Refusal 2: must be run from the main checkout — worktrees are torn down after
+    # their PR merges; a plist pointing into one silently stops working.
+    if [ "$REPO_ROOT" != "$MAIN_WT" ]; then
+      echo "Error: --install-schedule must be run from the main checkout (${MAIN_WT})." >&2
+      echo "Current location: ${REPO_ROOT}" >&2
+      echo "cd to ${MAIN_WT} and re-run." >&2
+      exit 1
+    fi
+    mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
+    launchctl bootout "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true  # idempotent: ignore "not loaded"
+    build_plist "$SIM_RECAP_DB_PASSWORD" > "$PLIST_PATH"
+    launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+    echo "Installed ${PLIST_LABEL} (StartInterval 300s). Program: $PROGRAM"
+    ;;
+  uninstall)
+    launchctl bootout "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true  # idempotent
+    rm -f "$PLIST_PATH"                                                    # idempotent: no error if absent
+    echo "Uninstalled ${PLIST_LABEL}."
+    ;;
+esac

--- a/bin/sim-recap-prompt
+++ b/bin/sim-recap-prompt
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# bin/sim-recap-prompt
+#
+# Prints the assembled sim-recap Claude prompt to stdout.
+# Performs NO database access of any kind — the agent that receives this prompt
+# queries live game data itself via mysql.
+#
+# Usage:
+#   bin/sim-recap-prompt --sim=N --mentions=<path> --themes=<path>
+#
+# --mentions JSON shape: {"Team Name": "snowflake-string-or-null", ...}
+#   Keys are teams that played in the sim. Values are Discord snowflakes as
+#   STRINGS (never numbers — values exceed 2^53; see D11) or null for teams
+#   with no Discord ID. Null-value teams render as plain team names.
+#
+# --themes JSON shape: ["narrative angle used", ...] or [] for empty ledger
+#
+# Env seams (SIM_RECAP_* convention):
+#   SIM_RECAP_EXEMPLAR  Path to the pinned exemplar txt file.
+#                       Default: <repo_root>/bin/lib/sim-recap-exemplar.txt
+#   SIM_RECAP_DB_HOST   MySQL host for the agent to connect to. Default: 127.0.0.1
+#   SIM_RECAP_DB_PORT   MySQL port. Default: 13306
+#   SIM_RECAP_DB_USER   MySQL user (no default — must be set in env)
+#   SIM_RECAP_DB_NAME   MySQL database name (no default — must be set in env)
+#
+# The database password is NEVER injected into the prompt. It travels via
+# MYSQL_PWD in the agent's environment. Prompts appear in logs and process
+# arguments; a credential in the prompt text is a credential leaked.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Env seams ---
+SIM_RECAP_EXEMPLAR="${SIM_RECAP_EXEMPLAR:-$REPO_ROOT/bin/lib/sim-recap-exemplar.txt}"
+SIM_RECAP_DB_HOST="${SIM_RECAP_DB_HOST:-127.0.0.1}"
+SIM_RECAP_DB_PORT="${SIM_RECAP_DB_PORT:-13306}"
+SIM_RECAP_DB_USER="${SIM_RECAP_DB_USER:-}"
+SIM_RECAP_DB_NAME="${SIM_RECAP_DB_NAME:-}"
+
+# --- Arg parsing ---
+sim=""
+mentions_path=""
+themes_path=""
+for arg in "$@"; do
+    case "$arg" in
+        --sim=*)      sim="${arg#--sim=}" ;;
+        --mentions=*) mentions_path="${arg#--mentions=}" ;;
+        --themes=*)   themes_path="${arg#--themes=}" ;;
+    esac
+done
+
+# --- Fail closed: exemplar must exist ---
+# Emitting a prompt without the anchor would silently produce off-format output —
+# the worst failure mode available here. Exit 1 instead.
+if [[ ! -f "$SIM_RECAP_EXEMPLAR" ]]; then
+    echo "Error: sim-recap exemplar not found at: $SIM_RECAP_EXEMPLAR" >&2
+    exit 1
+fi
+
+# =============================================================================
+# Block 1: Voice spec (verbatim from /tmp/sim-recap-decisions-digest.md)
+#
+# The original voice spec ends with: "add a standings-context paragraph at the end,
+# as a big wrap-up summary of what transpired during the entire sim."
+#
+# The pinned exemplar (below) opens with WHERE THINGS STAND at the TOP — before any
+# per-game recaps. These contradict. Resolution (plan 2b): the exemplar wins on layout.
+# That single clause is replaced here with the exemplar-authoritative ordering sentence.
+#
+# Do NOT restore "at the end" or any variant. If both instructions reach the model,
+# it emits two standings sections — one at the top and a second at the end.
+# =============================================================================
+cat <<'VOICE_EOF'
+
+== VOICE SPEC ==
+
+on production, the most recent sim results are up. write a summary paragraph for each simmed game, similar to an ESPN-style write-up. write in the voice of Bill Simmons. avoid writing like an LLM (e.g. no em-dashes, short punchy sentences, "it's not this, it's that", "and here's the thing", "load-bearing" – all of those cliché LLM patterns of speech). try to use Simmons' humor (ideally his actually funny humor, not just what's funny to him). whenever you find yourself repeating an old theme, try to tie in a pop culture reference, whether of the player's real-life era, the era the games are simulated in, or of the real-life era of today. these paragraphs will be posted on Discord. before each paragraph, write the team names and the final scores, and on a line below, @mention the GM's of each team. don't list GM names next to the Discord mentions, it will look redundant. use mysql to pull data. ibl_sim_dates holds the dates of the last sim. ibl_box_scores and ibl_box_scores_teams has the raw box score data. ibl_schedule and ibl_standings will tell you the league schedule and where teams are in the standings. ibl_jsb_transactions lists injuries during the sim – mention the injuries in each game when possible. ibl_power contains post-sim win/loss streak information. Use it to call out any long streaks and to know when a big streak was snapped. open with a WHERE THINGS STAND standings-context section at the top of the output, first, before any per-game recaps — the pinned exemplar's ordering is authoritative. here's a sample of what you produced last time – ok to improve, expand upon, or change it for the better. if you don't continuously improve, expand, or change it up, referencing old content to create new content will become an ouroboros and get stale too quickly.
+
+VOICE_EOF
+
+# =============================================================================
+# Block 2: Anti-LLM-tell prohibitions (explicit, by name — user required these)
+# =============================================================================
+cat <<'TELLS_EOF'
+
+== ANTI-LLM-TELL PROHIBITIONS ==
+
+These are hard bans. Not suggestions. Every one of these will get called out if you use them:
+
+  - No em-dashes (—). Not a single one. Use a comma, a period, or restructure the sentence.
+  - No "it's not this, it's that" constructions. Not in any form or disguise.
+  - No "and here's the thing" — not that phrase or anything that works the same way.
+  - Never use the word "load-bearing" under any circumstances.
+  - Short, punchy sentences. If a sentence has more than two clauses, cut it in half.
+
+TELLS_EOF
+
+# =============================================================================
+# Block 3: Data access (expands DB env seams — never expands MYSQL_PWD or any
+# credential. The password travels via MYSQL_PWD in the agent's environment only.)
+# =============================================================================
+cat <<DATA_EOF
+
+== DATA ACCESS ==
+
+Sim number: ${sim}
+
+Query live game data using the mysql client. Connect with:
+
+  mysql -h ${SIM_RECAP_DB_HOST} -P ${SIM_RECAP_DB_PORT} -u ${SIM_RECAP_DB_USER} ${SIM_RECAP_DB_NAME}
+
+The database password is available in your environment as MYSQL_PWD. Do not pass it on
+the command line — mysql reads it from MYSQL_PWD automatically.
+
+Relevant tables:
+
+  ibl_sim_dates         — sim, start_date, end_date (identifies which dates are in this sim)
+  ibl_box_scores        — raw box score data per game
+  ibl_box_scores_teams  — per-team box score lines (scores, player stats)
+  ibl_schedule          — league schedule
+  ibl_standings         — current standings: wins, losses, pct, conference, division,
+                          leagueRecord, confRecord, divRecord, homeRecord, awayRecord,
+                          gamesUnplayed, confMagicNumber, divMagicNumber
+  ibl_jsb_transactions  — injuries and transactions during the sim: injury_games_missed,
+                          injury_description, transaction_type, player_name, from_teamid, to_teamid
+  ibl_power             — post-sim power rankings: ranking, streak_type (W/L), streak length,
+                          sos, remaining_sos
+
+DATA_EOF
+
+# =============================================================================
+# Block 4: Discord mention map
+# Snowflakes rendered as strings via jq -r (never arithmetic, never int-cast —
+# Discord IDs exceed 2^53 and cannot be represented as IEEE 754 doubles).
+# Teams with null values render as plain team names (no angle brackets).
+# =============================================================================
+echo ""
+echo "== DISCORD MENTION MAP =="
+echo ""
+echo "Use these @mentions when writing each game recap."
+echo "Format: away-team-mention · home-team-mention (middle-dot separated, on one line below the score header)."
+echo ""
+
+if [[ -n "$mentions_path" && -f "$mentions_path" ]]; then
+    jq -r 'to_entries[] | if .value == null then .key else "\(.key) → <@\(.value)>" end' \
+        "$mentions_path"
+else
+    echo "(no mentions map provided)"
+fi
+
+echo ""
+
+# =============================================================================
+# Block 5: Themes ledger (narrative angles used in the last 5 sims — avoid them)
+# This is the ONLY anti-repetition input. The agent never sees prior recap prose.
+# An empty ledger builds cleanly — "(none recorded yet)" instead of null or [].
+# =============================================================================
+echo "== THEMES LEDGER =="
+echo ""
+echo "These narrative angles were used in the last five sims. Avoid repeating them:"
+echo ""
+
+if [[ -n "$themes_path" && -f "$themes_path" ]]; then
+    themes_list=$(jq -r '.[]' "$themes_path" 2>/dev/null)
+    if [[ -z "$themes_list" ]]; then
+        echo "(none recorded yet)"
+    else
+        echo "$themes_list" | while IFS= read -r theme; do
+            echo "- $theme"
+        done
+    fi
+else
+    echo "(none recorded yet)"
+fi
+
+echo ""
+
+# =============================================================================
+# Block 6: Output contract
+# Write exactly ONE file to cwd: payload.json satisfying SimRecapPayload::fromJson()
+# =============================================================================
+cat <<'CONTRACT_EOF'
+
+== OUTPUT CONTRACT ==
+
+Write exactly ONE file to your current working directory using the Write tool:
+
+  payload.json
+
+This must be a valid JSON document satisfying SimRecapPayload::fromJson(). Required shape:
+
+{
+  "intro_text": "…",
+  "outro_text": "…",
+  "recap_text": "…",
+  "themes": ["…"],
+  "games": [
+    {
+      "season_year": N,
+      "game_date": "YYYY-MM-DD",
+      "visitor_teamid": N,
+      "home_teamid": N,
+      "game_of_that_day": N,
+      "box_id": N_or_null,
+      "sort_order": N,
+      "recap_text": "…"
+    }
+  ]
+}
+
+Strict field types:
+  - season_year, visitor_teamid, home_teamid, game_of_that_day, sort_order: JSON integers
+  - game_date: non-empty string, format YYYY-MM-DD
+  - recap_text (per game and top-level): non-empty strings
+  - box_id: integer or null
+  - game_of_that_day: use 0 (integer zero, not null) when there was exactly one game on that date
+  - themes: array of strings — narrative angles you used this run (for the next ledger)
+
+Write nothing else, anywhere. One file. payload.json. That is all.
+
+CONTRACT_EOF
+
+# =============================================================================
+# Block 7: Pinned exemplar (authoritative format reference — printed last)
+# This file is the anti-ouroboros anchor: it never absorbs the pipeline's own output.
+# Match its structure, voice, and energy. Do not copy its content.
+# =============================================================================
+cat <<'EXEMPLAR_HEADER_EOF'
+
+== PINNED EXEMPLAR ==
+
+The following is the authoritative format reference. Match its structure exactly:
+  - Title line (e.g. "IBL SIM RECAPS — Month DD – Month DD, YYYY (N games)")
+  - Voice/Format preamble lines
+  - 80-character = separator
+  - WHERE THINGS STAND section (standings, scene-setter) — at the TOP, before game recaps
+  - 80-character = separator
+  - Per date: ================================ Mon DD ========================================= separator
+  - Per game: **Away Team NNN @ Home Team NNN** header (bold), then <@id> · <@id> mentions
+    line (away snowflake · home snowflake, middle-dot separated), then one prose paragraph
+
+Injuries woven into prose. Long streaks called out. Pop culture references tied to the era.
+
+--------------------------------------------------------------------------------
+EXEMPLAR_HEADER_EOF
+
+cat "$SIM_RECAP_EXEMPLAR"
+
+cat <<EXEMPLAR_FOOTER_EOF
+--------------------------------------------------------------------------------
+
+End of pinned exemplar. Write the recap for sim ${sim} now, using live data from the database.
+EXEMPLAR_FOOTER_EOF

--- a/bin/sim-recap-tick
+++ b/bin/sim-recap-tick
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/sim-recap-tick — the poll-only sim-recap pipeline driver (ADR-0092).
+#
+# Fired every 300s by the launchd LaunchAgent (bin/sim-recap-cron-setup). On an
+# EMPTY tick it exits 0 having spawned ZERO `claude` processes — the cost guard,
+# and the property that makes this branch safe to merge ahead of unit 3b (the
+# producer QueueSimSummaryStep is still unregistered, so the queue is always
+# empty and this is the only path the tick ever takes today).
+#
+# Trust split (ADR-0092): the Mac holds ONE credential — a SELECT-only MySQL
+# user reached over an SSH tunnel — handed only to the generation agent for game
+# data. Every privileged queue action is a prod-side `ssh php simRecapQueue.php`
+# call the agent cannot make (claiming a row is an UPDATE the read-only user is
+# refused). All *_id fields are read as STRINGS with `jq -r` (snowflake rule).
+#
+# NOT set -e: one sim's failure must never abort the tick before its park branch
+# runs. Backoff and stale-lease timers are computed SERVER-side by parkOrFail /
+# reclaimStaleClaim, so this file needs no local timestamp math.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Env seams (default to production values; the test harness overrides) ───────
+SIM_RECAP_SSH_BIN="${SIM_RECAP_SSH_BIN:-ssh}"
+SIM_RECAP_JQ_BIN="${SIM_RECAP_JQ_BIN:-jq}"
+SIM_RECAP_CLAUDE_BIN="${SIM_RECAP_CLAUDE_BIN:-claude}"
+SIM_RECAP_PROMPT_BIN="${SIM_RECAP_PROMPT_BIN:-$REPO_ROOT/bin/sim-recap-prompt}"
+SIM_RECAP_SSH_HOST="${SIM_RECAP_SSH_HOST:-}"
+SIM_RECAP_REMOTE_ROOT="${SIM_RECAP_REMOTE_ROOT:-}"
+SIM_RECAP_MODEL="${SIM_RECAP_MODEL:-claude-opus-4-8}"
+SIM_RECAP_CLAUDE_TIMEOUT="${SIM_RECAP_CLAUDE_TIMEOUT:-1800}"
+SIM_RECAP_DB_HOST="${SIM_RECAP_DB_HOST:-127.0.0.1}"
+SIM_RECAP_DB_PORT="${SIM_RECAP_DB_PORT:-13306}"
+SIM_RECAP_DB_USER="${SIM_RECAP_DB_USER:-}"
+SIM_RECAP_DB_NAME="${SIM_RECAP_DB_NAME:-}"
+# SIM_RECAP_DB_PASSWORD is read from the environment ONLY (never defaulted, never
+# argv, never logged). require_password() enforces its presence on the live path.
+
+# The prompt builder reads the DB coordinates from its environment (never the
+# password — that reaches the agent through MYSQL_PWD at spawn time).
+export SIM_RECAP_DB_HOST SIM_RECAP_DB_PORT SIM_RECAP_DB_USER SIM_RECAP_DB_NAME
+
+# ── Per-run temp working dir (security constraint 7 / ADR-0062) ───────────────
+# Global so the EXIT trap can see it; assigned in generate()/dry_run().
+WORKDIR=""
+cleanup_workdir() {
+    [ -n "${SIM_RECAP_KEEP_WORKDIR:-}" ] && return 0
+    [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"
+    return 0
+}
+trap cleanup_workdir EXIT
+
+# ── Logging (prints messages, never the environment) ──────────────────────────
+# Diagnostics go to stderr, never stdout: in --dry-run stdout carries the
+# generated payload.json alone (a clean, pipeable document — row 60/61), so no
+# log line may interleave with it. launchd captures both streams in live mode.
+log() { printf '[%s] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" >&2; }
+
+# ── Usage/rate-limit detector (regex copied from bin/bug-pipeline-tick:76-79) ──
+claude_env_error() {
+    printf '%s' "$1" | grep -qiE \
+        "hit your [a-z0-9 -]*limit|usage limit reached|api error:[[:space:]]*(401|403|429|529)|overloaded_error|rate_limit_error"
+}
+
+# ── One seam for every prod-side queue call ───────────────────────────────────
+# q <verb> [flags...] -> one JSON object on stdout.
+q() {
+    "$SIM_RECAP_SSH_BIN" "$SIM_RECAP_SSH_HOST" \
+        "php $SIM_RECAP_REMOTE_ROOT/ibl5/scripts/simRecapQueue.php $*"
+}
+
+# jq_ok <json> <filter> -> true when the filter succeeds (fail-closed on garbage).
+jq_ok() { printf '%s' "$1" | "$SIM_RECAP_JQ_BIN" -e "$2" >/dev/null 2>&1; }
+
+# Refuse to run the live path without the one credential, BEFORE any ssh/agent.
+require_password() {
+    if [ -z "${SIM_RECAP_DB_PASSWORD:-}" ]; then
+        log "ERROR: SIM_RECAP_DB_PASSWORD is unset — refusing to run (it belongs in the launchd plist EnvironmentVariables)"
+        exit 1
+    fi
+}
+
+# ── Park a failed sim, branching on the three-valued queue outcome ────────────
+# 'none' is a DISTINCT outcome (lost claim — another run owns the sim now), not
+# an error and not a retry. Never collapse it into a failure path.
+park() { # sim
+    local sim="$1" resp outcome
+    resp="$(q park --sim="$sim")"
+    outcome="$(printf '%s' "$resp" | "$SIM_RECAP_JQ_BIN" -r '.outcome // empty' 2>/dev/null)"
+    case "$outcome" in
+        pending) log "sim $sim: parked — re-queued with backoff; a later tick retries" ;;
+        failed)  log "sim $sim: parked FAILED — attempt ceiling reached; terminal" ;;
+        none)    log "sim $sim: park returned 'none' — lost the claim; another run owns it now, stopping" ;;
+        *)       log "sim $sim: park returned an unexpected outcome '$outcome'" ;;
+    esac
+    return 0
+}
+
+# ── Fetch the two DB-derived inputs the agent gets, into the workdir ──────────
+# Returns non-zero if either fetch is unusable, so the caller can park.
+fetch_agent_inputs() { # sim  (writes mentions.json + themes-ledger.json into WORKDIR)
+    local sim="$1" mm rt
+    mm="$(q mention-map)"
+    if ! jq_ok "$mm" '.ok == true'; then
+        log "sim $sim: mention-map fetch failed"
+        return 1
+    fi
+    printf '%s' "$mm" | "$SIM_RECAP_JQ_BIN" '.teams' > "$WORKDIR/mentions.json" 2>/dev/null
+
+    rt="$(q recent-themes)"
+    if ! jq_ok "$rt" '.ok == true'; then
+        log "sim $sim: recent-themes fetch failed"
+        return 1
+    fi
+    # .themes is a flat JSON array of strings — string-safe by construction.
+    printf '%s' "$rt" | "$SIM_RECAP_JQ_BIN" '.themes' > "$WORKDIR/themes-ledger.json" 2>/dev/null
+    return 0
+}
+
+# ── Run the generation agent in the temp dir; leaves payload.json on success ──
+run_agent() { # sim prompt
+    local sim="$1" prompt="$2"
+    # --allowedTools is the STRUCTURAL enforcement of security constraint 2: with
+    # only Bash(mysql:*) and Write, the agent has no ssh, no curl, no gh. The
+    # password reaches it via MYSQL_PWD in this subshell env — never in the prompt,
+    # never in argv, never logged.
+    ( cd "$WORKDIR" && MYSQL_PWD="${SIM_RECAP_DB_PASSWORD:-}" \
+        timeout "$SIM_RECAP_CLAUDE_TIMEOUT" "$SIM_RECAP_CLAUDE_BIN" -p "$prompt" \
+            --model "$SIM_RECAP_MODEL" --output-format json \
+            --allowedTools "Bash(mysql:*)" "Write" ) > "$WORKDIR/agent.json" 2>&1
+    return $?
+}
+
+# ── generate <sim> — inject, prompt, run agent, store or park ─────────────────
+generate() { # sim
+    local sim="$1"
+    WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/sim-recap-XXXXXX")"
+    log "workdir $WORKDIR for sim $sim"
+
+    if ! fetch_agent_inputs "$sim"; then
+        park "$sim"; return 0
+    fi
+
+    local prompt
+    if ! prompt="$("$SIM_RECAP_PROMPT_BIN" --sim="$sim" \
+            --mentions="$WORKDIR/mentions.json" --themes="$WORKDIR/themes-ledger.json")"; then
+        log "sim $sim: prompt build failed (missing exemplar?) — parking"
+        park "$sim"; return 0
+    fi
+
+    local agent_rc
+    run_agent "$sim" "$prompt"; agent_rc=$?
+
+    if claude_env_error "$(cat "$WORKDIR/agent.json" 2>/dev/null)"; then
+        log "sim $sim: agent hit a usage limit — parking with a backoff"
+        park "$sim"; return 0
+    fi
+
+    if [ ! -f "$WORKDIR/payload.json" ] || \
+       ! "$SIM_RECAP_JQ_BIN" -e '(.games | type == "array") and (.games | length > 0)' \
+            "$WORKDIR/payload.json" >/dev/null 2>&1; then
+        log "sim $sim: agent produced no valid payload.json (rc=$agent_rc) — parking"
+        park "$sim"; return 0
+    fi
+
+    # Store: pipe the payload on stdin (never argv — multi-KB, ps-visible).
+    local store store_rc
+    store="$("$SIM_RECAP_SSH_BIN" "$SIM_RECAP_SSH_HOST" \
+        "php $SIM_RECAP_REMOTE_ROOT/ibl5/scripts/storeSimRecap.php --sim=$sim" \
+        < "$WORKDIR/payload.json" 2>&1)"
+    store_rc=$?
+    if [ "$store_rc" -eq 0 ] && jq_ok "$store" '.ok == true'; then
+        log "sim $sim: stored ($(printf '%s' "$store" | "$SIM_RECAP_JQ_BIN" -r '.games' 2>/dev/null) game recaps)"
+        return 0
+    fi
+    log "sim $sim: store failed (rc=$store_rc): $store — parking"
+    park "$sim"
+    return 0
+}
+
+# ── --dry-run --sim=N — regenerate for tuning; touches NO queue row, NO DB write.
+# Fetches read-only inputs, runs the agent, prints the complete payload.json to
+# stdout (themes included, under .themes). Never claims, parks, stores, or posts.
+dry_run() {
+    local sim="$DRY_SIM"
+    if [ -z "$sim" ] || ! printf '%s' "$sim" | grep -qE '^[0-9]+$'; then
+        log "ERROR: --dry-run requires an explicit --sim=N (it never chooses a sim implicitly)"
+        exit 1
+    fi
+    WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/sim-recap-XXXXXX")"
+    log "workdir $WORKDIR for dry-run sim $sim"
+
+    # Read-only fetches only; a failure here is not worth parking a row we don't own.
+    fetch_agent_inputs "$sim" || true
+    [ -f "$WORKDIR/mentions.json" ] || printf '{}' > "$WORKDIR/mentions.json"
+    [ -f "$WORKDIR/themes-ledger.json" ] || printf '[]' > "$WORKDIR/themes-ledger.json"
+
+    local prompt
+    if ! prompt="$("$SIM_RECAP_PROMPT_BIN" --sim="$sim" \
+            --mentions="$WORKDIR/mentions.json" --themes="$WORKDIR/themes-ledger.json")"; then
+        log "dry-run sim $sim: prompt build failed (missing exemplar?)"
+        exit 1
+    fi
+
+    run_agent "$sim" "$prompt"
+
+    if [ ! -f "$WORKDIR/payload.json" ]; then
+        log "dry-run sim $sim: agent produced no payload.json"
+        exit 1
+    fi
+    # stdout carries the complete generated document, pretty-printed: a human
+    # reads it against the exemplar (row 60) and 3b's contract test pipes it
+    # through SimRecapPayload::fromJson() (row 61). Themes live inside .themes of
+    # this same payload, so there is nothing to echo separately — one channel,
+    # one document. All diagnostics have gone to stderr via log().
+    "$SIM_RECAP_JQ_BIN" '.' "$WORKDIR/payload.json"
+    return 0
+}
+
+# ── main — flag parse, then the claim loop with the empty-tick invariant ──────
+main() {
+    local DRY_RUN=0
+    DRY_SIM=""
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            --dry-run) DRY_RUN=1 ;;
+            --sim=*)   DRY_SIM="${arg#--sim=}" ;;
+            *) log "unknown argument: $arg"; exit 2 ;;
+        esac
+    done
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        dry_run
+        return $?
+    fi
+
+    # Live path: refuse without the credential BEFORE any ssh or agent call.
+    require_password
+
+    # Reclaim first, unconditionally — a crashed run's sim is recoverable on the
+    # very next tick. Rides the multiplexed ssh connection, so ~tens of ms.
+    local rec sim_rec
+    rec="$(q reclaim-stale)"
+    if jq_ok "$rec" '.ok == true'; then
+        sim_rec="$(printf '%s' "$rec" | "$SIM_RECAP_JQ_BIN" -r '.sim // empty' 2>/dev/null)"
+        [ -n "$sim_rec" ] && [ "$sim_rec" != "null" ] && \
+            log "reclaimed stale sim $sim_rec back to pending"
+    fi
+
+    local claim normalized sim
+    claim="$(q claim-next)"
+    normalized="$(printf '%s' "$claim" | tr -d '[:space:]')"
+
+    # ★ EMPTY-TICK COST GUARD — no work, spawn zero `claude`, exit cheap.
+    if [ -z "$normalized" ]; then
+        log "no pending sim — exiting cheap"
+        return 0
+    fi
+
+    # Fail-closed: a truncated ssh, an HTML error page, or a stub returning
+    # garbage must NOT be parsed into a bogus sim number and spawn the agent.
+    if ! jq_ok "$claim" 'type == "object" and .ok == true'; then
+        log "ERROR: claim-next did not return a valid queue object — aborting tick (no claude spawned)"
+        return 1
+    fi
+
+    sim="$(printf '%s' "$claim" | "$SIM_RECAP_JQ_BIN" -r '.sim // empty' 2>/dev/null)"
+    if [ -z "$sim" ] || [ "$sim" = "null" ]; then
+        log "no pending sim — exiting cheap"
+        return 0
+    fi
+
+    log "claimed sim $sim"
+    generate "$sim"
+}
+
+main "$@"

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-sim-recap-tick — harness for bin/sim-recap-tick (tick cases) and
+# bin/sim-recap-prompt (prompt cases).
+#
+# Stubs for ssh/claude/sim-recap-prompt are injected via env seams only —
+# no PATH modification.  jq is real.
+#
+# Run: bin/test-sim-recap-tick  (exit 0 = all pass, 1 = failures)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRT_DRIVER="$SCRIPT_DIR/sim-recap-tick"
+SRT_PROMPT_BIN="$SCRIPT_DIR/sim-recap-prompt"
+SRT_EXEMPLAR="$SCRIPT_DIR/lib/sim-recap-exemplar.txt"
+
+FAILED=0
+SRT_RC=0
+SRT_PROMPT_RC=0
+
+srt_ok()   { echo "ok: $1"; }
+srt_fail() { echo "FAIL: $1"; FAILED=1; }
+
+# srt_expect_eq <name> <want> <got>
+srt_expect_eq() {
+    if [ "$2" = "$3" ]; then srt_ok "$1"
+    else srt_fail "$1 — want [$2] got [$3]"; fi
+}
+# srt_log_has   <stub-dir> <file> <pattern> <name>
+# srt_log_lacks <stub-dir> <file> <pattern> <name>
+srt_log_has() {
+    if grep -qF -- "$3" "$1/$2" 2>/dev/null; then srt_ok "$4"
+    else srt_fail "$4 — '$3' absent from $2"; fi
+}
+srt_log_lacks() {
+    if grep -qF -- "$3" "$1/$2" 2>/dev/null; then srt_fail "$4 — '$3' unexpectedly present in $2"
+    else srt_ok "$4"; fi
+}
+# srt_file_absent <path> <name>
+srt_file_absent() {
+    if [ -e "$1" ]; then srt_fail "$2 — $1 exists"
+    else srt_ok "$2"; fi
+}
+# srt_count <name> <want> <file>  — count non-blank lines
+srt_count() {
+    local got
+    got="$(grep -c . "$3" 2>/dev/null)"
+    srt_expect_eq "$1" "$2" "${got:-0}"
+}
+
+# ── One-time scaffolding ───────────────────────────────────────────────────────
+srt_setup() {
+    STUB="$(mktemp -d)"
+    trap 'rm -rf "$STUB"' EXIT
+
+    # ssh stub: log every call; dispatch on storeSimRecap.php vs verb.
+    # $STUB is exported and available to the stub at exec time.
+    cat > "$STUB/ssh" <<'SH'
+#!/usr/bin/env bash
+echo "$*" >> "$STUB/ssh.log"
+cmd="$2"
+if printf '%s' "$cmd" | grep -q 'storeSimRecap\.php'; then
+    if [ -f "$STUB/store-fails" ]; then
+        printf '{"ok":false,"error":"stub store failure"}\n'
+        exit 1
+    fi
+    cat "$STUB/resp.store" 2>/dev/null || printf '{"ok":true,"sim":42,"games":5}\n'
+    exit 0
+fi
+verb=$(printf '%s' "$cmd" | grep -oE 'simRecapQueue\.php [a-z-]+' | awk '{print $2}')
+if [ -f "$STUB/resp.$verb" ]; then
+    cat "$STUB/resp.$verb"
+else
+    case "$verb" in
+        reclaim-stale) printf '{"ok":true,"cmd":"reclaim-stale","sim":null}\n' ;;
+        claim-next)    printf '{"ok":true,"cmd":"claim-next","sim":null}\n' ;;
+        mention-map)   printf '{"ok":true,"cmd":"mention-map","teams":{}}\n' ;;
+        recent-themes) printf '{"ok":true,"cmd":"recent-themes","themes":[]}\n' ;;
+        park)          printf '{"ok":true,"cmd":"park","sim":42,"outcome":"pending"}\n' ;;
+        *)             printf '{"error":"unknown verb %s"}\n' "$verb"; exit 1 ;;
+    esac
+fi
+SH
+
+    # claude stub: touch sentinel, log call; write valid payload.json unless
+    # agent-fails is set; emit usage-limit line when agent-usage-limit is set.
+    cat > "$STUB/claude" <<'SH'
+#!/usr/bin/env bash
+echo "claude $*" >> "$STUB/claude.log"
+touch "$STUB/claude.sentinel"
+if [ -f "$STUB/agent-usage-limit" ]; then
+    printf 'api error: 429 rate_limit_error\n'
+    exit 0
+fi
+if [ ! -f "$STUB/agent-fails" ]; then
+    printf '%s\n' \
+        '{"intro_text":"intro","outro_text":"outro","recap_text":"recap",' \
+        '"themes":["theme1"],' \
+        '"games":[{"season_year":2008,"game_date":"2026-07-23",' \
+        '"visitor_teamid":1,"home_teamid":2,"game_of_that_day":0,' \
+        '"box_id":null,"sort_order":1,"recap_text":"game recap"}]}' \
+        | tr -d '\n' > payload.json
+fi
+exit 0
+SH
+
+    # sim-recap-prompt stub: echo a fixed marker (tick plumbing only).
+    cat > "$STUB/prompt" <<'SH'
+#!/usr/bin/env bash
+printf 'PROMPT_MARKER_SIM_RECAP\n'
+SH
+
+    chmod +x "$STUB/ssh" "$STUB/claude" "$STUB/prompt"
+
+    export STUB
+    export SIM_RECAP_SSH_BIN="$STUB/ssh"
+    export SIM_RECAP_CLAUDE_BIN="$STUB/claude"
+    export SIM_RECAP_PROMPT_BIN="$STUB/prompt"
+    export SIM_RECAP_SSH_HOST="test-host"
+    export SIM_RECAP_REMOTE_ROOT=""
+    export SIM_RECAP_DB_HOST="127.0.0.1"
+    export SIM_RECAP_DB_PORT="13306"
+    export SIM_RECAP_DB_USER="testuser"
+    export SIM_RECAP_DB_NAME="testdb"
+    export SIM_RECAP_DB_PASSWORD="test_db_password"
+    export SIM_RECAP_MODEL="test-model"
+    export SIM_RECAP_CLAUDE_TIMEOUT="30"
+}
+
+# Per-case reset: wipe logs and all per-case control sentinels.
+srt_reset() {
+    rm -f "$STUB"/ssh.log "$STUB"/claude.log "$STUB"/claude.sentinel \
+          "$STUB"/tick.out "$STUB"/agent-fails "$STUB"/agent-usage-limit \
+          "$STUB"/store-fails "$STUB"/resp.* 2>/dev/null
+    export SIM_RECAP_DB_PASSWORD="test_db_password"
+    unset SIM_RECAP_KEEP_WORKDIR 2>/dev/null || true
+}
+
+# srt_run [args…] — invoke the tick with combined stdout+stderr → tick.out.
+srt_run() {
+    "$SRT_DRIVER" "$@" > "$STUB/tick.out" 2>&1
+    SRT_RC=$?
+}
+
+srt_setup
+
+# ══ TICK CASES ════════════════════════════════════════════════════════════════
+
+# ── empty_tick_exits_zero / empty_tick_spawns_zero_claude /
+#    empty_tick_logs_cheap_exit / claim_next_null_short_circuits
+# Default claim-next → {"ok":true,"cmd":"claim-next","sim":null}
+srt_reset
+srt_run
+srt_expect_eq "empty_tick_exits_zero" 0 "$SRT_RC"
+srt_file_absent "$STUB/claude.sentinel" "empty_tick_spawns_zero_claude"
+srt_log_has "$STUB" tick.out "no pending sim — exiting cheap" "empty_tick_logs_cheap_exit"
+# Same run: valid JSON object with null sim still short-circuits (no claude)
+srt_file_absent "$STUB/claude.sentinel" "claim_next_null_short_circuits"
+
+# ── whitespace_payload_is_empty ───────────────────────────────────────────────
+srt_reset
+printf '  \n ' > "$STUB/resp.claim-next"
+srt_run
+srt_expect_eq "whitespace_payload_is_empty" 0 "$SRT_RC"
+srt_file_absent "$STUB/claude.sentinel" "whitespace_payload_is_empty — zero claude"
+
+# ── malformed_queue_json_fails_closed ─────────────────────────────────────────
+srt_reset
+printf 'not json at all' > "$STUB/resp.claim-next"
+srt_run
+srt_expect_eq "malformed_queue_json_fails_closed" 1 "$SRT_RC"
+srt_file_absent "$STUB/claude.sentinel" "malformed_queue_json_fails_closed — no claude"
+
+# ── pending_sim_dispatches_one_claude ─────────────────────────────────────────
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+srt_run
+srt_count "pending_sim_dispatches_one_claude" 1 "$STUB/claude.log"
+
+# ── stale_reclaim_fires ───────────────────────────────────────────────────────
+# reclaim-stale returns a non-null sim; claim-next still returns null (cheap exit)
+srt_reset
+printf '{"ok":true,"cmd":"reclaim-stale","sim":"7"}' > "$STUB/resp.reclaim-stale"
+srt_run
+r_line="$(grep -n "reclaim-stale" "$STUB/ssh.log" 2>/dev/null | head -1 | cut -d: -f1)"
+c_line="$(grep -n "claim-next"    "$STUB/ssh.log" 2>/dev/null | head -1 | cut -d: -f1)"
+if [ -n "$r_line" ] && [ -n "$c_line" ] && [ "$r_line" -lt "$c_line" ]; then
+    srt_ok "stale_reclaim_fires — reclaim-stale before claim-next in ssh.log"
+else
+    srt_fail "stale_reclaim_fires — reclaim-stale not before claim-next (r:${r_line:-?} c:${c_line:-?})"
+fi
+srt_log_has "$STUB" tick.out "reclaimed stale sim 7" "stale_reclaim_fires — logged reclaim"
+
+# ── park_none_is_distinct ─────────────────────────────────────────────────────
+# outcome "none" → exit 0, "lost the claim" log, NO store call
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+touch "$STUB/agent-fails"
+printf '{"ok":true,"cmd":"park","sim":42,"outcome":"none"}' > "$STUB/resp.park"
+srt_run
+srt_expect_eq "park_none_is_distinct — exit 0" 0 "$SRT_RC"
+srt_log_has  "$STUB" tick.out "lost the claim" "park_none_is_distinct — lost-claim log line"
+srt_log_lacks "$STUB" ssh.log "storeSimRecap"  "park_none_is_distinct — no store call"
+
+# ── park_failed_is_terminal ───────────────────────────────────────────────────
+# outcome "failed" → exit 0, "terminal" log line
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+touch "$STUB/agent-fails"
+printf '{"ok":true,"cmd":"park","sim":42,"outcome":"failed"}' > "$STUB/resp.park"
+srt_run
+srt_expect_eq "park_failed_is_terminal — exit 0" 0 "$SRT_RC"
+srt_log_has "$STUB" tick.out "terminal" "park_failed_is_terminal — terminal log line"
+
+# ── missing_payload_parks_not_stores ─────────────────────────────────────────
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+touch "$STUB/agent-fails"
+srt_run
+srt_log_has  "$STUB" ssh.log "park"         "missing_payload_parks_not_stores — park in ssh.log"
+srt_log_lacks "$STUB" ssh.log "storeSimRecap" "missing_payload_parks_not_stores — no store"
+
+# ── usage_limit_parks_with_reason ─────────────────────────────────────────────
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+touch "$STUB/agent-usage-limit"
+srt_run
+srt_log_has "$STUB" tick.out "usage limit" "usage_limit_parks_with_reason — logged"
+srt_log_has "$STUB" ssh.log  "park"        "usage_limit_parks_with_reason — park in ssh.log"
+
+# ── dry_run_touches_nothing ───────────────────────────────────────────────────
+# --dry-run --sim=N: calls mention-map/recent-themes (read-only) but NO
+# claim-next, park, or storeSimRecap.
+srt_reset
+srt_run --dry-run --sim=42
+srt_log_has  "$STUB" ssh.log "mention-map"   "dry_run_touches_nothing — mention-map"
+srt_log_has  "$STUB" ssh.log "recent-themes" "dry_run_touches_nothing — recent-themes"
+srt_log_lacks "$STUB" ssh.log "claim-next"    "dry_run_touches_nothing — no claim-next"
+srt_log_lacks "$STUB" ssh.log "park"          "dry_run_touches_nothing — no park"
+srt_log_lacks "$STUB" ssh.log "storeSimRecap" "dry_run_touches_nothing — no store"
+
+# ── dry_run_requires_sim ──────────────────────────────────────────────────────
+srt_reset
+"$SRT_DRIVER" --dry-run > "$STUB/tick.out" 2>&1
+SRT_RC=$?
+srt_expect_eq "dry_run_requires_sim" 1 "$SRT_RC"
+
+# ── workdir_removed_on_success ────────────────────────────────────────────────
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+srt_run
+_wd="$(sed -n 's/.*\] workdir \(\/[^ ]*\) .*/\1/p' "$STUB/tick.out" | head -1)"
+if [ -z "$_wd" ]; then
+    srt_fail "workdir_removed_on_success — workdir path not found in tick.out"
+elif [ -d "$_wd" ]; then
+    srt_fail "workdir_removed_on_success — workdir still exists: $_wd"
+else
+    srt_ok "workdir_removed_on_success"
+fi
+
+# ── workdir_removed_on_failure ────────────────────────────────────────────────
+# Drive via store failure: workdir is created, store fails, park is called,
+# EXIT trap still fires and removes the workdir.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+touch "$STUB/store-fails"
+srt_run
+_wd="$(sed -n 's/.*\] workdir \(\/[^ ]*\) .*/\1/p' "$STUB/tick.out" | head -1)"
+if [ -z "$_wd" ]; then
+    srt_fail "workdir_removed_on_failure — workdir path not found in tick.out"
+elif [ -d "$_wd" ]; then
+    srt_fail "workdir_removed_on_failure — workdir still exists: $_wd"
+else
+    srt_ok "workdir_removed_on_failure"
+fi
+
+# ── missing_password_exits_before_ssh ────────────────────────────────────────
+srt_reset
+( unset SIM_RECAP_DB_PASSWORD; "$SRT_DRIVER" > "$STUB/tick.out" 2>&1 )
+SRT_RC=$?
+srt_expect_eq "missing_password_exits_before_ssh — exit 1" 1 "$SRT_RC"
+srt_file_absent "$STUB/ssh.log" "missing_password_exits_before_ssh — no ssh called"
+
+# ── password_never_logged ─────────────────────────────────────────────────────
+# Use a claimed sim so more code paths run; sentinel value must not appear in output.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+touch "$STUB/agent-fails"
+export SIM_RECAP_DB_PASSWORD="hunter2_sentinel_xyz"
+srt_run
+export SIM_RECAP_DB_PASSWORD="test_db_password"
+srt_log_lacks "$STUB" tick.out "hunter2_sentinel_xyz" "password_never_logged"
+
+# ── seams_resolve_from_env ────────────────────────────────────────────────────
+# Full generation path: every stub reached via env seam, no PATH modification.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+srt_run
+srt_expect_eq "seams_resolve_from_env — exit 0" 0 "$SRT_RC"
+srt_log_has "$STUB" ssh.log "mention-map" "seams_resolve_from_env — ssh stub reached"
+if [ -f "$STUB/claude.sentinel" ]; then
+    srt_ok "seams_resolve_from_env — claude stub reached"
+else
+    srt_fail "seams_resolve_from_env — claude stub not reached"
+fi
+
+# ── no_plist_committed ────────────────────────────────────────────────────────
+_repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+_plist_count="$(git -C "$_repo_root" ls-files '*.plist' 2>/dev/null | wc -l | tr -d ' ')"
+if [ "${_plist_count:-0}" -eq 0 ]; then
+    srt_ok "no_plist_committed"
+else
+    srt_fail "no_plist_committed — found: $(git -C "$_repo_root" ls-files '*.plist')"
+fi
+
+# ══ PROMPT GROUP — real bin/sim-recap-prompt ══════════════════════════════════
+
+_FIX="$STUB/fixtures"
+mkdir -p "$_FIX"
+printf '{"Team Alpha": "123456789012345678", "Team Beta": "987654321098765432"}' \
+    > "$_FIX/mentions.json"
+printf '["past theme one", "past theme two"]'    > "$_FIX/themes.json"
+printf '{"Known Team": "123456789012345678", "Unknown Team": null}' \
+    > "$_FIX/mentions-unmapped.json"
+printf '[]' > "$_FIX/themes-empty.json"
+
+# Run the real builder; output → prompt.out, errors → prompt.err.
+run_prompt() {
+    SIM_RECAP_EXEMPLAR="$SRT_EXEMPLAR" \
+        "$SRT_PROMPT_BIN" "$@" > "$STUB/prompt.out" 2>"$STUB/prompt.err"
+    SRT_PROMPT_RC=$?
+}
+
+# ── exemplar_embedded ─────────────────────────────────────────────────────────
+run_prompt --sim=1 --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json"
+srt_log_has "$STUB" prompt.out "WHERE THINGS STAND" "exemplar_embedded — WHERE THINGS STAND"
+srt_log_has "$STUB" prompt.out "===== "             "exemplar_embedded — date separator"
+
+# ── anti_tell_list_present ────────────────────────────────────────────────────
+# Reuse same output from exemplar_embedded run.
+srt_log_has "$STUB" prompt.out "load-bearing"          "anti_tell_list_present — load-bearing"
+srt_log_has "$STUB" prompt.out "em-dash"               "anti_tell_list_present — em-dash"
+srt_log_has "$STUB" prompt.out "and here's the thing"  "anti_tell_list_present — and here's the thing"
+
+# ── standings_placement_singular ─────────────────────────────────────────────
+srt_log_has  "$STUB" prompt.out "before any per-game recaps" \
+    "standings_placement_singular — exemplar-authoritative ordering present"
+srt_log_lacks "$STUB" prompt.out "paragraph at the end" \
+    "standings_placement_singular — superseded 'at the end' phrasing absent"
+
+# ── mentions_render_as_strings ────────────────────────────────────────────────
+# Snowflake digit-for-digit in output (same run, but rerun for clarity).
+run_prompt --sim=1 --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json"
+srt_log_has "$STUB" prompt.out "123456789012345678" \
+    "mentions_render_as_strings — snowflake digit-for-digit"
+
+# ── negative_unmapped_team ────────────────────────────────────────────────────
+run_prompt --sim=1 --mentions="$_FIX/mentions-unmapped.json" --themes="$_FIX/themes.json"
+srt_log_has  "$STUB" prompt.out "Unknown Team" "negative_unmapped_team — plain name present"
+srt_log_lacks "$STUB" prompt.out "<@>"          "negative_unmapped_team — no empty mention tag"
+srt_log_lacks "$STUB" prompt.out "<@null>"      "negative_unmapped_team — no null mention tag"
+
+# ── negative_empty_ledger ─────────────────────────────────────────────────────
+run_prompt --sim=1 --mentions="$_FIX/mentions.json" --themes="$_FIX/themes-empty.json"
+srt_log_has "$STUB" prompt.out "(none recorded yet)" \
+    "negative_empty_ledger — none-recorded-yet for empty themes"
+
+# ── negative_missing_exemplar ─────────────────────────────────────────────────
+SIM_RECAP_EXEMPLAR="/nonexistent/exemplar.txt" \
+    "$SRT_PROMPT_BIN" --sim=1 \
+    --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json" \
+    > "$STUB/prompt.out" 2>"$STUB/prompt.err"
+SRT_PROMPT_RC=$?
+srt_expect_eq "negative_missing_exemplar — exit 1" 1 "$SRT_PROMPT_RC"
+_stdout_size="$(wc -c < "$STUB/prompt.out" | tr -d ' ')"
+srt_expect_eq "negative_missing_exemplar — empty stdout" "0" "$_stdout_size"
+
+# ── negative_no_credential_leak ───────────────────────────────────────────────
+# MYSQL_PWD value must not appear in any stdout (the var name 'MYSQL_PWD' may appear).
+MYSQL_PWD="s3cr3t_pw_xyz" SIM_RECAP_EXEMPLAR="$SRT_EXEMPLAR" \
+    "$SRT_PROMPT_BIN" --sim=1 \
+    --mentions="$_FIX/mentions.json" --themes="$_FIX/themes.json" \
+    > "$STUB/prompt.out" 2>"$STUB/prompt.err"
+srt_log_lacks "$STUB" prompt.out "s3cr3t_pw_xyz" "negative_no_credential_leak"
+
+echo "----"
+[ "$FAILED" -eq 0 ] && echo "ALL PASS" || echo "FAILURES"
+exit "$FAILED"

--- a/ibl5/docs/decisions/0093-autonomous-agent-production-read-credential.md
+++ b/ibl5/docs/decisions/0093-autonomous-agent-production-read-credential.md
@@ -1,0 +1,53 @@
+---
+description: An unattended agent is given a production-reaching credential safely by starving it to one SELECT-only MySQL user over an SSH tunnel while every privileged write happens prod-side behind a CLI guard.
+last_verified: 2026-07-23
+---
+
+# ADR-0093: An autonomous agent holding a production read-only credential
+
+**Status:** Accepted
+**Date:** 2026-07-23
+
+## Context
+
+An autonomous `claude` agent, spawned unattended by a launchd poll on a personal Mac, must generate sim recaps from live league data — which means it must reach the **production** database. That is a materially new trust case: the Mac-local pipeline of ADR-0080 and the starved-environment sandbox of ADR-0081 both let their agent reach only a *local Docker* database, where a compromised or prompt-injected agent can do nothing that matters. Here the same topology points at production, so the question the pipeline could previously ignore — what, exactly, can this agent do with the credential it holds? — has to be answered structurally rather than by trust. The measurement of that answer (a live spike against the production grant surface) is recorded below.
+
+## Decision
+
+The agent is made **incapable by construction**, not trusted to behave. Four structural properties, each enforced by a named mechanism rather than a convention:
+
+1. **The agent is credential-starved.** It receives exactly one credential — a `SELECT`-only MySQL user reached over an SSH tunnel, passed only through `MYSQL_PWD` in the agent's environment — and `--allowedTools` is limited to `Bash(mysql:*)` and `Write`. It has no Discord, no `ssh`, and no write path of any kind. Reading game data is the *whole* of what the credential can do.
+2. **Every privileged action happens prod-side**, performed by CLI-guarded scripts the agent cannot invoke. `ibl5/scripts/simRecapQueue.php` drives the queue (claiming a row is an `UPDATE`, which the read-only user cannot perform at all) and `ibl5/scripts/storeSimRecap.php` writes the recap; each carries a `PHP_SAPI !== 'cli'` guard as its first executable statement and an `ibl5/scripts/.htaccess` file-scoped deny behind it. The Mac-side tick (`bin/sim-recap-tick`) reaches them only over `ssh`, composing no SQL of its own.
+3. **The Mac holds exactly one credential**, injected through launchd `EnvironmentVariables` by `bin/sim-recap-cron-setup` and **never written into the repository tree** — the repo ships the generator, never a `.plist`.
+4. **The agent's working directory is a per-run temp dir**, created and `trap`-cleaned each tick, so it cannot touch the checkout or persist state between runs.
+
+## Alternatives Considered
+
+- **A second, write-capable MySQL user on the Mac** — removes the `ssh` round-trip for queue writes. Rejected because it puts a production-writing credential on the untrusted end of the boundary, collapsing properties 1 and 2 at once.
+- **Extending `ibl5/scripts/storeSimRecap.php` with queue subcommands** instead of a second script — one fewer file. Rejected: its CLI contract is frozen and pinned assertion-by-assertion by `ibl5/tests/WideUnit/Scripts/StoreSimRecapGuardTest.php`, and keeping the single privileged *writer* single-purpose is worth a second guarded entry point.
+- **Sanitizing the database text (player/team/transaction strings) before it reaches the prompt** — the intuitive prompt-injection defense. Rejected because the real mitigation is structural (see Consequences): sanitizing would degrade the recap and misrepresent where the safety comes from.
+
+## Consequences
+
+- **Positive — the boundary was measured, not assumed.** A live spike on 2026-07-23 took the tunnel branch and recorded five probes against the production grant surface:
+  - A positive read succeeded over the tunnel (`SELECT sim,start_date,end_date FROM ibl_sim_dates ORDER BY sim DESC LIMIT 1` → `720 / 2008-02-26 / 2008-03-04`).
+  - The exact claim statement was **refused**: `ERROR 1142 (42000): UPDATE command denied to user 'iblhoops_select'@'localhost' for table iblhoops_ibl5.ibl_sim_summaries`.
+  - A throwaway DDL was **refused**: `ERROR 1142 (42000): CREATE command denied to user 'iblhoops_select'@'localhost' ...`.
+  - The granted scope over the tunnel is `GRANT SELECT ON iblhoops_ibl5.* TO iblhoops_select@localhost` (plus `USAGE`) — no write of any kind.
+  - An off-tunnel direct connect to the production host on 3306 **succeeded at spike time**, as `iblhoops_select` scoped to a specific IP (a cPanel Remote-MySQL host entry), not `%`.
+- **Positive / accepted boundary — the reachability path is "SSH tunnel + the operator's single management host," not "tunnel-only."** The spike's off-tunnel probe surfaced two Remote-MySQL entries. The wildcard `%` entry — open-internet reachability, the exact misconfiguration the probe guards against — was **removed** by the operator on 2026-07-23. The operator's own management-host IP entry is **retained deliberately and is non-negotiable**: the operator needs direct DB access to administer the website, and that access grants nothing beyond `SELECT` on `iblhoops_ibl5`. So the accepted boundary is honestly *the tunnel plus one operator-owned host*, not a claim that the tunnel is the only path. The agent still reaches production only via the tunnel as the SELECT-only user; the retained entry is the *operator's* path, not the agent's. **Caveat to prune:** if the operator's host IP is dynamic, churn can strand a stale `SELECT` grant on a now-unowned IP — the grant list should be pruned periodically.
+- **Negative — a sleeping or offline Mac silently delays the recap.** There is no alerting, and nothing distinguishes "late" from "broken": the queue row simply stays `pending`. Accepted, because the consumer is a non-time-critical human review step and the admin viewer shows queue state on demand.
+- **Negative — the prompt-injection surface is real and is not sanitized.** Player names, team names, and transaction text reach the prompt straight from the database. The mitigation is *structural*: a prompt-injected agent's maximum achievable outcome is a bad recap in a temp file, because it holds no credential able to do anything else. That is stronger than input filtering and does not degrade the output.
+- **Negative — prose quality is not testable.** Every automated check in this unit verifies plumbing, format, and permissions; whether a recap is *good* is a human reading it — which is exactly why the pipeline posts recaps for review rather than publishing them.
+
+## References
+
+- `bin/sim-recap-tick` — the credential-starved poll driver; claim loop, agent run, `--dry-run`.
+- `bin/sim-recap-prompt`, `bin/lib/sim-recap-exemplar.txt` — the prompt builder and pinned exemplar (no DB access).
+- `bin/sim-recap-cron-setup` — the launchd generator that injects the one credential and ships no `.plist`.
+- `bin/test-sim-recap-tick` — the harness carrying the zero-`claude`-on-empty-tick invariant.
+- `ibl5/scripts/simRecapQueue.php`, `ibl5/scripts/storeSimRecap.php`, `ibl5/scripts/.htaccess` — the prod-side privileged entry points and their web deny.
+- `ibl5/tests/WideUnit/Scripts/SimRecapQueueGuardTest.php` — source-content guard for the CLI guard, `.htaccess` scoping, and the string-cast-on-snowflakes property.
+- `ibl5/classes/SimRecap/SimSummaryRepository.php` — the frozen queue primitives the CLI exposes.
+- `ibl5/docs/decisions/0080-mac-local-discord-bug-pipeline-cron-topology.md`, `ibl5/docs/decisions/0081-hunter-trust-split-starved-env-sandbox.md` — the prior-art topology and trust split this ADR extends to a production-reaching agent.
+- `ibl5/docs/decisions/0062-all-work-in-worktrees.md`, `ibl5/docs/decisions/0046-worktrees-outside-repo.md` — why property 4's temp working dir enforces the read-only checkout, and why the generated plist points at the main checkout.

--- a/ibl5/scripts/.htaccess
+++ b/ibl5/scripts/.htaccess
@@ -8,3 +8,11 @@
 <Files "storeSimRecap.php">
     Require all denied
 </Files>
+
+# simRecapQueue.php is a second privileged CLI-only entry point (drives the sim
+# queue with production credentials) and is invoked only as
+# `php ibl5/scripts/simRecapQueue.php <verb>`. Same file-scoped deny; the PHP
+# PHP_SAPI guard in the script is the real control (security constraint 4).
+<Files "simRecapQueue.php">
+    Require all denied
+</Files>

--- a/ibl5/scripts/simRecapQueue.php
+++ b/ibl5/scripts/simRecapQueue.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CLI-only queue driver for the sim-recap pipeline.
+ *
+ * Usage: php ibl5/scripts/simRecapQueue.php <verb> [--sim=N]
+ *   Verbs: claim-next | claim --sim=N | reclaim-stale | park --sim=N
+ *          | find --sim=N | recent-themes | mention-map
+ *   One JSON object is emitted on stdout; bad argv writes
+ *   "simRecapQueue: <message>" to stderr and exits 1 before any repo is built.
+ *
+ * This is the queue half of the trust boundary (ADR-0092): the Mac-side tick
+ * holds only a read-only MySQL credential and so cannot drive the queue over
+ * the tunnel at all (claiming a row is an UPDATE). Every privileged queue
+ * action happens here, prod-side, reached over ssh — never from the Mac.
+ *
+ * Zero SQL is composed in this file; every statement stays bound inside
+ * SimRecap\SimSummaryRepository. Protected by both the PHP_SAPI guard below
+ * (the first executable statement) and an ibl5/scripts/.htaccess scoped deny.
+ */
+
+// ── CLI-only guard — must stay the FIRST executable statement: a web hit must
+//    be refused before any resource (autoload, config, db) is touched.
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit('This script is CLI-only.');
+}
+
+// ── Minimal bootstrap (mirrors scripts/storeSimRecap.php) ─────────────────────
+$_SERVER['PHP_SELF'] = 'simRecapQueue';
+$_SERVER['SERVER_NAME'] = 'localhost';
+$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// Worktree fix: vendor/ symlinks to the main repo, so PSR-4 resolves classes/
+// there; register the local classes/ dir so this worktree's code is used.
+$localClassesDir = realpath(__DIR__ . '/../classes');
+if ($localClassesDir !== false) {
+    spl_autoload_register(static function (string $class) use ($localClassesDir): void {
+        $path = $localClassesDir . '/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($path)) {
+            require_once $path;
+        }
+    });
+}
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../db/db.php';
+
+/** @var \mysqli $mysqli_db */
+
+function fail(string $msg): never
+{
+    fwrite(STDERR, "simRecapQueue: {$msg}\n");
+    exit(1);
+}
+
+/**
+ * Flatten the last 5 sims' themes into a de-duplicated list, newest first.
+ * recentThemes() returns raw JSON strings (decoding is the caller's job);
+ * a malformed or non-array entry is skipped rather than aborting the ledger.
+ *
+ * @return list<string>
+ */
+function collectRecentThemes(\SimRecap\SimSummaryRepository $repo): array
+{
+    $seen = [];
+    $themes = [];
+    foreach ($repo->recentThemes() as $row) {
+        $decoded = json_decode($row['themes_used'], true);
+        if (!is_array($decoded)) {
+            continue;
+        }
+        foreach ($decoded as $theme) {
+            if (!is_string($theme) || isset($seen[$theme])) {
+                continue;
+            }
+            $seen[$theme] = true;
+            $themes[] = $theme;
+        }
+    }
+
+    return $themes;
+}
+
+/**
+ * Team name → Discord snowflake, as STRINGS. Teams with no id are omitted
+ * entirely so the prompt's plain-team-name fallback fires on a missing key
+ * and no "<@null>" can ever be built.
+ *
+ * The snowflake is emitted as a JSON string, never a bare JSON number: a bare
+ * number round-trips only under jq >= 1.7 with no arithmetic, and corrupts under
+ * jq <= 1.6 (IEEE-754) or any other consumer. The (string) cast removes every
+ * such case at once — and is a string cast, not an integer cast, so it leaves
+ * the single pinned numeric conversion on --sim untouched.
+ *
+ * @return array<string, string>
+ */
+function buildMentionMap(\mysqli $db): array
+{
+    $teams = new \Repositories\TeamIdentityRepository($db);
+    $map = [];
+    foreach ($teams->getAllRealTeams() as $team) {
+        $name = $team['team_name'];
+        $id = $teams->getTeamDiscordID($name);
+        if ($id === null) {
+            continue;
+        }
+        $map[$name] = (string) $id;
+    }
+
+    return $map;
+}
+
+// ── Argv parse — positional verb, then flags (mirrors bug-pipeline/transition.php).
+//    Runs entirely before any repository is constructed.
+$verb = null;
+$simRaw = null;
+foreach (array_slice($argv, 1) as $arg) {
+    if (!is_string($arg)) {
+        continue;
+    }
+    if (str_starts_with($arg, '--sim=')) {
+        $simRaw = substr($arg, 6);
+    } elseif ($verb === null && !str_starts_with($arg, '--')) {
+        $verb = $arg;
+    } else {
+        fail("unexpected argument: {$arg}");
+    }
+}
+
+if ($verb === null) {
+    fail('a verb is required (claim-next|claim|reclaim-stale|park|find|recent-themes|mention-map)');
+}
+
+// Verbs that require --sim; parse and validate it once, here.
+$sim = null;
+if (in_array($verb, ['claim', 'park', 'find'], true)) {
+    if ($simRaw === null || !ctype_digit($simRaw)) {
+        fail("--sim=N (positive integer) is required for verb {$verb}");
+    }
+    $sim = (int) $simRaw;
+    if ($sim < 1) {
+        fail('--sim must be >= 1');
+    }
+}
+
+// ── Dispatch ──────────────────────────────────────────────────────────────────
+$repo = new \SimRecap\SimSummaryRepository($mysqli_db);
+
+switch ($verb) {
+    case 'claim-next':
+        $out = ['ok' => true, 'cmd' => 'claim-next', 'sim' => $repo->claimNextPending()];
+        break;
+
+    case 'claim':
+        /** @var int $sim */
+        $out = ['ok' => true, 'cmd' => 'claim', 'sim' => $sim, 'claimed' => $repo->claimPending($sim)];
+        break;
+
+    case 'reclaim-stale':
+        $out = ['ok' => true, 'cmd' => 'reclaim-stale', 'sim' => $repo->reclaimStaleClaim()];
+        break;
+
+    case 'park':
+        /** @var int $sim */
+        $out = ['ok' => true, 'cmd' => 'park', 'sim' => $sim, 'outcome' => $repo->parkOrFail($sim)];
+        break;
+
+    case 'find':
+        /** @var int $sim */
+        $row = $repo->find($sim);
+        // Project the full envelope down to the six queue-state keys the tick
+        // reads; the frozen find() returns recap_text (MEDIUMTEXT) and the
+        // prose fields too, and none of that should cross the ssh pipe per poll.
+        $projected = $row === null ? null : [
+            'sim' => $row['sim'],
+            'status' => $row['status'],
+            'attempts' => $row['attempts'],
+            'blocked_until' => $row['blocked_until'],
+            'claimed_at' => $row['claimed_at'],
+            'generated_at' => $row['generated_at'],
+        ];
+        $out = ['ok' => true, 'cmd' => 'find', 'row' => $projected];
+        break;
+
+    case 'recent-themes':
+        $out = ['ok' => true, 'cmd' => 'recent-themes', 'themes' => collectRecentThemes($repo)];
+        break;
+
+    case 'mention-map':
+        $out = ['ok' => true, 'cmd' => 'mention-map', 'teams' => buildMentionMap($mysqli_db)];
+        break;
+
+    default:
+        fail("unknown verb: {$verb}");
+}
+
+echo json_encode($out), "\n";
+exit(0);

--- a/ibl5/tests/WideUnit/Scripts/SimRecapQueueGuardTest.php
+++ b/ibl5/tests/WideUnit/Scripts/SimRecapQueueGuardTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\WideUnit\Scripts;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source-content guard tests for the prod-side queue CLI. Mirrors
+ * StoreSimRecapGuardTest: it asserts on the script's SOURCE and never shells
+ * out to the real script, because a real run happens outside PHPUnit (so the
+ * isPhpUnit short-circuits do not engage) and could fire live side effects.
+ * The queue behavior itself is covered by SimSummaryRepositoryTest.
+ */
+final class SimRecapQueueGuardTest extends TestCase
+{
+    private string $src;
+
+    protected function setUp(): void
+    {
+        $this->src = (string) file_get_contents(__DIR__ . '/../../../scripts/simRecapQueue.php');
+    }
+
+    // ── Script guard tests ─────────────────────────────────────────────────────
+
+    public function testGuardIsPresent(): void
+    {
+        self::assertTrue(str_contains($this->src, "PHP_SAPI !== 'cli'"));
+    }
+
+    public function testGuardIsTheFirstExecutableStatement(): void
+    {
+        $guardPos = strpos($this->src, "PHP_SAPI !== 'cli'");
+        self::assertNotFalse($guardPos);
+
+        $requirePos = strpos($this->src, 'require_once');
+        self::assertNotFalse($requirePos);
+
+        $newPos = strpos($this->src, 'new ');
+        self::assertNotFalse($newPos);
+
+        self::assertLessThan($requirePos, $guardPos, 'SAPI guard must appear before any require_once');
+        self::assertLessThan($newPos, $guardPos, 'SAPI guard must appear before any object construction');
+    }
+
+    public function testGuardReturns403(): void
+    {
+        self::assertTrue(str_contains($this->src, 'http_response_code(403)'));
+    }
+
+    public function testScriptDoesNotHardcodeAWebhookOrSnowflake(): void
+    {
+        self::assertSame(
+            0,
+            preg_match('/discord\.com\/api\/webhooks/i', $this->src),
+            'Script must not hardcode a Discord webhook URL'
+        );
+        self::assertSame(
+            0,
+            preg_match('/\b\d{17,19}\b/', $this->src),
+            'Script must not hardcode a Discord snowflake ID'
+        );
+    }
+
+    public function testScriptComposesNoSql(): void
+    {
+        self::assertSame(0, preg_match('/SELECT /i', $this->src), 'Script must not compose SELECT');
+        self::assertSame(0, preg_match('/INSERT /i', $this->src), 'Script must not compose INSERT');
+        self::assertSame(0, preg_match('/UPDATE /i', $this->src), 'Script must not compose UPDATE');
+        self::assertSame(0, preg_match('/DELETE /i', $this->src), 'Script must not compose DELETE');
+    }
+
+    public function testScriptCastsOnlyTheSimArgument(): void
+    {
+        self::assertSame(1, substr_count($this->src, '(int)'), 'Exactly one (int) cast expected (only --sim)');
+    }
+
+    public function testSnowflakesLeaveAsStrings(): void
+    {
+        // The mention-map path emits each id through (string), never (int).
+        self::assertTrue(
+            str_contains($this->src, '(string) $id'),
+            'Mention-map must cast the snowflake to string before it enters the JSON'
+        );
+    }
+
+    // ── Htaccess tests ─────────────────────────────────────────────────────────
+
+    public function testHtaccessDeniesSimRecapQueue(): void
+    {
+        $htaccess = (string) file_get_contents(__DIR__ . '/../../../scripts/.htaccess');
+
+        self::assertMatchesRegularExpression('/<Files\s+"simRecapQueue\.php">/', $htaccess);
+        self::assertStringContainsString('Require all denied', $htaccess);
+    }
+
+    public function testHtaccessDenyStaysFileScoped(): void
+    {
+        $htaccess = (string) file_get_contents(__DIR__ . '/../../../scripts/.htaccess');
+
+        // No directory-wide deny — updateAllTheThings.php and siblings stay web-reachable.
+        self::assertFalse(str_contains($htaccess, '<Directory'), 'Must not use a directory-wide block');
+
+        // Unit 1's storeSimRecap.php block must remain intact.
+        self::assertMatchesRegularExpression('/<Files\s+"storeSimRecap\.php">/', $htaccess);
+
+        // Every "Require all denied" occurrence must live inside a <Files> block.
+        $offset = 0;
+        while (($denyPos = strpos($htaccess, 'Require all denied', $offset)) !== false) {
+            $openPos = strrpos(substr($htaccess, 0, $denyPos), '<Files');
+            $closePos = strpos($htaccess, '</Files>', $denyPos);
+            self::assertNotFalse($openPos, 'Require all denied must be preceded by a <Files open');
+            self::assertNotFalse($closePos, 'Require all denied must be followed by a </Files close');
+            $offset = $denyPos + 1;
+        }
+    }
+
+    public function testHtaccessUsesApache24Syntax(): void
+    {
+        $htaccess = (string) file_get_contents(__DIR__ . '/../../../scripts/.htaccess');
+
+        self::assertFalse(str_contains($htaccess, 'Order deny'), 'Must use Apache 2.4 syntax, not Order deny');
+        self::assertFalse(str_contains($htaccess, 'Deny from'), 'Must use Apache 2.4 syntax, not Deny from');
+    }
+}


### PR DESCRIPTION
## Summary

- **bin/sim-recap-tick**: Poll-only daemon (fires every 300s via launchd). Returns immediately with zero cost on empty queue — safe to land before producer is registered.
- **bin/sim-recap-prompt**: Assembles Claude prompt from DB coordinates, exemplar, Discord mention map, and themes ledger. Password never enters prompt (MYSQL_PWD env seam).
- **bin/sim-recap-cron-setup**: One-time launchd LaunchAgent installer/uninstaller (--install-schedule, --uninstall-schedule, --print-schedule).
- **bin/lib/sim-recap-exemplar.txt**: Pinned format exemplar (267 lines, verbatim from decisions digest). Anchors output against ouroboros drift.
- **tests.yml**: Register bin/test-sim-recap-tick in CI.

No user-facing capability yet — this is phase 6's infrastructure layer. The queue will be empty until unit 3b (the producer) lands; every tick is a dry-run until then.

## Manual Testing

- [ ] 6 | The spike branch taken (live tunnel vs. JSON-payload fallback) is recorded before Phase 2 begins | Truly-manual | pre-impl | Phase 1e — recorded, then carried into ADR-0092
- [ ] 60 | The generated recap reads in the pinned exemplar's voice and layout, and its prose is worth a human posting publicly | Truly-manual | post-impl | Read the full output of `bin/sim-recap-tick --dry-run --sim=<the exemplar's source sim>` end to end and judge it against `bin/lib/sim-recap-exemplar.txt`
