### PR TITLE
chore: widen post-plan Phase 2.5 backlog trigger for plan-blind PRs

### DIFF
--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -105,16 +105,80 @@ If the shipped work implemented or resolved a backlog item, backlog housekeeping
 **Detect (run once — the PR gives the correct base):**
 
 ```bash
-BL_TOUCHED=$(gh pr diff --name-only 2>/dev/null | grep -E '^ibl5/docs/backlog/[^/]+-backlog\.md$' || true)
+# phase 2.5 trigger: emits exactly ONE verdict line, BL_TRIGGER=A|B|C|none, as the
+# first line of stdout. Self-contained on purpose — every /post-plan Bash block runs
+# in its own fresh shell, so nothing from Phase 1 is in scope here. $PLAN_FILE is
+# overridable only so bin/test-postplan-arm-conditions can exercise this block (and
+# so an automouse run can pass Phase 1's authoritative handoff path instead of the
+# slug guess).
+PLAN_FILE="${PLAN_FILE:-$HOME/claude-plans/$(git rev-parse --abbrev-ref HEAD).md}"
+CHANGED=$(gh pr diff --name-only 2>/dev/null || true)
+
+# Trigger A — a backlog file is already in the diff. Excludes README.md (no
+# -backlog.md suffix) and archive/ ([^/]+ cannot cross /), so a README-only or
+# archive-only diff does not fire.
+BL_TOUCHED=$(printf '%s\n' "$CHANGED" | grep -E '^ibl5/docs/backlog/[^/]+-backlog\.md$' || true)
+
+# Trigger C — plan-blind or plan-present PR whose diff carries substantive
+# (non-doc, non-asset, non-generated) changes. Deliberately INCLUSIVE: .claude/
+# and bin/ count as substantive because maintenance-backlog.md is heavily
+# dev-tooling. A false C costs one bounded grep (stage 2 below); a false "none"
+# is the bug this trigger exists to fix.
+SUBSTANTIVE=$(printf '%s\n' "$CHANGED" \
+    | grep -vE '\.(lock|snap|css|scss|json|ya?ml)$|^\.github/|^ibl5/docs/|(^|/)README\.md$|^ibl5/migrations/[^/]*\.sql$' \
+    | grep -v '^$' || true)
+
+if [ -n "$BL_TOUCHED" ]; then
+    VERDICT=A; echo "BL_TRIGGER=A"; printf '%s\n' "$BL_TOUCHED"
+elif [ -f "$PLAN_FILE" ] && grep -qiE '^#+.*backlog' "$PLAN_FILE"; then
+    VERDICT=B; echo "BL_TRIGGER=B"; echo "PLAN_FILE=$PLAN_FILE"
+elif [ -n "$SUBSTANTIVE" ]; then
+    VERDICT=C; echo "BL_TRIGGER=C"; printf '%s\n' "$SUBSTANTIVE"
+else
+    VERDICT=none; echo "BL_TRIGGER=none"
+fi
+
+# phase 2.5 probe: stage 2 of Trigger C — a BOUNDED evidence gate, not a second
+# trigger. Greps existing backlog entries for the paths this PR actually changed
+# (and their basenames — entries carry a structured **Location:** `<path>` field).
+# A miss licenses a one-line no-op WITHOUT reading any backlog body (~2,381 lines
+# across 9 files). $BL_DIR is overridable only so bin/test-postplan-arm-conditions
+# can point this at a fixture directory.
+if [ "$VERDICT" = "C" ]; then
+    BL_DIR="${BL_DIR:-$(git rev-parse --show-toplevel)/ibl5/docs/backlog}"
+    BL_HITS=$(printf '%s\n' "$SUBSTANTIVE" | head -40 | while read -r f; do
+        [ -n "$f" ] || continue
+        grep -n -F -- "$f" "$BL_DIR"/*-backlog.md 2>/dev/null
+        grep -n -F -- "$(basename "$f")" "$BL_DIR"/*-backlog.md 2>/dev/null
+    done | sort -u | head -40)
+    if [ -n "$BL_HITS" ]; then
+        echo "BL_PROBE=hit"; printf '%s\n' "$BL_HITS"
+    else
+        echo "BL_PROBE=miss"
+    fi
+fi
 ```
 
-Also treat housekeeping as triggered if the plan file (`$PLAN_FILE` from Phase 1) declares a resolved or discovered backlog item (a `## Backlog` / tracking-doc status-update section, per `.claude/skills/plan/_architect-contract.md`). The regex **excludes** `README.md` (no `-backlog.md` suffix) and anything under `archive/` (`[^/]+` cannot cross `/`), so a README-only or archive-only diff does **not** trigger.
+Also treat housekeeping as triggered if the plan file (`$PLAN_FILE` from Phase 1) declares a resolved or discovered backlog item (a `## Backlog` / tracking-doc status-update section, per `.claude/skills/plan/_architect-contract.md`). The block mechanizes the common case (`grep -qiE '^#+.*backlog'` over the plan file); it is a floor, not a ceiling. If the plan declares a resolved or discovered backlog item in prose that the heading grep misses, treat the verdict as `B` anyway. No case that fired before this block existed stops firing. The regex **excludes** `README.md` (no `-backlog.md` suffix) and anything under `archive/` (`[^/]+` cannot cross `/`), so a README-only or archive-only diff does **not** fire Trigger A.
 
-**If neither signal fires:** print `Phase 2.5: no backlog item resolved — skipping.` and continue to Phase 3.
+**Deliberate fallback direction:** when `$PLAN_FILE` does not exist (the plan-blind case, `PLAN_FOUND=none`), the `[ -f "$PLAN_FILE" ]` guard fails and evaluation falls through to C. That is the intended widening, not an accident: a missing plan means *less* information, so the PR must be probed rather than silently skipped.
+
+The block prints exactly one `BL_TRIGGER=` line first, then its evidence (matched paths, or the plan path). Read the verdict from that first line — `A` and `B` run the full `backlog-housekeep` checklist; `C` runs the evidence-anchored subset in *Trigger C scope* below; `none` skips.
+
+**If `BL_TRIGGER=none`:** print `Phase 2.5: no backlog item resolved — skipping.` and continue to Phase 3.
+
+**Trigger C scope (plan-blind and code-only PRs)**
+
+1. **`BL_PROBE=miss` → stop.** Print `Phase 2.5: no backlog entry references this PR's changes — skipping.` and continue to Phase 3. **Do not Read any backlog file.** This is the expected outcome for most Trigger C PRs and is a success, not a failure.
+2. **`BL_PROBE=hit` → Read only the files named in the hit lines**, not the whole directory, then follow `.claude/skills/backlog-housekeep/SKILL.md` inline as the existing paragraph already directs.
+3. **Evidence anchoring (the no-fabrication rule).** Under Trigger C you may only act on entries the probe surfaced. Every edit must trace to a `BL_HITS` line. If an entry the probe surfaced is *not* actually resolved by this PR's diff, leave it alone. *"If nothing qualifies (no flip, no discovery, no archive), **no-op** and say so in one line — never fabricate edits."*
+4. **Narrowed operation set.** Trigger C runs only operations **1 (source-backlog status flip)**, **4 (cross-backlog redundancy sweep / `**Superseded by:**` stamp)** and **7 (self-verify `bin/check-docs`)** from `backlog-housekeep/SKILL.md`. Operation **2 (provenance-stamped discoveries)** is explicitly **out of reach** under Trigger C, because Phase 2.5 runs *before Phase 4 review* — there is no discovery source yet, so any "discovered" item would be invented. Operations 3, 5 and 6 remain available under Triggers A and B, where a human-authored plan or an already-edited backlog file supplies the intent. **Triggers A and B are unchanged and still run the full checklist**.
 
 **If triggered — run INLINE, no subagent.** Post-plan runs as **Sonnet 4.6** and its `disallowed-tools` includes **`Skill`**, so it **cannot** call `/backlog-housekeep`. Instead **Read `.claude/skills/backlog-housekeep/SKILL.md` and follow it inline**, taking that skill's **Sonnet/Haiku caller branch** (execute inline — a same-tier subagent spawn is pure overhead per `feedback_default_sonnet_execution`). Apply its housekeeping checklist with `#<PR>` as the `<ref>` and the PR base as the `--since` base (default `origin/master`; the PR's `baseRefName` for a stacked PR).
 
 **Self-verify + checkpoint (mandatory):** run `bin/check-docs --since=origin/master` (substitute the PR base for a stacked PR), fix any diagnostic, then **commit + push** the housekeeping edits. Per Incremental Checkpoints, this phase modifies files, so the edits must be committed and pushed before Phase 3 — they belong in the diff that Phase 3 classifies and Phase 6.5 arms on.
+
+**Engine divergence.** Triggers A, B and C are **skill-only**. The compiled harness (`tools/postplan-harness`) runs no Phase 2.5 at all — backlog housekeeping is a documented, accepted scope reduction there (`tools/postplan-harness/README.md`), so a harness-driven run ships no housekeeping regardless of verdict. A harness run that should have done housekeeping is not a bug in this section; it is that scope reduction. Only a skill run (the fallback path, or `POST_PLAN_SKILL=1 bin/post-plan-now`) exercises Trigger C.
 
 ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,8 +60,10 @@ jobs:
               - 'ibl5/bin/**'
               - '.github/workflows/tests.yml'
               # bin/test-postplan-arm-conditions reads the Phase 6.5 condition
-              # blocks here, so a SKILL.md-only edit must run the harness job.
+              # blocks AND the Phase 2.5 backlog trigger block from these two
+              # files, so an edit to either alone must run the harness job.
               - '.claude/skills/post-plan/SKILL.md'
+              - '.claude/skills/post-plan/_phase-6.5-arm-auto-merge.md'
               # bin/test-post-review-findings reads the Step 7 / Step 1 blocks here,
               # so a command-only edit must run the harness job too.
               - '.claude/commands/pr-review.md'

--- a/bin/test-postplan-arm-conditions
+++ b/bin/test-postplan-arm-conditions
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 #
-# bin/test-postplan-arm-conditions — regression guard for the /post-plan Phase 6.5
-# auto-merge conditions that call the shared predicate bin/lib/pr-armable.sh
+# bin/test-postplan-arm-conditions — regression guard for the /post-plan blocks
+# that must survive being run in their own shell — the Phase 6.5 auto-merge
+# conditions and the Phase 2.5 backlog trigger.
+# Phase 6.5 conditions call the shared predicate bin/lib/pr-armable.sh
 # (conditions (1) Manual-Testing, (5) golden, (6) Depends-on, (8) feat:), plus
 # condition (3), the Phase-5.0 conformance gate (no predicate; /tmp state only).
 #
-# Why this exists: those conditions live as separate ```bash blocks inside
-# _phase-6.5-arm-auto-merge.md (extracted from SKILL.md by the lazy-load
-# refactor), and the orchestrator runs each block in its OWN shell after
-# Reading that file. A block that relied on a hoisted `source` or a shared
-# `PR_JSON` from a preamble would have an UNDEFINED predicate function — and
-# for condition (8) that fails OPEN (no BLOCKED line emitted → a feat: PR
-# auto-arms). This test runs each block in an isolated `bash -c` against a gh
-# shim and asserts the holds, plus a structural check that every
-# predicate-using block re-`source`s the lib itself.
+# Why this exists: those blocks live as separate ```bash blocks inside
+# _phase-6.5-arm-auto-merge.md and SKILL.md, and the orchestrator runs each
+# block in its OWN shell after Reading those files. A block that relied on a
+# hoisted `source` or a shared `PR_JSON` from a preamble would have an UNDEFINED
+# predicate function — and for condition (8) that fails OPEN (no BLOCKED line
+# emitted → a feat: PR auto-arms). A Phase 2.5 block that emitted no verdict,
+# or fell through to `none` on a plan-blind code PR, would silently restore the
+# 87%-of-PRs skip this trigger exists to fix. This test runs each block in an
+# isolated `bash -c` against a gh shim and asserts the holds, plus a structural
+# check that every predicate-using block re-`source`s the lib itself.
 #
 # Run: bin/test-postplan-arm-conditions  (exit 0 = all pass, 1 = a case failed)
 
@@ -23,18 +26,28 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKILL="$REPO_ROOT/.claude/skills/post-plan/_phase-6.5-arm-auto-merge.md"
+P25_SKILL="$REPO_ROOT/.claude/skills/post-plan/SKILL.md"
 
 BASE_TMP="$(mktemp -d)"
 trap 'rm -rf "$BASE_TMP"' EXIT
 FAILED=0
 
 # A gh shim emulating the only calls the condition blocks make:
+#   gh pr diff --name-only               -> $GH_DIFF_FIXTURE contents (or exit 1 if unset/missing)
 #   gh pr view <n> --json state          -> predecessor state (#1100 OPEN else MERGED)
 #   gh pr view --json <fields> --jq F    -> jq -r F applied to $GH_PR_FIXTURE
 SHIMD="$BASE_TMP/shim"
 mkdir -p "$SHIMD"
 cat > "$SHIMD/gh" <<'SHIM'
 #!/usr/bin/env bash
+if [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
+  # gh pr diff --name-only -> the fixture path list. An unset/missing fixture
+  # emulates a gh failure (no PR, network error), which the Phase 2.5 block must
+  # survive with BL_TRIGGER=none rather than aborting.
+  [ -n "${GH_DIFF_FIXTURE:-}" ] && [ -f "$GH_DIFF_FIXTURE" ] || exit 1
+  cat "$GH_DIFF_FIXTURE"
+  exit 0
+fi
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
   if [[ "$3" =~ ^[0-9]+$ ]]; then
     case "$3" in 1100) echo '{"state":"OPEN"}' ;; *) echo '{"state":"MERGED"}' ;; esac
@@ -51,15 +64,16 @@ exit 1
 SHIM
 chmod +x "$SHIMD/gh"
 
-# extract_block <literal-marker> — print the first ```bash fenced block whose
-# body contains the literal marker substring (e.g. "# condition (8)"). Uses
-# index() (literal), not regex, so the parens in the marker are matched verbatim.
+# extract_block <literal-marker> [file] — print the first ```bash fenced block
+# whose body contains the literal marker substring (e.g. "# condition (8)").
+# Uses index() (literal), not regex, so the parens in the marker are matched
+# verbatim. File defaults to $SKILL when omitted.
 extract_block() {
     awk -v want="$1" '
         /^```bash$/ { inb=1; buf=""; next }
         /^```$/     { if (inb && index(buf, want) > 0) { printf "%s", buf } ; inb=0; next }
         inb         { buf = buf $0 "\n" }
-    ' "$SKILL"
+    ' "${2:-$SKILL}"
 }
 
 # run_isolated <block> <fixture-json> <golden_changed> <headless> — run the block
@@ -112,12 +126,56 @@ assert_self_contained() { # marker name
     fi
 }
 
+# run_p25 <block> <changed-paths|__GHFAIL__> <plan-body|""> <bl-dir> — the Phase 2.5
+# block reads `gh pr diff --name-only`, an optional plan file, and $BL_DIR; all
+# three are env-overridable in-block, so supply them from $BASE_TMP and run the
+# block in its OWN fresh shell (the failure model this whole test guards).
+run_p25() {
+    local diff_f="$BASE_TMP/p25-diff.txt" plan_f="$BASE_TMP/p25-plan.md"
+    rm -f "$diff_f" "$plan_f"
+    [ "$2" != "__GHFAIL__" ] && printf '%s' "$2" > "$diff_f"
+    [ -n "$3" ] && printf '%s' "$3" > "$plan_f"
+    PATH="$SHIMD:$PATH" GH_DIFF_FIXTURE="$diff_f" \
+        PLAN_FILE="$plan_f" BL_DIR="$4" \
+        bash -c "$1" 2>&1
+}
+
+# expect_p25 <name> <A|B|C|none> <hit|miss|absent> <output> — assert the verdict,
+# the probe state, and that EXACTLY ONE verdict line was printed (a second one
+# would mean a fallthrough, and the orchestrator reads only the first).
+expect_p25() {
+    local v p n
+    v="$(printf '%s\n' "$4" | grep -m1 '^BL_TRIGGER=' | cut -d= -f2)"
+    p="$(printf '%s\n' "$4" | grep -m1 '^BL_PROBE=' | cut -d= -f2)"
+    n="$(printf '%s\n' "$4" | grep -c '^BL_TRIGGER=')"
+    [ -z "$p" ] && p="absent"
+    if [ "$v" = "$2" ] && [ "$p" = "$3" ] && [ "$n" -eq 1 ]; then
+        echo "ok: $1"
+    else
+        echo "FAIL: $1 — expected trigger=$2 probe=$3 (1 verdict), got trigger='$v' probe='$p' verdicts=$n; output: '$4'"
+        FAILED=1
+    fi
+}
+
+# mk_bl_dir <name> <entry-location> — fixture backlog dir with ONE entry whose
+# **Location:** names <entry-location>, plus a README.md and an archive/ entry
+# that name the SAME path. The probe must ignore those two.
+mk_bl_dir() {
+    local d="$BASE_TMP/bl-$1"
+    mkdir -p "$d/archive"
+    printf $'# X\n\n**Location:** `%s`\n' "$2" > "$d/x-backlog.md"
+    printf $'# Index\n\n**Location:** `%s`\n' "$2" > "$d/README.md"
+    printf $'# Old\n\n**Location:** `%s`\n' "$2" > "$d/archive/old-backlog.md"
+    echo "$d"
+}
+
 B1="$(extract_block '# condition (1)')"
 B3="$(extract_block '# condition (3)')"
 B5="$(extract_block '# condition (5)')"
 B6="$(extract_block '# condition (6)')"
 B8="$(extract_block '# condition (8)')"
 B10="$(extract_block '# condition (10)')"
+B25="$(extract_block '# phase 2.5 trigger' "$P25_SKILL")"
 
 # --- structural: every predicate-using block must source the lib itself ---
 assert_self_contained '# condition (1)' "condition (1)"
@@ -125,6 +183,21 @@ assert_self_contained '# condition (5)' "condition (5)"
 assert_self_contained '# condition (6)' "condition (6)"
 assert_self_contained '# condition (8)' "condition (8)"
 assert_self_contained '# condition (10)' "condition (10)"
+
+# The Phase 2.5 failure model: each /post-plan block runs in its own shell, so a
+# block that read Phase 1's $PLAN_FILE without re-deriving it would silently take
+# the C branch on EVERY PR, including plan-present ones.
+# shellcheck disable=SC2016  # grep patterns match literal ${VAR:-...} text in the block
+if [ -z "$B25" ]; then
+    echo "FAIL: phase 2.5 — no block matching '# phase 2.5 trigger' in $P25_SKILL"
+    FAILED=1
+elif printf '%s' "$B25" | grep -q 'PLAN_FILE="${PLAN_FILE:-' \
+    && printf '%s' "$B25" | grep -q 'BL_DIR="${BL_DIR:-'; then
+    echo "ok: phase 2.5 block re-derives PLAN_FILE and BL_DIR in-block"
+else
+    echo "FAIL: phase 2.5 block does NOT re-derive PLAN_FILE/BL_DIR in-block (cross-shell state = wrong verdict)"
+    FAILED=1
+fi
 
 # --- behavioral: each block, run in isolation, holds correctly ---
 expect_block "(1) HELD manual rows -> BLOCK" BLOCK \
@@ -170,9 +243,66 @@ expect_block "(10) pipeline-authored label -> BLOCK" BLOCK \
 expect_block "(10) no pipeline label -> NONE" NONE \
     "$(run_isolated "$B10" '{"labels":[]}' '' '')"
 
+# --- Phase 2.5 backlog trigger cases ---
+BL_HIT="$(mk_bl_dir hit ibl5/classes/Updater/StandingsUpdater.php)"
+BL_MISS="$(mk_bl_dir miss ibl5/classes/Unrelated.php)"
+BL_EMPTY="$BASE_TMP/bl-empty"
+mkdir -p "$BL_EMPTY"
+BL_NOBL="$(mk_bl_dir nobl ibl5/classes/Updater/StandingsUpdater.php)"
+rm "$BL_NOBL/x-backlog.md"
+
+# Trigger A fires when a backlog file is in the diff; probe does not run.
+expect_p25 'p25_trigger_a' 'A' 'absent' \
+    "$(run_p25 "$B25" "$(printf 'ibl5/docs/backlog/ci-backlog.md\nbin/foo')" '' "$BL_MISS")"
+
+# Trigger B outranks C when both would match.
+expect_p25 'p25_trigger_b_precedence' 'B' 'absent' \
+    "$(run_p25 "$B25" 'bin/foo' "$(printf '## Backlog\n- resolved x')" "$BL_MISS")"
+
+# Trigger C fires on plan-blind PRs with substantive code changes.
+expect_p25 'p25_trigger_c_planblind_code' 'C' 'miss' \
+    "$(run_p25 "$B25" 'ibl5/classes/Updater/StandingsUpdater.php' '' "$BL_MISS")"
+
+# Trigger C also fires on tooling-only diffs (.claude/, bin/).
+expect_p25 'p25_trigger_c_tooling' 'C' 'miss' \
+    "$(run_p25 "$B25" "$(printf '.claude/skills/foo/SKILL.md\nbin/wt-new')" '' "$BL_MISS")"
+
+# Trivial diffs (docs/README/lockfile/workflow only) yield none.
+expect_p25 'p25_trigger_none_trivial' 'none' 'absent' \
+    "$(run_p25 "$B25" "$(printf 'ibl5/docs/x.md\nREADME.md\nibl5/composer.lock\n.github/workflows/tests.yml')" '' "$BL_MISS")"
+
+# backlog/README.md and backlog/archive/* fire neither A nor C.
+expect_p25 'p25_trigger_backlog_readme_archive' 'none' 'absent' \
+    "$(run_p25 "$B25" "$(printf 'ibl5/docs/backlog/README.md\nibl5/docs/backlog/archive/old-backlog.md')" '' "$BL_MISS")"
+
+# gh failure: block must yield none with exit 0, not crash.
+out_ghfail="$(run_p25 "$B25" '__GHFAIL__' '' "$BL_MISS")"
+rc_ghfail=$?
+expect_p25 'p25_trigger_gh_failure' 'none' 'absent' "$out_ghfail"
+if [ "$rc_ghfail" -ne 0 ]; then
+    echo "FAIL: p25_trigger_gh_failure — block exited $rc_ghfail (not 0); gh failure must not abort the block"
+    FAILED=1
+fi
+
+# Probe hit: a changed path named by a backlog entry yields BL_PROBE=hit.
+expect_p25 'p25_probe_hit' 'C' 'hit' \
+    "$(run_p25 "$B25" 'ibl5/classes/Updater/StandingsUpdater.php' '' "$BL_HIT")"
+
+# Probe miss: substantive changes no entry references yield BL_PROBE=miss.
+expect_p25 'p25_probe_miss' 'C' 'miss' \
+    "$(run_p25 "$B25" 'ibl5/classes/Unrelated2.php' '' "$BL_MISS")"
+
+# Probe excludes README.md and archive/: only those name the path → miss.
+expect_p25 'p25_probe_excludes_readme_archive' 'C' 'miss' \
+    "$(run_p25 "$B25" 'ibl5/classes/Updater/StandingsUpdater.php' '' "$BL_NOBL")"
+
+# Empty BL_DIR (glob stays literal) yields miss, not a crash.
+expect_p25 'p25_probe_empty_dir' 'C' 'miss' \
+    "$(run_p25 "$B25" 'ibl5/classes/Updater/StandingsUpdater.php' '' "$BL_EMPTY")"
+
 if [ "$FAILED" -eq 0 ]; then
-    echo "All post-plan arm-condition checks passed."
+    echo "All post-plan block checks passed."
 else
-    echo "Some post-plan arm-condition checks FAILED."
+    echo "Some post-plan block checks FAILED."
 fi
 exit "$FAILED"

--- a/tools/postplan-harness/README.md
+++ b/tools/postplan-harness/README.md
@@ -106,5 +106,7 @@ intent log — without touching GitHub.
    harness records a Phase 9 intent only.
 
 Known scope reductions vs the full skill (accepted at install): no backlog
-housekeeping, no worktree teardown, no E2E verify track (Docker stack), no
+housekeeping (the skill's Phase 2.5 now fires on plan-blind PRs too via its
+Trigger C, so this gap widened — a harness run ships no housekeeping on ANY
+PR class), no worktree teardown, no E2E verify track (Docker stack), no
 review Agent C (prior-PR feedback). The skill fallback retains all of them.


### PR DESCRIPTION
## What

Widens the `/post-plan` Phase 2.5 backlog housekeeping trigger so it fires on plan-blind PRs that contain substantive code changes (Trigger C), not only on PRs that already touch a backlog file (Trigger A) or have a plan declaring a resolved item (Trigger B).

**The three-signal design:**
- **Trigger A** — a backlog file is already in the diff (unchanged, byte-identical regex)
- **Trigger B** — plan file has a `## Backlog` heading (unchanged; now mechanized as a grep floor)
- **Trigger C** — plan-blind or plan-present PR with substantive non-doc/non-asset changes (new)

Trigger C includes a bounded two-stage probe: a `grep -F` over backlog entries seeded from changed paths (capped at 40 needles/40 lines). A probe miss costs one grep and produces a one-line no-op with **zero** backlog bodies read. A probe hit reads only the named entry files.

## Files changed

- `.claude/skills/post-plan/SKILL.md` — Phase 2.5 section rewritten with self-contained `BL_TRIGGER=A|B|C|none` block and bounded `BL_PROBE` stanza; Trigger C scope prose added; engine divergence paragraph added; `last_verified` bumped
- `bin/test-postplan-arm-conditions` — extended with second skill path, parameterized `extract_block`, `gh pr diff --name-only` shim branch, `run_p25`/`expect_p25`/`mk_bl_dir` helpers, structural self-containment assert, and 11 `p25_*` cases
- `tools/postplan-harness/README.md` — scope-reduction line updated to name Trigger C as the widened gap
- `.github/workflows/tests.yml` — `shell:` dorny filter widened to include `_phase-6.5-arm-auto-merge.md` (closes pre-existing gap: the test reads it but it was never in the filter)

## Why

Plan-blind PRs are the dominant class (~60 merged PRs vs ~30 plan files). Before this change, Phase 2.5 silently skipped 87% of post-plan runs. The widened trigger fixes that gap without imposing full backlog-file reads on every run (the probe gate handles cost).

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.