### PR TITLE
fix(sim-recap): add ~/.local/bin to launchd PATH and validate agent binary

### DIFF
--- a/bin/bug-pipeline-cron-setup
+++ b/bin/bug-pipeline-cron-setup
@@ -79,9 +79,15 @@ build_plist() {
 		<key>DB_NAME</key>
 		<string>iblhoops_ibl5</string>
 		<!-- launchd agents start with a minimal PATH that omits Homebrew; claude, php,
-		     curl, git must resolve. No API-key env var — claude uses ambient CLI auth. -->
+		     curl, git must resolve. No API-key env var — claude uses ambient CLI auth.
+		     ~/.local/bin is where the Claude Code NATIVE installer puts the claude
+		     binary — omitting it is not a cosmetic gap: every tick then dies rc=127
+		     inside timeout, which reads downstream as "the agent produced nothing". That
+		     silently killed this pipeline for days. HOME interpolates HERE, at
+		     generation time — launchd does NOT expand variables in
+		     EnvironmentVariables, so a literal $HOME would bake in a dead path. -->
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${HOME}/.local/bin</string>
 		<key>BUG_PIPELINE_ISSUE_REPO</key>
 		<string>${BUG_PIPELINE_ISSUE_REPO}</string>
 		<key>BUG_PIPELINE_APPROVER_ID</key>

--- a/bin/sim-recap-cron-setup
+++ b/bin/sim-recap-cron-setup
@@ -81,9 +81,15 @@ build_plist() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<!-- launchd agents start with a minimal PATH that omits Homebrew; claude, ssh,
-		     mysql, git must resolve. No API-key env var — claude uses ambient CLI auth. -->
+		     mysql, git must resolve. No API-key env var — claude uses ambient CLI auth.
+		     ~/.local/bin is where the Claude Code NATIVE installer puts the claude
+		     binary — omitting it is not a cosmetic gap: the tick then dies rc=127
+		     inside timeout, which generate() reads as "no payload" and parks, burning an
+		     attempt per poll (sim 721, 2026-07-25). HOME interpolates HERE, at
+		     generation time — launchd does NOT expand variables in
+		     EnvironmentVariables, so a literal $HOME would bake in a dead path. -->
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${HOME}/.local/bin</string>
 		<key>SIM_RECAP_SSH_HOST</key>
 		<string>${SIM_RECAP_SSH_HOST:-}</string>
 		<key>SIM_RECAP_REMOTE_ROOT</key>

--- a/bin/sim-recap-tick
+++ b/bin/sim-recap-tick
@@ -284,6 +284,19 @@ main() {
         esac
     done
 
+    # Preflight: the agent binary must actually resolve, BEFORE anything claims a
+    # sim. An unresolvable $SIM_RECAP_CLAUDE_BIN makes `timeout` exit 127, which
+    # generate() cannot tell apart from "the agent ran and produced nothing" — so
+    # it parks and burns an attempt, every poll, until parkOrFail's ceiling marks
+    # the sim permanently `failed`. That is exactly what happened when the Claude
+    # Code native installer moved `claude` to ~/.local/bin, off the launchd PATH
+    # (sim 721, 2026-07-25). Abort loudly instead: a broken environment must cost
+    # zero attempts.
+    if ! command -v "$SIM_RECAP_CLAUDE_BIN" >/dev/null 2>&1; then
+        log "ERROR: agent binary '$SIM_RECAP_CLAUDE_BIN' not found on PATH ($PATH) — aborting tick (no sim claimed)"
+        return 1
+    fi
+
     if [ "$DRY_RUN" -eq 1 ]; then
         dry_run
         return $?


### PR DESCRIPTION
## Summary
- Added `${HOME}/.local/bin` to PATH in cron setup plist files (bug-pipeline and sim-recap agents)
- Claude Code native installer places `claude` binary in `~/.local/bin`, which wasn't on launchd's minimal PATH
- Omitting it caused agent to fail with rc=127, silently parsed as "no payload" by caller, burning attempt per poll
- Added preflight binary resolution check in sim-recap-tick to abort loudly before claiming sim if agent binary unresolvable
- launchd does not interpolate variables in EnvironmentVariables, so `${HOME}` interpolates at plist generation time, not runtime

**Incident**: sim 721 (2026-07-25) showed this pattern — every tick died inside timeout until parkOrFail ceiling marked sim failed

## Manual Testing

No manual testing needed — verified by automated tests.
