### PR TITLE
ci(iblbot): add vitest and type-check job to tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,12 @@ on:
       - 'ibl5/migrations/**.sql'
       - 'bin/**'
       - 'ibl5/bin/**'
+      # IBLbot (Discord bot + bug-bot HTTP server) has no other CI host — without
+      # this line an IBLbot-only push to master never triggers this workflow, so
+      # the iblbot job would gate PRs but not master. Every `changes` output is
+      # blanket-true on push, so such a push also fans out to the PHP/IBL6 jobs;
+      # that is pre-existing sibling behaviour (`bin/**` does the same), not new.
+      - 'ibl5/IBLbot/**'
   pull_request:
     branches: [ master, develop ]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -31,6 +37,7 @@ jobs:
       shell: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.shell == 'true' }}
       ibl6: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.ibl6 == 'true' }}
       ibl5ts: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.ibl5ts == 'true' }}
+      iblbot: ${{ github.event_name == 'push' || github.event.pull_request.user.login == 'dependabot[bot]' || steps.filter.outputs.iblbot == 'true' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
@@ -76,6 +83,13 @@ jobs:
               - 'ibl5/vitest.unit.config.ts'
               - 'ibl5/package.json'
               - 'ibl5/bun.lock'
+              - '.github/workflows/tests.yml'
+
+            iblbot:
+              # IBLbot has its own npm package + tsconfig + vitest suite
+              # (src/bug-bot/*.test.ts). Whole-directory glob: every source file
+              # is either compiled by tsc or exercised by the suite.
+              - 'ibl5/IBLbot/**'
               - '.github/workflows/tests.yml'
 
   test:
@@ -270,6 +284,39 @@ jobs:
     - name: TS unit tests (vitest)
       working-directory: ibl5
       run: bun run test:unit
+
+  iblbot:
+    name: IBLbot Type Check & Unit Tests
+    needs: [changes]
+    if: needs.changes.outputs.iblbot == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: '22'
+        cache: 'npm'
+        cache-dependency-path: ibl5/IBLbot/package-lock.json
+
+    - name: Install dependencies
+      working-directory: ibl5/IBLbot
+      run: npm ci
+
+    # main.yml compiles IBLbot with tsc on the PROD host during deploy, so a type
+    # error there breaks a live deploy with no earlier backstop. Catch it here.
+    - name: Type check (tsc)
+      working-directory: ibl5/IBLbot
+      run: npx tsc --noEmit
+
+    # Pure-unit vitest suite (src/bug-bot/*.test.ts — no DB, no network). The
+    # opt-in live smoke is describe.runIf(BUG_BOT_LIVE) so it stays skipped here.
+    - name: Unit tests (vitest)
+      working-directory: ibl5/IBLbot
+      run: npm test
 
   db-integration:
     name: Database Integration Tests
@@ -692,7 +739,7 @@ jobs:
   gate:
     name: Tests and Analysis
     if: always()
-    needs: [changes, test, audit-php, audit-js, ibl6-checks, ibl5-ts-unit, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, static-guards, harness-tests, pinact-check]
+    needs: [changes, test, audit-php, audit-js, ibl6-checks, ibl5-ts-unit, iblbot, db-integration, phpstan, phpunit-hygiene, shellcheck, host-mariadb-guard, automouse-impl-model-test, update-baselines, static-guards, harness-tests, pinact-check]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary
- Add `ibl5/IBLbot/**` path filter so IBLbot-only changes trigger the workflow (matches `bin/**` sibling behavior)
- New `iblbot` job runs tsc type checking and vitest unit tests (catches type errors before prod deploy)
- Update `gate` job to depend on new `iblbot` job

## Manual Testing

No manual testing needed — verified by automated tests.
