### PR TITLE
refactor(depth-chart): extract SlotAssignmentResolver from SavedDepthChartService

### DIFF
--- a/ibl5/classes/SavedDepthChart/Contracts/SlotAssignmentResolverInterface.php
+++ b/ibl5/classes/SavedDepthChart/Contracts/SlotAssignmentResolverInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SavedDepthChart\Contracts;
+
+/**
+ * Resolves which submitted depth-chart form slot (1..15) a roster player occupies,
+ * and returns that slot's depth-chart settings.
+ *
+ * Extracted from SavedDepthChartService (backlog 1.34) so the pid -> name -> ordinal
+ * matching strategy is independently testable and substitutable.
+ *
+ * @phpstan-type SlotSettings array{
+ *     pg: int,
+ *     sg: int,
+ *     sf: int,
+ *     pf: int,
+ *     c: int,
+ *     canPlayInGame: int,
+ *     min: int,
+ *     of: int,
+ *     df: int,
+ *     oi: int,
+ *     di: int,
+ *     bh: int
+ * }
+ */
+interface SlotAssignmentResolverInterface
+{
+    /**
+     * Resolve the depth-chart settings for one roster player from the submitted form.
+     *
+     * Matching strategy, in order: (1) `pid<N>` hidden field equal to the player's pid;
+     * (2) `Name<N>` field whose trimmed, tag-stripped value equals the player's name;
+     * (3) the player's 1-based roster ordinal, if `Name<ordinal>` was submitted at all.
+     *
+     * @param array<string, mixed> $player   Roster row; reads only 'pid' and 'name'.
+     * @param array<string, mixed> $postData Raw submitted form fields.
+     * @param int $ordinal                   1-based roster position (last-resort match).
+     * @return SlotSettings|null             Null when the player occupies no submitted slot.
+     */
+    public function resolveSlotSettings(array $player, array $postData, int $ordinal): ?array;
+}

--- a/ibl5/classes/SavedDepthChart/SavedDepthChartService.php
+++ b/ibl5/classes/SavedDepthChart/SavedDepthChartService.php
@@ -6,6 +6,7 @@ namespace SavedDepthChart;
 
 use SavedDepthChart\Contracts\SavedDepthChartServiceInterface;
 use SavedDepthChart\Contracts\SavedDepthChartRepositoryInterface;
+use SavedDepthChart\Contracts\SlotAssignmentResolverInterface;
 use Season\Season;
 
 /**
@@ -19,6 +20,7 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
 {
     private SavedDepthChartRepositoryInterface $repository;
     private \mysqli $db;
+    private SlotAssignmentResolverInterface $slotResolver;
 
     /**
      * Optional PSR-3 logger. When null, falls back to LoggerFactory::getChannel('audit').
@@ -37,11 +39,13 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
     public function __construct(
         \mysqli $db,
         ?SavedDepthChartRepositoryInterface $repo = null,
-        ?\Psr\Log\LoggerInterface $logger = null
+        ?\Psr\Log\LoggerInterface $logger = null,
+        ?SlotAssignmentResolverInterface $slotResolver = null
     ) {
         $this->db = $db;
         $this->repository = $repo ?? new SavedDepthChartRepository($db);
         $this->logger = $logger ?? \Logging\LoggerFactory::getChannel('audit');
+        $this->slotResolver = $slotResolver ?? new SlotAssignmentResolver();
     }
 
     /**
@@ -348,85 +352,17 @@ class SavedDepthChartService implements SavedDepthChartServiceInterface
         $ordinal = 1;
 
         foreach ($rosterPlayers as $player) {
-            $pidKey = $this->findPidIndex($player, $postData, $ordinal);
-            if ($pidKey === 0) {
+            $dcSettings = $this->slotResolver->resolveSlotSettings($player, $postData, $ordinal);
+            if ($dcSettings === null) {
                 $ordinal++;
                 continue;
             }
-
-            $dcSettings = [
-                'pg' => $this->extractIntFromPost($postData, 'pg' . $pidKey),
-                'sg' => $this->extractIntFromPost($postData, 'sg' . $pidKey),
-                'sf' => $this->extractIntFromPost($postData, 'sf' . $pidKey),
-                'pf' => $this->extractIntFromPost($postData, 'pf' . $pidKey),
-                'c' => $this->extractIntFromPost($postData, 'c' . $pidKey),
-                'canPlayInGame' => $this->extractIntFromPost($postData, 'canPlayInGame' . $pidKey),
-                'min' => $this->extractIntFromPost($postData, 'min' . $pidKey),
-                'of' => $this->extractIntFromPost($postData, 'OF' . $pidKey),
-                'df' => $this->extractIntFromPost($postData, 'DF' . $pidKey),
-                'oi' => $this->extractIntFromPost($postData, 'OI' . $pidKey),
-                'di' => $this->extractIntFromPost($postData, 'DI' . $pidKey),
-                'bh' => $this->extractIntFromPost($postData, 'BH' . $pidKey),
-            ];
 
             $snapshots[] = $this->buildPlayerSnapshot($player, $dcSettings, $ordinal);
             $ordinal++;
         }
 
         return $snapshots;
-    }
-
-    /**
-     * Find the form index for a player by matching pid fields in POST data
-     *
-     * Falls back to ordinal position if pid fields aren't present
-     *
-     * @param array<string, mixed> $player
-     * @param array<string, mixed> $postData
-     */
-    private function findPidIndex(array $player, array $postData, int $ordinal): int
-    {
-        $playerPid = $this->toInt($player['pid'] ?? 0);
-
-        // Try to match by pid hidden field
-        for ($i = 1; $i <= 15; $i++) {
-            $pidField = 'pid' . $i;
-            if (isset($postData[$pidField]) && $this->toInt($postData[$pidField]) === $playerPid) {
-                return $i;
-            }
-        }
-
-        // Fall back to matching by name (existing pattern) or ordinal
-        $playerName = $this->toString($player['name'] ?? '');
-        for ($i = 1; $i <= 15; $i++) {
-            $nameField = 'Name' . $i;
-            $postName = isset($postData[$nameField]) ? $this->toString($postData[$nameField]) : '';
-            if ($postName !== '' && trim(strip_tags($postName)) === $playerName) {
-                return $i;
-            }
-        }
-
-        // Last resort: use ordinal position
-        if (isset($postData['Name' . $ordinal])) {
-            return $ordinal;
-        }
-
-        return 0;
-    }
-
-    /**
-     * @param array<string, mixed> $postData
-     */
-    private function extractIntFromPost(array $postData, string $key): int
-    {
-        $value = $postData[$key] ?? 0;
-        if (is_int($value)) {
-            return $value;
-        }
-        if (is_string($value) && is_numeric($value)) {
-            return (int) $value;
-        }
-        return 0;
     }
 
     private function calculateNextSimStartDate(string $lastSimEndDate): string

--- a/ibl5/classes/SavedDepthChart/SlotAssignmentResolver.php
+++ b/ibl5/classes/SavedDepthChart/SlotAssignmentResolver.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SavedDepthChart;
+
+use SavedDepthChart\Contracts\SlotAssignmentResolverInterface;
+
+/**
+ * @phpstan-import-type SlotSettings from Contracts\SlotAssignmentResolverInterface
+ *
+ * @see SlotAssignmentResolverInterface
+ */
+class SlotAssignmentResolver implements SlotAssignmentResolverInterface
+{
+    /** Number of player rows the depth-chart form submits. */
+    private const MAX_SLOTS = 15;
+
+    /**
+     * @see SlotAssignmentResolverInterface::resolveSlotSettings()
+     * @param array<string, mixed> $player
+     * @param array<string, mixed> $postData
+     * @return SlotSettings|null
+     */
+    public function resolveSlotSettings(array $player, array $postData, int $ordinal): ?array
+    {
+        $slot = $this->findPidIndex($player, $postData, $ordinal);
+        if ($slot === 0) {
+            return null;
+        }
+
+        return [
+            'pg' => $this->extractIntFromPost($postData, 'pg' . $slot),
+            'sg' => $this->extractIntFromPost($postData, 'sg' . $slot),
+            'sf' => $this->extractIntFromPost($postData, 'sf' . $slot),
+            'pf' => $this->extractIntFromPost($postData, 'pf' . $slot),
+            'c' => $this->extractIntFromPost($postData, 'c' . $slot),
+            'canPlayInGame' => $this->extractIntFromPost($postData, 'canPlayInGame' . $slot),
+            'min' => $this->extractIntFromPost($postData, 'min' . $slot),
+            'of' => $this->extractIntFromPost($postData, 'OF' . $slot),
+            'df' => $this->extractIntFromPost($postData, 'DF' . $slot),
+            'oi' => $this->extractIntFromPost($postData, 'OI' . $slot),
+            'di' => $this->extractIntFromPost($postData, 'DI' . $slot),
+            'bh' => $this->extractIntFromPost($postData, 'BH' . $slot),
+        ];
+    }
+
+    /**
+     * Find the form index for a player by matching pid fields in POST data.
+     *
+     * Falls back to name match, then to ordinal position. Returns 0 for no match.
+     *
+     * @param array<string, mixed> $player
+     * @param array<string, mixed> $postData
+     */
+    private function findPidIndex(array $player, array $postData, int $ordinal): int
+    {
+        $playerPid = $this->toInt($player['pid'] ?? 0);
+
+        // Try to match by pid hidden field
+        for ($i = 1; $i <= self::MAX_SLOTS; $i++) {
+            $pidField = 'pid' . $i;
+            if (isset($postData[$pidField]) && $this->toInt($postData[$pidField]) === $playerPid) {
+                return $i;
+            }
+        }
+
+        // Fall back to matching by name (existing pattern) or ordinal
+        $playerName = $this->toString($player['name'] ?? '');
+        for ($i = 1; $i <= self::MAX_SLOTS; $i++) {
+            $nameField = 'Name' . $i;
+            $postName = isset($postData[$nameField]) ? $this->toString($postData[$nameField]) : '';
+            if ($postName !== '' && trim(strip_tags($postName)) === $playerName) {
+                return $i;
+            }
+        }
+
+        // Last resort: use ordinal position
+        if (isset($postData['Name' . $ordinal])) {
+            return $ordinal;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param array<string, mixed> $postData
+     */
+    private function extractIntFromPost(array $postData, string $key): int
+    {
+        $value = $postData[$key] ?? 0;
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_string($value) && is_numeric($value)) {
+            return (int) $value;
+        }
+        return 0;
+    }
+
+    /**
+     * Safely convert mixed value to int
+     */
+    private function toInt(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_string($value) && is_numeric($value)) {
+            return (int) $value;
+        }
+        if (is_float($value)) {
+            return (int) $value;
+        }
+        return 0;
+    }
+
+    /**
+     * Safely convert mixed value to string
+     */
+    private function toString(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return '';
+    }
+}

--- a/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
@@ -1,6 +1,6 @@
 ---
 description: Historical archive: completed/declined maintenance-audit findings, extracted from maintenance-backlog.md.
-last_verified: 2026-07-25
+last_verified: 2026-07-26
 ---
 
 # Maintenance-Cost Reduction Backlog — Archive
@@ -172,6 +172,16 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 
 
 **Table evidence (2026-07-25):** SearchView 485 LOC string-concat. Extracted `renderResultList()` + ob_start migration; VR pin.
+
+### 1.34 SavedDepthChartService — Data Assembly + Slot-Conflict Resolution (626 LOC)
+**Location:** `ibl5/classes/SavedDepthChart/SavedDepthChartService.php` (626 lines)
+**Problem:** One service assembles depth-chart page data and resolves slot conflicts, mixing orchestration with conflict-resolution logic.
+**Suggested direction:** Extract a slot-resolution collaborator; keep the service as the page-data assembler.
+**Est. effort:** M
+**Risk if untouched:** Depth-chart conflict logic hidden inside a large service; green-green extraction.
+**Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
+**Status:** Implemented 2026-07-26 — `SlotAssignmentResolver` + `SlotAssignmentResolverInterface` extracted; `buildAllSnapshots()` delegates via `resolveSlotSettings()`. Slot resolution now lives in `ibl5/classes/SavedDepthChart/SlotAssignmentResolver.php` behind `Contracts/SlotAssignmentResolverInterface.php`, injected into `SavedDepthChartService` with a nullable default. Behavior byte-identical; pinned by `testBuildAllSnapshots*` characterization tests plus `ibl5/tests/SavedDepthChart/SlotAssignmentResolverTest.php`.
+
 ## Axis 2: Module Structure Inconsistency
 
 ### 2.2 ActivityTracker / AllStarAppearances — No Service Layer

--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -1,6 +1,6 @@
 ---
 description: Long-running backlog of maintenance-cost reduction opportunities, organized by axis. Each item is a candidate for a future plan.
-last_verified: 2026-07-25
+last_verified: 2026-07-26
 ---
 
 # Maintenance-Cost Reduction Backlog
@@ -47,10 +47,10 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 | Status | Count |
 |--------|------:|
-| ✅ Implemented | 228 |
+| ✅ Implemented | 229 |
 | ◑ Partial | 25 |
 | 📋 Planned (plan queued / PR open) | 1 |
-| ⬜ Open | 67 |
+| ⬜ Open | 66 |
 | 🚫 Declined | 10 |
 
 > Status counts re-verified 2026-06-28 (exact, from the per-axis tables); **6.20 / 6.21 added 2026-06-29** from the PR #1107 review (⬜ Open +2); **6.22 added 2026-06-29** from the #1066 reject-IDOR review (⬜ Open +1). Two stale-Open rows were flipped directly (no plan owned them): **13.3**, **13.9** (✅ +2, ⬜ −2 vs the master re-count). **1.21–1.31 added 2026-07-24** from the hot-files comment→backlog migration (⬜ Open +11: 8 🟩 auto-mergeable, 3 🟨 conditional — 1.23/1.25/1.31 need characterization/endpoint pins). **Ground-truth audit 2026-07-24:** 7 stale-Open items flipped ✅, 2 false findings marked 🚫, 5 new Axis-1 rows seeded (1.32–1.36); IDOR PRs #1107–1110 merged 2026-06-29 (unblocking 2.10/2.13/2.14/2.25/7.7/14.6); PRs #1240/#1230/#1204 merged (2.6/2.31/2.32/5.18 already ✅/Open on own merits). **9.19 and 9.20 implemented 2026-07-24** — added READMEs to all 68 missing class dirs + frontmatter to all 16 existing class READMEs that lacked it; extended bin/check-docs IN_SCOPE_GLOBS (✅ +2, ⬜ −2); roll-up recomputed from grep (331 rows total, unchanged). **6.16 flipped ✅ 2026-07-24** (all Api data repos + JsonResponder + SystemClock tested; ✅ +1, ◑ −1). **6.14 Status updated 2026-07-24** (ProcessBoxscoresStep/GenerateSeasonAwardsStep/ParseJsbFilesStep added; still ◑). **Resolved rows collapsed 2026-07-25** — ✅/🚫 findings no longer appear as table rows; each axis carries a `> ✅ resolved (N): …` / `> 🚫 declined (N): …` summary line and their evidence lives in [archive/maintenance-backlog-archive.md](archive/maintenance-backlog-archive.md). **Recount recipe:** resolved = sum of the `(N)` in the per-axis summary lines; open = grep of the per-axis table rows; total = the two added. Counts above are unchanged by the collapse (238 + 93 = 331).
@@ -74,7 +74,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 **Automouse audit (verified 2026-06-20):**
 
-> ✅ resolved (18): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.20 — evidence in [archive](archive/maintenance-backlog-archive.md)
+> ✅ resolved (19): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.20, 1.34 — evidence in [archive](archive/maintenance-backlog-archive.md)
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
@@ -93,7 +93,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 1.31 | ⬜ Open | 🟨 | TradeRosterPreviewApiHandler 508 LOC — API handler mixing param validation + cash-row building + table render. Extract validation and cash-row collaborators; endpoint (request-handling) → add an E2E/characterization pin. |
 | 1.32 | ⬜ Open | 🟩 | StandingsRepository 726 LOC — per-category standings query methods. Extract per-category query collaborators; green-green DB pin. Shares `classes/Standings/` with 1.35 — plan as ONE chunk. |
 | 1.33 | ⬜ Open | 🟩 | Player 671 LOC — typed-getter accumulation. Extract per-domain typed-getter groups (contract, stats, identity); green-green. |
-| 1.34 | ⬜ Open | 🟩 | SavedDepthChartService 626 LOC — depth-chart data assembly + slot-conflict resolution. Extract slot-resolution collaborator; green-green. |
 | 1.35 | ⬜ Open | 🟩 | StandingsView 610 LOC — per-division block renderers. Extract per-division renderer collaborators; golden-master pin. Shares `classes/Standings/` with 1.32 — plan as ONE chunk. |
 | 1.36 | ⬜ Open | 🟩 | FreeAgencyView 590 LOC — offer-table/form/decision-panel renderers. Extract per-section renderer collaborators; golden-master pin. |
 
@@ -216,14 +215,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** Extract per-domain typed-getter groups (contract, stats, identity) into focused value-object collaborators; keep `Player` as the root entity.
 **Est. effort:** M
 **Risk if untouched:** Every new player attribute inflates one file; getter search spans the entire class.
-**Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
-
-### 1.34 SavedDepthChartService — Data Assembly + Slot-Conflict Resolution (626 LOC)
-**Location:** `ibl5/classes/SavedDepthChart/SavedDepthChartService.php` (626 lines)
-**Problem:** One service assembles depth-chart page data and resolves slot conflicts, mixing orchestration with conflict-resolution logic.
-**Suggested direction:** Extract a slot-resolution collaborator; keep the service as the page-data assembler.
-**Est. effort:** M
-**Risk if untouched:** Depth-chart conflict logic hidden inside a large service; green-green extraction.
 **Provenance:** Seeded 2026-07-24 — ground-truth audit hot-file scan.
 
 ### 1.35 StandingsView — Per-Division Block Renderer (610 LOC)

--- a/ibl5/tests/SavedDepthChart/SavedDepthChartServiceTest.php
+++ b/ibl5/tests/SavedDepthChart/SavedDepthChartServiceTest.php
@@ -226,6 +226,123 @@ class SavedDepthChartServiceTest extends WideUnitTestCase
         $this->assertQueryExecuted('ibl_saved_depth_charts');
     }
 
+    // ── buildAllSnapshots characterization (pins the slot-resolution seam) ──
+
+    /**
+     * Twelve depth-chart POST fields for one form slot, each a distinct value,
+     * so a mis-mapped key is visibly wrong rather than accidentally equal.
+     *
+     * NOTE the deliberate mixed casing: pg/sg/sf/pf/c/canPlayInGame/min are
+     * lowercase in the form; OF/DF/OI/DI/BH are UPPERCASE.
+     *
+     * @return array<string, int>
+     */
+    private function slotFields(int $slot, int $base): array
+    {
+        return [
+            'pg' . $slot => $base + 1,
+            'sg' . $slot => $base + 2,
+            'sf' . $slot => $base + 3,
+            'pf' . $slot => $base + 4,
+            'c' . $slot => $base + 5,
+            'canPlayInGame' . $slot => $base + 6,
+            'min' . $slot => $base + 7,
+            'OF' . $slot => $base + 8,
+            'DF' . $slot => $base + 9,
+            'OI' . $slot => $base + 10,
+            'DI' . $slot => $base + 11,
+            'BH' . $slot => $base + 12,
+        ];
+    }
+
+    /**
+     * Run saveOnSubmit through a mock repository and return the snapshot list
+     * that buildAllSnapshots() produced.
+     *
+     * @param list<array<string, mixed>> $rosterPlayers
+     * @param array<string, mixed> $postData
+     * @return list<array<string, mixed>>
+     */
+    private function captureSnapshots(array $rosterPlayers, array $postData): array
+    {
+        $captured = [];
+
+        $repo = self::createStub(SavedDepthChartRepositoryInterface::class);
+        $repo->method('getSavedDepthChartById')->willReturn([
+            'id' => 5, 'teamid' => 1, 'username' => 'testuser', 'name' => 'My DC',
+            'phase' => 'Regular Season', 'season_year' => 2024,
+            'sim_start_date' => '2024-01-01', 'sim_end_date' => null,
+            'sim_number_start' => 1, 'sim_number_end' => null,
+            'is_active' => 1, 'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        $repo->method('updateDepthChartPlayers')
+            ->willReturnCallback(function (int $id, array $snapshots) use (&$captured): void {
+                $captured = $snapshots;
+            });
+
+        $service = new SavedDepthChartService($this->mockDb, $repo);
+        $season = new Season($this->mockDb);
+        $service->saveOnSubmit(1, 'testuser', 'My DC', $rosterPlayers, $postData, 5, $season);
+
+        return $captured;
+    }
+
+    public function testBuildAllSnapshotsMapsEveryPostFieldToItsColumn(): void
+    {
+        $snapshots = $this->captureSnapshots(
+            [['pid' => 500, 'name' => 'Alice']],
+            ['pid1' => 500] + $this->slotFields(1, 100)
+        );
+
+        $this->assertCount(1, $snapshots);
+        $this->assertSame([
+            'pid' => 500,
+            'player_name' => 'Alice',
+            'ordinal' => 1,
+            'dc_pg_depth' => 101,
+            'dc_sg_depth' => 102,
+            'dc_sf_depth' => 103,
+            'dc_pf_depth' => 104,
+            'dc_c_depth' => 105,
+            'dc_can_play_in_game' => 106,
+            'dc_minutes' => 107,
+            'dc_of' => 108,
+            'dc_df' => 109,
+            'dc_oi' => 110,
+            'dc_di' => 111,
+            'dc_bh' => 112,
+        ], $snapshots[0]);
+    }
+
+    public function testBuildAllSnapshotsAdvancesOrdinalPastASkippedPlayer(): void
+    {
+        // Player 1 matches nothing (no pid1, no Name1) → skipped, but must still
+        // consume ordinal 1 so player 2 is recorded at ordinal 2.
+        $snapshots = $this->captureSnapshots(
+            [
+                ['pid' => 111, 'name' => 'Skipped'],
+                ['pid' => 222, 'name' => 'Matched'],
+            ],
+            ['pid2' => 222] + $this->slotFields(2, 200)
+        );
+
+        $this->assertCount(1, $snapshots);
+        $this->assertSame(222, $snapshots[0]['pid']);
+        $this->assertSame(2, $snapshots[0]['ordinal']);
+        $this->assertSame(201, $snapshots[0]['dc_pg_depth']);
+    }
+
+    public function testBuildAllSnapshotsProducesNoRowsWhenPostDataIsEmpty(): void
+    {
+        $snapshots = $this->captureSnapshots(
+            [['pid' => 999, 'name' => 'Nobody']],
+            []
+        );
+
+        $this->assertSame([], $snapshots);
+    }
+
     public function testSaveOnSubmitReusesUnusedMostRecentDc(): void
     {
         // loadedDcId = 0, so skip first branch

--- a/ibl5/tests/SavedDepthChart/SlotAssignmentResolverTest.php
+++ b/ibl5/tests/SavedDepthChart/SlotAssignmentResolverTest.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SavedDepthChart;
+
+use PHPUnit\Framework\TestCase;
+use SavedDepthChart\SlotAssignmentResolver;
+
+/**
+ * @covers \SavedDepthChart\SlotAssignmentResolver
+ */
+class SlotAssignmentResolverTest extends TestCase
+{
+    private SlotAssignmentResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resolver = new SlotAssignmentResolver();
+    }
+
+    /**
+     * Twelve depth-chart POST fields for one form slot, each a distinct value,
+     * so a mis-mapped key is visibly wrong rather than accidentally equal.
+     *
+     * Mixed casing is deliberate and load-bearing: pg/sg/sf/pf/c/canPlayInGame/min
+     * are lowercase in the submitted form; OF/DF/OI/DI/BH are UPPERCASE.
+     *
+     * @return array<string, int>
+     */
+    private function slotFields(int $slot, int $base): array
+    {
+        return [
+            'pg' . $slot => $base + 1,
+            'sg' . $slot => $base + 2,
+            'sf' . $slot => $base + 3,
+            'pf' . $slot => $base + 4,
+            'c' . $slot => $base + 5,
+            'canPlayInGame' . $slot => $base + 6,
+            'min' . $slot => $base + 7,
+            'OF' . $slot => $base + 8,
+            'DF' . $slot => $base + 9,
+            'OI' . $slot => $base + 10,
+            'DI' . $slot => $base + 11,
+            'BH' . $slot => $base + 12,
+        ];
+    }
+
+    // ── Case 1: loop bound of the pid strategy ──────────────────────────────
+
+    public function testPidMatchAtSlotFifteenIsFound(): void
+    {
+        // Player sits at ordinal 1, but its pid is submitted in slot 15.
+        // Mutant `$i < 15` → pid loop misses → ordinal fallback returns slot 1 → 201.
+        $post = ['pid15' => 700, 'Name1' => 'Someone Else']
+            + $this->slotFields(15, 100)
+            + $this->slotFields(1, 200);
+
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 700, 'name' => 'Zed'],
+            $post,
+            1
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(101, $result['pg']);
+    }
+
+    // ── Case 2: loop bound of the name strategy ─────────────────────────────
+
+    public function testNameMatchAtSlotFifteenIsFound(): void
+    {
+        // No pid fields at all, so the name loop is the only path to slot 15.
+        // Mutant `$i < 15` → name loop misses → ordinal fallback returns slot 1 → 201.
+        $post = ['Name15' => 'Zed', 'Name1' => 'Someone Else']
+            + $this->slotFields(15, 100)
+            + $this->slotFields(1, 200);
+
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 700, 'name' => 'Zed'],
+            $post,
+            1
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(101, $result['pg']);
+    }
+
+    // ── Case 4: the empty-name guard ────────────────────────────────────────
+
+    public function testEmptySubmittedNameDoesNotMatchAnEmptyPlayerName(): void
+    {
+        // Player has neither pid nor name; both submitted Name fields are ''.
+        // With the `$postName !== ''` guard the name loop matches nothing and the
+        // ordinal fallback returns slot 2. Mutant (guard removed) matches Name1
+        // against the empty player name and returns slot 1 → 101.
+        $post = ['Name1' => '', 'Name2' => '']
+            + $this->slotFields(1, 100)
+            + $this->slotFields(2, 200);
+
+        $result = $this->resolver->resolveSlotSettings([], $post, 2);
+
+        $this->assertNotNull($result);
+        $this->assertSame(201, $result['pg']);
+    }
+
+    // ── Case 5: strip_tags ──────────────────────────────────────────────────
+
+    public function testHtmlTagsInSubmittedNameAreStripped(): void
+    {
+        // Interesting slot is 3; player ordinal is 1 and Name1 exists, so a
+        // surviving mutant (strip_tags removed) falls through to slot 1 → 101.
+        $post = ['Name1' => 'Bob', 'Name3' => '<b>Alice</b>']
+            + $this->slotFields(1, 100)
+            + $this->slotFields(3, 300);
+
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 500, 'name' => 'Alice'],
+            $post,
+            1
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(301, $result['pg']);
+    }
+
+    // ── Case 6: trim (separate from case 5 on purpose) ──────────────────────
+
+    public function testWhitespacePaddedSubmittedNameIsTrimmed(): void
+    {
+        // Same shape as case 5 but exercising trim() alone — no tags involved,
+        // so removing strip_tags cannot mask a removed trim() or vice versa.
+        $post = ['Name1' => 'Bob', 'Name3' => '  Alice  ']
+            + $this->slotFields(1, 100)
+            + $this->slotFields(3, 300);
+
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 500, 'name' => 'Alice'],
+            $post,
+            1
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(301, $result['pg']);
+    }
+
+    // ── Case 7: strategy precedence ─────────────────────────────────────────
+
+    public function testPidMatchWinsOverNameMatchWhenTheyPointToDifferentSlots(): void
+    {
+        // pid says slot 4, name says slot 2. pid must win.
+        // Mutant that reorders the strategy chain (or drops the pid loop) → 201.
+        $post = ['pid4' => 500, 'Name2' => 'Alice']
+            + $this->slotFields(4, 400)
+            + $this->slotFields(2, 200);
+
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 500, 'name' => 'Alice'],
+            $post,
+            1
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(401, $result['pg']);
+    }
+
+    // ── Case 8: duplicate names + fall-through ──────────────────────────────
+
+    public function testDuplicateRosterNamesBothTakeTheFirstMatchingSlotAndUnmatchedPlayerFallsThrough(): void
+    {
+        // No pid fields — the name loop is the only strategy that can fire.
+        // Documented pre-existing behavior: BOTH same-named players resolve to the
+        // FIRST matching Name index (slot 1). A mutant that scans the name loop in
+        // reverse, or starts it at $ordinal, sends the second player to slot 2 → 201.
+        $post = ['Name1' => 'Alice', 'Name2' => 'Alice']
+            + $this->slotFields(1, 100)
+            + $this->slotFields(2, 200);
+
+        $first = $this->resolver->resolveSlotSettings(['pid' => 500, 'name' => 'Alice'], $post, 1);
+        $second = $this->resolver->resolveSlotSettings(['pid' => 501, 'name' => 'Alice'], $post, 2);
+        // Third player matches nothing and has no Name3 → falls through to null.
+        $third = $this->resolver->resolveSlotSettings(['pid' => 502, 'name' => 'Zoe'], $post, 3);
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertSame(101, $first['pg']);
+        $this->assertSame(101, $second['pg']);
+        $this->assertNull($third);
+    }
+
+    // ── Case 9: over-full chart (16th player) ───────────────────────────────
+
+    public function testSixteenthPlayerOnAnOverFullChartResolvesToNull(): void
+    {
+        // All 15 slots submitted and occupied by other players; this player is 16th.
+        $post = [];
+        for ($i = 1; $i <= 15; $i++) {
+            $post['pid' . $i] = $i;
+            $post['Name' . $i] = 'Player ' . $i;
+            $post += $this->slotFields($i, $i * 10);
+        }
+
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 999, 'name' => 'Sixteenth Man'],
+            $post,
+            16
+        );
+
+        $this->assertNull($result);
+    }
+
+    // ── Case 10: empty POST ─────────────────────────────────────────────────
+
+    public function testEmptyPostDataResolvesToNull(): void
+    {
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 500, 'name' => 'Alice'],
+            [],
+            1
+        );
+
+        $this->assertNull($result);
+    }
+
+    // ── Case 11: the full 12-key mapping, including field-name casing ───────
+
+    public function testEveryDepthChartKeyMapsFromTheMatchedSlot(): void
+    {
+        // assertSame on the whole array kills any key-rename or casing mutant
+        // (e.g. 'OF' -> 'of', 'canPlayInGame' -> 'canplayingame').
+        $post = ['pid7' => 500] + $this->slotFields(7, 700);
+
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 500, 'name' => 'Alice'],
+            $post,
+            1
+        );
+
+        $this->assertSame([
+            'pg' => 701,
+            'sg' => 702,
+            'sf' => 703,
+            'pf' => 704,
+            'c' => 705,
+            'canPlayInGame' => 706,
+            'min' => 707,
+            'of' => 708,
+            'df' => 709,
+            'oi' => 710,
+            'di' => 711,
+            'bh' => 712,
+        ], $result);
+    }
+
+    // ── Case 12: extractIntFromPost coercion, incl. negative paths ──────────
+
+    public function testNonNumericMissingAndNullPostValuesCoerceToZero(): void
+    {
+        $post = [
+            'pid2' => 500,
+            'pg2' => '12',    // numeric string -> 12
+            'sg2' => 'abc',   // non-numeric string -> 0
+            'sf2' => null,    // null -> 0 (?? fires)
+            'pf2' => 7,       // int passes through
+            'c2' => 1.9,      // float is NOT handled by extractIntFromPost -> 0
+            // min2 / OF2 / DF2 / OI2 / DI2 / BH2 absent -> 0
+        ];
+
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 500, 'name' => 'Alice'],
+            $post,
+            1
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(12, $result['pg']);
+        $this->assertSame(0, $result['sg']);
+        $this->assertSame(0, $result['sf']);
+        $this->assertSame(7, $result['pf']);
+        $this->assertSame(0, $result['c']);
+        $this->assertSame(0, $result['min']);
+        $this->assertSame(0, $result['bh']);
+    }
+
+    // ── Case 13: pid comparison is int-normalized on both sides ─────────────
+
+    public function testNumericStringPidInPostStillMatchesAnIntegerPlayerPid(): void
+    {
+        // Form fields arrive as strings. Mutant that drops toInt() around the POST
+        // value makes '500' === 500 false → falls through to slot 1 → 101.
+        $post = ['pid3' => '500', 'Name1' => 'Someone Else']
+            + $this->slotFields(3, 300)
+            + $this->slotFields(1, 100);
+
+        $result = $this->resolver->resolveSlotSettings(
+            ['pid' => 500, 'name' => 'Alice'],
+            $post,
+            1
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(301, $result['pg']);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the pid→name→ordinal slot-matching logic and POST-field assembly out of `SavedDepthChartService` into a new `SlotAssignmentResolver` behind a new `SlotAssignmentResolverInterface`, injected as a nullable constructor default.

**New files:**
- `ibl5/classes/SavedDepthChart/Contracts/SlotAssignmentResolverInterface.php` — typed `resolveSlotSettings()` contract + `SlotSettings` PHPStan shape
- `ibl5/classes/SavedDepthChart/SlotAssignmentResolver.php` — three-strategy match (pid→name→ordinal), `extractIntFromPost()`, `MAX_SLOTS=15` constant
- `ibl5/tests/SavedDepthChart/SlotAssignmentResolverTest.php` — 12 mutation-surviving tests

**Modified files:**
- `ibl5/classes/SavedDepthChart/SavedDepthChartService.php` — constructor gains 4th nullable param; `buildAllSnapshots()` loop delegates; `findPidIndex()` and `extractIntFromPost()` deleted
- `ibl5/tests/SavedDepthChart/SavedDepthChartServiceTest.php` — +3 characterization tests pinning the seam
- `ibl5/docs/backlog/maintenance-backlog.md` — item 1.34 flipped ✅, archived

Behavior is byte-identical. Resolves maintenance-backlog item 1.34.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
