### PR TITLE
chore(playwright-tag): prefer installed version in node_modules

### DIFF
--- a/bin/playwright-image-tag
+++ b/bin/playwright-image-tag
@@ -1,12 +1,17 @@
 #!/bin/bash
 # bin/playwright-image-tag — derive the pinned Playwright Docker image ref from
-# a package.json's exact-pinned @playwright/test version. Single source of truth
-# for the version-to-image-tag mapping (see ADR-0070). Used by visual-regression.sh,
-# the setup-docker-e2e composite action so the installed
-# @playwright/test client and the Docker image tag can never drift.
+# the INSTALLED @playwright/test version (node_modules), falling back to the
+# declared version in package.json. Single source of truth for the version-to-image-tag
+# mapping (see ADR-0070). Used by visual-regression.sh, the setup-docker-e2e composite
+# action so the installed @playwright/test client and the Docker image tag can never drift.
+#
+# Reading from node_modules (installed) rather than package.json (declared) prevents a
+# class of mismatch: when a lockfile (bun.lock) is stale vs package.json (e.g. Dependabot
+# bumps package.json but not bun.lock), the cache restores the old packages but
+# package.json advertises the new version, causing Docker image/npm version skew.
 #
 # Usage: bin/playwright-image-tag <path-to-package.json>
-# Echoes e.g. the Microsoft Playwright image ref tagged with the pinned version.
+# Echoes e.g. the Microsoft Playwright image ref tagged with the installed version.
 set -eu
 
 pkg="${1:?usage: playwright-image-tag <path-to-package.json>}"
@@ -15,13 +20,29 @@ if [ ! -f "$pkg" ]; then
   exit 1
 fi
 
-# Exact-pin only (value starts with a digit, no caret) — doubles as a pin-convention
-# guard. Anchored on "@playwright/test" so @axe-core/playwright, eslint-plugin-playwright
-# and the bare "playwright" dep are never matched.
-ver="$(grep -oE '"@playwright/test": *"[0-9]+\.[0-9]+\.[0-9]+"' "$pkg" \
-  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+pkg_dir="$(dirname "$pkg")"
+
+# Prefer the INSTALLED version from node_modules — it matches what bun/npm actually
+# resolved, which is what will run tests. Falls back to the declared version in
+# package.json when node_modules isn't present (e.g. during a fresh checkout before
+# install, or in non-node_modules-aware environments).
+installed_pkg="$pkg_dir/node_modules/@playwright/test/package.json"
+if [ -f "$installed_pkg" ]; then
+  ver="$(grep -oE '"version": *"[0-9]+\.[0-9]+\.[0-9]+"' "$installed_pkg" \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+fi
+
+if [ -z "${ver:-}" ]; then
+  # Fallback: read declared version from package.json.
+  # Exact-pin only (value starts with a digit, no caret) — doubles as a pin-convention
+  # guard. Anchored on "@playwright/test" so @axe-core/playwright, eslint-plugin-playwright
+  # and the bare "playwright" dep are never matched.
+  ver="$(grep -oE '"@playwright/test": *"[0-9]+\.[0-9]+\.[0-9]+"' "$pkg" \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+fi
+
 if [ -z "$ver" ]; then
-  echo "playwright-image-tag: no exact @playwright/test version in $pkg" >&2
+  echo "playwright-image-tag: no @playwright/test version found in $pkg or $installed_pkg" >&2
   exit 1
 fi
 

--- a/bin/test-playwright-version
+++ b/bin/test-playwright-version
@@ -5,8 +5,10 @@
 # image-tag derivation (ADR-0070). Covers:
 #   1. bin/playwright-image-tag maps a package.json @playwright/test version to the
 #      Docker image ref, including a BUMPED version (the self-heal proof — no real bump).
-#   2. bin/playwright-image-tag fails on a package.json with no exact pin.
-#   3. bin/check-playwright-pinning REJECTS a hardcoded literal and PASSES on the
+#   2. bin/playwright-image-tag prefers the INSTALLED version (node_modules) over
+#      the declared version in package.json (stale-lockfile regression guard).
+#   3. bin/playwright-image-tag fails on a package.json with no exact pin.
+#   4. bin/check-playwright-pinning REJECTS a hardcoded literal and PASSES on the
 #      derived ($PW_IMAGE) form.
 #
 # Run: bin/test-playwright-version  (exit 0 = all pass, 1 = a case failed)
@@ -29,14 +31,27 @@ expect_exit() { # name want-code got-code
     else echo "FAIL: $1 — expected exit $2, got $3"; FAILED=1; fi
 }
 
-# 1. bumped version derives bumped tag (self-heal proof)
+# 1. bumped version derives bumped tag (fallback: no node_modules present)
 printf '{\n  "devDependencies": {\n    "@playwright/test": "9.9.9"\n  }\n}\n' > "$TMP/bumped.json"
 got="$("$TAG" "$TMP/bumped.json")"
-expect_eq "bumped version derives bumped tag" \
+expect_eq "declared version derives tag when no node_modules" \
     "mcr.microsoft.com/playwright:v9.9.9-jammy" "$got"
 
-# 2. real ibl5/package.json derives a well-formed tag (version-agnostic so it
-#    survives future Dependabot bumps)
+# 2. installed version (node_modules) wins over declared version in package.json —
+#    regression guard for stale-lockfile scenario (Dependabot bumps package.json
+#    but not bun.lock; cache restores old node_modules; Docker image must match
+#    what's actually installed, not what package.json declares).
+mkdir -p "$TMP/stale/node_modules/@playwright/test"
+printf '{\n  "devDependencies": {\n    "@playwright/test": "9.9.9"\n  }\n}\n' \
+  > "$TMP/stale/package.json"
+printf '{\n  "name": "@playwright/test",\n  "version": "8.8.8"\n}\n' \
+  > "$TMP/stale/node_modules/@playwright/test/package.json"
+got="$("$TAG" "$TMP/stale/package.json")"
+expect_eq "installed version (node_modules) wins over declared version" \
+    "mcr.microsoft.com/playwright:v8.8.8-jammy" "$got"
+
+# 3. real ibl5/package.json derives a well-formed tag (version-agnostic so it
+#    survives future Dependabot bumps); node_modules present so installed version used
 REAL="$(cd "$SCRIPT_DIR/.." && pwd)/ibl5/package.json"
 got="$("$TAG" "$REAL")"
 case "$got" in
@@ -45,17 +60,17 @@ case "$got" in
     *)  echo "FAIL: real package.json derived malformed tag: [$got]"; FAILED=1 ;;
 esac
 
-# 3. missing @playwright/test → non-zero exit
+# 4. missing @playwright/test → non-zero exit
 printf '{\n  "devDependencies": {}\n}\n' > "$TMP/empty.json"
 "$TAG" "$TMP/empty.json" >/dev/null 2>&1
 expect_exit "missing @playwright/test fails" 1 "$?"
 
-# 4. guard REJECTS a hardcoded literal
+# 5. guard REJECTS a hardcoded literal
 printf 'docker pull %s\n' "mcr.microsoft.com/playwright:v1.2.3-jammy" > "$TMP/bad.yml"
 "$GUARD" "$TMP/bad.yml" >/dev/null 2>&1
 expect_exit "guard rejects hardcoded literal" 1 "$?"
 
-# 5. guard PASSES on the derived form
+# 6. guard PASSES on the derived form
 printf 'docker pull "$PW_IMAGE"\n' > "$TMP/good.yml"
 "$GUARD" "$TMP/good.yml" >/dev/null 2>&1
 expect_exit "guard passes derived form" 0 "$?"


### PR DESCRIPTION
## Summary
- Prefer installed @playwright/test version from node_modules over package.json declaration
- Prevents Docker image/npm skew when lockfile is stale (Dependabot updates package.json but not bun.lock, cache restores old packages)
- Adds regression test for stale-lockfile scenario

## Manual Testing

No manual testing needed — verified by automated tests.
