### PR TITLE
chore: fix stale CI path refs + de-harden meta-tooling-bar counts

### DIFF
--- a/.claude/rules/meta-tooling-bar.md
+++ b/.claude/rules/meta-tooling-bar.md
@@ -1,6 +1,6 @@
 ---
 description: Before adding a new hook, CI gate, workflow, or bin/ script, first ask whether an existing one can be extended; quarterly cull retires dead meta-tooling.
-last_verified: 2026-07-21
+last_verified: 2026-07-25
 paths:
   - "bin/**"
   - ".github/workflows/**"
@@ -9,7 +9,7 @@ paths:
 
 # Meta-Tooling Bar
 
-As of 2026-07-09 (UTC), the repo carries: 113 files in `bin/` (30 `test-*`, 18 `check-*`), 27 CI workflows in `.github/workflows/`, 20 hooks in `~/.claude/hooks/`, and 28 always-loaded rules in `.claude/rules/`. Roughly a quarter of `bin/` (`test-*`) exists to maintain the other three-quarters — every gate is itself code that needs upkeep and can carry its own bugs. Evidence that gates need upkeep (not that they are broken now): the persist-gate append blindspot (fixed 2026-07-04) and the check-docs rebase author-date bug (fixed PR #1262). This rule caps growth two ways: an **extend-before-add bar** checked at creation time, and a **quarterly cull** that retires dead tooling.
+The repo carries a large and growing meta-tooling surface — `bin/` scripts, CI workflows, hooks, and always-loaded rules (recount them with the block below; the numbers move too fast to pin here). Roughly a quarter of `bin/` (`test-*`) exists to maintain the other three-quarters — every gate is itself code that needs upkeep and can carry its own bugs. Evidence that gates need upkeep (not that they are broken now): the persist-gate append blindspot (fixed 2026-07-04) and the check-docs rebase author-date bug (fixed PR #1262). This rule caps growth two ways: an **extend-before-add bar** checked at creation time, and a **quarterly cull** that retires dead tooling.
 
 Recount at any time:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,9 +65,9 @@ jobs:
               - '.claude/skills/post-plan/SKILL.md'
               - '.claude/skills/post-plan/_phase-6.5-arm-auto-merge.md'
               # bin/test-post-review-findings reads the Step 7 / Step 1 blocks here,
-              # so a command-only edit must run the harness job too.
-              - '.claude/commands/pr-review.md'
-              - '.claude/commands/security-audit.md'
+              # so a skill-only edit must run the harness job too.
+              - '.claude/skills/pr-review/SKILL.md'
+              - '.claude/skills/security-audit/SKILL.md'
               # bin/test-human-signoff-classifier guards the classifier lib that
               # human-signoff.yml sources, so a workflow-only edit must run it too.
               - '.github/workflows/human-signoff.yml'


### PR DESCRIPTION
## Summary

Fix stale CI path refs + de-harden meta-tooling-bar counts.

**Phase 1** — Repoints the `shell:` filter group in `.github/workflows/tests.yml` from two dead `.claude/commands/` paths (which never existed on disk and silently disabled the harness gate) to the live SKILL.md paths:
- `.claude/commands/pr-review.md` → `.claude/skills/pr-review/SKILL.md`
- `.claude/commands/security-audit.md` → `.claude/skills/security-audit/SKILL.md`
- Also fixes comment wording: `command-only` → `skill-only`

**Phase 2** — Strips six hardcoded snapshot counts from the opening paragraph of `.claude/rules/meta-tooling-bar.md` (113 files in `bin/`, 30 `test-*`, 18 `check-*`, 27 CI workflows, 20 hooks, 28 always-loaded rules — all from a 2026-07-09 snapshot), replaces them with a pointer to the existing recount block directly beneath, and bumps `last_verified` to 2026-07-25.

**Phase 3** — Removes the untracked `.claude/commands/` directory (contained only an ignored `.DS_Store`; no git-tracked files). Produces no git diff as expected — the directory had no tracked content.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.