### PR TITLE
chore(post-plan): add done-marker for Phase 5.0 conformance verification

### DIFF
--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -5,7 +5,7 @@ disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
   - Skill
-last_verified: 2026-07-21
+last_verified: 2026-07-25
 ---
 
 # Post-Plan Orchestrator
@@ -142,7 +142,13 @@ Each Bash tool call runs in a fresh shell, so the classification flags are **not
 
 **INLINE invariant — Critical-Files must-appear rule (do NOT move to the reference file):** every file listed in the plan's `## Critical Files` section MUST appear in the PR diff, **unless** its annotation carries an explicit reference marker (`reference` / `read-only` / `verify` / `template` / `no-edit` / `unchanged` / `context`). A must-appear Critical File absent from the diff is a `MISSING-FILE:` finding that stays UNRESOLVED — and **blocks Phase 6.5 arming** — until you either make the dropped change (the #923 remedy) or note the legitimate cut in a PR comment. The matching regex, the `awk` that enforces it, and the sibling planned-test conformance check live in the reference file.
 
-Phase 5 consumes the Phase-3 flags `$HAS_PHP`, `$HAS_GO`, `$HAS_MATRIX`, `$PLAN_FOUND` — carried from Phase 3, never recomputed. **You MUST Read `.claude/skills/post-plan/_phase-5-final-verification.md` and run every block it lists, in order,** before computing the status. It writes the two carry-forward artifacts Phase 6.5 reads: the UNRESOLVED-items bridge `/tmp/post-plan-missing-tests-$PPID` and the status file `/tmp/post-plan-phase5-status-$PPID`.
+Phase 5 consumes the Phase-3 flags `$HAS_PHP`, `$HAS_GO`, `$HAS_MATRIX`, `$PLAN_FOUND` — carried from Phase 3, never recomputed. **You MUST Read `.claude/skills/post-plan/_phase-5-final-verification.md` and run every block it lists, in order,** before computing the status. It writes the three carry-forward artifacts Phase 6.5 reads: the UNRESOLVED-items bridge `/tmp/post-plan-missing-tests-$PPID`, the Phase-5.0 done-marker `/tmp/post-plan-conformance-done-$PPID`, and the status file `/tmp/post-plan-phase5-status-$PPID`.
+
+**Write the done-marker whether 5.0 runs or is skipped — this is mandatory on BOTH paths.** An empty bridge file cannot distinguish "5.0 ran clean" from "5.0 never finished", so condition (3) blocks when the marker is absent. When you **skip** Phase 5.0 (`PLAN_FOUND=none` or `! $HAS_MATRIX` — the majority case, since most PRs are plan-blind), write it here, before moving on; the reference file's END-of-5.0 write never executes on this path:
+
+```bash
+touch /tmp/post-plan-conformance-done-$PPID
+```
 
 ### Phase 5 END: emit `PHASE5_VERIFY_STATUS`
 
@@ -191,7 +197,7 @@ Enable auto-merge **before** watching CI. This is the earliest point all gating 
 
 1. Manual testing cleared — the PR body carries the `No manual testing needed` sentinel Phase 6 writes.
 2. No review/audit finding scored `>= 80` (scored in Phase 4).
-3. No unresolved `MISSING:` planned-test **or** `MISSING-FILE:` planned-file items from Phase 5.0 — `/tmp/post-plan-missing-tests-$PPID` is absent or empty (absent/empty = PASS, non-blocking).
+3. No unresolved `MISSING:` planned-test **or** `MISSING-FILE:` planned-file items from Phase 5.0 — **and Phase 5.0 provably finished**: the done-marker `/tmp/post-plan-conformance-done-$PPID` exists AND the bridge `/tmp/post-plan-missing-tests-$PPID` is absent or empty. Marker absent = indeterminate = BLOCKED (an empty bridge file alone means nothing — 5.0 truncates it at START).
 4. Phase 5 did not deterministically fail — `PHASE5_VERIFY_STATUS` is `pass` or `skipped`, **not** `fail`.
 5. Golden-snapshot safety — a change to `engine/internal/sim/testdata/golden.json` does NOT auto-ship unattended (headless-only block).
 6. Merge-order — every PR named in a `Depends-on:` line is already `MERGED`.
@@ -206,13 +212,13 @@ Enable auto-merge **before** watching CI. This is the earliest point all gating 
 
 **Each condition block is SELF-CONTAINED** — it `source`s the predicate and fetches its own inputs in-block, exactly as condition (7) re-derives `$PLAN_FILE` and the original (6)/(8) ran their own `gh pr view`. **Do not** hoist the `source` or a shared `PR_JSON` into a preamble block: a sourced function or a shell variable does not survive into a separately-executed block (only exported env vars like `$CLAUDE_HEADLESS` do), and a missing `source` would make `pr_feat_hold` a no-op — **failing OPEN, auto-arming a `feat:` PR**. Each block re-`source`ing the lib is idempotent and cheap. Every block extracts gh output with `gh ... --jq` (gh does the decode — no `echo`/`printf` round-trip needed); when a block must round-trip a multi-field `PR_JSON` it uses `printf '%s'` (never `echo`, whose zsh `\n` expansion corrupts jq's parse).
 
-**You MUST Read `.claude/skills/post-plan/_phase-6.5-arm-auto-merge.md` and run each condition's block, in order, BEFORE arming — do not arm without it.** The reference holds the seven per-condition bash blocks (conditions 1, 4, 5, 6, 7, 8, 10 — conditions 2/3/9 are the Phase-4 score check, the `/tmp/post-plan-missing-tests-$PPID` bridge check, and the realized-diff hold-enumeration, run against state you already hold), each **self-contained** per the SELF-CONTAINED invariant above (every block re-`source`s the predicate in-block — a hoisted `source` does not survive into a separately-executed block and would fail OPEN). It also holds the per-condition blocker-reporting detail. Phase 6.5 consumes carried state only — the Phase-3 flags `$GOLDEN_CHANGED`/`$HAS_MIGRATION`/`COUNT_*`, the env `$CLAUDE_HEADLESS`/`$PPID`, the Phase-4 finding scores, the Phase-6 manual-testing sentinel, and the Phase-5 status file — never recompute them.
+**You MUST Read `.claude/skills/post-plan/_phase-6.5-arm-auto-merge.md` and run each condition's block, in order, BEFORE arming — do not arm without it.** The reference holds the eight per-condition bash blocks (conditions 1, 3, 4, 5, 6, 7, 8, 10 — conditions 2/9 are the Phase-4 score check and the realized-diff hold-enumeration, run against state you already hold), each **self-contained** per the SELF-CONTAINED invariant above (every block re-`source`s the predicate in-block — a hoisted `source` does not survive into a separately-executed block and would fail OPEN). It also holds the per-condition blocker-reporting detail. Phase 6.5 consumes carried state only — the Phase-3 flags `$GOLDEN_CHANGED`/`$HAS_MIGRATION`/`COUNT_*`, the env `$CLAUDE_HEADLESS`/`$PPID`, the Phase-4 finding scores, the Phase-6 manual-testing sentinel, and the Phase-5 status file — never recompute them.
 
 **Fail-closed default:** if any condition is indeterminate, errors, or you are unsure, treat it as **BLOCKED** and do NOT arm. A false HOLD costs one manual human merge; a false ARM ships unreviewed code — only under-holding is dangerous.
 
 **If every condition passes:** arm with `gh pr merge --squash --auto --delete-branch` — `--auto` *queues* the merge (it does not merge now); GitHub fires it once required checks pass. Do not sync local to master here.
 
-**If any condition blocks:** do NOT arm. Report which condition(s) blocked — the per-condition report text is in the reference (e.g. `cat /tmp/post-plan-missing-tests-$PPID` for (3); which Phase-5 track failed for (4)). Continue to Phase 7 regardless to monitor and fix CI; a re-run clears a red-track block, but the intent/type holds (7), (8), (10) stay held until a human acts.
+**If any condition blocks:** do NOT arm. Report which condition(s) blocked — the per-condition report text is in the reference (for (3), report whether the block hit the no-done-marker branch — "Phase 5.0 never reached its end" — or listed unresolved items from `/tmp/post-plan-missing-tests-$PPID`; which Phase-5 track failed for (4)). Continue to Phase 7 regardless to monitor and fix CI; a re-run clears a red-track block, but the intent/type holds (7), (8), (10) stay held until a human acts.
 
 **Interactive golden warning:** when `$GOLDEN_CHANGED` is `true` and `$CLAUDE_HEADLESS` is unset (so condition 5 did not block), still surface the warning prominently so the human confirms the simulation change was an intentional `make -C engine golden-update`, not a masked regression.
 
@@ -283,7 +289,7 @@ Kill known lingering patterns so their tool results deliver immediately (cache w
 pkill -f 'bin/e2e-wt\.sh' 2>/dev/null
 pkill -f 'bunx.*playwright' 2>/dev/null
 pkill -f 'gh pr checks.*--watch' 2>/dev/null
-rm -f /tmp/post-plan-spec-diff-$PPID /tmp/post-plan-spec-prod-diff-$PPID /tmp/post-plan-missing-tests-$PPID 2>/dev/null
+rm -f /tmp/post-plan-spec-diff-$PPID /tmp/post-plan-spec-prod-diff-$PPID /tmp/post-plan-missing-tests-$PPID /tmp/post-plan-conformance-done-$PPID 2>/dev/null
 echo "Background process cleanup complete"
 ```
 

--- a/.claude/skills/post-plan/_phase-5-final-verification.md
+++ b/.claude/skills/post-plan/_phase-5-final-verification.md
@@ -4,10 +4,11 @@ Purpose: the full Phase 5 final-verification how-to (all prose steps + all bash 
 
 ### Phase 5.0: Plan→test & Plan→file conformance — skip if `PLAN_FOUND=none` or `! $HAS_MATRIX`
 
-At Phase 5.0 START, clear the conformance bridge file so each run begins from a clean slate (an empty file means "nothing unresolved"):
+At Phase 5.0 START, clear the conformance bridge file AND remove the done-marker, so each run begins from a clean slate. An empty bridge file alone is **not** enough to mean "nothing unresolved" — it is byte-identical to "5.0 died before writing anything", which is why the separate done-marker exists (Phase 6.5 condition (3) treats a missing marker as indeterminate → BLOCKED):
 
 ```bash
 : > /tmp/post-plan-missing-tests-$PPID
+rm -f /tmp/post-plan-conformance-done-$PPID
 ```
 
 Read the Verification Matrix from `$PLAN_FILE`. Collect the test-file path from the "Test file / location" column of every row whose Test type is PHPUnit, API-test, E2E, or Visual-regression. Confirm the PR diff actually wrote each one:
@@ -41,6 +42,16 @@ done
 For each `MISSING-FILE:`, the impl dropped a planned change. Either (a) make the change now — the plan's implementation steps describe it (this is the #923 remedy: finish the work), run any relevant check, and checkpoint (commit + push) — or (b) if the file was legitimately cut from scope, or is a reference the plan author forgot to annotate, note that in a PR comment. A `MISSING-FILE:` item is **resolved** by (a) or (b); otherwise **unresolved**.
 
 At Phase 5.0 END, append each remaining **UNRESOLVED** `MISSING:` and `MISSING-FILE:` item (label + path + reason) to `/tmp/post-plan-missing-tests-$PPID`, one per line. Authored-green / implemented-and-checkpointed / cut-with-comment items are NOT written. This bridge file is consulted by the Phase 6.5 auto-merge gate.
+
+Then — **last action of Phase 5.0, after the appends above** — write the done-marker:
+
+```bash
+touch /tmp/post-plan-conformance-done-$PPID
+```
+
+The marker is the positive assertion that 5.0 reached its end; the bridge file only says *what* was unresolved. Without it, "5.0 ran and found nothing" and "5.0 died mid-section" are indistinguishable and condition (3) would fail OPEN. **The marker must also be written on the skip path** (`PLAN_FOUND=none` or `! $HAS_MATRIX`) — that instruction lives in `SKILL.md` Phase 5.0, because a run that skips 5.0 may never read this file. Omitting the skip-path write would block auto-merge on every plan-blind PR, which is the dominant case.
+
+Compiled-harness note: `tools/postplan-harness` computes conformance in-process (`harness/conformance.py` returns the unresolved list to `armable.py`) and never touches either `/tmp` file. The marker is a **skill-path** mechanism only — do not "port" it to the harness.
 
 **PHPUnit + PHPStan — direct Bash (no agent):** **Skip if** `! $HAS_PHP`. The PostToolUse hook already ran both during edits, and a PHP-less diff cannot regress either suite. Run both as **blocking** (foreground) direct Bash calls — do **NOT** pass `run_in_background: true`. Both finish in ~1–2 min, well under the per-phase cap, and backgrounding them here is the trap that stall-killed the 2026-06-21 runs: when the E2E track is skipped there is nothing left to wait on in-turn, so the model backgrounds them and ends the turn expecting a re-invocation that headless mode never delivers. Running blocking returns their results in-turn and you proceed straight to Phase 6. Output is ~5 lines each — agent overhead (~25K tokens) is never justified. (If you ever do background them for parallelism with the E2E agent, the drain rule at the top of this skill is mandatory: poll `BashOutput` to completion before computing `PHASE5_VERIFY_STATUS` — never end the turn on a pending task.)
 

--- a/.claude/skills/post-plan/_phase-6.5-arm-auto-merge.md
+++ b/.claude/skills/post-plan/_phase-6.5-arm-auto-merge.md
@@ -11,7 +11,22 @@ CLEAR=$(pr_manual_testing_clearance "$(gh pr view --json body --jq '.body')")
 [ "$CLEAR" != "CLEARED" ] && echo "BLOCKED: Manual-Testing not cleared (state=$CLEAR) — held for human review"
 ```
 
-**Condition (4) blocks on the VALUE, not file presence** — the status file is non-empty for `pass` and `skipped` too (it always contains `PHASE5_VERIFY_STATUS=...`), so the `[ -s ... ]` idiom condition (3) uses would wrongly block every `pass`/`skipped`. Block only on the literal `fail` value; **absent file OR `pass` OR `skipped` = PASS (non-blocking)** — a `skipped` status (docs-only / PHP-less PR with no mapped E2E) must NOT block, or every such PR would stop arming, a regression worse than #887:
+**Condition (3) is three-state, and an indeterminate Phase 5.0 BLOCKS.** The bridge file `/tmp/post-plan-missing-tests-$PPID` is truncated at 5.0 START and appended to at 5.0 END, so *empty* is ambiguous on its own: it is byte-identical for "5.0 ran and found nothing unresolved" and "5.0 died before it finished". Reading empty as PASS is a fail-OPEN that contradicts the fail-closed default. The disambiguator is the **done-marker** `/tmp/post-plan-conformance-done-$PPID`, written as the last action of Phase 5.0 on **both** the normal path and the skip path (`PLAN_FOUND=none` or `! $HAS_MATRIX` — see `SKILL.md` Phase 5.0). Marker absent ⇒ indeterminate ⇒ **BLOCKED**; marker present + empty bridge ⇒ clean ⇒ pass. The skip-path write is what keeps this from blocking every plan-blind PR (the dominant case), so treat it as load-bearing, not defensive. The compiled harness computes conformance in-process and uses neither file:
+
+```bash
+# condition (3): three-state — missing done-marker means Phase 5.0 never finished,
+# which is INDETERMINATE, not clean, so it blocks (fail-closed). $DONE_MARK/$BRIDGE
+# are overridable only so bin/test-postplan-arm-conditions can exercise this block.
+DONE_MARK="${DONE_MARK:-/tmp/post-plan-conformance-done-$PPID}"
+BRIDGE="${BRIDGE:-/tmp/post-plan-missing-tests-$PPID}"
+if [ ! -f "$DONE_MARK" ]; then
+  echo "BLOCKED: Phase 5.0 conformance never reached its end (no done-marker) — indeterminate, not clean"
+elif [ -s "$BRIDGE" ]; then
+  echo "BLOCKED: unresolved Phase 5.0 conformance items:"; cat "$BRIDGE"
+fi
+```
+
+**Condition (4) blocks on the VALUE, not file presence** — the status file is non-empty for `pass` and `skipped` too (it always contains `PHASE5_VERIFY_STATUS=...`), so the `[ -s ... ]` idiom condition (3) uses on its bridge file would wrongly block every `pass`/`skipped`. Block only on the literal `fail` value; **absent file OR `pass` OR `skipped` = PASS (non-blocking)** — a `skipped` status (docs-only / PHP-less PR with no mapped E2E) must NOT block, or every such PR would stop arming, a regression worse than #887:
 
 ```bash
 # condition (4): fails ONLY when the status is the literal `fail`

--- a/bin/test-postplan-arm-conditions
+++ b/bin/test-postplan-arm-conditions
@@ -3,7 +3,8 @@
 #
 # bin/test-postplan-arm-conditions — regression guard for the /post-plan Phase 6.5
 # auto-merge conditions that call the shared predicate bin/lib/pr-armable.sh
-# (conditions (1) Manual-Testing, (5) golden, (6) Depends-on, (8) feat:).
+# (conditions (1) Manual-Testing, (5) golden, (6) Depends-on, (8) feat:), plus
+# condition (3), the Phase-5.0 conformance gate (no predicate; /tmp state only).
 #
 # Why this exists: those conditions live as separate ```bash blocks inside
 # _phase-6.5-arm-auto-merge.md (extracted from SKILL.md by the lazy-load
@@ -70,6 +71,20 @@ run_isolated() {
         bash -c "$1" 2>&1
 }
 
+# run_cond3 <block> <marker: yes|no> <bridge: absent|empty|items> — condition (3)
+# reads /tmp state rather than gh, so it gets its own runner: the block's
+# $DONE_MARK/$BRIDGE defaults are overridden to point into $BASE_TMP.
+run_cond3() {
+    local mark="$BASE_TMP/done-marker" bridge="$BASE_TMP/bridge"
+    rm -f "$mark" "$bridge"
+    [ "$2" = "yes" ] && touch "$mark"
+    case "$3" in
+        empty) : > "$bridge" ;;
+        items) echo 'MISSING: ibl5/tests/FooTest.php (matrix planned a test the diff never wrote)' > "$bridge" ;;
+    esac
+    DONE_MARK="$mark" BRIDGE="$bridge" bash -c "$1" 2>&1
+}
+
 expect_block() { # name  BLOCK|NONE  output
     local got_block=0
     [[ "$3" == *BLOCKED* ]] && got_block=1
@@ -98,6 +113,7 @@ assert_self_contained() { # marker name
 }
 
 B1="$(extract_block '# condition (1)')"
+B3="$(extract_block '# condition (3)')"
 B5="$(extract_block '# condition (5)')"
 B6="$(extract_block '# condition (6)')"
 B8="$(extract_block '# condition (8)')"
@@ -117,6 +133,19 @@ expect_block "(1) cleared sentinel -> NONE" NONE \
     "$(run_isolated "$B1" '{"body":"## Manual Testing\nNo manual testing needed — automated."}' '' '')"
 expect_block "(1) no section (UNKNOWN) -> BLOCK (fail-closed)" BLOCK \
     "$(run_isolated "$B1" '{"body":"hand-made PR, no manual testing heading"}' '' '')"
+
+# condition (3) — the fail-open this gate closed: an empty bridge file is
+# byte-identical for "5.0 ran clean" and "5.0 died", so only the done-marker
+# distinguishes them. The marker+absent-bridge case is the plan-blind majority
+# (Phase 5.0 skipped) — if it ever BLOCKs, nearly every PR stops arming.
+expect_block "(3) no done-marker -> BLOCK (indeterminate, fail-closed)" BLOCK \
+    "$(run_cond3 "$B3" no empty)"
+expect_block "(3) marker + unresolved items -> BLOCK" BLOCK \
+    "$(run_cond3 "$B3" yes items)"
+expect_block "(3) marker + empty bridge -> NONE (5.0 ran clean)" NONE \
+    "$(run_cond3 "$B3" yes empty)"
+expect_block "(3) marker + absent bridge -> NONE (5.0 skipped, plan-blind)" NONE \
+    "$(run_cond3 "$B3" yes absent)"
 
 expect_block "(5) golden + headless -> BLOCK" BLOCK \
     "$(run_isolated "$B5" '{"files":[{"path":"engine/internal/sim/testdata/golden.json"}]}' '' '1')"


### PR DESCRIPTION
## Summary
- Add `/tmp/post-plan-conformance-done-$PPID` sentinel file written at end of Phase 5.0 (both normal and skip paths)
- Fixes fail-open bug in auto-merge condition (3): empty bridge file alone is ambiguous (clean run vs Phase 5.0 crash mid-execution)
- Done-marker + empty bridge = clean; marker absent = indeterminate → BLOCKED (fail-closed)
- Update Phase 5.0 final-verification and auto-merge gate docs with three-state detection logic
- Add test harness (`run_cond3`) and regression tests for condition (3) state matrix

## Manual Testing

No manual testing needed — verified by automated tests.
