### PR TITLE
fix(bug-pipeline): validate env vars and CLI options

### DIFF
--- a/bin/bug-pipeline-cron-setup
+++ b/bin/bug-pipeline-cron-setup
@@ -126,6 +126,28 @@ case "$ACTION" in
     build_plist
     ;;
   install)
+    # Refusal (checked first, before any launchctl call, so it is testable from a
+    # worktree): every required var must be set — don't install a job that fails every
+    # 180s. An unset var is NOT harmless here: build_plist writes ${VAR:-}, so it lands
+    # as a well-formed <string></string> and launchd hands the tick an empty value that
+    # reads exactly like a configured one. Both consumers of APPROVER_ID fail soft
+    # (gather stays gathering; give_up_needs_human logs "continuing"), so an empty id
+    # would silently mean no human is ever pinged — one log line per tick, forever.
+    # The same defect shipped live as an empty SIM_RECAP_DB_NAME (PR #1646). Fail at
+    # install time instead. Vars with a real non-empty default (BUG_PIPELINE_ISSUE_REPO)
+    # are deliberately NOT listed — they cannot be empty.
+    missing=""
+    # One-element loop on purpose: same shape as bin/sim-recap-cron-setup's refusal,
+    # so adding a second required var is a one-word edit.
+    # shellcheck disable=SC2043
+    for var in BUG_PIPELINE_APPROVER_ID; do
+      [ -n "${!var:-}" ] || missing="${missing} ${var}"
+    done
+    if [ -n "$missing" ]; then
+      echo "Error: unset required env var(s):${missing}" >&2
+      echo "Export them before running --install-schedule (see --help)." >&2
+      exit 1
+    fi
     mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
     launchctl bootout "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true  # idempotent: ignore "not loaded"
     build_plist > "$PLIST_PATH"

--- a/bin/test-bug-pipeline-tick
+++ b/bin/test-bug-pipeline-tick
@@ -52,6 +52,32 @@ else
     bpt_fail "queued row should dispatch to classifier"
 fi
 
+# ── NEG — cron-setup refuses to install with an empty BUG_PIPELINE_APPROVER_ID ──
+# The var has no default, so an unset one interpolates into the plist as a
+# well-formed <string></string> and launchd hands the tick a value that reads exactly
+# like a configured one — both consumers then fail soft forever. Only the refusal path
+# is asserted: the success path would really bootstrap the live LaunchAgent.
+# `launchctl`/`gh` are stubbed and their logs asserted ABSENT, so a mis-ordered guard
+# fails a case here instead of tearing down the running job.
+_cs_home="$(mktemp -d)"
+mkdir -p "$_cs_home/bin"
+for _cs_bin in launchctl gh; do
+    cat > "$_cs_home/bin/$_cs_bin" <<SH
+#!/usr/bin/env bash
+echo "\$0 \$*" >> "$_cs_home/$_cs_bin.log"
+SH
+done
+chmod +x "$_cs_home"/bin/*
+env -u BUG_PIPELINE_APPROVER_ID HOME="$_cs_home" PATH="$_cs_home/bin:$PATH" \
+    "$(dirname "$BPT_DRIVER")/bug-pipeline-cron-setup" --install-schedule \
+    > "$_cs_home/guard.out" 2>&1
+bpt_expect_eq "empty APPROVER_ID → cron-setup exits 1" 1 "$?"
+bpt_log_has "$_cs_home" guard.out "BUG_PIPELINE_APPROVER_ID" "refusal names the unset var"
+bpt_file_absent "$_cs_home/Library/LaunchAgents/com.ibl5.bug-pipeline-cron.plist" \
+    "refusal writes no plist"
+bpt_file_absent "$_cs_home/launchctl.log" "refusal precedes every launchctl call"
+bpt_file_absent "$_cs_home/gh.log" "refusal precedes issue-tracking bootstrap"
+
 echo "----"
 [ "$FAILED" -eq 0 ] && echo "ALL PASS" || echo "FAILURES"
 exit "$FAILED"

--- a/ibl5/scripts/bug-pipeline/transition.php
+++ b/ibl5/scripts/bug-pipeline/transition.php
@@ -36,6 +36,18 @@ const VALID_STATUSES = [
 ];
 const VALID_CLASSES = ['bug', 'feature', 'not_a_thing'];
 
+/**
+ * The exact option vocabularies from the usage block above. Anything else is a caller
+ * bug: `--attempts 5` (space instead of `=`) used to register a meaningless
+ * `$flags['attempts']` and silently drop the 5, and a typo'd `--realese-lease` was a
+ * no-op UPDATE. Rejecting an unrecognized key catches both at the CLI boundary rather
+ * than one call site at a time.
+ */
+const VALID_VAL_OPTS = [
+    'class', 'pr', 'issue', 'attempts', 'thread-id', 'approval-message-id', 'blocked-until',
+];
+const VALID_FLAGS = ['release-lease', 'reminder-now', 'last-processed-now', 'clear-blocked'];
+
 function fail(string $msg): never
 {
     fwrite(STDERR, "transition: {$msg}\n");
@@ -51,8 +63,20 @@ foreach (array_slice($argv, 1) as $arg) {
         $body = substr($arg, 2);
         if (str_contains($body, '=')) {
             [$k, $v] = explode('=', $body, 2);
+            if (!in_array($k, VALID_VAL_OPTS, true)) {
+                fail(in_array($k, VALID_FLAGS, true)
+                    ? "--{$k} is a flag and takes no value."
+                    : "unknown option --{$k}. Valid: --" . implode('=, --', VALID_VAL_OPTS)
+                        . '=, --' . implode(', --', VALID_FLAGS) . '.');
+            }
             $valOpts[$k] = $v;
         } else {
+            if (!in_array($body, VALID_FLAGS, true)) {
+                fail(in_array($body, VALID_VAL_OPTS, true)
+                    ? "--{$body} takes a value: --{$body}=<value> (not --{$body} <value>)."
+                    : "unknown flag --{$body}. Valid: --" . implode(', --', VALID_FLAGS)
+                        . '; value opts: --' . implode('=, --', VALID_VAL_OPTS) . '=.');
+            }
             $flags[$body] = true;
         }
     } else {

--- a/ibl5/tests/DatabaseIntegration/BugPipeline/BugPipelineCliTest.php
+++ b/ibl5/tests/DatabaseIntegration/BugPipeline/BugPipelineCliTest.php
@@ -272,6 +272,14 @@ class BugPipelineCliTest extends DatabaseTestCase
         foreach ([
             [(string) self::ID_QUEUED, 'not_a_status'],
             ['abc', 'queued'],
+            // A value opt passed space-separated: used to register a meaningless
+            // $flags['attempts'] and silently drop the 5 (the parser accepted anything).
+            [(string) self::ID_QUEUED, 'fixed', '--attempts', '5'],
+            // A typo'd/unknown option is a no-op UPDATE unless the parser rejects it.
+            [(string) self::ID_QUEUED, 'fixed', '--realese-lease'],
+            [(string) self::ID_QUEUED, 'fixed', '--bogus=1'],
+            // A flag given a value is equally a caller bug.
+            [(string) self::ID_QUEUED, 'fixed', '--release-lease=1'],
         ] as $badArgs) {
             $r = $this->runCli('transition.php', $badArgs);
             self::assertSame(1, $r['code'], 'expected exit 1 for: ' . implode(' ', $badArgs));


### PR DESCRIPTION
## Summary
- Add guard to `bug-pipeline-cron-setup` to validate required `BUG_PIPELINE_APPROVER_ID` env var before install
  - Prevents silent launchd job failures when env var is unset
- Add validation to `transition.php` CLI parser to reject unknown/malformed options
  - Catches typos, space-separated args, and flag/value confusion
- Add tests verifying both guards catch invalid input and fail fast

## Manual Testing

No manual testing needed — verified by automated tests.
