### PR TITLE
chore(db): guard against silent database name mismatches

### DIFF
--- a/.claude/rules/database-access.md
+++ b/.claude/rules/database-access.md
@@ -59,7 +59,11 @@ mariadb -h 127.0.0.1 --skip-ssl -u root -proot iblhoops_ibl5
 
 **When to use `db-query`:** Use this script to explore the database schema, verify data after making changes, check record counts, and validate your work. This is the preferred method for Claude to query the local database since it's configured for auto-approval in the user's Claude Code settings.
 
-**Which database it hits:** the wrapper resolves its own symlink and always reads `ibl5/config.php` (never the repo-root `config.php`), then connects over `127.0.0.1:3306`. Both of those are fixed regardless of the directory you invoke it from — so it targets the **main** stack, using `ibl5/config.php`'s `$dbname`. On `Unknown database '<name>'`, read that file's `$dbname` fallback rather than assuming the container is down.
+**Which database it hits:** the wrapper resolves its own symlink and always reads `ibl5/config.php` (never the repo-root `config.php`), then connects over `127.0.0.1:3306`. Both of those are fixed regardless of the directory you invoke it from — so it targets the **main** stack, using `ibl5/config.php`'s `$dbname`.
+
+**On `ERROR 1049` (unknown database), `db-query` self-diagnoses.** It prints the resolved `$dbname`, the absolute `config.php` it was read from, whether `DB_NAME` was set in the environment, and the databases that do exist. On a host shell `DB_NAME` is normally **unset**, so the file's fallback *is* the value that gets used — the env line is there to tell you the exceptions (`php -r` inherits the shell's environment, so an exported `DB_NAME` overrides the fallback). Read that block instead of assuming the container is down. The diagnostic fires **only** for 1049 — an ordinary bad-table or syntax error still just prints MariaDB's message — and the script's exit status is still MariaDB's.
+
+The companion guard is in `materialize_worktree_config` (`bin/lib/git-helpers.sh`), which copies main's `config.php` into every new worktree: when no `DB_NAME` is in the environment it echoes the `$dbname` fallback it just propagated. It validates nothing (the file is deliberately league-agnostic) — it only makes the inherited name visible, since a stale fallback in the main checkout otherwise fans out silently to every worktree created afterwards.
 
 ## Migration Runner
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -450,8 +450,9 @@ jobs:
           set -e
           # Worktrees run a separate dockerized MariaDB per worktree. Calling the host
           # `mariadb` client with -h 127.0.0.1 bypasses worktree isolation and will read
-          # or mutate the wrong database. Only bin/db-query is allowed to do this because
-          # it hands off to docker exec internally.
+          # or mutate the wrong database. Only bin/db-query is allowed to do this: it
+          # deliberately targets the main stack's published 3306 and, on ERROR 1049,
+          # names the $dbname it used and where that name came from.
           offenders=$(
             grep -rEn '^[[:space:]]*mariadb[[:space:]]+(-h[[:space:]]*127|-u[[:space:]]*root)' \
               bin/ ibl5/bin/ 2>/dev/null \

--- a/bin/lib/git-helpers.sh
+++ b/bin/lib/git-helpers.sh
@@ -96,6 +96,16 @@ materialize_worktree_config() {
     [ -L "$dest" ] && rm -f "$dest"
     if [ -s "$main_ibl5/config.php" ]; then
         cp "$main_ibl5/config.php" "$dest"
+        # Announce the $dbname being propagated when no DB_NAME is in the
+        # environment — that's exactly when the copied fallback becomes
+        # load-bearing. A stale one silently fans out to every new worktree
+        # otherwise (observed: 40 worktrees inheriting 'iblhoops_rehearsal').
+        # Echo only, no policy: the name is league-agnostic by design.
+        if [ -z "${DB_NAME:-}" ] && command -v php >/dev/null 2>&1; then
+            local propagated_db
+            propagated_db=$(php -r "error_reporting(0); include '$dest'; echo \$dbname;" 2>/dev/null)
+            [ -n "$propagated_db" ] && echo "config.php: DB_NAME unset — worktree will use \$dbname fallback '$propagated_db'." >&2
+        fi
     elif [ -s "$main_ibl5/config.php.example" ]; then
         echo "WARNING: $main_ibl5/config.php missing — copying config.php.example (placeholder values)." >&2
         cp "$main_ibl5/config.php.example" "$dest"

--- a/ibl5/bin/db-query
+++ b/ibl5/bin/db-query
@@ -26,12 +26,47 @@ if [ ! -f "$CONFIG" ]; then
     exit 1
 fi
 
+# config.php resolves $dbname as getenv('DB_NAME') ?: '<fallback>', and php -r
+# inherits this shell's environment — so an exported DB_NAME still wins. Capture
+# it before the assignment below clobbers it, for the diagnostic.
+ENV_DB_NAME="${DB_NAME:-}"
+
 DB_USER=$(php -r "error_reporting(0); include '$CONFIG'; echo \$dbuname;" 2>/dev/null)
 DB_PASS=$(php -r "error_reporting(0); include '$CONFIG'; echo \$dbpass;" 2>/dev/null)
 DB_NAME=$(php -r "error_reporting(0); include '$CONFIG'; echo \$dbname;" 2>/dev/null)
+
+STDERR_FILE=$(mktemp)
+trap 'rm -f "$STDERR_FILE"' EXIT
 
 mariadb -h 127.0.0.1 --skip-ssl \
     -u "$DB_USER" -p"$DB_PASS" \
     --table \
     "$DB_NAME" \
-    -e "$1"
+    -e "$1" 2>"$STDERR_FILE"
+STATUS=$?
+
+cat "$STDERR_FILE" >&2
+
+# ERROR 1049 means the database named in config.php does not exist. That fails
+# loudly but names no cause, so a stale $dbname fallback can sit unnoticed for
+# weeks. Print where the name came from — never the credentials.
+if [ "$STATUS" -ne 0 ] && grep -q "ERROR 1049" "$STDERR_FILE"; then
+    {
+        echo
+        echo "db-query: that database does not exist. Where the name came from:"
+        echo "  \$dbname resolved to : $DB_NAME"
+        echo "  read from           : $CONFIG"
+        if [ -n "$ENV_DB_NAME" ]; then
+            echo "  DB_NAME in env      : $ENV_DB_NAME — env wins over the config fallback"
+        else
+            echo "  DB_NAME in env      : unset — the config fallback above is load-bearing"
+        fi
+        echo "  databases present   :"
+        mariadb -h 127.0.0.1 --skip-ssl -u "$DB_USER" -p"$DB_PASS" \
+            -N -B -e "SHOW DATABASES" 2>/dev/null | sed 's/^/    /'
+        echo
+        echo "Fix: correct \$dbname in $CONFIG, or export DB_NAME before running."
+    } >&2
+fi
+
+exit "$STATUS"


### PR DESCRIPTION
## Summary
- `db-query` now self-diagnoses ERROR 1049 with resolved `$dbname`, config path, env override status, and available databases
- `materialize_worktree_config` announces inherited `$dbname` fallback when no `DB_NAME` env var is set
- Updated `.claude/rules/database-access.md` documenting ERROR 1049 diagnostic and worktree config propagation
- Updated CI workflow comments explaining `db-query`'s exclusive access to main stack

Prevents stale database names silently fanning out across 40+ worktrees (observed fallback: `iblhoops_rehearsal`)

## Manual Testing

No manual testing needed — verified by automated tests.
