### PR TITLE
feat(sim-recap): preserve linebreaks in recap prose

### DIFF
--- a/ibl5/classes/SimRecap/SimSummariesView.php
+++ b/ibl5/classes/SimRecap/SimSummariesView.php
@@ -93,7 +93,7 @@ class SimSummariesView
 <?php else: ?>
 <?php $intro = $recap['intro_text'] ?? null; ?>
 <?php if (is_string($intro) && $intro !== ''): ?>
-        <p id="recap-intro"><?= HtmlSanitizer::e($intro) ?></p>
+        <p id="recap-intro" class="whitespace-pre-line"><?= HtmlSanitizer::e($intro) ?></p>
 <?php endif; ?>
 <?php if ($gameRecaps !== []): ?>
         <ol id="recap-games">
@@ -105,14 +105,14 @@ class SimSummariesView
 ?>
             <li class="recap-game">
                 <span class="recap-game__meta"><?= HtmlSanitizer::e(is_string($gDate) ? $gDate : '') ?> · team <?= HtmlSanitizer::e(is_scalar($gVid) ? (string) $gVid : '') ?> at team <?= HtmlSanitizer::e(is_scalar($gHid) ? (string) $gHid : '') ?></span>
-                <p class="recap-game__text"><?= HtmlSanitizer::e($game['recap_text'] ?? '') ?></p>
+                <p class="recap-game__text whitespace-pre-line"><?= HtmlSanitizer::e($game['recap_text'] ?? '') ?></p>
             </li>
 <?php endforeach; ?>
         </ol>
 <?php endif; ?>
 <?php $outro = $recap['outro_text'] ?? null; ?>
 <?php if (is_string($outro) && $outro !== ''): ?>
-        <p id="recap-outro"><?= HtmlSanitizer::e($outro) ?></p>
+        <p id="recap-outro" class="whitespace-pre-line"><?= HtmlSanitizer::e($outro) ?></p>
 <?php endif; ?>
         <textarea id="recap-body" readonly rows="24" cols="100"><?= HtmlSanitizer::e($body) ?></textarea>
         <p>

--- a/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
+++ b/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
@@ -164,6 +164,31 @@ final class SimSummariesViewTest extends TestCase
         self::assertSame(3, substr_count($html, '&lt;script&gt;alert(1)&lt;/script&gt;'));
     }
 
+    /**
+     * The recap arrives as plain text whose newlines carry its shape (score header,
+     * mention line, then prose). HTML collapses those newlines, so the three prose
+     * paragraphs must opt into `white-space: pre-line`. Escaping is the reason this
+     * is a CSS class and not nl2br(): `<br>` would have to be echoed unescaped, and
+     * LLM prose never goes through HtmlSanitizer::trusted().
+     */
+    public function testProseParagraphsPreserveNewlines(): void
+    {
+        $html = $this->view->render(
+            [],
+            $this->recapRow('Body.', null, "Intro line one\nIntro line two", "Outro line one\nOutro line two"),
+            [['game_date' => '2025-01-01', 'visitor_teamid' => 1, 'home_teamid' => 2, 'game_of_that_day' => 1, 'sort_order' => 0, 'recap_text' => "**A 1 @ B 2**\nGame prose."]],
+            null
+        );
+
+        self::assertStringContainsString('<p id="recap-intro" class="whitespace-pre-line">', $html);
+        self::assertStringContainsString('<p class="recap-game__text whitespace-pre-line">', $html);
+        self::assertStringContainsString('<p id="recap-outro" class="whitespace-pre-line">', $html);
+        // The newlines themselves must survive escaping — pre-line has nothing to act on otherwise.
+        self::assertStringContainsString("Intro line one\nIntro line two", $html);
+        self::assertStringContainsString("**A 1 @ B 2**\nGame prose.", $html);
+        self::assertStringContainsString("Outro line one\nOutro line two", $html);
+    }
+
     public function testOmitsPerGameListWhenRecapTextIsNull(): void
     {
         // When a row has no recap_text the caller passes [] for $gameRecaps;


### PR DESCRIPTION
## Summary
- Adds `white-space: pre-line` CSS class to recap intro, game, and outro text paragraphs to preserve LLM-generated newlines that would otherwise collapse in HTML
- Uses CSS instead of nl2br() because prose text bypasses HtmlSanitizer::trusted(), making unescaped `<br>` tags unsafe
- Adds test coverage verifying newline preservation across all three prose paragraph types

## Manual Testing
No manual testing needed — all changes are covered by unit and E2E tests.