### PR TITLE
chore(engine): add fastclass-share calibration data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,8 @@ tools/postplan-harness/fixtures/scenarios/
 tools/postplan-harness/**/__pycache__/
 tools/postplan-harness/**/*.pyc
 tools/postplan-harness/.pytest_cache/
+
+# Separate IBL6 SvelteKit tree that lives inside this checkout — build output,
+# node_modules, and a local .env only; no source. Ignored so `git add -A` in the
+# main checkout can never commit its .env.
+/IBL6/

--- a/engine/internal/validate/testdata/calibration-5.60-20260721-fastclass-share.json
+++ b/engine/internal/validate/testdata/calibration-5.60-20260721-fastclass-share.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-07-21T10:28:42-07:00",
+  "stride": 1,
+  "runs": 4,
+  "seed": 20240601,
+  "snapshots": 97,
+  "total_possessions": 85767226,
+  "drb_push_class": 10608830,
+  "half_court": 75158396,
+  "drb_push_share_pct": 12.369328582458758,
+  "half_court_share_pct": 87.63067141754124
+}

--- a/engine/internal/validate/testdata/calibration-5.60-20260722-fastclass-share.json
+++ b/engine/internal/validate/testdata/calibration-5.60-20260722-fastclass-share.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-07-22T13:54:48-07:00",
+  "stride": 1,
+  "runs": 4,
+  "seed": 20200101,
+  "snapshots": 705,
+  "total_possessions": 584154789,
+  "drb_push_class": 68333607,
+  "half_court": 515821182,
+  "drb_push_share_pct": 11.697859589061762,
+  "half_court_share_pct": 88.30214041093824
+}


### PR DESCRIPTION
## Summary
- Add calibration test snapshots for fastclass-share validation (2026-07-21, 2026-07-22)
- Ignore `/IBL6/` directory (local SvelteKit tree with build output and .env)

## Manual Testing

No manual testing needed — verified by automated tests.
