### PR TITLE
ci(rebase-prs): prioritize green PRs in rebase queue

### DIFF
--- a/.github/workflows/rebase-prs.yml
+++ b/.github/workflows/rebase-prs.yml
@@ -46,8 +46,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_PAT }}
         run: |
-          # Get all open PRs targeting master
-          prs=$(gh pr list --base master --state open --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"')
+          # Get all open PRs targeting master, ordered so that PRs currently
+          # passing all their checks rebase (and thus re-enter the CI queue)
+          # before PRs with failing/pending checks. A PR is "green" when its
+          # status-check rollup has no entry outside SUCCESS/NEUTRAL/SKIPPED
+          # (an empty rollup — no checks — also counts as green). sort_by is
+          # stable, so relative order within each group is preserved. This is a
+          # scheduling-under-contention optimization: when runners are free it's
+          # a no-op; when they're scarce, green PRs re-confirm first.
+          prs=$(gh pr list --base master --state open \
+            --json number,headRefName,statusCheckRollup \
+            --jq '
+              map(.green = (
+                [.statusCheckRollup[]? | (.conclusion // .state)
+                  | select(. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED")]
+                | length == 0
+              ))
+              | sort_by(.green | not)
+              | .[] | "\(.number) \(.headRefName)"')
 
           if [ -z "$prs" ]; then
             echo "No open PRs targeting master"


### PR DESCRIPTION
## Summary

Reorder PR rebasing by CI status so that passing PRs re-enter the queue before failing/pending ones. When runners are constrained, this ensures successful builds confirm first rather than being blocked behind red builds.

- Fetch `statusCheckRollup` from each PR
- Compute 'green' status (no checks outside SUCCESS/NEUTRAL/SKIPPED)
- Sort stable: green PRs first
- Scheduling-under-contention optimization; no-op when runners are free

## Manual Testing

No manual testing needed — verified by automated tests.
