### PR TITLE
chore: Canonicalize plans directory to ~/claude-plans/

### DIFF
--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -21,7 +21,7 @@ Use `/plan <task description>` for implementation planning.
 ls ~/claude-plans/"$(git rev-parse --abbrev-ref HEAD)".md
 ```
 
-This is exactly how `bin/post-plan-now` resolves the plan for a branch. `~/.claude/plans/` is a **pre-migration path** that still holds old plan files — reading there looks like it worked while missing everything recent.
+This is exactly how `bin/post-plan-now` resolves the plan for a branch. `~/claude-plans/` is the single source of truth — no other directory holds plan files.
 
 ## Worktree Setup
 

--- a/engine/docs/backlog/jsb-native-backlog.md
+++ b/engine/docs/backlog/jsb-native-backlog.md
@@ -7,7 +7,7 @@ last_verified: 2026-07-24
 
 **Purpose:** Catalogue the remaining work to bring the Go engine (`engine/`) to cut-over fidelity with jumpshot 5.60, with an explicit **model-tier** on every item — separating what only Fable-class reasoning has cracked, what is Opus judgment, and what is now a Sonnet-executable recipe. Each open entry is a candidate for a `/plan`.
 
-**Origin:** Advisor triage (2026-07-08), immediately after two static-RE closures refuted long-standing "requires live debugging" premises: the foul-divisor pin (2026-07-07, Fable session) and the CEngine runtime-doubles resolution (2026-07-08). Statuses verified against `$HOME/.claude/plans/`, `jsb-native/re-artifacts/`, and git log on 2026-07-08.
+**Origin:** Advisor triage (2026-07-08), immediately after two static-RE closures refuted long-standing "requires live debugging" premises: the foul-divisor pin (2026-07-07, Fable session) and the CEngine runtime-doubles resolution (2026-07-08). Statuses verified against `$HOME/claude-plans/`, `jsb-native/re-artifacts/`, and git log on 2026-07-08.
 
 **Companion to** the other backlogs in [README.md](README.md); same status taxonomy. The AutoResearch loop item here (J14) is the engine-side companion of [loop-engineering-backlog.md](loop-engineering-backlog.md) L9.
 

--- a/ibl5/docs/backlog/archive/jsb-native-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/jsb-native-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed JSB native-engine backlog entries (J-items), extracted from engine/docs/backlog/jsb-native-backlog.md.
-last_verified: 2026-07-22
+last_verified: 2026-07-24
 ---
 
 # JSB Native-Engine Backlog — Archive
@@ -10,7 +10,7 @@ Read-only historical record of ✅ Implemented / 🚫 Declined entries. For OPEN
 ---
 
 ### J1 Faithful foul-bucket pair port
-**Location:** `engine/internal/sim/bucketweights.go` `foulBucketWeight` + `teamquality.go` (ADR-0061's `offQualityConstant = 1.575` corpus stand-in). Plan: `$HOME/.claude/plans/jsb-faithful-foul-pair.md` (written 2026-07-08, `impl_model: sonnet`, `auto_merge: true`).
+**Location:** `engine/internal/sim/bucketweights.go` `foulBucketWeight` + `teamquality.go` (ADR-0061's `offQualityConstant = 1.575` corpus stand-in). Plan: `$HOME/claude-plans/jsb-faithful-foul-pair.md` (written 2026-07-08, `impl_model: sonnet`, `auto_merge: true`).
 **Problem:** The stand-in is structurally unfaithful — it couples BOTH teams' foul weights to defense at ~0.38, where the statically-pinned 5.60 behavior is an asymmetric pair: HOME = deterministic defense-coupled weight `(defQ − (5/6)·teamDef)/5 + 0.2`; AWAY/NEUTRAL = a stochastic `U[0, 0.6)` redraw with zero coupling. This is also why ADR-0061's GATE-1 (±0.5 home margin) was proven unsatisfiable in the healthy foul range.
 **Result:** Merged 2026-07-10 (PR #1395, ADR-0082, k = 8.6 pair). Count-axis effect ~3% of the Cov gap (gt2 −0.000807 → −0.000774); sign survived, arming J2.
 **Caveat (J2 session 1, then re-corrected by J6 — all same day):** the k-sweep's A-relative gates calibrated the pair to reproduce the pre-existing 1.8× FTA-level inflation (37.8 vs real 20.65/g) — still true, corrected by J15's level re-anchor. J2 additionally called the home arm "dynamically dead" via J5's defQ ≡ 0 pin, but J6 overturned that pin (+0xDD0 is live STL/MIN×44), so the shipped home arm's coupling STRUCTURE is closer to faithful than J2 concluded — its inputs (Go's defQuality formula) and scale are what remain unfaithful. Resolution owner: J15.

--- a/ibl5/docs/backlog/archive/loop-engineering-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/loop-engineering-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed autonomous-loop engineering entries, extracted from loop-engineering-backlog.md.
-last_verified: 2026-07-23
+last_verified: 2026-07-24
 ---
 
 # Autonomous-Loop Engineering Backlog — Archive
@@ -19,9 +19,9 @@ Read-only historical record of ✅ Implemented entries. For OPEN items see ../lo
 ### L17 Shared-context artifact for multi-plan splits
 **Location:** `/plan` Step 2.5 multi-PR path (`.claude/skills/plan/SKILL.md`) — Steps 3–5 run once per unit, each plan fully self-contained; the Discord bug pipeline hand-rolled a shared-context spec file to avoid exactly this.
 **Problem (was):** When a task splits into N plans, each plan-architect run and each implementation session re-derives the shared orientation (blast radius, patterns, front-loaded decisions) independently — N× the exploration spend — and each plan re-inlines the shared background, inflating it toward gate `[C]`. This is a tax on splitting, i.e. a disincentive against the very decomposition the context-budget gate demands.
-**Suggested direction (was):** Formalize the pattern the Discord pipeline improvised: when Step 2.5 splits, persist Step 2's exploration pointers (`path:line` + load-bearing fact, never file bodies) plus recorded Step 3.5 decisions once to `$HOME/.claude/plans/<program>-shared-context.md`; each split plan references it instead of restating it. Plans get smaller, and each architect run becomes targeted confirmation instead of re-exploration.
+**Suggested direction (was):** Formalize the pattern the Discord pipeline improvised: when Step 2.5 splits, persist Step 2's exploration pointers (`path:line` + load-bearing fact, never file bodies) plus recorded Step 3.5 decisions once to `$HOME/claude-plans/<program>-shared-context.md`; each split plan references it instead of restating it. Plans get smaller, and each architect run becomes targeted confirmation instead of re-exploration.
 **Risk if untouched (was):** Splitting stays expensive, so plans skew large — working against L16/T11.
-**Status (2026-07-11):** ✅ Implemented — formalizes the shared-context artifact in `/plan`: on a Step 2.5 split, SKILL.md Steps 2/2.5/3/3.5/5 seed `$HOME/.claude/plans/<program>-shared-context.md` once and each unit references it instead of restating shared background, with matching guidance in `_architect-contract.md`. L16 and T11 remain open.
+**Status (2026-07-11):** ✅ Implemented — formalizes the shared-context artifact in `/plan`: on a Step 2.5 split, SKILL.md Steps 2/2.5/3/3.5/5 seed `$HOME/claude-plans/<program>-shared-context.md` once and each unit references it instead of restating shared background, with matching guidance in `_architect-contract.md`. L16 and T11 remain open.
 
 ### L13 Per-phase impl-model routing
 **Location:** `bin/automouse-run` (single `--model` per plan, resolved once by `bin/lib/plan-impl-model`); plans already label every phase Sonnet / Haiku / self per `.claude/skills/plan/_architect-contract.md` § Agent-tiering guidance — nothing consumes those labels at run time (verified 2026-07-08).
@@ -48,7 +48,7 @@ Read-only historical record of ✅ Implemented entries. For OPEN items see ../lo
 **Status (2026-07-15):** ✅ Implemented — `bin/check-plan` gate `[S]` now checks, for `impl_model: sonnet` plans only: every `### Delegate` packet carries a `**Self-verify:**` line (fence-aware, reusing gate T's parse), and a phased plan carries >=1 edit-anchor signal (Anchor keyword / `line NN` ref / 4-backtick fence). A `sonnet-recipe:` marker clears the gate. Tested in `bin/test-check-plan` (gateS-* cases).
 
 ### L9 JSB AutoResearch loop
-**Location:** JSB sim engine + RE distribution targets; instrumentation groundwork exists (`$HOME/.claude/plans/jsb-l1-gate1-counterfactual-instrument.md` and siblings).
+**Location:** JSB sim engine + RE distribution targets; instrumentation groundwork exists (`$HOME/claude-plans/jsb-l1-gate1-counterfactual-instrument.md` and siblings).
 **Problem (was):** Engine-parameter tuning is human-paced despite having exactly what a self-improvement loop needs: an objective metric (simulated stat distributions vs real targets).
 **Suggested direction (was):** An eval harness that perturbs engine params in a worktree, sims N seasons, scores distribution error, keeps only improvements, and logs each trial — overnight, hundreds of trials. Wants an ADR (metric definition, param search space, acceptance rule).
 **Risk if untouched (was):** RE convergence stays bottlenecked on human iteration bandwidth.

--- a/ibl5/docs/backlog/archive/token-spend-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/token-spend-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed token-spend reduction entries, extracted from token-spend-backlog.md.
-last_verified: 2026-07-16
+last_verified: 2026-07-24
 ---
 
 # Token-Spend Reduction Backlog — Archive
@@ -47,7 +47,7 @@ Read-only historical record of ✅ Implemented entries. For OPEN items see ../to
 ### T10 Tool-output token guards
 **Location:** `$HOME/.claude/hooks/output-guard.sh` (PreToolUse, warn-only), extending the `ci-log-guard.sh` family.
 **Problem (was):** Unbounded Bash output (`cat`, unbounded `git log`/`find`, full Playwright runs) lands in context once and is re-billed as a cache read every remaining turn.
-**Status (2026-07-07):** ✅ Implemented — guards the four measured worst categories (scoped from 27,899 transcript Bash calls); warns with the bounded alternative; skips subagents. Plan archive: `$HOME/.claude/plans/output-guard-hook.md`.
+**Status (2026-07-07):** ✅ Implemented — guards the four measured worst categories (scoped from 27,899 transcript Bash calls); warns with the bounded alternative; skips subagents. Plan archive: `$HOME/claude-plans/output-guard-hook.md`.
 
 ### T11 Tier-boundary plan splitting
 **Location:** `.claude/skills/plan/SKILL.md` — Step 2.5 (split criteria) and Step 4 gate 13 (`impl_model` criterion).
@@ -81,12 +81,12 @@ Read-only historical record of ✅ Implemented entries. For OPEN items see ../to
 **Suggested direction (was):** Extend an existing hook surface rather than add one (meta-tooling-bar): the PostToolUse/PreToolUse guard family (e.g. `$HOME/.claude/hooks/output-guard.sh`) can read the last `usage` block from the session transcript and emit a one-line advisory when context first crosses ~100K and again at ~125K — "context ≥100K: delegate remaining mechanical work (work-triage § execution routing), or split/hand off the session." Warn-only, once per threshold, skip subagents/headless (automouse peak-context is L16's territory). Verify effect via `bin/token-report` bucket distribution after two weeks.
 **Risk if untouched (was):** The single largest residual spend class (~half of weekly cache-read) stays invisible at the moment it's created; T6's 200K cap only bounds the worst case.
 **Provenance:** discovered 2026-07-16 during the post-backlog re-measure (advisory session).
-**Status (2026-07-16):** ✅ Implemented — context-ceiling hook added to `~/.claude/hooks/output-guard.sh`; warns at 100K and 125K tokens, once per threshold per session; skips subagents and headless runs. 10 new tests added (24–33) to `~/.claude/hooks/test-output-guard.sh`. Plan: `$HOME/.claude/plans/t14-context-ceiling-nudge.md`.
+**Status (2026-07-16):** ✅ Implemented — context-ceiling hook added to `~/.claude/hooks/output-guard.sh`; warns at 100K and 125K tokens, once per threshold per session; skips subagents and headless runs. 10 new tests added (24–33) to `~/.claude/hooks/test-output-guard.sh`. Plan: `$HOME/claude-plans/t14-context-ceiling-nudge.md`.
 
 ### T15 Read-payload accretion guard
 **Location:** `$HOME/.claude/hooks/output-guard.sh` (Check E, PreToolUse warn-only); `~/GitHub/IBL5/.claude/settings.local.json` (new `"Read"` matcher entry).
 **Problem (was):** Read results injected 17.3M chars (~4.3M tokens) into contexts over 7 days — 67% of all tool-result bytes. A full-file Read early in a long session is the compounding version of the T10 problem: its tokens are re-billed as cache-read on every subsequent call. The Read tool supports `offset`/`limit` but nothing pushed back on a no-limit Read of a large file.
-**Status (2026-07-16):** ✅ Implemented — `output-guard.sh` extended with Check E: PreToolUse warn when a Read call targets a file over 500 lines with no `offset`/`limit` parameter. Advisory names the LSP-first rule and Explore sub-agent delegation as cheaper paths. Warn-only; skips subagents (their contexts are discarded at SubagentStop). Wired via a new `"Read"` matcher entry in `settings.local.json`. Harness extended with 6 new tests (18–23). Plan: `$HOME/.claude/plans/t15-read-payload-accretion-guard.md`.
+**Status (2026-07-16):** ✅ Implemented — `output-guard.sh` extended with Check E: PreToolUse warn when a Read call targets a file over 500 lines with no `offset`/`limit` parameter. Advisory names the LSP-first rule and Explore sub-agent delegation as cheaper paths. Warn-only; skips subagents (their contexts are discarded at SubagentStop). Wired via a new `"Read"` matcher entry in `settings.local.json`. Harness extended with 6 new tests (18–23). Plan: `$HOME/claude-plans/t15-read-payload-accretion-guard.md`.
 
 ### T16 Poll-shaped Bash round-trips → background/Monitor routing
 **Location:** `.claude/rules/work-triage.md` (new "Execution routing: repeat-polling is a spend bug" section).

--- a/ibl5/docs/backlog/dev-efficiency-backlog.md
+++ b/ibl5/docs/backlog/dev-efficiency-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Development-efficiency backlog — inner-loop speed (diff-scoped analysis, parallel tests), CI caching, dependency-bump batching, and worktree lifecycle automation, with per-entry status.
-last_verified: 2026-07-14
+last_verified: 2026-07-24
 ---
 
 # Development-Efficiency Backlog
@@ -97,7 +97,7 @@ last_verified: 2026-07-14
 **Status (2026-07-14):** ◑ Partial — cheap-gate well exhausted; the only remaining item (free-agents guard) is a standalone `/plan`. 🟨.
 
 ### E9 Meta-tooling growth bar
-**Location:** Plan: `$HOME/.claude/plans/meta-tooling-bar.md` (queued) — extend-before-add rule + quarterly cull.
+**Location:** Plan: `$HOME/claude-plans/meta-tooling-bar.md` (queued) — extend-before-add rule + quarterly cull.
 **Problem:** ~27 of 101 `bin/` scripts exist to test the other scripts; the gate layer itself has had bugs. Nothing pushes back on meta-tooling growth.
 **Status (2026-07-07):** 📋 Planned — queued. 🟦 (rule authoring wants human eyes on merge).
 
@@ -107,7 +107,7 @@ last_verified: 2026-07-14
 **Status (2026-07-07):** ✅ Implemented — on every master push, CI rebuilds the schema from migrations and auto-commits `ibl5/docs/schema/current-schema.sql` if changed. (The `000_baseline` migration snapshot itself is intentionally untouched — the regenerated dump is the source of truth for schema questions.)
 
 ### E11 In-PR pre-baked image build
-**Location:** Plan: `$HOME/.claude/plans/in-pr-prebaked-image-build.md` (queued). Today only `.github/workflows/cache-dependencies.yml` builds the image, on schedule/push — never in-PR.
+**Location:** Plan: `$HOME/claude-plans/in-pr-prebaked-image-build.md` (queued). Today only `.github/workflows/cache-dependencies.yml` builds the image, on schedule/push — never in-PR.
 **Problem:** A PR changing the Dockerfile or composer deps is E2E-tested against the *previous* master image; the mismatch surfaces only after merge.
 **Status (2026-07-07):** 📋 Planned — queued; paths-filtered so normal PRs are unaffected. 🟦.
 

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-07-23
+last_verified: 2026-07-24
 ---
 
 # Loop-Engineering Backlog
@@ -85,7 +85,7 @@ last_verified: 2026-07-23
 ### L5 Master-canary between runs
 **Location:** `bin/automouse-run` refreshes master between plans (fetch + `--ff-only` merge) but runs no health check; `bin/check-master-ci-green` exists as a building block.
 **Problem:** After an overnight auto-merge, the next plan builds on the new master with no smoke check — a poisoned master cascades failures through every remaining plan.
-**Suggested direction:** Between plans, gate on `bin/check-master-ci-green` plus a cheap local smoke (main-stack curl); on red, park the queue rather than continue. (Adjacent: `$HOME/.claude/plans/pr-canary-fast-conflict-signal.md` covers the PR-level pre-merge signal.)
+**Suggested direction:** Between plans, gate on `bin/check-master-ci-green` plus a cheap local smoke (main-stack curl); on red, park the queue rather than continue. (Adjacent: `$HOME/claude-plans/pr-canary-fast-conflict-signal.md` covers the PR-level pre-merge signal.)
 **Risk if untouched:** One bad merge converts the rest of the night into cascading noise.
 **Status (2026-07-07):** ⬜ Open — 🟦.
 
@@ -94,7 +94,7 @@ last_verified: 2026-07-23
 **Status (2026-07-10):** ✅ Implemented — merged PR #1390.
 
 ### L7 Queue-add shift-left preflight
-**Location:** `bin/automouse-queue` `add` runs zero preflight (verified); staleness is caught only at 2am by the impl agent, then self-heal requeues (L8). Plan: `$HOME/.claude/plans/staleness-guard-fp-fix-and-queue-check.md` (not yet queued).
+**Location:** `bin/automouse-queue` `add` runs zero preflight (verified); staleness is caught only at 2am by the impl agent, then self-heal requeues (L8). Plan: `$HOME/claude-plans/staleness-guard-fp-fix-and-queue-check.md` (not yet queued).
 **Problem:** A stale anchor costs a night when it could be fixed in 30 seconds at queue-add time, while a human is at the keyboard.
 **Suggested direction (per the plan):** Run `bin/check-plan` + `bin/check-plan-staleness` at add time; also fixes known staleness-check false positives.
 **Risk if untouched:** Recurring burned queue slots for trivially-fixable staleness.

--- a/ibl5/docs/decisions/0007-nightly-autonomous-workflow.md
+++ b/ibl5/docs/decisions/0007-nightly-autonomous-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: ADR for the automouse autonomous workflow (formerly "nightly") — headless Claude executes queued plans via launchd on a recurring schedule.
-last_verified: 2026-06-20
+last_verified: 2026-07-24
 ---
 
 # ADR-0007: Nightly Autonomous Workflow
@@ -29,7 +29,7 @@ Enforcement: `launchd` plist at `~/Library/LaunchAgents/com.ibl5.automouse.plist
 ## Consequences
 
 - Positive: Plans execute overnight without human presence, producing review-ready PRs by morning.
-- Positive: Symlink-based queue preserves original plans in `~/.claude/plans/` while tracking execution state.
+- Positive: Symlink-based queue preserves original plans in `~/claude-plans/` while tracking execution state.
 - Positive: `CLAUDE_HEADLESS` env var is a clean, extensible gate for headless-specific behavior in any skill.
 - Negative: Mac must remain awake overnight (clamshell mode with external monitor and power connected, or display-sleep-only with lid open). System sleep prevents `launchd` from firing; clamshell mode avoids this.
 - Negative: `--dangerously-skip-permissions` grants full tool access to the headless agent — mitigated by plan validation and skip-on-ambiguity behavior.

--- a/ibl5/docs/decisions/0079-stale-docs-auto-remediation.md
+++ b/ibl5/docs/decisions/0079-stale-docs-auto-remediation.md
@@ -1,6 +1,6 @@
 ---
 description: Act on the nightly stale-docs audit automatically — on a NEW/CHANGED stale set, a self-hosted macOS runner fires a headless Claude run that refreshes exactly the stale docs and opens a PR (held for human merge) that Closes the tracker issue.
-last_verified: 2026-07-15
+last_verified: 2026-07-24
 ---
 
 # ADR-0079: Autonomous stale-docs remediation via a self-hosted macOS runner
@@ -41,7 +41,7 @@ that refreshes exactly the docs in `<sig>`, then opens a PR that `Closes #<issue
    exactly as `bin/post-plan-now` and `bin/automouse-run` already rely on. `bin/docfix-run` clones
    that idiom, differing only in that it first creates the worktree and points the run at it.
 4. **The produced PR is HELD for human merge** (`auto_merge` NOT armed). `bin/docfix-run` seeds a
-   minimal plan at `$HOME/.claude/plans/<slug>.md` with line-1 frontmatter `auto_merge: false`;
+   minimal plan at `$HOME/claude-plans/<slug>.md` with line-1 frontmatter `auto_merge: false`;
    the fix run ends with `bin/post-plan-now` (NOT `--auto`), and `/post-plan` Phase 6.5 condition
    (7) reads that frontmatter and refuses to arm auto-merge. A machine-authored doc edit gets a
    human read before it lands.

--- a/ibl5/docs/tsi-progression-analysis.md
+++ b/ibl5/docs/tsi-progression-analysis.md
@@ -1,6 +1,6 @@
 ---
 description: TSI (total skill index) progression analysis for player development tracking.
-last_verified: 2026-06-10
+last_verified: 2026-07-24
 ---
 
 # TSI → Rating Progression Analysis Results (Revised)
@@ -46,4 +46,4 @@ All ratings monotonic. Cross-validated across early and late eras.
 
 ## For Custom Sim Engine
 
-Use `tsi_sum = T + S + I` as a single progression modifier. No need to differentiate T/S/I for progression mechanics. See full analysis: `~/.claude/plans/TSI_PROGRESSION_ANALYSIS.md`
+Use `tsi_sum = T + S + I` as a single progression modifier. No need to differentiate T/S/I for progression mechanics. See full analysis: `~/claude-plans/TSI_PROGRESSION_ANALYSIS.md`

--- a/ibl5/tests/YourAccount/YourAccountViewCharacterizationTest.php
+++ b/ibl5/tests/YourAccount/YourAccountViewCharacterizationTest.php
@@ -13,7 +13,7 @@ use YourAccount\YourAccountView;
  * byte-identical equality against the pre-refactor fixture, guaranteeing
  * the delegating facade produces unchanged HTML.
  *
- * @see /Users/ajaynicolas/.claude/plans/extract-youraccountview-page-variants.md
+ * @see /Users/ajaynicolas/claude-plans/extract-youraccountview-page-variants.md
  */
 final class YourAccountViewCharacterizationTest extends TestCase
 {

--- a/tools/postplan-harness/harness/planfile.py
+++ b/tools/postplan-harness/harness/planfile.py
@@ -92,11 +92,6 @@ def locate_plan(slug: str, plans_dir: str | None = None, explicit_path: str | No
         path = explicit_path or os.path.join(
             plans_dir or os.environ.get("PLANS_DIR")
             or os.path.expanduser("~/claude-plans"), f"{slug}.md")
-        if not os.path.isfile(path) and plans_dir is None and explicit_path is None:
-            # Pre-migration archive; retire once no plans remain there.
-            legacy = os.path.join(os.path.expanduser("~/.claude/plans"), f"{slug}.md")
-            if os.path.isfile(legacy):
-                path = legacy
         if not os.path.isfile(path):
             return info
         info.path = path


### PR DESCRIPTION
## Summary
- Normalize all references from pre-migration `~/.claude/plans/` to canonical `~/claude-plans/`
- Remove legacy directory fallback logic in `planfile.py`
- Update `last_verified` timestamps to 2026-07-24 across backlog and ADR documents

## Manual Testing

No manual testing needed — verified by automated tests.
