### PR TITLE
fix(sim-recap): ensure DB tunnel up before agent spawn

### DIFF
--- a/bin/sim-recap-tick
+++ b/bin/sim-recap-tick
@@ -18,6 +18,8 @@
 # data. Every privileged queue action is a prod-side `ssh php simRecapQueue.php`
 # call the agent cannot make (claiming a row is an UPDATE the read-only user is
 # refused). All *_id fields are read as STRINGS with `jq -r` (snowflake rule).
+# This script OWNS bringing that tunnel up (ensure_tunnel, called on every
+# generation path) — the poller runs unattended, so nothing else can.
 #
 # NOT set -e: one sim's failure must never abort the tick before its park branch
 # runs. Backoff and stale-lease timers are computed SERVER-side by parkOrFail /
@@ -136,6 +138,27 @@ fetch_agent_inputs() { # sim  (writes mentions.json + themes-ledger.json into WO
     return 0
 }
 
+# ── Ensure the SELECT-only MySQL tunnel is up before the agent runs ───────────
+# Nothing else opens it: the poller runs unattended, so a reboot (or the
+# ControlMaster exiting) would otherwise leave every tick generating against a
+# dead port. `-O forward` attaches the forward to the master the queue calls
+# already keep alive (ControlMaster auto / ControlPersist 10m in ~/.ssh/config)
+# and is idempotent — rc 0, no duplicate listener, when the forward exists.
+# Fails CLOSED: a bare "port 13306 is open" probe would green-light a LOCAL
+# MySQL bound to the same port and recap the wrong database, so a port we could
+# not establish ourselves is treated as no tunnel at all.
+ensure_tunnel() {
+    local fwd="${SIM_RECAP_DB_PORT}:127.0.0.1:3306"
+    "$SIM_RECAP_SSH_BIN" -O forward -L "$fwd" "$SIM_RECAP_SSH_HOST" >/dev/null 2>&1 && return 0
+    log "no ssh ControlMaster to attach the DB tunnel to — opening one"
+    # ExitOnForwardFailure=yes is load-bearing: without it a bind conflict leaves
+    # a stray background ssh with rc 0 — one leaked process per tick, forever.
+    "$SIM_RECAP_SSH_BIN" -f -N -o ExitOnForwardFailure=yes -L "$fwd" "$SIM_RECAP_SSH_HOST" \
+        >/dev/null 2>&1 && return 0
+    log "ERROR: could not bring up the DB tunnel on port $SIM_RECAP_DB_PORT — parking rather than querying a dead port"
+    return 1
+}
+
 # ── Run the generation agent in the temp dir; leaves payload.json on success ──
 run_agent() { # sim prompt
     local sim="$1" prompt="$2"
@@ -164,6 +187,13 @@ generate() { # sim
     if ! prompt="$("$SIM_RECAP_PROMPT_BIN" --sim="$sim" \
             --mentions="$WORKDIR/mentions.json" --themes="$WORKDIR/themes-ledger.json")"; then
         log "sim $sim: prompt build failed (missing exemplar?) — parking"
+        park "$sim"; return 0
+    fi
+
+    # Before spawning claude — a dead tunnel means every mysql call it makes
+    # fails, burning a full agent run to produce nothing.
+    if ! ensure_tunnel; then
+        log "sim $sim: no DB tunnel — parking without spawning the agent"
         park "$sim"; return 0
     fi
 
@@ -218,6 +248,11 @@ dry_run() {
     if ! prompt="$("$SIM_RECAP_PROMPT_BIN" --sim="$sim" \
             --mentions="$WORKDIR/mentions.json" --themes="$WORKDIR/themes-ledger.json")"; then
         log "dry-run sim $sim: prompt build failed (missing exemplar?)"
+        exit 1
+    fi
+
+    if ! ensure_tunnel; then
+        log "dry-run sim $sim: no DB tunnel — not spawning the agent"
         exit 1
     fi
 

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -60,6 +60,15 @@ srt_setup() {
     cat > "$STUB/ssh" <<'SH'
 #!/usr/bin/env bash
 echo "$*" >> "$STUB/ssh.log"
+# Tunnel calls carry a -L forward and no remote command. Matched on the flag
+# rather than on $1 so reordering the fallback's flags can't drop them into the
+# verb dispatch below (where they'd hit the unknown-verb branch and exit 1).
+case " $* " in
+    *" -L "*)
+        [ -f "$STUB/fail.tunnel" ] && exit 255
+        exit 0
+        ;;
+esac
 cmd="$2"
 if printf '%s' "$cmd" | grep -q 'storeSimRecap\.php'; then
     if [ -f "$STUB/record-stdin" ]; then
@@ -273,6 +282,39 @@ touch "$STUB/agent-usage-limit"
 srt_run
 srt_log_has "$STUB" tick.out "usage limit" "usage_limit_parks_with_reason — logged"
 srt_log_has "$STUB" ssh.log  "park"        "usage_limit_parks_with_reason — park in ssh.log"
+
+# ── tunnel_attached_before_agent ──────────────────────────────────────────────
+# The generation path must attach the SELECT-only MySQL forward to the existing
+# ControlMaster before spawning claude — nothing else opens it (the poller runs
+# unattended), so without this every tick after a reboot queries a dead port.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+srt_run
+srt_log_has "$STUB" ssh.log "-O forward -L 13306:127.0.0.1:3306" \
+    "tunnel_attached_before_agent — forward requested"
+
+# ── tunnel_failure_parks_without_spawning_claude ──────────────────────────────
+# Both ssh paths fail (no master to attach to, and opening one fails). The tick
+# must park WITHOUT burning an agent run — the empty-tick cost guard applies to
+# a broken tunnel too. Asserting zero claude (not just the log line) is what
+# catches ensure_tunnel being wired in after run_agent.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+touch "$STUB/fail.tunnel"
+srt_run
+srt_expect_eq "tunnel_failure_parks_without_spawning_claude — exit 0" 0 "$SRT_RC"
+srt_log_has   "$STUB" tick.out "could not bring up the DB tunnel" \
+    "tunnel_failure_parks_without_spawning_claude — names the failure"
+srt_log_has   "$STUB" ssh.log  "park"          "tunnel_failure — park in ssh.log"
+srt_log_lacks "$STUB" ssh.log  "storeSimRecap" "tunnel_failure — no store"
+srt_file_absent "$STUB/claude.sentinel" "tunnel_failure — zero claude"
+
+# ── dry_run_tunnel_failure_exits_nonzero ──────────────────────────────────────
+srt_reset
+touch "$STUB/fail.tunnel"
+srt_run --dry-run --sim=42
+srt_expect_eq "dry_run_tunnel_failure_exits_nonzero" 1 "$SRT_RC"
+srt_file_absent "$STUB/claude.sentinel" "dry_run_tunnel_failure — zero claude"
 
 # ── dry_run_touches_nothing ───────────────────────────────────────────────────
 # --dry-run --sim=N: calls mention-map/recent-themes (read-only) but NO


### PR DESCRIPTION
## Summary
- Add `ensure_tunnel()` to verify MySQL forward is established before spawning agent
- Attaches to existing ControlMaster or opens new connection (idempotent via `-O forward`)
- Prevents dead tunnel after reboots or ControlMaster exit
- Parks tick and skips agent spawn if tunnel setup fails
- Add test coverage for tunnel attachment, failure paths, and dry-run behavior

## Manual Testing

No manual testing needed — verified by automated tests.
