### PR TITLE
chore(plan-now): auto-fire /plan-prompt via detached headless Sonnet

### DIFF
--- a/.claude/rules/agent-tiering-detail.md
+++ b/.claude/rules/agent-tiering-detail.md
@@ -1,6 +1,6 @@
 ---
 description: Read-on-demand detail for agent-tiering — the skip-vs-spawn heuristic, Fable approval-gate procedure (incl. the asm-level static-RE exception where Fable is the recommended tier), flat-fan-out (nested sub-agent) rationale, the bounded-checklist diff-triage exception that scopes the Opus row's open-ended diff-triage, orchestrator context economics (delegate-don't-dismiss, split-don't-self-clear), and per-tier prompt style. Loads only when editing workflow orchestration defs.
-last_verified: 2026-07-25
+last_verified: 2026-07-27
 paths:
   - ".claude/skills/**/*.md"
 ---
@@ -128,7 +128,7 @@ Tier the orchestrator by the judgment **it** retains:
 - **Single backlog item** → **Sonnet** (Steps 2.5/3/4 orchestrator calls are light; same recipe-backed class the "Opus (delegated)" row routes to `plan-architect-sonnet`).
 - **Multiple items in one pass** → **Opus** (cross-item PR decomposition, **dependency ordering**, tier-boundary splits). Cheaper: run each as its own **Sonnet** `/plan` and make only the ordering call yourself.
 
-**Getting to a Sonnet orchestrator from an Opus session:** when an expensive session has already done the design thinking, don't run `/plan` inline — run `/plan-prompt` (`.claude/skills/plan-prompt/SKILL.md`), which drafts a paste-ready `/plan` prompt carrying the ground-truth pointers, the already-measured evidence, and an explicit Step-3 tier directive. A fresh Sonnet session then orchestrates, and the tier directive is what keeps the *design* on Opus. Sonnet-orchestrating is only cheaper than Opus-orchestrating if the context actually crosses the session boundary — that handoff prompt is the thing that carries it.
+**Getting to a Sonnet orchestrator from an Opus session:** when an expensive session has already done the design thinking, don't run `/plan` inline — run `/plan-prompt` (`.claude/skills/plan-prompt/SKILL.md`), which drafts a `/plan` prompt carrying the ground-truth pointers, the already-measured evidence, and an explicit Step-3 tier directive, then fires it via `bin/plan-now` as a **detached headless Sonnet 4.6 session** (the clipboard copy remains, for running it by hand). Sonnet orchestrates; the tier directive is what keeps the *design* on Opus. Because that run has no human in it, `/plan-prompt` Step 4.5 makes the drafting session resolve the user-facing forks that `/plan` Step 3.5 would otherwise put to a human, and `bin/plan-now` holds auto-merge on any fork that survives. Sonnet-orchestrating is only cheaper than Opus-orchestrating if the context actually crosses the session boundary — that handoff prompt is the thing that carries it.
 
 ## Explore Agent Tiering
 

--- a/.claude/skills/plan-prompt/SKILL.md
+++ b/.claude/skills/plan-prompt/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: plan-prompt
-description: "Draft a paste-ready /plan prompt to hand to a fresh Sonnet session, distilled from the current conversation — ground-truth pointers, already-measured evidence, scope, constraints, verification, and the Step-3 architect tier. Use after a design discussion when the planning run should be offloaded off the expensive session."
+description: "Draft a /plan prompt distilled from the current conversation — ground-truth pointers, already-measured evidence, scope, constraints, verification, and the Step-3 architect tier — then fire it as a detached headless Sonnet 4.6 run via bin/plan-now. Use after a design discussion when the planning run should be offloaded off the expensive session."
 disable-model-invocation: true
-last_verified: 2026-07-24
+last_verified: 2026-07-27
 ---
 
-# Draft a `/plan` handoff prompt for a fresh Sonnet session
+# Draft a `/plan` handoff prompt and fire it headless
 
-Emit a paste-ready prompt that a **fresh Sonnet session** can run as `/plan`, carrying
-everything this conversation figured out.
+Compose a prompt that a **fresh Sonnet session** runs as `/plan`, carrying everything
+this conversation figured out — then hand it to `bin/plan-now`, which runs it in a
+detached headless Sonnet 4.6 session (Step 5). The clipboard copy stays, as the
+fallback for running it by hand.
 
 **Why this exists.** A `/plan` run costs mostly orchestration, not design: the design
 happens in one `plan-architect` sub-agent spawn (`.claude/rules/agent-tiering.md`
@@ -108,10 +110,36 @@ several items decomposed in one pass → **Opus** (`agent-tiering.md` §
 `/plan` orchestrator model). If the answer is Opus, say so — this skill's default
 isn't always right.
 
-## Step 5 — Emit
+## Step 4.5 — Pre-resolve the user-facing forks (gate)
+
+The run this skill fires has **no human in it**, so `/plan` Step 3.5 — which surfaces
+each `needs-user-input` fork with `AskUserQuestion` — has nobody to ask. That
+resolution has to happen *here*, where a human is present.
+
+Re-read the block you just composed and ask: does anything in it turn on a
+**preference the codebase cannot reveal** — which of two UXes, how aggressive a
+default, whether a behavior change is acceptable? If yes, **ask it now** with
+`AskUserQuestion` (2–4 options, your recommendation first) and bake the answer into
+the block as a hard constraint (section 4), not as an open question.
+
+Keep the distinction sharp:
+
+| Fork | Where it goes |
+|---|---|
+| The architect can settle it by reading the code | Block section 5 — "resolve inside the plan" |
+| Only the user can settle it | **Ask now**, then block section 4 as a fixed constraint |
+
+Do not ask conventional or irreducible forks (`/plan` Step 3.5 rule) — asking about
+things with an obvious answer is the failure mode on the other side.
+
+`bin/plan-now` appends a coda telling the run to never ask, and to record + hold
+(`auto_merge: false`) any fork that survives anyway. That coda is the backstop, not
+the plan: a fork you could have resolved here costs a held PR.
+
+## Step 5 — Emit and fire
 
 1. Print the block(s).
-2. Copy the first block to the clipboard:
+2. Write block 1 to a temp file and copy it to the clipboard:
 
    ```bash
    f=$(mktemp -t plan-prompt); : > "$f"   # write the block into "$f" first
@@ -120,7 +148,32 @@ isn't always right.
 
    Use `mktemp`, not a fixed `/tmp` name — several sessions run this repo at once.
    With multiple blocks, copy block 1 and say which one is on the clipboard.
-3. **Outside** the fenced block — never inside, so the paste stays clean — add:
+   Keep the `pbcopy` even though step 3 fires the run: if the fire fails, the block
+   is still on the clipboard and you have degraded to the old manual paste, not lost
+   the draft.
+3. Fire it — the file from step 2 is the argument:
+
+   ```bash
+   bin/plan-now "$f"                    # default: leaves the plan on disk for review
+   bin/plan-now --queue "$f"            # only when the user asked for it to auto-queue
+   bin/plan-now --model opus "$f"       # when Step 4 said the ORCHESTRATOR wants Opus
+   ```
+
+   This runs `/plan` in a **detached headless Sonnet 4.6 session** (launchd — it
+   survives closing Claude Code), then runs `bin/check-plan` on the produced plan and
+   logs the verdict. Report the log path it prints; don't poll it.
+
+   **Default disposition is `--implement`** — the plan lands on disk and is *not*
+   queued for automouse. `/plan`'s own default is auto-queue, and that is deliberately
+   inverted here: nobody watched this plan get written, so a human reads it before it
+   implements. `--queue` only when the user asked for end-to-end automation.
+
+   With multiple blocks, fire **only block 1**. Later blocks are stacked PRs whose base
+   branch does not exist yet — write them out, and say they fire after block 1's PR.
+
+   Skip the fire (draft only) when the user asked for the prompt itself, or when
+   Step 4.5 left a fork you could not resolve. Say which happened.
+4. **Outside** the fenced block — never inside, so the paste stays clean — add:
    - which model should run it, and why (Step 4);
    - any judgment call you made for the user (scope picked, split chosen);
    - if a network failure kills the architect mid-run, **re-spawn the same tier**.
@@ -129,4 +182,6 @@ isn't always right.
      plan — the prompt doesn't need to ask for piecewise delivery, and a stall is
      never a reason to downgrade the tier.
 
-Then stop. This skill drafts the prompt; it does not run `/plan`.
+Then stop. The plan is being written in another process; do not wait on it, tail its
+log on a loop, or start implementing. The user picks it up from
+`~/claude-plans/<slug>.md` when the run finishes.

--- a/bin/plan-now
+++ b/bin/plan-now
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# bin/plan-now — fire a detached headless Sonnet 4.6 session that RUNS a drafted
+# /plan handoff prompt, replacing the manual "paste this into a fresh session" step
+# at the end of the /plan-prompt skill.
+#
+# Usage:
+#   bin/plan-now <prompt-file>              # run it; leave the plan on disk (--implement)
+#   bin/plan-now --queue <prompt-file>      # ... and queue it for automouse if check-plan passes
+#   bin/plan-now --model opus <prompt-file> # orchestrator model (default claude-sonnet-4-6)
+#
+# <prompt-file> holds the /plan prompt block exactly as /plan-prompt drafted it —
+# multi-KB markdown with backticks, quotes and $. It is passed to the detached job
+# BY PATH and expanded there (`claude -p "$(cat …)"`), so the block itself never
+# crosses a shell-quoting or plist-XML boundary; only tame paths do.
+#
+# Two proven patterns, assembled:
+#   - detach: the launchd RunAtLoad one-shot from bin/post-plan-now. A plain
+#     `nohup … &` fired from Claude Code's Bash tool shares the tool-shell's
+#     process group and dies with it, so launchd is load-bearing here too.
+#   - headless /plan: the invocation bin/bug-pipeline-tick drive_ready_for_plan()
+#     already runs in production (claude -p "/plan …" --model claude-sonnet-4-6
+#     --dangerously-skip-permissions, plan-dir diff to detect the new plan).
+#
+# NO HUMAN IS PRESENT in the fired run, so /plan Step 3.5 cannot use
+# AskUserQuestion to resolve a needs-user-input fork. Two things cover that:
+#   1. The drafting session pre-resolves user-facing forks and bakes the answers
+#      into the prompt as hard constraints (/plan-prompt Step 4.5).
+#   2. This script appends a headless coda (below) telling the run to never ask,
+#      to record any surviving fork in the plan, and to hold auto-merge for it.
+# The discriminator for "did losing the human degrade the plan" is bin/check-plan,
+# which already fails on unresolved decisions (DECIDE / TBD / "subject to …") and
+# on `auto_merge: false` without a hold justification. The job runs it on the
+# produced plan and reports PASS/FAIL in the log — a real machine verdict, rather
+# than bug-pipeline's weaker "a new plan file appeared".
+#
+# Run from anywhere inside the repo (the main checkout is fine: /plan only READS
+# repo files and writes to ~/claude-plans/, so it does not violate ADR-0062).
+# Deliberately NO master/main branch guard — plan-now runs BEFORE the plan's
+# worktree exists, so master is the expected branch.
+
+set -euo pipefail
+
+MODEL="claude-sonnet-4-6"
+DISPOSITION="implement"
+PROMPT_SRC=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --queue)  DISPOSITION="queue"; shift ;;
+        --model)  MODEL="${2:?--model needs a value}"; shift 2 ;;
+        -h|--help)
+            sed -n '/^# Usage:/,/^#$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -*)
+            echo "plan-now: unknown flag '$1'" >&2; exit 2 ;;
+        *)
+            [ -n "$PROMPT_SRC" ] && { echo "plan-now: one prompt file, not two." >&2; exit 2; }
+            PROMPT_SRC="$1"; shift ;;
+    esac
+done
+
+[ -n "$PROMPT_SRC" ] || { echo "plan-now: usage: bin/plan-now [--queue] [--model M] <prompt-file>" >&2; exit 2; }
+[ -s "$PROMPT_SRC" ] || { echo "plan-now: prompt file '$PROMPT_SRC' is missing or empty." >&2; exit 2; }
+
+grep -q '^/plan' "$PROMPT_SRC" \
+    || { echo "plan-now: '$PROMPT_SRC' has no line starting with '/plan' — that is not a plan prompt." >&2; exit 2; }
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
+    || { echo "plan-now: not inside a git repo." >&2; exit 1; }
+
+# Overridable for the smoke test only — ~/claude-plans is the single source of truth
+# (workflow-continuity.md), same shape as bug-pipeline-tick's BUG_PIPELINE_PLANS_DIR.
+PLANS_DIR="${PLAN_NOW_PLANS_DIR:-$HOME/claude-plans}"
+mkdir -p "$PLANS_DIR"
+
+TS=$(date +%Y%m%d-%H%M%S)
+LABEL="com.ibl5.plan-now-$TS"
+LOG="/tmp/plan-now-$TS.log"
+PROMPT="/tmp/plan-now-$TS.prompt"
+RUNNER="/tmp/plan-now-$TS.sh"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+# Own a private copy: the caller's mktemp block may be cleaned up long before
+# launchd gets around to running the job.
+cp "$PROMPT_SRC" "$PROMPT"
+
+# The headless coda. It lives HERE, not in the skill's drafted block, so every
+# fired run carries it even when the drafting session forgets — and so the block
+# on the clipboard stays a clean paste for a human-run session.
+if [ "$DISPOSITION" = "queue" ]; then
+    DISPOSITION_LINE="Disposition: run \`bin/automouse-queue <slug>\` for this plan once \`bin/check-plan\` passes (the /plan Step 5 default). If check-plan does NOT pass, fix the plan; never queue a failing plan."
+else
+    DISPOSITION_LINE="Disposition: **--implement**. Leave the plan on disk at \`~/claude-plans/<slug>.md\` and do NOT run \`bin/automouse-queue\` — a human reviews it before it implements."
+fi
+
+cat >> "$PROMPT" <<CODA
+
+---
+
+**Headless run constraints (appended by \`bin/plan-now\` — these override any
+conflicting default in the skill):**
+
+- **No human is present.** Never call \`AskUserQuestion\`, never pause for input,
+  never end a turn waiting for an answer. The forks a human could answer were
+  already resolved by the session that drafted this prompt; they appear above as
+  hard constraints.
+- If you hit a genuine \`needs-user-input\` fork that the constraints above do not
+  settle: pick the safest option, **record the fork and your choice explicitly in
+  the plan's Approach section**, and set \`auto_merge: false\` in the line-1
+  frontmatter. \`auto_merge: false\` requires an \`## Automouse Hold Justification\`
+  section naming the unresolved fork, or \`bin/check-plan\` gate [H] fails.
+- Before finishing, run \`bin/check-plan ~/claude-plans/<slug>.md\` and fix
+  everything it reports. This job re-runs it after you exit and logs the verdict.
+- $DISPOSITION_LINE
+CODA
+
+# ---------------------------------------------------------------------------
+# The detached job. The plist invokes this runner by path rather than inlining
+# the body as one XML string (post-plan-now's shape): the plan-dir diff and the
+# check-plan verdict are multi-line bash, and escaping them through XML twice is
+# how quoting bugs get in.
+# ---------------------------------------------------------------------------
+{
+    printf '#!/usr/bin/env bash\n'
+    printf '# Generated by bin/plan-now at %s. Left on disk next to the log for debugging.\n' "$TS"
+    printf 'ROOT=%q\n'       "$ROOT"
+    printf 'PLANS_DIR=%q\n'  "$PLANS_DIR"
+    printf 'PROMPT=%q\n'     "$PROMPT"
+    printf 'MODEL=%q\n'      "$MODEL"
+    printf 'LABEL=%q\n'      "$LABEL"
+    printf 'PLIST=%q\n'      "$PLIST"
+    printf 'CHECK_PLAN=%q\n' "$ROOT/bin/check-plan"
+    # PLAN_NOW_CLAUDE lets a smoke test stub the model call and exercise the
+    # detection + check-plan half of the runner (same shape as bug-pipeline-tick's
+    # $CLAUDE_BIN). Unset in real use.
+    printf 'CLAUDE_BIN=%q\n' "${PLAN_NOW_CLAUDE:-claude}"
+    cat <<'RUNNER_EOF'
+# launchd runs with a minimal env — same PATH prelude bin/automouse-run uses.
+export PATH="/usr/local/bin:/opt/homebrew/bin:$HOME/.bun/bin:$HOME/.local/bin:/Applications/cmux.app/Contents/Resources/bin:$PATH"
+cd "$ROOT" || exit 1
+
+before=$(ls "$PLANS_DIR"/*.md 2>/dev/null | sort)
+
+# CLAUDE_HEADLESS=1 marks the run unattended (skills branch on it).
+# CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 lifts the interactive 120K
+# autoCompactWindow pin — rationale in bin/automouse-run.
+# caffeinate -s keeps the Mac awake on AC for the run's duration.
+CLAUDE_HEADLESS=1 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 caffeinate -s \
+    timeout 3600 "$CLAUDE_BIN" -p "$(cat "$PROMPT")" \
+    --dangerously-skip-permissions \
+    --model "$MODEL" \
+    --effort high \
+    --name "$LABEL"
+rc=$?
+
+after=$(ls "$PLANS_DIR"/*.md 2>/dev/null | sort)
+new_plan=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep -E '\.md$' | head -1)
+
+echo "----------------------------------------------------------------"
+echo "plan-now: claude exited $rc"
+if [ -n "$new_plan" ]; then
+    echo "plan-now: new plan -> $new_plan"
+    if "$CHECK_PLAN" "$new_plan"; then
+        echo "plan-now: RESULT ok — plan written and check-plan PASSED."
+    else
+        echo "plan-now: RESULT degraded — plan written but check-plan FAILED (see above)."
+        echo "plan-now: a human must fix $new_plan before it is queued or implemented."
+    fi
+else
+    # An edit to an EXISTING plan file leaves the listing unchanged, so this is a
+    # 'could not confirm', not a hard 'nothing happened'.
+    echo "plan-now: RESULT unconfirmed — no NEW file in $PLANS_DIR."
+    echo "plan-now: check the transcript above; the run may have updated an existing plan, or failed."
+fi
+
+rm -f "$PLIST"
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+RUNNER_EOF
+} > "$RUNNER"
+chmod +x "$RUNNER"
+
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>$LABEL</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-lc</string>
+		<string>exec "$RUNNER"</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>WorkingDirectory</key>
+	<string>$ROOT</string>
+	<key>StandardOutPath</key>
+	<string>$LOG</string>
+	<key>StandardErrorPath</key>
+	<string>$LOG</string>
+</dict>
+</plist>
+PLIST_EOF
+
+if [ "${PLAN_NOW_DRY_RUN:-0}" = "1" ]; then
+    echo "plan-now: DRY RUN — plist and runner written, not bootstrapped."
+    echo "  runner: $RUNNER"
+    echo "  plist:  $PLIST"
+    echo "  prompt: $PROMPT"
+    exit 0
+fi
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+
+echo "plan-now: fired a detached headless /plan run."
+echo "  model:       $MODEL   (orchestrator; the Step-3 architect tier is set by the prompt)"
+echo "  disposition: $DISPOSITION"
+echo "  supervised by launchd — survives closing Claude Code / the terminal"
+echo "  log:    tail -f $LOG"
+echo "  prompt: $PROMPT"
+echo "  label:  $LABEL   (self-removes when the run finishes)"
+echo "  The log ends with a check-plan verdict on the produced plan."

--- a/ibl5/docs/decisions/0096-headless-plan-autofire.md
+++ b/ibl5/docs/decisions/0096-headless-plan-autofire.md
@@ -1,0 +1,45 @@
+---
+description: /plan-prompt fires its drafted prompt as a detached headless Sonnet 4.6 run via bin/plan-now, with the user-facing forks pre-resolved in-session and bin/check-plan as the quality discriminator.
+last_verified: 2026-07-27
+---
+
+# ADR-0096: `/plan-prompt` auto-fires the planning run headlessly
+
+**Status:** Accepted
+**Date:** 2026-07-27
+
+## Context
+
+`/plan-prompt` exists to move a planning run off an expensive Opus session: it distills the design conversation into a `/plan` prompt for a cheap Sonnet orchestrator, with a Step-3 architect-tier directive that keeps the *design* on Opus. But the skill stopped at the clipboard — the human then had to open a fresh session and paste. That last manual step is where the offload leaks: the paste is easy to defer, and a deferred paste means the design context decays in a session that keeps growing. The repo already had both halves of the fix in production — `bin/post-plan-now`'s launchd detach and `bin/bug-pipeline-tick`'s headless `claude -p "/plan …" --model claude-sonnet-4-6` — but nothing wired them together for a *design-derived* plan.
+
+The hazard in doing so is specific: `/plan` Step 3.5 resolves `needs-user-input` forks with `AskUserQuestion`, and a headless run has nobody to ask. `bug-pipeline-tick` gets away with it because it plans a Discord one-liner with no prior design session; `/plan-prompt` is the opposite case — the session that drafts the prompt is exactly the one that knows which forks are live.
+
+## Decision
+
+`/plan-prompt` Step 5 fires its drafted prompt via `bin/plan-now`, a launchd-detached headless Sonnet 4.6 `/plan` run, instead of stopping at the clipboard (the `pbcopy` stays, so a failed fire degrades to the old manual paste rather than losing the draft). Two mechanisms cover the missing human: **(a)** `/plan-prompt` Step 4.5 is a gate requiring the drafting session to resolve user-facing forks with `AskUserQuestion` *while a human is present* and bake the answers into the prompt as hard constraints; **(b)** `bin/plan-now` appends a headless coda instructing the run never to ask, and to record any surviving fork plus `auto_merge: false` (which `bin/check-plan` gate `[H]` then forces to carry a justification). The job runs `bin/check-plan` on the produced plan and logs a PASS/FAIL verdict — `check-plan` already fails on unresolved decisions (`DECIDE` / `TBD` / "subject to …"), which is precisely the failure mode of removing the human, so it is the discriminator for "did headless degrade this plan". Default disposition is `--implement`: the plan lands on disk and is **not** auto-queued for automouse, inverting `/plan` Step 5's own default, because nobody watched this plan get written. `--queue` is opt-in.
+
+## Alternatives Considered
+
+- **Keep drafting only** — status quo, human pastes into a fresh session. Rejected because: the manual step is the leak the skill was built to close, and it is the step most likely to be skipped.
+- **Fold the launcher into `bin/post-plan-now`** — one detached-run script with a mode flag. Rejected because: it fires on a genuinely different event (start-of-work planning vs end-of-work shipping), takes a different input (a prompt file vs a branch), and bolting a second mode on would strain that script's single responsibility — the `meta-tooling-bar` add-new conditions are met.
+- **Auto-queue the plan for automouse by default** — full hands-off design→implement→PR. Rejected because: it would put a plan no human ever read onto the auto-merge path; the escalation over "human pastes and watches" is too large for a default, so it is `--queue`.
+- **Let the headless run call `AskUserQuestion` and time out** — rely on the fork surfacing somewhere. Rejected because: a fork that only appears as a stalled unattended run is worse than one recorded in the plan with auto-merge held.
+- **Inline the whole job body in the plist XML** (`post-plan-now`'s shape). Rejected because: the multi-KB prompt block is arbitrary markdown, and the plan-dir diff plus check-plan verdict are multi-line bash — escaping both through XML is how quoting bugs get in. `bin/plan-now` writes a runner script and passes the prompt **by path**, expanded inside the job.
+
+## Consequences
+
+- Positive: a design conversation ends in a plan on disk without a human-mediated paste, and the expensive session stops there instead of orchestrating.
+- Positive: the quality question ("did losing the human degrade the plan?") gets a machine answer from `bin/check-plan`, stronger than `bug-pipeline-tick`'s "a new file appeared" heuristic.
+- Positive: forks now get resolved at the moment the human is present, rather than by an unattended agent guessing.
+- Negative: a plan can be written by a run nobody watched. Mitigated by the `--implement` default (a human reads it before it implements) and the `check-plan` verdict in the log, not eliminated.
+- Negative: one more `bin/` script to maintain, and one more launchd label shape to recognize when auditing stray jobs.
+
+## References
+
+- `bin/plan-now` — the launcher; header documents the two patterns it assembles.
+- `.claude/skills/plan-prompt/SKILL.md` — Step 4.5 (fork pre-resolution gate) and Step 5 (fire).
+- `bin/post-plan-now` — the launchd RunAtLoad one-shot detach pattern.
+- `bin/bug-pipeline-tick` — `drive_ready_for_plan()`, the production headless `/plan` invocation and plan-dir-diff detection.
+- `bin/check-plan` — gates `[7]` (unresolved decisions) and `[H]` (hold justification), the discriminator this ADR relies on.
+- `.claude/rules/agent-tiering.md` and `.claude/rules/agent-tiering-detail.md` § `/plan` orchestrator model — why the orchestrator is Sonnet and the architect tier directive is load-bearing.
+- `.claude/rules/meta-tooling-bar.md` — the extend-before-add bar answered in Alternatives.

--- a/ibl5/docs/decisions/README.md
+++ b/ibl5/docs/decisions/README.md
@@ -1,6 +1,6 @@
 ---
 description: Index of IBL5 Architecture Decision Records (ADRs). Source of truth for every load-bearing decision and its rationale.
-last_verified: 2026-07-24
+last_verified: 2026-07-27
 ---
 
 # IBL5 Architecture Decision Records
@@ -30,6 +30,7 @@ Every load-bearing decision in IBL5 is captured here as a numbered ADR so that f
 | [0085](0085-just-in-time-opus-escalation-on-final-automouse-retry.md) | Just-in-time Opus escalation on the final automouse retry | Accepted | Non-Opus plans escalate only their final retry to Opus with the prior attempt's capped failure report; env-stops never escalate. |
 | [0092](0092-postplan-harness-in-repo-with-python-ci.md) | Post-plan harness in-repo with dedicated Python CI | Accepted | Harness ships under `tools/postplan-harness/` gated by a path-scoped `python-tests.yml`; real-data dirs gitignored; `bin/post-plan-now` pinned to the main checkout. |
 | [0095](0095-retire-ibl6-svelte-frontend.md) | Retire the IBL6 SvelteKit frontend; site stays PHP+HTMX | Accepted | Ported IBL6's one page (boxscore) into IBL5 as a PHP module; deleted the second stack + all its CI/Docker/deploy/smoke surface. |
+| [0096](0096-headless-plan-autofire.md) | `/plan-prompt` auto-fires the planning run headlessly | Accepted | `bin/plan-now` runs the drafted prompt as a detached Sonnet 4.6 `/plan`; user-facing forks pre-resolved in-session, `bin/check-plan` verdict logged, `--implement` (not auto-queue) by default. |
 
 ## When an ADR is Required
 


### PR DESCRIPTION
## Summary

- New `bin/plan-now` script: fires `/plan-prompt` drafts as detached headless Sonnet 4.6 runs via launchd, replacing manual paste into a fresh session
- `/plan-prompt` Step 4.5 gate: pre-resolves user-facing forks with `AskUserQuestion` while human is present; bakes answers as hard constraints into the prompt
- `/plan-prompt` Step 5: fires prompt via `bin/plan-now` after clipboard copy (clipboard copy persists; fire failure degrades to manual paste)
- `bin/plan-now` appends headless coda: forbids `AskUserQuestion`, records any surviving forks, holds auto-merge for them
- Quality discriminator: job runs `bin/check-plan` on produced plan, logs PASS/FAIL verdict (check-plan already fails on unresolved decisions)
- Default disposition `--implement`: plan lands on disk, not auto-queued for automouse (human reviews before implementation); `--queue` is opt-in
- ADR-0096: documents decision, rationale, alternatives, consequences

## Manual Testing

No manual testing needed — verified by automated tests.
