### PR TITLE
chore(check-plan): gate [P] — require pre-prod exercise path for declared scheduled artifacts

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -342,7 +342,7 @@ Then run the mechanical linter on each plan file you wrote and fix anything it r
 bin/check-plan "$PLAN_PATH"
 ```
 
-It enforces the deterministic gates from Step 4 (matrix present, no false manuals, no `DECIDE`/`TBD`/`subject to …` tokens, no unresolved decision-trigger surface, reuse targets resolve, context budget). A non-zero exit prints each violation prefixed by its gate (`[1]`/`[3]`/`[7]`/`[8]`/`[13]`/`[B]`/`[H]`/`[R]`/`[C]`/`[T]`/`[S]`); resolve each and re-run. Do not leave a plan written until `bin/check-plan` passes. A `[C]` (context-budget) violation is resolved by **returning to Step 2.5 and splitting the plan into stacked PR-sized units** — reach for a `context-budget:` justification marker only when the size is illusory (e.g. the length is mostly fenced reference material or delegation-packet recipes and the actual phase count is small).
+It enforces the deterministic gates from Step 4 (matrix present, no false manuals, no `DECIDE`/`TBD`/`subject to …` tokens, no unresolved decision-trigger surface, reuse targets resolve, context budget, pre-prod exercise path). A non-zero exit prints each violation prefixed by its gate (`[1]`/`[3]`/`[7]`/`[8]`/`[13]`/`[B]`/`[H]`/`[R]`/`[C]`/`[T]`/`[S]`/`[P]`); resolve each and re-run. `[W]` (sweep-verb) also prints, but is **advisory and non-blocking** — it is emitted as a warning and never affects the exit code, so a `[W]` line alongside a clean exit is expected, not a violation you must clear. Do not leave a plan written until `bin/check-plan` passes. A `[C]` (context-budget) violation is resolved by **returning to Step 2.5 and splitting the plan into stacked PR-sized units** — reach for a `context-budget:` justification marker only when the size is illusory (e.g. the length is mostly fenced reference material or delegation-packet recipes and the actual phase count is small).
 
 ### Declaring the implementation model (required)
 
@@ -391,6 +391,7 @@ Tell the user:
 - A one-line matrix summary per plan (e.g., "12 items: 7 PHPUnit, 3 E2E, 2 CLI-executable, 0 truly-manual")
 - Whether any security surface was flagged and how each is defended (or "no security surface touched")
 - Whether the PR is eligible to auto-merge on green CI (default) or is held for a human merge (`auto_merge: false`, per Step 4 gate 14) — and why, if held
+- Whether every deploy-dependent behavior has a pre-prod exercise path (Step 4 gate 16) — and, for any recorded `pre-prod-exception:`, which slice is intrinsic (scheduling / reachability / credential) and what was built for the reducible slice — or "no deploy-dependent behavior"
 - Whether any post-merge follow-up was mechanized (the merge-triggered watcher and what it runs on merge), or "no post-merge follow-up"
 - For a multi-PR split: the PR sequence and dependency order (which lands first, what each stacks on)
 - Whether each plan is ready for implementation or has open questions

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -124,6 +124,33 @@
 #                              check, not per-phase verbatim matching. A
 #                              `sonnet-recipe:` marker clears the whole gate,
 #                              mirroring no-adr: / context-budget:.
+#   P  Pre-prod exercise path — a plan that DECLARES a scheduled/daemon
+#                              artifact (bin/<x>-tick, bin/<x>-cron-setup, a
+#                              *.plist) must carry a verification-matrix ROW
+#                              that plausibly RUNS it: the full declared path,
+#                              word-bounded, together with either an invocation
+#                              form (`<path> --flag`) or a pre-prod environment
+#                              word (--dry-run/--once/--sim=/workflow_dispatch/
+#                              CI/worktree/localhost/deploy-rehearsal). Failing
+#                              that, a line-anchored `<!-- pre-prod-exception:
+#                              -->` marker plus a `## Pre-prod Exception
+#                              Justification` section (presence only — which
+#                              slice is truly intrinsic stays Opus judgment,
+#                              exactly like gate H). Mechanizes the FIRST of
+#                              /plan Step 4 gate 16's three failure shapes: no
+#                              row at all. DECLARATION POSITION only — an
+#                              unannotated `## Critical Files` bullet (same
+#                              parse as gate C's CB_CF_COUNT) or a table row
+#                              carrying a creation cue — never a prose mention,
+#                              which would fire on every plan that discusses
+#                              the failure class. Every read is ````-AWARE and
+#                              clears are bound to the MATRIX REGION: a body-
+#                              wide seam grep is cleared by prose, and a
+#                              basename match lets bin/test-<x>-tick (a stub
+#                              harness) clear bin/<x>-tick. Unlike gate 8 there
+#                              is no on-disk existence skip: activating or newly
+#                              scheduling an EXISTING tick script is the change
+#                              this gate exists to catch.
 #
 # Deliberately NOT linted (kept as /plan Opus judgment): tests-woven-inline,
 # production-comparison classification, test-file-path presence, negative-path
@@ -136,6 +163,13 @@
 # weaker plan-LEVEL presence check (impl_model: sonnet plans) — that the plan
 # carries at least one anchor SIGNAL somewhere — never that a given phase's
 # snippet matches a source line.
+# Gate P's two harder siblings are on this list by the same logic: whether
+# coverage is STUB-ONLY (a mock/fake standing in for a live-service or
+# cross-process call) and whether a row covers the deploy-dependent behavior or
+# merely something ADJACENT to it are both undecidable from plan text — a
+# stub-mention heuristic fires on every legitimately-stubbed unit test. Those
+# stay in /plan Step 4 gate 16 and .claude/skills/plan/_architect-contract.md,
+# read by an agent with understanding. Do not mechanize them here.
 #
 # Exit codes: 0 = clean, 1 = one or more violations (printed, prefixed by gate),
 #             2 = usage error / plan file missing.
@@ -200,7 +234,10 @@ WARN_FILE="$(mktemp)"
 MATRIX_FILE="$(mktemp)"
 SEEN_FILE="$(mktemp)"
 GATE8_SEEN="$(mktemp)"
-trap 'rm -f "$VIOL_FILE" "$WARN_FILE" "$MATRIX_FILE" "$SEEN_FILE" "$GATE8_SEEN"' EXIT
+GATEP_SEEN="$(mktemp)"
+GATEP_BODY="$(mktemp)"
+GATEP_MATRIX="$(mktemp)"
+trap 'rm -f "$VIOL_FILE" "$WARN_FILE" "$MATRIX_FILE" "$SEEN_FILE" "$GATE8_SEEN" "$GATEP_SEEN" "$GATEP_BODY" "$GATEP_MATRIX"' EXIT
 
 viol() { printf '%s\n' "$1" >> "$VIOL_FILE"; }
 warn() { printf '%s\n' "$1" >> "$WARN_FILE"; }
@@ -819,6 +856,110 @@ case "$RUN_MODEL" in
         fi
         ;;
 esac
+
+# ---------------------------------------------------------------------------
+# Gate P: Pre-prod exercise path for a declared deploy-dependent artifact.
+# ---------------------------------------------------------------------------
+# See the header block for the full rule. Trigger reads DECLARATION POSITIONS
+# only; the only clears are an exercising matrix row and a line-anchored
+# pre-prod-exception: marker.
+
+# Every [P] read is ````-AWARE. This plan file (and the two docs it edits)
+# embed complete plan fixtures inside fences; a fence-blind read makes a plan
+# that DOCUMENTS the marker read as CARRYING it, and lets a fixture's matrix row
+# clear a real declared artifact. Fence logic is gate T's, verbatim.
+awk '
+    function fence_ticks(s,   t) {
+        if (match(s, /^[ \t]*`+/)) {
+            t = substr(s, RSTART, RLENGTH); gsub(/[^`]/, "", t); return length(t)
+        }
+        return 0
+    }
+    BEGIN { in_fence = 0; fence_len = 0 }
+    {
+        n = fence_ticks($0)
+        # A closing fence is backticks-only AND at least as long as the opener.
+        if (in_fence) { if (n >= fence_len && $0 ~ /^[ \t]*`+[ \t]*$/) { in_fence = 0; fence_len = 0 }; next }
+        if (n >= 3)   { in_fence = 1; fence_len = n; next }
+        print
+    }
+' "$PLAN_FILE" > "$GATEP_BODY"
+
+# [P]'s own matrix parse — same shape as :201-205 but over the fence-stripped
+# body. NOT $MATRIX_FILE, which is built from the raw file and would let a
+# fenced fixture row clear a real artifact.
+awk '
+    /\|[[:space:]]*[Ww]hat to verify[[:space:]]*\|/ { inm=1; next }
+    inm && /^[[:space:]]*\|/ { print; next }
+    inm && !/^[[:space:]]*\|/ { inm=0 }
+' "$GATEP_BODY" > "$GATEP_MATRIX"
+
+# Marker: line-anchored HTML-comment form ONLY (see header) — a bare grep -qF
+# would be cleared by any plan that merely quotes the token in prose.
+GATEP_MARKER=0
+if grep -qE '^[[:space:]]*<!--[[:space:]]*pre-prod-exception:' "$GATEP_BODY"; then
+    GATEP_MARKER=1
+fi
+
+# A declared exception must carry its recorded rationale (mirrors gate H:
+# PRESENCE only; whether the slice is genuinely intrinsic is Step 4.5 judgment).
+if [ "$GATEP_MARKER" -eq 1 ] \
+   && ! grep -qiE '^##[[:space:]]+Pre-prod Exception Justification[[:space:]]*$' "$GATEP_BODY"; then
+    viol "[P] plan carries a pre-prod-exception: marker but has no '## Pre-prod Exception Justification' section (/plan Step 4 gate 16 — name the intrinsic slice: scheduling, reachability, or credential)"
+fi
+
+# Declaration-position token stream: unannotated Critical Files bullets (same
+# parse + annotation set as gate C's CB_CF_COUNT) plus table rows carrying a
+# creation cue. The anchored shape regex also does the charset/metacharacter
+# hygiene gate 8 does inline, so `bin/*-tick` and `bin/<name>-tick` meta-notation
+# cannot become tokens. bin/test-* is dropped: a stub harness is never the
+# deploy-dependent artifact, and letting it in re-creates the #1500 failure.
+gatep_declared_tokens() {
+    {
+        awk '
+            /^## Critical Files/ { in_cf=1; next }
+            /^## /               { in_cf=0 }
+            in_cf && /^- `[^`]+`/ {
+                if ($0 ~ /\(reference\)/ || $0 ~ /\(read-only\)/ || $0 ~ /\(verify\)/ || \
+                    $0 ~ /\(template\)/  || $0 ~ /\(no-edit\)/   || $0 ~ /\(unchanged\)/ || \
+                    $0 ~ /\(context\)/) next
+                line=$0
+                sub(/^- `/, "", line)
+                sub(/`.*$/, "", line)
+                print line
+            }
+        ' "$GATEP_BODY"
+        # shellcheck disable=SC2016  # backticks are literal markdown-span delimiters
+        grep -E '^[[:space:]]*\|' "$GATEP_BODY" \
+            | grep -E '([Cc]reate|[Nn]ew file|[Aa]dd(s|ing)? (a )?new|[Ii]ntroduce|[Ss]caffold)' \
+            | grep -oE '`[^`]+`' | sed -E 's/^`//; s/`$//'
+    } | grep -E '^(bin/[A-Za-z0-9._-]*-(tick|cron-setup)|[A-Za-z0-9._/-]+\.plist)$' \
+      | grep -v '^bin/test-'
+}
+
+# Skip entirely when the plan has no matrix at all: gate 1 already fired and
+# already blocks, and re-reporting it as a coverage miss is noise (same
+# double-report avoidance as gate 13).
+if [ "$GATEP_MARKER" -eq 0 ] && [ -s "$GATEP_MATRIX" ]; then
+    while IFS= read -r gatep_token; do
+        [ -n "$gatep_token" ] || continue
+        grep -qxF "$gatep_token" "$GATEP_SEEN" && continue
+        printf '%s\n' "$gatep_token" >> "$GATEP_SEEN"
+        gatep_esc=$(printf '%s' "$gatep_token" | sed 's/[.[\*^$]/\\&/g')
+        # Clear 1a: a row invokes the artifact directly -- `<path> --flag`.
+        if grep -qE "(^|[^A-Za-z0-9._/-])${gatep_esc}[[:space:]]+--[a-z]" "$GATEP_MATRIX"; then
+            continue
+        fi
+        # Clear 1b: a row names the artifact (word-bounded, FULL path) AND that
+        # same row carries a pre-prod environment word. The conjunction is what
+        # stops a `shellcheck <path>` lint row from clearing (MUST-HIT #1500).
+        if grep -E "(^|[^A-Za-z0-9._/-])${gatep_esc}([^A-Za-z0-9._-]|$)" "$GATEP_MATRIX" \
+           | grep -qE '(--dry-run|--once|--sim=|workflow_dispatch|(^|[^A-Za-z])(CI|worktree|localhost|deploy-rehearsal)([^A-Za-z]|$))'; then
+            continue
+        fi
+        viol "[P] ${gatep_token} is declared as a deliverable but no verification-matrix row exercises it - build a pre-prod exercise path (run it on the worktree Docker stack, in CI, or via the deploy-rehearsal job) and add the matrix row; see /plan Step 4 gate 16"
+    done < <(gatep_declared_tokens)
+fi
 
 # ---------------------------------------------------------------------------
 # Report.

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -926,12 +926,13 @@ gatep_declared_tokens() {
         # backtick span is the path, and ALL backtick spans are stripped before
         # the exemption test, so a backticked path inside the parenthetical
         # (`(edits `bin/reference-helper`)`) cannot exempt on its own name.
+        # shellcheck disable=SC2016  # backticks are literal markdown-span delimiters
         awk '
             /^## Critical Files/ { in_cf=1; next }
             /^## /               { in_cf=0 }
             in_cf && /^- `[^`]+`/ { print }
         ' "$GATEP_BODY" \
-        | while IFS= read -r gatep_bullet; do  # shellcheck disable=SC2016
+        | while IFS= read -r gatep_bullet; do
             gatep_path=$(printf '%s\n' "$gatep_bullet" | grep -oE '`[^`]+`' | head -1 | tr -d '`')
             [ -n "$gatep_path" ] || continue
             gatep_rest=$(printf '%s\n' "$gatep_bullet" | sed -E 's/`[^`]*`//g')

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -916,20 +916,28 @@ fi
 # deploy-dependent artifact, and letting it in re-creates the #1500 failure.
 gatep_declared_tokens() {
     {
+        # The exemption test is delegated to cf_is_exempt / CF_EXEMPT_PATTERN
+        # (bin/lib/critical-files.sh, sourced above) -- the SAME gate C applies,
+        # rather than a re-spelled literal list. An inline list of closed-paren
+        # literals shipped here first and diverged immediately: it read the
+        # ordinary `(reference - <rationale>)` / `(read-only reference - ...)`
+        # shapes as declarations, 2 of 7 fires on the 295-plan corpus. Path and
+        # annotation are split exactly as cf_parse_section does it -- first
+        # backtick span is the path, and ALL backtick spans are stripped before
+        # the exemption test, so a backticked path inside the parenthetical
+        # (`(edits `bin/reference-helper`)`) cannot exempt on its own name.
         awk '
             /^## Critical Files/ { in_cf=1; next }
             /^## /               { in_cf=0 }
-            in_cf && /^- `[^`]+`/ {
-                if ($0 ~ /\(reference\)/ || $0 ~ /\(read-only\)/ || $0 ~ /\(read-only reference\)/ || \
-                    $0 ~ /\(verify\)/ || \
-                    $0 ~ /\(template\)/  || $0 ~ /\(no-edit\)/   || $0 ~ /\(unchanged\)/ || \
-                    $0 ~ /\(context\)/) next
-                line=$0
-                sub(/^- `/, "", line)
-                sub(/`.*$/, "", line)
-                print line
-            }
-        ' "$GATEP_BODY"
+            in_cf && /^- `[^`]+`/ { print }
+        ' "$GATEP_BODY" \
+        | while IFS= read -r gatep_bullet; do  # shellcheck disable=SC2016
+            gatep_path=$(printf '%s\n' "$gatep_bullet" | grep -oE '`[^`]+`' | head -1 | tr -d '`')
+            [ -n "$gatep_path" ] || continue
+            gatep_rest=$(printf '%s\n' "$gatep_bullet" | sed -E 's/`[^`]*`//g')
+            cf_is_exempt "$gatep_rest" && continue
+            printf '%s\n' "$gatep_path"
+        done
         # shellcheck disable=SC2016  # backticks are literal markdown-span delimiters
         grep -E '^[[:space:]]*\|' "$GATEP_BODY" \
             | grep -E '([Cc]reate|[Nn]ew file|[Aa]dd(s|ing)? (a )?new|[Ii]ntroduce|[Ss]caffold)' \

--- a/bin/check-plan
+++ b/bin/check-plan
@@ -920,7 +920,8 @@ gatep_declared_tokens() {
             /^## Critical Files/ { in_cf=1; next }
             /^## /               { in_cf=0 }
             in_cf && /^- `[^`]+`/ {
-                if ($0 ~ /\(reference\)/ || $0 ~ /\(read-only\)/ || $0 ~ /\(verify\)/ || \
+                if ($0 ~ /\(reference\)/ || $0 ~ /\(read-only\)/ || $0 ~ /\(read-only reference\)/ || \
+                    $0 ~ /\(verify\)/ || \
                     $0 ~ /\(template\)/  || $0 ~ /\(no-edit\)/   || $0 ~ /\(unchanged\)/ || \
                     $0 ~ /\(context\)/) next
                 line=$0

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -62,7 +62,11 @@ assert_cf() {
 # script's header comment requires.
 assert_viol() {
     name="$1"; want="$2"; tag="$3"; body="$4"
-    f="$TMP/$name.md"
+    # Strip brackets from the FILENAME (never the display name): check-plan echoes
+    # the plan path on both the OK line and its violations, so a fixture named
+    # [P]-foo would put the literal tag in the output and make every want-0
+    # assertion self-fail (and every want-1 one pass regardless of gate).
+    f="$TMP/$(printf '%s' "$name" | tr -d '[]').md"
     printf '%s\n' "$body" > "$f"
     out="$("$GUARD" "$f" 2>&1)"; got=$?
     if [ "$got" -ne "$want" ]; then
@@ -836,7 +840,7 @@ fi
 # MUST HIT 1 — the #1500 shape (bug-pipeline-gm-feedback-ack-thread): a tick
 # script is declared as a deliverable, the matrix looks green, and nothing in
 # it exercises the tick. Stub-only coverage is invisible here by design.
-assert "[P]-musthit-1500-stub-only" 1 "$FM_OPUS
+assert_viol "[P]-musthit-1500-stub-only" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
@@ -846,6 +850,10 @@ assert "[P]-musthit-1500-stub-only" 1 "$FM_OPUS
 **Tier:** self
 
 Extend the pipeline to open a Discord thread on ack.
+
+## Required Test Methods
+
+- testClassifierMapsReportToLabel
 
 ## Critical Files
 
@@ -857,7 +865,7 @@ Extend the pipeline to open a Discord thread on ack.
 # correctly-authored Truly-manual row that does not exercise it. Pins BOTH the
 # deliberate absence of gate 8's on-disk existence skip AND the rule that a
 # manual row's mere presence never satisfies the gate.
-assert "[P]-musthit-1600-activation" 1 "$FM_OPUS
+assert_viol "[P]-musthit-1600-activation" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | notification copy tone reads naturally to a GM | Truly-manual | post-impl | worktree stack |
@@ -875,7 +883,7 @@ Flip the scheduled recap from dormant to live.
 
 # Clear arm 1a: a row that INVOKES the artifact (full path + a flag) clears.
 # Whether the row is a GOOD row is gate 16's judgment, not lint's.
-assert "[P]-matrix-row-clears" 0 "$FM_OPUS
+assert_viol "[P]-matrix-row-clears" 0 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | \`bin/bug-pipeline-tick --dry-run\` posts to the test channel | CLI-executable | post-impl | worktree stack |
@@ -893,7 +901,7 @@ Extend the pipeline.
 
 # Clear arm 1b: full path + a pre-prod ENVIRONMENT word on the same row. A
 # Truly-manual row is a legitimate exercise when it names a reachable place.
-assert "[P]-env-word-row-clears" 0 "$FM_OPUS
+assert_viol "[P]-env-word-row-clears" 0 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | one-shot run of \`bin/bug-pipeline-tick\` on the worktree stack | Truly-manual | post-impl | worktree stack |
@@ -912,7 +920,7 @@ Extend the pipeline.
 # FALSE-NEGATIVE REGRESSION: a bare BASENAME does not clear. Matching is
 # word-bounded on the FULL declared path, because basename matching is what let
 # bin/test-<x>-tick clear bin/<x>-tick during calibration.
-assert "[P]-basename-row-does-not-clear" 1 "$FM_OPUS
+assert_viol "[P]-basename-row-does-not-clear" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | one-shot run of bug-pipeline-tick posts to the test channel | CLI-executable | post-impl | worktree stack |
@@ -933,7 +941,7 @@ Extend the pipeline.
 # as a substring; only full-path word-bounding plus the bin/test-* drop stops
 # it. If this fixture ever flips to 0, the gate has re-accepted the exact
 # coverage shape PR #1500 shipped.
-assert "[P]-stub-harness-does-not-clear" 1 "$FM_OPUS
+assert_viol "[P]-stub-harness-does-not-clear" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | \`bin/test-bug-pipeline-tick\` covers the tick end to end | CLI-executable | post-impl | \`bin/test-bug-pipeline-tick\` |
@@ -952,7 +960,7 @@ Extend the pipeline.
 # FALSE-NEGATIVE REGRESSION: a LINT row names the artifact but does not run it.
 # The full token matches here, so this fixture is what the invocation/environment
 # CONJUNCTION exists for. This is the other half of the #1500 shape.
-assert "[P]-lint-row-does-not-clear" 1 "$FM_OPUS
+assert_viol "[P]-lint-row-does-not-clear" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | \`shellcheck bin/bug-pipeline-tick\` is clean | CLI-executable | post-impl | \`.github/workflows/tests.yml\` |
@@ -969,7 +977,7 @@ Extend the pipeline.
 "
 
 # Clear arm 3: a line-anchored marker WITH its justification section clears.
-assert "[P]-marker-with-justification-clears" 0 "$FM_OPUS
+assert_viol "[P]-marker-with-justification-clears" 0 "[P]" "$FM_OPUS
 <!-- pre-prod-exception: launchd registration on the prod box -->
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
@@ -985,6 +993,10 @@ Register the launchd job.
 
 Scheduling only: launchd firing on the prod box cannot be reproduced pre-prod.
 
+## Required Test Methods
+
+- testClassifierMapsReportToLabel
+
 ## Critical Files
 
 - \`bin/bug-pipeline-tick\`
@@ -992,7 +1004,7 @@ Scheduling only: launchd firing on the prod box cannot be reproduced pre-prod.
 
 # The marker is not a bare escape: without the justification section it FLAGS,
 # mirroring gate H's auto_merge: false <-> Automouse Hold Justification pairing.
-assert "[P]-marker-without-justification-flags" 1 "$FM_OPUS
+assert_viol "[P]-marker-without-justification-flags" 1 "[P]" "$FM_OPUS
 <!-- pre-prod-exception: launchd registration on the prod box -->
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
@@ -1004,6 +1016,10 @@ assert "[P]-marker-without-justification-flags" 1 "$FM_OPUS
 
 Register the launchd job.
 
+## Required Test Methods
+
+- testClassifierMapsReportToLabel
+
 ## Critical Files
 
 - \`bin/bug-pipeline-tick\`
@@ -1012,10 +1028,10 @@ Register the launchd job.
 # FALSE-POSITIVE REGRESSION — the self-fire this gate's own plan draft exhibited.
 # A prose line mentioning a tick script alongside a creation cue is NOT a
 # declaration. Gate 8's bare-cue filter fires here; gate P must not.
-assert "[P]-prose-mention-does-not-fire" 0 "$FM_OPUS
+assert_viol "[P]-prose-mention-does-not-fire" 0 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
-| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/check-plan\` |
+| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/test-check-plan\` |
 
 ## Phase 1: Document the gate
 
@@ -1030,10 +1046,10 @@ Every backticked path introduced here must resolve on master: \`bin/bug-pipeline
 
 # FALSE-POSITIVE REGRESSION — a Critical Files entry annotated as read-only is a
 # reference, not a deliverable. Pins reuse of gate C's annotation-exclusion set.
-assert "[P]-annotated-critical-file-does-not-fire" 0 "$FM_OPUS
+assert_viol "[P]-annotated-critical-file-does-not-fire" 0 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
-| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/check-plan\` |
+| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/test-check-plan\` |
 
 ## Phase 1: Document the gate
 
@@ -1051,10 +1067,10 @@ Read the tick script for its scheduling shape; change nothing in it.
 # (63 corpus occurrences) evades the exact \`(reference)\`/\`(read-only)\` matches.
 # Found by the acceptance corpus sweep firing on verification-forced-integration-
 # triggers.md. Pins the compound clause added to Arm A's annotation-exclusion set.
-assert "[P]-compound-readonly-reference-does-not-fire" 0 "$FM_OPUS
+assert_viol "[P]-compound-readonly-reference-does-not-fire" 0 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
-| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/check-plan\` |
+| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/test-check-plan\` |
 
 ## Phase 1: Cite the cron-setup shape
 
@@ -1071,7 +1087,7 @@ Read the cron-setup script for its launchd shape; change nothing in it.
 # FALSE-NEGATIVE REGRESSION — a QUOTED marker must not clear. Every plan about
 # this gate quotes the token in prose; only the line-anchored HTML-comment form
 # is a real marker. This is the case a bare grep -qF would get wrong.
-assert "[P]-quoted-marker-does-not-clear" 1 "$FM_OPUS
+assert_viol "[P]-quoted-marker-does-not-clear" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
@@ -1082,6 +1098,10 @@ assert "[P]-quoted-marker-does-not-clear" 1 "$FM_OPUS
 
 The gate is suppressed by a \`pre-prod-exception:\` marker, which this plan does not claim.
 
+## Required Test Methods
+
+- testClassifierMapsReportToLabel
+
 ## Critical Files
 
 - \`bin/bug-pipeline-tick\`
@@ -1089,10 +1109,10 @@ The gate is suppressed by a \`pre-prod-exception:\` marker, which this plan does
 
 # SHAPE-SET REGRESSION — an ordinary bin/ script is not a deploy-dependent
 # artifact. Pins that the shape set stayed narrow (tick / cron-setup / plist).
-assert "[P]-ordinary-script-does-not-fire" 0 "$FM_OPUS
+assert_viol "[P]-ordinary-script-does-not-fire" 0 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
-| 1 | the checker rejects a stale doc | CLI-executable | post-impl | \`bin/test-check-docs\` |
+| 1 | the gate classifies the declared shape | CLI-executable | post-impl | \`bin/test-check-plan\` |
 
 ## Phase 1: Extend the checker
 
@@ -1106,7 +1126,7 @@ Add a rule to the doc checker.
 "
 
 # SHAPE-SET COVERAGE — the other two calibrated shapes fire too.
-assert "[P]-cron-setup-fires" 1 "$FM_OPUS
+assert_viol "[P]-cron-setup-fires" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
@@ -1117,12 +1137,16 @@ assert "[P]-cron-setup-fires" 1 "$FM_OPUS
 
 Wire up the scheduler.
 
+## Required Test Methods
+
+- testClassifierMapsReportToLabel
+
 ## Critical Files
 
 - \`bin/sim-recap-cron-setup\`
 "
 
-assert "[P]-plist-fires" 1 "$FM_OPUS
+assert_viol "[P]-plist-fires" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
 | 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
@@ -1132,6 +1156,10 @@ assert "[P]-plist-fires" 1 "$FM_OPUS
 **Tier:** self
 
 Define the launchd job.
+
+## Required Test Methods
+
+- testClassifierMapsReportToLabel
 
 ## Critical Files
 
@@ -1144,10 +1172,10 @@ Define the launchd job.
 # ships gate [P] fails its own gate.
 
 # (a) A fenced `## Critical Files` bullet is recipe text, not a declaration.
-assert "[P]-fenced-critical-files-does-not-fire" 0 "$FM_OPUS
+assert_viol "[P]-fenced-critical-files-does-not-fire" 0 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
-| 1 | the checker rejects a stale doc | CLI-executable | post-impl | \`bin/test-check-docs\` |
+| 1 | the gate classifies the declared shape | CLI-executable | post-impl | \`bin/test-check-plan\` |
 
 ## Phase 1: Document the gate
 
@@ -1169,10 +1197,10 @@ The fixture below is recipe text, not a deliverable:
 # (b) A fenced matrix row must NOT clear a REAL declaration. This is the fixture
 # that fails if [P] is ever 'simplified' to reuse \$MATRIX_FILE, which is built
 # from the raw file at :201-205 and is fence-blind.
-assert "[P]-fenced-matrix-row-does-not-clear" 1 "$FM_OPUS
+assert_viol "[P]-fenced-matrix-row-does-not-clear" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
-| 1 | the checker rejects a stale doc | CLI-executable | post-impl | \`bin/test-check-docs\` |
+| 1 | the gate classifies the declared shape | CLI-executable | post-impl | \`bin/test-check-plan\` |
 
 ## Phase 1: Post the ack thread
 
@@ -1193,10 +1221,10 @@ Recipe text, not this plan's own matrix:
 # (c) A fenced marker must NOT clear. Line-anchoring alone is not enough: inside
 # a fence the marker IS at line start. Every plan documenting the marker --
 # starting with this one -- would otherwise suppress the gate it ships.
-assert "[P]-fenced-marker-does-not-clear" 1 "$FM_OPUS
+assert_viol "[P]-fenced-marker-does-not-clear" 1 "[P]" "$FM_OPUS
 | # | What to verify | Test type | Timing | Test file / location |
 |---|---|---|---|---|
-| 1 | the checker rejects a stale doc | CLI-executable | post-impl | \`bin/test-check-docs\` |
+| 1 | the gate classifies the declared shape | CLI-executable | post-impl | \`bin/test-check-plan\` |
 
 ## Phase 1: Post the ack thread
 

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -1047,6 +1047,27 @@ Read the tick script for its scheduling shape; change nothing in it.
 - \`bin/sim-recap-tick\` (reference)
 "
 
+# FALSE-POSITIVE REGRESSION — the COMPOUND \`(read-only reference)\` annotation
+# (63 corpus occurrences) evades the exact \`(reference)\`/\`(read-only)\` matches.
+# Found by the acceptance corpus sweep firing on verification-forced-integration-
+# triggers.md. Pins the compound clause added to Arm A's annotation-exclusion set.
+assert "[P]-compound-readonly-reference-does-not-fire" 0 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/check-plan\` |
+
+## Phase 1: Cite the cron-setup shape
+
+**Tier:** self
+
+Read the cron-setup script for its launchd shape; change nothing in it.
+
+## Critical Files
+
+- \`bin/check-plan\`
+- \`bin/sim-recap-cron-setup\` (read-only reference)
+"
+
 # FALSE-NEGATIVE REGRESSION — a QUOTED marker must not clear. Every plan about
 # this gate quotes the token in prose; only the line-anchored HTML-comment form
 # is a real marker. This is the case a bare grep -qF would get wrong.

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -1084,6 +1084,69 @@ Read the cron-setup script for its launchd shape; change nothing in it.
 - \`bin/sim-recap-cron-setup\` (read-only reference)
 "
 
+# FALSE-POSITIVE REGRESSION — the annotation is a paren GROUP whose contents
+# include a canonical token, per CF_EXEMPT_PATTERN; an explanatory tail inside
+# the same parens is allowed. Both bodies below are copied verbatim from real
+# corpus plans (game-of-that-day-validation-floor.md:302 and
+# ci-path-filter-sim-recap-coupling.md:448) — each fired [P] under the inline
+# literal-match list this gate shipped with, which required the group to be
+# exactly \`(reference)\`. Note the FIRST is the plainest \`(reference — …)\`
+# shape, so the literal list failed on the most common annotation there is.
+assert_viol "[P]-reference-with-trailing-rationale-does-not-fire" 0 "[P]" "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/test-check-plan\` |
+
+## Phase 1: Cite the park-on-reject rationale
+
+**Tier:** self
+
+Read the store-result handling for its fail-closed shape; change nothing in it.
+
+## Critical Files
+
+- \`bin/check-plan\`
+- \`bin/sim-recap-tick\` (reference — lines 242-245 read the non-zero store result and park the sim for retry; the \"reject means park\" half of the fail-closed rationale)
+"
+
+assert_viol "[P]-readonly-reference-with-trailing-rationale-does-not-fire" 0 "[P]" "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/test-check-plan\` |
+
+## Phase 1: Cite the path-filter evidence
+
+**Tier:** self
+
+Read the two call sites for their coupling evidence; change nothing in them.
+
+## Critical Files
+
+- \`bin/check-plan\`
+- \`bin/sim-recap-tick\` (read-only reference — lines 92 and 243 are the primary-source evidence that \`simRecapQueue.php\` and \`storeSimRecap.php\` belong in the \`both:\` group; not edited)
+"
+
+# FALSE-NEGATIVE GUARD on the widened exemption — a backticked path inside the
+# parenthetical is an identifier, never a marker. cf_parse_section strips every
+# backtick span before the exemption test and gate [P] mirrors that, so the
+# artifact's own name here cannot exempt the bullet that declares it.
+assert_viol "[P]-backticked-path-in-annotation-does-not-exempt" 1 "[P]" "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/test-check-plan\` |
+
+## Phase 1: Add the tick driver
+
+**Tier:** self
+
+Create the poll driver.
+
+## Critical Files
+
+- \`bin/check-plan\`
+- \`bin/sim-recap-tick\` (new driver — copies the loop shape from \`bin/reference-helper\`)
+"
+
 # FALSE-NEGATIVE REGRESSION — a QUOTED marker must not clear. Every plan about
 # this gate quotes the token in prose; only the line-anchored HTML-comment form
 # is a real marker. This is the case a bare grep -qF would get wrong.

--- a/bin/test-check-plan
+++ b/bin/test-check-plan
@@ -827,6 +827,393 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Gate [P]: pre-prod exercise path for a declared deploy-dependent artifact.
+# The two MUST-HIT fixtures below are the PRs this gate exists for; they are
+# named after the failures, not after the mechanism, so a future softening
+# reads as "we stopped catching #1500", not "a regex changed".
+# ---------------------------------------------------------------------------
+
+# MUST HIT 1 — the #1500 shape (bug-pipeline-gm-feedback-ack-thread): a tick
+# script is declared as a deliverable, the matrix looks green, and nothing in
+# it exercises the tick. Stub-only coverage is invisible here by design.
+assert "[P]-musthit-1500-stub-only" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
+
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+Extend the pipeline to open a Discord thread on ack.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# MUST HIT 2 — the #1600 shape (sim-recap-automation-3b-activation): the tick
+# script ALREADY EXISTS on disk and is merely activated, and the plan carries a
+# correctly-authored Truly-manual row that does not exercise it. Pins BOTH the
+# deliberate absence of gate 8's on-disk existence skip AND the rule that a
+# manual row's mere presence never satisfies the gate.
+assert "[P]-musthit-1600-activation" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | notification copy tone reads naturally to a GM | Truly-manual | post-impl | worktree stack |
+
+## Phase 1: Activate the recap job
+
+**Tier:** self
+
+Flip the scheduled recap from dormant to live.
+
+## Critical Files
+
+- \`bin/sim-recap-tick\`
+"
+
+# Clear arm 1a: a row that INVOKES the artifact (full path + a flag) clears.
+# Whether the row is a GOOD row is gate 16's judgment, not lint's.
+assert "[P]-matrix-row-clears" 0 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | \`bin/bug-pipeline-tick --dry-run\` posts to the test channel | CLI-executable | post-impl | worktree stack |
+
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+Extend the pipeline.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# Clear arm 1b: full path + a pre-prod ENVIRONMENT word on the same row. A
+# Truly-manual row is a legitimate exercise when it names a reachable place.
+assert "[P]-env-word-row-clears" 0 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | one-shot run of \`bin/bug-pipeline-tick\` on the worktree stack | Truly-manual | post-impl | worktree stack |
+
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+Extend the pipeline.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# FALSE-NEGATIVE REGRESSION: a bare BASENAME does not clear. Matching is
+# word-bounded on the FULL declared path, because basename matching is what let
+# bin/test-<x>-tick clear bin/<x>-tick during calibration.
+assert "[P]-basename-row-does-not-clear" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | one-shot run of bug-pipeline-tick posts to the test channel | CLI-executable | post-impl | worktree stack |
+
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+Extend the pipeline.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# FALSE-NEGATIVE REGRESSION, and the #1500 failure mechanized: a stub harness
+# is not an exercise. bin/test-bug-pipeline-tick CONTAINS bin/bug-pipeline-tick
+# as a substring; only full-path word-bounding plus the bin/test-* drop stops
+# it. If this fixture ever flips to 0, the gate has re-accepted the exact
+# coverage shape PR #1500 shipped.
+assert "[P]-stub-harness-does-not-clear" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | \`bin/test-bug-pipeline-tick\` covers the tick end to end | CLI-executable | post-impl | \`bin/test-bug-pipeline-tick\` |
+
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+Extend the pipeline.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# FALSE-NEGATIVE REGRESSION: a LINT row names the artifact but does not run it.
+# The full token matches here, so this fixture is what the invocation/environment
+# CONJUNCTION exists for. This is the other half of the #1500 shape.
+assert "[P]-lint-row-does-not-clear" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | \`shellcheck bin/bug-pipeline-tick\` is clean | CLI-executable | post-impl | \`.github/workflows/tests.yml\` |
+
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+Extend the pipeline.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# Clear arm 3: a line-anchored marker WITH its justification section clears.
+assert "[P]-marker-with-justification-clears" 0 "$FM_OPUS
+<!-- pre-prod-exception: launchd registration on the prod box -->
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
+
+## Phase 1: Register the job
+
+**Tier:** self
+
+Register the launchd job.
+
+## Pre-prod Exception Justification
+
+Scheduling only: launchd firing on the prod box cannot be reproduced pre-prod.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# The marker is not a bare escape: without the justification section it FLAGS,
+# mirroring gate H's auto_merge: false <-> Automouse Hold Justification pairing.
+assert "[P]-marker-without-justification-flags" 1 "$FM_OPUS
+<!-- pre-prod-exception: launchd registration on the prod box -->
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
+
+## Phase 1: Register the job
+
+**Tier:** self
+
+Register the launchd job.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# FALSE-POSITIVE REGRESSION — the self-fire this gate's own plan draft exhibited.
+# A prose line mentioning a tick script alongside a creation cue is NOT a
+# declaration. Gate 8's bare-cue filter fires here; gate P must not.
+assert "[P]-prose-mention-does-not-fire" 0 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/check-plan\` |
+
+## Phase 1: Document the gate
+
+**Tier:** self
+
+Every backticked path introduced here must resolve on master: \`bin/bug-pipeline-tick\`, for example.
+
+## Critical Files
+
+- \`bin/check-plan\`
+"
+
+# FALSE-POSITIVE REGRESSION — a Critical Files entry annotated as read-only is a
+# reference, not a deliverable. Pins reuse of gate C's annotation-exclusion set.
+assert "[P]-annotated-critical-file-does-not-fire" 0 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | gate letter is registered | CLI-executable | post-impl | \`bin/check-plan\` |
+
+## Phase 1: Document the gate
+
+**Tier:** self
+
+Read the tick script for its scheduling shape; change nothing in it.
+
+## Critical Files
+
+- \`bin/check-plan\`
+- \`bin/sim-recap-tick\` (reference)
+"
+
+# FALSE-NEGATIVE REGRESSION — a QUOTED marker must not clear. Every plan about
+# this gate quotes the token in prose; only the line-anchored HTML-comment form
+# is a real marker. This is the case a bare grep -qF would get wrong.
+assert "[P]-quoted-marker-does-not-clear" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
+
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+The gate is suppressed by a \`pre-prod-exception:\` marker, which this plan does not claim.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# SHAPE-SET REGRESSION — an ordinary bin/ script is not a deploy-dependent
+# artifact. Pins that the shape set stayed narrow (tick / cron-setup / plist).
+assert "[P]-ordinary-script-does-not-fire" 0 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | the checker rejects a stale doc | CLI-executable | post-impl | \`bin/test-check-docs\` |
+
+## Phase 1: Extend the checker
+
+**Tier:** self
+
+Add a rule to the doc checker.
+
+## Critical Files
+
+- \`bin/check-docs\`
+"
+
+# SHAPE-SET COVERAGE — the other two calibrated shapes fire too.
+assert "[P]-cron-setup-fires" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
+
+## Phase 1: Register the schedule
+
+**Tier:** self
+
+Wire up the scheduler.
+
+## Critical Files
+
+- \`bin/sim-recap-cron-setup\`
+"
+
+assert "[P]-plist-fires" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | classifier maps a report to the right label | PHPUnit | post-impl | \`tests/BugPipelineTest.php\` |
+
+## Phase 1: Add the job definition
+
+**Tier:** self
+
+Define the launchd job.
+
+## Critical Files
+
+- \`ibl5/ops/com.ibl5.recap.plist\`
+"
+
+# FENCE-AWARENESS — three fixtures, one for each read that a fence-blind gate
+# would corrupt. Each embeds RECIPE TEXT inside a fence, exactly as a real plan
+# about this gate does. Without $GATEP_BODY all three invert, and the plan that
+# ships gate [P] fails its own gate.
+
+# (a) A fenced `## Critical Files` bullet is recipe text, not a declaration.
+assert "[P]-fenced-critical-files-does-not-fire" 0 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | the checker rejects a stale doc | CLI-executable | post-impl | \`bin/test-check-docs\` |
+
+## Phase 1: Document the gate
+
+**Tier:** self
+
+The fixture below is recipe text, not a deliverable:
+
+\`\`\`
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+\`\`\`
+
+## Critical Files
+
+- \`docs/decisions/0100-x.md\`
+"
+
+# (b) A fenced matrix row must NOT clear a REAL declaration. This is the fixture
+# that fails if [P] is ever 'simplified' to reuse \$MATRIX_FILE, which is built
+# from the raw file at :201-205 and is fence-blind.
+assert "[P]-fenced-matrix-row-does-not-clear" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | the checker rejects a stale doc | CLI-executable | post-impl | \`bin/test-check-docs\` |
+
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+Recipe text, not this plan's own matrix:
+
+\`\`\`
+| # | What to verify | Test type | Timing | Test file / location |
+| 1 | \`bin/bug-pipeline-tick --dry-run\` runs | CLI-executable | post-impl | worktree |
+\`\`\`
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# (c) A fenced marker must NOT clear. Line-anchoring alone is not enough: inside
+# a fence the marker IS at line start. Every plan documenting the marker --
+# starting with this one -- would otherwise suppress the gate it ships.
+assert "[P]-fenced-marker-does-not-clear" 1 "$FM_OPUS
+| # | What to verify | Test type | Timing | Test file / location |
+|---|---|---|---|---|
+| 1 | the checker rejects a stale doc | CLI-executable | post-impl | \`bin/test-check-docs\` |
+
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+The marker form this plan documents:
+
+\`\`\`
+<!-- pre-prod-exception: launchd registration is intrinsic -->
+\`\`\`
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+"
+
+# ATTRIBUTION — a plan with NO matrix exits 1 from gate 1 alone; gate P must
+# stay silent rather than pile a second, misleading line onto the same failure.
+_pf="$TMP/gateP-no-matrix.md"
+printf '%s\n' "$FM_OPUS
+## Phase 1: Post the ack thread
+
+**Tier:** self
+
+Extend the pipeline.
+
+## Critical Files
+
+- \`bin/bug-pipeline-tick\`
+" > "$_pf"
+if "$GUARD" "$_pf" 2>&1 | grep -q '\[P\]'; then
+    echo "FAIL: gate P fired on a plan with no matrix (gate 1 owns that failure)"
+    FAILED=1
+else
+    echo "ok: gate P silent on a no-matrix plan (attribution preserved)"
+fi
+
+# ---------------------------------------------------------------------------
 # Gate [W]: sweep-verb advisory tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`bin/check-plan` gate `[P]`: a plan that **declares** a scheduled/daemon artifact (`bin/<x>-tick`, `bin/<x>-cron-setup`, `*.plist`) must carry a verification-matrix row that plausibly **runs** it — full declared path, word-bounded, together with either an invocation form (`<path> --flag`) or a pre-prod environment word (`--dry-run`/`--once`/`--sim=`/`workflow_dispatch`/`CI`/`worktree`/`localhost`/`deploy-rehearsal`). Escape: a line-anchored `<!-- pre-prod-exception: … -->` marker plus a `## Pre-prod Exception Justification` section.

Mechanizes the first of `/plan` Step 4 gate 16's three failure shapes: **no row at all.** The "stub-only coverage" and "adjacent coverage" shapes stay in the prose gate (gate 16 + `_architect-contract.md`), which require understanding.

**Trigger discipline:** declaration position only (unannotated `## Critical Files` bullet or creation-cue table row); never a prose mention. Every read is 4-backtick-fence-aware. Clears are bound to the matrix region — no file-wide seam grep.

**Blocked and non-blocking distinction:** `[P]` emits via `viol()` (blocking). `[W]` sweep-verb advisory is documented in this diff as non-blocking (`[W]` was already implemented at `bin/check-plan:654`; this PR only documents it in `SKILL.md`).

This is unit 2 of a two-unit stacked plan. Unit 1 (the doctrine: Step 4 gate 16, `_architect-contract.md` contract) merged on `master` as the base of this PR.

## Changes

- `.claude/skills/plan/SKILL.md`: register `[P]` in the Step 5 gate-letter list; document `[W]` as advisory and non-blocking; add Step 6 pre-prod exercise path report bullet
- `bin/check-plan`: implement gate `[P]` (fence-aware, declaration-position-only, matrix-region-bound clears); three temp files; header block entry
- `bin/test-check-plan`: 22 named regression fixtures for `[P]`, including both MUST-HIT shapes and the two self-reference regressions observed during calibration

## Implementation fixes (post-plan)

One fix commit: `fix(check-plan): exclude (read-only reference) annotation from gate [P] Arm A`. The compound annotation `(read-only reference)` used in `verification-forced-integration-triggers.md` is outside gate `[C]`'s closed seven-token vocabulary that Edit 3.3 reuses. The gate correctly fires on that plan (fifth calibrated hit, adjudicated and accepted). When the plan's author implements it they will use the canonical single-token form — the gate teaching the vocabulary gate `[C]` has used since it shipped.

### Gate [P] corpus calibration

Corpus: 218 top-level `.md` plans in `~/claude-plans/` at implementation time (2026-07-25); was 201 when authored (2026-07-24). Fire set = 5:

| Plan | Token | Verdict |
|---|---|---|
| `bug-pipeline-gm-feedback-ack-thread.md` | `bin/bug-pipeline-tick` | **TRUE — MUST-HIT #1500.** Only tick row is a `shellcheck` lint (static, not an exercise). |
| `sim-recap-automation-3b-activation.md` | `bin/sim-recap-tick` | **TRUE — MUST-HIT #1600.** Zero rows name the tick. |
| `bug-pipeline-plan-timeout-size-gate.md` | `bin/bug-pipeline-tick` | TRUE. One tick row is an inline `jq` parse of a heredoc constant — never runs the script. |
| `discord-bug-pipeline-5a-cron-core.md` | `bin/bug-pipeline-tick` | TRUE. Four rows, all via `bin/test-bug-pipeline-tick` (stub harness). Stub-only = uncovered. |
| `verification-forced-integration-triggers.md` | `bin/sim-recap-cron-setup` | TRUE (new hit, accepted). Arm A bullet uses compound annotation `(read-only reference)` outside the closed seven-token set; structurally IS a declaration. Fix commit extends the annotation exclusion to cover compound forms. |

Floor (`comm -13`): **empty** — no listed plan stopped firing; both MUST-HITs present. Extra (`comm -23`): `verification-forced-integration-triggers.md` — adjudicated and accepted above.

Collateral: 4 exit-code flips (0→1, none 1→0). `discord-bug-pipeline-5a-cron-core` already exited 1 from another gate, so it adds a `[P]` line without flipping. No other gate perturbed.

## Rebase onto master (2026-08-08)

Rebased onto `origin/master` (42 commits ahead of the old merge-base). One conflict, in `.claude/skills/plan/SKILL.md`: master added `[B]` to the same Step 5 gate-letter sentence this PR adds `[P]` to. Resolved by keeping both.

The rebase also picked up two gates that landed while this branch was open — `[M]` (a PHPUnit matrix row demands `## Required Test Methods`, PR #1765) and `[G]` (a matrix row naming `bin/test-*`/`bin/check-*` must name one CI runs, PR #1765). Six `[P]` fixtures failed on those gates rather than on `[P]`. Follow-up commit `test(check-plan): adapt gate [P] fixtures to gates [M]/[G] and pin attribution`:

- adds `## Required Test Methods` to the six fixtures carrying a PHPUnit row, and retargets the seven matrix cells naming `bin/check-plan` / `bin/test-check-docs` (neither wired into a workflow) at `bin/test-check-plan`, which CI does run. No cell naming a `[P]` artifact was touched, so every clear/fire arm is unchanged;
- converts all 19 `[P]` fixtures from `assert` to `assert_viol "[P]"`, so a fixture exiting 1 for another gate's reason now fails loudly — the collision plain `assert` hid;
- fixes `assert_viol` to strip brackets from the fixture **filename**: `check-plan` echoes the plan path on its OK line, so a fixture named `[P]-foo` put the literal tag in the output and self-failed every want-0 assertion.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.


## Review finding — gate [P] annotation exemption diverged from the canonical one (2026-08-08)

Found while reviewing this PR for merge. Gate `[P]`'s `## Critical Files` parse re-spelled annotation exemption as eight exact closed-paren string matches, while the canonical exemption is `CF_EXEMPT_PATTERN` in `bin/lib/critical-files.sh` — which `bin/check-plan` already sources at line 221, and which gate `[C]` routes through. The gate's own comment claimed parity with gate `[C]`'s `CB_CF_COUNT`; it did not have it.

Consequence: any annotation carrying explanatory text *inside* the parenthetical was read as a declaration — including the plainest `(reference — <rationale>)` shape, which is the most common annotation form in the corpus. This is the same defect class the earlier fix commit `05d173001` patched one instance of; the fix there extended the literal list rather than replacing it.

**Corpus measurement, all 300 plans in `~/claude-plans/`, pristine vs. fixed `bin/check-plan`:**

| | fires |
|---|---|
| before | 8 |
| after | **6** |
| newly firing | **0** |

Both drops are read-only references that are correctly exempt:

| Plan | Bullet |
|---|---|
| `ci-path-filter-sim-recap-coupling.md:448` | `` `bin/sim-recap-tick` (read-only reference — lines 92 and 243 are the primary-source evidence …; not edited) `` |
| `game-of-that-day-validation-floor.md:302` | `` `bin/sim-recap-tick` (reference — lines 242-245 read the non-zero store result and park the sim for retry; …) `` |

All 6 survivors are the already-adjudicated true positives, with both MUST-HITs (#1500 `bug-pipeline-gm-feedback-ack-thread.md`, #1600 `sim-recap-automation-3b-activation.md`) among them.

The path/annotation split now mirrors `cf_parse_section` byte-for-byte: first backtick span is the path, and **all** backtick spans are stripped before the exemption test, so a backticked path inside the parenthetical cannot exempt on its own name. Three fixtures pin this — the two real corpus bullets verbatim, plus a false-negative guard for the backticked-path case.

**One deliberate semantic widening, considered and accepted.** `CF_EXEMPT_PATTERN` also exempts `(conditional — …)`. For gate `[C]` that is exactly right (the file may or may not appear in the diff); for `[P]` it is slightly loose — a daemon declared `(conditional — only if we take branch B)` *is* a declaration when that branch is taken, and now escapes the exercise-path requirement. Zero corpus impact (the both-directions diff would have surfaced it), and re-diverging from the canonical pattern is precisely the defect being fixed here, so the fix keeps `CF_EXEMPT_PATTERN` whole rather than subsetting it.

**Blast radius is author-time only.** `bin/check-plan` is invoked at plan-authoring time (`/plan` Step 5, `bin/plan-now`) and nowhere else: `bin/automouse-queue` uses only `bin/lib/plan-model-consistency`, and `bin/automouse-prompt-impl` / `bin/automouse-self-heal` use `bin/check-plan-staleness`, a separate script. No already-shipped plan is re-gated, so the 6 true positives block no live work.

