### PR TITLE
chore(ci): guard shallow git fetches to prevent .git corruption

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -614,6 +614,34 @@ jobs:
       # Phase 1) caps it. Backlog: token-spend-backlog T2.
       - name: Check path-unscoped rules byte budget
         run: bin/check-rules-byte-budget
+      # shallow-fetch guard: a shallow fetch inside repo tooling is safe on a CI
+      # runner but silently CREATES .git/shallow in a full local clone, grafting
+      # origin/<base> to one commit. merge-base then returns nothing and the next
+      # rebase replays the whole history and conflicts — and because every worktree
+      # shares the main checkout's .git, one local run breaks the ship pipeline
+      # repo-wide (that is exactly how check-rules-byte-budget:86 failed a
+      # post-plan run). Shallow flags must sit behind an is-shallow-repository
+      # guard and carry a `# shallow-ok` marker on the line.
+      - name: Check shallow git fetches are guarded
+        run: |
+          set +e
+          # NO \b — git grep -E is POSIX ERE and silently matches NOTHING on \b,
+          # which would make this gate fail open. Verified against origin/master.
+          raw=$(git grep -nE 'git[^#]*(fetch|pull)[^#]*--(depth|shallow-since|shallow-exclude)' \
+                  -- bin .claude tools ibl5/bin)
+          rc=$?
+          set -e
+          # rc 0 = matches, 1 = none; anything higher means git grep itself failed
+          # (e.g. a pathspec that stopped existing) — fail closed, never green.
+          [ "$rc" -le 1 ] || { echo "FAIL: git grep errored (rc=$rc) — gate cannot verify" >&2; exit 1; }
+          hits=$(printf '%s' "$raw" | grep -v '# shallow-ok' || true)
+          if [ -n "$hits" ]; then
+            echo "FAIL: unguarded shallow git fetch (corrupts a full local clone's .git):" >&2
+            echo "$hits" >&2
+            echo "Guard it, then mark the line: if [ \"\$(git rev-parse --is-shallow-repository)\" = true ]; then git fetch --depth=1 ...  # shallow-ok" >&2
+            exit 1
+          fi
+          echo "OK: no unguarded shallow git fetch"
 
   harness-tests:
     name: Shell harness regression tests

--- a/bin/check-rules-byte-budget
+++ b/bin/check-rules-byte-budget
@@ -79,11 +79,23 @@ fi
 # ~/.claude/hooks/plan-gate-edit.sh) — report SKIP, never FAIL.
 #
 # In CI the checkout may be shallow (fetch-depth: 1), so `git diff origin/master`
-# can fail non-fatally due to missing objects. Explicitly fetch the base branch
-# first to guarantee origin/<base> is available, then compute the changed-files
-# set once before the loop.
+# can fail non-fatally due to missing objects. Fetch the base branch first to
+# guarantee origin/<base> is available, then compute the changed-files set once
+# before the loop.
+#
+# `--depth=1` is CI-ONLY and MUST stay behind the is-shallow guard. In a full
+# clone a shallow fetch CREATES .git/shallow, grafting origin/<base> to a single
+# commit — `git merge-base` then returns nothing and any later rebase replays the
+# entire history and conflicts. This hook also runs at commit time (.git/hooks/
+# pre-commit) against the shared main .git, so one unguarded run breaks the ship
+# pipeline for every worktree. Locally origin/<base> already exists, so the fetch
+# is unnecessary; if it somehow doesn't, fetch it at FULL depth.
 _BASE_BRANCH="${GITHUB_BASE_REF:-master}"
-git fetch --depth=1 origin "$_BASE_BRANCH" 2>/dev/null || true
+if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+  git fetch --depth=1 origin "$_BASE_BRANCH" 2>/dev/null || true  # shallow-ok
+elif ! git rev-parse --verify --quiet "origin/$_BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$_BASE_BRANCH" 2>/dev/null || true
+fi
 _CHANGED_RULES="$(git diff --name-only "origin/$_BASE_BRANCH" -- .claude/rules/ 2>/dev/null || true)"
 
 glob_fail=0


### PR DESCRIPTION
## Summary
- Add CI check to detect unguarded shallow git fetches (`--depth`, `--shallow-since`, `--shallow-exclude`)
- Fix `bin/check-rules-byte-budget` to guard its `--depth=1` fetch behind `is-shallow-repository` check
- In a full local clone, an unguarded shallow fetch creates `.git/shallow`, grafting origin/<base> to a single commit. This breaks `git merge-base` and causes subsequent rebases to replay full history and conflict — corrupting the shared .git for all worktrees
- Unguarded shallow fetches must carry `# shallow-ok` marker for CI-only contexts

## Manual Testing

No manual testing needed — verified by automated tests.
