### PR TITLE
fix: token-report dedup overcounting and subagent transcript inclusion

### DIFF
--- a/bin/test-token-report
+++ b/bin/test-token-report
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bin/test-token-report — regression harness for bin/token-report's two fixes:
+#   1. Dedup: a repeated message.id must be counted once, not per duplicate line.
+#   2. Subagent inclusion: <proj>/<uuid>/subagents/*.jsonl must be summed too.
+#   3. Automouse exclusion: automouse/ subtree must stay out of totals.
+#   4. No-subagents graceful: project dir with no subagent dirs exits 0.
+#
+# Builds a synthetic TOKEN_REPORT_PROJ fixture tree, runs the real bin/token-report
+# against it, and asserts the **Total** row Input value. No live transcripts touched.
+# Requires jq (already a hard dependency of bin/token-report).
+#
+# Run: bin/test-token-report   (exit 0 = all pass, 1 = a case failed)
+set -u
+DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAILED=0
+
+# total_input <proj-dir> — run the report, echo the Input cell of the **Total** row.
+total_input() {
+    TOKEN_REPORT_PROJ="$1" "$DIR/token-report" --days 3650 \
+      | awk -F'|' '/\*\*Total\*\*/ { gsub(/ /, "", $3); print $3 }'
+}
+
+check() { # name want got
+    if [ "$3" = "$2" ]; then echo "ok: $1 (Total Input $3)"
+    else echo "FAIL: $1 — expected $2, got $3"; FAILED=1; fi
+}
+
+# Case 1 — dedup: one message.id (M1) written 3×, input 100 each. Expect 100, not 300.
+P1="$TMP/dedup"; mkdir -p "$P1"
+L='{"message":{"id":"M1","model":"claude-x","usage":{"input_tokens":100,"output_tokens":10}}}'
+printf '%s\n%s\n%s\n' "$L" "$L" "$L" > "$P1/main.jsonl"
+check "dedup collapses 3x message.id" 100 "$(total_input "$P1")"
+
+# Case 2 — subagent inclusion: main (input 100) + subagent (input 50). Expect 150.
+P2="$TMP/subs"; mkdir -p "$P2/1111-uuid/subagents"
+printf '%s\n' '{"message":{"id":"A","model":"m","usage":{"input_tokens":100}}}' > "$P2/main.jsonl"
+printf '%s\n' '{"message":{"id":"B","model":"m","usage":{"input_tokens":50}}}'  > "$P2/1111-uuid/subagents/sub.jsonl"
+check "subagent transcript is counted" 150 "$(total_input "$P2")"
+
+# Case 3 — automouse exclusion: add automouse subagent (input 999). Expect still 150.
+mkdir -p "$P2/automouse/aut-uuid/subagents"
+printf '%s\n' '{"message":{"id":"C","model":"m","usage":{"input_tokens":999}}}' \
+  > "$P2/automouse/aut-uuid/subagents/aut.jsonl"
+check "automouse subagent excluded" 150 "$(total_input "$P2")"
+
+# Case 4 — no-subagents graceful: project dir with no subagent dirs exits 0.
+P4="$TMP/nosubs"; mkdir -p "$P4"
+printf '%s\n' '{"message":{"id":"D","model":"m","usage":{"input_tokens":77}}}' > "$P4/main.jsonl"
+check "no-subagents dir exits 0 with correct total" 77 "$(total_input "$P4")"
+
+exit "$FAILED"

--- a/bin/token-report
+++ b/bin/token-report
@@ -36,39 +36,47 @@ esac
 PROJ="${TOKEN_REPORT_PROJ:-$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5}"
 [ -d "$PROJ" ] || { echo "No project transcript dir: $PROJ" >&2; exit 1; }
 
-# Top-level session transcripts only (maxdepth 1) — the automouse/ subdir holds
-# nightly logs, not interactive sessions.
-file_count=$(find "$PROJ" -maxdepth 1 -type f -name '*.jsonl' -mtime -"$DAYS" | wc -l | tr -d ' ')
+# Interactive session transcripts: top-level sessions (maxdepth 1) plus subagent
+# transcripts nested at <session>/subagents/*.jsonl (depth 3). The automouse/
+# subtree holds nightly logs, not interactive sessions, and stays excluded.
+file_count=$( { find "$PROJ" -maxdepth 1 -type f -name '*.jsonl' -mtime -"$DAYS"; \
+                find "$PROJ" -mindepth 3 -maxdepth 3 -type f -name '*.jsonl' -path '*/subagents/*' ! -path '*/automouse/*' -mtime -"$DAYS"; \
+              } | wc -l | tr -d ' ')
 echo "# Token report — last $DAYS days"
 echo
 if [ "$file_count" -eq 0 ]; then
     echo "No session transcripts modified in the last $DAYS days under $PROJ."
     exit 0
 fi
-echo "_Source: $file_count interactive session transcript(s) under \`$PROJ\` (by file mtime)._"
+echo "_Source: $file_count session + subagent transcript file(s) under \`$PROJ\` (by file mtime)._"
 echo
 echo "| Model | Input | Cache-write | Cache-read | Output |"
 echo "|---|---:|---:|---:|---:|"
 
-find "$PROJ" -maxdepth 1 -type f -name '*.jsonl' -mtime -"$DAYS" -exec cat {} + \
+{ find "$PROJ" -maxdepth 1 -type f -name '*.jsonl' -mtime -"$DAYS" -exec cat {} +; \
+  find "$PROJ" -mindepth 3 -maxdepth 3 -type f -name '*.jsonl' -path '*/subagents/*' ! -path '*/automouse/*' -mtime -"$DAYS" -exec cat {} +; \
+} \
   | jq -rc -R '
       try fromjson catch null
       | select(. != null)
       | (.message.usage // .usage) as $u
       | select($u != null)
       | (.message.model // .model // "unknown") as $m
+      | (.message.id // .uuid // "no-id") as $mid
       | (if ($u.iterations | type) == "array" and ($u.iterations | length) > 0
          then $u.iterations else [$u] end) as $its
-      | $its[]
-      | [ (.model // $m),
-          (.input_tokens // 0),
-          (.cache_creation_input_tokens // 0),
-          (.cache_read_input_tokens // 0),
-          (.output_tokens // 0) ] | @tsv
+      | range($its | length) as $i
+      | $its[$i] as $it
+      | [ ($mid + "::" + ($i | tostring)),
+          ($it.model // $m),
+          ($it.input_tokens // 0),
+          ($it.cache_creation_input_tokens // 0),
+          ($it.cache_read_input_tokens // 0),
+          ($it.output_tokens // 0) ] | @tsv
     ' \
   | awk -F'\t' '
-      { i[$1]+=$2; cw[$1]+=$3; cr[$1]+=$4; o[$1]+=$5
-        iT+=$2; cwT+=$3; crT+=$4; oT+=$5 }
+      !seen[$1]++ { i[$2]+=$3; cw[$2]+=$4; cr[$2]+=$5; o[$2]+=$6
+        iT+=$3; cwT+=$4; crT+=$5; oT+=$6 }
       END {
         for (m in i) printf "| %s | %d | %d | %d | %d |\n", m, i[m], cw[m], cr[m], o[m]
         printf "| **Total** | %d | %d | %d | %d |\n", iT, cwT, crT, oT


### PR DESCRIPTION
## Summary

Fixes two independent bugs in `bin/token-report` (a local bash token analysis tool):

**Bug 1 — Dedup overcounting:** A single assistant turn (one `message.id`) is written to the transcript multiple times as the JSONL line is re-emitted. The jq pipeline was emitting one TSV row per JSONL line, so `awk` summed the same `usage` block once per duplicate — causing every token column to be overcounted by the per-message duplication factor (~2–7×). Fix: add a compound dedup key `(message.id + "::" + iteration_index)` as the first TSV column and guard aggregation with `!seen[$1]++`.

**Bug 2 — Subagent undercount:** `bin/token-report` was using `find "$PROJ" -maxdepth 1` which only reached top-level session transcripts. Subagent transcripts at `$PROJ/<session-uuid>/subagents/*.jsonl` (depth 3) were silently dropped from totals. Fix: add a second `find` targeting `-mindepth 3 -maxdepth 3 -path '*/subagents/*'` while excluding the `automouse/` subtree.

**New:** `bin/test-token-report` regression harness with four fixture-based cases covering both fixes.

no-adr: regression test for bin/token-report, extends existing bin/test-* pattern; no new architectural constraint

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.