### PR TITLE
chore(docs): update last-verified dates

### DIFF
--- a/ibl5/classes/Repositories/README.md
+++ b/ibl5/classes/Repositories/README.md
@@ -1,6 +1,6 @@
 ---
 description: Cross-cutting repositories for team/player/salary lookups used across the codebase
-last_verified: 2026-05-16
+last_verified: 2026-07-24
 ---
 
 # Repositories

--- a/ibl5/classes/Trading/README.md
+++ b/ibl5/classes/Trading/README.md
@@ -1,6 +1,6 @@
 ---
 description: Trading module naming convention — Trading* prefix vs Trade* prefix rule.
-last_verified: 2026-05-20
+last_verified: 2026-07-24
 ---
 
 # Trading Module Naming Convention

--- a/ibl5/classes/Validation/README.md
+++ b/ibl5/classes/Validation/README.md
@@ -1,6 +1,6 @@
 ---
 description: Cross-cutting validation primitives used by 3+ modules
-last_verified: 2026-05-16
+last_verified: 2026-07-24
 ---
 
 # Validation


### PR DESCRIPTION
## Summary
- Updated `last_verified` dates to 2026-07-24 in Repositories, Trading, and Validation README files

## Manual Testing

No manual testing needed — verified by automated tests.
