### PR TITLE
chore(rules): clarify multi-check architecture of plan-gate-edit.sh

### DIFF
--- a/.claude/rules/work-triage-detail.md
+++ b/.claude/rules/work-triage-detail.md
@@ -1,6 +1,6 @@
 ---
-description: Read-on-demand detail for work-triage — measurement context for the inline-Opus leak, ADR-0067 gateway framing, hard-trigger gate properties (sub-agent exemption, per-turn scoping, escape hatch, self-test), inline-vs-delegated criteria, safety-mirror backstop, and repeat-polling spend rationale.
-last_verified: 2026-07-25
+description: Read-on-demand detail for work-triage — measurement context for the inline-Opus leak, ADR-0067 gateway framing, hard-trigger gate properties (sub-agent exemption, per-turn scoping, escape hatch, self-test), the other checks sharing plan-gate-edit.sh, inline-vs-delegated criteria, safety-mirror backstop, and repeat-polling spend rationale.
+last_verified: 2026-07-27
 paths:
   - ".claude/rules/work-triage.md"
   - "~/.claude/hooks/plan-gate-edit.sh"
@@ -34,6 +34,10 @@ The prose routing guidance in `work-triage.md` is a judgment call, and judgment 
 - **Escape hatch, deliberately loud:** `touch /tmp/claude-sweep-override-<prompt_id>` (example) releases it for that turn. Legitimate when the edits are genuinely *entangled* with the design — for example authoring a rule doc, its detail companion, and the ADR recording the decision together. Using it silently defeats the gate: **say out loud that you're overriding and why**, in the same turn.
 
 Self-test: `bash ~/.claude/hooks/test-plan-gate-edit.sh`
+
+### Other checks in the same hook
+
+`plan-gate-edit.sh` is one file registered on `Read|Edit|Write`, but only Check 1 implements the sweep trigger. Don't read a deny from it as "I hit the ≥5-file limit" without reading the message — the **cross-worktree straddle gate** (Check 3) denies a **Read** whose target resolves inside a *different* worktree of this same repo than the session cwd, because touching it loads that tree's `.claude/rules/*.md` on top of the byte-identical set already resident, re-sent every turn for the rest of the session (ADR-0046). Its remedy is `EnterWorktree` to re-root the session, not delegation; reading back into the tree whose rules are already loaded stays allowed. It carries its own escape hatch — `touch /tmp/claude-tree-override-<session_id>` (example) — keyed per **session**, not per turn like Check 1's.
 
 ## Repeat-polling
 

--- a/.claude/rules/work-triage.md
+++ b/.claude/rules/work-triage.md
@@ -1,6 +1,6 @@
 ---
 description: Triage every non-trivial unit of work as ad-hoc vs /plan before starting; ad-hoc bar, ad-hoc safety mirror, Sonnet execution-routing (trigger stays resident, reasoning in work-triage-detail.md), hard trigger (≥5 files), and calibration.
-last_verified: 2026-07-25
+last_verified: 2026-07-27
 ---
 
 # Work Triage Rule
@@ -48,7 +48,7 @@ Stay inline (Opus edits directly) only when: the edits are genuinely **entangled
 
 **The numeric rule: the fifth distinct repo file you edit on the main thread within one user turn is the handoff point.** Four files is a change; five is a sweep. Route the remainder to one `subagent_type: "sonnet-4-6"` sub-agent (omit `model`) before making that fifth edit — don't wait to be stopped.
 
-Enforced by `~/.claude/hooks/plan-gate-edit.sh`, which **denies** the Edit/Write — the gate cannot be read past, and its deny message carries the routing instruction and the escape hatch. Gate properties, escape hatch, and self-test: `work-triage-detail.md` § Hard trigger.
+Enforced by `~/.claude/hooks/plan-gate-edit.sh` **§ Check 1**, which **denies** the Edit/Write — the gate cannot be read past, and its deny message carries the routing instruction and the escape hatch. The same hook also denies *Reads* under an unrelated check (the cross-worktree straddle gate); only Check 1 is the sweep trigger. Gate properties, escape hatch, and self-test: `work-triage-detail.md` § Hard trigger.
 
 ## Execution routing: repeat-polling is a spend bug
 


### PR DESCRIPTION
## Summary
- Document that `plan-gate-edit.sh` implements multiple independent checks (Check 1: sweep trigger on ≥5 files; Check 3: cross-worktree straddle gate)
- Add details on cross-worktree gate behavior, remedy (EnterWorktree), and per-session escape hatch
- Update verification dates and routing guidance in work-triage rules

## Manual Testing

No manual testing needed — verified by automated tests.
