### PR TITLE
feat(simrecap): Assemble full recap documents from parts

### DIFF
--- a/bin/sim-recap-prompt
+++ b/bin/sim-recap-prompt
@@ -156,7 +156,7 @@ echo ""
 echo "== DISCORD MENTION MAP =="
 echo ""
 echo "Use these @mentions when writing each game recap."
-echo "Format: away-team-mention · home-team-mention (middle-dot separated, on one line below the score header)."
+echo "Format: away-team-mention · home-team-mention (middle-dot separated, on one line below the score header). The prose paragraph follows after a blank line."
 echo ""
 
 if [[ -n "$mentions_path" && -f "$mentions_path" ]]; then
@@ -273,7 +273,8 @@ The following is the authoritative format reference. Match its structure exactly
   - 80-character = separator
   - Per date: ================================ Mon DD ========================================= separator
   - Per game: **Away Team NNN @ Home Team NNN** header (bold), then <@id> · <@id> mentions
-    line (away snowflake · home snowflake, middle-dot separated), then one prose paragraph
+    line (away snowflake · home snowflake, middle-dot separated), then a blank line, then
+    one prose paragraph
 
 Injuries woven into prose. Long streaks called out. Pop culture references tied to the era.
 

--- a/ibl5/classes/SimRecap/README.md
+++ b/ibl5/classes/SimRecap/README.md
@@ -1,6 +1,6 @@
 ---
 description: Ingests externally-generated sim recap documents and queues them for the sim recap pipeline.
-last_verified: 2026-07-24
+last_verified: 2026-07-25
 ---
 
 # SimRecap
@@ -12,3 +12,4 @@ Handles the ingest of externally-generated simulation recap documents into the a
 | `SimRecapPayload` | Parses and validates incoming recap documents |
 | `SimSummaryRepository` | Atomic queue operations for the recap pipeline |
 | `SimSummariesView` | Renders sim recap summaries |
+| `RecapDocument` | Assembles the postable document from intro + game rows + outro, shaped like `bin/lib/sim-recap-exemplar.txt` |

--- a/ibl5/classes/SimRecap/RecapDocument.php
+++ b/ibl5/classes/SimRecap/RecapDocument.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimRecap;
+
+/**
+ * Assembles the postable recap document from the parts the generator stored.
+ *
+ * `ibl_sim_summaries.recap_text` is a ~220-character teaser, not the document — the
+ * document only exists as pieces: `intro_text`, one row per game in
+ * `ibl_sim_game_recaps`, and `outro_text`. This class is the one place that joins
+ * them back into the shape of `bin/lib/sim-recap-exemplar.txt`, which is what a GM
+ * actually pastes into Discord.
+ *
+ * Plain text in, plain text out — no HTML, no escaping. Callers that put the result
+ * in a page still run it through HtmlSanitizer::e() like any other stored value.
+ */
+final class RecapDocument
+{
+    /**
+     * Two blank lines separate the top-level blocks: intro, each date section, outro.
+     * Exemplar lines 12-15 (intro rule → blank → blank → date rule) and 263-266.
+     */
+    private const BLOCK_GAP = "\n\n\n";
+
+    /**
+     * One blank line separates the pieces inside a date section — the rule from the
+     * first game, and each game from the next. Exemplar lines 15-17 and 20-22.
+     */
+    private const INNER_GAP = "\n\n";
+
+    /**
+     * The date rule is fixed-count, not width-normalized: the exemplar's own rules are
+     * 81 chars for "Feb 26" and 80 for "Mar 1". Padding them to a common width would
+     * diverge from the format the exemplar defines.
+     */
+    private const RULE_PREFIX = 32;
+    private const RULE_SUFFIX = 41;
+
+    /** `<@123> · <@456>` — the GM mention line the generator writes under each score header. */
+    private const MENTION_LINE = '/^<@\d+>(?:\s*·\s*<@\d+>)*$/u';
+
+    /**
+     * @param list<array<string, mixed>> $gameRecaps From SimSummaryRepository::findDisplayableGameRecaps(), already in sort order
+     */
+    public static function assemble(?string $intro, array $gameRecaps, ?string $outro): string
+    {
+        $blocks = [];
+
+        $introText = self::clean($intro);
+        if ($introText !== '') {
+            $blocks[] = $introText;
+        }
+
+        foreach (self::groupByDate($gameRecaps) as $section) {
+            $rule     = $section['date'] === '' ? '' : self::dateRule($section['date']) . self::INNER_GAP;
+            $blocks[] = $rule . implode(self::INNER_GAP, $section['texts']);
+        }
+
+        $outroText = self::clean($outro);
+        if ($outroText !== '') {
+            $blocks[] = $outroText;
+        }
+
+        return $blocks === [] ? '' : implode(self::BLOCK_GAP, $blocks) . "\n";
+    }
+
+    /**
+     * Games keep the order the caller gave them; a new section starts only when the
+     * date changes, so each date gets exactly one rule. A map keyed by date would be
+     * shorter but PHP coerces numeric-looking keys to int, so the sections are a list.
+     * Rows with no usable text are dropped — an empty block is a stray blank line.
+     *
+     * @param  list<array<string, mixed>>                 $gameRecaps
+     * @return list<array{date: string, texts: list<string>}>
+     */
+    private static function groupByDate(array $gameRecaps): array
+    {
+        $sections = [];
+        foreach ($gameRecaps as $game) {
+            $text = self::clean($game['recap_text'] ?? null);
+            if ($text === '') {
+                continue;
+            }
+
+            $date  = self::clean($game['game_date'] ?? null);
+            $last  = count($sections) - 1;
+            $block = self::normalizeGameBlock($text);
+
+            if ($last >= 0 && $sections[$last]['date'] === $date) {
+                $sections[$last]['texts'][] = $block;
+                continue;
+            }
+
+            $sections[] = ['date' => $date, 'texts' => [$block]];
+        }
+
+        return $sections;
+    }
+
+    /**
+     * The generator writes the score header, the mention line and the prose on three
+     * consecutive lines; the exemplar puts a blank line between the mentions and the
+     * prose (lines 17-20). Rather than leave every already-stored recap a line off the
+     * format, repair it on read. The match is deliberately narrow — only a line that is
+     * nothing but `<@id>` mentions counts, so ordinary prose is never split.
+     */
+    private static function normalizeGameBlock(string $text): string
+    {
+        $lines = explode("\n", str_replace("\r\n", "\n", $text));
+
+        if (count($lines) >= 3 && $lines[2] !== '' && preg_match(self::MENTION_LINE, $lines[1]) === 1) {
+            array_splice($lines, 2, 0, ['']);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private static function dateRule(string $date): string
+    {
+        return str_repeat('=', self::RULE_PREFIX)
+            . ' ' . self::dateLabel($date) . ' '
+            . str_repeat('=', self::RULE_SUFFIX);
+    }
+
+    /**
+     * `Mar 5`, not `Mar 05` — the exemplar's own rules read "Mar 1", "Mar 4". A date the
+     * DB gave us that PHP cannot parse is printed verbatim rather than dropped.
+     */
+    private static function dateLabel(string $date): string
+    {
+        $parsed = date_create_immutable($date);
+
+        return $parsed === false ? $date : $parsed->format('M j');
+    }
+
+    private static function clean(mixed $value): string
+    {
+        return is_string($value) ? trim($value) : '';
+    }
+}

--- a/ibl5/classes/SimRecap/RecapDocument.php
+++ b/ibl5/classes/SimRecap/RecapDocument.php
@@ -67,6 +67,78 @@ final class RecapDocument
     }
 
     /**
+     * What the GM actually pastes — the assembled document when the stored parts carry
+     * the format, the stored `recap_text` when they don't.
+     *
+     * The generator is not guaranteed to have written the shape `bin/sim-recap-prompt`
+     * asks for. Sim 722 (2026-07-26) stored 56 per-game parts that were bare prose: no
+     * `**Away 110 @ Home 104**` score header and no `<@id> · <@id>` mention line, while
+     * its `recap_text` held the complete 25K document including all 112 mentions.
+     * Assembling those parts produces a document that reads fine and silently drops
+     * every GM's Discord tag — worse than what the league had before this class existed.
+     * So when the parts are degraded, fall back to the stored text.
+     *
+     * `assemble()` deliberately stays shape-tolerant (it is a pure formatter and cannot
+     * see the stored text), which is why the choice lives here instead.
+     *
+     * @param list<array<string, mixed>> $gameRecaps From SimSummaryRepository::findDisplayableGameRecaps(), already in sort order
+     */
+    public static function postableText(?string $intro, array $gameRecaps, ?string $outro, ?string $storedText): string
+    {
+        $document = self::assemble($intro, $gameRecaps, $outro);
+        $stored   = is_string($storedText) ? $storedText : '';
+
+        // Nothing to fall back to — the assembled document is all there is, even if degraded.
+        if (trim($stored) === '') {
+            return $document;
+        }
+
+        // No parts at all: the stored text, returned verbatim. Trimming would change the
+        // exported bytes, so the emptiness test above is the only place `trim()` is used.
+        if ($document === '') {
+            return $stored;
+        }
+
+        return self::gamesCarryTheirMentionLines($gameRecaps) ? $document : $stored;
+    }
+
+    /**
+     * All-or-nothing per sim, not per game: a run where only some games carry their
+     * mentions means the generator was inconsistent, and assembling it would leave
+     * exactly the GMs of the malformed games un-notified — the silent failure this
+     * guard exists to prevent.
+     *
+     * At least one non-empty part is required. A sim with a full stored document and no
+     * usable parts would otherwise assemble an intro+outro that looks like a complete
+     * recap with every game missing.
+     *
+     * The mention line is checked at index 1 alone, independently of what follows, so a
+     * part already in the exemplar's header/mentions/blank/prose shape still counts.
+     *
+     * @param list<array<string, mixed>> $gameRecaps
+     */
+    private static function gamesCarryTheirMentionLines(array $gameRecaps): bool
+    {
+        $sawAGame = false;
+
+        foreach ($gameRecaps as $game) {
+            $text = self::clean($game['recap_text'] ?? null);
+            if ($text === '') {
+                continue;
+            }
+
+            $sawAGame = true;
+            $lines    = explode("\n", str_replace("\r\n", "\n", $text));
+
+            if (!isset($lines[1]) || preg_match(self::MENTION_LINE, $lines[1]) !== 1) {
+                return false;
+            }
+        }
+
+        return $sawAGame;
+    }
+
+    /**
      * Games keep the order the caller gave them; a new section starts only when the
      * date changes, so each date gets exactly one rule. A map keyed by date would be
      * shorter but PHP coerces numeric-looking keys to int, so the sections are a list.

--- a/ibl5/classes/SimRecap/SimSummariesView.php
+++ b/ibl5/classes/SimRecap/SimSummariesView.php
@@ -115,17 +115,16 @@ class SimSummariesView
         <p id="recap-outro" class="whitespace-pre-line"><?= HtmlSanitizer::e($outro) ?></p>
 <?php endif; ?>
 <?php
-        // recap_text is a ~220-char teaser; the postable document only exists as
-        // intro + per-game rows + outro. Fall back to the teaser only when there is
-        // nothing to assemble, so Copy is never empty.
-        $document = RecapDocument::assemble(
+        // recap_text is usually a ~220-char teaser; the postable document only exists as
+        // intro + per-game rows + outro. postableText() falls back to the stored text
+        // when there is nothing to assemble or the parts lost their GM mention lines,
+        // so Copy is never empty and never silently drops a tag.
+        $document = RecapDocument::postableText(
             is_string($intro) ? $intro : null,
             $gameRecaps,
-            is_string($outro) ? $outro : null
+            is_string($outro) ? $outro : null,
+            $body
         );
-        if ($document === '') {
-            $document = $body;
-        }
 ?>
         <textarea id="recap-body" readonly rows="24" cols="100"><?= HtmlSanitizer::e($document) ?></textarea>
         <p>

--- a/ibl5/classes/SimRecap/SimSummariesView.php
+++ b/ibl5/classes/SimRecap/SimSummariesView.php
@@ -114,7 +114,20 @@ class SimSummariesView
 <?php if (is_string($outro) && $outro !== ''): ?>
         <p id="recap-outro" class="whitespace-pre-line"><?= HtmlSanitizer::e($outro) ?></p>
 <?php endif; ?>
-        <textarea id="recap-body" readonly rows="24" cols="100"><?= HtmlSanitizer::e($body) ?></textarea>
+<?php
+        // recap_text is a ~220-char teaser; the postable document only exists as
+        // intro + per-game rows + outro. Fall back to the teaser only when there is
+        // nothing to assemble, so Copy is never empty.
+        $document = RecapDocument::assemble(
+            is_string($intro) ? $intro : null,
+            $gameRecaps,
+            is_string($outro) ? $outro : null
+        );
+        if ($document === '') {
+            $document = $body;
+        }
+?>
+        <textarea id="recap-body" readonly rows="24" cols="100"><?= HtmlSanitizer::e($document) ?></textarea>
         <p>
             <button type="button" id="recap-copy">Copy</button>
             <span id="recap-copied" hidden>Copied</span>

--- a/ibl5/simSummaries.php
+++ b/ibl5/simSummaries.php
@@ -57,20 +57,21 @@ if ($wantsTxt) {
         exit;
     }
 
-    // recap_text is a ~220-char teaser; assemble the full document from parts before
-    // emitting headers so a fatal in assembly cannot produce partial output.
+    // recap_text is usually a ~220-char teaser; assemble the full document from parts
+    // before emitting headers so a fatal in assembly cannot produce partial output.
     $introText = $row['intro_text'] ?? null;
     $outroText = $row['outro_text'] ?? null;
-    $document  = \SimRecap\RecapDocument::assemble(
+    $document  = \SimRecap\RecapDocument::postableText(
         is_string($introText) ? $introText : null,
         $repo->findDisplayableGameRecaps($sim),
-        is_string($outroText) ? $outroText : null
+        is_string($outroText) ? $outroText : null,
+        (string) $row['recap_text']
     );
 
     header('Content-Type: text/plain; charset=utf-8');
     header('Content-Disposition: attachment; filename="sim-' . $sim . '-recap.txt"');
     header('X-Content-Type-Options: nosniff');
-    echo $document !== '' ? $document : (string) $row['recap_text'];
+    echo $document;
     exit;
 }
 

--- a/ibl5/simSummaries.php
+++ b/ibl5/simSummaries.php
@@ -57,10 +57,20 @@ if ($wantsTxt) {
         exit;
     }
 
+    // recap_text is a ~220-char teaser; assemble the full document from parts before
+    // emitting headers so a fatal in assembly cannot produce partial output.
+    $introText = $row['intro_text'] ?? null;
+    $outroText = $row['outro_text'] ?? null;
+    $document  = \SimRecap\RecapDocument::assemble(
+        is_string($introText) ? $introText : null,
+        $repo->findDisplayableGameRecaps($sim),
+        is_string($outroText) ? $outroText : null
+    );
+
     header('Content-Type: text/plain; charset=utf-8');
     header('Content-Disposition: attachment; filename="sim-' . $sim . '-recap.txt"');
     header('X-Content-Type-Options: nosniff');
-    echo (string) $row['recap_text'];
+    echo $document !== '' ? $document : (string) $row['recap_text'];
     exit;
 }
 

--- a/ibl5/tests/WideUnit/SimRecap/RecapDocumentTest.php
+++ b/ibl5/tests/WideUnit/SimRecap/RecapDocumentTest.php
@@ -170,4 +170,129 @@ final class RecapDocumentTest extends TestCase
 
         self::assertSame("Game.\n", $doc);
     }
+
+    /**
+     * Sim-722 shape: game parts are multi-line bare prose with no mention line at
+     * index 1. postableText() must return the stored text verbatim — assembling
+     * mention-less parts would silently drop every GM's Discord tag.
+     */
+    public function testPostableTextReturnsStoredTextWhenPartsAreBareProse(): void
+    {
+        $stored = "Stored monolith including <@7> and <@12> tags.\n\nAll 56 games are here.";
+        $game   = $this->game('2026-07-26', "The visitors came out strong.\nThey held the lead."); // line 1 is prose, not a mention
+
+        $result = RecapDocument::postableText('Intro.', [$game], 'Outro.', $stored);
+
+        self::assertSame($stored, $result);
+    }
+
+    /**
+     * Sim-721 shape: every part carries a mention line at index 1. Assembly is
+     * preferred — the stored text is a ~220-char teaser, not the document.
+     */
+    public function testPostableTextReturnsAssembledDocumentWhenPartsAreWellFormed(): void
+    {
+        $game   = $this->game('2026-02-26', "**A 100 @ B 114**\n<@1> · <@2>\nGame prose.");
+        $result = RecapDocument::postableText('Intro.', [$game], 'Outro.', 'Short teaser.');
+
+        self::assertSame(RecapDocument::assemble('Intro.', [$game], 'Outro.'), $result);
+    }
+
+    /**
+     * One game carries its mention line; the other is a single-line string with no
+     * index-1 entry at all. gamesCarryTheirMentionLines() is all-or-nothing — the
+     * mixed batch must fall back to the stored text.
+     */
+    public function testPostableTextIsAllOrNothingAcrossGames(): void
+    {
+        $wellFormed = $this->game('2026-02-26', "**A 100 @ B 114**\n<@1> · <@2>\nGame prose.");
+        $bareProse  = $this->game('2026-02-26', 'Single-line prose.');
+
+        $result = RecapDocument::postableText('Intro.', [$wellFormed, $bareProse], 'Outro.', 'Stored.');
+
+        self::assertSame('Stored.', $result);
+    }
+
+    /**
+     * Zero game rows: the assembled document is either empty (no intro/outro) or
+     * carries no game sections (intro+outro only). Both paths fall back to the stored
+     * text — via the $document === '' guard when parts are absent entirely, and via
+     * gamesCarryTheirMentionLines() returning false when intro+outro assembles but
+     * the game check still fails.
+     */
+    public function testPostableTextReturnsStoredTextWhenNoGameParts(): void
+    {
+        // No intro, no outro, no games → assemble() returns '' → $document === '' guard fires.
+        self::assertSame('Stored.', RecapDocument::postableText(null, [], null, 'Stored.'));
+
+        // Intro + outro, no games → assemble() is non-empty but gamesCarryTheirMentionLines([]) is false.
+        self::assertSame('Stored.', RecapDocument::postableText('Intro.', [], 'Outro.', 'Stored.'));
+    }
+
+    /**
+     * Empty-string and whitespace-only game rows are skipped by gamesCarryTheirMentionLines().
+     * The one remaining non-empty row carries a mention line, so assembly is preferred.
+     */
+    public function testPostableTextSkipsEmptyGameRowsWhenCheckingMentionLines(): void
+    {
+        $empty      = $this->game('2026-02-26', '');
+        $whitespace = $this->game('2026-02-26', '   ');
+        $wellFormed = $this->game('2026-02-26', "**A 100 @ B 114**\n<@1> · <@2>\nGame prose.");
+
+        $result = RecapDocument::postableText('Intro.', [$empty, $whitespace, $wellFormed], 'Outro.', 'Stored.');
+
+        self::assertSame(RecapDocument::assemble('Intro.', [$empty, $whitespace, $wellFormed], 'Outro.'), $result);
+    }
+
+    /**
+     * When stored text is empty, null, or whitespace, the assembled document is
+     * returned regardless of whether parts carry mention lines — there is nothing
+     * to fall back to.
+     */
+    public function testPostableTextReturnsAssembledDocumentWhenStoredTextIsEmpty(): void
+    {
+        $game      = $this->game('2026-02-26', 'Bare prose with no mention line.');
+        $assembled = RecapDocument::assemble(null, [$game], null);
+
+        self::assertSame($assembled, RecapDocument::postableText(null, [$game], null, null));
+        self::assertSame($assembled, RecapDocument::postableText(null, [$game], null, ''));
+        self::assertSame($assembled, RecapDocument::postableText(null, [$game], null, '   '));
+    }
+
+    /**
+     * A single mention at index 1 with no middle dot is well-formed — the regex
+     * /^<@\d+>(?:\s*·\s*<@\d+>)*$/u matches a bare <@id> with zero repetitions.
+     */
+    public function testPostableTextCountsSingleMentionAsWellFormed(): void
+    {
+        $game   = $this->game('2026-02-26', "**A 100 @ B 114**\n<@7>\nGame prose.");
+        $result = RecapDocument::postableText('Intro.', [$game], 'Outro.', 'Stored.');
+
+        self::assertSame(RecapDocument::assemble('Intro.', [$game], 'Outro.'), $result);
+    }
+
+    /**
+     * A part already in the exemplar's four-line shape (header / mentions / blank /
+     * prose) passes the mention-line check at index 1. This is the shape
+     * normalizeGameBlock() produces; the regression guard ensures a round-trip is stable.
+     */
+    public function testPostableTextCountsAlreadyNormalizedPartAsWellFormed(): void
+    {
+        $game   = $this->game('2026-02-26', "**A 100 @ B 114**\n<@1> · <@2>\n\nGame prose.");
+        $result = RecapDocument::postableText('Intro.', [$game], 'Outro.', 'Stored.');
+
+        self::assertSame(RecapDocument::assemble('Intro.', [$game], 'Outro.'), $result);
+    }
+
+    /**
+     * When there are no parts, no intro, no outro, and no stored text (null, empty,
+     * or whitespace), postableText() returns '' — Copy shows nothing rather than an
+     * undefined value.
+     */
+    public function testPostableTextReturnsEmptyStringWhenThereIsNothingAtAll(): void
+    {
+        self::assertSame('', RecapDocument::postableText(null, [], null, null));
+        self::assertSame('', RecapDocument::postableText(null, [], null, ''));
+        self::assertSame('', RecapDocument::postableText(null, [], null, '   '));
+    }
 }

--- a/ibl5/tests/WideUnit/SimRecap/RecapDocumentTest.php
+++ b/ibl5/tests/WideUnit/SimRecap/RecapDocumentTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\WideUnit\SimRecap;
+
+use PHPUnit\Framework\TestCase;
+use SimRecap\RecapDocument;
+
+/**
+ * The expected strings here are transcribed from `bin/lib/sim-recap-exemplar.txt`,
+ * which is the format contract — the date rules on its lines 15 and 129, and the
+ * blank-line counts between its blocks. They are written out literally rather than
+ * rebuilt with str_repeat() so the test is an independent oracle, not a mirror of
+ * the implementation.
+ */
+final class RecapDocumentTest extends TestCase
+{
+    /** Exemplar line 15 — 32 '=', the label, 41 '='. */
+    private const FEB_26_RULE = '================================ Feb 26 =========================================';
+
+    /** Exemplar line 129 — the same fixed counts, so a shorter label yields a shorter line. */
+    private const MAR_1_RULE = '================================ Mar 1 =========================================';
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function game(string $date, string $text): array
+    {
+        return [
+            'game_date'        => $date,
+            'visitor_teamid'   => 1,
+            'home_teamid'      => 2,
+            'game_of_that_day' => 1,
+            'sort_order'       => 0,
+            'recap_text'       => $text,
+        ];
+    }
+
+    public function testAssemblesTheWholeDocumentInExemplarShape(): void
+    {
+        $doc = RecapDocument::assemble(
+            "IBL SIM RECAPS\n====\n\nWHERE THINGS STAND\n\nUtah is still Utah.\n====",
+            [
+                $this->game('2008-02-26', "**A 100 @ B 114**\n<@1> · <@2>\n\nFirst game."),
+                $this->game('2008-02-26', "**C 103 @ D 139**\n<@3> · <@4>\n\nSecond game."),
+                $this->game('2008-03-01', "**E 111 @ F 120**\n<@5> · <@6>\n\nThird game."),
+            ],
+            "====\nEND. 3 games."
+        );
+
+        $expected = "IBL SIM RECAPS\n====\n\nWHERE THINGS STAND\n\nUtah is still Utah.\n===="
+            . "\n\n\n" . self::FEB_26_RULE
+            . "\n\n" . "**A 100 @ B 114**\n<@1> · <@2>\n\nFirst game."
+            . "\n\n" . "**C 103 @ D 139**\n<@3> · <@4>\n\nSecond game."
+            . "\n\n\n" . self::MAR_1_RULE
+            . "\n\n" . "**E 111 @ F 120**\n<@5> · <@6>\n\nThird game."
+            . "\n\n\n" . "====\nEND. 3 games.\n";
+
+        self::assertSame($expected, $doc);
+    }
+
+    /**
+     * The whole point of the class: `recap_text` on the summary row is a ~220-char
+     * teaser, and the document is only ever the sum of intro + games + outro.
+     */
+    public function testDocumentIsNotTheSummaryTeaser(): void
+    {
+        $doc = RecapDocument::assemble('Intro.', [$this->game('2008-02-26', 'Only game.')], 'Outro.');
+
+        self::assertStringContainsString('Only game.', $doc);
+        self::assertStringContainsString('Intro.', $doc);
+        self::assertStringContainsString('Outro.', $doc);
+    }
+
+    /**
+     * The generator writes header / mentions / prose on three consecutive lines; the
+     * exemplar has a blank line between the mentions and the prose. Every recap stored
+     * before that contract was tightened needs the repair on read.
+     */
+    public function testInsertsTheMissingBlankLineAfterTheMentionLine(): void
+    {
+        $doc = RecapDocument::assemble(
+            null,
+            [$this->game('2008-02-26', "**A 120 @ B 117**\n<@395705560068259840> · <@669349908989345802>\nVancouver's frontcourt.")],
+            null
+        );
+
+        self::assertStringContainsString(
+            "**A 120 @ B 117**\n<@395705560068259840> · <@669349908989345802>\n\nVancouver's frontcourt.",
+            $doc
+        );
+    }
+
+    public function testLeavesAnAlreadyCorrectGameBlockAlone(): void
+    {
+        $block = "**A 120 @ B 117**\n<@1> · <@2>\n\nProse.";
+        $doc   = RecapDocument::assemble(null, [$this->game('2008-02-26', $block)], null);
+
+        self::assertSame(self::FEB_26_RULE . "\n\n" . $block . "\n", $doc);
+    }
+
+    /**
+     * The repair keys on a line that is *nothing but* mentions, so a second line of
+     * ordinary prose is never split away from the paragraph it belongs to.
+     */
+    public function testDoesNotSplitProseThatIsNotAMentionLine(): void
+    {
+        $block = "**A 120 @ B 117**\nWashington won by 36.\nAnd it wasn't close.";
+        $doc   = RecapDocument::assemble(null, [$this->game('2008-02-26', $block)], null);
+
+        self::assertStringContainsString($block, $doc);
+    }
+
+    /**
+     * A single-mention line still counts — a game where only one team has a GM on file
+     * is stored the same way, minus the middle dot.
+     */
+    public function testRepairsASingleMentionLine(): void
+    {
+        $doc = RecapDocument::assemble(null, [$this->game('2008-02-26', "**A 1 @ B 2**\n<@7>\nProse.")], null);
+
+        self::assertStringContainsString("<@7>\n\nProse.", $doc);
+    }
+
+    /**
+     * A summary row whose games never made it into `ibl_sim_game_recaps` must not
+     * silently produce a two-line "document" that looks like a complete recap — but it
+     * must not fatal either. Intro and outro come through, joined like any two blocks.
+     */
+    public function testDegradesToIntroAndOutroWhenThereAreNoGames(): void
+    {
+        self::assertSame("Intro.\n\n\nOutro.\n", RecapDocument::assemble('Intro.', [], 'Outro.'));
+    }
+
+    public function testReturnsAnEmptyStringWhenThereIsNothingToAssemble(): void
+    {
+        self::assertSame('', RecapDocument::assemble(null, [], null));
+        self::assertSame('', RecapDocument::assemble('  ', [], "\n"));
+    }
+
+    public function testSkipsGameRowsWithNoText(): void
+    {
+        $doc = RecapDocument::assemble(
+            null,
+            [
+                $this->game('2008-02-26', ''),
+                $this->game('2008-02-26', 'Real game.'),
+            ],
+            null
+        );
+
+        self::assertSame(self::FEB_26_RULE . "\n\nReal game.\n", $doc);
+    }
+
+    /**
+     * A date the DB hands over that PHP cannot parse is printed verbatim: losing the
+     * separator entirely would be a worse failure than an odd-looking label.
+     */
+    public function testPrintsAnUnparseableDateVerbatim(): void
+    {
+        $doc = RecapDocument::assemble(null, [$this->game('not-a-date', 'Game.')], null);
+
+        self::assertStringContainsString('================================ not-a-date =', $doc);
+    }
+
+    public function testOmitsTheRuleWhenTheDateIsMissing(): void
+    {
+        $doc = RecapDocument::assemble(null, [$this->game('', 'Game.')], null);
+
+        self::assertSame("Game.\n", $doc);
+    }
+}

--- a/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
+++ b/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
@@ -149,7 +149,11 @@ final class SimSummariesViewTest extends TestCase
             'home_teamid'      => 2,
             'game_of_that_day' => 1,
             'sort_order'       => 0,
-            'recap_text'       => $xss,
+            // Deliberately well-formed (score header + mention line), so postableText()
+            // picks the assembled document. A bare-prose payload would route the textarea
+            // to the stored teaser and leave the assembled path — the one that concatenates
+            // every LLM field — untested by this, the only XSS test covering it.
+            'recap_text'       => "**A 1 @ B 2**\n<@1> · <@2>\n" . $xss,
         ];
         $html = $this->view->render(
             [],
@@ -225,8 +229,8 @@ final class SimSummariesViewTest extends TestCase
      */
     public function testTextareaCarriesAssembledDocumentNotTeaser(): void
     {
-        $game1 = ['game_date' => '2008-02-26', 'visitor_teamid' => 1, 'home_teamid' => 2, 'game_of_that_day' => 1, 'sort_order' => 0, 'recap_text' => 'First game prose here.'];
-        $game2 = ['game_date' => '2008-03-01', 'visitor_teamid' => 3, 'home_teamid' => 4, 'game_of_that_day' => 1, 'sort_order' => 1, 'recap_text' => 'Second game prose here.'];
+        $game1 = ['game_date' => '2008-02-26', 'visitor_teamid' => 1, 'home_teamid' => 2, 'game_of_that_day' => 1, 'sort_order' => 0, 'recap_text' => "**A 100 @ B 114**\n<@1> · <@2>\nFirst game prose here."];
+        $game2 = ['game_date' => '2008-03-01', 'visitor_teamid' => 3, 'home_teamid' => 4, 'game_of_that_day' => 1, 'sort_order' => 1, 'recap_text' => "**C 90 @ D 110**\n<@3> · <@4>\nSecond game prose here."];
         $html  = $this->view->render(
             [],
             $this->recapRow('Teaser body.', null, 'Intro text.', 'Outro text.'),
@@ -273,5 +277,76 @@ final class SimSummariesViewTest extends TestCase
         $textareaBody = substr($html, $bodyStart, $bodyEnd - $bodyStart);
 
         self::assertStringContainsString('Fallback teaser.', $textareaBody);
+    }
+
+    private function textareaBody(string $html): string
+    {
+        $markerOpen  = '<textarea id="recap-body" readonly rows="24" cols="100">';
+        $markerClose = '</textarea>';
+        $startOffset = strpos($html, $markerOpen);
+        self::assertIsInt($startOffset, 'Expected recap-body textarea in rendered output');
+        $bodyStart = $startOffset + strlen($markerOpen);
+        $bodyEnd   = strpos($html, $markerClose, $bodyStart);
+        self::assertIsInt($bodyEnd, 'Expected closing </textarea> after recap-body');
+        return substr($html, $bodyStart, $bodyEnd - $bodyStart);
+    }
+
+    /**
+     * Sim-722 shape: per-game parts are bare prose with no mention line at index 1.
+     * postableText() falls back to the stored monolith so no GM Discord tag is dropped.
+     * HtmlSanitizer::e() escapes the '<@' markers: '<@5>' → '&lt;@5&gt;'.
+     */
+    public function testTextareaShowsStoredMonolithWhenPartsAreBareProse(): void
+    {
+        $game = [
+            'game_date'        => '2026-07-26',
+            'visitor_teamid'   => 5,
+            'home_teamid'      => 12,
+            'game_of_that_day' => 1,
+            'sort_order'       => 0,
+            'recap_text'       => "The visiting team came out strong.\nThey held the lead all night.",
+        ];
+        $stored = "Full monolith with <@5> and <@12> mention tags stored in recap_text.";
+        $html = $this->view->render(
+            [],
+            $this->recapRow($stored, null, 'Intro text.', 'Outro text.'),
+            [$game],
+            null
+        );
+        $body = $this->textareaBody($html);
+        // The stored text is used verbatim; the escaped '<@' markers must appear.
+        self::assertStringContainsString('&lt;@5&gt;', $body);
+        // No date rule — the stored monolith is not re-assembled.
+        self::assertStringNotContainsString('================================', $body);
+    }
+
+    /**
+     * Sim-721 shape: every per-game part carries a mention line at index 1.
+     * postableText() uses the assembled document; the date rule and escaped GM tags
+     * must reach the textarea — this is the 722-fix regression guard.
+     */
+    public function testTextareaShowsAssembledDocumentWhenPartsAreWellFormed(): void
+    {
+        $game = [
+            'game_date'        => '2026-07-21',
+            'visitor_teamid'   => 3,
+            'home_teamid'      => 7,
+            'game_of_that_day' => 1,
+            'sort_order'       => 0,
+            'recap_text'       => "**Away 110 @ Home 104**\n<@3> · <@7>\nGame prose goes here.",
+        ];
+        $html = $this->view->render(
+            [],
+            $this->recapRow('Short teaser.', null, 'Intro text.', 'Outro text.'),
+            [$game],
+            null
+        );
+        $body = $this->textareaBody($html);
+        // Assembled document: date rule present.
+        self::assertStringContainsString('================================ Jul 21 =', $body);
+        // GM mention tags survive into the textarea (escaped by HtmlSanitizer::e()).
+        self::assertStringContainsString('&lt;@3&gt;', $body);
+        // The short teaser is not the textarea content.
+        self::assertNotSame('Short teaser.', $body);
     }
 }

--- a/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
+++ b/ibl5/tests/WideUnit/SimRecap/SimSummariesViewTest.php
@@ -160,8 +160,9 @@ final class SimSummariesViewTest extends TestCase
 
         // None of the LLM-sourced payloads may appear unescaped anywhere in the output.
         self::assertStringNotContainsString('<script>alert(1)</script>', $html);
-        // All three occurrences (intro, game recap, outro) must be entity-encoded.
-        self::assertSame(3, substr_count($html, '&lt;script&gt;alert(1)&lt;/script&gt;'));
+        // 3 occurrences in the per-field display panels (intro <p>, game <p>, outro <p>)
+        // plus 3 more in the assembled document inside the textarea (intro + game + outro) = 6.
+        self::assertSame(6, substr_count($html, '&lt;script&gt;alert(1)&lt;/script&gt;'));
     }
 
     /**
@@ -216,5 +217,61 @@ final class SimSummariesViewTest extends TestCase
         self::assertIsInt($thirdPos);
         self::assertLessThan($secondPos, $firstPos, 'Game recaps must appear in the order the caller provides');
         self::assertLessThan($thirdPos, $secondPos, 'Game recaps must appear in the order the caller provides');
+    }
+
+    /**
+     * The textarea must carry the full assembled document (intro + date rules + game prose +
+     * outro), not merely the ~220-char teaser stored in recap_text.
+     */
+    public function testTextareaCarriesAssembledDocumentNotTeaser(): void
+    {
+        $game1 = ['game_date' => '2008-02-26', 'visitor_teamid' => 1, 'home_teamid' => 2, 'game_of_that_day' => 1, 'sort_order' => 0, 'recap_text' => 'First game prose here.'];
+        $game2 = ['game_date' => '2008-03-01', 'visitor_teamid' => 3, 'home_teamid' => 4, 'game_of_that_day' => 1, 'sort_order' => 1, 'recap_text' => 'Second game prose here.'];
+        $html  = $this->view->render(
+            [],
+            $this->recapRow('Teaser body.', null, 'Intro text.', 'Outro text.'),
+            [$game1, $game2],
+            null
+        );
+
+        $markerOpen  = '<textarea id="recap-body" readonly rows="24" cols="100">';
+        $markerClose = '</textarea>';
+        $startOffset = strpos($html, $markerOpen);
+        self::assertIsInt($startOffset);
+        $bodyStart    = $startOffset + strlen($markerOpen);
+        $bodyEnd      = strpos($html, $markerClose, $bodyStart);
+        self::assertIsInt($bodyEnd);
+        $textareaBody = substr($html, $bodyStart, $bodyEnd - $bodyStart);
+
+        // The assembled document is present: game prose and the date separator rule.
+        self::assertStringContainsString('First game prose here.', $textareaBody);
+        self::assertStringContainsString('================================ Feb 26 =', $textareaBody);
+        // The textarea holds more than the teaser alone.
+        self::assertNotSame('Teaser body.', $textareaBody);
+    }
+
+    /**
+     * When there is nothing to assemble (no intro, no games, no outro), the textarea
+     * must fall back to the teaser so Copy is never empty.
+     */
+    public function testTextareaFallsBackToTeaserWhenAssemblyIsEmpty(): void
+    {
+        $html = $this->view->render(
+            [],
+            $this->recapRow('Fallback teaser.'),
+            [],
+            null
+        );
+
+        $markerOpen  = '<textarea id="recap-body" readonly rows="24" cols="100">';
+        $markerClose = '</textarea>';
+        $startOffset = strpos($html, $markerOpen);
+        self::assertIsInt($startOffset);
+        $bodyStart    = $startOffset + strlen($markerOpen);
+        $bodyEnd      = strpos($html, $markerClose, $bodyStart);
+        self::assertIsInt($bodyEnd);
+        $textareaBody = substr($html, $bodyStart, $bodyEnd - $bodyStart);
+
+        self::assertStringContainsString('Fallback teaser.', $textareaBody);
     }
 }

--- a/ibl5/tests/e2e/fixtures/ci-seed.sql
+++ b/ibl5/tests/e2e/fixtures/ci-seed.sql
@@ -119,9 +119,9 @@ INSERT INTO ibl_team_info (teamid, team_city, team_name, color1, color2, uuid) V
 -- ibl_box_scores_teams rows further down, so all three pass the admin viewer's
 -- archived-box-score existence filter.
 INSERT INTO ibl_sim_game_recaps (sim, season_year, game_date, visitor_teamid, home_teamid, game_of_that_day, box_id, sort_order, recap_text) VALUES
-  (689, 2026, '2026-02-20', 1, 2, 1, NULL, 0, 'The Metros dominated from the opening tip, cruising to a 105-98 victory.'),
-  (689, 2026, '2026-03-03', 1, 3, 1, NULL, 1, 'A balanced offensive attack lifted the Metros past the Cougars in a tightly contested game.'),
-  (689, 2026, '2026-03-05', 2, 1, 1, NULL, 2, 'The Stars held off a late Metros rally to steal a road win, 95-88.');
+  (689, 2026, '2026-02-20', 1, 2, 1, NULL, 0, '**Metros 105 @ Stars 98**\n<@1> · <@2>\nThe Metros dominated from the opening tip, cruising to a 105-98 victory.'),
+  (689, 2026, '2026-03-03', 1, 3, 1, NULL, 1, '**Metros 117 @ Cougars 108**\n<@1> · <@3>\nA balanced offensive attack lifted the Metros past the Cougars in a tightly contested game.'),
+  (689, 2026, '2026-03-05', 2, 1, 1, NULL, 2, '**Stars 95 @ Metros 88**\n<@2> · <@1>\nThe Stars held off a late Metros rally to steal a road win, 95-88.');
 
 -- ============================================================
 -- Standings (28 teams — FK to ibl_team_info)

--- a/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
+++ b/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
@@ -11,22 +11,33 @@ import { assertNoPhpErrors } from '../helpers/php-errors';
  * "valid but absent" path has a stable fixture.
  */
 
-// Full assembled recap document for sim 689 (RecapDocument::assemble output) — the
+// Full assembled recap document for sim 689 (RecapDocument::postableText output) — the
 // textarea and plain-text export must reproduce it byte-for-byte without HTML wrapping.
+// Game rows include score header + mention line + blank + prose — the shape
+// normalizeGameBlock() enforces (seeded via ci-seed.sql with \n-separated parts).
 const SIM_689_BODY = `Another week of IBL action delivered drama from tip-off to the final buzzer.
 
 
 ================================ Feb 20 =========================================
+
+**Metros 105 @ Stars 98**
+<@1> · <@2>
 
 The Metros dominated from the opening tip, cruising to a 105-98 victory.
 
 
 ================================ Mar 3 =========================================
 
+**Metros 117 @ Cougars 108**
+<@1> · <@3>
+
 A balanced offensive attack lifted the Metros past the Cougars in a tightly contested game.
 
 
 ================================ Mar 5 =========================================
+
+**Stars 95 @ Metros 88**
+<@2> · <@1>
 
 The Stars held off a late Metros rally to steal a road win, 95-88.
 

--- a/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
+++ b/ibl5/tests/e2e/smoke/sim-summaries-admin.spec.ts
@@ -11,10 +11,28 @@ import { assertNoPhpErrors } from '../helpers/php-errors';
  * "valid but absent" path has a stable fixture.
  */
 
-// Byte-exact `recap_text` of the newest seeded row — the download/copy paths
-// must reproduce it without HTML wrapping or entity encoding.
-const SIM_689_BODY =
-  'Sim 689 recap: the Cannons erased a nine-point fourth-quarter deficit to win by three.';
+// Full assembled recap document for sim 689 (RecapDocument::assemble output) — the
+// textarea and plain-text export must reproduce it byte-for-byte without HTML wrapping.
+const SIM_689_BODY = `Another week of IBL action delivered drama from tip-off to the final buzzer.
+
+
+================================ Feb 20 =========================================
+
+The Metros dominated from the opening tip, cruising to a 105-98 victory.
+
+
+================================ Mar 3 =========================================
+
+A balanced offensive attack lifted the Metros past the Cougars in a tightly contested game.
+
+
+================================ Mar 5 =========================================
+
+The Stars held off a late Metros rally to steal a road win, 95-88.
+
+
+The Cannons are one to watch as the season reaches its final stretch.
+`;
 
 const SEEDED_ROW_COUNT = 4;
 


### PR DESCRIPTION
## Summary
- Introduces `RecapDocument` class to assemble complete recap documents from intro + game rows + outro components
- Applies proper formatting with date separators and spacing matching exemplar format
- Updates recap export and UI textarea to display full formatted document instead of ~220-char teaser
- Repairs legacy game recaps missing blank line between mention line and prose
- Adds `whitespace-pre-line` CSS class to preserve text newlines in display
- Comprehensive test coverage for assembly and formatting logic

## Manual Testing

No manual testing needed — verified by automated tests.
