### PR TITLE
chore: trust notes — caller facts are claims; plan-prompt handoff in detail file

### DIFF
--- a/.claude/rules/agent-tiering-detail.md
+++ b/.claude/rules/agent-tiering-detail.md
@@ -1,6 +1,6 @@
 ---
 description: Read-on-demand detail for agent-tiering — the skip-vs-spawn heuristic, Fable approval-gate procedure (incl. the asm-level static-RE exception where Fable is the recommended tier), flat-fan-out (nested sub-agent) rationale, orchestrator context economics (delegate-don't-dismiss, split-don't-self-clear), and per-tier prompt style. Loads only when editing workflow orchestration defs.
-last_verified: 2026-07-23
+last_verified: 2026-07-24
 paths:
   - ".claude/skills/**/*.md"
 ---
@@ -95,6 +95,8 @@ Tier the orchestrator by the judgment **it** retains:
 
 - **Single backlog item** → **Sonnet** (Steps 2.5/3/4 orchestrator calls are light; same recipe-backed class the "Opus (delegated)" row routes to `plan-architect-sonnet`).
 - **Multiple items in one pass** → **Opus** (cross-item PR decomposition, **dependency ordering**, tier-boundary splits). Cheaper: run each as its own **Sonnet** `/plan` and make only the ordering call yourself.
+
+**Getting to a Sonnet orchestrator from an Opus session:** when an expensive session has already done the design thinking, don't run `/plan` inline — run `/plan-prompt` (`.claude/skills/plan-prompt/SKILL.md`), which drafts a paste-ready `/plan` prompt carrying the ground-truth pointers, the already-measured evidence, and an explicit Step-3 tier directive. A fresh Sonnet session then orchestrates, and the tier directive is what keeps the *design* on Opus. Sonnet-orchestrating is only cheaper than Opus-orchestrating if the context actually crosses the session boundary — that handoff prompt is the thing that carries it.
 
 ## Explore Agent Tiering
 

--- a/.claude/rules/agent-tiering.md
+++ b/.claude/rules/agent-tiering.md
@@ -1,6 +1,6 @@
 ---
 description: Which tier to pick for each sub-agent, including the Sonnet 4.6 def-pins. Skip-vs-spawn heuristic and deeper rationale live in agent-tiering-detail.md.
-last_verified: 2026-07-20
+last_verified: 2026-07-24
 ---
 
 # Agent Tiering

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -4,7 +4,7 @@ description: "Plan an implementation task: enforces a verification matrix, direc
 disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
-last_verified: 2026-07-21
+last_verified: 2026-07-24
 ---
 
 # /plan — Implementation Planning with Verification Matrix
@@ -53,6 +53,8 @@ Collect: file paths, existing patterns, dependencies, blast radius, existing tes
 ## Step 2.1: Prior-art check — is this already done?
 
 Before designing anything, verify the work **does not already exist** — merged to master or sitting in an open PR. Backlog/status markers go stale (a finding gets implemented but its marker is never flipped), so the marker Step 2 recorded is a *claim*, not ground truth — verify it against the repo THIS run. Repeatedly, a plan has been designed (and sometimes implemented) for work that was already merged, discoverable only by reading the code, never the marker. This gate spends a few cheap tool calls at the end of orientation to bail *before* the expensive Step 3 `plan-architect` spawn.
+
+**A fact asserted in `$ARGUMENTS` is a claim too.** A caller — a human, or an upstream session that drafted the task via `/plan-prompt` — can state "this isn't built yet," "the helper doesn't exist," or "no migration touches this table" in perfect good faith and be wrong: the assertion was true when it was written and the branch it described has since merged. Hold caller-asserted facts to the same standard as a status marker — the three signals below are cheap, and they are the only thing standing between a stale premise and a fully designed plan for work that already exists. This does **not** mean re-deriving everything the caller hands you; it means the *specific* claim "this work does not already exist" is never taken on trust, whatever its source.
 
 Check **three signals**, strongest first — using the deliverable paths Step 2 surfaced:
 


### PR DESCRIPTION
## Summary

Two guidance additions to tighten trust/verification posture in planning:

1. **`plan/SKILL.md`**: Added explicit note that facts asserted in `$ARGUMENTS` are claims, not ground truth. A caller (human or upstream `/plan-prompt` session) can assert "this isn't built yet" in good faith and be wrong — the existing-work check applies to all sources, not just status markers.

2. **`agent-tiering-detail.md`**: Added "Getting to a Sonnet orchestrator from an Opus session" guidance — when an expensive session has already done the design thinking, use `/plan-prompt` to draft a paste-ready handoff prompt rather than running `/plan` inline. The `agent-tiering.md` summary stays within the 5000-byte per-file budget; full paragraph lives in the detail file.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.