### PR TITLE
chore: add context distribution metrics to token-report

### DIFF
--- a/bin/token-report
+++ b/bin/token-report
@@ -39,6 +39,12 @@ PROJ="${TOKEN_REPORT_PROJ:-$HOME/.claude/projects/-Users-ajaynicolas-GitHub-IBL5
 # Interactive session transcripts: top-level sessions (maxdepth 1) plus subagent
 # transcripts nested at <session>/subagents/*.jsonl (depth 3). The automouse/
 # subtree holds nightly logs, not interactive sessions, and stays excluded.
+scan_files() {
+    find "$PROJ" -maxdepth 1 -type f -name '*.jsonl' -mtime -"$DAYS" -exec cat {} +
+    find "$PROJ" -mindepth 3 -maxdepth 3 -type f -name '*.jsonl' \
+      -path '*/subagents/*' ! -path '*/automouse/*' -mtime -"$DAYS" -exec cat {} +
+}
+
 file_count=$( { find "$PROJ" -maxdepth 1 -type f -name '*.jsonl' -mtime -"$DAYS"; \
                 find "$PROJ" -mindepth 3 -maxdepth 3 -type f -name '*.jsonl' -path '*/subagents/*' ! -path '*/automouse/*' -mtime -"$DAYS"; \
               } | wc -l | tr -d ' ')
@@ -53,9 +59,7 @@ echo
 echo "| Model | Input | Cache-write | Cache-read | Output |"
 echo "|---|---:|---:|---:|---:|"
 
-{ find "$PROJ" -maxdepth 1 -type f -name '*.jsonl' -mtime -"$DAYS" -exec cat {} +; \
-  find "$PROJ" -mindepth 3 -maxdepth 3 -type f -name '*.jsonl' -path '*/subagents/*' ! -path '*/automouse/*' -mtime -"$DAYS" -exec cat {} +; \
-} \
+scan_files \
   | jq -rc -R '
       try fromjson catch null
       | select(. != null)
@@ -81,3 +85,56 @@ echo "|---|---:|---:|---:|---:|"
         for (m in i) printf "| %s | %d | %d | %d | %d |\n", m, i[m], cw[m], cr[m], o[m]
         printf "| **Total** | %d | %d | %d | %d |\n", iT, cwT, crT, oT
       }'
+
+# Context-distribution section.
+# Uses top-level usage (input+cache_creation+cache_read) as total context per API
+# call — the context window size at the time of the call, deduplicated by message ID.
+# Compaction events: subtype=compact_boundary (trigger=auto = harness-initiated).
+echo
+echo "## Context distribution"
+echo
+echo "| Calls | p50 ctx | p90 ctx | ≥100K calls | Share |"
+echo "|---|---:|---:|---:|---:|"
+
+scan_files \
+  | jq -rcR '
+      try fromjson catch null | select(. != null)
+      | (.message.usage // .usage) as $u
+      | select($u != null)
+      | (.message.id // .uuid // "no-id") as $mid
+      | [$mid,
+         (($u.input_tokens // 0)
+          + ($u.cache_creation_input_tokens // 0)
+          + ($u.cache_read_input_tokens // 0))] | @tsv
+    ' \
+  | sort -k1,1 -u \
+  | awk -F'\t' '{print $2}' \
+  | sort -n \
+  | awk '
+      { a[++n] = $1; if ($1 >= 100000) over++ }
+      END {
+        if (n == 0) { printf "| 0 | — | — | 0 | — |\n"; exit }
+        p50 = a[int(n * 0.5) + 1]
+        p90 = a[int(n * 0.9) + 1]
+        printf "| %d | %d | %d | %d | %d%% |\n", n, p50, p90, over+0, int((over+0) * 100 / n)
+      }'
+
+compact_count=$(
+  scan_files \
+    | jq -rR '
+        try fromjson catch null | select(. != null)
+        | select(.type == "system" and .subtype == "compact_boundary")
+        | .compactMetadata.trigger // "unknown"
+      ' \
+    | sort | uniq -c | sort -rn
+)
+echo
+if [ -z "$compact_count" ]; then
+    echo "_Auto-compactions: **0**_"
+else
+    echo "_Auto-compactions (by trigger):_"
+    echo
+    echo "| Trigger | Count |"
+    echo "|---|---:|"
+    echo "$compact_count" | awk '{ printf "| %s | %d |\n", $2, $1 }'
+fi


### PR DESCRIPTION
## Summary
- Extract duplicate file-scanning logic into `scan_files()` function
- Add context distribution section with p50/p90 percentiles and ≥100K token call metrics
- Add auto-compaction trigger tracking and reporting

## Manual Testing

No manual testing needed — verified by automated tests.
