### PR TITLE
chore(test): add Api/Updater/Clock test coverage

### DIFF
--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -45,13 +45,13 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 | Status | Count |
 |--------|------:|
-| ✅ Implemented | 227 |
-| ◑ Partial | 26 |
+| ✅ Implemented | 228 |
+| ◑ Partial | 25 |
 | 📋 Planned (plan queued / PR open) | 1 |
 | ⬜ Open | 67 |
 | 🚫 Declined | 10 |
 
-> Status counts re-verified 2026-06-28 (exact, from the per-axis tables); **6.20 / 6.21 added 2026-06-29** from the PR #1107 review (⬜ Open +2); **6.22 added 2026-06-29** from the #1066 reject-IDOR review (⬜ Open +1). Two stale-Open rows were flipped directly (no plan owned them): **13.3**, **13.9** (✅ +2, ⬜ −2 vs the master re-count). **1.21–1.31 added 2026-07-24** from the hot-files comment→backlog migration (⬜ Open +11: 8 🟩 auto-mergeable, 3 🟨 conditional — 1.23/1.25/1.31 need characterization/endpoint pins). **Ground-truth audit 2026-07-24:** 7 stale-Open items flipped ✅, 2 false findings marked 🚫, 5 new Axis-1 rows seeded (1.32–1.36); IDOR PRs #1107–1110 merged 2026-06-29 (unblocking 2.10/2.13/2.14/2.25/7.7/14.6); PRs #1240/#1230/#1204 merged (2.6/2.31/2.32/5.18 already ✅/Open on own merits). **9.19 and 9.20 implemented 2026-07-24** — added READMEs to all 68 missing class dirs + frontmatter to all 16 existing class READMEs that lacked it; extended bin/check-docs IN_SCOPE_GLOBS (✅ +2, ⬜ −2); roll-up recomputed from grep (331 rows total, unchanged).
+> Status counts re-verified 2026-06-28 (exact, from the per-axis tables); **6.20 / 6.21 added 2026-06-29** from the PR #1107 review (⬜ Open +2); **6.22 added 2026-06-29** from the #1066 reject-IDOR review (⬜ Open +1). Two stale-Open rows were flipped directly (no plan owned them): **13.3**, **13.9** (✅ +2, ⬜ −2 vs the master re-count). **1.21–1.31 added 2026-07-24** from the hot-files comment→backlog migration (⬜ Open +11: 8 🟩 auto-mergeable, 3 🟨 conditional — 1.23/1.25/1.31 need characterization/endpoint pins). **Ground-truth audit 2026-07-24:** 7 stale-Open items flipped ✅, 2 false findings marked 🚫, 5 new Axis-1 rows seeded (1.32–1.36); IDOR PRs #1107–1110 merged 2026-06-29 (unblocking 2.10/2.13/2.14/2.25/7.7/14.6); PRs #1240/#1230/#1204 merged (2.6/2.31/2.32/5.18 already ✅/Open on own merits). **9.19 and 9.20 implemented 2026-07-24** — added READMEs to all 68 missing class dirs + frontmatter to all 16 existing class READMEs that lacked it; extended bin/check-docs IN_SCOPE_GLOBS (✅ +2, ⬜ −2); roll-up recomputed from grep (331 rows total, unchanged). **6.16 flipped ✅ 2026-07-24** (all Api data repos + JsonResponder + SystemClock tested; ✅ +1, ◑ −1). **6.14 Status updated 2026-07-24** (ProcessBoxscoresStep/GenerateSeasonAwardsStep/ParseJsbFilesStep added; still ◑).
 
 **Automouse-readiness of the not-yet-complete (⬜/◑/📋) items:**
 
@@ -611,9 +611,9 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 6.11 | ✅ Implemented | 🟩 | SeasonHighs thin; additive. |
 | 6.12 | ✅ Implemented | 🟩 | TeamSchedule thin; additive. |
 | 6.13 | ◑ Partial | 🟩 | Player ~0.45 ratio (69 prod / 31 test files); additive (L — chunk it). |
-| 6.14 | ◑ Partial | 🟩 | Updater steps; additive. |
+| 6.14 | ◑ Partial | 🟩 | ProcessBoxscoresStep/GenerateSeasonAwardsStep/ParseJsbFilesStep added (2026-07-24); ~19 step classes + OlympicsFlatStandingsUpdater/UpdaterView/JsbSourceResolver remain. |
 | 6.15 | ✅ Implemented | — | VotingRepositoryTest + SubmissionResultTest added (aggregation, column allowlist). |
-| 6.16 | ◑ Partial | 🟩 | ApiKeyRepositoryTest + RateLimitRepositoryTest added; data repos + JsonResponder/SystemClock still untested. |
+| 6.16 | ✅ Implemented | — | All data repos (ApiGame/Injuries/Leaders/Player/PlayerStats/Standings/Team + Health) + JsonResponder + SystemClock tested (2026-07-24). |
 | 6.17 | ◑ Partial | 🟩 | TradeAssetRepositoryTest + TradeOfferRepositoryTest added (draft-pick mapping, offer lifecycle); TradeExecutionRepository untested + TradeFormRepository partial. |
 | 6.18 | ◑ Partial | 🟩 | Unit tests added: DraftPickLocator repo, LeagueSchedule Game, TransactionHistory repo, CapSpace repo. NextSim/SavedDepthChart/DepthChartEntry verified covered. Residual: SQL aggregation/ordering + SDC write-path are DB-integration-only. |
 | 6.19 | ◑ Partial | 🟩 | AllStarAppearances + GMContactList repo unit tests added. Season entity predicates blocked by `Season\Season`→mock alias (QueryRepo plumbing covered). `Shared` N/A (deleted 2.23). |
@@ -650,7 +650,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** Per-step W-L aggregation, date ordering, format parsing.
 **Est. effort:** L
 **Risk if untouched:** Nightly automation corrupts standings/schedules/stats silently.
-**Status:** ◑ Partial (this PR, 2026-06-27). Added `ibl5/tests/Updater/StandingsUpdaterTest.php` (league/home/away/conference/division W-L aggregation, plus unknown-team-skip, empty-config, and zero-games boundaries) and `ibl5/tests/Updater/PowerRankingsUpdaterTest.php` (ranking formula + div-by-zero guard); extended `ibl5/tests/Updater/RecordParserTest.php` with empty/non-numeric/leading-dash boundaries. `ScheduleUpdater` already covered (`ibl5/tests/Updater/ScheduleUpdaterTest.php`). **Residual:** `Updater/Steps/` (22 step classes), `OlympicsFlatStandingsUpdater`, `UpdaterView`, and `JsbSourceResolver` remain untested; the 37-file module is still well below a 0.5 ratio.
+**Status:** ◑ Partial (this PR, 2026-06-27). Added `ibl5/tests/Updater/StandingsUpdaterTest.php` (league/home/away/conference/division W-L aggregation, plus unknown-team-skip, empty-config, and zero-games boundaries) and `ibl5/tests/Updater/PowerRankingsUpdaterTest.php` (ranking formula + div-by-zero guard); extended `ibl5/tests/Updater/RecordParserTest.php` with empty/non-numeric/leading-dash boundaries. `ScheduleUpdater` already covered (`ibl5/tests/Updater/ScheduleUpdaterTest.php`). Added `ibl5/tests/Updater/ProcessBoxscoresStepTest.php`, `ibl5/tests/Updater/GenerateSeasonAwardsStepTest.php`, `ibl5/tests/Updater/ParseJsbFilesStepTest.php` (2026-07-24). **Residual:** `Updater/Steps/` (~19 step classes remain), `OlympicsFlatStandingsUpdater`, `UpdaterView`, and `JsbSourceResolver` untested; module still below 0.5 ratio.
 
 ### 6.16 Api Module — Subthreshold (48 files, 22 tests, 0.46 ratio)
 **Location:** `ibl5/classes/Api`
@@ -658,7 +658,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** Header parsing, token-bucket logic, pagination offset/limit edges.
 **Est. effort:** L
 **Risk if untouched:** Auth bypass; rate limiter broken; pagination off-by-one.
-**Status:** Partial (verified 2026-06-27) — tests/Api/Repository/ApiKeyRepositoryTest.php + tests/Api/Repository/RateLimitRepositoryTest.php added (active-key-only lookup, token-bucket upsert/window count). ApiKeyAuthenticator/RateLimiter/Paginator already well-covered. Residual: data repositories (ApiGameRepository, ApiInjuriesRepository, ApiLeadersRepository, ApiPlayerRepository, ApiPlayerStatsRepository, ApiStandingsRepository, ApiTeamRepository, HealthRepository) + JsonResponder + SystemClock.
+**Status:** ✅ Implemented (2026-07-24). Prior coverage: ApiKeyAuthenticator/RateLimiter/Paginator/ApiKeyRepository/RateLimitRepository. All named residuals now covered: `ibl5/tests/Api/Repository/ApiGameRepositoryTest.php`, `ApiInjuriesRepositoryTest.php`, `ApiLeadersRepositoryTest.php`, `ApiPlayerRepositoryTest.php`, `ApiPlayerStatsRepositoryTest.php`, `ApiStandingsRepositoryTest.php`, `ApiTeamRepositoryTest.php`, `HealthRepositoryTest.php` (unreachable-false branch via anonymous subclass override), `ibl5/tests/Api/Response/JsonResponderTest.php` (ob_start/ob_get_clean capture pattern), `ibl5/tests/Clock/SystemClockTest.php` (Clock module testsuite added to phpunit.xml).
 
 ### 6.17 Trading Module — Subthreshold (27 files, 12 tests, 0.44 ratio)
 **Location:** `ibl5/classes/Trading`

--- a/ibl5/phpunit.xml
+++ b/ibl5/phpunit.xml
@@ -163,6 +163,9 @@
         <testsuite name="API Module Tests">
             <directory>tests/Api</directory>
         </testsuite>
+        <testsuite name="Clock Module Tests">
+            <directory>tests/Clock</directory>
+        </testsuite>
         <testsuite name="ApiKeys Module Tests">
             <directory>tests/ApiKeys</directory>
         </testsuite>

--- a/ibl5/tests/Api/Repository/ApiGameRepositoryTest.php
+++ b/ibl5/tests/Api/Repository/ApiGameRepositoryTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Repository;
+
+use Api\Pagination\Paginator;
+use Api\Repository\ApiGameRepository;
+use Tests\WideUnit\WideUnitTestCase;
+
+class ApiGameRepositoryTest extends WideUnitTestCase
+{
+    private ApiGameRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ApiGameRepository($this->mockDb);
+    }
+
+    // --- getGames ---
+
+    public function testGetGamesReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['game_uuid' => 'g-uuid-1', 'season_year' => 2025, 'game_status' => 'Final'],
+        ]);
+
+        $result = $this->repository->getGames($this->buildPaginator());
+
+        self::assertCount(1, $result);
+        self::assertSame('g-uuid-1', $result[0]['game_uuid']);
+    }
+
+    public function testGetGamesQueriesScheduleView(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getGames($this->buildPaginator());
+
+        $this->assertQueryExecuted('vw_schedule_upcoming');
+    }
+
+    public function testGetGamesWithSeasonFilterBindsSeason(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getGames($this->buildPaginator(), ['season' => '2025']);
+
+        $this->assertQueryExecuted('season_year');
+    }
+
+    public function testGetGamesWithStatusFilterBindsStatus(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getGames($this->buildPaginator(), ['status' => 'Final']);
+
+        $this->assertQueryExecuted('game_status');
+    }
+
+    public function testGetGamesWithTeamFilterBindsTeamUuid(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getGames($this->buildPaginator(), ['team' => 'team-uuid-1']);
+
+        $this->assertQueryExecuted('visitor_uuid');
+    }
+
+    public function testGetGamesWithDateFilterBindsDate(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getGames($this->buildPaginator(), ['date' => '2025-01-15']);
+
+        $this->assertQueryExecuted('game_date =');
+    }
+
+    public function testGetGamesWithDateRangeFilter(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getGames($this->buildPaginator(), [
+            'date_start' => '2025-01-01',
+            'date_end' => '2025-01-31',
+        ]);
+
+        $this->assertQueryExecuted('game_date >=');
+    }
+
+    public function testGetGamesReturnsEmptyWhenNone(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getGames($this->buildPaginator());
+
+        self::assertSame([], $result);
+    }
+
+    // --- countGames ---
+
+    public function testCountGamesReturnsTotal(): void
+    {
+        $this->mockDb->setMockData([['total' => 42]]);
+
+        $count = $this->repository->countGames();
+
+        self::assertSame(42, $count);
+    }
+
+    public function testCountGamesReturnsZeroWhenNoneFound(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $count = $this->repository->countGames();
+
+        self::assertSame(0, $count);
+    }
+
+    public function testCountGamesWithSeasonFilterAppliesWhereClause(): void
+    {
+        $this->mockDb->setMockData([['total' => 10]]);
+
+        $this->repository->countGames(['season' => '2025']);
+
+        $this->assertQueryExecuted('season_year');
+    }
+
+    // --- getGameByUuid ---
+
+    public function testGetGameByUuidReturnsGame(): void
+    {
+        $this->mockDb->setMockData([
+            ['game_uuid' => 'g-uuid-abc', 'season_year' => 2025, 'game_status' => 'Final'],
+        ]);
+
+        $result = $this->repository->getGameByUuid('g-uuid-abc');
+
+        self::assertIsArray($result);
+        self::assertSame('g-uuid-abc', $result['game_uuid']);
+    }
+
+    public function testGetGameByUuidReturnsNullWhenNotFound(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getGameByUuid('no-such-uuid');
+
+        self::assertNull($result);
+    }
+
+    public function testGetGameByUuidQueriesGameUuid(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getGameByUuid('test-uuid');
+
+        $this->assertQueryExecuted('game_uuid');
+    }
+
+    // --- getBoxscoreTeams ---
+
+    public function testGetBoxscoreTeamsReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['visitor_q1_points' => 30, 'home_q1_points' => 28],
+        ]);
+
+        $result = $this->repository->getBoxscoreTeams(1, 2, '2025-01-15');
+
+        self::assertCount(1, $result);
+    }
+
+    public function testGetBoxscoreTeamsQueriesBoxScoresTable(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getBoxscoreTeams(1, 2, '2025-01-15');
+
+        $this->assertQueryExecuted('ibl_box_scores_teams');
+    }
+
+    // --- getBoxscorePlayers ---
+
+    public function testGetBoxscorePlayersReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['name' => 'Player A', 'pos' => 'PG', 'game_min' => 38],
+        ]);
+
+        $result = $this->repository->getBoxscorePlayers(1, 2, '2025-01-15');
+
+        self::assertCount(1, $result);
+        self::assertSame('Player A', $result[0]['name']);
+    }
+
+    public function testGetBoxscorePlayersQueriesBoxScoresTable(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getBoxscorePlayers(1, 2, '2025-01-15');
+
+        $this->assertQueryExecuted('ibl_box_scores');
+    }
+
+    private function buildPaginator(): Paginator
+    {
+        return new Paginator([], 'game_date', ['game_date', 'season_year', 'game_status']);
+    }
+}

--- a/ibl5/tests/Api/Repository/ApiInjuriesRepositoryTest.php
+++ b/ibl5/tests/Api/Repository/ApiInjuriesRepositoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Repository;
+
+use Api\Repository\ApiInjuriesRepository;
+use Tests\WideUnit\WideUnitTestCase;
+
+class ApiInjuriesRepositoryTest extends WideUnitTestCase
+{
+    private ApiInjuriesRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ApiInjuriesRepository($this->mockDb);
+    }
+
+    public function testGetInjuredPlayersReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['player_uuid' => 'uuid-1', 'pid' => 10, 'name' => 'John Doe', 'pos' => 'PG', 'injured' => 5,
+             'teamid' => 1, 'team_uuid' => 'team-uuid-1', 'team_city' => 'Chicago', 'team_name' => 'Bulls'],
+        ]);
+
+        $result = $this->repository->getInjuredPlayers();
+
+        self::assertCount(1, $result);
+        self::assertSame('John Doe', $result[0]['name']);
+    }
+
+    public function testGetInjuredPlayersReturnsEmptyArrayWhenNone(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getInjuredPlayers();
+
+        self::assertSame([], $result);
+    }
+
+    public function testQueryFiltersOnInjuredColumn(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getInjuredPlayers();
+
+        $this->assertQueryExecuted('injured');
+    }
+
+    public function testQueryJoinsTeamInfo(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getInjuredPlayers();
+
+        $this->assertQueryExecuted('ibl_team_info');
+    }
+}

--- a/ibl5/tests/Api/Repository/ApiLeadersRepositoryTest.php
+++ b/ibl5/tests/Api/Repository/ApiLeadersRepositoryTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Repository;
+
+use Api\Pagination\Paginator;
+use Api\Repository\ApiLeadersRepository;
+use Tests\WideUnit\WideUnitTestCase;
+
+class ApiLeadersRepositoryTest extends WideUnitTestCase
+{
+    private ApiLeadersRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ApiLeadersRepository($this->mockDb);
+    }
+
+    // --- getLeaders ---
+
+    public function testGetLeadersReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['player_uuid' => 'uuid-1', 'pid' => 10, 'name' => 'Alice', 'games' => 82, 'pts' => 2000],
+        ]);
+
+        $result = $this->repository->getLeaders($this->buildPaginator());
+
+        self::assertCount(1, $result);
+        self::assertSame('Alice', $result[0]['name']);
+    }
+
+    public function testGetLeadersQueriesHistTable(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getLeaders($this->buildPaginator());
+
+        $this->assertQueryExecuted('ibl_hist');
+    }
+
+    public function testGetLeadersWithPpgCategoryUsesPpgSortExpression(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getLeaders($this->buildPaginator(), ['category' => 'ppg']);
+
+        // The ppg sort expression divides points by games
+        $this->assertQueryExecuted('fgm');
+    }
+
+    public function testGetLeadersWithRpgCategoryUsesRpgSortExpression(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getLeaders($this->buildPaginator(), ['category' => 'rpg']);
+
+        $this->assertQueryExecuted('reb');
+    }
+
+    public function testGetLeadersWithInvalidCategoryFallsBackToPpg(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getLeaders($this->buildPaginator(), ['category' => 'invalid_category']);
+
+        // Falls back to ppg — the ppg expression includes fgm
+        $this->assertQueryExecuted('fgm');
+        // Should NOT use an invalid sort expression
+        $this->assertQueryNotExecuted('invalid_category');
+    }
+
+    public function testGetLeadersWithSeasonFilterAppliesWhere(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getLeaders($this->buildPaginator(), ['season' => '2025']);
+
+        $this->assertQueryExecuted('h.year');
+    }
+
+    public function testGetLeadersWithMinGamesFilterAboveZeroAppliesWhere(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getLeaders($this->buildPaginator(), ['min_games' => '10']);
+
+        $this->assertQueryExecuted('h.games >=');
+    }
+
+    public function testGetLeadersWithMinGamesFilterOfZeroDoesNotApplyWhere(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getLeaders($this->buildPaginator(), ['min_games' => '0']);
+
+        $this->assertQueryNotExecuted('h.games >=');
+    }
+
+    public function testGetLeadersReturnsEmptyWhenNone(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getLeaders($this->buildPaginator());
+
+        self::assertSame([], $result);
+    }
+
+    // --- countLeaders ---
+
+    public function testCountLeadersReturnsTotal(): void
+    {
+        $this->mockDb->setMockData([['total' => 150]]);
+
+        $count = $this->repository->countLeaders();
+
+        self::assertSame(150, $count);
+    }
+
+    public function testCountLeadersReturnsZeroWhenNoResult(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $count = $this->repository->countLeaders();
+
+        self::assertSame(0, $count);
+    }
+
+    public function testCountLeadersWithSeasonFilterAppliesWhere(): void
+    {
+        $this->mockDb->setMockData([['total' => 80]]);
+
+        $this->repository->countLeaders(['season' => '2025']);
+
+        $this->assertQueryExecuted('h.year');
+    }
+
+    // --- getAvailableSeasons ---
+
+    public function testGetAvailableSeasonsReturnsSeasonYears(): void
+    {
+        $this->mockDb->setMockData([
+            ['year' => 2025],
+            ['year' => 2024],
+        ]);
+
+        $result = $this->repository->getAvailableSeasons();
+
+        self::assertIsArray($result);
+    }
+
+    private function buildPaginator(): Paginator
+    {
+        return new Paginator([], 'pts', ['pts', 'games', 'ast']);
+    }
+}

--- a/ibl5/tests/Api/Repository/ApiPlayerRepositoryTest.php
+++ b/ibl5/tests/Api/Repository/ApiPlayerRepositoryTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Repository;
+
+use Api\Pagination\Paginator;
+use Api\Repository\ApiPlayerRepository;
+use Tests\WideUnit\WideUnitTestCase;
+
+class ApiPlayerRepositoryTest extends WideUnitTestCase
+{
+    private ApiPlayerRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ApiPlayerRepository($this->mockDb);
+    }
+
+    // --- getPlayers ---
+
+    public function testGetPlayersReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['player_uuid' => 'uuid-1', 'pid' => 10, 'name' => 'Alice', 'position' => 'PG'],
+        ]);
+
+        $result = $this->repository->getPlayers($this->buildPaginator());
+
+        self::assertCount(1, $result);
+        self::assertSame('Alice', $result[0]['name']);
+    }
+
+    public function testGetPlayersQueriesPlayerCurrentView(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getPlayers($this->buildPaginator());
+
+        $this->assertQueryExecuted('vw_player_current');
+    }
+
+    public function testGetPlayersWithPositionFilterAppliesWhereClause(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getPlayers($this->buildPaginator(), ['position' => 'PG']);
+
+        $this->assertQueryExecuted('position =');
+    }
+
+    public function testGetPlayersWithTeamFilterAppliesWhereClause(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getPlayers($this->buildPaginator(), ['team' => 'team-uuid-1']);
+
+        $this->assertQueryExecuted('team_uuid =');
+    }
+
+    public function testGetPlayersWithSearchFilterAppliesLike(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getPlayers($this->buildPaginator(), ['search' => 'james']);
+
+        $this->assertQueryExecuted('name LIKE');
+    }
+
+    public function testGetPlayersReturnsEmptyWhenNone(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getPlayers($this->buildPaginator());
+
+        self::assertSame([], $result);
+    }
+
+    // --- countPlayers ---
+
+    public function testCountPlayersReturnsTotal(): void
+    {
+        $this->mockDb->setMockData([['total' => 320]]);
+
+        $count = $this->repository->countPlayers();
+
+        self::assertSame(320, $count);
+    }
+
+    public function testCountPlayersReturnsZeroWhenNoResult(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $count = $this->repository->countPlayers();
+
+        self::assertSame(0, $count);
+    }
+
+    public function testCountPlayersWithPositionFilterAppliesWhere(): void
+    {
+        $this->mockDb->setMockData([['total' => 80]]);
+
+        $this->repository->countPlayers(['position' => 'SG']);
+
+        $this->assertQueryExecuted('position =');
+    }
+
+    // --- getAllPlayersForExport ---
+
+    public function testGetAllPlayersForExportReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['player_uuid' => 'uuid-1', 'name' => 'Alice'],
+            ['player_uuid' => 'uuid-2', 'name' => 'Bob'],
+        ]);
+
+        $result = $this->repository->getAllPlayersForExport();
+
+        self::assertCount(2, $result);
+    }
+
+    public function testGetAllPlayersForExportQueriesViewOrderedByName(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getAllPlayersForExport();
+
+        $this->assertQueryExecuted('name ASC');
+    }
+
+    // --- getPlayerByUuid ---
+
+    public function testGetPlayerByUuidReturnsPlayer(): void
+    {
+        $this->mockDb->setMockData([
+            ['player_uuid' => 'uuid-abc', 'name' => 'Charlie', 'position' => 'SF'],
+        ]);
+
+        $result = $this->repository->getPlayerByUuid('uuid-abc');
+
+        self::assertIsArray($result);
+        self::assertSame('Charlie', $result['name']);
+    }
+
+    public function testGetPlayerByUuidReturnsNullWhenNotFound(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getPlayerByUuid('no-such-uuid');
+
+        self::assertNull($result);
+    }
+
+    public function testGetPlayerByUuidQueriesPlayerUuidColumn(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getPlayerByUuid('test-uuid');
+
+        $this->assertQueryExecuted('player_uuid');
+    }
+
+    private function buildPaginator(): Paginator
+    {
+        return new Paginator([], 'name', ['name', 'position', 'points_per_game']);
+    }
+}

--- a/ibl5/tests/Api/Repository/ApiPlayerStatsRepositoryTest.php
+++ b/ibl5/tests/Api/Repository/ApiPlayerStatsRepositoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Repository;
+
+use Api\Repository\ApiPlayerStatsRepository;
+use Tests\WideUnit\WideUnitTestCase;
+
+class ApiPlayerStatsRepositoryTest extends WideUnitTestCase
+{
+    private ApiPlayerStatsRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ApiPlayerStatsRepository($this->mockDb);
+    }
+
+    public function testGetCareerStatsReturnsRowForKnownUuid(): void
+    {
+        $this->mockDb->setMockData([
+            ['player_uuid' => 'uuid-abc', 'pid' => 42, 'name' => 'Jane Smith', 'career_games' => 120],
+        ]);
+
+        $result = $this->repository->getCareerStats('uuid-abc');
+
+        self::assertIsArray($result);
+        self::assertSame('Jane Smith', $result['name']);
+        self::assertSame(120, $result['career_games']);
+    }
+
+    public function testGetCareerStatsReturnsNullWhenPlayerNotFound(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getCareerStats('uuid-unknown');
+
+        self::assertNull($result);
+    }
+
+    public function testGetCareerStatsQueriesCareerStatsView(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getCareerStats('uuid-test');
+
+        $this->assertQueryExecuted('vw_player_career_stats');
+    }
+
+    public function testGetSeasonHistoryReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['player_uuid' => 'uuid-abc', 'pid' => 42, 'year' => 2025, 'games' => 82, 'pts' => 2050],
+            ['player_uuid' => 'uuid-abc', 'pid' => 42, 'year' => 2024, 'games' => 75, 'pts' => 1800],
+        ]);
+
+        $result = $this->repository->getSeasonHistory('uuid-abc');
+
+        self::assertCount(2, $result);
+        self::assertSame(2025, $result[0]['year']);
+    }
+
+    public function testGetSeasonHistoryReturnsEmptyWhenNone(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getSeasonHistory('uuid-no-history');
+
+        self::assertSame([], $result);
+    }
+
+    public function testGetSeasonHistoryQueriesHistTable(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getSeasonHistory('uuid-test');
+
+        $this->assertQueryExecuted('ibl_hist');
+    }
+}

--- a/ibl5/tests/Api/Repository/ApiStandingsRepositoryTest.php
+++ b/ibl5/tests/Api/Repository/ApiStandingsRepositoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Repository;
+
+use Api\Repository\ApiStandingsRepository;
+use Tests\WideUnit\WideUnitTestCase;
+
+class ApiStandingsRepositoryTest extends WideUnitTestCase
+{
+    private ApiStandingsRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ApiStandingsRepository($this->mockDb);
+    }
+
+    public function testGetStandingsWithoutFilterReturnsAllRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1, 'team_uuid' => 'uuid-1', 'conference' => 'East', 'win_percentage' => 0.75],
+            ['teamid' => 2, 'team_uuid' => 'uuid-2', 'conference' => 'West', 'win_percentage' => 0.50],
+        ]);
+
+        $result = $this->repository->getStandings();
+
+        self::assertCount(2, $result);
+    }
+
+    public function testGetStandingsWithoutFilterQueriesView(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getStandings();
+
+        $this->assertQueryExecuted('vw_team_standings');
+    }
+
+    public function testGetStandingsWithConferenceFilterQueriesWithConference(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1, 'team_uuid' => 'uuid-1', 'conference' => 'East', 'win_percentage' => 0.75],
+        ]);
+
+        $result = $this->repository->getStandings('East');
+
+        self::assertCount(1, $result);
+        $this->assertQueryExecuted('conference');
+    }
+
+    public function testGetStandingsWithConferenceFilterDoesNotReturnOtherConferences(): void
+    {
+        // MockDatabase returns whatever is in mockData regardless, but the SQL with
+        // conference filter is sent — verify the WHERE fragment is in the query
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getStandings('West');
+
+        $this->assertQueryExecuted('conference =');
+    }
+
+    public function testGetStandingsReturnsEmptyWhenNone(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getStandings();
+
+        self::assertSame([], $result);
+    }
+}

--- a/ibl5/tests/Api/Repository/ApiTeamRepositoryTest.php
+++ b/ibl5/tests/Api/Repository/ApiTeamRepositoryTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Repository;
+
+use Api\Pagination\Paginator;
+use Api\Repository\ApiTeamRepository;
+use Tests\WideUnit\WideUnitTestCase;
+
+class ApiTeamRepositoryTest extends WideUnitTestCase
+{
+    private ApiTeamRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ApiTeamRepository($this->mockDb);
+    }
+
+    // --- getTeams ---
+
+    public function testGetTeamsReturnsRows(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1, 'uuid' => 'team-uuid-1', 'team_city' => 'Chicago', 'team_name' => 'Bulls'],
+            ['teamid' => 2, 'uuid' => 'team-uuid-2', 'team_city' => 'New York', 'team_name' => 'Knicks'],
+        ]);
+
+        $result = $this->repository->getTeams($this->buildPaginator());
+
+        self::assertCount(2, $result);
+        self::assertSame('Bulls', $result[0]['team_name']);
+    }
+
+    public function testGetTeamsQueriesTeamInfoTable(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getTeams($this->buildPaginator());
+
+        $this->assertQueryExecuted('ibl_team_info');
+    }
+
+    public function testGetTeamsFiltersToRealTeamIds(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getTeams($this->buildPaginator());
+
+        $this->assertQueryExecuted('BETWEEN 1 AND');
+    }
+
+    public function testGetTeamsReturnsEmptyWhenNone(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getTeams($this->buildPaginator());
+
+        self::assertSame([], $result);
+    }
+
+    // --- countTeams ---
+
+    public function testCountTeamsReturnsTotal(): void
+    {
+        $this->mockDb->setMockData([['total' => 32]]);
+
+        $count = $this->repository->countTeams();
+
+        self::assertSame(32, $count);
+    }
+
+    public function testCountTeamsReturnsZeroWhenFetchReturnsNull(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $count = $this->repository->countTeams();
+
+        self::assertSame(0, $count);
+    }
+
+    public function testCountTeamsQueriesTeamInfoTable(): void
+    {
+        $this->mockDb->setMockData([['total' => 32]]);
+
+        $this->repository->countTeams();
+
+        $this->assertQueryExecuted('ibl_team_info');
+    }
+
+    // --- getTeamByUuid ---
+
+    public function testGetTeamByUuidReturnsTeam(): void
+    {
+        $this->mockDb->setMockData([
+            ['teamid' => 1, 'uuid' => 'team-uuid-abc', 'team_city' => 'Boston', 'team_name' => 'Celtics'],
+        ]);
+
+        $result = $this->repository->getTeamByUuid('team-uuid-abc');
+
+        self::assertIsArray($result);
+        self::assertSame('Celtics', $result['team_name']);
+    }
+
+    public function testGetTeamByUuidReturnsNullWhenNotFound(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $result = $this->repository->getTeamByUuid('no-such-uuid');
+
+        self::assertNull($result);
+    }
+
+    public function testGetTeamByUuidQueriesOnUuid(): void
+    {
+        $this->mockDb->setMockData([]);
+
+        $this->repository->getTeamByUuid('test-uuid');
+
+        $this->assertQueryExecuted('t.uuid =');
+    }
+
+    private function buildPaginator(): Paginator
+    {
+        return new Paginator([], 'team_name', ['team_name', 'team_city', 'conference']);
+    }
+}

--- a/ibl5/tests/Api/Repository/HealthRepositoryTest.php
+++ b/ibl5/tests/Api/Repository/HealthRepositoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Repository;
+
+use Api\Repository\HealthRepository;
+use Tests\WideUnit\WideUnitTestCase;
+
+class HealthRepositoryTest extends WideUnitTestCase
+{
+    public function testIsReachableReturnsTrueWhenDbAnswers(): void
+    {
+        $this->mockDb->setMockData([['ok' => 1]]);
+
+        $repository = new HealthRepository($this->mockDb);
+
+        self::assertTrue($repository->isReachable());
+    }
+
+    public function testIsReachableReturnsFalseWhenFetchOneThrows(): void
+    {
+        $repository = new class ($this->mockDb) extends HealthRepository {
+            protected function fetchOne(string $query, string $types = '', mixed ...$params): ?array
+            {
+                throw new \RuntimeException('Simulated connection failure');
+            }
+        };
+
+        self::assertFalse($repository->isReachable());
+    }
+
+    public function testIsReachableQueriesSelectOne(): void
+    {
+        $this->mockDb->setMockData([['ok' => 1]]);
+
+        $repository = new HealthRepository($this->mockDb);
+        $repository->isReachable();
+
+        $this->assertQueryExecuted('SELECT 1');
+    }
+}

--- a/ibl5/tests/Api/Response/JsonResponderTest.php
+++ b/ibl5/tests/Api/Response/JsonResponderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Response;
+
+use Api\Response\JsonResponder;
+use PHPUnit\Framework\TestCase;
+
+class JsonResponderTest extends TestCase
+{
+    private JsonResponder $responder;
+
+    protected function setUp(): void
+    {
+        $this->responder = new JsonResponder();
+    }
+
+    public function testSuccessOutputsValidJsonWithStatusAndData(): void
+    {
+        ob_start();
+        $this->responder->success(['players' => 10]);
+        $output = (string) ob_get_clean();
+
+        $decoded = json_decode($output, true);
+        self::assertIsArray($decoded);
+        self::assertSame('success', $decoded['status']);
+        self::assertSame(['players' => 10], $decoded['data']);
+    }
+
+    public function testSuccessIncludesDefaultMetaFields(): void
+    {
+        ob_start();
+        $this->responder->success([]);
+        $output = (string) ob_get_clean();
+
+        $decoded = json_decode($output, true);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('meta', $decoded);
+        self::assertArrayHasKey('timestamp', $decoded['meta']);
+        self::assertSame('v1', $decoded['meta']['version']);
+    }
+
+    public function testSuccessMergesCustomMetaFields(): void
+    {
+        ob_start();
+        $this->responder->success([], ['page' => 2, 'total' => 50]);
+        $output = (string) ob_get_clean();
+
+        $decoded = json_decode($output, true);
+        self::assertIsArray($decoded);
+        self::assertSame(2, $decoded['meta']['page']);
+        self::assertSame(50, $decoded['meta']['total']);
+        self::assertSame('v1', $decoded['meta']['version']);
+    }
+
+    public function testErrorOutputsJsonWithErrorEnvelope(): void
+    {
+        ob_start();
+        $this->responder->error(404, 'not_found', 'Player not found');
+        $output = (string) ob_get_clean();
+
+        $decoded = json_decode($output, true);
+        self::assertIsArray($decoded);
+        self::assertSame('error', $decoded['status']);
+        self::assertSame('not_found', $decoded['error']['code']);
+        self::assertSame('Player not found', $decoded['error']['message']);
+    }
+
+    public function testErrorIncludesMetaTimestampAndVersion(): void
+    {
+        ob_start();
+        $this->responder->error(400, 'bad_request', 'Invalid parameter');
+        $output = (string) ob_get_clean();
+
+        $decoded = json_decode($output, true);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('meta', $decoded);
+        self::assertArrayHasKey('timestamp', $decoded['meta']);
+        self::assertSame('v1', $decoded['meta']['version']);
+    }
+
+    public function testRawOutputsFlatBodyWithoutEnvelope(): void
+    {
+        ob_start();
+        $this->responder->raw(['status' => 'ok', 'db' => true]);
+        $output = (string) ob_get_clean();
+
+        $decoded = json_decode($output, true);
+        self::assertIsArray($decoded);
+        self::assertSame('ok', $decoded['status']);
+        self::assertTrue($decoded['db']);
+        self::assertArrayNotHasKey('data', $decoded);
+    }
+
+    public function testNotModifiedOutputsNoBody(): void
+    {
+        ob_start();
+        $this->responder->notModified();
+        $output = (string) ob_get_clean();
+
+        self::assertSame('', $output);
+    }
+}

--- a/ibl5/tests/Clock/SystemClockTest.php
+++ b/ibl5/tests/Clock/SystemClockTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Clock;
 
 use Clock\SystemClock;
-use Clock\ClockInterface;
 use PHPUnit\Framework\TestCase;
 
 class SystemClockTest extends TestCase
@@ -30,10 +29,5 @@ class SystemClockTest extends TestCase
 
         self::assertGreaterThanOrEqual($before, $result);
         self::assertLessThanOrEqual($after, $result);
-    }
-
-    public function testImplementsClockInterface(): void
-    {
-        self::assertInstanceOf(ClockInterface::class, $this->clock);
     }
 }

--- a/ibl5/tests/Clock/SystemClockTest.php
+++ b/ibl5/tests/Clock/SystemClockTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Clock;
+
+use Clock\SystemClock;
+use Clock\ClockInterface;
+use PHPUnit\Framework\TestCase;
+
+class SystemClockTest extends TestCase
+{
+    private SystemClock $clock;
+
+    protected function setUp(): void
+    {
+        $this->clock = new SystemClock();
+    }
+
+    public function testNowReturnsAnInteger(): void
+    {
+        self::assertIsInt($this->clock->now());
+    }
+
+    public function testNowApproximatesCurrentTime(): void
+    {
+        $before = time();
+        $result = $this->clock->now();
+        $after = time();
+
+        self::assertGreaterThanOrEqual($before, $result);
+        self::assertLessThanOrEqual($after, $result);
+    }
+
+    public function testImplementsClockInterface(): void
+    {
+        self::assertInstanceOf(ClockInterface::class, $this->clock);
+    }
+}

--- a/ibl5/tests/Updater/GenerateSeasonAwardsStepTest.php
+++ b/ibl5/tests/Updater/GenerateSeasonAwardsStepTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Updater;
+
+use PHPUnit\Framework\TestCase;
+use Updater\Steps\GenerateSeasonAwardsStep;
+
+class GenerateSeasonAwardsStepTest extends TestCase
+{
+    public function testGetLabelReturnsSeasonAwards(): void
+    {
+        $step = $this->buildStep();
+        self::assertSame('Season awards', $step->getLabel());
+    }
+
+    public function testAlreadyGeneratedReturnsSuccessWithDetail(): void
+    {
+        $step = $this->buildStep(awardsAlreadyGenerated: true);
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertStringContainsString('already generated', $result->detail);
+        self::assertStringContainsString('2025', $result->detail);
+    }
+
+    public function testNotPlayoffsPhaseReturnsSkipped(): void
+    {
+        $step = $this->buildStep(seasonPhase: 'Regular Season');
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertStringContainsString('Playoffs', $result->detail);
+    }
+
+    public function testPreseasonPhaseReturnsSkipped(): void
+    {
+        $step = $this->buildStep(seasonPhase: 'Preseason');
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertStringContainsString('Playoffs', $result->detail);
+    }
+
+    public function testVotesBelowThresholdReturnsSkipped(): void
+    {
+        // 32 teams, threshold = ceil(32 * 0.75) = 24; 23 votes is below threshold
+        $step = $this->buildStep(
+            seasonPhase: 'Playoffs',
+            eoyVotesCast: 23,
+            totalRealTeams: 32,
+        );
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertStringContainsString('23', $result->detail);
+        self::assertStringContainsString('32', $result->detail);
+    }
+
+    public function testVotesAtThresholdProceedsPastVotingGate(): void
+    {
+        // 32 teams, threshold = ceil(32 * 0.75) = 24; 24 votes is exactly at threshold
+        // With leadersHtmExists = false it still skips, but for the *voting* reason only
+        $step = $this->buildStep(
+            seasonPhase: 'Playoffs',
+            eoyVotesCast: 24,
+            totalRealTeams: 32,
+            leadersHtmExists: false,
+        );
+        $result = $step->execute();
+
+        // Skipped due to missing Leaders.htm, NOT due to insufficient votes
+        self::assertTrue($result->success);
+        self::assertStringContainsString('Leaders.htm', $result->detail);
+        self::assertStringNotContainsStringIgnoringCase('votes', $result->detail);
+    }
+
+    public function testNoLeadersHtmReturnsSkipped(): void
+    {
+        $step = $this->buildStep(
+            seasonPhase: 'Playoffs',
+            eoyVotesCast: 30,
+            totalRealTeams: 32,
+            leadersHtmExists: false,
+        );
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertStringContainsString('Leaders.htm', $result->detail);
+    }
+
+    public function testAllConditionsMetReturnsSuccessWithInlineHtml(): void
+    {
+        $step = $this->buildStep(
+            seasonPhase: 'Playoffs',
+            eoyVotesCast: 30,
+            totalRealTeams: 32,
+            leadersHtmExists: true,
+        );
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertStringContainsString('generate_awards', $result->inlineHtml);
+    }
+
+    public function testAwardsAlreadyGeneratedShortCircuitsEvenInWrongPhase(): void
+    {
+        $step = $this->buildStep(
+            seasonPhase: 'Preseason',
+            awardsAlreadyGenerated: true,
+        );
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertStringContainsString('already generated', $result->detail);
+    }
+
+    /**
+     * @param non-empty-string $seasonPhase
+     */
+    private function buildStep(
+        string $seasonPhase = 'Playoffs',
+        int $seasonEndingYear = 2025,
+        int $eoyVotesCast = 30,
+        int $totalRealTeams = 32,
+        bool $awardsAlreadyGenerated = false,
+        bool $leadersHtmExists = true,
+    ): GenerateSeasonAwardsStep {
+        return new GenerateSeasonAwardsStep(
+            seasonPhase: $seasonPhase,
+            seasonEndingYear: $seasonEndingYear,
+            eoyVotesCast: $eoyVotesCast,
+            totalRealTeams: $totalRealTeams,
+            awardsAlreadyGenerated: $awardsAlreadyGenerated,
+            leadersHtmExists: $leadersHtmExists,
+        );
+    }
+}

--- a/ibl5/tests/Updater/ParseJsbFilesStepTest.php
+++ b/ibl5/tests/Updater/ParseJsbFilesStepTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Updater;
+
+use JsbParser\JsbImportResult;
+use JsbParser\JsbImportService;
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\JsbSourceResolverInterface;
+use Updater\Steps\ParseJsbFilesStep;
+
+class ParseJsbFilesStepTest extends TestCase
+{
+    public function testGetLabelReturnsJsbFilesParsed(): void
+    {
+        $step = $this->buildStep(files: []);
+        self::assertSame('JSB files parsed', $step->getLabel());
+    }
+
+    public function testNoFilesFoundReturnsSuccessWithNoChanges(): void
+    {
+        $step = $this->buildStep(files: []);
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertSame('No changes', $result->detail);
+        self::assertEmpty($result->messages);
+    }
+
+    public function testOnlyTrnFileProcessedWhenPresent(): void
+    {
+        $trnResult = new JsbImportResult();
+        $trnResult->addInserted(3);
+
+        $service = $this->createStub(JsbImportService::class);
+        $service->method('processTrnData')->willReturn($trnResult);
+
+        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver->method('getContents')
+            ->willReturnCallback(static fn (string $ext) => $ext === 'trn' ? 'trn-data' : null);
+
+        $step = new ParseJsbFilesStep($service, $resolver, 2025);
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertSame('3 inserted', $result->detail);
+        self::assertCount(1, $result->messages);
+        self::assertStringContainsString('TRN:', $result->messages[0]);
+    }
+
+    public function testMultipleFilesAreMergedIntoSummary(): void
+    {
+        $trnResult = new JsbImportResult();
+        $trnResult->addInserted(2);
+
+        $carResult = new JsbImportResult();
+        $carResult->addUpdated(5);
+
+        $service = $this->createStub(JsbImportService::class);
+        $service->method('processTrnData')->willReturn($trnResult);
+        $service->method('processCarData')->willReturn($carResult);
+
+        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver->method('getContents')
+            ->willReturnCallback(static function (string $ext): ?string {
+                return in_array($ext, ['trn', 'car'], true) ? $ext . '-data' : null;
+            });
+
+        $step = new ParseJsbFilesStep($service, $resolver, 2025);
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertSame('2 inserted, 5 updated', $result->detail);
+        self::assertCount(2, $result->messages);
+    }
+
+    public function testMessageErrorCountPropagatesFromImportResult(): void
+    {
+        $hisResult = new JsbImportResult();
+        $hisResult->addError('Unknown player ID 999');
+
+        $service = $this->createStub(JsbImportService::class);
+        $service->method('processHisData')->willReturn($hisResult);
+
+        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver->method('getContents')
+            ->willReturnCallback(static fn (string $ext) => $ext === 'his' ? 'his-data' : null);
+
+        $step = new ParseJsbFilesStep($service, $resolver, 2025);
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertSame(1, $result->messageErrorCount);
+        self::assertNotEmpty($result->messages);
+    }
+
+    /**
+     * @param list<string> $files Extensions that should return non-null content
+     */
+    private function buildStep(array $files): ParseJsbFilesStep
+    {
+        $emptyResult = new JsbImportResult();
+
+        $service = $this->createStub(JsbImportService::class);
+        $service->method('processTrnData')->willReturn($emptyResult);
+        $service->method('processCarData')->willReturn($emptyResult);
+        $service->method('processHisData')->willReturn($emptyResult);
+        $service->method('processAswData')->willReturn($emptyResult);
+        $service->method('processRcbData')->willReturn($emptyResult);
+
+        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver->method('getContents')
+            ->willReturnCallback(static fn (string $ext) => in_array($ext, $files, true) ? $ext . '-data' : null);
+
+        return new ParseJsbFilesStep($service, $resolver, 2025);
+    }
+}

--- a/ibl5/tests/Updater/ParseJsbFilesStepTest.php
+++ b/ibl5/tests/Updater/ParseJsbFilesStepTest.php
@@ -33,10 +33,10 @@ class ParseJsbFilesStepTest extends TestCase
         $trnResult = new JsbImportResult();
         $trnResult->addInserted(3);
 
-        $service = $this->createStub(JsbImportService::class);
+        $service = self::createStub(JsbImportService::class);
         $service->method('processTrnData')->willReturn($trnResult);
 
-        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver = self::createStub(JsbSourceResolverInterface::class);
         $resolver->method('getContents')
             ->willReturnCallback(static fn (string $ext) => $ext === 'trn' ? 'trn-data' : null);
 
@@ -57,11 +57,11 @@ class ParseJsbFilesStepTest extends TestCase
         $carResult = new JsbImportResult();
         $carResult->addUpdated(5);
 
-        $service = $this->createStub(JsbImportService::class);
+        $service = self::createStub(JsbImportService::class);
         $service->method('processTrnData')->willReturn($trnResult);
         $service->method('processCarData')->willReturn($carResult);
 
-        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver = self::createStub(JsbSourceResolverInterface::class);
         $resolver->method('getContents')
             ->willReturnCallback(static function (string $ext): ?string {
                 return in_array($ext, ['trn', 'car'], true) ? $ext . '-data' : null;
@@ -80,10 +80,10 @@ class ParseJsbFilesStepTest extends TestCase
         $hisResult = new JsbImportResult();
         $hisResult->addError('Unknown player ID 999');
 
-        $service = $this->createStub(JsbImportService::class);
+        $service = self::createStub(JsbImportService::class);
         $service->method('processHisData')->willReturn($hisResult);
 
-        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver = self::createStub(JsbSourceResolverInterface::class);
         $resolver->method('getContents')
             ->willReturnCallback(static fn (string $ext) => $ext === 'his' ? 'his-data' : null);
 
@@ -102,14 +102,14 @@ class ParseJsbFilesStepTest extends TestCase
     {
         $emptyResult = new JsbImportResult();
 
-        $service = $this->createStub(JsbImportService::class);
+        $service = self::createStub(JsbImportService::class);
         $service->method('processTrnData')->willReturn($emptyResult);
         $service->method('processCarData')->willReturn($emptyResult);
         $service->method('processHisData')->willReturn($emptyResult);
         $service->method('processAswData')->willReturn($emptyResult);
         $service->method('processRcbData')->willReturn($emptyResult);
 
-        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver = self::createStub(JsbSourceResolverInterface::class);
         $resolver->method('getContents')
             ->willReturnCallback(static fn (string $ext) => in_array($ext, $files, true) ? $ext . '-data' : null);
 

--- a/ibl5/tests/Updater/ProcessBoxscoresStepTest.php
+++ b/ibl5/tests/Updater/ProcessBoxscoresStepTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Updater;
+
+use Boxscore\BoxscoreProcessor;
+use Boxscore\BoxscoreView;
+use PHPUnit\Framework\TestCase;
+use Updater\Contracts\JsbSourceResolverInterface;
+use Updater\Steps\ProcessBoxscoresStep;
+
+class ProcessBoxscoresStepTest extends TestCase
+{
+    public function testGetLabelReturnsBoxscoresProcessed(): void
+    {
+        $step = $this->buildStep(scoContents: null);
+        self::assertSame('Boxscores processed', $step->getLabel());
+    }
+
+    public function testSkipsWhenNoScoFileFound(): void
+    {
+        $step = $this->buildStep(scoContents: null);
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertStringContainsStringIgnoringCase('sco', $result->detail);
+    }
+
+    public function testSucceedsWhenScoFilePresent(): void
+    {
+        $scoData = 'IBL5.sco file data';
+
+        $processor = $this->createStub(BoxscoreProcessor::class);
+        $processor->method('processScoData')->willReturn([
+            'success' => true,
+            'gamesInserted' => 2,
+            'gamesUpdated' => 1,
+            'gamesSkipped' => 0,
+            'linesProcessed' => 3,
+            'messages' => [],
+        ]);
+
+        $view = $this->createStub(BoxscoreView::class);
+        $view->method('renderParseLog')->willReturn('<div>Parse log</div>');
+
+        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver->method('getContents')->willReturn($scoData);
+
+        $step = new ProcessBoxscoresStep($processor, $view, $resolver);
+        $result = $step->execute();
+
+        self::assertTrue($result->success);
+        self::assertTrue($result->collapsibleLog);
+        self::assertStringContainsString('Parse log', $result->inlineHtml);
+    }
+
+    private function buildStep(?string $scoContents): ProcessBoxscoresStep
+    {
+        $processor = $this->createStub(BoxscoreProcessor::class);
+        $view = $this->createStub(BoxscoreView::class);
+
+        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver->method('getContents')->willReturn($scoContents);
+
+        return new ProcessBoxscoresStep($processor, $view, $resolver);
+    }
+}

--- a/ibl5/tests/Updater/ProcessBoxscoresStepTest.php
+++ b/ibl5/tests/Updater/ProcessBoxscoresStepTest.php
@@ -31,7 +31,7 @@ class ProcessBoxscoresStepTest extends TestCase
     {
         $scoData = 'IBL5.sco file data';
 
-        $processor = $this->createStub(BoxscoreProcessor::class);
+        $processor = self::createStub(BoxscoreProcessor::class);
         $processor->method('processScoData')->willReturn([
             'success' => true,
             'gamesInserted' => 2,
@@ -41,10 +41,10 @@ class ProcessBoxscoresStepTest extends TestCase
             'messages' => [],
         ]);
 
-        $view = $this->createStub(BoxscoreView::class);
+        $view = self::createStub(BoxscoreView::class);
         $view->method('renderParseLog')->willReturn('<div>Parse log</div>');
 
-        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver = self::createStub(JsbSourceResolverInterface::class);
         $resolver->method('getContents')->willReturn($scoData);
 
         $step = new ProcessBoxscoresStep($processor, $view, $resolver);
@@ -57,10 +57,10 @@ class ProcessBoxscoresStepTest extends TestCase
 
     private function buildStep(?string $scoContents): ProcessBoxscoresStep
     {
-        $processor = $this->createStub(BoxscoreProcessor::class);
-        $view = $this->createStub(BoxscoreView::class);
+        $processor = self::createStub(BoxscoreProcessor::class);
+        $view = self::createStub(BoxscoreView::class);
 
-        $resolver = $this->createStub(JsbSourceResolverInterface::class);
+        $resolver = self::createStub(JsbSourceResolverInterface::class);
         $resolver->method('getContents')->willReturn($scoContents);
 
         return new ProcessBoxscoresStep($processor, $view, $resolver);


### PR DESCRIPTION
## Summary
- Added 13 new test files covering Api repositories (Game, Injuries, Leaders, Player, PlayerStats, Standings, Team, Health), JsonResponder, SystemClock, and Updater steps (ProcessBoxscores, GenerateSeasonAwards, ParseJsb)
- Extended phpunit.xml to include Clock module testsuite
- Updated maintenance backlog to reflect completed test coverage: 6.16 (Api) moved to ✅ Implemented, 6.14 and 9.19/9.20 (Updater) updated with coverage details

## Manual Testing

No manual testing needed — verified by automated tests.
