### PR TITLE
refactor: extract TradeRosterPreviewParamValidator and CashRowBuilder behind interfaces (backlog 1.31)

### DIFF
--- a/ibl5/classes/Trading/Contracts/TradeRosterPreviewCashRowBuilderInterface.php
+++ b/ibl5/classes/Trading/Contracts/TradeRosterPreviewCashRowBuilderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trading\Contracts;
+
+/**
+ * TradeRosterPreviewCashRowBuilderInterface - Contract for building the
+ * synthetic cash-consideration rows shown in the trade roster preview's
+ * contracts view.
+ *
+ * Extracted verbatim from TradeRosterPreviewApiHandler. The builder reads the
+ * already-validated cash `$_GET` parameters through a
+ * TradeRosterPreviewParamValidatorInterface collaborator and never touches the
+ * database.
+ */
+interface TradeRosterPreviewCashRowBuilderInterface
+{
+    /**
+     * Build synthetic cash rows for the contracts view
+     *
+     * @return list<array<string, mixed>> Synthetic cash player rows with isCashRow flag
+     */
+    public function buildCashRows(int $viewingTeamId): array;
+}

--- a/ibl5/classes/Trading/Contracts/TradeRosterPreviewParamValidatorInterface.php
+++ b/ibl5/classes/Trading/Contracts/TradeRosterPreviewParamValidatorInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trading\Contracts;
+
+/**
+ * TradeRosterPreviewParamValidatorInterface - Contract for validating the
+ * trade roster preview endpoint's `$_GET` query parameters.
+ *
+ * Each method reads its parameter directly from the `$_GET` superglobal and
+ * returns a narrowed, validated value. Extracted verbatim from
+ * TradeRosterPreviewApiHandler to isolate the pure (no-DB) param-validation
+ * surface from rendering. No method touches the database.
+ */
+interface TradeRosterPreviewParamValidatorInterface
+{
+    /**
+     * Validate teamid query parameter
+     */
+    public function validateTeamID(): int;
+
+    /**
+     * Validate a PID list query parameter (addPids or removePids)
+     *
+     * Returns empty array for empty/missing values (valid — no players to add/remove).
+     * Returns null for invalid values (non-numeric, exceeds max).
+     *
+     * @return list<int>|null Validated PID list or null if invalid
+     */
+    public function validatePidList(string $paramName): ?array;
+
+    /**
+     * Validate display query parameter against whitelist
+     */
+    public function validateDisplay(): string;
+
+    /**
+     * Validate a string query parameter
+     */
+    public function validateStringParam(string $paramName): string;
+
+    /**
+     * Validate an integer query parameter (positive)
+     */
+    public function validateIntParam(string $paramName): int;
+
+    /**
+     * Validate a cash amount query parameter (0-2000)
+     */
+    public function validateCashAmount(string $paramName): int;
+}

--- a/ibl5/classes/Trading/TradeRosterPreviewApiHandler.php
+++ b/ibl5/classes/Trading/TradeRosterPreviewApiHandler.php
@@ -7,6 +7,7 @@ namespace Trading;
 use Team\TeamRepository;
 use Team\TeamTableService;
 use Trading\Contracts\TradeAssetRepositoryInterface;
+use Trading\Contracts\TradeRosterPreviewParamValidatorInterface;
 use UI\Components\TableViewDropdown;
 use Team\Team;
 use Season\Season;
@@ -20,21 +21,9 @@ use Season\Season;
  */
 class TradeRosterPreviewApiHandler
 {
-    private const VALID_DISPLAY_MODES = [
-        'ratings',
-        'total_s',
-        'avg_s',
-        'per36mins',
-        'contracts',
-        'split',
-        'chunk',
-        'playoffs',
-    ];
-
-    private const MAX_PIDS = 20;
-
     private \mysqli $db;
     private TradeAssetRepositoryInterface $tradeAssetRepository;
+    private TradeRosterPreviewParamValidatorInterface $paramValidator;
 
     /**
      * The logged-in user's team ID, used to decide whether eligibility action
@@ -47,12 +36,13 @@ class TradeRosterPreviewApiHandler
      */
     private ?Season $season = null;
 
-    public function __construct(\mysqli $db, TradeAssetRepositoryInterface $tradeAssetRepository, int $loggedInTeamID = 0, ?Season $season = null)
+    public function __construct(\mysqli $db, TradeAssetRepositoryInterface $tradeAssetRepository, int $loggedInTeamID = 0, ?Season $season = null, ?TradeRosterPreviewParamValidatorInterface $paramValidator = null)
     {
         $this->db = $db;
         $this->tradeAssetRepository = $tradeAssetRepository;
         $this->loggedInTeamID = $loggedInTeamID;
         $this->season = $season;
+        $this->paramValidator = $paramValidator ?? new TradeRosterPreviewParamValidator();
     }
 
     public function handle(): void
@@ -60,25 +50,25 @@ class TradeRosterPreviewApiHandler
         header('Content-Type: application/json; charset=utf-8');
         $responder = new \Api\Response\HtmlResponder();
 
-        $teamid = $this->validateTeamID();
+        $teamid = $this->paramValidator->validateTeamID();
         if ($teamid === 0) {
             $responder->json(['html' => '']);
             return;
         }
 
-        $addPids = $this->validatePidList('addPids');
+        $addPids = $this->paramValidator->validatePidList('addPids');
         if ($addPids === null) {
             $responder->json(['html' => '']);
             return;
         }
 
-        $removePids = $this->validatePidList('removePids');
+        $removePids = $this->paramValidator->validatePidList('removePids');
         if ($removePids === null) {
             $responder->json(['html' => '']);
             return;
         }
 
-        $display = $this->validateDisplay();
+        $display = $this->paramValidator->validateDisplay();
 
         // Validate split parameter when display is 'split'
         $split = null;
@@ -175,76 +165,6 @@ class TradeRosterPreviewApiHandler
     }
 
     /**
-     * Validate teamid query parameter
-     */
-    private function validateTeamID(): int
-    {
-        if (!isset($_GET['teamid']) || !is_string($_GET['teamid'])) {
-            return 0;
-        }
-
-        $raw = $_GET['teamid'];
-        if (!ctype_digit($raw) || $raw === '0') {
-            return 0;
-        }
-
-        return (int) $raw;
-    }
-
-    /**
-     * Validate a PID list query parameter (addPids or removePids)
-     *
-     * Returns empty array for empty/missing values (valid — no players to add/remove).
-     * Returns null for invalid values (non-numeric, exceeds max).
-     *
-     * @return list<int>|null Validated PID list or null if invalid
-     */
-    private function validatePidList(string $paramName): ?array
-    {
-        if (!isset($_GET[$paramName]) || !is_string($_GET[$paramName])) {
-            return [];
-        }
-
-        $raw = $_GET[$paramName];
-        if ($raw === '') {
-            return [];
-        }
-
-        $parts = explode(',', $raw);
-        if (count($parts) > self::MAX_PIDS) {
-            return null;
-        }
-
-        $pids = [];
-        foreach ($parts as $part) {
-            $trimmed = trim($part);
-            if ($trimmed === '' || !ctype_digit($trimmed)) {
-                return null;
-            }
-            $pids[] = (int) $trimmed;
-        }
-
-        return $pids;
-    }
-
-    /**
-     * Validate display query parameter against whitelist
-     */
-    private function validateDisplay(): string
-    {
-        if (!isset($_GET['display']) || !is_string($_GET['display'])) {
-            return 'ratings';
-        }
-
-        $raw = $_GET['display'];
-        if (in_array($raw, self::VALID_DISPLAY_MODES, true)) {
-            return $raw;
-        }
-
-        return 'ratings';
-    }
-
-    /**
      * Build synthetic cash rows for the contracts view
      *
      * Creates in-memory player-format rows representing cash exchanges,
@@ -254,11 +174,11 @@ class TradeRosterPreviewApiHandler
      */
     private function buildCashRows(int $viewingTeamId): array
     {
-        $userTeam = $this->validateStringParam('userTeam');
-        $partnerTeam = $this->validateStringParam('partnerTeam');
-        $userTeamId = $this->validateIntParam('userTeamId');
-        $cashStartYear = $this->validateIntParam('cashStartYear');
-        $cashEndYear = $this->validateIntParam('cashEndYear');
+        $userTeam = $this->paramValidator->validateStringParam('userTeam');
+        $partnerTeam = $this->paramValidator->validateStringParam('partnerTeam');
+        $userTeamId = $this->paramValidator->validateIntParam('userTeamId');
+        $cashStartYear = $this->paramValidator->validateIntParam('cashStartYear');
+        $cashEndYear = $this->paramValidator->validateIntParam('cashEndYear');
 
         if ($userTeam === '' || $partnerTeam === '' || $cashStartYear === 0 || $cashEndYear === 0) {
             return [];
@@ -282,8 +202,8 @@ class TradeRosterPreviewApiHandler
         $hasPartnerCash = false;
 
         for ($yr = $cashStartYear; $yr <= $cashEndYear; $yr++) {
-            $uAmount = $this->validateCashAmount('userCash' . $yr);
-            $pAmount = $this->validateCashAmount('partnerCash' . $yr);
+            $uAmount = $this->paramValidator->validateCashAmount('userCash' . $yr);
+            $pAmount = $this->paramValidator->validateCashAmount('partnerCash' . $yr);
             $userCash[$yr] = $uAmount;
             $partnerCash[$yr] = $pAmount;
             if ($uAmount > 0) {
@@ -428,52 +348,6 @@ class TradeRosterPreviewApiHandler
             // Cash row flag
             'isCashRow' => true,
         ];
-    }
-
-    /**
-     * Validate a string query parameter
-     */
-    private function validateStringParam(string $paramName): string
-    {
-        if (!isset($_GET[$paramName]) || !is_string($_GET[$paramName])) {
-            return '';
-        }
-        $raw = trim($_GET[$paramName]);
-        return $raw !== '' ? $raw : '';
-    }
-
-    /**
-     * Validate an integer query parameter (positive)
-     */
-    private function validateIntParam(string $paramName): int
-    {
-        if (!isset($_GET[$paramName]) || !is_string($_GET[$paramName])) {
-            return 0;
-        }
-        $raw = $_GET[$paramName];
-        if (!ctype_digit($raw)) {
-            return 0;
-        }
-        return (int) $raw;
-    }
-
-    /**
-     * Validate a cash amount query parameter (0-2000)
-     */
-    private function validateCashAmount(string $paramName): int
-    {
-        if (!isset($_GET[$paramName]) || !is_string($_GET[$paramName])) {
-            return 0;
-        }
-        $raw = $_GET[$paramName];
-        if (!ctype_digit($raw)) {
-            return 0;
-        }
-        $amount = (int) $raw;
-        if ($amount > 2000) {
-            return 0;
-        }
-        return $amount;
     }
 
     /**

--- a/ibl5/classes/Trading/TradeRosterPreviewApiHandler.php
+++ b/ibl5/classes/Trading/TradeRosterPreviewApiHandler.php
@@ -7,6 +7,7 @@ namespace Trading;
 use Team\TeamRepository;
 use Team\TeamTableService;
 use Trading\Contracts\TradeAssetRepositoryInterface;
+use Trading\Contracts\TradeRosterPreviewCashRowBuilderInterface;
 use Trading\Contracts\TradeRosterPreviewParamValidatorInterface;
 use UI\Components\TableViewDropdown;
 use Team\Team;
@@ -24,6 +25,7 @@ class TradeRosterPreviewApiHandler
     private \mysqli $db;
     private TradeAssetRepositoryInterface $tradeAssetRepository;
     private TradeRosterPreviewParamValidatorInterface $paramValidator;
+    private TradeRosterPreviewCashRowBuilderInterface $cashRowBuilder;
 
     /**
      * The logged-in user's team ID, used to decide whether eligibility action
@@ -36,13 +38,14 @@ class TradeRosterPreviewApiHandler
      */
     private ?Season $season = null;
 
-    public function __construct(\mysqli $db, TradeAssetRepositoryInterface $tradeAssetRepository, int $loggedInTeamID = 0, ?Season $season = null, ?TradeRosterPreviewParamValidatorInterface $paramValidator = null)
+    public function __construct(\mysqli $db, TradeAssetRepositoryInterface $tradeAssetRepository, int $loggedInTeamID = 0, ?Season $season = null, ?TradeRosterPreviewParamValidatorInterface $paramValidator = null, ?TradeRosterPreviewCashRowBuilderInterface $cashRowBuilder = null)
     {
         $this->db = $db;
         $this->tradeAssetRepository = $tradeAssetRepository;
         $this->loggedInTeamID = $loggedInTeamID;
         $this->season = $season;
         $this->paramValidator = $paramValidator ?? new TradeRosterPreviewParamValidator();
+        $this->cashRowBuilder = $cashRowBuilder ?? new TradeRosterPreviewCashRowBuilder($this->paramValidator);
     }
 
     public function handle(): void
@@ -119,7 +122,7 @@ class TradeRosterPreviewApiHandler
                 }
 
                 // Synthetic cash rows for the in-progress trade
-                $tradeCashRows = $this->buildCashRows($teamid);
+                $tradeCashRows = $this->cashRowBuilder->buildCashRows($teamid);
                 foreach ($tradeCashRows as $cashRow) {
                     $roster[] = $cashRow;
                 }
@@ -162,192 +165,6 @@ class TradeRosterPreviewApiHandler
             }
             $responder->json(['html' => '']);
         }
-    }
-
-    /**
-     * Build synthetic cash rows for the contracts view
-     *
-     * Creates in-memory player-format rows representing cash exchanges,
-     * mirroring the pattern used by CashTransactionHandler::createCashTransaction().
-     *
-     * @return list<array<string, mixed>> Synthetic cash player rows with isCashRow flag
-     */
-    private function buildCashRows(int $viewingTeamId): array
-    {
-        $userTeam = $this->paramValidator->validateStringParam('userTeam');
-        $partnerTeam = $this->paramValidator->validateStringParam('partnerTeam');
-        $userTeamId = $this->paramValidator->validateIntParam('userTeamId');
-        $cashStartYear = $this->paramValidator->validateIntParam('cashStartYear');
-        $cashEndYear = $this->paramValidator->validateIntParam('cashEndYear');
-
-        if ($userTeam === '' || $partnerTeam === '' || $cashStartYear === 0 || $cashEndYear === 0) {
-            return [];
-        }
-
-        // Sanitize team names before embedding in HTML labels
-        $userTeam = \Security\HtmlSanitizer::safeHtmlOutput($userTeam);
-        $partnerTeam = \Security\HtmlSanitizer::safeHtmlOutput($partnerTeam);
-
-        $partnerTeamId = 0;
-        if ($viewingTeamId !== $userTeamId) {
-            $partnerTeamId = $viewingTeamId;
-        }
-
-        // Collect cash amounts per year
-        /** @var array<int, int> $userCash */
-        $userCash = [];
-        /** @var array<int, int> $partnerCash */
-        $partnerCash = [];
-        $hasUserCash = false;
-        $hasPartnerCash = false;
-
-        for ($yr = $cashStartYear; $yr <= $cashEndYear; $yr++) {
-            $uAmount = $this->paramValidator->validateCashAmount('userCash' . $yr);
-            $pAmount = $this->paramValidator->validateCashAmount('partnerCash' . $yr);
-            $userCash[$yr] = $uAmount;
-            $partnerCash[$yr] = $pAmount;
-            if ($uAmount > 0) {
-                $hasUserCash = true;
-            }
-            if ($pAmount > 0) {
-                $hasPartnerCash = true;
-            }
-        }
-
-        if (!$hasUserCash && !$hasPartnerCash) {
-            return [];
-        }
-
-        $rows = [];
-        $isViewingUserTeam = ($viewingTeamId === $userTeamId);
-
-        if ($isViewingUserTeam) {
-            // Viewing user's team
-            if ($hasUserCash) {
-                $rows[] = $this->makeCashRow(
-                    '| Cash to ' . $partnerTeam,
-                    $viewingTeamId,
-                    $userCash,
-                    $cashStartYear,
-                    $cashEndYear,
-                    false
-                );
-            }
-            if ($hasPartnerCash) {
-                $rows[] = $this->makeCashRow(
-                    '| Cash from ' . $partnerTeam,
-                    $viewingTeamId,
-                    $partnerCash,
-                    $cashStartYear,
-                    $cashEndYear,
-                    true
-                );
-            }
-        } else {
-            // Viewing partner's team
-            if ($hasPartnerCash) {
-                $rows[] = $this->makeCashRow(
-                    '| Cash to ' . $userTeam,
-                    $partnerTeamId,
-                    $partnerCash,
-                    $cashStartYear,
-                    $cashEndYear,
-                    false
-                );
-            }
-            if ($hasUserCash) {
-                $rows[] = $this->makeCashRow(
-                    '| Cash from ' . $userTeam,
-                    $partnerTeamId,
-                    $userCash,
-                    $cashStartYear,
-                    $cashEndYear,
-                    true
-                );
-            }
-        }
-
-        /** @var list<array<string, mixed>> $rows */
-        return $rows;
-    }
-
-    /**
-     * Create a single synthetic cash player row
-     *
-     * @param array<int, int> $amounts Cash amounts keyed by year index
-     * @return array<string, mixed>
-     */
-    private function makeCashRow(string $label, int $teamId, array $amounts, int $startYear, int $endYear, bool $negate): array
-    {
-        $salaryYr1 = $salaryYr2 = $salaryYr3 = $salaryYr4 = $salaryYr5 = $salaryYr6 = 0;
-        $totalYears = 0;
-
-        for ($yr = $startYear; $yr <= $endYear; $yr++) {
-            $amount = $amounts[$yr] ?? 0;
-            if ($negate) {
-                $amount = -$amount;
-            }
-            $cyIndex = $yr - $startYear + 1;
-            if ($cyIndex >= 1 && $cyIndex <= 6) {
-                match ($cyIndex) {
-                    1 => $salaryYr1 = $amount,
-                    2 => $salaryYr2 = $amount,
-                    3 => $salaryYr3 = $amount,
-                    4 => $salaryYr4 = $amount,
-                    5 => $salaryYr5 = $amount,
-                    6 => $salaryYr6 = $amount,
-                };
-                if ($amount !== 0 && $cyIndex > $totalYears) {
-                    $totalYears = $cyIndex;
-                }
-            }
-        }
-
-        if ($totalYears === 0) {
-            $totalYears = 1;
-        }
-
-        return [
-            // Basic fields
-            'pid' => 0,
-            'name' => $label,
-            'nickname' => '',
-            'ordinal' => 100000,
-            'teamid' => $teamId,
-            'pos' => '',
-            'age' => null,
-            'color1' => null,
-            'color2' => null,
-            // Ratings (all zero, matching DB cash rows)
-            'r_fga' => 0, 'r_fgp' => 0, 'r_fta' => 0, 'r_ftp' => 0,
-            'r_3ga' => 0, 'r_3gp' => 0, 'r_orb' => 0, 'r_drb' => 0,
-            'r_ast' => 0, 'r_stl' => 0, 'r_tvr' => 0, 'r_blk' => 0, 'r_foul' => 0,
-            'oo' => 0, 'od' => 0, 'r_drive_off' => 0, 'dd' => 0,
-            'po' => 0, 'pd' => 0, 'r_trans_off' => 0, 'td' => 0,
-            'clutch' => null, 'consistency' => null,
-            'talent' => 0, 'skill' => 0, 'intangibles' => 0,
-            // Free agency (null, matching DB cash rows)
-            'loyalty' => null, 'playing_time' => null, 'winner' => null,
-            'tradition' => null, 'security' => null,
-            // Contract fields
-            'exp' => 1,
-            'bird' => null,
-            'cy' => 1,
-            'cyt' => $totalYears,
-            'salary_yr1' => $salaryYr1, 'salary_yr2' => $salaryYr2, 'salary_yr3' => $salaryYr3,
-            'salary_yr4' => $salaryYr4, 'salary_yr5' => $salaryYr5, 'salary_yr6' => $salaryYr6,
-            // Draft (zero/empty, matching DB cash rows)
-            'draftyear' => 0, 'draftround' => 0, 'draftpickno' => 0,
-            'draftedby' => '', 'draftedbycurrentname' => '', 'college' => '',
-            // Physical (zero, matching DB cash rows)
-            'htft' => 0, 'htin' => 0, 'wt' => 0,
-            // Status
-            'injured' => null,
-            'retired' => 0,
-            'droptime' => 0,
-            // Cash row flag
-            'isCashRow' => true,
-        ];
     }
 
     /**

--- a/ibl5/classes/Trading/TradeRosterPreviewCashRowBuilder.php
+++ b/ibl5/classes/Trading/TradeRosterPreviewCashRowBuilder.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trading;
+
+use Trading\Contracts\TradeRosterPreviewCashRowBuilderInterface;
+use Trading\Contracts\TradeRosterPreviewParamValidatorInterface;
+
+/**
+ * Builds the synthetic cash-consideration rows for the trade roster preview's
+ * contracts view.
+ *
+ * Extracted verbatim from TradeRosterPreviewApiHandler. Pure — reads the
+ * already-validated cash `$_GET` parameters through the injected
+ * TradeRosterPreviewParamValidatorInterface and never touches the database, so
+ * it needs no database connection. Behaviour must not change; the sanitizer calls and the
+ * cash-label strings are security-load-bearing.
+ */
+class TradeRosterPreviewCashRowBuilder implements TradeRosterPreviewCashRowBuilderInterface
+{
+    public function __construct(private TradeRosterPreviewParamValidatorInterface $validator)
+    {
+    }
+
+    /**
+     * Build synthetic cash rows for the contracts view
+     *
+     * Creates in-memory player-format rows representing cash exchanges,
+     * mirroring the pattern used by CashTransactionHandler::createCashTransaction().
+     *
+     * @return list<array<string, mixed>> Synthetic cash player rows with isCashRow flag
+     */
+    public function buildCashRows(int $viewingTeamId): array
+    {
+        $userTeam = $this->validator->validateStringParam('userTeam');
+        $partnerTeam = $this->validator->validateStringParam('partnerTeam');
+        $userTeamId = $this->validator->validateIntParam('userTeamId');
+        $cashStartYear = $this->validator->validateIntParam('cashStartYear');
+        $cashEndYear = $this->validator->validateIntParam('cashEndYear');
+
+        if ($userTeam === '' || $partnerTeam === '' || $cashStartYear === 0 || $cashEndYear === 0) {
+            return [];
+        }
+
+        // Sanitize team names before embedding in HTML labels
+        $userTeam = \Security\HtmlSanitizer::safeHtmlOutput($userTeam);
+        $partnerTeam = \Security\HtmlSanitizer::safeHtmlOutput($partnerTeam);
+
+        $partnerTeamId = 0;
+        if ($viewingTeamId !== $userTeamId) {
+            $partnerTeamId = $viewingTeamId;
+        }
+
+        // Collect cash amounts per year
+        /** @var array<int, int> $userCash */
+        $userCash = [];
+        /** @var array<int, int> $partnerCash */
+        $partnerCash = [];
+        $hasUserCash = false;
+        $hasPartnerCash = false;
+
+        for ($yr = $cashStartYear; $yr <= $cashEndYear; $yr++) {
+            $uAmount = $this->validator->validateCashAmount('userCash' . $yr);
+            $pAmount = $this->validator->validateCashAmount('partnerCash' . $yr);
+            $userCash[$yr] = $uAmount;
+            $partnerCash[$yr] = $pAmount;
+            if ($uAmount > 0) {
+                $hasUserCash = true;
+            }
+            if ($pAmount > 0) {
+                $hasPartnerCash = true;
+            }
+        }
+
+        if (!$hasUserCash && !$hasPartnerCash) {
+            return [];
+        }
+
+        $rows = [];
+        $isViewingUserTeam = ($viewingTeamId === $userTeamId);
+
+        if ($isViewingUserTeam) {
+            // Viewing user's team
+            if ($hasUserCash) {
+                $rows[] = $this->makeCashRow(
+                    '| Cash to ' . $partnerTeam,
+                    $viewingTeamId,
+                    $userCash,
+                    $cashStartYear,
+                    $cashEndYear,
+                    false
+                );
+            }
+            if ($hasPartnerCash) {
+                $rows[] = $this->makeCashRow(
+                    '| Cash from ' . $partnerTeam,
+                    $viewingTeamId,
+                    $partnerCash,
+                    $cashStartYear,
+                    $cashEndYear,
+                    true
+                );
+            }
+        } else {
+            // Viewing partner's team
+            if ($hasPartnerCash) {
+                $rows[] = $this->makeCashRow(
+                    '| Cash to ' . $userTeam,
+                    $partnerTeamId,
+                    $partnerCash,
+                    $cashStartYear,
+                    $cashEndYear,
+                    false
+                );
+            }
+            if ($hasUserCash) {
+                $rows[] = $this->makeCashRow(
+                    '| Cash from ' . $userTeam,
+                    $partnerTeamId,
+                    $userCash,
+                    $cashStartYear,
+                    $cashEndYear,
+                    true
+                );
+            }
+        }
+
+        /** @var list<array<string, mixed>> $rows */
+        return $rows;
+    }
+
+    /**
+     * Create a single synthetic cash player row
+     *
+     * @param array<int, int> $amounts Cash amounts keyed by year index
+     * @return array<string, mixed>
+     */
+    public function makeCashRow(string $label, int $teamId, array $amounts, int $startYear, int $endYear, bool $negate): array
+    {
+        $salaryYr1 = $salaryYr2 = $salaryYr3 = $salaryYr4 = $salaryYr5 = $salaryYr6 = 0;
+        $totalYears = 0;
+
+        for ($yr = $startYear; $yr <= $endYear; $yr++) {
+            $amount = $amounts[$yr] ?? 0;
+            if ($negate) {
+                $amount = -$amount;
+            }
+            $cyIndex = $yr - $startYear + 1;
+            if ($cyIndex >= 1 && $cyIndex <= 6) {
+                match ($cyIndex) {
+                    1 => $salaryYr1 = $amount,
+                    2 => $salaryYr2 = $amount,
+                    3 => $salaryYr3 = $amount,
+                    4 => $salaryYr4 = $amount,
+                    5 => $salaryYr5 = $amount,
+                    6 => $salaryYr6 = $amount,
+                };
+                if ($amount !== 0 && $cyIndex > $totalYears) {
+                    $totalYears = $cyIndex;
+                }
+            }
+        }
+
+        if ($totalYears === 0) {
+            $totalYears = 1;
+        }
+
+        return [
+            // Basic fields
+            'pid' => 0,
+            'name' => $label,
+            'nickname' => '',
+            'ordinal' => 100000,
+            'teamid' => $teamId,
+            'pos' => '',
+            'age' => null,
+            'color1' => null,
+            'color2' => null,
+            // Ratings (all zero, matching DB cash rows)
+            'r_fga' => 0, 'r_fgp' => 0, 'r_fta' => 0, 'r_ftp' => 0,
+            'r_3ga' => 0, 'r_3gp' => 0, 'r_orb' => 0, 'r_drb' => 0,
+            'r_ast' => 0, 'r_stl' => 0, 'r_tvr' => 0, 'r_blk' => 0, 'r_foul' => 0,
+            'oo' => 0, 'od' => 0, 'r_drive_off' => 0, 'dd' => 0,
+            'po' => 0, 'pd' => 0, 'r_trans_off' => 0, 'td' => 0,
+            'clutch' => null, 'consistency' => null,
+            'talent' => 0, 'skill' => 0, 'intangibles' => 0,
+            // Free agency (null, matching DB cash rows)
+            'loyalty' => null, 'playing_time' => null, 'winner' => null,
+            'tradition' => null, 'security' => null,
+            // Contract fields
+            'exp' => 1,
+            'bird' => null,
+            'cy' => 1,
+            'cyt' => $totalYears,
+            'salary_yr1' => $salaryYr1, 'salary_yr2' => $salaryYr2, 'salary_yr3' => $salaryYr3,
+            'salary_yr4' => $salaryYr4, 'salary_yr5' => $salaryYr5, 'salary_yr6' => $salaryYr6,
+            // Draft (zero/empty, matching DB cash rows)
+            'draftyear' => 0, 'draftround' => 0, 'draftpickno' => 0,
+            'draftedby' => '', 'draftedbycurrentname' => '', 'college' => '',
+            // Physical (zero, matching DB cash rows)
+            'htft' => 0, 'htin' => 0, 'wt' => 0,
+            // Status
+            'injured' => null,
+            'retired' => 0,
+            'droptime' => 0,
+            // Cash row flag
+            'isCashRow' => true,
+        ];
+    }
+}

--- a/ibl5/classes/Trading/TradeRosterPreviewParamValidator.php
+++ b/ibl5/classes/Trading/TradeRosterPreviewParamValidator.php
@@ -10,7 +10,7 @@ use Trading\Contracts\TradeRosterPreviewParamValidatorInterface;
  * Validates the trade roster preview endpoint's `$_GET` query parameters.
  *
  * Extracted verbatim from TradeRosterPreviewApiHandler (ADR-0001). Pure — reads
- * only `$_GET`, never the database, so it takes no `\mysqli`. Each method
+ * only `$_GET`, never the database, so it needs no database connection. Each method
  * reproduces the handler's original validation exactly; behaviour must not change.
  */
 class TradeRosterPreviewParamValidator implements TradeRosterPreviewParamValidatorInterface

--- a/ibl5/classes/Trading/TradeRosterPreviewParamValidator.php
+++ b/ibl5/classes/Trading/TradeRosterPreviewParamValidator.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trading;
+
+use Trading\Contracts\TradeRosterPreviewParamValidatorInterface;
+
+/**
+ * Validates the trade roster preview endpoint's `$_GET` query parameters.
+ *
+ * Extracted verbatim from TradeRosterPreviewApiHandler (ADR-0001). Pure — reads
+ * only `$_GET`, never the database, so it takes no `\mysqli`. Each method
+ * reproduces the handler's original validation exactly; behaviour must not change.
+ */
+class TradeRosterPreviewParamValidator implements TradeRosterPreviewParamValidatorInterface
+{
+    private const VALID_DISPLAY_MODES = [
+        'ratings',
+        'total_s',
+        'avg_s',
+        'per36mins',
+        'contracts',
+        'split',
+        'chunk',
+        'playoffs',
+    ];
+
+    private const MAX_PIDS = 20;
+
+    /**
+     * Validate teamid query parameter
+     */
+    public function validateTeamID(): int
+    {
+        if (!isset($_GET['teamid']) || !is_string($_GET['teamid'])) {
+            return 0;
+        }
+
+        $raw = $_GET['teamid'];
+        if (!ctype_digit($raw) || $raw === '0') {
+            return 0;
+        }
+
+        return (int) $raw;
+    }
+
+    /**
+     * Validate a PID list query parameter (addPids or removePids)
+     *
+     * Returns empty array for empty/missing values (valid — no players to add/remove).
+     * Returns null for invalid values (non-numeric, exceeds max).
+     *
+     * @return list<int>|null Validated PID list or null if invalid
+     */
+    public function validatePidList(string $paramName): ?array
+    {
+        if (!isset($_GET[$paramName]) || !is_string($_GET[$paramName])) {
+            return [];
+        }
+
+        $raw = $_GET[$paramName];
+        if ($raw === '') {
+            return [];
+        }
+
+        $parts = explode(',', $raw);
+        if (count($parts) > self::MAX_PIDS) {
+            return null;
+        }
+
+        $pids = [];
+        foreach ($parts as $part) {
+            $trimmed = trim($part);
+            if ($trimmed === '' || !ctype_digit($trimmed)) {
+                return null;
+            }
+            $pids[] = (int) $trimmed;
+        }
+
+        return $pids;
+    }
+
+    /**
+     * Validate display query parameter against whitelist
+     */
+    public function validateDisplay(): string
+    {
+        if (!isset($_GET['display']) || !is_string($_GET['display'])) {
+            return 'ratings';
+        }
+
+        $raw = $_GET['display'];
+        if (in_array($raw, self::VALID_DISPLAY_MODES, true)) {
+            return $raw;
+        }
+
+        return 'ratings';
+    }
+
+    /**
+     * Validate a string query parameter
+     */
+    public function validateStringParam(string $paramName): string
+    {
+        if (!isset($_GET[$paramName]) || !is_string($_GET[$paramName])) {
+            return '';
+        }
+        $raw = trim($_GET[$paramName]);
+        return $raw !== '' ? $raw : '';
+    }
+
+    /**
+     * Validate an integer query parameter (positive)
+     */
+    public function validateIntParam(string $paramName): int
+    {
+        if (!isset($_GET[$paramName]) || !is_string($_GET[$paramName])) {
+            return 0;
+        }
+        $raw = $_GET[$paramName];
+        if (!ctype_digit($raw)) {
+            return 0;
+        }
+        return (int) $raw;
+    }
+
+    /**
+     * Validate a cash amount query parameter (0-2000)
+     */
+    public function validateCashAmount(string $paramName): int
+    {
+        if (!isset($_GET[$paramName]) || !is_string($_GET[$paramName])) {
+            return 0;
+        }
+        $raw = $_GET[$paramName];
+        if (!ctype_digit($raw)) {
+            return 0;
+        }
+        $amount = (int) $raw;
+        if ($amount > 2000) {
+            return 0;
+        }
+        return $amount;
+    }
+}

--- a/ibl5/classes/Trading/TradingController.php
+++ b/ibl5/classes/Trading/TradingController.php
@@ -136,7 +136,8 @@ class TradingController implements TradingControllerInterface
 
         $tradeAssetRepo = new TradeAssetRepository($this->db);
         $paramValidator = new TradeRosterPreviewParamValidator();
-        $handler = new TradeRosterPreviewApiHandler($this->db, $tradeAssetRepo, $loggedInTeamID, null, $paramValidator);
+        $cashRowBuilder = new TradeRosterPreviewCashRowBuilder($paramValidator);
+        $handler = new TradeRosterPreviewApiHandler($this->db, $tradeAssetRepo, $loggedInTeamID, null, $paramValidator, $cashRowBuilder);
         $handler->handle();
     }
 

--- a/ibl5/classes/Trading/TradingController.php
+++ b/ibl5/classes/Trading/TradingController.php
@@ -135,7 +135,8 @@ class TradingController implements TradingControllerInterface
         }
 
         $tradeAssetRepo = new TradeAssetRepository($this->db);
-        $handler = new TradeRosterPreviewApiHandler($this->db, $tradeAssetRepo, $loggedInTeamID);
+        $paramValidator = new TradeRosterPreviewParamValidator();
+        $handler = new TradeRosterPreviewApiHandler($this->db, $tradeAssetRepo, $loggedInTeamID, null, $paramValidator);
         $handler->handle();
     }
 

--- a/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
+++ b/ibl5/docs/backlog/archive/maintenance-backlog-archive.md
@@ -215,6 +215,17 @@ Split completed in PR #1145. `SeasonArchiveView.php` deleted; replaced by `ibl5/
 **Provenance:** Seeded 2026-07-24 — hot-files comment→backlog migration.
 **Status (2026-07-26):** ✅ Implemented — PR #1679. Extracted `RecapHeaderRenderer`, `RecapTabsRenderer`, `RecapPanelRenderer`, `RecapInjuryCellRenderer`, `RecapBattlesRenderer` (5 renderer classes) + `RecapTeamNameHelper`; `LastSimRecapView` thinned to a pure orchestrator. Output byte-identical across all 5 golden-master scenarios. 57 mutation-surviving renderer unit tests + 5 helper tests (62 total) in `ibl5/tests/LastSimRecap/`.
 
+### 1.31 TradeRosterPreviewApiHandler — Validation + Cash + Render in One Handler (508 LOC)
+**Location:** `ibl5/classes/Trading/TradeRosterPreviewApiHandler.php` (508 lines)
+**Problem:** One request handler validates params (`validateTeamID`, `validatePidList`, `validateCashAmount`, `validateStringParam`), builds cash rows, and renders the roster-preview table.
+**Suggested direction:** Extract a request-validation collaborator and a cash-row builder; keep `handle()` thin.
+**Est. effort:** M
+**Risk if untouched:** A request-handling API endpoint — a wrong extraction can alter validation behavior, so add an E2E/characterization pin before refactor (🟨).
+**Provenance:** Seeded 2026-07-24 — hot-files comment→backlog migration.
+**Status:** ✅ Implemented (2026-07-27) — extracted into TradeRosterPreviewParamValidator + TradeRosterPreviewCashRowBuilder (branch trading-1-31-api-handler-extract)
+
+**Table evidence (2026-07-27):** TradeRosterPreviewApiHandler 508 LOC — API handler mixing param validation + cash-row building + table render. Extract validation and cash-row collaborators; endpoint (request-handling) → add an E2E/characterization pin.
+
 ### 1.34 SavedDepthChartService — Data Assembly + Slot-Conflict Resolution (626 LOC)
 **Location:** `ibl5/classes/SavedDepthChart/SavedDepthChartService.php` (626 lines)
 **Problem:** One service assembles depth-chart page data and resolves slot conflicts, mixing orchestration with conflict-resolution logic.

--- a/ibl5/docs/backlog/maintenance-backlog.md
+++ b/ibl5/docs/backlog/maintenance-backlog.md
@@ -25,7 +25,7 @@ Effort scale:
 - **M** — multi-step plan, 1-3 days, may touch several modules
 - **L** — refactor or platform shift, > 3 days, likely needs ADR
 
-**Status:** Complete — 15-axis audit, 312 findings (+2 post-audit follow-ups from the PR #1107 review, +1 from the #1066 reject-IDOR review → 315 tracked; +11 Axis-1 size seeds 1.21–1.31 from the hot-files comment→backlog migration 2026-07-24 → 326 tracked; +5 Axis-1 size seeds 1.32–1.36 from the ground-truth audit 2026-07-24 → 331 tracked).
+**Status:** Complete — 15-axis audit, 312 findings (+2 post-audit follow-ups from the PR #1107 review, +1 from the #1066 reject-IDOR review → 315 tracked; +11 Axis-1 size seeds 1.21–1.31 from the hot-files comment→backlog migration 2026-07-24 → 326 tracked; +5 Axis-1 size seeds 1.32–1.36 from the ground-truth audit 2026-07-24 → 331 tracked; +1 Axis-2 robustness item 2.39 discovered 2026-07-27 during trading-1-31-api-handler-extract → 332 tracked).
 
 ---
 
@@ -43,17 +43,17 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 > A file still >500 LOC after a ✅ does **not** reopen the finding when the finding's named concern was narrower than "shrink below 500 LOC"; residual size is noted, not re-flagged.
 
-### Roll-up (331 findings)
+### Roll-up (332 findings)
 
 | Status | Count |
 |--------|------:|
-| ✅ Implemented | 234 |
+| ✅ Implemented | 235 |
 | ◑ Partial | 24 |
 | 📋 Planned (plan queued / PR open) | 1 |
 | ⬜ Open | 62 |
 | 🚫 Declined | 10 |
 
-> Status counts re-verified 2026-06-28 (exact, from the per-axis tables); **6.20 / 6.21 added 2026-06-29** from the PR #1107 review (⬜ Open +2); **6.22 added 2026-06-29** from the #1066 reject-IDOR review (⬜ Open +1). Two stale-Open rows were flipped directly (no plan owned them): **13.3**, **13.9** (✅ +2, ⬜ −2 vs the master re-count). **1.21–1.31 added 2026-07-24** from the hot-files comment→backlog migration (⬜ Open +11: 8 🟩 auto-mergeable, 3 🟨 conditional — 1.23/1.25/1.31 need characterization/endpoint pins). **Ground-truth audit 2026-07-24:** 7 stale-Open items flipped ✅, 2 false findings marked 🚫, 5 new Axis-1 rows seeded (1.32–1.36); IDOR PRs #1107–1110 merged 2026-06-29 (unblocking 2.10/2.13/2.14/2.25/7.7/14.6); PRs #1240/#1230/#1204 merged (2.6/2.31/2.32/5.18 already ✅/Open on own merits). **9.19 and 9.20 implemented 2026-07-24** — added READMEs to all 68 missing class dirs + frontmatter to all 16 existing class READMEs that lacked it; extended bin/check-docs IN_SCOPE_GLOBS (✅ +2, ⬜ −2); roll-up recomputed from grep (331 rows total, unchanged). **6.16 flipped ✅ 2026-07-24** (all Api data repos + JsonResponder + SystemClock tested; ✅ +1, ◑ −1). **6.14 Status updated 2026-07-24** (ProcessBoxscoresStep/GenerateSeasonAwardsStep/ParseJsbFilesStep added; still ◑). **Resolved rows collapsed 2026-07-25** — ✅/🚫 findings no longer appear as table rows; each axis carries a `> ✅ resolved (N): …` / `> 🚫 declined (N): …` summary line and their evidence lives in [archive/maintenance-backlog-archive.md](archive/maintenance-backlog-archive.md). **Recount recipe:** resolved = sum of the `(N)` in the per-axis summary lines; open = grep of the per-axis table rows; total = the two added. Counts above are unchanged by the collapse (238 + 93 = 331). **1.36 and 7.7 flipped ✅ 2026-07-26** (✅ +2, ⬜ −1, ◑ −1); total tracked rows unchanged at 331. **1.29 flipped ✅ 2026-07-26 (PR #1679)** (✅ +1, ⬜ −1); total tracked rows unchanged at 331. **1.27 flipped ✅ 2026-07-27** — extracted 10 per-entity collaborators into `ibl5/classes/JsbParser/Repositories/`; JsbImportRepository reduced to thin facade (✅ +1, ⬜ −1); total tracked rows unchanged at 331. **1.23 flipped ✅ 2026-07-27 (`oneonone-1-23-pins-and-extract`)** (✅ +1, ⬜ −1); total tracked rows unchanged at 331.
+> Status counts re-verified 2026-06-28 (exact, from the per-axis tables); **6.20 / 6.21 added 2026-06-29** from the PR #1107 review (⬜ Open +2); **6.22 added 2026-06-29** from the #1066 reject-IDOR review (⬜ Open +1). Two stale-Open rows were flipped directly (no plan owned them): **13.3**, **13.9** (✅ +2, ⬜ −2 vs the master re-count). **1.21–1.31 added 2026-07-24** from the hot-files comment→backlog migration (⬜ Open +11: 8 🟩 auto-mergeable, 3 🟨 conditional — 1.23/1.25/1.31 need characterization/endpoint pins). **Ground-truth audit 2026-07-24:** 7 stale-Open items flipped ✅, 2 false findings marked 🚫, 5 new Axis-1 rows seeded (1.32–1.36); IDOR PRs #1107–1110 merged 2026-06-29 (unblocking 2.10/2.13/2.14/2.25/7.7/14.6); PRs #1240/#1230/#1204 merged (2.6/2.31/2.32/5.18 already ✅/Open on own merits). **9.19 and 9.20 implemented 2026-07-24** — added READMEs to all 68 missing class dirs + frontmatter to all 16 existing class READMEs that lacked it; extended bin/check-docs IN_SCOPE_GLOBS (✅ +2, ⬜ −2); roll-up recomputed from grep (331 rows total, unchanged). **6.16 flipped ✅ 2026-07-24** (all Api data repos + JsonResponder + SystemClock tested; ✅ +1, ◑ −1). **6.14 Status updated 2026-07-24** (ProcessBoxscoresStep/GenerateSeasonAwardsStep/ParseJsbFilesStep added; still ◑). **Resolved rows collapsed 2026-07-25** — ✅/🚫 findings no longer appear as table rows; each axis carries a `> ✅ resolved (N): …` / `> 🚫 declined (N): …` summary line and their evidence lives in [archive/maintenance-backlog-archive.md](archive/maintenance-backlog-archive.md). **Recount recipe:** resolved = sum of the `(N)` in the per-axis summary lines; open = grep of the per-axis table rows; total = the two added. Counts above are unchanged by the collapse (238 + 93 = 331). **1.36 and 7.7 flipped ✅ 2026-07-26** (✅ +2, ⬜ −1, ◑ −1); total tracked rows unchanged at 331. **1.29 flipped ✅ 2026-07-26 (PR #1679)** (✅ +1, ⬜ −1); total tracked rows unchanged at 331. **1.27 flipped ✅ 2026-07-27** — extracted 10 per-entity collaborators into `ibl5/classes/JsbParser/Repositories/`; JsbImportRepository reduced to thin facade (✅ +1, ⬜ −1); total tracked rows unchanged at 331. **1.23 flipped ✅ 2026-07-27 (`oneonone-1-23-pins-and-extract`)** (✅ +1, ⬜ −1); total tracked rows unchanged at 331. **1.31 flipped ✅ 2026-07-27** — extracted `TradeRosterPreviewParamValidator` + `TradeRosterPreviewCashRowBuilder` collaborators; DB characterization pin + validator/cash-row unit suites landed (✅ +1, ⬜ −1). **2.39 seeded 2026-07-27** — cash-year range unbounded/unordered in `TradeRosterPreviewCashRowBuilder::buildCashRows()`; cashStartYear/cashEndYear come from `$_GET` with no upper bound (discovered during trading-1-31-api-handler-extract) (⬜ +1); total tracked: 332 (✅ 235, ◑ 24, 📋 1, ⬜ 62, 🚫 10).
 
 **Automouse-readiness of the not-yet-complete (⬜/◑/📋) items:**
 
@@ -74,7 +74,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 
 **Automouse audit (verified 2026-06-20):**
 
-> ✅ resolved (24): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.20, 1.23, 1.27, 1.28, 1.29, 1.34, 1.36 — evidence in [archive](archive/maintenance-backlog-archive.md)
+> ✅ resolved (25): 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.20, 1.23, 1.27, 1.28, 1.29, 1.31, 1.34, 1.36 — evidence in [archive](archive/maintenance-backlog-archive.md)
 
 | # | Status | Automouse | Evidence / note |
 |---|--------|-----------|-----------------|
@@ -86,7 +86,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 1.25 | ⬜ Open | 🟨 | BoxscoreProcessor 559 LOC — mutating .sco import pipeline; regular/all-star/rising-stars game processors in one class. Extract per-game-type processors; import-fidelity-critical → characterization pins first. Size finding only; the Processor→Service *rename* is separately declined at 2.5. |
 | 1.26 | ⬜ Open | 🟩 | BugReportRepository 546 LOC — 24 methods spanning claim/lease/transition state-machine + reporter-profile + queue queries. Split by query group; green-green with DB-integration pins. |
 | 1.30 | ⬜ Open | 🟩 | TradingService 516 LOC — page-data orchestration + offer-grouping + future-salary calc. Extract offer-grouping and salary collaborators; green-green. |
-| 1.31 | ⬜ Open | 🟨 | TradeRosterPreviewApiHandler 508 LOC — API handler mixing param validation + cash-row building + table render. Extract validation and cash-row collaborators; endpoint (request-handling) → add an E2E/characterization pin. |
 | 1.32 | ⬜ Open | 🟩 | StandingsRepository 726 LOC — per-category standings query methods. Extract per-category query collaborators; green-green DB pin. Shares `classes/Standings/` with 1.35 — plan as ONE chunk. |
 | 1.33 | ⬜ Open | 🟩 | Player 671 LOC — typed-getter accumulation. Extract per-domain typed-getter groups (contract, stats, identity); green-green. |
 | 1.35 | ⬜ Open | 🟩 | StandingsView 610 LOC — per-division block renderers. Extract per-division renderer collaborators; golden-master pin. Shares `classes/Standings/` with 1.32 — plan as ONE chunk. |
@@ -156,14 +155,6 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Risk if untouched:** Trade page-data logic concentrated in one service; green-green.
 **Provenance:** Seeded 2026-07-24 — hot-files comment→backlog migration.
 
-### 1.31 TradeRosterPreviewApiHandler — Validation + Cash + Render in One Handler (508 LOC)
-**Location:** `ibl5/classes/Trading/TradeRosterPreviewApiHandler.php` (508 lines)
-**Problem:** One request handler validates params (`validateTeamID`, `validatePidList`, `validateCashAmount`, `validateStringParam`), builds cash rows, and renders the roster-preview table.
-**Suggested direction:** Extract a request-validation collaborator and a cash-row builder; keep `handle()` thin.
-**Est. effort:** M
-**Risk if untouched:** A request-handling API endpoint — a wrong extraction can alter validation behavior, so add an E2E/characterization pin before refactor (🟨).
-**Provenance:** Seeded 2026-07-24 — hot-files comment→backlog migration.
-
 ### 1.32 StandingsRepository — Per-Category Query Accumulation (726 LOC)
 **Location:** `ibl5/classes/Standings/StandingsRepository.php` (726 lines)
 **Problem:** Multiple per-category standings-query methods accumulated in one repository (division standings, tiebreaker, playoff seeding, historical standings, etc.).
@@ -212,6 +203,7 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 | 2.29 | ⬜ Open | 🟨 | DEFERRED — global-namespace elimination: JSB 291 callers, BaseMysqliRepository 257, ContractRules 37 (585 caller files). L-effort, high-collision; needs its own sequenced PR (one class at a time), not an unattended wave item. |
 | 2.31 | ⬜ Open | 🟩 | UI/ 1 interface of 15; add interfaces systematically. Additive. |
 | 2.32 | ◑ Partial | 🟩 | Shipped: common `Api\Contracts\TransformerInterface` (7 uniform transformers) + flattened `Middleware/Contracts/`→`Api/Contracts/`. **Status:** partial 2026-06-26; residual = divergent-transformer interfaces (Boxscore/PlayerStats), responder interfaces (Csv/Json — disjoint shapes), `Response/Contracts/` flatten. |
+| 2.39 | ⬜ Open | 🟨 | `TradeRosterPreviewCashRowBuilder::buildCashRows()` iterates `cashStartYear`..`cashEndYear` from `$_GET` with no upper bound and no ordering check — `cashStartYear=1&cashEndYear=999999` drives an ~1M-iteration loop. Add bounds + ordering enforcement; upfront: choose max-year cap. (discovered 2026-07-27 during trading-1-31-api-handler-extract) |
 
 ### 2.1 Legacy Global Functions in Module Entrypoints (5 modules)
 **Location:** `modules/Voting/index.php` (lines 40, 74, 85, 156), `modules/Waivers/index.php` (:25), `modules/ComparePlayers/index.php` (:29, :79), `modules/ApiKeys/index.php` (:85, :99), `modules/News/index.php` (:28)
@@ -319,6 +311,14 @@ Every finding is classified on two orthogonal axes below, **verified against on-
 **Suggested direction:** Flatten `Middleware/Contracts/` into `Api/Contracts/`; add interfaces for Transformer + Response classes; document the Api module's different structure.
 **Est. effort:** S (flatten) / M (full interface coverage)
 **Risk if untouched:** Two `Contracts/` directories confuse discovery; Transformers can't be substituted.
+
+### 2.39 TradeRosterPreviewCashRowBuilder — Unbounded Cash-Year Range From `$_GET`
+**Location:** `ibl5/classes/Trading/TradeRosterPreviewCashRowBuilder.php` (`buildCashRows()`)
+**Problem:** `cashStartYear` and `cashEndYear` come directly from `$_GET` with no upper bound and no ordering check. `cashStartYear=1&cashEndYear=999999` drives an ~1M-iteration loop in `buildCashRows()` — a DoS vector on an authenticated endpoint.
+**Suggested direction:** Add an upper bound (e.g. current season + a reasonable forward horizon) and an ordering check (`cashStartYear ≤ cashEndYear`); ideally wire the validation into `TradeRosterPreviewParamValidator` (already extracted in trading-1-31-api-handler-extract).
+**Est. effort:** S
+**Risk if untouched:** Authenticated users can trigger arbitrary-length computation loops via crafted requests to the trade-roster-preview API endpoint.
+**Provenance:** Discovered 2026-07-27 during trading-1-31-api-handler-extract.
 
 ## Axis 3: Top-Level Legacy PHP Files
 

--- a/ibl5/phpstan-rules/BanRawSuperglobalsRule.php
+++ b/ibl5/phpstan-rules/BanRawSuperglobalsRule.php
@@ -30,7 +30,7 @@ final class BanRawSuperglobalsRule implements Rule
     private const ALLOWLIST_BY_SUPERGLOBAL = [
         '_GET' => [
             'suffixes' => ['Controller.php', 'ApiHandler.php', 'Bootstrap.php', 'Authenticator.php'],
-            'files' => ['CsrfGuard.php', 'LeagueContext.php', 'TestCookieOverrides.php'],
+            'files' => ['CsrfGuard.php', 'LeagueContext.php', 'TestCookieOverrides.php', 'TradeRosterPreviewParamValidator.php'],
         ],
         '_POST' => [
             'suffixes' => ['Controller.php', 'ApiHandler.php', 'Bootstrap.php', 'Authenticator.php'],

--- a/ibl5/tests/DatabaseIntegration/Trading/TradeRosterPreviewApiCharacterizationTest.php
+++ b/ibl5/tests/DatabaseIntegration/Trading/TradeRosterPreviewApiCharacterizationTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\DatabaseIntegration\Trading;
+
+use PHPUnit\Framework\Attributes\Group;
+use Tests\DatabaseIntegration\DatabaseTestCase;
+
+/**
+ * DB characterization pin for Trading\TradeRosterPreviewApiHandler.
+ *
+ * Each test runs inside DatabaseTestCase's rolled-back transaction — no commit
+ * is ever called, so no production data is mutated. The seeded fixture is a
+ * synthetic team (teamid 99, sole occupant of CharTestConf/CharTestDiv) with
+ * one player 'Preview Pinner' whose cy (1) !== cyt (3), making the row survive
+ * both getRosterUnderContract() and getFreeAgencyRoster() regardless of season
+ * phase.
+ *
+ * DISCIPLINE: Tests 5-8 assert empty HTML. Those assertions are load-bearing
+ * ONLY because tests 1-4 prove the same fixture ('Preview Pinner' on team 99)
+ * yields non-empty HTML for valid requests. The handler's catch(\Throwable)
+ * block swallows all crashes as '' — so if tests 1-4 are weakened, tests 5-8
+ * lose all signal. Do NOT relax the assertStringContainsString('Preview Pinner')
+ * assertions in tests 1-4 to a bare assertNotSame('', $html).
+ */
+#[Group('database')]
+final class TradeRosterPreviewApiCharacterizationTest extends DatabaseTestCase
+{
+    private const TEAM_ID = 99;
+    private const PID     = 200140101;
+    private const PLAYER  = 'Preview Pinner';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Three inserts copied verbatim from
+        // TeamServicePageDataCharacterizationTest::seedCharTeam()
+        $this->insertRow('ibl_team_info', [
+            'teamid'      => self::TEAM_ID,
+            'team_city'   => 'Testville',
+            'team_name'   => 'CharTest',
+            'color1'      => '102030',
+            'color2'      => 'A0B0C0',
+            'arena'       => 'Test Arena',
+            'capacity'    => 18000,
+            'owner_name'  => 'Test Owner',
+            'owner_email' => 'owner@test.local',
+            'gm_username' => 'char_gm',
+        ]);
+
+        $this->insertRow('ibl_standings', [
+            'teamid'         => self::TEAM_ID,
+            'team_name'      => 'CharTest',
+            'pct'            => 0.600,
+            'league_record'  => '12-8',
+            'wins'           => 12,
+            'losses'         => 8,
+            'conference'     => 'CharTestConf',
+            'conf_record'    => '7-5',
+            'conf_gb'        => 0.0,
+            'division'       => 'CharTestDiv',
+            'div_record'     => '4-2',
+            'div_gb'         => 0.0,
+            'home_record'    => '8-2',
+            'away_record'    => '4-6',
+            'games_unplayed' => 62,
+        ]);
+
+        $this->insertRow('ibl_power', [
+            'teamid'        => self::TEAM_ID,
+            'ranking'       => 5,
+            'last_win'      => 3,
+            'last_loss'     => 1,
+            'streak_type'   => 'W',
+            'streak'        => 2,
+            'sos'           => 0.500,
+            'remaining_sos' => 0.510,
+        ]);
+
+        // cy (1) !== cyt (3) deliberately — survives both roster query paths
+        $this->insertTestPlayer(self::PID, self::PLAYER, [
+            'teamid'     => self::TEAM_ID,
+            'cy'         => 1,
+            'cyt'        => 3,
+            'salary_yr1' => 100,
+            'salary_yr2' => 100,
+            'ordinal'    => 1,
+        ]);
+
+        $_GET = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = [];
+        parent::tearDown();
+    }
+
+    /**
+     * Set $_GET, capture handle() JSON output, return decoded array.
+     *
+     * @param array<string, string> $get
+     * @return array<string, mixed>
+     */
+    private function invoke(array $get): array
+    {
+        $_GET = $get;
+        ob_start();
+        $handler = new \Trading\TradeRosterPreviewApiHandler(
+            $this->db,
+            new \Trading\TradeAssetRepository($this->db),
+            self::TEAM_ID
+        );
+        $handler->handle();
+        $json = (string) ob_get_clean();
+        /** @var array<string, mixed> */
+        return json_decode($json, true);
+    }
+
+    // ── Valid-request pins (tests 1-4 give 5-8 their signal) ───────
+
+    public function testValidRatingsRequestRendersSeededPlayer(): void
+    {
+        $decoded = $this->invoke(['teamid' => '99', 'display' => 'ratings']);
+
+        self::assertIsArray($decoded);
+        $html = (string) ($decoded['html'] ?? '');
+        self::assertNotSame('', $html);
+        self::assertStringContainsString(self::PLAYER, $html);
+    }
+
+    public function testUnknownDisplayRendersIdenticalHtmlToRatings(): void
+    {
+        $bogus   = $this->invoke(['teamid' => '99', 'display' => 'bogus']);
+        $ratings = $this->invoke(['teamid' => '99', 'display' => 'ratings']);
+
+        self::assertSame($ratings['html'], $bogus['html']);
+    }
+
+    public function testInvalidSplitKeyRendersIdenticalHtmlToRatings(): void
+    {
+        $split   = $this->invoke(['teamid' => '99', 'display' => 'split', 'split' => 'not-a-key']);
+        $ratings = $this->invoke(['teamid' => '99', 'display' => 'ratings']);
+
+        self::assertSame($ratings['html'], $split['html']);
+    }
+
+    public function testContractsWithCashParamsRendersCashLabel(): void
+    {
+        $decoded = $this->invoke([
+            'teamid'        => '99',
+            'display'       => 'contracts',
+            'userTeam'      => 'CharTest',
+            'partnerTeam'   => 'Rivals',
+            'userTeamId'    => '99',
+            'cashStartYear' => '1',
+            'cashEndYear'   => '2',
+            'userCash1'     => '50',
+        ]);
+
+        $html = (string) ($decoded['html'] ?? '');
+        self::assertStringContainsString('Cash to ', $html);
+        self::assertStringContainsString('Rivals', $html);
+        self::assertStringContainsString(self::PLAYER, $html);
+    }
+
+    // ── Negative pins (load-bearing because tests 1-4 proved non-empty) ──
+
+    public function testRejectedTeamIdReturnsEmptyHtml(): void
+    {
+        $decoded = $this->invoke(['teamid' => '0']);
+
+        self::assertSame('', (string) ($decoded['html'] ?? ''));
+    }
+
+    public function testNonNumericAddPidsReturnsEmptyHtml(): void
+    {
+        $decoded = $this->invoke(['teamid' => '99', 'addPids' => '1,abc']);
+
+        self::assertSame('', (string) ($decoded['html'] ?? ''));
+    }
+
+    // ── Boundary pin ────────────────────────────────────────────────
+
+    public function testAddPidsAtAndAboveMaximum(): void
+    {
+        // 20 PIDs (at MAX_PIDS) — validation passes; seeded player still renders
+        $twentyPids = implode(
+            ',',
+            array_map(
+                static fn (int $i): string => (string) (200200000 + $i),
+                range(1, 20)
+            )
+        );
+        $atMax    = $this->invoke(['teamid' => '99', 'addPids' => $twentyPids]);
+        $htmlAtMax = (string) ($atMax['html'] ?? '');
+        self::assertNotSame('', $htmlAtMax);
+        self::assertStringContainsString(self::PLAYER, $htmlAtMax);
+
+        // 21 PIDs (exceeds MAX_PIDS) — validation fails; returns ''
+        $twentyOnePids = implode(
+            ',',
+            array_map(
+                static fn (int $i): string => (string) (200200000 + $i),
+                range(1, 21)
+            )
+        );
+        $aboveMax = $this->invoke(['teamid' => '99', 'addPids' => $twentyOnePids]);
+        self::assertSame('', (string) ($aboveMax['html'] ?? ''));
+    }
+
+    // ── Response shape pin ───────────────────────────────────────────
+
+    public function testResponseCarriesOnlyTheHtmlKey(): void
+    {
+        $decoded = $this->invoke(['teamid' => '99', 'display' => 'ratings']);
+
+        self::assertSame(['html'], array_keys($decoded));
+    }
+}

--- a/ibl5/tests/PHPStanRules/BanRawSuperglobalsRuleTest.php
+++ b/ibl5/tests/PHPStanRules/BanRawSuperglobalsRuleTest.php
@@ -104,6 +104,14 @@ final class BanRawSuperglobalsRuleTest extends RuleTestCase
         );
     }
 
+    public function testAllowsGetSuperglobalAccessInTradeRosterPreviewParamValidator(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixtures/classes/TradeRosterPreviewParamValidator.php'],
+            [],
+        );
+    }
+
     public function testAllowsSuperglobalAccessOutsideClassesDirectory(): void
     {
         $this->analyse(

--- a/ibl5/tests/PHPStanRules/Fixtures/classes/TradeRosterPreviewParamValidator.php
+++ b/ibl5/tests/PHPStanRules/Fixtures/classes/TradeRosterPreviewParamValidator.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+$teamid = $_GET['teamid'] ?? '';

--- a/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
+++ b/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Trading;
 use PHPUnit\Framework\TestCase;
 use Tests\WideUnit\Mocks\MockDatabase;
 use Trading\Contracts\TradeAssetRepositoryInterface;
+use Trading\Contracts\TradeRosterPreviewCashRowBuilderInterface;
 use Trading\Contracts\TradeRosterPreviewParamValidatorInterface;
 use Trading\TradeRosterPreviewApiHandler;
 
@@ -27,9 +28,9 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
         $_GET = [];
     }
 
-    private function buildHandler(?TradeAssetRepositoryInterface $repo = null, ?TradeRosterPreviewParamValidatorInterface $validator = null): TradeRosterPreviewApiHandler
+    private function buildHandler(?TradeAssetRepositoryInterface $repo = null, ?TradeRosterPreviewParamValidatorInterface $validator = null, ?TradeRosterPreviewCashRowBuilderInterface $cashRowBuilder = null): TradeRosterPreviewApiHandler
     {
-        return new TradeRosterPreviewApiHandler($this->mockDb, $repo ?? $this->stubTradeAssetRepo, 0, null, $validator);
+        return new TradeRosterPreviewApiHandler($this->mockDb, $repo ?? $this->stubTradeAssetRepo, 0, null, $validator, $cashRowBuilder);
     }
 
     private function captureOutput(callable $fn): string
@@ -403,5 +404,24 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
 
         $this->assertIsArray($decoded);
         $this->assertSame('', $decoded['html']);
+    }
+
+    public function testInjectedCashRowBuilderIsUsed(): void
+    {
+        $_GET = ['teamid' => '1', 'display' => 'contracts'];
+
+        /** @var TradeRosterPreviewCashRowBuilderInterface&\PHPUnit\Framework\MockObject\MockObject $mockBuilder */
+        $mockBuilder = $this->createMock(TradeRosterPreviewCashRowBuilderInterface::class);
+        $mockBuilder->expects($this->once())->method('buildCashRows')->with(1)->willReturn([]);
+
+        $handler = $this->buildHandler(cashRowBuilder: $mockBuilder);
+
+        $output = $this->captureOutput(fn () => $handler->handle());
+
+        /** @var array{html: string} $decoded */
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('html', $decoded);
     }
 }

--- a/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
+++ b/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Trading;
 use PHPUnit\Framework\TestCase;
 use Tests\WideUnit\Mocks\MockDatabase;
 use Trading\Contracts\TradeAssetRepositoryInterface;
+use Trading\Contracts\TradeRosterPreviewParamValidatorInterface;
 use Trading\TradeRosterPreviewApiHandler;
 
 class TradeRosterPreviewApiHandlerTest extends TestCase
@@ -26,9 +27,9 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
         $_GET = [];
     }
 
-    private function buildHandler(?TradeAssetRepositoryInterface $repo = null): TradeRosterPreviewApiHandler
+    private function buildHandler(?TradeAssetRepositoryInterface $repo = null, ?TradeRosterPreviewParamValidatorInterface $validator = null): TradeRosterPreviewApiHandler
     {
-        return new TradeRosterPreviewApiHandler($this->mockDb, $repo ?? $this->stubTradeAssetRepo);
+        return new TradeRosterPreviewApiHandler($this->mockDb, $repo ?? $this->stubTradeAssetRepo, 0, null, $validator);
     }
 
     private function captureOutput(callable $fn): string
@@ -375,6 +376,25 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
         $mockRepo->expects($this->never())->method('getPlayersByIds');
 
         $handler = $this->buildHandler($mockRepo);
+
+        $output = $this->captureOutput(fn () => $handler->handle());
+
+        /** @var array{html: string} $decoded */
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertSame('', $decoded['html']);
+    }
+
+    public function testInjectedValidatorIsUsed(): void
+    {
+        $_GET = [];
+
+        /** @var TradeRosterPreviewParamValidatorInterface&\PHPUnit\Framework\MockObject\MockObject $mockValidator */
+        $mockValidator = $this->createMock(TradeRosterPreviewParamValidatorInterface::class);
+        $mockValidator->expects($this->once())->method('validateTeamID')->willReturn(0);
+
+        $handler = $this->buildHandler(validator: $mockValidator);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 

--- a/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
+++ b/ibl5/tests/Trading/TradeRosterPreviewApiHandlerTest.php
@@ -26,6 +26,11 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
         $_GET = [];
     }
 
+    private function buildHandler(?TradeAssetRepositoryInterface $repo = null): TradeRosterPreviewApiHandler
+    {
+        return new TradeRosterPreviewApiHandler($this->mockDb, $repo ?? $this->stubTradeAssetRepo);
+    }
+
     private function captureOutput(callable $fn): string
     {
         ob_start();
@@ -42,7 +47,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = [];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -57,7 +62,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '0'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -72,7 +77,11 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'addPids' => '1,abc,3'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        /** @var TradeAssetRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(TradeAssetRepositoryInterface::class);
+        $mockRepo->expects($this->never())->method('getPlayersByIds');
+
+        $handler = $this->buildHandler($mockRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -87,7 +96,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'removePids' => 'x,y'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -103,7 +112,11 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
         $pids = implode(',', range(1, 21));
         $_GET = ['teamid' => '1', 'addPids' => $pids];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        /** @var TradeAssetRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(TradeAssetRepositoryInterface::class);
+        $mockRepo->expects($this->never())->method('getPlayersByIds');
+
+        $handler = $this->buildHandler($mockRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -119,7 +132,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
         $pids = implode(',', range(1, 21));
         $_GET = ['teamid' => '1', 'removePids' => $pids];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -134,7 +147,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -149,7 +162,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'display' => 'split'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -164,7 +177,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'display' => 'split', 'split' => 'invalid_key'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -179,7 +192,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = [];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -191,7 +204,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'addPids' => '', 'removePids' => '1,2'];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -206,7 +219,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
     {
         $_GET = ['teamid' => '1', 'addPids' => '1,2', 'removePids' => ''];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -230,7 +243,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'userCash1' => '500',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -248,7 +261,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'display' => 'contracts',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -273,7 +286,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'partnerCash1' => '0',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -298,7 +311,7 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'partnerCash1' => '0',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
 
         $output = $this->captureOutput(fn () => $handler->handle());
 
@@ -323,7 +336,45 @@ class TradeRosterPreviewApiHandlerTest extends TestCase
             'partnerCash1' => '0',
         ];
 
-        $handler = new TradeRosterPreviewApiHandler($this->mockDb, $this->stubTradeAssetRepo);
+        $handler = $this->buildHandler();
+
+        $output = $this->captureOutput(fn () => $handler->handle());
+
+        /** @var array{html: string} $decoded */
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertSame('', $decoded['html']);
+    }
+
+    public function testValidAddPidsDoesReachTheRepository(): void
+    {
+        $_GET = ['teamid' => '1', 'addPids' => '1,2'];
+
+        /** @var TradeAssetRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(TradeAssetRepositoryInterface::class);
+        $mockRepo->expects($this->once())->method('getPlayersByIds')->with([1, 2]);
+
+        $handler = $this->buildHandler($mockRepo);
+
+        $output = $this->captureOutput(fn () => $handler->handle());
+
+        /** @var array{html: string} $decoded */
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertSame('', $decoded['html']);
+    }
+
+    public function testRemovePidsRejectionAlsoSkipsTheRepository(): void
+    {
+        $_GET = ['teamid' => '1', 'removePids' => 'x,y'];
+
+        /** @var TradeAssetRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject $mockRepo */
+        $mockRepo = $this->createMock(TradeAssetRepositoryInterface::class);
+        $mockRepo->expects($this->never())->method('getPlayersByIds');
+
+        $handler = $this->buildHandler($mockRepo);
 
         $output = $this->captureOutput(fn () => $handler->handle());
 

--- a/ibl5/tests/Trading/TradeRosterPreviewCashRowBuilderTest.php
+++ b/ibl5/tests/Trading/TradeRosterPreviewCashRowBuilderTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Trading;
+
+use PHPUnit\Framework\TestCase;
+use Trading\TradeRosterPreviewCashRowBuilder;
+use Trading\TradeRosterPreviewParamValidator;
+use Trading\Contracts\TradeRosterPreviewParamValidatorInterface;
+
+class TradeRosterPreviewCashRowBuilderTest extends TestCase
+{
+    private TradeRosterPreviewCashRowBuilder $sut;
+
+    protected function setUp(): void
+    {
+        $this->sut = new TradeRosterPreviewCashRowBuilder(new TradeRosterPreviewParamValidator());
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = [];
+    }
+
+    // -------------------------------------------------------------------------
+    // makeCashRow() — row shape and edge cases
+    // -------------------------------------------------------------------------
+
+    public function testMakeCashRowReturnsTheFullRowShape(): void
+    {
+        $actual = $this->sut->makeCashRow('| Cash to Boston', 7, [1 => 500], 1, 1, false);
+
+        $expected = [
+            'pid' => 0,
+            'name' => '| Cash to Boston',
+            'nickname' => '',
+            'ordinal' => 100000,
+            'teamid' => 7,
+            'pos' => '',
+            'age' => null,
+            'color1' => null,
+            'color2' => null,
+            'r_fga' => 0, 'r_fgp' => 0, 'r_fta' => 0, 'r_ftp' => 0,
+            'r_3ga' => 0, 'r_3gp' => 0, 'r_orb' => 0, 'r_drb' => 0,
+            'r_ast' => 0, 'r_stl' => 0, 'r_tvr' => 0, 'r_blk' => 0, 'r_foul' => 0,
+            'oo' => 0, 'od' => 0, 'r_drive_off' => 0, 'dd' => 0,
+            'po' => 0, 'pd' => 0, 'r_trans_off' => 0, 'td' => 0,
+            'clutch' => null, 'consistency' => null,
+            'talent' => 0, 'skill' => 0, 'intangibles' => 0,
+            'loyalty' => null, 'playing_time' => null, 'winner' => null,
+            'tradition' => null, 'security' => null,
+            'exp' => 1,
+            'bird' => null,
+            'cy' => 1,
+            'cyt' => 1,
+            'salary_yr1' => 500, 'salary_yr2' => 0, 'salary_yr3' => 0,
+            'salary_yr4' => 0, 'salary_yr5' => 0, 'salary_yr6' => 0,
+            'draftyear' => 0, 'draftround' => 0, 'draftpickno' => 0,
+            'draftedby' => '', 'draftedbycurrentname' => '', 'college' => '',
+            'htft' => 0, 'htin' => 0, 'wt' => 0,
+            'injured' => null,
+            'retired' => 0,
+            'droptime' => 0,
+            'isCashRow' => true,
+        ];
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testMakeCashRowMapsCyIndexOneToSalaryYr1AndSixToSalaryYr6(): void
+    {
+        $amounts = [1 => 100, 2 => 200, 3 => 300, 4 => 400, 5 => 500, 6 => 600];
+
+        $actual = $this->sut->makeCashRow('| Cash to Boston', 1, $amounts, 1, 6, false);
+
+        $this->assertSame(100, $actual['salary_yr1']);
+        $this->assertSame(200, $actual['salary_yr2']);
+        $this->assertSame(300, $actual['salary_yr3']);
+        $this->assertSame(400, $actual['salary_yr4']);
+        $this->assertSame(500, $actual['salary_yr5']);
+        $this->assertSame(600, $actual['salary_yr6']);
+        $this->assertSame(6, $actual['cyt']);
+    }
+
+    public function testMakeCashRowSilentlyDropsYearSevenAmount(): void
+    {
+        // cyIndex 7 falls outside [1..6]; year-7 amount is silently discarded (Preserve-don't-fix)
+        $amounts = [1 => 100, 2 => 200, 3 => 300, 4 => 400, 5 => 500, 6 => 600, 7 => 700];
+
+        $actual = $this->sut->makeCashRow('| Cash to Boston', 1, $amounts, 1, 7, false);
+
+        $this->assertSame(100, $actual['salary_yr1']);
+        $this->assertSame(200, $actual['salary_yr2']);
+        $this->assertSame(300, $actual['salary_yr3']);
+        $this->assertSame(400, $actual['salary_yr4']);
+        $this->assertSame(500, $actual['salary_yr5']);
+        $this->assertSame(600, $actual['salary_yr6']);
+        $this->assertSame(6, $actual['cyt']);
+    }
+
+    public function testMakeCashRowNegatesAmountsWhenNegateIsTrue(): void
+    {
+        $amounts = [1 => 100, 2 => 200];
+
+        $actual = $this->sut->makeCashRow('| Cash from Boston', 1, $amounts, 1, 2, true);
+
+        $this->assertSame(-100, $actual['salary_yr1']);
+        $this->assertSame(-200, $actual['salary_yr2']);
+        // Negated non-zero amounts still count toward totalYears
+        $this->assertSame(2, $actual['cyt']);
+    }
+
+    public function testMakeCashRowDefaultsCytToOneWhenAllAmountsAreZero(): void
+    {
+        $amounts = [1 => 0, 2 => 0];
+
+        $actual = $this->sut->makeCashRow('| Cash to Boston', 1, $amounts, 1, 2, false);
+
+        $this->assertSame(0, $actual['salary_yr1']);
+        $this->assertSame(0, $actual['salary_yr2']);
+        $this->assertSame(1, $actual['cyt']);
+    }
+
+    public function testMakeCashRowUsesZeroForMissingYearKey(): void
+    {
+        // amounts[2] is absent — the ?? 0 path fills it with 0
+        $amounts = [1 => 100];
+
+        $actual = $this->sut->makeCashRow('| Cash to Boston', 1, $amounts, 1, 2, false);
+
+        $this->assertSame(100, $actual['salary_yr1']);
+        $this->assertSame(0, $actual['salary_yr2']);
+        $this->assertSame(1, $actual['cyt']);
+    }
+
+    // -------------------------------------------------------------------------
+    // buildCashRows() — guard cases returning []
+    // -------------------------------------------------------------------------
+
+    public function testBuildCashRowsReturnsEmptyWhenUserTeamIsEmpty(): void
+    {
+        $_GET = [
+            // userTeam intentionally absent → validateStringParam returns ''
+            'partnerTeam' => 'Boston',
+            'userTeamId' => '1',
+            'cashStartYear' => '1',
+            'cashEndYear' => '1',
+            'userCash1' => '500',
+        ];
+
+        $this->assertSame([], $this->sut->buildCashRows(1));
+    }
+
+    public function testBuildCashRowsReturnsEmptyWhenPartnerTeamIsEmpty(): void
+    {
+        $_GET = [
+            'userTeam' => 'Miami',
+            // partnerTeam intentionally absent → validateStringParam returns ''
+            'userTeamId' => '1',
+            'cashStartYear' => '1',
+            'cashEndYear' => '1',
+            'userCash1' => '500',
+        ];
+
+        $this->assertSame([], $this->sut->buildCashRows(1));
+    }
+
+    public function testBuildCashRowsReturnsEmptyWhenCashStartYearIsZero(): void
+    {
+        $_GET = [
+            'userTeam' => 'Miami',
+            'partnerTeam' => 'Boston',
+            'userTeamId' => '1',
+            // cashStartYear absent → validateIntParam returns 0
+            'cashEndYear' => '1',
+            'userCash1' => '500',
+        ];
+
+        $this->assertSame([], $this->sut->buildCashRows(1));
+    }
+
+    public function testBuildCashRowsReturnsEmptyWhenCashEndYearIsZero(): void
+    {
+        $_GET = [
+            'userTeam' => 'Miami',
+            'partnerTeam' => 'Boston',
+            'userTeamId' => '1',
+            'cashStartYear' => '1',
+            // cashEndYear absent → validateIntParam returns 0
+            'userCash1' => '500',
+        ];
+
+        $this->assertSame([], $this->sut->buildCashRows(1));
+    }
+
+    public function testBuildCashRowsReturnsEmptyWhenAllCashAmountsAreZero(): void
+    {
+        $_GET = [
+            'userTeam' => 'Miami',
+            'partnerTeam' => 'Boston',
+            'userTeamId' => '1',
+            'cashStartYear' => '1',
+            'cashEndYear' => '1',
+            'userCash1' => '0',
+            'partnerCash1' => '0',
+        ];
+
+        $this->assertSame([], $this->sut->buildCashRows(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // buildCashRows() — viewing own team
+    // -------------------------------------------------------------------------
+
+    public function testBuildCashRowsViewingOwnTeamWithUserCashReturnsOneCashToRow(): void
+    {
+        $_GET = [
+            'userTeam' => 'Miami',
+            'partnerTeam' => 'Boston',
+            'userTeamId' => '1',
+            'cashStartYear' => '1',
+            'cashEndYear' => '1',
+            'userCash1' => '500',
+            // partnerCash1 absent → 0, so no partner-cash row
+        ];
+
+        $rows = $this->sut->buildCashRows(1);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('| Cash to Boston', $rows[0]['name']);
+        $this->assertSame(1, $rows[0]['teamid']);
+    }
+
+    public function testBuildCashRowsViewingOwnTeamWithPartnerCashReturnsOneCashFromRow(): void
+    {
+        $_GET = [
+            'userTeam' => 'Miami',
+            'partnerTeam' => 'Boston',
+            'userTeamId' => '1',
+            'cashStartYear' => '1',
+            'cashEndYear' => '1',
+            // userCash1 absent → 0, so no user-cash row
+            'partnerCash1' => '300',
+        ];
+
+        $rows = $this->sut->buildCashRows(1);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('| Cash from Boston', $rows[0]['name']);
+        $this->assertSame(1, $rows[0]['teamid']);
+    }
+
+    public function testBuildCashRowsViewingOwnTeamWithBothCashReturnsTwoRowsInOrder(): void
+    {
+        $_GET = [
+            'userTeam' => 'Miami',
+            'partnerTeam' => 'Boston',
+            'userTeamId' => '1',
+            'cashStartYear' => '1',
+            'cashEndYear' => '1',
+            'userCash1' => '500',
+            'partnerCash1' => '300',
+        ];
+
+        $rows = $this->sut->buildCashRows(1);
+
+        $this->assertCount(2, $rows);
+        // Cash to comes before Cash from
+        $this->assertSame('| Cash to Boston', $rows[0]['name']);
+        $this->assertSame('| Cash from Boston', $rows[1]['name']);
+    }
+
+    // -------------------------------------------------------------------------
+    // buildCashRows() — viewing partner's team
+    // -------------------------------------------------------------------------
+
+    public function testBuildCashRowsViewingPartnerTeamHasCorrectLabelsAndTeamId(): void
+    {
+        $_GET = [
+            'userTeam' => 'Miami',
+            'partnerTeam' => 'Boston',
+            'userTeamId' => '1',
+            'cashStartYear' => '1',
+            'cashEndYear' => '1',
+            'userCash1' => '500',
+            'partnerCash1' => '300',
+        ];
+
+        // viewingTeamId=2 !== userTeamId=1 → viewing partner's team
+        $rows = $this->sut->buildCashRows(2);
+
+        $this->assertCount(2, $rows);
+        // Partner's cash going to user's team (Miami)
+        $this->assertSame('| Cash to Miami', $rows[0]['name']);
+        $this->assertSame(2, $rows[0]['teamid']);
+        // User's cash (Miami) received by partner
+        $this->assertSame('| Cash from Miami', $rows[1]['name']);
+        $this->assertSame(2, $rows[1]['teamid']);
+    }
+
+    // -------------------------------------------------------------------------
+    // buildCashRows() — XSS escaping
+    // -------------------------------------------------------------------------
+
+    public function testBuildCashRowsEscapesXssInPartnerTeamName(): void
+    {
+        $_GET = [
+            'userTeam' => 'Miami',
+            'partnerTeam' => '<script>alert(1)</script>',
+            'userTeamId' => '1',
+            'cashStartYear' => '1',
+            'cashEndYear' => '1',
+            'userCash1' => '500',
+        ];
+
+        $rows = $this->sut->buildCashRows(1);
+
+        $this->assertCount(1, $rows);
+        $this->assertStringNotContainsString('<script>', $rows[0]['name']);
+        $this->assertStringContainsString('| Cash to ', $rows[0]['name']);
+    }
+
+    // -------------------------------------------------------------------------
+    // buildCashRows() — injected validator contract
+    // -------------------------------------------------------------------------
+
+    public function testBuildCashRowsUsesTheInjectedValidator(): void
+    {
+        /** @var TradeRosterPreviewParamValidatorInterface&\PHPUnit\Framework\MockObject\MockObject $mockValidator */
+        $mockValidator = $this->createMock(TradeRosterPreviewParamValidatorInterface::class);
+        // validateStringParam is called for both 'userTeam' and 'partnerTeam' before the guard check
+        $mockValidator->expects($this->atLeastOnce())->method('validateStringParam')->willReturn('');
+
+        $sut = new TradeRosterPreviewCashRowBuilder($mockValidator);
+
+        $this->assertSame([], $sut->buildCashRows(1));
+    }
+}

--- a/ibl5/tests/Trading/TradeRosterPreviewParamValidatorTest.php
+++ b/ibl5/tests/Trading/TradeRosterPreviewParamValidatorTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Trading;
+
+use PHPUnit\Framework\TestCase;
+use Trading\TradeRosterPreviewParamValidator;
+
+class TradeRosterPreviewParamValidatorTest extends TestCase
+{
+    private TradeRosterPreviewParamValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new TradeRosterPreviewParamValidator();
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = [];
+    }
+
+    // ── validateTeamID ──────────────────────────────────────────────────────
+
+    public function testValidateTeamIDReturnsZeroWhenMissing(): void
+    {
+        $_GET = [];
+        $this->assertSame(0, $this->validator->validateTeamID());
+    }
+
+    public function testValidateTeamIDReturnsZeroWhenNonString(): void
+    {
+        $_GET = ['teamid' => ['1']];
+        $this->assertSame(0, $this->validator->validateTeamID());
+    }
+
+    public function testValidateTeamIDReturnsZeroWhenZeroString(): void
+    {
+        $_GET = ['teamid' => '0'];
+        $this->assertSame(0, $this->validator->validateTeamID());
+    }
+
+    public function testValidateTeamIDReturnsZeroWhenAlpha(): void
+    {
+        $_GET = ['teamid' => 'abc'];
+        $this->assertSame(0, $this->validator->validateTeamID());
+    }
+
+    public function testValidateTeamIDReturnsParsedInt(): void
+    {
+        $_GET = ['teamid' => '12'];
+        $this->assertSame(12, $this->validator->validateTeamID());
+    }
+
+    public function testValidateTeamIDStripsLeadingZeros(): void
+    {
+        $_GET = ['teamid' => '007'];
+        $this->assertSame(7, $this->validator->validateTeamID());
+    }
+
+    // ── validatePidList ─────────────────────────────────────────────────────
+
+    public function testValidatePidListReturnsEmptyArrayWhenMissing(): void
+    {
+        $_GET = [];
+        $this->assertSame([], $this->validator->validatePidList('addPids'));
+    }
+
+    public function testValidatePidListReturnsEmptyArrayWhenEmptyString(): void
+    {
+        $_GET = ['addPids' => ''];
+        $this->assertSame([], $this->validator->validatePidList('addPids'));
+    }
+
+    public function testValidatePidListReturnsParsedInts(): void
+    {
+        $_GET = ['addPids' => '1,2'];
+        $this->assertSame([1, 2], $this->validator->validatePidList('addPids'));
+    }
+
+    public function testValidatePidListTrimsParts(): void
+    {
+        $_GET = ['addPids' => ' 3 , 4 '];
+        $this->assertSame([3, 4], $this->validator->validatePidList('addPids'));
+    }
+
+    public function testValidatePidListAcceptsExactlyTwentyPids(): void
+    {
+        $_GET = ['addPids' => implode(',', range(1, 20))];
+        $this->assertSame(range(1, 20), $this->validator->validatePidList('addPids'));
+    }
+
+    public function testValidatePidListReturnsNullWhenTwentyOnePids(): void
+    {
+        $_GET = ['addPids' => implode(',', range(1, 21))];
+        $this->assertNull($this->validator->validatePidList('addPids'));
+    }
+
+    public function testValidatePidListReturnsNullWhenEmptyPart(): void
+    {
+        $_GET = ['addPids' => '1,,2'];
+        $this->assertNull($this->validator->validatePidList('addPids'));
+    }
+
+    public function testValidatePidListReturnsNullWhenAlphaPart(): void
+    {
+        $_GET = ['addPids' => '1,abc'];
+        $this->assertNull($this->validator->validatePidList('addPids'));
+    }
+
+    public function testValidatePidListReturnsNullWhenNegative(): void
+    {
+        $_GET = ['addPids' => '-1'];
+        $this->assertNull($this->validator->validatePidList('addPids'));
+    }
+
+    // ── validateDisplay ─────────────────────────────────────────────────────
+
+    public function testValidateDisplayReturnsRatings(): void
+    {
+        $_GET = ['display' => 'ratings'];
+        $this->assertSame('ratings', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayReturnsTotalS(): void
+    {
+        $_GET = ['display' => 'total_s'];
+        $this->assertSame('total_s', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayReturnsAvgS(): void
+    {
+        $_GET = ['display' => 'avg_s'];
+        $this->assertSame('avg_s', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayReturnsPer36Mins(): void
+    {
+        $_GET = ['display' => 'per36mins'];
+        $this->assertSame('per36mins', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayReturnsContracts(): void
+    {
+        $_GET = ['display' => 'contracts'];
+        $this->assertSame('contracts', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayReturnsSplit(): void
+    {
+        $_GET = ['display' => 'split'];
+        $this->assertSame('split', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayReturnsChunk(): void
+    {
+        $_GET = ['display' => 'chunk'];
+        $this->assertSame('chunk', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayReturnsPlayoffs(): void
+    {
+        $_GET = ['display' => 'playoffs'];
+        $this->assertSame('playoffs', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayDefaultsToRatingsWhenMissing(): void
+    {
+        $_GET = [];
+        $this->assertSame('ratings', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayDefaultsToRatingsForBogusValue(): void
+    {
+        $_GET = ['display' => 'bogus'];
+        $this->assertSame('ratings', $this->validator->validateDisplay());
+    }
+
+    public function testValidateDisplayIsCaseSensitive(): void
+    {
+        $_GET = ['display' => 'RATINGS'];
+        $this->assertSame('ratings', $this->validator->validateDisplay());
+    }
+
+    // ── validateStringParam ─────────────────────────────────────────────────
+
+    public function testValidateStringParamReturnsEmptyWhenMissing(): void
+    {
+        $_GET = [];
+        $this->assertSame('', $this->validator->validateStringParam('myParam'));
+    }
+
+    public function testValidateStringParamReturnsEmptyWhenWhitespace(): void
+    {
+        $_GET = ['myParam' => '  '];
+        $this->assertSame('', $this->validator->validateStringParam('myParam'));
+    }
+
+    public function testValidateStringParamTrimsWhitespace(): void
+    {
+        $_GET = ['myParam' => '  x  '];
+        $this->assertSame('x', $this->validator->validateStringParam('myParam'));
+    }
+
+    // ── validateIntParam ────────────────────────────────────────────────────
+
+    public function testValidateIntParamReturnsZeroWhenMissing(): void
+    {
+        $_GET = [];
+        $this->assertSame(0, $this->validator->validateIntParam('myParam'));
+    }
+
+    public function testValidateIntParamReturnsZeroForAlpha(): void
+    {
+        $_GET = ['myParam' => 'abc'];
+        $this->assertSame(0, $this->validator->validateIntParam('myParam'));
+    }
+
+    public function testValidateIntParamReturnsZeroForNegative(): void
+    {
+        $_GET = ['myParam' => '-5'];
+        $this->assertSame(0, $this->validator->validateIntParam('myParam'));
+    }
+
+    public function testValidateIntParamReturnsParsedInt(): void
+    {
+        $_GET = ['myParam' => '12'];
+        $this->assertSame(12, $this->validator->validateIntParam('myParam'));
+    }
+
+    // ── validateCashAmount ──────────────────────────────────────────────────
+
+    public function testValidateCashAmountReturnsZeroWhenMissing(): void
+    {
+        $_GET = [];
+        $this->assertSame(0, $this->validator->validateCashAmount('myCash'));
+    }
+
+    public function testValidateCashAmountReturnsZeroForAlpha(): void
+    {
+        $_GET = ['myCash' => 'abc'];
+        $this->assertSame(0, $this->validator->validateCashAmount('myCash'));
+    }
+
+    public function testValidateCashAmountReturnsAmountFor2000(): void
+    {
+        $_GET = ['myCash' => '2000'];
+        $this->assertSame(2000, $this->validator->validateCashAmount('myCash'));
+    }
+
+    public function testValidateCashAmountReturnsZeroFor2001(): void
+    {
+        $_GET = ['myCash' => '2001'];
+        $this->assertSame(0, $this->validator->validateCashAmount('myCash'));
+    }
+
+    public function testValidateCashAmountReturnsZeroForZeroString(): void
+    {
+        $_GET = ['myCash' => '0'];
+        $this->assertSame(0, $this->validator->validateCashAmount('myCash'));
+    }
+}


### PR DESCRIPTION
## Summary

Behavior-preserving extraction of two collaborators from `Trading\TradeRosterPreviewApiHandler` (508 LOC), behind interfaces, with a DB characterization net landing first. Implements backlog item **1.31**.

**Changes:**
- New `TradeRosterPreviewParamValidatorInterface` + `TradeRosterPreviewParamValidator` — six validation methods extracted verbatim, no `\mysqli`
- New `TradeRosterPreviewCashRowBuilderInterface` + `TradeRosterPreviewCashRowBuilder` — `buildCashRows()` + `makeCashRow()` extracted with sanitizer positions preserved exactly
- `TradeRosterPreviewApiHandler` reduced to ~230 LOC; collaborators injected via nullable constructor params with `??` defaults
- `TradingController::handleRosterPreviewApi()` wires all three classes (ADR-0027/0028)
- DB characterization pin (8 tests) + unit-suite discriminator upgrade with `never()` assertions to prove rejected input doesn't reach the repository
- Validator (100% MSI) + cash-row builder (100% MSI) unit suites added
- PHPStan `BanRawSuperglobals` rule + fixture updated for the new validator class
- Backlog 1.31 retired; Axis-2 item 2.39 stamped for the unbounded cash-year range

**Security:** Validation logic moved verbatim — no reordering, no widening. `HtmlSanitizer::safeHtmlOutput()` calls preserved in exact position. Auth gate in `TradingController` untouched. See plan for the human-review requirement.

## Manual Testing

No manual testing needed — all changes are covered by unit and E2E tests.
