### PR TITLE
chore(postplan-harness): update harness path to tools/ checkout

### DIFF
--- a/.claude/rules/workflow-continuity.md
+++ b/.claude/rules/workflow-continuity.md
@@ -47,7 +47,7 @@ bin/post-plan-now --auto
 
 (Ad-hoc branch with no plan file → post-plan runs plan-blind; expected, not an error. The merge-arming decision still happens at `/post-plan` Phase 6.5, so auto-opening the PR never auto-merges a `feat:`/`auto_merge: false`/visual PR without human signoff.)
 
-This spawns a detached, launchd-supervised post-plan run on this branch (survives you closing Claude Code). Engine: the **compiled post-plan harness** (`~/GitHub/postplan-harness`, deterministic sequencer + bounded LLM calls) when installed, falling back to a fresh **Sonnet 4.6** `/post-plan` skill session if the harness fails or is absent (`POST_PLAN_SKILL=1` forces the skill). Notes:
+This spawns a detached, launchd-supervised post-plan run on this branch (survives you closing Claude Code). Engine: the **compiled post-plan harness** (`tools/postplan-harness`, deterministic sequencer + bounded LLM calls; `bin/post-plan-now` pins the MAIN-CHECKOUT copy, never the worktree's — ADR-0092) when present, falling back to a fresh **Sonnet 4.6** `/post-plan` skill session if the harness fails or is absent (`POST_PLAN_SKILL=1` forces the skill). Notes:
 
 - **Do NOT commit first.** Leave the worktree **dirty** — `/post-plan` commits the uncommitted tree in Phase 2 and opens the PR. Committing here changes what it ships.
 - **Only fire when verification passed.** If implementation did **not** verify clean (failing tests, unresolved blocker, you stopped to ask the user something), do **not** fire — leave the worktree dirty and hand off in prose. Turn-end ≠ done; that judgment is yours.

--- a/bin/post-plan-now
+++ b/bin/post-plan-now
@@ -3,8 +3,8 @@
 # bin/post-plan-now — fire a detached post-plan run on the current worktree's
 # branch, replacing the manual "open a new session and hand off" step.
 #
-# Engine selection: when the compiled post-plan harness is installed
-# (~/GitHub/postplan-harness, see its README) it runs `./run isolated <root>
+# Engine selection: when the compiled post-plan harness is present in the main
+# checkout (tools/postplan-harness, see its README) it runs `./run isolated <root>
 # --live` — the deterministic phase sequencer with bounded LLM calls (~65-100x
 # fewer gross tokens than a skill session). If the harness exits nonzero, or is
 # absent on this machine, the same launchd job falls back to the original


### PR DESCRIPTION
## Summary
- Update harness location references from `~/GitHub/postplan-harness` to `tools/postplan-harness`
- Clarify in documentation and build scripts that the harness uses the MAIN-CHECKOUT copy, not the worktree's (ADR-0092)
- Internal path cleanup; no user-facing changes

## Manual Testing

No manual testing needed — verified by automated tests.
