### PR TITLE
chore: Phase 9 class-fix escalation ladder + class registry seed

### DIFF
--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -336,7 +336,54 @@ Auto-merge was already armed (or deliberately not armed) in Phase 6.5 — this p
 
 ## Phase 9: Retrospective
 
-Before saving any memory, ask: **"Can this be a PHPStan rule instead?"** If the mistake is mechanical and deterministic, it belongs in `ibl5/phpstan-rules/` as a new custom rule — open a TODO comment in the plan file rather than a memory entry. (For an **engine-side** learning, the analog is: "Can this be a `golangci-lint` linter or a `go vet` rule?" — a mechanical, deterministic Go mistake belongs in `engine/.golangci.yml` config or a custom analyzer, not memory.) Memories are for things a linter cannot express (architectural judgment, environment quirks, incident context).
+Read `IS_FIX_OF_PLAN_BEHAVIOR` from the Phase 3 classification summary already in this session's
+context — do not re-derive it.
+
+**If `IS_FIX_OF_PLAN_BEHAVIOR=false`** (this branch shipped something new), ask only the original
+question: **"Can this be a PHPStan rule instead?"** If the mistake is mechanical and deterministic, it
+belongs in `ibl5/phpstan-rules/` as a new custom rule — open a TODO comment in the plan file rather
+than a memory entry. (For an **engine-side** learning, the analog is: "Can this be a `golangci-lint`
+linter or a `go vet` rule?" — a mechanical, deterministic Go mistake belongs in `engine/.golangci.yml`
+config or a custom analyzer, not memory.) Then continue to the memory rule below.
+
+**If `IS_FIX_OF_PLAN_BEHAVIOR=true`** (this branch fixes behavior a merged plan shipped), the fix is
+evidence that a *class* of defect got past planning. Name the class in one sentence — the general
+shape, not this instance — then walk the ladder and stop at the **first** rung that can express it.
+Most mechanical first:
+
+**Rung 1 — a static-analysis rule.** A PHPStan rule in `ibl5/phpstan-rules/`, or for Go a
+`golangci-lint` linter or analyzer via `engine/.golangci.yml`. Use when the defect is decidable from
+source text alone.
+
+**Rung 2 — extend an existing `bin/check-*` gate.** Add the assertion to a gate that already runs in
+CI. Use when the defect is decidable from repo state (files, docs, config) but not from a single
+source file. Extend an existing gate; do not add a new one.
+
+**Rung 3 — a forced-trigger row in `.claude/review-shared/_plan-verification.md`.** Use when the
+defect is only catchable by a test the plan should have required. That file already carries the
+forced E2E trigger table and the forced manual-verification trigger table; add a row to whichever
+fits. A forced integration-verification trigger table is being added by the
+verification-forced-integration-triggers work — once it lands, cross-script wire contracts and
+environment preconditions belong there.
+
+**Rung 4 — a rule doc.** A new or amended file under `.claude/rules/`. Use when the defect needs
+judgment applied at a decision point, so no gate can decide it, but the guidance applies to every
+session.
+
+**Rung 5 — memory.** The fallback, governed by the paragraph below. Use only when the class is
+environment- or incident-specific and would not generalize into a rule doc.
+
+Then append one line to the `## Class registry` table in
+`ibl5/docs/backlog/loop-engineering-backlog.md`, in that section's existing format:
+
+```
+| <YYYY-MM-DD> | #<this PR> | class: <one-sentence class> | routed to: Rung <n> - <destination> | prior: <#PR, #PR or --> |
+```
+
+Before writing it, scan the existing rows for the same class. If one matches, put its PR numbers in
+`prior:` and route **one rung more mechanical** than that earlier line did — a recurrence means the
+rung chosen last time was too weak. If none matches, `prior:` is `--`. The table is append-only:
+never edit or delete an existing row.
 
 Save to memory only if something was learned that would **prevent a bug** in a future session AND cannot be mechanized AND isn't already in MEMORY.md, CLAUDE.md, `.claude/rules/`, or an existing PHPStan rule. Read the target memory file first to avoid duplicates. If nothing qualifies, skip silently.
 

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -5,7 +5,7 @@ disallowed-tools:
   - EnterPlanMode
   - ExitPlanMode
   - Skill
-last_verified: 2026-07-30
+last_verified: 2026-08-09
 ---
 
 # Post-Plan Orchestrator
@@ -360,11 +360,10 @@ CI. Use when the defect is decidable from repo state (files, docs, config) but n
 source file. Extend an existing gate; do not add a new one.
 
 **Rung 3 — a forced-trigger row in `.claude/review-shared/_plan-verification.md`.** Use when the
-defect is only catchable by a test the plan should have required. That file already carries the
-forced E2E trigger table and the forced manual-verification trigger table; add a row to whichever
-fits. A forced integration-verification trigger table is being added by the
-verification-forced-integration-triggers work — once it lands, cross-script wire contracts and
-environment preconditions belong there.
+defect is only catchable by a test the plan should have required. That file carries the forced E2E
+trigger table, the forced manual-verification trigger table, and the forced
+integration-verification trigger table; add a row to whichever fits. Cross-script wire contracts and
+environment preconditions belong in the integration-verification table.
 
 **Rung 4 — a rule doc.** A new or amended file under `.claude/rules/`. Use when the defect needs
 judgment applied at a decision point, so no gate can decide it, but the guidance applies to every

--- a/.claude/skills/post-plan/SKILL.md
+++ b/.claude/skills/post-plan/SKILL.md
@@ -386,6 +386,15 @@ never edit or delete an existing row.
 
 Save to memory only if something was learned that would **prevent a bug** in a future session AND cannot be mechanized AND isn't already in MEMORY.md, CLAUDE.md, `.claude/rules/`, or an existing PHPStan rule. Read the target memory file first to avoid duplicates. If nothing qualifies, skip silently.
 
+**Engine divergence.** The escalation ladder and the registry append are **skill-only**. The compiled
+harness (`tools/postplan-harness`) never computes `IS_FIX_OF_PLAN_BEHAVIOR` — its `Classification`
+dataclass has no such field, and its Phase 3 port sees only the file list and the diff text, never
+commit subjects — and its Phase 9 is a bounded Haiku retrospective that records a memory-save intent
+without reading this file. So a harness-driven run routes nothing up the ladder and appends no
+registry row, whatever the fix was. Like Phase 2.5's housekeeping, that is an accepted scope
+reduction, not a bug in this section. Only a skill run (the fallback path, or
+`POST_PLAN_SKILL=1 bin/post-plan-now`) exercises the ladder.
+
 ---
 
 ## Phase 10: Preview Environment

--- a/.claude/skills/post-plan/_phase-3-classify-diff.md
+++ b/.claude/skills/post-plan/_phase-3-classify-diff.md
@@ -111,11 +111,17 @@ HAS_COMMENTS_IN_DIFF=$([ "$COMMENT_COUNT" -gt 0 ] && echo true || echo false)
 # PHP lines changed (gates Phase 4B Agents B-C size threshold)
 LINES_PHP_CHANGED=$(git diff origin/master...HEAD -- '*.php' | grep -cE '^\+[^+]' || true)
 
+# Does this branch fix behavior a merged plan shipped? (gates the Phase 9 escalation ladder)
+# Two dots, not three: `git log A...B` is symmetric difference, so a master-side commit can win
+# `head -1`. `git diff A...B` above is correct for diff (merge-base semantics) - log differs.
+IS_FIX_OF_PLAN_BEHAVIOR=$(git log --format='%s' origin/master..HEAD | head -1 | grep -qE '^fix[:(]' && echo true || echo false)
+
 # Classification summary for the run log (Claude reads these and remembers them for later phases)
 echo "=== Diff classification ==="
 echo "  total=$COUNT_TOTAL php=$COUNT_PHP css=$COUNT_CSS md=$COUNT_MD migration=$COUNT_MIGRATION test=$COUNT_TEST lock=$COUNT_LOCK snapshot=$COUNT_SNAPSHOT"
 echo "  DOCS_ONLY=$DOCS_ONLY CSS_ONLY=$CSS_ONLY MIGRATION_ONLY=$MIGRATION_ONLY TEST_ONLY=$TEST_ONLY NON_CODE_ONLY=$NON_CODE_ONLY"
 echo "  HAS_PHP=$HAS_PHP HAS_CSS=$HAS_CSS HAS_MODIFIED=$HAS_MODIFIED HAS_COMMENTS_IN_DIFF=$HAS_COMMENTS_IN_DIFF LINES_PHP_CHANGED=$LINES_PHP_CHANGED"
+echo "  IS_FIX_OF_PLAN_BEHAVIOR=$IS_FIX_OF_PLAN_BEHAVIOR"
 echo "  HAS_E2E_SPECS=$HAS_E2E_SPECS HAS_E2E_PROD_OVERLAP=$HAS_E2E_PROD_OVERLAP"
 echo "  HAS_GO=$HAS_GO GO_TOUCHED=$GO_TOUCHED ENGINE_ONLY=$ENGINE_ONLY GOLDEN_CHANGED=$GOLDEN_CHANGED COUNT_GO=$COUNT_GO"
 echo "  E2E_SPEC_MODULES=$(echo $E2E_SPEC_MODULES | tr '\n' ' ')"

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -242,6 +242,30 @@ last_verified: 2026-08-08
 
 ---
 
+## Class registry
+
+Append-only. One line per **class of defect**, written by `/post-plan` Phase 9 when a run routes a
+learning up the escalation ladder. Never edit or delete a line — the value is in the history.
+
+The `prior:` field is the anti-recurrence lever: when a new line's class matches an existing one,
+record the earlier PR numbers there. A non-empty `prior:` means the class has recurred, and recurrence
+is the signal that the previously chosen rung was too weak — escalate one rung rather than re-routing
+to the same place. This is a **prompted** loop, not an automated one: nothing scans this table on a
+schedule, and no gate fails on it.
+
+The table is fenced so the forward-referenced section names inside it do not resolve as live
+documentation references while the PR that adds them is still open.
+
+```
+| Date       | PR   | Class                                                                 | Routed to rung                                                                                          | Prior          |
+| ---------- | ---- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------- |
+| 2026-07-25 | #1633 | class: env/supervisor precondition unverified before a long-running job | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger, lands with verification-forced-integration-triggers) | prior: -- |
+| 2026-07-25 | --   | class: shared-context wire contract between two scripts is unasserted   | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger, lands with verification-forced-integration-triggers) | prior: -- |
+| 2026-07-25 | #1654 | class: CLI entrypoint accepts an unknown flag silently instead of erroring | routed to: Rung 1 - PHPStan rule over argv option parsing; queued, and a fourth occurrence forces it      | prior: #1354, #1496 |
+```
+
+---
+
 ## Burn-down process
 
 1. Pick an entry; `/plan` it. Loop-machinery changes should default to `auto_merge: false` — a bug here costs whole nights.

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -59,6 +59,7 @@ last_verified: 2026-08-09
 | L30 | Concurrent `automouse-run` sessions corrupt the shared cost report (lost rows, duplicated weekly aggregate) | ⬜ Open | 🟦 | S |
 | L31 | One shared daily log per calendar day: concurrent runners cross-read each other's cost, stall-kill, and env-stop signals | ⬜ Open | 🟥 | M |
 | L32 | Concurrent `bin/wt-new` on the shared main checkout can lose a queued plan to a `skipped/` disposition | ⬜ Open | 🟥 | S |
+| L33 | CLI entrypoints accept unknown flags silently; no static rule enforces argv option allowlisting | ⬜ Open | 🟦 | S |
 
 ### L1 Plan dependency DAG
 **Location:** `bin/automouse-queue` — queue order is symlink mtime (`ls -1tr`); `bin/automouse-queue-reorder-ui` re-touches mtimes by hand. No `depends_on` anywhere (verified).
@@ -240,6 +241,15 @@ last_verified: 2026-08-09
 **Closes gap:** disposition correctness — a transient must not be spent as a verdict.
 **Status (2026-08-08):** ⬜ Open — 🟥 (touches impl-disposition classification; reproduce before designing).
 
+### L33 CLI entrypoints accept unknown flags silently; no static rule enforces argv option allowlisting
+**Location:** `ibl5/phpstan-rules/` — no rule inspects `$argv` / `getopt()` option parsing (verified 2026-08-09: zero rule files mention either). The one hardened entrypoint is `ibl5/scripts/bug-pipeline/transition.php`, allowlisted by hand in PR #1654.
+**Problem:** A CLI entrypoint that ignores an unrecognized option runs with the caller's intent silently dropped — a typo'd or renamed flag produces a successful-looking run that did something else. It has now recurred three times (#1354, #1496, #1654), each fixed one entrypoint at a time, which is the signature of a class that needs a mechanical check rather than another point fix.
+**Suggested direction:** A PHPStan rule over argv/`getopt()` option parsing in CLI entrypoints, asserting that an unrecognized option is rejected rather than ignored. Extend the existing `ibl5/phpstan-rules/` set — this is Rung 1 on the `/post-plan` Phase 9 ladder, and the class registry routes it there.
+**Interim backstop (2026-08-08):** PR #1668 added a forced integration-verification trigger — a plan that adds a CLI flag or flag-parsing branch must carry a row asserting the rejected form fails loudly (`.claude/review-shared/_plan-verification.md` § Forced integration-verification trigger). That is plan-time, so it catches *new* flags only; it does not sweep the entrypoints that already exist.
+**Risk if untouched:** A fourth occurrence, and the existing unhardened entrypoints stay unswept — the backstop above never looks at them.
+**Status (2026-08-09):** ⬜ Open — 🟦.
+**Provenance (2026-08-09):** Surfaced by the `## Class registry` seed row for this class, which routed it to Rung 1 and recorded it as queued; nothing was in fact queued. This entry is that queue.
+
 ---
 
 ## Class registry
@@ -263,7 +273,7 @@ not add backticks or markdown links to a row.
 | ---------- | ---- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------- |
 | 2026-07-25 | #1633 | class: env/supervisor precondition unverified before a long-running job | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger) | prior: -- |
 | 2026-07-25 | --   | class: shared-context wire contract between two scripts is unasserted   | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger) | prior: -- |
-| 2026-07-25 | #1654 | class: CLI entrypoint accepts an unknown flag silently instead of erroring | routed to: Rung 1 - PHPStan rule over argv option parsing; queued, and a fourth occurrence forces it      | prior: #1354, #1496 |
+| 2026-07-25 | #1654 | class: CLI entrypoint accepts an unknown flag silently instead of erroring | routed to: Rung 1 - PHPStan rule over argv option parsing, queued as L33 in this backlog, not yet built; interim Rung 3 backstop shipped in #1668 (section: Forced integration-verification trigger). A fourth occurrence forces the Rung 1 rule. | prior: #1354, #1496 |
 ```
 
 ---

--- a/ibl5/docs/backlog/loop-engineering-backlog.md
+++ b/ibl5/docs/backlog/loop-engineering-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Loop-engineering backlog — automouse queue robustness (dependency ordering, circuit breakers, canaries, self-healing), autonomous intake loops, plan decomposition/tier-routing machinery, and the human comprehension counter-loop, with per-entry status.
-last_verified: 2026-08-08
+last_verified: 2026-08-09
 ---
 
 # Loop-Engineering Backlog
@@ -253,14 +253,16 @@ is the signal that the previously chosen rung was too weak — escalate one rung
 to the same place. This is a **prompted** loop, not an automated one: nothing scans this table on a
 schedule, and no gate fails on it.
 
-The table is fenced so the forward-referenced section names inside it do not resolve as live
-documentation references while the PR that adds them is still open.
+The table is fenced and every path inside it is written bare — no backticks, no link syntax. The
+bare paths are what keep a row naming a destination that does not exist yet from failing the
+dead-reference check; the fence alone would not, since the checker does not strip fenced blocks. Do
+not add backticks or markdown links to a row.
 
 ```
 | Date       | PR   | Class                                                                 | Routed to rung                                                                                          | Prior          |
 | ---------- | ---- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------- |
-| 2026-07-25 | #1633 | class: env/supervisor precondition unverified before a long-running job | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger, lands with verification-forced-integration-triggers) | prior: -- |
-| 2026-07-25 | --   | class: shared-context wire contract between two scripts is unasserted   | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger, lands with verification-forced-integration-triggers) | prior: -- |
+| 2026-07-25 | #1633 | class: env/supervisor precondition unverified before a long-running job | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger) | prior: -- |
+| 2026-07-25 | --   | class: shared-context wire contract between two scripts is unasserted   | routed to: Rung 3 - forced-trigger row in .claude/review-shared/_plan-verification.md (section: Forced integration-verification trigger) | prior: -- |
 | 2026-07-25 | #1654 | class: CLI entrypoint accepts an unknown flag silently instead of erroring | routed to: Rung 1 - PHPStan rule over argv option parsing; queued, and a fourth occurrence forces it      | prior: #1354, #1496 |
 ```
 


### PR DESCRIPTION
## Summary

Widen post-plan Phase 9 into a five-rung class-fix escalation ladder, and seed the class registry.

### Changes

- **`.claude/skills/post-plan/_phase-3-classify-diff.md`** — adds `IS_FIX_OF_PLAN_BEHAVIOR` classification flag (two-dot revision range; emitted in the Diff classification summary)
- **`ibl5/docs/backlog/loop-engineering-backlog.md`** — adds `## Class registry` section with three seed rows (fenced table; append-only ledger), plus backlog entry **L33** as the real queue for the Rung 1 argv-allowlist PHPStan rule that seed row 3 routes to
- **`.claude/skills/post-plan/SKILL.md`** — replaces Phase 9's single PHPStan question with a gated five-rung escalation ladder + registry-append instruction; adds an **Engine divergence** note recording that the ladder and registry append are skill-only (the compiled harness never computes `IS_FIX_OF_PLAN_BEHAVIOR`); updates `last_verified`

### Why

When a post-plan run ships a fix for behavior a merged plan introduced, Phase 9 previously only asked "Can this be a PHPStan rule?". The new ladder routes the defect class to the most-mechanical permanent remedy (Rung 1 static analysis → Rung 5 memory), and records each routing in an append-only class registry so recurrence is visible and escalates automatically.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.