### PR TITLE
feat(sim-recap): activate automation with viewer links

### DIFF
--- a/bin/sim-recap-tick
+++ b/bin/sim-recap-tick
@@ -4,10 +4,14 @@
 # bin/sim-recap-tick — the poll-only sim-recap pipeline driver (ADR-0092).
 #
 # Fired every 300s by the launchd LaunchAgent (bin/sim-recap-cron-setup). On an
-# EMPTY tick it exits 0 having spawned ZERO `claude` processes — the cost guard,
-# and the property that makes this branch safe to merge ahead of unit 3b (the
-# producer QueueSimSummaryStep is still unregistered, so the queue is always
-# empty and this is the only path the tick ever takes today).
+# EMPTY tick it exits 0 having spawned ZERO `claude` processes — the cost guard
+# that makes a 300s poll cheap enough to run unattended forever.
+#
+# "Empty" means the queue call SUCCEEDED and reported no sim. A queue call that
+# FAILS returns empty stdout too — byte-identical to an idle queue — so every
+# call goes through q(), which logs a distinct ERROR and returns non-zero, and
+# main() aborts the tick rather than reporting a cheap exit. Without that, a
+# broken pipeline is indistinguishable from a quiet one in the launchd log.
 #
 # Trust split (ADR-0092): the Mac holds ONE credential — a SELECT-only MySQL
 # user reached over an SSH tunnel — handed only to the generation agent for game
@@ -67,10 +71,21 @@ claude_env_error() {
 }
 
 # ── One seam for every prod-side queue call ───────────────────────────────────
-# q <verb> [flags...] -> one JSON object on stdout.
+# q <verb> [flags...] -> one JSON object on stdout; exit status of the call.
+#
+# A dead ssh, an undeployed simRecapQueue.php, or a PHP fatal all yield EMPTY
+# stdout plus a non-zero exit. Empty stdout alone is ambiguous (an idle queue
+# looks the same), so the exit status is the ONLY signal that separates them —
+# name the verb here so one grep of the launchd log identifies the broken call.
 q() {
+    local verb="$1" rc
     "$SIM_RECAP_SSH_BIN" "$SIM_RECAP_SSH_HOST" \
         "php $SIM_RECAP_REMOTE_ROOT/ibl5/scripts/simRecapQueue.php $*"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        log "ERROR: queue call '$verb' failed (exit $rc) — remote simRecapQueue.php did not complete"
+    fi
+    return "$rc"
 }
 
 # jq_ok <json> <filter> -> true when the filter succeeds (fail-closed on garbage).
@@ -244,8 +259,16 @@ main() {
 
     # Reclaim first, unconditionally — a crashed run's sim is recoverable on the
     # very next tick. Rides the multiplexed ssh connection, so ~tens of ms.
-    local rec sim_rec
+    local rec sim_rec rc
     rec="$(q reclaim-stale)"
+    rc=$?
+    # Fail-closed on the FIRST queue call: if the remote side is unreachable or
+    # undeployed, nothing downstream can work, and continuing would land in the
+    # cheap-exit path and log an idle queue that was never actually consulted.
+    if [ "$rc" -ne 0 ]; then
+        log "ERROR: reclaim-stale did not complete — aborting tick (no claude spawned)"
+        return 1
+    fi
     if jq_ok "$rec" '.ok == true'; then
         sim_rec="$(printf '%s' "$rec" | "$SIM_RECAP_JQ_BIN" -r '.sim // empty' 2>/dev/null)"
         [ -n "$sim_rec" ] && [ "$sim_rec" != "null" ] && \
@@ -254,6 +277,15 @@ main() {
 
     local claim normalized sim
     claim="$(q claim-next)"
+    rc=$?
+    # This check MUST precede the empty-tick guard below: a failed call returns
+    # empty stdout, so the guard would swallow it and report an idle queue. That
+    # is not hypothetical — the poller logged 342 consecutive "exiting cheap"
+    # ticks while simRecapQueue.php was simply absent from the remote root.
+    if [ "$rc" -ne 0 ]; then
+        log "ERROR: claim-next did not complete — aborting tick (no claude spawned)"
+        return 1
+    fi
     normalized="$(printf '%s' "$claim" | tr -d '[:space:]')"
 
     # ★ EMPTY-TICK COST GUARD — no work, spawn zero `claude`, exit cheap.

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -62,6 +62,10 @@ srt_setup() {
 echo "$*" >> "$STUB/ssh.log"
 cmd="$2"
 if printf '%s' "$cmd" | grep -q 'storeSimRecap\.php'; then
+    if [ -f "$STUB/record-stdin" ]; then
+        printf '%s\n' "$2" > "$STUB/store.cmd"
+        cat > "$STUB/store.stdin"
+    fi
     if [ -f "$STUB/store-fails" ]; then
         printf '{"ok":false,"error":"stub store failure"}\n'
         exit 1
@@ -133,7 +137,8 @@ SH
 srt_reset() {
     rm -f "$STUB"/ssh.log "$STUB"/claude.log "$STUB"/claude.sentinel \
           "$STUB"/tick.out "$STUB"/agent-fails "$STUB"/agent-usage-limit \
-          "$STUB"/store-fails "$STUB"/resp.* 2>/dev/null
+          "$STUB"/store-fails "$STUB"/resp.* \
+          "$STUB"/record-stdin "$STUB"/store.cmd "$STUB"/store.stdin 2>/dev/null
     export SIM_RECAP_DB_PASSWORD="test_db_password"
     unset SIM_RECAP_KEEP_WORKDIR 2>/dev/null || true
 }
@@ -313,6 +318,58 @@ if [ "${_plist_count:-0}" -eq 0 ]; then
     srt_ok "no_plist_committed"
 else
     srt_fail "no_plist_committed — found: $(git -C "$_repo_root" ls-files '*.plist')"
+fi
+
+# ── payload_contract_stdin_and_command ───────────────────────────────────────
+# Verify: tick emits --sim= in the storeSimRecap command (no --themes= flag),
+# and the payload piped on stdin is valid JSON that passes
+# SimRecapPayload::fromJson() in the same shape storeSimRecap.php consumes.
+srt_reset
+touch "$STUB/record-stdin"
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+srt_run
+srt_expect_eq "payload_contract — exit 0" 0 "$SRT_RC"
+
+if [ -f "$STUB/store.cmd" ]; then
+    srt_log_has   "$STUB" store.cmd "--sim="    "payload_contract — command has --sim="
+    srt_log_lacks "$STUB" store.cmd "--themes=" "payload_contract — command has no --themes="
+else
+    srt_fail "payload_contract — store.cmd not created (ssh stub did not record the command)"
+fi
+
+_ibl5_dir="$(cd "${SCRIPT_DIR}/.." && pwd)/ibl5"
+if [ -f "$STUB/store.stdin" ]; then
+    _validate_php="$(mktemp /tmp/payload-validate-XXXXXX.php)"
+    cat > "$_validate_php" << 'PHPEOF'
+<?php
+$ibl5Dir = $argv[1];
+require $ibl5Dir . '/vendor/autoload.php';
+$localClassesDir = realpath($ibl5Dir . '/classes');
+if ($localClassesDir !== false) {
+    spl_autoload_register(static function (string $class) use ($localClassesDir): void {
+        $path = $localClassesDir . '/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($path)) {
+            require_once $path;
+        }
+    });
+}
+$json = (string) stream_get_contents(STDIN);
+try {
+    \SimRecap\SimRecapPayload::fromJson($json);
+    exit(0);
+} catch (Throwable $e) {
+    fwrite(STDERR, 'error: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
+}
+PHPEOF
+    if php "$_validate_php" "$_ibl5_dir" < "$STUB/store.stdin" 2>/dev/null; then
+        srt_ok "payload_contract — stdin passes SimRecapPayload::fromJson()"
+    else
+        srt_fail "payload_contract — stdin fails SimRecapPayload::fromJson()"
+    fi
+    rm -f "$_validate_php"
+else
+    srt_fail "payload_contract — store.stdin not created (ssh stub did not record stdin)"
 fi
 
 # ══ PROMPT GROUP — real bin/sim-recap-prompt ══════════════════════════════════

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -343,7 +343,10 @@ if [ -f "$STUB/store.stdin" ]; then
     cat > "$_validate_php" << 'PHPEOF'
 <?php
 $ibl5Dir = $argv[1];
-require $ibl5Dir . '/vendor/autoload.php';
+$autoload = $ibl5Dir . '/vendor/autoload.php';
+if (file_exists($autoload)) {
+    require $autoload;
+}
 $localClassesDir = realpath($ibl5Dir . '/classes');
 if ($localClassesDir !== false) {
     spl_autoload_register(static function (string $class) use ($localClassesDir): void {

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -74,6 +74,12 @@ if printf '%s' "$cmd" | grep -q 'storeSimRecap\.php'; then
     exit 0
 fi
 verb=$(printf '%s' "$cmd" | grep -oE 'simRecapQueue\.php [a-z-]+' | awk '{print $2}')
+# fail.<verb> reproduces a dead ssh / undeployed remote script: EMPTY stdout
+# with a non-zero exit — deliberately indistinguishable from an idle queue on
+# stdout alone, so only the exit status can catch it.
+if [ -f "$STUB/fail.$verb" ]; then
+    exit 255
+fi
 if [ -f "$STUB/resp.$verb" ]; then
     cat "$STUB/resp.$verb"
 else
@@ -137,7 +143,7 @@ SH
 srt_reset() {
     rm -f "$STUB"/ssh.log "$STUB"/claude.log "$STUB"/claude.sentinel \
           "$STUB"/tick.out "$STUB"/agent-fails "$STUB"/agent-usage-limit \
-          "$STUB"/store-fails "$STUB"/resp.* \
+          "$STUB"/store-fails "$STUB"/resp.* "$STUB"/fail.* \
           "$STUB"/record-stdin "$STUB"/store.cmd "$STUB"/store.stdin 2>/dev/null
     export SIM_RECAP_DB_PASSWORD="test_db_password"
     unset SIM_RECAP_KEEP_WORKDIR 2>/dev/null || true
@@ -170,6 +176,39 @@ printf '  \n ' > "$STUB/resp.claim-next"
 srt_run
 srt_expect_eq "whitespace_payload_is_empty" 0 "$SRT_RC"
 srt_file_absent "$STUB/claude.sentinel" "whitespace_payload_is_empty — zero claude"
+# The distinction that matters: whitespace with exit 0 IS an empty queue, so the
+# cheap exit is correct here. The two cases below are the same stdout with a
+# non-zero exit, and must NOT reach this path.
+srt_log_has "$STUB" tick.out "no pending sim — exiting cheap" "whitespace_with_rc0_is_still_a_cheap_exit"
+
+# ── claim_next_remote_failure_fails_closed ────────────────────────────────────
+# A dead ssh / undeployed simRecapQueue.php returns empty stdout with a non-zero
+# exit. Before this guard the empty-tick cost guard swallowed it and the tick
+# logged an idle queue — 342 consecutive ticks reported "exiting cheap" while
+# the remote script was never present at all.
+srt_reset
+touch "$STUB/fail.claim-next"
+srt_run
+srt_expect_eq "claim_next_remote_failure_exits_nonzero" 1 "$SRT_RC"
+srt_log_has "$STUB" tick.out "queue call 'claim-next' failed" \
+    "claim_next_remote_failure_names_the_verb"
+srt_log_lacks "$STUB" tick.out "no pending sim — exiting cheap" \
+    "claim_next_remote_failure_is_not_a_cheap_exit"
+srt_file_absent "$STUB/claude.sentinel" "claim_next_remote_failure — zero claude"
+
+# ── reclaim_stale_remote_failure_fails_closed ─────────────────────────────────
+# reclaim-stale is the FIRST queue call; its failure used to log nothing at all
+# (the jq_ok guard just skipped the log line), which is strictly worse than a
+# misleading cheap exit. Failing the first call aborts the tick.
+srt_reset
+touch "$STUB/fail.reclaim-stale"
+srt_run
+srt_expect_eq "reclaim_stale_remote_failure_exits_nonzero" 1 "$SRT_RC"
+srt_log_has "$STUB" tick.out "queue call 'reclaim-stale' failed" \
+    "reclaim_stale_remote_failure_names_the_verb"
+srt_log_lacks "$STUB" tick.out "no pending sim — exiting cheap" \
+    "reclaim_stale_remote_failure_is_not_a_cheap_exit"
+srt_file_absent "$STUB/claude.sentinel" "reclaim_stale_remote_failure — zero claude"
 
 # ── malformed_queue_json_fails_closed ─────────────────────────────────────────
 srt_reset

--- a/ibl5/classes/SimRecap/SimSummaryLink.php
+++ b/ibl5/classes/SimRecap/SimSummaryLink.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimRecap;
+
+/**
+ * The single source of the sim-recap viewer route.
+ *
+ * Pure and stateless: no DB, no config lookup. The absolute-URL host arrives as
+ * a parameter rather than being read here, so this class is fully unit-testable
+ * and both call sites — the updater-page notification (unit 3b, Phase 2) and the
+ * Discord message (Phase 3) — share one route definition and cannot drift.
+ *
+ * The route targets unit 2's admin-gated viewer; neither method bypasses that
+ * gate — they only compose the path the gate already protects.
+ */
+final class SimSummaryLink
+{
+    /**
+     * The relative viewer path for a given sim, e.g. `simSummaries.php?sim=689`.
+     */
+    public static function path(int $sim): string
+    {
+        return 'simSummaries.php?sim=' . $sim;
+    }
+
+    /**
+     * The absolute viewer URL for a given sim on a bare canonical host.
+     *
+     * `$host` is a bare hostname with no scheme and no trailing slash (e.g.
+     * `iblhoops.net`); this method supplies the scheme and the `/ibl5/` prefix.
+     */
+    public static function absolute(int $sim, string $host): string
+    {
+        return 'https://' . $host . '/ibl5/' . self::path($sim);
+    }
+}

--- a/ibl5/classes/SimRecap/SimSummaryLink.php
+++ b/ibl5/classes/SimRecap/SimSummaryLink.php
@@ -18,21 +18,29 @@ namespace SimRecap;
 final class SimSummaryLink
 {
     /**
-     * The relative viewer path for a given sim, e.g. `simSummaries.php?sim=689`.
+     * The root-absolute viewer path for a given sim, e.g.
+     * `/ibl5/simSummaries.php?sim=689`.
+     *
+     * Root-absolute so it resolves independently of the rendering page's own
+     * directory depth and of whether that page emits a `<base href>`. The
+     * viewer lives at the `ibl5/` root, but the updater page that links to it
+     * is served from `ibl5/scripts/` and builds a `<head>` with no `<base>`, so
+     * a bare relative path resolved to `/ibl5/scripts/simSummaries.php` and 404'd.
      */
     public static function path(int $sim): string
     {
-        return 'simSummaries.php?sim=' . $sim;
+        return '/ibl5/simSummaries.php?sim=' . $sim;
     }
 
     /**
      * The absolute viewer URL for a given sim on a bare canonical host.
      *
      * `$host` is a bare hostname with no scheme and no trailing slash (e.g.
-     * `iblhoops.net`); this method supplies the scheme and the `/ibl5/` prefix.
+     * `iblhoops.net`); this method supplies the scheme, and `path()` already
+     * carries the leading `/ibl5/`.
      */
     public static function absolute(int $sim, string $host): string
     {
-        return 'https://' . $host . '/ibl5/' . self::path($sim);
+        return 'https://' . $host . self::path($sim);
     }
 }

--- a/ibl5/classes/Updater/Steps/QueueSimSummaryStep.php
+++ b/ibl5/classes/Updater/Steps/QueueSimSummaryStep.php
@@ -8,11 +8,12 @@ use Updater\Contracts\PipelineStepInterface;
 use Updater\StepResult;
 
 /**
- * Enqueue the current sim for recap generation.
+ * Enqueue the current sim for recap generation, and notify the admin running
+ * the updater with a link into the recap viewer.
  *
- * Ships UNREGISTERED — updateAllTheThings.php is NOT touched by this PR.
- * Registration and the accompanying page notification ship in unit 3 so the
- * producer and its consumer go live in one deploy (shared-context decision 11).
+ * Registered as the last step of the non-Olympics pipeline (unit 3b). Two
+ * notified states, both carrying a link: a new sim was queued, or there was no
+ * new sim and the link points at the last generated recap.
  */
 class QueueSimSummaryStep implements PipelineStepInterface
 {
@@ -36,9 +37,89 @@ class QueueSimSummaryStep implements PipelineStepInterface
         }
 
         if ($this->summaries->queuePendingIfAbsent($sim)) {
-            return StepResult::success($this->getLabel(), "Queued sim {$sim} for recap generation.");
+            return StepResult::success(
+                $this->getLabel(),
+                "Queued sim {$sim} for recap generation.",
+                inlineHtml: $this->queuedHtml($sim),
+            );
         }
 
-        return StepResult::skipped($this->getLabel(), "Sim {$sim} already has a summary row.");
+        return StepResult::success(
+            $this->getLabel(),
+            "Sim {$sim} already has a summary row.",
+            inlineHtml: $this->noNewSimHtml(),
+        );
+    }
+
+    /**
+     * State (a): a new sim was queued. The copy sets the expectation honestly —
+     * queuing is not generation; the write-up is produced later by the agent.
+     */
+    private function queuedHtml(int $sim): string
+    {
+        $safeSim = self::escape((string) $sim);
+
+        return 'Sim ' . $safeSim . ' has been queued for recap generation — the write-up is produced'
+            . ' shortly by the recap agent. '
+            . $this->viewerLink($sim, 'View sim ' . $safeSim . ' in the recap viewer');
+    }
+
+    /**
+     * State (b): no new sim to recap. Links to the last generated (done) recap.
+     * With no done recap anywhere, renders text only — no anchor to a sim that
+     * does not exist.
+     */
+    private function noNewSimHtml(): string
+    {
+        $lastDone = $this->lastGeneratedSim();
+
+        if ($lastDone === null) {
+            return 'No new sim to recap this run, and no recap has been generated yet.';
+        }
+
+        $safeSim = self::escape((string) $lastDone);
+
+        return 'No new sim to recap this run. '
+            . $this->viewerLink($lastDone, 'View the last generated recap (sim ' . $safeSim . ')');
+    }
+
+    /**
+     * The highest sim whose status is done, or null if none is done yet.
+     *
+     * listAll() is already ORDER BY sim DESC, so the first done row is the most
+     * recent generated recap. Reuses unit 2's read rather than widening the
+     * frozen repository interface with a latestDoneSim() method.
+     */
+    private function lastGeneratedSim(): ?int
+    {
+        foreach ($this->summaries->listAll() as $row) {
+            if (($row['status'] ?? null) !== 'done') {
+                continue;
+            }
+            $sim = $row['sim'] ?? null;
+            if (is_int($sim)) {
+                return $sim;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * A viewer anchor. The href is escaped even though its only dynamic part is
+     * an int today — the markup does not enforce that, so the escape is the
+     * guard if the value ever stops being an int. $label is pre-escaped by the
+     * caller.
+     */
+    private function viewerLink(int $sim, string $label): string
+    {
+        $href = self::escape(\SimRecap\SimSummaryLink::path($sim));
+
+        return '<a href="' . $href . '">' . $label . '</a>.';
+    }
+
+    private static function escape(string $value): string
+    {
+        return \Security\HtmlSanitizer::e($value);
     }
 }

--- a/ibl5/config.php.example
+++ b/ibl5/config.php.example
@@ -61,6 +61,15 @@ define('IBL6_BASE_URL', 'https://ibl6.iblhoops.net');
 # precedence over this constant (see Auth\DemoLoginGate, ADR-0034).
 define('DEMO_LOGIN_TOKEN', getenv('DEMO_LOGIN_TOKEN') ?: '');
 
+# IBL5_CANONICAL_HOST — the bare production hostname (no scheme, no www., no
+# trailing slash, e.g. iblhoops.net) used from CLI context for two things: it is
+# passed to Discord::init() so a prod-side sim-recap post routes to #admin-chat
+# instead of the testing webhook, and it builds the absolute viewer link the
+# post carries. Leave it EMPTY on every non-production machine — empty is the
+# safe default (Discord stays on the testing webhook, links stay relative).
+# Set the real value only in production's gitignored config.php.
+define('IBL5_CANONICAL_HOST', getenv('IBL5_CANONICAL_HOST') ?: '');
+
 /**********************************************************************/
 /* You finished to configure the Database. Now you can change all     */
 /* you want in the Administration Section.   To enter just launch     */

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -278,6 +278,9 @@
         <testsuite name="GameBoxscore Module Tests">
             <directory>tests/GameBoxscore</directory>
         </testsuite>
+        <testsuite name="SimRecap Module Tests">
+            <directory>tests/SimRecap</directory>
+        </testsuite>
     </testsuites>
     <groups>
         <exclude>

--- a/ibl5/scripts/storeSimRecap.php
+++ b/ibl5/scripts/storeSimRecap.php
@@ -103,9 +103,23 @@ if ($row === null || $row['status'] !== 'done') {
     fail("store failed: sim {$sim} is not in state done after write");
 }
 
+// ── Resolve the canonical host (prod-side config only, never from argv) ───────
+// One value feeds both jobs below. A real bare hostname makes Discord's
+// isProduction() true so the post routes to #admin-chat; an empty host — CI,
+// dev, any machine without the constant — leaves it on the testing webhook and
+// keeps the link relative. Empty is the safe default, never an error.
+$rawHost = defined('IBL5_CANONICAL_HOST') ? constant('IBL5_CANONICAL_HOST') : '';
+$host = is_string($rawHost) ? $rawHost : '';
+
+\Discord\Discord::init($host);
+
+$viewerUrl = $host === ''
+    ? \SimRecap\SimSummaryLink::path($sim)
+    : \SimRecap\SimSummaryLink::absolute($sim, $host);
+
 // ── Post to Discord, only after a confirmed write ─────────────────────────────
-\Discord\Discord::postToChannel('#admin-chat', "Sim {$sim} recap is ready for review.");
+\Discord\Discord::postToChannel('#admin-chat', "Sim {$sim} recap is ready for review: {$viewerUrl}");
 
 // ── Success output ────────────────────────────────────────────────────────────
-echo json_encode(['ok' => true, 'sim' => $sim, 'games' => count($payload->getGames())]), "\n";
+echo json_encode(['ok' => true, 'sim' => $sim, 'games' => count($payload->getGames()), 'url' => $viewerUrl]), "\n";
 exit(0);

--- a/ibl5/scripts/updateAllTheThings.php
+++ b/ibl5/scripts/updateAllTheThings.php
@@ -267,6 +267,10 @@ try {
             $plrService, $jsbRepo, $season->endingYear, $sourceResolver,
         ));
         $updaterService->addStep(new Updater\Steps\RefreshIblHistStep($mysqli_db));
+        $updaterService->addStep(new Updater\Steps\QueueSimSummaryStep(
+            new \SimRecap\SimSummaryRepository($mysqli_db),
+            new \Season\SeasonQueryRepository($mysqli_db),
+        ));
     }
 
     $controller = new Updater\UpdaterController($updaterService, $view);

--- a/ibl5/tests/DatabaseIntegration/SimRecap/QueueSimSummaryStepDbTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/QueueSimSummaryStepDbTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\SimRecap;
+
+use PHPUnit\Framework\Attributes\Group;
+use Season\SeasonQueryRepository;
+use SimRecap\SimSummaryRepository;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+use Updater\Steps\QueueSimSummaryStep;
+
+/**
+ * Database integration test for QueueSimSummaryStep.
+ *
+ * Verifies that execute() queues a pending recap row for the current sim,
+ * is idempotent on a second call, and returns rows in the shape the admin
+ * viewer requires (recap_length alias, no recap body, ORDER BY sim DESC).
+ *
+ * Isolation: transaction rollback. Sim 9001 is outside the 686–689 seed
+ * band asserted by unit 2, so this test cannot interfere with it.
+ */
+#[Group('database')]
+final class QueueSimSummaryStepDbTest extends DatabaseTestCase
+{
+    private SimSummaryRepository $repo;
+    private SeasonQueryRepository $seasonQuery;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repo = new SimSummaryRepository($this->db);
+        $this->seasonQuery = new SeasonQueryRepository($this->db);
+
+        // Insert an ibl_sim_dates row so getLastSimDatesArray() returns sim 9001
+        // (highest value in the table within this transaction).
+        $this->insertRow('ibl_sim_dates', [
+            'sim'        => 9001,
+            'start_date' => '2099-01-01',
+            'end_date'   => '2099-01-07',
+        ]);
+    }
+
+    /**
+     * execute() queues a pending row for the current sim.
+     *
+     * Verification matrix row 35.
+     */
+    public function testProducerStepCreatesAPendingRow(): void
+    {
+        $step = new QueueSimSummaryStep($this->repo, $this->seasonQuery);
+        $step->execute();
+
+        $row = $this->repo->find(9001);
+        self::assertNotNull($row, 'find(9001) must return a row after execute()');
+        self::assertSame('pending', $row['status'], 'Newly queued row must have status=pending');
+        self::assertSame(0, $row['attempts'], 'Newly queued row must have attempts=0');
+    }
+
+    /**
+     * A second execute() call leaves exactly one row (queuePendingIfAbsent is idempotent).
+     *
+     * Verification matrix row 36.
+     */
+    public function testSecondExecuteDoesNotCreateDuplicateRow(): void
+    {
+        $step = new QueueSimSummaryStep($this->repo, $this->seasonQuery);
+        $step->execute();
+        $step->execute();
+
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) AS cnt FROM `ibl_sim_summaries` WHERE `sim` = 9001'
+        );
+        self::assertNotFalse($stmt, 'Prepare must succeed: ' . $this->db->error);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        /** @var array{cnt: int}|null $countRow */
+        $countRow = $result->fetch_assoc();
+        $stmt->close();
+
+        self::assertNotNull($countRow);
+        self::assertSame(
+            1,
+            (int) ($countRow['cnt'] ?? 0),
+            'queuePendingIfAbsent must be idempotent — exactly one row after two execute() calls'
+        );
+    }
+
+    /**
+     * listAll() returns the new row with the recap_length alias present and
+     * the recap body absent, with sim 9001 sorting first (ORDER BY sim DESC).
+     *
+     * Verification matrix row 37.
+     */
+    public function testListAllReturnsRowInViewerShape(): void
+    {
+        $step = new QueueSimSummaryStep($this->repo, $this->seasonQuery);
+        $step->execute();
+
+        $rows = $this->repo->listAll();
+
+        self::assertNotEmpty($rows, 'listAll() must return at least one row');
+
+        $firstRow = $rows[0];
+
+        // sim 9001 must sort first — it exceeds every seed sim (≤ 689).
+        self::assertSame(
+            9001,
+            $firstRow['sim'] ?? null,
+            '9001 must be first in listAll() (ORDER BY sim DESC)'
+        );
+
+        // The recap_length computed alias must be present for the viewer index.
+        self::assertArrayHasKey(
+            'recap_length',
+            $firstRow,
+            'listAll() must expose the recap_length computed alias'
+        );
+
+        // The recap body must NOT be returned — listAll() is the index read.
+        self::assertArrayNotHasKey(
+            'recap_text',
+            $firstRow,
+            'listAll() must not return recap_text (index read, not body read)'
+        );
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/SimRecap/StoreSimRecapCliTest.php
+++ b/ibl5/tests/DatabaseIntegration/SimRecap/StoreSimRecapCliTest.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\SimRecap;
+
+use PHPUnit\Framework\Attributes\Group;
+use SimRecap\SimSummaryRepository;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+/**
+ * Database integration test for scripts/storeSimRecap.php.
+ *
+ * Launches the script as a real child process (isolated connection) so the
+ * full path through argv-parse → stdin-parse → markDone → Discord-short-circuit
+ * → stdout-JSON is exercised against a live database.
+ *
+ * ISOLATION: Each test runs in autocommit mode. DatabaseTestCase::setUp() starts
+ * a transaction which is immediately committed in this class's setUp() so the
+ * connection switches to autocommit. This is required because the child is a
+ * separate connection and cannot see the parent's uncommitted state.
+ * tearDown() unconditionally removes sim 9001 rows.
+ *
+ * SECURITY: Every child process invocation prepends
+ *   define('PHPUNIT_RUNNING', true);
+ * before requiring storeSimRecap.php.  Discord::postToChannel() short-circuits on
+ * defined('PHPUNIT_RUNNING'), so no live Discord POST can fire on any machine.
+ * 'iblhoops.net' is never used as a host — 'example.test' is the only test host.
+ */
+#[Group('database')]
+final class StoreSimRecapCliTest extends DatabaseTestCase
+{
+    private const SIM = 9001;
+
+    /**
+     * A minimal valid payload that passes SimRecapPayload::fromJson().
+     * themes=["comeback"] so themes_used stores '["comeback"]' after markDone.
+     */
+    private const VALID_PAYLOAD = '{"intro_text":"Intro text.","outro_text":"Outro text.",'
+        . '"recap_text":"This is the recap text.","themes":["comeback"],'
+        . '"games":[{"season_year":2025,"game_date":"2025-01-01","visitor_teamid":1,'
+        . '"home_teamid":2,"game_of_that_day":1,"box_id":null,"sort_order":0,'
+        . '"recap_text":"Game recap text."}]}';
+
+    private SimSummaryRepository $repo;
+    private string $scriptPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Immediately commit the empty transaction that DatabaseTestCase::setUp()
+        // opened — this switches the connection to autocommit mode so every
+        // subsequent write is visible to the child process on its own connection.
+        $this->db->commit();
+
+        $this->repo = new SimSummaryRepository($this->db);
+
+        $path = realpath(__DIR__ . '/../../../scripts/storeSimRecap.php');
+        self::assertNotFalse($path, 'storeSimRecap.php must exist at the expected path');
+        $this->scriptPath = $path;
+    }
+
+    protected function tearDown(): void
+    {
+        // Unconditional cleanup — removes any committed rows even when the test
+        // failed mid-way. parent::tearDown() calls rollback() (a no-op in
+        // autocommit mode) then close().
+        try {
+            if (isset($this->db)) {
+                $this->db->query('DELETE FROM `ibl_sim_game_recaps` WHERE `sim` = ' . self::SIM);
+                $this->db->query('DELETE FROM `ibl_sim_summaries` WHERE `sim` = ' . self::SIM);
+                $this->db->query('DELETE FROM `ibl_sim_dates` WHERE `sim` = ' . self::SIM);
+            }
+        } catch (\Throwable) {
+            // Best-effort — connection may be in an unrecoverable state.
+        }
+        parent::tearDown();
+    }
+
+    // ── Happy path ─────────────────────────────────────────────────────────────
+
+    /**
+     * Happy path: stdout JSON shape, exit 0, row persisted as done.
+     *
+     * Verification matrix rows 38–39.
+     */
+    public function testHappyPathStdoutAndDbState(): void
+    {
+        $this->repo->queuePendingIfAbsent(self::SIM);
+        // Autocommit — each query commits immediately; no explicit commit needed.
+
+        $result = $this->runScript(['--sim=' . self::SIM], self::VALID_PAYLOAD);
+
+        self::assertSame(0, $result['exit_code'], 'exit 0 expected for happy path');
+
+        // Stdout must be a well-formed JSON object.
+        $json = json_decode($result['stdout'], true);
+        self::assertIsArray($json, 'stdout must be a valid JSON object');
+        self::assertTrue($json['ok'] ?? false, 'ok must be true');
+        self::assertSame(self::SIM, $json['sim'] ?? null, 'sim must echo the requested sim');
+        self::assertSame(1, $json['games'] ?? null, 'games count must match the payload (1 game)');
+
+        // URL must contain the sim number and the viewer path (decision 23 pin).
+        $url = is_string($json['url'] ?? null) ? $json['url'] : '';
+        self::assertStringContainsString((string) self::SIM, $url, 'url must contain the sim number');
+        self::assertStringContainsString('simSummaries.php', $url, 'url must point at simSummaries.php');
+
+        // Read-back: row must be done with the expected prose and themes.
+        $row = $this->repo->find(self::SIM);
+        self::assertNotNull($row, 'find() must return a row after the script runs');
+        self::assertSame('done', $row['status'], 'status must be done after store');
+        self::assertSame('This is the recap text.', $row['recap_text'], 'recap_text must round-trip');
+        self::assertSame('["comeback"]', $row['themes_used'], 'themes_used must store the JSON array');
+    }
+
+    // ── Negative cases ─────────────────────────────────────────────────────────
+
+    /**
+     * Missing --sim: non-zero exit, exact STDERR, nothing written.
+     *
+     * Verification matrix row 40 (missing-sim branch).
+     */
+    public function testMissingSimArgExitsWithExpectedStderr(): void
+    {
+        $result = $this->runScript([], self::VALID_PAYLOAD);
+
+        self::assertNotSame(0, $result['exit_code'], 'exit must be non-zero for missing --sim');
+        self::assertStringContainsString(
+            'storeSimRecap: --sim=N is required',
+            $result['stderr'],
+            'exact STDERR message expected for missing --sim'
+        );
+        self::assertNull($this->repo->find(self::SIM), 'no row must be written when --sim is missing');
+    }
+
+    /**
+     * Non-numeric --sim: non-zero exit, distinct STDERR, nothing written.
+     *
+     * Verification matrix row 40 (non-numeric-sim branch).
+     */
+    public function testNonNumericSimArgExitsWithExpectedStderr(): void
+    {
+        $result = $this->runScript(['--sim=abc'], self::VALID_PAYLOAD);
+
+        self::assertNotSame(0, $result['exit_code'], 'exit must be non-zero for non-numeric --sim');
+        self::assertStringContainsString(
+            'storeSimRecap: --sim must be a positive integer, got: abc',
+            $result['stderr'],
+            'exact STDERR message expected for non-numeric --sim'
+        );
+        self::assertNull($this->repo->find(self::SIM), 'no row must be written for non-numeric --sim');
+    }
+
+    /**
+     * Malformed JSON on stdin: exit 1, nothing written.
+     *
+     * Verification matrix row 41 (malformed-JSON branch).
+     */
+    public function testMalformedJsonExitsOneWithNothingWritten(): void
+    {
+        $result = $this->runScript(['--sim=' . self::SIM], 'not valid json at all');
+
+        self::assertSame(1, $result['exit_code'], 'exit 1 expected for malformed JSON');
+        self::assertStringContainsString('storeSimRecap:', $result['stderr']);
+        self::assertNull($this->repo->find(self::SIM), 'no row must be written for malformed JSON');
+    }
+
+    /**
+     * Missing required recap_text field: exit 1, nothing written.
+     *
+     * Verification matrix row 41 (missing-field branch).
+     */
+    public function testMissingRecapTextExitsOne(): void
+    {
+        $payloadWithoutRecapText = '{"intro_text":"Intro.","outro_text":"Outro.",'
+            . '"games":[{"season_year":2025,"game_date":"2025-01-01","visitor_teamid":1,'
+            . '"home_teamid":2,"game_of_that_day":1,"box_id":null,"sort_order":0,'
+            . '"recap_text":"Game."}]}';
+
+        $result = $this->runScript(['--sim=' . self::SIM], $payloadWithoutRecapText);
+
+        self::assertSame(1, $result['exit_code'], 'exit 1 expected for missing recap_text');
+        self::assertNull($this->repo->find(self::SIM), 'no row must be written for missing recap_text');
+    }
+
+    /**
+     * Malformed themes field: SimRecapPayload degrades to null, script still
+     * exits 0, recap is stored with themes_used = null.
+     *
+     * Verification matrix row 42.
+     */
+    public function testMalformedThemesDegradesToNullThemesUsed(): void
+    {
+        // themes is a bare string, not a list — parseThemes degrades to null.
+        $payloadBadThemes = '{"intro_text":"Intro.","outro_text":"Outro.",'
+            . '"recap_text":"Recap text.","themes":"not-a-list",'
+            . '"games":[{"season_year":2025,"game_date":"2025-01-01","visitor_teamid":1,'
+            . '"home_teamid":2,"game_of_that_day":1,"box_id":null,"sort_order":0,'
+            . '"recap_text":"Game."}]}';
+
+        $result = $this->runScript(['--sim=' . self::SIM], $payloadBadThemes);
+
+        self::assertSame(0, $result['exit_code'], 'exit 0 expected even when themes degrade');
+
+        $row = $this->repo->find(self::SIM);
+        self::assertNotNull($row, 'row must be written even when themes degrade');
+        self::assertSame('done', $row['status']);
+        self::assertNull($row['themes_used'], 'themes_used must be null when themes degrade');
+    }
+
+    /**
+     * Second run against already-done sim: markDone is an UPSERT, so the script
+     * exits 0 and the row remains valid (not corrupted).
+     *
+     * Verification matrix row 43.
+     */
+    public function testSecondRunAgainstDoneSimFollowsMarkDoneSemantics(): void
+    {
+        $this->repo->queuePendingIfAbsent(self::SIM);
+
+        $result1 = $this->runScript(['--sim=' . self::SIM], self::VALID_PAYLOAD);
+        self::assertSame(0, $result1['exit_code'], 'first run must exit 0');
+
+        $rowAfterFirst = $this->repo->find(self::SIM);
+        self::assertNotNull($rowAfterFirst);
+        self::assertSame('done', $rowAfterFirst['status']);
+
+        // Second run: markDone UPSERT overwrites in place — must not error or corrupt.
+        $result2 = $this->runScript(['--sim=' . self::SIM], self::VALID_PAYLOAD);
+        self::assertSame(0, $result2['exit_code'], 'second run must exit 0 (ODKU is idempotent)');
+
+        $rowAfterSecond = $this->repo->find(self::SIM);
+        self::assertNotNull($rowAfterSecond, 'row must still exist after second run');
+        self::assertSame('done', $rowAfterSecond['status'], 'row must still be done after second run');
+    }
+
+    // ── Host-branch cases ───────────────────────────────────────────────────────
+
+    /**
+     * No IBL5_CANONICAL_HOST in child env: url must be a relative path,
+     * not an absolute URL.
+     *
+     * Verification matrix row 44.
+     */
+    public function testEmptyHostProducesRelativeUrl(): void
+    {
+        $this->repo->queuePendingIfAbsent(self::SIM);
+
+        // runScript() removes IBL5_CANONICAL_HOST from the child env by default.
+        $result = $this->runScript(['--sim=' . self::SIM], self::VALID_PAYLOAD);
+
+        self::assertSame(0, $result['exit_code']);
+
+        $json = json_decode($result['stdout'], true);
+        self::assertIsArray($json);
+
+        $url = is_string($json['url'] ?? null) ? $json['url'] : '';
+        self::assertStringNotContainsString('https://', $url, 'url must be relative when host is empty');
+        self::assertStringContainsString('simSummaries.php', $url);
+    }
+
+    /**
+     * IBL5_CANONICAL_HOST=example.test in child env: url must be the full
+     * absolute URL https://example.test/ibl5/simSummaries.php?sim=9001.
+     *
+     * Verification matrix row 45. 'example.test' is the test host;
+     * 'iblhoops.net' must never appear here.
+     */
+    public function testPopulatedHostProducesAbsoluteUrl(): void
+    {
+        $this->repo->queuePendingIfAbsent(self::SIM);
+
+        $result = $this->runScript(
+            ['--sim=' . self::SIM],
+            self::VALID_PAYLOAD,
+            ['IBL5_CANONICAL_HOST' => 'example.test']
+        );
+
+        self::assertSame(0, $result['exit_code']);
+
+        $json = json_decode($result['stdout'], true);
+        self::assertIsArray($json);
+
+        $url = is_string($json['url'] ?? null) ? $json['url'] : '';
+        self::assertSame(
+            'https://example.test/ibl5/simSummaries.php?sim=' . self::SIM,
+            $url,
+            'url must be the full absolute URL when IBL5_CANONICAL_HOST is set'
+        );
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Launch storeSimRecap.php as a child process.
+     *
+     * A bootstrap tmpfile defines PHPUNIT_RUNNING before requiring the script
+     * so Discord::postToChannel() short-circuits — no live webhook POST can fire
+     * on any machine.  Using a tmpfile (rather than php -r) gives predictable
+     * $argv indexing: $argv[0] = bootstrap path, $argv[1..] = caller's args,
+     * so storeSimRecap.php's array_slice($argv, 1) sees exactly what we pass.
+     * (php -r encodes the path via json_encode which escapes forward slashes
+     * as \/ — PHP's double-quoted strings keep the backslash, breaking the path.)
+     *
+     * proc_open() is used with an explicit env array built from the full current
+     * environment (so PATH and DB_* vars reach the child), with IBL5_CANONICAL_HOST
+     * removed by default and selectively set by callers who test the host branch.
+     *
+     * @param list<string> $argv   Arguments forwarded to the script (e.g. ['--sim=9001'])
+     * @param string       $stdin  JSON payload to pipe on stdin
+     * @param array<string, string> $envOverrides  Extra env vars for the child
+     * @return array{exit_code: int, stdout: string, stderr: string}
+     */
+    private function runScript(array $argv, string $stdin, array $envOverrides = []): array
+    {
+        // Write a one-shot bootstrap file that defines PHPUNIT_RUNNING then
+        // requires the script.  var_export() produces a single-quoted PHP string
+        // literal — no forward-slash escaping, so the path is always correct.
+        $bootstrapFile = tempnam(sys_get_temp_dir(), 'sim-recap-bootstrap-');
+        if ($bootstrapFile === false) {
+            self::fail('tempnam must succeed');
+        }
+
+        $bootstrapContent = '<?php' . "\n"
+            . "define('PHPUNIT_RUNNING', true);\n"
+            . 'require ' . var_export($this->scriptPath, true) . ";\n";
+
+        try {
+            if (file_put_contents($bootstrapFile, $bootstrapContent) === false) {
+                self::fail('Failed to write bootstrap file');
+            }
+
+            // Build env: inherit all current env vars, remove IBL5_CANONICAL_HOST
+            // by default (safe non-production default). Callers pass it via
+            // $envOverrides for the host-branch tests.
+            $envVars = getenv();
+            $env = is_array($envVars) ? $envVars : [];
+            unset($env['IBL5_CANONICAL_HOST']);
+            foreach ($envOverrides as $key => $value) {
+                $env[$key] = $value;
+            }
+
+            // $argv[0] = bootstrap file (set by PHP), $argv[1..] = caller's args.
+            $command = array_merge([PHP_BINARY, $bootstrapFile], $argv);
+
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+
+            $process = proc_open($command, $descriptors, $pipes, null, $env);
+            if ($process === false) {
+                self::fail('proc_open failed to launch the child process');
+            }
+
+            fwrite($pipes[0], $stdin);
+            fclose($pipes[0]);
+
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+
+            $exitCode = proc_close($process);
+
+            return [
+                'exit_code' => $exitCode,
+                'stdout'    => is_string($stdout) ? $stdout : '',
+                'stderr'    => is_string($stderr) ? $stderr : '',
+            ];
+        } finally {
+            @unlink($bootstrapFile);
+        }
+    }
+}

--- a/ibl5/tests/SimRecap/SimSummaryLinkTest.php
+++ b/ibl5/tests/SimRecap/SimSummaryLinkTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SimRecap;
+
+use PHPUnit\Framework\TestCase;
+use SimRecap\SimSummaryLink;
+
+final class SimSummaryLinkTest extends TestCase
+{
+    public function testPathReturnsRelativeViewerRoute(): void
+    {
+        self::assertSame('simSummaries.php?sim=689', SimSummaryLink::path(689));
+    }
+
+    public function testPathComposesSimNumber(): void
+    {
+        self::assertSame('simSummaries.php?sim=1', SimSummaryLink::path(1));
+    }
+
+    public function testAbsoluteComposesSchemeHostPrefixAndPath(): void
+    {
+        self::assertSame(
+            'https://iblhoops.net/ibl5/simSummaries.php?sim=689',
+            SimSummaryLink::absolute(689, 'iblhoops.net'),
+        );
+    }
+
+    public function testAbsoluteUsesProvidedHostNotConstant(): void
+    {
+        // Proves the class is pure: if absolute() secretly read IBL5_CANONICAL_HOST
+        // (defined as '' in CI) instead of the $host parameter, the output would be
+        // 'https:///ibl5/...' rather than the expected composed URL. Seeing the
+        // explicit host in the result proves the parameter is used, not the constant.
+        $result = SimSummaryLink::absolute(100, 'explicit-host.example.com');
+
+        self::assertStringContainsString('explicit-host.example.com', $result);
+        self::assertStringNotContainsString('https:///', $result);
+    }
+}

--- a/ibl5/tests/SimRecap/SimSummaryLinkTest.php
+++ b/ibl5/tests/SimRecap/SimSummaryLinkTest.php
@@ -9,14 +9,24 @@ use SimRecap\SimSummaryLink;
 
 final class SimSummaryLinkTest extends TestCase
 {
-    public function testPathReturnsRelativeViewerRoute(): void
+    public function testPathReturnsRootAbsoluteViewerRoute(): void
     {
-        self::assertSame('simSummaries.php?sim=689', SimSummaryLink::path(689));
+        self::assertSame('/ibl5/simSummaries.php?sim=689', SimSummaryLink::path(689));
     }
 
     public function testPathComposesSimNumber(): void
     {
-        self::assertSame('simSummaries.php?sim=1', SimSummaryLink::path(1));
+        self::assertSame('/ibl5/simSummaries.php?sim=1', SimSummaryLink::path(1));
+    }
+
+    /**
+     * The updater page is served from `ibl5/scripts/` and emits no `<base href>`,
+     * so a bare relative path resolved to `/ibl5/scripts/simSummaries.php` — a 404.
+     * The leading slash is what makes the link depth-independent; guard it directly.
+     */
+    public function testPathIsRootAbsoluteSoItSurvivesADeeperRenderingPage(): void
+    {
+        self::assertStringStartsWith('/ibl5/', SimSummaryLink::path(689));
     }
 
     public function testAbsoluteComposesSchemeHostPrefixAndPath(): void

--- a/ibl5/tests/Updater/QueueSimSummaryStepTest.php
+++ b/ibl5/tests/Updater/QueueSimSummaryStepTest.php
@@ -73,13 +73,84 @@ class QueueSimSummaryStepTest extends TestCase
         self::assertSame('Sim recap queued', $step->getLabel());
     }
 
-    public function testStepIsNotRegisteredInTheUpdaterPipeline(): void
+    public function testStepIsRegisteredInTheUpdaterPipeline(): void
     {
-        // unit 3 removes this test as part of its registration phase — the inline comment is intentional
-        self::assertStringNotContainsString(
-            'QueueSimSummaryStep',
-            (string) file_get_contents(__DIR__ . '/../../scripts/updateAllTheThings.php')
+        $src = (string) file_get_contents(__DIR__ . '/../../scripts/updateAllTheThings.php');
+
+        self::assertStringContainsString('QueueSimSummaryStep', $src);
+        self::assertSame(1, substr_count($src, 'QueueSimSummaryStep'));
+
+        $posRefresh = strpos($src, 'RefreshIblHistStep');
+        $posQueue = strpos($src, 'QueueSimSummaryStep');
+        $posController = strpos($src, 'UpdaterController');
+        self::assertIsInt($posRefresh, 'RefreshIblHistStep must be present in the pipeline');
+        self::assertIsInt($posQueue, 'QueueSimSummaryStep must be present in the pipeline');
+        self::assertIsInt($posController, 'UpdaterController must be present in the pipeline');
+        self::assertGreaterThan($posRefresh, $posQueue, 'QueueSimSummaryStep must appear after RefreshIblHistStep');
+        self::assertLessThan($posController, $posQueue, 'QueueSimSummaryStep must appear before UpdaterController');
+    }
+
+    public function testQueuedInlineHtmlContainsSimAndLink(): void
+    {
+        $this->mockDb->onQuery('ibl_sim_dates', [['sim' => 412, 'start_date' => '2026-01-01', 'end_date' => '2026-01-07']]);
+        $this->mockDb->setAffectedRows(1);
+
+        $result = $this->buildStep()->execute();
+
+        self::assertStringContainsString('has been queued for recap generation', $result->inlineHtml);
+        self::assertStringContainsString(\SimRecap\SimSummaryLink::path(412), $result->inlineHtml);
+    }
+
+    public function testStateBLinksLastDoneSimNotCurrentSim(): void
+    {
+        $this->mockDb->onQuery('ibl_sim_dates', [['sim' => 412, 'start_date' => '2026-01-01', 'end_date' => '2026-01-07']]);
+        $this->mockDb->setAffectedRows(0);
+        $this->mockDb->onQuery('ibl_sim_summaries', [
+            ['sim' => 400, 'status' => 'done', 'attempts' => 3, 'generated_at' => '2026-01-01', 'created_at' => '2025-12-01', 'recap_length' => 500],
+            ['sim' => 412, 'status' => 'pending', 'attempts' => 0, 'generated_at' => null, 'created_at' => '2026-01-07', 'recap_length' => null],
+        ]);
+
+        $result = $this->buildStep()->execute();
+
+        self::assertStringContainsString('No new sim to recap this run', $result->inlineHtml);
+        self::assertStringContainsString(\SimRecap\SimSummaryLink::path(400), $result->inlineHtml);
+        self::assertStringNotContainsString(\SimRecap\SimSummaryLink::path(412), $result->inlineHtml);
+    }
+
+    public function testStateBRendersTextOnlyWhenNoDoneRecapExists(): void
+    {
+        $this->mockDb->onQuery('ibl_sim_dates', [['sim' => 412, 'start_date' => '2026-01-01', 'end_date' => '2026-01-07']]);
+        $this->mockDb->setAffectedRows(0);
+        $this->mockDb->onQuery('ibl_sim_summaries', []);
+
+        $result = $this->buildStep()->execute();
+
+        self::assertSame(
+            'No new sim to recap this run, and no recap has been generated yet.',
+            $result->inlineHtml,
         );
+    }
+
+    public function testSentinelSimZeroProducesEmptyInlineHtml(): void
+    {
+        $this->mockDb->onQuery('ibl_sim_dates', []);
+
+        $result = $this->buildStep()->execute();
+
+        self::assertSame('', $result->inlineHtml);
+    }
+
+    public function testEscapingPrimitiveNeutralizesHtmlPayload(): void
+    {
+        // $sim is typed int through the call chain, so injection via execute() is
+        // type-blocked under declare(strict_types=1). This test proves the escape
+        // primitive itself neutralizes a payload — a regression guard if the type
+        // constraint ever changes.
+        $dangerous = '1"><script>alert(1)</script>';
+        $escaped = \Security\HtmlSanitizer::e($dangerous);
+
+        self::assertStringNotContainsString('<', $escaped);
+        self::assertStringNotContainsString('"', $escaped);
     }
 
     private function buildStep(): QueueSimSummaryStep

--- a/ibl5/tests/WideUnit/Scripts/StoreSimRecapHostSeamTest.php
+++ b/ibl5/tests/WideUnit/Scripts/StoreSimRecapHostSeamTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\WideUnit\Scripts;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source-shape pins for the host-seam additions to scripts/storeSimRecap.php.
+ *
+ * These assertions are separate from StoreSimRecapGuardTest so the security
+ * pins in that file are never touched when the host-seam code changes.
+ */
+final class StoreSimRecapHostSeamTest extends TestCase
+{
+    private string $src;
+
+    protected function setUp(): void
+    {
+        $this->src = (string) file_get_contents(__DIR__ . '/../../../scripts/storeSimRecap.php');
+    }
+
+    public function testScriptReadsCanonicalHostConstant(): void
+    {
+        self::assertStringContainsString('IBL5_CANONICAL_HOST', $this->src);
+    }
+
+    public function testScriptInitialisesDiscordWithHost(): void
+    {
+        self::assertStringContainsString('Discord::init(', $this->src);
+    }
+
+    public function testScriptUsesSimSummaryLinkForViewerUrl(): void
+    {
+        self::assertStringContainsString('SimSummaryLink', $this->src);
+    }
+
+    public function testScriptContainsNoHardcodedHostname(): void
+    {
+        self::assertStringNotContainsString('iblhoops.net', $this->src);
+    }
+
+    public function testScriptDoesNotAcceptHostFromArgv(): void
+    {
+        // The host is never accepted from argv — only from IBL5_CANONICAL_HOST.
+        // A '--host' token in the source would indicate a security regression
+        // where the production routing decision could be spoofed by the caller.
+        self::assertStringNotContainsString('--host', $this->src);
+    }
+}

--- a/ibl5/tests/e2e/smoke/admin-pages.spec.ts
+++ b/ibl5/tests/e2e/smoke/admin-pages.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures/auth';
-import { assertNoPhpErrors, PHP_ERROR_PATTERNS } from '../helpers/php-errors';
+import { assertNoPhpErrors, PHP_ERROR_PATTERNS, PHP_WARNING_REGEX } from '../helpers/php-errors';
 import { triggerUpdater } from '../helpers/updater';
 
 // Admin-only page smoke tests — require roles_mask = 1 (ADMIN) on the test user.
@@ -20,6 +20,14 @@ test.describe('Admin page smoke tests', () => {
     // The page renders an Initialization section and a completion summary.
     expect(body).toContain('Initialization');
     expect(body).toMatch(/\d+\s+(steps?\s+completed|succeeded)/i);
+    // (20) QueueSimSummaryStep state (b): CI seed has sim 689 as 'done', so
+    // queuePendingIfAbsent returns false → noNewSimHtml() runs every time.
+    expect(body, 'updater output must contain state-(b) no-new-sim copy').toContain('No new sim to recap this run');
+    // (21) The step always renders a simSummaries.php viewer link (state a or b).
+    expect(body, 'updater output must contain a sim recap viewer href').toContain('simSummaries.php?sim=');
+    // (22) No PHP warnings, notices, or undefined-variable errors from the new step.
+    expect(body, 'PHP Warning in updater output').not.toMatch(PHP_WARNING_REGEX);
+    expect(body, 'Undefined variable/constant in updater output').not.toContain('Undefined');
   });
 
   test('admin GET to updateAllTheThings redirects to LCP without running pipeline', async ({


### PR DESCRIPTION
## Summary
- Register QueueSimSummaryStep in non-Olympics updater pipeline as final step
- Add SimSummaryLink for single-source viewer URL generation (relative & absolute)
- Implement host-seam in storeSimRecap.php: resolves IBL5_CANONICAL_HOST, routes Discord to #admin-chat only when set, adds viewer URL to JSON output
- Updater now notifies admins with inline links: "queued for recap" (state a) or "no new sim; here's the last done recap" (state b)
- Database integration tests for step idempotence, CLI payload contract, and host routing
- E2E assertions for notification presence and link validity

## Manual Testing

- [ ] 23 | The notification copy reads correctly to an admin running the updater — tone and phrasing are a subjective judgement | Truly-manual | post-impl | League Control Panel on the worktree stack
