### PR TITLE
fix(sim-recap): pin mysql 8.4 and fix store stderr

### DIFF
--- a/bin/sim-recap-prompt
+++ b/bin/sim-recap-prompt
@@ -22,6 +22,15 @@
 #   SIM_RECAP_DB_PORT   MySQL port. Default: 13306
 #   SIM_RECAP_DB_USER   MySQL user (no default — must be set in env)
 #   SIM_RECAP_DB_NAME   MySQL database name (no default — must be set in env)
+#   SIM_RECAP_MYSQL_BIN mysql client the agent is told to run.
+#                       Default: /opt/homebrew/opt/mysql@8.4/bin/mysql
+#                       Pinned deliberately, NOT left as bare `mysql`. The
+#                       launchd PATH resolves `mysql` to Homebrew's current
+#                       release (9.7.1), whose client DROPPED the
+#                       mysql_native_password plugin — it cannot authenticate
+#                       against the prod server at all (ERROR 2059). Every run
+#                       otherwise burns agent turns rediscovering that and
+#                       hunting for an 8.x client (sim 722, 2026-07-26).
 #
 # The database password is NEVER injected into the prompt. It travels via
 # MYSQL_PWD in the agent's environment. Prompts appear in logs and process
@@ -38,6 +47,7 @@ SIM_RECAP_DB_HOST="${SIM_RECAP_DB_HOST:-127.0.0.1}"
 SIM_RECAP_DB_PORT="${SIM_RECAP_DB_PORT:-13306}"
 SIM_RECAP_DB_USER="${SIM_RECAP_DB_USER:-}"
 SIM_RECAP_DB_NAME="${SIM_RECAP_DB_NAME:-}"
+SIM_RECAP_MYSQL_BIN="${SIM_RECAP_MYSQL_BIN:-/opt/homebrew/opt/mysql@8.4/bin/mysql}"
 
 # --- Arg parsing ---
 sim=""
@@ -107,9 +117,15 @@ cat <<DATA_EOF
 
 Sim number: ${sim}
 
-Query live game data using the mysql client. Connect with:
+Query live game data using the mysql client. Use this EXACT command — copy the binary
+path and the --default-auth flag verbatim:
 
-  mysql -h ${SIM_RECAP_DB_HOST} -P ${SIM_RECAP_DB_PORT} -u ${SIM_RECAP_DB_USER} ${SIM_RECAP_DB_NAME}
+  ${SIM_RECAP_MYSQL_BIN} --default-auth=mysql_native_password -h ${SIM_RECAP_DB_HOST} -P ${SIM_RECAP_DB_PORT} -u ${SIM_RECAP_DB_USER} ${SIM_RECAP_DB_NAME}
+
+Do not substitute a bare "mysql". The one on PATH is a 9.x client that has dropped the
+mysql_native_password plugin and cannot authenticate against this server (ERROR 2059).
+The path above is the working client; it is already resolved for you, so do not go
+looking for another one.
 
 The database password is available in your environment as MYSQL_PWD. Do not pass it on
 the command line — mysql reads it from MYSQL_PWD automatically.
@@ -218,7 +234,25 @@ Strict field types:
   - game_of_that_day: use 0 (integer zero, not null) when there was exactly one game on that date
   - themes: array of strings — narrative angles you used this run (for the next ledger)
 
-Write nothing else, anywhere. One file. payload.json. That is all.
+== HOW TO PRODUCE IT ==
+
+Write payload.json DIRECTLY with the Write tool, as literal JSON.
+
+Do NOT write a Python (or any other) script that generates, assembles, templates,
+or emits payload.json. No gen.py, no build_payload.py, no heredoc'd generator. You
+are the generator. Every recap_text is prose you write; every field around it is a
+value you already looked up. Putting those same literals into a script that then
+prints them adds a step and buys nothing — the caller already validates the result.
+
+Scratch files, when you genuinely need one (a query dump, notes):
+
+  - Put them in your CURRENT WORKING DIRECTORY. Nowhere else.
+  - NEVER write to /tmp. /tmp survives between runs, so a file you write there
+    collides with one an EARLIER run left behind — that is not hypothetical, it
+    cost sim 722 a full needless rewrite of a 27KB file under a second name.
+  - Your cwd is a fresh per-run directory that is deleted when the run ends.
+    Nothing you put there can collide with anything, and you never need to clean
+    it up or pick a "fresh path" to dodge an existing file.
 
 CONTRACT_EOF
 

--- a/bin/sim-recap-tick
+++ b/bin/sim-recap-tick
@@ -43,12 +43,19 @@ SIM_RECAP_DB_HOST="${SIM_RECAP_DB_HOST:-127.0.0.1}"
 SIM_RECAP_DB_PORT="${SIM_RECAP_DB_PORT:-13306}"
 SIM_RECAP_DB_USER="${SIM_RECAP_DB_USER:-}"
 SIM_RECAP_DB_NAME="${SIM_RECAP_DB_NAME:-}"
+# Pinned, not bare `mysql`: the launchd PATH resolves to Homebrew's 9.x client,
+# which dropped mysql_native_password and cannot authenticate at all (ERROR 2059).
+# Same default as sim-recap-prompt, which documents the full why; the tick keeps
+# its own copy so preflight_mysql can check the binary the agent will actually be
+# told to run, and exports it so both sides can never disagree.
+SIM_RECAP_MYSQL_BIN="${SIM_RECAP_MYSQL_BIN:-/opt/homebrew/opt/mysql@8.4/bin/mysql}"
 # SIM_RECAP_DB_PASSWORD is read from the environment ONLY (never defaulted, never
 # argv, never logged). require_password() enforces its presence on the live path.
 
 # The prompt builder reads the DB coordinates from its environment (never the
 # password — that reaches the agent through MYSQL_PWD at spawn time).
 export SIM_RECAP_DB_HOST SIM_RECAP_DB_PORT SIM_RECAP_DB_USER SIM_RECAP_DB_NAME
+export SIM_RECAP_MYSQL_BIN
 
 # ── Per-run temp working dir (security constraint 7 / ADR-0062) ───────────────
 # Global so the EXIT trap can see it; assigned in generate()/dry_run().
@@ -162,10 +169,20 @@ ensure_tunnel() {
 # ── Run the generation agent in the temp dir; leaves payload.json on success ──
 run_agent() { # sim prompt
     local sim="$1" prompt="$2"
-    # --allowedTools is the STRUCTURAL enforcement of security constraint 2: with
-    # only Bash(mysql:*) and Write, the agent has no ssh, no curl, no gh. The
-    # password reaches it via MYSQL_PWD in this subshell env — never in the prompt,
-    # never in argv, never logged.
+    # --allowedTools narrows what runs WITHOUT a prompt; it is NOT a sandbox, and
+    # this comment used to claim otherwise. ~/.claude/settings.json allows bare
+    # `Bash` with defaultMode auto, so the flag is additive: the agent can and does
+    # run python3, rm, sed. Do not "fix" that by tightening Bash to mysql-only —
+    # the generation run legitimately needs scratch-file tooling.
+    #
+    # What actually enforces security constraint 2 is the CREDENTIAL split, and it
+    # holds independently of any tool flag: the only secret this subshell hands the
+    # agent is MYSQL_PWD for a SELECT-only user (never in the prompt, never in
+    # argv, never logged). Every privileged queue action is a prod-side
+    # simRecapQueue.php call the tick makes on its own, with inputs the agent never
+    # supplies. Residual gap, accepted: the agent inherits the Mac's ssh identity
+    # and could in principle reach prod that way — the trust boundary here is the
+    # code we hand it, not the tool list.
     ( cd "$WORKDIR" && MYSQL_PWD="${SIM_RECAP_DB_PASSWORD:-}" \
         timeout "$SIM_RECAP_CLAUDE_TIMEOUT" "$SIM_RECAP_CLAUDE_BIN" -p "$prompt" \
             --model "$SIM_RECAP_MODEL" --output-format json \
@@ -213,10 +230,18 @@ generate() { # sim
     fi
 
     # Store: pipe the payload on stdin (never argv — multi-KB, ps-visible).
+    # Do NOT add 2>&1 here. ssh writes non-JSON banners to stderr — OpenSSH 10.2
+    # emits a post-quantum-KEX warning whenever a store opens a fresh connection
+    # instead of riding the ControlMaster — and merging that into $store makes
+    # jq_ok choke on a perfectly good response. That is not hypothetical: sim 722
+    # (2026-07-26) stored all 56 recaps, then logged "store failed (rc=0)" and
+    # tried to park an already-done row. Leave stderr on the tick's own stderr,
+    # where launchd captures it uninterleaved. (run_agent's 2>&1 is different and
+    # correct — claude_env_error greps that merged blob for rate-limit text.)
     local store store_rc
     store="$("$SIM_RECAP_SSH_BIN" "$SIM_RECAP_SSH_HOST" \
         "php $SIM_RECAP_REMOTE_ROOT/ibl5/scripts/storeSimRecap.php --sim=$sim" \
-        < "$WORKDIR/payload.json" 2>&1)"
+        < "$WORKDIR/payload.json")"
     store_rc=$?
     if [ "$store_rc" -eq 0 ] && jq_ok "$store" '.ok == true'; then
         log "sim $sim: stored ($(printf '%s' "$store" | "$SIM_RECAP_JQ_BIN" -r '.games' 2>/dev/null) game recaps)"
@@ -294,6 +319,18 @@ main() {
     # zero attempts.
     if ! command -v "$SIM_RECAP_CLAUDE_BIN" >/dev/null 2>&1; then
         log "ERROR: agent binary '$SIM_RECAP_CLAUDE_BIN' not found on PATH ($PATH) — aborting tick (no sim claimed)"
+        return 1
+    fi
+
+    # Same preflight, for the mysql client. The prompt hands the agent this exact
+    # path and tells it not to go hunting for another one — which is right (the
+    # one on PATH cannot authenticate) but removes the recovery it improvised for
+    # sim 722. If the pin ever goes stale (mysql@8.4 unlinked, EOL'd, upgraded out
+    # from under us), every query the agent makes fails, it produces no payload,
+    # and the sim parks — one wasted attempt per poll, same shape as sim 721's
+    # rc=127. Cost zero attempts instead.
+    if ! command -v "$SIM_RECAP_MYSQL_BIN" >/dev/null 2>&1; then
+        log "ERROR: mysql client '$SIM_RECAP_MYSQL_BIN' not found — aborting tick (no sim claimed)"
         return 1
     fi
 

--- a/bin/test-sim-recap-tick
+++ b/bin/test-sim-recap-tick
@@ -79,6 +79,14 @@ if printf '%s' "$cmd" | grep -q 'storeSimRecap\.php'; then
         printf '{"ok":false,"error":"stub store failure"}\n'
         exit 1
     fi
+    # store-banner: real ssh writes non-JSON banners to STDERR while still
+    # exiting 0 with good JSON on stdout (OpenSSH 10.2's post-quantum-KEX
+    # warning). If the tick merges stderr into the captured response, the JSON
+    # parse fails and a successful store is misreported as a failure.
+    if [ -f "$STUB/store-banner" ]; then
+        printf '** WARNING: connection is not using a post-quantum key exchange algorithm.\n' >&2
+        printf '** This session may be vulnerable to "store now, decrypt later" attacks.\n' >&2
+    fi
     cat "$STUB/resp.store" 2>/dev/null || printf '{"ok":true,"sim":42,"games":5}\n'
     exit 0
 fi
@@ -131,12 +139,22 @@ SH
 printf 'PROMPT_MARKER_SIM_RECAP\n'
 SH
 
-    chmod +x "$STUB/ssh" "$STUB/claude" "$STUB/prompt"
+    # mysql stub: never executed here (only the agent queries, and the agent is
+    # stubbed) — it exists so the tick's preflight `command -v` has something to
+    # resolve. Without it the suite would pass or fail on whether THIS machine
+    # happens to have mysql@8.4 installed.
+    cat > "$STUB/mysql" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+    chmod +x "$STUB/ssh" "$STUB/claude" "$STUB/prompt" "$STUB/mysql"
 
     export STUB
     export SIM_RECAP_SSH_BIN="$STUB/ssh"
     export SIM_RECAP_CLAUDE_BIN="$STUB/claude"
     export SIM_RECAP_PROMPT_BIN="$STUB/prompt"
+    export SIM_RECAP_MYSQL_BIN="$STUB/mysql"
     export SIM_RECAP_SSH_HOST="test-host"
     export SIM_RECAP_REMOTE_ROOT=""
     export SIM_RECAP_DB_HOST="127.0.0.1"
@@ -152,9 +170,10 @@ SH
 srt_reset() {
     rm -f "$STUB"/ssh.log "$STUB"/claude.log "$STUB"/claude.sentinel \
           "$STUB"/tick.out "$STUB"/agent-fails "$STUB"/agent-usage-limit \
-          "$STUB"/store-fails "$STUB"/resp.* "$STUB"/fail.* \
+          "$STUB"/store-fails "$STUB"/store-banner "$STUB"/resp.* "$STUB"/fail.* \
           "$STUB"/record-stdin "$STUB"/store.cmd "$STUB"/store.stdin 2>/dev/null
     export SIM_RECAP_DB_PASSWORD="test_db_password"
+    export SIM_RECAP_MYSQL_BIN="$STUB/mysql"
     unset SIM_RECAP_KEEP_WORKDIR 2>/dev/null || true
 }
 
@@ -362,6 +381,20 @@ else
     srt_ok "workdir_removed_on_failure"
 fi
 
+# ── missing_mysql_bin_aborts_before_claiming ─────────────────────────────────
+# The prompt pins the mysql path and tells the agent not to look for another one,
+# so a stale pin is unrecoverable from inside the agent: it would query nothing,
+# emit no payload, and park — burning one of two attempts every 300s poll until
+# the sim is permanently failed. Preflight it like the claude binary (sim 721):
+# a broken environment must cost zero attempts and zero agent spawns.
+srt_reset
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+SIM_RECAP_MYSQL_BIN="$STUB/nonexistent-mysql" srt_run
+srt_expect_eq  "missing_mysql_bin_aborts_before_claiming — exit 1" 1 "$SRT_RC"
+srt_file_absent "$STUB/ssh.log"         "missing_mysql_bin_aborts_before_claiming — no ssh called"
+srt_file_absent "$STUB/claude.sentinel" "missing_mysql_bin_aborts_before_claiming — zero claude"
+srt_log_has    "$STUB" tick.out "mysql client" "missing_mysql_bin_aborts_before_claiming — logged why"
+
 # ── missing_password_exits_before_ssh ────────────────────────────────────────
 srt_reset
 ( unset SIM_RECAP_DB_PASSWORD; "$SRT_DRIVER" > "$STUB/tick.out" 2>&1 )
@@ -400,6 +433,22 @@ if [ "${_plist_count:-0}" -eq 0 ]; then
 else
     srt_fail "no_plist_committed — found: $(git -C "$_repo_root" ls-files '*.plist')"
 fi
+
+# ── ssh_stderr_banner_does_not_break_store ───────────────────────────────────
+# Regression, sim 722 (2026-07-26): the store call captured stdout with 2>&1, so
+# an ssh stderr banner landed in front of the JSON, jq_ok rejected it, and a
+# store that had written all 56 recaps logged "store failed (rc=0)" and then
+# tried to park an already-done row. The data was correct and only the log lied,
+# so this bug is invisible without a test. Guard: stderr noise + rc 0 + good
+# JSON on stdout must still read as a success — no "store failed", no park.
+srt_reset
+touch "$STUB/store-banner"
+printf '{"ok":true,"cmd":"claim-next","sim":"42"}' > "$STUB/resp.claim-next"
+srt_run
+srt_expect_eq  "ssh_stderr_banner_does_not_break_store — exit 0" 0 "$SRT_RC"
+srt_log_has    "$STUB" tick.out  "stored"        "ssh_stderr_banner_does_not_break_store — logged stored"
+srt_log_lacks  "$STUB" tick.out  "store failed"  "ssh_stderr_banner_does_not_break_store — no false failure"
+srt_log_lacks  "$STUB" ssh.log   "simRecapQueue.php park" "ssh_stderr_banner_does_not_break_store — no park"
 
 # ── payload_contract_stdin_and_command ───────────────────────────────────────
 # Verify: tick emits --sim= in the storeSimRecap command (no --themes= flag),


### PR DESCRIPTION
## Summary
- Pin `SIM_RECAP_MYSQL_BIN` to mysql@8.4 (mysql 9.x dropped `mysql_native_password` auth, cannot connect to prod server)
- Fix regression: remove `2>&1` from store ssh call to prevent stderr banners (OpenSSH 10.2 post-quantum KEX warnings) from corrupting JSON parsing on successful stores
- Add preflight `command -v` check for mysql binary to fail early if stale, eliminating wasted agent attempts
- Add guidance to agent prompt: write payload.json directly (not via script generator), use scratch files in cwd only (not /tmp) to avoid collisions with prior runs
- Add tests for missing mysql binary and stderr banner scenarios

## Manual Testing

No manual testing needed — verified by automated tests.
