### PR TITLE
chore(ci): install composer deps for lighthouse baseline

### DIFF
--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -58,6 +58,11 @@ jobs:
           mkdir -p ibl5/.lighthouseci
           cp /tmp/baseline/manifest.json ibl5/.lighthouseci/manifest-filtered.json
 
+      - name: Install PHP dependencies (baseline path)
+        if: steps.freshness.outputs.use_baseline == 'true'
+        working-directory: ibl5
+        run: composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs
+
       - uses: ./.github/actions/lighthouse-setup
         if: steps.freshness.outputs.use_baseline != 'true'
 


### PR DESCRIPTION
## Summary
- Add `composer install` step for lighthouse audit baseline path
- Fixes missing PHP dependencies during baseline comparison setup

## Manual Testing

No manual testing needed — verified by automated tests.
