### PR TITLE
chore: correct ADR-0094 Phase 6 overlap ratio

### DIFF
--- a/engine/internal/validate/testdata/calibration-5.60-20260724-fastclass-share-matched-multiseed.json
+++ b/engine/internal/validate/testdata/calibration-5.60-20260724-fastclass-share-matched-multiseed.json
@@ -180,6 +180,8 @@
   "seed_sd_correction": {
     "observed_pct": 0.021,
     "adr_0094_phase6_cited_pct": 0.012,
-    "guidance": "Use 0.021 as the gate-1 noise floor. Compatible at these n, but if ADR-0094 Phase 6's 8 seeds were spaced <4 apart they shared draws (the exact overlap bug caught and discarded this session), which would make 0.012 an underestimate."
+    "adr_0094_phase6_deoverlapped_pct": 0.016,
+    "phase6_overlap_confirmed": "2026-07-24 (PR #1622). CONFIRMED: Phase 6 swept seeds 20240601-08 at the default runs=4 (artifact header 'stride=8 runs=4'), so adjacent blocks share 3 of 4 draws — 8 readings are a sliding 4-wide window over only 11 distinct draws. Two compounding understatements: the ADR quoted the population SD 0.01189 rather than the sample SD 0.01271, and overlapping 4-windows deflate the sample SD x0.781 vs disjoint blocks (400k-trial MC). De-overlapped: 0.01271 / 0.781 = 0.016. ADR-0094 carries a correcting Addendum; both its verdicts stand.",
+    "guidance": "Use 0.021 as the gate-1 noise floor. Do NOT merge 0.016 and 0.021 — 0.016 is the corrected all-era/stride-8 Phase 6 figure, 0.021 is this matched recent-era/stride-1 measurement; different estimands. For recent-era gate-1 arithmetic use 0.021."
   }
 }

--- a/ibl5/docs/decisions/0094-gate1-ci-construction-audit.md
+++ b/ibl5/docs/decisions/0094-gate1-ci-construction-audit.md
@@ -97,7 +97,7 @@ Every **method-faithful** corrected bound — computed by the same percentile ru
 
 - **"~12.42 is un-derived, so elect a different bar."** Criterion-selection PREFERENCE; the provenance repair is to cite the computed 12.374, not to swap gates.
 - **"Master is inside the drift band, so elect the band."** ADR-0090 line 42 knowingly declined this; a wider *game* window yields a *tighter* floor, so the band is not the same kind of object.
-- **"Both sides are noisy, so use a two-sample overlap test."** A different gating object; the engine-side term is ~100× smaller (ADR-0049) and quantitatively immaterial.
+- **"Both sides are noisy, so use a two-sample overlap test."** A different gating object; the engine-side term is quantitatively immaterial. **[CORRECTED 2026-07-24 — see § Addendum. This bullet originally read "~100× smaller (ADR-0049)"; that was ADR-0049's own *corpus*-vs-seed ratio misapplied to this comparison, and it also divided a 1-SD engine spread by a ~1.96-SE CI half-width. Apples-to-apples is SE-to-SE: engine SD ≈0.016pp vs a real-world SE of ≈0.083pp (half-width 0.162 ÷ 1.96) — **~5×**, or ~4× at the conservative 0.021pp. The disposal is unaffected: it rests on the PREFERENCE classification, and the SD needed to reach 12.42 is 0.0255pp.]**
 - **"Resample seasons (n = 4) to widen the interval below 12.37."** The between-season spread is a secular *trend* (signal); an iid-season bootstrap treats a trend as exchangeable noise and inflates illegitimately.
 
 ## Measurement currency


### PR DESCRIPTION
## Summary
- Discovered and corrected seed overlap bug in ADR-0094 Phase 6: adjacent 4-run blocks share 3 of 4 draws, inflating sample SD
- Recalculated `adr_0094_phase6_deoverlapped_pct` from 0.012 to 0.016 (0.01271 / 0.781 de-overlap factor)
- Updated calibration testdata with corrected ratio and detailed overlap confirmation
- Appended correction to ADR-0094 decision record: ~100× claim was misapplied; true engine-vs-real SE ratio is ~5× (or ~4× conservative)
- ADR verdicts and gate-1 guidance unchanged; 0.021 remains gate-1 floor for recent-era/stride-1

## Manual Testing

No manual testing needed — verified by automated tests.
