### PR TITLE
refactor: split BugReportRepository into three sub-repositories behind interfaces

### DIFF
--- a/ibl5/classes/BugPipeline/BugPipelineStateRepository.php
+++ b/ibl5/classes/BugPipeline/BugPipelineStateRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BugPipeline;
+
+use BugPipeline\Contracts\BugPipelineStateRepositoryInterface;
+
+/**
+ * Per-channel backfill watermark store for the Discord bug pipeline
+ * (`ibl_bug_pipeline_state`). Split out of {@see BugReportRepository}
+ * (backlog 1.26); the facade delegates to it.
+ */
+class BugPipelineStateRepository extends \BaseMysqliRepository implements BugPipelineStateRepositoryInterface
+{
+    public function upsertPipelineState(string $channelId, string $messageId): void
+    {
+        // Monotonic: GREATEST() keeps the highest snowflake seen — the cursor only moves forward.
+        $this->execute(
+            'INSERT INTO `ibl_bug_pipeline_state` (channel_id, last_processed_message_id, updated_at)
+             VALUES (?, ?, NOW())
+             ON DUPLICATE KEY UPDATE
+                 last_processed_message_id = GREATEST(last_processed_message_id, VALUES(last_processed_message_id)),
+                 updated_at = NOW()',
+            'ss',
+            $channelId,
+            $messageId
+        );
+    }
+
+    /**
+     * PR #4 backfill cursor. Returns the watermark snowflake as a STRING, or null on first boot.
+     */
+    public function findPipelineState(string $channelId): ?string
+    {
+        $row = $this->fetchOne(
+            'SELECT last_processed_message_id FROM `ibl_bug_pipeline_state` WHERE channel_id = ? LIMIT 1',
+            's',
+            $channelId
+        );
+        if ($row === null) {
+            return null;
+        }
+        return isset($row['last_processed_message_id']) && is_scalar($row['last_processed_message_id'])
+            ? (string) $row['last_processed_message_id']
+            : null;
+    }
+}

--- a/ibl5/classes/BugPipeline/BugReportClaimRepository.php
+++ b/ibl5/classes/BugPipeline/BugReportClaimRepository.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BugPipeline;
+
+use BugPipeline\Contracts\BugReportClaimRepositoryInterface;
+
+/**
+ * Lease/claim + state-machine writer for the Discord bug pipeline.
+ *
+ * Owns the atomic lease primitives (single-flight claims, stale-lease reclaim,
+ * blocked-hunt resume), the general transition() writer, and the conditional
+ * writers transition()'s value-bind cannot express. Split out of
+ * {@see BugReportRepository} (backlog 1.26); the facade delegates to it.
+ *
+ * @phpstan-import-type BugReportRow from \BugPipeline\BugReportRowCasting
+ */
+class BugReportClaimRepository extends \BaseMysqliRepository implements BugReportClaimRepositoryInterface
+{
+    use BugReportRowCasting;
+
+    /**
+     * Optional column => mysqli type map for transition(). Column names are compile-time
+     * literals from this fixed map (never caller input); values are always bound.
+     *
+     * @var array<string, string>
+     */
+    private const OPTIONAL_TRANSITION_COLUMNS = [
+        'class'               => 's',
+        'pr_number'           => 'i',
+        'issue_number'        => 'i',
+        'thread_id'           => 's',
+        'approval_message_id' => 's',
+        'blocked_until'       => 's',
+        'hunt_attempts'       => 'i',
+    ];
+
+    /**
+     * Fetch a single report by PK, snowflake-cast. Private helper so the claim
+     * primitives can return the freshly-claimed row without depending on the
+     * facade's read methods.
+     *
+     * @phpstan-return BugReportRow|null
+     */
+    private function fetchReportById(int $id): ?array
+    {
+        $row = $this->fetchOne('SELECT * FROM `ibl_bug_reports` WHERE id = ? LIMIT 1', 'i', $id);
+        return $row === null ? null : $this->castRow($row);
+    }
+
+    /**
+     * Single-flight claim: the "AND status='queued'" guard makes this atomic.
+     * A row already 'hunting' (claimed by another worker) matches 0 rows => returns false.
+     */
+    public function claimQueued(int $id, string $leaseOwner, string $leaseExpires): bool
+    {
+        return $this->execute(
+            "UPDATE `ibl_bug_reports` SET status = 'hunting', lease_owner = ?, lease_expires = ?
+             WHERE id = ? AND status = 'queued'",
+            'ssi',
+            $leaseOwner,
+            $leaseExpires,
+            $id
+        ) === 1;
+    }
+
+    /**
+     * Pick oldest queued report and claim it. One attempt — lost-race returns null.
+     * @phpstan-return BugReportRow|null
+     */
+    public function claimNextQueued(string $leaseOwner, string $leaseExpires): ?array
+    {
+        $row = $this->fetchOne(
+            "SELECT id FROM `ibl_bug_reports` WHERE status = 'queued' ORDER BY id ASC LIMIT 1"
+        );
+        if ($row === null) {
+            return null;
+        }
+        /** @var int $id */
+        $id = $row['id'];
+
+        // Lost-race safe: if another worker claimed $id, claimQueued matches 0 rows => null.
+        if (!$this->claimQueued($id, $leaseOwner, $leaseExpires)) {
+            return null;
+        }
+        return $this->fetchReportById($id);
+    }
+
+    /**
+     * Reclaim a crashed hunt whose lease expired. Separate primitive — never widens claimQueued.
+     * @phpstan-return BugReportRow|null
+     */
+    public function reclaimStaleLease(string $newLeaseOwner, string $leaseExpires): ?array
+    {
+        $row = $this->fetchOne(
+            "SELECT id FROM `ibl_bug_reports`
+             WHERE status = 'hunting' AND lease_expires < NOW()
+             ORDER BY id ASC LIMIT 1"
+        );
+        if ($row === null) {
+            return null;
+        }
+        /** @var int $id */
+        $id = $row['id'];
+
+        // Re-assert both predicates in the UPDATE so a concurrent reclaimer can't double-claim.
+        $claimed = $this->execute(
+            "UPDATE `ibl_bug_reports` SET lease_owner = ?, lease_expires = ?
+             WHERE id = ? AND status = 'hunting' AND lease_expires < NOW()",
+            'ssi',
+            $newLeaseOwner,
+            $leaseExpires,
+            $id
+        ) === 1;
+        if (!$claimed) {
+            return null;
+        }
+        return $this->fetchReportById($id);
+    }
+
+    /**
+     * Pick the oldest queued report that is READY TO HUNT and claim it into `hunting`.
+     * One attempt — lost-race returns null (PR #5b Phase 2 — the deadlock-closing claim).
+     *
+     * Narrower than claimNextQueued() by design: a hunt may only start on a row that has
+     * already been classified (`class IS NOT NULL`) and is not parked by a usage-limit
+     * backoff (`blocked_until` in the future). claimNextQueued() stays as-is for any caller
+     * that wants the raw oldest-queued primitive; this method never widens it.
+     *
+     * @phpstan-return BugReportRow|null
+     */
+    public function claimNextHuntable(string $leaseOwner, string $leaseExpires): ?array
+    {
+        $row = $this->fetchOne(
+            "SELECT id FROM `ibl_bug_reports`
+             WHERE status = 'queued'
+               AND class IS NOT NULL
+               AND (blocked_until IS NULL OR blocked_until <= NOW())
+             ORDER BY id ASC LIMIT 1"
+        );
+        if ($row === null) {
+            return null;
+        }
+        /** @var int $id */
+        $id = $row['id'];
+
+        // Lost-race safe: claimQueued re-asserts `status='queued'` in the UPDATE (0 rows => null).
+        if (!$this->claimQueued($id, $leaseOwner, $leaseExpires)) {
+            return null;
+        }
+        return $this->fetchReportById($id);
+    }
+
+    /**
+     * Atomically resume a usage-limit-parked hunt: `blocked` → `hunting`, re-stamping the lease.
+     * Returns true only when THIS call flipped the row (PR #5b Phase 7 — the resume guard).
+     *
+     * transition() is an unconditional `WHERE id = ?` write, so it cannot express the
+     * single-flight predicate two overlapping ticks need: both surface the ripe `blocked`
+     * row, both call this, only the one whose UPDATE still sees `status='blocked'` wins
+     * (affected_rows == 1); the loser gets 0 and skips. Re-stamping lease_expires closes the
+     * window where reclaimStaleLease() could immediately steal the freshly-resumed hunt.
+     */
+    public function resumeBlockedHunt(string $leaseOwner, string $leaseExpires, int $id): bool
+    {
+        return $this->execute(
+            "UPDATE `ibl_bug_reports`
+                SET status = 'hunting', lease_owner = ?, lease_expires = ?, updated_at = NOW()
+             WHERE id = ?
+               AND status = 'blocked'
+               AND (blocked_until IS NULL OR blocked_until <= NOW())",
+            'ssi',
+            $leaseOwner,
+            $leaseExpires,
+            $id
+        ) === 1;
+    }
+
+    /**
+     * General state-machine writer: set status plus any subset of optional metadata columns.
+     * The §3d cron CLI (transition <id> <status> [opts]) is a thin wrapper over this method.
+     *
+     * Conditional-SQL, NOT null-bind: only columns whose key is present in $opts are written;
+     * an absent key keeps the column's current value ("build conditional SQL; bind_param has no
+     * NULL type" — core-coding.md). Keys outside OPTIONAL_TRANSITION_COLUMNS are ignored.
+     *
+     * $setClauses fragments ('status = ?', 'pr_number = ?', …) derive from the fixed
+     * OPTIONAL_TRANSITION_COLUMNS constant (compile-time literal column names / bound params) —
+     * concatenate literal fragments, do NOT interpolate values.
+     *
+     * @param array<string, int|string> $opts Accepted keys: pr_number, issue_number, hunt_attempts
+     *   (ints); class (ENUM string); thread_id, approval_message_id (snowflakes, bound "s");
+     *   blocked_until (DATETIME string). Any other key is ignored.
+     * @param bool $releaseLease When true, atomically NULLs lease_owner + lease_expires in the
+     *   SAME UPDATE. Required for →needs_human / →queued reset to be a single-flight-safe op.
+     * @return bool True when the row (PK $id) was updated.
+     */
+    public function transition(int $id, string $status, array $opts = [], bool $releaseLease = false): bool
+    {
+        $setClauses = ['status = ?'];
+        $types = 's';
+        $values = [$status];
+
+        foreach (self::OPTIONAL_TRANSITION_COLUMNS as $col => $type) {
+            if (array_key_exists($col, $opts)) {
+                $setClauses[] = $col . ' = ?';
+                $types .= $type;
+                $values[] = $opts[$col];
+            }
+        }
+        if ($releaseLease) {
+            // Literal NULLs (no bound param) — atomic lease-drop for →needs_human / →queued reset.
+            $setClauses[] = 'lease_owner = NULL';
+            $setClauses[] = 'lease_expires = NULL';
+        }
+        $setClauses[] = 'updated_at = NOW()';
+
+        // $setClauses elements are literal fragments from the fixed constant map above;
+        // no runtime value is interpolated into column names — only ? placeholders for values.
+        $query = 'UPDATE `ibl_bug_reports` SET ' . implode(', ', $setClauses) . ' WHERE id = ?';
+        $types .= 'i';
+        $values[] = $id;
+
+        return $this->execute($query, $types, ...$values) === 1;
+    }
+
+    /**
+     * Advance a report from awaiting_ajay to the ready-for-plan sub-state by NULLing
+     * approval_message_id. Status stays 'awaiting_ajay' — the cron drives /plan then sets 'planned'.
+     */
+    public function advanceOnApproval(string $messageId): bool
+    {
+        // ✅ = "ready-for-plan", NOT "planned". NULL the approval pointer and keep
+        // status='awaiting_ajay' so the cron can enumerate awaiting_ajay AND approval_message_id IS NULL.
+        return $this->execute(
+            "UPDATE `ibl_bug_reports` SET approval_message_id = NULL
+             WHERE approval_message_id = ? AND status = 'awaiting_ajay'",
+            's',
+            $messageId
+        ) === 1;
+    }
+
+    public function stampThreadReply(string $threadId): bool
+    {
+        return $this->execute(
+            'UPDATE `ibl_bug_reports` SET last_gm_reply_at = NOW() WHERE thread_id = ?',
+            's',
+            $threadId
+        ) >= 1;
+    }
+
+    /**
+     * At-most-once idle reminder stamp. The `AND reminder_sent_at IS NULL` guard makes a repeat
+     * call a no-op, so a row can receive at most one reminder over its lifetime (PR #5a Phase 6).
+     * transition()'s value-bind cannot express this conditional WHERE, hence a dedicated method.
+     */
+    public function markReminderSent(int $id): bool
+    {
+        return $this->execute(
+            "UPDATE `ibl_bug_reports` SET reminder_sent_at = NOW(), updated_at = NOW()
+             WHERE id = ? AND reminder_sent_at IS NULL",
+            'i',
+            $id
+        ) === 1;
+    }
+
+    /** Stamp last_processed_at = NOW() so the same GM reply is not re-processed next tick. */
+    public function stampLastProcessed(int $id): bool
+    {
+        return $this->execute(
+            'UPDATE `ibl_bug_reports` SET last_processed_at = NOW(), updated_at = NOW() WHERE id = ?',
+            'i',
+            $id
+        ) === 1;
+    }
+
+    /**
+     * Clear a usage-limit park stamp (blocked_until = NULL). Literal NULL, no bound value —
+     * mirrors transition()'s $releaseLease idiom (bind_param has no NULL type). PR #5a Phase 6 resume.
+     */
+    public function clearBlocked(int $id): bool
+    {
+        return $this->execute(
+            'UPDATE `ibl_bug_reports` SET blocked_until = NULL, updated_at = NOW() WHERE id = ?',
+            'i',
+            $id
+        ) === 1;
+    }
+}

--- a/ibl5/classes/BugPipeline/BugReportRepository.php
+++ b/ibl5/classes/BugPipeline/BugReportRepository.php
@@ -4,35 +4,31 @@ declare(strict_types=1);
 
 namespace BugPipeline;
 
+use BugPipeline\Contracts\BugPipelineStateRepositoryInterface;
+use BugPipeline\Contracts\BugReportClaimRepositoryInterface;
+use BugPipeline\Contracts\BugReporterProfileRepositoryInterface;
+
 /**
- * Single source of all queue DB logic for the Discord bug pipeline.
+ * Facade over the Discord bug-pipeline queue DB logic (backlog 1.26 split).
  *
- * All snowflake columns are (string)-cast on read (see castRow()) because
- * db/db.php:100 sets MYSQLI_OPT_INT_AND_FLOAT_NATIVE — BIGINT reads back as
- * PHP int, and json_encode of a bare int loses precision above 2^53.
+ * The read path + crash-safe enqueue live here; the lease/claim + state-machine
+ * writers, reporter-profile store, and per-channel watermark store are delegated
+ * to three sub-repositories behind {@see BugReportClaimRepositoryInterface},
+ * {@see BugReporterProfileRepositoryInterface}, and
+ * {@see BugPipelineStateRepositoryInterface}. All 14 call sites keep calling this
+ * facade unchanged — the split is behavior-preserving.
  *
- * @phpstan-type BugReportRow array{
- *   id: int,
- *   discord_author_id: string,
- *   channel_id: string,
- *   original_message_id: string,
- *   original_text: string,
- *   thread_id: ?string,
- *   class: ?string,
- *   status: string,
- *   lease_owner: ?string,
- *   lease_expires: ?string,
- *   hunt_attempts: int,
- *   pr_number: ?int,
- *   issue_number: ?int,
- *   approval_message_id: ?string,
- *   blocked_until: ?string,
- *   last_gm_reply_at: ?string,
- *   last_processed_at: ?string,
- *   reminder_sent_at: ?string,
- *   created_at: string,
- *   updated_at: string
- * }
+ * The sub-repositories are built in the constructor from the facade's OWN mysqli
+ * handle, so a call the facade wraps in {@see \BaseMysqliRepository::transactional()}
+ * (enqueueAuthorizedAndAdvance) and the delegated write it makes share one
+ * connection and one transaction/SAVEPOINT — the enqueue stays atomic.
+ *
+ * Snowflake casting (castRow / SNOWFLAKE_COLUMNS) and the BugReportRow row shape
+ * live in {@see BugReportRowCasting}, shared with the sub-repositories. The
+ * `ibl_bug_report_attachments` child table stays on the facade alongside its
+ * parent's read path — see the attachment methods below.
+ *
+ * @phpstan-import-type BugReportRow from \BugPipeline\BugReportRowCasting
  * @phpstan-type BugAttachmentRow array{
  *   id: int,
  *   report_id: int,
@@ -55,48 +51,24 @@ namespace BugPipeline;
  */
 class BugReportRepository extends \BaseMysqliRepository
 {
-    /** Snowflake columns of ibl_bug_reports that must serialize as JSON strings (see db.php:100). */
-    private const SNOWFLAKE_COLUMNS = [
-        'discord_author_id',
-        'channel_id',
-        'original_message_id',
-        'thread_id',
-        'approval_message_id',
-    ];
+    use BugReportRowCasting;
 
-    /**
-     * Optional column => mysqli type map for transition(). Column names are compile-time
-     * literals from this fixed map (never caller input); values are always bound.
-     *
-     * @var array<string, string>
-     */
-    private const OPTIONAL_TRANSITION_COLUMNS = [
-        'class'               => 's',
-        'pr_number'           => 'i',
-        'issue_number'        => 'i',
-        'thread_id'           => 's',
-        'approval_message_id' => 's',
-        'blocked_until'       => 's',
-        'hunt_attempts'       => 'i',
-    ];
+    private readonly BugReportClaimRepositoryInterface $claims;
+    private readonly BugReporterProfileRepositoryInterface $reporterProfile;
+    private readonly BugPipelineStateRepositoryInterface $pipelineState;
 
-    /**
-     * @param array<string, mixed> $row
-     * @phpstan-return BugReportRow
-     */
-    private function castRow(array $row): array
+    public function __construct(\mysqli $db, ?\League\LeagueContext $leagueContext = null)
     {
-        foreach (self::SNOWFLAKE_COLUMNS as $col) {
-            if (isset($row[$col]) && is_scalar($row[$col])) {
-                $row[$col] = (string) $row[$col];
-            }
-        }
-        /** @var BugReportRow $row */
-        return $row;
+        parent::__construct($db, $leagueContext);
+        // Share the facade's own $db handle so a delegated write inside
+        // enqueueAuthorizedAndAdvance()'s transaction runs on the same connection.
+        $this->claims = new BugReportClaimRepository($db, $leagueContext);
+        $this->reporterProfile = new BugReporterProfileRepository($db, $leagueContext);
+        $this->pipelineState = new BugPipelineStateRepository($db, $leagueContext);
     }
 
     // -------------------------------------------------------------------------
-    // Read methods (Phase 2)
+    // Read methods
     // -------------------------------------------------------------------------
 
     /**
@@ -128,8 +100,81 @@ class BugReportRepository extends \BaseMysqliRepository
         return $row === null ? null : $this->castRow($row);
     }
 
+    /**
+     * Every row currently in the `pr_open` terminal-ish state, for the cron's async reconcile
+     * pass (PR #5b Phase 5 Fork B). The hunter leaves a shipped row at `pr_open` immediately
+     * (before the PR number is known); the trusted cron later fills `pr_number` from `gh` and,
+     * on merge, advances `pr_open` → `fixed`. Read-only enumerator — no lease, no state change.
+     *
+     * @phpstan-return list<BugReportRow>
+     */
+    public function listPrOpen(): array
+    {
+        $rows = $this->fetchAll(
+            "SELECT * FROM `ibl_bug_reports` WHERE status = 'pr_open' ORDER BY id ASC"
+        );
+        return array_values(array_map(fn (array $row): array => $this->castRow($row), $rows));
+    }
+
+    /**
+     * The tick's actionable set — every row the poll-only driver must inspect this tick.
+     *
+     * Union (see discord-bug-pipeline-shared-context.md §3d + PR #5a Phase 3/5):
+     *   (a) queued AND class IS NULL          — needs first-classification
+     *   (b) awaiting_info / gathering          — GM reply re-assessment OR idle/park candidate
+     *                                            (the 1h idle POLICY lives in the bash driver, not here)
+     *   (c) awaiting_ajay AND approval_message_id IS NULL — ready-for-plan (A-Jay reacted ✅)
+     *   (d) blocked                              — a usage-limit-parked hunt whose backoff has
+     *                                              elapsed; the outer blocked_until gate only lets
+     *                                              a RIPE one through, so the bash driver resumes it
+     *                                              (blocked → hunting) via resumeBlockedHunt (#5b Phase 7)
+     *
+     * Global gates: excludes `hunting` (an in-flight hunt is invisible — the single-flight
+     * constraint) and all terminal states, and excludes any row still parked by a future
+     * `blocked_until` (usage-limit backoff). A row whose `blocked_until` has passed re-surfaces in
+     * its real status and retries — so "skip while parked" and "auto-resume" both fall out of the
+     * one blocked-until gate.
+     *
+     * @phpstan-return list<BugReportRow>
+     */
+    public function listActiveConversations(): array
+    {
+        $rows = $this->fetchAll(
+            "SELECT * FROM `ibl_bug_reports`
+             WHERE status NOT IN ('hunting','dropped','fixed','needs_human','parked_idle','pr_open')
+               AND (blocked_until IS NULL OR blocked_until <= NOW())
+               AND (
+                     (status = 'queued' AND class IS NULL)
+                  OR (status IN ('awaiting_info','gathering'))
+                  OR (status = 'awaiting_ajay' AND approval_message_id IS NULL)
+                  OR (status = 'blocked')
+               )
+             ORDER BY id ASC"
+        );
+        return array_values(array_map(fn (array $row): array => $this->castRow($row), $rows));
+    }
+
+    /**
+     * PR #4 /prMerged resolver. pr_number is a PR number (small INT, bound "i"), NOT a snowflake.
+     * Returns the thread_id snowflake as a STRING, or null if unresolved.
+     */
+    public function findThreadIdByPrNumber(int $prNumber): ?string
+    {
+        $row = $this->fetchOne(
+            'SELECT thread_id FROM `ibl_bug_reports` WHERE pr_number = ? LIMIT 1',
+            'i',
+            $prNumber
+        );
+        if ($row === null) {
+            return null;
+        }
+        return isset($row['thread_id']) && is_scalar($row['thread_id'])
+            ? (string) $row['thread_id']
+            : null;
+    }
+
     // -------------------------------------------------------------------------
-    // Write path — insert, upserts, mutators (Phase 3)
+    // Crash-safe enqueue (owns its own transaction; delegates the watermark write)
     // -------------------------------------------------------------------------
 
     public function insertQueuedReport(string $authorId, string $channelId, string $messageId, string $text): int
@@ -147,52 +192,12 @@ class BugReportRepository extends \BaseMysqliRepository
         return $this->getLastInsertId();
     }
 
-    public function upsertReporterProfile(string $discordId, string $techLevel): void
-    {
-        // ON DUPLICATE KEY UPDATE => affected-rows is 0|1|2; success is "no exception", not "=== 1".
-        $this->execute(
-            'INSERT INTO `ibl_bug_reporter_profile` (discord_author_id, tech_level, created_at, updated_at)
-             VALUES (?, ?, NOW(), NOW())
-             ON DUPLICATE KEY UPDATE tech_level = VALUES(tech_level), updated_at = NOW()',
-            'ss',
-            $discordId,
-            $techLevel
-        );
-    }
-
-    public function getReporterTechLevel(string $discordId): ?string
-    {
-        $row = $this->fetchOne(
-            'SELECT tech_level FROM `ibl_bug_reporter_profile` WHERE discord_author_id = ? LIMIT 1',
-            's',
-            $discordId
-        );
-        if ($row === null) {
-            return null;
-        }
-        /** @var string $techLevel */
-        $techLevel = $row['tech_level'];
-        return $techLevel;
-    }
-
-    public function upsertPipelineState(string $channelId, string $messageId): void
-    {
-        // Monotonic: GREATEST() keeps the highest snowflake seen — the cursor only moves forward.
-        $this->execute(
-            'INSERT INTO `ibl_bug_pipeline_state` (channel_id, last_processed_message_id, updated_at)
-             VALUES (?, ?, NOW())
-             ON DUPLICATE KEY UPDATE
-                 last_processed_message_id = GREATEST(last_processed_message_id, VALUES(last_processed_message_id)),
-                 updated_at = NOW()',
-            'ss',
-            $channelId,
-            $messageId
-        );
-    }
-
     /**
      * Crash-safe, replay-safe enqueue: INSERT + watermark advance run in one transaction.
      * Pre-insert findByOriginalMessageId dedupe makes it replay-safe for PR #4's backfill.
+     *
+     * The watermark write is delegated to the pipeline-state sub-repository, which shares
+     * this facade's mysqli handle — so it runs inside the same transaction opened here.
      */
     public function enqueueAuthorizedAndAdvance(string $authorId, string $channelId, string $messageId, string $text): int
     {
@@ -201,16 +206,24 @@ class BugReportRepository extends \BaseMysqliRepository
             // Replay-safe: a message already enqueued returns its existing id, no 2nd row.
             $existing = $this->findByOriginalMessageId($messageId);
             if ($existing !== null) {
-                $this->upsertPipelineState($channelId, $messageId);
+                $this->pipelineState->upsertPipelineState($channelId, $messageId);
                 return $existing['id'];
             }
             // Insert + watermark advance in the SAME transaction => crash between them rolls back both.
             $newId = $this->insertQueuedReport($authorId, $channelId, $messageId, $text);
-            $this->upsertPipelineState($channelId, $messageId);
+            $this->pipelineState->upsertPipelineState($channelId, $messageId);
             return $newId;
         });
         return $id;
     }
+
+    // -------------------------------------------------------------------------
+    // Attachment child table (ibl_bug_report_attachments)
+    //
+    // Stays on the facade alongside the parent row it hangs off: the child table carries no
+    // lease/claim, reporter-profile, or watermark concern, and insertAttachments() runs AFTER
+    // the enqueue transaction above commits — so it needs no shared-transaction sub-repository.
+    // -------------------------------------------------------------------------
 
     /**
      * Persist attachment metadata for a report. Best-effort, replay-safe, storage-idempotent.
@@ -292,354 +305,139 @@ class BugReportRepository extends \BaseMysqliRepository
         return $grouped;
     }
 
-    public function stampThreadReply(string $threadId): bool
-    {
-        return $this->execute(
-            'UPDATE `ibl_bug_reports` SET last_gm_reply_at = NOW() WHERE thread_id = ?',
-            's',
-            $threadId
-        ) >= 1;
-    }
+    // -------------------------------------------------------------------------
+    // Reporter-profile delegations
+    // -------------------------------------------------------------------------
 
     /**
-     * Advance a report from awaiting_ajay to the ready-for-plan sub-state by NULLing
-     * approval_message_id. Status stays 'awaiting_ajay' — the cron drives /plan then sets 'planned'.
+     * @see BugReporterProfileRepository::upsertReporterProfile()
      */
-    public function advanceOnApproval(string $messageId): bool
+    public function upsertReporterProfile(string $discordId, string $techLevel): void
     {
-        // ✅ = "ready-for-plan", NOT "planned". NULL the approval pointer and keep
-        // status='awaiting_ajay' so the cron can enumerate awaiting_ajay AND approval_message_id IS NULL.
-        return $this->execute(
-            "UPDATE `ibl_bug_reports` SET approval_message_id = NULL
-             WHERE approval_message_id = ? AND status = 'awaiting_ajay'",
-            's',
-            $messageId
-        ) === 1;
+        $this->reporterProfile->upsertReporterProfile($discordId, $techLevel);
+    }
+
+    /**
+     * @see BugReporterProfileRepository::getReporterTechLevel()
+     */
+    public function getReporterTechLevel(string $discordId): ?string
+    {
+        return $this->reporterProfile->getReporterTechLevel($discordId);
     }
 
     // -------------------------------------------------------------------------
-    // Atomic lease primitives (Phase 4)
+    // Pipeline-state (watermark) delegations
     // -------------------------------------------------------------------------
 
     /**
-     * Single-flight claim: the "AND status='queued'" guard makes this atomic.
-     * A row already 'hunting' (claimed by another worker) matches 0 rows => returns false.
+     * @see BugPipelineStateRepository::upsertPipelineState()
+     */
+    public function upsertPipelineState(string $channelId, string $messageId): void
+    {
+        $this->pipelineState->upsertPipelineState($channelId, $messageId);
+    }
+
+    /**
+     * @see BugPipelineStateRepository::findPipelineState()
+     */
+    public function findPipelineState(string $channelId): ?string
+    {
+        return $this->pipelineState->findPipelineState($channelId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Lease/claim + state-machine writer delegations
+    // -------------------------------------------------------------------------
+
+    /**
+     * @see BugReportClaimRepository::claimQueued()
      */
     public function claimQueued(int $id, string $leaseOwner, string $leaseExpires): bool
     {
-        return $this->execute(
-            "UPDATE `ibl_bug_reports` SET status = 'hunting', lease_owner = ?, lease_expires = ?
-             WHERE id = ? AND status = 'queued'",
-            'ssi',
-            $leaseOwner,
-            $leaseExpires,
-            $id
-        ) === 1;
+        return $this->claims->claimQueued($id, $leaseOwner, $leaseExpires);
     }
 
     /**
-     * Pick oldest queued report and claim it. One attempt — lost-race returns null.
+     * @see BugReportClaimRepository::claimNextQueued()
      * @phpstan-return BugReportRow|null
      */
     public function claimNextQueued(string $leaseOwner, string $leaseExpires): ?array
     {
-        $row = $this->fetchOne(
-            "SELECT id FROM `ibl_bug_reports` WHERE status = 'queued' ORDER BY id ASC LIMIT 1"
-        );
-        if ($row === null) {
-            return null;
-        }
-        /** @var int $id */
-        $id = $row['id'];
-
-        // Lost-race safe: if another worker claimed $id, claimQueued matches 0 rows => null.
-        if (!$this->claimQueued($id, $leaseOwner, $leaseExpires)) {
-            return null;
-        }
-        return $this->findById($id);
+        return $this->claims->claimNextQueued($leaseOwner, $leaseExpires);
     }
 
     /**
-     * Reclaim a crashed hunt whose lease expired. Separate primitive — never widens claimQueued.
+     * @see BugReportClaimRepository::reclaimStaleLease()
      * @phpstan-return BugReportRow|null
      */
     public function reclaimStaleLease(string $newLeaseOwner, string $leaseExpires): ?array
     {
-        $row = $this->fetchOne(
-            "SELECT id FROM `ibl_bug_reports`
-             WHERE status = 'hunting' AND lease_expires < NOW()
-             ORDER BY id ASC LIMIT 1"
-        );
-        if ($row === null) {
-            return null;
-        }
-        /** @var int $id */
-        $id = $row['id'];
-
-        // Re-assert both predicates in the UPDATE so a concurrent reclaimer can't double-claim.
-        $claimed = $this->execute(
-            "UPDATE `ibl_bug_reports` SET lease_owner = ?, lease_expires = ?
-             WHERE id = ? AND status = 'hunting' AND lease_expires < NOW()",
-            'ssi',
-            $newLeaseOwner,
-            $leaseExpires,
-            $id
-        ) === 1;
-        if (!$claimed) {
-            return null;
-        }
-        return $this->findById($id);
+        return $this->claims->reclaimStaleLease($newLeaseOwner, $leaseExpires);
     }
 
     /**
-     * Pick the oldest queued report that is READY TO HUNT and claim it into `hunting`.
-     * One attempt — lost-race returns null (PR #5b Phase 2 — the deadlock-closing claim).
-     *
-     * Narrower than claimNextQueued() by design: a hunt may only start on a row that has
-     * already been classified (`class IS NOT NULL`) and is not parked by a usage-limit
-     * backoff (`blocked_until` in the future). claimNextQueued() stays as-is for any caller
-     * that wants the raw oldest-queued primitive; this method never widens it.
-     *
+     * @see BugReportClaimRepository::claimNextHuntable()
      * @phpstan-return BugReportRow|null
      */
     public function claimNextHuntable(string $leaseOwner, string $leaseExpires): ?array
     {
-        $row = $this->fetchOne(
-            "SELECT id FROM `ibl_bug_reports`
-             WHERE status = 'queued'
-               AND class IS NOT NULL
-               AND (blocked_until IS NULL OR blocked_until <= NOW())
-             ORDER BY id ASC LIMIT 1"
-        );
-        if ($row === null) {
-            return null;
-        }
-        /** @var int $id */
-        $id = $row['id'];
-
-        // Lost-race safe: claimQueued re-asserts `status='queued'` in the UPDATE (0 rows => null).
-        if (!$this->claimQueued($id, $leaseOwner, $leaseExpires)) {
-            return null;
-        }
-        return $this->findById($id);
+        return $this->claims->claimNextHuntable($leaseOwner, $leaseExpires);
     }
 
     /**
-     * Atomically resume a usage-limit-parked hunt: `blocked` → `hunting`, re-stamping the lease.
-     * Returns true only when THIS call flipped the row (PR #5b Phase 7 — the resume guard).
-     *
-     * transition() is an unconditional `WHERE id = ?` write, so it cannot express the
-     * single-flight predicate two overlapping ticks need: both surface the ripe `blocked`
-     * row, both call this, only the one whose UPDATE still sees `status='blocked'` wins
-     * (affected_rows == 1); the loser gets 0 and skips. Re-stamping lease_expires closes the
-     * window where reclaimStaleLease() could immediately steal the freshly-resumed hunt.
+     * @see BugReportClaimRepository::resumeBlockedHunt()
      */
     public function resumeBlockedHunt(string $leaseOwner, string $leaseExpires, int $id): bool
     {
-        return $this->execute(
-            "UPDATE `ibl_bug_reports`
-                SET status = 'hunting', lease_owner = ?, lease_expires = ?, updated_at = NOW()
-             WHERE id = ?
-               AND status = 'blocked'
-               AND (blocked_until IS NULL OR blocked_until <= NOW())",
-            'ssi',
-            $leaseOwner,
-            $leaseExpires,
-            $id
-        ) === 1;
+        return $this->claims->resumeBlockedHunt($leaseOwner, $leaseExpires, $id);
     }
 
     /**
-     * Every row currently in the `pr_open` terminal-ish state, for the cron's async reconcile
-     * pass (PR #5b Phase 5 Fork B). The hunter leaves a shipped row at `pr_open` immediately
-     * (before the PR number is known); the trusted cron later fills `pr_number` from `gh` and,
-     * on merge, advances `pr_open` → `fixed`. Read-only enumerator — no lease, no state change.
-     *
-     * @phpstan-return list<BugReportRow>
-     */
-    public function listPrOpen(): array
-    {
-        $rows = $this->fetchAll(
-            "SELECT * FROM `ibl_bug_reports` WHERE status = 'pr_open' ORDER BY id ASC"
-        );
-        return array_values(array_map(fn (array $row): array => $this->castRow($row), $rows));
-    }
-
-    // -------------------------------------------------------------------------
-    // General state/metadata writer (Phase 4b)
-    // -------------------------------------------------------------------------
-
-    /**
-     * General state-machine writer: set status plus any subset of optional metadata columns.
-     * The §3d cron CLI (transition <id> <status> [opts]) is a thin wrapper over this method.
-     *
-     * Conditional-SQL, NOT null-bind: only columns whose key is present in $opts are written;
-     * an absent key keeps the column's current value ("build conditional SQL; bind_param has no
-     * NULL type" — core-coding.md). Keys outside OPTIONAL_TRANSITION_COLUMNS are ignored.
-     *
-     * $setClauses fragments ('status = ?', 'pr_number = ?', …) derive from the fixed
-     * OPTIONAL_TRANSITION_COLUMNS constant (compile-time literal column names / bound params) —
-     * concatenate literal fragments, do NOT interpolate values.
-     *
-     * @param array<string, int|string> $opts Accepted keys: pr_number, issue_number, hunt_attempts
-     *   (ints); class (ENUM string); thread_id, approval_message_id (snowflakes, bound "s");
-     *   blocked_until (DATETIME string). Any other key is ignored.
-     * @param bool $releaseLease When true, atomically NULLs lease_owner + lease_expires in the
-     *   SAME UPDATE. Required for →needs_human / →queued reset to be a single-flight-safe op.
-     * @return bool True when the row (PK $id) was updated.
+     * @see BugReportClaimRepository::transition()
+     * @param array<string, int|string> $opts
      */
     public function transition(int $id, string $status, array $opts = [], bool $releaseLease = false): bool
     {
-        $setClauses = ['status = ?'];
-        $types = 's';
-        $values = [$status];
-
-        foreach (self::OPTIONAL_TRANSITION_COLUMNS as $col => $type) {
-            if (array_key_exists($col, $opts)) {
-                $setClauses[] = $col . ' = ?';
-                $types .= $type;
-                $values[] = $opts[$col];
-            }
-        }
-        if ($releaseLease) {
-            // Literal NULLs (no bound param) — atomic lease-drop for →needs_human / →queued reset.
-            $setClauses[] = 'lease_owner = NULL';
-            $setClauses[] = 'lease_expires = NULL';
-        }
-        $setClauses[] = 'updated_at = NOW()';
-
-        // $setClauses elements are literal fragments from the fixed constant map above;
-        // no runtime value is interpolated into column names — only ? placeholders for values.
-        $query = 'UPDATE `ibl_bug_reports` SET ' . implode(', ', $setClauses) . ' WHERE id = ?';
-        $types .= 'i';
-        $values[] = $id;
-
-        return $this->execute($query, $types, ...$values) === 1;
+        return $this->claims->transition($id, $status, $opts, $releaseLease);
     }
 
-    // -------------------------------------------------------------------------
-    // Reader methods for PR #4 (Phase 9)
-    // -------------------------------------------------------------------------
-
     /**
-     * PR #4 backfill cursor. Returns the watermark snowflake as a STRING, or null on first boot.
+     * @see BugReportClaimRepository::advanceOnApproval()
      */
-    public function findPipelineState(string $channelId): ?string
+    public function advanceOnApproval(string $messageId): bool
     {
-        $row = $this->fetchOne(
-            'SELECT last_processed_message_id FROM `ibl_bug_pipeline_state` WHERE channel_id = ? LIMIT 1',
-            's',
-            $channelId
-        );
-        if ($row === null) {
-            return null;
-        }
-        return isset($row['last_processed_message_id']) && is_scalar($row['last_processed_message_id'])
-            ? (string) $row['last_processed_message_id']
-            : null;
+        return $this->claims->advanceOnApproval($messageId);
     }
 
     /**
-     * PR #4 /prMerged resolver. pr_number is a PR number (small INT, bound "i"), NOT a snowflake.
-     * Returns the thread_id snowflake as a STRING, or null if unresolved.
+     * @see BugReportClaimRepository::stampThreadReply()
      */
-    public function findThreadIdByPrNumber(int $prNumber): ?string
+    public function stampThreadReply(string $threadId): bool
     {
-        $row = $this->fetchOne(
-            'SELECT thread_id FROM `ibl_bug_reports` WHERE pr_number = ? LIMIT 1',
-            'i',
-            $prNumber
-        );
-        if ($row === null) {
-            return null;
-        }
-        return isset($row['thread_id']) && is_scalar($row['thread_id'])
-            ? (string) $row['thread_id']
-            : null;
-    }
-
-    // -------------------------------------------------------------------------
-    // Cron enumerator + conditional writers (PR #5a — the poll-only orchestrator)
-    //
-    // NOTE (scope): PR #3 deliberately deferred the cron's actionable-set query to
-    // #5a (see advanceOnApproval()'s comment: "so the cron can enumerate awaiting_ajay
-    // AND approval_message_id IS NULL"). These methods are the single home of that
-    // enumerator + the three conditional writers transition()'s value-bind can't express.
-    // -------------------------------------------------------------------------
-
-    /**
-     * The tick's actionable set — every row the poll-only driver must inspect this tick.
-     *
-     * Union (see discord-bug-pipeline-shared-context.md §3d + PR #5a Phase 3/5):
-     *   (a) queued AND class IS NULL          — needs first-classification
-     *   (b) awaiting_info / gathering          — GM reply re-assessment OR idle/park candidate
-     *                                            (the 1h idle POLICY lives in the bash driver, not here)
-     *   (c) awaiting_ajay AND approval_message_id IS NULL — ready-for-plan (A-Jay reacted ✅)
-     *   (d) blocked                              — a usage-limit-parked hunt whose backoff has
-     *                                              elapsed; the outer blocked_until gate only lets
-     *                                              a RIPE one through, so the bash driver resumes it
-     *                                              (blocked → hunting) via resumeBlockedHunt (#5b Phase 7)
-     *
-     * Global gates: excludes `hunting` (an in-flight hunt is invisible — the single-flight
-     * constraint) and all terminal states, and excludes any row still parked by a future
-     * `blocked_until` (usage-limit backoff). A row whose `blocked_until` has passed re-surfaces in
-     * its real status and retries — so "skip while parked" and "auto-resume" both fall out of the
-     * one blocked-until gate.
-     *
-     * @phpstan-return list<BugReportRow>
-     */
-    public function listActiveConversations(): array
-    {
-        $rows = $this->fetchAll(
-            "SELECT * FROM `ibl_bug_reports`
-             WHERE status NOT IN ('hunting','dropped','fixed','needs_human','parked_idle','pr_open')
-               AND (blocked_until IS NULL OR blocked_until <= NOW())
-               AND (
-                     (status = 'queued' AND class IS NULL)
-                  OR (status IN ('awaiting_info','gathering'))
-                  OR (status = 'awaiting_ajay' AND approval_message_id IS NULL)
-                  OR (status = 'blocked')
-               )
-             ORDER BY id ASC"
-        );
-        return array_values(array_map(fn (array $row): array => $this->castRow($row), $rows));
+        return $this->claims->stampThreadReply($threadId);
     }
 
     /**
-     * At-most-once idle reminder stamp. The `AND reminder_sent_at IS NULL` guard makes a repeat
-     * call a no-op, so a row can receive at most one reminder over its lifetime (PR #5a Phase 6).
-     * transition()'s value-bind cannot express this conditional WHERE, hence a dedicated method.
+     * @see BugReportClaimRepository::markReminderSent()
      */
     public function markReminderSent(int $id): bool
     {
-        return $this->execute(
-            "UPDATE `ibl_bug_reports` SET reminder_sent_at = NOW(), updated_at = NOW()
-             WHERE id = ? AND reminder_sent_at IS NULL",
-            'i',
-            $id
-        ) === 1;
-    }
-
-    /** Stamp last_processed_at = NOW() so the same GM reply is not re-processed next tick. */
-    public function stampLastProcessed(int $id): bool
-    {
-        return $this->execute(
-            'UPDATE `ibl_bug_reports` SET last_processed_at = NOW(), updated_at = NOW() WHERE id = ?',
-            'i',
-            $id
-        ) === 1;
+        return $this->claims->markReminderSent($id);
     }
 
     /**
-     * Clear a usage-limit park stamp (blocked_until = NULL). Literal NULL, no bound value —
-     * mirrors transition()'s $releaseLease idiom (bind_param has no NULL type). PR #5a Phase 6 resume.
+     * @see BugReportClaimRepository::stampLastProcessed()
+     */
+    public function stampLastProcessed(int $id): bool
+    {
+        return $this->claims->stampLastProcessed($id);
+    }
+
+    /**
+     * @see BugReportClaimRepository::clearBlocked()
      */
     public function clearBlocked(int $id): bool
     {
-        return $this->execute(
-            'UPDATE `ibl_bug_reports` SET blocked_until = NULL, updated_at = NOW() WHERE id = ?',
-            'i',
-            $id
-        ) === 1;
+        return $this->claims->clearBlocked($id);
     }
 }

--- a/ibl5/classes/BugPipeline/BugReportRowCasting.php
+++ b/ibl5/classes/BugPipeline/BugReportRowCasting.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BugPipeline;
+
+/**
+ * Shared snowflake-casting for the Discord bug pipeline repositories.
+ *
+ * All snowflake columns are (string)-cast on read (see castRow()) because
+ * db/db.php:100 sets MYSQLI_OPT_INT_AND_FLOAT_NATIVE — BIGINT reads back as
+ * PHP int, and json_encode of a bare int loses precision above 2^53.
+ *
+ * The `BugReportRow` type is defined here (not on any one repository) so every
+ * sub-repository and the facade can share one row shape via
+ * `@phpstan-import-type BugReportRow from \BugPipeline\BugReportRowCasting`.
+ *
+ * @phpstan-type BugReportRow array{
+ *   id: int,
+ *   discord_author_id: string,
+ *   channel_id: string,
+ *   original_message_id: string,
+ *   original_text: string,
+ *   thread_id: ?string,
+ *   class: ?string,
+ *   status: string,
+ *   lease_owner: ?string,
+ *   lease_expires: ?string,
+ *   hunt_attempts: int,
+ *   pr_number: ?int,
+ *   issue_number: ?int,
+ *   approval_message_id: ?string,
+ *   blocked_until: ?string,
+ *   last_gm_reply_at: ?string,
+ *   last_processed_at: ?string,
+ *   reminder_sent_at: ?string,
+ *   created_at: string,
+ *   updated_at: string
+ * }
+ */
+trait BugReportRowCasting
+{
+    /** Snowflake columns of ibl_bug_reports that must serialize as JSON strings (see db.php:100). */
+    private const SNOWFLAKE_COLUMNS = [
+        'discord_author_id',
+        'channel_id',
+        'original_message_id',
+        'thread_id',
+        'approval_message_id',
+    ];
+
+    /**
+     * @param array<string, mixed> $row
+     * @phpstan-return BugReportRow
+     */
+    private function castRow(array $row): array
+    {
+        foreach (self::SNOWFLAKE_COLUMNS as $col) {
+            if (isset($row[$col]) && is_scalar($row[$col])) {
+                $row[$col] = (string) $row[$col];
+            }
+        }
+        /** @var BugReportRow $row */
+        return $row;
+    }
+}

--- a/ibl5/classes/BugPipeline/BugReporterProfileRepository.php
+++ b/ibl5/classes/BugPipeline/BugReporterProfileRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BugPipeline;
+
+use BugPipeline\Contracts\BugReporterProfileRepositoryInterface;
+
+/**
+ * Reporter tech-level profile store for the Discord bug pipeline
+ * (`ibl_bug_reporter_profile`). Split out of {@see BugReportRepository}
+ * (backlog 1.26); the facade delegates to it.
+ */
+class BugReporterProfileRepository extends \BaseMysqliRepository implements BugReporterProfileRepositoryInterface
+{
+    public function upsertReporterProfile(string $discordId, string $techLevel): void
+    {
+        // ON DUPLICATE KEY UPDATE => affected-rows is 0|1|2; success is "no exception", not "=== 1".
+        $this->execute(
+            'INSERT INTO `ibl_bug_reporter_profile` (discord_author_id, tech_level, created_at, updated_at)
+             VALUES (?, ?, NOW(), NOW())
+             ON DUPLICATE KEY UPDATE tech_level = VALUES(tech_level), updated_at = NOW()',
+            'ss',
+            $discordId,
+            $techLevel
+        );
+    }
+
+    public function getReporterTechLevel(string $discordId): ?string
+    {
+        $row = $this->fetchOne(
+            'SELECT tech_level FROM `ibl_bug_reporter_profile` WHERE discord_author_id = ? LIMIT 1',
+            's',
+            $discordId
+        );
+        if ($row === null) {
+            return null;
+        }
+        /** @var string $techLevel */
+        $techLevel = $row['tech_level'];
+        return $techLevel;
+    }
+}

--- a/ibl5/classes/BugPipeline/Contracts/BugPipelineStateRepositoryInterface.php
+++ b/ibl5/classes/BugPipeline/Contracts/BugPipelineStateRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BugPipeline\Contracts;
+
+/**
+ * Per-channel backfill watermark contract for the Discord bug pipeline
+ * (`ibl_bug_pipeline_state`). Split out of {@see \BugPipeline\BugReportRepository}
+ * (backlog 1.26); the facade delegates to it.
+ */
+interface BugPipelineStateRepositoryInterface
+{
+    /**
+     * @see \BugPipeline\BugPipelineStateRepository::upsertPipelineState()
+     */
+    public function upsertPipelineState(string $channelId, string $messageId): void;
+
+    /**
+     * @see \BugPipeline\BugPipelineStateRepository::findPipelineState()
+     */
+    public function findPipelineState(string $channelId): ?string;
+}

--- a/ibl5/classes/BugPipeline/Contracts/BugReportClaimRepositoryInterface.php
+++ b/ibl5/classes/BugPipeline/Contracts/BugReportClaimRepositoryInterface.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BugPipeline\Contracts;
+
+/**
+ * Lease/claim + state-machine writer contract for the Discord bug pipeline.
+ *
+ * Groups the atomic lease primitives (single-flight claims, stale-lease reclaim,
+ * blocked-hunt resume), the general transition() writer, and the conditional
+ * writers transition()'s value-bind cannot express (advanceOnApproval,
+ * stampThreadReply, markReminderSent, stampLastProcessed, clearBlocked).
+ *
+ * @phpstan-import-type BugReportRow from \BugPipeline\BugReportRowCasting
+ */
+interface BugReportClaimRepositoryInterface
+{
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::claimQueued()
+     */
+    public function claimQueued(int $id, string $leaseOwner, string $leaseExpires): bool;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::claimNextQueued()
+     * @phpstan-return BugReportRow|null
+     */
+    public function claimNextQueued(string $leaseOwner, string $leaseExpires): ?array;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::reclaimStaleLease()
+     * @phpstan-return BugReportRow|null
+     */
+    public function reclaimStaleLease(string $newLeaseOwner, string $leaseExpires): ?array;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::claimNextHuntable()
+     * @phpstan-return BugReportRow|null
+     */
+    public function claimNextHuntable(string $leaseOwner, string $leaseExpires): ?array;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::resumeBlockedHunt()
+     */
+    public function resumeBlockedHunt(string $leaseOwner, string $leaseExpires, int $id): bool;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::transition()
+     * @param array<string, int|string> $opts
+     */
+    public function transition(int $id, string $status, array $opts = [], bool $releaseLease = false): bool;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::advanceOnApproval()
+     */
+    public function advanceOnApproval(string $messageId): bool;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::stampThreadReply()
+     */
+    public function stampThreadReply(string $threadId): bool;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::markReminderSent()
+     */
+    public function markReminderSent(int $id): bool;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::stampLastProcessed()
+     */
+    public function stampLastProcessed(int $id): bool;
+
+    /**
+     * @see \BugPipeline\BugReportClaimRepository::clearBlocked()
+     */
+    public function clearBlocked(int $id): bool;
+}

--- a/ibl5/classes/BugPipeline/Contracts/BugReporterProfileRepositoryInterface.php
+++ b/ibl5/classes/BugPipeline/Contracts/BugReporterProfileRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BugPipeline\Contracts;
+
+/**
+ * Reporter tech-level profile contract for the Discord bug pipeline
+ * (`ibl_bug_reporter_profile`). Split out of {@see \BugPipeline\BugReportRepository}
+ * (backlog 1.26); the facade delegates to it.
+ */
+interface BugReporterProfileRepositoryInterface
+{
+    /**
+     * @see \BugPipeline\BugReporterProfileRepository::upsertReporterProfile()
+     */
+    public function upsertReporterProfile(string $discordId, string $techLevel): void;
+
+    /**
+     * @see \BugPipeline\BugReporterProfileRepository::getReporterTechLevel()
+     */
+    public function getReporterTechLevel(string $discordId): ?string;
+}

--- a/ibl5/classes/BugPipeline/README.md
+++ b/ibl5/classes/BugPipeline/README.md
@@ -1,8 +1,14 @@
 ---
 description: Provides the repository backing the Discord bug report ingestion pipeline.
-last_verified: 2026-07-24
+last_verified: 2026-08-08
 ---
 
 # BugPipeline
 
-Backs the Discord bug report pipeline with a single repository class, `BugReportRepository`. It handles queue reads and writes for incoming Discord bug reports, including correct handling of snowflake column precision by casting BIGINT Discord IDs to strings.
+Backs the Discord bug report pipeline. `BugReportRepository` is the entry point every call site constructs. It keeps the `ibl_bug_reports` read path (`findById`, `findByThreadId`, `listPrOpen`, `listActiveConversations`, …), the enqueue writers, and the `ibl_bug_report_attachments` child table on itself, and delegates the rest to three focused sub-repositories. All four share a single `mysqli` handle, so `enqueueAuthorizedAndAdvance()`'s insert-plus-watermark work stays atomic within one transaction:
+
+- **`BugReportClaimRepository`** (`ibl_bug_reports`) — the claim/state-machine writers: single-flight claims, stale-lease reclaim, blocked/backoff resume, `transition()`, and the conditional writers around approvals, thread replies and reminders.
+- **`BugReporterProfileRepository`** (`ibl_bug_reporter_profile`) — reporter tech-level upserts and lookups.
+- **`BugPipelineStateRepository`** (`ibl_bug_pipeline_state`) — the monotonic per-channel backfill watermark.
+
+Each sub-repository implements an interface under `Contracts/`, and the shared `BugReportRowCasting` trait handles snowflake column precision by casting BIGINT Discord IDs to strings. Call sites construct `BugReportRepository` exactly as before.

--- a/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
@@ -211,6 +211,16 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Status (2026-08-08):** ✅ Implemented — extracted to three renderer collaborators (`RecordTableRenderer`, `PlayerRecordSectionRenderer`, `TeamRecordSectionRenderer`); `RecordHoldersView` thinned to constructor + `render()` (this PR). Golden-master byte-identical throughout.
 **Provenance:** Seeded 2026-07-24 — hot-files comment→backlog migration.
 
+### 1.26 BugReportRepository — State-Machine + Profile + Queue in One Repo (546 LOC)
+**Location:** `ibl5/classes/BugPipeline/BugReportRepository.php` (546 lines)
+**Problem:** 24 methods spanning the claim/lease/transition state machine (`claimQueued`, `reclaimStaleLease`, `resumeBlockedHunt`, `transition`), reporter-profile upserts, and queue/conversation lookups.
+**Suggested direction:** Split into query-group collaborators (lease/claim vs profile vs transition/lookup) behind the existing interface.
+**Est. effort:** M
+**Risk if untouched:** The bug-pipeline's central repo keeps accreting query methods; green-green with DB-integration pins.
+**Provenance:** Seeded 2026-07-24 — hot-files comment→backlog migration.
+**Status (2026-07-26):** ✅ Implemented — split into a thin `BugReportRepository` facade delegating to `BugReportClaimRepository` (`ibl_bug_reports`), `BugReporterProfileRepository` (`ibl_bug_reporter_profile`), and `BugPipelineStateRepository` (`ibl_bug_pipeline_state`), each behind a `Contracts/` interface and sharing one `mysqli` handle for cross-table transaction atomicity, with a shared `BugReportRowCasting` trait for snowflake→string casting. All 14 call sites byte-unchanged; green-green with new per-sub-repository DB-integration pins.
+**Table evidence (2026-07-26):** BugReportRepository 546 LOC — 24 methods spanning claim/lease/transition state-machine + reporter-profile + queue queries. Split by query group; green-green with DB-integration pins.
+
 ### 1.27 JsbImportRepository — One Upsert Per Record Type (539 LOC)
 **Location:** `ibl5/classes/JsbParser/JsbImportRepository.php` (539 lines)
 **Problem:** 15 `upsert*`/`replace*` methods, one per imported entity (transaction, history, all-star roster/score, award, draft result, retired player, HoF inductee, RCB records, PLB snapshot), all in one repo.

--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -61,14 +61,13 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 **Automouse audit (verified 2026-06-20):**
 
-> ✅ resolved (30): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.19, 1.20, 1.21, 1.23, 1.24, 1.27, 1.28, 1.29, 1.31, 1.32, 1.34, 1.35, 1.36 — evidence in [archive](archive/maintenance-backlog-archive.md)
+> ✅ resolved (31): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.19, 1.20, 1.21, 1.23, 1.24, 1.26, 1.27, 1.28, 1.29, 1.31, 1.32, 1.34, 1.35, 1.36 — evidence in [archive](archive/maintenance-backlog-archive.md)
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
 | 1.18 | ◑ Partial | 🟩 | StandingsUpdater. `82`→`League::REGULAR_SEASON_GAMES` DONE (refactor PR). echo→logger + `$log` removal DEFERRED: behavior-changing — echoes feed the rendered pipeline `capturedLog` (UpdateStandingsStep→UpdaterController); `$log` feeds admin-rendered `DebugOutput::display`. Needs a non-`refactor:` PR. |
 | 1.22 | ⬜ Open | 🟩 | TradingView 606 LOC — offer-form/review/closed renderers + row/pick/cash builders in one view. Split into per-page views or extract row-builders; behavior-preserving golden-master pin. |
 | 1.25 | ⬜ Open | 🟨 | BoxscoreProcessor 559 LOC — mutating .sco import pipeline; regular/all-star/rising-stars game processors in one class. Extract per-game-type processors; import-fidelity-critical → characterization pins first. Size finding only; the Processor→Service *rename* is separately declined at 2.5. |
-| 1.26 | ⬜ Open | 🟩 | BugReportRepository 546 LOC — 24 methods spanning claim/lease/transition state-machine + reporter-profile + queue queries. Split by query group; green-green with DB-integration pins. |
 | 1.30 | ⬜ Open | 🟩 | TradingService 516 LOC — page-data orchestration + offer-grouping + future-salary calc. Extract offer-grouping and salary collaborators; green-green. |
 | 1.33 | ⬜ Open | 🟩 | Player 671 LOC — typed-getter accumulation. Extract per-domain typed-getter groups (contract, stats, identity); green-green. |
 
@@ -103,14 +102,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** Extract per-game-type processors behind a common interface; keep `BoxscoreProcessor` as the file-level dispatcher.
 **Est. effort:** M
 **Risk if untouched:** Import-fidelity-critical mutating pipeline — needs characterization pins before refactor (🟨). This is a **size** finding only; the separate Processor→Service *rename* was deliberately declined at 2.5 (mutating pipeline ⇒ `Processor` is the correct house name) and is not reopened here.
-**Provenance:** Seeded 2026-07-24 — hot-files comment→backlog migration.
-
-### 1.26 BugReportRepository — State-Machine + Profile + Queue in One Repo (546 LOC)
-**Location:** `ibl5/classes/BugPipeline/BugReportRepository.php` (546 lines)
-**Problem:** 24 methods spanning the claim/lease/transition state machine (`claimQueued`, `reclaimStaleLease`, `resumeBlockedHunt`, `transition`), reporter-profile upserts, and queue/conversation lookups.
-**Suggested direction:** Split into query-group collaborators (lease/claim vs profile vs transition/lookup) behind the existing interface.
-**Est. effort:** M
-**Risk if untouched:** The bug-pipeline's central repo keeps accreting query methods; green-green with DB-integration pins.
 **Provenance:** Seeded 2026-07-24 — hot-files comment→backlog migration.
 
 ### 1.30 TradingService — Page-Data + Offer-Grouping + Salary Calc (516 LOC)

--- a/ibl5/phpstan-baseline.neon
+++ b/ibl5/phpstan-baseline.neon
@@ -148,7 +148,7 @@ parameters:
 			rawMessage: 'SQL string concatenates a non-constant value. Concatenating a runtime value into query text risks SQL injection. Use bound parameters (?) for values, and a validated allowlist/match() for identifiers (table/column names).'
 			identifier: ibl.sqlStringConcatenation
 			count: 1
-			path: classes/BugPipeline/BugReportRepository.php
+			path: classes/BugPipeline/BugReportClaimRepository.php
 
 		-
 			rawMessage: 'Direct now-returning time call is banned outside the Clock seam. Inject Clock\ClockInterface (constructor for instance classes; settable static clock with factory fallback for static classes) and call $clock->now(). Pass an explicit timestamp to date()/strtotime() for deterministic formatting.'

--- a/ibl5/tests/DatabaseIntegration/BugPipeline/BugPipelineStateRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BugPipeline/BugPipelineStateRepositoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\BugPipeline;
+
+use BugPipeline\BugPipelineStateRepository;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+#[Group('database')]
+class BugPipelineStateRepositoryTest extends DatabaseTestCase
+{
+    private BugPipelineStateRepository $repo;
+
+    // Representative snowflake fixtures — real Discord IDs are 17–19 digits
+    private const CHANNEL = '200000000000000002';
+    private const MSG_ID  = '300000000000000003';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new BugPipelineStateRepository($this->db);
+    }
+
+    // ── upsertPipelineState / findPipelineState ────────────────────────────────
+
+    public function testFindPipelineStateReturnsNullWhenNoRow(): void
+    {
+        self::assertNull($this->repo->findPipelineState('999999999999999999'));
+    }
+
+    public function testUpsertPipelineStateInsertsAndReturnsString(): void
+    {
+        $this->repo->upsertPipelineState(self::CHANNEL, self::MSG_ID);
+        $cursor = $this->repo->findPipelineState(self::CHANNEL);
+        self::assertSame(self::MSG_ID, $cursor);
+    }
+
+    public function testUpsertPipelineStateIsMonotonic(): void
+    {
+        // Lower ID first, then higher — cursor advances
+        $lower  = '200000000000000001';
+        $higher = '300000000000000002';
+        $this->repo->upsertPipelineState(self::CHANNEL, $lower);
+        $this->repo->upsertPipelineState(self::CHANNEL, $higher);
+        self::assertSame($higher, $this->repo->findPipelineState(self::CHANNEL));
+
+        // Replaying older message must NOT regress the cursor
+        $this->repo->upsertPipelineState(self::CHANNEL, $lower);
+        self::assertSame($higher, $this->repo->findPipelineState(self::CHANNEL));
+    }
+
+    public function testUpsertPipelineStateKeepsHigherWatermarkWhenLowerArrivesFirst(): void
+    {
+        // Seed with a higher snowflake first, then attempt a lower one.
+        // GREATEST() must keep the cursor at the higher value.
+        $channel = '200000000000000099';
+        $lower   = '200000000000000001';
+        $higher  = '300000000000000002';
+        $this->repo->upsertPipelineState($channel, $higher);
+        $this->repo->upsertPipelineState($channel, $lower);
+        self::assertSame($higher, $this->repo->findPipelineState($channel));
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/BugPipeline/BugReportClaimRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BugPipeline/BugReportClaimRepositoryTest.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\BugPipeline;
+
+use BugPipeline\BugReportClaimRepository;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+#[Group('database')]
+class BugReportClaimRepositoryTest extends DatabaseTestCase
+{
+    private BugReportClaimRepository $repo;
+
+    // Representative snowflake fixtures — real Discord IDs are 17–19 digits
+    private const AUTHOR   = '100000000000000001';
+    private const CHANNEL  = '200000000000000002';
+    private const MSG_ID   = '300000000000000003';
+    private const THREAD   = '400000000000000004';
+    private const REPLY_ID = '500000000000000005';
+    private const APPROVAL = '600000000000000006';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new BugReportClaimRepository($this->db);
+    }
+
+    // ── claimQueued ────────────────────────────────────────────────────────────
+
+    public function testClaimQueuedReturnsTrueAndSetsStatusHunting(): void
+    {
+        $id = $this->insertBugReport();
+        $ok = $this->repo->claimQueued($id, 'worker-1', '2099-01-01 00:00:00');
+        self::assertTrue($ok);
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertSame('hunting', $row['status']);
+        self::assertSame('worker-1', $row['lease_owner']);
+    }
+
+    public function testClaimQueuedReturnsFalseWhenAlreadyClaimed(): void
+    {
+        $id = $this->insertBugReport(['status' => 'hunting']);
+        self::assertFalse($this->repo->claimQueued($id, 'worker-2', '2099-01-01 00:00:00'));
+    }
+
+    // ── claimNextQueued ────────────────────────────────────────────────────────
+
+    public function testClaimNextQueuedReturnsNullWhenQueueEmpty(): void
+    {
+        self::assertNull($this->repo->claimNextQueued('worker-1', '2099-01-01 00:00:00'));
+    }
+
+    public function testClaimNextQueuedClaimsOldestRow(): void
+    {
+        $id1 = $this->insertBugReport(['original_message_id' => self::MSG_ID]);
+        $id2 = $this->insertBugReport(['original_message_id' => self::REPLY_ID]);
+        $row = $this->repo->claimNextQueued('worker-1', '2099-01-01 00:00:00');
+        self::assertNotNull($row);
+        self::assertSame($id1, $row['id'], 'Oldest row (lowest id) must be claimed first');
+        // Second claim gets next
+        $row2 = $this->repo->claimNextQueued('worker-2', '2099-01-01 00:00:00');
+        self::assertNotNull($row2);
+        self::assertSame($id2, $row2['id']);
+    }
+
+    // ── reclaimStaleLease ──────────────────────────────────────────────────────
+
+    public function testReclaimStaleLeaseReturnsNullWhenNoExpired(): void
+    {
+        self::assertNull($this->repo->reclaimStaleLease('worker-2', '2099-01-01 00:00:00'));
+    }
+
+    public function testReclaimStaleLeaseReclaimsExpiredRow(): void
+    {
+        $id = $this->insertBugReport([
+            'status'        => 'hunting',
+            'lease_owner'   => 'crashed-worker',
+            'lease_expires' => '2000-01-01 00:00:00',
+        ]);
+        $row = $this->repo->reclaimStaleLease('worker-2', '2099-01-01 00:00:00');
+        self::assertNotNull($row);
+        self::assertSame($id, $row['id']);
+        self::assertSame('worker-2', $row['lease_owner']);
+    }
+
+    // ── transition ─────────────────────────────────────────────────────────────
+
+    public function testTransitionChangesStatus(): void
+    {
+        $id = $this->insertBugReport();
+        self::assertTrue($this->repo->transition($id, 'hunting'));
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertSame('hunting', $row['status']);
+    }
+
+    public function testTransitionSetsOptionalColumns(): void
+    {
+        $id = $this->insertBugReport();
+        $this->repo->transition($id, 'pr_open', ['pr_number' => 99, 'thread_id' => self::THREAD]);
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertSame(99, $row['pr_number']);
+        self::assertSame(self::THREAD, $row['thread_id']);
+    }
+
+    public function testTransitionWithReleaseLeaseClearsLeaseColumns(): void
+    {
+        $id = $this->insertBugReport([
+            'status'        => 'hunting',
+            'lease_owner'   => 'worker-1',
+            'lease_expires' => '2099-01-01 00:00:00',
+        ]);
+        $this->repo->transition($id, 'needs_human', [], true);
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertSame('needs_human', $row['status']);
+        self::assertNull($row['lease_owner']);
+        self::assertNull($row['lease_expires']);
+    }
+
+    public function testTransitionReturnsFalseForUnknownId(): void
+    {
+        self::assertFalse($this->repo->transition(999999, 'queued'));
+    }
+
+    // ── stampThreadReply ───────────────────────────────────────────────────────
+
+    public function testStampThreadReplyReturnsFalseWhenNoMatch(): void
+    {
+        self::assertFalse($this->repo->stampThreadReply('999999999999999999'));
+    }
+
+    public function testStampThreadReplyReturnsTrueAndUpdatesTimestamp(): void
+    {
+        $id = $this->insertBugReport(['thread_id' => self::THREAD]);
+        self::assertTrue($this->repo->stampThreadReply(self::THREAD));
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertNotNull($row['last_gm_reply_at']);
+    }
+
+    // ── advanceOnApproval ──────────────────────────────────────────────────────
+
+    public function testAdvanceOnApprovalReturnsFalseWhenNoMatch(): void
+    {
+        self::assertFalse($this->repo->advanceOnApproval('999999999999999999'));
+    }
+
+    public function testAdvanceOnApprovalNullsApprovalMessageAndReturnsTrueOnAwaitingAjay(): void
+    {
+        $id = $this->insertBugReport([
+            'status'              => 'awaiting_ajay',
+            'approval_message_id' => self::APPROVAL,
+        ]);
+        self::assertTrue($this->repo->advanceOnApproval(self::APPROVAL));
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertNull($row['approval_message_id']);
+        self::assertSame('awaiting_ajay', $row['status']);
+    }
+
+    public function testAdvanceOnApprovalReturnsFalseWhenStatusIsNotAwaitingAjay(): void
+    {
+        $this->insertBugReport([
+            'status'              => 'queued',
+            'approval_message_id' => self::APPROVAL,
+        ]);
+        self::assertFalse($this->repo->advanceOnApproval(self::APPROVAL));
+    }
+
+    // ── claimNextHuntable (pre-impl characterization pins) ─────────────────────
+
+    public function testClaimNextHuntableSkipsUnclassifiedRow(): void
+    {
+        // Unclassified (class IS NULL) row is skipped even though it is the oldest queued row.
+        $this->insertBugReport(['original_message_id' => self::MSG_ID]); // class NULL by default
+        $classified = $this->insertBugReport(['original_message_id' => self::REPLY_ID, 'class' => 'bug']);
+
+        $row = $this->repo->claimNextHuntable('worker-1', '2099-01-01 00:00:00');
+        self::assertNotNull($row);
+        self::assertSame($classified, $row['id'], 'Only a classified (class IS NOT NULL) queued row is huntable');
+        self::assertSame('hunting', $row['status']);
+        self::assertSame('worker-1', $row['lease_owner']);
+
+        // The classified row is now hunting; only the unclassified queued row remains → null.
+        self::assertNull($this->repo->claimNextHuntable('worker-2', '2099-01-01 00:00:00'));
+    }
+
+    public function testClaimNextHuntableSkipsRowParkedByBackoff(): void
+    {
+        // Future backoff → parked → not huntable (even though classified + queued).
+        $this->insertBugReport([
+            'original_message_id' => self::MSG_ID,
+            'class'               => 'bug',
+            'blocked_until'       => '2099-01-01 00:00:00',
+        ]);
+        self::assertNull($this->repo->claimNextHuntable('worker-1', '2099-01-01 00:00:00'));
+
+        // A ripe (past) backoff is claimable.
+        $ripe = $this->insertBugReport([
+            'original_message_id' => self::REPLY_ID,
+            'class'               => 'bug',
+            'blocked_until'       => '2000-01-01 00:00:00',
+        ]);
+        // Distinct lease args from the parked-row attempt above: a byte-identical
+        // claimNextHuntable() call would make PHPStan carry the earlier assertNull()
+        // narrowing forward (it can't see the ripe INSERT between the two calls).
+        $row = $this->repo->claimNextHuntable('worker-2', '2099-06-01 00:00:00');
+        self::assertNotNull($row);
+        self::assertSame($ripe, $row['id']);
+        self::assertSame('hunting', $row['status']);
+    }
+
+    // ── resumeBlockedHunt (pre-impl characterization pins) ─────────────────────
+
+    public function testResumeBlockedHuntFlipsBlockedToHunting(): void
+    {
+        $id = $this->insertBugReport([
+            'status'        => 'blocked',
+            'blocked_until' => '2000-01-01 00:00:00',
+        ]);
+        self::assertTrue($this->repo->resumeBlockedHunt('worker-1', '2099-01-01 00:00:00', $id));
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertSame('hunting', $row['status']);
+        self::assertSame('worker-1', $row['lease_owner']);
+        self::assertSame('2099-01-01 00:00:00', $row['lease_expires']);
+
+        // Single-flight: the row is no longer 'blocked', so a second immediate call flips nothing.
+        self::assertFalse($this->repo->resumeBlockedHunt('worker-2', '2099-01-01 00:00:00', $id));
+    }
+
+    public function testResumeBlockedHuntRejectsUnripeBackoff(): void
+    {
+        $id = $this->insertBugReport([
+            'status'        => 'blocked',
+            'blocked_until' => '2099-01-01 00:00:00',
+        ]);
+        self::assertFalse($this->repo->resumeBlockedHunt('worker-1', '2099-01-01 00:00:00', $id));
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertSame('blocked', $row['status']);
+    }
+
+    // ── markReminderSent (pre-impl characterization pin) ───────────────────────
+
+    public function testMarkReminderSentIsAtMostOnce(): void
+    {
+        $id = $this->insertBugReport();
+        self::assertTrue($this->repo->markReminderSent($id));
+        $first = $this->fetchBugReport($id);
+        self::assertNotNull($first);
+        self::assertNotNull($first['reminder_sent_at']);
+
+        // At-most-once: a second call is a no-op and the original stamp is preserved.
+        self::assertFalse($this->repo->markReminderSent($id));
+        $second = $this->fetchBugReport($id);
+        self::assertNotNull($second);
+        self::assertSame($first['reminder_sent_at'], $second['reminder_sent_at']);
+    }
+
+    // ── stampLastProcessed (pre-impl characterization pin) ─────────────────────
+
+    public function testStampLastProcessedUpdatesTimestamp(): void
+    {
+        $id = $this->insertBugReport();
+        self::assertTrue($this->repo->stampLastProcessed($id));
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertNotNull($row['last_processed_at']);
+
+        self::assertFalse($this->repo->stampLastProcessed(999999));
+    }
+
+    // ── clearBlocked (pre-impl characterization pin) ───────────────────────────
+
+    public function testClearBlockedNullsBackoff(): void
+    {
+        $id = $this->insertBugReport(['blocked_until' => '2099-01-01 00:00:00']);
+        self::assertTrue($this->repo->clearBlocked($id));
+        $row = $this->fetchBugReport($id);
+        self::assertNotNull($row);
+        self::assertNull($row['blocked_until']);
+
+        self::assertFalse($this->repo->clearBlocked(999999));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /**
+     * @param array<string, int|string> $overrides
+     */
+    private function insertBugReport(array $overrides = []): int
+    {
+        return $this->insertRow('ibl_bug_reports', array_merge([
+            'discord_author_id'   => self::AUTHOR,
+            'channel_id'          => self::CHANNEL,
+            'original_message_id' => self::MSG_ID,
+            'original_text'       => 'test bug report',
+            'status'              => 'queued',
+            'created_at'          => date('Y-m-d H:i:s'),
+            'updated_at'          => date('Y-m-d H:i:s'),
+        ], $overrides));
+    }
+
+    /**
+     * Direct-SQL read-back for write-verify assertions.
+     * BugReportClaimRepository is a writer-only sub-repository and does not expose findById().
+     *
+     * Applies the same snowflake casting as BugReportRowCasting::castRow() so that
+     * BIGINT snowflake columns (which MYSQLI_OPT_INT_AND_FLOAT_NATIVE returns as int)
+     * are cast to string — matching the shape the original findById()-based assertions expect.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function fetchBugReport(int $id): ?array
+    {
+        $stmt = $this->db->prepare('SELECT * FROM `ibl_bug_reports` WHERE id = ? LIMIT 1');
+        self::assertNotFalse($stmt);
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        self::assertNotFalse($result);
+        $row = $result->fetch_assoc();
+        $stmt->close();
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        foreach (['discord_author_id', 'channel_id', 'original_message_id', 'thread_id', 'approval_message_id'] as $col) {
+            if (isset($row[$col]) && is_scalar($row[$col])) {
+                $row[$col] = (string) $row[$col];
+            }
+        }
+
+        return $row;
+    }
+}

--- a/ibl5/tests/DatabaseIntegration/BugPipeline/BugReportRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BugPipeline/BugReportRepositoryTest.php
@@ -402,7 +402,200 @@ class BugReportRepositoryTest extends DatabaseTestCase
         self::assertCount(1, $map[$reportB]);
     }
 
+    // ── claimNextHuntable (pre-impl characterization pins) ─────────────────────
+
+    public function testClaimNextHuntableSkipsUnclassifiedRow(): void
+    {
+        // Unclassified (class IS NULL) row is skipped even though it is the oldest queued row.
+        $this->insertBugReport(['original_message_id' => self::MSG_ID]); // class NULL by default
+        $classified = $this->insertBugReport(['original_message_id' => self::REPLY_ID, 'class' => 'bug']);
+
+        $row = $this->repo->claimNextHuntable('worker-1', '2099-01-01 00:00:00');
+        self::assertNotNull($row);
+        self::assertSame($classified, $row['id'], 'Only a classified (class IS NOT NULL) queued row is huntable');
+        self::assertSame('hunting', $row['status']);
+        self::assertSame('worker-1', $row['lease_owner']);
+
+        // The classified row is now hunting; only the unclassified queued row remains → null.
+        self::assertNull($this->repo->claimNextHuntable('worker-2', '2099-01-01 00:00:00'));
+    }
+
+    public function testClaimNextHuntableSkipsRowParkedByBackoff(): void
+    {
+        // Future backoff → parked → not huntable (even though classified + queued).
+        $this->insertBugReport([
+            'original_message_id' => self::MSG_ID,
+            'class'               => 'bug',
+            'blocked_until'       => '2099-01-01 00:00:00',
+        ]);
+        self::assertNull($this->repo->claimNextHuntable('worker-1', '2099-01-01 00:00:00'));
+
+        // A ripe (past) backoff is claimable.
+        $ripe = $this->insertBugReport([
+            'original_message_id' => self::REPLY_ID,
+            'class'               => 'bug',
+            'blocked_until'       => '2000-01-01 00:00:00',
+        ]);
+        // Distinct lease args from the parked-row attempt above: a byte-identical
+        // claimNextHuntable() call would make PHPStan carry the earlier assertNull()
+        // narrowing forward (it can't see the ripe INSERT between the two calls).
+        $row = $this->repo->claimNextHuntable('worker-2', '2099-06-01 00:00:00');
+        self::assertNotNull($row);
+        self::assertSame($ripe, $row['id']);
+        self::assertSame('hunting', $row['status']);
+    }
+
+    // ── resumeBlockedHunt (pre-impl characterization pins) ─────────────────────
+
+    public function testResumeBlockedHuntFlipsBlockedToHunting(): void
+    {
+        $id = $this->insertBugReport([
+            'status'        => 'blocked',
+            'blocked_until' => '2000-01-01 00:00:00',
+        ]);
+        self::assertTrue($this->repo->resumeBlockedHunt('worker-1', '2099-01-01 00:00:00', $id));
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertSame('hunting', $row['status']);
+        self::assertSame('worker-1', $row['lease_owner']);
+        self::assertSame('2099-01-01 00:00:00', $row['lease_expires']);
+
+        // Single-flight: the row is no longer 'blocked', so a second immediate call flips nothing.
+        self::assertFalse($this->repo->resumeBlockedHunt('worker-2', '2099-01-01 00:00:00', $id));
+    }
+
+    public function testResumeBlockedHuntRejectsUnripeBackoff(): void
+    {
+        $id = $this->insertBugReport([
+            'status'        => 'blocked',
+            'blocked_until' => '2099-01-01 00:00:00',
+        ]);
+        self::assertFalse($this->repo->resumeBlockedHunt('worker-1', '2099-01-01 00:00:00', $id));
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertSame('blocked', $row['status']);
+    }
+
+    // ── markReminderSent (pre-impl characterization pin) ───────────────────────
+
+    public function testMarkReminderSentIsAtMostOnce(): void
+    {
+        $id = $this->insertBugReport();
+        self::assertTrue($this->repo->markReminderSent($id));
+        $first = $this->repo->findById($id);
+        self::assertNotNull($first);
+        self::assertNotNull($first['reminder_sent_at']);
+
+        // At-most-once: a second call is a no-op and the original stamp is preserved.
+        self::assertFalse($this->repo->markReminderSent($id));
+        $second = $this->repo->findById($id);
+        self::assertNotNull($second);
+        self::assertSame($first['reminder_sent_at'], $second['reminder_sent_at']);
+    }
+
+    // ── stampLastProcessed (pre-impl characterization pin) ─────────────────────
+
+    public function testStampLastProcessedUpdatesTimestamp(): void
+    {
+        $id = $this->insertBugReport();
+        self::assertTrue($this->repo->stampLastProcessed($id));
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertNotNull($row['last_processed_at']);
+
+        self::assertFalse($this->repo->stampLastProcessed(999999));
+    }
+
+    // ── clearBlocked (pre-impl characterization pin) ───────────────────────────
+
+    public function testClearBlockedNullsBackoff(): void
+    {
+        $id = $this->insertBugReport(['blocked_until' => '2099-01-01 00:00:00']);
+        self::assertTrue($this->repo->clearBlocked($id));
+        $row = $this->repo->findById($id);
+        self::assertNotNull($row);
+        self::assertNull($row['blocked_until']);
+
+        self::assertFalse($this->repo->clearBlocked(999999));
+    }
+
+    // ── listPrOpen (pre-impl characterization pin) ─────────────────────────────
+
+    public function testListPrOpenReturnsOnlyPrOpenRowsWithCastSnowflakes(): void
+    {
+        // Empty table → empty list.
+        self::assertSame([], $this->repo->listPrOpen());
+
+        $prOpen = $this->insertBugReport(['original_message_id' => self::MSG_ID, 'status' => 'pr_open']);
+        $this->insertBugReport(['original_message_id' => self::REPLY_ID, 'status' => 'fixed']);
+        $this->insertBugReport(['original_message_id' => self::APPROVAL, 'status' => 'queued']);
+
+        $rows = $this->repo->listPrOpen();
+        self::assertCount(1, $rows);
+        self::assertSame($prOpen, $rows[0]['id']);
+        self::assertIsString($rows[0]['channel_id'], 'snowflake must be cast to string');
+        self::assertSame(self::CHANNEL, $rows[0]['channel_id']);
+    }
+
+    // ── listActiveConversations (pre-impl characterization pin) ────────────────
+
+    public function testListActiveConversationsUnionAndExclusions(): void
+    {
+        // Included — one row per union branch, captured in id (insertion) order.
+        $queuedUnclassified = $this->insertBugReport([
+            'original_message_id' => '700000000000000001',
+            'status'              => 'queued', // class IS NULL by default → branch (a)
+        ]);
+        $awaitingInfo = $this->insertBugReport([
+            'original_message_id' => '700000000000000002',
+            'status'              => 'awaiting_info', // branch (b)
+        ]);
+        $readyForPlan = $this->insertBugReport([
+            'original_message_id' => '700000000000000003',
+            'status'              => 'awaiting_ajay', // approval_message_id NULL → branch (c)
+        ]);
+        $blockedRipe = $this->insertBugReport([
+            'original_message_id' => '700000000000000004',
+            'status'              => 'blocked', // blocked_until NULL → branch (d)
+        ]);
+
+        // Excluded — each fails a branch predicate or a global gate.
+        $this->insertBugReport(['original_message_id' => '800000000000000001', 'status' => 'queued', 'class' => 'bug']);
+        $this->insertBugReport(['original_message_id' => '800000000000000002', 'status' => 'awaiting_ajay', 'approval_message_id' => self::APPROVAL]);
+        $this->insertBugReport(['original_message_id' => '800000000000000003', 'status' => 'hunting']);
+        $this->insertBugReport(['original_message_id' => '800000000000000004', 'status' => 'fixed']);
+        $this->insertBugReport(['original_message_id' => '800000000000000005', 'status' => 'dropped']);
+        $this->insertBugReport(['original_message_id' => '800000000000000006', 'status' => 'pr_open']);
+        $this->insertBugReport(['original_message_id' => '800000000000000007', 'status' => 'needs_human']);
+        $this->insertBugReport(['original_message_id' => '800000000000000008', 'status' => 'parked_idle']);
+        $this->insertBugReport(['original_message_id' => '800000000000000009', 'status' => 'blocked', 'blocked_until' => '2099-01-01 00:00:00']);
+
+        $rows = $this->repo->listActiveConversations();
+        $ids  = array_map(static fn (array $r): int => $r['id'], $rows);
+        self::assertSame(
+            [$queuedUnclassified, $awaitingInfo, $readyForPlan, $blockedRipe],
+            $ids,
+            'Exactly the four union branches, in id ASC order'
+        );
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /**
+     * @param array<string, int|string> $overrides
+     */
+    private function insertBugReport(array $overrides = []): int
+    {
+        return $this->insertRow('ibl_bug_reports', array_merge([
+            'discord_author_id'   => self::AUTHOR,
+            'channel_id'          => self::CHANNEL,
+            'original_message_id' => self::MSG_ID,
+            'original_text'       => 'test bug report',
+            'status'              => 'queued',
+            'created_at'          => date('Y-m-d H:i:s'),
+            'updated_at'          => date('Y-m-d H:i:s'),
+        ], $overrides));
+    }
 
     /**
      * @param array<string, int|string|null> $overrides
@@ -420,21 +613,5 @@ class BugReportRepositoryTest extends DatabaseTestCase
             'file_size'     => 12345,
         ], $overrides);
         return $input;
-    }
-
-    /**
-     * @param array<string, int|string> $overrides
-     */
-    private function insertBugReport(array $overrides = []): int
-    {
-        return $this->insertRow('ibl_bug_reports', array_merge([
-            'discord_author_id'   => self::AUTHOR,
-            'channel_id'          => self::CHANNEL,
-            'original_message_id' => self::MSG_ID,
-            'original_text'       => 'test bug report',
-            'status'              => 'queued',
-            'created_at'          => date('Y-m-d H:i:s'),
-            'updated_at'          => date('Y-m-d H:i:s'),
-        ], $overrides));
     }
 }

--- a/ibl5/tests/DatabaseIntegration/BugPipeline/BugReportRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BugPipeline/BugReportRepositoryTest.php
@@ -162,6 +162,29 @@ class BugReportRepositoryTest extends DatabaseTestCase
         self::assertSame(1, $row['cnt']);
     }
 
+    /**
+     * Atomicity pin for the 1.26 split: the delegated watermark write must run on the
+     * facade's OWN mysqli handle. DatabaseTestCase already opens a transaction on that
+     * handle, so rolling it back here discards every write that joined it. If a
+     * sub-repository ever gets its own connection, its watermark write commits
+     * independently and survives this rollback — which is exactly the regression the
+     * split risks and which replay-safety alone does not detect.
+     */
+    public function testEnqueueAuthorizedAndAdvanceWatermarkJoinsTheFacadeTransaction(): void
+    {
+        $id = $this->repo->enqueueAuthorizedAndAdvance(self::AUTHOR, self::CHANNEL, self::MSG_ID, 'bug text');
+        self::assertNotNull($this->repo->findById($id));
+        self::assertSame(self::MSG_ID, $this->repo->findPipelineState(self::CHANNEL));
+
+        $this->db->rollback();
+
+        self::assertNull($this->repo->findById($id), 'report row must roll back with the transaction');
+        self::assertNull(
+            $this->repo->findPipelineState(self::CHANNEL),
+            'watermark must roll back with it — a second connection would have committed it'
+        );
+    }
+
     // ── stampThreadReply ───────────────────────────────────────────────────────
 
     public function testStampThreadReplyReturnsFalseWhenNoMatch(): void

--- a/ibl5/tests/DatabaseIntegration/BugPipeline/BugReporterProfileRepositoryTest.php
+++ b/ibl5/tests/DatabaseIntegration/BugPipeline/BugReporterProfileRepositoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\BugPipeline;
+
+use BugPipeline\BugReporterProfileRepository;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+#[Group('database')]
+class BugReporterProfileRepositoryTest extends DatabaseTestCase
+{
+    private BugReporterProfileRepository $repo;
+
+    // Representative snowflake fixture — real Discord IDs are 17–19 digits
+    private const AUTHOR = '100000000000000001';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new BugReporterProfileRepository($this->db);
+    }
+
+    // ── upsertReporterProfile / getReporterTechLevel ───────────────────────────
+
+    public function testGetReporterTechLevelReturnsNullWhenMissing(): void
+    {
+        self::assertNull($this->repo->getReporterTechLevel('999999999999999999'));
+    }
+
+    public function testUpsertReporterProfileInsertsAndUpdates(): void
+    {
+        $this->repo->upsertReporterProfile(self::AUTHOR, 'technical');
+        self::assertSame('technical', $this->repo->getReporterTechLevel(self::AUTHOR));
+
+        // Idempotent update
+        $this->repo->upsertReporterProfile(self::AUTHOR, 'nontechnical');
+        self::assertSame('nontechnical', $this->repo->getReporterTechLevel(self::AUTHOR));
+    }
+}


### PR DESCRIPTION
Backlog item **1.26**. `BugReportRepository` was 546 LOC / 23 public methods spanning three unrelated tables and three unrelated concerns. This PR splits it into four production classes while keeping all 14 call sites byte-unchanged (green-green).

## What changed

- **NEW** `BugReportRowCasting` trait — single home of `SNOWFLAKE_COLUMNS`, `castRow()`, and `@phpstan-type BugReportRow`
- **NEW** `BugReportClaimRepository` — 11 state-mutating methods (claim, lease, transition, stamps) behind `Contracts/BugReportClaimRepositoryInterface`
- **NEW** `BugReporterProfileRepository` — `ibl_bug_reporter_profile` access (2 methods) behind `Contracts/BugReporterProfileRepositoryInterface`
- **NEW** `BugPipelineStateRepository` — monotonic poll watermark on `ibl_bug_pipeline_state` (2 methods) behind `Contracts/BugPipelineStateRepositoryInterface`
- **REFACTORED** `BugReportRepository` becomes a delegating facade (~250 LOC from 546): 8 real method bodies, 15 one-line delegations, 3 sub-repo properties built from the same `\mysqli` handle (load-bearing: `enqueueAuthorizedAndAdvance` wraps all three in one `transactional()` unit)
- **NEW** 3 per-group DB-integration test files pinning each sub-repository directly
- **BACKLOG** `maintenance-backlog.md` item 1.26 flipped to ✅ Implemented; `BugPipeline/README.md` updated

No call sites changed. No schema changes. `BugPipelineCliTest.php` passes unchanged (the de-facto call-site integration check).

## Manual Testing

<!-- Row 25 from the Verification Matrix is Truly-manual -->

**The mechanical half is done — it was run against a scratch DB on 2026-08-09, using this branch's code.** The plan's original step ("drive a report on `http://<slug>.localhost/ibl5/`") was never executable and has been removed: there is no bug-pipeline web UI, and a worktree's dev DB carries only the three pipeline tables, so it has neither `ibl_api_keys` (API-key auth fails) nor `ibl_team_info` (`isKnownDiscordID()` fails). That is an environment property, not a gap this PR left open.

What was actually run — `bin/bug-pipeline-tick` end to end against a scratch DB (migrations 153 + 158) with a fake bot HTTP responder and stubbed `CLAUDE_BIN`/`GH_BIN`, real PHP CLI, real DB writes:

| Path exercised | Result |
|---|---|
| `enqueueAuthorizedAndAdvance` → row + watermark | both written; both roll back together under an explicit `rollback()` (the cross-repository atomicity pin) |
| tick 1 — classify | `create-thread` + `post-to-thread` posted, `class=bug`, `thread_id`, `issue_number` persisted |
| tick 2 — hunter claim | `queued → hunting` with lease set; `wt-new` failure released the lease and re-queued |
| tick 3 — reconcile | `pr_open → fixed` on a MERGED PR |
| feature path | `queued --class=feature → gathering → awaiting_ajay --approval-message-id=…` |
| single-flight, genuinely concurrent | 8 `claim-next` processes fired simultaneously against 4 huntable rows: 3 rows claimed, each by exactly one `lease_owner`, **no id returned twice**; the 5 losers printed nothing and exited 0 (a loser does not fall through to the next row — deliberate: `BugReportClaimRepository::claimNextHuntable()` returns null when its `claimQueued()` re-assert loses) |
| idle reminder, at-most-once | a `gathering` row idle past `IDLE_SECS`: three consecutive ticks produced **exactly one** `post-to-thread` and one `reminder_sent_at`; a fourth tick with the reminder unanswered parked it (`parked_idle`) |
| read path | `list-pr-open`, `list-active-conversations` (non-empty), `findByThreadId` all return the right rows |
| reporter profile | `set-reporter-tech-level` / `get-reporter-tech-level` round-trip |
| snowflake fidelity | `thread_id`, `approval_message_id`, `discord_author_id` all read back as PHP `string`, values above 2^53 unchanged |

**What remains for the reviewer** is the subjective half of row 25 — its three mechanical properties (statuses, lease behaviour under a concurrent tick, at-most-once reminder) are in the table above: does the transition matrix above still *read* as the same pipeline a GM experiences in Discord? That judgment is why `auto_merge: false` is set — it is intrinsic to the change (live cron-driven pipeline; failure mode is silent and concurrency-shaped), not a reducible verification gap.

> **Out-of-scope finding, logged not fixed here.** `bin/bug-pipeline-tick` parses DB timestamps with host-local `date -j` (`epoch_of`, line 136) and writes host-local ones back (`future_ts`, line 139), but MariaDB stores UTC and the host runs PDT. So idle reminders fire ~7h late and `blocked_until` backoffs expire on write. Pre-existing in the bash driver — **not** touched by this PR, which is PHP-only.
